### PR TITLE
stm32_common/flashpage: fix stm32l4 erase error

### DIFF
--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -111,6 +111,7 @@ static void _erase_page(void *page_addr)
     }
     pn = (uint8_t)page;
 #endif
+    CNTRL_REG &= ~FLASH_CR_PNB;
     CNTRL_REG |= (uint32_t)(pn << FLASH_CR_PNB_Pos);
     CNTRL_REG |= FLASH_CR_STRT;
 #else /* CPU_FAM_STM32F0 || CPU_FAM_STM32F1 */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR fixes a ~couple of ~bug~s~ in flashpage stm32l4 implementation.

- Fixes `_erase()` for stm32l4. When erasing the page number to write was not reset before `oring`
the new one, this resulted in the wrong page being erase after a couple of erase sequence on different pages. 

~~- In `flash_common` `FLASH_SR_EOP` is cleared by writing to 0, when RM states that it is cleared by writing 1 (check any STM32 `FLASH_SR` register description).~~
~~- When writing to flash the first operation is performed before checking if there was any ongoing operation. This should also be done according to the RM.~~

### Testing procedure

~~The second and third point don't need testing, just verify my statement in the RM.~~

For the first point in master, for any STML4:

`make -C tests/periph_flashpage/ BOARD=nucleo-l476rg flash -j3 term`

```
> test 128
2019-07-03 09:49:06,670 - INFO #  test 128
2019-07-03 09:49:06,719 - INFO # wrote local page buffer to flash page 128 at addr 0x8040000
> test 64
2019-07-03 09:49:07,813 - INFO #  test 64
2019-07-03 09:49:07,839 - INFO # error verifying the content of page 64
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

With this PR:

```
> test 128
2019-07-03 09:55:58,557 - INFO #  test 128
2019-07-03 09:55:58,606 - INFO # wrote local page buffer to flash page 128 at addr 0x8040000
> test 64
2019-07-03 09:55:59,893 - INFO #  test 64
2019-07-03 09:55:59,942 - INFO # wrote local page buffer to flash page 64 at addr 0x8020000
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
