### PR TITLE
common/arduino-mkr: add usbdev feature

### DIFF
--- a/boards/common/arduino-mkr/Makefile.features
+++ b/boards/common/arduino-mkr/Makefile.features
@@ -7,6 +7,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -252,6 +252,20 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+    }
+};
+/** @} */
+
+/**
  * @name RTC configuration
  * @{
  */


### PR DESCRIPTION
### Contribution description

The arduino MKR class of boards (at least the ones supported by RIOT) have a now support USB peripheral, this PR adds the necessary config for this.

### Testing procedure

Similar to #11636 and #11639, test if the boards show up correctly in `lsusb` on the host computer side when flashing with `examples/usbus_minimal`

 - [ ] arduino-mkr1000
 - [ ] arduino-mkrzero
 - [ ] arduino-mkrfox1200

### Issues/PRs references

None