### PR TITLE
tests/lua_loader: run the test in CI

### DIFF
--- a/tests/lua_loader/Makefile
+++ b/tests/lua_loader/Makefile
@@ -13,4 +13,8 @@ ifneq ($(BOARD),native)
   CFLAGS += -DTHREAD_STACKSIZE_MAIN='(THREAD_STACKSIZE_DEFAULT+2048)'
 endif
 
+TEST_ON_CI_WHITELIST += all
+# HACK Blacklist native as `murdock` fails on utf-8 characters for native tests
+TEST_ON_CI_BLACKLIST += native
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

Enable running the test as the test is available.

### Testing procedure

The test must be successfully executed by CI (check the listed tests).


### Issues/PRs references

Found it was not enabled while working on https://github.com/RIOT-OS/RIOT/pull/11680

I blacklisted native due to #11691
