### PR TITLE
boards/single: use FLASHFILE

### DIFF
--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -18,6 +18,6 @@ DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 DEBUGSERVER = st-util
 
 # define st-flash parameters
-HEXFILE = $(BINFILE)
-FFLAGS = write $(HEXFILE) 0x8000000
+FLASHFILE ?= $(BINFILE)
+FFLAGS = write $(FLASHFILE) 0x8000000
 DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -5,8 +5,8 @@ FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
 DEBUGGER =
 DEBUGSERVER =
 
-HEXFILE = $(BINFILE)
-FFLAGS = $(HEXFILE)
+FLASHFILE ?= $(BINFILE)
+FFLAGS = $(FLASHFILE)
 DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -7,8 +7,8 @@ FLASHER = $(RIOTBOARD)/$(BOARD)/dist/robotis-loader.py
 DEBUGGER =
 DEBUGSERVER =
 
-HEXFILE = $(BINFILE)
-FFLAGS = $(PORT) $(HEXFILE)
+FLASHFILE ?= $(BINFILE)
+FFLAGS = $(PORT) $(FLASHFILE)
 DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -6,7 +6,8 @@ CPU_MODEL = mk20dx256vlh7
 TEENSY_LOADER = $(RIOTTOOLS)/teensy-loader-cli/teensy_loader
 FLASHER = $(TEENSY_LOADER)
 
-FFLAGS ?= --mcu=mk20dx256 $(HEXFILE)
+FLASHFILE ?= $(HEXFILE)
+FFLAGS ?= --mcu=mk20dx256 $(FLASHFILE)
 
 ifeq ($(TEENSY_LOADER),$(FLASHER))
   FLASHDEPS += $(TEENSY_LOADER)

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -11,4 +11,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # flash tool configuration
 FLASHER = $(RIOTTOOLS)/goodfet/goodfet.bsl
-FFLAGS = --telosb -c $(PORT) -r -e -I -p $(HEXFILE)
+FLASHFILE ?= $(HEXFILE)
+FFLAGS = --telosb -c $(PORT) -r -e -I -p $(FLASHFILE)

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -10,4 +10,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup flash tool
 FLASHER = $(RIOTTOOLS)/goodfet/goodfet.bsl
-FFLAGS = --z1 -I -c $(PORT) -r -e -p $(HEXFILE)
+FLASHFILE ?= $(HEXFILE)
+FFLAGS = --z1 -I -c $(PORT) -r -e -p $(FLASHFILE)


### PR DESCRIPTION
### Contribution description

Update the boards that do not use a `common` board for their flasher.
Update to use FLASHFILE as file to be flashed on the board.

### Testing procedure

Testing on all the board, or trust the testing without a board.

```
BOARDS=$(git diff --name-status HEAD~5 | cut -f 2 -d/)
echo ${BOARDS}
f4vi1 mbed_lpc1768 opencm904 teensy31 telosb z1
```

### Testing without a board

The output of the FFLAGS is the same on master and this PR.

<details><summary><code>for board in ${BOARDS}; do echo ${board}; BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done</code></summary><p>

```
for board in ${BOARDS}; do echo ${board}; BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done
f4vi1
true write /home/harter/work/git/RIOT/examples/hello-world/bin/f4vi1/hello-world.bin 0x8000000
mbed_lpc1768
true /home/harter/work/git/RIOT/examples/hello-world/bin/mbed_lpc1768/hello-world.bin
opencm904
true /dev/ttyACM0 /home/harter/work/git/RIOT/examples/hello-world/bin/opencm904/hello-world.bin
teensy31
true --mcu=mk20dx256 /home/harter/work/git/RIOT/examples/hello-world/bin/teensy31/hello-world.hex
telosb
true --telosb -c /dev/ttyUSB0 -r -e -I -p /home/harter/work/git/RIOT/examples/hello-world/bin/telosb/hello-world.hex
z1
true --z1 -I -c /dev/ttyUSB0 -r -e -p /home/harter/work/git/RIOT/examples/hello-world/bin/z1/hello-world.hex
```

</p></details>

<details><summary><code>for board in ${BOARDS}; do echo ${board}; FLASHFILE=dogo BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done</code></summary><p>

```
for board in ${BOARDS}; do echo ${board}; FLASHFILE=dogo BOARD=${board} make --no-print-directory -C examples/hello-world/ FLASHER=true flash-only; done
f4vi1
true write dogo 0x8000000
mbed_lpc1768
true dogo
opencm904
true /dev/ttyACM0 dogo
teensy31
true --mcu=mk20dx256 dogo
telosb
true --telosb -c /dev/ttyUSB0 -r -e -I -p dogo
z1
true --z1 -I -c /dev/ttyUSB0 -r -e -p dogo
```

</p></details>

### Issues/PRs references

Part of #8838