### PR TITLE
tests/shell: Initialize xtimer when stdio_rtt is used

### DIFF
--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -24,6 +24,10 @@
 #include "shell_commands.h"
 #include "shell.h"
 
+#if MODULE_STDIO_RTT
+#include "xtimer.h"
+#endif
+
 static int print_teststart(int argc, char **argv)
 {
     (void) argc;
@@ -64,6 +68,9 @@ int main(void)
 
     printf("test_shell.\n");
 
+#if MODULE_STDIO_RTT
+    xtimer_init();
+#endif
 
     /* define buffer to be used by the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];


### PR DESCRIPTION
### Contribution description
As explained in #11605, the shell test application does not initialize xtimer, which is needed for stdio_rtt. This PR initializes the module when stdio_rtt is used.

**Note**: I added the commits from #11604 so it's easier to test. They should be removed when #11604 gets merged. Make term does not work without it.

### Testing procedure
Run the shell test on a board that uses Segger RTT.
e.g. `BOARD=ruuvitag make all flash test -C tests/shell`, the test should succeed.

### Issues/PRs references
Depends on #11604 
Fixes #11605 
