### PR TITLE
boards/mips-malta: set FLASHFILE

### DIFF
--- a/boards/mips-malta/Makefile.include
+++ b/boards/mips-malta/Makefile.include
@@ -4,3 +4,7 @@ export USE_DSP = 1
 export USE_UHI_SYSCALLS = 1
 
 HEXFILE = $(BINFILE)
+# Not sure if the file used for flashing is BINFILE (there is no flasher).
+# I chose this one as HEXFILE was overwritten to BINFILE so it keeps the
+# same behavior of generating the '.bin'.
+FLASHFILE ?= $(BINFILE)


### PR DESCRIPTION
### Contribution description

Set FLASHFILE to the file that was generated before.

It still need to have HEXFILE=$(BINFILE) as it cannot generate a hex file.

This will be cleaned up when `HEXFILE` is not always generated anymore, but depends on all boards being updated to `FLASHFILE`.

### Testing procedure

The board does not have any flasher, so it is only theoretical.

### Testing without board

The `binfile` is used as flashfile and it can be overwritten from the environment.

```
BOARD=mips-malta make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE
/home/harter/work/git/RIOT/examples/hello-world/bin/mips-malta/hello-world.bin

FLASHFILE=stout BOARD=mips-malta make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE
stout
```

### Issues/PRs references

Part of the FLASHFILE introduction #8838
