### PR TITLE
at86rf2xx: move PHY and MAC layer components to at86rf2xx_netdev

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -73,8 +73,13 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     at86rf2xx_set_addr_long(dev, ntohll(addr_long.uint64.u64));
     at86rf2xx_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
 
-    /* set default channel */
-    at86rf2xx_set_chan(dev, AT86RF2XX_DEFAULT_CHANNEL);
+    /* set default channel and page */
+#ifdef MODULE_AT86RF212B
+    at86rf2xx_configure_phy(dev, AT86RF2XX_DEFAULT_CHANNEL, AT86RF2XX_DEFAULT_PAGE);
+#else
+    at86rf2xx_configure_phy(dev, AT86RF2XX_DEFAULT_CHANNEL, 0);
+#endif
+
     /* set default TX power */
     at86rf2xx_set_txpower(dev, AT86RF2XX_DEFAULT_TXPOWER);
     /* set default options */
@@ -88,9 +93,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* enable safe mode (protect RX FIFO until reading data starts) */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
                         AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
-#ifdef MODULE_AT86RF212B
-    at86rf2xx_set_page(dev, AT86RF2XX_DEFAULT_PAGE);
-#endif
 
     /* don't populate masked interrupt flags to IRQ_STATUS register */
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_1);

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -136,17 +136,11 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, const uint8_t *data,
 
 void at86rf2xx_tx_exec(const at86rf2xx_t *dev)
 {
-    netdev_t *netdev = (netdev_t *)dev;
-
     /* write frame length field in FIFO */
     at86rf2xx_sram_write(dev, 0, &(dev->tx_frame_len), 1);
     /* trigger sending of pre-loaded frame */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE,
                         AT86RF2XX_TRX_STATE__TX_START);
-    if (netdev->event_callback &&
-        (dev->flags & AT86RF2XX_OPT_TELL_TX_START)) {
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
-    }
 }
 
 bool at86rf2xx_cca(at86rf2xx_t *dev)

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -170,49 +170,6 @@ void at86rf2xx_set_addr_long(at86rf2xx_t *dev, uint64_t addr)
     }
 }
 
