### PR TITLE
boards/kw41z: phynode-kw41z now also use the kw41z common Makefile.include

### DIFF
--- a/boards/common/kw41z/Makefile.include
+++ b/boards/common/kw41z/Makefile.include
@@ -4,7 +4,6 @@ export CPU_MODEL = mkw41z512vht4
 
 # include this module into the build
 INCLUDES += -I$(RIOTBOARD)/common/kw41z/include
-USEMODULE += boards_common_kw41z
 
 # This board comes with OpenSDA configured for JLink compatibility
 DEBUG_ADAPTER ?= jlink

--- a/boards/frdm-kw41z/Makefile.include
+++ b/boards/frdm-kw41z/Makefile.include
@@ -1,1 +1,4 @@
+# This board uses the shared board_init function
+USEMODULE += boards_common_kw41z
+
 include $(RIOTBOARD)/common/kw41z/Makefile.include

--- a/boards/phynode-kw41z/Makefile.include
+++ b/boards/phynode-kw41z/Makefile.include
@@ -1,20 +1,13 @@
-# define the cpu used by the board
-export CPU = kinetis
-export CPU_MODEL = mkw41z512vht4
-
-# include this module into the build
-INCLUDES += -I$(RIOTBOARD)/common/kw41z/include
-
 # use openocd by default to program this board
 PROGRAMMER ?= openocd
 
 # dap debug adapter is required for openocd
 ifeq (openocd,$(PROGRAMMER))
-DEBUG_ADAPTER = dap
+  DEBUG_ADAPTER = dap
 endif
 
 # Enable direct write to FCF (required for setting FOPT byte).
 export OPENOCD_PRE_FLASH_CMDS += "-c kinetis fcf_source write"
 
 # Include default FRDM board config
-include $(RIOTBOARD)/common/frdm/Makefile.include
+include $(RIOTBOARD)/common/kw41z/Makefile.include

--- a/boards/usb-kw41z/Makefile.include
+++ b/boards/usb-kw41z/Makefile.include
@@ -1,1 +1,4 @@
+# This board uses the shared board_init function
+USEMODULE += boards_common_kw41z
+
 include $(RIOTBOARD)/common/kw41z/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

fixes #11616

In #11044 the phynode-kw41z was not updated to make use the common kw41z Makefile.include because it was not sharing the same debug adapter (dap instead of jlink) and not using the same `board_init` function (in board.c).

After #11616 was opened, I thought it would make more sense to explicitly move the `USEMODULE += boards_common_kw41z` in the boards that use it instead of using it by default in the common part. This simplify reuse of the common Makefile.include.

Now `phynode-kw41z` also uses the common Makefile.include and still doesn't depend on `boards_common_kw41z` since it provides its own `board_init` function.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Normally, we should test that flashing still works on `phynode-kw41z` boards.
For the rest, a green Murdock should be ok.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #11616, follow-up of #11044 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
