### PR TITLE
boards/mbed_lpc1768: fix file format documentation in flash

### DIFF
--- a/boards/mbed_lpc1768/dist/flash.sh
+++ b/boards/mbed_lpc1768/dist/flash.sh
@@ -58,7 +58,7 @@ fi
 rm -f ${MOUNT}/*.bin
 # copy new binary to device
 cp ${BINFILE} ${MOUNT}
-# make sure hexfile was written
+# make sure binary was written
 sync
 
 # unmount the device if we have manually mounted it before


### PR DESCRIPTION
### Contribution description

The board is flashing using a binary file and not a 'hex' file.
I did not update the documentation when renaming the variable.

The comment was copied from the other boards using 'fscopy' and a
hexfile.


This was found by https://github.com/RIOT-OS/RIOT/pull/11710#pullrequestreview-253268559

### Testing procedure

The file used for flashing is the binary file.

```
BOARD=mbed_lpc1768 make --no-print-directory -C examples/hello-world/ info-debug-variable-FFLAGS
/home/harter/work/git/RIOT/examples/hello-world/bin/mbed_lpc1768/hello-world.bin
```

### Issues/PRs references

* Found in https://github.com/RIOT-OS/RIOT/pull/11710#pullrequestreview-253268559
* https://github.com/RIOT-OS/RIOT/commit/8b2ff285beaed5b294fb8e5a4b033f00f51cb35b