-uint8_t at86rf2xx_get_chan(const at86rf2xx_t *dev)
-{
-    return dev->netdev.chan;
-}
-
-void at86rf2xx_set_chan(at86rf2xx_t *dev, uint8_t channel)
-{
-    if ((channel > AT86RF2XX_MAX_CHANNEL)
-#if AT86RF2XX_MIN_CHANNEL /* is zero for sub-GHz */
-       || (channel < AT86RF2XX_MIN_CHANNEL)
-#endif
-        ) {
-        return;
-    }
-
-    dev->netdev.chan = channel;
-
-    at86rf2xx_configure_phy(dev);
-}
-
-uint8_t at86rf2xx_get_page(const at86rf2xx_t *dev)
-{
-#ifdef MODULE_AT86RF212B
-    return dev->page;
-#else
-    (void) dev;
-    return 0;
-#endif
-}
-
-void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page)
-{
-#ifdef MODULE_AT86RF212B
-    if ((page == 0) || (page == 2)) {
-        dev->page = page;
-        at86rf2xx_configure_phy(dev);
-    }
-#else
-    (void) dev;
-    (void) page;
-#endif
-}
-
 uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev)
 {
     return dev->netdev.pan;

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -32,104 +32,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#ifdef MODULE_AT86RF212B
-/* See: Table 9-15. Recommended Mapping of TX Power, Frequency Band, and
- * PHY_TX_PWR (register 0x05), AT86RF212B data sheet. */
-static const uint8_t dbm_to_tx_pow_868[] = { 0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x18,
-                                             0x17, 0x15, 0x14, 0x13, 0x12, 0x11,
-                                             0x10, 0x0f, 0x31, 0x30, 0x2f, 0x94,
-                                             0x93, 0x91, 0x90, 0x29, 0x49, 0x48,
-                                             0x47, 0xad, 0xcd, 0xcc, 0xcb, 0xea,
-                                             0xe9, 0xe8, 0xe7, 0xe6, 0xe4, 0x80,
-                                             0xa0 };
-static const uint8_t dbm_to_tx_pow_915[] = { 0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x17,
-                                             0x16, 0x15, 0x14, 0x13, 0x12, 0x11,
-                                             0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b,
-                                             0x09, 0x91, 0x08, 0x07, 0x05, 0x27,
-                                             0x04, 0x03, 0x02, 0x01, 0x00, 0x86,
-                                             0x40, 0x84, 0x83, 0x82, 0x80, 0xc1,
-                                             0xc0 };
-static const int16_t rx_sens_to_dbm[] = { -110, -98, -94, -91, -88, -85, -82,
-                                          -79, -76, -73, -70, -67, -63, -60, -57,
-                                          -54 };
-static const uint8_t dbm_to_rx_sens[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x01, 0x01, 0x01, 0x01, 0x02, 0x02,
-                                          0x02, 0x03, 0x03, 0x03, 0x04, 0x04,
-                                          0x04, 0x05, 0x05, 0x05, 0x06, 0x06,
-                                          0x06, 0x07, 0x07, 0x07, 0x08, 0x08,
-                                          0x08, 0x09, 0x09, 0x09, 0x0a, 0x0a,
-                                          0x0a, 0x0b, 0x0b, 0x0b, 0x0b, 0x0c,
-                                          0x0c, 0x0c, 0x0d, 0x0d, 0x0d, 0x0e,
-                                          0x0e, 0x0e, 0x0f };
-
-static int16_t _tx_pow_to_dbm_212b(uint8_t channel, uint8_t page, uint8_t reg)
-{
-    if (page == 0 || page == 2) {
-        const uint8_t *dbm_to_tx_pow;
-        size_t nelem;
-
-        if (channel == 0) {
-            /* Channel 0 is 868.3 MHz */
-            dbm_to_tx_pow = &dbm_to_tx_pow_868[0];
-            nelem = sizeof(dbm_to_tx_pow_868) / sizeof(dbm_to_tx_pow_868[0]);
-        }
-        else {
-            /* Channels 1+ are 915 MHz */
-            dbm_to_tx_pow = &dbm_to_tx_pow_915[0];
-            nelem = sizeof(dbm_to_tx_pow_915) / sizeof(dbm_to_tx_pow_915[0]);
-        }
-
-        for (size_t i = 0; i < nelem; ++i) {
-            if (dbm_to_tx_pow[i] == reg) {
-                return (i - AT86RF2XX_TXPOWER_OFF);
-            }
-        }
-    }
-
-    return 0;
-}
-
-#elif MODULE_AT86RF233
-static const int16_t tx_pow_to_dbm[] = { 4, 4, 3, 3, 2, 2, 1,
-                                         0, -1, -2, -3, -4, -6, -8, -12, -17 };
-static const uint8_t dbm_to_tx_pow[] = { 0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
-                                         0x0e, 0x0d, 0x0d, 0x0d, 0x0c, 0x0c,
-                                         0x0b, 0x0b, 0x0a, 0x09, 0x08, 0x07,
-                                         0x06, 0x05, 0x03, 0x00 };
-static const int16_t rx_sens_to_dbm[] = { -101, -94, -91, -88, -85, -82, -79,
-                                          -76, -73, -70, -67, -64, -61, -58, -55,
-                                          -52 };
-static const uint8_t dbm_to_rx_sens[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x00, 0x01, 0x01, 0x01, 0x02, 0x02,
-                                          0x02, 0x03, 0x03, 0x03, 0x04, 0x04,
-                                          0x04, 0x05, 0x05, 0x05, 0x06, 0x06,
-                                          0x06, 0x07, 0x07, 0x07, 0x08, 0x08,
-                                          0x08, 0x09, 0x09, 0x09, 0x0a, 0x0a,
-                                          0x0a, 0x0b, 0x0b, 0x0b, 0x0c, 0x0c,
-                                          0x0c, 0x0d, 0x0d, 0x0d, 0x0e, 0x0e,
-                                          0x0e, 0x0f };
-#else
-static const int16_t tx_pow_to_dbm[] = { 3, 3, 2, 2, 1, 1, 0,
-                                         -1, -2, -3, -4, -5, -7, -9, -12, -17 };
-static const uint8_t dbm_to_tx_pow[] = { 0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
-                                         0x0e, 0x0d, 0x0d, 0x0c, 0x0c, 0x0b,
-                                         0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06,
-                                         0x05, 0x03, 0x00 };
-static const int16_t rx_sens_to_dbm[] = { -101, -91, -88, -85, -82, -79, -76
-                                          -73, -70, -67, -64, -61, -58, -55, -52,
-                                          -49 };
-static const uint8_t dbm_to_rx_sens[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x00, 0x00, 0x00, 0x00, 0x01, 0x01,
-                                          0x01, 0x02, 0x02, 0x02, 0x03, 0x03,
-                                          0x03, 0x04, 0x04, 0x04, 0x05, 0x05,
-                                          0x05, 0x06, 0x06, 0x06, 0x07, 0x07,
-                                          0x07, 0x08, 0x08, 0x08, 0x09, 0x09,
-                                          0x09, 0x0a, 0x0a, 0x0a, 0x0b, 0x0b,
-                                          0x0b, 0x0c, 0x0c, 0x0c, 0x0d, 0x0d,
-                                          0x0d, 0x0e, 0x0e, 0x0e, 0x0f };
-#endif
-
 uint16_t at86rf2xx_get_addr_short(const at86rf2xx_t *dev)
 {
     return (dev->netdev.short_addr[0] << 8) | dev->netdev.short_addr[1];
@@ -184,65 +86,35 @@ void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan)
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PAN_ID_1, le_pan.u8[1]);
 }
 
