### PR TITLE
WIP CLEANUP TESTING NEEDED pkg/pkg.mk: use intermediate state files

### DIFF
--- a/dist/tools/bossa/Makefile
+++ b/dist/tools/bossa/Makefile
@@ -4,7 +4,7 @@ PKG_VERSION  = 26154375695f345491bba158d57177aa231d6765
 PKG_LICENSE  = BSD-3-Clause
 PKG_BUILDDIR = $(CURDIR)/bin
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all: git-download
 	@echo "[INFO] compiling bossac from source now"
@@ -13,5 +13,3 @@ all: git-download
 
 distclean::
 	@rm -f $(CURDIR)/bossac
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -4,7 +4,7 @@ PKG_VERSION=4f5d490bfffc7fd10855e513e6e88be5a9a3f789
 PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR=$(CURDIR)/bin
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all: git-download
 # Start edbg build in a clean environment, so variables set by RIOT's build process
@@ -12,5 +12,3 @@ all: git-download
 # be built cleanly for the native platform.
 	env -i PATH="$(PATH)" TERM="$(TERM)" "$(MAKE)" -C "$(PKG_BUILDDIR)"
 	mv $(PKG_BUILDDIR)/edbg .
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/dist/tools/mosquitto_rsmb/Makefile
+++ b/dist/tools/mosquitto_rsmb/Makefile
@@ -4,6 +4,8 @@ PKG_VERSION  = 9b99a3be9a26635b93aec8fa2ed744e8c49e7262
 PKG_LICENSE  = EPL-1.0
 PKG_BUILDDIR = $(CURDIR)/bin
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 # set default configuration file
 RSMB_CFG ?= $(CURDIR)/config.cnf
 
@@ -13,8 +15,6 @@ RIOTTOOLS ?= $(CURDIR)/..
 GITCACHE ?= $(RIOTTOOLS)/git/git-cache
 
 $(info $(RIOTBASE))
-
-.PHONY: all clean
 
 all: git-download
 # Start mosquitto_rsmb build in a clean environment, so variables set by RIOT's
@@ -32,5 +32,3 @@ clean::
 	@rm -f $(CURDIR)/mosquitto_rsmb
 	@rm -f $(CURDIR)/Messages.1.*
 	@rm -f $(CURDIR)/FFDC.CWNAN.*.dmp
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/dist/tools/pic32prog/Makefile
+++ b/dist/tools/pic32prog/Makefile
@@ -4,6 +4,8 @@ PKG_VERSION  = b9f8db3b352804392b02b42475fc42874ac8bf04
 PKG_LICENSE  = GPL-2
 PKG_BUILDDIR = bin
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 # Building it requires some dependencies, on ubuntu:
 #
 #     sudo apt-get install libusb-dev libusb-1.0-0-dev libudev-dev
@@ -15,5 +17,3 @@ all: git-download
 
 distclean::
 	@rm -f pic32prog
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/dist/tools/teensy-loader-cli/Makefile
+++ b/dist/tools/teensy-loader-cli/Makefile
@@ -2,6 +2,8 @@ PKG_NAME=teensy-loader-cli
 PKG_LICENSE=GPL-3
 PKG_BUILDDIR=$(CURDIR)/bin
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 # resolv build host in a hacky way
 UNAME=$(shell uname)
 TARGET=WINDOWS
@@ -21,10 +23,6 @@ else
   PKG_VERSION=76921edbdd81ae99b869b104404c16c06b0a266f
 endif
 
-.PHONY: all
-
 all: git-download
 	env -i PATH=$(PATH) TERM=$(TERM) "$(MAKE)" -C $(PKG_BUILDDIR)
 	mv $(PKG_BUILDDIR)/teensy_loader_cli ./teensy_loader
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/Makefile.git
+++ b/pkg/Makefile.git
@@ -2,9 +2,8 @@ PKG_NAME=		# name of the package
 PKG_URL=		# source url of the package's git repository
 PKG_VERSION=	# version of the package to use e.g. a git commit/ref
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	$(MAKE) -C $(CURDIR)/$(PKG_NAME)
 
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cayenne-lpp/Makefile
+++ b/pkg/cayenne-lpp/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/aabadie/cayenne-lpp
 PKG_VERSION=0.1.1
 PKG_LICENSE=LGPLv2.1
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -3,10 +3,11 @@ PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
 PKG_VERSION=e37b02c5cb20e9acccea2394be40f7e570a66a4b
 PKG_LICENSE=ISC
 
-.PHONY: all ..cmake_version_supported
+include $(RIOTBASE)/pkg/pkg.mk
+
+.PHONY: ..cmake_version_supported
 
 CMAKE_MINIMAL_VERSION = 3.6.0
-
 
 RIOT_CFLAGS = $(INCLUDES)
 
@@ -35,8 +36,6 @@ git-download: | ..cmake_version_supported
 	CMAKE_VERSION=$$(cmake --version | sed -n '1 {s/cmake version //;s/-rc.*//;p;}'); \
 	$(RIOTTOOLS)/has_minimal_version/has_minimal_version.sh "$${CMAKE_VERSION}" "$(CMAKE_MINIMAL_VERSION)" cmake
 
