### PR TITLE
cpu/stm32f7/4/2: add flashpage and flashpage_raw

### DIFF
--- a/cpu/stm32_common/periph/flash_common.c
+++ b/cpu/stm32_common/periph/flash_common.c
@@ -32,7 +32,7 @@
 #define CNTRL_REG_LOCK         (FLASH_PECR_PELOCK)
 #define KEY_REG                (FLASH->PEKEYR)
 #else
-#if defined(CPU_FAM_STM32L4)
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F4)
 #define FLASH_KEY1             ((uint32_t)0x45670123)
 #define FLASH_KEY2             ((uint32_t)0xCDEF89AB)
 #endif

--- a/cpu/stm32_common/periph/flash_common.c
+++ b/cpu/stm32_common/periph/flash_common.c
@@ -32,7 +32,8 @@
 #define CNTRL_REG_LOCK         (FLASH_PECR_PELOCK)
 #define KEY_REG                (FLASH->PEKEYR)
 #else
-#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F4)
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F2) || \
+    defined(CPU_FAM_STM32F4)
 #define FLASH_KEY1             ((uint32_t)0x45670123)
 #define FLASH_KEY2             ((uint32_t)0xCDEF89AB)
 #endif

--- a/cpu/stm32_common/periph/flash_common.c
+++ b/cpu/stm32_common/periph/flash_common.c
@@ -33,7 +33,7 @@
 #define KEY_REG                (FLASH->PEKEYR)
 #else
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F2) || \
-    defined(CPU_FAM_STM32F4)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7)
 #define FLASH_KEY1             ((uint32_t)0x45670123)
 #define FLASH_KEY2             ((uint32_t)0xCDEF89AB)
 #endif

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -42,7 +42,7 @@
 #else
 #if defined(CPU_FAM_STM32L4)
 #define FLASHPAGE_DIV          (8U)
-#elif defined(CPU_FAM_STM32F4)
+#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
 #define FLASHSECTORS_BANK      (12)
 #define FLASHPAGE_DIV          (4U)
 #else
@@ -157,7 +157,7 @@ static void _erase_sector_page(void *page_addr)
 }
 #endif
 
-#if !(defined(CPU_FAM_STM32F4))
+#if !(defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4))
 static void _erase_page(void *page_addr)
 {
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
@@ -246,7 +246,7 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
            (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)) + 1);
 
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-    defined(CPU_FAM_STM32F4)
+    defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
     uint32_t *dst = target_addr;
     const uint32_t *data_addr = data;
 #elif defined(CPU_FAM_STM32L4)
@@ -270,7 +270,7 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     /* make sure no flash operation is ongoing */
     _wait_for_pending_operations();
 
-#if defined(CPU_FAM_STM32F4)
+#if defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
     /* set parallelism to 32bits */
     CNTRL_REG &= FLASH_CR_PSIZE_Msk;
     CNTRL_REG |= (0x2 << FLASH_CR_PSIZE_Pos);
@@ -300,7 +300,8 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     _lock();
 
 #if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-      defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F4))
+      defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F2) || \
+      defined(CPU_FAM_STM32F4))
     /* restore the HSI state */
     if (!hsi_state) {
         stmclk_disable_hsi();
@@ -322,7 +323,7 @@ void flashpage_write(int page, const void *data)
     uint16_t *page_addr = flashpage_addr(page);
 #endif
 
-#if !(defined(CPU_FAM_STM32F4))
+#if !(defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4))
     /* ERASE sequence */
     _erase_page(page_addr);
 #else

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -336,9 +336,8 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     /* lock the flash module again */
     _lock();
 
-#if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-      defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F2) || \
-      defined(CPU_FAM_STM32F4))
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F3)
     /* restore the HSI state */
     if (!hsi_state) {
         stmclk_disable_hsi();

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -42,6 +42,9 @@
 #else
 #if defined(CPU_FAM_STM32L4)
 #define FLASHPAGE_DIV          (8U)
+#elif defined(CPU_FAM_STM32F4)
+#define FLASHSECTORS_BANK      (12)
+#define FLASHPAGE_DIV          (4U)
 #else
 #define FLASHPAGE_DIV          (2U)
 #endif
@@ -69,6 +72,92 @@ static void _unlock_flash(void)
 #endif
 }
 
