### PR TITLE
cpu/efm32/periph_gpio: fix wrong GPIO_IntDisable() in gpio_init_int()

### DIFF
--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -115,7 +115,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     }
 
     /* just in case, disable the interrupt for this pin */
-    GPIO_IntDisable(_pin_num(pin));
+    GPIO_IntDisable(_pin_mask(pin));
 
     /* store interrupt callback */
     isr_ctx[_pin_num(pin)].cb = cb;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`gpio_init_int()` initially disables interrupts for the pin it's called on, however there's an typo which causes wrong pins to be disabled. The call to `GPIO_IntDisable()` needs the pin mask instead of the pin number.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
without this PR:
<pre><code>/* this works */
gpio_init_int(GPIO_PIN(<b>PA, 0</b>), GPIO_IN_PD, GPIO_RISING, _button_callback, (void*)0); 

/* this works too, but now <b>PA_0</b> stopped working because this wrongly unsets GPIO->IEN.bit0 */
gpio_init_int(GPIO_PIN(<b>PA, 1</b>), GPIO_IN_PD, GPIO_RISING, _button_callback, (void*)1); 
</code></pre>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Not actually related is #11719 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
