### PR TITLE
tests/unittests: enable boards with enough memory

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -11,30 +11,25 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-nano \
                              arduino-uno \
                              arduino-zero \
-                             avsextrem \
                              b-l072z-lrwan1 \
                              blackpill \
                              bluepill \
                              calliope-mini \
-                             cc2538dk \
                              cc2650-launchpad \
                              cc2650stk \
                              chronos \
                              ek-lm4f120xl \
                              feather-m0 \
-                             firefly \
                              hamilton \
                              i-nucleo-lrwan1 \
                              ikea-tradfri \
                              limifrog-v1 maple-mini \
                              lobaro-lorabox \
                              lsn50 \
-                             mbed_lpc1768 \
                              mega-xplained \
                              microbit \
                              msb-430 \
                              msb-430h \
-                             msba2 \
                              nrf51dk \
                              nrf51dongle \
                              nrf6310 \
@@ -56,19 +51,13 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              nucleo-l433rc \
                              nz32-sc151 \
                              opencm904 \
-                             openmote-cc2538 \
-                             openmote-b \
                              pba-d-01-kw2x \
-                             remote-pa \
-                             remote-reva \
-                             remote-revb \
                              saml10-xpro \
                              saml11-xpro \
                              saml21-xpro \
                              samd21-xpro \
                              samr21-xpro \
                              samr30-xpro \
-                             seeeduino_arch-pro \
                              sensebox_samd21 \
                              slstk3401a \
                              sltb001a \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -56,7 +56,6 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              nucleo-l433rc \
                              nz32-sc151 \
                              opencm904 \
-                             openmote \
                              openmote-cc2538 \
                              openmote-b \
                              pba-d-01-kw2x \


### PR DESCRIPTION
### Contribution description
    
Now that tests with packages have been moved out of `unittests`
re-enable boards with enough memory.

The removed boards list matches the boards that now compiled locally
with `BUILD_IN_DOCKER=1 make buildtest` and also the output of murdock
for boards that were able to link despite being in the list:
    
    avsextrem:gnu
    cc2538dk:gnu
    firefly:gnu
    mbed_lpc1768:gnu
    msba2:gnu
    openmote-b:gnu
    openmote-cc2538:gnu
    remote-pa:gnu
    remote-reva:gnu
    remote-revb:gnu
    seeeduino_arch-pro:gnu

The non-existing `openmote` board is removed too.

### Testing procedure

The compilation detected in https://github.com/RIOT-OS/RIOT/pull/11168 that it could link for these boards.

CI can correctly compile for all boards.

Compilation for these boards worked locally with `BUILD_IN_DOCKER=1 make buildtest`.

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/issues/10187