### PR TITLE
cpu/nrf5x: implement wdt peripheral driver

### DIFF
--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_temperature
 FEATURES_PROVIDED += periph_uart_modecfg
+FEATURES_PROVIDED += periph_wdt periph_wdt_cb
 
 # Various other features (if any)
 FEATURES_PROVIDED += radio_nrfmin

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -165,6 +165,15 @@ typedef struct {
     uint8_t miso;       /**< MISO pin */
 } spi_conf_t;
 
+/**
+ * @name    WDT upper and lower bound times in ms
+ * @{
+ */
+#define NWDT_TIME_LOWER_LIMIT          (1)
+/* Set upper limit to the maximum possible value that could go in CRV register */
+#define NWDT_TIME_UPPER_LIMIT          ((UINT32_MAX >> 15) * US_PER_MS + 1)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf5x_common/periph/wdt.c
+++ b/cpu/nrf5x_common/periph/wdt.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_wdt
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the watchdog peripheral interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "timex.h"
+#include "periph/wdt.h"
+
+#include "nrf_clock.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/* By default, allow watchdog during sleep.
+   Warning: pausing the watchdog during sleep will deactivate it when RIOT
+   switches to idle thread where pm_set_lowest is called. */
+#ifndef NRF_WDT_SLEEP_MODE
+#define NRF_WDT_SLEEP_MODE (WDT_CONFIG_SLEEP_Run)
+#endif
+
+/* By default, allow watchdog during debug session. */
+#ifndef NRF_WDT_HALT_MODE
+#define NRF_WDT_HALT_MODE (WDT_CONFIG_HALT_Run)
+#endif
+
+#ifdef MODULE_PERIPH_WDT_CB
+static wdt_cb_t wdt_cb;
+static void *wdt_arg;
+#endif
+
+void wdt_start(void)
+{
+    DEBUG("[wdt] start watchdog\n");
+
+    NRF_WDT->TASKS_START = 1;
+}
+
+void wdt_stop(void)
+{
+    DEBUG("[wdt] stopping the watchdog is not supported\n");
+    assert(0);
+}
+
+void wdt_kick(void)
+{
+    assert(NRF_WDT->RUNSTATUS == WDT_RUNSTATUS_RUNSTATUS_Running);
+
+    DEBUG("[wdt] reload the watchdog\n");
+
+    NRF_WDT->RR[0] = WDT_RR_RR_Reload;
+}
+
+void wdt_setup_reboot(uint32_t min_time, uint32_t max_time)
+{
+    (void)min_time;
+
+    /* Windowed wdt not supported */
+    assert(min_time == 0);
+
+    /* Check reset time limit */
+    assert((max_time > NWDT_TIME_LOWER_LIMIT) || \
+           (max_time < NWDT_TIME_UPPER_LIMIT));
+
+    /* configure watchdog behavior during sleep */
+    NRF_WDT->CONFIG &= ~(WDT_CONFIG_SLEEP_Msk << WDT_CONFIG_SLEEP_Pos);
+    NRF_WDT->CONFIG |= (NRF_WDT_SLEEP_MODE << WDT_CONFIG_SLEEP_Pos);
+
+    /* configure watchdog behavior during debug */
+    NRF_WDT->CONFIG &= ~(WDT_CONFIG_HALT_Msk << WDT_CONFIG_HALT_Pos);
+    NRF_WDT->CONFIG |= (NRF_WDT_HALT_MODE << WDT_CONFIG_HALT_Pos);
+
+    /* timeout (s) = (CRV + 1) / 32768 */
+    uint32_t crv = ((max_time << 15) / 1000) - 1;
+    DEBUG("[wdt] setting CRV to %"PRIu32"\n", crv);
+    NRF_WDT->CRV = crv;
+
+    DEBUG("[wdt] CRV configuration: %"PRIu32"\n", NRF_WDT->CRV);
+
+    /* Enable reload requests */
+    NRF_WDT->RREN = (WDT_RREN_RR0_Enabled << WDT_RREN_RR0_Pos);
+
+    DEBUG("[wdt] watchdog setup complete\n");
+}
+
+#ifdef MODULE_PERIPH_WDT_CB
+/* The reset can't be stopped when the callback is triggered: so the MCU will
+   reset in any case after 2 cycles of 32.768kHz clock. This is very short so
+   only basic and fast operations can be perfomed in the callback function. */
+void wdt_setup_reboot_with_callback(uint32_t min_time, uint32_t max_time,
+                                    wdt_cb_t cb, void* arg)
+{
+    wdt_cb = cb;
+    wdt_arg = arg;
+
+    /* Disable interrupt */
+    NVIC_DisableIRQ(WDT_IRQn);
+
+    if (cb) {
+        /* enable interrupt */
+        NVIC_EnableIRQ(WDT_IRQn);
+        NRF_WDT->INTENSET = WDT_INTENSET_TIMEOUT_Enabled;
+    }
+
+    wdt_setup_reboot(min_time, max_time);
+}
+
+void isr_wdt(void)
+{
+    wdt_cb(wdt_arg);
+
+    cortexm_isr_end();
+}
+#endif /* MODULE_PERIPH_WDT_CB */

--- a/tests/periph_wdt/main.c
+++ b/tests/periph_wdt/main.c
@@ -32,8 +32,8 @@ int get_range(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-    printf("lower_bound: %d upper_bound: %d \n", NWDT_TIME_LOWER_LIMIT,
-           NWDT_TIME_UPPER_LIMIT);
+    printf("lower_bound: %d upper_bound: %"PRIu32" \n", NWDT_TIME_LOWER_LIMIT,
+           (uint32_t)NWDT_TIME_UPPER_LIMIT);
     return 0;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR implement the watchdog peripheral interface as proposed in #11527 on nRF5x CPU.

It has been tested with success on nrf52832-mdk, nrf52840-mdk and microbit.

On nrf, it's not possible to stop the watchdog once it's started so when setting up a timeout callback, the CPU is reset in all the case after 2 cycles of 32768kHz clock. This is quite fast and doesn't allow complex task to happen before reset: so I'm wondering if it's relevant to provide `periph_wdt_cb` on this platform.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I used the following sample application to test the feature but it'll be more useful to test with the test application provided in #11252:
- main.c
```c
#include <stdio.h>

#include "xtimer.h"
#include "periph/wdt.h"

int main(void)
{
    puts("Setup watchdog");
    wdt_setup_reboot(0, 2000);
    wdt_start();

    uint8_t cnt = 5;
    printf("%d\n", cnt);
    while (cnt--) {
        xtimer_sleep(1);
        printf("%d\n", cnt);
        wdt_kick();
    }

    puts("Reboot");

    return 0;
}
```
- Makefile:
```mk
APPLICATION = wdt-sample
BOARD ?= nrf52830-mdk
RIOTBASE ?= $(CURDIR)/../..

FEATURES_REQUIRED += periph_wdt
USEMODULE += xtimer

include $(RIOTBASE)/Makefile.include
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #11527 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
