### PR TITLE
isrpipe: change API to be in line with `tsrb`

### DIFF
--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -52,7 +52,7 @@ typedef struct {
  * @param[in]   buf         buffer to use as ringbuffer (must be power of two sized!)
  * @param[in]   bufsize     size of @p buf
  */
-void isrpipe_init(isrpipe_t *isrpipe, char *buf, size_t bufsize);
+void isrpipe_init(isrpipe_t *isrpipe, uint8_t *buf, size_t bufsize);
 
 /**
  * @brief   Put one character into the isrpipe's buffer
@@ -63,7 +63,7 @@ void isrpipe_init(isrpipe_t *isrpipe, char *buf, size_t bufsize);
  * @returns     0 if character could be added
  * @returns     -1 if buffer was full
  */
-int isrpipe_write_one(isrpipe_t *isrpipe, char c);
+int isrpipe_write_one(isrpipe_t *isrpipe, uint8_t c);
 
 /**
  * @brief   Read data from isrpipe (blocking)
@@ -74,7 +74,7 @@ int isrpipe_write_one(isrpipe_t *isrpipe, char c);
  *
  * @returns     number of bytes read
  */
-int isrpipe_read(isrpipe_t *isrpipe, char *buf, size_t count);
+int isrpipe_read(isrpipe_t *isrpipe, uint8_t *buf, size_t count);
 
 #ifdef __cplusplus
 }

--- a/sys/include/isrpipe/read_timeout.h
+++ b/sys/include/isrpipe/read_timeout.h
@@ -44,7 +44,7 @@ extern "C" {
  * @returns     number of bytes read
  * @returns     -ETIMEDOUT on timeout
  */
-int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buf, size_t count, uint32_t timeout);
+int isrpipe_read_timeout(isrpipe_t *isrpipe, uint8_t *buf, size_t count, uint32_t timeout);
 
 /**
  * @brief   Read data from isrpipe (with timeout, blocking, wait until all read)
@@ -60,7 +60,7 @@ int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buf, size_t count, uint32_t t
  * @returns     number of bytes read
  * @returns     -ETIMEDOUT on timeout
  */
-int isrpipe_read_all_timeout(isrpipe_t *isrpipe, char *buf, size_t count, uint32_t timeout);
+int isrpipe_read_all_timeout(isrpipe_t *isrpipe, uint8_t *buf, size_t count, uint32_t timeout);
 
 #ifdef __cplusplus
 }

--- a/sys/include/tsrb.h
+++ b/sys/include/tsrb.h
@@ -47,9 +47,7 @@ typedef struct tsrb {
 /**
  * @brief Static initializer
  */
-/* XXX remove this implicit cast as soon as possible (requires API change
- *     to isrpipe)*/
-#define TSRB_INIT(BUF) { (uint8_t *)(BUF), sizeof (BUF), 0, 0 }
+#define TSRB_INIT(BUF) { (BUF), sizeof (BUF), 0, 0 }
 
 /**
  * @brief        Initialize a tsrb.

--- a/sys/isrpipe/isrpipe.c
+++ b/sys/isrpipe/isrpipe.c
@@ -19,13 +19,13 @@
 
 #include "isrpipe.h"
 
-void isrpipe_init(isrpipe_t *isrpipe, char *buf, size_t bufsize)
+void isrpipe_init(isrpipe_t *isrpipe, uint8_t *buf, size_t bufsize)
 {
     mutex_init(&isrpipe->mutex);
-    tsrb_init(&isrpipe->tsrb, (uint8_t *)buf, bufsize);
+    tsrb_init(&isrpipe->tsrb, buf, bufsize);
 }
 
-int isrpipe_write_one(isrpipe_t *isrpipe, char c)
+int isrpipe_write_one(isrpipe_t *isrpipe, uint8_t c)
 {
     int res = tsrb_add_one(&isrpipe->tsrb, c);
 
@@ -37,11 +37,11 @@ int isrpipe_write_one(isrpipe_t *isrpipe, char c)
     return res;
 }
 
-int isrpipe_read(isrpipe_t *isrpipe, char *buffer, size_t count)
+int isrpipe_read(isrpipe_t *isrpipe, uint8_t *buffer, size_t count)
 {
     int res;
 
-    while (!(res = tsrb_get(&isrpipe->tsrb, (uint8_t *)buffer, count))) {
+    while (!(res = tsrb_get(&isrpipe->tsrb, buffer, count))) {
         mutex_lock(&isrpipe->mutex);
     }
     return res;

--- a/sys/isrpipe/read_timeout/read_timeout.c
+++ b/sys/isrpipe/read_timeout/read_timeout.c
@@ -35,7 +35,7 @@ static void _cb(void *arg)
     mutex_unlock(_timeout->mutex);
 }
 
-int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_t timeout)
+int isrpipe_read_timeout(isrpipe_t *isrpipe, uint8_t *buffer, size_t count, uint32_t timeout)
 {
     int res;
 
@@ -44,7 +44,7 @@ int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_
     xtimer_t timer = { .callback = _cb, .arg = &_timeout };
 
     xtimer_set(&timer, timeout);
-    while (!(res = tsrb_get(&isrpipe->tsrb, (uint8_t *)buffer, count))) {
+    while (!(res = tsrb_get(&isrpipe->tsrb, buffer, count))) {
         mutex_lock(&isrpipe->mutex);
         if (_timeout.flag) {
             res = -ETIMEDOUT;
@@ -57,9 +57,9 @@ int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_
 }
 
 
-int isrpipe_read_all_timeout(isrpipe_t *isrpipe, char *buffer, size_t count, uint32_t timeout)
+int isrpipe_read_all_timeout(isrpipe_t *isrpipe, uint8_t *buffer, size_t count, uint32_t timeout)
 {
-    char *pos = buffer;
+    uint8_t *pos = buffer;
 
     while (count) {
         int res = isrpipe_read_timeout(isrpipe, pos, count, timeout);

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -48,7 +48,7 @@ extern ethos_t ethos;
 #include "debug.h"
 
 #ifdef MODULE_STDIO_UART_RX
-static char _rx_buf_mem[STDIO_UART_RX_BUFSIZE];
+static uint8_t _rx_buf_mem[STDIO_UART_RX_BUFSIZE];
 isrpipe_t stdio_uart_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
 #endif
 
@@ -81,7 +81,7 @@ void stdio_init(void)
 ssize_t stdio_read(void* buffer, size_t count)
 {
 #ifdef MODULE_STDIO_UART_RX
-    return (ssize_t)isrpipe_read(&stdio_uart_isrpipe, (char *)buffer, count);
+    return (ssize_t)isrpipe_read(&stdio_uart_isrpipe, buffer, count);
 #else
     (void)buffer;
     (void)count;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The API of `tsrb` was changed because of confusing type situations.
This API change takes this API change of changing `char` to `uint8_t`
up a level. Since `isrpipe` most often is used together with
`periph_uart` this change even is beneficial, as `periph_uart` also
uses `uint8_t` instead of `char`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Everything should still compile (see Murdock).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None (based on already merged #11634).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
