### PR TITLE
cpu/esp*: use FLASHFILE for esp32 and esp8266 boards

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -140,6 +140,9 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
 LINKFLAGS += -nostdlib -lgcc -u putchar -Wl,-gc-sections
 LINKFLAGS += -Wl,--warn-unresolved-symbols
 
+# The ELFFILE is the base one used for flashing
+FLASHFILE ?= $(ELFFILE)
+
 # configure preflasher to convert .elf to .bin before flashing
 FLASH_MODE ?= dout  # FIX configuration, DO NOT CHANGE
 FLASH_FREQ  = 40m   # FIX configuration, DO NOT CHANGE
@@ -147,12 +150,12 @@ FLASH_SIZE ?= 2MB
 PREFLASHER = $(ESPTOOL)
 PREFFLAGS  = --chip esp32 elf2image
 PREFFLAGS += -fm $(FLASH_MODE) -fs $(FLASH_SIZE) -ff $(FLASH_FREQ)
-PREFFLAGS += -o $(ELFFILE).bin $(ELFFILE);
+PREFFLAGS += -o $(FLASHFILE).bin $(FLASHFILE);
 PREFFLAGS += echo "" > $(BINDIR)/partitions.csv;
 PREFFLAGS += echo "nvs, data, nvs, 0x9000, 0x6000" >> $(BINDIR)/partitions.csv;
 PREFFLAGS += echo "phy_init, data, phy, 0xf000, 0x1000" >> $(BINDIR)/partitions.csv;
 PREFFLAGS += echo -n "factory, app, factory, 0x10000, " >> $(BINDIR)/partitions.csv;
-PREFFLAGS += ls -l $(ELFFILE).bin | awk '{ print $$5 }' >> $(BINDIR)/partitions.csv;
+PREFFLAGS += ls -l $(FLASHFILE).bin | awk '{ print $$5 }' >> $(BINDIR)/partitions.csv;
 
 PREFFLAGS += python $(RIOTCPU)/$(CPU)/gen_esp32part.py --disable-sha256sum
 PREFFLAGS += --verify $(BINDIR)/partitions.csv $(BINDIR)/partitions.bin
@@ -167,7 +170,7 @@ ifeq ($(QEMU), 1)
     FFLAGS += head -c $$((0x8000)) |
     FFLAGS += cat - $(BINDIR)/partitions.bin tmp.bin |
     FFLAGS += head -c $$((0x10000)) |
-    FFLAGS += cat - $(ELFFILE).bin tmp.bin |
+    FFLAGS += cat - $(FLASHFILE).bin tmp.bin |
     FFLAGS += head -c $$((0x400000)) > $(BINDIR)/esp32flash.bin && rm tmp.bin &&
     FFLAGS += cp $(RIOTCPU)/$(CPU)/bin/rom_0x3ff90000_0x00010000.bin $(BINDIR)/rom1.bin &&
     FFLAGS += cp $(RIOTCPU)/$(CPU)/bin/rom_0x40000000_0x000c2000.bin $(BINDIR)/rom.bin
@@ -179,5 +182,5 @@ else
     FFLAGS += -z -fm $(FLASH_MODE) -fs detect -ff $(FLASH_FREQ)
     FFLAGS += 0x1000 $(RIOTCPU)/$(CPU)/bin/bootloader.bin
     FFLAGS += 0x8000 $(BINDIR)/partitions.bin
-    FFLAGS += 0x10000 $(ELFFILE).bin
+    FFLAGS += 0x10000 $(FLASHFILE).bin
 endif

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -128,24 +128,27 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/eagle.rom.addr.v6.ld
 LINKFLAGS += -nostdlib -lgcc -u ets_run -Wl,-gc-sections # -Wl,--print-gc-sections
 LINKFLAGS += -Wl,--warn-unresolved-symbols
 