+#if defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
+static inline int flashbank_sector(void *addr) {
+    uint8_t sn = (uint8_t)(((uint32_t)addr - CPU_FLASH_BASE) / FLASHSECTOR_SIZE_MIN);
+    if(sn > 3 && sn < 8) {
+        sn = 4;
+    }
+    else if(sn > 8){
+        sn = (sn / 8) + 4;
+    }
+    return sn;
+}
+
+static inline int flashsector_sector(void *addr) {
+#if(FLASH_DUAL_BANK == 1)
+    if((uint32_t) addr >= (STM32_FLASHSIZE / 2) + CPU_FLASH_BASE) {
+        DEBUG("[flashsector]: dual bank sector \n");
+        addr = (void *)((uint32_t) addr - (STM32_FLASHSIZE / 2));
+        return FLASHSECTORS_BANK + flashbank_sector(addr);
+    }
+    else {
+        DEBUG("[flashsector]: single bank sector \n");
+        return flashbank_sector(addr);
+    }
+#else
+    return flashbank_sector(addr);
+#endif
+}
+
+static void _erase_sector(uint8_t sn)
+{
+    /* make sure no flash operation is ongoing */
+    _wait_for_pending_operations();
+
+    /* unlock the flash module */
+    _unlock_flash();
+
+    /* set parallelism to 32bits */
+    CNTRL_REG &= FLASH_CR_PSIZE_Msk;
+    CNTRL_REG |= (0x2 << FLASH_CR_PSIZE_Pos);
+
+    /* make sure no flash operation is ongoing */
+    _wait_for_pending_operations();
+
+    DEBUG("[flashsector] erase: setting the sector erase code\n");
+    CNTRL_REG |= ((sn % FLASHSECTORS_BANK) << FLASH_CR_SNB_Pos);
+#if( FLASH_DUAL_BANK == 1)
+    CNTRL_REG |= (sn / FLASHSECTORS_BANK) * FLASH_CR_SNB_4;
+#endif
+    DEBUG("[flashsector] erase: setting the erase bit\n");
+    CNTRL_REG |= FLASH_CR_SER;
+
+    DEBUG("[flashsector] erase: trigger the page erase\n");
+    CNTRL_REG |= FLASH_CR_STRT;
+
+    /* wait as long as device is busy */
+    _wait_for_pending_operations();
+
+    /* reset PER bit */
+    DEBUG("[flashsector] erase: resetting the sector erase bit\n");
+    CNTRL_REG &= ~FLASH_CR_SER;
+
+    /* lock the flash module again */
+    _lock();
+}
+
+static void _erase_sector_page(void *page_addr)
+{
+    DEBUG("[flashsector] erase: address to erase: %p\n", page_addr);
+    /* avoid erasing whole sector if "page" is blank*/
+    bool blank = true;
+    for (unsigned i = 0; i < FLASHPAGE_SIZE; i += sizeof(uint32_t)) {
+        if (*(uint32_t *) (page_addr + i) != 0xffffffff) {
+            blank = false;
+            break;
+        }
+    }
+    /* erase the sector if it failed the blank check */
+    if (!blank) {
+        uint8_t sn = flashsector_sector(page_addr);
+        DEBUG("[flashsector] erase: erasing sector: %d\n", sn);
+        _erase_sector(sn);
+    }
+}
+#endif
+
+#if !(defined(CPU_FAM_STM32F4))
 static void _erase_page(void *page_addr)
 {
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
@@ -140,6 +229,7 @@ static void _erase_page(void *page_addr)
     }
 #endif
 }
+#endif
 
 void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 {
@@ -155,7 +245,8 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     assert(((unsigned)target_addr + len) <
            (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)) + 1);
 
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
+    defined(CPU_FAM_STM32F4)
     uint32_t *dst = target_addr;
     const uint32_t *data_addr = data;
 #elif defined(CPU_FAM_STM32L4)
@@ -179,6 +270,12 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     /* make sure no flash operation is ongoing */
     _wait_for_pending_operations();
 
+#if defined(CPU_FAM_STM32F4)
+    /* set parallelism to 32bits */
+    CNTRL_REG &= FLASH_CR_PSIZE_Msk;
+    CNTRL_REG |= (0x2 << FLASH_CR_PSIZE_Pos);
+#endif
+
     DEBUG("[flashpage_raw] write: now writing the data\n");
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4)
@@ -191,7 +288,6 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
         /* wait as long as device is busy */
         _wait_for_pending_operations();
     }
-
     /* clear program bit again */
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4)
@@ -199,11 +295,12 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 #endif
     DEBUG("[flashpage_raw] write: done writing data\n");
 
