### PR TITLE
makefiles/tools/uniflash.inc.mk: remove empty RESET_FLAGS

### DIFF
--- a/makefiles/tools/uniflash.inc.mk
+++ b/makefiles/tools/uniflash.inc.mk
@@ -13,7 +13,6 @@ ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   _XDS110RESET ?= $(UNIFLASH_PATH)/simplelink/imagecreator/bin/xds110reset
   XDS110RESET ?= $(firstword $(wildcard $(_XDS110RESET) $(_XDS110RESET_4_0_4_3)) xds110reset)
   RESET = $(XDS110RESET)
-  RESET_FLAGS
 else
   FLASHER = $(UNIFLASH_PATH)/uniflash.sh
   FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(FLASHFILE)


### PR DESCRIPTION
### Contribution description

Remove the line with only 'RESET_FLAGS'. This was a migration mistake
when removing 'export'.

The complete line should have been removed here.

### Review procedure

It was not reported by murdock as it does not have `UNIFLASH_PATH` set and the default is to use the `uniflash 3` configuration.

It should also be the only required fix as it was the only relevant line without an `=` sign:

``` diff
git diff 1dc479de0..d486598f -- '*' ':!dist/tools/buildsystem_sanity_check/*' | grep -v '^+++' | grep '^+' | grep -v '='
+
+  RESET_FLAGS
+# FLASHER                    # The command to call on "make flash".
+# FFLAGS                     # The parameters to supply to FLASHER.
+# DEBUGGER                   # The command to call on "make debug", usually a script starting the GDB front-end.
+# DEBUGGER_FLAGS             # The parameters to supply to DEBUGGER.
+# DEBUGSERVER                # The command to call on "make debug-server", usually a script starting the GDB server.
+# DEBUGSERVER_FLAGS          # The parameters to supply to DEBUGSERVER.
+# RESET                      # The command to call on "make reset", this command resets/reboots the target.
+# RESET_FLAGS                # The parameters to supply to RESET.
```


### Testing procedure

When `UNIFLASH_PATH` is set to a valid uniflash 4 installation, the compilation should now work.

```
UNIFLASH_PATH=~/ti/uniflash_4.0/ BOARD=cc2650-launchpad make --no-print-directory -C examples/hello-world/
Building application "hello-world" for "cc2650-launchpad" with MCU "cc26x0".

"make" -C /home/harter/work/git/RIOT/boards/cc2650-launchpad
"make" -C /home/harter/work/git/RIOT/core
"make" -C /home/harter/work/git/RIOT/cpu/cc26x0
"make" -C /home/harter/work/git/RIOT/cpu/cc26x0/periph
"make" -C /home/harter/work/git/RIOT/cpu/cortexm_common
"make" -C /home/harter/work/git/RIOT/cpu/cortexm_common/periph
"make" -C /home/harter/work/git/RIOT/drivers
"make" -C /home/harter/work/git/RIOT/drivers/periph_common
"make" -C /home/harter/work/git/RIOT/sys
"make" -C /home/harter/work/git/RIOT/sys/auto_init
"make" -C /home/harter/work/git/RIOT/sys/newlib_syscalls_default
"make" -C /home/harter/work/git/RIOT/sys/stdio_uart
   text    data     bss     dec     hex filename
   7212     116    2540    9868    268c /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf
```

In master it failed

```
UNIFLASH_PATH=~/ti/uniflash_4.0/ BOARD=cc2650-launchpad make --no-print-directory -C examples/hello-world/
/home/harter/work/git/RIOT/makefiles/tools/uniflash.inc.mk:16: *** missing separator.  Stop.
```


### Issues/PRs references

Introduced by https://github.com/RIOT-OS/RIOT/pull/11554

Found by @MrKevinWeiss while testing https://github.com/RIOT-OS/RIOT/pull/11612