### PR TITLE
cpu/sam0_common: add hwrng driver

### DIFF
--- a/cpu/sam0_common/periph/hwrng.c
+++ b/cpu/sam0_common/periph/hwrng.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_sam0_common
+ * @ingroup     drivers_periph_hwrng
+ * @{
+ *
+ * @file
+ * @brief       Low-level random number generator driver implementation
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph/hwrng.h"
+
+void hwrng_init(void)
+{
+    /* Enable the MCLK */
+    MCLK->APBCMASK.bit.TRNG_ = 1;
+
+    /* Enable the TRNG */
+    TRNG->CTRLA.bit.ENABLE = 1;
+}
+
+uint32_t hwrand(void)
+{
+    while (!TRNG->INTFLAG.bit.DATARDY) {}
+    return TRNG->DATA.reg;
+}
+
+void hwrng_read(void *buf, unsigned int num)
+{
+    unsigned int count = 0;
+    uint8_t *b = (uint8_t *)buf;
+
+    while (count < num) {
+        /* read next 4 bytes of random data */
+        uint32_t tmp = hwrand();
+
+        /* copy data into result vector */
+        for (int i = 0; i < 4 && count < num; i++) {
+            b[count++] = (uint8_t)tmp;
+            tmp = tmp >> 8;
+        }
+    }
+}

--- a/cpu/samd5x/Makefile.features
+++ b/cpu/samd5x/Makefile.features
@@ -1,1 +1,3 @@
+FEATURES_PROVIDED += periph_hwrng
+
 include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml1x/Makefile.features
+++ b/cpu/saml1x/Makefile.features
@@ -1,1 +1,3 @@
+FEATURES_PROVIDED += periph_hwrng
+
 include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml21/Makefile.features
+++ b/cpu/saml21/Makefile.features
@@ -1,1 +1,8 @@
+# The SAMR30 line of MCUs does not contain a TRNG
+BOARDS_WITHOUT_HWRNG += samr30-xpro
+
+ifeq (,$(filter $(BOARDS_WITHOUT_HWRNG),$(BOARD)))
+  FEATURES_PROVIDED += periph_hwrng
+endif
+
 -include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml21/Makefile.features
+++ b/cpu/saml21/Makefile.features
@@ -5,4 +5,4 @@ ifeq (,$(filter $(BOARDS_WITHOUT_HWRNG),$(BOARD)))
   FEATURES_PROVIDED += periph_hwrng
 endif
 
--include $(RIOTCPU)/sam0_common/Makefile.features
+include $(RIOTCPU)/sam0_common/Makefile.features


### PR DESCRIPTION
SAML1X, SAML2X and SAMD5X all share the same HWRNG peripheral.

This adds a driver for it.