### PR TITLE
cpu/efm32/periph_gpio: fix NUMOF_IRQS off-by-one error

### DIFF
--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Number of external interrupt lines.
  */
-#define NUMOF_IRQS         (GPIO_PIN_MAX)
+#define NUMOF_IRQS         (GPIO_PIN_MAX + 1)
 
 /**
  * @brief   Hold one interrupt context per interrupt line


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The value for NUMOF_IRQS seems wrong (eg 15 vs 16). I'm mostly sure this is the right fix, but honestly I didn't look too closely yet. Someone more familiar with this can probably make the right determination without any effort?

This does fix a problem I had where gpio interrupts weren't working on a particular pin (15) whereas all other pins (<15) worked. With a debugger attached I found it was stuck in the for loop in `gpio.c:gpio_irq()` unable to clear the interrupt for pin 15 due to stopping one iteration too soon.

I searched and I don't find any other places that make incorrect use of GPIO_PIN_MAX.

### Testing procedure
Try using a gpio interrupt (call `gpio_init_int()` and then assert the pin to trigger an interrupt) with pin 15 on any port. It should work with this PR. Without it, asserting the pin triggers a lockup as described above.