### PR TITLE
sys/ubjson: Do not invert bool when writing it

### DIFF
--- a/sys/ubjson/ubjson-write.c
+++ b/sys/ubjson/ubjson-write.c
@@ -70,7 +70,7 @@ ssize_t ubjson_write_bool(ubjson_cookie_t *restrict cookie, bool value)
 {
     static const char marker_false[] = { UBJSON_MARKER_FALSE };
     static const char marker_true[] = { UBJSON_MARKER_TRUE };
-    return cookie->rw.write(cookie, value ? &marker_false : &marker_true, 1);
+    return cookie->rw.write(cookie, value ? &marker_true : &marker_false, 1);
 }
 
 ssize_t ubjson_write_i32(ubjson_cookie_t *restrict cookie, int32_t value)


### PR DESCRIPTION
### Contribution description

The UBJSON writer inverts boolean values when writing the output. This does not seem to be the intended behavior. This PR reverts the inversion.

UBJSON in general uses a `<type-marker>[value]` syntax, and for boolean values, there are [two dedicated markers](http://ubjson.org/type-reference/value-types/#boolean) for true (`T`) and false (`F`). Those are interchanged when writing.

### Testing procedure

The following demo application can be run on `native` to examine the issue in isolation:

<details>
<summary>main.c</summary>

```c
#include <ctype.h>
#include <stdio.h>
#include "ubjson.h"

/** Callback to print the data to the console. */
int write_cb(ubjson_cookie_t *cookie, const void *buf, size_t len);

int main(void)
{
    ubjson_cookie_t cookie;
    ubjson_write_init(&cookie, write_cb);
    ubjson_open_object(&cookie);
    ubjson_write_key(&cookie, "bool_true", 9);
    ubjson_write_bool(&cookie, true);
    ubjson_write_key(&cookie, "bool_false", 10);
    ubjson_write_bool(&cookie, false);
    ubjson_close_object(&cookie);
    return 0;
}

int write_cb(ubjson_cookie_t *cookie, const void *buf, size_t len)
{
    (void)cookie;
    const uint8_t *tbuf = buf;
    for(size_t idx = 0; idx < len; idx++) {
        printf("0x%02x ", tbuf[idx]);
        putchar(isprint(tbuf[idx]) ? tbuf[idx] : '.');
        printf("\n");
    }
    return len;
}
```

</details>

<details>
<summary>Makefile</summary>

```Makefile
APPLICATION = ubjson-test-bool
BOARD ?= native
RIOTBASE ?= $(CURDIR)/../..
DEVELHELP ?= 1
QUIET ?= 1
USEMODULE += ubjson
include $(RIOTBASE)/Makefile.include
```

</details>

Before applying the fix, it will output:

```
0x7b 0x69 0x09 0x62 0x6f 0x6f 0x6c 0x5f 0x74 0x72 0x75 0x65 0x46 0x69 0x0a 0x62 0x6f 0x6f 0x6c 0x5f 0x66 0x61 0x6c 0x73 0x65 0x54 0x7d
{    i    .    b    o    o    l    _    t    r    u    e    F    i    .    b    o    o    l    _    f    a    l    s    e    T    }
```

With the fix, the values will be correct (note the different markers after `bool_true` and `bool_false`):

```
0x7b 0x69 0x09 0x62 0x6f 0x6f 0x6c 0x5f 0x74 0x72 0x75 0x65 0x54 0x69 0x0a 0x62 0x6f 0x6f 0x6c 0x5f 0x66 0x61 0x6c 0x73 0x65 0x46 0x7d
{    i    .    b    o    o    l    _    t    r    u    e    T    i    .    b    o    o    l    _    f    a    l    s    e    F    }
```

### Issues/PRs references

None.
