### PR TITLE
core/schedstatistics: fix call to uninitialized xtimer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -610,6 +610,7 @@ endif
 
 ifneq (,$(filter schedstatistics,$(USEMODULE)))
   USEMODULE += xtimer
+  USEMODULE += sched_cb
 endif
 
 ifneq (,$(filter arduino,$(USEMODULE)))

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -224,14 +224,16 @@ extern schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
  *          caller thread
  */
 void init_schedstatistics(void);
+#endif /* MODULE_SCHEDSTATISTICS */
 
+#ifdef MODULE_SCHED_CB
 /**
  *  @brief  Register a callback that will be called on every scheduler run
  *
  *  @param[in] callback The callback functions the will be called
  */
 void sched_register_cb(void (*callback)(kernel_pid_t, kernel_pid_t));
-#endif /* MODULE_SCHEDSTATISTICS */
+#endif /* MODULE_SCHED_CB */
 
 #ifdef __cplusplus
 }

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -220,11 +220,17 @@ typedef struct {
 extern schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
 
 /**
+ *  @brief  Registers the sched statistics callback and sets laststart for
+ *          caller thread
+ */
+void init_schedstatistics(void);
+
+/**
  *  @brief  Register a callback that will be called on every scheduler run
  *
  *  @param[in] callback The callback functions the will be called
  */
-void sched_register_cb(void (*callback)(uint32_t, uint32_t));
+void sched_register_cb(void (*callback)(kernel_pid_t, kernel_pid_t));
 #endif /* MODULE_SCHEDSTATISTICS */
 
 #ifdef __cplusplus

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -29,10 +29,6 @@
 
 #include "periph/pm.h"
 
-#ifdef MODULE_SCHEDSTATISTICS
-#include "sched.h"
-#endif
-
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -47,11 +43,6 @@ static void *main_trampoline(void *arg)
 
 #ifdef MODULE_AUTO_INIT
     auto_init();
-#endif
-
-#ifdef MODULE_SCHEDSTATISTICS
-    schedstat_t *ss = &sched_pidlist[thread_getpid()];
-    ss->laststart = 0;
 #endif
 
     LOG_INFO("main(): This is RIOT! (Version: " RIOT_VERSION ")\n");

--- a/core/sched.c
+++ b/core/sched.c
@@ -74,8 +74,10 @@ FORCE_USED_SECTION
 const uint8_t _tcb_name_offset = offsetof(thread_t, name);
 #endif
 
-#ifdef MODULE_SCHEDSTATISTICS
+#ifdef MODULE_SCHED_CB
 static void (*sched_cb) (kernel_pid_t active_thread, kernel_pid_t next_thread) = NULL;
+#endif
+#ifdef MODULE_SCHEDSTATISTICS
 schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
 #endif
 
@@ -112,7 +114,7 @@ int __attribute__((used)) sched_run(void)
 #endif
     }
 
-#ifdef MODULE_SCHEDSTATISTICS
+#ifdef MODULE_SCHED_CB
     if (sched_cb) {
         /* Use `sched_active_pid` instead of `active_thread` since after `sched_task_exit()` is
            called `active_thread` is set to NULL while `sched_active_thread` isn't updated until
@@ -204,12 +206,14 @@ NORETURN void sched_task_exit(void)
     cpu_switch_context_exit();
 }
 
-#ifdef MODULE_SCHEDSTATISTICS
+#ifdef MODULE_SCHED_CB
 void sched_register_cb(void (*callback)(kernel_pid_t, kernel_pid_t))
 {
     sched_cb = callback;
 }
+#endif
 
+#ifdef MODULE_SCHEDSTATISTICS
 void sched_statistics_cb(kernel_pid_t active_thread, kernel_pid_t next_thread)
 {
     uint32_t now = xtimer_now().ticks32;

--- a/core/sched.c
+++ b/core/sched.c
@@ -75,7 +75,7 @@ const uint8_t _tcb_name_offset = offsetof(thread_t, name);
 #endif
 
 #ifdef MODULE_SCHEDSTATISTICS
-static void (*sched_cb) (uint32_t timestamp, uint32_t value) = NULL;
+static void (*sched_cb) (kernel_pid_t active_thread, kernel_pid_t next_thread) = NULL;
 schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
 #endif
 
@@ -100,10 +100,6 @@ int __attribute__((used)) sched_run(void)
         return 0;
     }
 
-#ifdef MODULE_SCHEDSTATISTICS
-    uint32_t now = xtimer_now().ticks32;
-#endif
-
     if (active_thread) {
         if (active_thread->status == STATUS_RUNNING) {
             active_thread->status = STATUS_PENDING;
@@ -114,21 +110,14 @@ int __attribute__((used)) sched_run(void)
             LOG_WARNING("scheduler(): stack overflow detected, pid=%" PRIkernel_pid "\n", active_thread->pid);
         }
 #endif
-
-#ifdef MODULE_SCHEDSTATISTICS
-        schedstat_t *active_stat = &sched_pidlist[active_thread->pid];
-        if (active_stat->laststart) {
-            active_stat->runtime_ticks += now - active_stat->laststart;
-        }
-#endif
     }
 
 #ifdef MODULE_SCHEDSTATISTICS
-    schedstat_t *next_stat = &sched_pidlist[next_thread->pid];
-    next_stat->laststart = now;
-    next_stat->schedules++;
     if (sched_cb) {
-        sched_cb(now, next_thread->pid);
+        /* Use `sched_active_pid` instead of `active_thread` since after `sched_task_exit()` is
+           called `active_thread` is set to NULL while `sched_active_thread` isn't updated until
+           `next_thread` is scheduled*/
+        sched_cb(sched_active_pid, next_thread->pid);
     }
 #endif
 
