### PR TITLE
 gnrc_tftp: initialize unititialized 'tftp_context_t'

### DIFF
--- a/sys/include/net/gnrc/tftp.h
+++ b/sys/include/net/gnrc/tftp.h
@@ -15,6 +15,9 @@
  * @file
  * @brief       TFTP support library
  *
+ * @warning Currently only runs with link-local addresses when there is only
+ *          one interface
+ *
  * The TFTP module add's support for the TFTP protocol.
  * It implements the following RFC's:
  *  - https://tools.ietf.org/html/rfc1350
@@ -162,6 +165,8 @@ int gnrc_tftp_server_stop(void);
 /**
  * @brief Start an TFTP client read action from the given destination
  *
+ * @pre `(GNRC_NETIF_NUMOF == 1) || !ipv6_addr_is_link_local(addr)`
+ *
  * @param [in] addr         the address of the server
  * @param [in] file_name    the filename of the file to get
  * @param [in] mode         the transfer mode
@@ -179,6 +184,8 @@ int gnrc_tftp_client_read(ipv6_addr_t *addr, const char *file_name, tftp_mode_t 
 
 /**
  * @brief Start an TFTP client write action to the given destination
+ *
+ * @pre `(GNRC_NETIF_NUMOF == 1) || !ipv6_addr_is_link_local(addr)`
  *
  * @param [in] addr         the address of the server
  * @param [in] file_name    the filename of the file to write

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -406,6 +406,7 @@ int gnrc_tftp_server(tftp_data_cb_t data_cb, tftp_start_cb_t start_cb, tftp_stop
 
     /* context will be initialized when a connection is established */
     tftp_context_t ctxt = {
+        .src_port = GNRC_TFTP_DEFAULT_DST_PORT,
         .data_cb = data_cb,
         .start_cb = start_cb,
         .stop_cb = stop_cb,

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -405,11 +405,12 @@ int gnrc_tftp_server(tftp_data_cb_t data_cb, tftp_start_cb_t start_cb, tftp_stop
     }
 
     /* context will be initialized when a connection is established */
-    tftp_context_t ctxt;
-    ctxt.data_cb = data_cb;
-    ctxt.start_cb = start_cb;
-    ctxt.stop_cb = stop_cb;
-    ctxt.enable_options = use_options;
+    tftp_context_t ctxt = {
+        .data_cb = data_cb,
+        .start_cb = start_cb,
+        .stop_cb = stop_cb,
+        .enable_options = use_options,
+    };
 
     /* validate our arguments */
     assert(data_cb);

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -702,6 +702,8 @@ tftp_state _tftp_state_processes(tftp_context_t *ctxt, msg_t *m)
 
             if (proc == TS_DUP) {
                 DEBUG("tftp: duplicated data received, acking...\n");
+                ctxt->dst_port = byteorder_ntohs(udp->src_port);
+                DEBUG("tftp: client's port is %" PRIu16 "\n", ctxt->dst_port);
                 _tftp_send_dack(ctxt, outbuf, TO_ACK);
                 return TS_BUSY;
             }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixes #11772.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Follow procedure in #11772. It should succeed and also not run into a failed assertion. Also try the instruction in `example/gnrc_tftp`'s README.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses #11772.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
