### PR TITLE
pkg/nordic_softdevice_ble: reset memory in the .hex file

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -21,7 +21,7 @@ ifeq (jlink,$(PROGRAMMER))
 
   # special options when using SoftDevice
   ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
-    export JLINK_PRE_FLASH := erase\nloadfile $(BINDIR)/softdevice.hex
+    export JLINK_PRE_FLASH := loadfile $(BINDIR)/softdevice.hex
     export FLASH_ADDR := 0x1f000
     export LINKER_SCRIPT ?= $(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL)_sd.ld
     # murdock: softdevice.hex file is used for flashing

--- a/pkg/nordic_softdevice_ble/Makefile
+++ b/pkg/nordic_softdevice_ble/Makefile
@@ -21,8 +21,11 @@ prepare: $(PKG_SRCDIR)/.extracted
 $(BINDIR)/ble_6lowpan.a: $(PKG_SRCDIR)/.extracted
 	cp $(PKG_SRCDIR)/$(BLE_6LOWPAN_LIB) $@
 
+# softdevice.hex has the `[0x8bc, 0x3000[` addresses not set.
+# However, it requires that the value at `0x2000` is 0xFFFFFFFF
+# We just put all the undefined memory to 0xff as it is the rom reset value anyway.
 $(BINDIR)/softdevice.hex: $(PKG_SRCDIR)/.extracted
-	cp $(PKG_SRCDIR)/$(SOFTDEVICE) $@
+	$(Q)$(OBJCOPY) $(OFLAGS) -Oihex --gap-fill 0xff $(PKG_SRCDIR)/$(SOFTDEVICE) $@
 
 $(PKG_SRCDIR)/.extracted: $(PKG_BUILDDIR)/$(PKG_FILE)
 	rm -rf $(@D)


### PR DESCRIPTION
### Contribution description

softdevice needs the memory at 0x2000 to be initialized to 0xffffffff
according to #5893 and testing. However, the addresses [0x8bc, 0x3000[ are not
set in softdevice.hex.

So use a modified hex file with all the memory set to 0xff as it is the rom
reset value anyway.

This change updates the `.hex` file instead on relying on erasing the
memory.

### Testing procedure

Testing procedure adapted from https://github.com/RIOT-OS/RIOT/pull/11470

<details><summary>Hack not needed anymore</summary>
<blockquote>

Comment `FEATURES_OPTIONAL += periph_hwrng` in `Makefile.dep` as it currently prevent `gnrc_networking` to work even in `master`.

```
diff --git a/Makefile.dep b/Makefile.dep
index 3de6f2bf7..b45f78142 100644
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -680,7 +680,7 @@ ifneq (,$(filter random,$(USEMODULE)))
   endif
 
   ifeq (,$(filter puf_sram,$(USEMODULE)))
-    FEATURES_OPTIONAL += periph_hwrng
+    #FEATURES_OPTIONAL += periph_hwrng
   endif
 
   USEMODULE += luid
```

Then try
</blockquote>
</details>

```
BOARD=nrf52dk make -C examples/saul flash
BOARD=nrf52dk make -C examples/gnrc_networking flash term
# The board should reply

2019-06-03 18:38:47,103 - INFO # Connect to serial port /dev/riot/ttyNRF52DK
Welcome to pyterm!
Type '/exit' to exit.
2019-06-03 18:38:48,106 - INFO # main(): This is RIOT! (Version: 2019.07-devel-554-g5ef30-pr/softdevice/ensure_memory_value)
2019-06-03 18:38:48,107 - INFO # RIOT network stack example application
2019-06-03 18:38:48,107 - INFO # All up, running the shell now
> help
2019-06-03 18:38:51,295 - INFO #  help
2019-06-03 18:38:51,298 - INFO # Command              Description
2019-06-03 18:38:51,301 - INFO # ---------------------------------------
2019-06-03 18:38:51,307 - INFO # udp                  send data over UDP and listen on UDP ports
2019-06-03 18:38:51,310 - INFO # reboot               Reboot the node
2019-06-03 18:38:51,316 - INFO # ps                   Prints information about running threads.
2019-06-03 18:38:51,319 - INFO # ping6                Ping via ICMPv6
2019-06-03 18:38:51,322 - INFO # random_init          initializes the PRNG
2019-06-03 18:38:51,327 - INFO # random_get           returns 32 bit of pseudo randomness
2019-06-03 18:38:51,332 - INFO # nib                  Configure neighbor information base
2019-06-03 18:38:51,337 - INFO # ifconfig             Configure network interfaces
```

Without only removing the `erase` it would fail.

On my board it worked without the fix… but was not working alone in https://github.com/RIOT-OS/RIOT/pull/11470

### Issues/PRs references

Alternative fix done in https://github.com/RIOT-OS/RIOT/pull/5893
Was required to not duplicate the `erase` in `openocd` as here the issue is the flashed file, not that erasing memory should be done.
Split out of https://github.com/RIOT-OS/RIOT/pull/11470