### PR TITLE
tests/pkg_u8g2: run the test in CI

### DIFF
--- a/tests/pkg_u8g2/Makefile
+++ b/tests/pkg_u8g2/Makefile
@@ -59,4 +59,8 @@ CFLAGS += -DTEST_PIN_RESET=$(TEST_PIN_RESET)
 
 CFLAGS += -DTEST_DISPLAY=$(TEST_DISPLAY)
 
+TEST_ON_CI_WHITELIST += all
+# HACK Blacklist native as `murdock` fails on utf-8 characters for native tests
+TEST_ON_CI_BLACKLIST += native
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

Enable running the test as the test is available.

### Testing procedure

The test must be successfully executed by CI (check the listed tests).


### Issues/PRs references

Found it was not enabled while working on https://github.com/RIOT-OS/RIOT/pull/11680
I blacklisted `native` due to https://github.com/RIOT-OS/RIOT/issues/11691
