### PR TITLE
gcoap: Add 'observable' option to resources

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -36,7 +36,7 @@ static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, vo
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
-    { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, NULL },
+    { "/cli/stats", COAP_GET | COAP_OBSERVABLE | COAP_PUT, _stats_handler, NULL },
     { "/riot/board", COAP_GET, _riot_board_handler, NULL },
 };
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -105,6 +105,7 @@ extern "C" {
 #define COAP_POST               (0x2)
 #define COAP_PUT                (0x4)
 #define COAP_DELETE             (0x8)
+#define COAP_OBSERVABLE         (0x800)  /**< The resource can be observed */
 #define COAP_MATCH_SUBTREE      (0x8000) /**< Path is considered as a prefix
                                               when matching */
 /** @} */

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -923,7 +923,7 @@ int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
             size_t path_len = strlen(resource->path);
             if (out) {
                 /* only add new resources if there is space in the buffer */
-                if ((pos + path_len + 3) > maxlen) {
+                if ((pos + path_len + (resource->methods & COAP_OBSERVABLE ? 7 : 3)) > maxlen) {
                     break;
                 }
                 if (pos) {
@@ -933,9 +933,16 @@ int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
                 memcpy(&out[pos], resource->path, path_len);
                 pos += path_len;
                 out[pos++] = '>';
+
+                /* if the resource is observable inform it */
+                if (resource->methods & COAP_OBSERVABLE) {
+                    memcpy(&out[pos], ";obs", 4);
+                    pos += 4;
+                }
             }
             else {
                 pos += (pos) ? 3 : 2;
+                pos += (resource->methods & COAP_OBSERVABLE) ? 4 : 0;
                 pos += path_len;
             }
             ++resource;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -923,7 +923,7 @@ int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
             size_t path_len = strlen(resource->path);
             if (out) {
                 /* only add new resources if there is space in the buffer */
-                if ((pos + path_len + (resource->methods & COAP_OBSERVABLE ? 7 : 3)) > maxlen) {
+                if ((pos + path_len + ((resource->methods & COAP_OBSERVABLE) ? 7 : 3)) > maxlen) {
                     break;
                 }
                 if (pos) {


### PR DESCRIPTION
### Contribution description
Currently gcoap supports observing on its resources, but the user cannot select which resources can be observed (right now all of them). Also, a request to `/.well-known/core` will not give any [hint](https://tools.ietf.org/html/rfc7641#section-6) if a resource could be observed or not (this is not mandatory but nice to have).

This PR adds a `COAP_OBSERVABLE` option to indicate that an 'observe' request should be accepted on a particular resource, and that the 'obs' attribute should be added on the `/.well-known/core` response.

### Testing procedure
Run the gcoap example. The `/cli/stats` should have the 'obs' attribute, and an attempt to observe it should succeed. On the other hand, the observe request to `/riot/board` should be ignored.

### Issues/PRs references
Somehow related to #11171