### PR TITLE
makefiles/pyocd.inc.mk use FLASHFILE

### DIFF
--- a/makefiles/tools/pyocd.inc.mk
+++ b/makefiles/tools/pyocd.inc.mk
@@ -3,7 +3,6 @@ DEBUGGER = $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 DEBUGSERVER = $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 RESET ?= $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 
-export OFLAGS ?= -O ihex
 FFLAGS ?= flash $(HEXFILE)
 DEBUGGER_FLAGS ?= debug $(ELFFILE)
 DEBUGSERVER_FLAGS ?= debug-server

--- a/makefiles/tools/pyocd.inc.mk
+++ b/makefiles/tools/pyocd.inc.mk
@@ -3,7 +3,8 @@ DEBUGGER = $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 DEBUGSERVER = $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 RESET ?= $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 
-FFLAGS ?= flash $(HEXFILE)
+FLASHFILE ?= $(HEXFILE)
+FFLAGS ?= flash $(FLASHFILE)
 DEBUGGER_FLAGS ?= debug $(ELFFILE)
 DEBUGSERVER_FLAGS ?= debug-server
 RESET_FLAGS ?= reset


### PR DESCRIPTION
### Contribution description
   
Update to use FLASHFILE as file to be flashed on the board.

This also removes `OFLAGS` that is set by `Makefile.include` in the `.bin` and `.hex` rules.

### Testing procedure

You can flash on a board using `pyocd`

```
PYOCD_BOARDS=$(git grep -l -e pyocd.inc.mk -e 'common/particle-mesh' '*' ':!boards/common' | cut -f 2 -d/ | sort -u)
echo ${PYOCD_BOARDS}
calliope-mini microbit nrf51dk nrf52832-mdk nrf52840-mdk particle-argon particle-boron particle-xenon
```

### Testing without a board

The output of the FFLAGS is the same on master and this PR with the default and `pyocd` programmer.


<details><summary><code>for board in ${PYOCD_BOARDS}; do echo ${board}; BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; PROGRAMMER=pyocd BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done</code></summary><p>

```
for board in ${PYOCD_BOARDS}; do echo ${board}; BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; PROGRAMMER=pyocd BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done
calliope-mini
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/calliope-mini/hello-world.elf
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/calliope-mini/hello-world.hex
microbit
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/microbit/hello-world.elf
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/microbit/hello-world.hex
nrf51dk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf51dk/hello-world.elf
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf51dk/hello-world.hex
nrf52832-mdk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52832-mdk/hello-world.hex
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52832-mdk/hello-world.hex
nrf52840-mdk
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.hex
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.hex
particle-argon
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/particle-argon/hello-world.hex
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/particle-argon/hello-world.hex
particle-boron
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/particle-boron/hello-world.hex
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/particle-boron/hello-world.hex
particle-xenon
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/particle-xenon/hello-world.hex
true flash /home/harter/work/git/RIOT/examples/hello-world/bin/particle-xenon/hello-world.hex
```

</p></details>


And the value can be changed from environment variable:

<details><summary><code>for board in ${PYOCD_BOARDS}; do echo ${board}; FLASHFILE=lala PROGRAMMER=pyocd BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done </code></summary><p>

```
for board in ${PYOCD_BOARDS}; do echo ${board}; FLASHFILE=lala PROGRAMMER=pyocd BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done 
calliope-mini
true flash lala
microbit
true flash lala
nrf51dk
true flash lala
nrf52832-mdk
true flash lala
nrf52840-mdk
true flash lala
particle-argon
true flash lala
particle-boron
true flash lala
particle-xenon
true flash lala
```

</p></details>

### Issues/PRs references

Part of #8838 
