### PR TITLE
boards: Initial support for board HiFive1B

### DIFF
--- a/boards/hifive1/Makefile.include
+++ b/boards/hifive1/Makefile.include
@@ -1,6 +1,6 @@
 # define the cpu used by the HiFive1 board
 export CPU = fe310
-export CPU_MODEL = fe310
+export CPU_MODEL = fe310_g000
 
 # Uses UART0 for stdio input/output (comment out to disable)
 USEMODULE += stdio_uart

--- a/boards/hifive1/board.c
+++ b/boards/hifive1/board.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     boards_hifive
+ * @ingroup     boards_hifive1
  * @{
  *
  * @file

--- a/boards/hifive1/include/board.h
+++ b/boards/hifive1/include/board.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    boards_hifive SiFive HiFive1 RISC-V board
+ * @defgroup    boards_hifive1 SiFive HiFive1 RISC-V board
  * @ingroup     boards
  * @brief       Support for the SiFive HiFive1 RISC-V board
  * @{

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     boards_hifive
+ * @ingroup     boards_hifive1
  * @{
  *
  * @file

--- a/boards/hifive1b/Makefile
+++ b/boards/hifive1b/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/hifive1b/Makefile.dep
+++ b/boards/hifive1b/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/fe310/Makefile.dep

--- a/boards/hifive1b/Makefile.features
+++ b/boards/hifive1b/Makefile.features
@@ -8,7 +8,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = risc_v
-
 include $(RIOTCPU)/fe310/Makefile.features

--- a/boards/hifive1b/Makefile.features
+++ b/boards/hifive1b/Makefile.features
@@ -1,0 +1,14 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+#FEATURES_PROVIDED += periph_i2c
+#FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+#FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = risc_v
+
+include $(RIOTCPU)/fe310/Makefile.features

--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -1,0 +1,20 @@
+# define the cpu used by the HiFive1 board
+export CPU = fe310
+export CPU_MODEL = fe310_g002
+
+# Uses UART0 for stdio input/output (comment out to disable)
+USEMODULE += stdio_uart
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyUSB1
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# setup JLink for flashing
+# export JLINK := JLink
+export JLINK_DEVICE := FE310
+export JLINK_IF := JTAG
+export FLASH_ADDR := 0x20010000
+include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/hifive1b/board.c
+++ b/boards/hifive1b/board.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2017, 2019 Ken Rabold, JP Bonn
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_hifive1b
+ * @{
+ *
+ * @file
+ * @brief       Support for the SiFive HiFive1b RISC-V board
+ *
+ * @author      Ken Rabold, JP Bonn
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <errno.h>
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+#include "vendor/encoding.h"
+#include "vendor/platform.h"
+#include "vendor/prci_driver.h"
+
+/*
+ * Configure the memory mapped flash for faster throughput
+ * to minimize interrupt latency on an I-Cache miss and refill
+ * from flash.  Alternatively (and faster) the interrupt
+ * routine could be put in SRAM.
+
+ * The flash chip on the HiFive1b is the ISSI 25LP03D
+ * http://www.issi.com/WW/pdf/25LP-WP032D.pdf
+ * The maximum frequency it can run at is 115MHz in
+ * "Fast Read Dual I/O" mode.
+ * #define MAX_FLASH_FREQ 115000000
+ *
+ * FYI - Like the FE310-G000, the G002 has problems with reading flash
+ * faster than 50MHz
+ */
+#define MAX_FLASH_FREQ 50000000
+
+/*
+ * CPU max is 320MHz+ according to datasheet but
+ * the relationship between cpu clock and spi clock is determined
+ * by SCKDIV.  Given we're trying to achieve maximum I-cache refill
+ * for the flash we let MAX_FLASH_FREQ dictate the CPU clock.
+ */
+#define CPU_DESIRED_FREQ 320000000
+
+/*
+ * The relationship between the input clock and SCK is given
+ * by the following formula (Fin is processor/tile-link clock):
+ *    Fsck = Fin/(2(div + 1))
+ */
+#define SCKDIV ((CPU_DESIRED_FREQ - 1) / (MAX_FLASH_FREQ * 2))
+
+/* This should work for any reasonable cpu clock value. */
+#define SCKDIV_SAFE 3
+
+/*
+ * By default the SPI FFMT initialized as:
+ * 	cmd_en = 1
+ * 	addr_len = 3
+ * 	cmd_code = 3
+ * 	all other fields = 0
+ */
+
+void board_init_clock(void)
+{
+     /* In case we are executing from QSPI, (which is quite likely) we need to
+      * set the QSPI clock divider appropriately before boosting the clock
+      * frequency. PRCI_set_hfrosctrim_for_f_cpu() tries multiple clocks
+      * so choose a safe value that should work for all frequencies.
+      */
+    SPI0_REG(SPI_REG_SCKDIV) = SCKDIV_SAFE;
+
+     /* Note: The range is limited to ~100MHz and depends on PLL settings */
+    PRCI_set_hfrosctrim_for_f_cpu(CPU_DESIRED_FREQ, PRCI_FREQ_UNDERSHOOT);
+
+    /* begin{code-style-ignore} */
+    SPI0_REG(SPI_REG_FFMT) =               /* setup "Fast Read Dual I/O"                             */
+        SPI_INSN_CMD_EN         |          /* Enable memory-mapped flash                    */
+        SPI_INSN_ADDR_LEN(3)    |          /* 25LP03D read commands have 3 address bytes    */
+        SPI_INSN_PAD_CNT(4)     |          /* 25LP03D Table 6.11 Read Dummy Cycles = 4      */
+        SPI_INSN_CMD_PROTO(SPI_PROTO_S) |  /* 25LP03D Table 8.1 "Instruction                */
+        SPI_INSN_ADDR_PROTO(SPI_PROTO_D) | /*  Set" shows mode for cmd, addr, and           */
+        SPI_INSN_DATA_PROTO(SPI_PROTO_D) | /*  data protocol for given instruction          */
+        SPI_INSN_CMD_CODE(0xBB) |          /* Set the instruction to "Fast Read Dual I/O"   */
+        SPI_INSN_PAD_CODE(0x00);           /* Dummy cycle sends 0 value bits                */
+    /* end{code-style-ignore} */
+
+    SPI0_REG(SPI_REG_SCKDIV) = SCKDIV;
+}
+
+__attribute__ ((section (".ramfunc")))
+void board_init_flash(void)
+{
+	/* Update the QSPI interface to adjust to the CPU speed
+	 * This function needs to execute from the RAM
+	 * when the QSPI interface is being reconfigured because the flash
+	 * can't be accessed during this time
+	 */
+
+	/* Disable SPI flash mode */
+	SPI0_REG(SPI_REG_FCTRL) &= ~SPI_FCTRL_EN;
+
+	/* Enable QPI mode by sending command to flash */
+    SPI0_REG(SPI_REG_TXFIFO) = 0x35;
+
+    /* begin{code-style-ignore} */
+    SPI0_REG(SPI_REG_FFMT) =               /* setup "Fast Read Quad I/O (QPI mode)"         */
+        SPI_INSN_CMD_EN         |          /* Enable memory-mapped flash                    */
+        SPI_INSN_ADDR_LEN(3)    |          /* 25LP03D read commands have 3 address bytes    */
+        SPI_INSN_PAD_CNT(6)     |          /* 25LP03D Table 6.11 Read Dummy Cycles = 6      */
+        SPI_INSN_CMD_PROTO(SPI_PROTO_Q) |  /* 25LP03D Table 8.1 "Instruction                */
+        SPI_INSN_ADDR_PROTO(SPI_PROTO_Q) | /*  Set" shows mode for cmd, addr, and           */
+        SPI_INSN_DATA_PROTO(SPI_PROTO_Q) | /*  data protocol for given instruction          */
+        SPI_INSN_CMD_CODE(0xEB) |          /* Set the instruction to "Fast Read Quad I/O"   */
+        SPI_INSN_PAD_CODE(0x00);           /* Dummy cycle sends 0 value bits                */
+    /* end{code-style-ignore} */
+
+	/* Re-enable SPI flash mode */
+	SPI0_REG(SPI_REG_FCTRL) |= SPI_FCTRL_EN;
+
+	/* Adjust the SPI clk divider for to boost flash speed */
+  //  SPI0_REG(SPI_REG_SCKDIV) = SCKDIV;
+}
+
+void board_init(void)
+{
+    /* Initialize CPU and clocks */
+    cpu_init();
+    board_init_clock();
+  //  board_init_flash();
+
+    /* Configure pin muxing for UART0 */
+    GPIO_REG(GPIO_OUTPUT_VAL) |= IOF0_UART0_MASK;
+    GPIO_REG(GPIO_OUTPUT_EN) |= IOF0_UART0_MASK;
+    GPIO_REG(GPIO_IOF_SEL) &= ~IOF0_UART0_MASK;
+    GPIO_REG(GPIO_IOF_EN) |= IOF0_UART0_MASK;
+
+    /* Configure GPIOs for LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
+
+    /* Turn all the LEDs off */
+    LED0_OFF;
+    LED1_OFF;
+    LED2_OFF;
+
+    /* Initialize newlib-nano library stubs */
+    nanostubs_init();
+}

--- a/boards/hifive1b/board.c
+++ b/boards/hifive1b/board.c
@@ -65,10 +65,10 @@
 
 /*
  * By default the SPI FFMT initialized as:
- * 	cmd_en = 1
- * 	addr_len = 3
- * 	cmd_code = 3
- * 	all other fields = 0
+ *  cmd_en = 1
+ *  addr_len = 3
+ *  cmd_code = 3
+ *  all other fields = 0
  */
 
 void board_init_clock(void)
@@ -101,16 +101,16 @@ void board_init_clock(void)
 __attribute__ ((section (".ramfunc")))
 void board_init_flash(void)
 {
-	/* Update the QSPI interface to adjust to the CPU speed
-	 * This function needs to execute from the RAM
-	 * when the QSPI interface is being reconfigured because the flash
-	 * can't be accessed during this time
-	 */
+    /* Update the QSPI interface to adjust to the CPU speed
+     * This function needs to execute from the RAM
+     * when the QSPI interface is being reconfigured because the flash
+     * can't be accessed during this time
+     */
 
-	/* Disable SPI flash mode */
-	SPI0_REG(SPI_REG_FCTRL) &= ~SPI_FCTRL_EN;
+    /* Disable SPI flash mode */
+    SPI0_REG(SPI_REG_FCTRL) &= ~SPI_FCTRL_EN;
 
-	/* Enable QPI mode by sending command to flash */
+    /* Enable QPI mode by sending command to flash */
     SPI0_REG(SPI_REG_TXFIFO) = 0x35;
 
     /* begin{code-style-ignore} */
@@ -125,10 +125,10 @@ void board_init_flash(void)
         SPI_INSN_PAD_CODE(0x00);           /* Dummy cycle sends 0 value bits                */
     /* end{code-style-ignore} */
 
-	/* Re-enable SPI flash mode */
-	SPI0_REG(SPI_REG_FCTRL) |= SPI_FCTRL_EN;
+    /* Re-enable SPI flash mode */
+    SPI0_REG(SPI_REG_FCTRL) |= SPI_FCTRL_EN;
 
-	/* Adjust the SPI clk divider for to boost flash speed */
+    /* Adjust the SPI clk divider for to boost flash speed */
   //  SPI0_REG(SPI_REG_SCKDIV) = SCKDIV;
 }
 

--- a/boards/hifive1b/include/board.h
+++ b/boards/hifive1b/include/board.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Ken Rabold
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_hifive1b SiFive HiFive1b RISC-V board
+ * @ingroup     boards
+ * @brief       Support for the SiFive HiFive1b RISC-V board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the SiFive HiFive1b RISC-V board
+ *
+ * @author      Ken Rabold
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Macros for controlling the on-board LEDs
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 22) /* Red */
+#define LED1_PIN            GPIO_PIN(0, 19) /* Green */
+#define LED2_PIN            GPIO_PIN(0, 21) /* Blue */
+
+#define LED0_ON             gpio_clear(LED0_PIN)
+#define LED0_OFF            gpio_set(LED0_PIN)
+#define LED0_TOGGLE         gpio_toggle(LED0_PIN)
+
+#define LED1_ON             gpio_clear(LED1_PIN)
+#define LED1_OFF            gpio_set(LED1_PIN)
+#define LED1_TOGGLE         gpio_toggle(LED1_PIN)
+
+#define LED2_ON             gpio_clear(LED2_PIN)
+#define LED2_OFF            gpio_set(LED2_PIN)
+#define LED2_TOGGLE         gpio_toggle(LED2_PIN)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+/**
+ * @brief   Initialize the board clock to use PLL and faster SPI access.
+ */
+void board_init_clock(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 Ken Rabold
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_hifive1b
+ * @{
+ *
+ * @file
+ * @brief       Peripheral specific definitions for the HiFive1b RISC-V board
+ *
+ * @author      Ken Rabold
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Core Clock configuration
+ * @{
+ */
+/* As defined in boards/hifive1/board.c CPU_DESIRED_FREQ **/
+#define CLOCK_CORECLOCK             (200000000ul)
+/** @} */
+
+/**
+ * @name    Xtimer configuration
+ * @{
+ */
+#define XTIMER_DEV                  (0)
+#define XTIMER_CHAN                 (0)
+#define XTIMER_WIDTH                (32)
+#define XTIMER_HZ                   (32768ul)
+/** @} */
+
+/**
+ * @name    Timer configuration
+ *
+ * @{
+ */
+#define TIMER_NUMOF                 (1)
+/** @} */
+
+/**
+ * @name    RTT/RTC configuration
+ *
+ * @{
+ */
+#define RTT_NUMOF                   (1)
+#define RTT_FREQUENCY               (1)             /* in Hz */
+#define RTT_MAX_VALUE               (0xFFFFFFFF)
+#define RTT_INTR_PRIORITY           (2)
+
+#define RTC_NUMOF                   (1)
+/** @} */
+
+/**
+ * @name    GPIO configuration
+ *
+ * @{
+ */
+#define GPIO_INTR_PRIORITY          (3)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ *
+ * @{
+ */
+#define PWM_NUMOF                   (3)
+/** @} */
+
+/**
+ * @name    UART configuration
+ *
+ * @{
+ */
+#define UART_NUMOF                  (2)
+#define UART0_RX_INTR_PRIORITY      (2)
+#define UART1_RX_INTR_PRIORITY      (2)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/hifive1b/include/vendor/LICENSE
+++ b/boards/hifive1b/include/vendor/LICENSE
@@ -1,0 +1,206 @@
+
+This software, except as otherwise noted in subrepositories,
+is licensed under the Apache 2 license, quoted below.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 SiFive, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/boards/hifive1b/include/vendor/hifive1.h
+++ b/boards/hifive1b/include/vendor/hifive1.h
@@ -1,0 +1,78 @@
+// See LICENSE for license details.
+
+#ifndef _SIFIVE_HIFIVE1_H
+#define _SIFIVE_HIFIVE1_H
+
+#include <stdint.h>
+
+/****************************************************************************
+ * GPIO Connections
+ *****************************************************************************/
+
+// These are the GPIO bit offsets for the RGB LED on HiFive1 Board.
+// These are also mapped to RGB LEDs on the Freedom E300 Arty
+// FPGA
+// Dev Kit.
+
+#define RED_LED_OFFSET   22
+#define GREEN_LED_OFFSET 19
+#define BLUE_LED_OFFSET  21
+
+// These are the GPIO bit offsets for the differen digital pins
+// on the headers for both the HiFive1 Board and the Freedom E300 Arty FPGA Dev Kit.
+#define PIN_0_OFFSET 16
+#define PIN_1_OFFSET 17
+#define PIN_2_OFFSET 18
+#define PIN_3_OFFSET 19
+#define PIN_4_OFFSET 20
+#define PIN_5_OFFSET 21
+#define PIN_6_OFFSET 22
+#define PIN_7_OFFSET 23
+#define PIN_8_OFFSET 0
+#define PIN_9_OFFSET 1
+#define PIN_10_OFFSET 2
+#define PIN_11_OFFSET 3
+#define PIN_12_OFFSET 4
+#define PIN_13_OFFSET 5
+//#define PIN_14_OFFSET 8 //This pin is not connected on either board.
+#define PIN_15_OFFSET 9
+#define PIN_16_OFFSET 10
+#define PIN_17_OFFSET 11
+#define PIN_18_OFFSET 12
+#define PIN_19_OFFSET 13
+
+// These are *PIN* numbers, not
+// GPIO Offset Numbers.
+#define PIN_SPI1_SCK    (13u)
+#define PIN_SPI1_MISO   (12u)
+#define PIN_SPI1_MOSI   (11u)
+#define PIN_SPI1_SS0    (10u)
+#define PIN_SPI1_SS1    (14u)
+#define PIN_SPI1_SS2    (15u)
+#define PIN_SPI1_SS3    (16u)
+
+#define SS_PIN_TO_CS_ID(x) \
+  ((x==PIN_SPI1_SS0 ? 0 :		 \
+    (x==PIN_SPI1_SS1 ? 1 :		 \
+     (x==PIN_SPI1_SS2 ? 2 :		 \
+      (x==PIN_SPI1_SS3 ? 3 :		 \
+       -1)))))
+
+
+// These buttons are present only on the Freedom E300 Arty Dev Kit.
+#ifdef HAS_BOARD_BUTTONS
+#define BUTTON_0_OFFSET 15
+#define BUTTON_1_OFFSET 30
+#define BUTTON_2_OFFSET 31
+
+#define INT_DEVICE_BUTTON_0 (INT_GPIO_BASE + BUTTON_0_OFFSET)
+#define INT_DEVICE_BUTTON_1 (INT_GPIO_BASE + BUTTON_1_OFFSET)
+#define INT_DEVICE_BUTTON_2 (INT_GPIO_BASE + BUTTON_2_OFFSET)
+
+#endif
+
+#define HAS_HFXOSC 1
+#define HAS_LFROSC_BYPASS 1
+
+
+#endif /* _SIFIVE_HIFIVE1_H */

--- a/cpu/fe310/include/vendor/i2c.h
+++ b/cpu/fe310/include/vendor/i2c.h
@@ -1,0 +1,33 @@
+// See LICENSE for license details.
+
+#ifndef _SIFIVE_I2C_H
+#define _SIFIVE_I2C_H
+
+/* Register offsets */
+#define I2C_PRESCALE_LO		(0x00)
+#define I2C_PRESCALE_HI		(0x04)
+#define I2C_CONTROL			(0x08)
+#define I2C_DATA			(0x0C)
+#define I2C_CMD				(0x10)
+#define I2C_STATUS			(0x10)
+
+/* CONTROL register */
+#define I2C_CONTROL_EN		(1 << 7)
+#define I2C_CONTROL_IE		(1 << 6)
+
+/* CMD register */
+#define I2C_CMD_STA			(1 << 7)
+#define I2C_CMD_STO			(1 << 6)
+#define I2C_CMD_RD			(1 << 5)
+#define I2C_CMD_WR			(1 << 4)
+#define I2C_CMD_ACK			(1 << 3)
+#define I2C_CMD_IACK		(1 << 0)
+
+/* STATUS register */
+#define I2C_STATUS_RXACK	(1 << 7)
+#define I2C_STATUS_BUSY		(1 << 6)
+#define I2C_STATUS_ALOST	(1 << 5)
+#define I2C_STATUS_TIP		(1 << 1)
+#define I2C_STATUS_IF		(1 << 0)
+
+#endif /* _SIFIVE_I2C_H */

--- a/cpu/fe310/include/vendor/platform.h
+++ b/cpu/fe310/include/vendor/platform.h
@@ -12,6 +12,7 @@
 #include "vendor/aon.h"
 #include "vendor/clint.h"
 #include "vendor/gpio.h"
+#include "vendor/i2c.h"
 #include "vendor/otp.h"
 #include "vendor/plic.h"
 #include "vendor/prci.h"
@@ -29,6 +30,7 @@
 #define TRAPVEC_TABLE_CTRL_ADDR	(0x00001010)
 #define OTP_MEM_ADDR 			(0x00020000)
 #define CLINT_CTRL_ADDR 		(0x02000000)
+#define ITIM_MEM_ADDR 		    (0x08000000)
 #define PLIC_CTRL_ADDR 			(0x0C000000)
 #define AON_CTRL_ADDR 			(0x10000000)
 #define PRCI_CTRL_ADDR 			(0x10008000)
@@ -37,6 +39,7 @@
 #define UART0_CTRL_ADDR 		(0x10013000)
 #define SPI0_CTRL_ADDR 			(0x10014000)
 #define PWM0_CTRL_ADDR 			(0x10015000)
+#define I2C0_CTRL_ADDR 			(0x10016000)
 #define UART1_CTRL_ADDR 		(0x10023000)
 #define SPI1_CTRL_ADDR 			(0x10024000)
 #define PWM1_CTRL_ADDR 			(0x10025000)
@@ -71,15 +74,17 @@
 #define IOF_SPI2_DQ2          	(30u)
 #define IOF_SPI2_DQ3          	(31u)
 
-//#define IOF0_I2C_MASK          (0x00003000)
+#define IOF0_I2C_MASK           (0x00003000)
+#define IOF_I2C0_SDA 			(12u)
+#define IOF_I2C0_SCL 			(13u)
 
 #define IOF0_UART0_MASK         (0x00030000)
 #define IOF_UART0_RX   			(16u)
 #define IOF_UART0_TX   			(17u)
 
-#define IOF0_UART1_MASK         (0x03000000)
-#define IOF_UART1_RX 			(24u)
-#define IOF_UART1_TX 			(25u)
+#define IOF0_UART1_MASK         (0x00840000)
+#define IOF_UART1_RX 			(18u)
+#define IOF_UART1_TX 			(23u)
 
 #define IOF1_PWM0_MASK          (0x0000000F)
 #define IOF1_PWM1_MASK          (0x00780000)
@@ -98,6 +103,7 @@
 #define INT_PWM0_BASE 			40
 #define INT_PWM1_BASE 			44
 #define INT_PWM2_BASE 			48
+#define INT_I2C_BASE 			52
 
 // Helper functions
 #define _REG32(p, i) 			(*(volatile uint32_t *) ((p) + (i)))
@@ -105,6 +111,7 @@
 #define AON_REG(offset) 		_REG32(AON_CTRL_ADDR, offset)
 #define CLINT_REG(offset) 		_REG32(CLINT_CTRL_ADDR, offset)
 #define GPIO_REG(offset) 		_REG32(GPIO_CTRL_ADDR, offset)
+#define I2C0_REG(offset) 		_REG32(I2C0_CTRL_ADDR, offset)
 #define OTP_REG(offset)  		_REG32(OTP_CTRL_ADDR, offset)
 #define PLIC_REG(offset) 		_REG32(PLIC_CTRL_ADDR, offset)
 #define PRCI_REG(offset) 		_REG32(PRCI_CTRL_ADDR, offset)
@@ -125,5 +132,7 @@
 #define PLIC_NUM_PRIORITIES 7
 
 #define RTC_FREQ 			32768
+
+#define ITIM_MEM_LEN		8192
 
 #endif /* _SIFIVE_PLATFORM_H */

--- a/cpu/fe310/ldscripts/fe310_g000.ld
+++ b/cpu/fe310/ldscripts/fe310_g000.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017   Ken Rabold
+ * Copyright (C) 2017, 2019   Ken Rabold
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief           Memory definitions for the SiFive FE310
+ * @brief           Memory definitions for the SiFive FE310_G000
  *
  * @author          Ken Rabold
  *
@@ -24,8 +24,9 @@ ENTRY( _start )
 
 MEMORY
 {
-  flash (rxai!w) : ORIGIN = 0x20400000, LENGTH = 512M
-  ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 16K
+  flash (rxai!w) : ORIGIN = 0x20400000, LENGTH = 0x1fc00000
+  ram   (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x00004000
+  itim  (wxa!ri) : ORIGIN = 0x08000000, LENGTH = 0x00002000
 }
 
 PHDRS
@@ -138,6 +139,7 @@ SECTIONS
 
   .data          :
   {
+    *(.ramfunc .ramfunc.*)
     *(.data .data.*)
     *(.gnu.linkonce.d.*)
     . = ALIGN(8);

--- a/cpu/fe310/ldscripts/fe310_g002.ld
+++ b/cpu/fe310/ldscripts/fe310_g002.ld
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2017, 2019   Ken Rabold
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_fe310
+ * @{
+ *
+ * @file
+ * @brief           Memory definitions for the SiFive FE310_G002
+ *
+ * @author          Ken Rabold
+ *
+ * @}
+ */
+
+OUTPUT_ARCH( "riscv" )
+
+ENTRY( _start )
+
+MEMORY
+{
+  flash (rxai!w) : ORIGIN = 0x20010000, LENGTH = 0x0006a120
+  ram   (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x00004000
+  itim  (wxa!ri) : ORIGIN = 0x08000000, LENGTH = 0x00002000
+}
+
+PHDRS
+{
+  flash PT_LOAD;
+  ram_init PT_LOAD;
+  ram PT_NULL;
+}
+
+SECTIONS
+{
+  __stack_size     = DEFINED(__stack_size) ? __stack_size : 1K;
+
+  .init           :
+  {
+    KEEP (*(SORT_NONE(.init)))
+  } >flash AT>flash :flash
+
+  .text           :
+  {
+    *(.text.unlikely .text.unlikely.*)
+    *(.text.startup .text.startup.*)
+    *(.text .text.*)
+    *(.gnu.linkonce.t.*)
+  } >flash AT>flash :flash
+
+  .fini           :
+  {
+    KEEP (*(SORT_NONE(.fini)))
+  } >flash AT>flash :flash
+
+  PROVIDE (__etext = .);
+  PROVIDE (_etext = .);
+  PROVIDE (etext = .);
+
+  .rodata         :
+  {
+    *(.rdata)
+    *(.rodata .rodata.*)
+    *(.gnu.linkonce.r.*)
+  } >flash AT>flash :flash
+
+  . = ALIGN(4);
+
+  .preinit_array  :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >flash AT>flash :flash
+
+  .init_array     :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+    KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >flash AT>flash :flash
+
+  .fini_array     :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+    KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >flash AT>flash :flash
+
+  .ctors          :
+  {
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+  } >flash AT>flash :flash
+
+  .dtors          :
+  {
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+  } >flash AT>flash :flash
+
+  .lalign         :
+  {
+    . = ALIGN(4);
+    PROVIDE( _data_lma = . );
+  } >flash AT>flash :flash
+
+  .dalign         :
+  {
+    . = ALIGN(4);
+    PROVIDE( _data = . );
+  } >ram AT>flash :ram_init
+
+  .data          :
+  {
+    *(.ramfunc .ramfunc.*)
+    *(.data .data.*)
+    *(.gnu.linkonce.d.*)
+    . = ALIGN(8);
+    PROVIDE( __global_pointer$ = . + 0x800 );
+    *(.sdata .sdata.*)
+    *(.gnu.linkonce.s.*)
+    . = ALIGN(8);
+    *(.srodata.cst16)
+    *(.srodata.cst8)
+    *(.srodata.cst4)
+    *(.srodata.cst2)
+    *(.srodata .srodata.*)
+  } >ram AT>flash :ram_init
+
+  . = ALIGN(4);
+  PROVIDE( _edata = . );
+  PROVIDE( edata = . );
+
+  PROVIDE( _fbss = . );
+  PROVIDE( __bss_start = . );
+  .bss            :
+  {
+    *(.sbss*)
+    *(.gnu.linkonce.sb.*)
+    *(.bss .bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN(4);
+  } >ram AT>ram :ram
+
+  . = ALIGN(8);
+  PROVIDE( _end = . );
+  PROVIDE( end = . );
+  PROVIDE( _heap_start = . );
+
+  .stack ORIGIN(ram) + LENGTH(ram) - __stack_size :
+  {
+    PROVIDE( _heap_end = . );
+    . = __stack_size;
+    PROVIDE( _sp = . );
+  } >ram AT>ram :ram
+}

--- a/examples/asymcute_mqttsn/Makefile
+++ b/examples/asymcute_mqttsn/Makefile
@@ -11,7 +11,7 @@ RIOTBASE ?= $(CURDIR)/../..
 # example...
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
-                             hifive1 i-nucleo-lrwan1 mega-xplained microbit \
+                             hifive1 hifive1b i-nucleo-lrwan1 mega-xplained microbit \
                              msb-430  msb-430h nrf51dk nrf51dongle nrf6310 \
                              nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-f070rb nucleo-f072rb nucleo-f303k8 \

--- a/examples/cord_ep/Makefile
+++ b/examples/cord_ep/Makefile
@@ -9,7 +9,7 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
-                             hifive1 i-nucleo-lrwan1 mega-xplained msb-430 \
+                             hifive1 hifive1b i-nucleo-lrwan1 mega-xplained msb-430 \
                              msb-430h nucleo-f030r8 nucleo-l053r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 stm32f0discovery \

--- a/examples/cord_epsim/Makefile
+++ b/examples/cord_epsim/Makefile
@@ -9,7 +9,7 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
-                             hifive1 i-nucleo-lrwan1 msb-430 msb-430h \
+                             hifive1 hifive1b i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f030r8 nucleo-l053r8 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-f334r8 \
                              nucleo-l031k6 mega-xplained stm32f0discovery \

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -15,7 +15,7 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    wsn430-v1_4 z1
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill calliope-mini \
-                             cc2650-launchpad cc2650stk hifive1 lsn50 i-nucleo-lrwan1 maple-mini \
+                             cc2650-launchpad cc2650stk hifive1 hifive1b lsn50 i-nucleo-lrwan1 maple-mini \
                              microbit nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f070rb nucleo-f072rb nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \

--- a/examples/emcute_mqttsn/Makefile
+++ b/examples/emcute_mqttsn/Makefile
@@ -9,7 +9,7 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
-                             hifive1 i-nucleo-lrwan1 msb-430 msb-430h \
+                             hifive1 hifive1b i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f072rb nucleo-f302r8 nucleo-f334r8 \

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -11,7 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno \
                              b-l072z-lrwan1 blackpill \
                              bluepill calliope-mini cc2650-launchpad cc2650stk \
-                             hifive1 i-nucleo-lrwan1 lsn50 maple-mini mega-xplained microbit msb-430 \
+                             hifive1 hifive1b i-nucleo-lrwan1 lsn50 maple-mini mega-xplained microbit msb-430 \
                              msb-430h nrf51dk nrf51dongle nrf6310 \
                              nucleo-f031k6 nucleo-f042k6 \
                              nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../..
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano \
                              arduino-uno blackpill bluepill calliope-mini \
-                             chronos hifive1 i-nucleo-lrwan1 mega-xplained \
+                             chronos hifive1 hifive1b i-nucleo-lrwan1 mega-xplained \
                              microbit msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../..
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno \
                              b-l072z-lrwan1 blackpill bluepill calliope-mini \
-                             chronos hifive1 i-nucleo-lrwan1 mega-xplained \
+                             chronos hifive1 hifive1b i-nucleo-lrwan1 mega-xplained \
                              microbit msb-430 msb-430h nrf51dk \
                              nrf51dongle nrf6310 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -8,7 +8,7 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill calliope-mini \
-                             cc2650-launchpad cc2650stk hifive1 i-nucleo-lrwan1 lobaro-lorabox lsn50 \
+                             cc2650-launchpad cc2650stk hifive1 hifive1b i-nucleo-lrwan1 lobaro-lorabox lsn50 \
                              maple-mini microbit nrf51dk nrf51dongle nrf6310 \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
                              nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -31,7 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano arduino-uno \
-                   chronos hifive1 jiminy-mega256rfr2 mega-xplained \
+                   chronos hifive1 hifive1b jiminy-mega256rfr2 mega-xplained \
                    msb-430 msb-430h pic32-clicker pic32-wifire telosb \
                    waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -18,7 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos hifive1 jiminy-mega256rfr2 \
+                   arduino-uno chronos hifive1 hifive1b jiminy-mega256rfr2 \
                    mega-xplained msb-430 msb-430h pic32-clicker \
                    pic32-wifire telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano \
-                             arduino-uno chronos hifive1 i-nucleo-lrwan1 \
+                             arduino-uno chronos hifive1 hifive1b i-nucleo-lrwan1 \
                              msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano \
-                             arduino-uno hifive1 i-nucleo-lrwan1 mega-xplained \
+                             arduino-uno hifive1 hifive1b i-nucleo-lrwan1 mega-xplained \
                              msb-430 msb-430h nucleo-f030r8 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \

--- a/tests/gnrc_netif/Makefile
+++ b/tests/gnrc_netif/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno \
                              b-l072z-lrwan1 blackpill bluepill calliope-mini \
-                             cc2650-launchpad cc2650stk chronos hifive1 \
+                             cc2650-launchpad cc2650stk chronos hifive1 hifive1b \
                              i-nucleo-lrwan1 lsn50 maple-mini \
                              mega-xplained microbit msb-430 msb-430h \
                              nrf51dk nrf51dongle nrf6310 \

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano \
-                             arduino-uno hifive1 i-nucleo-lrwan1 mega-xplained \
+                             arduino-uno hifive1 hifive1b i-nucleo-lrwan1 mega-xplained \
                              msb-430 msb-430h nucleo-f030r8 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
-                             hifive1 i-nucleo-lrwan1 msb-430 msb-430h \
+                             hifive1 hifive1b i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-f070rb nucleo-f070rb nucleo-f072rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -4,7 +4,7 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano \
-                             arduino-uno chronos hifive1 i-nucleo-lrwan1 \
+                             arduino-uno chronos hifive1 hifive1b i-nucleo-lrwan1 \
                              mega-xplained msb-430 msb-430h \
                              nucleo-f042k6 nucleo-f031k6 \
                              nucleo-f030r8 nucleo-f303k8 nucleo-l053r8 \

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -16,7 +16,7 @@ TCP_TEST_CYCLES ?= 3
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove \
                              arduino-leonardo arduino-mega2560 \
                              arduino-nano arduino-uno calliope-mini chronos \
-                             hifive1 i-nucleo-lrwan1 mega-xplained microbit \
+                             hifive1 hifive1b i-nucleo-lrwan1 mega-xplained microbit \
                              msb-430 msb-430h nrf51dk nrf51dongle nrf6310 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -15,7 +15,7 @@ TCP_TEST_CYCLES ?= 3
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove \
                              arduino-leonardo arduino-mega2560 \
                              arduino-nano arduino-uno calliope-mini chronos \
-                             hifive1 i-nucleo-lrwan1 mega-xplained microbit \
+                             hifive1 hifive1b i-nucleo-lrwan1 mega-xplained microbit \
                              msb-430 msb-430h \
                              nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano \
-                             arduino-uno calliope-mini chronos hifive1 \
+                             arduino-uno calliope-mini chronos hifive1 hifive1b \
                              i-nucleo-lrwan1 \
                              mega-xplained microbit msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -8,7 +8,7 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon hifive1 i-nucleo-lrwan1 nrf6310 \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon hifive1 hifive1b i-nucleo-lrwan1 nrf6310 \
                              nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l053r8 stm32f0discovery \

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -6,7 +6,7 @@ TEST_ON_CI_WHITELIST += all
 
 ifneq (,$(filter arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-uno waspmote-pro,$(BOARD)))
   TIMER_SPEED ?= 250000
-else ifneq (,$(filter hifive1 %-kw41z,$(BOARD)))
+else ifneq (,$(filter hifive1 hifive1b %-kw41z,$(BOARD)))
   TIMER_SPEED ?= 32768
 endif
 

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -9,6 +9,7 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     chronos \
                     f4vi1 \
                     hifive1 \
+                    hifive1b \
                     jiminy-mega256rfr2 \
                     mega-xplained \
                     msb-430 \

--- a/tests/pkg_ubasic/Makefile
+++ b/tests/pkg_ubasic/Makefile
@@ -15,6 +15,7 @@ BOARD_BLACKLIST := \
                    esp8266-esp-12x \
                    esp8266-olimex-mod \
                    hifive1 \
+                   hifive1b \
                    jiminy-mega256rfr2 \
                    mega-xplained \
                    msb-430 \

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno hifive1 i-nucleo-lrwan1 \
+                   arduino-nano arduino-uno hifive1 hifive1b i-nucleo-lrwan1 \
                    jiminy-mega256rfr2 mega-xplained stm32l0538-disco waspmote-pro
 
 # AVR platform: unknown type name: clockid_t


### PR DESCRIPTION
Add support for new SiFive RISC-V board [HiFive1B](https://www.sifive.com/boards/hifive1-rev-b)
Added support for the two variants of the FE310 CPU, FE310_G000 on the HiFive1 and FE310_G002 on the HiFive1B
Made minor tweaks to HiFive1 board for comments and FE310_G000.ld linker file
Added HiFive1B to same blacklists as HiFive1