### PR TITLE
riotboot/flashwrite: fix typo in doxygen documentation

### DIFF
--- a/sys/include/riotboot/flashwrite.h
+++ b/sys/include/riotboot/flashwrite.h
@@ -123,7 +123,7 @@ static inline int riotboot_flashwrite_init(riotboot_flashwrite_t *state,
  * @param[in,out]   state   ptr to previously used update state
  * @param[in]       bytes   ptr to data
  * @param[in]       len     len of data
- * @param[in]       more    whether more data is comming
+ * @param[in]       more    whether more data is coming
  *
  * @returns         0 on success, <0 otherwise
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing an obvious typo in the doxygen documentation of one of the riotboot flashwrite function.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Generate and read the documentation.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
