### PR TITLE
RPL: API update suggestions

### DIFF
--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -259,8 +259,17 @@ struct gnrc_rpl_parent {
  */
 typedef struct {
     uint16_t ocp;   /**< objective code point */
-    uint16_t (*calc_rank)(gnrc_rpl_parent_t *parent, uint16_t base_rank); /**< calculate the rank */
-    gnrc_rpl_parent_t *(*which_parent)(gnrc_rpl_parent_t *, gnrc_rpl_parent_t *); /**< retrieve the better parent */
+
+    /**
+     * @brief Calculate the rank of this node.
+     *
+     * @param[in]   dodag       RPL DODAG to calculate rank from.
+     * @param[in]   base_rank   BASE_RANK parameter as in rfc6550
+     *
+     * @return      RPL Rank of this node.
+     * @return      GNRC_RPL_INFINITE_RANK, if no rank calculation is possible.
+     */
+    uint16_t (*calc_rank)(gnrc_rpl_dodag_t *dodag, uint16_t base_rank);
 
     /**
      * @brief   Compare two @ref gnrc_rpl_parent_t.
@@ -279,9 +288,21 @@ typedef struct {
      */
     int (*parent_cmp)(gnrc_rpl_parent_t *parent1, gnrc_rpl_parent_t *parent2);
     gnrc_rpl_dodag_t *(*which_dodag)(gnrc_rpl_dodag_t *, gnrc_rpl_dodag_t *); /**< compare for dodags */
-    void (*reset)(gnrc_rpl_dodag_t *);    /**< resets the OF */
+
+    /**
+     * @brief Reset the state of the objective function.
+     *
+     * @param[in]   dodag   RPL dodag object.
+     */
+    void (*reset)(gnrc_rpl_dodag_t *dodag);
     void (*parent_state_callback)(gnrc_rpl_parent_t *, int, int); /**< retrieves the state of a parent*/
-    void (*init)(void);  /**< OF specific init function */
+
+    /**
+     * @brief Initialize the objective function.
+     *
+     * @param[in]   dodag   RPL dodag object.
+     */
+    void (*init)(gnrc_rpl_dodag_t *dodag);
     void (*process_dio)(void);  /**< DIO processing callback (acc. to OF0 spec, chpt 5) */
 } gnrc_rpl_of_t;
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -176,7 +176,8 @@ bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, k
 
 void gnrc_rpl_dodag_remove_all_parents(gnrc_rpl_dodag_t *dodag)
 {
-    gnrc_rpl_parent_t *elt, *tmp;
+    gnrc_rpl_parent_t *elt = NULL;
+    gnrc_rpl_parent_t *tmp = NULL;
     LL_FOREACH_SAFE(dodag->parents, elt, tmp) {
         gnrc_rpl_parent_remove(elt);
     }
@@ -306,7 +307,8 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
     gnrc_rpl_parent_t *old_best = dodag->parents;
     gnrc_rpl_parent_t *new_best = old_best;
     uint16_t old_rank = dodag->my_rank;
-    gnrc_rpl_parent_t *elt, *tmp;
+    gnrc_rpl_parent_t *elt = NULL;
+    gnrc_rpl_parent_t *tmp = NULL;
 
     if (dodag->parents == NULL) {
         return NULL;
@@ -339,7 +341,7 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
 
     }
 
-    dodag->my_rank = dodag->instance->of->calc_rank(dodag->parents, 0);
+    dodag->my_rank = dodag->instance->of->calc_rank(dodag, 0);
     if (dodag->my_rank != old_rank) {
         trickle_reset_timer(&dodag->trickle);
     }


### PR DESCRIPTION
@bergzand suggested I should pick up on #7498 before going forward with MRHOF, so I did.
It was pretty straightforward. `which_parent` was indeed unused now after #7468, so I removed it as suggested.

The `init` function is currently unused, so the API change had no effect.
`calc_rank()` now receives `dodag` instead of `dodag->parents`, so only minor adjustments were needed.

Will squash this to one commit if approved. 