### PR TITLE
makefiles/murdock.inc.mk: remove flashfile hack

### DIFF
--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -1,10 +1,6 @@
 #
 # This file contains helper targets used by the CI.
 #
-
-# (HACK) get actual flash binary from FFLAGS if not defined.
-FLASHFILE ?= $(filter $(HEXFILE) $(ELFFILE:.elf=.bin) $(ELFFILE),$(FFLAGS))
-
 #
 # This target will run "make test" on the CI cluster.
 #


### PR DESCRIPTION
### Contribution description

Setting FLASHFILE is now done for all boards requiring it.


### Testing procedure

Both on the current master and this PR, `FLASHFILE` has the same value.


<details><summary><code>for board in $(make info-boards); do echo ${board}; PORT=/dev/null ESP8266_NEWLIB_DIR=/tmp ESP32_SDK_DIR=/tmp ESP8266_SDK_DIR=/tmp BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE; done | sed "s|${PWD}/||"</code></summary><p>

```
for board in $(make info-boards); do echo ${board}; PORT=/dev/null ESP8266_NEWLIB_DIR=/tmp ESP32_SDK_DIR=/tmp ESP8266_SDK_DIR=/tmp BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-FLASHFILE; done | sed "s|${PWD}/||"
acd52832
examples/hello-world/bin/acd52832/hello-world.bin
airfy-beacon
examples/hello-world/bin/airfy-beacon/hello-world.elf
arduino-due
examples/hello-world/bin/arduino-due/hello-world.bin
arduino-duemilanove
examples/hello-world/bin/arduino-duemilanove/hello-world.hex
arduino-leonardo
examples/hello-world/bin/arduino-leonardo/hello-world.hex
arduino-mega2560
examples/hello-world/bin/arduino-mega2560/hello-world.hex
arduino-mkr1000
examples/hello-world/bin/arduino-mkr1000/hello-world.bin
arduino-mkrfox1200
examples/hello-world/bin/arduino-mkrfox1200/hello-world.bin
arduino-mkrzero
examples/hello-world/bin/arduino-mkrzero/hello-world.bin
arduino-nano
examples/hello-world/bin/arduino-nano/hello-world.hex
arduino-uno
examples/hello-world/bin/arduino-uno/hello-world.hex
arduino-zero
examples/hello-world/bin/arduino-zero/hello-world.bin
avsextrem
examples/hello-world/bin/avsextrem/hello-world.hex
b-l072z-lrwan1
examples/hello-world/bin/b-l072z-lrwan1/hello-world.elf
b-l475e-iot01a
examples/hello-world/bin/b-l475e-iot01a/hello-world.elf
blackpill
examples/hello-world/bin/blackpill/hello-world.elf
bluepill
examples/hello-world/bin/bluepill/hello-world.elf
calliope-mini
examples/hello-world/bin/calliope-mini/hello-world.elf
cc2538dk
examples/hello-world/bin/cc2538dk/hello-world.bin
cc2650-launchpad
examples/hello-world/bin/cc2650-launchpad/hello-world.elf
cc2650stk
examples/hello-world/bin/cc2650stk/hello-world.elf
chronos
examples/hello-world/bin/chronos/hello-world.hex
ek-lm4f120xl
examples/hello-world/bin/ek-lm4f120xl/hello-world.elf
esp32-mh-et-live-minikit
examples/hello-world/bin/esp32-mh-et-live-minikit/hello-world.elf
esp32-olimex-evb
examples/hello-world/bin/esp32-olimex-evb/hello-world.elf
esp32-wemos-lolin-d32-pro
examples/hello-world/bin/esp32-wemos-lolin-d32-pro/hello-world.elf
esp32-wroom-32
examples/hello-world/bin/esp32-wroom-32/hello-world.elf
esp32-wrover-kit
examples/hello-world/bin/esp32-wrover-kit/hello-world.elf
esp8266-esp-12x
examples/hello-world/bin/esp8266-esp-12x/hello-world.elf
esp8266-olimex-mod
examples/hello-world/bin/esp8266-olimex-mod/hello-world.elf
esp8266-sparkfun-thing
examples/hello-world/bin/esp8266-sparkfun-thing/hello-world.elf
f4vi1
examples/hello-world/bin/f4vi1/hello-world.bin
feather-m0
examples/hello-world/bin/feather-m0/hello-world.bin
firefly
examples/hello-world/bin/firefly/hello-world.bin
fox
examples/hello-world/bin/fox/hello-world.elf
frdm-k22f
examples/hello-world/bin/frdm-k22f/hello-world.elf
frdm-k64f
examples/hello-world/bin/frdm-k64f/hello-world.elf
frdm-kw41z
examples/hello-world/bin/frdm-kw41z/hello-world.elf
hamilton
examples/hello-world/bin/hamilton/hello-world.bin
hifive1
examples/hello-world/bin/hifive1/hello-world.elf
i-nucleo-lrwan1
examples/hello-world/bin/i-nucleo-lrwan1/hello-world.elf
ikea-tradfri
examples/hello-world/bin/ikea-tradfri/hello-world.bin
iotlab-a8-m3
examples/hello-world/bin/iotlab-a8-m3/hello-world.elf
iotlab-m3
examples/hello-world/bin/iotlab-m3/hello-world.elf
jiminy-mega256rfr2
examples/hello-world/bin/jiminy-mega256rfr2/hello-world.hex
limifrog-v1
examples/hello-world/bin/limifrog-v1/hello-world.elf
lobaro-lorabox
examples/hello-world/bin/lobaro-lorabox/hello-world.bin
lsn50
examples/hello-world/bin/lsn50/hello-world.elf
maple-mini
examples/hello-world/bin/maple-mini/hello-world.elf
mbed_lpc1768
examples/hello-world/bin/mbed_lpc1768/hello-world.bin
mega-xplained
examples/hello-world/bin/mega-xplained/hello-world.hex
microbit
examples/hello-world/bin/microbit/hello-world.elf
mips-malta
examples/hello-world/bin/mips-malta/hello-world.bin
msb-430
examples/hello-world/bin/msb-430/hello-world.hex
msb-430h
examples/hello-world/bin/msb-430h/hello-world.hex
msba2
examples/hello-world/bin/msba2/hello-world.hex
msbiot
examples/hello-world/bin/msbiot/hello-world.elf
mulle
examples/hello-world/bin/mulle/hello-world.elf
native

nrf51dk
examples/hello-world/bin/nrf51dk/hello-world.elf
nrf51dongle
examples/hello-world/bin/nrf51dongle/hello-world.bin
nrf52832-mdk
examples/hello-world/bin/nrf52832-mdk/hello-world.hex
nrf52840-mdk
examples/hello-world/bin/nrf52840-mdk/hello-world.hex
nrf52840dk
examples/hello-world/bin/nrf52840dk/hello-world.bin
nrf52dk
examples/hello-world/bin/nrf52dk/hello-world.bin
nrf6310
examples/hello-world/bin/nrf6310/hello-world.bin
nucleo-f030r8
examples/hello-world/bin/nucleo-f030r8/hello-world.elf
nucleo-f031k6
examples/hello-world/bin/nucleo-f031k6/hello-world.elf
nucleo-f042k6
examples/hello-world/bin/nucleo-f042k6/hello-world.elf
nucleo-f070rb
examples/hello-world/bin/nucleo-f070rb/hello-world.elf
nucleo-f072rb
examples/hello-world/bin/nucleo-f072rb/hello-world.elf
nucleo-f091rc
examples/hello-world/bin/nucleo-f091rc/hello-world.elf
nucleo-f103rb
examples/hello-world/bin/nucleo-f103rb/hello-world.elf
nucleo-f207zg
examples/hello-world/bin/nucleo-f207zg/hello-world.elf
nucleo-f302r8
examples/hello-world/bin/nucleo-f302r8/hello-world.elf
nucleo-f303k8
examples/hello-world/bin/nucleo-f303k8/hello-world.elf
nucleo-f303re
examples/hello-world/bin/nucleo-f303re/hello-world.elf
nucleo-f303ze
examples/hello-world/bin/nucleo-f303ze/hello-world.elf
nucleo-f334r8
examples/hello-world/bin/nucleo-f334r8/hello-world.elf
nucleo-f401re
examples/hello-world/bin/nucleo-f401re/hello-world.elf
nucleo-f410rb
examples/hello-world/bin/nucleo-f410rb/hello-world.elf
nucleo-f411re
examples/hello-world/bin/nucleo-f411re/hello-world.elf
nucleo-f412zg
examples/hello-world/bin/nucleo-f412zg/hello-world.elf
nucleo-f413zh
examples/hello-world/bin/nucleo-f413zh/hello-world.elf
nucleo-f429zi
examples/hello-world/bin/nucleo-f429zi/hello-world.elf
nucleo-f446re
examples/hello-world/bin/nucleo-f446re/hello-world.elf
nucleo-f446ze
examples/hello-world/bin/nucleo-f446ze/hello-world.elf
nucleo-f722ze
examples/hello-world/bin/nucleo-f722ze/hello-world.elf
nucleo-f746zg
examples/hello-world/bin/nucleo-f746zg/hello-world.elf
nucleo-f767zi
examples/hello-world/bin/nucleo-f767zi/hello-world.elf
nucleo-l031k6
examples/hello-world/bin/nucleo-l031k6/hello-world.elf
nucleo-l053r8
examples/hello-world/bin/nucleo-l053r8/hello-world.elf
nucleo-l073rz
examples/hello-world/bin/nucleo-l073rz/hello-world.elf
nucleo-l152re
examples/hello-world/bin/nucleo-l152re/hello-world.elf
nucleo-l432kc
examples/hello-world/bin/nucleo-l432kc/hello-world.elf
nucleo-l433rc
examples/hello-world/bin/nucleo-l433rc/hello-world.elf
nucleo-l452re
examples/hello-world/bin/nucleo-l452re/hello-world.elf
nucleo-l476rg
examples/hello-world/bin/nucleo-l476rg/hello-world.elf
nucleo-l496zg
examples/hello-world/bin/nucleo-l496zg/hello-world.elf
nz32-sc151
examples/hello-world/bin/nz32-sc151/hello-world.bin
opencm904
examples/hello-world/bin/opencm904/hello-world.bin
openmote-b
examples/hello-world/bin/openmote-b/hello-world.bin
openmote-cc2538
examples/hello-world/bin/openmote-cc2538/hello-world.bin
particle-argon
examples/hello-world/bin/particle-argon/hello-world.hex
particle-boron
examples/hello-world/bin/particle-boron/hello-world.hex
particle-xenon
examples/hello-world/bin/particle-xenon/hello-world.hex
pba-d-01-kw2x
examples/hello-world/bin/pba-d-01-kw2x/hello-world.elf
phynode-kw41z
examples/hello-world/bin/phynode-kw41z/hello-world.elf
pic32-clicker
examples/hello-world/bin/pic32-clicker/hello-world.hex
pic32-wifire
examples/hello-world/bin/pic32-wifire/hello-world.hex
pyboard
examples/hello-world/bin/pyboard/hello-world.bin
reel
examples/hello-world/bin/reel/hello-world.elf
remote-pa
examples/hello-world/bin/remote-pa/hello-world.bin
remote-reva
examples/hello-world/bin/remote-reva/hello-world.bin
remote-revb
examples/hello-world/bin/remote-revb/hello-world.bin
ruuvitag
examples/hello-world/bin/ruuvitag/hello-world.bin
samd21-xpro
examples/hello-world/bin/samd21-xpro/hello-world.bin
same54-xpro
examples/hello-world/bin/same54-xpro/hello-world.bin
saml10-xpro
examples/hello-world/bin/saml10-xpro/hello-world.bin
saml11-xpro
examples/hello-world/bin/saml11-xpro/hello-world.bin
saml21-xpro
examples/hello-world/bin/saml21-xpro/hello-world.bin
samr21-xpro
examples/hello-world/bin/samr21-xpro/hello-world.bin
samr30-xpro
examples/hello-world/bin/samr30-xpro/hello-world.bin
seeeduino_arch-pro
examples/hello-world/bin/seeeduino_arch-pro/hello-world.hex
sensebox_samd21
examples/hello-world/bin/sensebox_samd21/hello-world.bin
slstk3401a
examples/hello-world/bin/slstk3401a/hello-world.bin
slstk3402a
examples/hello-world/bin/slstk3402a/hello-world.bin
sltb001a
examples/hello-world/bin/sltb001a/hello-world.bin
slwstk6000b
examples/hello-world/bin/slwstk6000b/hello-world.bin
slwstk6220a
examples/hello-world/bin/slwstk6220a/hello-world.bin
sodaq-autonomo
examples/hello-world/bin/sodaq-autonomo/hello-world.bin
sodaq-explorer
examples/hello-world/bin/sodaq-explorer/hello-world.bin
sodaq-one
examples/hello-world/bin/sodaq-one/hello-world.bin
sodaq-sara-aff
examples/hello-world/bin/sodaq-sara-aff/hello-world.bin
spark-core
examples/hello-world/bin/spark-core/hello-world.bin
stk3600
examples/hello-world/bin/stk3600/hello-world.bin
stk3700
examples/hello-world/bin/stk3700/hello-world.bin
stm32f0discovery
examples/hello-world/bin/stm32f0discovery/hello-world.elf
stm32f3discovery
examples/hello-world/bin/stm32f3discovery/hello-world.elf
stm32f429i-disc1
examples/hello-world/bin/stm32f429i-disc1/hello-world.elf
stm32f4discovery
examples/hello-world/bin/stm32f4discovery/hello-world.elf
stm32f769i-disco
examples/hello-world/bin/stm32f769i-disco/hello-world.elf
stm32l476g-disco
examples/hello-world/bin/stm32l476g-disco/hello-world.elf
teensy31
examples/hello-world/bin/teensy31/hello-world.hex
telosb
examples/hello-world/bin/telosb/hello-world.hex
thingy52
examples/hello-world/bin/thingy52/hello-world.bin
ublox-c030-u201
examples/hello-world/bin/ublox-c030-u201/hello-world.elf
udoo
examples/hello-world/bin/udoo/hello-world.bin
usb-kw41z
examples/hello-world/bin/usb-kw41z/hello-world.elf
waspmote-pro
examples/hello-world/bin/waspmote-pro/hello-world.hex
wsn430-v1_3b
examples/hello-world/bin/wsn430-v1_3b/hello-world.hex
wsn430-v1_4
examples/hello-world/bin/wsn430-v1_4/hello-world.hex
yunjia-nrf51822
examples/hello-world/bin/yunjia-nrf51822/hello-world.elf
z1
examples/hello-world/bin/z1/hello-world.hex
```

You can note that `native` has no `FLASHFILE`, but it did not have a value in `master` either.
(addressed in https://github.com/RIOT-OS/RIOT/pull/11752)

</p></details>

### Issues/PRs references

* Part of Makefiles: add support to generate both `.hex` and `.bin` file and add FLASHFILE variable #8838
* Removes the FLASHFILE deducing hack from https://github.com/RIOT-OS/RIOT/pull/8801