### PR TITLE
makefiles/boards.inc.mk: list boards variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ welcome:
 print-versions:
 	@./dist/tools/ci/print_toolchain_versions.sh
 
+include makefiles/boards.inc.mk
 include makefiles/app_dirs.inc.mk
 
 -include makefiles/tests.inc.mk

--- a/Makefile.include
+++ b/Makefile.include
@@ -97,6 +97,9 @@ include $(RIOTMAKE)/color.inc.mk
 # include concurrency helpers
 include $(RIOTMAKE)/info-nproc.inc.mk
 
+# List of boards variables
+include $(RIOTMAKE)/boards.inc.mk
+
 GLOBAL_GOALS += buildtest info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
   BOARD=none

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -21,3 +21,5 @@ info-applications-supported-boards:
 	@for dir in $(APPLICATION_DIRS); do \
 	  make --no-print-directory -C $${dir} info-boards-supported 2>/dev/null | xargs -n 1 echo $${dir}; \
 	done
+# BOARDS values from 'boards.inc.mk' to only evaluate it once
+info-applications-supported-boards: export BOARDS ?=

--- a/makefiles/boards.inc.mk
+++ b/makefiles/boards.inc.mk
@@ -1,0 +1,14 @@
+# Default when RIOTBASE is not set and is executed from the RIOT directory
+RIOTBOARD ?= $(or $(RIOTBASE),$(CURDIR))/boards
+
+# List all boards.
+# By default, all directories in RIOTBOARD except 'common'
+#   use 'wildcard */.' to only list directories
+ALLBOARDS ?= $(sort $(filter-out common,$(patsubst $(RIOTBOARD)/%/.,%,$(wildcard $(RIOTBOARD)/*/.))))
+
+# Set the default value from `BOARDS`
+BOARDS ?= $(ALLBOARDS)
+
+.PHONY: info-boards
+info-boards:
+	@echo $(BOARDS)

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -37,7 +37,6 @@ define board_missing_features
   endif
 endef
 
-BOARDS ?= $(shell find $(RIOTBOARD)/* -maxdepth 0 -type d \! -name "common" -exec basename {} \;)
 BOARDS := $(filter $(if $(BOARD_WHITELIST), $(BOARD_WHITELIST), %), $(BOARDS))
 BOARDS := $(filter-out $(BOARD_BLACKLIST), $(BOARDS))
 


### PR DESCRIPTION
### Contribution description

Add a global definition of `BOARDS` not using `$(shell find)` but makefile `$(wildcard)` and a `info-boards` that list them all.
This can be used for scripts that want to repeat one thing on all boards.

The boards is by default the list of all `BOARDS`.

In an application, if a global target is used, it will still be overwritten to the supported boards. It was not changed by this PR.

This global definition has also been used for `make info-applications-supported-boards` to only evaluate the list of boards once.

This saved 46seconds of the execution time go from 2:45 to 2:00 with similar test conditions

* 2:45 (with find)
* 2:10 (with wildcard)
* 2:00 (with single evaluation)

### Further work

Evaluating `BOARDS` could be done only once in the murdock scripts too but not sure how it should be done. It would not save a lot of real time, but some cpu time.

### Testing procedure

List all boards in RIOT

```
make info-boards
# All boards space separated
```

The list of supported applications is the same as in master

```
make info-applications-supported-boards
# Same output
```

### Issues/PRs references

I needed a command to help checking refactoring on all boards.