### PR TITLE
boards/nucleo-l476rg: add riotboot

### DIFF
--- a/boards/nucleo-l476rg/Makefile.features
+++ b/boards/nucleo-l476rg/Makefile.features
@@ -8,6 +8,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 

--- a/cpu/stm32l4/Makefile.include
+++ b/cpu/stm32l4/Makefile.include
@@ -1,5 +1,11 @@
 export CPU_ARCH = cortex-m4f
 export CPU_FAM  = stm32l4
 
+# "The Vector table must be naturally aligned to a power of two whose alignment
+# value is greater than or equal to number of Exceptions supported x 4"
+# CPU_IRQ_NUMOFF for stm32l4 boards is < 91+16 so (107*4 bytes = 428 bytes ~= 0x200)
+# RIOTBOOT_HDR_LEN can be set to 0x200
+RIOTBOOT_HDR_LEN ?= 0x200
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32l4/include/cpu_conf.h
+++ b/cpu/stm32l4/include/cpu_conf.h
@@ -55,6 +55,7 @@ extern "C" {
 #else
 #define CPU_IRQ_NUMOF                   (82U)
 #endif
+#define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds riotboot support or nucleo-l476rg. It should work for all nucleo stm32l4 based boards. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run riotboot tests and everything should work as expected.

`BOARD=nucleo-l476rg FEATURES_REQUIRED+=riotboot make -C tests/xtimer_usleep riotboot/flash-extended-slot0 term`

`BOARD=nucleo-l476rg  FEATURES_REQUIRED+=riotboot make -C tests/xtimer_usleep riotboot/flash-slot1 term`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Related to #11641 
