### PR TITLE
make: add LOG_LEVEL to overridable variables

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -141,6 +141,14 @@ ifeq ($(DEVELHELP),1)
   CFLAGS += -DDEVELHELP
 endif
 
+# Override LOG_LEVEL if variable is set and if CFLAGS doesn't already contain
+# a LOG_LEVEL config
+ifdef LOG_LEVEL
+  ifneq (,$(filter -DLOG_LEVEL=%,$(CFLAGS)))
+    CFLAGS += -DLOG_LEVEL=$(LOG_LEVEL)
+  endif
+endif
+
 # Fail on warnings. Can be overridden by `make WERROR=0`.
 WERROR ?= 1
 export WERROR

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -95,3 +95,5 @@ export UNZIP_HERE            # Use `cd $(SOME_FOLDER) && $(UNZIP_HERE) $(SOME_FI
 
 export LAZYSPONGE            # Command saving stdin to a file only on content update.
 export LAZYSPONGE_FLAGS      # Parameters supplied to LAZYSPONGE.
+
+# LOG_LEVEL                  # Logging level as integer (NONE: 0, ERROR: 1, WARNING: 2, INFO: 3, DEBUG: 4, default: 3)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR allows to set the logging level via a make variable instead of having to explicitly set this via CFLAGS. Example:
With this PR, one can use `LOG_LEVEL=4 make -C <application dir>` to enable debug log level instead of CFLAGS=-DLOG_LEVEL=4 make -C <application dir>

If an application already set the log level via CFLAGS, then this variable is ignored.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

One can try to disable logging by using LOG_LEVEL=0 in any application an notice that the `This is RIOT!` welcome message is not displayed at any application startup.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Idea raised by @miri64 in #11573 (see https://github.com/RIOT-OS/RIOT/pull/11573#discussion_r287611278)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
