### PR TITLE
boards/lobaro-lorabox: add sx1272 radio driver dependency to netdev_default

### DIFF
--- a/boards/lobaro-lorabox/Makefile.dep
+++ b/boards/lobaro-lorabox/Makefile.dep
@@ -1,3 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += sx1272
+endif

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -38,7 +38,7 @@ USEMODULE += ps
 USEMODULE += saul_default
 
 BOARD_PROVIDES_NETIF := acd52832 airfy-beacon b-l072z-lrwan1 cc2538dk fox \
-        iotlab-m3 iotlab-a8-m3 lsn50 mulle microbit native nrf51dk \
+        iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit native nrf51dk \
         nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf6310 \
         openmote-cc2538 pba-d-01-kw2x remote-pa remote-reva samr21-xpro \
         spark-core telosb yunjia-nrf51822 z1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds sx1272 radio driver dependency to the lobaro-lorabox when netdev-default module is loaded. This gives access to ifconfig/txtsnd with this board when using the examples/default application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash examples/default
- Play with ifconfig and txtsnd to control the LoRa radio interface

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while working on #11676.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
