### PR TITLE
ble/softdevice: add ble_nordic_softdevice feature

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -72,6 +72,7 @@ ifneq (,$(filter uhcpc,$(USEMODULE)))
 endif
 
 ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
+  FEATURES_REQUIRED += ble_nordic_softdevice
   USEMODULE += softdevice_handler
   USEMODULE += ble_common
   USEMODULE += ble_6lowpan

--- a/boards/acd52832/Makefile.features
+++ b/boards/acd52832/Makefile.features
@@ -3,4 +3,5 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.features
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/common/nrf52/Makefile.nrf52832.features
+++ b/boards/common/nrf52/Makefile.nrf52832.features
@@ -1,0 +1,2 @@
+# Nordic SoftDevice support in RIOT is verified for all nrf52832-based boards
+FEATURES_PROVIDED += ble_nordic_softdevice

--- a/boards/nrf52832-mdk/Makefile.features
+++ b/boards/nrf52832-mdk/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_uart
 
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.features
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52dk/Makefile.features
+++ b/boards/nrf52dk/Makefile.features
@@ -1,1 +1,2 @@
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.features
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features

--- a/boards/ruuvitag/Makefile.features
+++ b/boards/ruuvitag/Makefile.features
@@ -2,4 +2,5 @@
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.features
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/thingy52/Makefile.features
+++ b/boards/thingy52/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_uart
 
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.features
 include $(RIOTBOARD)/common/nrf52/Makefile.features


### PR DESCRIPTION
### Contribution description
This PR is a minor step on the path to make NimBLE the default solution for IP-over-BLE in RIOT, e.g. making it the default when building the `gnrc_networking` example.

But currently the softdevice is broken and there was some confusion about testing it also for the `nrf52840`, for which it was never verified to be working. This PR should clarify this situation once and for all :-)

Note about the approach: apparently the `CPU_MODEL` variable is not set when parsing the `Makefile.feature`s. At least I have not seen a more generic way in setting this feature explicitly for all `nrf52832`-based boards. Anything nicer is welcome :-)

### Testing procedure
Build the gnrc networking example for the e.g. `nrf52dk` (-> should be all good), and for the e.g. `nrf52840dk` (-> should complain about the missing feature).

### Issues/PRs references
partly related to #11559 and subsequently #11091