### PR TITLE
gcoap: don't call random_uint32_range() when COAP_ACK_VARIANCE=0

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -134,8 +134,10 @@ static void *_event_loop(void *arg)
                     memo->send_limit--;
                     unsigned i        = COAP_MAX_RETRANSMIT - memo->send_limit;
                     uint32_t timeout  = ((uint32_t)COAP_ACK_TIMEOUT << i) * US_PER_SEC;
+#if COAP_ACK_VARIANCE > 0
                     uint32_t variance = ((uint32_t)COAP_ACK_VARIANCE << i) * US_PER_SEC;
                     timeout = random_uint32_range(timeout, timeout + variance);
+#endif
 
                     ssize_t bytes = sock_udp_send(&_sock, memo->msg.data.pdu_buf,
                                                   memo->msg.data.pdu_len,
@@ -753,8 +755,10 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
             if (memo->msg.data.pdu_buf) {
                 memo->send_limit  = COAP_MAX_RETRANSMIT;
                 timeout           = (uint32_t)COAP_ACK_TIMEOUT * US_PER_SEC;
+#if COAP_ACK_VARIANCE > 0
                 uint32_t variance = (uint32_t)COAP_ACK_VARIANCE * US_PER_SEC;
                 timeout = random_uint32_range(timeout, timeout + variance);
+#endif
             }
             else {
                 memo->state = GCOAP_MEMO_UNUSED;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`COAP_ACK_VARIANCE` is a configurable macro, so when it is 0, the [precondition for `random_uint32_range()`][1] is not held.

Background is that for some experimental setups you want to disable the randomness in retransmissions to have better comparibility, as we did e.g. for [this paper](https://conferences.sigcomm.org/acm-icn/2018/proceedings/icn18-final46.pdf).

[1]: https://doc.riot-os.org/group__sys__random.html#gab6ee09e1e56df3cc78acd1fbf97bfb24

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compiling `examples/gcoap` with `COAP_ACK_VARIANCE=0` and the default value should still work. The randomness should be reduced with `COAP_ACK_VARIANCE`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
