### PR TITLE
boards/dfu-util: use FLASHFILE for boards using dfu-util

### DIFF
--- a/boards/common/stm32f103c8/Makefile.include
+++ b/boards/common/stm32f103c8/Makefile.include
@@ -27,10 +27,10 @@ ifeq ($(PROGRAMMER),dfu-util)
   DEBUGGER = # no debugger
   RESET ?= # dfu-util has no support for resetting the device
 
-  HEXFILE = $(BINFILE)
-  FFLAGS = -d 1eaf:0003 -a 2 -D "$(HEXFILE)"
+  FLASHFILE ?= $(BINFILE)
+  FFLAGS = -d 1eaf:0003 -a 2 -D $(FLASHFILE)
   # for older bootloader versions use this:
-  # FFLAGS = -d 1d50:6017 -s 0x08002000:leave -D "$(HEXFILE)"
+  # FFLAGS = -d 1d50:6017 -s 0x08002000:leave -D $(FLASHFILE)
 else
 
   # this board uses openocd by default

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -13,8 +13,8 @@ FLASHER = dfu-util
 DEBUGGER = # dfu-util has no debugger
 RESET ?= # dfu-util has no support for resetting the device
 
-HEXFILE = $(BINFILE)
-FFLAGS = -d $(ID) -a 0 -s 0x08000000:leave -D "$(HEXFILE)"
+FLASHFILE ?= $(BINFILE)
+FFLAGS = -d $(ID) -a 0 -s 0x08000000:leave -D $(FLASHFILE)
 
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -11,8 +11,8 @@ FLASHER = dfu-util
 DEBUGGER = # spark core has no debugger
 RESET ?= # dfu-util has no support for resetting the device
 
-HEXFILE = $(BINFILE)
-FFLAGS = -d 1d50:607f -a 0 -s 0x08005000:leave -D "$(HEXFILE)"
+FLASHFILE ?= $(BINFILE)
+FFLAGS = -d 1d50:607f -a 0 -s 0x08005000:leave -D $(FLASHFILE)
 
 # Skip the space needed by the embedded bootloader
 export ROM_OFFSET ?= 0x5000

--- a/makefiles/tools/dfu.inc.mk
+++ b/makefiles/tools/dfu.inc.mk
@@ -1,8 +1,8 @@
 DFU ?= dfu-util
 FLASHER ?= $(DFU)
-HEXFILE = $(BINFILE)
+FLASHFILE ?= $(BINFILE)
 
-FFLAGS ?= -D $(HEXFILE) --reset $(DFU_ARGS)
+FFLAGS ?= -D $(FLASHFILE) --reset $(DFU_ARGS)
 
 RESET ?= $(DFU)
 RESET_FLAGS ?= $(DFU_ARGS) -t $(DFU_DEVICE_TYPE)


### PR DESCRIPTION
### Contribution description

Update to use FLASHFILE as file to be flashed on the board.

### Testing procedure

Flash on a board using `dfu-util`

```
DFU_BOARDS=$(git grep -l -e tools/dfu.inc.mk -e dfu-util -e common/stm32f103c8 'boards/*' ':!boards/common'  | cut -f 2 -d/ | sort -u)
echo ${DFU_BOARDS}
blackpill bluepill nz32-sc151 pyboard spark-core
```

### Testing without a board

The output of the `FFLAGS` has the same file as in master.
It is a bit different as I removed the `"` around the file name as we do not do it for any other boards.

<details><summary><code>for board in ${DFU_BOARDS}; do echo ${board}; PROGRAMMER=dfu-util BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done</code></summary><p>

```
for board in ${DFU_BOARDS}; do echo ${board}; PROGRAMMER=dfu-util BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done
blackpill
true -d 1eaf:0003 -a 2 -D /home/harter/work/git/RIOT/examples/hello-world/bin/blackpill/hello-world.bin
bluepill
true -d 1eaf:0003 -a 2 -D /home/harter/work/git/RIOT/examples/hello-world/bin/bluepill/hello-world.bin
nz32-sc151
true -d 0483:df11 -a 0 -s 0x08000000:leave -D /home/harter/work/git/RIOT/examples/hello-world/bin/nz32-sc151/hello-world.bin
pyboard
true -D /home/harter/work/git/RIOT/examples/hello-world/bin/pyboard/hello-world.bin --reset --alt 0 -s 0x8000000
spark-core
true -d 1d50:607f -a 0 -s 0x08005000:leave -D /home/harter/work/git/RIOT/examples/hello-world/bin/spark-core/hello-world.bin
```

</p></details>

Only diff is the `"` that were removed

```diff
wdiff  output_master output_pr 
blackpill
true -d 1eaf:0003 -a 2 -D [-"/home/harter/work/git/RIOT/examples/hello-world/bin/blackpill/hello-world.bin"-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/blackpill/hello-world.bin+}
bluepill
true -d 1eaf:0003 -a 2 -D [-"/home/harter/work/git/RIOT/examples/hello-world/bin/bluepill/hello-world.bin"-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/bluepill/hello-world.bin+}
nz32-sc151
true -d 0483:df11 -a 0 -s 0x08000000:leave -D [-"/home/harter/work/git/RIOT/examples/hello-world/bin/nz32-sc151/hello-world.bin"-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/nz32-sc151/hello-world.bin+}
pyboard
true -D /home/harter/work/git/RIOT/examples/hello-world/bin/pyboard/hello-world.bin --reset --alt 0 -s 0x8000000
spark-core
true -d 1d50:607f -a 0 -s 0x08005000:leave -D [-"/home/harter/work/git/RIOT/examples/hello-world/bin/spark-core/hello-world.bin"-] {+/home/harter/work/git/RIOT/examples/hello-world/bin/spark-core/hello-world.bin+}
```

The value can be changed from environment variable:

<details><summary><code>for board in ${DFU_BOARDS}; do echo ${board}; PROGRAMMER=dfu-util FLASHFILE=beer BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done</code></summary><p>

```
for board in ${DFU_BOARDS}; do echo ${board}; PROGRAMMER=dfu-util FLASHFILE=beer BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done
blackpill
true -d 1eaf:0003 -a 2 -D beer
bluepill
true -d 1eaf:0003 -a 2 -D beer
nz32-sc151
true -d 0483:df11 -a 0 -s 0x08000000:leave -D beer
pyboard
true -D beer --reset --alt 0 -s 0x8000000
spark-core
true -d 1d50:607f -a 0 -s 0x08005000:leave -D beer
```

</p></details>

### Issues/PRs references

Part of #8838 