### PR TITLE
sys/Makefile.include: include riotboot headers when FEATURES_REQUIRED=riotboot

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -77,7 +77,7 @@ ifneq (,$(filter printf_float,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter riotboot_%,$(USEMODULE)))
+ifneq (,$(filter riotboot,$(FEATURES_USED)))
   include $(RIOTBASE)/sys/riotboot/Makefile.include
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Currently when wanting to use riotboot on any application `riotboot_slot` module has to be included manually either by passing as make argument or editing the Makefile itself. Because of this if following [riotboot/README](https://github.com/RIOT-OS/RIOT/blob/209d90bc00458501ae710148d3cf0e1b59faff8b/bootloaders/riotboot/README.md) you will end up with `/bin/sh: 1: arithmetic expression: expecting primary: " + "` error. 

Since whenever someone uses `riotboot` feature it needs `riotboot_slot` modules (either for the bootloader or the application) it could be included as a dependency. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run:

`BOARD=samr21-xpro FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C examples/hello-world riotboot/flash-combined-slot0`

Works with this PR, On master it fails with error:

```
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
/bin/sh: 1: arithmetic expression: expecting primary: " + "
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
