### PR TITLE
boards/stm32l4: add riotboot support

### DIFF
--- a/boards/b-l475e-iot01a/Makefile.features
+++ b/boards/b-l475e-iot01a/Makefile.features
@@ -8,4 +8,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l432kc/Makefile.features
+++ b/boards/nucleo-l432kc/Makefile.features
@@ -6,6 +6,13 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+# Note that a recent version of OpenOCD is required for flashing an image on
+# the second slot of the flash memory. This version has to be built from source
+# and at least contains the following commit
+# https://github.com/ntfreak/openocd/commit/a4d50544de07f13e3f9644d2b48e41ebdc91a7a3
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
 

--- a/boards/nucleo-l433rc/Makefile.features
+++ b/boards/nucleo-l433rc/Makefile.features
@@ -8,6 +8,13 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+# Note that a recent version of OpenOCD is required for flashing an image on
+# the second slot of the flash memory. This version has to be built from source
+# and at least contains the following commit
+# https://github.com/ntfreak/openocd/commit/a4d50544de07f13e3f9644d2b48e41ebdc91a7a3
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 

--- a/boards/nucleo-l452re/Makefile.features
+++ b/boards/nucleo-l452re/Makefile.features
@@ -6,6 +6,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -7,6 +7,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart periph_lpuart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 

--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -4,4 +4,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 include $(RIOTCPU)/stm32l4/Makefile.features


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Now that #11643 is merged, this PR adds riotboot to all stm32l4 based boards. Changes provided in #11643 are compatible for all L4.

Not tested yet.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Flash riotboot and check application is working:
```
$ make BOARD=nucleo-l476rg -C tests/riotboot riotboot/flash term
> help
> curslotnr
```
- Flash an image on slot0:
$ make BOARD=nucleo-l476rg -C tests/riotboot riotboot/flash-slot0 term
> curslotnr  # Should return slot 0
```
- Flash an image on slot1:
$ make BOARD=nucleo-l476rg -C tests/riotboot riotboot/flash-slot1 term
> curslotnr  # Should return slot 1
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #11643 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