-int16_t at86rf2xx_get_txpower(const at86rf2xx_t *dev)
-{
-#ifdef MODULE_AT86RF212B
-    uint8_t txpower = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_TX_PWR);
-    DEBUG("txpower value: %x\n", txpower);
-    return _tx_pow_to_dbm_212b(dev->netdev.chan, dev->page, txpower);
-#else
-    uint8_t txpower = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_TX_PWR)
-                      & AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR;
-    return tx_pow_to_dbm[txpower];
-#endif
-}
-
-void at86rf2xx_set_txpower(const at86rf2xx_t *dev, int16_t txpower)
-{
-    txpower += AT86RF2XX_TXPOWER_OFF;
-
-    if (txpower < 0) {
-        txpower = 0;
-    }
-    else if (txpower > AT86RF2XX_TXPOWER_MAX) {
-        txpower = AT86RF2XX_TXPOWER_MAX;
-    }
-#ifdef MODULE_AT86RF212B
-    if (dev->netdev.chan == 0) {
-        at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_TX_PWR,
-                            dbm_to_tx_pow_868[txpower]);
-    }
-    else if (dev->netdev.chan < 11) {
-        at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_TX_PWR,
-                            dbm_to_tx_pow_915[txpower]);
-    }
-#else
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_TX_PWR,
-                        dbm_to_tx_pow[txpower]);
-#endif
-}
-
 int16_t at86rf2xx_get_rxsensitivity(const at86rf2xx_t *dev)
 {
     uint8_t rxsens = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RX_SYN)
                      & AT86RF2XX_RX_SYN__RX_PDT_LEVEL;
-    return rx_sens_to_dbm[rxsens];
+    return rxsens;
+}
+
+int16_t at86rf2xx_get_txpower(const at86rf2xx_t *dev)
+{
+#ifdef MODULE_AT86RF212B
+    uint8_t txpower = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_TX_PWR);
+#else
+    uint8_t txpower = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_TX_PWR)
+                      & AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR;
+#endif
+    return txpower;
+}
+
+void at86rf2xx_set_txpower(const at86rf2xx_t *dev, int16_t txpower)
+{
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_TX_PWR,
+                        txpower);
 }
 
 void at86rf2xx_set_rxsensitivity(const at86rf2xx_t *dev, int16_t rxsens)
 {
-    rxsens += MIN_RX_SENSITIVITY;
-
-    if (rxsens < 0) {
-        rxsens = 0;
-    }
-    else if (rxsens > MAX_RX_SENSITIVITY) {
-        rxsens = MAX_RX_SENSITIVITY;
-    }
-
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RX_SYN);
     tmp &= ~(AT86RF2XX_RX_SYN__RX_PDT_LEVEL);
