### PR TITLE
murdock: chunked get_jobs()

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -62,11 +62,17 @@ is_in_list() {
     echo "$haystack" | grep -q -w "$needle"
 }
 
+# grep that doesn't return error on empty input
+_grep() {
+    grep "$@"
+    true
+}
+
 _greplist() {
     if [ $# -eq 0 ]; then
         echo cat
     else
-        echo -n "grep -E ($1"
+        echo -n "_grep -E ($1"
         shift
         for i in $*; do
             echo -n "|$i"

--- a/.murdock
+++ b/.murdock
@@ -118,9 +118,14 @@ get_supported_toolchains() {
 
 # given an app dir as parameter, print "$appdir $board:$toolchain" for each
 # supported board and toolchain. Only print for boards in $BOARDS.
+# if extra args are given, they will be prepended to each output line.
 get_app_board_toolchain_pairs() {
     local appdir=$1
     local boards="$(get_supported_boards $appdir)"
+
+    # collect extra arguments into prefix variable
+    shift
+    local prefix="$*"
 
     if [ "$boards" = makefile_broken ]; then
         echo "$appdir makefile_broken"
@@ -131,7 +136,7 @@ get_app_board_toolchain_pairs() {
     do
         for toolchain in $(get_supported_toolchains $appdir $board)
         do
-            echo $appdir $board:$toolchain
+            echo $prefix $appdir $board:$toolchain
         done
     done | $(_greplist $BOARDS)
 }
@@ -140,8 +145,7 @@ get_app_board_toolchain_pairs() {
 get_compile_jobs() {
     get_apps | \
         dwqc ${DWQ_ENV} -s \
-        "$0 get_app_board_toolchain_pairs \${1}" \
-        | xargs '-d\n' -n 1 echo $0 compile
+        "$0 get_app_board_toolchain_pairs \${1} $0 compile"
 }
 
 print_worker() {

--- a/.murdock
+++ b/.murdock
@@ -145,6 +145,7 @@ get_app_board_toolchain_pairs() {
 get_compile_jobs() {
     get_apps | \
         dwqc ${DWQ_ENV} -s \
+        ${DWQ_JOBID:+--subjob} \
         "$0 get_app_board_toolchain_pairs \${1} $0 compile"
 }
 

--- a/.murdock
+++ b/.murdock
@@ -287,9 +287,13 @@ static_tests() {
     BUILDTEST_MCU_GROUP=static-tests ./dist/tools/ci/build_and_test.sh
 }
 
-get_jobs() {
+get_non_compile_jobs() {
     [ "$STATIC_TESTS" = "1" ] && \
         echo "$0 static_tests###{ \"jobdir\" : \"exclusive\" }"
+}
+
+get_jobs() {
+    get_non_compile_jobs
     get_compile_jobs
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, murdock would first collect all jobs, then start building. This PR collects a couple of changes to make job creation happen in parallel to job collection.

The effect is that the first build jobs will start before job collection is complete. You'll notice that as soon as the percentage bar appears, the first jobs (1000 - 5000, depending on the performance of the workers that process job collection) complete really fast, as they're actually already done and only the result gets processed. This should cut the total build time by at least 30 seconds, and mitigate the impact of a slow worker taking it's time to process it's part of "get_jobs()".

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- confirm all jobs are still built
- maybe re-trigger this PR while watching the output. Concentrate on what happens after "collecting jobs..." is done and the percentage bar appears.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
