### PR TITLE
boards/microbit: add QEMU emulation

### DIFF
--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -14,5 +14,12 @@ else ifeq (pyocd,$(PROGRAMMER))
   include $(RIOTMAKE)/tools/pyocd.inc.mk
 endif
 
+# QEMU 4.0 added microbit system emulation.
+EMULATOR = qemu-system-arm
+EMULATOR_FLAGS = -M microbit -device loader,file=$(ELFFILE) \
+                 -serial stdio \
+                 -monitor telnet::45454,server,nowait \
+                 -nographic
+
 # include nrf51 boards common configuration
 include $(RIOTBOARD)/common/nrf51/Makefile.include

--- a/boards/microbit/doc.txt
+++ b/boards/microbit/doc.txt
@@ -77,4 +77,23 @@ With the JLink firmware, you can now also do in-circuit debugging etc.
 **Note: The current version of the JLink firmware
 (JLink_OB_BBC_microbit_16-07-29.hex) does not support any serial port over USB,
 so you can not use the RIOT shell with this firmware.**
+
+
+### QEMU emulation
+
+The microbit can be partly emulated by QEMU.
+
+This requires at least QEMU 4.0 with ARM platform support enabled.
+
+*NOTE*: not all peripherals are emulated. See
+[this](https://wiki.qemu.org/Features/MicroBit) page for an overview.
+E.g., there's no emulation for the radio, thus applications using that will
+fail.
+
+Use it like this:
+
+    $ cd examples/hello-world
+    $ BOARD=microbit make clean all -j4
+    $ BOARD=microbit make emulate
+
  */


### PR DESCRIPTION
### Contribution description

QEMU 4.0 added system emulation for the microbit.
See https://www.qemu.org/2019/05/22/microbit/ for more information.

My initial plan was to integrate this for CI testing, but the new qemu version is not available precompiled for Ubuntu bionic. So here's the first step for local testing.

### Testing procedure

Get qemu 4.0 (Arch has it in the repos), then

```
cd ecamples/hello-world
BOARD=microbit make clean all -j4
BOARD=microbit make emulate
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
