### PR TITLE
sys: Revert #11310 (make stdio_rx optional)

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -397,18 +397,8 @@ ifneq (,$(filter stdio_rtt,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter shell,$(USEMODULE)))
-  ifneq (,$(filter stdio_uart,$(USEMODULE)))
-    USEMODULE += stdio_uart_rx
-  endif
-endif
-
-ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
-  USEMODULE += isrpipe
-  USEMODULE += stdio_uart
-endif
-
 ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  USEMODULE += isrpipe
   FEATURES_REQUIRED += periph_uart
 endif
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -70,7 +70,6 @@ PSEUDOMODULES += sock
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp
 PSEUDOMODULES += sock_udp
-PSEUDOMODULES += stdio_uart_rx
 
 # print ascii representation in function od_hex_dump()
 PSEUDOMODULES += od_string

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -27,8 +27,6 @@
  * @}
  */
 
-#include <errno.h>
-
 #include "stdio_uart.h"
 
 #include "board.h"
@@ -47,31 +45,16 @@ extern ethos_t ethos;
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#ifdef MODULE_STDIO_UART_RX
+
 static char _rx_buf_mem[STDIO_UART_RX_BUFSIZE];
 isrpipe_t stdio_uart_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
-#endif
 
 void stdio_init(void)
 {
-    uart_rx_cb_t cb;
-    void *arg;
-
-#ifdef MODULE_STDIO_UART_RX
-    cb = (uart_rx_cb_t) isrpipe_write_one;
-    arg = &stdio_uart_isrpipe;
-#else
-#ifdef USE_ETHOS_FOR_STDIO
-#error "ethos needs stdio_uart_rx"
-#endif
-    cb = NULL;
-    arg = NULL;
-#endif
-
 #ifndef USE_ETHOS_FOR_STDIO
-    uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, cb, arg);
+    uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, (uart_rx_cb_t) isrpipe_write_one, &stdio_uart_isrpipe);
 #else
-    uart_init(ETHOS_UART, ETHOS_BAUDRATE, cb, arg);
+    uart_init(ETHOS_UART, ETHOS_BAUDRATE, (uart_rx_cb_t) isrpipe_write_one, &stdio_uart_isrpipe);
 #endif
 #if MODULE_VFS
     vfs_bind_stdio();
@@ -80,13 +63,7 @@ void stdio_init(void)
 
 ssize_t stdio_read(void* buffer, size_t count)
 {
-#ifdef MODULE_STDIO_UART_RX
     return (ssize_t)isrpipe_read(&stdio_uart_isrpipe, (char *)buffer, count);
-#else
-    (void)buffer;
-    (void)count;
-    return -ENOTSUP;
-#endif
 }
 
 ssize_t stdio_write(const void* buffer, size_t len)


### PR DESCRIPTION

### Contribution description

This change was breaking (dependencies for) ethos, and other serial users, as well as an unknown number of external apps (API change.).

See #11525 for more details.

The reverted PR's functionality can be reintroduced once issues have been addressed. In other words, this revert is not to contest the feature itself, but its current embodiment.

### Testing procedure

(taken from #11525)

run:

```
make -C tests/xtimer_usleep flash
make -C tests/xtimer_usleep test
```

After the revert the test works again (i.e. it waits for input before initiating)

### Issues/PRs references

Fixes #11525.