### PR TITLE
shell_commands: fix regression to ifconfig introduced in #10350

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -378,7 +378,7 @@ static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
                 break;
         }
     }
-    puts("");
+    _newline(0U, _LINE_THRESHOLD);
 }
 
 static void _netif_list_groups(ipv6_addr_t *addr)
@@ -386,8 +386,9 @@ static void _netif_list_groups(ipv6_addr_t *addr)
     if ((ipv6_addr_is_multicast(addr))) {
         char addr_str[IPV6_ADDR_MAX_STR_LEN];
         ipv6_addr_to_str(addr_str, addr, sizeof(addr_str));
-        printf("inet6 group: %s\n", addr_str);
+        printf("inet6 group: %s", addr_str);
     }
+    _newline(0U, _LINE_THRESHOLD);
 }
 #endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The indentation of `ifconfig` is currently broken, due to an attempt to fix some `scan-build` errors.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```C
make -C examples/gnrc_networking all term
```

and

```
ifconfig
```

The indentation of the IPv6 addresses should be correct again.

```
TOOLCHAIN=llvm make -C examples/gnrc_networking scan-build
```

Passes for `sys/shell/commands` (new errors were introduced since #10350 though).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references


Was mentioned here that the output should be re-tested https://github.com/RIOT-OS/RIOT/pull/10350#pullrequestreview-219124544 (I did not have time to do it before the merge @cladmi)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
