### PR TITLE
gnrc_ipv6_nib: add address from netif to address validation timer

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -178,7 +178,8 @@ void _handle_dad(const ipv6_addr_t *addr)
     if (idx >= 0) {
         ipv6_addr_set_solicited_nodes(&sol_nodes, addr);
         _snd_ns(addr, netif, &ipv6_addr_unspecified, &sol_nodes);
-        _evtimer_add((void *)addr, GNRC_IPV6_NIB_VALID_ADDR,
+        _evtimer_add((void *)&netif->ipv6.addrs[idx],
+                     GNRC_IPV6_NIB_VALID_ADDR,
                      &netif->ipv6.addrs_timers[idx],
                      netif->ipv6.retrans_time);
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -193,6 +193,9 @@ void _handle_valid_addr(const ipv6_addr_t *addr)
     gnrc_netif_t *netif = NULL;
     int idx = _get_netif_state(&netif, addr);
 
+    DEBUG("nib: validating address %s (idx: %d, netif: %d)\n",
+          ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)), idx,
+          (netif != NULL) ? netif->pid : 0);
     if (idx >= 0) {
         netif->ipv6.addrs_flags[idx] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
         netif->ipv6.addrs_flags[idx] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1031,6 +1031,8 @@ static void _handle_nbr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         int idx = gnrc_netif_ipv6_addr_idx(tgt_netif, &nbr_adv->tgt);
 
         if (gnrc_netif_ipv6_addr_dad_trans(tgt_netif, idx)) {
+            DEBUG("nib: duplicate address detected, removing target address "
+                  "from this interface\n");
             /* cancel validation timer */
             evtimer_del(&_nib_evtimer,
                         &tgt_netif->ipv6.addrs_timers[idx].event);
@@ -1087,6 +1089,7 @@ static void _handle_nbr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
          * traditional DAD */
         if ((aro_status == _ADDR_REG_STATUS_UNAVAIL) &&
             gnrc_netif_is_6ln(netif)) {
+            DEBUG("nib: No ARO in NA, falling back to classic DAD\n");
             _handle_dad(&ipv6->dst);
         }
 #elif GNRC_IPV6_NIB_CONF_6LN


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
During [a demo](https://github.com/miri64/RIOT_playground/tree/30a37a76b57211b6253ab64139ee9eccf959c9c5/lndw18_luke) for LNdW in Berlin] last weekend, we faced the problem, that the nodes oftentimes registered with their link-local address to the resource directory. This was caused by a bug in the duplicate address detection, causing the global address never to become valid.

The `addr` parameter of the NIB's `_handle_dad()` can come from anywhere (e.g. in the fallback to classic SLAAC the destination address of the IP header is used),

https://github.com/RIOT-OS/RIOT/blob/f32ab700cb68567b87f3854f3c78c594b19a1c6c/sys/net/gnrc/network_layer/ipv6/nib/nib.c#L1085-L1092

so putting that pointer in a timer is not a good idea. Instead we use the version of
the address that is stored within the interface.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Since it may happen that `addr` still contains the correct address (and only occurs when working with a Raspberry Pi), when the timer is fired, this is not easy to reproduce. But here is a try.

`examples/gnrc_networking` should at least be still compilable. The rest is verifiable by looking carefully at the code.

Make sure 4845265 is in your tested version!

Enable DEBUG in `sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c` and flash `gnrc_networking` to multiple 6LoWPAN-capable nodes (remember to set `-DGNRC_IPV6_NIB_CONF_SLAAC=1` in `CFLAGS`). Have a a Raspberry Pi with a 6LoWPAN-capable interface and reset all the nodes. Without the last change, some of the nodes will output garbage in the debug output. With it it will always be the global address.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
