### PR TITLE
boards/*: remove unused FEATURES_MCU_GROUP variable

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,15 +13,4 @@ pipeline:
 matrix:
     BUILDTEST_MCU_GROUP:
         - static-tests
-        - cortex_m4_3
-        - cortex_m4_2
-        - cortex_m4_1
-        - cortex_m0_2
-        - cortex_m0_1
-        - x86
-        - cortex_m3_2
-        - cortex_m3_1
-        - avr8
-        - msp430
-        - arm7
         - host

--- a/boards/arduino-zero/Makefile.features
+++ b/boards/arduino-zero/Makefile.features
@@ -11,7 +11,4 @@ FEATURES_PROVIDED += periph_usbdev
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/avsextrem/Makefile.features
+++ b/boards/avsextrem/Makefile.features
@@ -7,7 +7,4 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = arm7
-
 include $(RIOTCPU)/lpc2387/Makefile.features

--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -13,7 +13,4 @@ FEATURES_PROVIDED += periph_uart
 # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
 FEATURES_PROVIDED += riotboot
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/b-l475e-iot01a/Makefile.features
+++ b/boards/b-l475e-iot01a/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_adc
 # Various other features (if any)
 FEATURES_PROVIDED += emulator_renode
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/cc2650-launchpad/Makefile.features
+++ b/boards/cc2650-launchpad/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_i2c
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/cc26x0/Makefile.features

--- a/boards/cc2650stk/Makefile.features
+++ b/boards/cc2650stk/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/cc26x0/Makefile.features

--- a/boards/chronos/Makefile.features
+++ b/boards/chronos/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_rtc
 
 # Various other features (if any)
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = msp430
-
 include $(RIOTCPU)/cc430/Makefile.features

--- a/boards/common/arduino-due/Makefile.features
+++ b/boards/common/arduino-due/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/sam3/Makefile.features

--- a/boards/common/arduino-mkr/Makefile.features
+++ b/boards/common/arduino-mkr/Makefile.features
@@ -11,6 +11,3 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
-
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/common/iotlab/Makefile.features
+++ b/boards/common/iotlab/Makefile.features
@@ -7,6 +7,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/common/saml1x/Makefile.features
+++ b/boards/common/saml1x/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # Put other features on these boards (in alphabetical order)
 FEATURES_PROVIDED += riotboot
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m23
-
 include $(RIOTCPU)/saml1x/Makefile.features

--- a/boards/common/stm32f103c8/Makefile.features
+++ b/boards/common/stm32f103c8/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/common/wsn430/Makefile.features
+++ b/boards/common/wsn430/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = msp430
-
 include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/ek-lm4f120xl/Makefile.features
+++ b/boards/ek-lm4f120xl/Makefile.features
@@ -5,7 +5,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
-
 include $(RIOTCPU)/lm4f120/Makefile.features

--- a/boards/f4vi1/Makefile.features
+++ b/boards/f4vi1/Makefile.features
@@ -2,7 +2,4 @@
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/firefly/Makefile.features
+++ b/boards/firefly/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 -include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -5,7 +5,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/frdm-k22f/Makefile.features
+++ b/boards/frdm-k22f/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
-
 include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -11,7 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
-
 include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/hamilton/Makefile.features
+++ b/boards/hamilton/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 -include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -7,7 +7,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = risc_v
-
 include $(RIOTCPU)/fe310/Makefile.features

--- a/boards/i-nucleo-lrwan1/Makefile.features
+++ b/boards/i-nucleo-lrwan1/Makefile.features
@@ -7,7 +7,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/limifrog-v1/Makefile.features
+++ b/boards/limifrog-v1/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/maple-mini/Makefile.features
+++ b/boards/maple-mini/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/mbed_lpc1768/Makefile.features
+++ b/boards/mbed_lpc1768/Makefile.features
@@ -3,7 +3,4 @@ FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/lpc1768/Makefile.features

--- a/boards/mips-malta/Makefile.features
+++ b/boards/mips-malta/Makefile.features
@@ -1,7 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = mips32r2
-
 include $(RIOTCPU)/mips32r2_generic/Makefile.features

--- a/boards/msb-430/Makefile.features
+++ b/boards/msb-430/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = msp430
-
 include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/msb-430h/Makefile.features
+++ b/boards/msb-430h/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = msp430
-
 include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = arm7
-
 include $(RIOTCPU)/lpc2387/Makefile.features

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -7,7 +7,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/mulle/Makefile.features
+++ b/boards/mulle/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_qdec
 FEATURES_PROVIDED += ethernet
 FEATURES_PROVIDED += motor_driver
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = x86
-
 include $(RIOTCPU)/native/Makefile.features

--- a/boards/nucleo-f030r8/Makefile.features
+++ b/boards/nucleo-f030r8/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f031k6/Makefile.features
+++ b/boards/nucleo-f031k6/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f042k6/Makefile.features
+++ b/boards/nucleo-f042k6/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f070rb/Makefile.features
+++ b/boards/nucleo-f070rb/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f072rb/Makefile.features
+++ b/boards/nucleo-f072rb/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_spi
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f091rc/Makefile.features
+++ b/boards/nucleo-f091rc/Makefile.features
@@ -11,7 +11,4 @@ FEATURES_PROVIDED += periph_spi
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f103rb/Makefile.features
+++ b/boards/nucleo-f103rb/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/stm32f2/Makefile.features

--- a/boards/nucleo-f302r8/Makefile.features
+++ b/boards/nucleo-f302r8/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303k8/Makefile.features
+++ b/boards/nucleo-f303k8/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303re/Makefile.features
+++ b/boards/nucleo-f303re/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303ze/Makefile.features
+++ b/boards/nucleo-f303ze/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo 144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f334r8/Makefile.features
+++ b/boards/nucleo-f334r8/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f401re/Makefile.features
+++ b/boards/nucleo-f401re/Makefile.features
@@ -11,7 +11,4 @@ FEATURES_PROVIDED += periph_qdec
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f410rb/Makefile.features
+++ b/boards/nucleo-f410rb/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f411re/Makefile.features
+++ b/boards/nucleo-f411re/Makefile.features
@@ -7,7 +7,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f412zg/Makefile.features
+++ b/boards/nucleo-f412zg/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f413zh/Makefile.features
+++ b/boards/nucleo-f413zh/Makefile.features
@@ -13,7 +13,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f446re/Makefile.features
+++ b/boards/nucleo-f446re/Makefile.features
@@ -14,7 +14,4 @@ FEATURES_PROVIDED += motor_driver
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f446ze/Makefile.features
+++ b/boards/nucleo-f446ze/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f722ze/Makefile.features
+++ b/boards/nucleo-f722ze/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m7
-
 include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-f746zg/Makefile.features
+++ b/boards/nucleo-f746zg/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m7
-
 include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m7
-
 include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-l031k6/Makefile.features
+++ b/boards/nucleo-l031k6/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l053r8/Makefile.features
+++ b/boards/nucleo-l053r8/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l073rz/Makefile.features
+++ b/boards/nucleo-l073rz/Makefile.features
@@ -18,7 +18,4 @@ FEATURES_PROVIDED += riotboot
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l152re/Makefile.features
+++ b/boards/nucleo-l152re/Makefile.features
@@ -15,7 +15,4 @@ FEATURES_PROVIDED += riotboot
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/nucleo-l432kc/Makefile.features
+++ b/boards/nucleo-l432kc/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
-
 include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l433rc/Makefile.features
+++ b/boards/nucleo-l433rc/Makefile.features
@@ -11,7 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l452re/Makefile.features
+++ b/boards/nucleo-l452re/Makefile.features
@@ -9,7 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l476rg/Makefile.features
+++ b/boards/nucleo-l476rg/Makefile.features
@@ -11,7 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart periph_lpuart
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nz32-sc151/Makefile.features
+++ b/boards/nz32-sc151/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/opencm904/Makefile.features
+++ b/boards/opencm904/Makefile.features
@@ -2,7 +2,4 @@
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/openmote-b/Makefile.features
+++ b/boards/openmote-b/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/openmote-cc2538/Makefile.features
+++ b/boards/openmote-cc2538/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -11,7 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/pic32-clicker/Makefile.features
+++ b/boards/pic32-clicker/Makefile.features
@@ -3,7 +3,4 @@ FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = mips32r2
-
 include $(RIOTCPU)/mips_pic32mx/Makefile.features

--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -3,7 +3,4 @@ FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = mips32r2
-
 include $(RIOTCPU)/mips_pic32mz/Makefile.features

--- a/boards/pyboard/Makefile.features
+++ b/boards/pyboard/Makefile.features
@@ -5,7 +5,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/remote-pa/Makefile.features
+++ b/boards/remote-pa/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/remote-reva/Makefile.features
+++ b/boards/remote-reva/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -7,7 +7,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4f
-
 include $(RIOTCPU)/samd5x/Makefile.features

--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -10,7 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/saml21/Makefile.features

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -12,7 +12,4 @@ FEATURES_PROVIDED += periph_usbdev
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/samr30-xpro/Makefile.features
+++ b/boards/samr30-xpro/Makefile.features
@@ -7,8 +7,5 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 # samr30 is a specific flavor of saml21
 include $(RIOTCPU)/saml21/Makefile.features

--- a/boards/seeeduino_arch-pro/Makefile.features
+++ b/boards/seeeduino_arch-pro/Makefile.features
@@ -3,7 +3,4 @@ FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_1
-
 include $(RIOTCPU)/lpc1768/Makefile.features

--- a/boards/sensebox_samd21/Makefile.features
+++ b/boards/sensebox_samd21/Makefile.features
@@ -7,7 +7,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/slstk3401a/Makefile.features
+++ b/boards/slstk3401a/Makefile.features
@@ -8,9 +8,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTBOARD)/common/silabs/Makefile.features
 
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slstk3402a/Makefile.features
+++ b/boards/slstk3402a/Makefile.features
@@ -8,9 +8,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTBOARD)/common/silabs/Makefile.features
 
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/sltb001a/Makefile.features
+++ b/boards/sltb001a/Makefile.features
@@ -8,9 +8,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTBOARD)/common/silabs/Makefile.features
 
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slwstk6000b/Makefile.features
+++ b/boards/slwstk6000b/Makefile.features
@@ -8,9 +8,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTBOARD)/common/silabs/Makefile.features
 
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slwstk6220a/Makefile.features
+++ b/boards/slwstk6220a/Makefile.features
@@ -3,7 +3,4 @@ FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MCU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
-
 include $(RIOTCPU)/ezr32wg/Makefile.features

--- a/boards/sodaq-autonomo/Makefile.features
+++ b/boards/sodaq-autonomo/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-explorer/Makefile.features
+++ b/boards/sodaq-explorer/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-one/Makefile.features
+++ b/boards/sodaq-one/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
 include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/spark-core/Makefile.features
+++ b/boards/spark-core/Makefile.features
@@ -3,7 +3,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/stk3600/Makefile.features
+++ b/boards/stk3600/Makefile.features
@@ -10,9 +10,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTBOARD)/common/silabs/Makefile.features
 
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/stk3700/Makefile.features
+++ b/boards/stk3700/Makefile.features
@@ -10,9 +10,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m3_2
-
 include $(RIOTBOARD)/common/silabs/Makefile.features
 
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/stm32f0discovery/Makefile.features
+++ b/boards/stm32f0discovery/Makefile.features
@@ -5,7 +5,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_1
-
 include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/stm32f3discovery/Makefile.features
+++ b/boards/stm32f3discovery/Makefile.features
@@ -7,7 +7,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -11,9 +11,6 @@ FEATURES_PROVIDED += periph_uart
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 # TODO: re-think concept for conflicts based on actual used peripherals...
 FEATURES_CONFLICT += periph_spi:periph_dac
 FEATURES_CONFLICT_MSG += "On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0."

--- a/boards/stm32f769i-disco/Makefile.features
+++ b/boards/stm32f769i-disco/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m7
-
 include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -4,7 +4,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/teensy31/Makefile.features
+++ b/boards/teensy31/Makefile.features
@@ -5,7 +5,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
-
 include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/telosb/Makefile.features
+++ b/boards/telosb/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = msp430
-
 include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/ublox-c030-u201/Makefile.features
+++ b/boards/ublox-c030-u201/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_3
-
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/z1/Makefile.features
+++ b/boards/z1/Makefile.features
@@ -6,7 +6,4 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = msp430
-
 include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -108,6 +108,23 @@ check_not_exporting_variables() {
     fi
 }
 
+# Deprecated variables or patterns
+# Prevent deprecated variables or patterns to re-appear after cleanup
+check_deprecated_vars_patterns() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e 'FEATURES_MCU_GROUP')
+
+    # Pathspec with exclude should start by an inclusive pathspec in git 2.7.4
+    pathspec+=('*')
+
+    # Ignore this file when matching as it self matches
+    pathspec+=(":!${SCRIPT_PATH}")
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message 'Deprecated variables or patterns:'
+}
 
 error_on_input() {
     grep '' && return 1
@@ -116,6 +133,7 @@ error_on_input() {
 all_checks() {
     check_not_parsing_features
     check_not_exporting_variables
+    check_deprecated_vars_patterns
 }
 
 main() {

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -19,13 +19,6 @@ define board_missing_features
 
   include $(RIOTBASE)/Makefile.features
 
-  ifdef BUILDTEST_MCU_GROUP
-    ifneq ($(BUILDTEST_MCU_GROUP), $$(FEATURES_MCU_GROUP))
-      BOARDS_FEATURES_MISSING += "$(1) $(BUILDTEST_MCU_GROUP)"
-    BOARDS_WITH_MISSING_FEATURES += $(1)
-    endif
-  endif
-
   include $(RIOTBASE)/Makefile.dep
 
   FEATURES_MISSING := $$(sort $$(filter-out $$(FEATURES_PROVIDED), $$(FEATURES_REQUIRED)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This variable is only used by `drone.yml` file and we don't use drone.io as CI anymore. Maybe the `.drone.yml` could also be removed ?

For the record, the `Makefile.include` of related boards were updated using the following command:
```
find . -name Makefile.features | xargs sed -i '/^# The board M[P,C]U family/,+2d'
```
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green CI should be ok.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #10491
Waiting on https://github.com/RIOT-OS/RIOT/pull/11672 as the way to handle the error message needs special handling with mac.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
