### PR TITLE
boards/openmote-b/doc: Add doc.txt to openmote-b

### DIFF
--- a/boards/openmote-b/doc.txt
+++ b/boards/openmote-b/doc.txt
@@ -1,0 +1,59 @@
+/**
+@defgroup    boards_openmote-b OpenMote-b
+@ingroup     boards
+@brief       Support for the OpenMote-b board
+
+## Overview
+
+The [OpenMote](http://www.openmote.com/) is slim board that comes with a TI
+SoC combining an ARM Cortex-M3 microcontroller with an IEEE802.15.4 radio.
+
+## Hardware
+| MCU        | CC2538SF53        |
+|:------------- |:--------------------- |
+| Family | ARM Cortex-M3     |
+| Vendor | Texas Instruments |
+| RAM        | 32Kb  |
+| Flash      | 512Kb             |
+| Frequency  | 32MHz |
+| FPU        | no                |
+| Timers | 4 |
+| ADCs       | 1x 12-bit (8 channels)        |
+| UARTs      | 2                 |
+| SPIs       | 2                 |
+| I2Cs       | 1                 |
+| Vcc        | 2V - 3.6V         |
+| Datasheet  | [Datasheet](http://www.ti.com/lit/gpn/cc2538) (pdf file) |
+| Reference Manual | [Reference Manual](http://www.ti.com/lit/pdf/swru319) |
+
+##  Flashing and Debugging
+
+Currently RIOT supports flashing the OpenMote using a Segger JLink JTAG
+adapter or via USB, using the bootloader on the board.
+
+### Flashing via USB
+
+RIOT support flashing with USB by default.
+
+`make flash`
+
+You may have to specify the flashing port with
+`PORT_BSL=<my_openmote_port> make flash`
+
+@note       On some boards the MSP430 chip responsible for controlling
+the bootloading pins may not be functioning.  If you are only able to flash
+when there is no image (either the first time after purchase or after erasing
+with the jtag).  Please contact the manufacturer to provide a fix.
+
+### Flashing via JTAG
+
+To be able to flash the board via JTAG you need to install Seggers JLinkExe
+tool. Once you have this in place, you can simply flash by calling
+
+`PROGRAMMER=jlink make flash`
+
+from your application folder.
+
+Mac OS users may experiment a command line expecting `connect`. Just type it
+and the process will continue.
+ */

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_openmote-b OpenMote-B
- * @ingroup     boards
- * @brief       Support for the OpenMote-B board
+ * @ingroup     boards_openmote-b
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description

It seems the doc was not added during the port.
This adds documentation similar to the openmote-cc2538.
This also expands on some flashing issues that have occurred.

### Testing procedure

`make doc` and read to see if it makes sense.

### Issues/PRs references
I don't know if it should close #11684