### PR TITLE
riotboot: set FLASHFILE to RIOTBOOT_EXTENDED_BIN if riotboot feature is used

### DIFF
--- a/bootloaders/riotboot/README.md
+++ b/bootloaders/riotboot/README.md
@@ -63,7 +63,8 @@ the riotboot test in tests/.
 # Single Slot
 Just compile your application with `FEATURES_REQUIRED += riotboot`. The header
 is generated automatically according to your `APP_VER`, which can be optionally
-set (0 by default) in your makefile.
+set (current system time in seconds since 1970 (epoch) by default) in your
+makefile.
 
 
 ## Flashing example
@@ -102,15 +103,6 @@ target `riotboot/flash-extended-slot0` is the way to go (resulting in only
 slot 0 being valid, thus being booted). This is done automatically by `make
 flash` if the `riotboot` feature is used.
 
-## Flashing examples
+## Testing riotboot
 
-The following sequence of commands tests building, flashing and booting slot 0,
-then slot 1. tests/riotboot prints out the current booted slot in the shell.
-
-To test building, flashing and booting the first slot:
-
-`BOARD=samr21-xpro APP_VER=$(date +%s) make -C tests/riotboot/ riotboot/flash-combined-slot0 test`
-
-For the second slot:
-
-`BOARD=samr21-xpro APP_VER=$(date +%s) make -C tests/riotboot/ riotboot/flash-slot1 test`
+See [tests/riotboot/README.md](https://github.com/RIOT-OS/RIOT/blob/master/tests/riotboot/README.md).

--- a/bootloaders/riotboot/README.md
+++ b/bootloaders/riotboot/README.md
@@ -61,13 +61,18 @@ The above requirements are usually met if the board succeeds to execute
 the riotboot test in tests/.
 
 # Single Slot
-Just compile your application using the target `riotboot`. The header
-is generated automatically according to your `APP_VER`, which can be
-optionally set (0 by default) in your makefile.
+Just compile your application with `FEATURES_REQUIRED += riotboot`. The header
+is generated automatically according to your `APP_VER`, which can be optionally
+set (0 by default) in your makefile.
 
 
 ## Flashing example
-The image can be flashed using `riotboot/flash` which also flashes
+If your application is using the riotboot feature, the usual targets (`all`,
+`flash`, `flash-only`) will automatically compile and/or flash both the
+bootloader and slot0, while ensuring that slot 1 is invalidated so slot 0 will
+be booted.
+
+The image can also be flashed using `riotboot/flash` which also flashes
 the bootloader. Below a concrete example:
 
 `BOARD=samr21-xpro FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C examples/hello-world riotboot/flash-combined-slot0`
@@ -94,7 +99,8 @@ Dedicated make targets are available to build and flash several slots:
 
 In particular, if one wants to be sure to boot a particular image, using the
 target `riotboot/flash-extended-slot0` is the way to go (resulting in only
-slot 0 being valid, thus being booted).
+slot 0 being valid, thus being booted). This is done automatically by `make
+flash` if the `riotboot` feature is used.
 
 ## Flashing examples
 

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -126,6 +126,11 @@ riotboot/slot1: $(SLOT1_RIOT_BIN)
 # Default flashing rule for bootloader + slot 0
 riotboot/flash: riotboot/flash-slot0 riotboot/flash-bootloader
 
+# make applications that use the riotboot feature default to actually using it
+# Target 'all' will generate the combined file directly.
+# It also makes 'flash' and 'flash-only' work without specific command.
+FLASHFILE = $(RIOTBOOT_EXTENDED_BIN)
+
 else
 riotboot:
 	$(Q)echo "error: riotboot feature not selected! (try FEATURES_REQUIRED += riotboot)"

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -18,9 +18,5 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-# Target 'all' will generate the combined file directly.
-# It also makes 'flash' and 'flash-only' work without specific command.
-FLASHFILE = $(RIOTBOOT_COMBINED_BIN)
-
 include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/riotboot_flashwrite/Makefile
+++ b/tests/riotboot_flashwrite/Makefile
@@ -7,8 +7,10 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              chronos i-nucleo-lrwan1 \
                              msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f303k8 nucleo-l053r8 stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+                             nucleo-f302r8 nucleo-f303k8 nucleo-f334r8 \
+                             nucleo-l053r8 saml10-xpro saml11-xpro \
+                             stm32f0discovery telosb waspmote-pro \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present


### PR DESCRIPTION
### Contribution description

Previously, even an application that had "FEATURES_REQUIRED += riotboot"
set would still flash the non-riotboot binary on "make flash".
This is usually not what the user wants.

This commit set's the FLASHFILE variable to the combined "riotboot
bootloader + slot0 + empty slot1" binary, if the riotboot feature is used.
This has the effect that "make all", "make flash" and "make flash-only" will compile and/or flash a working riotboot setup.

This was previously done for tests/riotboot within that application's Makefile. This PR moves the definition into ```makefiles/boot/riotboot.inc.mk```, guarded by whether the riotboot feature is used.

### Testing procedure

- confirm that non-riotboot flashing still works (e.g., by flashing hello-world)
- run "make flash" in tests/riotboot. It should flash the combined binary

### Issues/PRs references

