### PR TITLE
tests/cortexm_common_ldscript: update code section for kinetis

### DIFF
--- a/tests/cortexm_common_ldscript/Makefile
+++ b/tests/cortexm_common_ldscript/Makefile
@@ -86,10 +86,15 @@ OFFSETS_TESTS = 0x1000 0x2000
 tests-offsets: $(OFFSETS_TESTS:%=test-offset_%)
 
 .PHONY: test-offset_%
+# Match the 'code' section. It is usually '.text' but is '.vector' on `kinetis`.
+# * [ 1] .text             PROGBITS        08001000 001000 001ef8 ...
+# * [ 1] .vector           PROGBITS        00001000 001000 000400 ...
+# So match with the section [ 1] being `PROGBITS`. Adapt if new cases appear.
+CODE_SECTION = \[ 1\] \.[a-zA-Z_.]* *PROGBITS
 test-offset_%: $(BINDIR)/$(APPLICATION)_offset_%.elf
 	$(Q)echo -n "Test compilation with offset $*: "
 	$(Q)\
-	TEST_START_ADDR=$$($(PREFIX)readelf --section-headers $^ 2>/dev/null | awk '/.text/{printf "0x%s\n", $$5}'); \
+	TEST_START_ADDR=$$($(PREFIX)readelf --section-headers $^ 2>/dev/null | awk '/$(CODE_SECTION)/{printf "0x%s\n", $$5}'); \
 	EXPECT_START_ADDR=$$(printf "0x%08x" $$(( $(ROM_START_ADDR) + $* ))); \
 	if test $${TEST_START_ADDR} != $${EXPECT_START_ADDR}; then \
 	  echo "[ERROR] Linker offset not used $${TEST_START_ADDR} != $${EXPECT_START_ADDR}" >&2; \


### PR DESCRIPTION
### Contribution description

Update the 'code' section detection to also work on kinetis.

The boards using 'cortexm.ld' have the code section starting with
'.text'. For the 'cpu/kinetis/kinetis.ls' the first section is '.vector'.

Update the 'awk' matching pattern to correctly detect the kinetis boards.
It is a dependency to allow testing upcoming offset support with kinetis.

I am not 100% sure about the pattern for awk.

### Testing procedure

All the currently supported boards still work. It will be tested by `CI` during compilation (no need to run tests).
You can also run the test for `samr21-xpro` or `iotlab-m3` if you want.

```
RIOT_CI_BUILD=1 BOARD=iotlab-m3 make
Building application "tests_cortexm_common_ldscript" for "iotlab-m3" with MCU "stm32f1".

   text    data     bss     dec     hex filename
   7888     120    2556   10564    2944 /home/harter/work/git/RIOT/tests/cortexm_common_ldscript/bin/iotlab-m3/tests_cortexm_common_ldscript.elf
Test rom offset 1 byte overflow detection: [OK]
Test rom offset substracted from rom length in elffile: [SKIP](Reason: board does not have a ROM_OFFSET configured)
Test compilation with offset 0x1000: [OK]
Test compilation with offset 0x2000: [OK]
Test compilation with half ROM length: [OK]
Test ROM overflow detection (too_big_for_rom): [OK]
Test ROM overflow detection (offset_and_romlen): [OK]
```

For the `frdm-kw41z` the test fails with only this pull request but works with #11562 . However the address of `0x0000` is currently detected and fails as expected.

```
RIOT_CI_BUILD=1 BOARD=frdm-kw41z BOARD_WHITELIST=frdm-kw41z make
Building application "tests_cortexm_common_ldscript" for "frdm-kw41z" with MCU "kinetis".

   text    data     bss     dec     hex filename
   8928     116    2544   11588    2d44 /home/harter/work/git/RIOT/tests/cortexm_common_ldscript/bin/frdm-kw41z/tests_cortexm_common_ldscript.elf
Test rom offset 1 byte overflow detection: [OK]
Test rom offset substracted from rom length in elffile: [SKIP](Reason: board does not have a ROM_OFFSET configured)
Test compilation with offset 0x1000: [ERROR] Linker offset not used 0x00000000 != 0x00001000
Makefile:95: recipe for target 'test-offset_0x1000' failed
make: *** [test-offset_0x1000] Error 1
```


With `master` it was detecting `0x410` which was not the base of the whole code section as it starts with `.vector/.fcfield/.text`.

```
RIOT_CI_BUILD=1 BOARD=frdm-kw41z BOARD_WHITELIST=frdm-kw41z make
Building application "tests_cortexm_common_ldscript" for "frdm-kw41z" with MCU "kinetis".

   text    data     bss     dec     hex filename
   8928     116    2544   11588    2d44 /home/harter/work/git/RIOT/tests/cortexm_common_ldscript/bin/frdm-kw41z/tests_cortexm_common_ldscript.elf
Test rom offset 1 byte overflow detection: [OK]
Test rom offset substracted from rom length in elffile: [SKIP](Reason: board does not have a ROM_OFFSET configured)
Test compilation with offset 0x1000: [ERROR] Linker offset not used 0x00000410 != 0x00001000
Makefile:90: recipe for target 'test-offset_0x1000' failed
make: *** [test-offset_0x1000] Error 1
```


### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/11562