### PR TITLE
boards/msbiot: Added missing doc in board.h

### DIFF
--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -30,52 +30,52 @@ extern "C" {
  * @name    Configure connected CC1101 (radio) device
  * @{
  */
-#define CC110X_PARAM_SPI    SPI_DEV(0)
-#define CC110X_PARAM_CS     GPIO_PIN(PORT_B, 12)
-#define CC110X_PARAM_GDO0   GPIO_PIN(PORT_C, 4)
-#define CC110X_PARAM_GDO1   GPIO_PIN(PORT_A, 6)
-#define CC110X_PARAM_GDO2   GPIO_PIN(PORT_C, 5)
+#define CC110X_PARAM_SPI    SPI_DEV(0)              /**< SPI interface CC1101 is connected to */
+#define CC110X_PARAM_CS     GPIO_PIN(PORT_B, 12)    /**< CS pin of CC1101 */
+#define CC110X_PARAM_GDO0   GPIO_PIN(PORT_C, 4)     /**< GDO0 pin of CC1101 */
+#define CC110X_PARAM_GDO1   GPIO_PIN(PORT_A, 6)     /**< GDO1 pin of CC1101 */
+#define CC110X_PARAM_GDO2   GPIO_PIN(PORT_C, 5)     /**< GDO2 pin of CC1101 */
 /** @} */
 
 /**
  * @name    Configure connected MPU-9150 device
  * @{
  */
-#define MPU9150_PARAM_COMP_ADDR   (0x0E)
+#define MPU9150_PARAM_COMP_ADDR   (0x0E)            /**< I2C address of the MPU9150 */
 /** @} */
 
 /**
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 8)
-#define LED1_PIN            GPIO_PIN(PORT_B, 14)
-#define LED2_PIN            GPIO_PIN(PORT_B, 15)
+#define LED0_PIN            GPIO_PIN(PORT_B, 8)     /**< Pin of red LED */
+#define LED1_PIN            GPIO_PIN(PORT_B, 14)    /**< Pin of yellow LED */
+#define LED2_PIN            GPIO_PIN(PORT_B, 15)    /**< Pin of green LED */
 
-#define LED_PORT            GPIOB
-#define LED0_MASK           (1 << 8)
-#define LED1_MASK           (1 << 14)
-#define LED2_MASK           (1 << 15)
+#define LED_PORT            GPIOB       /**< GPIO port LEDs are connected to */
+#define LED0_MASK           (1 << 8)    /**< Bitmask to address red LED in @ref LED_PORT */
+#define LED1_MASK           (1 << 14)   /**< Bitmask to address yellow LED in @ref LED_PORT */
+#define LED2_MASK           (1 << 15)   /**< Bitmask to address green LED in @ref LED_PORT */
 
-#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED_PORT->ODR  ^= LED0_MASK)
+#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)            /**< Turn red LED on */
+#define LED0_OFF            (LED_PORT->BSRR = (LED0_MASK << 16))    /**< Turn red LED off */
+#define LED0_TOGGLE         (LED_PORT->ODR  ^= LED0_MASK)           /**< Toggle red LED */
 
-#define LED1_ON             (LED_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED_PORT->ODR  ^= LED1_MASK)
+#define LED1_ON             (LED_PORT->BSRR = LED1_MASK)            /**< Turn yellow LED on */
+#define LED1_OFF            (LED_PORT->BSRR = (LED1_MASK << 16))    /**< Turn yellow LED off */
+#define LED1_TOGGLE         (LED_PORT->ODR  ^= LED1_MASK)           /**< Toggle yellow LED */
 
-#define LED2_ON             (LED_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED_PORT->ODR  ^= LED2_MASK)
+#define LED2_ON             (LED_PORT->BSRR = LED2_MASK)            /**< Turn green LED on */
+#define LED2_OFF            (LED_PORT->BSRR = (LED2_MASK << 16))    /**< Turn green LED off */
+#define LED2_TOGGLE         (LED_PORT->ODR  ^= LED2_MASK)           /**< Toggle green LED */
 /** @} */
 
 /**
  * @name    Button pin definitions
  * @{
  */
-#define BUTTON0_PIN         GPIO_PIN(PORT_B, 13)
-#define BUTTON1_PIN         GPIO_PIN(PORT_A, 0)
+#define BUTTON0_PIN         GPIO_PIN(PORT_B, 13)    /**< Pin of left button */
+#define BUTTON1_PIN         GPIO_PIN(PORT_A, 0)     /**< Pin of right button */
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

Added missing doc to `board.h`
- Fixes warnings with current Doxygen version
- Resolves issue with Doxygen linking e.g. LED0_PIN to the doc of a different board
- `LED0_ON` etc. are still linked to the LED driver for me. The [documentation for `\ref`](http://www.doxygen.nl/manual/commands.html#cmdref) in Doxygen indicates there is now way to specify the target group of an `\ref` command to resolve ambiguity...

### Testing procedure

- Run `make doc` and check if `LED0_PIN`, `LED1_PIN` and `LED2_PIN` are still linked to a different board

### Issues/PRs references

Added `@ref LED0_PIN` etc. in #11748, which currently is sadly linked to an unrelated board