### PR TITLE
gnrc_tftp: Add minimum packet length check

### DIFF
--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -51,6 +51,7 @@ static kernel_pid_t _tftp_kernel_pid;
 
 #define TFTP_TIMEOUT_MSG            0x4000
 #define TFTP_STOP_SERVER_MSG        0x4001
+#define TFTP_MIN_PACKET_LEN         4
 #define TFTP_DEFAULT_DATA_SIZE      (GNRC_TFTP_MAX_TRANSFER_UNIT    \
                                      + sizeof(tftp_packet_data_t))
 
@@ -598,6 +599,11 @@ tftp_state _tftp_state_processes(tftp_context_t *ctxt, msg_t *m)
     }
 
     gnrc_pktsnip_t *pkt = m->content.ptr;
+    if (pkt->size < TFTP_MIN_PACKET_LEN) {
+       DEBUG("tftp: packet is too short\n");
+       gnrc_pktbuf_release(outbuf);
+       return TS_FAILED;
+    }
 
     gnrc_pktsnip_t *tmp;
     tmp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_UDP);


### PR DESCRIPTION

### Contribution description

Adds a minimum packet length check. If I understand [RFC 1350](https://tools.ietf.org/html/rfc1350) correctly, the shortest valid packet should be:

```
 2 bytes     2 bytes
 ---------------------
| Opcode |   Block #  |
 ---------------------

 Figure 5-3: ACK packet
```

Thus the minimum length of a valid packet should be 4 bytes.

### Testing procedure

See #10927.

### Issues/PRs references

Fixes #10927
See also: #11737 

CC: @smlng 