### PR TITLE
tests/periph_pm: make usage more intuitive and move shell commands to sys/

### DIFF
--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -50,6 +50,14 @@ extern "C" {
 #endif
 
 /**
+ * @brief Power Management mode blocker typedef
+ */
+typedef union {
+    uint32_t val_u32;                   /**< power mode blockers u32 */
+    uint8_t val_u8[PM_NUM_MODES];       /**< power mode blockers u8 */
+} pm_blocker_t;
+
+/**
  * @brief   Block a power mode
  *
  * @param[in]   mode      power mode to block

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -34,14 +34,6 @@
 #endif
 
 /**
- * @brief Power Management mode typedef
- */
-typedef union {
-    uint32_t val_u32;
-    uint8_t val_u8[PM_NUM_MODES];
-} pm_blocker_t;
-
-/**
  * @brief Global variable for keeping track of blocked modes
  */
 volatile pm_blocker_t pm_blocker = { .val_u32 = PM_BLOCKER_INITIAL };

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -8,7 +8,7 @@ endif
 ifneq (,$(filter mci,$(USEMODULE)))
   SRC += sc_disk.c
 endif
-ifneq (,$(filter pm_layered,$(USEMODULE)))
+ifneq (,$(filter periph_pm,$(USEMODULE)))
   SRC += sc_pm.c
 endif
 ifneq (,$(filter ps,$(USEMODULE)))

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -8,6 +8,9 @@ endif
 ifneq (,$(filter mci,$(USEMODULE)))
   SRC += sc_disk.c
 endif
+ifneq (,$(filter pm_layered,$(USEMODULE)))
+  SRC += sc_pm.c
+endif
 ifneq (,$(filter ps,$(USEMODULE)))
   SRC += sc_ps.c
 endif

--- a/sys/shell/commands/sc_pm.c
+++ b/sys/shell/commands/sc_pm.c
@@ -13,49 +13,182 @@
  * @file
  * @brief       Shell command to interact with the PM subsystem
  *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Thomas Stilwell <stilwellt@openlabs.co>
  *
  * @}
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include "periph/pm.h"
+
+#ifdef MODULE_PM_LAYERED
 #include "pm_layered.h"
 
-/* TODO deduplicate this definition with the one in sys/pm_layered/pm.c */
-typedef union {
-    uint32_t val_u32;
-    uint8_t val_u8[PM_NUM_MODES];
-} pm_blocker_t;
-
 extern volatile pm_blocker_t pm_blocker; /* sys/pm_layered/pm.c */
+#endif /* MODULE_PM_LAYERED */
 
 static void _print_usage(void) {
-    printf("usage: pm show: display current blockers for each power mode\n");
+    puts("Usage:");
+#ifdef MODULE_PM_LAYERED
+    puts("\tpm show: display current blockers for each power mode");
+    puts("\tpm set <mode>: manually set power mode (lasts until WFI returns)");
+    puts("\tpm block <mode>: manually block power mode");
+    puts("\tpm unblock <mode>: manually unblock power mode");
+#endif /* MODULE_PM_LAYERED */
+    puts("\tpm off: call pm_off()");
 }
 
