### PR TITLE
tests/rng: fix for msp430

### DIFF
--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -5,6 +5,10 @@ BOARD_BLACKLIST += nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 pic32-clicker
 BOARD_INSUFFICIENT_MEMORY += arduino-duemilanove arduino-leonardo arduino-nano \
                              arduino-uno
 
+# Default stack with printf + the tests buffer uint32_t[32]/uint8_t[256]
+MAIN_THREAD_SIZE = THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF+256
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=\($(MAIN_THREAD_SIZE)\)
+
 # override PRNG if desired (see sys/random for alternatives)
 # USEMODULE += prng_minstd
 

--- a/tests/rng/main.c
+++ b/tests/rng/main.c
@@ -260,7 +260,7 @@ static int cmd_speed(int argc, char **argv)
 int main(void)
 {
     puts("Starting shell...");
-    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    static char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;

--- a/tests/rng/tests/01-run.py
+++ b/tests/rng/tests/01-run.py
@@ -14,16 +14,21 @@ from testrunner import run
 def testfunc(child):
     # RNG source
     child.sendline("source 0")
+    child.expect_exact("> ")
     child.sendline("seed 1337")
+    child.expect_exact("Seed set to 1337")
+    child.expect_exact("> ")
 
     child.sendline("fips")
-    child.expect("Running FIPS 140-2 test, with seed 1337 using Tiny Mersenne Twister PRNG.")
+    child.expect_exact("Running FIPS 140-2 test, with seed 1337 using Tiny Mersenne Twister PRNG.")
     child.expect("Monobit test: passed")
     child.expect("Poker test: passed")
     child.expect("Run test: passed")
     child.expect("Longrun test: passed")
+    child.expect_exact("> ")
 
     child.sendline("dump 10")
+    child.expect_exact("Running dump test, with seed 1337 using Tiny Mersenne Twister PRNG.")
     child.expect("1555530734")
     child.expect("2178333451")
     child.expect("2272913641")
@@ -34,13 +39,18 @@ def testfunc(child):
     child.expect("1550167154")
     child.expect("3454972398")
     child.expect("1034066532")
+    child.expect_exact("> ")
 
     child.sendline("entropy")
     child.expect(re.compile(r"Calculated 7\.994\d{3} bits of entropy from 10000 samples\."))
+    child.expect_exact("> ")
 
     # Constant source
     child.sendline("source 1")
+    child.expect_exact("> ")
     child.sendline("seed 1337")
+    child.expect_exact("Seed set to 1337")
+    child.expect_exact("> ")
 
     child.sendline("fips")
     child.expect("Running FIPS 140-2 test, with seed 1337 using constant value.")
@@ -48,6 +58,7 @@ def testfunc(child):
     child.expect("- Poker test: failed")
     child.expect("- Run test: failed")
     child.expect("- Longrun test: passed")
+    child.expect_exact("> ")
 
     child.sendline("dump 10")
     child.expect("1337")
@@ -60,9 +71,12 @@ def testfunc(child):
     child.expect("1337")
     child.expect("1337")
     child.expect("1337")
+    child.expect_exact("> ")
 
     child.sendline("entropy")
+    child.expect_exact("Running entropy test, with seed 1337 using constant value.")
     child.expect(re.compile(r"Calculated 0\.017\d{3} bits of entropy from 10000 samples\."))
+    child.expect_exact("> ")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description


In the current master, `tests/rng` resets the board on `wsn430-v1_3b` and `z1` https://github.com/RIOT-OS/RIOT/issues/11043

This pull request increase stack size to prevent this.
It now have a main stack usage of 514 bytes out of 768 on `wsn430-v1_3b`.

It also fixes the automated test sending commands before the end of the previous one to have a more correct test execution.

### Testing procedure

The test succeeds on `wsn430` based boards.
Some other small boards can be tested too.

<details><summary><code>IOTLAB_NODE=auto-ssh RIOT_CI_BUILD=1 BOARD=wsn430-v1_3b make --no-print-directory -C tests/rng/ test</code></summary><p>

```
IOTLAB_NODE=auto-ssh RIOT_CI_BUILD=1 BOARD=wsn430-v1_3b make --no-print-directory -C tests/rng/ test
source 0
ssh -t harter@strasbourg.iot-lab.info 'socat - tcp:wsn430-14.strasbourg.iot-lab.info:20000'
RIOT MSP430 hardware initialization complete.
random: NO SEED AVAILABLE!
main(): This is RIOT! (Version: buildtest)
Starting shell...
> source 0
seed 1337

> seed 1337


Seed set to 1337
> fips
fips


Running FIPS 140-2 test, with seed 1337 using Tiny Mersenne Twister PRNG.

- Monobit test: passed
- Poker test: passed
- Run test: passed
- Longrun test: passed
> dump 10
dump 10


Running dump test, with seed 1337 using Tiny Mersenne Twister PRNG.

1555530734
2178333451
2272913641
3790481823
3190025502
798555366
1918982324
1550167154
3454972398
1034066532
> entropy
entropy


Running entropy test, with seed 1337 using Tiny Mersenne Twister PRNG.

Calculated 7.994708 bits of entropy from 10000 samples.
> source 1
source 1


> seed 1337
seed 1337


Seed set to 1337
> fips
fips


Running FIPS 140-2 test, with seed 1337 using constant value.

- Monobit test: failed
- Poker test: failed
- Run test: failed
- Longrun test: passed
> dump 10
dump 10


Running dump test, with seed 1337 using constant value.

1337
1337
1337
1337
1337
1337
1337
1337
1337
1337
> entropy
entropy


Running entropy test, with seed 1337 using constant value.

Calculated 0.017260 bits of entropy from 10000 samples.
> 
```

</p></details>

Failing output in `master`:

<details><summary><code>IOTLAB_NODE=auto-ssh RIOT_CI_BUILD=1 BOARD=wsn430-v1_3b make --no-print-directory -C tests/rng/ test</code></summary><p>

```
IOTLAB_NODE=auto-ssh RIOT_CI_BUILD=1 BOARD=wsn430-v1_3b make --no-print-directory -C tests/rng/ test
source 0
seed 1337
fips
ssh -t harter@strasbourg.iot-lab.info 'socat - tcp:wsn430-14.strasbourg.iot-lab.info:20000'
RIOT MSP430 hardware initialization complete.
random: NO SEED AVAILABLE!
main(): This is RIOT! (Version: buildtest)
Starting shell...
> source 0
> seed 1337
Seed set to 1337
> fips
Running FIPS 140-2 test, with seed 1337 using Tiny Mersenne Twister PRNG.

- Monobit test: passed
- Poker test: passed
- Run test: passed
- Longrun test: passed
> dump 10
Timeout in expect script at "child.expect("1555530734")" (tests/rng/tests/01-run.py:27)

make: *** [test] Error 1
/home/harter/work/git/RIOT/tests/rng/../../Makefile.include:578: recipe for target 'test' failed
```

</p></details>

You can also check the stack usage with the following diff:

<details><summary><code>git diff # enable 'ps' output</code></summary><p>

``` diff
diff --git a/tests/rng/Makefile b/tests/rng/Makefile
index c772140bd..9b08f20fc 100644
--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -17,6 +17,9 @@ USEMODULE += random
 USEMODULE += shell
 USEMODULE += xtimer

+USEMODULE += shell_commands
+USEMODULE += ps
+
 FEATURES_OPTIONAL += periph_hwrng

 TEST_ON_CI_WHITELIST += native
diff --git a/tests/rng/tests/01-run.py b/tests/rng/tests/01-run.py
index e0009378a..b88823ebe 100755
--- a/tests/rng/tests/01-run.py
+++ b/tests/rng/tests/01-run.py
@@ -12,6 +12,9 @@ from testrunner import run


 def testfunc(child):
+    child.sendline("ps")
+    child.expect_exact("ps")
+    child.expect_exact("> ")
     # RNG source
     child.sendline("source 0")
     child.expect_exact("> ")
@@ -78,6 +81,10 @@ def testfunc(child):
     child.expect(re.compile(r"Calculated 0\.017\d{3} bits of entropy from 10000 samples\."))
     child.expect_exact("> ")

+    child.sendline("ps")
+    child.expect_exact("ps")
+    child.expect_exact("> ")
+

 if __name__ == "__main__":
     sys.exit(run(testfunc))
```

</p></details>

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/11043