### PR TITLE
sys/shell/prompt: display return value of command if it was nonzero

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -51,6 +51,8 @@ static void flush_if_needed(void)
 #endif
 }
 
+static int _last_exit_status;
+
 static shell_command_handler_t find_handler(const shell_command_t *command_list, char *command)
 {
     const shell_command_t *command_lists[] = {
@@ -212,14 +214,16 @@ static void handle_input_line(const shell_command_t *command_list, char *line)
     /* then we call the appropriate handler */
     shell_command_handler_t handler = find_handler(command_list, argv[0]);
     if (handler != NULL) {
-        handler(argc, argv);
+        _last_exit_status = handler(argc, argv);
     }
     else {
         if (strcmp("help", argv[0]) == 0) {
             print_help(command_list);
+            _last_exit_status = 0;
         }
         else {
             printf("shell: command not found: %s\n", argv[0]);
+            _last_exit_status = 1;
         }
     }
 }
@@ -279,8 +283,15 @@ static int readline(char *buf, size_t size)
 static inline void print_prompt(void)
 {
 #ifndef SHELL_NO_PROMPT
-    _putchar('>');
-    _putchar(' ');
+    if (_last_exit_status) {
+        /* error prompt */
+        printf("%i > ", _last_exit_status);
+    }
+    else {
+        /* normal prompt */
+        _putchar('>');
+        _putchar(' ');
+    }
 #endif
 
     flush_if_needed();


### PR DESCRIPTION
### Context
Currently the return value of shell commands is not used at all, but I've seen that many shell commands do return nonzero values in case of error. Sometimes it can be useful to know what value a command returned, or at least that the return was nonzero.

On Linux, we can `echo $?` if we need to see the return value of the last command we ran. Or we might have bash configured to automatically print the nonzero return value somewhere in the prompt so it's always there to see. On Riot, I think the latter approach works well.

### Contribution description

This PR modifies the shell prompt to display the return value of the last command in the event that the value was nonzero. I made it consistent with the way my bash prompt works (minus coloring the `>` yellow for a nonzero return, which I'd actually like to do to Riot too) but I'm open to feedback on changing the format. I just think it's useful to have the return value displayed one way or another.

A zero return value gives the normal prompt:
```shell
>
```
Whereas a nonzero return gives a prompt like this:
```shell
-7 >
```

### Testing procedure
I guess this shouldn't break anything. Try running all your usual commands with some incorrect parameters and you might enjoy seeing the return value now. Although probably commands will be found with incorrect return values and it is not within the scope of this PR to address those.

```shell
> ifconfif
shell: command not found: ifconfif
1 > date
2019-06-22 19:38:57.019073 PDT
RTC differs from system time by -0.000426 seconds
> nib
usage: nib {neigh|prefix|route|help} ...
> nib asdfasdf
usage: nib {neigh|prefix|route|help} ...
1 > ntpdate -g
2019-06-23 02:39:08 UTC (6485 us offset from system time)
> ntpdate -g # I disabled the border router to cause an error here
Error in synchronization
-2 > uptime
4812681.758026 seconds # I couldn't resist. This makes me proud and if you're reading this it should make you proud too
> 
```