### PR TITLE
tests/driver_rn2xx3: fix invalid element index for txmode

### DIFF
--- a/tests/driver_rn2xx3/main.c
+++ b/tests/driver_rn2xx3/main.c
@@ -358,10 +358,10 @@ int rn2xx3_mac_cmd(int argc, char **argv) {
         }
         else if (strcmp(argv[2], "txmode") == 0) {
             loramac_tx_mode_t mode;
-            if (strcmp(argv[2], "cnf") == 0) {
+            if (strcmp(argv[3], "cnf") == 0) {
                 mode = LORAMAC_TX_CNF;
             }
-            else if (strcmp(argv[2], "uncnf") == 0) {
+            else if (strcmp(argv[3], "uncnf") == 0) {
                 mode = LORAMAC_TX_UNCNF;
             }
             else {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While testing #11658, I noticed that setting txmode was broken in the RN2XX3 driver tests application. This PR fixes that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run `tests/driver_rn2xx3`
- Check current txmode and change it to unconfirmable:
```
> mac get txmode
TX mode: confirmable
> mac set txmode uncnf
```
- Verify it's correclty set:
```
> mac get txmode
TX mode: unconfirmable
```

On master setting tx mode doesn't work at all, the shell returns the mac command usage.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while working on #11658 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
