### PR TITLE
pkg/nimble: add dependency to ble_nimble feature + remove board whitelist from tests and examples

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -795,7 +795,7 @@ ifneq (,$(filter skald_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter skald,$(USEMODULE)))
-  FEATURES_REQUIRED += radio_ble
+  FEATURES_REQUIRED += radio_nrfble
   USEMODULE += xtimer
   USEMODULE += random
 endif

--- a/boards/common/nrf52/Makefile.features
+++ b/boards/common/nrf52/Makefile.features
@@ -6,7 +6,7 @@ ifeq (,$(filter nordic_softdevice_ble,$(USEPKG)))
 endif
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_ble
+FEATURES_PROVIDED += ble_nimble
 FEATURES_PROVIDED += radio_nrfble
 
 include $(RIOTCPU)/nrf52/Makefile.features

--- a/examples/nimble_gatt/Makefile
+++ b/examples/nimble_gatt/Makefile
@@ -4,9 +4,6 @@ APPLICATION = nimble_gatt
 # If no BOARD is found in the environment, use this default:
 BOARD ?= nrf52dk
 
-# So far, NimBLE only works on nRF52 based platforms
-BOARD_WHITELIST := nrf52dk nrf52840dk nrf52832-mdk
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 

--- a/examples/nimble_scanner/Makefile
+++ b/examples/nimble_scanner/Makefile
@@ -4,9 +4,6 @@ APPLICATION = nimble_scanner
 # If no BOARD is found in the environment, use this default:
 BOARD ?= nrf52dk
 
-# So far, NimBLE only works on nRF52 based platforms
-BOARD_WHITELIST := nrf52dk nrf52840dk
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -3,6 +3,9 @@ USEMODULE += posix_semaphore
 USEMODULE += event_callback
 USEMODULE += xtimer
 
+# Requires nimble feature
+FEATURES_REQUIRED += ble_nimble
+
 # glue code
 USEMODULE += nimble_riot_contrib
 

--- a/tests/nimble_l2cap/Makefile
+++ b/tests/nimble_l2cap/Makefile
@@ -1,6 +1,5 @@
-# Configure default and allowed boards
+# Configure nrf52dk as default board
 BOARD ?= nrf52dk
-BOARD_WHITELIST := nrf52dk nrf52840dk
 
 # load the default test environment
 include ../Makefile.tests_common

--- a/tests/nimble_l2cap_server/Makefile
+++ b/tests/nimble_l2cap_server/Makefile
@@ -1,6 +1,5 @@
-# Configure default and allowed boards
+# Configure nrf52dk as default board
 BOARD ?= nrf52dk
-BOARD_WHITELIST := nrf52dk nrf52840dk
 
 # load the default test environment
 include ../Makefile.tests_common


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR modifies the nimble applications to make use of `radio_nrfble` for nimble applications. Only nrf52 based boards are supported and provide this feature (until #11463 is merged).

It's simpler this way and more boards can be used (without an error message) with these applications.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build and test `examples/nimble_*` applications on nrf52 boards other than nrf52dk, nrf52840dk. They should just work fine.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
