### PR TITLE
driver/at: add return code for CME/CMS errors

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -208,10 +208,10 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
                 return -1;
             }
             else if (strncmp(pos, "+CME ERROR:", 11) == 0) {
-                return -1;
+                return -2;
             }
             else if (strncmp(pos, "+CMS ERROR:", 11) == 0) {
-                return -1;
+                return -2;
             }
             else {
                 pos += res;

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -183,8 +183,9 @@ ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command, char *resp_buf,
  * This function sends the supplied @p command, then returns all response
  * lines until the device sends "OK".
  *
- * If a line starts with "ERROR" or "+CME ERROR:", or the buffer is full, the
- * function returns -1.
+ * If a line starts with "ERROR" or the buffer is full, the function returns -1.
+ * If a line starts with "+CME ERROR" or +CMS ERROR", the function returns -2.
+ * In this case resp_buf contains the error string.
  *
  * @param[in]   dev         device to operate on
  * @param[in]   command     command to send
@@ -194,7 +195,8 @@ ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command, char *resp_buf,
  * @param[in]   timeout     timeout (in usec)
  *
  * @returns     length of response on success
- * @returns     <0 on error
+ * @returns     -1 on error
+ * @returns     -2 on CMS or CME error
  */
 ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command, char *resp_buf,
                               size_t len, bool keep_eol, uint32_t timeout);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
in case of CME or CMS errors, the error codes or human readable strings are in the response buffer. We want to indicate to the AT driver user that when this case occurs so he can extract the error codes.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Call `at_send_cmd_get_lines`, check response buffer for errors in case return code is -2.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
