### PR TITLE
sys/log: add module for colorized logging

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -665,6 +665,14 @@ class SerCmd(cmd.Cmd):
             else:
                 output += c
 
+            # Hack to correctly handle reset ANSI escape code in the stream
+            # When the reset escape sequence is detected, it is written and
+            # flushed immediately to stdout
+            if output == '\033[0m':
+                sys.stdout.write(output)
+                sys.stdout.flush()
+                output = ""
+
             crreceived = c == '\r'
             nlreceived = c == '\n'
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -44,6 +44,7 @@ PSEUDOMODULES += l2filter_whitelist
 PSEUDOMODULES += lis2dh12_spi
 PSEUDOMODULES += log
 PSEUDOMODULES += log_printfnoformat
+PSEUDOMODULES += log_color
 PSEUDOMODULES += lora
 PSEUDOMODULES += mpu_stack_guard
 PSEUDOMODULES += nanocoap_%

--- a/sys/log/Makefile.include
+++ b/sys/log/Makefile.include
@@ -1,3 +1,7 @@
 ifneq (,$(filter log_printfnoformat,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/log/log_printfnoformat
 endif
+
+ifneq (,$(filter log_color,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/sys/log/log_color
+endif

--- a/sys/log/log_color/log_module.h
+++ b/sys/log/log_color/log_module.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_log_color Colored log module
+ * @ingroup     sys
+ * @brief       This module implements a logging module with colored output
+ * @{
+ *
+ * @file
+ * @brief       log_module header
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef LOG_MODULE_H
+#define LOG_MODULE_H
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "log.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default ANSI color escape code for error logs
+ *
+ * Default is bold red
+ */
+#ifndef LOG_ERROR_ANSI_COLOR_CODE
+#define LOG_ERROR_ANSI_COLOR_CODE       ("\033[1;31m")
+#endif
+
+/**
+ * @brief   Default ANSI color escape code for warning logs
+ *
+ * Default is bold yellow
+ */
+#ifndef LOG_WARNING_ANSI_COLOR_CODE
+#define LOG_WARNING_ANSI_COLOR_CODE     ("\033[1;33m")
+#endif
+
+/**
+ * @brief   Default ANSI color escape code for info logs
+ *
+ * Default is bold white
+ */
+#ifndef LOG_INFO_ANSI_COLOR_CODE
+#define LOG_INFO_ANSI_COLOR_CODE        ("\033[1m")
+#endif
+
+/**
+ * @brief   Default ANSI color escape code for debug logs
+ *
+ * Default is green
+ */
+#ifndef LOG_DEBUG_ANSI_COLOR_CODE
+#define LOG_DEBUG_ANSI_COLOR_CODE       ("\033[0;32m")
+#endif
+
+/**
+ * @brief   ANSI color escape code used for resetting color
+ */
+#define LOG_RESET_ANSI_COLOR_CODE       ("\033[0m")
+
+/**
+ * @brief   ANSI color escape codes array
+ *
+ * Internal use only
+ */
+static const char * const _ansi_codes[] =
+{
+    [LOG_ERROR] = LOG_ERROR_ANSI_COLOR_CODE,
+    [LOG_WARNING] = LOG_WARNING_ANSI_COLOR_CODE,
+    [LOG_INFO] = LOG_INFO_ANSI_COLOR_CODE,
+    [LOG_DEBUG] = LOG_DEBUG_ANSI_COLOR_CODE,
+};
+
+/**
+ * @brief log_write overridden function for colored output
+ *
+ * @param[in] level  Logging level
+ * @param[in] format String format to print
+ */
+static inline void log_write(unsigned level, const char *format, ...)
+{
+    assert(level > 0);
+
+    printf("%s", _ansi_codes[level]);
+    va_list args;
+    va_start(args, format);
+    /* Temporarily disable clang format-nonliteral warning */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif /* clang */
+    vprintf(format, args);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif /* clang */
+    va_end(args);
+    printf(LOG_RESET_ANSI_COLOR_CODE);
+
+#ifdef MODULE_NEWLIB
+    /* no fflush on msp430 */
+    fflush(stdout);
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif
+/**@}*/
+#endif /* LOG_MODULE_H */

--- a/tests/log_color/Makefile
+++ b/tests/log_color/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+USEMODULE += log_color
+
+# Enable debug log level
+CFLAGS += -DLOG_LEVEL=4
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/log_color/main.c
+++ b/tests/log_color/main.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Test logging with colors gives the expected output
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#include <inttypes.h>
+
+#include "log.h"
+
+int main(void)
+{
+    const uint8_t value = 42;
+    const char *string = "test";
+    const char *format = "Logging value '%d' and string '%s'\n";
+
+    LOG_ERROR(format, value, string);
+    LOG_WARNING(format, value, string);
+    LOG_INFO(format, value, string);
+    LOG_DEBUG(format, value, string);
+
+    return 0;
+}

--- a/tests/log_color/tests/01-run.py
+++ b/tests/log_color/tests/01-run.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Alexandre Abadie <alexandre.abadie@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+VALUE = 42
+STRING = 'test'
+
+STRING_FORMAT = '{}{}Logging value \'{}\' and string \'{}\''
+ERROR = '\033[1;31m'
+WARNING = '\033[1;33m'
+INFO = '\033[1m'
+DEBUG = '\033[0;32m'
+RESET = '\033[0m'
+
+LEVELS = [ERROR, WARNING, INFO, DEBUG]
+
+
+def testfunc(child):
+    for level in LEVELS:
+        child.expect_exact(STRING_FORMAT.format(RESET, level, VALUE, STRING))
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds a custom logging module for adding colors to displayed messages using ANSI escape codes. It can be useful to distinguish the type of messages displayed (ERROR, DEBUG, INFO, etc).
Colors are customizable using CFLAGS.

I had to patch the pyterm script to process the reset sequence correctly when the log message is not terminated by a newline. I haven't found a better solution so far.

### Testing procedure

```
$ make  BOARD=<your favorite board> -C tests/log_color flash test
$ RIOT_TERMINAL=socat make BOARD=<your favorite board> -C tests/log_color flash term
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

~Based on #11572~

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
