### PR TITLE
 tsrb: change input type to `uint8_t`

### DIFF
--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -60,7 +60,7 @@ void ethos_setup(ethos_t *dev, const ethos_params_t *params)
     dev->last_framesize = 0;
     dev->accept_new = true;
 
-    tsrb_init(&dev->inbuf, (char*)params->buf, params->bufsize);
+    tsrb_init(&dev->inbuf, params->buf, params->bufsize);
     mutex_init(&dev->out_mutex);
 
     uint32_t a = random_uint32();
@@ -127,7 +127,7 @@ static void _end_of_frame(ethos_t *dev)
             /* fall through */
         case ETHOS_FRAME_TYPE_HELLO_REPLY:
             if (dev->framesize == 6) {
-                tsrb_get(&dev->inbuf, (char*)dev->remote_mac_addr, 6);
+                tsrb_get(&dev->inbuf, dev->remote_mac_addr, 6);
             }
             break;
     }

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -44,7 +44,7 @@ static int _init(netdev_t *netdev)
     DEBUG("slipdev: initializing device %p on UART %i with baudrate %" PRIu32 "\n",
           (void *)dev, dev->config.uart, dev->config.baudrate);
     /* initialize buffers */
-    tsrb_init(&dev->inbuf, dev->rxmem, sizeof(dev->rxmem));
+    tsrb_init(&dev->inbuf, (uint8_t *)dev->rxmem, sizeof(dev->rxmem));
     if (uart_init(dev->config.uart, dev->config.baudrate, _slip_rx_cb,
                   dev) != UART_OK) {
         LOG_ERROR("slipdev: error initializing UART %i with baudrate %" PRIu32 "\n",

--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -42,7 +42,8 @@ typedef struct {
 /**
  * @brief   Static initializer for irspipe
  */
-#define ISRPIPE_INIT(tsrb_buf) { .mutex = MUTEX_INIT, .tsrb = TSRB_INIT(tsrb_buf) }
+#define ISRPIPE_INIT(tsrb_buf) { .mutex = MUTEX_INIT, \
+                                 .tsrb = TSRB_INIT(tsrb_buf) }
 
 /**
  * @brief   Initialisation function for isrpipe

--- a/sys/include/tsrb.h
+++ b/sys/include/tsrb.h
@@ -28,6 +28,7 @@
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,7 +38,7 @@ extern "C" {
  * @brief     thread-safe ringbuffer struct
  */
 typedef struct tsrb {
-    char *buf;                  /**< Buffer to operate on. */
+    uint8_t *buf;               /**< Buffer to operate on. */
     unsigned int size;          /**< Size of buffer, must be power of 2. */
     volatile unsigned reads;    /**< total number of reads */
     volatile unsigned writes;   /**< total number of writes */
@@ -46,7 +47,9 @@ typedef struct tsrb {
 /**
  * @brief Static initializer
  */
-#define TSRB_INIT(BUF) { (BUF), sizeof (BUF), 0, 0 }
+/* XXX remove this implicit cast as soon as possible (requires API change
+ *     to isrpipe)*/
+#define TSRB_INIT(BUF) { (uint8_t *)(BUF), sizeof (BUF), 0, 0 }
 
 /**
  * @brief        Initialize a tsrb.
@@ -54,7 +57,7 @@ typedef struct tsrb {
  * @param[in]    buffer    Buffer to use by tsrb.
  * @param[in]    bufsize   `sizeof (buffer)`, must be power of 2.
  */
-static inline void tsrb_init(tsrb_t *rb, char *buffer, unsigned bufsize)
+static inline void tsrb_init(tsrb_t *rb, uint8_t *buffer, unsigned bufsize)
 {
     /* make sure bufsize is a power of two.
      * http://www.exploringbinary.com/ten-ways-to-check-if-an-integer-is-a-power-of-two-in-c/
@@ -125,7 +128,7 @@ int tsrb_get_one(tsrb_t *rb);
  * @param[in]   n   max number of bytes to write to @p dst
  * @return      nr of bytes written to @p dst
  */
-int tsrb_get(tsrb_t *rb, char *dst, size_t n);
+int tsrb_get(tsrb_t *rb, uint8_t *dst, size_t n);
 
 /**
  * @brief       Drop bytes from ringbuffer
@@ -142,7 +145,7 @@ int tsrb_drop(tsrb_t *rb, size_t n);
  * @return      0   on success
  * @return      -1  if no space available
  */
-int tsrb_add_one(tsrb_t *rb, char c);
+int tsrb_add_one(tsrb_t *rb, uint8_t c);
 
 /**
  * @brief       Add bytes to ringbuffer
@@ -151,7 +154,7 @@ int tsrb_add_one(tsrb_t *rb, char c);
  * @param[in]   n   max number of bytes to read from @p src
  * @return      nr of bytes read from @p src
  */
-int tsrb_add(tsrb_t *rb, const char *src, size_t n);
+int tsrb_add(tsrb_t *rb, const uint8_t *src, size_t n);
 
 #ifdef __cplusplus
 }

--- a/sys/isrpipe/isrpipe.c
+++ b/sys/isrpipe/isrpipe.c
@@ -22,7 +22,7 @@
 void isrpipe_init(isrpipe_t *isrpipe, char *buf, size_t bufsize)
 {
     mutex_init(&isrpipe->mutex);
-    tsrb_init(&isrpipe->tsrb, buf, bufsize);
+    tsrb_init(&isrpipe->tsrb, (uint8_t *)buf, bufsize);
 }
 
 int isrpipe_write_one(isrpipe_t *isrpipe, char c)
@@ -41,7 +41,7 @@ int isrpipe_read(isrpipe_t *isrpipe, char *buffer, size_t count)
 {
     int res;
 
-    while (!(res = tsrb_get(&isrpipe->tsrb, buffer, count))) {
+    while (!(res = tsrb_get(&isrpipe->tsrb, (uint8_t *)buffer, count))) {
         mutex_lock(&isrpipe->mutex);
     }
     return res;

--- a/sys/isrpipe/read_timeout/read_timeout.c
+++ b/sys/isrpipe/read_timeout/read_timeout.c
@@ -44,7 +44,7 @@ int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_
     xtimer_t timer = { .callback = _cb, .arg = &_timeout };
 
     xtimer_set(&timer, timeout);
-    while (!(res = tsrb_get(&isrpipe->tsrb, buffer, count))) {
+    while (!(res = tsrb_get(&isrpipe->tsrb, (uint8_t *)buffer, count))) {
         mutex_lock(&isrpipe->mutex);
         if (_timeout.flag) {
             res = -ETIMEDOUT;

--- a/sys/tsrb/tsrb.c
+++ b/sys/tsrb/tsrb.c
@@ -19,12 +19,12 @@
 
 #include "tsrb.h"
 
-static void _push(tsrb_t *rb, char c)
+static void _push(tsrb_t *rb, uint8_t c)
 {
     rb->buf[rb->writes++ & (rb->size - 1)] = c;
 }
 
-static char _pop(tsrb_t *rb)
+static uint8_t _pop(tsrb_t *rb)
 {
     return rb->buf[rb->reads++ & (rb->size - 1)];
 }
@@ -39,7 +39,7 @@ int tsrb_get_one(tsrb_t *rb)
     }
 }
 
-int tsrb_get(tsrb_t *rb, char *dst, size_t n)
+int tsrb_get(tsrb_t *rb, uint8_t *dst, size_t n)
 {
     size_t tmp = n;
     while (tmp && !tsrb_empty(rb)) {
@@ -59,7 +59,7 @@ int tsrb_drop(tsrb_t *rb, size_t n)
     return (n - tmp);
 }
 
-int tsrb_add_one(tsrb_t *rb, char c)
+int tsrb_add_one(tsrb_t *rb, uint8_t c)
 {
     if (!tsrb_full(rb)) {
         _push(rb, c);
@@ -70,7 +70,7 @@ int tsrb_add_one(tsrb_t *rb, char c)
     }
 }
 
-int tsrb_add(tsrb_t *rb, const char *src, size_t n)
+int tsrb_add(tsrb_t *rb, const uint8_t *src, size_t n)
 {
     size_t tmp = n;
     while (tmp && !tsrb_full(rb)) {

--- a/sys/tsrb/tsrb.c
+++ b/sys/tsrb/tsrb.c
@@ -32,7 +32,7 @@ static uint8_t _pop(tsrb_t *rb)
 int tsrb_get_one(tsrb_t *rb)
 {
     if (!tsrb_empty(rb)) {
-        return (unsigned char)_pop(rb);
+        return _pop(rb);
     }
     else {
         return -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This is a follow-up to #11624. It makes the API of `tsrb` more in line with our [coding conventions](https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions#types) and also prevents confusing signedness errors when comparing the input of `tsrb_add_one()` with the output of `tsrb_get_one()` that was introduced with the fix of the casting error in #11624.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Cherry-pick the commits from #11632, apply the following patch:

```diff
diff --git a/tests/unittests/tests-tsrb/tests-tsrb.c b/tests/unittests/tests-tsrb/tests-tsrb.c
index 6699ce814..5cdcb56cd 100644
--- a/tests/unittests/tests-tsrb/tests-tsrb.c
+++ b/tests/unittests/tests-tsrb/tests-tsrb.c
@@ -11,6 +11,7 @@
  *
  * @file
  */
+#include <stdint.h>
 #include <string.h>
 
 #include "embUnit/embUnit.h"
@@ -19,14 +20,14 @@
 #include "tsrb.h"
 #include "tests-tsrb.h"
 
-#define TEST_INPUT          '\xdb'
+#define TEST_INPUT          (0xdb)
 #define TEST_DROP_NUM       (4U)
 #define BUFFER_SIZE         (16)    /* intentionally not unsigned to easier
                                      * check for implicit casting problems */
-#define IO_BUFFER_CANARY    ('\xb8')
+#define IO_BUFFER_CANARY    (0xb8)
 
-static char _tsrb_buffer[BUFFER_SIZE];
-static char _io_buffer[BUFFER_SIZE * 2];
+static uint8_t _tsrb_buffer[BUFFER_SIZE];
+static uint8_t _io_buffer[BUFFER_SIZE * 2];
 static tsrb_t _tsrb = TSRB_INIT(_tsrb_buffer);
 
 static void tear_down(void)
@@ -84,12 +85,12 @@ static void test_get_one(void)
     TEST_ASSERT_EQUAL_INT(0, tsrb_add_one(&_tsrb, TEST_INPUT));
     TEST_ASSERT_EQUAL_INT(TEST_INPUT, tsrb_get_one(&_tsrb));
     TEST_ASSERT_EQUAL_INT(-1, tsrb_get_one(&_tsrb));
-    TEST_ASSERT_EQUAL_INT(0, tsrb_add_one(&_tsrb, '\x0'));
-    TEST_ASSERT_EQUAL_INT('\x0', tsrb_get_one(&_tsrb));
+    TEST_ASSERT_EQUAL_INT(0, tsrb_add_one(&_tsrb, 0x0));
+    TEST_ASSERT_EQUAL_INT(0x0, tsrb_get_one(&_tsrb));
     TEST_ASSERT_EQUAL_INT(-1, tsrb_get_one(&_tsrb));
-    TEST_ASSERT_EQUAL_INT(0, tsrb_add_one(&_tsrb, '\xff'));
+    TEST_ASSERT_EQUAL_INT(0, tsrb_add_one(&_tsrb, 0xff));
     res = tsrb_get_one(&_tsrb);
-    TEST_ASSERT_EQUAL_INT('\xff', res);
+    TEST_ASSERT_EQUAL_INT(0xff, res);
     TEST_ASSERT(-1 != res);
     TEST_ASSERT_EQUAL_INT(-1, tsrb_get_one(&_tsrb));
 }
```

and follow the testing procedures from #11632. The tests should now succeed.

CI tests should all still pass.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #11624.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
