### PR TITLE
makefiles/utils/variables: add functions to help managing variables

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -80,6 +80,9 @@ MAKEOVERRIDES += $(foreach v,$(__DIRECTORY_VARIABLES),$(v)=$($(v)))
 # trailing '/' is important when RIOTPROJECT == CURDIR
 BUILDRELPATH ?= $(patsubst $(RIOTPROJECT)/%,%,$(CURDIR)/)
 
+# include makefiles utils tools
+include $(RIOTMAKE)/utils/variables.mk
+
 # get host operating system
 OS := $(shell uname)
 

--- a/makefiles/utils/test-variables.mk
+++ b/makefiles/utils/test-variables.mk
@@ -15,5 +15,24 @@ test-exported-variables:
 	$(Q)bash -c 'test "$(MY_VARIABLE)" = "$${MY_VARIABLE}" || { echo ERROR: "$(MY_VARIABLE)" != "$${MY_VARIABLE}"; exit 1; }'
 	$(Q)bash -c 'test $(PARSE_TIME) -lt $${CURRENT_TIME} || { echo ERROR: $(PARSE_TIME) \>= $${CURRENT_TIME} >&2; exit 1; }'
 
+
+MEMOIZED_CURRENT_TIME = $(call memoized,MEMOIZED_CURRENT_TIME,$(call date_nanoseconds))
+MEMOIZED_CURRENT_TIME_2 = $(call memoized,MEMOIZED_CURRENT_TIME_2,$(call date_nanoseconds))
+
+PRE_MEMOIZED_TIME := $(call date_nanoseconds)
+# Two separate evaluations
+REF_CURRENT_TIME_1 := $(MEMOIZED_CURRENT_TIME)
+# Strip to detect added whitespaces by function
+REF_CURRENT_TIME_2 := $(strip $(MEMOIZED_CURRENT_TIME))
+
+test-memoized-variables:
+	@# The value was only evaluated on first use
+	$(Q)test $(PRE_MEMOIZED_TIME) -lt $(REF_CURRENT_TIME_1) || { echo ERROR: $(PRE_MEMOIZED_TIME) \>= $(REF_CURRENT_TIME_1) >&2; exit 1; }
+	@# Both evaluation return the same time and without added whitespace
+	$(Q)test "$(REF_CURRENT_TIME_1)" = "$(REF_CURRENT_TIME_2)" || { echo ERROR: "$(REF_CURRENT_TIME_1)" != "$(REF_CURRENT_TIME_2)" >&2; exit 1; }
+	@# The second memoized value was only evaluated when calling the target
+	$(Q)test $(PARSE_TIME) -lt $(MEMOIZED_CURRENT_TIME_2) || { echo ERROR: $(PARSE_TIME) \>= $(MEMOIZED_CURRENT_TIME_2) >&2; exit 1; }
+
+
 # Immediate evaluation for comparing
 PARSE_TIME := $(call date_nanoseconds)

--- a/makefiles/utils/test-variables.mk
+++ b/makefiles/utils/test-variables.mk
@@ -1,0 +1,19 @@
+include variables.mk
+
+# Timestamp in nanoseconds (to be an integer)
+# OSx 'date' does not support 'date +%s%N' so rely on python instead
+# It could be OSx specific but we do not have 'OS' defined here to differentiate
+date_nanoseconds = $(shell python -c 'import time; print(int(time.time() * 1000000000))')
+
+EXPORTED_VARIABLES = MY_VARIABLE CURRENT_TIME
+MY_VARIABLE = my_variable
+# Defered evaluation to the test
+CURRENT_TIME = $(call date_nanoseconds)
+
+$(call target-export-variables,test-exported-variables,$(EXPORTED_VARIABLES))
+test-exported-variables:
+	$(Q)bash -c 'test "$(MY_VARIABLE)" = "$${MY_VARIABLE}" || { echo ERROR: "$(MY_VARIABLE)" != "$${MY_VARIABLE}"; exit 1; }'
+	$(Q)bash -c 'test $(PARSE_TIME) -lt $${CURRENT_TIME} || { echo ERROR: $(PARSE_TIME) \>= $${CURRENT_TIME} >&2; exit 1; }'
+
+# Immediate evaluation for comparing
+PARSE_TIME := $(call date_nanoseconds)

