### PR TITLE
tests/unittests: remove unused LARGE_STACK_TESTS

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -246,10 +246,6 @@ ifneq (,$(filter tests-cpp_%, $(UNIT_TESTS)))
   export CPPMIX := 1
 endif
 
-ifneq (,$(filter $(LARGE_STACK_TESTS), $(UNIT_TESTS)))
-  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(4*THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF\)
-endif
-
 DISABLE_MODULE += auto_init
 
 # Pull in `Makefile.include`s from the test suites:


### PR DESCRIPTION
### Contribution description

All tests that were in LARGE_STACK_TESTS have been moved out of the directory.
This handling is not needed anymore.

Usage was remove as part of https://github.com/RIOT-OS/RIOT/issues/10187

### Testing procedure

No lines matching `LARGE_STACK_TESTS` anymore.

```
git grep LARGE_STACK_TESTS | wc -l
0
```

### Issues/PRs references

Part of cleanup in https://github.com/RIOT-OS/RIOT/issues/10187