### PR TITLE
kinetis/timer: fix read from un-initialized timers

### DIFF
--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -118,17 +118,21 @@ extern "C"
  */
 #ifdef SIM_SCGC5_LPTMR_SHIFT
 /** Enable LPTMR clock gate */
-#define LPTMR_CLKEN()  (bit_set32(&SIM->SCGC5, SIM_SCGC5_LPTMR_SHIFT))
+#define LPTMR_CLKEN()      (bit_set32(&SIM->SCGC5, SIM_SCGC5_LPTMR_SHIFT))
+#define LPTMR_CLK_IS_EN()  (SIM->SCGC5 & SIM_SCGC5_LPTMR_MASK)
 #endif
 #if defined(SIM_SCGC6_PIT_SHIFT)
 /** Enable PIT clock gate */
-#define PIT_CLKEN()    (bit_set32(&SIM->SCGC6, SIM_SCGC6_PIT_SHIFT))
+#define PIT_CLKEN()        (bit_set32(&SIM->SCGC6, SIM_SCGC6_PIT_SHIFT))
+#define PIT_CLK_IS_EN()    (SIM->SCGC6 & SIM_SCGC6_PIT_MASK)
 #elif defined(SIM_SCGC_PIT_SHIFT)
-#define PIT_CLKEN()    (bit_set32(&SIM->SCGC, SIM_SCGC_PIT_SHIFT))
+#define PIT_CLKEN()        (bit_set32(&SIM->SCGC, SIM_SCGC_PIT_SHIFT))
+#define PIT_CLK_IS_EN()    (SIM->SCGC & SIM_SCGC_PIT_MASK)
+
 #endif
 #ifdef SIM_SCGC6_RTC_SHIFT
 /** Enable RTC clock gate */
-#define RTC_CLKEN()    (bit_set32(&SIM->SCGC6, SIM_SCGC6_RTC_SHIFT))
+#define RTC_CLKEN()        (bit_set32(&SIM->SCGC6, SIM_SCGC6_RTC_SHIFT))
 #endif
 /** @} */
 

--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -128,7 +128,6 @@ extern "C"
 #elif defined(SIM_SCGC_PIT_SHIFT)
 #define PIT_CLKEN()        (bit_set32(&SIM->SCGC, SIM_SCGC_PIT_SHIFT))
 #define PIT_CLK_IS_EN()    (SIM->SCGC & SIM_SCGC_PIT_MASK)
-
 #endif
 #ifdef SIM_SCGC6_RTC_SHIFT
 /** Enable RTC clock gate */

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -708,10 +708,22 @@ unsigned int timer_read(tim_t dev)
     /* demultiplex to handle two types of hardware timers */
     switch (_timer_variant(dev)) {
         case TIMER_PIT:
-            return pit_read(_pit_index(dev));
+            if(PIT_CLK_IS_EN()) {
+                return pit_read(_pit_index(dev));
+            }
+            /* uninitialized timer*/
+            else {
+                return 0;
+            }
 #ifdef KINETIS_HAVE_LPTMR
         case TIMER_LPTMR:
-            return lptmr_read(_lptmr_index(dev));
+            if(LPTMR_CLK_IS_EN()) {
+                return lptmr_read(_lptmr_index(dev));
+            }
+            /* uninitialized timer*/
+            else {
+                return 0;
+            }
 #endif
         default:
             return 0;

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -708,7 +708,7 @@ unsigned int timer_read(tim_t dev)
     /* demultiplex to handle two types of hardware timers */
     switch (_timer_variant(dev)) {
         case TIMER_PIT:
-            if(PIT_CLK_IS_EN()) {
+            if (PIT_CLK_IS_EN()) {
                 return pit_read(_pit_index(dev));
             }
             /* uninitialized timer*/
@@ -717,7 +717,7 @@ unsigned int timer_read(tim_t dev)
             }
 #ifdef KINETIS_HAVE_LPTMR
         case TIMER_LPTMR:
-            if(LPTMR_CLK_IS_EN()) {
+            if (LPTMR_CLK_IS_EN()) {
                 return lptmr_read(_lptmr_index(dev));
             }
             /* uninitialized timer*/


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`PIT->CHANNEL[ch].CVAL` can'te be read when: (a) timer is not enabled and (b) time clock is not enabled, add a check on `pit_read` and `lptmr_read` to not do that. If done a hardfault occurs.

### Testing procedure

In master apply the following patch:

```diff
diff --git a/tests/periph_timer/main.c b/tests/periph_timer/main.c
index 1cd0a9e39b..538f8bda07 100644
--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -115,6 +115,9 @@ int main(void)
 
     puts("\nTest for peripheral TIMERs\n");
 
+    timer_read(TIMER_DEV(0));
+    timer_read(TIMER_DEV(1));
+
     printf("Available timers: %i\n", TIMER_NUMOF);
 
     /* test all configured timers */
```

fails in master and passes with this PR.

```
2020-01-15 16:42:08,241 # main(): This is RIOT! (Version: 2020.01-devel-1833-g43d2c-HEAD)
2020-01-15 16:42:08,241 # 
2020-01-15 16:42:08,241 # Test for peripheral TIMERs
2020-01-15 16:42:08,241 # 
2020-01-15 16:42:08,242 # 
2020-01-15 16:42:08,246 # Context before hardfault:
2020-01-15 16:42:08,247 #    r0: 0x00000000
2020-01-15 16:42:08,247 #    r1: 0x1fff8224
2020-01-15 16:42:08,251 #    r2: 0x00000000
2020-01-15 16:42:08,252 #    r3: 0x400370fc
2020-01-15 16:42:08,252 #   r12: 0x00000000
2020-01-15 16:42:08,256 #    lr: 0x000010cf
2020-01-15 16:42:08,259 #    pc: 0x000015a2
2020-01-15 16:42:08,260 #   psr: 0x61000000
2020-01-15 16:42:08,261 # 
2020-01-15 16:42:08,261 # Misc
2020-01-15 16:42:08,262 # EXC_RET: 0xfffffffd
2020-01-15 16:42:08,266 # Attempting to reconstruct state for debugging...
2020-01-15 16:42:08,267 # In GDB:
2020-01-15 16:42:08,271 #   set $pc=0x15a2
2020-01-15 16:42:08,272 #   frame 0
2020-01-15 16:42:08,273 #   bt
```
