### PR TITLE
pkg/nimble: add IP-over-BLE support via netif/GNRC

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -826,6 +826,10 @@ ifneq (,$(filter bluetil_addr,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
+ifneq (,$(filter nimble_%,$(USEMODULE)))
+  USEPKG += nimble
+endif
+
 ifneq (,$(filter cord_epsim,$(USEMODULE)))
   USEMODULE += cord_common
   USEMODULE += gcoap

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -443,6 +443,10 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
   ifneq (,$(filter fib,$(USEMODULE)))
     USEMODULE += posix_inet
   endif
+  ifneq (,$(filter nimble_netif,$(USEMODULE)))
+    USEMODULE += nimble_scanner
+    USEMODULE += nimble_scanlist
+  endif
 endif
 
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))

--- a/boards/common/nrf52/Makefile.dep
+++ b/boards/common/nrf52/Makefile.dep
@@ -7,3 +7,9 @@ endif
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_nrf_temperature
 endif
+
+ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+  ifeq (,$(filter nordic_softdevice_ble nrfmin nrf802154,$(USEMODULE) $(USEPKG)))
+    USEMODULE += nimble_netif
+  endif
+endif

--- a/boards/nrf52840dk/Makefile.dep
+++ b/boards/nrf52840dk/Makefile.dep
@@ -1,7 +1,7 @@
-include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep
-
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   ifeq (,$(filter nrfmin,$(USEMODULE)))
     USEMODULE += nrf802154
   endif
 endif
+
+include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep

--- a/boards/nrf52dk/Makefile.dep
+++ b/boards/nrf52dk/Makefile.dep
@@ -1,7 +1,1 @@
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep
-
-ifeq (,$(filter nrfmin nimble_netif,$(USEMODULE)))
-  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-    USEPKG += nordic_softdevice_ble
-  endif
-endif

--- a/boards/nrf52dk/Makefile.dep
+++ b/boards/nrf52dk/Makefile.dep
@@ -1,6 +1,6 @@
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep
 
-ifeq (,$(filter nrfmin,$(USEMODULE)))
+ifeq (,$(filter nrfmin nimble_netif,$(USEMODULE)))
   ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEPKG += nordic_softdevice_ble
   endif

--- a/boards/reel/Makefile.dep
+++ b/boards/reel/Makefile.dep
@@ -3,4 +3,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += mma8x5x
 endif
 
+ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+  ifeq (,$(filter nrfmin,$(USEMODULE)))
+    USEMODULE += nrf802154
+  endif
+endif
+
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/examples/ndn-ping/Makefile
+++ b/examples/ndn-ping/Makefile
@@ -16,6 +16,10 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              waspmote-pro weio \
                              wsn430-v1_3b wsn430-v1_4 z1
 
+# Do not build for any board that supports nimble_netif, as NimBLE and ndn-riot
+# use different crypto libraries that have name clashes (tinycrypt vs uECC)
+BOARD_BLACKLIST := acd52832 nrf52832-mdk nrf52dk ruuvitag thingy52
+
 # Include packages that pull up and auto-init the link layer.
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -71,6 +71,9 @@ nimble_drivers_nrf5x:
 nimble_addr:
 	"$(MAKE)" -C $(TDIR)/addr/
 
+nimble_netif:
+	"$(MAKE)" -C $(TDIR)/netif/
+
 nimble_scanlist:
 	"$(MAKE)" -C $(TDIR)/scanlist
 

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -14,6 +14,9 @@ ifeq (llvm,$(TOOLCHAIN))
 # `nimble/controller/src/ble_ll_adv.c` isn't used in our compilation path, so
 # tell LLVM/clang not to be so pedantic with this.
   CFLAGS += -Wno-unused-function
+# Workaround, until https://github.com/apache/mynewt-nimble/pull/566 is merged
+# upstream and the NimBLE version in RIOT is updated.
+  CFLAGS += -Wno-sometimes-uninitialized
 else
   CFLAGS += -Wno-unused-but-set-variable
 endif

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -34,6 +34,7 @@ ifneq (,$(filter nimble_controller,$(USEMODULE)))
   endif
 endif
 
+# RIOT specific submodule dependencies
 ifneq (,$(filter nimble_addr,$(USEMODULE)))
   USEMODULE += bluetil_addr
 endif
@@ -41,4 +42,22 @@ endif
 ifneq (,$(filter nimble_scanlist,$(USEMODULE)))
   USEMODULE += nimble_addr
   USEMODULE += bluetil_ad
+endif
+
+ifneq (,$(filter nimble_netif,$(USEMODULE)))
+  USEMODULE += l2util
+  USEMODULE += bluetil_addr
+  ifneq (,$(filter gnrc_ipv6_%,$(USEMODULE)))
+    USEMODULE += nimble_svc_ipss
+  endif
+  ifneq (,$(filter gnrc_ipv6_router_default,$(USEMODULE)))
+    USEMODULE += gnrc_ipv6_nib_6lr
+    USEMODULE += gnrc_sixlowpan
+    USEMODULE += gnrc_sixlowpan_iphc
+  endif
+  ifneq (,$(filter gnrc_ipv6_default,$(USEMODULE)))
+    USEMODULE += gnrc_ipv6_nib_6ln
+    USEMODULE += gnrc_sixlowpan
+    USEMODULE += gnrc_sixlowpan_iphc
+  endif
 endif

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -76,6 +76,18 @@ endif
 ifneq (,$(filter nimble_addr,$(USEMODULE)))
   INCLUDES += -I$(RIOTPKG)/nimble/addr/include
 endif
+ifneq (,$(filter nimble_netif,$(USEMODULE)))
+  INCLUDES += -I$(RIOTPKG)/nimble/netif/include
+
+  # configure NimBLE's internals
+  NIMBLE_MAX_CONN ?= 3
+  CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE=264
+  CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM=$(NIMBLE_MAX_CONN)
+  CFLAGS += -DMYNEWT_VAL_BLE_MAX_CONNECTIONS=$(NIMBLE_MAX_CONN)
+  # NimBLEs internal buffer need to hold one IPv6 MTU per connection
+  # for the internal MTU of 256 byte, we need 10 mbufs per connection...
+  CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=35
+endif
 ifneq (,$(filter nimble_scanlist,$(USEMODULE)))
   INCLUDES += -I$(RIOTPKG)/nimble/scanlist/include
 endif

