### PR TITLE
cpu/stm32/i2c: Fix error flag clearing in sr1

### DIFF
--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -360,9 +360,9 @@ static int _is_sr1_mask_set(I2C_TypeDef *i2c, uint32_t mask, uint8_t flags)
     uint16_t tick = TICK_TIMEOUT;
     while (tick--) {
         uint32_t sr1 = i2c->SR1;
-        i2c->SR1 &= ~ERROR_FLAG;
         if (sr1 & I2C_SR1_AF) {
             DEBUG("[i2c] is_sr1_mask_set: NACK received\n");
+            i2c->SR1 &= ~ERROR_FLAG;
             if (!(flags & I2C_NOSTOP)) {
                 _stop(i2c);
             }
@@ -370,10 +370,12 @@ static int _is_sr1_mask_set(I2C_TypeDef *i2c, uint32_t mask, uint8_t flags)
         }
         if ((sr1 & I2C_SR1_ARLO) || (sr1 & I2C_SR1_BERR)) {
             DEBUG("[i2c] is_sr1_mask_set: arb lost or bus ERROR_FLAG\n");
+            i2c->SR1 &= ~ERROR_FLAG;
             _stop(i2c);
             return -EAGAIN;
         }
         if (sr1 & mask) {
+            i2c->SR1 &= ~ERROR_FLAG;
             return 0;
         }
     }
@@ -381,6 +383,7 @@ static int _is_sr1_mask_set(I2C_TypeDef *i2c, uint32_t mask, uint8_t flags)
     * If timeout occurs this means a problem that must be handled on a higher
     * level.  A SWRST is recommended by the datasheet.
     */
+    i2c->SR1 &= ~ERROR_FLAG;
     _stop(i2c);
     return -ETIMEDOUT;
 }


### PR DESCRIPTION
### Contribution description
This commit fixes the clearing of a error condition after read.
This causes the incorrect errorcodes if the register is read
then an error occurs, then it is cleared.
By clearing only after the error is processed the bug is fixed.
This can be tested by reading a i2c slave that is not there.

Discovered by the HiL i2c tests.

### Testing procedure
- run `tests/periph_i2c` on any F1, F2, L1, and F4 without anything connected
- acquire the bus
- spam read register requests to get the `ENXIO` error

On master there will be occasional `ETIMEDOUT` errors due to the SR1 being read, then after being read but before getting cleared the AF error bit is set, then it gets cleared without ever being read into the buffer.  The definition of a volatile register :)

### Issues/PRs references

