### PR TITLE
tests/riotboot: add automatic test

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -43,8 +43,14 @@ $(BINDIR_APP)-slot0.elf: FW_ROM_LEN=$$((SLOT0_LEN - $(RIOTBOOT_HDR_LEN)))
 $(BINDIR_APP)-slot0.elf: ROM_OFFSET=$(SLOT0_IMAGE_OFFSET)
 $(BINDIR_APP)-slot1.elf: FW_ROM_LEN=$$((SLOT1_LEN - $(RIOTBOOT_HDR_LEN)))
 $(BINDIR_APP)-slot1.elf: ROM_OFFSET=$(SLOT1_IMAGE_OFFSET)
-
 SLOT_RIOT_ELFS = $(BINDIR_APP)-slot0.elf $(BINDIR_APP)-slot1.elf
+
+# ensure both slot elf files are always linked
+# this ensures that both "make test" and "make test-murdock" can rely on them
+# being present without having to trigger re-compilation.
+ifneq (1, $(RIOTNOLINK))
+link: $(SLOT_RIOT_ELFS)
+endif
 
 # Create binary target with RIOT header
 $(SLOT_RIOT_BINS): %.riot.bin: %.hdr %.bin

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -18,5 +18,16 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+# The test script assumes initially version "0" is flashed,
+# as done by the CI.
+# Thus default to that (instead of epoch set by makefiles/boot/riotboot.inc.mk).
+APP_VER?=0
+
+# The test needs the linked slot binaries without header in order to be able to
+# create final binaries with specific APP_VER values. The CI RasPi test workers
+# don't compile themselves, thus add the required files here so they will be
+# submitted along with the test jobs.
+TEST_EXTRA_FILES=$(SLOT_RIOT_ELFS)
+
 include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/riotboot/README.md
+++ b/tests/riotboot/README.md
@@ -17,5 +17,24 @@ This test should foremost give you an overview how to use riotboot:
 In this test two modules `riotboot_hdr` and `riotboot_slot` are used to showcase
 the access to riotboot shared functions.
 
-  - `make test` can be executed to run the automatic Python test that checks
-  basic functionalities of riotboot
+Automatic test
+==============
+
+This application's "test" target can be used to test basic riotboot
+functionality:
+
+    BOARD=<board> make flash test
+
+This will:
+
+1. flash bootloader and slot0 with APP_VER=0, invalidate slot1
+2. verify slot0 has been booted and has APP_VER set to 0
+
+3. flash slot1 with APP_VER set to 1
+4. verify slot1 has booted and shows APP_VER==1
+
+5. flash slot0 with APP_VER set to 2
+6. verify slot0 has booted and shows APP_VER==2
+
+If this test runs correctly, it shows that riotboot's basic functions and are
+working properly on the target board.

--- a/tests/riotboot/tests/01_test_slot_selection.sh
+++ b/tests/riotboot/tests/01_test_slot_selection.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export RIOTBOOT_SKIP_COMPILE=1
+set -e
+
+${APPDIR}/tests/common/assert_slotnum.py 0 0
+
+APP_VER=1 make -C${APPDIR} riotboot/flash-slot1
+${APPDIR}/tests/common/assert_slotnum.py 1 1
+
+APP_VER=2 make -C${APPDIR} riotboot/flash-slot0
+${APPDIR}/tests/common/assert_slotnum.py 0 2
+
+echo "[TEST PASSED]"

--- a/tests/riotboot/tests/common/assert_slotnum.py
+++ b/tests/riotboot/tests/common/assert_slotnum.py
@@ -9,11 +9,18 @@
 import sys
 from testrunner import run
 
+slotnum = int(sys.argv[1])
+app_ver = int(sys.argv[2])
+print("expecting slot number %s, app_ver %s" % (slotnum, app_ver))
+
 
 def testfunc(child):
+    global slotnum
+    global app_ver
+
     # Ask for current slot, should be 0 or 1
     child.sendline("curslotnr")
-    child.expect("Current slot=[0-1]")
+    child.expect("Current slot=%s" % (slotnum))
     child.expect('>')
 
     # Ask for current slot header info and checks for basic output integrity
@@ -21,7 +28,7 @@ def testfunc(child):
     # Magic number is "RIOT" (always in little endian)
     child.expect_exact("Image magic_number: 0x544f4952")
     # Other info is hardware/app dependant so we just check basic compliance
-    child.expect("Image Version: 0x[0-9a-fA-F]{8}")
+    child.expect("Image Version: %s" % ("{0:#0{1}x}".format(app_ver, 10)))
     child.expect("Image start address: 0x[0-9a-fA-F]{8}")
     child.expect("Header chksum: 0x[0-9a-fA-F]{8}")
     child.expect('>')


### PR DESCRIPTION
### Contribution description

This PR adds a script that automatically tests riotboot's image selection.
It expects slot0, APP_VER=0 be pre-flashed on the device (and verifies that). This is what happens when "make flash" is run, and also happens on the CI.

A following "make test" will:
1. verify slot0, APP_VER=0
2. flash slot1, APP_VER=1, verify it is booting
3. flash slot0, APP_VER=2, verify it is booting

### Testing procedure

1. look at CI output
2. try local ```make -Ctests/riotboot flash test```

### Issues/PRs references

Needs ~~#11697~~ and ~~#11690~~.