-    tmp |= (dbm_to_rx_sens[rxsens] & AT86RF2XX_RX_SYN__RX_PDT_LEVEL);
+    tmp |= (rxsens & AT86RF2XX_RX_SYN__RX_PDT_LEVEL);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__RX_SYN, tmp);
 }
 

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -205,8 +205,6 @@ void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state)
             if (state) {
                 DEBUG("[at86rf2xx] opt: enabling CSMA mode" \
                       "(4 retries, min BE: 3 max BE: 5)\n");
-                /* Initialize CSMA seed with hardware address */
-                at86rf2xx_set_csma_seed(dev, dev->netdev.long_addr);
                 at86rf2xx_set_csma_max_retries(dev, 4);
                 at86rf2xx_set_csma_backoff_exp(dev, 3, 5);
             }

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -32,52 +32,23 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-uint16_t at86rf2xx_get_addr_short(const at86rf2xx_t *dev)
+void at86rf2xx_set_hwfilter_addr_short(at86rf2xx_t *dev, uint16_t addr)
 {
-    return (dev->netdev.short_addr[0] << 8) | dev->netdev.short_addr[1];
-}
-
-void at86rf2xx_set_addr_short(at86rf2xx_t *dev, uint16_t addr)
-{
-    dev->netdev.short_addr[0] = (uint8_t)(addr);
-    dev->netdev.short_addr[1] = (uint8_t)(addr >> 8);
-#ifdef MODULE_SIXLOWPAN
-    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
-     * 0 for unicast addresses */
-    dev->netdev.short_addr[0] &= 0x7F;
-#endif
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_0,
-                        dev->netdev.short_addr[1]);
+                        (uint8_t) (addr >> 8));
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_1,
-                        dev->netdev.short_addr[0]);
+                        (uint8_t) (addr));
 }
 
-uint64_t at86rf2xx_get_addr_long(const at86rf2xx_t *dev)
-{
-    uint64_t addr;
-    uint8_t *ap = (uint8_t *)(&addr);
-
-    for (int i = 0; i < 8; i++) {
-        ap[i] = dev->netdev.long_addr[i];
-    }
-    return addr;
-}
-
-void at86rf2xx_set_addr_long(at86rf2xx_t *dev, uint64_t addr)
+void at86rf2xx_set_hwfilter_addr_long(at86rf2xx_t *dev, uint64_t addr)
 {
     for (int i = 0; i < 8; i++) {
-        dev->netdev.long_addr[i] = (uint8_t)(addr >> (i * 8));
         at86rf2xx_reg_write(dev, (AT86RF2XX_REG__IEEE_ADDR_0 + i),
                             (addr >> ((7 - i) * 8)));
     }
 }
 
-uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev)
-{
-    return dev->netdev.pan;
-}
-
-void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan)
+void at86rf2xx_set_hwfilter_pan(at86rf2xx_t *dev, uint16_t pan)
 {
     le_uint16_t le_pan = byteorder_btols(byteorder_htons(pan));
 

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -158,8 +158,6 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev, uint8_t chan, uint8_t page)
 #ifdef MODULE_AT86RF212B
     /* The TX power register must be updated after changing the channel if
      * moving between bands. */
-    int16_t txpower = at86rf2xx_get_txpower(dev);
-
     uint8_t trx_ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
     uint8_t rf_ctrl0 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RF_CTRL_0);
 
@@ -196,11 +194,6 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev, uint8_t chan, uint8_t page)
     /* Update the channel register */
     phy_cc_cca |= (chan & AT86RF2XX_PHY_CC_CCA_MASK__CHANNEL);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_CC_CCA, phy_cc_cca);
-
-#ifdef MODULE_AT86RF212B
-    /* Update the TX power register to achieve the same power (in dBm) */
-    at86rf2xx_set_txpower(dev, txpower);
-#endif
 
     /* Return to the state we had before reconfiguring */
     at86rf2xx_set_state(dev, prev_state);

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -149,10 +149,11 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
              && (dev->state != AT86RF2XX_STATE_P_ON));
 }
 
