### PR TITLE
posix_sockets: set read/write permissions for socket fd

### DIFF
--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <arpa/inet.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -343,7 +344,7 @@ int socket(int domain, int type, int protocol)
         case AF_INET6:
 #endif
         {
-            int fd = vfs_bind(VFS_ANY_FD, 0, &socket_ops, s);
+            int fd = vfs_bind(VFS_ANY_FD, O_RDWR, &socket_ops, s);
 
             if (fd < 0) {
                 errno = ENFILE;
@@ -443,7 +444,7 @@ int accept(int socket, struct sockaddr *restrict address,
                                                   sa_len);
 
                 }
-                int fd = vfs_bind(VFS_ANY_FD, 0, &socket_ops, new_s);
+                int fd = vfs_bind(VFS_ANY_FD, O_RDWR, &socket_ops, new_s);
                 if (fd < 0) {
                     errno = ENFILE;
                     res = -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In https://github.com/RIOT-OS/RIOT/issues/11212 it was discovered, that the permissions for the file descriptors of POSIX sockets are not set so `write` and `read` can be used. This fixes that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash and run the application provided in #11212 on 2 `samr21-xpro`s. Without this PR `echo send` returns "Bad file descriptor" as its `write()` call ends up here

https://github.com/RIOT-OS/RIOT/blob/f6ee0ace8ed2953f8ba6c13a4858076ffbbe8fc5/sys/vfs/vfs.c#L325-L328
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #11212.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