-int _pm(int argc, char **argv)
+#ifdef MODULE_PM_LAYERED
+static int check_mode(int argc, char **argv)
 {
-    if (argc != 2) {
-        _print_usage();
+    if (argc != 3) {
+        printf("Usage: %s %s <power mode>\n", argv[0], argv[1]);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int parse_mode(char *argv)
+{
+    uint8_t mode = atoi(argv);
+
+    if (mode >= PM_NUM_MODES) {
+        printf("Error: power mode not in range 0 - %d.\n", PM_NUM_MODES - 1);
+        return -1;
+    }
+
+    return mode;
+}
+
+static int cmd_block(char *arg)
+{
+    int mode = parse_mode(arg);
+    if (mode < 0) {
         return 1;
     }
 
-    if (strcmp(argv[1], "show")) {
-        _print_usage();
-        return 2;
+    printf("Blocking power mode %d.\n", mode);
+    fflush(stdout);
+
+    pm_block(mode);
+
+    return 0;
+}
+
+static int cmd_set(char *arg)
+{
+    int mode = parse_mode(arg);
+    if (mode < 0) {
+        return 1;
     }
 
+    printf("CPU is entering power mode %d.\n", mode);
+    puts("Now waiting for a wakeup event...");
+    fflush(stdout);
+
+    pm_set(mode);
+    /* execution stops here until anything (like shell input) wakes the CPU */
+
+    printf("CPU has returned from power mode %d.\n", mode);
+
+    return 0;
+}
+
+static int cmd_unblock(char *arg)
+{
+    int mode = parse_mode(arg);
+
+    if (mode < 0) {
+        return 1;
+    }
+
+    if (pm_blocker.val_u8[mode] == 0) {
+        printf("Mode %d is already unblocked.\n", mode);
+        return 1;
+    }
+
+    printf("Unblocking power mode %d.\n", mode);
+    fflush(stdout);
+
+    pm_unblock(mode);
+
+    return 0;
+}
+
+static int cmd_show(char *arg)
+{
+    (void)arg;
     uint8_t lowest_allowed_mode = 0;
 
     for (unsigned i = 0; i < PM_NUM_MODES; i++) {
         printf("mode %u blockers: %u \n", i, pm_blocker.val_u8[i]);
-        if (pm_blocker.val_u8[i] == 1) {
+        if (pm_blocker.val_u8[i]) {
             lowest_allowed_mode = i + 1;
         }
     }
 
-    printf("lowest allowed mode: %u\n", lowest_allowed_mode);
+    printf("Lowest allowed mode: %u\n", lowest_allowed_mode);
+    return 0;
+}
+#endif /* MODULE_PM_LAYERED */
+
+static int cmd_off(char *arg)
+{
+    (void)arg;
+
+    pm_off();
 
     return 0;
+}
+
+int _pm_handler(int argc, char **argv)
+{
+#ifdef MODULE_PM_LAYERED
+    if (!strcmp(argv[1], "show")) {
+        if (argc != 2) {
+            puts("usage: pm show: display current blockers for each power mode");
+            return 1;
+        }
+
+        return cmd_show(argv[1]);
+    }
+
+    if (!strcmp(argv[1], "block")) {
+        if (check_mode(argc, argv) != 0) {
+            return 1;
+        }
+
+        return cmd_block(argv[2]);
+    }
+
+    if (!strcmp(argv[1], "unblock")) {
+        if (check_mode(argc, argv) != 0) {
+            return 1;
+        }
+
+        return cmd_unblock(argv[2]);
+    }
+
+    if (!strcmp(argv[1], "set")) {
+        if (check_mode(argc, argv) != 0) {
+            return 1;
+        }
+
+        return cmd_set(argv[2]);
+    }
+#else
+    (void)argc;
+#endif /* MODULE_PM_LAYERED */
+
+    if (!strcmp(argv[1], "off")) {
+        return cmd_off(NULL);
+    }
+
+    _print_usage();
+    return 1;
 }

--- a/sys/shell/commands/sc_pm.c
+++ b/sys/shell/commands/sc_pm.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell command to interact with the PM subsystem
+ *
+ * @author      Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "pm_layered.h"
+
+/* TODO deduplicate this definition with the one in sys/pm_layered/pm.c */
+typedef union {
+    uint32_t val_u32;
+    uint8_t val_u8[PM_NUM_MODES];
+} pm_blocker_t;
+
+extern volatile pm_blocker_t pm_blocker; /* sys/pm_layered/pm.c */
+
+static void _print_usage(void) {
+    printf("usage: pm show: display current blockers for each power mode\n");
+}
+
+int _pm(int argc, char **argv)
+{
+    if (argc != 2) {
+        _print_usage();
+        return 1;
+    }
+
+    if (strcmp(argv[1], "show")) {
+        _print_usage();
+        return 2;
+    }
+
+    uint8_t lowest_allowed_mode = 0;
+
+    for (unsigned i = 0; i < PM_NUM_MODES; i++) {
+        printf("mode %u blockers: %u \n", i, pm_blocker.val_u8[i]);
+        if (pm_blocker.val_u8[i] == 1) {
+            lowest_allowed_mode = i + 1;
+        }
+    }
+
+    printf("lowest allowed mode: %u\n", lowest_allowed_mode);
+
+    return 0;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -34,8 +34,8 @@ extern int _id_handler(int argc, char **argv);
 extern int _heap_handler(int argc, char **argv);
 #endif
 
-#ifdef MODULE_PM_LAYERED
-extern int _pm(int argc, char **argv);
+#ifdef MODULE_PERIPH_PM
+extern int _pm_handler(int argc, char **argv);
 #endif
 
 #ifdef MODULE_PS
@@ -184,8 +184,8 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_HEAP_CMD
     {"heap", "Prints heap statistics.", _heap_handler},
 #endif
-#ifdef MODULE_PM_LAYERED
-    { "pm", "interact with layered PM subsystem", _pm },
+#ifdef MODULE_PERIPH_PM
+    { "pm", "interact with layered PM subsystem", _pm_handler },
 #endif
 #ifdef MODULE_PS
     {"ps", "Prints information about running threads.", _ps_handler},

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -34,6 +34,10 @@ extern int _id_handler(int argc, char **argv);
 extern int _heap_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_PM_LAYERED
+extern int _pm(int argc, char **argv);
+#endif
+
 #ifdef MODULE_PS
 extern int _ps_handler(int argc, char **argv);
 #endif
@@ -179,6 +183,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_HEAP_CMD
     {"heap", "Prints heap statistics.", _heap_handler},
+#endif
+#ifdef MODULE_PM_LAYERED
+    { "pm", "interact with layered PM subsystem", _pm },
 #endif
 #ifdef MODULE_PS
     {"ps", "Prints information about running threads.", _ps_handler},

--- a/tests/driver_sx127x/Makefile.ci
+++ b/tests/driver_sx127x/Makefile.ci
@@ -5,5 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-f042k6 \
+    nucleo-l031k6 \
     stm32f030f4-demo \
     #

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -7,6 +7,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    blackpill \
+    bluepill \
     calliope-mini \
     chronos \
     derfmega128 \

--- a/tests/lwip/Makefile.ci
+++ b/tests/lwip/Makefile.ci
@@ -11,6 +11,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-l031k6 \
     nucleo-l053r8 \
+    saml10-xpro \
+    saml11-xpro \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \

--- a/tests/periph_pm/Makefile
+++ b/tests/periph_pm/Makefile
@@ -8,5 +8,6 @@ FEATURES_OPTIONAL += periph_rtc
 FEATURES_OPTIONAL += periph_gpio_irq
 
 USEMODULE += shell
+USEMODULE += shell_commands
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -40,6 +40,15 @@
 #endif
 
 #ifdef MODULE_PM_LAYERED
+
+/* TODO deduplicate this definition with the one in sys/pm_layered/pm.c */
+typedef union {
+    uint32_t val_u32;
+    uint8_t val_u8[PM_NUM_MODES];
+} pm_blocker_t;
+
+extern volatile pm_blocker_t pm_blocker; /* sys/pm_layered/pm.c */
+
 static int check_mode(int argc, char **argv)
 {
     if (argc < 2) {
@@ -173,6 +182,11 @@ static int cmd_unblock(int argc, char **argv)
         return 1;
     }
 
+    if (pm_blocker.val_u8[mode] == 0) {
+        printf("Mode %d is already unblocked.\n", mode);
+        return 1;
+    }
+
     printf("Unblocking power mode %d.\n", mode);
     fflush(stdout);
 
@@ -192,6 +206,11 @@ static int cmd_unblock_rtc(int argc, char **argv)
     int duration = parse_duration(argv[2]);
 
     if (mode < 0 || duration < 0) {
+        return 1;
+    }
+
+    if (pm_blocker.val_u8[mode] == 0) {
+        printf("Mode %d is already unblocked.\n", mode);
         return 1;
     }
 

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -32,8 +32,10 @@
 #include "periph/rtc.h"
 #endif
 #include "pm_layered.h"
-extern int _pm(int argc, char **argv);
 #endif
+
+extern int _pm_handler(int argc, char **argv);
+
 #include "shell.h"
 
 #ifndef BTN0_INT_FLANK
@@ -42,18 +44,13 @@ extern int _pm(int argc, char **argv);
 
 #ifdef MODULE_PM_LAYERED
 
-/* TODO deduplicate this definition with the one in sys/pm_layered/pm.c */
-typedef union {
-    uint32_t val_u32;
-    uint8_t val_u8[PM_NUM_MODES];
-} pm_blocker_t;
-
 extern volatile pm_blocker_t pm_blocker; /* sys/pm_layered/pm.c */
 
-static int check_mode(int argc, char **argv)
+#ifdef MODULE_PERIPH_RTC
+static int check_mode_duration(int argc, char **argv)
 {
-    if (argc < 2) {
-        printf("Usage: %s <power mode>\n", argv[0]);
+    if (argc != 3) {
+        printf("Usage: %s <power mode> <duration (s)>\n", argv[0]);
         return -1;
     }
 
@@ -70,17 +67,6 @@ static int parse_mode(char *argv)
     }
 
     return mode;
-}
-
-#ifdef MODULE_PERIPH_RTC
-static int check_mode_duration(int argc, char **argv)
-{
-    if (argc != 3) {
-        printf("Usage: %s <power mode> <duration (s)>\n", argv[0]);
-        return -1;
-    }
-
-    return 0;
 }
 
 static int parse_duration(char *argv)
@@ -101,106 +87,7 @@ static void cb_rtc(void *arg)
 
     pm_block(level);
 }
-#endif /* MODULE_PERIPH_RTC */
-#endif /* MODULE_PM_LAYERED */
 
-static int cmd_off(int argc, char **argv)
-{
-    (void) argc;
-    (void) argv;
-
-    puts("CPU will turn off.");
-    fflush(stdout);
-
-    pm_off();
-
-    return 0;
-}
-
-static int cmd_reboot(int argc, char **argv)
-{
-    (void) argc;
-    (void) argv;
-
-    puts("CPU will reboot.");
-    fflush(stdout);
-
-    pm_reboot();
-
-    return 0;
-}
-
-#ifdef MODULE_PM_LAYERED
-static int cmd_block(int argc, char **argv)
-{
-    if (check_mode(argc, argv) != 0) {
-        return 1;
-    }
-
-    int mode = parse_mode(argv[1]);
-
-    if (mode < 0) {
-        return 1;
-    }
-
-    printf("Blocking power mode %d.\n", mode);
-    fflush(stdout);
-
-    pm_block(mode);
-
-    return 0;
-}
-
-static int cmd_set(int argc, char **argv)
-{
-    if (check_mode(argc, argv) != 0) {
-        return 1;
-    }
-
-    int mode = parse_mode(argv[1]);
-
-    if (mode < 0) {
-        return 1;
-    }
-
-    printf("CPU is entering power mode %d.\n", mode);
-    printf("Now waiting for a wakeup event...\n");
-    fflush(stdout);
-
-    pm_set(mode);
-    /* execution stops here until anything (like shell input) wakes the CPU */
-
-    printf("CPU has returned from power mode %d.\n", mode);
-
-    return 0;
-}
-
-static int cmd_unblock(int argc, char **argv)
-{
-    if (check_mode(argc, argv) != 0) {
-        return 1;
-    }
-
-    int mode = parse_mode(argv[1]);
-
-    if (mode < 0) {
-        return 1;
-    }
-
-    if (pm_blocker.val_u8[mode] == 0) {
-        printf("Mode %d is already unblocked.\n", mode);
-        return 1;
-    }
-
-    printf("Unblocking power mode %d.\n", mode);
-    fflush(stdout);
-
-    pm_unblock(mode);
-
-    return 0;
-}
-
-#ifdef MODULE_PERIPH_RTC
 static int cmd_unblock_rtc(int argc, char **argv)
 {
     if (check_mode_duration(argc, argv) != 0) {
@@ -248,15 +135,8 @@ static void btn_cb(void *ctx)
  * @brief   List of shell commands for this example.
  */
 static const shell_command_t shell_commands[] = {
-    { "off", "turn off", cmd_off },
-    { "reboot", "reboot", cmd_reboot },
-#ifdef MODULE_PM_LAYERED
-    { "block", "block power mode", cmd_block },
-    { "set", "set power mode", cmd_set },
-    { "unblock", "unblock power mode", cmd_unblock },
-#ifdef MODULE_PERIPH_RTC
-    { "unblock_rtc", "temporary unblock power mode", cmd_unblock_rtc },
-#endif
+#if defined MODULE_PM_LAYERED && defined MODULE_PERIPH_RTC
+    { "unblock_rtc", "temporarily unblock power mode", cmd_unblock_rtc },
 #endif
     { NULL, NULL, NULL }
 };
@@ -280,7 +160,7 @@ int main(void)
      * the state of PM blockers so that the user will know which power mode has
      * been entered and is presumably responsible for the unresponsive shell.
      */
-    _pm(2, (char *[]){"pm", "show"});
+    _pm_handler(2, (char *[]){"pm", "show"});
 
 #else
     puts("This application allows you to test the CPU power management.\n"

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -32,6 +32,7 @@
 #include "periph/rtc.h"
 #endif
 #include "pm_layered.h"
+extern int _pm(int argc, char **argv);
 #endif
 #include "shell.h"
 
@@ -270,6 +271,13 @@ int main(void)
            "save more power, but may require an event/interrupt to wake up\n"
            "the CPU. Reset the CPU if needed.\n",
            PM_NUM_MODES - 1);
+
+    /* In case the system boots into an unresponsive shell, at least display
+     * the state of PM blockers so that the user will know which power mode has
+     * been entered and is presumably responsible for the unresponsive shell.
+     */
+    _pm(2, (char *[]){"pm", "show"});
+
 #else
     puts("This application allows you to test the CPU power management.\n"
          "Layered support is not unavailable for this CPU. Reset the CPU if\n"

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -163,10 +163,14 @@ static int cmd_set(int argc, char **argv)
         return 1;
     }
 
-    printf("CPU will enter power mode %d.\n", mode);
+    printf("CPU is entering power mode %d.\n", mode);
+    printf("Now waiting for a wakeup event...\n");
     fflush(stdout);
 
     pm_set(mode);
+    /* execution stops here until anything (like shell input) wakes the CPU */
+
+    printf("CPU has returned from power mode %d.\n", mode);
 
     return 0;
 }


### PR DESCRIPTION
### Contribution description
Using tests/periph_pm can be unintuitive if you aren't already very familiar with the PM subsystem. I identified and addressed two specific causes and I think this greatly improves the situation.
1. there is no way to see which modes are currently blocked or unblocked
1. unblocking an already-unblocked mode triggers an assertion failure and kernel panic which can make the user/tester/developer think there's some serious problem when really there is no problem

This PR addresses 1) by adding a new command `pm show` to view blockers and 2) by adding a check to print a friendly error message when unblocking an unblocked mode.

### Testing procedure
```shell
> pm show
mode 0 blockers: 1 
mode 1 blockers: 0 
mode 2 blockers: 0 
mode 3 blockers: 0 
> unblock 2
Mode 2 is already unblocked.
1 >
```


### Issues/PRs references
I think some confusion earlier in #7897 can be avoided with these changes.

### Updates
1. Print current PM blockers on startup (execute `pm show`). In case we boot into an unresponsive shell, we at least get some direction for troubleshooting, as this tells us which power mode must have been entered.
1. Increased `pm_set()` verbosity. It may not be obvious to the user that running shell command `set %i` (which calls `pm_set(i)`) is *forcing* the CPU into the specified power mode, and that such manual forcing is not necessarily an orthodox thing to do. I tried to increase the verbosity somewhat so the process is clearer. Also, this verbosity provides an event (some printf output)  which indicates the moment when the CPU woke up, whereas previously we didn't know when it had woken up except by typing into the shell to check for a response. In some cases, the CPU might always wake immediately (or just sooner than expected) after `set %i`. This should reveal those cases.