### PR TITLE
esp*: updates to the programmer configuration

### DIFF
--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -9,4 +9,4 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
 RESET ?= esptool.py
-RESET_FLAGS ?= --before default_reset run
+RESET_FLAGS ?= --port $(PORT) --before default_reset run

--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -8,4 +8,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
-RESET ?= esptool.py --before default_reset run
+RESET ?= esptool.py
+RESET_FLAGS ?= --before default_reset run

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -9,4 +9,4 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
 RESET ?= esptool.py
-RESET_FLAGS ?= --before default_reset run
+RESET_FLAGS ?= --port $(PORT) --before default_reset run

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -8,4 +8,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
-RESET ?= esptool.py --before default_reset run
+RESET ?= esptool.py
+RESET_FLAGS ?= --before default_reset run

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -159,7 +159,7 @@ PREFFLAGS += ls -l $(FLASHFILE).bin | awk '{ print $$5 }' >> $(BINDIR)/partition
 
 PREFFLAGS += python $(RIOTCPU)/$(CPU)/gen_esp32part.py --disable-sha256sum
 PREFFLAGS += --verify $(BINDIR)/partitions.csv $(BINDIR)/partitions.bin
-FLASHDEPS  = preflash
+FLASHDEPS += preflash
 
 # flasher configuration
 ifeq ($(QEMU), 1)

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -132,7 +132,7 @@ LINKFLAGS += -Wl,--warn-unresolved-symbols
 FLASHFILE ?= $(ELFFILE)
 
 # configure preflasher to convert .elf to .bin before flashing
-FLASH_SIZE = -fs 8m
+FLASH_SIZE = -fs 1MB
 PREFLASHER ?= esptool.py
 PREFFLAGS  ?= elf2image $(FLASH_SIZE) $(FLASHFILE)
 FLASHDEPS  += preflash

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -135,7 +135,7 @@ FLASHFILE ?= $(ELFFILE)
 FLASH_SIZE = -fs 8m
 PREFLASHER ?= esptool.py
 PREFFLAGS  ?= elf2image $(FLASH_SIZE) $(FLASHFILE)
-FLASHDEPS  ?= preflash
+FLASHDEPS  += preflash
 
 # flasher configuration
 ifeq ($(QEMU), 1)


### PR DESCRIPTION
### Contribution description

This updates/cleans up some the declaration of the flasher/reset interaction.