-
-include $(RIOTBASE)/pkg/pkg.mk
 ifneq (,$(filter -Wformat-nonliteral -Wformat=2, $(CFLAGS)))
   CFLAGS += -Wno-format-nonliteral
 endif

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -15,20 +15,24 @@ ifeq (llvm,$(TOOLCHAIN))
   RIOT_CFLAGS += -Wno-char-subscripts
 endif
 
-TOOLCHAIN_FILE=$(PKG_BUILDDIR)/xcompile-toolchain.cmake
+TOOLCHAIN_FILE = $(PKG_BUILDDIR)/xcompile-toolchain.cmake
 
-all: $(PKG_BUILDDIR)/src/Makefile
-	$(MAKE) -C $(PKG_BUILDDIR)/src && \
-	cp $(PKG_BUILDDIR)/src/lib/libccnl-riot.a $(BINDIR)/ccn-lite.a
+all: $(BINDIR)/ccn-lite.a
 
-$(PKG_BUILDDIR)/src/Makefile: $(TOOLCHAIN_FILE)
-	cd $(PKG_BUILDDIR)/src && \
-	cmake -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
-		  -DCCNL_RIOT=1 -DRIOT_CFLAGS="$(RIOT_CFLAGS)" -DBUILD_TESTING=OFF .
-$(TOOLCHAIN_FILE): git-download
+$(BINDIR)/ccn-lite.a: $(PKG_BUILDDIR)/bin/lib/libccnl-riot.a
+	cp $< $@
+
+$(PKG_BUILDDIR)/bin/lib/libccnl-riot.a: $(PKG_BUILDDIR)/bin/Makefile
+	$(MAKE) -C $(PKG_BUILDDIR)/bin clean
+	$(MAKE) -C $(PKG_BUILDDIR)/bin
+
+$(PKG_BUILDDIR)/bin/Makefile: $(PKG_PREPARED) $(TOOLCHAIN_FILE) | ..cmake_version_supported
+	cmake -B$(PKG_BUILDDIR)/bin -H$(PKG_BUILDDIR)/src \
+	      -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
+	      -DCCNL_RIOT=1 -DRIOT_CFLAGS="$(RIOT_CFLAGS)" -DBUILD_TESTING=OFF
+
+$(TOOLCHAIN_FILE): FORCE
 	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
-
-git-download: | ..cmake_version_supported
 
 ..cmake_version_supported:
 	@ # Remove '-rcX' from version as they are not well handled

--- a/pkg/cifra/Makefile
+++ b/pkg/cifra/Makefile
@@ -3,9 +3,8 @@ PKG_URL=https://github.com/ctz/cifra
 PKG_VERSION=cfa6df9ca0007abe3c70409d02b3779ac1742297
 PKG_LICENSE=CC-0
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.cifra
 
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -2,11 +2,10 @@ PKG_NAME=cmsis-dsp
 PKG_URL=https://github.com/ARM-software/CMSIS_5
 PKG_VERSION=5.4.0
 PKG_LICENSE=Apache-2.0
-CFLAGS += -Wno-strict-aliasing -Wno-unused-parameter
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
+
+CFLAGS += -Wno-strict-aliasing -Wno-unused-parameter
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -8,4 +8,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -Wno-strict-aliasing -Wno-unused-parameter
 
 all:
-	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME) all

--- a/pkg/cmsis-dsp/Makefile.cmsis-dsp
+++ b/pkg/cmsis-dsp/Makefile.cmsis-dsp
@@ -36,8 +36,5 @@ $(OBJ): | $(CMSIS_BINDIRS)
 $(CMSIS_BINDIRS):
 	@mkdir -p $@
 
-# Reset the default goal.
-.DEFAULT_GOAL :=
-
 # Include RIOT settings and recipes
 include $(RIOTBASE)/Makefile.base

--- a/pkg/cn-cbor/Makefile
+++ b/pkg/cn-cbor/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/cabo/cn-cbor
 PKG_VERSION=f1cf9ffdf5cfab935a45900556f9b68af925c256
 PKG_LICENSE=MIT
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.cn-cbor
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/emb6/Makefile
+++ b/pkg/emb6/Makefile
@@ -3,6 +3,8 @@ PKG_URL=https://github.com/hso-esk/emb6.git
 PKG_VERSION=14e4a3cfff01644e078870e14e16a1fe60dcc895
 PKG_LICENSE=BSD-3-Clause
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 # GCC 7.x fails on (intentional) fallthrough, thus disable implicit-fallthrough.
 CFLAGS += -Wno-implicit-fallthrough
 CFLAGS += -Wno-strict-aliasing
@@ -16,16 +18,12 @@ EMB6_SUBMODULES:=$(filter-out emb6_contrib \
                               emb6_router \
                               emb6_sock_%,$(filter emb6_%,$(USEMODULE)))
 
-.PHONY: all
-
 all: $(EMB6_SUBMODULES)
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 # Rule for all submodules
 emb6_%:
 	"$(MAKE)" -C $(dir $(shell grep -lR "MODULE.*=.*\<$@\>" $(PKG_BUILDDIR)))
-
-include $(RIOTBASE)/pkg/pkg.mk
 
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-tautological-compare

