### PR TITLE
gnrc_sixlowpan_frag: fix timeout config macro name

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -64,8 +64,8 @@ extern "C" {
  * @note    Only applicable with
  *          [gnrc_sixlowpan_frag](@ref net_gnrc_sixlowpan_frag) module
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_MS
-#define GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_MS (3U * US_PER_SEC)
+#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US
+#define GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US (3U * US_PER_SEC)
 #endif
 
 /**
@@ -76,7 +76,7 @@ extern "C" {
  *
  * When set to a non-zero value this will cause the reassembly buffer to
  * override the oldest entry no matter what. When set to zero only the oldest
- * entry that is older than @ref GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_MS will be
+ * entry that is older than @ref GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be
  * overwritten (they will still timeout normally if reassembly buffer is not
  * full).
  */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -324,7 +324,7 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
         assert(!rbuf_entry_empty(oldest));
         if (GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE ||
             ((now_usec - oldest->arrival) >
-            GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_MS)) {
+            GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US)) {
             DEBUG("6lo rfrag: reassembly buffer full, remove oldest entry\n");
             gnrc_pktbuf_release(oldest->super.pkt);
             rbuf_rm(oldest);

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -37,7 +37,7 @@ extern "C" {
  * @{
  */
 #define RBUF_SIZE           (GNRC_SIXLOWPAN_FRAG_RBUF_SIZE)
-#define RBUF_TIMEOUT        (GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_MS)
+#define RBUF_TIMEOUT        (GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US)
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
As @cgundogan rightly pointed out in https://github.com/RIOT-OS/RIOT/pull/11442#discussion_r287407172, the macro is misnamed as it is defining the timeout in microseconds (μs or us) not milliseconds (ms).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`gnrc_sixlowpan_frag` should still compile (e.g. when building `gnrc_networking` for an IEEE 802.15.4-based platform).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but pointed out in #11442.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
