### PR TITLE
make: add print-versions helper target

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -41,7 +41,7 @@ Please paste or specifically describe the actual output.
 <!--
 Operating system: Mac OSX, Linux, Vagrant VM
 Build environment: GCC, CLang versions (you can run the following command from
-the RIOT base directory: ./dist/tools/ci/print_toolchain_versions.sh).
+the RIOT base directory: make print-versions).
 -->
 
 <!-- Thanks for contributing! -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ other contributors understand your issue and eventually reproduce it:
 To fill the `Versions` section, you can use the script provided in the RIOT git
 repository:
 ```
-./dist/tools/ci/print_toolchain_versions.sh
+make print-versions
 ```
 
 In summary, try to include as much information as possible, to help maintainers

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .all:
 
-.PHONY: all doc doc-man doc-latex docclean welcome
+.PHONY: all doc doc-man doc-latex docclean print-versions welcome
 
 all: welcome
 	@echo ""
@@ -36,6 +36,9 @@ welcome:
 	@echo "    https://doc.riot-os.org/getting-started.html"
 	@echo "Or ask questions on our mailing list:"
 	@echo "    users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)"
+
+print-versions:
+	@./dist/tools/ci/print_toolchain_versions.sh
 
 include makefiles/app_dirs.inc.mk
 

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -80,7 +80,7 @@ then
             exit $RESULT
         fi
 
-        run ./dist/tools/ci/print_toolchain_versions.sh
+        run make print-versions
 
         run ./dist/tools/commit-msg/check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/whitespacecheck/check.sh ${CI_BASE_BRANCH}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a new `print-versions` target that calls the `print_toolchain_versions.sh` script. With make auto_completion this make it very easy to find.

The CONTRIBUTING.md was updated accordingly

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `make print-versions`, it should print the same output as calling `./dist/tools/ci/print_toolchain_versions.sh`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