--- a/pkg/fatfs/Makefile
+++ b/pkg/fatfs/Makefile
@@ -4,10 +4,8 @@ PKG_VERSION=34f371c7735fc6fc8e714a74a7a73a61d3ed5633
 PKG_LICENSE=BSD-1-Clause
 MODULE_MAKEFILE := $(CURDIR)/Makefile.fatfs
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	@cp $(MODULE_MAKEFILE) $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -3,6 +3,8 @@ PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
 PKG_VERSION=755f5430c05d95812603524f9aa7516964dd5758
 PKG_LICENSE=Zlib
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 ifneq ($(CPU),efm32)
   $(error This package can only be used with EFM32 CPUs)
 endif
@@ -11,9 +13,5 @@ ifneq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-int-in-bool-context
 endif
 
-.PHONY: all
-
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/dist
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/hacl/Makefile
+++ b/pkg/hacl/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/mitls/hacl-c
 PKG_VERSION=aac05f5094fc92569169d5a2af54c12387160634
 PKG_LICENSE=MIT
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/heatshrink/Makefile
+++ b/pkg/heatshrink/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=heatshrink
 PKG_URL=https://github.com/atomicobject/heatshrink.git
 PKG_VERSION=7d419e1fa4830d0b919b9b6a91fe2fb786cf3280
+PKG_LICENSE=ISC-License
 
 .PHONY: all
 

--- a/pkg/heatshrink/Makefile
+++ b/pkg/heatshrink/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/atomicobject/heatshrink.git
 PKG_VERSION=7d419e1fa4830d0b919b9b6a91fe2fb786cf3280
 PKG_LICENSE=ISC-License
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.heatshrink
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -3,7 +3,7 @@ PKG_URL=https://github.com/jerryscript-project/jerryscript.git
 PKG_VERSION=6e94414f9c3ad9b77c4635a0ca9e796752a205f0
 PKG_LICENSE=Apache-2.0
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 CFLAGS += -Wno-implicit-fallthrough
 
@@ -14,5 +14,3 @@ endif
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript all
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jsmn/Makefile
+++ b/pkg/jsmn/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/zserge/jsmn
 PKG_VERSION=6784c826d9674915a4d89649c6288e6aecb4110d
 PKG_LICENSE=MIT
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jsmn
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libb2/Makefile
+++ b/pkg/libb2/Makefile
@@ -3,10 +3,8 @@ PKG_URL     = https://github.com/BLAKE2/libb2
 PKG_VERSION = 60ea749837362c226e8501718f505ab138e5c19d # v0.98
 PKG_LICENSE = CC0-1.0
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src \
 			  -f $(RIOTPKG)/libb2/Makefile.$(PKG_NAME)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -3,15 +3,13 @@ PKG_URL=https://github.com/obgm/libcoap
 PKG_VERSION=ef41ce5d02d64cec0751882ae8fd95f6c32bc018
 PKG_LICENSE=BSD-2-Clause
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 # GCC 7.x fails on (intentional) fallthrough, thus disable implicit-fallthrough.
 CFLAGS += -Wno-implicit-fallthrough
 
-.PHONY: all
-
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk
 
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-format-nonliteral

--- a/pkg/libcose/Makefile
+++ b/pkg/libcose/Makefile
@@ -3,10 +3,8 @@ PKG_URL=https://github.com/bergzand/libcose
 PKG_VERSION=8b5f651c3203682a2d98121cd3e5c844cb2b4c36
 PKG_LICENSE=LGPL
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.libcose
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src/crypt -f $(CURDIR)/Makefile.libcose_crypt
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -3,9 +3,7 @@ PKG_VERSION  := 7f9c966b5c473770dc93940e3e6e5323f3c1ad69
 PKG_URL      := https://github.com/PetteriAimonen/libfixmath
 PKG_LICENSE  := MIT
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	$(Q)"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libhydrogen/Makefile
+++ b/pkg/libhydrogen/Makefile
@@ -3,13 +3,11 @@ PKG_URL     = https://github.com/jedisct1/libhydrogen
 PKG_VERSION = 39eb529905ce118b674a7723c0d2b48074b9986d
 PKG_LICENSE = ISC
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 # This warning is triggered on non-32bit platforms
 CFLAGS += -Wno-type-limits
-
-.PHONY: all
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) \
 			  -f $(RIOTPKG)/libhydrogen/Makefile.$(PKG_NAME)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/littlefs/Makefile
+++ b/pkg/littlefs/Makefile
@@ -4,9 +4,7 @@ PKG_URL=https://github.com/geky/littlefs.git
 PKG_VERSION=0bb1f7af17755bd792f0c4966877fb1886dfc802
 PKG_LICENSE=Apache-2.0
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.littlefs
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lora-serialization/Makefile
+++ b/pkg/lora-serialization/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/leandrolanzieri/lora-serialization
 PKG_VERSION=90e49e4acd119f20ad2ad7b98751b88b08f564d7
 PKG_LICENSE=LGPLv2.1
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lua/Makefile
+++ b/pkg/lua/Makefile
@@ -4,10 +4,8 @@ PKG_URL=https://github.com/lua/lua.git
 PKG_VERSION=e354c6355e7f48e087678ec49e340ca0696725b1
 PKG_LICENSE=MIT
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all: Makefile.lua
 	@cp Makefile.lua $(PKG_BUILDDIR)
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f Makefile.lua
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -4,12 +4,14 @@ PKG_URL=https://git.savannah.nongnu.org/git/lwip.git
 PKG_VERSION=159e31b689577dbf69cf0683bbaffbd71fa5ee10
 PKG_LICENSE=BSD-3-Clause
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 LWIP_MODULES         = lwip_api lwip_core lwip_ipv4 lwip_ipv6 \
                        lwip_netif lwip_netif_ppp lwip_polarssl
 LWIP_USEMODULE       = $(filter $(LWIP_MODULES),$(USEMODULE))
 LWIP_MODULE_MAKEFILE = $(RIOTBASE)/Makefile.base
 
