### PR TITLE
boards/same54-xpro: add riotboot support

### DIFF
--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -7,4 +7,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 include $(RIOTCPU)/samd5x/Makefile.features

--- a/cpu/samd5x/Makefile.include
+++ b/cpu/samd5x/Makefile.include
@@ -4,7 +4,7 @@ export CPU_FAM  = samd5x
 # Slot size is determined by "((total_flash_size - RIOTBOOT_LEN) / 2)".
 # If RIOTBOOT_LEN uses an uneven number of flashpages, the remainder of the
 # flash cannot be divided by two slots while staying FLASHPAGE_SIZE aligned.
-RIOTBOOT_LEN ?= 0x2000
+RIOTBOOT_LEN ?= 0x4000
 
 USEMODULE += pm_layered
 


### PR DESCRIPTION
### Contribution description

With #11655 applied, clock initialization should still work when called twice, so let's enable riotboot support.

The Flash Page Size is 8k on samd5x, so set `RIOTBOOT_LEN` to twice that to follow the bodge introduced by nrf52 and kinetis.
In a future PR, the flash page size should be taken into account when calculating slot offsets.

### Testing procedure

- Flash riotboot and check application is working:
```
$ make BOARD=same54-xpro -C tests/riotboot riotboot/flash term
> help
> curslotnr
```

- Flash an image on slot0:

```
$ make BOARD=same54-xpro -C tests/riotboot riotboot/flash-slot0 term
curslotnr # Should return slot 0
```

- Flash an image on slot1:

```
$ make BOARD=same54-xpro -C tests/riotboot riotboot/flash-slot1 term
> curslotnr  # Should return slot 1
```

### Issues/PRs references
 Depends on PR #11655