-void at86rf2xx_configure_phy(at86rf2xx_t *dev)
+void at86rf2xx_configure_phy(at86rf2xx_t *dev, uint8_t chan, uint8_t page)
 {
     /* we must be in TRX_OFF before changing the PHY configuration */
     uint8_t prev_state = at86rf2xx_set_state(dev, AT86RF2XX_STATE_TRX_OFF);
+    (void) page;
 
 #ifdef MODULE_AT86RF212B
     /* The TX power register must be updated after changing the channel if
@@ -167,17 +168,17 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev)
     /* Clear previous configuration for GC_TX_OFFS */
     rf_ctrl0 &= ~AT86RF2XX_RF_CTRL_0_MASK__GC_TX_OFFS;
 
-    if (dev->netdev.chan != 0) {
+    if (chan != 0) {
         /* Set sub mode bit on 915 MHz as recommended by the data sheet */
         trx_ctrl2 |= AT86RF2XX_TRX_CTRL_2_MASK__SUB_MODE;
     }
 
-    if (dev->page == 0) {
+    if (page == 0) {
         /* BPSK coding */
         /* Data sheet recommends using a +2 dB setting for BPSK */
         rf_ctrl0 |= AT86RF2XX_RF_CTRL_0_GC_TX_OFFS__2DB;
     }
-    else if (dev->page == 2) {
+    else if (page == 2) {
         /* O-QPSK coding */
         trx_ctrl2 |= AT86RF2XX_TRX_CTRL_2_MASK__BPSK_OQPSK;
         /* Data sheet recommends using a +1 dB setting for O-QPSK */
@@ -193,7 +194,7 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev)
     phy_cc_cca &= ~(AT86RF2XX_PHY_CC_CCA_MASK__CHANNEL);
 
     /* Update the channel register */
-    phy_cc_cca |= (dev->netdev.chan & AT86RF2XX_PHY_CC_CCA_MASK__CHANNEL);
+    phy_cc_cca |= (chan & AT86RF2XX_PHY_CC_CCA_MASK__CHANNEL);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_CC_CCA, phy_cc_cca);
 
 #ifdef MODULE_AT86RF212B

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -215,6 +215,9 @@ static void _reset(netdev_t *netdev)
     netdev->driver->set(netdev, NETOPT_ADDRESS, &short_addr,
             sizeof(uint16_t));
 
+    /* Initialize CSMA seed with hardware address */
+    at86rf2xx_set_csma_seed(dev, dev->netdev.long_addr);
+
     /* set default options */
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_AUTOACK, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -288,10 +288,8 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
     switch (opt) {
         case NETOPT_CHANNEL_PAGE:
             assert(max_len >= sizeof(uint16_t));
-#ifdef MODULE_AT86RF212B
             ((uint8_t *)val)[1] = 0;
-            ((uint8_t *)val)[0] = dev->netdev.page;
-#endif
+            ((uint8_t *)val)[0] = AT86RF2XX_SUBGHZ ? dev->netdev.page : 0;
             return sizeof(uint16_t);
 
         case NETOPT_STATE:

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -82,6 +82,8 @@ static int _init(netdev_t *netdev)
     /* reset device to default values and put it into RX state */
     at86rf2xx_reset(dev);
 
+    dev->netdev.txpower = AT86RF2XX_DEFAULT_TXPOWER;
+
     /* test if the SPI is set up correctly and the device is responding */
     if (at86rf2xx_reg_read(dev, AT86RF2XX_REG__PART_NUM) != AT86RF2XX_PARTNUM) {
         DEBUG("[at86rf2xx] error: unable to read correct part number\n");
@@ -250,6 +252,7 @@ static int _set_state(at86rf2xx_t *dev, netopt_state_t state)
             }
             break;
         case NETOPT_STATE_RESET:
+            dev->netdev.txpower = AT86RF2XX_DEFAULT_TXPOWER;
             at86rf2xx_reset(dev);
             break;
         default:
@@ -371,7 +374,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
     switch (opt) {
         case NETOPT_TX_POWER:
             assert(max_len >= sizeof(int16_t));
-            *((uint16_t *)val) = at86rf2xx_get_txpower(dev);
+            *((uint16_t *)val) = dev->netdev.txpower;
             res = sizeof(uint16_t);
             break;
 
@@ -484,6 +487,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
         case NETOPT_TX_POWER:
             assert(len <= sizeof(int16_t));
+            dev->netdev.txpower = *((const int16_t *)val);
             at86rf2xx_set_txpower(dev, *((const int16_t *)val));
             res = sizeof(uint16_t);
             break;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -278,6 +278,10 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     /* send data out directly if pre-loading id disabled */
     if (!(dev->flags & AT86RF2XX_OPT_PRELOADING)) {
         at86rf2xx_tx_exec(dev);
+        if (netdev->event_callback &&
+            (dev->flags & AT86RF2XX_OPT_TELL_TX_START)) {
+            netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
+        }
     }
     /* return the number of bytes that were actually loaded into the frame
      * buffer/send out */
@@ -381,6 +385,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _set_state(at86rf2xx_t *dev, netopt_state_t state)
 {
+    netdev_t *netdev = (netdev_t*) netdev;
     switch (state) {
         case NETOPT_STATE_STANDBY:
             at86rf2xx_set_state(dev, AT86RF2XX_STATE_TRX_OFF);
@@ -411,6 +416,10 @@ static int _set_state(at86rf2xx_t *dev, netopt_state_t state)
                 }
                 at86rf2xx_set_state(dev, AT86RF2XX_STATE_TX_ARET_ON);
                 at86rf2xx_tx_exec(dev);
+                if (netdev->event_callback &&
+                    (dev->flags & AT86RF2XX_OPT_TELL_TX_START)) {
+                    netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
+                }
             }
             break;
         case NETOPT_STATE_RESET:

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -289,7 +289,11 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
         case NETOPT_CHANNEL_PAGE:
             assert(max_len >= sizeof(uint16_t));
             ((uint8_t *)val)[1] = 0;
-            ((uint8_t *)val)[0] = at86rf2xx_get_page(dev);
+#ifdef MODULE_AT86RF212B
+            ((uint8_t *)val)[0] = dev->page;
+#else
+            ((uint8_t *)val)[0] = 0;
+#endif
             return sizeof(uint16_t);
 
         case NETOPT_STATE:
@@ -470,7 +474,11 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
                 res = -EINVAL;
                 break;
             }
-            at86rf2xx_set_chan(dev, chan);
+#if MODULE_AT86RF212B
+            at86rf2xx_configure_phy(dev, chan, dev->page);
+#else
+            at86rf2xx_configure_phy(dev, chan, 0);
+#endif
             /* don't set res to set netdev_ieee802154_t::chan */
             break;
 
@@ -482,7 +490,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
                 res = -EINVAL;
             }
             else {
-                at86rf2xx_set_page(dev, page);
+                at86rf2xx_configure_phy(dev, dev->netdev.chan, page);
                 res = sizeof(uint16_t);
             }
 #else

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -205,9 +205,15 @@ static void _reset(netdev_t *netdev)
     /* make sure we mark the address as non-multicast and not globally unique */
     addr_long.uint8[0] &= ~(0x01);
     addr_long.uint8[0] |=  (0x02);
+
     /* set short and long address */
-    at86rf2xx_set_addr_long(dev, ntohll(addr_long.uint64.u64));
-    at86rf2xx_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
+    uint64_t long_addr = ntohll(addr_long.uint64.u64);
+    uint16_t short_addr = ntohs(addr_long.uint16[0].u16);
+
+    netdev->driver->set(netdev, NETOPT_ADDRESS_LONG, &long_addr,
+            sizeof(uint64_t));
+    netdev->driver->set(netdev, NETOPT_ADDRESS, &short_addr,
+            sizeof(uint16_t));
 
     /* set default options */
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_AUTOACK, true);
@@ -601,17 +607,17 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(len <= sizeof(uint16_t));
-            at86rf2xx_set_addr_short(dev, *((const uint16_t *)val));
+            at86rf2xx_set_hwfilter_addr_short(dev, *((const uint16_t *)val));
             /* don't set res to set netdev_ieee802154_t::short_addr */
             break;
         case NETOPT_ADDRESS_LONG:
             assert(len <= sizeof(uint64_t));
-            at86rf2xx_set_addr_long(dev, *((const uint64_t *)val));
+            at86rf2xx_set_hwfilter_addr_long(dev, *((const uint64_t *)val));
             /* don't set res to set netdev_ieee802154_t::long_addr */
             break;
         case NETOPT_NID:
             assert(len <= sizeof(uint16_t));
-            at86rf2xx_set_pan(dev, *((const uint16_t *)val));
+            at86rf2xx_set_hwfilter_pan(dev, *((const uint16_t *)val));
             /* don't set res to set netdev_ieee802154_t::pan */
             break;
         case NETOPT_CHANNEL:

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -167,14 +167,6 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev);
  */
 void at86rf2xx_hardware_reset(at86rf2xx_t *dev);
 
-
-/**
- * @brief   Set PHY parameters based on channel and page number
- *
- * @param[in,out] dev   device to configure
- */
-void at86rf2xx_configure_phy(at86rf2xx_t *dev);
-
 #if defined(MODULE_AT86RF233) || defined(MODULE_AT86RF231) || defined(DOXYGEN)
 /**
  * @brief   Read random data from the RNG

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -59,10 +59,12 @@ extern "C" {
 #define AT86RF2XX_DEFAULT_CHANNEL       (IEEE802154_DEFAULT_SUBGHZ_CHANNEL)
 /* Page 2 is O-QPSK 100 kbit/s (channel 0), or 250 kbit/s (channels 1-10) */
 #define AT86RF2XX_DEFAULT_PAGE          (IEEE802154_DEFAULT_SUBGHZ_PAGE)
+#define AT86RF2XX_SUBGHZ                (1)
 #else
 #define AT86RF2XX_MIN_CHANNEL           (IEEE802154_CHANNEL_MIN)
 #define AT86RF2XX_MAX_CHANNEL           (IEEE802154_CHANNEL_MAX)
 #define AT86RF2XX_DEFAULT_CHANNEL       (IEEE802154_DEFAULT_CHANNEL)
+#define AT86RF2XX_SUBGHZ                (0)
 /* Only page 0 is supported in the 2.4 GHz band */
 #endif
 /** @} */
@@ -537,6 +539,35 @@ bool at86rf2xx_cca(at86rf2xx_t *dev);
  */
 void at86rf2xx_configure_phy(at86rf2xx_t *dev, uint8_t chan, uint8_t page);
 
+/**
+ * @brief   Check if a combination of channel and page is supported
+ *
+ * @param[in] dev           device to check
+ * @param[in] chan          channel number
+ * @param[in] page          channel page
+ *
+ * @return                  true if combination is supported
+ * @return                  false otherwise
+ */
+static inline bool at86rf2xx_phy_is_supported(at86rf2xx_t *dev, uint8_t chan,
+        uint8_t page) {
+    /* The following snippet is a workaround. At some point, this logic will
+     * be removed in order to support instances of different class of devices
+     * (e.g sub ghz and 2.4 ghz radio running simultaneosuly) */
+
+    (void) dev;
+    if(AT86RF2XX_SUBGHZ) {
+        if((page != 0 && page != 2) || chan >= 11) {
+            return false;
+        }
+    }
+    else {
+        if(page != 0 || chan < 11 || chan > 26) {
+            return false;
+        }
+    }
+    return true;
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -237,38 +237,20 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params);
 void at86rf2xx_reset(at86rf2xx_t *dev);
 
 /**
- * @brief   Get the short address of the given device
- *
- * @param[in] dev           device to read from
- *
- * @return                  the currently set (2-byte) short address
- */
-uint16_t at86rf2xx_get_addr_short(const at86rf2xx_t *dev);
-
-/**
  * @brief   Set the short address of the given device
  *
  * @param[in,out] dev       device to write to
  * @param[in] addr          (2-byte) short address to set
  */
-void at86rf2xx_set_addr_short(at86rf2xx_t *dev, uint16_t addr);
+void at86rf2xx_set_hwfilter_addr_short(at86rf2xx_t *dev, uint16_t addr);
 
 /**
- * @brief   Get the configured long address of the given device
- *
- * @param[in] dev           device to read from
- *
- * @return                  the currently set (8-byte) long address
- */
-uint64_t at86rf2xx_get_addr_long(const at86rf2xx_t *dev);
-
-/**
- * @brief   Set the long address of the given device
+ * @brief   Set the HW filter long address of the given device
  *
  * @param[in,out] dev       device to write to
  * @param[in] addr          (8-byte) long address to set
  */
-void at86rf2xx_set_addr_long(at86rf2xx_t *dev, uint64_t addr);
+void at86rf2xx_set_hwfilter_addr_long(at86rf2xx_t *dev, uint64_t addr);
 
 /**
  * @brief   Get the configured channel number of the given device
@@ -305,21 +287,12 @@ uint8_t at86rf2xx_get_page(const at86rf2xx_t *dev);
 void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page);
 
 /**
- * @brief   Get the configured PAN ID of the given device
- *
- * @param[in] dev           device to read from
- *
- * @return                  the currently set PAN ID
- */
-uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev);
-
-/**
  * @brief   Set the PAN ID of the given device
  *
  * @param[in,out] dev       device to write to
  * @param[in] pan           PAN ID to set
  */
