### PR TITLE
tests/pkg_semtech-loramac: don't init the mac from main

### DIFF
--- a/tests/pkg_semtech-loramac/main.c
+++ b/tests/pkg_semtech-loramac/main.c
@@ -73,8 +73,6 @@ static void *_wait_recv(void *arg)
 
 int main(void)
 {
-    semtech_loramac_init(&loramac);
-
 #ifdef MODULE_SEMTECH_LORAMAC_RX
     thread_create(_recv_stack, sizeof(_recv_stack),
                   THREAD_PRIORITY_MAIN - 1, 0, _wait_recv, NULL, "recv thread");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a fix that prevent the semtech-loramac stack from being initialized twice in the `tests/pkg_semtech-loramac` application. In fact, the init function is a first time from auto_init and a second time from the main function of the application. The fix simply consists in removing the latter.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Enable debug in `semtech-loramac.c`
- Flash and run the `tests/pkg_semtech-loramac` application
- With this PR, one can noticed the stack is initialized once, on master it's initialized twice.
- Also don't forget to verify that the application features still work: join, send, receive, etc

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while debugging #11626 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
