### PR TITLE
cpu/stm32f4: add riotboot requirements

### DIFF
--- a/boards/nucleo-f446re/Makefile.features
+++ b/boards/nucleo-f446re/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_qdec
 
 # Various other features (if any)
 FEATURES_PROVIDED += motor_driver
+FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -4,4 +4,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 include $(RIOTCPU)/stm32f4/Makefile.features

--- a/cpu/stm32f4/Makefile.include
+++ b/cpu/stm32f4/Makefile.include
@@ -1,5 +1,22 @@
 export CPU_ARCH = cortex-m4f
 export CPU_FAM  = stm32f4
 
+# STM32F4 uses sectors instead of pages, where the minimum sector length is 16KB
+# (the first sector), therefore RIOTBOOT_LEN must be 16KB to cover a whole sector.
+RIOTBOOT_LEN ?= 0x4000
+
+# CPU_IRQ_NUMOF for STM32F4 boards is < 102+16 so (118*4 bytes = 472 bytes ~= 0x200)
+# RIOTBOOT_HDR_LEN can be set to 0x200.
+# Details on alignment requirements for M4 in `cpu/cortexm_common/Makefile.include`.
+RIOTBOOT_HDR_LEN ?= 0x200
+
+# Sectors don't have the same length. Per bank there can be up to 12 sectors. The
+# first 4 sectors are 16kB long, the 5th is 64kB and the remaining 7 are 128kB.
+# Since flash can only be erased by sector, slots can't overlap over sectors.
+# RIOTBOOT_LEN is removed twice, once at the start of the flash for the bootloader,
+# and a second time at the end of the flash, to get evenly sized and distributed slots.
+SLOT0_LEN ?= $(shell printf "0x%x" $$((($(ROM_LEN:%K=%*1024)-2*$(RIOTBOOT_LEN)) / $(NUM_SLOTS))))
+SLOT1_LEN ?= $(SLOT0_LEN)
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds riotboot for stm32f4. Since F4 works with sectors for riotboot to work each slot must start at the beginning of a ~~slot~~sector. For stm32f4 the smallest ~~slot~~sector is of length 16kB, therefore that must be the length of the bootloader and the same amount must be taken from the second half of the flash to optimize flash usage.

This PR is part of 3, since just adding riotboot doesn't make much sense if it can't perform ota. Although it doesn't depend on them it is highly related to:

* Support flashpage: https://github.com/RIOT-OS/RIOT/pull/11681
* Don't erase fist page at un update finish: https://github.com/RIOT-OS/RIOT/pull/11683

### Testing procedure

It has been tested on the supported boards: `nucleo-f446re` and `stm32f429i-disc1`. 

1.- Test riotboot:

`BOARD=nucleo-f446r FEATURES_REQUIRED+=riotboot make -C tests/xtimer_usleep riotboot/flash-extended-slot0 term`

`BOARD=nucleo-f446rFEATURES_REQUIRED+=riotboot make -C tests/xtimer_usleep riotboot/flash-slot1 term`

In both cases it should run without issues.

2.- Since the sector division is important when updating the slots by writing to flash directly it would be ideal to reba se on top off flashpage: https://github.com/RIOT-OS/RIOT/pull/11681 and https://github.com/RIOT-OS/RIOT/pull/11683

and run `tests/riotboot_flashwrite`

The following patch can be applied to the test Makefile

```
diff --git a/tests/riotboot_flashwrite/Makefile b/tests/riotboot_flashwrite/Makefile
index 32f127d70..d3c9f20b4 100644
--- a/tests/riotboot_flashwrite/Makefile
+++ b/tests/riotboot_flashwrite/Makefile
@@ -39,11 +39,17 @@ LOW_MEMORY_BOARDS := nucleo-f334r8
 GNRC_NETIF_NUMOF := 2
 
 # uncomment these to use ethos
-#USEMODULE += ethos gnrc_uhcpc
+USEMODULE += ethos gnrc_uhcpc  stdio_uart_rx
 #
 ## ethos baudrate can be configured from make command
-#ETHOS_BAUDRATE ?= 115200
-#CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
+ETHOS_BAUDRATE ?= 115200
+CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
+
+TAP ?= tap0
+IPV6_PREFIX ?= 2001:db8::/64
+
+TERMPROG ?= sudo sh $(RIOTTOOLS)/ethos/start_network.sh
+TERMFLAGS ?= $(PORT) $(TAP) $(IPV6_PREFIX)
 
 ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
   $(info Using low-memory configuration for microcoap_server.)

```

Then to test:

- provided the node `make -C tests/riotboot_flashwrite/ BOARD=stm32f429i-disc1 riotboot/flash term`
- compile new firmware: `make -C tests/riotboot_flashwrite/ BOARD=stm32f429i-disc1 riotboot`
- launch an updated: `coap-client -m post coap://[fe80::2%tap0]/flashwrite -f tests/riotboot_flashwrite/bin/stm32f429i-disc1/tests_riotboot_flashwrite-slot1.riot.bin -b 64`

When the update finished reboot the node manually it should have started from a different slot.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Related to  https://github.com/RIOT-OS/RIOT/pull/11681 and https://github.com/RIOT-OS/RIOT/pull/11683