### PR TITLE
periph/i2c: handle i2c register write/read helper function correctly in big endian

### DIFF
--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -195,7 +195,7 @@ typedef enum {
 #ifndef HAVE_I2C_FLAGS_T
 typedef enum {
     I2C_ADDR10  = 0x01,     /**< use 10-bit device addressing */
-    I2C_REG16   = 0x02,     /**< use 16-bit register addressing */
+    I2C_REG16   = 0x02,     /**< use 16-bit register addressing, big-endian */
     I2C_NOSTOP  = 0x04,     /**< do not issue a STOP condition after transfer */
     I2C_NOSTART = 0x08,     /**< skip START sequence, ignores address field */
 } i2c_flags_t;

--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -22,6 +22,7 @@
 #include "board.h"
 #include "cpu.h"
 #include "periph/i2c.h"
+#include "byteorder.h"
 
 #ifdef I2C_NUMOF
 
@@ -37,11 +38,19 @@ int i2c_read_reg(i2c_t dev, uint16_t addr, uint16_t reg,
 int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                   void *data, size_t len, uint8_t flags)
 {
+    uint16_t reg_end = reg;
+
     if (flags & (I2C_NOSTOP | I2C_NOSTART)) {
         return -EOPNOTSUPP;
     }
+
+    /* Handle endianess of register if 16 bit */
+    if (flags & I2C_REG16) {
+        reg_end = htons(reg); /* Make sure register is in big-endian on I2C bus */
+    }
+
     /* First set ADDR and register with no stop */
-    int ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
+    int ret = i2c_write_bytes(dev, addr, &reg_end, (flags & I2C_REG16) ? 2 : 1,
                               flags | I2C_NOSTOP);
     if (ret < 0) {
         return ret;
@@ -73,11 +82,19 @@ int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                    const void *data, size_t len, uint8_t flags)
 {
+    uint16_t reg_end = reg;
+
     if (flags & (I2C_NOSTOP | I2C_NOSTART)) {
         return -EOPNOTSUPP;
     }
+
+    /* Handle endianess of register if 16 bit */
+    if (flags & I2C_REG16) {
+        reg_end = htons(reg); /* Make sure register is in big-endian on I2C bus */
+    }
+
     /* First set ADDR and register with no stop */
-    int ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
+    int ret = i2c_write_bytes(dev, addr, &reg_end, (flags & I2C_REG16) ? 2 : 1,
                               flags | I2C_NOSTOP);
     if (ret < 0) {
         return ret;


### PR DESCRIPTION
### Contribution description
In RIOT I2C we have helper functions to read/write I2C devices (mostly EEPROMS) that need a 16-bit addressing. The standard does not dictate the endianess of this addressing but all the examples found are big-endian. The current code doesn't correctly force a translation to big-endian, therefore it will not work on little-endian architectures.
This PR fixes this by making sure the 16-bit address is always converted into big-endian.

### Testing procedure
The test in `tests/periph_i2c` can be used, specifiying to `i2c_read_reg` the flag value of 2 (equivalent to `I2C_REG16` value)

### Issues/PRs references
Fixed #11544 . Discussion on implementation on that Issue.