-.PHONY: all $(LWIP_MODULES)
+.PHONY: $(LWIP_MODULES)
 
 CFLAGS += -Wno-address
 
@@ -40,5 +42,3 @@ lwip_netif_ppp:
 
 lwip_polarssl:
 	$(call make_module,$@,$(PKG_BUILDDIR)/src/netif/ppp/polarssl)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/kmackay/micro-ecc.git
 PKG_VERSION=b6c0cdbe7d20af48b0c2a909a66ff00b093d1542
 PKG_LICENSE=BSD-2-Clause
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/microcoap/Makefile
+++ b/pkg/microcoap/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/1248/microcoap.git
 PKG_VERSION=ef272895925f0d4c563725fe0102966f544a0fdc
 PKG_LICENSE=MIT
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/minmea/Makefile
+++ b/pkg/minmea/Makefile
@@ -3,10 +3,8 @@ PKG_URL=https://github.com/kosma/minmea
 PKG_VERSION=ae4dd9442a9041345d5ef108f062e7e4ec6954f2
 PKG_LICENSE=WTFPL
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	@cp Makefile.$(PKG_NAME) $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/monocypher/Makefile
+++ b/pkg/monocypher/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/LoupVaillant/Monocypher
 PKG_VERSION=d9cc2aea29158971ed4b7dc074efdcb35e7183d5
 PKG_LICENSE=CC-0
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	$(Q)"$(MAKE)" -C $(PKG_BUILDDIR)/src
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nanocbor/Makefile
+++ b/pkg/nanocbor/Makefile
@@ -3,10 +3,8 @@ PKG_URL     = https://github.com/bergzand/nanocbor
 PKG_VERSION = 3a672f79b2458a96393447e50a41174f741eadc5
 PKG_LICENSE = LGPL-2.1
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src \
 		-f $(RIOTPKG)/nanocbor/Makefile.$(PKG_NAME)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/ndn-riot/Makefile
+++ b/pkg/ndn-riot/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/named-data-iot/ndn-riot
 PKG_VERSION=34c5eb8adf198049f0a56048825b505c561a8874
 PKG_LICENSE=LGPLv2.1
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -3,6 +3,8 @@ PKG_URL     = https://github.com/apache/mynewt-nimble.git
 PKG_VERSION = fb7651b773734a075c47ff10210b92e6d55ef55b
 PKG_LICENSE = Apache-2.0
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 TDIR = $(RIOTPKG)/$(PKG_NAME)
 PDIR = $(PKG_BUILDDIR)
 
@@ -82,5 +84,3 @@ nimble_scanlist:
 
 nimble_scanner:
 	"$(MAKE)" -C $(TDIR)/scanner
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -3,14 +3,14 @@ PKG_URL=https://github.com/OLSR/OONF.git
 PKG_VERSION=v0.3.0
 PKG_LICENSE=BSD-3-Clause
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 MODULE:=$(PKG_NAME)
 
 # GCC 7.x fails on (intentional) fallthrough, thus disable implicit-fallthrough.
 CFLAGS += -Wno-implicit-fallthrough
 
 COMBINED_ARCHIVE = $(BINDIR)/$(MODULE).a
-
-.PHONY: all
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
@@ -37,7 +37,6 @@ $(BINDIR)/$(MODULE).mri:
 	$(file >$@,$(call MRI_TEMPLATE,$(COMBINED_ARCHIVE),$(PARTIAL_ARCHIVES)))
 	@true
 
-include $(RIOTBASE)/pkg/pkg.mk
 ifneq (,$(filter -Wformat-nonliteral -Wformat=2, $(CFLAGS)))
   CFLAGS += -Wno-format-nonliteral
 endif

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
 PKG_VERSION=thread-reference-20180926
+PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR ?= $(PKGDIRBASE)/$(PKG_NAME)
 
 ifneq (,$(filter openthread-ftd,$(USEMODULE)))

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -2,7 +2,8 @@ PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
 PKG_VERSION=thread-reference-20180926
 PKG_LICENSE=BSD-3-Clause
-PKG_BUILDDIR ?= $(PKGDIRBASE)/$(PKG_NAME)
+
+include $(RIOTBASE)/pkg/pkg.mk
 
 ifneq (,$(filter openthread-ftd,$(USEMODULE)))
   TD = ftd
@@ -22,8 +23,6 @@ endif
 OPENTHREAD_ARGS += $(CLI_ARG) $(JOINER_ARG) --enable-application-coap
 CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"platform_config.h\"'
 $(info $$OPENTHREAD_ARGS is [${OPENTHREAD_ARGS}])
-
-.PHONY: all
 
 OPENTHREAD_COMMON_FLAGS = -fdata-sections -ffunction-sections -Os
 OPENTHREAD_COMMON_FLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter
