### PR TITLE
drivers/sx127x: fix device reset

### DIFF
--- a/drivers/sx127x/include/sx127x_internal.h
+++ b/drivers/sx127x/include/sx127x_internal.h
@@ -42,6 +42,17 @@ extern "C" {
 /** @} */
 
 /**
+ * @name   Device specific logic level to indicate POR-cycle is active
+ * @{
+ */
+#if defined(MODULE_SX1272)
+#define SX127X_POR_ACTIVE_LOGIC_LEVEL                      (1)
+#else /* MODULE_SX1276 */
+#define SX127X_POR_ACTIVE_LOGIC_LEVEL                      (0)
+#endif
+/** @} */
+
+/**
  * @brief   Check the transceiver version
  *
  * @param[in] dev                      The sx127x device descriptor

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -40,6 +40,22 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+/* The reset signal must be applied for at least 100 µs to trigger the manual
+   reset of the device. To ensure this value is big enough even with an
+   inaccurate clock source, an additional 10 % error margin is added. */
+#define SX127X_MANUAL_RESET_SIGNAL_LEN_US       (110U)
+
+/* After triggering a manual reset the device needs at least 5 ms to become
+   ready before interacting with it. To ensure this value is big enough even
+   with an inaccurate clock source, an additional 10 % error margin is added. */
+#define SX127X_MANUAL_RESET_WAIT_FOR_READY_US   (5500U)
+
+/* When the device is started by enabling its power supply for the first time
+   i.e. on Power-on-Reset (POR), it needs at least 10 ms after the POR cycle is
+   done to become ready. To ensure this value is big enough even with an
+   inaccurate clock source, an additional 10 % error margin is added. */
+#define SX127X_POR_WAIT_FOR_READY_US            (11U * US_PER_MS)
+
 /* Internal functions */
 static int _init_spi(sx127x_t *dev);
 static int _init_gpios(sx127x_t *dev);
@@ -71,7 +87,13 @@ int sx127x_reset(const sx127x_t *dev)
      * See http://www.semtech.com/images/datasheet/sx1276.pdf for SX1276
      * See http://www.semtech.com/images/datasheet/sx1272.pdf for SX1272
      *
+     * For SX1272:
+     * 1. Set Reset pin to HIGH for at least 100 us
+     *
+     * For SX1276:
      * 1. Set NReset pin to LOW for at least 100 us
+     *
+     * For both:
      * 2. Set NReset in Hi-Z state
      * 3. Wait at least 5 milliseconds
      */
@@ -95,17 +117,15 @@ int sx127x_reset(const sx127x_t *dev)
     gpio_set(dev->params.rx_switch_pin);
 #endif
 
-    /* Set reset pin to 0 */
-    gpio_clear(dev->params.reset_pin);
+    /* set reset pin to the state that triggers manual reset */
+    gpio_write(dev->params.reset_pin, SX127X_POR_ACTIVE_LOGIC_LEVEL);
 
-    /* Wait 1 ms */
-    xtimer_usleep(1000);
+    xtimer_usleep(SX127X_MANUAL_RESET_SIGNAL_LEN_US);
 
     /* Put reset pin in High-Z */
     gpio_init(dev->params.reset_pin, GPIO_IN);
 
-    /* Wait 10 ms */
-    xtimer_usleep(1000 * 10);
+    xtimer_usleep(SX127X_MANUAL_RESET_WAIT_FOR_READY_US);
 
     return 0;
 }
@@ -124,8 +144,23 @@ int sx127x_init(sx127x_t *dev)
         return -SX127X_ERR_NODEV;
     }
 
+    /* Check if the reset pin is defined */
+    if (dev->params.reset_pin == GPIO_UNDEF) {
+        DEBUG("[sx127x] error: No reset pin defined.\n");
+        return -SX127X_ERR_GPIOS;
+    }
+
     _init_timers(dev);
-    xtimer_usleep(1000); /* wait 1 millisecond */
+
+    /* reset pin should be left floating during POR */
+    gpio_init(dev->params.reset_pin, GPIO_IN);
+
+    /* wait till device signals end of POR cycle */
+    while ((gpio_read(dev->params.reset_pin) > 0) ==
+           SX127X_POR_ACTIVE_LOGIC_LEVEL ) {};
+
+    /* wait for the device to become ready */
+    xtimer_usleep(SX127X_POR_WAIT_FOR_READY_US);
 
     sx127x_reset(dev);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixes the reset for sx1272, and adapts the timeouts to adhere to what the datasheet specifies when coming from power-on-reset (POR).
Previously the logic level for triggering the reset was fixed to LOW, which is only the case for sx1276 and not sx1272.
See corresponding section 7.2.1 and 7.2.2 in the datasheets of [SX1272](https://www.semtech.com/uploads/documents/SX1272_DS_V4.pdf#page=114) and [SX1276](https://www.semtech.com/uploads/documents/DS_SX1276-7-8-9_W_APP_V6.pdf#page=116).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Use any application that uses the sx127x driver and connect a scope to the reset pin of the radio.
Then do a power cycle (e.g. unplug and plug USB) for POR. To test manual reset, calling sx127x_reset is enough.
With current master you won't see a proper reset pattern, compared to the datasheets linked above.
With this PR this should be fixed. Note: the change will only be directly visible for sx1272 as for the 1276 only the waiting timings are increased a bit. To see the effect on the 1276 I suggest to connect another channel of your scope to one of the SPI pins to see that interaction with the device is started to early in master.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
