### PR TITLE
tests/xtimer_mutex_lock_timeout: add simple case test

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -38,6 +38,10 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+/*
+ * @brief: struct for mutex lock with timeout
+ * xtimer_mutex_lock_timeout() uses it to give information to the timer callback function
+ */
 typedef struct {
     mutex_t *mutex;
     thread_t *thread;

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -45,7 +45,7 @@
 typedef struct {
     mutex_t *mutex;
     thread_t *thread;
-    int timeout;
+    volatile int timeout;
 } mutex_thread_t;
 
 static void _callback_unlock_mutex(void* arg)

--- a/tests/xtimer_mutex_lock_timeout/Makefile
+++ b/tests/xtimer_mutex_lock_timeout/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+USEMODULE += shell
+
+TEST_ON_CI_WHITELIST += all
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_mutex_lock_timeout/main.c
+++ b/tests/xtimer_mutex_lock_timeout/main.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin,
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       testing xtimer_mutex_lock_timeout function
+ *
+ *
+ * @author      Julian Holzwarth <julian.holzwarth@fu-berlin.de>
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "shell.h"
+#include "xtimer.h"
+
+/* timeout at one millisecond (1000 us) to make sure it does not spin. */
+#define LONG_MUTEX_TIMEOUT 1000
+
+/**
+ * Foward declarations
+ */
+static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
+                                                            char **argv);
+
+/**
+ * @brief   List of command for this application.
+ */
+static const shell_command_t shell_commands[] = {
+    { "mutex_timeout_long_unlocked", "unlocked mutex with long timeout",
+      cmd_test_xtimer_mutex_lock_timeout_long_unlocked, },
+    { NULL, NULL, NULL }
+};
+
+/**
+ * @brief   shell command to test xtimer_mutex_lock_timeout
+ *
+ * the mutex is not locked before the function call and
+ * the timer long. Meaning the timer will get removed
+ * before triggering.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return 0 on success
+ */
+static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
+                                                            char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("starting test: xtimer mutex lock timeout");
+    mutex_t test_mutex = MUTEX_INIT;
+
+    if (xtimer_mutex_lock_timeout(&test_mutex, LONG_MUTEX_TIMEOUT) == 0) {
+        /* mutex has to be locked */
+        if (mutex_trylock(&test_mutex) == 0) {
+            puts("OK");
+        }
+        else {
+            puts("error mutex not locked");
+        }
+    }
+    else {
+        puts("error: mutex timed out");
+    }
+
+    return 0;
+}
+
+/**
+ * @brief   main function starting shell
+ *
+ * @return 0 on success
+ */
+int main(void)
+{
+    puts("Starting shell...");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/xtimer_mutex_lock_timeout/main.c
+++ b/tests/xtimer_mutex_lock_timeout/main.c
@@ -31,6 +31,8 @@
  */
 static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
                                                             char **argv);
+static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
+                                                          char **argv);
 
 /**
  * @brief   List of command for this application.
@@ -38,6 +40,8 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
 static const shell_command_t shell_commands[] = {
     { "mutex_timeout_long_unlocked", "unlocked mutex with long timeout",
       cmd_test_xtimer_mutex_lock_timeout_long_unlocked, },
+    { "mutex_timeout_long_locked", "locked mutex with long timeout",
+      cmd_test_xtimer_mutex_lock_timeout_long_locked, },
     { NULL, NULL, NULL }
 };
 
@@ -72,6 +76,43 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
     }
     else {
         puts("error: mutex timed out");
+    }
+
+    return 0;
+}
+
+/**
+ * @brief   shell command to test xtimer_mutex_lock_timeout
+ *
+ * the mutex is locked before the function call and
+ * the timer long. Meaning the timer will trigger
+ * and remove the thread from the mutex waiting list.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return 0 on success
+ */
+static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
+                                                          char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("starting test: xtimer mutex lock timeout");
+    mutex_t test_mutex = MUTEX_INIT;
+    mutex_lock(&test_mutex);
+
+    if (xtimer_mutex_lock_timeout(&test_mutex, LONG_MUTEX_TIMEOUT) == 0) {
+        puts("Error: mutex taken");
+    }
+    else {
+        /* mutex has to be locked */
+        if (mutex_trylock(&test_mutex) == 0) {
+            puts("OK");
+        }
+        else {
+            puts("error mutex not locked");
+        }
     }
 
     return 0;

--- a/tests/xtimer_mutex_lock_timeout/tests/01-run.py
+++ b/tests/xtimer_mutex_lock_timeout/tests/01-run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2019 Freie Universität Berlin,
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Julian Holzwarth <julian.holzwarth@fu-berlin.de>
+
+import sys
+import pexpect
+from testrunner import run
+
+
+def testfunc(child):
+    # Try to wait for the shell
+    for _ in range(0, 10):
+        child.sendline("help")
+        if child.expect_exact(["> ", pexpect.TIMEOUT], timeout=1) == 0:
+            break
+    child.sendline("mutex_timeout_long_unlocked")
+    child.expect("starting test: xtimer mutex lock timeout")
+    child.expect("OK")
+    child.expect_exact("> ")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/xtimer_mutex_lock_timeout/tests/01-run.py
+++ b/tests/xtimer_mutex_lock_timeout/tests/01-run.py
@@ -23,6 +23,10 @@ def testfunc(child):
     child.expect("starting test: xtimer mutex lock timeout")
     child.expect("OK")
     child.expect_exact("> ")
+    child.sendline("mutex_timeout_long_locked")
+    child.expect("starting test: xtimer mutex lock timeout")
+    child.expect("OK")
+    child.expect_exact("> ")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This pr implements normal test case tests for `xtimer_mutex_lock_timeout` in `xtimer.c `. As the timeout 1000us or 1 millisecond is used to make sure it does not spin. And adds a short comment for the struct it uses (`mutex_thread_t`). Also because the integer `timeout` in the struct is modified from interupt context it must be volatile. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`BOARD=native make -C tests/xtimer_mutex_lock timeout/ flash test`
output:

```
...
> mutex_timeout_n_spin_unlocked
starting test: xtimer mutex lock timeout
OK
> mutex_timeout_n_spin_locked
mutex_timeout_n_spin_locked
starting test: xtimer mutex lock timeout
OK
> 
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
 the tracking pr: #11660