+
     /* lock the flash module again */
     _lock();
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
-    defined(CPU_FAM_STM32F3)
+#if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
+      defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F4))
     /* restore the HSI state */
     if (!hsi_state) {
         stmclk_disable_hsi();
@@ -225,9 +322,12 @@ void flashpage_write(int page, const void *data)
     uint16_t *page_addr = flashpage_addr(page);
 #endif
 
+#if !(defined(CPU_FAM_STM32F4))
     /* ERASE sequence */
     _erase_page(page_addr);
-
+#else
+    _erase_sector_page(page_addr);
+#endif
     /* WRITE sequence */
     if (data != NULL) {
         flashpage_write_raw(page_addr, data, FLASHPAGE_SIZE);

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -82,10 +82,10 @@ static inline void * _flashsector_addr(uint8_t sn)
     uint32_t addr = CPU_FLASH_BASE;
 #endif
     if (sn <= 4) {
-        addr += CPU_FLASH_BASE(FLASHSECTOR_SIZE_MIN * sn);
+        addr += (FLASHSECTOR_SIZE_MIN * sn);
     }
     else {
-        addr += CPU_FLASH_BASE(FLASHSECTOR_SIZE_MIN * (sn - 4));
+        addr += (FLASHSECTOR_SIZE_MIN * (sn - 4));
     }
     return (void *) addr;
 }
@@ -174,6 +174,7 @@ static void _erase_sector_page(void *page_addr)
     if(_flashsector_addr(sn) == page_addr) {
         DEBUG("[flashsector] erase: erasing sector: %d\n", sn);
         _erase_sector(sn);
+        return;
     }
     /* avoid erasing whole sector if "page" is blank */
     bool blank = true;

--- a/cpu/stm32f2/Makefile.features
+++ b/cpu/stm32f2/Makefile.features
@@ -1,3 +1,5 @@
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_flashpage_raw
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f2/include/cpu_conf.h
+++ b/cpu/stm32f2/include/cpu_conf.h
@@ -58,6 +58,8 @@ extern "C" {
 /* To keep the same flashpage functionality an arbitrary 1K < FLASHSECTOR_SIZE_MIN
  * (size of smaller sector) is defined
  */
+/* An erase byte in flash is set to 0xff */
+#define FLASH_ERASE_STATE         (0xff)
 #define FLASHPAGE_SIZE            (1024U)
 #define FLASHPAGE_NUMOF           (STM32_FLASHSIZE / FLASHPAGE_SIZE)
 /* The minimum block size which can be written is 4B. However, the erase

--- a/cpu/stm32f2/include/cpu_conf.h
+++ b/cpu/stm32f2/include/cpu_conf.h
@@ -38,6 +38,36 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
+/**
+ * @brief   Flash sector configuration
+ *
+ * @{
+ */
+#define FLASH_DUAL_BANK           (0)
+#define FLASHSECTOR_SIZE_MIN      (16*1024U)
+/** @} */
+
+/**
+ * @brief   Flash page configuration
+ *
+ *          NOTE: STM32F2 flash is organized in sectors, FLASHPAGE_* is
+ *                defined as a wrapper over sectors.
+ *
+ * @{
+ */
+/* To keep the same flashpage functionality an arbitrary 1K < FLASHSECTOR_SIZE_MIN
+ * (size of smaller sector) is defined
+ */
+#define FLASHPAGE_SIZE            (1024U)
+#define FLASHPAGE_NUMOF           (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+/* The minimum block size which can be written is 4B. However, the erase
+ * depends on the specific sector.
+ */
+#define FLASHPAGE_RAW_BLOCKSIZE    (4U)
+/* Writing should be always 4 bytes aligned */
+#define FLASHPAGE_RAW_ALIGNMENT    (4U)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f4/Makefile.features
+++ b/cpu/stm32f4/Makefile.features
@@ -1,4 +1,6 @@
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_flashpage_raw
 
 # the granularity of provided feature definition for STMs is currently by CPU
 # sub-family (e.g., stm32f[1234]).  Unfortunately, only some of e.g., the

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -55,6 +55,41 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
+/**
+ * @brief   Flash sector configuration
+ *
+ * @{
+ */
+#if (defined(CPU_LINE_STM32F429xx) || defined(CPU_LINE_STM32F437xx)) && \
+    (STM32_FLASHSIZE == (2048*1024))
+#define FLASH_DUAL_BANK           (1)
+#else
+#define FLASH_DUAL_BANK           (0)
+#endif
+#define FLASHSECTOR_SIZE_MIN      (16*1024U)
+/** @} */
+
+/**
+ * @brief   Flash page configuration
+ *
+ *          NOTE: STM32F4 flash is organized in sectors, FLASHPAGE_* is
+ *                defined as a wrapper over sectors.
+ *
+ * @{
+ */
+/* To keep the same flashpage functionality an arbitrary 1K < FLASHSECTOR_SIZE_MIN
+ * (size of smaller sector) is defined
+ */
+#define FLASHPAGE_SIZE            (1024)
+#define FLASHPAGE_NUMOF           (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+/* The minimum block size which can be written is 4B. However, the erase
+ * depends on the specific sector.
+ */
+#define FLASHPAGE_RAW_BLOCKSIZE    (4U)
+/* Writing should be always 4 bytes aligned */
+#define FLASHPAGE_RAW_ALIGNMENT    (4U)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f7/Makefile.features
+++ b/cpu/stm32f7/Makefile.features
@@ -1,2 +1,5 @@
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_flashpage_raw
+
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f7/include/cpu_conf.h
+++ b/cpu/stm32f7/include/cpu_conf.h
@@ -52,9 +52,10 @@ extern "C" {
  * @{
  */
 #define FLASH_DUAL_BANK           (0)
-#if defined(CPU_LINE_STM32F746xx) || defined(CPU_LINE_STM32F722xx)
+#if defined(CPU_LINE_STM32F722xx)
 #define FLASHSECTOR_SIZE_MIN      (16*1024U)
-#elif defined(CPU_LINE_STM32F767xx) || defined(CPU_LINE_STM32F769xx)
+#elif defined(CPU_LINE_STM32F767xx) || defined(CPU_LINE_STM32F769xx) || \
+      defined(CPU_LINE_STM32F746xx)
 #define FLASHSECTOR_SIZE_MIN      (32*1024UL)
 #endif
 
@@ -69,6 +70,8 @@ extern "C" {
 /* To keep the same flashpage functionality an arbitrary 1K < FLASHSECTOR_SIZE_MIN
  * (size of smaller sector) is defined
  */
+/* An erase byte in flash is set to 0xff */
+#define FLASH_ERASE_STATE         (0xff)
 #define FLASHPAGE_SIZE            (1024U)
 #define FLASHPAGE_NUMOF           (STM32_FLASHSIZE / FLASHPAGE_SIZE)
 /* The minimum block size which can be written is 4B. However, the erase
@@ -78,7 +81,6 @@ extern "C" {
 /* Writing should be always 4 bytes aligned */
 #define FLASHPAGE_RAW_ALIGNMENT    (4U)
 /** @} */
-
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32f7/include/cpu_conf.h
+++ b/cpu/stm32f7/include/cpu_conf.h
@@ -43,7 +43,42 @@ extern "C" {
 #elif defined(CPU_LINE_STM32F722xx)
 #define CPU_IRQ_NUMOF                   (104U)
 #endif
+#define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
+
+/**
+ * @brief   Flash sector configuration
+ *
+ * @{
+ */
+#define FLASH_DUAL_BANK           (0)
+#if defined(CPU_LINE_STM32F746xx) || defined(CPU_LINE_STM32F722xx)
+#define FLASHSECTOR_SIZE_MIN      (16*1024U)
+#elif defined(CPU_LINE_STM32F767xx) || defined(CPU_LINE_STM32F769xx)
+#define FLASHSECTOR_SIZE_MIN      (32*1024UL)
+#endif
+
+/**
+ * @brief   Flash page configuration
+ *
+ *          NOTE: STM32F7 flash is organized in sectors, FLASHPAGE_* is
+ *                defined as a wrapper over sectors.
+ *
+ * @{
+ */
+/* To keep the same flashpage functionality an arbitrary 1K < FLASHSECTOR_SIZE_MIN
+ * (size of smaller sector) is defined
+ */
+#define FLASHPAGE_SIZE            (1024U)
+#define FLASHPAGE_NUMOF           (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+/* The minimum block size which can be written is 4B. However, the erase
+ * depends on the specific sector.
+ */
+#define FLASHPAGE_RAW_BLOCKSIZE    (4U)
+/* Writing should be always 4 bytes aligned */
+#define FLASHPAGE_RAW_ALIGNMENT    (4U)
+/** @} */
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds `flashpage` and `flashpage_raw` for stm32f2/4/7~~stm32f2 and stm32f4~~. They ~~both~~ use sectors as the way of dividing flash, instead of the usual page. These sector do not have the same size, and they can vary according to the specific CPU.

This PR implements `flashpage` and `flashpage_raw` as a wrapper over sectors. To still keep the page notion, an arbitrary `page` of length 1kB has been defined. When an erase is requested the sector where this `page` is located is only erased if the `page` was in not in a erase state anymore, i.e. '0xFF'. 

NOTE1: this "wrapper" concept is only for erasing, when it comes to writing it's pretty much the same than for other STM32.

~~NOTE2: there is an api change since a `flashpage_init()` is introduced. Not sure if that is the best option.~~

~~NOTE3: I tried to make it work for `stm32f7` but I have problems with unexpected latency when performing flash operations, so delaying it out; but the general approach works as well for `stm32f7`.~~

### Testing procedure

Tested on `nucleo-f207zg`, `nucleo-f446re`, `nucleo-f767zi` & `stm32f429i-disc1`. On these or other `stm32f2` and `stm32f4` run:

`make clean -C tests/periph_flashpage/ BOARD=nucleo-f207zg flash test`
everything should pass.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
