### PR TITLE
pkg/nimble: cleanup doxygen groups for submodules

### DIFF
--- a/pkg/nimble/addr/include/nimble_addr.h
+++ b/pkg/nimble/addr/include/nimble_addr.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    ble_nimble_addr Address helper for NimBLE
+ * @defgroup    ble_nimble_addr Address Helper
  * @ingroup     ble_nimble
  * @brief       NimBLE specific helper functions for handling addresses
  * @{

--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -7,7 +7,10 @@
  */
 
 /**
+ * @defgroup    ble_nimble_contrib RIOT Integration
  * @ingroup     ble_nimble
+ * @brief       Basic RIOT integration of NimBLE, including e.g. stack
+ *              configuration and (auto)initialization code
  * @{
  *
  * @file

--- a/pkg/nimble/scanlist/include/nimble_scanlist.h
+++ b/pkg/nimble/scanlist/include/nimble_scanlist.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    ble_nimble_scanlist Scan Result List
+ * @defgroup    ble_nimble_scanlist Scan Result Helper
  * @ingroup     ble_nimble
  * @brief       List for storing and printing BLE scan results
  *

--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    ble_nimble_scanner NimBLE Scanner Helper
+ * @defgroup    ble_nimble_scanner Scanner Helper
  * @ingroup     ble_nimble
  * @brief       Helper module to simplify the usage of NimBLE in scanning mode
  * @{


### PR DESCRIPTION
### Contribution description
Simple cleanup of doxygen groups for NimBLEs submodules. This PR makes the subgroup names a little more coherent, and also moves the RIOT integration code into its own subgroup for consistency.

### Testing procedure
`make doc` and look at the compiled html output

### Issues/PRs references
none