### PR TITLE
ldscripts: move .noinit section behind .bss section

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -127,17 +127,6 @@ SECTIONS
         _erelocate = .;
     } > ram AT> rom
 
-    /*
-     * collect all uninitialized sections that go into RAM
-     */
-    .noinit (NOLOAD) :
-    {
-        __noinit_start = .;
-        *(.noinit)
-        . = ALIGN(4);
-        __noinit_end = .;
-    }  > ram
-
     /* .bss section which is used for uninitialized data */
     .bss (NOLOAD) :
     {
@@ -150,6 +139,17 @@ SECTIONS
         _ebss = . ;
         _ezero = .;
     } > ram
+
+    /*
+     * collect all uninitialized sections that go into RAM
+     */
+    .noinit (NOLOAD) :
+    {
+        __noinit_start = .;
+        *(.noinit)
+        . = ALIGN(4);
+        __noinit_end = .;
+    }  > ram
 
     /* heap section */
     . = ALIGN(4);

--- a/cpu/lpc2387/ldscripts/lpc2387.ld
+++ b/cpu/lpc2387/ldscripts/lpc2387.ld
@@ -155,19 +155,6 @@ SECTIONS
     } >ram
 
     /*
-     * collect all uninitialized sections that go into RAM
-     */
-    .noinit (NOLOAD) :
-    {
-        __noinit_start = .;
-        PROVIDE(__fiq_handler = .);
-        *(.fiq)
-        *(.noinit)
-    }  > ram
-    . = ALIGN(4);
-    __noinit_end = .;
-
-    /*
      * collect all zero initialized sections that go into RAM
      */
     .bss (NOLOAD) :
@@ -213,6 +200,18 @@ SECTIONS
     . = ALIGN(4);                       /* ensure data is aligned so relocation can use 4-byte operations */
     _edata = .;                         /* define a global symbol marking the end of the .data section  */
 
+    /*
+     * collect all uninitialized sections that go into RAM
+     */
+    .noinit (NOLOAD) :
+    {
+        __noinit_start = .;
+        PROVIDE(__fiq_handler = .);
+        *(.fiq)
+        *(.noinit)
+    }  > ram
+    . = ALIGN(4);
+    __noinit_end = .;
 
     /*
      * Exception frames (newer linker versions generate these but they use of


### PR DESCRIPTION
### Contribution description
If the `.noinit` section starts at the beginning of the RAM, a bootloader that is unaware of it will clear it.
Instead, move it behind the `.bss` section, hoping that a bootloader will always use less `.bss` memory than RIOT proper.

I would much rather have placed the `.noinit` section at a defined place, e.g. the end of RAM.
However, it does not seem possible as there is no way to get the size of an *input section* without first placing it into an *output section*. If an input section is placed into multiple output sections (so we could place it in a dummy section just to get the size), the first one is the one that counts.

### Testing procedure
```
int main(void)
{
    static uint32_t counter __attribute__((section(".noinit")));
    static uint32_t magic __attribute__((section(".noinit")));

    if (magic != 0xdeadbeef) {
        magic  = 0xdeadbeef;
        counter = 0;
    }

    printf("count: %lu\n", ++counter);

    return 0;
}
```

The counter should increment with every reset, even when e.g. an Arduino Bootloader is being used.

### Issues/PRs references
@keestux  noticed the issue in #11520