--- a/makefiles/utils/variables.mk
+++ b/makefiles/utils/variables.mk
@@ -2,6 +2,20 @@
 # These functions should help replacing immediate evaluation and global 'export'
 
 
+# Evaluate a deferred variable only once on its first usage
+# Uses after that will be as if it was an immediate evaluation
+# This can replace using `:=` by default
+#
+# The goal is to use it for `shell` commands
+#
+# variable = $(call memoized,<variable>,<value>)
+#
+# Parameters
+#  variable: name of the variable you set
+#  value: value that should be set when evaluated
+memoized = $2$(eval $1:=$2)
+
+
 # Target specific export the variables for that target
 #
 # target-export-variables <target> <variables>

--- a/makefiles/utils/variables.mk
+++ b/makefiles/utils/variables.mk
@@ -1,0 +1,19 @@
+# Utilities to set variables and environment for targets
+# These functions should help replacing immediate evaluation and global 'export'
+
+
+# Target specific export the variables for that target
+#
+# target-export-variables <target> <variables>
+#
+# Parameters
+#   target: name of target
+#   variables: the variables to export
+#
+# The variable will only be evaluated when executing the target as when
+# doing export
+target-export-variables = $(foreach var,$(2),$(call _target-export-variable,$1,$(var)))
+
+# '$1: export $2' cannot be used alone
+# By using '?=' the variable is evaluated at runtime only
+_target-export-variable = $(eval $1: export $2?=)

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -16,7 +16,8 @@ endef
 
 MAKEFILES_UTILS = $(RIOTMAKE)/utils
 
-COMPILE_TESTS = test-ensure_value test-ensure_value-negative
+COMPILE_TESTS += test-ensure_value test-ensure_value-negative
+COMPILE_TESTS += test-exported-variables
 
 # Tests will be run both in the host machine and in `docker`
 all: build-system-utils-tests
@@ -31,3 +32,6 @@ test-ensure_value:
 
 test-ensure_value-negative:
 	$(Q)$(call command_should_fail,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-checks.mk test-ensure_value-negative)
+
+test-exported-variables:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-exported-variables)

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -18,6 +18,7 @@ MAKEFILES_UTILS = $(RIOTMAKE)/utils
 
 COMPILE_TESTS += test-ensure_value test-ensure_value-negative
 COMPILE_TESTS += test-exported-variables
+COMPILE_TESTS += test-memoized-variables
 
 # Tests will be run both in the host machine and in `docker`
 all: build-system-utils-tests
@@ -35,3 +36,6 @@ test-ensure_value-negative:
 
 test-exported-variables:
 	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-exported-variables)
+
+test-memoized-variables:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-memoized-variables)


### PR DESCRIPTION
### Contribution description

Add functions to set variables and environment for targets
These functions should help replacing immediate evaluation and global 'export'

#### `target-export-variables`

`target-export-variables <target> <variables>` function that exports a list of variables for some targets

This should help exporting variables only for the required targets so not evaluate `shell` calls for nothing.
Like `make clean` does not need `CFLAGS` but if the variable is exported, it will evaluate which options are supported in `CFLAGS` anyway.

#### `memoized`

`VARIABLE = $(call memoized,VARIABLE,<value>)` function that allows only evaluating `value` when the variable is used like a normal deferred variable, but further evaluations will use an immediate value.

This should help not assigning `shell` commands results with `:=` to call it once only, as it result to evaluating even if not needed. Replacing by a direct `=` would result in the command be executed on each evaluation which is not wanted.
This gives the best of both worlds.

The implementation requires to repeat the variable name in the `call memoized` arguments.

### Testing procedure

Review and run the test in `tests/build_system_utils`.

```
make -C tests/build_system_utils/
```
If it executes without error, it is working.


You can also run it with `QUIET=0` to see the executed commands.

### Issues/PRs references

Tracking: remove harmful use of `export` in make and immediate evaluation #10850