### PR TITLE
sys/bluetil: add bluetil_addr_from_str()

### DIFF
--- a/sys/include/net/bluetil/addr.h
+++ b/sys/include/net/bluetil/addr.h
@@ -56,6 +56,19 @@ void bluetil_addr_sprint(char *out, const uint8_t *addr);
 void bluetil_addr_print(const uint8_t *addr);
 
 /**
+ * @brief   Parse a BLE address from the given string
+ *
+ * @param[out] addr     buffer to write the BLE address, *must* be able to hold
+ *                      BLE_ADDR_LEN bytes
+ * @param[in] addr_str  address string, must be at least of length
+ *                      (BLUETIL_ADDR_STRLEN - 1)
+ *
+ * @return  a pointer to the resulting address on success
+ * @return  NULL on parsing error
+ */
+uint8_t *bluetil_addr_from_str(uint8_t *addr, const char *addr_str);
+
+/**
  * @brief   Get a string representation of the given BLE addresses IID-based
  *          link local address
  *

--- a/sys/net/ble/bluetil/bluetil_addr/bluetil_addr.c
+++ b/sys/net/ble/bluetil/bluetil_addr/bluetil_addr.c
@@ -26,6 +26,13 @@
 #include "net/eui48.h"
 #include "net/bluetil/addr.h"
 
+static int _is_hex_char(char c)
+{
+    return (((c >= '0') && (c <= '9')) ||
+            ((c >= 'A') && (c <= 'F')) ||
+            ((c >= 'a') && (c <= 'f')));
+}
+
 void bluetil_addr_sprint(char *out, const uint8_t *addr)
 {
     assert(out);
@@ -48,6 +55,28 @@ void bluetil_addr_print(const uint8_t *addr)
     char str[BLUETIL_ADDR_STRLEN];
     bluetil_addr_sprint(str, addr);
     printf("%s", str);
+}
+
+uint8_t *bluetil_addr_from_str(uint8_t *addr, const char *addr_str)
+{
+    assert(addr);
+    assert(addr_str);
+
+    /* check for colons */
+    for (unsigned i = 2; i < (BLUETIL_ADDR_STRLEN - 1); i += 3) {
+        if (addr_str[i] != ':') {
+            return NULL;
+        }
+    }
+
+    unsigned pos = BLE_ADDR_LEN;
+    for (unsigned i = 0; i < (BLUETIL_ADDR_STRLEN - 1); i += 3) {
+        if (!_is_hex_char(addr_str[i]) || !_is_hex_char(addr_str[i + 1])) {
+            return NULL;
+        }
+        addr[--pos] = fmt_hex_byte(addr_str + i);
+    }
+    return addr;
 }
 
 void bluetil_addr_ipv6_l2ll_sprint(char *out, const uint8_t *addr)


### PR DESCRIPTION
### Contribution description
This PR adds a function to the `bluetil/addr` helper module for parsing BLE link layer addresses from a string (`xx:xx:xx:xx:xx:xx`).

Should be simple and straight forward.

### Testing procedure
https://github.com/RIOT-OS/RIOT/pull/11578 is reabsed on this PR. So to test this function, flash the `examples/nimble_gnrc` application to any supported board and run the `ble connect BLE_ADDR` shell command.

### Issues/PRs references
needed for #11578