### PR TITLE
pkg: remove not needed git-downloaded dependencies

### DIFF
--- a/pkg/Makefile.git
+++ b/pkg/Makefile.git
@@ -4,7 +4,7 @@ PKG_VERSION=	# version of the package to use e.g. a git commit/ref
 
 .PHONY: all
 
-all: git-download
+all:
 	$(MAKE) -C $(CURDIR)/$(PKG_NAME)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cayenne-lpp/Makefile
+++ b/pkg/cayenne-lpp/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=LGPLv2.1
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -6,7 +6,7 @@ CFLAGS += -Wno-strict-aliasing -Wno-unused-parameter
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cn-cbor/Makefile
+++ b/pkg/cn-cbor/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=MIT
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.cn-cbor
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/emb6/Makefile
+++ b/pkg/emb6/Makefile
@@ -18,11 +18,11 @@ EMB6_SUBMODULES:=$(filter-out emb6_contrib \
 
 .PHONY: all
 
-all: git-download $(EMB6_SUBMODULES)
+all: $(EMB6_SUBMODULES)
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 # Rule for all submodules
-emb6_%: git-download
+emb6_%:
 	"$(MAKE)" -C $(dir $(shell grep -lR "MODULE.*=.*\<$@\>" $(PKG_BUILDDIR)))
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/fatfs/Makefile
+++ b/pkg/fatfs/Makefile
@@ -6,7 +6,7 @@ MODULE_MAKEFILE := $(CURDIR)/Makefile.fatfs
 
 .PHONY: all
 
-all: git-download
+all:
 	@cp $(MODULE_MAKEFILE) $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -13,7 +13,7 @@ endif
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/dist
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/hacl/Makefile
+++ b/pkg/hacl/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=MIT
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/heatshrink/Makefile
+++ b/pkg/heatshrink/Makefile
@@ -4,7 +4,7 @@ PKG_VERSION=7d419e1fa4830d0b919b9b6a91fe2fb786cf3280
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.heatshrink
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -12,7 +12,7 @@ ifeq ($(TOOLCHAIN)_$(BOARD),llvm_native)
   CFLAGS += -Wno-macro-redefined -Wno-gnu-folding-constant
 endif
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript all
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jsmn/Makefile
+++ b/pkg/jsmn/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=MIT
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jsmn
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libb2/Makefile
+++ b/pkg/libb2/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE = CC0-1.0
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src \
 			  -f $(RIOTPKG)/libb2/Makefile.$(PKG_NAME)
 

--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -8,7 +8,7 @@ CFLAGS += -Wno-implicit-fallthrough
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libcose/Makefile
+++ b/pkg/libcose/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=LGPL
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.libcose
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src/crypt -f $(CURDIR)/Makefile.libcose_crypt
 

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE  := MIT
 
 .PHONY: all
 
-all: git-download
+all:
 	$(Q)"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libhydrogen/Makefile
+++ b/pkg/libhydrogen/Makefile
@@ -8,7 +8,7 @@ CFLAGS += -Wno-type-limits
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) \
 			  -f $(RIOTPKG)/libhydrogen/Makefile.$(PKG_NAME)
 

--- a/pkg/littlefs/Makefile
+++ b/pkg/littlefs/Makefile
@@ -6,7 +6,7 @@ PKG_LICENSE=Apache-2.0
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.littlefs
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lora-serialization/Makefile
+++ b/pkg/lora-serialization/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=LGPLv2.1
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -15,7 +15,7 @@ CFLAGS += -Wno-address
 
 make_module = "$(MAKE)" -f $(LWIP_MODULE_MAKEFILE) MODULE=$(1) -C $(2)
 
-all: git-download lwip
+all: lwip
 
 lwip: $(LWIP_USEMODULE)
 	$(call make_module,$@,$(PKG_BUILDDIR))

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=BSD-2-Clause
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/microcoap/Makefile
+++ b/pkg/microcoap/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=MIT
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/minmea/Makefile
+++ b/pkg/minmea/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=WTFPL
 
 .PHONY: all
 
-all: git-download
+all:
 	@cp Makefile.$(PKG_NAME) $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 

--- a/pkg/monocypher/Makefile
+++ b/pkg/monocypher/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=CC-0
 
 .PHONY: all
 
-all: git-download
+all:
 	$(Q)"$(MAKE)" -C $(PKG_BUILDDIR)/src
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/ndn-riot/Makefile
+++ b/pkg/ndn-riot/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=LGPLv2.1
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -22,7 +22,7 @@ SUBMODS := $(filter nimble_%,$(USEMODULE))
 
 .PHONY: all
 
-all: git-download $(SUBMODS)
+all: $(SUBMODS)
 
 # blue code and RIOT port modules
 nimble_riot_contrib:

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -10,7 +10,7 @@ CFLAGS += -Wno-implicit-fallthrough
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 	"$(MAKE)" $(BINDIR)/$(MODULE).a
 

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -27,7 +27,7 @@ $(info $$OPENTHREAD_ARGS is [${OPENTHREAD_ARGS}])
 OPENTHREAD_COMMON_FLAGS = -fdata-sections -ffunction-sections -Os
 OPENTHREAD_COMMON_FLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter
 
