### PR TITLE
slipdev: make rxmem buffer uint8_t

### DIFF
--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -61,7 +61,7 @@ typedef struct {
     netdev_t netdev;                        /**< parent class */
     slipdev_params_t config;                /**< configuration parameters */
     tsrb_t inbuf;                           /**< RX buffer */
-    char rxmem[SLIPDEV_BUFSIZE];            /**< memory used by RX buffer */
+    uint8_t rxmem[SLIPDEV_BUFSIZE];         /**< memory used by RX buffer */
     uint16_t inesc;                         /**< device previously received an escape
                                              *   byte */
 } slipdev_t;

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -44,7 +44,7 @@ static int _init(netdev_t *netdev)
     DEBUG("slipdev: initializing device %p on UART %i with baudrate %" PRIu32 "\n",
           (void *)dev, dev->config.uart, dev->config.baudrate);
     /* initialize buffers */
-    tsrb_init(&dev->inbuf, (uint8_t *)dev->rxmem, sizeof(dev->rxmem));
+    tsrb_init(&dev->inbuf, dev->rxmem, sizeof(dev->rxmem));
     if (uart_init(dev->config.uart, dev->config.baudrate, _slip_rx_cb,
                   dev) != UART_OK) {
         LOG_ERROR("slipdev: error initializing UART %i with baudrate %" PRIu32 "\n",


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`tsrb` changed to that type, so there is no reason for us, to keep the
internally used buffer as a `char` (especially since the rest of the
driver already uses `uint8_t`)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/slip` should still compile.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #11634.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
