### PR TITLE
gnrc_neterr: move doxygen group into GNRC group

### DIFF
--- a/sys/include/net/gnrc/neterr.h
+++ b/sys/include/net/gnrc/neterr.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    net_gnrc_neterr Error reporting
- * @ingroup     net
+ * @ingroup     net_gnrc
  * @brief       Allows for asynchronous error reporting in the network stack.
  * @{
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Noticed this little error while replying to #11551.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make doc` and open `doc/doxygen/html/index.html` with a browser of your choice. "Error reporting" should now appear under "Generic (GNRC) network stack" not under general "Networking"
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