* Set FLASHFILE as file used for flashing. A machine with only `esptool.py` and no toolchain can correctly flash the device (Split in https://github.com/RIOT-OS/RIOT/pull/11648)
* ~use esptool.py from the path~ removed from this one
* Update to use `RESET_FLAGS` and use `?=` for affectation
* Use `PORT` for `reset` too.
* Append the `FLASHDEPS`
* Use new size format (only a warning removal)

These updates are required for me for flashing the boards that are on another machine without toolchain with multiple boards connected. https://github.com/RIOT-OS/RIOT/pull/10870

### Testing procedure

Flashing and resetting with `esptool.py` installed from pip and without the `SDK` installed using `PORT`.

<details><summary><code>PORT=/dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_d27cb210df3de81181be72c97a7060d0-if00-port0 BOARD=esp32-wroom-32 BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/default/ reset flash term</code></summary><p>

```
PORT=/dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_d27cb210df3de81181be72c97a7060d0-if00-port0 BOARD=esp32-wroom-32 BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/default/ reset flash term 2>&1 | tee output_esp32
make: Entering directory '/home/harter/work/git/RIOT/examples/default'
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
esptool.py --port /dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_d27cb210df3de81181be72c97a7060d0-if00-port0 --before default_reset run
esptool.py v2.6
Serial port /dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_d27cb210df3de81181be72c97a7060d0-if00-port0
Connecting....
Detecting chip type... ESP32
Chip is ESP32D0WDQ5 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
MAC: 30:ae:a4:d3:46:00
Uploading stub...
Running stub...
Stub running...
Hard resetting via RTS pin...
[1;32mLaunching build container using image "riot/riotbuild:latest".[0m
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'     \
    -e 'BOARD=esp32-wroom-32' \
    -w '/data/riotbuild/riotbase/examples/default/' \
    'riot/riotbuild:latest' make   
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
[1;32mBuilding application "default" for "esp32-wroom-32" with MCU "esp32".[0m

"make" -C /data/riotbuild/riotbase/boards/esp32-wroom-32
"make" -C /data/riotbuild/riotbase/boards/common/esp32
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/esp32
"make" -C /data/riotbuild/riotbase/cpu/esp32/freertos
"make" -C /data/riotbuild/riotbase/cpu/esp32/periph
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/driver
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/esp32
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/heap
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/soc
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/spi_flash
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/wpa_supplicant
"make" -C /data/riotbuild/riotbase/cpu/esp_common
"make" -C /data/riotbuild/riotbase/cpu/esp_common/vendor
"make" -C /data/riotbuild/riotbase/cpu/esp_common/vendor/xtensa
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/saul
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/auto_init/saul
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/log
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/phydat
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/sys/random/tinymt32
"make" -C /data/riotbuild/riotbase/sys/saul_reg
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  71157	   4884	   6252	  82293	  14175	/data/riotbuild/riotbase/examples/default/bin/esp32-wroom-32/default.elf
esptool.py --chip esp32 elf2image -fm dout -fs 2MB -ff 40m    -o /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/default.elf.bin /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/default.elf; echo "" > /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; echo "nvs, data, nvs, 0x9000, 0x6000" >> /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; echo "phy_init, data, phy, 0xf000, 0x1000" >> /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; echo -n "factory, app, factory, 0x10000, " >> /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; ls -l /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/default.elf.bin | awk '{ print $5 }' >> /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; python /home/harter/work/git/RIOT/cpu/esp32/gen_esp32part.py --disable-sha256sum --verify /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.bin
esptool.py v2.6
Parsing CSV input...
esptool.py --chip esp32 -p /dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_d27cb210df3de81181be72c97a7060d0-if00-port0 -b 460800 --before default_reset --after hard_reset write_flash -z -fm dout -fs detect -ff 40m    0x1000 /home/harter/work/git/RIOT/cpu/esp32/bin/bootloader.bin 0x8000 /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.bin 0x10000 /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/default.elf.bin
esptool.py v2.6
Serial port /dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_d27cb210df3de81181be72c97a7060d0-if00-port0
Connecting....
Chip is ESP32D0WDQ5 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
MAC: 30:ae:a4:d3:46:00
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Auto-detected Flash size: 4MB
Flash params set to 0x0320
Compressed 20608 bytes to 12166...

Writing at 0x00001000... (100 %)
Wrote 20608 bytes (12166 compressed) at 0x00001000 in 0.3 seconds (effective 597.4 kbit/s)...
Hash of data verified.
Compressed 3072 bytes to 85...

Writing at 0x00008000... (100 %)
Wrote 3072 bytes (85 compressed) at 0x00008000 in 0.0 seconds (effective 4526.8 kbit/s)...
Hash of data verified.
Compressed 103840 bytes to 49682...

Writing at 0x00010000... (25 %)
Writing at 0x00014000... (50 %)
Writing at 0x00018000... (75 %)
Writing at 0x0001c000... (100 %)
Wrote 103840 bytes (49682 compressed) at 0x00010000 in 1.4 seconds (effective 597.0 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_d27cb210df3de81181be72c97a7060d0-if00-port0" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-06-06 15:17:35,259 - INFO # Connect to serial port /dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_d27cb210df3de81181be72c97a7060d0-if00-port0
Welcome to pyterm!
Type '/exit' to exit.
2019-06-06 15:17:36,265 - INFO # esp_image: segment 1: paddr=0x000127e0 vaddr=0x3ffb0000 size=0x01314 (  4884) load[0m
2019-06-06 15:17:36,266 - INFO # [0;32mI (105) esp_image: segment 2: paddr=0x00013afc vaddr=0x40080000 size=0x00400 (  1024) load[0m
2019-06-06 15:17:36,267 - INFO # [0;32mI (112) esp_image: segment 3: paddr=0x00013f04 vaddr=0x40080400 size=0x054e8 ( 21736) load[0m
2019-06-06 15:17:36,268 - INFO # [0;32mI (130) esp_image: segment 4: paddr=0x000193f4 vaddr=0x00000000 size=0x06c1c ( 27676) [0m
2019-06-06 15:17:36,269 - INFO # [0;32mI (141) esp_image: segment 5: paddr=0x00020018 vaddr=0x400d0018 size=0x09558 ( 38232) map[0m
2019-06-06 15:17:36,270 - INFO # [0;32mI (158) boot: Loaded app from partition at offset 0x10000[0m
2019-06-06 15:17:36,271 - INFO # [0;32mI (158) boot: Disabling RNG early entropy source...[0m
2019-06-06 15:17:36,271 - INFO # 
2019-06-06 15:17:36,272 - INFO # Starting ESP32 with ID: 1730aea4d34600
2019-06-06 15:17:36,272 - INFO # 
2019-06-06 15:17:36,273 - INFO # Current clocks in Hz: CPU=80000000 APB=80000000 XTAL=40000000 SLOW=150000
2019-06-06 15:17:36,274 - INFO # PRO cpu is up (single core mode, only PRO cpu is used)
2019-06-06 15:17:36,274 - INFO # PRO cpu starts user code
2019-06-06 15:17:36,275 - INFO # Used clocks in Hz: CPU=80000000 APB=80000000 XTAL=40000000 FAST=8000000 SLOW=150000
2019-06-06 15:17:36,276 - INFO # XTAL calibration value: 3283802
2019-06-06 15:17:36,276 - INFO # Heap free: 184320 bytes
2019-06-06 15:17:36,276 - INFO # System time: 1970-01-01 00:00:00
2019-06-06 15:17:36,276 - INFO # 
2019-06-06 15:17:36,277 - INFO # Board configuration:
2019-06-06 15:17:36,277 - INFO # 	UART_DEV(0)	txd=1 rxd=3
2019-06-06 15:17:36,277 - INFO # 	UART_DEV(1)	txd=10 rxd=9
2019-06-06 15:17:36,278 - INFO # 	LED		pins=[ ]
2019-06-06 15:17:36,278 - INFO # 	BUTTONS		pins=[ 0 ]
2019-06-06 15:17:36,278 - INFO # 
2019-06-06 15:17:36,278 - INFO # Starting RIOT kernel on PRO cpu
2019-06-06 15:17:36,279 - INFO # I (258) [main_trampoline]: main(): This is RIOT! (Version: 2019.07-devel-621-g1b354-pr/esp/programmer_update)
2019-06-06 15:17:36,280 - INFO # Welcome to RIOT!
> 2019-06-06 15:17:47,574 - INFO #  help
2019-06-06 15:17:47,581 - INFO # Command              Description
2019-06-06 15:17:47,585 - INFO # ---------------------------------------
2019-06-06 15:17:47,587 - INFO # reboot               Reboot the node
2019-06-06 15:17:47,592 - INFO # ps                   Prints information about running threads.
2019-06-06 15:17:47,597 - INFO # random_init          initializes the PRNG
2019-06-06 15:17:47,603 - INFO # random_get           returns 32 bit of pseudo randomness
2019-06-06 15:17:47,607 - INFO # rtc                  control RTC peripheral interface
2019-06-06 15:17:47,611 - INFO # saul                 interact with sensors and actuators using SAUL
> 
```

</p></details>


<details><summary><code>PORT=/dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0 BOARD=esp8266-esp-12x BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/default/ reset flash term</code></summary><p>

```
PORT=/dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0 BOARD=esp8266-esp-12x BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/default/ reset flash term 2>&1 | tee output_esp8266
make: Entering directory '/home/harter/work/git/RIOT/examples/default'
ESP8266_NEWLIB_DIR should be defined as /path/to/newlib directory
ESP8266_NEWLIB_DIR is set by default to /opt/esp/newlib-xtensa
ESP8266_SDK_DIR should be defined as /path/to/sdk directory
ESP8266_SDK_DIR is set by default to /opt/esp/esp-open-sdk/sdk
esptool.py --port /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0 --before default_reset run
esptool.py v2.6
Serial port /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0
Connecting....
Detecting chip type... ESP8266
Chip is ESP8266EX
Features: WiFi
MAC: 68:c6:3a:ac:a1:fb
Uploading stub...
Running stub...
Stub running...
Hard resetting via RTS pin...
[1;32mLaunching build container using image "riot/riotbuild:latest".[0m
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'     \
    -e 'BOARD=esp8266-esp-12x' \
    -w '/data/riotbuild/riotbase/examples/default/' \
    'riot/riotbuild:latest' make   
ESP8266_NEWLIB_DIR should be defined as /path/to/newlib directory
ESP8266_NEWLIB_DIR is set by default to /opt/esp/newlib-xtensa
ESP8266_SDK_DIR should be defined as /path/to/sdk directory
ESP8266_SDK_DIR is set by default to /opt/esp/esp-open-sdk/sdk
[1;32mBuilding application "default" for "esp8266-esp-12x" with MCU "esp8266".[0m

"make" -C /data/riotbuild/riotbase/boards/esp8266-esp-12x
"make" -C /data/riotbuild/riotbase/boards/common/esp8266
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/esp8266
"make" -C /data/riotbuild/riotbase/cpu/esp8266/periph
"make" -C /data/riotbuild/riotbase/cpu/esp8266/sdk
"make" -C /data/riotbuild/riotbase/cpu/esp8266/vendor
"make" -C /data/riotbuild/riotbase/cpu/esp8266/vendor/esp
"make" -C /data/riotbuild/riotbase/cpu/esp_common
"make" -C /data/riotbuild/riotbase/cpu/esp_common/vendor
"make" -C /data/riotbuild/riotbase/cpu/esp_common/vendor/xtensa
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/mtd
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/saul
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/auto_init/saul
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/phydat
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/sys/random/tinymt32
"make" -C /data/riotbuild/riotbase/sys/saul_reg
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  81987	   4324	   7296	  93607	  16da7	/data/riotbuild/riotbase/examples/default/bin/esp8266-esp-12x/default.elf
esptool.py elf2image -fs 1MB /home/harter/work/git/RIOT/examples/default/bin/esp8266-esp-12x/default.elf
esptool.py v2.6
Creating image for ESP8266...
esptool.py -p /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0 -b 460800 write_flash -fm dout 0 /home/harter/work/git/RIOT/examples/default/bin/esp8266-esp-12x/default.elf-0x00000.bin 0x10000 /home/harter/work/git/RIOT/examples/default/bin/esp8266-esp-12x/default.elf-0x10000.bin; esptool.py -p /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0 run
esptool.py v2.6
Serial port /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0
Connecting....
Detecting chip type... ESP8266
Chip is ESP8266EX
Features: WiFi
MAC: 68:c6:3a:ac:a1:fb
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Auto-detected Flash size: 4MB
Flash params set to 0x0340
Compressed 23456 bytes to 12030...

Writing at 0x00000000... (100 %)
Wrote 23456 bytes (12030 compressed) at 0x00000000 in 0.3 seconds (effective 696.6 kbit/s)...
Hash of data verified.
Compressed 62904 bytes to 44608...

Writing at 0x00010000... (33 %)
Writing at 0x00014000... (66 %)
Writing at 0x00018000... (100 %)
Wrote 62904 bytes (44608 compressed) at 0x00010000 in 1.0 seconds (effective 501.7 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
esptool.py v2.6
Serial port /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0
Connecting....
Detecting chip type... ESP8266
Chip is ESP8266EX
Features: WiFi
MAC: 68:c6:3a:ac:a1:fb
Uploading stub...
Running stub...
Stub running...
Hard resetting via RTS pin...
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-06-06 15:11:45,846 - INFO # Connect to serial port /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_8266-if00-port0
Welcome to pyterm!
Type '/exit' to exit.
2019-06-06 15:11:46,858 - INFO # heap: 62944 (free 61440) byte
2019-06-06 15:11:46,860 - INFO # sysmem: 1500 (used 36, free 1464)
2019-06-06 15:11:46,860 - INFO # 
2019-06-06 15:11:46,861 - INFO # Board configuration:
2019-06-06 15:11:46,862 - INFO # 	PWM_DEV(0): channels=[ 2 4 5 ]
2019-06-06 15:11:46,864 - INFO # 	I2C_DEV(0): scl=5 sda=4
2019-06-06 15:11:46,864 - INFO # 	SPI: no devices
2019-06-06 15:11:46,865 - INFO # 	UART_DEV(0): txd=1 rxd=3
2019-06-06 15:11:46,867 - INFO # 	TIMER_DEV(0): 1 channel(s)
2019-06-06 15:11:46,867 - INFO # 	LED: pins=[ 2 ]
2019-06-06 15:11:46,868 - INFO # 
2019-06-06 15:11:46,872 - INFO # main(): This is RIOT! (Version: 2019.07-devel-621-g1b354-pr/esp/programmer_update)
2019-06-06 15:11:46,873 - INFO # Welcome to RIOT!
> 2019-06-06 15:11:48,738 - INFO #  help
2019-06-06 15:11:48,741 - INFO # Command              Description
2019-06-06 15:11:48,744 - INFO # ---------------------------------------
2019-06-06 15:11:48,747 - INFO # reboot               Reboot the node
2019-06-06 15:11:48,752 - INFO # ps                   Prints information about running threads.
2019-06-06 15:11:48,756 - INFO # random_init          initializes the PRNG
2019-06-06 15:11:48,761 - INFO # random_get           returns 32 bit of pseudo randomness
2019-06-06 15:11:48,768 - INFO # saul                 interact with sensors and actuators using SAUL
> 
```
</p></details>

`FLASHDEPS` can already contain values, these two prints `info-build` before flashing

```
FLASHDEPS=info-build BOARD=esp32-wroom-32 make -C examples/default/ flash-only
FLASHDEPS=info-build  BOARD=esp8266-esp-12x make -C examples/default/ flash-only
```

`RESET` can be overwritten from the environment

```
RESET=true BOARD=esp32-wroom-32 make --no-print-directory -C examples/default/ reset
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
true --port /dev/ttyUSB0 --before default_reset run
```

```
 RESET=true BOARD=esp8266-esp-12x make --no-print-directory -C examples/default/ reset
ESP8266_NEWLIB_DIR should be defined as /path/to/newlib directory
ESP8266_NEWLIB_DIR is set by default to /opt/esp/newlib-xtensa
ESP8266_SDK_DIR should be defined as /path/to/sdk directory
ESP8266_SDK_DIR is set by default to /opt/esp/esp-open-sdk/sdk
true --port /dev/ttyUSB0 --before default_reset run
```

> FLASHFILE test will gets on its own in a separate PR

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/10870

Depends on https://github.com/RIOT-OS/RIOT/pull/11648