### PR TITLE
saml1x: enable pm_layered by default

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -98,7 +98,7 @@ enum {
  * @name    Power mode configuration
  * @{
  */
-#ifdef CPU_FAM_SAML11
+#ifdef CPU_SAML1X
 #define PM_NUM_MODES        (2)
 #else
 #define PM_NUM_MODES        (3)

--- a/cpu/saml1x/Makefile.include
+++ b/cpu/saml1x/Makefile.include
@@ -1,4 +1,6 @@
 export CPU_ARCH = cortex-m23
 
+USEMODULE += pm_layered
+
 include $(RIOTCPU)/sam0_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -27,6 +27,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Override the default initial PM blocker
+ * @todo   Idle modes are enabled by default, deep sleep mode blocked
+ */
+#define PM_BLOCKER_INITIAL  { .val_u32 = 0x00000001 }
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 static const int8_t exti_config[1][32] = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR enables pm_layered module by default for SAML10 and SAML11 MCUs.


### Testing procedure

Use the usual testing procedure for power management.


### Issues/PRs references
should fix a bug for #11346 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
