### PR TITLE
cpu/stm32f3: add support for flashpage and flashpage_raw

### DIFF
--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -77,7 +77,8 @@ static void _erase_page(void *page_addr)
 #else
     uint16_t *dst = page_addr;
 #endif
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F3)
     uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
     /* the internal RC oscillator (HSI) must be enabled */
     stmclk_enable_hsi();
@@ -113,7 +114,7 @@ static void _erase_page(void *page_addr)
 #endif
     CNTRL_REG |= (uint32_t)(pn << FLASH_CR_PNB_Pos);
     CNTRL_REG |= FLASH_CR_STRT;
-#else /* CPU_FAM_STM32F0 || CPU_FAM_STM32F1 */
+#else /* CPU_FAM_STM32F0 || CPU_FAM_STM32F1 || CPU_FAM_STM32F3 */
     DEBUG("[flashpage] erase: setting the page address\n");
     FLASH->AR = (uint32_t)dst;
     /* trigger the page erase and wait for it to be finished */
@@ -130,7 +131,8 @@ static void _erase_page(void *page_addr)
     /* lock the flash module again */
     _lock();
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F3)
     /* restore the HSI state */
     if (!hsi_state) {
         stmclk_disable_hsi();
@@ -163,7 +165,8 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     const uint16_t *data_addr = data;
 #endif
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F3)
     uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
     /* the internal RC oscillator (HSI) must be enabled */
     stmclk_enable_hsi();
@@ -174,7 +177,7 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 
     DEBUG("[flashpage_raw] write: now writing the data\n");
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
-    defined(CPU_FAM_STM32L4)
+    defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4)
     /* set PG bit and program page to flash */
     CNTRL_REG |= FLASH_CR_PG;
 #endif
@@ -187,7 +190,7 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 
     /* clear program bit again */
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
-    defined(CPU_FAM_STM32L4)
+    defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4)
     CNTRL_REG &= ~(FLASH_CR_PG);
 #endif
     DEBUG("[flashpage_raw] write: done writing data\n");
@@ -195,7 +198,8 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     /* lock the flash module again */
     _lock();
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F3)
     /* restore the HSI state */
     if (!hsi_state) {
         stmclk_disable_hsi();

--- a/cpu/stm32f3/Makefile.features
+++ b/cpu/stm32f3/Makefile.features
@@ -1,1 +1,4 @@
+FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_flashpage_raw
+
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f3/include/cpu_conf.h
+++ b/cpu/stm32f3/include/cpu_conf.h
@@ -43,6 +43,20 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
+/**
+ * @name    Flash page configuration
+ * @{
+ */
+#define FLASHPAGE_SIZE      (2048U)
+#define FLASHPAGE_NUMOF     (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+
+/* The minimum block size which can be written is 2B. However, the erase
+ * block is always FLASHPAGE_SIZE.
+ */
+#define FLASHPAGE_RAW_BLOCKSIZE    (2U)
+/* Writing should be always 4 bytes aligned */
+#define FLASHPAGE_RAW_ALIGNMENT    (4U)
+/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is adding support for `periph_flashpage` and `periph_flashpage_raw` on stm32f3 MCU.

I tested it with success on all stm32f3 boards supported in RIOT: nucleo-f303re, nucleo-f303ze, nucleo-f303k8, nucleo-f302r8, nucleo-f334r8

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following command should work:
```
make BOARD=<stm32f3 based board> -C tests/periph_flashpage flash test
```

The boards to test: nucleo-f303{re,ze,k8}, nucleo-f302r8 and nucleo-f334r8

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
