### PR TITLE
boards/lobaro-lorabox: use FLASHFILE for boards using stm32loader.py

### DIFF
--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -13,14 +13,12 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 FLASHER = $(RIOTTOOLS)/stm32loader/stm32loader.py
-
-# needed for now so the build system generates the .bin file
-HEXFILE = $(BINFILE)
+FLASHFILE ?= $(BINFILE)
 
 # -e: erase
 # -u: use sector by sector erase
 # -S: swap RTS and DTR
 # -l 0x1ff: amount of sectors to erase
-FFLAGS += -p $(PORT) -e -u -S -l 0x1ff -w $(BINFILE)
+FFLAGS += -p $(PORT) -e -u -S -l 0x1ff -w $(FLASHFILE)
 
 TERMFLAGS +=  --set-rts 0


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.


### Testing procedure

The board can still be flashed as before

### Review without the board

The FFLAGS did not change from master:

```
BOARD=lobaro-lorabox make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only
true -p /dev/ttyUSB0 -e -u -S -l 0x1ff -w /home/harter/work/git/RIOT/examples/hello-world/bin/lobaro-lorabox/hello-world.bin
```

The FLASHFILE can be configured from the command line

```
FLASHFILE='$(ELFFILE)' BOARD=lobaro-lorabox make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only
true -p /dev/ttyUSB0 -e -u -S -l 0x1ff -w /home/harter/work/git/RIOT/examples/hello-world/bin/lobaro-lorabox/hello-world.elf
```

### Issues/PRs references

This is part of adding support for FLASHFILE https://github.com/RIOT-OS/RIOT/pull/8838