### PR TITLE
Add stdin pseudo module and set it as dependency for applications using getchar

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -398,6 +398,10 @@ ifneq (,$(filter stdio_rtt,$(USEMODULE)))
 endif
 
 ifneq (,$(filter shell,$(USEMODULE)))
+  USEMODULE += stdin
+endif
+
+ifneq (,$(filter stdin,$(USEMODULE)))
   ifneq (,$(filter stdio_uart,$(USEMODULE)))
     USEMODULE += stdio_uart_rx
   endif

--- a/dist/tools/nrf52_resetpin_cfg/Makefile
+++ b/dist/tools/nrf52_resetpin_cfg/Makefile
@@ -5,6 +5,9 @@ APPLICATION = nrf52_resetpin_cfg
 BOARD ?= nrf52dk
 RIOTBASE ?= $(CURDIR)/../../..
 
+# This application uses getchar and thus expects input from stdio
+USEMODULE += stdin
+
 # the RESET_PIN environment variable allows for manually specifying the reset
 # pin that is programmed. Below this Makefile already contains the specific pins
 # for some known platforms

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -73,6 +73,7 @@ PSEUDOMODULES += sock
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp
 PSEUDOMODULES += sock_udp
+PSEUDOMODULES += stdin
 PSEUDOMODULES += stdio_uart_rx
 
 # print ascii representation in function od_hex_dump()

--- a/sys/include/stdio_uart.h
+++ b/sys/include/stdio_uart.h
@@ -13,6 +13,12 @@
  *
  * @brief       Standard input/output backend using UART
  *
+ * @warning Standard input is disabled by default on UART. To enable it, load
+ *          the `stdin` module in your application:
+ * ```
+ * USEMODULE += stdin
+ * ```
+ *
  * @{
  * @file
  *

--- a/tests/lua_loader/Makefile
+++ b/tests/lua_loader/Makefile
@@ -2,6 +2,9 @@ include ../Makefile.tests_common
 
 USEPKG += lua
 
+# This application uses getchar and thus expects input from stdio
+USEMODULE += stdin
+
 BOARD_WHITELIST += native samr21-xpro
 
 ifneq ($(BOARD),native)

--- a/tests/posix_time/Makefile
+++ b/tests/posix_time/Makefile
@@ -2,6 +2,9 @@ include ../Makefile.tests_common
 
 USEMODULE += posix_time
 
+# This application uses getchar and thus expects input from stdio
+USEMODULE += stdin
+
 TEST_ON_CI_WHITELIST += all
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -5,6 +5,9 @@ USEMODULE += xtimer
 # This test randomly fails on `native` so disable it from CI
 TEST_ON_CI_WHITELIST += samr21-xpro
 
+# This application uses getchar and thus expects input from stdio
+USEMODULE += stdin
+
 # Port and pin configuration for probing with oscilloscope
 # Port number should be found in port enum e.g in cpu/include/periph_cpu.h
 #FEATURES_REQUIRED += periph_gpio


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

fixes #11525

This PR introduces the stdio_rx pseudomodule that is now required when an application needs input from UART (or any other bus used for stdio), e.g. when using the getchar function.

`git grep getchar` shows that 3 applications in the RIOT code base are using getchar: `tests/xtimer_usleep`, `tests/posix_time` and another one related to nrf in `dist/tools`. The Makefiles of these application has been updated.

This PR also introduces a new test application to avoid regressions in the future. 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

See #11525 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #11525 and (better) alternative as #11594 (so closes #11594)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
