### PR TITLE
makefiles/bossa.inc.mk: use FLASHFILE

### DIFF
--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -1,7 +1,6 @@
+FLASHFILE ?= $(BINFILE)
 FLASHER ?= $(RIOTTOOLS)/bossa/bossac
-FFLAGS  ?= -p $(PORT) -e -i -w -v -b -R $(HEXFILE)
-
-HEXFILE = $(BINFILE)
+FFLAGS  ?= -p $(PORT) -e -i -w -v -b -R $(FLASHFILE)
 
 # some arduino boards need to toggle the serial interface a little bit to get
 # them ready for flashing...


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.


### Testing procedure

You can flash on a board using bossa.

```
BOSSA_BOARDS=$(git grep -l -e tools/bossa.inc.mk -e common/arduino-due -e common/arduino-mkr '*' ':!boards/common'  | cut -f 2 -d/ | sort -u)
echo ${BOSSA_BOARDS} 
arduino-due arduino-mkr1000 arduino-mkrfox1200 arduino-mkrzero feather-m0 sensebox_samd21 sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff udoo
```

### Testing without a board


The flash command is still the same with this PR and with master
Here `PREFLASHER` must be updated otherwise it tries to use a board that is not there.

<details><summary><code>for board in ${BOSSA_BOARDS}; do echo ${board}; PROGRAMMER=bossa FLASHFILE=lala BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true PREFLASHER=true flash-only; done</code></summary><p>

```
for board in ${BOSSA_BOARDS}; do echo ${board}; PROGRAMMER=bossa FLASHFILE=lala BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true PREFLASHER=true flash-only; done
arduino-due
true -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-due/hello-world.bin
arduino-mkr1000
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-mkr1000/hello-world.bin
arduino-mkrfox1200
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-mkrfox1200/hello-world.bin
arduino-mkrzero
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/arduino-mkrzero/hello-world.bin
feather-m0
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/feather-m0/hello-world.bin
sensebox_samd21
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/sensebox_samd21/hello-world.bin
sodaq-autonomo
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/sodaq-autonomo/hello-world.bin
sodaq-explorer
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/sodaq-explorer/hello-world.bin
sodaq-one
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/sodaq-one/hello-world.bin
sodaq-sara-aff
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/sodaq-sara-aff/hello-world.bin
udoo
true -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
true -p /dev/ttyACM0 -e -i -w -v -b -R /home/harter/work/git/RIOT/examples/hello-world/bin/udoo/hello-world.bin
```

</p></details>

And the file to flash can be overwritten from environment

<details><summary><code>for board in ${BOSSA_BOARDS}; do echo ${board}; PROGRAMMER=bossa FLASHFILE=lala BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true PREFLASHER=true flash-only; done</code></summary><p>

```
for board in ${BOSSA_BOARDS}; do echo ${board}; PROGRAMMER=bossa FLASHFILE=lala BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true PREFLASHER=true flash-only; done
arduino-due
true -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
arduino-mkr1000
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
arduino-mkrfox1200
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
arduino-mkrzero
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
feather-m0
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
sensebox_samd21
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
sodaq-autonomo
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
sodaq-explorer
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
sodaq-one
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
sodaq-sara-aff
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
udoo
true -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
true -p /dev/ttyACM0 -e -i -w -v -b -R lala
```
</p></details>


### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/8838