### PR TITLE
boards/cc2538: use FLASHFILE for boards using cc2538-bsl.py

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -24,14 +24,14 @@ export PROGRAMMER ?= cc2538-bsl
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
   export FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  export FFLAGS  = -p "$(PORT)" -e -w -v $(HEXFILE)
+  export FFLAGS  = -p "$(PORT)" -e -w -v $(FLASHFILE)
 else ifeq ($(PROGRAMMER),jlink)
   export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
-  export FFLAGS  = $(BINDIR) $(HEXFILE)
+  export FFLAGS  = $(BINDIR) $(FLASHFILE)
 endif
 
 OFLAGS = --gap-fill 0xff
-HEXFILE = $(BINFILE)
+FLASHFILE ?= $(BINFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)
 

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -14,10 +14,10 @@ ifeq ($(PROGRAMMER),cc2538-bsl)
   endif
   export RESET = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py -p "$(PORT_BSL)"
   export FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  export FFLAGS  = -p "$(PORT_BSL)" -e -w -v -b 115200 $(HEXFILE)
+  export FFLAGS  = -p "$(PORT_BSL)" -e -w -v -b 115200 $(FLASHFILE)
 else ifeq ($(PROGRAMMER),jlink)
   export FLASHER = $(RIOTBOARD)/common/remote/dist/flash.sh
-  export FFLAGS  = $(BINDIR) $(HEXFILE)
+  export FFLAGS  = $(BINDIR) $(FLASHFILE)
   export DEBUGGER = $(RIOTBOARD)/common/remote/dist/debug.sh
   export DEBUGSERVER = JLinkGDBServer -device CC2538SF53
   export RESET = $(RIOTBOARD)/common/remote/dist/reset.sh
@@ -25,7 +25,7 @@ else ifeq ($(PROGRAMMER),jlink)
 endif
 
 OFLAGS = --gap-fill 0xff
