### PR TITLE
boards/mspdebug: use FLASHFILE for boards using mspdebug

### DIFF
--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -3,8 +3,9 @@ export CPU = cc430
 export CPU_MODEL = cc430f6137
 
 # flasher configuration
+FLASHFILE ?= $(HEXFILE)
 FLASHER = mspdebug
-FFLAGS = rf2500 "prog $(HEXFILE)"
+FFLAGS = rf2500 "prog $(FLASHFILE)"
 
 INCLUDES += -I$(RIOTBOARD)/$(BOARD)/drivers/include
 

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -15,7 +15,8 @@ ifeq ($(strip $(PROGRAMMER)),uif)
   MSPDEBUGFLAGS += -d $(PORT)
 endif
 FLASHER ?= mspdebug
-FFLAGS = $(MSPDEBUGFLAGS) "prog $(HEXFILE)"
+FLASHFILE ?= $(HEXFILE)
+FFLAGS = $(MSPDEBUGFLAGS) "prog $(FLASHFILE)"
 
 # setup debugger
 DEBUGSERVER = $(FLASHER)

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -14,7 +14,8 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # configure the flash tool
 FLASHER = mspdebug
-FFLAGS = -d $(PORT) -j uif "prog $(HEXFILE)"
+FLASHFILE ?= $(HEXFILE)
+FFLAGS = -d $(PORT) -j uif "prog $(FLASHFILE)"
 
 # Use the HEXFILE when using iot-lab.single.inc.mk
-IOTLAB_FLASHFILE = $(HEXFILE)
+IOTLAB_FLASHFILE = $(FLASHFILE)


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.


### Testing procedure

You can flash on a board using `mspdebug`.

```
MSPDEBUG_BOARDS=$(git grep -l -e  mspdebug -e common/msb-430 -e common/wsn430 '*' ':!boards/common' | cut -f 2 -d/ | sort -u)
echo ${MSPDEBUG_BOARDS} 
chronos msb-430 msb-430h wsn430-v1_3b wsn430-v1_4
```

### Testing without a board


The output of the FFLAGS is the same on master and this PR.

<details><summary><code>for board in ${MSPDEBUG_BOARDS}; do echo ${board}; BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done</code></summary><p>

```
for board in ${MSPDEBUG_BOARDS}; do echo ${board}; BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done
chronos
true rf2500 "prog /home/harter/work/git/RIOT/examples/hello-world/bin/chronos/hello-world.hex"
msb-430
true -j olimex "prog /home/harter/work/git/RIOT/examples/hello-world/bin/msb-430/hello-world.hex"
msb-430h
true -j olimex "prog /home/harter/work/git/RIOT/examples/hello-world/bin/msb-430h/hello-world.hex"
wsn430-v1_3b
true -d /dev/ttyUSB0 -j uif "prog /home/harter/work/git/RIOT/examples/hello-world/bin/wsn430-v1_3b/hello-world.hex"
wsn430-v1_4
true -d /dev/ttyUSB0 -j uif "prog /home/harter/work/git/RIOT/examples/hello-world/bin/wsn430-v1_4/hello-world.hex"
```

</p></details>

And the value can be changed from environment variable:

<details><summary><code>for board in ${MSPDEBUG_BOARDS}; do echo ${board}; FLASHFILE=toto BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done</code></summary><p>

```
for board in ${MSPDEBUG_BOARDS}; do echo ${board}; FLASHFILE=toto BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done
chronos
true rf2500 "prog toto"
msb-430
true -j olimex "prog toto"
msb-430h
true -j olimex "prog toto"
wsn430-v1_3b
true -d /dev/ttyUSB0 -j uif "prog toto"
wsn430-v1_4
true -d /dev/ttyUSB0 -j uif "prog toto"
```
</p></details>


### IOTLAB_NODE update

The value for `IOTLAB_NODE` is correctly overwritten to the `.hex` file as it was in master.

```
IOTLAB_NODE=wsn430-1.grenoble.iot-lab.info BOARD=wsn430-v1_3b make --no-print-directory -C examples/hello-world/ info-debug-variable-IOTLAB_FLASHFILE
/home/harter/work/git/RIOT/examples/hello-world/bin/wsn430-v1_3b/hello-world.hex
```
### Issues/PRs references

Part of #8838