### PR TITLE
cpu/nrf5x_common: map hwrng to SoC library if SoftDevice is present

### DIFF
--- a/cpu/nrf5x_common/periph/hwrng.c
+++ b/cpu/nrf5x_common/periph/hwrng.c
@@ -24,12 +24,20 @@
 
 #include "cpu.h"
 #include "periph/hwrng.h"
+#ifndef MODULE_NORDIC_SOFTDEVICE_BLE
+#include "assert.h"
+#endif
 
 void hwrng_init(void)
 {
     /* nothing to do here */
 }
 
+/*
+ * The hardware peripheral is used by the SoftDevice. When the SoftDevice is
+ * enabled, it shall only be accessed through the SoftDevice API
+ */
+#ifndef MODULE_NORDIC_SOFTDEVICE_BLE
 void hwrng_read(void *buf, unsigned int num)
 {
     unsigned int count = 0;
@@ -62,3 +70,24 @@ void hwrng_read(void *buf, unsigned int num)
     NRF_RNG->POWER = 0;
 #endif
 }
+
+#else
+
+void hwrng_read(void *buf, unsigned int num)
+{
+    uint32_t ret;
+    uint8_t avail;
+
+    assert(num <= 0xff);
+
+    /* this is not the most efficient, but this way we can assure that there are
+     * enough bytes of random data available */
+    do {
+        sd_rand_application_bytes_available_get(&avail);
+    } while (avail < (uint8_t)num);
+
+    ret = sd_rand_application_vector_get((uint8_t *)buf, (uint8_t)num);
+    assert(ret == NRF_SUCCESS);
+    (void)ret;
+}
+#endif /* MODULE_NORDIC_SOFTDEVICE_BLE */


### PR DESCRIPTION
### Contribution description

According to [this comment](https://github.com/RIOT-OS/RIOT/issues/11091#issuecomment-470456909) which bases on Nordic documentation, the hardware RNG can't be accessed when the SoftDevice is used. The fix maps our `hwrng_read()` function the the respective library function call (see [here](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.s132.api.v3.0.0%2Fgroup___n_r_f___s_o_c___f_u_n_c_t_i_o_n_s.html) for reference)


### Testing procedure
#### (i)
Build/flash/term *examples/gnrc_networking* for an nrf5X based board.

#### (ii)
Build/flash/term *tests/periph_hwrng* for an nrf5x based board and include the SoftDevice package. E.g.:
`USEPKG=nordic_softdevice_ble BOARD=nrf52dk make -C tests/periph_hwrng flash term`

W/o this fix, there is no output as the initialization hangs before main() is called. W/ this fix, everything should work as expected.

### Issues/PRs references

Fixes #11091