### PR TITLE
make: allow to override RESET and RESET_FLAGS for all boards and tools

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -17,7 +17,7 @@ include $(RIOTMAKE)/tools/renode.inc.mk
 # debugger config
 DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 DEBUGSERVER = JLinkGDBServer -device CC2538SF53
-RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 
 # Define the flash-tool and default port:
 export PROGRAMMER ?= cc2538-bsl
@@ -33,6 +33,6 @@ endif
 OFLAGS = --gap-fill 0xff
 FLASHFILE ?= $(BINFILE)
 DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
-RESET_FLAGS = $(BINDIR)
+RESET_FLAGS ?= $(BINDIR)
 
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb

--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -8,4 +8,4 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
-RESET = esptool.py --before default_reset run
+RESET ?= esptool.py --before default_reset run

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -8,4 +8,4 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
-RESET = esptool.py --before default_reset run
+RESET ?= esptool.py --before default_reset run

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -12,7 +12,7 @@ ifeq ($(PROGRAMMER),cc2538-bsl)
   else ifeq ($(OS),Darwin)
     PORT_BSL ?= $(PORT_DARWIN)
   endif
-  RESET = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py -p "$(PORT_BSL)"
+  RESET ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py -p "$(PORT_BSL)"
   FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
   FFLAGS  = -p "$(PORT_BSL)" -e -w -v -b 115200 $(FLASHFILE)
 else ifeq ($(PROGRAMMER),jlink)
@@ -20,8 +20,8 @@ else ifeq ($(PROGRAMMER),jlink)
   FFLAGS  = $(BINDIR) $(FLASHFILE)
   DEBUGGER = $(RIOTBOARD)/common/remote/dist/debug.sh
   DEBUGSERVER = JLinkGDBServer -device CC2538SF53
-  RESET = $(RIOTBOARD)/common/remote/dist/reset.sh
-  RESET_FLAGS = $(BINDIR)
+  RESET ?= $(RIOTBOARD)/common/remote/dist/reset.sh
+  RESET_FLAGS ?= $(BINDIR)
 endif
 
 OFLAGS = --gap-fill 0xff

--- a/boards/common/stm32f103c8/Makefile.include
+++ b/boards/common/stm32f103c8/Makefile.include
@@ -25,7 +25,7 @@ ifeq ($(PROGRAMMER),dfu-util)
   export ROM_OFFSET ?= 0x2000 # Skip the space needed by the embedded bootloader
   FLASHER = dfu-util
   DEBUGGER = # no debugger
-  RESET = # dfu-util has no support for resetting the device
+  RESET ?= # dfu-util has no support for resetting the device
 
   HEXFILE = $(BINFILE)
   FFLAGS = -d 1eaf:0003 -a 2 -D "$(HEXFILE)"

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -11,7 +11,7 @@ export ID ?= 0483:df11
 
 FLASHER = dfu-util
 DEBUGGER = # dfu-util has no debugger
-RESET = # dfu-util has no support for resetting the device
+RESET ?= # dfu-util has no support for resetting the device
 
 HEXFILE = $(BINFILE)
 FFLAGS = -d $(ID) -a 0 -s 0x08000000:leave -D "$(HEXFILE)"

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -23,12 +23,12 @@ else ifeq ($(PROGRAMMER),jlink)
   FFLAGS  = $(BINDIR) $(FLASHFILE)
   DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
   DEBUGSERVER = JLinkGDBServer -device CC2538SF53
-  RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+  RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 endif
 
 FLASHFILE ?= $(BINFILE)
 DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
-RESET_FLAGS = $(BINDIR)
+RESET_FLAGS ?= $(BINDIR)
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 
 # setup serial terminal

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -9,7 +9,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 FLASHER = dfu-util
 DEBUGGER = # spark core has no debugger
-RESET = # dfu-util has no support for resetting the device
+RESET ?= # dfu-util has no support for resetting the device
 
 HEXFILE = $(BINFILE)
 FFLAGS = -d 1d50:607f -a 0 -s 0x08005000:leave -D "$(HEXFILE)"

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -1,7 +1,7 @@
 FLASHER = $(RIOTTOOLS)/jlink/jlink.sh
 DEBUGGER = $(RIOTTOOLS)/jlink/jlink.sh
 DEBUGSERVER = $(RIOTTOOLS)/jlink/jlink.sh
-RESET = $(RIOTTOOLS)/jlink/jlink.sh
+RESET ?= $(RIOTTOOLS)/jlink/jlink.sh
 
 FLASHFILE ?= $(BINFILE)
 

--- a/makefiles/tools/uniflash.inc.mk
+++ b/makefiles/tools/uniflash.inc.mk
@@ -12,13 +12,13 @@ ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   _XDS110RESET_4_0_4_3 ?= $(UNIFLASH_PATH)/simplelink/gen2/bin/xds110reset
   _XDS110RESET ?= $(UNIFLASH_PATH)/simplelink/imagecreator/bin/xds110reset
   XDS110RESET ?= $(firstword $(wildcard $(_XDS110RESET) $(_XDS110RESET_4_0_4_3)) xds110reset)
-  RESET = $(XDS110RESET)
+  RESET ?= $(XDS110RESET)
 else
   FLASHER = $(UNIFLASH_PATH)/uniflash.sh
   FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(FLASHFILE)
   # configure uniflash for resetting target
-  RESET = $(UNIFLASH_PATH)/uniflash.sh
-  RESET_FLAGS = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset
+  RESET ?= $(UNIFLASH_PATH)/uniflash.sh
+  RESET_FLAGS ?= -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset
 endif
 # configure the debug server
 DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adapts Makefiles to allow for overriding the RESET command (or tool) and required RESET_FLAGS (if any present). For some boards like sam0 based once this is already possible, this PR adds this for all remaining.

This is required to allow for custom or special reset commands, for instance when running hardware-in-the-loop tests in a well known (special) environment which might allow to reset a board by controlling the power via a side-channel.


### Testing procedure

try to run `make reset` for you favourite board that should still work. You may also try to run `RESET="" RESET_FLAGS="" make reset` which than should fail to reset the board.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->