### PR TITLE
pkg/nanopb: add nanoPb protocol buffers library package

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -52,6 +52,10 @@ ifeq ($(strip $(ASSMSRC))$(NO_AUTO_SRC),)
   ASSMSRC := $(wildcard *.S)
 endif
 
+# include makefile snippets that modify GENSRC here:
+#include foo/bar.inc.mk
+
+GENOBJC     := $(GENSRC:%.c=%.o)
 OBJC_LTO    := $(SRC:%.c=$(BINDIR)/$(MODULE)/%.o)
 OBJC_NOLTO  := $(SRC_NOLTO:%.c=$(BINDIR)/$(MODULE)/%.o)
 OBJC        := $(OBJC_NOLTO) $(OBJC_LTO)
@@ -59,7 +63,7 @@ OBJCXX      := $(SRCXX:%.cpp=$(BINDIR)/$(MODULE)/%.o)
 ASMOBJ      := $(ASMSRC:%.s=$(BINDIR)/$(MODULE)/%.o)
 ASSMOBJ     := $(ASSMSRC:%.S=$(BINDIR)/$(MODULE)/%.o)
 
-OBJ := $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ)
+OBJ := $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ) $(GENOBJC)
 DEP := $(OBJC:.o=.d) $(OBJCXX:.o=.d) $(ASSMOBJ:.o=.d)
 
 $(BINDIR)/$(MODULE)/:
