### PR TITLE
boards/b-l072z-lrwan1: use STM32 common i2C configuration

### DIFF
--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -22,6 +22,7 @@
 #include "periph_cpu.h"
 #include "l0/cfg_clock_32_16_1.h"
 #include "cfg_rtt_default.h"
+#include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -173,29 +174,6 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
-/** @} */
-
-/**
- * @name I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev            = I2C1,
-        .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 8),
-        .sda_pin        = GPIO_PIN(PORT_B, 9),
-        .scl_af         = GPIO_AF4,
-        .sda_af         = GPIO_AF4,
-        .bus            = APB1,
-        .rcc_mask       = RCC_APB1ENR_I2C1EN,
-        .irqn           = I2C1_IRQn
-    }
-};
-
-#define I2C_0_ISR           isr_i2c1
-
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
+++ b/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
@@ -53,9 +53,11 @@ static const i2c_conf_t i2c_config[] = {
 #elif CPU_FAM_STM32F7
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
         .irqn           = I2C1_ER_IRQn,
-#elif CPU_FAM_STM32F0
+#elif CPU_FAM_STM32F0 || CPU_FAM_STM32L0
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
+#if CPU_FAM_STM32F0
         .rcc_sw_mask    = RCC_CFGR3_I2C1SW,
+#endif
         .irqn           = I2C1_IRQn,
 #endif
     }
@@ -65,7 +67,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_ev
 #elif CPU_FAM_STM32L4 || CPU_FAM_STM32F7
 #define I2C_0_ISR           isr_i2c1_er
-#elif CPU_FAM_STM32F0
+#elif CPU_FAM_STM32F0 || CPU_FAM_STM32L0
 #define I2C_0_ISR           isr_i2c1
 #endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR slightly adapts the STM32 common I2C configuration to make it compatible with STM32L0 cpus. The board b-l072z-lrwan1 peripheral configuration is adapted to use the common I2C configuration, since it's almost the same.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try an I2C sensor on b-l072z-lrwan1, it should still work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
