### PR TITLE
riotboot/flashwrite: use chunks instead of pages, support flashpage_write_raw

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -872,6 +872,7 @@ endif
 ifneq (,$(filter riotboot_flashwrite, $(USEMODULE)))
   USEMODULE += riotboot_slot
   FEATURES_REQUIRED += periph_flashpage
+  FEATURES_OPTIONAL += periph_flashpage_raw
 endif
 
 ifneq (,$(filter riotboot_slot, $(USEMODULE)))

--- a/cpu/efm32/include/cpu_conf.h
+++ b/cpu/efm32/include/cpu_conf.h
@@ -43,6 +43,8 @@ extern "C" {
  * @brief   Flash page configuration
  * @{
  */
+/* An erase byte in flash is set to 0xFF */
+#define FLASH_ERASE_STATE               (0xFF)
 #define FLASHPAGE_SIZE                  (FLASH_PAGE_SIZE)
 #define FLASHPAGE_NUMOF                 (FLASH_SIZE / FLASH_PAGE_SIZE)
 /** @} */

--- a/cpu/msp430_common/include/cpu_conf.h
+++ b/cpu/msp430_common/include/cpu_conf.h
@@ -28,6 +28,9 @@ extern "C" {
  */
 #define FLASHPAGE_SIZE      (512)
 
+/* An erase byte in flash is set to 0xFF */
+#define FLASH_ERASE_STATE   (0xFF)
+
 #if defined (CPU_MODEL_MSP430F1611)
 #define CPU_FLASH_BASE      (0x4000)
 #define FLASHPAGE_NUMOF     (96)        /* 48K */

--- a/cpu/nrf51/include/cpu_conf.h
+++ b/cpu/nrf51/include/cpu_conf.h
@@ -44,6 +44,9 @@ extern "C" {
  */
 #define FLASHPAGE_SIZE          (1024U)
 
+/* An erase byte in flash is set to 0xFF */
+#define FLASH_ERASE_STATE       (0xFF)
+
 #if defined(CPU_MODEL_NRF51X22XXAA) || defined(CPU_MODEL_NRF51X22XXAC)
 #define FLASHPAGE_NUMOF         (256U)
 #elif defined(CPU_MODEL_NRF51X22XXAB)

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -57,6 +57,9 @@ extern "C" {
  */
 #define FLASHPAGE_SIZE                  (4096U)
 
+/* An erase byte in flash is set to 0xFF */
+#define FLASH_ERASE_STATE               (0xFF)
+
 #if defined(CPU_MODEL_NRF52832XXAA)
 #define FLASHPAGE_NUMOF                 (128U)
 #elif defined(CPU_MODEL_NRF52840XXAA)

--- a/cpu/sam0_common/include/cpu_conf.h
+++ b/cpu/sam0_common/include/cpu_conf.h
@@ -65,7 +65,8 @@ as shown in the NVM Row Organization figure. */
 #else
 #error "Unsupported Device"
 #endif
-
+/* An erase byte in flash is set to 0xFF */
+#define FLASH_ERASE_STATE          (0xFF)
 /* one SAM0 row contains 4 SAM0 pages, so 4 SAM0 pages contain
  * the amount of a RIOT flashpage
  */

--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -63,6 +63,8 @@ extern "C" {
 #endif
 
 #define FLASHPAGE_NUMOF     (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+/* An erase byte in flash is set to 0xFF */
+#define FLASH_ERASE_STATE          (0xFF)
 
 /* The minimum block size which can be written is 2B. However, the erase
  * block is always FLASHPAGE_SIZE.

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -55,6 +55,8 @@ extern "C" {
 #endif
 
 #define FLASHPAGE_NUMOF     (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+/* An erase byte in flash is set to 0xFF */
+#define FLASH_ERASE_STATE          (0xFF)
 
 /* The minimum block size which can be written is 2B. However, the erase
  * block is always FLASHPAGE_SIZE.

--- a/cpu/stm32l0/include/cpu_conf.h
+++ b/cpu/stm32l0/include/cpu_conf.h
@@ -51,6 +51,8 @@ extern "C" {
 #define FLASHPAGE_SIZE      (128U)
 
 #define FLASHPAGE_NUMOF     (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+/* An erase byte in flash is set to 0x00 */
+#define FLASH_ERASE_STATE          (0x00)
 
 /* The minimum block size which can be written is 4B. However, the erase
  * block is always FLASHPAGE_SIZE.

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -78,7 +78,8 @@ extern "C" {
  */
 #define FLASHPAGE_SIZE             (256U)
 #define FLASHPAGE_NUMOF            (STM32_FLASHSIZE / FLASHPAGE_SIZE)
-
+/* An erase byte in flash is set to 0x00 */
+#define FLASH_ERASE_STATE          (0x00)
 /* The minimum block size which can be written is 4B. However, the erase
  * block is always FLASHPAGE_SIZE.
  */

--- a/cpu/stm32l4/include/cpu_conf.h
+++ b/cpu/stm32l4/include/cpu_conf.h
@@ -66,6 +66,9 @@ extern "C" {
 
 #define FLASHPAGE_NUMOF     (STM32_FLASHSIZE / FLASHPAGE_SIZE)
 
+/* An erase byte in flash is set to 0x00 */
+#define FLASH_ERASE_STATE          (0x00)
+
 /* The minimum block size which can be written is 8B. However, the erase
  * block is always FLASHPAGE_SIZE.
  */

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -74,6 +74,16 @@ extern "C" {
 #ifdef DOXYGEN
 #define FLASHPAGE_RAW_ALIGNMENT
 #endif
+
+/**
+ * @def FLASH_ERASE_STATE
+ *
+ * @brief   State of an erased byte in memory
+ */
+#ifdef DOXYGEN
+#define FLASH_ERASE_STATE
+#endif
+
 /**
  * @def FLASHPAGE_SIZE
  *
@@ -85,6 +95,7 @@ extern "C" {
 #ifndef FLASHPAGE_NUMOF
 #error "periph/flashpage: FLASHPAGE_NUMOF not defined"
 #endif
+
 
 /**
  * @brief   Return values used in this interface

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -169,6 +169,44 @@ void flashpage_write(int page, const void *data);
 void flashpage_write_raw(void *target_addr, const void *data, size_t len);
 
 /**
+ * @brief   Write any number of data bytes to agains a given location in flash
+ *
+ * @param[in] target_addr   start address to verify. MUST be aligned
+ *                          FLASHPAGE_RAW_ALIGNMENT
+ * @param[in] data          data to verify against. MUST be aligned
+ *                          to FLASHPAGE_RAW_ALIGNMENT.
+ * @param[in] len           length of the data to verify against. It MUST be
+ *                          multiple of FLASHPAGE_RAW_BLOCKSIZE.
+ *
+ * @return              FLASHPAGE_OK if data in the flash is identical to @p data
+ * @return              FLASHPAGE_NOMATCH if data and flash content diverge
+ */
+int flashpage_verify_raw(void *target_addr, const void *data, size_t len);
+
+/**
+ * @brief   Write any number of data bytes to a given location in the
+ *          flash memory and verify it was written
+ *
+ * @warning Make sure the targeted memory area is erased before calling
+ *          this function
+ *
+ * Both target address and data address must be aligned to
+ * FLASHPAGE_RAW_ALIGN. @p len must be a multiple of FLASHPAGE_RAW_BLOCKSIZE.
+ * This function doesn't erase any area in flash, thus be sure the targeted
+ * memory area is erased before writing on it (using the flashpage_write function).
+ *
+ * @param[in] target_addr   address in flash to write to. MUST be aligned
+ *                          to FLASHPAGE_RAW_ALIGNMENT.
+ * @param[in] data          data to write to the address. MUST be aligned
+ *                          to FLASHPAGE_RAW_ALIGNMENT.
+ * @param[in] len           length of the data to be written. It MUST be
+ *                          multiple of FLASHPAGE_RAW_BLOCKSIZE. Also,
+ *                          ensure it doesn't exceed the actual flash
+ *                          memory size.
+ */
+int flashpage_write_and_verify_raw(void *target_addr, const void *data, size_t len);
+
+/**
  * @brief   Read the given page into the given memory location
  *
  * @param[in]  page     page to read

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -96,7 +96,6 @@ extern "C" {
 #error "periph/flashpage: FLASHPAGE_NUMOF not defined"
 #endif
 
-
 /**
  * @brief   Return values used in this interface
  */

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -53,6 +53,24 @@ int flashpage_write_and_verify(int page, const void *data)
     return flashpage_verify(page, data);
 }
 
+#if defined(MODULE_PERIPH_FLASHPAGE_RAW)
+int flashpage_verify_raw(void *target_addr, const void *data, size_t len)
+{
+    if (memcmp(target_addr, data, len) == 0) {
+        return FLASHPAGE_OK;
+    }
+    else {
+        return FLASHPAGE_NOMATCH;
+    }
+}
+
+int flashpage_write_and_verify_raw(void *target_addr, const void *data, size_t len)
+{
+    flashpage_write_raw(target_addr, data, len);
+    return flashpage_verify_raw(target_addr, data, len);
+}
+
+#endif
 
 #if defined(FLASHPAGE_RWWEE_NUMOF)
 

--- a/sys/include/riotboot/flashwrite.h
+++ b/sys/include/riotboot/flashwrite.h
@@ -59,12 +59,12 @@ extern "C" {
 
 
 #ifdef MODULE_PERIPH_FLASHPAGE_RAW
-#define FLASHCHUNK_SIZE         64
+#define FLASHCHUNK_SIZE         FLASHPAGE_RAW_BLOCKSIZE
 #else
 #define FLASHCHUNK_SIZE         FLASHPAGE_SIZE
 #endif
 
-#define FLASHCHUNK_PAGE         (FLASHPAGE_SIZE / FLASHCHUNK_SIZE)
+#define FLASHCHUNK_PER_PAGE     (FLASHPAGE_SIZE / FLASHCHUNK_SIZE)
 
 /**
  * @brief   firmware update state structure
@@ -80,21 +80,6 @@ typedef struct {
  * @brief Amount of bytes to skip at initial write of first page
  */
 #define RIOTBOOT_FLASHWRITE_SKIPLEN     sizeof(RIOTBOOT_MAGIC)
-
-/**
- * @brief   Translate the given chunk number into the chunk's starting address
- *
- * @note    The given chunk MUST be valid, otherwise the returned address points
- *          to an undefined memory location!
- *
- * @param[in] chunk      chunk number to get the address of
- *
- * @return               starting memory address of the given chunk
- */
-static inline void *flashchunk_addr(int chunk)
-{
-    return (void *)(CPU_FLASH_BASE + (chunk * FLASHCHUNK_SIZE));
-}
 
 /**
  * @brief   Initialize firmware update (raw version)

--- a/sys/include/riotboot/flashwrite.h
+++ b/sys/include/riotboot/flashwrite.h
@@ -57,20 +57,44 @@ extern "C" {
 #include "riotboot/slot.h"
 #include "periph/flashpage.h"
 
+
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+#define FLASHCHUNK_SIZE         64
+#else
+#define FLASHCHUNK_SIZE         FLASHPAGE_SIZE
+#endif
+
+#define FLASHCHUNK_PAGE         (FLASHPAGE_SIZE / FLASHCHUNK_SIZE)
+
 /**
  * @brief   firmware update state structure
  */
 typedef struct {
-    int target_slot;                        /**< update targets this slot     */
-    size_t offset;                          /**< update is at this position   */
-    unsigned flashpage;                     /**< update is at this flashpage  */
-    uint8_t flashpage_buf[FLASHPAGE_SIZE];  /**< flash writing buffer         */
+    int target_slot;                           /**< update targets this slot      */
+    size_t offset;                             /**< update is at this position    */
+    unsigned flashchunck;                      /**< update is at this flashchunck */
+    uint8_t flashchunck_buf[FLASHCHUNK_SIZE];  /**< flash writing buffer          */
 } riotboot_flashwrite_t;
 
 /**
  * @brief Amount of bytes to skip at initial write of first page
  */
 #define RIOTBOOT_FLASHWRITE_SKIPLEN     sizeof(RIOTBOOT_MAGIC)
+
+/**
+ * @brief   Translate the given chunk number into the chunk's starting address
+ *
+ * @note    The given chunk MUST be valid, otherwise the returned address points
+ *          to an undefined memory location!
+ *
+ * @param[in] chunk      chunk number to get the address of
+ *
+ * @return               starting memory address of the given chunk
+ */
+static inline void *flashchunk_addr(int chunk)
+{
+    return (void *)(CPU_FLASH_BASE + (chunk * FLASHCHUNK_SIZE));
+}
 
 /**
  * @brief   Initialize firmware update (raw version)

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -37,7 +37,7 @@ size_t riotboot_flashwrite_slotsize(const riotboot_flashwrite_t *state)
 {
     switch (state->target_slot) {
         case 0: return SLOT0_LEN;
-#if NUMOF_SLOTS==2
+#if NUMOF_SLOTS == 2
         case 1: return SLOT1_LEN;
 #endif
         default: return 0;
@@ -45,7 +45,7 @@ size_t riotboot_flashwrite_slotsize(const riotboot_flashwrite_t *state)
 }
 
 int riotboot_flashwrite_init_raw(riotboot_flashwrite_t *state, int target_slot,
-                             size_t offset)
+                                 size_t offset)
 {
     assert(offset <= FLASHPAGE_SIZE);
 
@@ -53,72 +53,102 @@ int riotboot_flashwrite_init_raw(riotboot_flashwrite_t *state, int target_slot,
              target_slot);
 
     memset(state, 0, sizeof(riotboot_flashwrite_t));
+    /* set flashchunck_buf to erase state values*/
+    memset(state->flashchunck_buf, FLASH_ERASE_STATE, offset);
 
     state->offset = offset;
     state->target_slot = target_slot;
-    state->flashpage = flashpage_page((void *)riotboot_slot_get_hdr(target_slot));
-
+    state->flashchunck = flashpage_page((void *)riotboot_slot_get_hdr(target_slot));
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+    state->flashchunck = (FLASHCHUNK_PAGE * state->flashchunck);
+    /* erase first page */
+    flashpage_write((state->flashchunck / FLASHCHUNK_PAGE), NULL);
+#endif
     return 0;
 }
 
 int riotboot_flashwrite_putbytes(riotboot_flashwrite_t *state,
                                  const uint8_t *bytes, size_t len, bool more)
 {
-    LOG_INFO(LOG_PREFIX "processing bytes %u-%u\n", state->offset, state->offset + len - 1);
+    LOG_INFO(LOG_PREFIX "processing bytes %u-%u\n", state->offset,
+             state->offset + len - 1);
 
     while (len) {
-        size_t flashpage_pos = state->offset % FLASHPAGE_SIZE;
-        size_t flashpage_avail = FLASHPAGE_SIZE - flashpage_pos;
+        size_t flashchunck_pos = state->offset % FLASHCHUNK_SIZE;
+        size_t flashchunck_avail = FLASHCHUNK_SIZE - flashchunck_pos;
 
-        size_t to_copy = min(flashpage_avail, len);
+        size_t to_copy = min(flashchunck_avail, len);
 
-        memcpy(state->flashpage_buf + flashpage_pos, bytes, to_copy);
-        flashpage_avail -= to_copy;
+        memcpy(state->flashchunck_buf + flashchunck_pos, bytes, to_copy);
+        flashchunck_avail -= to_copy;
 
         state->offset += to_copy;
-        flashpage_pos += to_copy;
+        flashchunck_pos += to_copy;
         bytes += to_copy;
         len -= to_copy;
-        if ((!flashpage_avail) || (!more)) {
-            if (flashpage_write_and_verify(state->flashpage, state->flashpage_buf) != FLASHPAGE_OK) {
-                LOG_WARNING(LOG_PREFIX "error writing flashpage %u!\n", state->flashpage);
+
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+        if (((int)flashchunk_addr(state->flashchunck) % FLASHPAGE_SIZE) == 0) {
+            LOG_DEBUG(LOG_PREFIX "Erasing page %u \n",
+                        (state->flashchunck / FLASHCHUNK_PAGE));
+            flashpage_write((state->flashchunck / FLASHCHUNK_PAGE), NULL);
+        }
+        if ((!flashchunck_avail) || (!more)) {
+            if (flashpage_write_and_verify_raw(flashchunk_addr(state->flashchunck),
+                                               state->flashchunck_buf,
+                                               FLASHCHUNK_SIZE) != FLASHPAGE_OK) {
+                LOG_WARNING(LOG_PREFIX "error writing flashchunck %u!\n",
+                            state->flashchunck);
                 return -1;
             }
-            state->flashpage++;
+            state->flashchunck++;
         }
+#else
+        if ((!flashchunck_avail) || (!more)) {
+            LOG_WARNING(LOG_PREFIX "writing flashchunck %u!\n", state->flashchunck);
+            if (flashpage_write_and_verify(state->flashchunck,
+                                           state->flashchunck_buf) != FLASHPAGE_OK) {
+                LOG_WARNING(LOG_PREFIX "error writing flashchunck %u!\n",
+                            state->flashchunck);
+                return -1;
+            }
+            state->flashchunck++;
+        }
+#endif
     }
-
     return 0;
 }
 
 int riotboot_flashwrite_finish_raw(riotboot_flashwrite_t *state,
-                               const uint8_t *bytes, size_t len)
+                                   const uint8_t *bytes, size_t len)
 {
-    assert(len <= FLASHPAGE_SIZE);
+    assert(len <= FLASHCHUNK_SIZE);
 
     int res = -1;
-
     uint8_t *slot_start = (uint8_t *)riotboot_slot_get_hdr(state->target_slot);
+    uint8_t *firstchunck;
 
-    uint8_t *firstpage;
-
-    if (len < FLASHPAGE_SIZE) {
-        firstpage = state->flashpage_buf;
-        memcpy(firstpage, bytes, len);
-        memcpy(firstpage + len,
-               slot_start + len,
-               FLASHPAGE_SIZE - len);
+    if (len < FLASHCHUNK_SIZE) {
+        firstchunck = state->flashchunck_buf;
+        memcpy(firstchunck, slot_start, FLASHCHUNK_SIZE);
+        memcpy(firstchunck, bytes, len);
     }
     else {
-        firstpage = (void *)bytes;
+        firstchunck = (void *)bytes;
     }
-
-    int flashpage = flashpage_page((void *)slot_start);
-    if (flashpage_write_and_verify(flashpage, firstpage) != FLASHPAGE_OK) {
-        LOG_WARNING(LOG_PREFIX "re-flashing first block failed!\n");
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+    if (flashpage_write_and_verify_raw((void *)slot_start, firstchunck,
+                                       FLASHCHUNK_SIZE) != FLASHPAGE_OK) {
+        LOG_WARNING(LOG_PREFIX "re-flashing first chunk failed!\n");
         goto out;
     }
-
+#else
+    int flashpage = flashpage_page((void *)slot_start);
+    if (flashpage_write_and_verify(flashpage, firstchunck) != FLASHPAGE_OK) {
+        LOG_WARNING(LOG_PREFIX "re-flashing first chunk failed!\n");
+        goto out;
+    }
+#endif
     LOG_INFO(LOG_PREFIX "riotboot flashing completed successfully\n");
     res = 0;
 

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -83,7 +83,6 @@ int riotboot_flashwrite_putbytes(riotboot_flashwrite_t *state,
         flashchunck_avail -= to_copy;
 
         state->offset += to_copy;
-        flashchunck_pos += to_copy;
         bytes += to_copy;
         len -= to_copy;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The following PR changes the approach used for flashwrite. Instead of always writing pages it writes chunks into flash. If `flashpage_raw` is supported these chunk can be smalled than FLASHPAGE_SIZE allowing for buffers as small as `FLASHPAGE_RAW_BLOCKSIZE`. This will also allow supporting stm32f4/2/7` or sectors based CPU since we can pick when to erase the flash.

The PR involves three changes (I can open separate PR's if the spirit of the PR is agreed upon):

* Introduces a `FLASH_ERASE_STATE` variable so the when skipping an offset or in this case `RIOTBOOT_MAGIC` we keep those bytes in an erase state so they don't need to be overwritten.
* Introduces `flashpage_write_and_verify_raw` and `flashpage_write_raw`. These are convenience functions.
* Changes the behaviour of `flashwrite` to be based on chunks

When implementing #11683 I was too focused on making it work for `stm32f2/4` and not on the global picture I think this approach works better by still having the same behavior for the base case an completely removing the use of page buffers when possible.

A buffer is still kept in `riotboot_flashwrite_t` for convenience, it makes it easier and more robust to handle unaligned `riotboot_flashwrite_putbytes`. The buffer could always be defined to `FLASHPAGE_RAW_BLOCKSIZE`. The choice of 64 bytes I made is based on having it the same size as a coap_block. But it could be changed

### Testing procedure

1. Verify that everything still works on supported board that support and don't support flashpage. Applying this diff can help in testing over ethos:

```
diff --git a/tests/riotboot_flashwrite/Makefile b/tests/riotboot_flashwrite/Makefile
index 32f127d70..d3c9f20b4 100644
--- a/tests/riotboot_flashwrite/Makefile
+++ b/tests/riotboot_flashwrite/Makefile
@@ -39,11 +39,17 @@ LOW_MEMORY_BOARDS := nucleo-f334r8
 GNRC_NETIF_NUMOF := 2
 
 # uncomment these to use ethos
-#USEMODULE += ethos gnrc_uhcpc
+USEMODULE += ethos gnrc_uhcpc  stdio_uart_rx
 #
 ## ethos baudrate can be configured from make command
-#ETHOS_BAUDRATE ?= 115200
-#CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
+ETHOS_BAUDRATE ?= 115200
+CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
+
+TAP ?= tap0
+IPV6_PREFIX ?= 2001:db8::/64
+
+TERMPROG ?= sudo sh $(RIOTTOOLS)/ethos/start_network.sh
+TERMFLAGS ?= $(PORT) $(TAP) $(IPV6_PREFIX)
 
 ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
   $(info Using low-memory configuration for microcoap_server.)
```

for nucleo-l073rz:

- provided the node `make -C tests/riotboot_flashwrite/ BOARD= nucleo-l073rz riotboot/flash term`
- compile new firmware: `make -C tests/riotboot_flashwrite/ BOARD= nucleo-l073rzriotboot`
- launch an updated: `coap-client -m post coap://[fe80::2%tap0]/flashwrite -f tests/riotboot_flashwrite/bin/ nucleo-l073rz/tests_riotboot_flashwrite-slot1.riot.bin -b 64`

for samr21-xpro:

- provided the node `make -C tests/riotboot_flashwrite/ BOARD= samr21-xpro riotboot/flash term`
- compile new firmware: `make -C tests/riotboot_flashwrite/ BOARD= samr21-xpro rzriotboot`
- launch an updated: `coap-client -m post coap://[fe80::2%tap0]/flashwrite -f tests/riotboot_flashwrite/bin/  samr21-xpro/tests_riotboot_flashwrite-slot1.riot.bin -b 64`

When the update finished reboot the node manually it should have started from a different slot.

2. rebase on top of https://github.com/RIOT-OS/RIOT/pull/11682 and https://github.com/RIOT-OS/RIOT/pull/11681 and test over an stm32f4 board, e.g. `nucleo-f446re`

- provided the node `make -C tests/riotboot_flashwrite/ BOARD=nucleo-f446re riotboot/flash term`
- compile new firmware: `make -C tests/riotboot_flashwrite/ BOARD=nucleo-f446re riotboot`
- launch an updated: `coap-client -m post coap://[fe80::2%tap0]/flashwrite -f tests/riotboot_flashwrite/bin/ nucleo-f446retests_riotboot_flashwrite-slot1.riot.bin -b 64`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Replaces #11683

Related to https://github.com/RIOT-OS/RIOT/pull/11682 and https://github.com/RIOT-OS/RIOT/pull/1168