### PR TITLE
[TRACKING]  xtimer/xtimer.c: xtimer_mutex_lock_timeout fix and improvements

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -23,6 +23,7 @@
 #define MUTEX_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "list.h"
 
@@ -87,7 +88,7 @@ static inline void mutex_init(mutex_t *mutex)
  * @return 1 if mutex was unlocked, now it is locked.
  * @return 0 if the mutex was locked.
  */
-int _mutex_lock(mutex_t *mutex, int blocking);
+int _mutex_lock(mutex_t *mutex, volatile uint8_t *blocking);
 
 /**
  * @brief Tries to get a mutex, non-blocking.
@@ -100,7 +101,8 @@ int _mutex_lock(mutex_t *mutex, int blocking);
  */
 static inline int mutex_trylock(mutex_t *mutex)
 {
-    return _mutex_lock(mutex, 0);
+    volatile uint8_t blocking = 0;
+    return _mutex_lock(mutex, &blocking);
 }
 
 /**
@@ -110,7 +112,8 @@ static inline int mutex_trylock(mutex_t *mutex)
  */
 static inline void mutex_lock(mutex_t *mutex)
 {
-    _mutex_lock(mutex, 1);
+    volatile uint8_t blocking = 1;
+    _mutex_lock(mutex, &blocking);
 }
 
 /**

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -32,7 +32,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-int _mutex_lock(mutex_t *mutex, int blocking)
+int _mutex_lock(mutex_t *mutex, volatile uint8_t *blocking)
 {
     unsigned irqstate = irq_disable();
 
@@ -46,7 +46,7 @@ int _mutex_lock(mutex_t *mutex, int blocking)
         irq_restore(irqstate);
         return 1;
     }
-    else if (blocking) {
+    else if (*blocking) {
         thread_t *me = (thread_t*)sched_active_thread;
         DEBUG("PID[%" PRIkernel_pid "]: Adding node to mutex queue: prio: %"
               PRIu32 "\n", sched_active_pid, (uint32_t)me->priority);

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -262,7 +262,7 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t timeout)
         t.arg = (void *)((mutex_thread_t *)&mt);
         xtimer_set64(&t, timeout);
     }
-    int ret = _mutex_lock(mutex, mt.blocking);
+    int ret = _mutex_lock(mutex, &mt.blocking);
     if (ret == 0) {
         return -1;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
This pr tracks the fix for `xtimer/xtimer.c: xtimer_mutex_lock_timeout`
This pr includes two throwaway test commits.

### Contribution description
This pr fixes Bugs in `xtimer.c: xtimer_mutex_lock_timeout()` and improves it. It addresses concurrency issues. The timer can trigger at a different time than expected.
Before there were problems when the timer spins. This happens when the timeout is less than `XTIMER_BACKOFF`. 

This pr also creates a new static function called `_mutex_remove_thread_from_waiting_queue`. The function removes a thread from a mutex waiting queue, when the thread waiting for the mutex. This was already used inside of the `_mutex_timeout` function. It is needed for the `xtimer_mutex_lock_timeout` function.
This function should go into` core/mutex` in the future because it modifies queue of the mutex_t struct. (in mutex_t struct comment: `@brief Mutex structure. Must never be modified by the user.` and in comment of queue `@brief   The process waiting queue of the mutex. **Must never be changed by the user.**`)

This pr also fixes `core/mutex.c:_mutex_lock()` there was a problem when it gets interrupted before disabling interrupt. This is fixed by giving it a pointer to blocking.

This pr also has tests and throwaway commits to show the bug and fix.

The struct for the `xtimer_mutex_lock_timeout` function called `mutex_thread_t` was changed to fix the function and name changes for better understanding.

This pull request is split into smaller parts:
 - [x] tests/xtimer_mutex_lock_timeout: add simple case test #11679 
 - [x] sys/xtimer/xtimer.c: _mutex_timeout() cleanup #11807
 - [x] sys/xtimer/xtimer.c: _mutex_timeout() bug fix #11992
 - [x] tests/xtimer_mutex_lock_timeout: New test #12008
 - [x] xtimer/xtimer.c:_mutex_timeout() improved #13185
 - [x] xtimer/xtimer.c: xtimer_mutex_lock_timeout fix with short timeout #13199
 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`BOARD=native make -C tests/xtimer_mutex_lock timeout/ flash test`
it outputs:
```
...
> mutex_timeout_long_unlocked
mutex_timeout_long_unlocked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked
mutex_timeout_long_locked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked_low
mutex_timeout_long_locked_low
starting test: xtimer mutex lock timeout with thread
threads = 2
THREAD low prio: start
MAIN THREAD: calling xtimer_mutex_lock_timeout
OK
threads = 3
MAIN THREAD: waiting for created thread to end
THREAD low prio: exiting low
threads = 2

> mutex_timeout_short_locked
mutex_timeout_short_locked
starting test: xtimer mutex lock timeout with short timeout and locked mutex
OK

> mutex_timeout_short_unlocked
mutex_timeout_short_unlocked
starting test: xtimer mutex lock timeout with short timeout and unlocked mutex
OK

>
```

Without the fixes this would fail.

The remove me commits show other bugs.
Go to the commit before "REMOVE ME" commit gets reverted.
Test will work.

Now go to the "REMOVE ME" commit. 
Test will fail.

To test the bug in mutex.c:_mutex_lock revert to the second "REMOVE ME" commit with the commit message 

> REMOVE ME
    
>  test commit to show bug in _mutex_lock
>  when interupted before irq_disable



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#11679: first tests
#11807: sys/xtimer/xtimer.c: _mutex_timeout() clean ups
#11992: sys/xtimer/xtimer.c: _mutex_timeout() bug fix
#12008: tests/xtimer_mutex_lock_timeout: New test
#13185: xtimer/xtimer.c:_mutex_timeout() improved 
#13199: xtimer/xtimer.c: xtimer_mutex_lock_timeout fix with short timeout 

needed for: 
    - #11977: xtimer/xtimer.c: xtimer_rmutex_lock_timeout
    - #11485: [TRACKING] FreeRTOS Adaption Layer