### PR TITLE
boards/nucleo-l476rg: Add DMA support

### DIFF
--- a/boards/nucleo-l476rg/Makefile.features
+++ b/boards/nucleo-l476rg/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -91,6 +91,28 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX | USART3_TX */
+    { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
+    { .stream = 3 },    /* DMA1 Channel 4 - USART1_TX */
+    { .stream = 6 },    /* DMA1 Channel 7 - USART2_TX */
+};
+
+#define DMA_0_ISR  isr_dma1_channel2
+#define DMA_1_ISR  isr_dma1_channel3
+#define DMA_2_ISR  isr_dma1_channel4
+#define DMA_3_ISR  isr_dma1_channel7
+
+#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+
+/**
  * @name    Timer configuration
  * @{
  */
@@ -125,9 +147,9 @@ static const uart_conf_t uart_config[] = {
         .irqn       = USART2_IRQn,
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
-#ifdef UART_USE_DMA
-        .dma_stream = 6,
-        .dma_chan   = 4
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 3,
+        .dma_chan   = 2
 #endif
     },
     {
@@ -141,9 +163,9 @@ static const uart_conf_t uart_config[] = {
         .irqn       = USART3_IRQn,
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
-#ifdef UART_USE_DMA
-        .dma_stream = 5,
-        .dma_chan   = 4
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 0,
+        .dma_chan   = 2
 #endif
     },
     {
@@ -157,9 +179,9 @@ static const uart_conf_t uart_config[] = {
         .irqn       = USART1_IRQn,
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
-#ifdef UART_USE_DMA
-        .dma_stream = 4,
-        .dma_chan   = 4
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 2,
+        .dma_chan   = 2
 #endif
     }
 };
@@ -244,7 +266,13 @@ static const spi_conf_t spi_config[] = {
         .cs_pin   = GPIO_UNDEF,
         .af       = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 1,
+        .tx_dma_chan = 1,
+        .rx_dma   = 0,
+        .rx_dma_chan = 1,
+#endif
     }
 };
 


### PR DESCRIPTION
### Contribution description
This PR:
- Adds DMA stream configurations
- Fixes DMA configurations for UARTs
- Adds DMA configurations for SPI

### Testing procedure
1- To test DMA on UART0, you can run the DMA periph test:
```
BOARD=nucleo-l476rg make all flash test -C tests/periph_dma/
```
<details>
<summary>Expected result</summary>

```
Welcome to pyterm!
Type '/exit' to exit.
2019-06-21 09:48:18,589 - INFO # main(): This is RIOT! (Version: 2019.07-devel-754-ge92516-pr/boards/nucleo-l476rg_dma_config)
2019-06-21 09:48:18,590 - INFO # DMA is working
```
</details>


2- To test the rest of the UARTs while using DMA, you can run the UART test activating the DMA and checking that it sends:
```
BOARD=nucleo-l476rg USEMODULE=periph_dma make all flash term -C tests/periph_uart
```
<details>
<summary>Expected result</summary>

```
Welcome to pyterm!
Type '/exit' to exit.
2019-06-21 10:05:37,965 - INFO # UARD_DEV(0): test uart_poweron() and uart_poweroff()  ->  [OK]
2019-06-21 10:05:37,965 - INFO # 
2019-06-21 10:05:37,966 - INFO # UART INFO:
2019-06-21 10:05:37,967 - INFO # Available devices:               3
2019-06-21 10:05:37,968 - INFO # UART used for STDIO (the shell): UART_DEV(0)
2019-06-21 10:05:37,968 - INFO # 
> init 1 9600
2019-06-21 10:05:41,720 - INFO #  init 1 9600
2019-06-21 10:05:41,725 - INFO # Success: Initialized UART_DEV(1) at BAUD 9600
2019-06-21 10:05:41,979 - INFO # UARD_DEV(1): test uart_poweron() and uart_poweroff()  ->  [OK]
> send 1 riot
2019-06-21 10:05:44,964 - INFO #  send 1 riot
2019-06-21 10:05:44,965 - INFO # UART_DEV(1) TX: riot
>
```
</details>

3- To test the SPI while using DMA, run the SPI periph test activating DMA:
```
BOARD=nucleo-l476rg USEMODULE=periph_dma make all flash term -C tests/periph_spi/
```

<details>
<summary>Expected result</summary>

```
Welcome to pyterm!
Type '/exit' to exit.
init 0 0 0 0 4
2019-06-21 10:13:31,000 - INFO # init 0 0 0 0 4
2019-06-21 10:13:31,006 - INFO # SPI_DEV(0) initialized: mode: 0, clk: 0, cs_port: 0, cs_pin: 4
> send WITH_DMA
2019-06-21 10:13:33,780 - INFO #  send WITH_DMA
2019-06-21 10:13:33,781 - INFO # Sent bytes
2019-06-21 10:13:33,785 - INFO #    0    1    2    3    4    5    6    7 
2019-06-21 10:13:33,789 - INFO #   0x57 0x49 0x54 0x48 0x5f 0x44 0x4d 0x41
2019-06-21 10:13:33,792 - INFO #     W    I    T    H    _    D    M    A 
2019-06-21 10:13:33,793 - INFO # 
2019-06-21 10:13:33,794 - INFO # Received bytes
2019-06-21 10:13:33,798 - INFO #    0    1    2    3    4    5    6    7 
2019-06-21 10:13:33,801 - INFO #   0x57 0x49 0x54 0x48 0x5f 0x44 0x4d 0x41
2019-06-21 10:13:33,805 - INFO #     W    I    T    H    _    D    M    A 
2019-06-21 10:13:33,805 - INFO # 
```
</details>

### Issues/PRs references
None