### PR TITLE
pkg/semtech-loramac: rework how session keys are get/set

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -29,6 +29,9 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+extern uint8_t LoRaMacAppSKey[];
+extern uint8_t LoRaMacNwkSKey[];
+
 void semtech_loramac_set_deveui(semtech_loramac_t *mac, const uint8_t *eui)
 {
     memcpy(mac->deveui, eui, LORAMAC_DEVEUI_LEN);
@@ -62,40 +65,28 @@ void semtech_loramac_get_appkey(const semtech_loramac_t *mac, uint8_t *key)
 void semtech_loramac_set_appskey(semtech_loramac_t *mac, const uint8_t *skey)
 {
     mutex_lock(&mac->lock);
-    MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_APP_SKEY;
-    memcpy(mibReq.Param.AppSKey, skey, LORAMAC_APPSKEY_LEN);
-    LoRaMacMibSetRequestConfirm(&mibReq);
+    memcpy(LoRaMacAppSKey, skey, LORAMAC_APPSKEY_LEN);
     mutex_unlock(&mac->lock);
 }
 
 void semtech_loramac_get_appskey(semtech_loramac_t *mac, uint8_t *skey)
 {
     mutex_lock(&mac->lock);
-    MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_APP_SKEY;
-    LoRaMacMibGetRequestConfirm(&mibReq);
-    memcpy(skey, mibReq.Param.AppSKey, LORAMAC_APPSKEY_LEN);
+    memcpy(skey, LoRaMacAppSKey, LORAMAC_APPSKEY_LEN);
     mutex_unlock(&mac->lock);
 }
 
 void semtech_loramac_set_nwkskey(semtech_loramac_t *mac, const uint8_t *skey)
 {
     mutex_lock(&mac->lock);
-    MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_NWK_SKEY;
-    memcpy(mibReq.Param.NwkSKey, skey, LORAMAC_NWKSKEY_LEN);
-    LoRaMacMibSetRequestConfirm(&mibReq);
+    memcpy(LoRaMacNwkSKey, skey, LORAMAC_NWKSKEY_LEN);
     mutex_unlock(&mac->lock);
 }
 
 void semtech_loramac_get_nwkskey(semtech_loramac_t *mac, uint8_t *skey)
 {
     mutex_lock(&mac->lock);
-    MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_NWK_SKEY;
-    LoRaMacMibGetRequestConfirm(&mibReq);
-    memcpy(skey, mibReq.Param.NwkSKey, LORAMAC_NWKSKEY_LEN);
+    memcpy(skey, LoRaMacNwkSKey, LORAMAC_NWKSKEY_LEN);
     mutex_unlock(&mac->lock);
 }
 

--- a/pkg/semtech-loramac/patches/0001-adapt-to-riot.patch
+++ b/pkg/semtech-loramac/patches/0001-adapt-to-riot.patch
@@ -1,16 +1,16 @@
-From 21a0864451b15d53a468a359e465084b498cc37b Mon Sep 17 00:00:00 2001
+From b94cb20e4c34dba2c643319c05e27e636cdee61a Mon Sep 17 00:00:00 2001
 From: Alexandre Abadie <alexandre.abadie@inria.fr>
 Date: Sun, 1 Apr 2018 19:52:58 +0200
 Subject: [PATCH] adapt to RIOT
 
 ---
- src/mac/LoRaMac.c       | 28 +++++++++++-----------------
+ src/mac/LoRaMac.c       | 32 +++++++++++++-------------------
  src/mac/LoRaMac.h       |  4 ++--
  src/mac/region/Region.h |  2 +-
- 3 files changed, 14 insertions(+), 20 deletions(-)
+ 3 files changed, 16 insertions(+), 22 deletions(-)
 
 diff --git a/src/mac/LoRaMac.c b/src/mac/LoRaMac.c
-index ca90cd2..ca9c370 100644
+index ca90cd2f..d2a89923 100644
 --- a/src/mac/LoRaMac.c
 +++ b/src/mac/LoRaMac.c
 @@ -32,6 +32,7 @@
@@ -21,6 +21,24 @@ index ca90cd2..ca9c370 100644
  
  /*!
   * Maximum PHY layer payload size
+@@ -86,7 +87,7 @@ static uint8_t *LoRaMacAppKey;
+ /*!
+  * AES encryption/decryption cipher network session key
+  */
+-static uint8_t LoRaMacNwkSKey[] =
++uint8_t LoRaMacNwkSKey[] =
+ {
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+@@ -95,7 +96,7 @@ static uint8_t LoRaMacNwkSKey[] =
+ /*!
+  * AES encryption/decryption cipher application session key
+  */
+-static uint8_t LoRaMacAppSKey[] =
++uint8_t LoRaMacAppSKey[] =
+ {
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 @@ -322,11 +323,6 @@ static LoRaMacPrimitives_t *LoRaMacPrimitives;
   */
  static LoRaMacCallback_t *LoRaMacCallbacks;
@@ -88,7 +106,7 @@ index ca90cd2..ca9c370 100644
      // Random seed initialization
      srand1( Radio.Random( ) );
 diff --git a/src/mac/LoRaMac.h b/src/mac/LoRaMac.h
-index 7899ac2..78ed66c 100644
+index 7899ac21..78ed66cb 100644
 --- a/src/mac/LoRaMac.h
 +++ b/src/mac/LoRaMac.h
 @@ -102,7 +102,7 @@
@@ -110,7 +128,7 @@ index 7899ac2..78ed66c 100644
  /*!
   * \brief   Queries the LoRaMAC if it is possible to send the next frame with
 diff --git a/src/mac/region/Region.h b/src/mac/region/Region.h
-index fa0fd44..810f0ea 100644
+index fa0fd445..810f0ea5 100644
 --- a/src/mac/region/Region.h
 +++ b/src/mac/region/Region.h
 @@ -54,7 +54,7 @@
@@ -123,5 +141,5 @@ index fa0fd44..810f0ea 100644
  /*!
   * Macro to compute bit of a channel index.
 -- 
-2.14.1
+2.20.1
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes #11626.

Although the reason is still unclear to me, I noticed that using Loramac MIB get/set functions to get/set network/application session keys were not working as expected after reading the values from EEPROM.

The idea of this PR is to skip the use of Loramac MIB get/set functions and patch the package to get a global access to the underlying arrays.
Even though this is not very nice, it avoids having to memcpy twice a 16bytes array for each keys.

I tested this change in the im880b board (stm32l1 + sx1272) and b-l072z-lrwan1 and on both it's working like a charm.

Note that I'm not sure this is the best fix, but at least it works.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run `tests/pkg_semtech-loramac` on b-l072z-lrwan1 and lobaro-lorabox boards
- For OTAA, test this workflow:
  - Ensure EEPROM is erased (`loramac erase`) and reboot
  - set deveui, appeui, appkey
  - join the network: `loramac join otaa`
  - save the parameters to the EEPROM `loramac save` and reboot
  - send something: it should work
- For ABP, test this workflow:
  - Ensure EEPROM is erased (`loramac erase`) and reboot
  - set devaddr, appskey, nwskey
  - join the network: `loramac join abp`
  - save the parameters to the EEPROM `loramac save` and reboot
  - eventually configure the rx2_dr (for TTN set it to 3) and send something: it should work

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #11626

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
