### PR TITLE
boards/stm32f3: add support for riotboot feature

### DIFF
--- a/boards/nucleo-f302r8/Makefile.features
+++ b/boards/nucleo-f302r8/Makefile.features
@@ -6,6 +6,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 

--- a/boards/nucleo-f303k8/Makefile.features
+++ b/boards/nucleo-f303k8/Makefile.features
@@ -5,6 +5,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
 

--- a/boards/nucleo-f303re/Makefile.features
+++ b/boards/nucleo-f303re/Makefile.features
@@ -6,6 +6,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 

--- a/boards/nucleo-f303ze/Makefile.features
+++ b/boards/nucleo-f303ze/Makefile.features
@@ -5,6 +5,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo 144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 

--- a/boards/nucleo-f334r8/Makefile.features
+++ b/boards/nucleo-f334r8/Makefile.features
@@ -5,6 +5,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is pretty straight-forward with #11749. `tests/riotboot` was tested on all stm32f3 boards supported in RIOT.

~For other F3 based boards, the CPU provides little flash memory (only 64KB) so I don't think riotboot will be usable (only 31KB per slot).~

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test `tests/riotboot` on the mentioned boards:
```
$ make BOARD=<stm32f3 board> -C tests/riotboot riotboot/flash term
$ make BOARD=<stm32f3 board> -C tests/riotboot riotboot/flash-slot1 term
$ make BOARD=<stm32f3 board> -C tests/riotboot riotboot/flash-slot0 term
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

based on #11749 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