-void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan);
+void at86rf2xx_set_hwfilter_pan(at86rf2xx_t *dev, uint16_t pan);
 
 /**
  * @brief   Get the configured transmission power of the given device [in dBm]

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -528,6 +528,16 @@ void at86rf2xx_tx_exec(const at86rf2xx_t *dev);
  */
 bool at86rf2xx_cca(at86rf2xx_t *dev);
 
+/**
+ * @brief   Set PHY parameters based on channel and page number
+ *
+ * @param[in] dev           device to configure
+ * @param[in] chan          channel number to set
+ * @param[in] page          channel page to set
+ */
+void at86rf2xx_configure_phy(at86rf2xx_t *dev, uint8_t chan, uint8_t page);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -112,6 +112,7 @@ typedef struct {
     uint8_t long_addr[IEEE802154_LONG_ADDRESS_LEN];
     uint8_t seq;                            /**< sequence number */
     uint8_t chan;                           /**< channel */
+    uint8_t page;                           /**< channel page */
     uint16_t flags;                         /**< flags as defined above */
     /** @} */
 } netdev_ieee802154_t;

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -114,6 +114,7 @@ typedef struct {
     uint8_t chan;                           /**< channel */
     uint8_t page;                           /**< channel page */
     uint16_t flags;                         /**< flags as defined above */
+    int16_t txpower;                        /**< tx power in dBm */
     /** @} */
 } netdev_ieee802154_t;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR is the first step of #11483 for moving the PHY and MAC logic out of drivers and define common layers for all transceivers.

The changes are:
- Remove `at86rf2xx_get_{pan, long_addr, short_addr}` and add `hwfilter` prefix to the setters. Usually devices are not aware of any kind of addresses (PAN ID, long address, short address) unless there device has hardware address filtering. In that case only setters for hardware address filters are needed (getters might be useful for testing though). In fact, most of this functions are replaced by netdev_ieee802154 stuff.
- Merge `at86rf2xx_set_channel` and `at86rf2xx_set_page` into `at86rf2xx_configure_phy`. In practice, the tuple `(channel_number, channel_page)` describes the PHY channel configuration, and these 2 numbers are not independent.
- Change API of power and rx sensitivity getters/setters: I noticed they always convert from dBm to and from the internal representation values. In practice, upper layers are only interested in the value in dBm. Thus, this logic is handled in the netdev abstraction and the device only sets/gets the internal value.
- Move TX start event to netdev.

With this change, the driver is mostly independent of `netdev`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `tests/drivers_at86rf2xx` and perform common operations (change addresses, send packets, etc).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
~~Depends on #11718~~
#11483 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
