### PR TITLE
sys/ubjson: Write missing marker for i64

### DIFF
--- a/sys/ubjson/ubjson-write.c
+++ b/sys/ubjson/ubjson-write.c
@@ -104,6 +104,7 @@ ssize_t ubjson_write_i64(ubjson_cookie_t *restrict cookie, int64_t value)
     }
 
     ssize_t result = 0;
+    WRITE_MARKER(UBJSON_MARKER_INT64);
     network_uint64_t buf = byteorder_htonll((uint64_t) value);
     WRITE_BUF(&buf, sizeof(buf));
     return result;


### PR DESCRIPTION
### Contribution description

The UBJSON writer skips the marker for large integer values (64 bit) when writing them. This makes the resulting UBJSON document unparsable for the receiver.

UBJSON in general uses a `<type-marker>[value]` syntax, and for 64 bit integers, one would expect an literal `L` followed by the 8 data bytes ([Reference](http://ubjson.org/type-reference/value-types/#numeric-64bit)).

### Testing procedure

The following demo application can be run on `native` to examine the issue in isolation. It prints a 64 bit value within an object structure.

<details>
<summary>main.c</summary>

```c
#include <ctype.h>
#include <stdio.h>
#include "ubjson.h"

/** Callback to print the data to the console. */
int write_cb(ubjson_cookie_t *cookie, const void *buf, size_t len);

int main(void)
{
    uint64_t big_number = 0x0123456789abcdef;
    ubjson_cookie_t cookie;
    ubjson_write_init(&cookie, write_cb);
    ubjson_open_object(&cookie);
    ubjson_write_key(&cookie, "big_number", 10);
    ubjson_write_i64(&cookie, big_number);
    ubjson_close_object(&cookie);
    return 0;
}

int write_cb(ubjson_cookie_t *cookie, const void *buf, size_t len)
{
    (void)cookie;
    const uint8_t *tbuf = buf;
    for(size_t idx = 0; idx < len; idx++) {
        printf("0x%02x ", tbuf[idx]);
        putchar(isprint(tbuf[idx]) ? tbuf[idx] : '.');
        printf("\n");
    }
    return len;
}
```

</details>

<details>
<summary>Makefile</summary>

```Makefile
APPLICATION = ubjson-test-bool
BOARD ?= native
RIOTBASE ?= $(CURDIR)/../..
DEVELHELP ?= 1
QUIET ?= 1
USEMODULE += ubjson
include $(RIOTBASE)/Makefile.include
```

</details>

Before applying the fix, it will output:

```
0x7b 0x69 0x0a 0x62 0x69 0x67 0x5f 0x6e 0x75 0x6d 0x62 0x65 0x72 0x01 0x23 0x45 0x67 0x89 0xab 0xcd 0xef 0x7d 
{    i    .    b    i    g    _    n    u    m    b    e    r    .    #    E    g    .    .    .    .    }
```

With the fix, the values will be correct (note the additional `L`):

```
0x7b 0x69 0x0a 0x62 0x69 0x67 0x5f 0x6e 0x75 0x6d 0x62 0x65 0x72 0x4c 0x01 0x23 0x45 0x67 0x89 0xab 0xcd 0xef 0x7d 
{    i    .    b    i    g    _    n    u    m    b    e    r    L    .    #    E    g    .    .    .    .    }
```

### Issues/PRs references

None.
