### PR TITLE
boards/native: fix undefinied reference to qdecs_value

### DIFF
--- a/boards/native/drivers/native-qdec.c
+++ b/boards/native/drivers/native-qdec.c
@@ -20,6 +20,8 @@
 #include <board.h>
 #include <log.h>
 
+#ifdef MODULE_PERIPH_QDEC
+
 extern int32_t qdecs_value[QDEC_NUMOF];
 
 void native_motor_driver_qdec_simulation(
@@ -52,3 +54,5 @@ void native_motor_driver_qdec_simulation(
             motor_driver, motor_id);
     }
 }
+
+#endif /* MODULE_PERIPH_QDEC */

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -141,7 +141,7 @@ void native_motor_driver_qdec_simulation( \
     int32_t pwm_duty_cycle);
 
 /* C++ standard do not support designated initializers */
-#ifndef __cplusplus
+#if !(defined __cplusplus) && (defined MODULE_PERIPH_QDEC)
 
 /**
  * @name Describe DC motors with PWM channel and GPIOs


### PR DESCRIPTION
### Contribution description

`qdecs_value` is used by `boards.c` which is compiled unconditionally. Without this change the build may fail during linking because `qdecs_value` which is declared as `extern` in `boards.c` is not defined. Example error message:

```
/usr/bin/ld: /home/nmeum/RIOT/examples/hello-world/bin/native/board.a(board.o): in function `native_motor_driver_qdec_simulation':
/home/nmeum/RIOT/boards/native/board.c:39: undefined reference to `qdecs_value'
/usr/bin/ld: /home/nmeum/RIOT/boards/native/board.c:39: undefined reference to `qdecs_value'
collect2: error: ld returned 1 exit status
```

### Testing procedure

1. Confirm that `boards/native/board.c` is compiled unconditionally.
2. Confirm that `boards/native/board.c` declares `qdecs_value` as `extern`.
3. Confirm that the code declaring `qdecs_value` (`cpu/native/periph/qdec.c`) is compiled conditionally.

### Issues/PRs references

See also: https://github.com/RIOT-OS/RIOT/pull/11572#issuecomment-496405388