@@ -48,5 +47,3 @@ all:
 ifneq (,$(filter openthread-cli,$(USEMODULE)))
 	cp $(PKG_BUILDDIR)/output/lib/libopenthread-cli-$(TD).a ${BINDIR}/openthread-cli.a
 endif
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -1,6 +1,11 @@
 #
 # Include this file if your Package needs to be checked out by git
 #
+# Packages should include this file just after defining the PKG_* variables
+# This will ensure the variables are defined in the Makefile.
+ifneq (,$(.DEFAULT_GOAL))
+  $(error $(lastword $(MAKEFILE_LIST)) must be included at the beginning of the file after defining the PKG_* variables)
+endif
 
 ifeq (,$(PKG_NAME))
   $(error PKG_NAME not defined)

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -70,4 +70,6 @@ clean::
 distclean::
 	rm -rf "$(PKG_BUILDDIR)"
 
+# Reset goal for package
+.DEFAULT_GOAL =
 endif

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -1,6 +1,20 @@
 #
 # Include this file if your Package needs to be checked out by git
 #
+
+ifeq (,$(PKG_NAME))
+  $(error PKG_NAME not defined)
+endif
+ifeq (,$(PKG_URL))
+  $(error PKG_URL not defined)
+endif
+ifeq (,$(PKG_VERSION))
+  $(error PKG_VERSION not defined)
+endif
+ifeq (,$(PKG_LICENSE))
+  $(error PKG_LICENSE not defined)
+endif
+
 PKG_DIR?=$(CURDIR)
 PKG_BUILDDIR?=$(PKGDIRBASE)/$(PKG_NAME)
 PKG_SOURCE_LOCAL ?= $(PKG_SOURCE_LOCAL_$(shell echo $(PKG_NAME) | tr a-z- A-Z_))

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -90,7 +90,7 @@ $(PKG_BUILDDIR)/.git:
 	$(GITCACHE) clone $(PKG_URL) $(PKG_VERSION) $(PKG_BUILDDIR)
 
 clean::
-	@-test -d $(PKG_BUILDDIR) && git -C $(PKG_BUILDDIR) clean -xdff
+	@-test -d $(PKG_BUILDDIR) && $(GIT_IN_PKG) clean -xdff
 
 distclean::
 	rm -rf $(PKG_BUILDDIR)

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -1,6 +1,9 @@
 #
 # Include this file if your Package needs to be checked out by git
 #
+# A package is up to date when its '.git-prepared' file is up to date.
+# Any change to the package makefile will force updating the repository
+#
 # Packages should include this file just after defining the PKG_* variables
 # This will ensure the variables are defined in the Makefile.
 ifneq (,$(.DEFAULT_GOAL))
@@ -20,8 +23,8 @@ ifeq (,$(PKG_LICENSE))
   $(error PKG_LICENSE not defined)
 endif
 
-PKG_DIR?=$(CURDIR)
-PKG_BUILDDIR?=$(PKGDIRBASE)/$(PKG_NAME)
+PKG_DIR ?= $(CURDIR)
+PKG_BUILDDIR ?= $(PKGDIRBASE)/$(PKG_NAME)
 PKG_SOURCE_LOCAL ?= $(PKG_SOURCE_LOCAL_$(shell echo $(PKG_NAME) | tr a-z- A-Z_))
 
 # allow overriding package source with local folder (useful during development)
@@ -29,51 +32,58 @@ ifneq (,$(PKG_SOURCE_LOCAL))
   include $(RIOTBASE)/pkg/local.mk
 else
 
-.PHONY: prepare git-download clean git-ensure-version
-
-prepare: git-download
-
-ifneq (,$(wildcard $(PKG_DIR)/patches))
-git-download: $(PKG_BUILDDIR)/.git-patched
-else
-git-download: git-ensure-version
-endif
-
 GITFLAGS ?= -c user.email=buildsystem@riot -c user.name="RIOT buildsystem"
 GITAMFLAGS ?= --no-gpg-sign --ignore-whitespace
 
