### PR TITLE
gnrc_ipv6_ext: don't read from `pkt->data` after `_demux()`

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -109,17 +109,19 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_process_all(gnrc_pktsnip_t *pkt,
             case PROTNUM_IPV6_EXT_ESP:
             case PROTNUM_IPV6_EXT_MOB: {
                 ipv6_ext_t *ext_hdr;
+                uint8_t nh;
 
                 DEBUG("ipv6: handle extension header (protnum = %u)\n",
                       *protnum);
                 ext_hdr = pkt->data;
+                nh = ext_hdr->nh;
                 if ((pkt = _demux(pkt, *protnum)) == NULL) {
                     DEBUG("ipv6: packet was consumed by extension header "
                           "handling\n");
                     return NULL;
                 }
-                *protnum = ext_hdr->nh;
-                if (_duplicate_hopopt(pkt, *protnum)) {
+                *protnum = nh;
+                if (_duplicate_hopopt(pkt, nh)) {
                     return NULL;
                 }
                 break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`_demux()` might change `pkt->data` in all kind of ways (moving it due
to `gnrc_pktbuf_mark()`, though unlikely; releasing it, because e.g. it
starts with a fragment header that marks a fragmented packet containing
only one fragment, etc.) so accessing the pointer *after* calling
`_demux()` is somewhat playing with fire. This change avoids this by
storing the value of `ext_hdr->nh` (all we are interested in here) in a
temporary variable that then is used to set the out-parameter `nh`.

`protnum` needs to be unchanged before the call to `_demux()` as it was
set by the previous iteration and determines what extension header
actually is handled (this is why a temporary variable is needed and we
can't just set `*protnum`).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
export BOARD="<your favorite>"
make -C tests/gnrc_ipv6_ext flash
sudo make -C tests/gnrc_ipv6_ext test
```

should still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
