### PR TITLE
stm32_common/flashpage: cleanup

### DIFF
--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -38,7 +38,6 @@
 #define CNTRL_REG              (FLASH->PECR)
 #define CNTRL_REG_LOCK         (FLASH_PECR_PELOCK)
 #define FLASH_CR_PER           (FLASH_PECR_ERASE | FLASH_PECR_PROG)
-#define FLASH_CR_PG            (FLASH_PECR_FPRG | FLASH_PECR_PROG)
 #define FLASHPAGE_DIV          (4U) /* write 4 bytes in one go */
 #else
 #if defined(CPU_FAM_STM32L4)
@@ -187,7 +186,10 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     }
 
     /* clear program bit again */
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32L4)
     CNTRL_REG &= ~(FLASH_CR_PG);
+#endif
     DEBUG("[flashpage_raw] write: done writing data\n");
 
     /* lock the flash module again */

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -175,7 +175,8 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     _unlock_flash();
 
     DEBUG("[flashpage_raw] write: now writing the data\n");
-#if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1))
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32L4)
     /* set PG bit and program page to flash */
     CNTRL_REG |= FLASH_CR_PG;
 #endif

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -99,7 +99,6 @@ static void _erase_page(void *page_addr)
     *dst = (uint32_t)0;
 #elif defined(CPU_FAM_STM32L4)
     DEBUG("[flashpage] erase: setting the page address\n");
-    CNTRL_REG |= FLASH_CR_PER;
     uint8_t pn;
 #if FLASHPAGE_NUMOF <= 256
     pn = (uint8_t)flashpage_page(dst);

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -77,7 +77,8 @@ static void _erase_page(void *page_addr)
     uint32_t *dst = page_addr;
 #else
     uint16_t *dst = page_addr;
-
+#endif
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1)
     uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
     /* the internal RC oscillator (HSI) must be enabled */
     stmclk_enable_hsi();
@@ -131,8 +132,7 @@ static void _erase_page(void *page_addr)
     /* lock the flash module again */
     _lock();
 
-#if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-      defined(CPU_FAM_STM32L4))
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1)
     /* restore the HSI state */
     if (!hsi_state) {
         stmclk_disable_hsi();
@@ -163,7 +163,9 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 #else
     uint16_t *dst = (uint16_t *)target_addr;
     const uint16_t *data_addr = data;
+#endif
 
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1)
     uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
     /* the internal RC oscillator (HSI) must be enabled */
     stmclk_enable_hsi();
@@ -191,8 +193,7 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     /* lock the flash module again */
     _lock();
 
-#if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-      defined(CPU_FAM_STM32L4))
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1)
     /* restore the HSI state */
     if (!hsi_state) {
         stmclk_disable_hsi();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR cleans up `flashpage.c`. Following discussion in https://github.com/RIOT-OS/RIOT/pull/11681 it changes defines to makes specific behaviors explicit. Some unused functions and definitions where removed, specifically for stm32l1/0 and stm32l4.

NOTE: to verify the stm32l1/l0 change you can refer to the RM p71 for L1 and p89 for L0x3 and p81 for L0x1.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run `make -C tests/periph_flashpage/ BOARD=nucleo-l476rg flash test` for an `stm32l1`, `stm32l0` and `stm32l4` , `stm32f0` and `stm32f1` board.

The test should still pass in all cases.

Tested on: `nucleo-l152re`, `b-l072rz-lrwan1`, `nucleo--l476rg`, `nucleo-f072rb`, `iotlab-m3`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
