### PR TITLE
boards/native: define FLASHFILE

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -13,8 +13,11 @@ else
   DEBUGGER ?= gdb
 endif
 
-TERMPROG ?= $(ELFFILE)
 FLASHER = true
+FLASHFILE ?= $(ELFFILE)
+
+TERMPROG ?= $(FLASHFILE)
+
 export VALGRIND ?= valgrind
 export CGANNOTATE ?= cg_annotate
 export GPROF ?= gprof


### PR DESCRIPTION
### Contribution description

Define FLASHFILE for `native`.

Even if native does not require flashing, it is the file used for running.

### Testing procedure

The variable is set correctly and can be overwritten from the environment.

```
make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE
/home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.elf

FLASHFILE=last_flashfile_missing make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE
last_flashfile_missing
```

### Issues/PRs references

Part of introducing FLASHFILE https://github.com/RIOT-OS/RIOT/pull/8838