-all: git-download
+all:
 	cd $(PKG_BUILDDIR) && PREFIX="/" ./bootstrap
 	cd $(PKG_BUILDDIR) && CPP="$(CPP)" CC="$(CC)" CXX="$(CXX)"\
 		OBJC="" OBJCXX="" AR="$(AR)" RANLIB="$(RANLIB)" NM="$(NM)" \

--- a/pkg/qDSA/Makefile
+++ b/pkg/qDSA/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=PD
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/$(QDSA_IMPL)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/semtech-loramac/Makefile
+++ b/pkg/semtech-loramac/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all
 
-all: git-download
+all:
 	@cp Makefile.loramac $(PKG_BUILDDIR)/Makefile
 	@cp Makefile.loramac_mac $(PKG_BUILDDIR)/src/mac/Makefile
 	@cp Makefile.loramac_region $(PKG_BUILDDIR)/src/mac/region/Makefile

--- a/pkg/spiffs/Makefile
+++ b/pkg/spiffs/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=MIT
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.spiffs
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tiny-asn1/Makefile
+++ b/pkg/tiny-asn1/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE = LGPL-3
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinycbor/Makefile
+++ b/pkg/tinycbor/Makefile
@@ -6,7 +6,7 @@ PKG_LICENSE=MIT
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.tinycbor
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinycrypt/Makefile
+++ b/pkg/tinycrypt/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all
 
-all: git-download
+all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)/lib/source/ \
 			  -f $(RIOTPKG)/tinycrypt/Makefile.$(PKG_NAME)
 

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -10,7 +10,7 @@ CFLAGS += -D_XOPEN_SOURCE=600
 
 .PHONY: all
 
-all: git-download
+all:
 	@cp $(PKG_BUILDDIR)/Makefile.riot $(PKG_BUILDDIR)/Makefile
 	@cp $(PKG_BUILDDIR)/aes/Makefile.riot $(PKG_BUILDDIR)/aes/Makefile
 	@cp $(PKG_BUILDDIR)/ecc/Makefile.riot $(PKG_BUILDDIR)/ecc/Makefile

--- a/pkg/tweetnacl/Makefile
+++ b/pkg/tweetnacl/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=PD
 
 .PHONY: all
 
-all: git-download
+all:
 	$(Q)"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.riot
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/u8g2/Makefile
+++ b/pkg/u8g2/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=BSD-2-Clause
 
 .PHONY: all
 
-all: git-download
+all:
 	cp $(RIOTBASE)/pkg/u8g2/src/Makefile $(PKG_BUILDDIR)/Makefile
 	cp $(RIOTBASE)/pkg/u8g2/src/csrc/Makefile $(PKG_BUILDDIR)/csrc/Makefile
 	cp $(RIOTBASE)/pkg/u8g2/src/csrc/u8g2_riotos.c $(PKG_BUILDDIR)/csrc/u8g2_riotos.c

--- a/pkg/ubasic/Makefile
+++ b/pkg/ubasic/Makefile
@@ -8,7 +8,7 @@ UBASIC_USEMODULE = $(filter $(UBASIC_MODULES),$(USEMODULE))
 
 .PHONY: all ubasic ubasic%
 
-all: git-download ubasic
+all: ubasic
 
 make_module = "$(MAKE)" -f $(RIOTPKG)/ubasic/$(1).mk -C $(2)
 

--- a/pkg/ucglib/Makefile
+++ b/pkg/ucglib/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=BSD-2-Clause
 
 .PHONY: all
 
-all: git-download
+all:
 	cp $(RIOTBASE)/pkg/ucglib/src/Makefile $(PKG_BUILDDIR)/Makefile
 	cp $(RIOTBASE)/pkg/ucglib/src/csrc/Makefile $(PKG_BUILDDIR)/csrc/Makefile
 	cp $(RIOTBASE)/pkg/ucglib/src/csrc/ucg_riotos.c $(PKG_BUILDDIR)/csrc/ucg_riotos.c

--- a/pkg/umorse/Makefile
+++ b/pkg/umorse/Makefile
@@ -7,7 +7,7 @@ CFLAGS += -D_XOPEN_SOURCE=600
 
 .PHONY: all
 
-all: git-download
+all:
 	@cp Makefile.umorse $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 


### PR DESCRIPTION
# Contribution description

Currently, "git-dowloaded" is evaluated twice, one time by the "pkg-prepare"-step of the main make
instance, then again in the build step of the package.

Since "git-ensure-version" this makes all packages that have either patches or a tag as version get checked out twice.

Anyhow, packages are not supposed to be built outside the build system, so doing the check twice doesn't make sence. Thus this PR removes the dependency on all the package's "all:" target.

### Testing procedure

Let CI build all packages.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#11129 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
