### PR TITLE
boards/pba-d-01-kw2x: add riotboot support

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -8,6 +8,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -4,6 +4,14 @@ ifeq (,$(KINETIS_SERIES))
   include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/kinetis-info.mk
 endif
 
+# "The Vector table must be naturally aligned to a power of two whose alignment
+# value is greater than or equal to number of Exceptions supported x 4"
+# CPU_IRQ_NUMOF for KWxD boards is < 81+16 so (81*4 bytes = 388 bytes ~= 0x200)
+# RIOTBOOT_HDR_LEN can be set to 0x200
+ifeq (DW, $(KINETIS_CORE)$(KINETIS_SERIES))
+  RIOTBOOT_HDR_LEN ?= 0x200
+endif
+
 # Add search path for linker scripts
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds riotboot support or pba-d-01-kw2x.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run riotboot tests and everything should work as expected.

`BOARD=pba-d-01-kw2xFEATURES_REQUIRED+=riotboot make -C tests/xtimer_usleep riotboot/flash-extended-slot0 term`

`BOARD=pba-d-01-kw2x FEATURES_REQUIRED+=riotboot make -C tests/xtimer_usleep riotboot/flash-slot1 term`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Related to #11641 