### PR TITLE
dist/tools/build_system_sanity_check: add reasons for each error type

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -17,6 +17,24 @@
 
 SCRIPT_PATH=dist/tools/buildsystem_sanity_check/check.sh
 
+
+tab_indent() {
+    # Ident using 'bashism' to to the tab compatible with 'bsd-sed'
+    sed 's/^/\'$'\t/'
+}
+
+prepend() {
+    # 'i' needs 'i\{newline}' and a newline after for 'bsd-sed'
+    sed '1i\
+'"$1"'
+'
+}
+
+error_with_message() {
+    tab_indent | prepend "${1}"
+}
+
+
 # Modules should not check the content of FEATURES_PROVIDED/_REQUIRED/OPTIONAL
 # Handling specific behaviors/dependencies should by checking the content of:
 # * `USEMODULE`
@@ -87,6 +105,10 @@ check_not_exporting_variables() {
     fi
 }
 
+
+error_on_input() {
+    grep '' && return 1
+}
 
 main() {
     local errors=''

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -110,19 +110,14 @@ error_on_input() {
     grep '' && return 1
 }
 
+all_checks() {
+    check_not_parsing_features
+    check_not_exporting_variables
+}
+
 main() {
-    local errors=''
-
-    errors+="$(check_not_parsing_features)"
-    errors+="$(check_not_exporting_variables)"
-
-    if [ -n "${errors}" ]
-    then
-        printf 'Invalid build system patterns found by %s:\n' "${0}"
-        printf '%s\n' "${errors}"
-        exit 1
-    fi
-    exit 0
+    all_checks | prepend 'Invalid build system patterns found by '"${0}:"  || error_on_input >&2
+    exit $?
 }
 
 

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -46,6 +46,7 @@ check_not_parsing_features() {
     patterns+=(-e 'if.*filter.*FEATURES_PROVIDED')
     patterns+=(-e 'if.*filter.*FEATURES_REQUIRED')
     patterns+=(-e 'if.*filter.*FEATURES_OPTIONAL')
+    patterns+=(-e 'if.*filter.*FEATURES_USED') # Not a real one, it is just to show the error
 
     # Pathspec with exclude should start by an inclusive pathspec in git 2.7.4
     pathspec+=('*')
@@ -78,8 +79,11 @@ UNEXPORTED_VARIABLES+=('DEBUG_ADAPTER' 'DEBUG_ADAPTER_ID')
 UNEXPORTED_VARIABLES+=('PROGRAMMER_SERIAL')
 UNEXPORTED_VARIABLES+=('STLINK_VERSION')
 UNEXPORTED_VARIABLES+=('PORT_LINUX' 'PORT_DARWIN')
+UNEXPORTED_VARIABLES+=('APPDEPS')
+
 
 EXPORTED_VARIABLES_ONLY_IN_VARS=()
+EXPORTED_VARIABLES_ONLY_IN_VARS+=('CC')
 check_not_exporting_variables() {
     local patterns=()
     local pathspec=()

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -56,7 +56,8 @@ check_not_parsing_features() {
     # These two files contain sanity checks using FEATURES_ so are allowed
     pathspec+=(':!Makefile.include' ':!makefiles/info-global.inc.mk')
 
-    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}"
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message 'Modules should not check the content of FEATURES_PROVIDED/_REQUIRED/OPTIONAL'
 }
 
 # Some variables do not need to be exported and even cause issues when being
@@ -87,7 +88,8 @@ check_not_exporting_variables() {
         patterns+=(-e "export[[:blank:]]\+${variable}")
     done
 
-    git -C "${RIOTBASE}" grep "${patterns[@]}"
+    git -C "${RIOTBASE}" grep "${patterns[@]}" \
+        | error_with_message 'Variables must not be exported:'
 
     # Some variables may still be exported in 'makefiles/vars.inc.mk' as the
     # only place that should export commont variables
@@ -101,7 +103,8 @@ check_not_exporting_variables() {
 
     # Only run if there are patterns, otherwise it matches everything
     if [ ${#patterns[@]} -ne 0 ]; then
-        git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}"
+        git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+            | error_with_message 'Variables must only be exported in `makefiles/vars.inc.mk`:'
     fi
 }
 


### PR DESCRIPTION
### Contribution description

Prepend the reason for the matched error pattern.
It will only add the reason if there is an error.

It currently requires using the `\\n` as using `errors += $(...)`
removes the last newline character. But it was a pattern used elsewhere
to cleaning it would be a separate task.


### Testing procedure

Run the script with the test commit and you should get the output with the justification.

Static-tests will fail with the test commit as expected:

https://travis-ci.org/RIOT-OS/RIOT/builds/544153413#L442-L460

```
./dist/tools/buildsystem_sanity_check/check.sh
Invalid build system patterns found by ./dist/tools/buildsystem_sanity_check/check.sh:

Invalid use of FEATURES_ variables content:
makefiles/boot/riotboot.mk:ifneq (,$(filter riotboot,$(FEATURES_USED)))
makefiles/boot/riotboot.mk:endif # (,$(filter riotboot,$(FEATURES_USED)))
sys/Makefile.include:ifneq (,$(filter riotboot,$(FEATURES_USED)))
Variables must not be exported:
boards/pic32-clicker/Makefile.include:export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
boards/pic32-wifire/Makefile.include:export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
makefiles/vars.inc.mk:export APPDEPS               # Files / Makefile targets that need to be created before the application can be build. Set in the application's Makefile.

Variables must only be exported in `makefiles/vars.inc.mk`:
Makefile.include:export CCACHE_CPP2=yes
makefiles/arch/mips.inc.mk:export CCAS = $(PREFIX)gcc
makefiles/arch/mips.inc.mk:export CCASUWFLAGS += -target $(TARGET_ARCH)
makefiles/toolchain/gnu.inc.mk:export CC         = $(PREFIX)gcc
makefiles/toolchain/gnu.inc.mk:export CCAS      ?= $(CC)
makefiles/toolchain/llvm.inc.mk:export CC          = clang
makefiles/toolchain/llvm.inc.mk:export CCAS       ?= $(CC)
```

Note: The usage of `FEATURES_USED` is correct but it was to trigger the error message

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/11671
