### PR TITLE
pkg/semtech-loramac: update rx parameters type

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -392,7 +392,7 @@ void _init_loramac(semtech_loramac_t *mac,
     semtech_loramac_set_tx_port(mac, LORAMAC_DEFAULT_TX_PORT);
     semtech_loramac_set_tx_mode(mac, LORAMAC_DEFAULT_TX_MODE);
     semtech_loramac_set_system_max_rx_error(mac,
-            LORAMAC_DEFAULT_SYSTEM_MAX_RX_ERROR);
+                                            LORAMAC_DEFAULT_SYSTEM_MAX_RX_ERROR);
     semtech_loramac_set_min_rx_symbols(mac, LORAMAC_DEFAULT_MIN_RX_SYMBOLS);
 #ifdef MODULE_PERIPH_EEPROM
     _read_loramac_config(mac);

--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -290,7 +290,7 @@ uint8_t semtech_loramac_get_tx_mode(semtech_loramac_t *mac)
     return mac->cnf;
 }
 
-void semtech_loramac_set_system_max_rx_error(semtech_loramac_t *mac, int error)
+void semtech_loramac_set_system_max_rx_error(semtech_loramac_t *mac, uint32_t error)
 {
     MibRequestConfirm_t mibReq;
     mutex_lock(&mac->lock);
@@ -300,7 +300,7 @@ void semtech_loramac_set_system_max_rx_error(semtech_loramac_t *mac, int error)
     mutex_unlock(&mac->lock);
 }
 
-void semtech_loramac_set_min_rx_symbols(semtech_loramac_t *mac, int min_rx)
+void semtech_loramac_set_min_rx_symbols(semtech_loramac_t *mac, uint8_t min_rx)
 {
     MibRequestConfirm_t mibReq;
     mutex_lock(&mac->lock);

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -429,7 +429,7 @@ void semtech_loramac_set_tx_port(semtech_loramac_t *mac, uint8_t port);
  * @param[in] mac          Pointer to the mac
  * @param[in] error        The maximum rx timing error
  */
-void semtech_loramac_set_system_max_rx_error(semtech_loramac_t *mac, int error);
+void semtech_loramac_set_system_max_rx_error(semtech_loramac_t *mac, uint32_t error);
 
 /**
  * @brief   Sets the minimum required number of symbols to detect a frame
@@ -437,7 +437,7 @@ void semtech_loramac_set_system_max_rx_error(semtech_loramac_t *mac, int error);
  * @param[in] mac          Pointer to the mac
  * @param[in] min_rx       The minimum rx symbols
  */
-void semtech_loramac_set_min_rx_symbols(semtech_loramac_t *mac, int min_rx);
+void semtech_loramac_set_min_rx_symbols(semtech_loramac_t *mac, uint8_t min_rx);
 
 /**
  * @brief   Gets the TX application port


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

System max RX error is in ms and should be uint32_t, min RX symbols is supposed to be uint8_t in loramac-node code.

This change should avoid surprises on non 32bit platforms.

I noticed that while working again on #9022 yesterday.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test the usual LoraWAN application, they should still work (at least on b-l072z-lrwan1)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while working on #9022 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
