### PR TITLE
Makefile.include: remove RIOT_VERSION_OVERRIDE

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -320,7 +320,7 @@ endif
 
 # set some settings useful for continuous integration builds
 ifeq ($(RIOT_CI_BUILD),1)
-    RIOT_VERSION_OVERRIDE:=buildtest
+    RIOT_VERSION ?= buildtest
     ifneq ($(filter $(BOARD_INSUFFICIENT_MEMORY), $(BOARD)),)
         $(info CI-build: skipping link step)
         RIOTNOLINK:=1
@@ -352,6 +352,12 @@ include $(RIOTMAKE)/cflags.inc.mk
 
 include $(RIOTMAKE)/git_version.inc.mk
 RIOT_VERSION ?= $(or $(GIT_VERSION),'UNKNOWN (builddir: $(RIOTBASE))')
+
+# Deprecate using RIOT_VERSION_OVERRIDE but currently keep the behavior
+ifneq (,$(RIOT_VERSION_OVERRIDE))
+  $(warning 'RIOT_VERSION_OVERRIDE' is deprecated, it can now be set with 'RIOT_VERSION' directly.)
+  RIOT_VERSION = $(RIOT_VERSION_OVERRIDE)
+endif
 
 # Set module by prepending APPLICATION name with 'application_'.
 # It prevents conflict with application and modules with the same name.
@@ -724,12 +730,7 @@ $(RIOTBUILD_CONFIG_HEADER_C): FORCE
 # Immediate evaluation but keep CLAGS_WITH_MACROS deferred
 _CFLAGS := $(CFLAGS)
 CFLAGS_WITH_MACROS = $(_CFLAGS)
-
-ifneq (,$(RIOT_VERSION_OVERRIDE))
-  CFLAGS_WITH_MACROS += -DRIOT_VERSION=\"$(RIOT_VERSION_OVERRIDE)\"
-else
-  CFLAGS_WITH_MACROS += -DRIOT_VERSION=\"$(RIOT_VERSION)\"
-endif
+CFLAGS_WITH_MACROS += -DRIOT_VERSION=\"$(RIOT_VERSION)\"
 
 CFLAGS := $(patsubst -D%,,$(CFLAGS))
 CFLAGS := $(patsubst -U%,,$(CFLAGS))

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -11,7 +11,7 @@ buildtest:
 	for board in $(BOARDS); do \
 		if BOARD=$${board} $(MAKE) check-toolchain-supported > /dev/null 2>&1; then \
 			$(COLOR_ECHO) -n "Building for $$board ... " ; \
-			BOARD=$${board} RIOT_CI_BUILD=1 RIOT_VERSION_OVERRIDE=buildtest \
+			BOARD=$${board} RIOT_CI_BUILD=1 \
 				$(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \
 			RES=$$? ; \
 			if [ $$RES -eq 0 ]; then \


### PR DESCRIPTION
### Contribution description

RIOT_VERSION is not used for building a specific RIOT version anymore
since #10543. The variable can now be used directly.


This now depends on https://github.com/RIOT-OS/RIOT/pull/11881 which prevents calling `git describe`

> When building with `RIOT_CI_BUILD=1` this also now prevents calling
> `git describe` and `git rev-parse` which saves around 0.1 seconds
> per execution on my machine.


### Testing procedure

No more usage in RIOT reported by `git grep RIOT_VERSION_OVERRIDE`

The `buildtest` version is correctly used for `CI` builds

```
RIOT_CI_BUILD=1 make --no-print-directory -C examples/hello-world/ info-debug-variable-RIOT_VERSION info-debug-variable-CFLAGS_WITH_MACROS
buildtest
-DDEVELHELP -Werror -Wall -Wextra -pedantic -std=gnu99 -m32 -fstack-protector-all -ffunction-sections -fdata-sections -DDEBUG_ASSERT_VERBOSE -DRIOT_APPLICATION="hello-world" -DBOARD_NATIVE="native" -DRIOT_BOARD=BOARD_NATIVE -DCPU_NATIVE="native" -DRIOT_CPU=CPU_NATIVE -DMCU_NATIVE="native" -DRIOT_MCU=MCU_NATIVE -fno-delete-null-pointer-checks -fdiagnostics-color -Wstrict-prototypes -Wold-style-definition -fno-common -Wall -Wextra -Wformat=2 -Wformat-overflow -Wformat-truncation -Wmissing-include-dirs -DMODULE_AUTO_INIT -DMODULE_BOARD -DMODULE_CORE -DMODULE_CORE_MSG -DMODULE_CPU -DMODULE_NATIVE_DRIVERS -DMODULE_PERIPH -DMODULE_PERIPH_COMMON -DMODULE_PERIPH_GPIO -DMODULE_PERIPH_PM -DMODULE_PERIPH_UART -DMODULE_SYS -DRIOT_VERSION="buildtest"
```
The version is used when given in the environment

```
RIOT_VERSION=beer make --no-print-directory -C examples/hello-world/ info-debug-variable-RIOT_VERSION info-debug-variable-CFLAGS_WITH_MACROS 
beer
-DDEVELHELP -Werror -Wall -Wextra -pedantic -std=gnu99 -m32 -fstack-protector-all -ffunction-sections -fdata-sections -DDEBUG_ASSERT_VERBOSE -DRIOT_APPLICATION="hello-world" -DBOARD_NATIVE="native" -DRIOT_BOARD=BOARD_NATIVE -DCPU_NATIVE="native" -DRIOT_CPU=CPU_NATIVE -DMCU_NATIVE="native" -DRIOT_MCU=MCU_NATIVE -fno-delete-null-pointer-checks -fdiagnostics-color -Wstrict-prototypes -Wold-style-definition -fno-common -Wall -Wextra -Wformat=2 -Wformat-overflow -Wformat-truncation -Wmissing-include-dirs -DMODULE_AUTO_INIT -DMODULE_BOARD -DMODULE_CORE -DMODULE_CORE_MSG -DMODULE_CPU -DMODULE_NATIVE_DRIVERS -DMODULE_PERIPH -DMODULE_PERIPH_COMMON -DMODULE_PERIPH_GPIO -DMODULE_PERIPH_PM -DMODULE_PERIPH_UART -DMODULE_SYS -DRIOT_VERSION="beer"
```


<details><summary>Speed update given by #11881 directly</summary>


Doing nothing is way faster for me, let's see the difference in CI, as in the `RIOT_CI_BUILD=1` context, the value from `git describe` is completely unnecessary.

```
time for i in {0..100}; do make --no-print-directory -C examples/hello-world/ info-debug-variable-ABC >/dev/null 2>/dev/null; done

real    0m19.081s
user    0m17.045s
sys     0m2.721s
```

```
time for i in {0..100}; do RIOT_CI_BUILD=1 make --no-print-directory -C examples/hello-world/ info-debug-variable-ABC >/dev/null 2>/dev/null; done

real    0m9.405s
user    0m7.987s
sys     0m2.092s
```
</details>

### Issues/PRs references

~Tracking: remove harmful use of `export` in make and immediate evaluation #10850~
~Depends on https://github.com/RIOT-OS/RIOT/pull/11881~
Makefile.include: remove functionality to build with another version. #10543