### PR TITLE
sys/tsrb: bug fix for tsrb_get_one()

### DIFF
--- a/sys/tsrb/tsrb.c
+++ b/sys/tsrb/tsrb.c
@@ -32,7 +32,7 @@ static char _pop(tsrb_t *rb)
 int tsrb_get_one(tsrb_t *rb)
 {
     if (!tsrb_empty(rb)) {
-        return _pop(rb);
+        return (unsigned char)_pop(rb);
     }
     else {
         return -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes bug for getting 0xFF byte from ring buffer.
When we want to get such byte as char (signed type), it returns -1 (means buffer is empty).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Put 0xFF byte to buffer and try to get it with tsrb_get_one()

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
