### PR TITLE
tests/stdin: add non regression test for stdin module

### DIFF
--- a/tests/stdin/Makefile
+++ b/tests/stdin/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.tests_common
+
+USEMODULE += stdin
+
+TEST_ON_CI_WHITELIST += all
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/stdin/main.c
+++ b/tests/stdin/main.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Shows that stdin module is required when one wants to use getchar
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#include <stdio.h>
+
+int main(void)
+{
+    int value = getchar();
+    printf("You entered '%c'\n", (char)value);
+    return 0;
+}

--- a/tests/stdin/tests/01-run.py
+++ b/tests/stdin/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Alexandre Abadie <alexandre.abadie@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.sendline('O')
+    child.expect_exact('You entered \'O\'')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduce the `tests/stdin` application for verifying `getchar` is working as expected when loading the stdin module.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

```
make BOARD=<your favorite board> -C tests/stdin flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #11598 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
