### PR TITLE
tests/lua_loader: remove deprecated test target

### DIFF
--- a/tests/lua_loader/Makefile
+++ b/tests/lua_loader/Makefile
@@ -11,6 +11,3 @@ ifneq ($(BOARD),native)
 endif
 
 include $(RIOTBASE)/Makefile.include
-
-test:
-	tests/01-run.py


### PR DESCRIPTION
### Contribution description

The test target is now defined in the common `Makefile.include`.
This removes the warning

    Makefile: warning: overriding recipe for target 'test'
    Makefile.include: warning: ignoring old recipe for target 'test'

The test is not enabled in `murdock` because it currently fails, so no need for `CI: run tests`

### Testing procedure

In master there were warnings which are not there anymore with the PR.

```
BOARD=native make -C tests/lua_loader/ all
BOARD=native make -C tests/lua_loader/ test
Makefile:16: warning: overriding recipe for target 'test'
/home/harter/work/git/RIOT/Makefile.include:589: warning: ignoring old recipe for target 'test'
```

### Issues/PRs references

Found while trying to enable the test in https://github.com/RIOT-OS/RIOT/pull/11680