### PR TITLE
murdock: introduce 'TEST_ON_CI_BLACKLIST'

### DIFF
--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -25,12 +25,19 @@ test-murdock:
 # Testing is enabled if all the following conditions are met:
 #
 #  * the board is whitelisted
+#  * the board is not blacklisted (by default none)
 #  * the board has enough memory and the executable is being linked
 #
-# TEST_ON_CI_WHITELIST can be empty, a board list or 'all'
+# TEST_ON_CI_WHITELIST and TEST_ON_CI_BLACKLIST can be empty, a board list or 'all'
+#
+# Prefer blacklisting boards that fail to whitelisting the ones that work.
+# It will help tracking what is failing.
+#
+# Disabling a test in some case must be justified to keep track of the reason.
 
 TEST_ON_CI_WHITELIST ?=
-TEST_ON_BOARD_ENABLED ?= $(filter $(TEST_ON_CI_WHITELIST:all=%),$(BOARD))
+TEST_ON_CI_BLACKLIST ?=
+TEST_ON_BOARD_ENABLED ?= $(filter-out $(TEST_ON_CI_BLACKLIST:all=%),$(filter $(TEST_ON_CI_WHITELIST:all=%),$(BOARD)))
 
 TEST_ON_CI_ENABLED ?= $(if $(RIOTNOLINK),,$(TEST_ON_BOARD_ENABLED))
 

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -3,7 +3,8 @@ include ../Makefile.tests_common
 USEMODULE += fmt
 USEMODULE += xtimer
 
+TEST_ON_CI_WHITELIST += all
 # This test randomly fails on `native` so disable it from CI
-TEST_ON_CI_WHITELIST += samr21-xpro
+TEST_ON_CI_BLACKLIST += native
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -2,8 +2,9 @@ include ../Makefile.tests_common
 
 USEMODULE += xtimer
 
+TEST_ON_CI_WHITELIST += all
 # This test randomly fails on `native` so disable it from CI
-TEST_ON_CI_WHITELIST += samr21-xpro
+TEST_ON_CI_BLACKLIST += native
 
 # This application uses getchar and thus expects input from stdio
 USEMODULE += stdin


### PR DESCRIPTION
### Contribution description

Introduce a variable to set that a test is blacklisted.

This is a move toward enabling tests by default and adding a blacklisting
reason instead for a board instead of not whitelisting them which hides
the problem.

Currently, a test should be both whitelisted and blacklisted at the same
time to have a meaning. It is planned to whitelist all by default in
an upcoming pull request.

### Testing procedure

#### TEST_ON_CI_BLACKLIST behaves properly

The `tests/xtimer_now64_continuity` and `tests/xtimer_usleep` must correctly run by murdock on `samr21-xpro` and `nrf52dk`, and not `native`.

https://ci.riot-os.org/RIOT-OS/RIOT/11743/bdd721fff476ae8ffe11b6240e7d0e0a6070999f/output/run_test/tests/xtimer_now64_continuity/nrf52dk:gnu.txt

And it is indeed not executed in `native` (it is in the compiler output for `native`).

https://ci.riot-os.org/RIOT-OS/RIOT/11743/bdd721fff476ae8ffe11b6240e7d0e0a6070999f/output/compile/tests/xtimer_now64_continuity/native:gnu.txt

It creates the `.test` file and `test-on-ci-enabled` has expected return value

```
export BOARD=native; RIOT_CI_BUILD=1 make -C tests/xtimer_usleep 2>/dev/null >/dev/null ; make --no-print-directory test-on-ci-enabled -C
 $_; ls $_/bin/${BOARD}/.test
/home/harter/work/git/RIOT/makefiles/murdock.inc.mk:46: recipe for target 'test-on-ci-enabled' failed
make: *** [test-on-ci-enabled] Error 1
ls: cannot access 'tests/xtimer_usleep/bin/native/.test': No such file or directory
export BOARD=samr21-xpro; RIOT_CI_BUILD=1 make -C tests/xtimer_usleep 2>/dev/null >/dev/null ; make --no-print-directory test-on-ci-enabl
ed -C $_; ls $_/bin/${BOARD}/.test
tests/xtimer_usleep/bin/samr21-xpro/.test
export BOARD=nrf52dk; RIOT_CI_BUILD=1 make -C tests/xtimer_usleep 2>/dev/null >/dev/null ; make --no-print-directory test-on-ci-enabled -
C $_; ls $_/bin/${BOARD}/.test
tests/xtimer_usleep/bin/nrf52dk/.test
```

#### Previous behavior is preserved

Tests with `TEST_ON_CI_WHITELIST += all` still create the `.test` file and `test-on-ci-enabled` has expected return value

``` bash
export BOARD=native; RIOT_CI_BUILD=1 make -C tests/bloom_bytes/ 2>/dev/null >/dev/null ; make --no-print-directory test-on-ci-enabled -C $_; ls $_/bin/${BOARD}/.test
tests/bloom_bytes//bin/native/.test
export BOARD=samr21-xpro; RIOT_CI_BUILD=1 make -C tests/bloom_bytes/ 2>/dev/null >/dev/null ; make --no-print-directory test-on-ci-enabled -C $_; ls $_/bin/${BOARD}/.test
tests/bloom_bytes//bin/samr21-xpro/.test
```

With `TEST_ON_CI_WHITELIST = native` only native does it

``` bash
export BOARD=native; RIOT_CI_BUILD=1 make -C tests/libfixmath_unittests/ 2>/dev/null >/dev/null ; make --no-print-directory test-on-ci-enabled -C $_; ls $_/bin/${BOARD}/.test
tests/libfixmath_unittests//bin/native/.test
export BOARD=samr21-xpro; RIOT_CI_BUILD=1 make -C tests/libfixmath_unittests/ 2>/dev/null >/dev/null ; make --no-print-directory test-on-ci-enabled -C $_; ls $_/bin/${BOARD}/.test
/home/harter/work/git/RIOT/makefiles/murdock.inc.mk:46: recipe for target 'test-on-ci-enabled' failed
make: *** [test-on-ci-enabled] Error 1
ls: cannot access 'tests/libfixmath_unittests//bin/samr21-xpro/.test': No such file or directory
```

If empty, tests are disabled

``` bash
export BOARD=native; RIOT_CI_BUILD=1 make -C examples/hello-world/ 2>/dev/null >/dev/null ; make --no-print-directory test-on-ci-enabled -C $_; ls $_/bin/${BOARD}/.test
/home/harter/work/git/RIOT/makefiles/murdock.inc.mk:46: recipe for target 'test-on-ci-enabled' failed
make: *** [test-on-ci-enabled] Error 1
ls: cannot access 'examples/hello-world//bin/native/.test': No such file or directory
```

### Issues/PRs references

* Split out ouf: makefiles/murdock.inc.mk: change policy to run tests by default #11680
* Asked in https://github.com/RIOT-OS/RIOT/pull/11687
