### PR TITLE
cpu/sam0_common: RTC & RTT cleanup

### DIFF
--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -187,14 +187,20 @@ static void clk_init(void)
     /* make sure we synchronize clock generator 0 before we go on */
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
-#if GEN2_ULP32K
     /* Setup Clock generator 2 with divider 1 (32.768kHz) */
     GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(2)  | GCLK_GENDIV_DIV(0));
-    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_GENEN |
-            GCLK_GENCTRL_RUNSTDBY |
-            GCLK_GENCTRL_SRC_OSCULP32K);
+    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_GENEN
+                      | GCLK_GENCTRL_RUNSTDBY
+#if GEN2_ULP32K
+                      | GCLK_GENCTRL_SRC_OSCULP32K);
+#else
+                      | GCLK_GENCTRL_SRC_XOSC32K);
 
-    while (GCLK->STATUS.bit.SYNCBUSY) {}
+    SYSCTRL->XOSC32K.reg = SYSCTRL_XOSC32K_ONDEMAND
+                         | SYSCTRL_XOSC32K_EN32K
+                         | SYSCTRL_XOSC32K_XTALEN
+                         | SYSCTRL_XOSC32K_STARTUP(6)
+                         | SYSCTRL_XOSC32K_ENABLE;
 #endif
 
     /* redirect all peripherals to a disabled clock generator (7) by default */

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -20,6 +20,7 @@
 
 #include "cpu.h"
 #include "periph/init.h"
+#include "periph_conf.h"
 #include "board.h"
 
 #ifdef CPU_FAM_SAML11
@@ -45,6 +46,7 @@ void cpu_init(void)
     /* turn on only needed APB peripherals */
     MCLK->APBAMASK.reg = MCLK_APBAMASK_MCLK
                          | MCLK_APBAMASK_OSCCTRL
+                         | MCLK_APBAMASK_OSC32KCTRL
                          | MCLK_APBAMASK_GCLK
                          | MCLK_APBAMASK_PM
 #ifdef MODULE_PERIPH_GPIO_IRQ
@@ -61,7 +63,7 @@ void cpu_init(void)
     while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_SWRST) {}
 
     PM->PLCFG.reg = PM_PLCFG_PLSEL_PL2;
-    while (0 == PM->INTFLAG.bit.PLRDY) {}
+    while (!PM->INTFLAG.bit.PLRDY) {}
 
     MCLK->APBBMASK.reg |= MCLK_APBBMASK_NVMCTRL;
     _NVMCTRL->CTRLB.reg |= NVMCTRL_CTRLB_RWS(1);

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -35,6 +35,41 @@ static void _gclk_setup(int gclk, uint32_t reg)
     while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_GENCTRL(gclk)) {}
 }
 
+static void _osc32k_setup(void)
+{
+#if INTERNAL_OSC32_SOURCE
+    uint32_t * pCalibrationArea;
+    uint32_t osc32kcal;
+
+    /* Read OSC32KCAL, calibration data for OSC32 !!! */
+    pCalibrationArea = (uint32_t*) NVMCTRL_OTP5;
+    osc32kcal = ( (*pCalibrationArea) & 0x1FC0 ) >> 6;
+
+    /* RTC use Low Power Internal Oscillator at 32kHz */
+    OSC32KCTRL->OSC32K.reg = OSC32KCTRL_OSC32K_RUNSTDBY
+                           | OSC32KCTRL_OSC32K_EN32K
+                           | OSC32KCTRL_OSC32K_CALIB(osc32kcal)
+                           | OSC32KCTRL_OSC32K_ENABLE;
+
+    /* Wait OSC32K Ready */
+    while (!OSC32KCTRL->STATUS.bit.OSC32KRDY) {}
+#endif /* INTERNAL_OSC32_SOURCE */
+}
+
+static void _xosc32k_setup(void)
+{
+#if EXTERNAL_OSC32_SOURCE
+    /* RTC uses External 32,768KHz Oscillator */
+    OSC32KCTRL->XOSC32K.reg = OSC32KCTRL_XOSC32K_XTALEN
+                            | OSC32KCTRL_XOSC32K_RUNSTDBY
+                            | OSC32KCTRL_XOSC32K_EN32K
+                            | OSC32KCTRL_XOSC32K_ENABLE;
+
+    /* Wait XOSC32K Ready */
+    while (!OSC32KCTRL->STATUS.bit.XOSC32KRDY) {}
+#endif
+}
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */
@@ -73,6 +108,9 @@ void cpu_init(void)
     OSCCTRL->OSC16MCTRL.bit.FSEL = 3;
     OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 0;
     OSCCTRL->OSC16MCTRL.bit.RUNSTDBY = 0;
