### PR TITLE
boards/common: use Makefile.features

### DIFF
--- a/boards/avsextrem/Makefile.features
+++ b/boards/avsextrem/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 
-include $(RIOTCPU)/lpc2387/Makefile.features
+include $(RIOTBOARD)/common/msba2/Makefile.features

--- a/boards/blackpill/Makefile.features
+++ b/boards/blackpill/Makefile.features
@@ -1,1 +1,1 @@
--include $(RIOTBOARD)/common/stm32f103c8/Makefile.features
+include $(RIOTBOARD)/common/stm32f103c8/Makefile.features

--- a/boards/bluepill/Makefile.features
+++ b/boards/bluepill/Makefile.features
@@ -1,1 +1,1 @@
--include $(RIOTBOARD)/common/stm32f103c8/Makefile.features
+include $(RIOTBOARD)/common/stm32f103c8/Makefile.features

--- a/boards/common/msba2/Makefile.features
+++ b/boards/common/msba2/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/lpc2387/Makefile.features

--- a/boards/common/remote/Makefile.features
+++ b/boards/common/remote/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/firefly/Makefile.features
+++ b/boards/firefly/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
--include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTBOARD)/common/remote/Makefile.features

--- a/boards/msb-430/Makefile.features
+++ b/boards/msb-430/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 
-include $(RIOTCPU)/msp430fxyz/Makefile.features
+include $(RIOTBOARD)/common/msb-430/Makefile.features

--- a/boards/msb-430h/Makefile.features
+++ b/boards/msb-430h/Makefile.features
@@ -4,4 +4,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-include $(RIOTCPU)/msp430fxyz/Makefile.features
+include $(RIOTBOARD)/common/msb-430/Makefile.features

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-include $(RIOTCPU)/lpc2387/Makefile.features
+include $(RIOTBOARD)/common/msba2/Makefile.features

--- a/boards/remote-pa/Makefile.features
+++ b/boards/remote-pa/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
-include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTBOARD)/common/remote/Makefile.features

--- a/boards/remote-reva/Makefile.features
+++ b/boards/remote-reva/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
-include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTBOARD)/common/remote/Makefile.features

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
-include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTBOARD)/common/remote/Makefile.features


### PR DESCRIPTION
### Contribution description

Update boards to use `boards/common/*/Makefile.features` if they were using `boards/common/*/Makefile.include` already.
This de-duplicates the including on `$(RIOTCPU)/cpu_name/Makefile.features`.

Also now the `include $(RIOTCPU)/cpu_name/Makefile.features` is done in the same module that defines `CPU`.

It is a cleanup to simplify moving `CPU/CPU_MODEL` to `Makefile.features`.

### Testing procedure

`info-build` gives the same output as in `master` for all boards with only the newly created file in `MAKEFILE_LIST`.

```
BOARDS=$(git diff --name-status 9b4c01c2dd5cdba222804f222acc79ee1ba1cda9 | grep -v 'common' | sed 's/M\t*//;s/^[^/]*\///;s/\/Makefile.features//')
echo ${BOARDS}
# avsextrem blackpill bluepill firefly msb-430 msb-430h msba2 remote-pa remote-reva remote-revb
for board in ${BOARDS}; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-build; done 
```

``` diff
diff  output_master output_pr
131a132
>       /home/harter/work/git/RIOT/boards/common/msba2/Makefile.features  
690a692
>       /home/harter/work/git/RIOT/boards/common/remote/Makefile.features  
845a848
>       /home/harter/work/git/RIOT/boards/common/msb-430/Makefile.features  
996a1000
>       /home/harter/work/git/RIOT/boards/common/msb-430/Makefile.features  
1159a1164
>       /home/harter/work/git/RIOT/boards/common/msba2/Makefile.features  
1336a1342
>       /home/harter/work/git/RIOT/boards/common/remote/Makefile.features  
1514a1521
>       /home/harter/work/git/RIOT/boards/common/remote/Makefile.features  
1692a1700
>       /home/harter/work/git/RIOT/boards/common/remote/Makefile.features  
```

### Issues/PRs references

Cleanup part of: Tracking: move CPU/CPU_MODEL to Makefile.features #11477
Related to https://github.com/RIOT-OS/RIOT/issues/11674