### PR TITLE
gcoap: remove all references to `gcoap_req_send2()`

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -196,7 +196,7 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
         return 0;
     }
 
-    bytes_sent = gcoap_req_send2(buf, len, &remote, _resp_handler);
+    bytes_sent = gcoap_req_send(buf, len, &remote, _resp_handler);
     if (bytes_sent > 0) {
         req_count++;
     }

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -110,7 +110,7 @@
  * If no payload, call only gcoap_request() to write the full request. If you
  * need to add Options, follow the first four steps in the list above instead.
  *
- * Finally, call gcoap_req_send2() with the sum of the metadata length and
+ * Finally, call gcoap_req_send() with the sum of the metadata length and
  * payload length, the destination endpoint, and a callback function for the
  * host's response.
  *

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -149,7 +149,7 @@ static int _update_remove(unsigned code, gcoap_resp_handler_t handle)
     ssize_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
 
     /* send request */
-    gcoap_req_send2(buf, pkt_len, &_rd_remote, handle);
+    gcoap_req_send(buf, pkt_len, &_rd_remote, handle);
 
     /* synchronize response */
     return _sync();
@@ -221,7 +221,7 @@ static int _discover_internal(const sock_udp_ep_t *remote,
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
     gcoap_add_qstring(&pkt, "rt", "core.rd");
     size_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
-    res = gcoap_req_send2(buf, pkt_len, remote, _on_discover);
+    res = gcoap_req_send(buf, pkt_len, remote, _on_discover);
     if (res < 0) {
         return CORD_EP_ERR;
     }
@@ -288,7 +288,7 @@ int cord_ep_register(const sock_udp_ep_t *remote, const char *regif)
     pkt_len += res;
 
     /* send out the request */
-    res = gcoap_req_send2(buf, pkt_len, remote, _on_register);
+    res = gcoap_req_send(buf, pkt_len, remote, _on_register);
     if (res < 0) {
         retval = CORD_EP_ERR;
         goto end;

--- a/sys/net/application_layer/cord/epsim/cord_epsim.c
+++ b/sys/net/application_layer/cord/epsim/cord_epsim.c
@@ -67,7 +67,7 @@ int cord_epsim_register(const sock_udp_ep_t *rd_ep)
     /* finish, we don't have any payload */
     ssize_t len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
     _state = CORD_EPSIM_BUSY;
-    if (gcoap_req_send2(buf, len, rd_ep, _req_handler) == 0) {
+    if (gcoap_req_send(buf, len, rd_ep, _req_handler) == 0) {
         return CORD_EPSIM_ERROR;
     }
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -172,7 +172,7 @@ static void _listen(sock_udp_t *sock)
     uint8_t open_reqs = gcoap_op_state();
 
     /* We expect a -EINTR response here when unlimited waiting (SOCK_NO_TIMEOUT)
-     * is interrupted when sending a message in gcoap_req_send2(). While a
+     * is interrupted when sending a message in gcoap_req_send(). While a
      * request is outstanding, sock_udp_recv() is called here with limited
      * waiting so the request's timeout can be handled in a timely manner in
      * _event_loop(). */
@@ -783,7 +783,7 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
 
     /* timeout may be zero for non-confirmable */
     if ((memo != NULL) && (res > 0) && (timeout > 0)) {
-        /* We assume gcoap_req_send2() is called on some thread other than
+        /* We assume gcoap_req_send() is called on some thread other than
          * gcoap's. First, put a message in the mbox for the sock udp object,
          * which will interrupt listening on the gcoap thread. (When there are
          * no outstanding requests, gcoap blocks indefinitely in _listen() at


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`gcoap_req_send2()` was deprecated in #11445 and was replaced with `gcoap_req_send()`. Our codebase should reflect that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The following applications should still compile:

- `examples/gcoap`
- `examples/cord_ep`
- `examples/cord_epsim`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #11445.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