--- a/pkg/nimble/README.ipv6-over-ble.md
+++ b/pkg/nimble/README.ipv6-over-ble.md
@@ -1,0 +1,179 @@
+# IPv6-over-BLE: Connecting Linux with RIOT using BLE
+
+This README contains information how to establish an IPv6-over-BLE connection
+between Linux and RIOT (using GNRC and NimBLE).
+
+**NOTE 1:** IPv6-over-BLE between RIOT and Linux is **highly experimental** at
+the moment and does suffer stability issues!
+
+**NOTE 2:** Currently, Linux does not support 6LoWPAN neighbor discovery (which
+RIOT uses per default with BLE), so RIOT needs to be compiled to use stateless
+address auto configuration (SLAAC) -> `CFLAGS=-DGNRC_IPV6_NIB_CONF_SLAAC=1`.
+
+## Prerequisites
+
+You need a BLE (NimBLE) capable RIOT board (currently only `nrf52`-based boards
+are supported), and a Linux host with at least Bluetooth 4.0 capabilities.
+
+Any Linux distribution should do fine, however this guide was tested with the
+following:
+- Mint 18.3
+- Kernel 4.15.0
+- bluez 5.37
+- [optional] radvd 2.11
+
+
+## Preparing the RIOT node
+
+First, you compile and flash the `examples/gnrc_networking` application to your
+RIOT device. When doing this, make sure to enable SLAAC
+(`CFLAGS=-DGNRC_IPV6_NIB_CONF_SLAAC=1`), see note above.
+
+Once the firmware is running, you can verify it by typing
+
+    ble info
+
+This should give you some information about your device's BLE address and
+status information about open connections. It should look similar to the
+following:
+
+    Own Address: UU:VV:WW:XX:YY:ZZ -> [FE80::UUVV:WWFF:FEXX:YYZZ]
+     Free slots: 3/3
+    Advertising: no
+       Contexts:
+    [ 0] state: 0x8000 - unused
+    [ 1] state: 0x8000 - unused
+    [ 2] state: 0x8000 - unused
+
+Once this is working, you need to tell the node to accept incoming connections
+and start advertising itself:
+
+    ble adv
+
+Thats it, the node can now be seen and connected to from Linux.
+
+
+## Establishing a connection from Linux
+
+### Preparing Linux
+
+First of all, the Linux kernel needs to be configured to use 6lowpan over BLE.
+This needs to be done only once per session and consists of the following steps:
+
+    # Log in as a root user (IMPORTANT, as the following steps will not work
+    # using explicit `sudo` for each step...)
+    sudo su
+
+    # Mount debugfs file system, already the case on many distributions
+    mount -t debugfs none /sys/kernel/debug
+
+    # Load 6LoWPAN module
+    modprobe bluetooth_6lowpan
+
+    # Enable the bluetooth 6lowpan module.
+    echo 1 > /sys/kernel/debug/bluetooth/6lowpan_enable
+
+Next, we should verify that our Bluetooth device is configured properly:
+
+    # Look for available HCI devices.
+    hciconfig
+
+This should show us some information about the available Blutooth devices. If no
+device is listed here, something is wrong...
+
+
+### Connecting to the RIOT node
+
+When connecting to the RIOT device, you need to know the BLE address of the
+device. There are two ways to find out:
+
+a) use `ble info` or `ifconfig` on the RIOT device directly and copy the address
+
+b) use `bluetoothctl` on Linux to scan for the device. Once `bluetoothctl` has
+   started, issue `scan on` to start scanning. The default name for the RIOT
+   device is set to `RIOT-GNRC`, so you should see it pop up.
+
+c) use `hcitool lescan` on the Linux host (older tool, predecessor of
+   `bluetoothctl`...)
+
+Once you have the address, you simply connect Linux to RIOT using the following
+command:
+
+    # Put your device address here...
+    # Note: the 2 after the address denotes a BLE public random address, default
+    #       used by `nimble_netif`
+    echo "connect UU:VV:WW:XX:YY:ZZ 2" > /sys/kernel/debug/bluetooth/6lowpan_control
+
+Thats it, you now have a IPv6 connection to your RIOT node. You can verify this
+using `ifconfig`, where something like the following should be visible:
+
+    bt0       Link encap:UNSPEC  HWaddr 00-19-86-00-16-CA-00-00-00-00-00-00-00-00-00-00
+          inet6 addr: fe80::19:86ff:fe00:16ca/64 Scope:Link
+          UP RUNNING MULTICAST  MTU:1280  Metric:1
+          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:18 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000
+          RX bytes:0 (0.0 B)  TX bytes:1624 (1.6 KB)
+
+You should also be able to ping your RIOT node. The devices link local address
+is also printed when running `ble info` on your RIOT device.
+
+    # Substitute the actual device address,
+    ping6 fe80::uuvv:wwff:fexx:yyzz%bt0
+
+Now everything should be fine :-)
+
+
+## [optional] Distributing a routeable Prefix
+
+You can use the Router Advertisement Deamon (`radvd`) in Linux to automatically
+distribute prefixes in your BLE network. For the following, you need to make
+sure that `radvd` is installed on your Linux host.
+
+As a first step, we need to enable IPv6 forwarding in Linux:
+
+    sudo echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+
+Next, we configure `radvd` (`etc/radvc.conf`) by using a configuration like
+this:
+
+    interface bt0
+    {
+        AdvSendAdvert on;
+        prefix 2001:db8::/64
+        {
+            AdvOnLink off;
+            AdvAutonomous on;
+            AdvRouterAddr on;
+        };
+        abro 2001:db8::zzyy:xxff:feuu:vvww
+        {
+            AdvVersionLow 10;
+            AdvVersionHigh 2;
+            AdvValidLifeTime 2;
+        };
+    };
+
+This will tell Linux to advertise the prefix `2001:db8::/64`. Do not forget to
+substitute the suffix of global address given in the `abro` section
+with the one of the BLE device on your Linux host.
+
+**NOTE:** The `abro` section is needed as otherwise the RIOT node will discard
+router advertisements, as it is in 6LN configuration
+(see https://tools.ietf.org/html/rfc6775#section-4.3).
+
+With this, simply (re-)start the deamon:
+
+    sudo service radvd restart
+
+or
+
+    sudo systemctl restart radvd
+
+Again, thats it. Your RIOT node should now have an address using the above
+prefix assigned. Simply verify with `ifconfig` on the RIOT node.
+
+Also you should be able to ping the RIOT node from Linux:
+
+    # make sure to use the actual devices address here...
+    ping6 -I bt0 2001:db8::uuvv:wwff:fexx:yyzz

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -103,6 +103,10 @@ void nimble_riot_init(void)
 #ifdef MODULE_NIMBLE_NETIF
     extern void nimble_netif_init(void);
     nimble_netif_init();
+#ifdef MODULE_SHELL_COMMANDS
+    extern void sc_nimble_netif_init(void);
+    sc_nimble_netif_init();
+#endif
 #endif
 
     /* initialize the configured, build-in services */

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -100,6 +100,11 @@ void nimble_riot_init(void)
     assert(res == 0);
     (void)res;
 
+#ifdef MODULE_NIMBLE_NETIF
+    extern void nimble_netif_init(void);
+    nimble_netif_init();
+#endif
+
     /* initialize the configured, build-in services */
 #ifdef MODULE_NIMBLE_SVC_GAP
     ble_svc_gap_init();

--- a/pkg/nimble/netif/Makefile
+++ b/pkg/nimble/netif/Makefile
@@ -1,0 +1,3 @@
+MODULE = nimble_netif
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2018-2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    pkg_nimble_netif GNRC netif Implementation
+ * @ingroup     ble_nimble
+ * @brief       GNRC netif implementation for NimBLE, enabling the integration
+ *              of NimBLE into GNRC
+ *
+ * # About
+ * This NimBLE submodule provides a GNRC netif wrapper for integrating NimBLE
+ * with GNRC and other network stacks using netif (e.g. CCNlite).
+ *
+ * # Concept
+ * According to the IPv6-over-BLE standards (RFC7668 and IPSP), this module
+ * exposes a (configurable) number of point-to-point BLE connections as a single
+ * network device to BLE. Unicast traffic is only send using the corresponding
+ * BLE connection. Multicast and Broadcast packets are duplicated and send via
+ * each open BLE connection.
+ *
+ * # Structure
+ * The netif implementation is able to handle multiple connections
+ * simultaneously. The maximum number of concurrent connections is configured
+ * during compile time, using NimBLEs MYNEWT_VAL_BLE_MAX_CONNECTIONS option.
+ * Dependent on this value, the netif implementation takes care of allocation
+ * all the memory needed. The API of this submodule uses simply integer values
+ * to reference the used connection context (like file descriptors in linux).
+ *
+ * Like any other GNRC network device, the NimBLE netif wrapper runs in its own
+ * thread. This thread is started and configured by the common netif code. All
+ * send and get/set operations are handled by this thread. For efficiency
+ * reasons, receiving of data is however handled completely in the NimBLE host
+ * thread, from where the received data is directly passed on to the
+ * corresponding GNRC thread.
+ *
+ * Although the wrapper hooks into GNRC using the netif interface, it does need
+ * to implement parts of the netdev interface as well. This is done where
+ * needed.
+ *
+ * # Usage
+ * This submodule is designed to work fully asynchronous, in the same way as the
+ * NimBLE interfaces are designed. All functions in this submodule will only
+ * trigger the intended action. Once this action is complete, the module will
+ * report the result asynchronously using the configured callback.
+ *
+ * So before using this module, make sure to register a callback using the
+ * @ref nimble_netif_eventcb() function.
+ *
+ * After this, this module provides functions for managing BLE connections to
+ * other devices. Once these connections are established, this module takes care
+ * of mapping IP packets to the corresponding connections.
+ *
+ * @{
+ *
+ * @file
+ * @brief       GNRC netif implementation for NimBLE
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef NIMBLE_NETIF_H
+#define NIMBLE_NETIF_H
+
+#include <stdint.h>
+
+#include "net/ble.h"
+
+#include "host/ble_hs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default L2CAP channel ID to use
+ */
+#ifndef NIMBLE_NETIF_CID
+#define NIMBLE_NETIF_CID            (BLE_L2CAP_CID_IPSP)
+#endif
+
+/**
+ * @brief   Default MTU size supported by the NimBLE netif wrapper
+ */
+/* NOTE: We do not use the @ref IPV6_MIN_MTU define here, as the iov6.h header
+         pulls in some other RIOT headers that clash with NimBLE header (e.g.
+ *       byteorder.h vs. endian.h) */
+#ifndef NIMBLE_NETIF_MTU
+#define NIMBLE_NETIF_MTU            (1280U)
+#endif
+
+/**
+ * @brief   Return codes used by the NimBLE netif module
+ */
+enum {
+    NIMBLE_NETIF_OK         =  0,   /**< everything went fine */
+    NIMBLE_NETIF_NOTCONN    = -1,   /**< not connected */
+    NIMBLE_NETIF_DEVERR     = -2,   /**< internal BLE stack error */
+    NIMBLE_NETIF_BUSY       = -3,   /**< network device is busy */
+    NIMBLE_NETIF_NOMEM      = -4,   /**< insufficient memory */
+    NIMBLE_NETIF_NOTADV     = -5,   /**< not advertising */
+    NIMBLE_NETIF_NOTFOUND   = -6,   /**< no fitting entry found */
+};
+
+/**
+ * @brief   Event types triggered by the NimBLE netif module
+ */
+typedef enum {
+    NIMBLE_NETIF_CONNECTED_MASTER,  /**< connection established as master */
+    NIMBLE_NETIF_CONNECTED_SLAVE,   /**< connection established as slave */
+    NIMBLE_NETIF_CLOSED_MASTER,     /**< connection closed (we were master) */
+    NIMBLE_NETIF_CLOSED_SLAVE,      /**< connection closed (we were slave) */
+    NIMBLE_NETIF_CONNECT_ABORT,     /**< connection establishment aborted */
+    NIMBLE_NETIF_CONN_UPDATED,      /**< connection parameter update done */
+} nimble_netif_event_t;
+
+/**
+ * @brief   Flags describing the state of a single connection context
+ */
+enum {
+    NIMBLE_NETIF_L2CAP_CLIENT       = 0x0001,   /**< L2CAP client */
+    NIMBLE_NETIF_L2CAP_SERVER       = 0x0002,   /**< L2CAP server */
+    NIMBLE_NETIF_L2CAP_CONNECTED    = 0x0003,   /**< L2CAP is connected */
+    NIMBLE_NETIF_GAP_MASTER         = 0x0010,   /**< GAP master */
+    NIMBLE_NETIF_GAP_SLAVE          = 0x0020,   /**< GAP slave */
+    NIMBLE_NETIF_GAP_CONNECTED      = 0x0030,   /**< GAP is connected */
+    NIMBLE_NETIF_ADV                = 0x0100,   /**< currently advertising */
+    NIMBLE_NETIF_CONNECTING         = 0x4000,   /**< connection in progress */
+    NIMBLE_NETIF_UNUSED             = 0x8000,   /**< context unused */
+    NIMBLE_NETIF_ANY                = 0xffff,   /**< match any state */
+};
+
+/**
+ * @brief   Event callback signature used for asynchronous event signaling
+ *
+ * @note    The event callback is always executed in NimBLE's host thread
+ *
+ * @param[in] handle        handle to the connection that triggered the event
+ * @param[in] event         type of the event
+ */
+typedef void(*nimble_netif_eventcb_t)(int handle, nimble_netif_event_t event);
+
+/**
+ * @brief   Initialize the netif implementation, spawns the netif thread
+ *
+ * This function is meant to be called once during system initialization, i.e.
+ * auto-init.
+ */
+void nimble_netif_init(void);
+
+/**
+ * @brief   Register a global event callback, servicing all NimBLE connections
+ *
+ * @note    The event callback is always executed in NimBLE's host thread
+ *
+ * @param[in] cb            event callback to register, may be NULL
+ */
+void nimble_netif_eventcb(nimble_netif_eventcb_t cb);
+
+/**
+ * @brief   Open a BLE connection as BLE master
+ *
+ * @param[in] addr          address of the advertising BLE slave, in the NimBLE
+ *                          addr format (little endian)
+ * @param[in] conn_params   connection (timing) parameters
+ * @param[in] timeout       connect timeout
+ *
+ * @return  the used connection handle on success
+ * @return  NIMBLE_NETIF_BUSY if already connected to the given address or if
+ *          a connection setup procedure is in progress
+ * @return  NIMBLE_NETIF_NOMEM if no connection context memory is available
+ */
+int nimble_netif_connect(const ble_addr_t *addr,
+                         const struct ble_gap_conn_params *conn_params,
+                         uint32_t timeout);
+
+/**
+ * @brief   Close the connection with the given handle
+ *
+ * @param[in] handle        handle for the connection to be closed
+ *
+ * @return  NIMBLE_NETIF_OK on success
+ * @return  NIMBLE_NETIF_NOTFOUND if the handle is invalid
+ * @return  NIMBLE_NETIF_NOTCONN if context for given handle is not connected
+ */
+int nimble_netif_close(int handle);
+
+/**
+ * @brief   Accept incoming connections by starting to advertise this node
+ *
+ * @param[in] ad            advertising data (in BLE AD format)
+ * @param[in] ad_len        length of @p ad in bytes
+ * @param[in] adv_params    advertising (timing) parameters to use
+ *
+ * @return  NIMBLE_NETIF_OK on success
+ * @return  NIMBLE_NETIF_BUSY if already advertising
+ * @return  NIMBLE_NETIF_NOMEM on insufficient connection memory
+ */
+int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
+                        const struct ble_gap_adv_params *adv_params);
+
+/**
+ * @brief   Stop accepting incoming connections (stop advertising)
+ * *
+ * @return  NIMBLE_NETIF_OK on success
+ * @return  NIMBLE_NETIF_NOTADV if not currently advertising
+ */
+int nimble_netif_accept_stop(void);
+
+/**
+ * @brief   Update the connection parameters for the given connection
+ *
+ * @param[in] handle        connection handle
+ * @param[in] conn_params   new connection parameters to apply
+ *
+ * @return  NIMBLE_NETIF_OK on success
+ * @return  NIMBLE_NETIF_NOTCONN if handle does not point to a connection
+ * @return  NIMBLE_NETIF_DEVERR if applying the given parameters failed
+ */
+int nimble_netif_update(int handle,
+                        const struct ble_gap_upd_params *conn_params);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIMBLE_NETIF_H */
+/** @} */

--- a/pkg/nimble/netif/include/nimble_netif_conn.h
+++ b/pkg/nimble/netif/include/nimble_netif_conn.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2018-2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    pkg_nimble_netif_conn Connection State Management for netif
+ * @ingroup     pkg_nimble_netif
+ * @brief       Helper module for managing the memory needed to store the
+ *              BLE connection state for the netif wrapper
+ * @{
+ *
+ * @file
+ * @brief       Connection allocation and maintenance for NimBLE netif
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef NIMBLE_NETIF_CONN_H
+#define NIMBLE_NETIF_CONN_H
+
+#include <stdint.h>
+
+#include "nimble_netif.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Value for marking a handle invalid
+ */
+#define NIMBLE_NETIF_CONN_INVALID       (-1)
+
+/**
+ * @brief   Memory layout for holding the relevant connection information
+ */
+typedef struct {
+    struct ble_l2cap_chan *coc;     /**< l2cap context as exposed by NimBLE */
+    uint16_t gaphandle;             /**< GAP handle exposed by NimBLE */
+    uint16_t state;                 /**< the current state of the context */
+    uint8_t addr[BLE_ADDR_LEN];     /**< BLE address of connected peer
+                                         (in network byte order) */
+} nimble_netif_conn_t;
+
+/**
+ * @brief   Iterator function signature used by @ref nimble_netif_conn_foreach()
+ *
+ * @param[in] conn          connection context of the current entry
+ * @param[in] handle        handle of the current entry
+ * @param[in] arg           user supplied argument
+ *
+ * @return  0 to continue
+ * @return  != 0 to stop iterating
+ */
+typedef int (*nimble_netif_conn_iter_t)(nimble_netif_conn_t *conn,
+                                        int handle, void *arg);
+
+/**
+ * @brief   Initialize the connection state manager
+ *
+ * This functions is typically called by @ref nimble_netif_init().
+ */
+void nimble_netif_conn_init(void);
+
+/**
+ * @brief   Get the connection context corresponding to the given handle
+ *
+ * @param[in] handle        handle to a connection context
+ *
+ * @return  pointer to the corresponding connection context
+ * @return  NULL if handle in invalid
+ */
+nimble_netif_conn_t *nimble_netif_conn_get(int handle);
+
+/**
+ * @brief   Get the handle to the context that is currently advertising
+ *
+ * @return  handle to the currently advertising context
+ * @return  NIMBLE_NETIF_CONN_INVALID if not advertising
+ */
+int nimble_netif_conn_get_adv(void);
+
+/**
+ * @brief   Get the handle to the context that is busy connecting
+ *
+ * @return  handle to the busy context
+ * @return  NIMBLE_NETIF_CONN_INVALID if not busy connecting
+ */
+int nimble_netif_conn_get_connecting(void);
+
+/**
+ * @brief   Find the connection to the peer with the given BLE address
+ *
+ * @param[in] addr          BLE address, in network byte order
+ *
+ * @return  handle to the matching connection context
+ * @return  NIMBLE_NETIF_CONN_INVALID if no matching connection was found
+ */
+int nimble_netif_conn_get_by_addr(const uint8_t *addr);
+
+/**
+ * @brief   Find the connection using the given NimBLE GAP handle
+ *
+ * @param[in] gaphandle     GAP handle as exposed by NimBLE
+ *
+ * @return  handle to the matching connection context
+ * @return  NIMBLE_NETIF_CONN_INVALID if no matching connection was found
+ */
+int nimble_netif_conn_get_by_gaphandle(uint16_t gaphandle);
+
+
+/**
+ * @brief   Iterate over all connection contexts that match the filter condition
+ *
+ * @warning Do not call any other nimble_netif_conn function from within the
+ *          callback, this will lead to a deadlock!
+ *
+ * @param[in] filter        filter mask
+ * @param[in] cb            callback called on each filtered entry
+ * @param[in] arg           user argument
+ */
+void nimble_netif_conn_foreach(uint16_t filter,
+                               nimble_netif_conn_iter_t cb, void *arg);
+
+/**
+ * @brief   Count the number of connections contexts for which the given filter
+ *          applies
+ *
+ * @param[in] filter        filter mask
+ *
+ * @return  number of contexts for which the filter applied
+ */
+
+unsigned nimble_netif_conn_count(uint16_t filter);
+
+/**
+ * @brief   Allocate an unused context for starting a connection
+ *
+ * @param[in] addr          the BLE address of the peer node, in network byte
+ *                          order
+ *
+ * @return handle used for the new connection
+ */
+int nimble_netif_conn_start_connection(const uint8_t *addr);
+
+/**
+ * @brief   Reserve a unused context for the purpose of accepting a new
+ *          connection
+ *
+ * @return  handle of the reserved context
+ * @return  NIMBLE_NETIF_CONN_INVALID if no unused context was available
+ */
+int nimble_netif_conn_start_adv(void);
+
+/**
+ * @brief   Free the connection context with the given handle
+ */
+void nimble_netif_conn_free(int handle);
+
+/**
+ * @brief   Find the connection context with a given GAP handle and return a
+ *          pointer to it
+ *
+ * @param[in] gh            GAP handle used by NimBLE
+ *
+ * @return  Pointer to the selected context
+ * @return  NULL if no fitting context was found
+ */
+static inline
+nimble_netif_conn_t *nimble_netif_conn_from_gaphandle(uint16_t gh)
+{
+    return nimble_netif_conn_get(nimble_netif_conn_get_by_gaphandle(gh));
+}
+
+/**
+ * @brief   Convenience function to check if any context is currently in the
+ *          connecting state (@ref NIMBLE_NETIF_CONNECTING)
+ *
+ * @return  != 0 if true
+ * @return  0 if false
+ */
+static inline int nimble_netif_conn_connecting(void)
+{
+    return (nimble_netif_conn_get_connecting() != NIMBLE_NETIF_CONN_INVALID);
+}
+
+/**
+ * @brief   Convenience function to check if we are currently connected to a
+ *          peer with the given address
+ *
+ * @param[in] addr          BLE address, in network byte order
+ *
+ * @return  != 0 if true
+ * @return  0 if false
+ */
+static inline int nimble_netif_conn_connected(const uint8_t *addr)
+{
+    return (nimble_netif_conn_get_by_addr(addr) != NIMBLE_NETIF_CONN_INVALID);
+}
+
+
+/**
+ * @brief   Convenience function to check if any context is currently in the
+ *          advertising state (@ref NIMBLE_NETIF_ADV)
+ *
+ * @return  != 0 if true
+ * @return  0 if false
+ */
+static inline int nimble_netif_conn_is_adv(void)
+{
+    return (nimble_netif_conn_get_adv() != NIMBLE_NETIF_CONN_INVALID);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIMBLE_NETIF_CONN_H */
+/** @} */

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -1,0 +1,630 @@
+/*
+ * Copyright (C) 2018-2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_nimble_netif
+ * @{
+ *
+ * @file
+ * @brief       GNRC netif wrapper for NimBLE
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <limits.h>
+#include <errno.h>
+
+#include "assert.h"
+#include "thread.h"
+#include "thread_flags.h"
+
+#include "net/ble.h"
+#include "net/bluetil/addr.h"
+#include "net/gnrc/netif.h"
+#include "net/gnrc/netif/hdr.h"
+#include "net/gnrc/netreg.h"
+#include "net/gnrc/pktbuf.h"
+#include "net/gnrc/nettype.h"
+
+#include "nimble_netif.h"
+#include "nimble_netif_conn.h"
+#include "nimble_riot.h"
+#include "host/ble_gap.h"
+#include "host/util/util.h"
+
+#define ENABLE_DEBUG            (0)
+#include "debug.h"
+
+#ifdef MODULE_GNRC_SIXLOWPAN
+#define NETTYPE                 GNRC_NETTYPE_SIXLOWPAN
+#elif defined(MODULE_GNRC_IPV6)
+#define NETTYPE                 GNRC_NETTYPE_IPV6
+#else
+#define NETTYPE                 GNRC_NETTYPE_UNDEF
+#endif
+
+/* buffer configuration
+ * - we need one RX and one TX buffer per connection */
+#define MTU_SIZE                (NIMBLE_NETIF_MTU)
+#define MBUF_OVHD               (sizeof(struct os_mbuf) + \
+                                 sizeof(struct os_mbuf_pkthdr))
+#define MBUF_SIZE               (MBUF_OVHD + MYNEWT_VAL_BLE_L2CAP_COC_MPS)
+#define MBUF_CNT                (MYNEWT_VAL_BLE_MAX_CONNECTIONS * 2 * \
+                                 ((MTU_SIZE + (MBUF_SIZE - 1)) / MBUF_SIZE))
+
+/* thread flag used for signaling transmit readiness */
+#define FLAG_TX_UNSTALLED       (1u << 13)
+
+/* allocate a stack for the netif device */
+static char _stack[THREAD_STACKSIZE_DEFAULT];
+static thread_t *_netif_thread;
+
+/* keep the actual device state */
+static gnrc_netif_t *_nimble_netif = NULL;
+static gnrc_nettype_t _nettype = NETTYPE;
+
+/* keep a reference to the event callback */
+static nimble_netif_eventcb_t _eventcb;
+
+/* allocation of memory for buffering IP packets when handing them to NimBLE */
+static os_membuf_t _mem[OS_MEMPOOL_SIZE(MBUF_CNT, MBUF_SIZE)];
+static struct os_mempool _mem_pool;
+static struct os_mbuf_pool _mbuf_pool;
+
+/* notify the user about state changes for a connection context */
+static void _notify(int handle, nimble_netif_event_t event)
+{
+    if (_eventcb) {
+        _eventcb(handle, event);
+    }
+}
+
+static void _netif_init(gnrc_netif_t *netif)
+{
+    (void)netif;
+
+    /* save the threads context pointer, so we can set its flags */
+    _netif_thread = (thread_t *)thread_get(thread_getpid());
+
+#ifdef MODULE_GNRC_SIXLOWPAN
+    /* we disable fragmentation for this device, as the L2CAP layer takes care
+     * of this */
+    _nimble_netif->sixlo.max_frag_size = 0;
+#endif
+}
+
+static int _send_pkt(nimble_netif_conn_t *conn, gnrc_pktsnip_t *pkt)
+{
+    int res;
+    int num_bytes = 0;
+
+    if (conn == NULL || conn->coc == NULL) {
+        return -ENOTCONN;
+    }
+
+    /* copy the data into a newly allocated mbuf */
+    struct os_mbuf *sdu = os_mbuf_get_pkthdr(&_mbuf_pool, 0);
+    if (sdu == NULL) {
+        return -ENOBUFS;
+    }
+    while (pkt) {
+        res = os_mbuf_append(sdu, pkt->data, pkt->size);
+        if (res != 0) {
+            os_mbuf_free_chain(sdu);
+            return -ENOBUFS;
+        }
+        num_bytes += (int)pkt->size;
+        pkt = pkt->next;
+    }
+
+    /* send packet via the given L2CAP COC */
+    do {
+        res = ble_l2cap_send(conn->coc, sdu);
+        if (res == BLE_HS_EBUSY) {
+            thread_flags_wait_all(FLAG_TX_UNSTALLED);
+        }
+    } while (res == BLE_HS_EBUSY);
+
+    if ((res != 0) && (res != BLE_HS_ESTALLED)) {
+        os_mbuf_free_chain(sdu);
+        return -ENOBUFS;
+    }
+
+    return num_bytes;
+}
+
+static int _netif_send_iter(nimble_netif_conn_t *conn,
+                            int handle, void *arg)
+{
+    (void)handle;
+    _send_pkt(conn, (gnrc_pktsnip_t *)arg);
+    return 0;
+}
+
+static int _netif_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
+{
+    assert(pkt->type == GNRC_NETTYPE_NETIF);
+
+    (void)netif;
+    int res;
+
+    gnrc_netif_hdr_t *hdr = (gnrc_netif_hdr_t *)pkt->data;
+    /* if packet is bcast or mcast, we send it to every connected node */
+    if (hdr->flags &
+        (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
+        nimble_netif_conn_foreach(NIMBLE_NETIF_L2CAP_CONNECTED,
+                                  _netif_send_iter, pkt->next);
+        res = (int)gnrc_pkt_len(pkt->next);
+    }
+    /* send unicast */
+    else {
+        int handle = nimble_netif_conn_get_by_addr(
+            gnrc_netif_hdr_get_dst_addr(hdr));
+        nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
+        res = _send_pkt(conn, pkt->next);
+    }
+
+    /* release the packet in GNRC's packet buffer */
+    gnrc_pktbuf_release(pkt);
+    return res;
+}
+
+/* not used, we pass incoming data to GNRC directly from the NimBLE thread */
+static gnrc_pktsnip_t *_netif_recv(gnrc_netif_t *netif)
+{
+    (void)netif;
+    return NULL;
+}
+
+static const gnrc_netif_ops_t _nimble_netif_ops = {
+    .init = _netif_init,
+    .send = _netif_send,
+    .recv = _netif_recv,
+    .get = gnrc_netif_get_from_netdev,
+    .set = gnrc_netif_set_from_netdev,
+    .msg_handler = NULL,
+};
+
+static inline int _netdev_init(netdev_t *dev)
+{
+    _nimble_netif = dev->context;
+
+    /* get our own address from the controller */
+    uint8_t tmp[6];
+    int res = ble_hs_id_copy_addr(nimble_riot_own_addr_type, tmp, NULL);
+    assert(res == 0);
+    (void)res;
+
+    bluetil_addr_swapped_cp(tmp, _nimble_netif->l2addr);
+    return 0;
+}
+
+static inline int _netdev_get(netdev_t *dev, netopt_t opt,
+                              void *value, size_t max_len)
+{
+    (void)dev;
+    int res = -ENOTSUP;
+
+    switch (opt) {
+        case NETOPT_ADDRESS:
+            assert(max_len >= BLE_ADDR_LEN);
+            memcpy(value, _nimble_netif->l2addr, BLE_ADDR_LEN);
+            res = BLE_ADDR_LEN;
+            break;
+        case NETOPT_ADDR_LEN:
+        case NETOPT_SRC_LEN:
+            assert(max_len == sizeof(uint16_t));
+            *((uint16_t *)value) = BLE_ADDR_LEN;
+            res = sizeof(uint16_t);
+            break;
+        case NETOPT_MAX_PACKET_SIZE:
+            assert(max_len >= sizeof(uint16_t));
+            *((uint16_t *)value) = MTU_SIZE;
+            res = sizeof(uint16_t);
+            break;
+        case NETOPT_PROTO:
+            assert(max_len == sizeof(gnrc_nettype_t));
+            *((gnrc_nettype_t *)value) = _nettype;
+            res = sizeof(gnrc_nettype_t);
+            break;
+        case NETOPT_DEVICE_TYPE:
+            assert(max_len == sizeof(uint16_t));
+            *((uint16_t *)value) = NETDEV_TYPE_BLE;
+            res = sizeof(uint16_t);
+            break;
+        default:
+            break;
+    }
+
+    return res;
+}
+
+static inline int _netdev_set(netdev_t *dev, netopt_t opt,
+                              const void *value, size_t val_len)
+{
+    (void)dev;
+    int res = -ENOTSUP;
+
+    switch (opt) {
+        case NETOPT_PROTO:
+            assert(val_len == sizeof(_nettype));
+            memcpy(&_nettype, value, sizeof(_nettype));
+            res = sizeof(_nettype);
+            break;
+        default:
+            break;
+    }
+
+    return res;
+}
+
+static const netdev_driver_t _nimble_netdev_driver = {
+    .send = NULL,
+    .recv = NULL,
+    .init = _netdev_init,
+    .isr  =  NULL,
+    .get  = _netdev_get,
+    .set  = _netdev_set,
+};
+
+static netdev_t _nimble_netdev_dummy = {
+    .driver = &_nimble_netdev_driver,
+};
+
+static void _on_data(nimble_netif_conn_t *conn, struct ble_l2cap_event *event)
+{
+    struct os_mbuf *rxb = event->receive.sdu_rx;
+    size_t rx_len = (size_t)OS_MBUF_PKTLEN(rxb);
+
+    /* allocate netif header */
+    gnrc_pktsnip_t *if_snip = gnrc_netif_hdr_build(conn->addr, BLE_ADDR_LEN,
+                                                   _nimble_netif->l2addr,
+                                                   BLE_ADDR_LEN);
+    if (if_snip == NULL) {
+        goto end;
+    }
+
+    /* we need to add the device PID to the netif header */
+    gnrc_netif_hdr_t *netif_hdr = (gnrc_netif_hdr_t *)if_snip->data;
+    netif_hdr->if_pid = _nimble_netif->pid;
+
+    /* allocate space in the pktbuf to store the packet */
+    gnrc_pktsnip_t *payload = gnrc_pktbuf_add(if_snip, NULL, rx_len, _nettype);
+    if (payload == NULL) {
+        gnrc_pktbuf_release(if_snip);
+        goto end;
+    }
+
+    /* copy payload from mbuf into pktbuffer */
+    int res = os_mbuf_copydata(rxb, 0, rx_len, payload->data);
+    if (res != 0) {
+        gnrc_pktbuf_release(payload);
+        goto end;
+    }
+
+    /* finally dispatch the receive packet to GNRC */
+    if (!gnrc_netapi_dispatch_receive(payload->type, GNRC_NETREG_DEMUX_CTX_ALL,
+                                      payload)) {
+        gnrc_pktbuf_release(payload);
+    }
+
+end:
+    /* free the mbuf and allocate a new one for receiving new data */
+    os_mbuf_free_chain(rxb);
+    rxb = os_mbuf_get_pkthdr(&_mbuf_pool, 0);
+    /* due to buffer provisioning, there should always be enough space */
+    assert(rxb != NULL);
+    ble_l2cap_recv_ready(event->receive.chan, rxb);
+}
+
+static int _on_l2cap_client_evt(struct ble_l2cap_event *event, void *arg)
+{
+    int handle = (int)arg;
+    nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
+    assert(conn && (conn->state & NIMBLE_NETIF_GAP_MASTER));
+
+    switch (event->type) {
+        case BLE_L2CAP_EVENT_COC_CONNECTED:
+            conn->coc = event->connect.chan;
+            conn->state |= NIMBLE_NETIF_L2CAP_CLIENT;
+            conn->state &= ~NIMBLE_NETIF_CONNECTING;
+            _notify(handle, NIMBLE_NETIF_CONNECTED_MASTER);
+            break;
+        case BLE_L2CAP_EVENT_COC_DISCONNECTED:
+            assert(conn->coc);
+            conn->coc = NULL;
+            conn->state &= ~NIMBLE_NETIF_L2CAP_CONNECTED;
+            break;
+        case BLE_L2CAP_EVENT_COC_ACCEPT:
+            /* this event should never be triggered for the L2CAP client */
+            assert(0);
+            break;
+        case BLE_L2CAP_EVENT_COC_DATA_RECEIVED:
+            _on_data(conn, event);
+            break;
+        case BLE_L2CAP_EVENT_COC_TX_UNSTALLED:
+            thread_flags_set(_netif_thread, FLAG_TX_UNSTALLED);
+            break;
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+static int _on_l2cap_server_evt(struct ble_l2cap_event *event, void *arg)
+{
+    (void)arg;
+    int handle;
+    nimble_netif_conn_t *conn;
+
+    switch (event->type) {
+        case BLE_L2CAP_EVENT_COC_CONNECTED:
+            handle = nimble_netif_conn_get_by_gaphandle(event->connect.conn_handle);
+            conn = nimble_netif_conn_get(handle);
+            assert(conn);
+            conn->coc = event->connect.chan;
+            conn->state |= NIMBLE_NETIF_L2CAP_SERVER;
+            conn->state &= ~(NIMBLE_NETIF_ADV | NIMBLE_NETIF_CONNECTING);
+            _notify(handle, NIMBLE_NETIF_CONNECTED_SLAVE);
+            break;
+        case BLE_L2CAP_EVENT_COC_DISCONNECTED:
+            conn = nimble_netif_conn_from_gaphandle(event->disconnect.conn_handle);
+            assert(conn && conn->coc);
+            conn->coc = NULL;
+            conn->state &= ~NIMBLE_NETIF_L2CAP_CONNECTED;
+            break;
+        case BLE_L2CAP_EVENT_COC_ACCEPT: {
+            struct os_mbuf *sdu_rx = os_mbuf_get_pkthdr(&_mbuf_pool, 0);
+            /* there should always be enough buffer space */
+            assert(sdu_rx != NULL);
+            ble_l2cap_recv_ready(event->accept.chan, sdu_rx);
+            break;
+        }
+        case BLE_L2CAP_EVENT_COC_DATA_RECEIVED:
+            conn = nimble_netif_conn_from_gaphandle(event->receive.conn_handle);
+            assert(conn);
+            _on_data(conn, event);
+            break;
+        case BLE_L2CAP_EVENT_COC_TX_UNSTALLED:
+            thread_flags_set(_netif_thread, FLAG_TX_UNSTALLED);
+            break;
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+static void _on_gap_connected(nimble_netif_conn_t *conn, uint16_t conn_handle)
+{
+    struct ble_gap_conn_desc desc;
+    int res = ble_gap_conn_find(conn_handle, &desc);
+    assert(res == 0);
+    (void)res;
+
+    conn->gaphandle = conn_handle;
+    bluetil_addr_swapped_cp(desc.peer_id_addr.val, conn->addr);
+}
+
+static int _on_gap_master_evt(struct ble_gap_event *event, void *arg)
+{
+    int res = 0;
+    int handle = (int)arg;
+    nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
+    assert(conn);
+
+    switch (event->type) {
+        case BLE_GAP_EVENT_CONNECT: {
+            if (event->connect.status != 0) {
+                nimble_netif_conn_free(handle);
+                _notify(handle, NIMBLE_NETIF_CONNECT_ABORT);
+                return 0;
+            }
+            _on_gap_connected(conn, event->connect.conn_handle);
+            conn->state |= NIMBLE_NETIF_GAP_MASTER;
+
+            struct os_mbuf *sdu_rx = os_mbuf_get_pkthdr(&_mbuf_pool, 0);
+            /* we should never run out of buffer space... */
+            assert(sdu_rx != NULL);
+            res = ble_l2cap_connect(event->connect.conn_handle,
+                                    NIMBLE_NETIF_CID, MTU_SIZE, sdu_rx,
+                                    _on_l2cap_client_evt, (void *)handle);
+            /* should always success as well */
+            assert(res == 0);
+            break;
+        }
+        case BLE_GAP_EVENT_DISCONNECT:
+            nimble_netif_conn_free(handle);
+            _notify(handle, NIMBLE_NETIF_CLOSED_MASTER);
+            break;
+        case BLE_GAP_EVENT_CONN_UPDATE:
+            _notify(handle, NIMBLE_NETIF_CONN_UPDATED);
+            break;
+        case BLE_GAP_EVENT_CONN_UPDATE_REQ:
+        case BLE_GAP_EVENT_MTU:
+            /* nothing to do here */
+            break;
+        default:
+            break;
+    }
+
+    return res;
+}
+
+static int _on_gap_slave_evt(struct ble_gap_event *event, void *arg)
+{
+    int handle = (int)arg;
+    nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
+    assert(conn);
+
+    switch (event->type) {
+        case BLE_GAP_EVENT_CONNECT: {
+            if (event->connect.status != 0) {
+                nimble_netif_conn_free(handle);
+                _notify(handle, NIMBLE_NETIF_CONNECT_ABORT);
+                break;
+            }
+            _on_gap_connected(conn, event->connect.conn_handle);
+            assert(conn->state == NIMBLE_NETIF_ADV);
+            conn->state = NIMBLE_NETIF_GAP_SLAVE;
+            break;
+        }
+        case BLE_GAP_EVENT_DISCONNECT:
+            nimble_netif_conn_free(handle);
+            _notify(handle, NIMBLE_NETIF_CLOSED_SLAVE);
+            break;
+        case BLE_GAP_EVENT_CONN_UPDATE:
+            _notify(handle, NIMBLE_NETIF_CONN_UPDATED);
+            break;
+        case BLE_GAP_EVENT_CONN_UPDATE_REQ:
+            /* nothing to do here */
+            break;
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+void nimble_netif_init(void)
+{
+    int res;
+    (void)res;
+
+    /* setup the connection context table */
+    nimble_netif_conn_init();
+
+    /* initialize of BLE related buffers */
+    res = os_mempool_init(&_mem_pool, MBUF_CNT, MBUF_SIZE, _mem, "nim_gnrc");
+    assert(res == 0);
+    res = os_mbuf_pool_init(&_mbuf_pool, &_mem_pool, MBUF_SIZE, MBUF_CNT);
+    assert(res == 0);
+
+    res = ble_l2cap_create_server(NIMBLE_NETIF_CID, MTU_SIZE,
+                                  _on_l2cap_server_evt, NULL);
+    assert(res == 0);
+    (void)res;
+
+    gnrc_netif_create(_stack, sizeof(_stack), GNRC_NETIF_PRIO,
+                      "nimble_netif", &_nimble_netdev_dummy, &_nimble_netif_ops);
+}
+
+void nimble_netif_eventcb(nimble_netif_eventcb_t cb)
+{
+    _eventcb = cb;
+}
+
+int nimble_netif_connect(const ble_addr_t *addr,
+                         const struct ble_gap_conn_params *conn_params,
+                         uint32_t timeout)
+{
+    assert(addr);
+    assert(_eventcb);
+
+    /* the netif_conn module expects addresses in network byte order */
+    uint8_t addrn[BLE_ADDR_LEN];
+    bluetil_addr_swapped_cp(addr->val, addrn);
+
+    /* check that there is no open connection with the given address */
+    if (nimble_netif_conn_connected(addrn) ||
+        nimble_netif_conn_connecting()) {
+        return NIMBLE_NETIF_BUSY;
+    }
+
+    /* get empty connection context */
+    int handle = nimble_netif_conn_start_connection(addrn);
+    if (handle == NIMBLE_NETIF_CONN_INVALID) {
+        return NIMBLE_NETIF_NOMEM;
+    }
+
+    int res = ble_gap_connect(nimble_riot_own_addr_type, addr, timeout,
+                              conn_params, _on_gap_master_evt, (void *)handle);
+    assert(res == 0);
+    (void)res;
+
+    return handle;
+}
+
+int nimble_netif_close(int handle)
+{
+    nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
+    if (conn == NULL) {
+        return NIMBLE_NETIF_NOTFOUND;
+    }
+    else if (!(conn->state & NIMBLE_NETIF_L2CAP_CONNECTED)) {
+        return NIMBLE_NETIF_NOTCONN;
+    }
+
+    int res = ble_gap_terminate(ble_l2cap_get_conn_handle(conn->coc),
+                                BLE_ERR_REM_USER_CONN_TERM);
+    assert(res == 0);
+    (void)res;
+
+    return NIMBLE_NETIF_OK;
+}
+
+int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
+                        const struct ble_gap_adv_params *adv_params)
+{
+    assert(ad);
+    assert(adv_params);
+
+    int handle;
+    int res;
+    (void)res;
+
+    /* allocate a connection context for incoming connections */
+    handle = nimble_netif_conn_start_adv();
+    if (handle < 0) {
+        return handle;
+    }
+
+    /* set advertisement data */
+    res = ble_gap_adv_set_data(ad, (int)ad_len);
+    assert(res == 0);
+    /* remember context and start advertising */
+    res = ble_gap_adv_start(nimble_riot_own_addr_type, NULL, BLE_HS_FOREVER,
+                            adv_params, _on_gap_slave_evt, (void *)handle);
+    assert(res == 0);
+
+    return NIMBLE_NETIF_OK;
+}
+
+int nimble_netif_accept_stop(void)
+{
+    int handle = nimble_netif_conn_get_adv();
+    if (handle == NIMBLE_NETIF_CONN_INVALID) {
+        return NIMBLE_NETIF_NOTADV;
+    }
+
+    int res = ble_gap_adv_stop();
+    assert(res == 0);
+    (void)res;
+    nimble_netif_conn_free(handle);
+
+    return NIMBLE_NETIF_OK;
+}
+
+int nimble_netif_update(int handle,
+                        const struct ble_gap_upd_params *conn_params)
+{
+    nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
+    if (conn == NULL) {
+        return NIMBLE_NETIF_NOTCONN;
+    }
+
+    int res = ble_gap_update_params(conn->gaphandle, conn_params);
+    if (res != 0) {
+        return NIMBLE_NETIF_DEVERR;
+    }
+
+    return NIMBLE_NETIF_OK;
+}

--- a/pkg/nimble/netif/nimble_netif_conn.c
+++ b/pkg/nimble/netif/nimble_netif_conn.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2018-2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_nimble_netif_conn
+ * @{
+ *
+ * @file
+ * @brief       Connection context handling for NimBLE netif
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "nimble_netif_conn.h"
+
+#define ENABLE_DEBUG            (0)
+#include "debug.h"
+
+#define CONN_CNT                (MYNEWT_VAL_BLE_MAX_CONNECTIONS)
+
+static mutex_t _lock = MUTEX_INIT;
+static nimble_netif_conn_t _conn[CONN_CNT];
+
+static int _find_by_state(uint16_t filter)
+{
+    for (unsigned i = 0; i < CONN_CNT; i++) {
+        if (_conn[i].state & filter) {
+            return (int)i;
+        }
+    }
+    return NIMBLE_NETIF_CONN_INVALID;
+}
+
+void nimble_netif_conn_init(void)
+{
+    DEBUG("conn_init\n");
+    memset(_conn, 0, sizeof(_conn));
+    for (unsigned i = 0; i < CONN_CNT; i++) {
+        _conn[i].state = NIMBLE_NETIF_UNUSED;
+    }
+}
+
+nimble_netif_conn_t *nimble_netif_conn_get(int handle)
+{
+    if ((handle < 0) || (handle >= CONN_CNT)) {
+        return NULL;
+    }
+    return &_conn[handle];
+}
+
+int nimble_netif_conn_get_adv(void)
+{
+    int handle;
+    DEBUG("nimble_netif_conn_get_adv\n");
+    mutex_lock(&_lock);
+    handle = _find_by_state(NIMBLE_NETIF_ADV);
+    mutex_unlock(&_lock);
+    return handle;
+}
+
+int nimble_netif_conn_get_connecting(void)
+{
+    int handle;
+    DEBUG("nimble_netif_conn_get_connecting\n");
+    mutex_lock(&_lock);
+    handle = _find_by_state(NIMBLE_NETIF_CONNECTING);
+    mutex_unlock(&_lock);
+    DEBUG("nimble_netif_conn_get_connecting - handle %i\n", handle);
+    return handle;
+}
+
+int nimble_netif_conn_get_by_addr(const uint8_t *addr)
+{
+    assert(addr);
+    int handle = NIMBLE_NETIF_CONN_INVALID;
+
+    DEBUG("nimble_netif_conn_get_by_addr %02x\n", (int)addr[5]);
+    mutex_lock(&_lock);
+    for (unsigned i = 0; i < CONN_CNT; i++) {
+        if ((_conn[i].state & NIMBLE_NETIF_L2CAP_CONNECTED) &&
+            memcmp(_conn[i].addr, addr, BLE_ADDR_LEN) == 0) {
+            handle = (int)i;
+            break;
+        }
+    }
+    mutex_unlock(&_lock);
+    DEBUG("nimble_netif_conn_get_by_addr - found: %i\n", handle);
+
+    return handle;
+}
+
+int nimble_netif_conn_get_by_gaphandle(uint16_t gaphandle)
+{
+    int handle = NIMBLE_NETIF_CONN_INVALID;
+
+    DEBUG("nimble_netif_conn_get_by_gaphandle %i\n", (int)gaphandle);
+    mutex_lock(&_lock);
+    for (unsigned i = 0; i < CONN_CNT; i++) {
+        if (_conn[i].gaphandle == gaphandle) {
+            handle = (int)i;
+            break;
+        }
+    }
+    mutex_unlock(&_lock);
+    DEBUG("nimble_netif_conn_get_by_gaphandle - found %i\n", handle);
+
+    return handle;
+}
+
+int nimble_netif_conn_start_connection(const uint8_t *addr)
+{
+    int handle;
+
+    DEBUG("nimble_netif_conn_start_connection, addr %02x\n", (int)addr[5]);
+    mutex_lock(&_lock);
+    handle = _find_by_state(NIMBLE_NETIF_UNUSED);
+    if (handle != NIMBLE_NETIF_CONN_INVALID) {
+        _conn[handle].state = NIMBLE_NETIF_CONNECTING;
+        memcpy(_conn[handle].addr, addr, BLE_ADDR_LEN);
+    }
+
+    mutex_unlock(&_lock);
+
+    return handle;
+}
+
+int nimble_netif_conn_start_adv(void)
+{
+    int handle;
+
+    DEBUG("nimble_netif_conn_start_adv\n");
+    mutex_lock(&_lock);
+    handle = _find_by_state(NIMBLE_NETIF_ADV);
+    if (handle != NIMBLE_NETIF_CONN_INVALID) {
+        handle = NIMBLE_NETIF_BUSY;
+    }
+    else {
+        handle = _find_by_state(NIMBLE_NETIF_UNUSED);
+        if (handle != NIMBLE_NETIF_CONN_INVALID) {
+            _conn[handle].state = NIMBLE_NETIF_ADV;
+        }
+        else {
+            handle = NIMBLE_NETIF_NOMEM;
+        }
+
+    }
+    mutex_unlock(&_lock);
+
+    return handle;
+}
+
+void nimble_netif_conn_free(int handle)
+{
+    assert((handle >= 0) && (handle < CONN_CNT));
+
+    DEBUG("nimble_netif_conn_free, handle %i\n", handle);
+    mutex_lock(&_lock);
+    memset(&_conn[handle], 0, sizeof(nimble_netif_conn_t));
+    _conn[handle].state = NIMBLE_NETIF_UNUSED;
+    mutex_unlock(&_lock);
+}
+
+void nimble_netif_conn_foreach(uint16_t filter,
+                               nimble_netif_conn_iter_t cb, void *arg)
+{
+    assert(cb);
+
+    DEBUG("nimble_netif_conn_foreach 0x%04x\n", (int)filter);
+    mutex_lock(&_lock);
+    for (unsigned i = 0; i < CONN_CNT; i++) {
+        if (_conn[i].state & filter) {
+            int res = cb(&_conn[i], (int)i, arg);
+            if (res != 0) {
+                break;
+            }
+        }
+    }
+    mutex_unlock(&_lock);
+}
+
+unsigned nimble_netif_conn_count(uint16_t filter)
+{
+    unsigned cnt = 0;
+
+    DEBUG("nimble_netif_conn_count, filter 0x%04x\n", (int)filter);
+    mutex_lock(&_lock);
+    for (unsigned i = 0; i < CONN_CNT; i++) {
+        if (_conn[i].state & filter) {
+            ++cnt;
+        }
+    }
+    mutex_unlock(&_lock);
+
+    return cnt;
+}

--- a/pkg/nimble/scanlist/nimble_scanlist.c
+++ b/pkg/nimble/scanlist/nimble_scanlist.c
@@ -55,6 +55,15 @@ void nimble_scanlist_init(void)
     }
 }
 
+nimble_scanlist_entry_t *nimble_scanlist_get_by_pos(unsigned pos)
+{
+    nimble_scanlist_entry_t *e = nimble_scanlist_get_next(NULL);
+    for (unsigned i = 0; (i < pos) && e; i++) {
+        e = nimble_scanlist_get_next(e);
+    }
+    return e;
+}
+
 void nimble_scanlist_update(const ble_addr_t *addr, int8_t rssi,
                             const uint8_t *ad, size_t len)
 {

--- a/sys/include/net/ble.h
+++ b/sys/include/net/ble.h
@@ -282,6 +282,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Channel identifiers defined for L2CAP LE-U link layers
+ * @{
+ */
+#define BLE_L2CAP_CID_IPSP                  (0x0023)
+#define BLE_L2CAP_CID_CB_MIN                (0x0040)
+#define BLE_L2CAP_CID_CB_MAX                (0x007f)
+/** @} */
+
+/**
  * @name    ATT protocol opcodes
  * @{
  */

--- a/sys/include/net/bluetil/addr.h
+++ b/sys/include/net/bluetil/addr.h
@@ -40,6 +40,15 @@ extern "C" {
 #define BLUETIL_IPV6_IID_STRLEN     (28U)
 
 /**
+ * @brief   Copy address and swap the byte order in the target buffer
+ *
+ * @param[in] src       buffer with source address, *must* hold BLE_ADDR_LEN
+ *                      bytes
+ * @param[out] dst      target buffer, *must* be able to hold BLE_ADDR_LEN bytes
+ */
+void bluetil_addr_swapped_cp(const uint8_t *src, uint8_t *dst);
+
+/**
  * @brief   Convert the given BLE address to a human readable string
  *
  * @param[out] out      '\0' terminated address string, *must* be able to hold

--- a/sys/include/net/bluetil/addr.h
+++ b/sys/include/net/bluetil/addr.h
@@ -73,6 +73,9 @@ void bluetil_addr_print(const uint8_t *addr);
 /**
  * @brief   Parse a BLE address from the given string
  *
+ * @note    The address is expected most significant byte first and is written
+ *          to @p addr in network byte order
+ *
  * @param[out] addr     buffer to write the BLE address, *must* be able to hold
  *                      @ref BLE_ADDR_LEN bytes
  * @param[in] addr_str  address string, must be at least of length

--- a/sys/include/net/bluetil/addr.h
+++ b/sys/include/net/bluetil/addr.h
@@ -42,25 +42,31 @@ extern "C" {
 /**
  * @brief   Copy address and swap the byte order in the target buffer
  *
- * @param[in] src       buffer with source address, *must* hold BLE_ADDR_LEN
+ * @param[in] src       buffer with source address, *must* hold
+ *                      @ref BLE_ADDR_LEN bytes
+ * @param[out] dst      target buffer, *must* be able to hold @ref BLE_ADDR_LEN
  *                      bytes
- * @param[out] dst      target buffer, *must* be able to hold BLE_ADDR_LEN bytes
  */
 void bluetil_addr_swapped_cp(const uint8_t *src, uint8_t *dst);
 
 /**
  * @brief   Convert the given BLE address to a human readable string
  *
+ * @note    The address is expected to be in network byte order
+ *
  * @param[out] out      '\0' terminated address string, *must* be able to hold
- *                      BLUETIL_ADDR_STRLEN bytes
- * @param[in] addr      address buffer, *must* hold BLE_ADDR_LEN bytes
+ *                      @ref BLUETIL_ADDR_STRLEN bytes
+ * @param[in] addr      address buffer, *must* hold @ref BLE_ADDR_LEN bytes
  */
 void bluetil_addr_sprint(char *out, const uint8_t *addr);
 
 /**
  * @brief   Print the given BLE address to STDOUT
  *
- * @param[in] addr      address to print, is expected to hold BLE_ADDR_LEN bytes
+ * @note    The address is expected to be in network byte order
+ *
+ * @param[in] addr      address to print, is expected to hold @ref BLE_ADDR_LEN
+ *                      bytes
  */
 void bluetil_addr_print(const uint8_t *addr);
 
@@ -68,9 +74,9 @@ void bluetil_addr_print(const uint8_t *addr);
  * @brief   Parse a BLE address from the given string
  *
  * @param[out] addr     buffer to write the BLE address, *must* be able to hold
- *                      BLE_ADDR_LEN bytes
+ *                      @ref BLE_ADDR_LEN bytes
  * @param[in] addr_str  address string, must be at least of length
- *                      (BLUETIL_ADDR_STRLEN - 1)
+ *                      (@ref BLUETIL_ADDR_STRLEN - 1)
  *
  * @return  a pointer to the resulting address on success
  * @return  NULL on parsing error
@@ -81,15 +87,19 @@ uint8_t *bluetil_addr_from_str(uint8_t *addr, const char *addr_str);
  * @brief   Get a string representation of the given BLE addresses IID-based
  *          link local address
  *
+ * @note    The address is expected to be in network byte order
+ *
  * @param[out] out      '\0' terminated string, *must* be able to hold
- *                      BLUETIL_IPV6_IID_STRLEN bytes
- * @param[in]  addr     address to convert, , *must* hold BLE_ADDR_LEN bytes
+ *                      @ref BLUETIL_IPV6_IID_STRLEN bytes
+ * @param[in]  addr     address to convert, , *must* hold @ref BLE_ADDR_LEN bytes
  */
 void bluetil_addr_ipv6_l2ll_sprint(char *out, const uint8_t *addr);
 
 /**
  * @brief   Dump the given BLE addresses IPv6 IID-based link local address to
  *          STDIO
+ *
+ * @note    The address is expected to be in network byte order
  *
  * @param[in] addr      generate IID for this address
  */

--- a/sys/net/ble/bluetil/bluetil_addr/bluetil_addr.c
+++ b/sys/net/ble/bluetil/bluetil_addr/bluetil_addr.c
@@ -78,12 +78,12 @@ uint8_t *bluetil_addr_from_str(uint8_t *addr, const char *addr_str)
         }
     }
 
-    unsigned pos = BLE_ADDR_LEN;
+    unsigned pos = 0;
     for (unsigned i = 0; i < (BLUETIL_ADDR_STRLEN - 1); i += 3) {
         if (!_is_hex_char(addr_str[i]) || !_is_hex_char(addr_str[i + 1])) {
             return NULL;
         }
-        addr[--pos] = fmt_hex_byte(addr_str + i);
+        addr[pos++] = fmt_hex_byte(addr_str + i);
     }
     return addr;
 }

--- a/sys/net/ble/bluetil/bluetil_addr/bluetil_addr.c
+++ b/sys/net/ble/bluetil/bluetil_addr/bluetil_addr.c
@@ -33,6 +33,16 @@ static int _is_hex_char(char c)
             ((c >= 'a') && (c <= 'f')));
 }
 
+void bluetil_addr_swapped_cp(const uint8_t *src, uint8_t *dst)
+{
+    dst[0] = src[5];
+    dst[1] = src[4];
+    dst[2] = src[3];
+    dst[3] = src[2];
+    dst[4] = src[1];
+    dst[5] = src[0];
+}
+
 void bluetil_addr_sprint(char *out, const uint8_t *addr)
 {
     assert(out);

--- a/sys/net/ble/bluetil/bluetil_addr/bluetil_addr.c
+++ b/sys/net/ble/bluetil/bluetil_addr/bluetil_addr.c
@@ -23,7 +23,6 @@
 
 #include "fmt.h"
 #include "assert.h"
-#include "net/eui48.h"
 #include "net/bluetil/addr.h"
 
 static int _is_hex_char(char c)
@@ -48,8 +47,8 @@ void bluetil_addr_sprint(char *out, const uint8_t *addr)
     assert(out);
     assert(addr);
 
-    fmt_byte_hex(out, addr[5]);
-    for (int i = 4; i >= 0; i--) {
+    fmt_byte_hex(out, addr[0]);
+    for (unsigned i = 1; i < BLE_ADDR_LEN; i++) {
         out += 2;
         *out++ = ':';
         fmt_byte_hex(out, addr[i]);
@@ -94,17 +93,18 @@ void bluetil_addr_ipv6_l2ll_sprint(char *out, const uint8_t *addr)
     assert(out);
     assert(addr);
 
-    eui64_t iid;
-    eui48_to_ipv6_iid(&iid, (const eui48_t *)addr);
-    memcpy(out, "[FE80::", 6);
-    out += 6;
-    for (unsigned i = 0; i < 4; i++) {
-        *out++ = ':';
-        fmt_byte_hex(out, iid.uint8[i * 2]);
-        out += 2;
-        fmt_byte_hex(out, iid.uint8[(i * 2) + 1]);
-        out += 2;
-    }
+    memcpy(out, "[FE80::", 7);
+    out += 7;
+    out += fmt_byte_hex(out, addr[0]);
+    out += fmt_byte_hex(out, addr[1]);
+    *out++ = ':';
+    out += fmt_byte_hex(out, addr[2]);
+    memcpy(out, "FF:FE", 5);
+    out += 5;
+    out += fmt_byte_hex(out, addr[3]);
+    *out++ = ':';
+    out += fmt_byte_hex(out, addr[4]);
+    out += fmt_byte_hex(out, addr[5]);
     *out++ = ']';
     *out = '\0';
 }

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -32,7 +32,7 @@ netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif)
 
     switch (netif->device_type) {
 #if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) || \
-    defined(MODULE_NORDIC_SOFTDEVICE_BLE)
+    defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
         case NETDEV_TYPE_IEEE802154:
         case NETDEV_TYPE_BLE: {
                 netdev_t *dev = netif->dev;
@@ -128,7 +128,7 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
 #endif
             break;
 #endif
-#ifdef MODULE_NORDIC_SOFTDEVICE_BLE
+#if defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
         case NETDEV_TYPE_BLE:
             netif->ipv6.mtu = IPV6_MIN_MTU;
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC

--- a/sys/net/link_layer/l2util/l2util.c
+++ b/sys/net/link_layer/l2util/l2util.c
@@ -41,7 +41,7 @@ int l2util_eui64_from_addr(int dev_type, const uint8_t *addr, size_t addr_len,
 {
     switch (dev_type) {
 #if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
-defined(MODULE_NORDIC_SOFTDEVICE_BLE)
+    defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
         case NETDEV_TYPE_ETHERNET:
         case NETDEV_TYPE_ESP_NOW:
         case NETDEV_TYPE_BLE:
@@ -133,14 +133,15 @@ int l2util_ipv6_iid_to_addr(int dev_type, const eui64_t *iid, uint8_t *addr)
 {
     switch (dev_type) {
 #if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
-    defined(MODULE_NORDIC_SOFTDEVICE_BLE)
+    defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
         case NETDEV_TYPE_ETHERNET:
         case NETDEV_TYPE_ESP_NOW:
         case NETDEV_TYPE_BLE:
             eui48_from_ipv6_iid((eui48_t *)addr, iid);
             return sizeof(eui48_t);
 #endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
-         * defined(MODULE_NORDIC_SOFTDEVICE_BLE) */
+         * defined(MODULE_NORDIC_SOFTDEVICE_BLE) || \
+         * defined(MODULE_NIMBLE_NETIF) */
 #if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE)
         case NETDEV_TYPE_IEEE802154:
             /* assume address was based on EUI-64
@@ -183,7 +184,7 @@ int l2util_ndp_addr_len_from_l2ao(int dev_type,
             return sizeof(uint8_t);
 #endif  /* MODULE_CC110X */
 #if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
-    defined(MODULE_NORDIC_SOFTDEVICE_BLE)
+    defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
         case NETDEV_TYPE_ETHERNET:
         case NETDEV_TYPE_ESP_NOW:
         case NETDEV_TYPE_BLE:

--- a/sys/net/link_layer/l2util/l2util.c
+++ b/sys/net/link_layer/l2util/l2util.c
@@ -52,7 +52,8 @@ int l2util_eui64_from_addr(int dev_type, const uint8_t *addr, size_t addr_len,
             else {
                 return -EINVAL;
             }
-#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) */
+#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) \
+           defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF) */
 #if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE)
         case NETDEV_TYPE_IEEE802154:
             switch (addr_len) {
@@ -118,6 +119,11 @@ int l2util_ipv6_iid_from_addr(int dev_type,
                 return -EINVAL;
             }
 #endif  /* defined(MODULE_CC110X) || defined(MODULE_NRFMIN) */
+#if defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
+        case NETDEV_TYPE_BLE:
+            /* for BLE we don't flip the universal/local flag... */
+            return l2util_eui64_from_addr(dev_type, addr, addr_len, iid);
+#endif  /* defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF) */
         default: {
             int res = l2util_eui64_from_addr(dev_type, addr, addr_len, iid);
             if (res == sizeof(eui64_t)) {
@@ -132,16 +138,22 @@ int l2util_ipv6_iid_from_addr(int dev_type,
 int l2util_ipv6_iid_to_addr(int dev_type, const eui64_t *iid, uint8_t *addr)
 {
     switch (dev_type) {
-#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
-    defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
+#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW)
         case NETDEV_TYPE_ETHERNET:
         case NETDEV_TYPE_ESP_NOW:
-        case NETDEV_TYPE_BLE:
             eui48_from_ipv6_iid((eui48_t *)addr, iid);
             return sizeof(eui48_t);
-#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
-         * defined(MODULE_NORDIC_SOFTDEVICE_BLE) || \
-         * defined(MODULE_NIMBLE_NETIF) */
+#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) */
+#if defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
+        case NETDEV_TYPE_BLE:
+            addr[0] = iid->uint8[0];
+            addr[1] = iid->uint8[1];
+            addr[2] = iid->uint8[2];
+            addr[3] = iid->uint8[5];
+            addr[4] = iid->uint8[6];
+            addr[5] = iid->uint8[7];
+            return sizeof(eui48_t);
+#endif  /* defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF) */
 #if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE)
         case NETDEV_TYPE_IEEE802154:
             /* assume address was based on EUI-64
@@ -195,7 +207,8 @@ int l2util_ndp_addr_len_from_l2ao(int dev_type,
             else {
                 return -EINVAL;
             }
-#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) */
+#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) \
+           defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF) */
 #ifdef MODULE_NRFMIN
         case NETDEV_TYPE_NRFMIN:
             (void)opt;

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -85,4 +85,8 @@ ifneq (,$(filter semtech-loramac,$(USEPKG)))
   SRC += sc_loramac.c
 endif
 
+ifneq (,$(filter nimble_netif,$(USEMODULE)))
+  SRC += sc_nimble_netif.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -1,0 +1,390 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell commands to control NimBLEs netif wrapper
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "xtimer.h"
+#include "nimble_riot.h"
+#include "nimble_scanlist.h"
+#include "nimble_scanner.h"
+#include "nimble_netif.h"
+#include "nimble_netif_conn.h"
+#include "net/bluetil/ad.h"
+#include "net/bluetil/addr.h"
+
+#define DEFAULT_NODE_NAME           "RIOT-GNRC"
+#define DEFAULT_SCAN_DURATION       (500U)      /* 500ms */
+#define DEFAULT_CONN_TIMEOUT        (500U)      /* 500ms */
+
+static void _on_ble_evt(int handle, nimble_netif_event_t event)
+{
+    switch (event) {
+        case NIMBLE_NETIF_CONNECTED_MASTER: {
+            printf("event: handle %i -> CONNECTED as MASTER (", handle);
+            bluetil_addr_print(nimble_netif_conn_get(handle)->addr);
+            puts(")");
+            break;
+        }
+        case NIMBLE_NETIF_CONNECTED_SLAVE:
+            printf("event: handle %i -> CONNECTED as SLAVE (", handle);
+            bluetil_addr_print(nimble_netif_conn_get(handle)->addr);
+            puts(")");
+            break;
+        case NIMBLE_NETIF_CLOSED_MASTER:
+        case NIMBLE_NETIF_CLOSED_SLAVE:
+            printf("event: handle %i -> CONNECTION CLOSED\n", handle);
+            break;
+        case NIMBLE_NETIF_CONNECT_ABORT:
+            printf("event: handle %i -> CONNECTION ABORT\n", handle);
+            break;
+        case NIMBLE_NETIF_CONN_UPDATED:
+        default:
+            /* do nothing */
+            break;
+    }
+}
+
+static int _conn_dump(nimble_netif_conn_t *conn, int handle, void *arg)
+{
+    (void)arg;
+    char role = (conn->state & NIMBLE_NETIF_GAP_MASTER) ? 'M' : 'S';
+
+    printf("[%2i] ", handle);
+    bluetil_addr_print(conn->addr);
+    printf(" (%c) -> ", role);
+    bluetil_addr_ipv6_l2ll_print(conn->addr);
+    puts("");
+
+    return 0;
+}
+
+static int _conn_state_dump(nimble_netif_conn_t *conn, int handle, void *arg)
+{
+    (void)arg;
+    printf("[%2i] state: 0x%04x -", handle, conn->state);
+    if (conn->state & NIMBLE_NETIF_UNUSED) {
+        printf(" unused");
+    }
+    if (conn->state & NIMBLE_NETIF_CONNECTING) {
+        printf(" connecting");
+    }
+    if (conn->state & NIMBLE_NETIF_ADV) {
+        printf(" advertising");
+    }
+    if (conn->state & NIMBLE_NETIF_GAP_SLAVE) {
+        printf(" GAP-slave");
+    }
+    if (conn->state & NIMBLE_NETIF_GAP_MASTER) {
+        printf(" GAP-master");
+    }
+    if (conn->state & NIMBLE_NETIF_L2CAP_SERVER) {
+        printf(" L2CAP-server");
+    }
+    if (conn->state & NIMBLE_NETIF_L2CAP_CLIENT) {
+        printf(" L2CAP-client");
+    }
+    puts("");
+    return 0;
+}
+
+static void _conn_list(void)
+{
+    nimble_netif_conn_foreach(NIMBLE_NETIF_L2CAP_CONNECTED, _conn_dump, NULL);
+}
+
+static void _cmd_info(void)
+{
+    unsigned free = nimble_netif_conn_count(NIMBLE_NETIF_UNUSED);
+    unsigned active = nimble_netif_conn_count(NIMBLE_NETIF_L2CAP_CONNECTED);
+
+    uint8_t own_addr[BLE_ADDR_LEN];
+    uint8_t tmp_addr[BLE_ADDR_LEN];
+    ble_hs_id_copy_addr(nimble_riot_own_addr_type, tmp_addr, NULL);
+    bluetil_addr_swapped_cp(tmp_addr, own_addr);
+    printf("Own Address: ");
+    bluetil_addr_print(own_addr);
+    printf(" -> ");
+    bluetil_addr_ipv6_l2ll_print(own_addr);
+    puts("");
+
+    printf(" Free slots: %u/%u\n", free, MYNEWT_VAL_BLE_MAX_CONNECTIONS);
+    printf("Advertising: ");
+    if (nimble_netif_conn_get_adv() != NIMBLE_NETIF_CONN_INVALID) {
+        puts("yes");
+    }
+    else {
+        puts("no");
+    }
+
+    if (active > 0) {
+        printf("Connections: %u\n", active);
+        _conn_list();
+    }
+
+    puts("   Contexts:");
+    nimble_netif_conn_foreach(NIMBLE_NETIF_ANY, _conn_state_dump, NULL);
+
+    puts("");
+}
+
+static void _cmd_adv(const char *name)
+{
+    int res;
+    (void)res;
+    uint8_t buf[BLE_HS_ADV_MAX_SZ];
+    bluetil_ad_t ad;
+    const struct ble_gap_adv_params _adv_params = {
+        .conn_mode = BLE_GAP_CONN_MODE_UND,
+        .disc_mode = BLE_GAP_DISC_MODE_LTD,
+        .itvl_min = BLE_GAP_ADV_FAST_INTERVAL2_MIN,
+        .itvl_max = BLE_GAP_ADV_FAST_INTERVAL2_MAX,
+    };
+
+    /* make sure no advertising is in progress */
+    if (nimble_netif_conn_is_adv()) {
+        puts("err: advertising already in progress");
+        return;
+    }
+
+    /* build advertising data */
+    res = bluetil_ad_init_with_flags(&ad, buf, BLE_HS_ADV_MAX_SZ,
+                                     BLUETIL_AD_FLAGS_DEFAULT);
+    assert(res == BLUETIL_AD_OK);
+    uint16_t ipss = BLE_GATT_SVC_IPSS;
+    res = bluetil_ad_add(&ad, BLE_GAP_AD_UUID16_INCOMP, &ipss, sizeof(ipss));
+    assert(res == BLUETIL_AD_OK);
+    if (name == NULL) {
+        name = DEFAULT_NODE_NAME;
+    }
+    res = bluetil_ad_add(&ad, BLE_GAP_AD_NAME, name, strlen(name));
+    if (res != BLUETIL_AD_OK) {
+        puts("err: the given name is too long");
+        return;
+    }
+
+    /* start listening for incoming connections */
+    res = nimble_netif_accept(ad.buf, ad.pos, &_adv_params);
+    if (res != NIMBLE_NETIF_OK) {
+        printf("err: unable to start advertising (%i)\n", res);
+    }
+    else {
+        printf("success: advertising this node as '%s'\n", name);
+    }
+}
+
+static void _cmd_adv_stop(void)
+{
+    int res = nimble_netif_accept_stop();
+    if (res == NIMBLE_NETIF_OK) {
+        puts("canceled advertising");
+    }
+    else if (res == NIMBLE_NETIF_NOTADV) {
+        puts("no advertising in progress");
+    }
+}
+
+static void _cmd_scan(unsigned duration)
+{
+    if (duration == 0) {
+        return;
+    }
+    printf("scanning (for %ums) ... ", (duration / 1000));
+    nimble_scanlist_clear();
+    nimble_scanner_start();
+    xtimer_usleep(duration);
+    nimble_scanner_stop();
+    puts("done");
+    nimble_scanlist_print();
+}
+
+static void _cmd_connect_addr(ble_addr_t *addr)
+{
+    /* simply use NimBLEs default connection parameters */
+    int res = nimble_netif_connect(addr, NULL, DEFAULT_CONN_TIMEOUT);
+    if (res < 0) {
+        printf("err: unable to trigger connection sequence (%i)\n", res);
+        return;
+    }
+
+    printf("initiated connection procedure with ");
+    uint8_t addrn[BLE_ADDR_LEN];
+    bluetil_addr_swapped_cp(addr->val, addrn);
+    bluetil_addr_print(addrn);
+    puts("");
+
+}
+
+static void _cmd_connect_addstr(const char *addr_str)
+{
+    uint8_t tmp[BLE_ADDR_LEN];
+    /* RANDOM is the most common type, has no noticeable effect when connecting
+       anyhow... */
+    ble_addr_t addr = { .type = BLE_ADDR_RANDOM };
+
+    if (bluetil_addr_from_str(tmp, addr_str) == NULL) {
+        puts("err: unable to parse address");
+        return;
+    }
+    /* NimBLE expects address in little endian, so swap */
+    bluetil_addr_swapped_cp(tmp, addr.val);
+    _cmd_connect_addr(&addr);
+}
+
+static void _cmd_connect(unsigned pos)
+{
+    nimble_scanlist_entry_t *sle = nimble_scanlist_get_by_pos(pos);
+    if (sle == NULL) {
+        puts("err: unable to find given entry in scanlist");
+        return;
+    }
+    _cmd_connect_addr(&sle->addr);
+}
+
+static void _cmd_close(int handle)
+{
+    int res = nimble_netif_close(handle);
+    if (res != NIMBLE_NETIF_OK) {
+        puts("err: unable to close connection with given handle");
+    }
+    else {
+        puts("success: connection tear down initiated");
+    }
+}
+
+static void _cmd_update(int handle, int itvl, int timeout)
+{
+    struct ble_gap_upd_params params;
+    params.itvl_min = (uint16_t)((itvl * 1000) / BLE_HCI_CONN_ITVL);
+    params.itvl_max = (uint16_t)((itvl * 1000) / BLE_HCI_CONN_ITVL);
+    params.latency = 0;
+    params.supervision_timeout = (uint16_t)(timeout / 10);
+    params.min_ce_len = BLE_GAP_INITIAL_CONN_MIN_CE_LEN;
+    params.max_ce_len = BLE_GAP_INITIAL_CONN_MAX_CE_LEN;
+
+    int res = nimble_netif_update(handle, &params);
+    if (res != NIMBLE_NETIF_OK) {
+        puts("err: unable to update connection parameters for given handle");
+    }
+    else {
+        puts("success: connection parameters updated");
+    }
+}
+
+static int _ishelp(char *argv)
+{
+    return memcmp(argv, "help", 4) == 0;
+}
+
+void sc_nimble_netif_init(void)
+{
+    /* setup the scanning environment */
+    nimble_scanlist_init();
+    nimble_scanner_init(NULL, nimble_scanlist_update);
+
+    /* register event callback with the netif wrapper */
+    nimble_netif_eventcb(_on_ble_evt);
+}
+
+int _nimble_netif_handler(int argc, char **argv)
+{
+    if ((argc == 1) || _ishelp(argv[1])) {
+        printf("usage: %s [help|info|adv|scan|connect|close|update]\n", argv[0]);
+        return 0;
+    }
+    if (memcmp(argv[1], "info", 4) == 0) {
+        _cmd_info();
+    }
+    else if (memcmp(argv[1], "adv", 3) == 0) {
+        char *name = NULL;
+        if (argc > 2) {
+            if (_ishelp(argv[2])) {
+                printf("usage: %s adv [help|stop|<name>]\n", argv[0]);
+                return 0;
+            }
+            if (memcmp(argv[2], "stop", 4) == 0) {
+                _cmd_adv_stop();
+                return 0;
+            }
+            name = argv[2];
+        }
+        _cmd_adv(name);
+    }
+    else if (memcmp(argv[1], "scan", 4) == 0) {
+        uint32_t duration = DEFAULT_SCAN_DURATION;
+        if (argc > 2) {
+            if (_ishelp(argv[2])) {
+                printf("usage: %s scan [help|list|[duration in ms]]\n", argv[0]);
+                return 0;
+            }
+            if (memcmp(argv[2], "list", 4) == 0) {
+                nimble_scanlist_print();
+                return 0;
+            }
+            duration = atoi(argv[2]);
+        }
+        _cmd_scan(duration * 1000);
+    }
+    else if (memcmp(argv[1], "connect", 7) == 0) {
+        if ((argc < 3) || _ishelp(argv[2])) {
+            printf("usage: %s connect [help|list|<scanlist entry #>|<BLE addr>]\n",
+                   argv[0]);
+        }
+        if (memcmp(argv[2], "list", 4) == 0) {
+            _conn_list();
+            return 0;
+        }
+        if (strlen(argv[2]) == (BLUETIL_ADDR_STRLEN - 1)) {
+            _cmd_connect_addstr(argv[2]);
+            return 0;
+        }
+        unsigned pos = atoi(argv[2]);
+        _cmd_connect(pos);
+    }
+    else if (memcmp(argv[1], "close", 5) == 0) {
+        if ((argc < 3) || _ishelp(argv[2])) {
+            printf("usage: %s close [help|list|<conn #>]\n", argv[0]);
+            return 0;
+        }
+        if (memcmp(argv[2], "list", 4) == 0) {
+            _conn_list();
+            return 0;
+        }
+        int handle = atoi(argv[2]);
+        _cmd_close(handle);
+    }
+    else if ((memcmp(argv[1], "update", 6) == 0)) {
+        if ((argc < 5) || _ishelp(argv[2])) {
+            printf("usage: %s update [help|<handle> <itvl> <timeout>]\n",
+                   argv[0]);
+            return 0;
+        }
+        int handle = atoi(argv[2]);
+        int itvl = atoi(argv[3]);
+        int timeout = atoi(argv[4]);
+        _cmd_update(handle, itvl, timeout);
+    }
+    else {
+        printf("unable to parse the command. Use '%s help' for more help\n",
+               argv[0]);
+    }
+
+    return 0;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -153,6 +153,10 @@ extern int _i2c_scan(int argc, char **argv);
 extern int _loramac_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_NIMBLE_NETIF
+extern int _nimble_netif_handler(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
 #ifdef MODULE_CONFIG
@@ -251,6 +255,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_SEMTECH_LORAMAC
     {"loramac", "Control Semtech loramac stack", _loramac_handler},
+#endif
+#ifdef MODULE_NIMBLE_NETIF
+    { "ble", "Manage BLE connections for NimBLE", _nimble_netif_handler },
 #endif
     {NULL, NULL, NULL}
 };

--- a/tests/l2util/Makefile
+++ b/tests/l2util/Makefile
@@ -15,7 +15,8 @@ CHECKED_IFDEF_PATHS = cc110x \
                       netdev_ieee802154 \
                       xbee \
                       nordic_softdevice_ble \
-                      nrfmin
+                      nrfmin \
+                      nimble_netif
 
 CFLAGS += $(foreach path,$(CHECKED_IFDEF_PATHS),\
             -DMODULE_$(shell echo $(path) | tr a-z A-Z))

--- a/tests/l2util/main.c
+++ b/tests/l2util/main.c
@@ -56,7 +56,7 @@ static void test_eui64_from_addr__success(void)
                                                  test_addr, sizeof(eui64_t),
                                                  &res));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&test_eui64, &res, sizeof(eui64_t)));
-    /* test (nordic softdevice) BLE */
+    /* test BLE */
     res.uint64.u64 = 0;
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t),
                           l2util_eui64_from_addr(NETDEV_TYPE_BLE,
@@ -105,7 +105,7 @@ static void test_eui64_from_addr__EINVAL(void)
                           l2util_eui64_from_addr(NETDEV_TYPE_IEEE802154,
                                                  test_addr, sizeof(eui48_t),
                                                  &res));
-    /* test (nordic softdevice) BLE */
+    /* test BLE */
     TEST_ASSERT_EQUAL_INT(-EINVAL,
                           l2util_eui64_from_addr(NETDEV_TYPE_BLE,
                                                  test_addr, sizeof(uint16_t),
@@ -145,6 +145,7 @@ static void test_iid_from_addr__success(void)
     static const eui64_t test_cc110x = { .uint8 = TEST_CC110X_IID };
     static const eui64_t test_eui48 = { .uint8 = TEST_EUI48_IID };
     static const eui64_t test_eui64 = { .uint8 = TEST_EUI64_IID };
+    static const eui64_t test_ble = { .uint8 = TEST_EUI48_EUI64 };
     eui64_t res;
 
     /* test Ethernet */
@@ -168,13 +169,13 @@ static void test_iid_from_addr__success(void)
                                                     IEEE802154_SHORT_ADDRESS_LEN,
                                                     &res));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&test_802154_s, &res, sizeof(eui64_t)));
-    /* test (nordic softdevice) BLE */
+    /* test BLE */
     res.uint64.u64 = 0;
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t),
                           l2util_ipv6_iid_from_addr(NETDEV_TYPE_BLE,
                                                     test_addr, sizeof(eui48_t),
                                                     &res));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(&test_eui48, &res, sizeof(eui64_t)));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(&test_ble, &res, sizeof(eui64_t)));
     /* test cc110x */
     res.uint64.u64 = 0;
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t),
@@ -213,7 +214,7 @@ static void test_iid_from_addr__EINVAL(void)
                           l2util_ipv6_iid_from_addr(NETDEV_TYPE_IEEE802154,
                                                     test_addr, sizeof(eui48_t),
                                                     &res));
-    /* test (nordic softdevice) BLE */
+    /* test BLE */
     TEST_ASSERT_EQUAL_INT(-EINVAL,
                           l2util_ipv6_iid_from_addr(NETDEV_TYPE_BLE,
                                                     test_addr, sizeof(uint16_t),
@@ -253,6 +254,7 @@ static void test_iid_to_addr__success(void)
     static const eui64_t test_cc110x = { .uint8 = TEST_CC110X_IID };
     static const eui64_t test_eui48 = { .uint8 = TEST_EUI48_IID };
     static const eui64_t test_eui64 = { .uint8 = TEST_EUI64_IID };
+    static const eui64_t test_ble = { .uint8 = TEST_EUI48_EUI64 };
     uint8_t res[L2UTIL_ADDR_MAX_LEN];
 
     /* test Ethernet */
@@ -267,11 +269,11 @@ static void test_iid_to_addr__success(void)
                           l2util_ipv6_iid_to_addr(NETDEV_TYPE_IEEE802154,
                                                   &test_eui64, res));
     TEST_ASSERT_EQUAL_INT(0, memcmp(test_addr, res, sizeof(eui64_t)));
-    /* test (nordic softdevice) BLE */
+    /* test BLE */
     memset(res, 0, sizeof(res));
     TEST_ASSERT_EQUAL_INT(sizeof(eui48_t),
                           l2util_ipv6_iid_to_addr(NETDEV_TYPE_BLE,
-                                                  &test_eui48, res));
+                                                  &test_ble, res));
     TEST_ASSERT_EQUAL_INT(0, memcmp(test_addr, res, sizeof(eui48_t)));
     /* test cc110x */
     memset(res, 0, sizeof(res));

--- a/tests/unittests/tests-bluetil/tests-bluetil.c
+++ b/tests/unittests/tests-bluetil/tests-bluetil.c
@@ -27,24 +27,24 @@ static void test_bluetil_addr(void)
     char istr[BLUETIL_IPV6_IID_STRLEN];
 
     bluetil_addr_sprint(astr, addr[0]);
-    TEST_ASSERT_EQUAL_STRING("AF:FE:AF:FE:AF:FE", astr);
+    TEST_ASSERT_EQUAL_STRING("FE:AF:FE:AF:FE:AF", astr);
     bluetil_addr_ipv6_l2ll_sprint(istr, addr[0]);
-    TEST_ASSERT_EQUAL_STRING("[FE80::FCAF:FEFF:FEAF:FEAF]", istr);
+    TEST_ASSERT_EQUAL_STRING("[FE80::FEAF:FEFF:FEAF:FEAF]", istr);
 
     bluetil_addr_sprint(astr, addr[1]);
-    TEST_ASSERT_EQUAL_STRING("AB:CD:EF:01:02:03", astr);
+    TEST_ASSERT_EQUAL_STRING("03:02:01:EF:CD:AB", astr);
     bluetil_addr_ipv6_l2ll_sprint(istr, addr[1]);
-    TEST_ASSERT_EQUAL_STRING("[FE80::0102:01FF:FEEF:CDAB]", istr);
+    TEST_ASSERT_EQUAL_STRING("[FE80::0302:01FF:FEEF:CDAB]", istr);
 
     bluetil_addr_sprint(astr, addr[2]);
     TEST_ASSERT_EQUAL_STRING("FF:FF:FF:FF:FF:FF", astr);
     bluetil_addr_ipv6_l2ll_sprint(istr, addr[2]);
-    TEST_ASSERT_EQUAL_STRING("[FE80::FDFF:FFFF:FEFF:FFFF]", istr);
+    TEST_ASSERT_EQUAL_STRING("[FE80::FFFF:FFFF:FEFF:FFFF]", istr);
 
     bluetil_addr_sprint(astr, addr[3]);
     TEST_ASSERT_EQUAL_STRING("00:00:00:00:00:00", astr);
     bluetil_addr_ipv6_l2ll_sprint(istr, addr[3]);
-    TEST_ASSERT_EQUAL_STRING("[FE80::0200:00FF:FE00:0000]", istr);
+    TEST_ASSERT_EQUAL_STRING("[FE80::0000:00FF:FE00:0000]", istr);
 }
 
 Test *tests_bluetil_tests(void)


### PR DESCRIPTION
### Contribution description
This PR provides support for IP-over-BLE by providing a GNRC-netif wrapper for Nimble. The provided behavior is should be conform to RFC7668 and the Bluetooth IPSP profile, but some details do still need to be verified.

The PR provides an application for 'fully manual' control of BLE behavior. Other means for BLE connection management (e.g. towards [ipv6-mesh-over-ble](https://tools.ietf.org/html/draft-ietf-6lo-blemesh-05)) will follow in upcoming PRs.

Current State:
- code (architecture, structure, implementation) is functional and ready to be looked at
- a lot of documentation (high-level and doxygen) is missing (hence the WIP label)
- some debug helpers are left in the code, will remove them once everything runs stable

I PR this code now, as it would be wonderful if someone could look over the code to see if there are some critical things I overlooked. I've been staring at this stuff for too long now and a bad tunnel vision :-)

### Testing procedure
The provided `nimble_gnrc` application provides a mighty `ble` shell command, that can be used for advertising, scanning, and connecting to other nodes. Once at least two nodes are connected, all the IP magic (udp, icmp, ifconfig, rpl) is available...

At least in theory, this code should also work for connecting a RIOT BLE node to Linux. But I did not try this, yet.

### Issues/PRs references
rebased on #11296

Known issues:
- using the unpatched Nimble version a node can only have a single connection. If a second connection is opened, Nimble fails to allocate a second connection context from its context buffer (see `nimble/host/src/ble_hs_conn.c` -> `ble_hs_conn_alloc()`). I can't tell why, but it seems the memblock list for `ble_hs_conn_pool` is corrupted somehow. But when renaming that var to `_ble_hs_conn_pool` everything works again. So really now idea yet, what is causing this...
- I did not fully verify, that GNRC behaves fully to spec of RFC7668 (e.g. neighbor discovery options...)