+# The ELFFILE is the base one used for flashing
+FLASHFILE ?= $(ELFFILE)
+
 # configure preflasher to convert .elf to .bin before flashing
 FLASH_SIZE = -fs 8m
 PREFLASHER ?= esptool.py
-PREFFLAGS  ?= elf2image $(FLASH_SIZE) $(ELFFILE)
+PREFFLAGS  ?= elf2image $(FLASH_SIZE) $(FLASHFILE)
 FLASHDEPS  ?= preflash
 
 # flasher configuration
 ifeq ($(QEMU), 1)
     FLASHER = cat
-    FFLAGS += $(ELFFILE)-0x00000.bin /dev/zero | head -c $$((0x10000)) | cat -
-    FFLAGS += $(ELFFILE)-0x10000.bin /dev/zero | head -c $$((0xfc000)) | cat -
-    FFLAGS += $(RIOTCPU)/$(CPU)/bin/esp_init_data_default.bin > $(ELFFILE).bin
+    FFLAGS += $(FLASHFILE)-0x00000.bin /dev/zero | head -c $$((0x10000)) | cat -
+    FFLAGS += $(FLASHFILE)-0x10000.bin /dev/zero | head -c $$((0xfc000)) | cat -
+    FFLAGS += $(RIOTCPU)/$(CPU)/bin/esp_init_data_default.bin > $(FLASHFILE).bin
 else
     FLASH_MODE ?= dout
     export PROGRAMMER_SPEED ?= 460800
     FLASHER = esptool.py
     FFLAGS += -p $(PORT) -b $(PROGRAMMER_SPEED) write_flash
     FFLAGS += -fm $(FLASH_MODE)
-    FFLAGS += 0 $(ELFFILE)-0x00000.bin
-    FFLAGS += 0x10000 $(ELFFILE)-0x10000.bin; esptool.py -p $(PORT) run
+    FFLAGS += 0 $(FLASHFILE)-0x00000.bin
+    FFLAGS += 0x10000 $(FLASHFILE)-0x10000.bin; esptool.py -p $(PORT) run
 endif


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.

By using `FLASHFILE=path_to_file BOARD=espXXXX make flash-only` a board can be flashed from a machine without the toolchain and only pip installed `esptool.py` installed 

> esp32 requires ESPTOOL set currently to `esptool.py` but it is fixed by https://github.com/RIOT-OS/RIOT/pull/11646


### Testing procedure

Both esp32 and esp8266 can still be flashed as in master.

The `flash-only` output is the same right now as in master

<details><summary><code>ESPTOOL=esptool.py BOARD=esp32-wroom-32 make --no-print-directory -C examples/default/ flash-only</code></summary><p>

```
ESPTOOL=esptool.py BOARD=esp32-wroom-32 make --no-print-directory -C examples/default/ flash-only
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
esptool.py --chip esp32 elf2image -fm dout -fs 2MB -ff 40m    -o /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/default.elf.bin /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/default.elf; echo "" > /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; echo "nvs, data, nvs, 0x9000, 0x6000" >> /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; echo "phy_init, data, phy, 0xf000, 0x1000" >> /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; echo -n "factory, app, factory, 0x10000, " >> /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; ls -l /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/default.elf.bin | awk '{ print $5 }' >> /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv; python /home/harter/work/git/RIOT/cpu/esp32/gen_esp32part.py --disable-sha256sum --verify /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.csv /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.bin
esptool.py v2.6
Parsing CSV input...
esptool.py --chip esp32 -p /dev/ttyUSB0 -b 460800 --before default_reset --after hard_reset write_flash -z -fm dout -fs detect -ff 40m    0x1000 /home/harter/work/git/RIOT/cpu/esp32/bin/bootloader.bin 0x8000 /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/partitions.bin 0x10000 /home/harter/work/git/RIOT/examples/default/bin/esp32-wroom-32/default.elf.bin
esptool.py v2.6
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32D0WDQ5 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
MAC: 30:ae:a4:d3:46:00
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Auto-detected Flash size: 4MB
Flash params set to 0x0320
Compressed 20608 bytes to 12166...
Wrote 20608 bytes (12166 compressed) at 0x00001000 in 0.3 seconds (effective 595.0 kbit/s)...
Hash of data verified.
Compressed 3072 bytes to 85...
Wrote 3072 bytes (85 compressed) at 0x00008000 in 0.0 seconds (effective 4235.5 kbit/s)...
Hash of data verified.
Compressed 103840 bytes to 49682...
Wrote 103840 bytes (49682 compressed) at 0x00010000 in 1.4 seconds (effective 599.3 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
```

