### PR TITLE
makefiles/app_dirs.inc.mk: target to list supported applications/boards

### DIFF
--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -1,4 +1,4 @@
-.PHONY: info-applications
+.PHONY: info-applications info-applications-supported-boards
 
 # fallback so empty RIOTBASE won't lead to "/examples/"
 RIOTBASE ?= .
@@ -15,3 +15,9 @@ APPLICATION_DIRS := $(sort $(patsubst ./%,%,$(patsubst %/,%,$(dir $(wildcard \
 
 info-applications:
 	@for dir in $(APPLICATION_DIRS); do echo $$dir; done
+
+# All applications / board output of `info-boards-supported`.
+info-applications-supported-boards:
+	@for dir in $(APPLICATION_DIRS); do \
+	  make --no-print-directory -C $${dir} info-boards-supported 2>/dev/null | xargs -n 1 echo $${dir}; \
+	done

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -1,3 +1,5 @@
+.PHONY: info-applications
+
 # fallback so empty RIOTBASE won't lead to "/examples/"
 RIOTBASE ?= .
 


### PR DESCRIPTION
### Contribution description
    
Slow implementation to list all supported boards.
It is adapted from what `.murdock` does without the `toolchain` handling.


### Testing procedure

Run `make info-applications-supported-boards` from the `RIOT` root.

```
make info-applications-supported-boards
bootloaders/riotboot acd52832
bootloaders/riotboot b-l072z-lrwan1
bootloaders/riotboot iotlab-a8-m3
bootloaders/riotboot iotlab-m3
bootloaders/riotboot lsn50
bootloaders/riotboot nrf52832-mdk
bootloaders/riotboot nrf52840-mdk
bootloaders/riotboot nrf52840dk
bootloaders/riotboot nrf52dk
bootloaders/riotboot nucleo-l073rz
bootloaders/riotboot nucleo-l152re
bootloaders/riotboot particle-argon
bootloaders/riotboot particle-boron
bootloaders/riotboot particle-xenon
bootloaders/riotboot reel
bootloaders/riotboot ruuvitag
bootloaders/riotboot saml10-xpro
bootloaders/riotboot saml11-xpro
bootloaders/riotboot saml21-xpro
bootloaders/riotboot samr21-xpro
bootloaders/riotboot thingy52
examples/arduino_hello-world arduino-due
examples/arduino_hello-world arduino-duemilanove
examples/arduino_hello-world arduino-leonardo
examples/arduino_hello-world arduino-mega2560
examples/arduino_hello-world arduino-mkr1000
examples/arduino_hello-world arduino-mkrfox1200
examples/arduino_hello-world arduino-mkrzero
examples/arduino_hello-world arduino-nano
examples/arduino_hello-world arduino-uno                                                 
...
```

The output of `.murdock` includes the toolchain but it is not supposed to replace it for the moment.

```
bash ./.murdock get_app_board_toolchain_pairs bootloaders/riotboot
bootloaders/riotboot acd52832:gnu
bootloaders/riotboot b-l072z-lrwan1:gnu
bootloaders/riotboot iotlab-a8-m3:gnu
bootloaders/riotboot iotlab-m3:gnu
bootloaders/riotboot iotlab-m3:llvm
bootloaders/riotboot lsn50:gnu
bootloaders/riotboot nrf52832-mdk:gnu
bootloaders/riotboot nrf52840-mdk:gnu
bootloaders/riotboot nrf52840dk:gnu
bootloaders/riotboot nrf52dk:gnu
bootloaders/riotboot nrf52dk:llvm
bootloaders/riotboot nucleo-l073rz:gnu
bootloaders/riotboot nucleo-l152re:gnu
bootloaders/riotboot particle-argon:gnu
bootloaders/riotboot particle-boron:gnu
bootloaders/riotboot particle-xenon:gnu
bootloaders/riotboot reel:gnu
bootloaders/riotboot ruuvitag:gnu
bootloaders/riotboot saml10-xpro:gnu
bootloaders/riotboot saml11-xpro:gnu
bootloaders/riotboot saml21-xpro:gnu
bootloaders/riotboot samr21-xpro:gnu
bootloaders/riotboot samr21-xpro:llvm
bootloaders/riotboot thingy52:gnu
```

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/11492 and will be used to review changes done through https://github.com/RIOT-OS/RIOT/issues/9913