### PR TITLE
murdock: allow multiple files to be sent along with a test job

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -34,6 +34,14 @@ error() {
     exit 1
 }
 
+# true if "$2" starts with "$1", false otherwise
+startswith() {
+  case "${2}" in
+    ${1}*) true ;;
+    *) false ;;
+  esac
+}
+
 # if MURDOCK_HOOK is set, this function will execute it and pass on all it's
 # parameters. should the hook script exit with negative exit code, hook() makes
 # this script exit with error, too.
@@ -247,19 +255,33 @@ test_job() {
     local appdir=$1
     local board=$(echo $2 | cut -f 1 -d':')
     local toolchain=$(echo $2 | cut -f 2 -d':')
-    local flashfile="$3"
 
-    [ ! -f "$flashfile" ] && {
-        echo "$0: _test(): flashfile \"$flashfile\" doesn't exist!"
-        return 1
-    }
+    # interpret any extra arguments as file names.
+    # They will be sent along with the job to the test worker
+    # and stored in the application's binary folder.
+    shift 2
+    local files=""
+    for filename in "$@"; do
+        # check if the file is within $(BINDIR)
+        if startswith "${BINDIR}" "${filename}"; then
+          # get relative (to $(BINDIR) path
+          local relpath="$(realpath --relative-to ${BINDIR} ${filename})"
+        else
+          error "$0: error: extra test files not within \${BINDIR}!"
+        fi
+
+        # set remote file path.
+        # currently, the test workers build in the default build path.
+        local remote_bindir="${appdir}/bin/${board}"
+        files="${files} --file ${filename}:${remote_bindir}/${relpath}"
+    done
 
     dwqc \
         ${DWQ_ENV} \
         ${DWQ_JOBID:+--subjob} \
-        --file $flashfile:$appdir/bin/${board}/$(basename $flashfile) \
         --queue ${TEST_QUEUE:-$board} \
         --maxfail 1 \
+        $files \
         "./.murdock run_test $appdir $board:$toolchain"
 }
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -611,7 +611,7 @@ test/available:
 # this target only makes sense if an ELFFILE is actually created, thus guard by
 # RIOTNOLINK="".
 ifeq (,$(RIOTNOLINK))
-test-input-hash: $(TESTS) $(ELFFILE)
+test-input-hash: $(TESTS) $(ELFFILE) $(TEST_EXTRA_FILES)
 	sha1sum $^ > $(BINDIR)/test-input-hash.sha1
 else
 test-input-hash:

--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -8,12 +8,17 @@
 # - DWQ_REPO and DWQ_COMMIT are set correctly
 # - the user has set up autossh & proper authentication for connecting to the CI
 # (intended to be used by CI only for now)
+#
+# By default, $(FLASHFILE) is copied to the test worker along with the job.
+# If the test needs any extra files, they can be added to the TEST_EXTRA_FILES
+# variable. They will also be sent to the test worker.
+# Note: *any TEST_EXTRA_FILES has to reside in ${BINDIR}*.
 test-murdock:
 	cd $(RIOTBASE) && \
 		./.murdock test_job \
 		$$(realpath --relative-to $(RIOTBASE) $(APPDIR)) \
 		"$(BOARD):$(TOOLCHAIN)" \
-		$(FLASHFILE)
+		$(FLASHFILE) $(TEST_EXTRA_FILES)
 
 # don't whitelist tests if there's no binary
 ifeq (1,$(RIOTNOLINK))


### PR DESCRIPTION
### Contribution description

Previously, this was hard-coded to allow one file, hard-coded to be
called "flash file".
This commit allows multiple files to be specified via adding them to the
TEST_EXTRA_FILES variable. All files will be stored in the worker's
application bin directory.

Also, the existence check has been removed, as dwqc bails out on missing
file anyways.

### Testing procedure

confirm CI tests on hardware are still working.

### Issues/PRs references

Prerequisite for #11707.