### PR TITLE
tools/edbg: escape values set by 'env'

### DIFF
--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -10,7 +10,7 @@ all: git-download
 # Start edbg build in a clean environment, so variables set by RIOT's build process
 # for cross compiling a specific target platform are reset and edbg can
 # be built cleanly for the native platform.
-	env -i PATH=$(PATH) TERM=$(TERM) "$(MAKE)" -C $(PKG_BUILDDIR)
+	env -i PATH="$(PATH)" TERM="$(TERM)" "$(MAKE)" -C "$(PKG_BUILDDIR)"
 	mv $(PKG_BUILDDIR)/edbg .
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description
Right now, for instance, if a path with spaces exists in the PATH environmental variable, the build process of edbg fails. This PR escapes the values passed to `env` in the Makefile of edbg (I'm not quite sure if this is also needed for `PKG_BULDDIR`).

### Testing procedure
Set either PATH or TERM variables to values that contain spaces and try to build edbg (e.g. by ensuring it is not in `dist/tools/edbg/edbg` and trying to flash some board that uses it, like samr21-xpro).

### Issues/PRs references
None