</p></details>

<details><summary><code>BOARD=esp8266-esp-12x make --no-print-directory -C examples/default/ flash-only</code></summary><p>

```
BOARD=esp8266-esp-12x make --no-print-directory -C examples/default/ flash-only
ESP8266_NEWLIB_DIR should be defined as /path/to/newlib directory
ESP8266_NEWLIB_DIR is set by default to /opt/esp/newlib-xtensa
ESP8266_SDK_DIR should be defined as /path/to/sdk directory
ESP8266_SDK_DIR is set by default to /opt/esp/esp-open-sdk/sdk
esptool.py elf2image -fs 8m /home/harter/work/git/RIOT/examples/default/bin/esp8266-esp-12x/default.elf
WARNING: Flash size arguments in megabits like '8m' are deprecated.
Please use the equivalent size '1MB'.
Megabit arguments may be removed in a future release.
esptool.py v2.6
Creating image for ESP8266...
esptool.py -p /dev/ttyUSB0 -b 460800 write_flash -fm dout 0 /home/harter/work/git/RIOT/examples/default/bin/esp8266-esp-12x/default.elf-0x00000.bin 0x10000 /home/harter/work/git/RIOT/examples/default/bin/esp8266-esp-12x/default.elf-0x10000.bin; esptool.py -p /dev/ttyUSB0 run
esptool.py v2.6
Serial port /dev/ttyUSB0
Connecting....
Detecting chip type... ESP8266
Chip is ESP8266EX
Features: WiFi
MAC: 68:c6:3a:ac:a1:fb
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Auto-detected Flash size: 4MB
Flash params set to 0x0340
Compressed 23456 bytes to 12030...
Wrote 23456 bytes (12030 compressed) at 0x00000000 in 0.3 seconds (effective 699.7 kbit/s)...
Hash of data verified.
Compressed 62904 bytes to 44608...
Wrote 62904 bytes (44608 compressed) at 0x00010000 in 1.0 seconds (effective 499.8 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
esptool.py v2.6
Serial port /dev/ttyUSB0
Connecting....
Detecting chip type... ESP8266
Chip is ESP8266EX
Features: WiFi
MAC: 68:c6:3a:ac:a1:fb
Uploading stub...
Running stub...
Stub running...
Hard resetting via RTS pin...
```

</p></details>


The file to flash can be configured from the environment using `FLASHFILE`.
Remove all other files in `bin` directory than the `default.elf` and this works:

```
FLASHFILE='$(RIOTBASE)/examples/default/bin/$(BOARD)/default.elf' BOARD=esp8266-esp-12x make --no-print-directory -C
examples/hello-world/ flash-only term
# Get the default shell
```
```
FLASHFILE='$(RIOTBASE)/examples/default/bin/$(BOARD)/default.elf' ESPTOOL=esptool.py BOARD=esp32-wroom-32 make --no-print-directory -C examples/hello-world/ flash-only term
# Get the default shell
```
### Issues/PRs references

Part of the FLASHFILE introduction https://github.com/RIOT-OS/RIOT/pull/8838
Required for https://github.com/RIOT-OS/RIOT/pull/11646

Real way of setting FLASHFILE that would be useful for https://github.com/RIOT-OS/RIOT/pull/11449
