### PR TITLE
netdev_ieee802154: add txpower and page

### DIFF
--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -112,6 +112,7 @@ typedef struct {
     uint8_t long_addr[IEEE802154_LONG_ADDRESS_LEN];
     uint8_t seq;                            /**< sequence number */
     uint8_t chan;                           /**< channel */
+    uint8_t page;                           /**< channel page */
     uint16_t flags;                         /**< flags as defined above */
     /** @} */
 } netdev_ieee802154_t;

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -114,6 +114,7 @@ typedef struct {
     uint8_t chan;                           /**< channel */
     uint8_t page;                           /**< channel page */
     uint16_t flags;                         /**< flags as defined above */
+    int16_t txpower;                        /**< tx power in dBm */
     /** @} */
 } netdev_ieee802154_t;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds `txpower` and `page` to the `netdev_ieee802154_t` struct, since it'ss currently holding most PHY and MAC values (PIB and MAC respectively).

This settings are not device specific. Thus, it's necessary to keep them in a common place.
Although 2.4 GHz doesn't allow to set page (a.k.a only page 0 is supported), it's still required to expose it to the upper layer.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Probably only `make doc` and static checks.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#11483 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