@@ -86,6 +90,12 @@ $(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(RIOTBUILD_CONFIG_HEADER_C)
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+
+$(GENOBJC): %.o: %.c $(RIOTBUILD_CONFIG_HEADER_C)
+	$(Q) $(CCACHE) $(CC) \
+		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$<)\" \
+		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
+		$(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $<
 
 $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.cpp $(RIOTBUILD_CONFIG_HEADER_C)
 	$(Q)$(CCACHE) $(CXX) \

--- a/Makefile.base
+++ b/Makefile.base
@@ -52,8 +52,8 @@ ifeq ($(strip $(ASSMSRC))$(NO_AUTO_SRC),)
   ASSMSRC := $(wildcard *.S)
 endif
 
-# include makefile snippets that modify GENSRC here:
-#include foo/bar.inc.mk
+# include makefile snippets for packages in $(USEPKG) that modify GENSRC:
+-include $(USEPKG:%=$(RIOTPKG)/%/Makefile.gensrc)
 
 GENOBJC     := $(GENSRC:%.c=%.o)
 OBJC_LTO    := $(SRC:%.c=$(BINDIR)/$(MODULE)/%.o)

--- a/pkg/nanopb/Makefile
+++ b/pkg/nanopb/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=nanopb
+PKG_URL=https://github.com/nanopb/nanopb
+PKG_VERSION=493adf3616bee052649c63c473f8355630c2797f # nanopb-0.3.9.4
+PKG_LICENSE=MIT
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.nanopb
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nanopb/Makefile.gensrc
+++ b/pkg/nanopb/Makefile.gensrc
@@ -1,0 +1,23 @@
+PROTOC ?= protoc
+PROTOC_GEN_NANOPB ?= $(PKGDIRBASE)/nanopb/generator/protoc-gen-nanopb
+
+PROTOBUF_FILES ?= $(wildcard *.proto)
+GENSRC   += $(PROTOBUF_FILES:%.proto=$(BINDIR)/$(MODULE)/%.pb.c)
+GENOBJC  := $(GENSRC:%.c=%.o)
+
+ifneq (, $(PROTOBUF_FILES))
+  INCLUDES += -I$(BINDIR)/$(MODULE)
+endif
+
+$(SRC): $(GENSRC)
+
+$(GENSRC): $(PROTOBUF_FILES)
+	$(Q)D=$(BINDIR)/$(MODULE) && \
+	  mkdir -p "$$D" && \
+		cd $(CURDIR) && \
+		make -C $(PKGDIRBASE)/nanopb/generator/proto && \
+		for protofile in $(PROTOBUF_FILES); do \
+			protoc --plugin=protoc-gen-nanopb=$(PROTOC_GEN_NANOPB) \
+				--nanopb_out="$$D" \
+				$^ \
+				; done

--- a/pkg/nanopb/Makefile.include
+++ b/pkg/nanopb/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/nanopb

--- a/pkg/nanopb/Makefile.nanopb
+++ b/pkg/nanopb/Makefile.nanopb
@@ -1,0 +1,3 @@
+SRCS := pb_encode.c pb_decode.c pb_common.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nanopb/doc.txt
+++ b/pkg/nanopb/doc.txt
@@ -1,0 +1,8 @@
+/**
+ * @defgroup pkg_nanopb small Protocol Buffers library
+ * @ingroup  pkg
+ * @ingroup  sys
+ * @brief    Provides a protocol buffers library to RIOT
+ *
+ * @see      https://github.com/nanopb/nanopb
+ */

--- a/pkg/nanopb/patches/0001-generator-nanopb_generator.py-use-python3.patch
+++ b/pkg/nanopb/patches/0001-generator-nanopb_generator.py-use-python3.patch
@@ -1,0 +1,22 @@
+From 416436502170cfd77d19c6e967cc79267b4513d6 Mon Sep 17 00:00:00 2001
+From: Kaspar Schleiser <kaspar@schleiser.de>
+Date: Sat, 12 Oct 2019 00:26:19 +0200
+Subject: [PATCH] generator/nanopb_generator.py: use python3
+
+---
+ generator/nanopb_generator.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/generator/nanopb_generator.py b/generator/nanopb_generator.py
+index 03f41a0..4f0ab47 100755
+--- a/generator/nanopb_generator.py
++++ b/generator/nanopb_generator.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ from __future__ import unicode_literals
+ 
+-- 
+2.23.0
+

--- a/tests/pkg_nanopb/Makefile
+++ b/tests/pkg_nanopb/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEPKG += nanopb
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_nanopb/README.md
+++ b/tests/pkg_nanopb/README.md
@@ -1,0 +1,10 @@
+# Introduction
+
+This is a test application for the nanoPb library.
+The library provides a Google Protocol Buffers encoder / decoder.
+
+# Prerequisites
+
+Install the protobuf compiler and the protobuf python bindings.
+On Debian/ubuntu, the corresponding packages are `protobuf-compiler` and
+`python-protobuf`. On Arch, it is `protobuf` and `python-protobuf`.

--- a/tests/pkg_nanopb/main.c
+++ b/tests/pkg_nanopb/main.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2011 Petteri Aimonen <jpa at nanopb.mail.kapsi.fi>
+ *
+ * This software is provided 'as-is', without any express or
+ * implied warranty. In no event will the authors be held liable
+ * for any damages arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any
+ * purpose, including commercial applications, and to alter it and
+ * redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you
+ *    must not claim that you wrote the original software. If you use
+ *    this software in a product, an acknowledgment in the product
+ *    documentation would be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and
+ *    must not be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ * distribution.
+ *
+ * This file has been taken from
+ * https://github.com/nanopb/nanopb/tree/master/examples/simple
+ * (commit 5866b34) and changed to integrate well with RIOT (and comply to
+ * RIOT's coding conventions).
+ *
+ *
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       nanopb test application
+ *
+ * @author      Petteri Aimonen <jpa at nanopb.mail.kapsi.fi>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de> (RIOT adaption)
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <pb_encode.h>
+#include <pb_decode.h>
+#include "simple.pb.h"
+
+int main(void)
+{
+    /* This is the buffer where we will store our message. */
+    uint8_t buffer[128];
+    size_t message_length;
+    bool status;
+
+    /* Encode our message */
+    {
+        /* Allocate space on the stack to store the message data.
+         *
+         * Nanopb generates simple struct definitions for all the messages.
+         * - check out the contents of simple.pb.h!
+         * It is a good idea to always initialize your structures
+         * so that you do not have garbage data from RAM in there.
+         */
+        SimpleMessage message = SimpleMessage_init_zero;
+
+        /* Create a stream that will write to our buffer. */
+        pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+
+        /* Fill in the lucky number */
+        message.lucky_number = 13;
+
+        /* Now we are ready to encode the message! */
+        status = pb_encode(&stream, SimpleMessage_fields, &message);
+        message_length = stream.bytes_written;
+
+        /* Then just check for any errors.. */
+        if (!status)
+        {
+            printf("Encoding failed: %s\n", PB_GET_ERROR(&stream));
+            return 1;
+        }
+    }
+
+    /* Now we could transmit the message over network, store it in a file or
+     * wrap it to a pigeon's leg.
+     */
+
+    /* But because we are lazy, we will just decode it immediately. */
+
+    {
+        /* Allocate space for the decoded message. */
+        SimpleMessage message = SimpleMessage_init_zero;
+
+        /* Create a stream that reads from the buffer. */
+        pb_istream_t stream = pb_istream_from_buffer(buffer, message_length);
+
+        /* Now we are ready to decode the message. */
+        status = pb_decode(&stream, SimpleMessage_fields, &message);
+
+        /* Check for errors... */
+        if (!status)
+        {
+            printf("Decoding failed: %s\n", PB_GET_ERROR(&stream));
+            return 1;
+        }
+
+        /* Print the data contained in the message. */
+        printf("Your lucky number was %d!\n", (int)message.lucky_number);
+    }
+
+    return 0;
+}

--- a/tests/pkg_nanopb/simple.proto
+++ b/tests/pkg_nanopb/simple.proto
@@ -1,0 +1,8 @@
+// A very simple protocol definition, consisting of only
+// one message.
+
+syntax = "proto2";
+
+message SimpleMessage {
+    required int32 lucky_number = 1;
+}

--- a/tests/pkg_nanopb/tests/01-run.py
+++ b/tests/pkg_nanopb/tests/01-run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('Your lucky number was 13!')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This PR adds a package for easy usage of google protocol buffers.
It adds some logic to automatically generate *.c files from *.proto files within a module's source folder.

In order to do so, a prerequisite commit adds generic support for generated sources.

### Testing procedure

See ```tests/pkg_nanopb/README.md``` for usage info. Specifically, in order to test this, you'll need to install the official protobuf compiler, it's python bindings and the nanopb generator plugin.

As that generator is not (yet) part of the build container, the test cannot be compiled on the CI.

This is an alternative to #11157. Differences:

- includes generic way to generate sources using tools like nanopb.
- uses official test code
- simpler package source compilation through using custom (one-line) Makefile instead of calling upstream cmake

### Issues/PRs references

#11157
