### PR TITLE
riotboot/Makefile.include: increase RIOTBOOT_HRD_LEN for ARMv7*-M

### DIFF
--- a/cpu/cortexm_common/Makefile.include
+++ b/cpu/cortexm_common/Makefile.include
@@ -25,6 +25,33 @@ LINKFLAGS += $(if $(ROM_OFFSET),$(LINKFLAGPREFIX)--defsym=_rom_offset=$(ROM_OFFS
 # FW_ROM_LEN: rom length to use for firmware linking. Allows linking only in a section of the rom.
 LINKFLAGS += $(if $(FW_ROM_LEN),$(LINKFLAGPREFIX)--defsym=_fw_rom_length=$(FW_ROM_LEN))
 
+# Cortex-M0+/1/3/4/7 riotboot settings
+
+# From ARMv7-M (M4, M3, M7) architecture reference manual, section B1.5.3
+# https://static.docs.arm.com/ddi0403/e/DDI0403E_d_armv7m_arm.pdf
+# "The Vector table must be naturally aligned to a power of two whose alignment
+# value is greater than or equal to number of Exceptions supported x 4"
+
+# From ARMv6-M (M0, M0+, M1) architecture reference manual, section B1.5.3
+# https://static.docs.arm.com/ddi0419/d/DDI0419D_armv6m_arm.pdf
+# "The table offset address that VTOR defines is 32-word aligned. Where more
+# than 16 external interrupts are used, the offset word alignment must be
+# increased to accommodate vectors for all the exceptions and interrupts
+# supported and keep the required table size naturally aligned."
+
+# For reference on the max number in interrupts per processor look in The
+# technical reference manual "Interrupt Controller Type Register, ICTR" section.
+# * For M4, M3 & M7: Maximum of 256 exceptions (256*4 bytes == 0x400).
+# * For M0, M0+ & M1: Maximum of 48 exceptions (48*4 bytes = 192 bytes ~= 0x100).
+
+# The values defined here are a theoretical maximum, in practice most cpu's
+# CPU_IRQ_NUMOF value is around 100, in these cases the value can be reduced
+# accordingly in the cpu Makefile.include, e.g: `kinetis/Makefile.include`
+ifneq (,$(filter cortex-m2% cortex-m4% cortex-m3% cortex-m7%,$(CPU_ARCH)))
+  RIOTBOOT_HDR_LEN ?= 0x400
+else
+  RIOTBOOT_HDR_LEN ?= 0x100
+endif
 
 # Configure riotboot bootloader and slot lengths
 # 4KB are currently enough

--- a/sys/riotboot/Makefile.include
+++ b/sys/riotboot/Makefile.include
@@ -1,6 +1,8 @@
-# Indicate the reserved space for a header, 256B by default
-# Notice that it must be 256B aligned. This is restricted by
-# the Cortex-M0+/3/4/7 architecture
+# Indicate the reserved space for a header, 256B by default.
+# The value must respect the cpu alignment requirements for the specific
+# cpu, it can be re-defined in the cpu Makefile.include accordingly.
+# e.g: `cortex-m` vector-table comes after `riotboot_hdr` and must be naturally
+# aligned according to CPU_IRQ_NUMOF (ref: cpu/cortexm_common/Makefile.include)
 RIOTBOOT_HDR_LEN ?= 0x100
 
 # By default, slot 0 is found just after RIOTBOOT_LEN. Slot 1 after


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

> "ARMv7-M Architecture Reference Manual" B1.5.3 The vector table

> The Vector table must be naturally aligned to a power of two whose alignment value is greater than or equal to (Number of Exceptions supported x 4), with a minimum alignment of 128 bytes.
> 
> "Cortex-M4 Devices Generic User Guide" 4.3.4. Vector Table Offset Register
> 
> 
> The minimum alignment is 32 words, enough for up to 16 interrupts. For more interrupts, adjust the alignment by rounding up to the next power of two. For example, if you require 21 interrupts, the alignment must be on a 64-word boundary because the required table size is 37 words, and the next power of two is 64.

Currently by default `RIOTBOOT_HDR_LEN` is defined at `0x100` this is fine for M0/M0+/M1 who only have 48 interrupts so `round_po2(4x48) = 0x100`. But for  ARMv7*-M the maximum number of interrups is 256 and in this case `round_po2(4x256) = 0x400`.

In must cases supported ISR in our boards is around 100, not more than 127. But the default case should work for all cpu/boards and when implementing `riotboot` for specific board this should be trimmed accordingly (for most ARMv7*-M `0x200` would be enough)

If the alignment isn't fixed form the `0x100` a hardfault occurs when trying to make riotboot work on otherwise almost enabled boards.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

With this PR running the following command succeeds with no hard fault:

`FEATURES_REQUIRED+=riotboot BOARD=pba-d-01-kw2x make -C tests/xtimer_usleep/ clean riotboot/flash term`

```
Without this PR running the following command succeeds with no hard fault:

2019-06-06 11:26:18,080 - INFO # Context before hardmain(): This is RIOT! (Version: 2019.07-devel-603-g86720-pr_riotboot_kw2x)
2019-06-06 11:26:18,085 - INFO # Running test 5 times with 7 distinct sleep times
2019-06-06 11:26:18,089 - INFO # Please hit any key and then ENTER to continue
2019-06-06 11:26:18,101 - INFO # 
2019-06-06 11:26:18,102 - INFO # Context before hardfault:
2019-06-06 11:26:18,104 - INFO #    r0: 0x00000000
2019-06-06 11:26:18,106 - INFO #    r1: 0x0000000b
2019-06-06 11:26:18,107 - INFO #    r2: 0x1fffc274
2019-06-06 11:26:18,109 - INFO #    r3: 0x00008080
2019-06-06 11:26:18,112 - INFO #   r12: 0x00000000
2019-06-06 11:26:18,113 - INFO #    lr: 0x0000174d
2019-06-06 11:26:18,115 - INFO #    pc: 0x0000174e
2019-06-06 11:26:18,116 - INFO #   psr: 0x01000041
2019-06-06 11:26:18,116 - INFO # 
2019-06-06 11:26:18,116 - INFO # FSR/FAR:
2019-06-06 11:26:18,117 - INFO #  CFSR: 0x00000000
2019-06-06 11:26:18,118 - INFO #  HFSR: 0x40000000
2019-06-06 11:26:18,120 - INFO #  DFSR: 0x00000000
2019-06-06 11:26:18,122 - INFO #  AFSR: 0x00000000
2019-06-06 11:26:18,122 - INFO # Misc
2019-06-06 11:26:18,123 - INFO # EXC_RET: 0xfffffff1
2019-06-06 11:26:18,128 - INFO # Attempting to reconstruct state for debugging...
2019-06-06 11:26:18,129 - INFO # In GDB:
2019-06-06 11:26:18,131 - INFO #   set $pc=0x174e
2019-06-06 11:26:18,131 - INFO #   frame 0
2019-06-06 11:26:18,132 - INFO #   bt
2019-06-06 11:26:18,132 - INFO # 
2019-06-06 11:26:18,135 - INFO # ISR stack overflowed by at least 72 bytes.

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
