### PR TITLE
drivers/rn2xx3: fix incorrectly terminated hex strings when writing an array of bytes

### DIFF
--- a/drivers/rn2xx3/rn2xx3_internal.c
+++ b/drivers/rn2xx3/rn2xx3_internal.c
@@ -228,9 +228,10 @@ void rn2xx3_cmd_start(rn2xx3_t *dev)
 
 void rn2xx3_cmd_append(rn2xx3_t *dev, const uint8_t *payload, uint8_t payload_len)
 {
-    char payload_str[2];
+    char payload_str[3] = { 0 };
     for (unsigned i = 0; i < payload_len; i++) {
         fmt_byte_hex(payload_str, payload[i]);
+        DEBUG("%s", payload_str);
         _uart_write_str(dev, payload_str);
     }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes #11499

This PR provides the proposed fix in #11499 because I think it makes sense and is safer. I did a couple of tests and couldn't find any issue.

The PR is also adding a debug statement for tracking what's being sent to the module.

Note that I couldn't reproduce the issue described in #11499 because I'm testing on arduino-zero and the toolchain used in #11499 is also known to have issues (arm gcc 4.9).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run tests/drivers_rn2xx3 and set set a network or application session key:
```
> mac set nwkskey AABBCCDDEEFF0011AABBCCDDEEFF0011
```
It should work (no error message displayed).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #11499

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
