### PR TITLE
tests/riotboot_flashwrite: report 4.08 error if sequence is not in order

### DIFF
--- a/tests/riotboot_flashwrite/coap_handler.c
+++ b/tests/riotboot_flashwrite/coap_handler.c
@@ -51,13 +51,14 @@ ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *con
 
     if (offset == writer->offset) {
         riotboot_flashwrite_putbytes(writer, payload_start, payload_len, block1.more);
+
+        if (block1.more == 1) {
+            result = COAP_CODE_CONTINUE;
+        }
     }
     else {
         printf("_flashwrite_handler(): skipping invalid offset (data=%u, writer=%u)\n", (unsigned)offset, (unsigned)writer->offset);
-    }
-
-    if (block1.more == 1) {
-        result = COAP_CODE_CONTINUE;
+        result = COAP_CODE_REQUEST_ENTITY_INCOMPLETE;
     }
 
     if (!blockwise || !block1.more) {


### PR DESCRIPTION
Report an error if the offset does not match, instead of just continuing.

From [RFC7959](https://tools.ietf.org/html/rfc7959#section-2.5):

>    If not all previous blocks are available at the server at the time of processing the final block, the transfer fails and error code 4.08 (Request Entity Incomplete, Section 2.9.2) MUST be returned.  A server MAY also return a 4.08 error code for any (final or non-final) Block1 transfer that is not in sequence
