### PR TITLE
tools/jlink: Fix do_term

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -254,6 +254,7 @@ do_term() {
             -jtagconf -1,-1 \
             -commandfile '${RIOTTOOLS}/jlink/term.seg' >/dev/null & \
             echo  \$! > $JLINK_PIDFILE" &
+    sleep 1
 
     sh -c "${JLINK_TERMPROG} ${JLINK_TERMFLAGS}"
 }

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -236,15 +236,16 @@ do_term() {
     JLINK_PIDFILE=$(mktemp -t "jilnk_pid.XXXXXXXXXX")
     # will be called by trap
     cleanup() {
-        JLINK_PID="$(cat ${JLINK_PIDFILE})"
-        kill ${JLINK_PID}
-        rm -r "${JLINK_PIDFILE}"
+        if [ -f $JLINK_PIDFILE ]; then
+            JLINK_PID="$(cat ${JLINK_PIDFILE})"
+            kill ${JLINK_PID}
+            rm -r "${JLINK_PIDFILE}"
+        fi
         exit 0
     }
     # cleanup after script terminates
-    trap "cleanup ${JLINK_PIDFILE}" EXIT
-    # don't trapon Ctrl+C, because JLink keeps running
-    trap '' INT
+    trap "cleanup ${JLINK_PIDFILE}" EXIT INT
+
     # start Jlink as RTT server
     sh -c "${JLINK} ${JLINK_SERIAL} \
             -ExitOnError 1 \


### PR DESCRIPTION
### Contribution description
As described in #11343 currently running `make term` does not work on boards that use J-Link Segger RTT, pyterm cannot connect to the Segger RTT server and it fails. By adding a delay after the server is launched pyterm is able to connect to the specified port.

This PR adds that delay, and also modifies the `do_term` function so it exits when pressing "Ctrl+C".

### Testing procedure
Try to run `make term` on some board that uses Segger RTT for the terminal (e.g. Ruuvitag, Thingy:52, Hamilton) on master: it should fail. After applying this PR the terminal should work.

e.g.: `BOARD=ruuvitag make flash term`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #11343
Fixes #11344 
Closes #11341
