### PR TITLE
dist/tools/build_system_sanity_check: BUG fix errors being ignored

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -110,7 +110,7 @@ check_not_exporting_variables() {
 
 
 error_on_input() {
-    grep '' && return 1
+    ! grep ''
 }
 
 all_checks() {

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -119,7 +119,7 @@ all_checks() {
 }
 
 main() {
-    all_checks | prepend 'Invalid build system patterns found by '"${0}:"  || error_on_input >&2
+    all_checks | prepend 'Invalid build system patterns found by '"${0}:" | error_on_input >&2
     exit $?
 }
 


### PR DESCRIPTION
### Contribution description

On error messages the exit code was still 0 due to the typo.
Having error messages again properly return with an exit code of 1.

Fix `error_on_input` that was always returning an error too.

### Testing procedure

With the test commit the static tests will fail (now `CI: needs squashing` is set).

Revert the revert commit `be1551c18` and run the script, it will exit with a '1' exit code. In the current master it would return 0.

### Issues/PRs references

Bug introduced by https://github.com/RIOT-OS/RIOT/pull/11672 which led to having this test commit merged https://github.com/RIOT-OS/RIOT/pull/11694/files
