### PR TITLE
Makefile.include: do not build HEXFILE by default anymore

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -473,7 +473,7 @@ ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container
 else
 ifeq (,$(RIOTNOLINK))
-link: ..compiler-check ..build-message $(ELFFILE) $(FLASHFILE) $(HEXFILE) print-size
+link: ..compiler-check ..build-message $(ELFFILE) $(FLASHFILE) print-size
 else
 link: ..compiler-check ..build-message $(BASELIBS)
 endif # RIOTNOLINK


### PR DESCRIPTION
### Contribution description

All boards must now use FLASHFILE


### Testing procedure


Building and testing in CI will work as expected.
I will only fail due to the `waiting for other PR`.

#### Solves the issue for `mips-malta`

This change has been dropped as `board/mips-malta` has been removed.


>> ##### boards/mips-malta: do not overwrite HEXFILE
>>     
>> Building the `.hex` file is failing on `mips-malta`.
>> Now that `HEXFILE` is not always built, it is not necessary to overwrite
>> it with `BINFILE`.
>>
>> 
>> When only removing the `HEXFILE = $(BINFILE)` you get the following error.
>> 
>> ```
>> DOCKER="sudo docker" BUILD_IN_DOCKER=1 BOARD=mips-malta make -C examples/hello-world/
>> ...
>> 
>> BFD: /data/riotbuild/riotbase/examples/hello-world/bin/mips-malta/hello-world.hex: address 0xffffffff80000000 out of range for Intel Hex file
>> /opt/mips-mti-elf/2016.05-03/bin/mips-mti-elf-objcopy:/data/riotbuild/riotbase/examples/hello-world/bin/mips-malta/hello-world.hex: Bad value
>> /data/riotbuild/riotbase/Makefile.include:487: recipe for target '/data/riotbuild/riotbase/examples/hello-world/bin/mips-malta/hello-world.hex' failed
>> make: *** [/data/riotbuild/riotbase/examples/hello-world/bin/mips-malta/hello-world.hex] Error 1
>> /home/harter/work/git/RIOT/makefiles/docker.inc.mk:266: recipe for target '..in-docker-container' failed
>> ```
>>
>> So the change in `Makefile.include` fixes the workaround described in https://github.com/RIOT-OS/RIOT/pull/11711/commits/78fdc49b32021d8b5dd841a6e0dd41520cc8a101

### Issues/PRs references

Waiting for https://github.com/RIOT-OS/RIOT/pull/11752 to be accurate with the documentation. But there is not build dependency.

Part of introducing FLASHFILE #8838