### PR TITLE
cpu/stm32: optimize stop mode for stm32f*

### DIFF
--- a/cpu/stm32_common/cpu_init.c
+++ b/cpu/stm32_common/cpu_init.c
@@ -26,6 +26,8 @@
  * @author      Víctor Ariño <victor.arino@zii.aero>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Vincent Dupont <vincent@otakeys.com>
+ * @author      Oleg Artamonov <oleg@unwds.com>
+ * @author      Francisco Molina <francisco.molina@inria.cl>
  *
  * @}
  */
@@ -41,6 +43,73 @@
 #define BIT_APB_PWREN       RCC_APB1ENR_PWREN
 #endif
 
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F2) || \
+    defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32F4) || \
+    defined(CPU_FAM_STM32F7)
+
+#define STM32_CPU_MAX_GPIOS    (12U)
+
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+#define GPIO_CLK              (AHB)
+#define GPIO_CLK_ENR          (RCC->AHBENR)
+#define GPIO_CLK_ENR_MASK     (0xFFFF0000)
+#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
+      defined(CPU_FAM_STM32F7)
+#define GPIO_CLK              (AHB1)
+#define GPIO_CLK_ENR          (RCC->AHB1ENR)
+#define GPIO_CLK_ENR_MASK     (0x0000FFFF)
+#endif
+
+#ifndef DISABLE_JTAG
+#define DISABLE_JTAG 0
+#endif
+
+/**
+ * @brief   Initialize gpio to AIN
+ *
+ * stm32f need to have all there pins initialized to AIN so the consumption
+ * of the input Schmitt trigger is saved when running in STOP mode.
+ *
+ * @see https://comm.eefocus.com/media/download/index/id-1013834
+ */
+static void _gpio_init_ain(void)
+{
+    uint32_t ahb_gpio_clocks;
+
+    /* enable GPIO clock and save GPIO clock configuration */
+    ahb_gpio_clocks = GPIO_CLK_ENR & GPIO_CLK_ENR_MASK;
+    periph_clk_en(GPIO_CLK, GPIO_CLK_ENR_MASK);
+
+    /* switch all GPIOs to AIN mode to minimize power consumption */
+    for (uint8_t i = 0; i < STM32_CPU_MAX_GPIOS; i++) {
+        GPIO_TypeDef *port;
+        port = (GPIO_TypeDef *)(GPIOA_BASE + i*(GPIOB_BASE - GPIOA_BASE));
+        if (IS_GPIO_ALL_INSTANCE(port)) {
+            if (!DISABLE_JTAG) {
+                switch (i) {
+                    /* preserve JTAG pins on PORTA and PORTB */
+                    case 0:
+                        port->MODER = 0xABFFFFFF;
+                        break;
+                    case 1:
+                        port->MODER = 0xFFFFFEBF;
+                        break;
+                    default:
+                        port->MODER = 0xFFFFFFFF;
+                        break;
+                }
+            }
+            else {
+                port->MODER = 0xFFFFFFFF;
+            }
+        }
+    }
+
+    /* restore GPIO clocks */
+    periph_clk_en(GPIO_CLK, ahb_gpio_clocks);
+}
+#endif
+
 void cpu_init(void)
 {
     /* initialize the Cortex-M core */
@@ -49,6 +118,11 @@ void cpu_init(void)
     periph_clk_en(APB1, BIT_APB_PWREN);
     /* initialize the system clock as configured in the periph_conf.h */
     stmclk_init_sysclk();
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F2) || \
+    defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32F4) || \
+    defined(CPU_FAM_STM32F7)
+    _gpio_init_ain();
+#endif
 #ifdef MODULE_PERIPH_DMA
     /*  initialize DMA streams */
     dma_init();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR is based on previous work in #11359, where STM32L1 has been cut from the PR. 

On start-up it configures all GPIO's as AIN. On other boards of the STM32 family (L0 & L4) this is done by default. There for this is only done for STM32F0-7~.

As stated in this [AN](https://comm.eefocus.com/media/download/index/id-1013834), doing this saves the consumption of the input Schmitt trigger. The only case where this shouldn't be done is when the pin is connected to an external driver that has a pull-up or pull-down setting, this should be handled by pertinent drivers.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Supply voltage for all the below measurement was 3.3V. Al pin headers where disconnected where disconnected, supply was measured directly threw the IDD pin either with a multi meter or NUCLEO-LPM01A power measurement extension.

As of know when entering STOP mode consumption on stm32f7 is around 1.24mA, with this PR it drops to **350uA** (270uA typ f746zg). To test run:

`make BOARD=nucleo-f746zg -C tests/periph_pm/ flash`

As of know when entering STOP mode consumption on stm32f4 is around 500uA, with this PR it drops to **120uA** (datasheet 120uA typ for f446re). To test run:

`make BOARD=nucleo-f446re -C tests/periph_pm/ flash`

As of know when entering STOP mode consumption on stm32f3 is around 1mA, with this PR it drops to **15.3uA** (datasheet 7.4uA typ for f303re). To test run:

`make BOARD=nucleo-f303re -C tests/periph_pm/ flash`

As of know when entering STOP mode consumption on stm32f2 is around 1.27mA, with this PR it drops to **200uA** (datasheet 200uA typ for f207zg). To test run:

`make BOARD=nucleo-f207zg -C tests/periph_pm/ flash`

As of know when entering STOP mode consumption on stm32f1 is around 100uA, with this PR it drops to **11uA** (13.5uA typ f103rb). Tested on nucleo-f103rb:

`make BOARD=nucleo-f103rb -C tests/periph_pm/ flash`

As of know when entering STOP mode consumption on stm32f0 is around 507uA, with this PR it drops to **10.7uA** (3.5uA typ f072rb). To test run:

`make BOARD=nucleo-f072rb -C tests/periph_pm/ flash`

NOTE: on nucleo boards if power is measured directly after programming there will be around 200uA of current consumption coming from the stlink. The stlink must start without being connected to the board or power the board externally.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Based on work from #8403 & #10052. Taken from #11359.