### PR TITLE
sys/ubjson: deprecate module.

### DIFF
--- a/sys/include/ubjson.h
+++ b/sys/include/ubjson.h
@@ -187,14 +187,15 @@ typedef enum {
     UBJSON_SIZE_ERROR,        /**< the length of a field exceeded SSIZE_MAX */
 } ubjson_read_callback_result_t;
 
-struct ubjson_cookie;
+struct __attribute__ ((deprecated("The UBJSON module will be removed in release 2020.01"))) ubjson_cookie;
 
 /**
  * @brief         A cookie passed between the read and write functions.
  * @details       You probably want to wrap the cookie in some other data structure,
  *                which you retrieve with container_of() in the callback.
  */
-typedef struct ubjson_cookie ubjson_cookie_t;
+typedef struct ubjson_cookie ubjson_cookie_t
+__attribute__ ((deprecated("The UBJSON module will be removed in release 2020.01")));
 
 /**
  * @brief         Method called by ubjson_read() to get more data.

--- a/sys/include/ubjson.h
+++ b/sys/include/ubjson.h
@@ -20,12 +20,16 @@
  * @defgroup sys_ubjson  Universal Binary JSON library
  * @ingroup  sys_serialization
  * @brief    Provides a library to read and write UBJSON serialized data
+ *
+ * @deprecated  This module is deprecated and will be removed in release 2020.01.
  * @{
  *
  * @file
  * @brief       Headers for the UBJSON module
  *
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
+ *
+ * @deprecated  This module is deprecated and will be removed in release 2020.01.
  */
 
 #ifndef UBJSON_H
@@ -289,6 +293,10 @@ ubjson_read_callback_result_t ubjson_read_next(ubjson_cookie_t *__restrict cooki
  *
  *                You probably want to wrap the cookie in some other data structure,
  *                which you retrieve with container_of() in the callback.
+ *
+ * @deprecated    This function and its containing module are deprecated and
+ *                will be removed in release 2020.01.
+ *
  * @param[in]     cookie     The cookie that is passed to the callback function.
  * @param[in]     read       The function that is called to receive more data.
  * @param[in]     callback   The callback function.
@@ -434,6 +442,10 @@ ubjson_read_callback_result_t ubjson_read_object(ubjson_cookie_t *__restrict coo
  *                The programmer needs to ensure that the API is used correctly.
  *                The library won't complain if you write multiple values that are not
  *                inside an array or object. The result will just not be properly serialized.
+ *
+ * @deprecated    This function and its containing module are deprecated and
+ *                will be removed in release 2020.01
+ *
  * @param[out]    cookie     The cookie that will be passed to ubjson_write_null() and friends.
  * @param[in]     write_fun  The function that will be called to write data.
  */

--- a/tests/unittests/tests-ubjson/Makefile.include
+++ b/tests/unittests/tests-ubjson/Makefile.include
@@ -1,2 +1,4 @@
 USEMODULE += ubjson
 USEMODULE += pipe
+
+CFLAGS += -Wno-error=deprecated-declarations


### PR DESCRIPTION
### Contribution description

_This is an API change, needs 2 approvals._

As expressed in PR #11724, the UBJSON module has issues which are not easy or worth fixing.

Before removing the module, it should be marked as deprecated to give users time to either migrate to another library, or copy the code to their own private repo.

The deprecation warning has been supressed from the unit tests. This has the ugly side-effect of suppressing deprecation warnings in other unit tests too, but that should not last long - only until the module is finally deleted.

### Testing procedure

Compile the ubjson tests and see the warnings:

```
make -C  tests/unittests/tests-ubjson
```

### Issues/PRs references

Required by #11724 .
