### PR TITLE
sock_ip: fix documenation referring to UDP sock

### DIFF
--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -362,7 +362,7 @@ void sock_ip_close(sock_ip_t *sock);
 int sock_ip_get_local(sock_ip_t *sock, sock_ip_ep_t *ep);
 
 /**
- * @brief   Gets the remote end point of a UDP sock object
+ * @brief   Gets the remote end point of a raw IPv4/IPv6 sock object
  *
  * @pre `(sock != NULL) && (ep != NULL)`
  *
@@ -373,7 +373,7 @@ int sock_ip_get_local(sock_ip_t *sock, sock_ip_ep_t *ep);
  * implementation might choose to return the address on this interface the
  * @p sock is bound to in @p ep's sock_ip_ep_t::addr.
  *
- * @param[in] sock  A UDP sock object.
+ * @param[in] sock  A raw IPv4/IPv6 sock object.
  * @param[out] ep   The remote end point.
  *
  * @return  0 on success.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Should be self-explanatory: The documentation of `sock_ip_get_remote()` refers to the sock as "UDP" sock. This is obviously incorrect.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
