### PR TITLE
examples/emcute_mqttsn: allow override of EMCUTE_ID

### DIFF
--- a/examples/emcute_mqttsn/Makefile
+++ b/examples/emcute_mqttsn/Makefile
@@ -33,6 +33,11 @@ USEMODULE += ps
 # For testing we also include the ping6 command and some stats
 USEMODULE += gnrc_icmpv6_echo
 
+# Allow for env-var-based override of the nodes name (EMCUTE_ID)
+ifneq (,$(EMCUTE_ID))
+  CFLAGS += -DEMCUTE_ID=\"$(EMCUTE_ID)\"
+endif
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/examples/emcute_mqttsn/README.md
+++ b/examples/emcute_mqttsn/README.md
@@ -101,7 +101,7 @@ That's it, happy publishing!
 
 ### I can't connect multiple RIOT nodes to a broker, what can I do?
 Each node that connects to the broker must have a unique node ID string set. Per
-default, this example sets this statically ID to `getrud`. If you want to
+default, this example sets this statically ID to `gertrud`. If you want to
 connect more than one node to the broker, you need to set a custom ID for each
 node during compile time. Simply use the `EMCUTE_ID` environment variable for
 this, e.g. build with `EMCUTE_ID=horst make all`.

--- a/examples/emcute_mqttsn/README.md
+++ b/examples/emcute_mqttsn/README.md
@@ -95,3 +95,13 @@ pub hello/world "One more beer, please."
 ```
 
 That's it, happy publishing!
+
+
+## FAQ
+
+### I can't connect multiple RIOT nodes to a broker, what can I do?
+Each node that connects to the broker must have a unique node ID string set. Per
+default, this example sets this statically ID to `getrud`. If you want to
+connect more than one node to the broker, you need to set a custom ID for each
+node during compile time. Simply use the `EMCUTE_ID` environment variable for
+this, e.g. build with `EMCUTE_ID=horst make all`.

--- a/examples/emcute_mqttsn/main.c
+++ b/examples/emcute_mqttsn/main.c
@@ -28,8 +28,10 @@
 #include "net/emcute.h"
 #include "net/ipv6/addr.h"
 
-#define EMCUTE_PORT         (1883U)
+#ifndef EMCUTE_ID
 #define EMCUTE_ID           ("gertrud")
+#endif
+#define EMCUTE_PORT         (1883U)
 #define EMCUTE_PRIO         (THREAD_PRIORITY_MAIN - 1)
 
 #define NUMOFSUBS           (16U)


### PR DESCRIPTION
### Contribution description
When trying to connect more than one RIOT node running `emcute` to a broker, each node must have a different node ID string. The current example application makes this slightly difficult by forcing to edit the source code for setting different IDs...

This PR simply lets the use override the default node ID during build time using the `EMCUTE_ID` environment variable, should be straight forward...

### Testing procedure
Compile the example with different values for `EMCUTE_ID` and verify that these values are actually used.

### Issues/PRs references
none