### PR TITLE
sys/sock/util: allow overriding of SOCK_*_MAXLEN

### DIFF
--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -99,13 +99,30 @@ bool sock_udp_ep_equal(const sock_udp_ep_t *a, const sock_udp_ep_t *b);
  * @name helper definitions
  * @{
  */
-#define SOCK_SCHEME_MAXLEN      (16U)   /**< maximum length of the scheme part
-                                             for sock_urlsplit. Ensures a hard
-                                             limit on the string iterator */
-#define SOCK_HOSTPORT_MAXLEN    (64U)   /**< maximum length of host:port part for
-                                             sock_urlsplit() */
-#define SOCK_URLPATH_MAXLEN     (64U)   /**< maximum length path for
-                                             sock_urlsplit() */
+
+/**
+ * @brief maximum length of the scheme part for sock_urlsplit.
+ *
+ * Ensures a hard limit on the string iterator
+ * */
+#ifndef SOCK_SCHEME_MAXLEN
+#define SOCK_SCHEME_MAXLEN      (16U)
+#endif
+
+/**
+ * @brief maximum length of host:port part for sock_urlsplit()
+ */
+#ifndef SOCK_HOSTPORT_MAXLEN
+#define SOCK_HOSTPORT_MAXLEN    (64U)
+#endif
+
+/**
+ * @brief maximum length path for sock_urlsplit()
+ */
+#ifndef SOCK_URLPATH_MAXLEN
+#define SOCK_URLPATH_MAXLEN     (64U)
+#endif
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

sock_util has some hard-coded defines for maximum url lengths.
This PR allows overriding them.

This came up with quite long SUIT update URLs [here](https://github.com/future-proof-iot/RIOT/issues/9).

### Testing procedure

Let CI do its magic.

### Issues/PRs references

