### PR TITLE
boards/frdm-kw41z-k64f: add riotboot

### DIFF
--- a/boards/common/kw41z/Makefile.features
+++ b/boards/common/kw41z/Makefile.features
@@ -5,4 +5,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -8,6 +8,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1
 

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -6,10 +6,17 @@ endif
 
 # "The Vector table must be naturally aligned to a power of two whose alignment
 # value is greater than or equal to number of Exceptions supported x 4"
-# CPU_IRQ_NUMOF for KWxD boards is < 81+16 so (81*4 bytes = 388 bytes ~= 0x200)
+# CPU_IRQ_NUMOF for KWxD and KxF boards is < 102+16 so (81*4 bytes = 472 bytes ~= 0x200)
 # RIOTBOOT_HDR_LEN can be set to 0x200
-ifeq (DW, $(KINETIS_CORE)$(KINETIS_SERIES))
+ifneq (,$(filter FK DW,$(KINETIS_CORE)$(KINETIS_SERIES)))
   RIOTBOOT_HDR_LEN ?= 0x200
+endif
+
+# Slot size is determined by "((total_flash_size - RIOTBOOT_LEN) / 2)".
+# If RIOTBOOT_LEN uses an uneven number of flashpages, the remainder of the
+# flash cannot be divided by two slots while staying FLASHPAGE_SIZE aligned.
+ifeq (K, $(KINETIS_SERIES))
+  RIOTBOOT_LEN ?= 0x2000
 endif
 
 # Add search path for linker scripts


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds riotboot support for kw41z. To do this the following changes had to be done:

- modify tests/cortex_comon_ldscript to also work for kinetis
- add script to prevent bricked kinetis when flashing binary files
- handle rom_offset in kinetis.ld script

I know the linker script related changes should be in another PR but I wanted to get @cladmi feedback on them before splitting them up.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run ldscript test:

`BOARD=frdm-kw41z APP_VER=$(date +%s) make -C tests/cortexm_common_ldscript/`

Run riotboot tests:
~~BOARD=frdm-kw41z FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C examples/hello-world/ riotboot/flash-extended-slot0~~

`BOARD=frdm-kw41z FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C tests/xtimer_usleep riotboot/flash-extended-slot0`

~~BOARD=frdm-kw41z FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C examples/hello-world/ riotboot/flash-slot1~~

`BOARD=frdm-kw41z FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C tests/xtimer_usleep riotboot/flash-slot1 `

### Issues/PRs references

Depends on:
* [x] tests/cortexm_common_ldscript: update code section for kinetis #11588 
* [x] kinetis/fcfield-check*: merge into single file and support binary flash #11589 
* [x] handle rom_offset in kinetis.ld script to split #11630 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
