### PR TITLE
make: add termdeps target

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -259,7 +259,12 @@ run_test() {
     print_worker
     echo "-- executing tests for $appdir on $board (compiled with $toolchain toolchain):"
     hook run_test_pre
-    BOARD=$board TOOLCHAIN=${toolchain} make -C$appdir flash-only test
+
+    # do flashing and building of termdeps simultaneously
+    BOARD=$board TOOLCHAIN=${toolchain} make -C$appdir flash-only termdeps -j2
+
+    # now run the actual test
+    BOARD=$board TOOLCHAIN=${toolchain} make -C$appdir test
     RES=$?
 
     if [ $RES -eq 0 -a -n "$TEST_HASH" ]; then

--- a/Makefile.include
+++ b/Makefile.include
@@ -399,7 +399,7 @@ include $(RIOTMAKE)/bindist.inc.mk
 include $(RIOTMAKE)/modules.inc.mk
 
 
-.PHONY: all link clean flash flash-only term doc debug debug-server reset objdump help info-modules
+.PHONY: all link clean flash flash-only termdeps term doc debug debug-server reset objdump help info-modules
 .PHONY: print-size elffile binfile hexfile flashfile
 .PHONY: ..in-docker-container
 
@@ -559,6 +559,8 @@ flash-only: $(FLASHDEPS)
 preflash: $(BUILD_BEFORE_FLASH)
 	$(PREFLASHER) $(PREFFLAGS)
 
+termdeps: $(TERMDEPS)
+
 term: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
@@ -588,6 +590,16 @@ reset:
 .PHONY: test test/available
 TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*[^~]),\
                         $(shell test -f $(file) -a -x $(file) && echo $(file)))
+
+# "make test" calls "make term" which would implicitly build it's dependencies,
+# but that increases the time "make test" needs to get ready. That can cause
+# problems ("make term" missing some lines) as terminal startup is not properly
+# sychronized, but depends on a static timeout (TESTRUNNER_START_DELAY).
+# Murdock builds the term dependencies before running "make test" to circumvent
+# this. In order to make local builds behave similar, add the term deps here.
+# See #11762.
+TEST_DEPS += $(TERMDEPS)
+
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
 		$$t || exit 1; \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Previously, tests in CI on RasPis are run using "make flash-only term".
If "make term" requires work (e.g., compiling ethos), this makes "make term" startup long enough to possibly lose input, because "make reset" is called by "make test" with a fixed delay.

This PR introduces the termdeps target and makes use of it within the murdock scripts.
Test runs are now two-stage:

1. make flash-only termdeps -j2
2. make test

This a) lowers total test time if "make term" has work to do, by building the deps in parallel to flashing, and b) ensures that "make term" dependencies are already built when "make test" calls "make term".

### Testing procedure

AFAIK currently no test is using ethos, thus ideally, nothing will change for now.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