-ifneq (,$(wildcard $(PKG_DIR)/patches))
-$(PKG_BUILDDIR)/.git-patched: git-ensure-version $(PKG_DIR)/Makefile $(PKG_DIR)/patches/*.patch
+.PHONY: all prepare git-download clean distclean
+
+PKG_PREPARED = $(PKG_BUILDDIR)/.git-prepared
+PKG_PATCHES = $(sort $(wildcard $(PKG_DIR)/patches/*.patch))
+PKG_PATCH_DEP_INC = $(PKG_BUILDDIR)/.git-patch-dep.inc
+
+# Declare 'all' first to have it being the default target
+all: $(PKG_PREPARED)
+prepare: $(PKG_PREPARED)
+
+# Compat with current packages
+git-download: $(PKG_PREPARED)
+
+
+# Create the makefile include file only on request
+# It ensures rebuild of '.git-prepared' on patches/ deletion
+.PHONY: _pkg_inc_file
+_pkg_inc_file: | $(PKG_BUILDDIR)/.git
+	@echo "$(PKG_BUILDDIR)/.git-prepared: $(PKG_PATCHES)" > $(PKG_PATCH_DEP_INC)
+	@for patch in $(PKG_PATCHES); do echo "$(patch):" >> $(PKG_PATCH_DEP_INC); done
+
+# Prepare the package
+# * clean, without removing the pre-steps state files
+# * checkout the wanted base commit
+# * apply patches if there are any. (If none, it does nothing)
+$(PKG_BUILDDIR)/.git-prepared: $(PKG_PATCHES) $(PKG_BUILDDIR)/.git-downloaded $(MAKEFILE_LIST) | _pkg_inc_file
+	git -C $(PKG_BUILDDIR) clean -xdff '**' ':!.git-downloaded' ':!.git-patch-dep.inc'
 	git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION)
-	git $(GITFLAGS) -C $(PKG_BUILDDIR) am $(GITAMFLAGS) "$(PKG_DIR)"/patches/*.patch
-	touch $@
-endif
+	git $(GITFLAGS) -C $(PKG_BUILDDIR) am $(GITAMFLAGS) $(PKG_PATCHES) </dev/null
+	@touch $@
 
-git-ensure-version: $(PKG_BUILDDIR)/.git-downloaded
-	if [ $(shell git -C $(PKG_BUILDDIR) rev-parse HEAD) != $(PKG_VERSION) ] ; then \
-		git -C $(PKG_BUILDDIR) clean -xdff ; \
-		git -C $(PKG_BUILDDIR) fetch "$(PKG_URL)" "$(PKG_VERSION)" ; \
-		git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION) ; \
-		touch $(PKG_BUILDDIR)/.git-downloaded ; \
-	fi
+$(PKG_BUILDDIR)/.git-downloaded: $(MAKEFILE_LIST) | $(PKG_BUILDDIR)/.git
+	git -C $(PKG_BUILDDIR) fetch $(PKG_URL) $(PKG_VERSION)
+	echo $(PKG_VERSION) > $@
 
-$(PKG_BUILDDIR)/.git-downloaded:
+$(PKG_BUILDDIR)/.git: $(MAKEFILE_LIST)
 	rm -Rf $(PKG_BUILDDIR)
 	mkdir -p $(PKG_BUILDDIR)
-	$(GITCACHE) clone "$(PKG_URL)" "$(PKG_VERSION)" "$(PKG_BUILDDIR)"
-	touch $@
+	$(GITCACHE) clone $(PKG_URL) $(PKG_VERSION) $(PKG_BUILDDIR)
 
 clean::
-	@test -d $(PKG_BUILDDIR) && { \
-		rm $(PKG_BUILDDIR)/.git-patched ; \
-		git -C $(PKG_BUILDDIR) clean -f ; \
-		git -C $(PKG_BUILDDIR) checkout "$(PKG_VERSION)"; \
-		make $(PKG_BUILDDIR)/.git-patched ; \
-		touch $(PKG_BUILDDIR)/.git-downloaded ; \
-	} > /dev/null 2>&1 || true
+	@test -d $(PKG_BUILDDIR) && \
+		git -C $(PKG_BUILDDIR) clean -xdff || \
+		true
 
 distclean::
-	rm -rf "$(PKG_BUILDDIR)"
+	rm -rf $(PKG_BUILDDIR)
+
+-include $(PKG_PATCH_DEP_INC)
 
 # Reset goal for package
 .DEFAULT_GOAL =

--- a/pkg/qDSA/Makefile
+++ b/pkg/qDSA/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/RIOT-OS/qDSA.git
 PKG_VERSION=dd2392b0c81ce4187fd3e1e2d3e0a4767f75782e
 PKG_LICENSE=PD
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/$(QDSA_IMPL)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -3,7 +3,7 @@ PKG_URL=https://github.com/relic-toolkit/relic.git
 PKG_VERSION=0b0442a8218df8d309266923f2dd5b9ae3b318ce
 PKG_LICENSE=LGPL-2.1
 
-.PHONY: all ..cmake_version_supported
+include $(RIOTBASE)/pkg/pkg.mk
 
 CMAKE_MINIMAL_VERSION = 3.6.0
 
@@ -31,6 +31,7 @@ $(TOOLCHAIN_FILE): git-download
 
 git-download: | ..cmake_version_supported
 
+.PHONY: ..cmake_version_supported
 ..cmake_version_supported:
 	@ # Remove '-rcX' from version as they are not well handled
 	$(Q)\
@@ -39,5 +40,3 @@ git-download: | ..cmake_version_supported
 
 clean::
 	@rm -rf $(BINDIR)/$(PKG_NAME).a
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/semtech-loramac/Makefile
+++ b/pkg/semtech-loramac/Makefile
@@ -3,7 +3,7 @@ PKG_URL=https://github.com/Lora-net/LoRaMac-node.git
 PKG_VERSION=1cdd9ccec4c9f05b616e7112059be4a9e358c571
 PKG_LICENSE=BSD-3-Clause
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	@cp Makefile.loramac $(PKG_BUILDDIR)/Makefile
@@ -12,5 +12,3 @@ all:
 	@cp Makefile.loramac_crypto $(PKG_BUILDDIR)/src/system/crypto/Makefile
 	@cp Makefile.loramac_arch $(PKG_BUILDDIR)/src/boards/mcu/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/spiffs/Makefile
+++ b/pkg/spiffs/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/pellepl/spiffs.git
 PKG_VERSION=287148c46587089c4543a21eef2d6e9e14b88364
 PKG_LICENSE=MIT
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.spiffs
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tiny-asn1/Makefile
+++ b/pkg/tiny-asn1/Makefile
@@ -3,9 +3,7 @@ PKG_URL = https://gitlab.com/mtausig/tiny-asn1.git
 PKG_VERSION = 5155ee9c8f0908af955ca2026c349ba8a5e12bc2
 PKG_LICENSE = LGPL-3
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinycbor/Makefile
+++ b/pkg/tinycbor/Makefile
@@ -4,9 +4,7 @@ PKG_URL=https://github.com/intel/tinycbor
 PKG_VERSION=d94ca09aa91f5b3c581527aa8bca179a82b79874
 PKG_LICENSE=MIT
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.tinycbor
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinycrypt/Makefile
+++ b/pkg/tinycrypt/Makefile
@@ -3,10 +3,8 @@ PKG_URL=https://github.com/01org/tinycrypt
 PKG_VERSION=6a22712bebbf2fc60d9fc6192dddefd5ad1933e3
 PKG_LICENSE=BSD-3-Clause
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/lib/source/ \
 			  -f $(RIOTPKG)/tinycrypt/Makefile.$(PKG_NAME)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -3,20 +3,18 @@ PKG_URL=https://github.com/eclipse/tinydtls.git
 PKG_VERSION=dcac93f1b38e74f0a57b5df47647943f3df005c2
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 CFLAGS += -Wno-implicit-fallthrough
 # following is require due to known issue with newlib 2.4.x, see bug report:
 # http://lists-archives.com/cygwin/97008-gettimeofday-not-defined.html
 CFLAGS += -D_XOPEN_SOURCE=600
-
-.PHONY: all
 
 all:
 	@cp $(PKG_BUILDDIR)/Makefile.riot $(PKG_BUILDDIR)/Makefile
 	@cp $(PKG_BUILDDIR)/aes/Makefile.riot $(PKG_BUILDDIR)/aes/Makefile
 	@cp $(PKG_BUILDDIR)/ecc/Makefile.riot $(PKG_BUILDDIR)/ecc/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk
 
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-format-nonliteral

--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -3,11 +3,8 @@ PKG_URL=https://github.com/mattconte/tlsf
 PKG_VERSION=a1f743ffac0305408b39e791e0ffb45f6d9bc777
 PKG_LICENSE=BSD
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all: Makefile.tlsf
 	@cp Makefile.tlsf $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tweetnacl/Makefile
+++ b/pkg/tweetnacl/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/RIOT-OS/tweetnacl
 PKG_VERSION=7ea05c7098a16c87fa66e9166ce301666f3f2623
 PKG_LICENSE=PD
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	$(Q)"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.riot
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/u8g2/Makefile
+++ b/pkg/u8g2/Makefile
@@ -3,7 +3,7 @@ PKG_URL=https://github.com/olikraus/u8g2
 PKG_VERSION=f08ff974c03e5c848bc5d2ae3fddb6a97897881a
 PKG_LICENSE=BSD-2-Clause
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	cp $(RIOTBASE)/pkg/u8g2/src/Makefile $(PKG_BUILDDIR)/Makefile
@@ -12,5 +12,3 @@ all:
 	cp $(RIOTBASE)/pkg/u8g2/src/sys/sdl/common/Makefile $(PKG_BUILDDIR)/sys/sdl/common/Makefile
 	cp $(RIOTBASE)/pkg/u8g2/src/sys/utf8/common/Makefile $(PKG_BUILDDIR)/sys/utf8/common/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/ubasic/Makefile
+++ b/pkg/ubasic/Makefile
@@ -3,10 +3,12 @@ PKG_URL=https://github.com/adamdunkels/ubasic
 PKG_VERSION=cc07193c231e21ecb418335aba5b199a08d4685c
 PKG_LICENSE=BSD-3-Clause
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 UBASIC_MODULES   = ubasic_tests
 UBASIC_USEMODULE = $(filter $(UBASIC_MODULES),$(USEMODULE))
 
-.PHONY: all ubasic ubasic%
+.PHONY: ubasic ubasic%
 
 all: ubasic
 
@@ -17,5 +19,3 @@ ubasic: $(UBASIC_USEMODULE)
 
 ubasic%:
 	$(call make_module,$@,$(PKG_BUILDDIR))
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/ucglib/Makefile
+++ b/pkg/ucglib/Makefile
@@ -3,7 +3,7 @@ PKG_URL=https://github.com/olikraus/ucglib
 PKG_VERSION=bf48515702dd7c87cbacdd17989738f33f003df2
 PKG_LICENSE=BSD-2-Clause
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	cp $(RIOTBASE)/pkg/ucglib/src/Makefile $(PKG_BUILDDIR)/Makefile
@@ -11,5 +11,3 @@ all:
 	cp $(RIOTBASE)/pkg/ucglib/src/csrc/ucg_riotos.c $(PKG_BUILDDIR)/csrc/ucg_riotos.c
 	cp $(RIOTBASE)/pkg/ucglib/src/sys/sdl/dev/Makefile $(PKG_BUILDDIR)/sys/sdl/dev/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/umorse/Makefile
+++ b/pkg/umorse/Makefile
@@ -3,12 +3,10 @@ PKG_URL=https://github.com/smlng/uMorse
 PKG_VERSION=1dc14abdba22cca2f7efc053b2bce327bc7db97e
 PKG_LICENSE=MIT
 
-CFLAGS += -D_XOPEN_SOURCE=600
+include $(RIOTBASE)/pkg/pkg.mk
 
-.PHONY: all
+CFLAGS += -D_XOPEN_SOURCE=600
 
 all:
 	@cp Makefile.umorse $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/wakaama/Makefile
+++ b/pkg/wakaama/Makefile
@@ -3,7 +3,7 @@ PKG_URL=https://github.com/eclipse/wakaama.git
 PKG_VERSION=da74b3c91570b9716fbb424e90935806b2b29814
 PKG_LICENSE=EDL-1.0,EPL-1.0
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
 
 all: patch
 	"$(MAKE)" -C $(PKG_BUILDDIR)/riotbuild
@@ -19,4 +19,3 @@ patch: git-download
 	echo 'MODULE:=wakaama' > $(PKG_BUILDDIR)/riotbuild/Makefile
 	echo 'include $$(RIOTBASE)/Makefile.base' >> $(PKG_BUILDDIR)/riotbuild/Makefile
 
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/wakaama/Makefile
+++ b/pkg/wakaama/Makefile
@@ -5,17 +5,15 @@ PKG_LICENSE=EDL-1.0,EPL-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-all: patch
-	"$(MAKE)" -C $(PKG_BUILDDIR)/riotbuild
+all:
+	"$(MAKE)" -C $(PKG_BUILDDIR)/riotbuild -f $(CURDIR)/Makefile.wakaama
 
-patch: git-download
+$(PKG_PREPARED): $(PKG_BUILDDIR)/riotbuild/copied
+$(PKG_BUILDDIR)/riotbuild/copied: $(PKG_PATCHED) FORCE
 	mkdir -p "$(PKG_BUILDDIR)/riotbuild"
 	cp $(PKG_BUILDDIR)/core/*.c $(PKG_BUILDDIR)/core/*.h $(PKG_BUILDDIR)/riotbuild
 	cp $(PKG_BUILDDIR)/core/er-coap-13/*.c $(PKG_BUILDDIR)/core/er-coap-13/*.h $(PKG_BUILDDIR)/riotbuild
 	cp $(PKG_BUILDDIR)/examples/client/object_server.c $(PKG_BUILDDIR)/riotbuild
 	cp $(PKG_BUILDDIR)/examples/client/object_security.c $(PKG_BUILDDIR)/riotbuild
 	cp $(PKG_BUILDDIR)/examples/client/object_access_control.c $(PKG_BUILDDIR)/riotbuild
-
-	echo 'MODULE:=wakaama' > $(PKG_BUILDDIR)/riotbuild/Makefile
-	echo 'include $$(RIOTBASE)/Makefile.base' >> $(PKG_BUILDDIR)/riotbuild/Makefile
-
+	touch $@

--- a/pkg/wolfssl/Makefile
+++ b/pkg/wolfssl/Makefile
@@ -5,7 +5,8 @@ PKG_URL=https://github.com/wolfssl/wolfssl.git
 PKG_VERSION=eaeaaf12c11dd52ab0cd6833252ed559656e9826
 PKG_LICENSE=GPLv2
 
-.PHONY: all
+include $(RIOTBASE)/pkg/pkg.mk
+
 all:  # Nothing to do here when building
 
 prepare:
@@ -14,5 +15,3 @@ prepare:
 	touch $(PKG_BUILDDIR)/wolfssl.a
 	cp Makefile.wolfcrypt-test $(PKG_BUILDDIR)/wolfcrypt/test/Makefile
 	cp Makefile.wolfcrypt-benchmark $(PKG_BUILDDIR)/wolfcrypt/benchmark/Makefile
-
-include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

Rely on file creation and dependencies instead of .PHONY targets.
Files will be rebuilt when changing version as the main `Makefile` will
have been updated. All steps are re-done on version change.

When deleting patches, the '.prepare' step should be redone thanks
to the included 'patch-dep.inc' file (TODO TEST ME).

Implementation in order:

* '.git': means the repository has been cloned.
* '.git-downloaded': Fetches the wanted version
* '.git-prepared': will clean checkout the version and apply patches

Somehow the base is that `patching` can only be done on the correct commit, so lets do it all at once.


### Infos:

* This is a one commit change to first see if it makes sense at all.
* This currently do not use the 'smart fetch' from https://github.com/RIOT-OS/RIOT/pull/11491
* Some parts may be possible to not re-do. Maybe the `.prepare` should use the content of `.git-downloaded` instead of the variable.
* Did not remove the `::` rules but should maybe be the occasion to clean this.

Should git-downloaded be updated only with `lazy_sponge` to not trigger more rebuild ?
I think `.git-prepare` must be always re-done as the package makefile may do further modifications afterwards… so not sure it would change anything

### TODO:

Change so that packages include `pkg/pkg.mk` earlier. Some packages use `PKG_BUILDDIR` before it is defined.

Update to use `$(PKG_PREPARED)` instead of the .PHONY target.

### Testing/Reviewing procedure

* Build all packages (lets see CI)
* See if it is indeed incremental
* See if it detects package deletion
* Any ideas on what to test ?

### Issues/PRs references

Discussions coming out of https://github.com/RIOT-OS/RIOT/pull/11491
