### PR TITLE
dist/tools/build_system_sanity_check: deprecate FEATURES_MCU_GROUP

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -108,6 +108,24 @@ check_not_exporting_variables() {
     fi
 }
 
+# Deprecated variables or patterns
+# Prevent deprecated varibles or patterns to re-appear after cleanup
+check_deprecated_vars_patterns() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e 'FEATURES_MCU_GROUP')
+
+    # Pathspec with exclude should start by an inclusive pathspec in git 2.7.4
+    pathspec+=('*')
+
+    # Ignore this file when matching as it self matches
+    pathspec+=(":!${SCRIPT_PATH}")
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message 'Deprecated variables or patterns:'
+}
+
 
 error_on_input() {
     grep '' && return 1
@@ -116,6 +134,7 @@ error_on_input() {
 all_checks() {
     check_not_parsing_features
     check_not_exporting_variables
+    check_deprecated_vars_patterns
 }
 
 main() {

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -119,7 +119,7 @@ all_checks() {
 }
 
 main() {
-    all_checks | prepend 'Invalid build system patterns found by '"${0}:"  || error_on_input >&2
+    all_checks | prepend 'Invalid build system patterns found by '"${0}:" | error_on_input >&2
     exit $?
 }
 


### PR DESCRIPTION
### Contribution description

Add a function to list deprecated variables or patterns and use it for
* FEATURES_MCU_GROUP

The pull request also adds a reasons for each error type found by the script that I will split.

### Testing procedure

Run the current version without rebasing


```
./dist/tools/buildsystem_sanity_check/check.sh  | head
Invalid build system patterns found by ./dist/tools/buildsystem_sanity_check/check.sh:

Deprecated variables or patterns:
boards/arduino-zero/Makefile.features:FEATURES_MCU_GROUP = cortex_m0_2
boards/avsextrem/Makefile.features:FEATURES_MCU_GROUP = arm7
boards/b-l072z-lrwan1/Makefile.features:FEATURES_MCU_GROUP = cortex_m0_1
boards/b-l475e-iot01a/Makefile.features:FEATURES_MCU_GROUP = cortex_m4_2
boards/cc2538dk/Makefile.features:FEATURES_MCU_GROUP = cortex_m3_1
boards/cc2650-launchpad/Makefile.features:FEATURES_MCU_GROUP = cortex_m3_1
boards/cc2650stk/Makefile.features:FEATURES_MCU_GROUP = cortex_m3_1
boards/chronos/Makefile.features:FEATURES_MCU_GROUP = msp430
```

Rebase it on top of https://github.com/RIOT-OS/RIOT/pull/11670 and it should output no errors


### Issues/PRs references

* [x] dist/tools/build_system_sanity_check: add reasons for each error type #11672
* [ ] dist/tools/build_system_sanity_check: BUG fix errors being ignored #11695
* [ ] Depends on https://github.com/RIOT-OS/RIOT/pull/11670