### PR TITLE
boards/native: remove toolchain variables duplication

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -7,33 +7,6 @@ export CPU = native
 
 USEMODULE += native-drivers
 
-# toolchain:
-export PREFIX =
-export CC ?= $(PREFIX)gcc
-export CXX ?= $(PREFIX)g++
-
-ifeq ($(LTO),1)
-  export AR = $(PREFIX)gcc-ar
-else
-  export AR = $(PREFIX)ar
-endif
-
-export AS ?= $(PREFIX)as
-export LINK ?= $(PREFIX)gcc
-export SIZE ?= $(PREFIX)size
-
-ifneq ($(shell uname -s),Darwin)
-  export OBJCOPY ?= $(PREFIX)objcopy
-else
-  ifeq (0,$(shell which gobjcopy 2>&1 > /dev/null ; echo $$?))
-    export OBJCOPY ?= gobjcopy
-  else
-    # If gobjcopy is not available, just do nothing. The hexfile
-    # is not used for native anyways.
-    export OBJCOPY ?= true
-  endif
-endif
-
 ifeq ($(shell uname -s),Darwin)
   DEBUGGER ?= lldb
 else


### PR DESCRIPTION
### Contribution description

boards/native: remove toolchain variables duplication

The toolchain variables were overwritten anyway in
`makefiles/toolchain/gnu|llvm.inc.mk` as they use `=` affectation,
except for `OBJCOPY`.
    
On my Linux ubuntu bionic machine, the only difference for `info-build`
with both gnu/llvm and also with LTO=1
is that it now uses an absolute path for `objcopy`
    
    -OBJCOPY: objcopy
    +OBJCOPY: /usr/bin/objcopy
    
On the OSX 17.7.0 I tested, there was no difference.

### Testing procedure

Compare the output of `info-build` with different toolchains and enabling LTO.

I used this output:

```
{ TOOLCHAIN=gnu BOARD=native make -C examples/hello-world/ info-build; TOOLCHAIN=gnu LTO=1 BOARD=native make -C examples/hello-world/ info-build; TOOLCHAIN=llvm BOARD=native make -C examples/hello-world/ info-build; TOOLCHAIN=llvm LTO=1 BOARD=native make -C examples/hello-world/ info-build; } | tee info_build_pr
```

On my Linux machine I get this difference

``` diff
diff -u info_build_*
--- info_build_master   2019-06-04 15:43:51.031958413 +0200
+++ info_build_pr       2019-06-04 15:44:01.800045718 +0200
@@ -88,7 +88,7 @@
        -Wl,--gc-sections
        -ffunction-sections

-OBJCOPY: objcopy
+OBJCOPY: /usr/bin/objcopy
 OFLAGS:

 FLASHER: true
@@ -241,7 +241,7 @@
        -ffunction-sections
        -flto

-OBJCOPY: objcopy
+OBJCOPY: /usr/bin/objcopy
 OFLAGS:

 FLASHER: true
@@ -390,7 +390,7 @@
        -Wl,--gc-sections
        -ffunction-sections

-OBJCOPY: objcopy
+OBJCOPY: /usr/bin/objcopy
 OFLAGS:

 FLASHER: true
@@ -540,7 +540,7 @@
        -ffunction-sections
        -flto

-OBJCOPY: objcopy
+OBJCOPY: /usr/bin/objcopy
 OFLAGS:

 FLASHER: true
```

On OSX I get the same output.

### Issues/PRs references

Found as a dependency for cleaning exports for compilation variables https://github.com/RIOT-OS/RIOT/issues/10850
Board/cpu cleanup https://github.com/RIOT-OS/RIOT/issues/8713#issuecomment-369609643
