### PR TITLE
gnrc_tftp: add deprecation note

### DIFF
--- a/sys/include/net/gnrc/tftp.h
+++ b/sys/include/net/gnrc/tftp.h
@@ -10,6 +10,10 @@
  * @defgroup    net_gnrc_tftp  TFTP Support Library
  * @ingroup     net_gnrc
  * @brief       Add's support for TFTP protocol parsing
+ *
+ * @deprecated  This module has serious quality defects and is not in a
+ *              maintainable state. It will be removed after the 2020.04 release
+ *              at the latest.
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`gnrc_tftp` got into a quite unmaintainable state and has many quality defects (the port of the server changes randomly on connect from a client, it does reliably not work with multiple interfaces, ...). As such I'm voting to deprecate it. With CoAP we have a way more stable alternative.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tftp` should appear in `doc/doxygen/html/deprecated.html` after `make doc`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Related to #11773, but not dependent on it.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
