### PR TITLE
usbus: simplify adding entry to list

### DIFF
--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -107,37 +107,24 @@ uint16_t usbus_add_interface(usbus_t *usbus, usbus_interface_t *iface)
      * usages. Furthermore, the O(1) append is not really necessary as this is
      * only used at init */
     uint16_t idx = 0;
-    usbus_interface_t *last = usbus->iface;
-
-    if (last) {
+    usbus_interface_t **last = &usbus->iface;
+    while (*last) {
+        last = &(*last)->next;
         idx++;
-        while (last->next) {
-            last = last->next;
-            idx++;
-        }
-        last->next = iface;
-    }
-    else {
-        usbus->iface = iface;
     }
     iface->idx = idx;
+    *last = iface;
     return idx;
 }
 
 void usbus_register_event_handler(usbus_t *usbus, usbus_handler_t *handler)
 {
     /* See note above for reasons against clist.h */
-    usbus_handler_t *last = usbus->handlers;
-
-    if (last) {
-        while (last->next) {
-            last = last->next;
-        }
-        last->next = handler;
+    usbus_handler_t **last = &usbus->handlers;
+    while (*last) {
+        last = &(*last)->next;
     }
-    else {
-        usbus->handlers = handler;
-    }
+    *last = handler;
 }
 
 usbus_endpoint_t *usbus_add_endpoint(usbus_t *usbus, usbus_interface_t *iface,


### PR DESCRIPTION
### Contribution description

This is a code simplification albeit that it will now use a pointer-pointer
(which some may claim to add complexity).
The advantage is that no initial if is needed. And it's my believe that
a compiler will make fairly optimized code for it, even with the pointer-pointer.

The original code is this
```
    usbus_handler_t *last = usbus->handlers;

    if (last) {
        while (last->next) {
            last = last->next;
        }
        last->next = handler;
    }
    else {
        usbus->handlers = handler;
    }
```

and the new code is this

```
    usbus_handler_t **last = &usbus->handlers;
    while (*last) {
        last = &(*last)->next;
    }
    *last = handler;
```

### Testing procedure

That particalur USB code is fairly new and only used in `cdc_ecm.c`. Are there
actual USB tests (besides running some examples)?

### Issues/PRs references

The code was recently added in #10916.