### PR TITLE
boards/nrf51-based: split shared timer/rtt config

### DIFF
--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -21,8 +21,9 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
-#include "periph_conf_common.h"
 #include "cfg_clock_16_1.h"
+#include "cfg_timer_012.h"
+#include "cfg_rtt_default.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -22,45 +22,12 @@
 
 #include "periph_cpu.h"
 #include "cfg_clock_16_0.h"
+#include "cfg_timer_012.h"
+#include "cfg_rtt_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Timer configuration
- * @{
- */
-static const timer_conf_t timer_config[] = {
-    {
-        .dev      = NRF_TIMER0,
-        .channels =  3,
-        .bitmode  = TIMER_BITMODE_BITMODE_24Bit,
-        .irqn     = TIMER0_IRQn
-    },
-    {
-        .dev      = NRF_TIMER1,
-        .channels = 3,
-        .bitmode  = TIMER_BITMODE_BITMODE_16Bit,
-        .irqn     = TIMER1_IRQn
-    }
-};
-
-#define TIMER_0_ISR         isr_timer0
-#define TIMER_1_ISR         isr_timer1
-
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
-/** @} */
-
-/**
- * @name    Real time counter configuration
- * @{
- */
-#define RTT_NUMOF           (1U)
-#define RTT_DEV             (1)             /* NRF_RTC1 */
-#define RTT_MAX_VALUE       (0x00ffffff)
-#define RTT_FREQUENCY       (1024)
-/** @} */
 
 /**
  * @name    UART configuration

--- a/boards/common/nrf51/include/cfg_rtt_default.h
+++ b/boards/common/nrf51/include/cfg_rtt_default.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Inria
+ *               2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_nrf51
+ * @{
+ *
+ * @file
+ * @brief       Shared default RTT configuration for nRF51-based boards
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef CFG_RTT_DEFAULT_H
+#define CFG_RTT_DEFAULT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             (1)             /* NRF_RTC1 */
+#define RTT_MAX_VALUE       (0x00ffffff)
+#define RTT_FREQUENCY       (1024)
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* CFG_RTT_DEFAULT_H */

--- a/boards/common/nrf51/include/cfg_timer_01.h
+++ b/boards/common/nrf51/include/cfg_timer_01.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Inria
+ *               2019 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,13 +12,14 @@
  * @{
  *
  * @file
- * @brief       Common peripheral MCU configuration for some nrf51 based boards
+ * @brief       Shared timer peripheral configuration mapping timers 0 and 1
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_CONF_COMMON_H
-#define PERIPH_CONF_COMMON_H
+#ifndef CFG_TIMER_01_H
+#define CFG_TIMER_01_H
 
 #include "periph_cpu.h"
 
@@ -30,27 +32,28 @@
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* dev, channels, width */
-    { NRF_TIMER0, 3, TIMER_BITMODE_BITMODE_24Bit, TIMER0_IRQn }
+    {
+        .dev      = NRF_TIMER0,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_24Bit,
+        .irqn     = TIMER0_IRQn,
+    },
+    {
+        .dev      = NRF_TIMER1,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_16Bit,
+        .irqn     = TIMER1_IRQn,
+    }
 };
 
 #define TIMER_0_ISR         isr_timer0
+#define TIMER_1_ISR         isr_timer1
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
-/** @} */
-
-/**
- * @name    Real time counter configuration
- * @{
- */
-#define RTT_NUMOF           (1U)
-#define RTT_DEV             (1)             /* NRF_RTC1 */
-#define RTT_MAX_VALUE       (0x00ffffff)
-#define RTT_FREQUENCY       (1024)
 /** @} */
 
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif
 
-#endif /* PERIPH_CONF_COMMON_H */
+#endif /* CFG_TIMER_01_H */

--- a/boards/common/nrf51/include/cfg_timer_012.h
+++ b/boards/common/nrf51/include/cfg_timer_012.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Inria
+ *               2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_nrf51
+ * @{
+ *
+ * @file
+ * @brief       Shared timer peripheral configuration mapping timers 0, 1, and 2
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef CFG_TIMER_012_H
+#define CFG_TIMER_012_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = NRF_TIMER0,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_24Bit,
+        .irqn     = TIMER0_IRQn,
+    },
+    {
+        .dev      = NRF_TIMER1,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_16Bit,
+        .irqn     = TIMER1_IRQn,
+    },
+    {
+        .dev      = NRF_TIMER2,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_16Bit,
+        .irqn     = TIMER2_IRQn,
+    }
+};
+
+#define TIMER_0_ISR         isr_timer0
+#define TIMER_1_ISR         isr_timer1
+#define TIMER_2_ISR         isr_timer2
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* CFG_TIMER_012_H */

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -21,52 +21,12 @@
 
 #include "periph_cpu.h"
 #include "cfg_clock_16_0.h"
+#include "cfg_timer_012.h"
+#include "cfg_rtt_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name Timer configuration
- * @{
- */
-static const timer_conf_t timer_config[] = {
-    {
-        .dev      = NRF_TIMER0,
-        .channels =  3,
-        .bitmode  = TIMER_BITMODE_BITMODE_24Bit,
-        .irqn     = TIMER0_IRQn
-    },
-    {
-        .dev      = NRF_TIMER1,
-        .channels = 3,
-        .bitmode  = TIMER_BITMODE_BITMODE_16Bit,
-        .irqn     = TIMER1_IRQn
-    },
-    {
-        .dev      = NRF_TIMER2,
-        .channels = 3,
-        .bitmode  = TIMER_BITMODE_BITMODE_16Bit,
-        .irqn     = TIMER2_IRQn
-    }
-};
-
-#define TIMER_0_ISR         isr_timer0
-#define TIMER_1_ISR         isr_timer1
-#define TIMER_2_ISR         isr_timer2
-
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
-/** @} */
-
-/**
- * @name    Real time counter configuration
- * @{
- */
-#define RTT_NUMOF           (1U)
-#define RTT_DEV             (1)             /* NRF_RTC1 */
-#define RTT_MAX_VALUE       (0x00ffffff)
-#define RTT_FREQUENCY       (1024)
-/** @} */
 
 /**
  * @name   UART configuration

--- a/boards/nrf51dk/include/periph_conf.h
+++ b/boards/nrf51dk/include/periph_conf.h
@@ -20,8 +20,9 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
-#include "periph_conf_common.h"
 #include "cfg_clock_16_1.h"
+#include "cfg_timer_012.h"
+#include "cfg_rtt_default.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/nrf51dongle/include/periph_conf.h
+++ b/boards/nrf51dongle/include/periph_conf.h
@@ -20,8 +20,9 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
-#include "periph_conf_common.h"
 #include "cfg_clock_16_1.h"
+#include "cfg_timer_012.h"
+#include "cfg_rtt_default.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -23,8 +23,9 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
-#include "periph_conf_common.h"
 #include "cfg_clock_16_1.h"
+#include "cfg_timer_012.h"
+#include "cfg_rtt_default.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -20,8 +20,9 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
-#include "periph_conf_common.h"
 #include "cfg_clock_16_0.h"
+#include "cfg_timer_012.h"
+#include "cfg_rtt_default.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description
This PR streamlines the shared RTT and timer configuration for `nrf51`-based boards:
- split RTT and timer config into separate headers
- allow to map 2 or all 3 hardware timers -> the `microbit` and `calliope` use `TIMER_DEV(2)` for their LED-matrix driver

### Testing procedure
Run `tests/periph_timer` for any of the effected boards

### Issues/PRs references
enables simpler adaption of #11463