+
+    _osc32k_setup();
+    _xosc32k_setup();
 
     /* Setup GCLK generators */
     _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -28,6 +28,41 @@ static void _gclk_setup(int gclk, uint32_t reg)
     while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_GENCTRL(gclk)) {}
 }
 
+static void _osc32k_setup(void)
+{
+#if INTERNAL_OSC32_SOURCE
+    uint32_t * pCalibrationArea;
+    uint32_t osc32kcal;
+
+    /* Read OSC32KCAL, calibration data for OSC32 !!! */
+    pCalibrationArea = (uint32_t*) NVMCTRL_OTP5;
+    osc32kcal = ( (*pCalibrationArea) & 0x1FC0 ) >> 6;
+
+    /* RTC use Low Power Internal Oscillator at 32kHz */
+    OSC32KCTRL->OSC32K.reg = OSC32KCTRL_OSC32K_RUNSTDBY
+                           | OSC32KCTRL_OSC32K_EN32K
+                           | OSC32KCTRL_OSC32K_CALIB(osc32kcal)
+                           | OSC32KCTRL_OSC32K_ENABLE;
+
+    /* Wait OSC32K Ready */
+    while (!OSC32KCTRL->STATUS.bit.OSC32KRDY) {}
+#endif /* INTERNAL_OSC32_SOURCE */
+}
+
+static void _xosc32k_setup(void)
+{
+#if EXTERNAL_OSC32_SOURCE
+    /* RTC uses External 32,768KHz Oscillator */
+    OSC32KCTRL->XOSC32K.reg = OSC32KCTRL_XOSC32K_XTALEN
+                            | OSC32KCTRL_XOSC32K_RUNSTDBY
+                            | OSC32KCTRL_XOSC32K_EN32K
+                            | OSC32KCTRL_XOSC32K_ENABLE;
+
+    /* Wait XOSC32K Ready */
+    while (!OSC32KCTRL->STATUS.bit.XOSC32KRDY) {}
+#endif
+}
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */
@@ -67,6 +102,9 @@ void cpu_init(void)
     OSCCTRL->OSC16MCTRL.bit.FSEL = 3;
     OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 0;
     OSCCTRL->OSC16MCTRL.bit.RUNSTDBY = 0;
+
+    _osc32k_setup();
+    _xosc32k_setup();
 
     /* Setup GCLK generators */
     _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -20,11 +20,12 @@
 
 #include "cpu.h"
 #include "periph/init.h"
+#include "periph_conf.h"
 
 static void _gclk_setup(int gclk, uint32_t reg)
 {
-    while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_GENCTRL(gclk)) {}
     GCLK->GENCTRL[gclk].reg = reg;
+    while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_GENCTRL(gclk)) {}
 }
 
 /**
@@ -59,17 +60,16 @@ void cpu_init(void)
     while (GCLK->CTRLA.reg & GCLK_CTRLA_SWRST) {}
     while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_SWRST) {}
 
+    PM->PLCFG.reg = PM_PLCFG_PLSEL_PL2;
+    while (!PM->INTFLAG.bit.PLRDY) {}
+
     /* set OSC16M to 16MHz */
     OSCCTRL->OSC16MCTRL.bit.FSEL = 3;
     OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 0;
     OSCCTRL->OSC16MCTRL.bit.RUNSTDBY = 0;
 
-    PM->PLCFG.reg = PM_PLCFG_PLSEL_PL2;
-    while (!PM->INTFLAG.bit.PLRDY) {}
-
     /* Setup GCLK generators */
     _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
-    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
 
 #ifdef MODULE_PERIPH_PM
     PM->CTRLA.reg = PM_CTRLA_MASK & (~PM_CTRLA_IORET);


### PR DESCRIPTION
### Contribution description
- RTC and RTT are the same peripheral, yet their setup & clock source options differ
- the setup routines of saml1x and saml21 are very similar, but have diverged in some places.

This PR tries to fix this. It also moves the Oscilator Setup code from the RTC/RTT driver into cpu.c where the oscillators are set up anyway. 

Functional Changes:
 - on saml21, GCLK1 is not configured as 32kHz anymore. It is not used anywhere, so I dropped it.
 - when `EXTERNAL_OSC32_SOURCE` is set, RTT is sourced from the external 32kHz Oscillator, just like RTC would before. This is the default for most boards. Before, RTT would always be sourced by the internal low power 32kHz Oscillator. This can still be achieved by setting `ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE`.

### Testing procedure
`tests/periph_rtt` & `tests/periph_rtc` should still run fine on all sam0 boards, both with `ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE` & `EXTERNAL_OSC32_SOURCE`.

I only tested this on same54-xpro & samr21-xpro.

### Issues/PRs references
I suspect #11486 getting stuck is related to this.
