### PR TITLE
tests/netstats_l2: use BOARD_WHITELIST

### DIFF
--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -6,9 +6,7 @@ BOARD_PROVIDES_NETIF := airfy-beacon fox iotlab-m3 mulle native nrf51dk nrf51don
     esp32-mh-et-live-minikit esp32-olimex-evb \
     esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit
 
-BOARDS ?= $(shell find $(RIOTBASE)/boards/* -maxdepth 0 -type d \! -name "common" -exec basename {} \;)
-
-BOARD_BLACKLIST := $(filter-out $(BOARD_PROVIDES_NETIF), $(BOARDS))
+BOARD_WHITELIST += $(BOARD_PROVIDES_NETIF)
 
 USEMODULE += shell
 USEMODULE += shell_commands


### PR DESCRIPTION
### Contribution description

Use BOARD_WHITELIST instead of calculating BOARD_BLACKLIST from BOARDS.

The output of `make info-boards-supported` kept the same.

This was found during a cleanup to define `BOARDS` globally.

*Note*: this was the only use case found for this pattern in the repository

### Testing procedure

The output of supported boards is the same as in master
```
make --no-print-directory -C tests/netstats_l2/ info-boards-supported
airfy-beacon esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit fox iotlab-m3 mulle native nrf51dk nrf51dongle nrf6310 pba-d-01-kw2x samd21-xpro saml21-xpro samr21-xpro spark-core yunjia-nrf51822
```

### Issues/PRs references

Cleaning of the `BOARDS` definition #11662
