### PR TITLE
kinetis/ldscript: handle _rom_offset

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm.ld
@@ -20,10 +20,7 @@
  * @}
  */
 
-_rom_offset = DEFINED( _rom_offset ) ? _rom_offset : 0x0;
-_fw_rom_length = DEFINED( _fw_rom_length ) ? _fw_rom_length : _rom_length - _rom_offset;
-
-ASSERT((_fw_rom_length <= _rom_length - _rom_offset), "Specified firmware size does not fit in ROM");
+INCLUDE cortexm_rom_offset.ld
 
 MEMORY
 {

--- a/cpu/cortexm_common/ldscripts/cortexm_rom_offset.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_rom_offset.ld
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017 Inria
+ *               2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_cortexm_common
+ * @{
+ *
+ * @file
+ * @brief           Rom offset and firmware size calculations
+ *
+ * @author          Francisco Acosta <francisco.acosta@inria.fr>
+ *                  Gaëtan Harter <gaetan.harter@inria.fr>
+ *
+ * @}
+ */
+
+_rom_offset = DEFINED( _rom_offset ) ? _rom_offset : 0x0;
+_fw_rom_length = DEFINED( _fw_rom_length ) ? _fw_rom_length : _rom_length - _rom_offset;
+
+ASSERT((_fw_rom_length <= _rom_length - _rom_offset), "Specified firmware size does not fit in ROM");

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -27,12 +27,6 @@ CFLAGS += \
   -DKINETIS_ROMSIZE=$(KINETIS_ROMSIZE) \
   #
 
-LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_rom_start_addr=$(ROM_START_ADDR)
-LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ram_base_addr=$(RAM_BASE_ADDR)
-LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ram_start_addr=$(RAM_START_ADDR)
-LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_rom_length=$(ROM_LEN)
-LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ram_length=$(RAM_LEN)
-
 # add the CPU specific flash configuration field for the linker
 export UNDEF += $(BINDIR)/cpu/fcfield.o
 

--- a/cpu/kinetis/ldscripts/kinetis.ld
+++ b/cpu/kinetis/ldscripts/kinetis.ld
@@ -25,11 +25,15 @@ OUTPUT_ARCH(arm)
 _vectors_length = 0x400;
 _flashsec_length = 0x10;
 
+INCLUDE cortexm_rom_offset.ld
+
+_flash_sec_offset = _vectors_length + _rom_offset;
+
 MEMORY
 {
-    vectors    : ORIGIN = _rom_start_addr, LENGTH = _vectors_length
-    flashsec   : ORIGIN = _rom_start_addr + _vectors_length, LENGTH = _flashsec_length
-    rom (rx)   : ORIGIN = _rom_start_addr + _vectors_length + _flashsec_length, LENGTH = _rom_length - (_vectors_length + _flashsec_length)
+    vectors    : ORIGIN = _rom_start_addr + _rom_offset, LENGTH = _vectors_length
+    flashsec   : ORIGIN = _rom_start_addr + _vectors_length + _rom_offset, LENGTH = _flashsec_length
+    rom (rx)   : ORIGIN = _rom_start_addr + _vectors_length + _flashsec_length + _rom_offset, LENGTH = _fw_rom_length - (_vectors_length + _flashsec_length)
     ram (!rx)  : ORIGIN = _ram_start_addr, LENGTH = _ram_length
 }
 
@@ -41,9 +45,9 @@ SECTIONS
         _isr_vectors = .;
         KEEP(*(SORT(.vector*)))
     } > vectors
-    ASSERT (SIZEOF(.vector) == 0x400, "Interrupt vector table of invalid size.")
-    ASSERT (ADDR(.vector) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
-    ASSERT (LOADADDR(.vector) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
+    ASSERT (SIZEOF(.vector) == _vectors_length, "Interrupt vector table of invalid size.")
+    ASSERT (ADDR(.vector) == _rom_offset, "Interrupt vector table at invalid location (linker-script error?)")
+    ASSERT (LOADADDR(.vector) == _rom_offset, "Interrupt vector table at invalid location (linker-script error?)")
 
     /* Flash configuration field, very important in order to not accidentally lock the device */
     /* Flash configuration field 0x400-0x40f. */
@@ -53,9 +57,9 @@ SECTIONS
         KEEP(*(.fcfield))
         . = ALIGN(4);
     } > flashsec
-    ASSERT (SIZEOF(.fcfield) == 0x10, "Flash configuration field of invalid size (linker-script error?)")
-    ASSERT (ADDR(.fcfield) == 0x400, "Flash configuration field at invalid position (linker-script error?)")
-    ASSERT (LOADADDR(.fcfield) == 0x400, "Flash configuration field at invalid position (linker-script error?)")
+    ASSERT (SIZEOF(.fcfield) == _flashsec_length, "Flash configuration field of invalid size (linker-script error?)")
+    ASSERT (ADDR(.fcfield) == _flash_sec_offset, "Flash configuration field at invalid position (linker-script error?)")
+    ASSERT (LOADADDR(.fcfield) == _flash_sec_offset, "Flash configuration field at invalid position (linker-script error?)")
 }
 
 INCLUDE cortexm_base.ld

--- a/tests/cortexm_common_ldscript/Makefile
+++ b/tests/cortexm_common_ldscript/Makefile
@@ -7,6 +7,13 @@ include ../Makefile.tests_common
 BOARD_WHITELIST += iotlab-a8-m3
 BOARD_WHITELIST += iotlab-m3
 BOARD_WHITELIST += samr21-xpro
+# Normally all boards using `kinetis/ldscripts/kinetis.ld` linkerscript
+BOARD_WHITELIST += frdm-kw41z
+BOARD_WHITELIST += frdm-k64f
+BOARD_WHITELIST += frdm-k22f
+BOARD_WHITELIST += mulle
+BOARD_WHITELIST += pba-d-01-kw2x
+BOARD_WHITELIST += teensy31
 # Boards using a bootloader and ROM_OFFSET by default
 BOARD_WHITELIST += arduino-mkr1000
 BOARD_WHITELIST += arduino-mkrfox1200


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR includes ROM_OFFSET handling for kinetis boards. This is a required step to be able to flash and link at an offset so `riotboot` can be used (among others). With this PR `tests/cortexm_common_ldscript` pases on kinetis platforms and is therefor whitelisted.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run `tests/cortexm_common_ldscript` on kinetis based boards:

`BOARD=frdm-kw41z make -C tests/cortexm_common_ldscript/`

Run `tests/cortexm_common_ldscript` on boards that where already whtelisted (CI should check this anyway):

`BOARD=samr21-xpro make -C tests/cortexm_common_ldscript/`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#11562 depends on it.