### PR TITLE
net/gcoap: add/publish link format attributes for a resource

### DIFF
--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -38,12 +38,14 @@ static const coap_resource_t resources_second[] = {
 static gcoap_listener_t listener = {
     .resources     = &resources[0],
     .resources_len = (sizeof(resources) / sizeof(resources[0])),
+    .link_encoder  = NULL,
     .next          = NULL
 };
 
 static gcoap_listener_t listener_second = {
     .resources     = &resources_second[0],
     .resources_len = (sizeof(resources_second) / sizeof(resources_second[0])),
+    .link_encoder  = NULL,
     .next          = NULL
 };
 


### PR DESCRIPTION
### Contribution description
CoRE link format allows for qualification of CoAP resources, for example by resource type or interface. Presently, gcoap resources only support specification of target path. gcoap would like to support link format without requiring all applications to use it.

So, this PR adds designation of a callback function to encode a link for gcoap_get_resource_list(). gcoap includes a default function that simply outputs the target path, as has been done historically. However, an application may override this default to qualify the resources. As an example, this PR also updates the gcoap example app with such a function.

This PR arose from discussion in #11328 to allow an application to specify link format parameters with low impact on the core gcoap/nanocoap implementation.

### Testing procedure
Run the gcoap example, and query it for /.well-known/core to see the link format parameters. I also ran pre-existing [tests](https://github.com/kb2ma/riot-coap-pytest) on the cord_ep and cord_epsim examples, and they still work. I also copied the _encode_link() function from the gcoap example to the cord_ep example, and successfully registered with an aiocoap RD.

### Issues/PRs references
Replaces #11328.
