### PR TITLE
cpu/sam0: sercom cleanup

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -323,16 +323,42 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
  *
  * @return              numeric id of the given SERCOM device
  */
-static inline int sercom_id(void *sercom)
+static inline int sercom_id(const void *sercom)
 {
-#if defined(CPU_FAM_SAMD21)
-    return ((((uint32_t)sercom) >> 10) & 0x7) - 2;
-#elif defined (CPU_FAM_SAML10) || defined (CPU_FAM_SAML11)
-    return ((((uint32_t)sercom) >> 10) & 0x7) - 1;
-#elif defined(CPU_FAM_SAML21) || defined(CPU_FAM_SAMR30)
-    /* Left side handles SERCOM0-4 while right side handles unaligned address of SERCOM5 */
-    return ((((uint32_t)sercom) >> 10) & 0x7) + ((((uint32_t)sercom) >> 22) & 0x04);
+#ifdef SERCOM0
+    if (sercom == SERCOM0)
+        return 0;
 #endif
+#ifdef SERCOM1
+    if (sercom == SERCOM1)
+        return 1;
+#endif
+#ifdef SERCOM2
+    if (sercom == SERCOM2)
+        return 2;
+#endif
+#ifdef SERCOM3
+    if (sercom == SERCOM3)
+        return 3;
+#endif
+#ifdef SERCOM4
+    if (sercom == SERCOM4)
+        return 4;
+#endif
+#ifdef SERCOM5
+    if (sercom == SERCOM5)
+        return 5;
+#endif
+#ifdef SERCOM6
+    if (sercom == SERCOM6)
+        return 6;
+#endif
+#ifdef SERCOM7
+    if (sercom == SERCOM7)
+        return 7;
+#endif
+
+    return -1;
 }
 
 /**

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -48,20 +48,12 @@ static inline SercomSpi *dev(spi_t bus)
 
 static inline void poweron(spi_t bus)
 {
-#if defined(CPU_FAM_SAMD21)
-    PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << sercom_id(dev(bus)));
-#elif defined(CPU_SAML21) || defined(CPU_SAML1X)
-    MCLK->APBCMASK.reg |= (MCLK_APBCMASK_SERCOM0 << sercom_id(dev(bus)));
-#endif
+    sercom_clk_en(dev(bus));
 }
 
 static inline void poweroff(spi_t bus)
 {
-#if defined(CPU_FAM_SAMD21)
-    PM->APBCMASK.reg &= ~(PM_APBCMASK_SERCOM0 << sercom_id(dev(bus)));
-#elif defined(CPU_SAML21) || defined(CPU_SAML1X)
-    MCLK->APBCMASK.reg &= ~(MCLK_APBCMASK_SERCOM0 << sercom_id(dev(bus)));
-#endif
+    sercom_clk_dis(dev(bus));
 }
 
 void spi_init(spi_t bus)

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -76,13 +76,10 @@ void spi_init(spi_t bus)
            (dev(bus)->SYNCBUSY.reg & SERCOM_SPI_SYNCBUSY_SWRST));
 
     /* configure base clock: using GLK GEN 0 */
-#if defined(CPU_FAM_SAMD21)
-    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 |
-                         (SERCOM0_GCLK_ID_CORE + sercom_id(dev(bus))));
-    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
-#elif defined(CPU_SAML21) || defined(CPU_SAML1X)
-    GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + sercom_id(dev(bus))].reg =
-                                (GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0);
+#ifdef GCLK_CLKCTRL_GEN_GCLK0
+    sercom_set_gen(dev(bus), GCLK_CLKCTRL_GEN_GCLK0);
+#else
+    sercom_set_gen(dev(bus), GCLK_PCHCTRL_GEN_GCLK0);
 #endif
 
     /* enable receiver and configure character size to 8-bit


### PR DESCRIPTION
As requested by @dylad I've split the SERCOM cleanup form #11305 into a separate PR.

This is to rely not on the name of the MCU family but rather what is defined in the ASF header files to simplify porting the code to new MCU families that share the same peripherals.

It also removes some minor code duplication.