### PR TITLE
posix_socket: initialize uninitialized fields

### DIFF
--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -221,6 +221,7 @@ static int _sockaddr_to_ep(const struct sockaddr *address, socklen_t address_len
                 return -1;
             }
             struct sockaddr_in *in_addr = (struct sockaddr_in *)address;
+            memset(out, 0, sizeof(*out));
             out->family = AF_INET;
             out->addr.ipv4_u32 = in_addr->sin_addr.s_addr;
             out->port = ntohs(in_addr->sin_port);
@@ -232,6 +233,7 @@ static int _sockaddr_to_ep(const struct sockaddr *address, socklen_t address_len
                 return -1;
             }
             struct sockaddr_in6 *in6_addr = (struct sockaddr_in6 *)address;
+            memset(out, 0, sizeof(*out));
             out->family = AF_INET6;
             memcpy(&out->addr.ipv6, &in6_addr->sin6_addr, sizeof(out->addr.ipv6));
             out->port = ntohs(in6_addr->sin6_port);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Some fields of `_sock_tl_ep` were not initialized when converting a sockaddr to a `_sock_tl_ep`. Though currently the only missing field is `netif` it is safer to use `memset()` here, to make the implementation more future proof.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash and run the application provided in https://github.com/RIOT-OS/RIOT/issues/11212 on 2 `samr21-xpro`s. Without this PR, the `echo send` command will report errno 22 (`EINVAL`), with it it will report `EBADF` (or crash if https://github.com/RIOT-OS/RIOT/issues/11212#issuecomment-495617061 is not applied).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses https://github.com/RIOT-OS/RIOT/issues/11212 but does not fix it, as that issue contains multiple bugs.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
