### PR TITLE
cpu/stm32l{1,4}: refactor flashpage numof macros

### DIFF
--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -76,18 +76,9 @@ extern "C" {
  * @name   Flash page configuration
  * @{
  */
-#if defined(CPU_MODEL_STM32L152RE) || defined(CPU_MODEL_STM32L151RC) || defined(CPU_MODEL_STM32L151CB)
 #define FLASHPAGE_SIZE             (256U)
-#if defined(CPU_MODEL_STM32L152RE)
-#define FLASHPAGE_NUMOF            (2048U)    /* 512KB */
-#endif
-#if defined(CPU_MODEL_STM32L151RC)
-#define FLASHPAGE_NUMOF            (1024U)    /* 256KB */
-#endif
-#if defined(CPU_MODEL_STM32L151CB)
-#define FLASHPAGE_NUMOF            (512U)     /* 128KB */
-#endif
-#endif
+#define FLASHPAGE_NUMOF            (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+
 /* The minimum block size which can be written is 4B. However, the erase
  * block is always FLASHPAGE_SIZE.
  */

--- a/cpu/stm32l4/include/cpu_conf.h
+++ b/cpu/stm32l4/include/cpu_conf.h
@@ -64,13 +64,8 @@ extern "C" {
  */
 #define FLASHPAGE_SIZE      (2048U)
 
-#if defined(CPU_MODEL_STM32L432KC) || defined(CPU_MODEL_STM32L433RC)
-#define FLASHPAGE_NUMOF            (128U)
-#elif defined(CPU_MODEL_STM32L452RE)
-#define FLASHPAGE_NUMOF            (256U)
-#else
-#define FLASHPAGE_NUMOF            (512U)
-#endif
+#define FLASHPAGE_NUMOF     (STM32_FLASHSIZE / FLASHPAGE_SIZE)
+
 /* The minimum block size which can be written is 8B. However, the erase
  * block is always FLASHPAGE_SIZE.
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The stm32l1 and stm32l4 flashpage numof are not using the generic `FLASHPAGE_NUMOF` definitions:
```
#define FLASHPAGE_NUMOF            (STM32_FLASHSIZE / FLASHPAGE_SIZE)
```

This PR is fixing that for both.

Tested on nucleo-l432kc, nucleo-l433rc, nucleo-l476rg and nucleo-l152re.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try:
```
$ make BOARD=<board to test> -C tests/periph_flashpage flash test
```

On nucleo-l152re, you might get a crash not related to this PR. The solution is to flash the application, open/close the IDD jumper and call `test`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