-HEXFILE = $(BINFILE)
+FLASHFILE ?= $(BINFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -26,7 +26,6 @@ else ifeq ($(PROGRAMMER),jlink)
   export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 endif
 
-export OFLAGS    = -O binary
 export HEXFILE = $(ELFFILE:.elf=.bin)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -17,16 +17,16 @@ ifeq ($(PROGRAMMER),cc2538-bsl)
     PORT_BSL ?= $(PORT_DARWIN)
   endif
   export FLASHER = $(RIOTBASE)/dist/tools/cc2538-bsl/cc2538-bsl.py
-  export FFLAGS  = -p "$(PORT_BSL)" --bootloader-invert-lines -e -w -v -b 460800 $(HEXFILE)
+  export FFLAGS  = -p "$(PORT_BSL)" --bootloader-invert-lines -e -w -v -b 460800 $(FLASHFILE)
 else ifeq ($(PROGRAMMER),jlink)
   export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
-  export FFLAGS  = $(BINDIR) $(HEXFILE)
+  export FFLAGS  = $(BINDIR) $(FLASHFILE)
   export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
   export DEBUGSERVER = JLinkGDBServer -device CC2538SF53
   export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 endif
 
-export HEXFILE = $(ELFFILE:.elf=.bin)
+FLASHFILE ?= $(BINFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -17,9 +17,9 @@ ifeq ($(PROGRAMMER),jlink)
   export TUI := 1
   include $(RIOTMAKE)/tools/jlink.inc.mk
 else
-  HEXFILE = $(BINFILE)
+  FLASHFILE ?= $(BINFILE)
   export FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  export FFLAGS  = -p "$(PORT)" -e -w -v -b 460800 $(HEXFILE)
+  export FFLAGS  = -p "$(PORT)" -e -w -v -b 460800 $(FLASHFILE)
 endif
 
 # setup serial terminal


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.

This also removes `OFLAGS` that is set by `Makefile.include` in the `.bin` and `.hex` rules.

### Testing procedure

Flash on a board using the `cc2538-bsl.py` and also by connecting a `jlink` to flash it with `PROGRAMMER=jlink`.

(I do not have any at the moment)

### Testing without a board

```
CC2538_BOARDS=$(git grep -e cc2538-bsl.py -e 'common/remote/Makefile.include' | grep -v 'boards/common' | cut -f 2 -d/)
echo ${CC2538_BOARDS} 
cc2538dk firefly openmote-b openmote-cc2538 remote-pa remote-reva remote-revb
```

The output of the `FFLAGS` is the same on `master` and this `PR` with the default and `jlink` programmer


#### cc2538


<details><summary><code>for board in ${CC2538_BOARDS}; do echo ${board}; BOARD=${board} make -C examples/hello-world --no-print-directory flash-only FLASHER=true PORT=none; done</code></summary><p>

```
for board in ${CC2538_BOARDS}; do echo ${board}; BOARD=${board} make -C examples/hello-world --no-print-directory flash-only FLASHER=true PORT=none; done
cc2538dk
true -p "none" -e -w -v /home/harter/work/git/RIOT/examples/hello-world/bin/cc2538dk/hello-world.bin
firefly
true -p "/dev/ttyUSB0" -e -w -v -b 115200 /home/harter/work/git/RIOT/examples/hello-world/bin/firefly/hello-world.bin
openmote-b
true -p "/dev/ttyUSB1" --bootloader-invert-lines -e -w -v -b 460800 /home/harter/work/git/RIOT/examples/hello-world/bin/openmote-b/hello-world.bin
openmote-cc2538
true -p "none" -e -w -v -b 460800 /home/harter/work/git/RIOT/examples/hello-world/bin/openmote-cc2538/hello-world.bin
remote-pa
true -p "/dev/ttyUSB1" -e -w -v -b 115200 /home/harter/work/git/RIOT/examples/hello-world/bin/remote-pa/hello-world.bin
remote-reva
true -p "/dev/ttyUSB0" -e -w -v -b 115200 /home/harter/work/git/RIOT/examples/hello-world/bin/remote-reva/hello-world.bin
remote-revb
true -p "/dev/ttyUSB0" -e -w -v -b 115200 /home/harter/work/git/RIOT/examples/hello-world/bin/remote-revb/hello-world.bin
```

</p></details>

### Jlink

<details><summary><code>for board in ${CC2538_BOARDS}; do echo ${board}; BOARD=${board} PROGRAMMER=jlink make -C examples/hello-world --no-print-directory flash-only FLASHER=true PORT=none; done</code></summary></p>

```
for board in ${CC2538_BOARDS}; do echo ${board}; BOARD=${board} PROGRAMMER=jlink make -C examples/hello-world --no-print-directory flash-only FLASHER=true PORT=none; done
cc2538dk
true /home/harter/work/git/RIOT/examples/hello-world/bin/cc2538dk /home/harter/work/git/RIOT/examples/hello-world/bin/cc2538dk/hello-world.bin
firefly
true /home/harter/work/git/RIOT/examples/hello-world/bin/firefly /home/harter/work/git/RIOT/examples/hello-world/bin/firefly/hello-world.bin
openmote-b
true /home/harter/work/git/RIOT/examples/hello-world/bin/openmote-b /home/harter/work/git/RIOT/examples/hello-world/bin/openmote-b/hello-world.bin
openmote-cc2538
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/openmote-cc2538/hello-world.bin
remote-pa
true /home/harter/work/git/RIOT/examples/hello-world/bin/remote-pa /home/harter/work/git/RIOT/examples/hello-world/bin/remote-pa/hello-world.bin
remote-reva
true /home/harter/work/git/RIOT/examples/hello-world/bin/remote-reva /home/harter/work/git/RIOT/examples/hello-world/bin/remote-reva/hello-world.bin
remote-revb
true /home/harter/work/git/RIOT/examples/hello-world/bin/remote-revb /home/harter/work/git/RIOT/examples/hello-world/bin/remote-revb/hello-world.bin
```

</p></details>

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/8838