### PR TITLE
boards/pic32-xx: set FLASHFILE to HEXFILE

### DIFF
--- a/boards/pic32-clicker/Makefile.include
+++ b/boards/pic32-clicker/Makefile.include
@@ -2,3 +2,5 @@ export CPU = mips_pic32mx
 export CPU_MODEL=p32mx470f512h
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
+
+FLASHFILE ?= $(HEXFILE)

--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -2,3 +2,5 @@ export CPU = mips_pic32mz
 export CPU_MODEL=p32mz2048efg100
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
+
+FLASHFILE ?= $(HEXFILE)


### PR DESCRIPTION
### Contribution description

The boards are using HEXFILE for flashing even if there is no
FLASHER for the moment.

### Testing procedure

The board do not have any flasher yet.
But in https://github.com/RIOT-OS/RIOT/pull/9259 the flasher was added for `pic32-wifire` and `pic32prog` requires the `HEXFILE`.


### Testing without board

The `hexfile` is used as flashfile and it can be overwritten from the environment.

```
BOARD=pic32-wifire make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE
/home/harter/work/git/RIOT/examples/hello-world/bin/pic32-wifire/hello-world.hex
BOARD=pic32-clicker make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE
/home/harter/work/git/RIOT/examples/hello-world/bin/pic32-clicker/hello-world.hex

FLASHFILE=lala BOARD=pic32-wifire make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE
lala
FLASHFILE=lala BOARD=pic32-clicker make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE
lala
```



### Issues/PRs references

* Part of the FLASHFILE introduction #8838
* part of pic32-wifire: add support for flashing with pic32prog #9259