@@ -150,13 +139,6 @@ int __attribute__((used)) sched_run(void)
 
     return 1;
 }
-
-#ifdef MODULE_SCHEDSTATISTICS
-void sched_register_cb(void (*callback)(uint32_t, uint32_t))
-{
-    sched_cb = callback;
-}
-#endif
 
 void sched_set_status(thread_t *process, thread_status_t status)
 {
@@ -221,3 +203,35 @@ NORETURN void sched_task_exit(void)
     sched_active_thread = NULL;
     cpu_switch_context_exit();
 }
+
+#ifdef MODULE_SCHEDSTATISTICS
+void sched_register_cb(void (*callback)(kernel_pid_t, kernel_pid_t))
+{
+    sched_cb = callback;
+}
+
+void sched_statistics_cb(kernel_pid_t active_thread, kernel_pid_t next_thread)
+{
+    uint32_t now = xtimer_now().ticks32;
+
+    /* Update active thread runtime, there is always an active thread since
+       first sched_run happens when main_trampoline gets scheduled */
+    schedstat_t *active_stat = &sched_pidlist[active_thread];
+    active_stat->runtime_ticks += now - active_stat->laststart;
+
+    /* Update next_thread stats */
+    schedstat_t *next_stat = &sched_pidlist[next_thread];
+    next_stat->laststart = now;
+    next_stat->schedules++;
+}
+
+void init_schedstatistics(void)
+{
+    /* Init laststart for the thread starting schedstatistics since the callback
+       wasn't registered when it was first scheduled */
+    schedstat_t *active_stat = &sched_pidlist[sched_active_pid];
+    active_stat->laststart = xtimer_now().ticks32;
+    active_stat->schedules = 1;
+    sched_register_cb(sched_statistics_cb);
+}
+#endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -70,6 +70,7 @@ PSEUDOMODULES += saul_gpio
 PSEUDOMODULES += saul_nrf_temperature
 PSEUDOMODULES += scanf_float
 PSEUDOMODULES += schedstatistics
+PSEUDOMODULES += sched_cb
 PSEUDOMODULES += semtech_loramac_rx
 PSEUDOMODULES += sock
 PSEUDOMODULES += sock_ip

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -92,6 +92,10 @@
 #include "net/sock/dtls.h"
 #endif
 
+#ifdef MODULE_SCHEDSTATISTICS
+#include "sched.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -104,6 +108,9 @@ void auto_init(void)
 #ifdef MODULE_XTIMER
     DEBUG("Auto init xtimer module.\n");
     xtimer_init();
+#endif
+#ifdef MODULE_SCHEDSTATISTICS
+    init_schedstatistics();
 #endif
 #ifdef MODULE_MCI
     DEBUG("Auto init mci module.\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR moves all the `schedstatistcs` code to a callback and makes uses of `sched_cb` to execute this callback every-time the `sched_run()` is called. 

An init function is added for `schedstatistcs` so that the callback isn't called before its dependency's have been started, in this case `xtimer`.

The `sched_cb` code is decoupled from the `schedstatistics` code as well.

### Testing procedure

Run:

    `make -C tests/ps_schedstatistics/ BOARD=samr21-xpro flash test`

still passes as well as other supported boards.

    `make -C tests/ps_schedstatistics/ BOARD=pba-d-01-kw2x flash test`

now passes, as well as for other kinetis boards (failed in master).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Related to https://github.com/RIOT-OS/RIOT/pull/11635