### PR TITLE
gnrc_tftp: set port on server init

### DIFF
--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -412,6 +412,7 @@ int gnrc_tftp_server(tftp_data_cb_t data_cb, tftp_start_cb_t start_cb, tftp_stop
 
     /* context will be initialized when a connection is established */
     tftp_context_t ctxt = {
+        .dst_port = GNRC_TFTP_DEFAULT_DST_PORT,
         .src_port = GNRC_TFTP_DEFAULT_DST_PORT,
         .data_cb = data_cb,
         .start_cb = start_cb,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
See https://github.com/RIOT-OS/RIOT/pull/11773#discussion_r299990171
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Use the test provided by @nmeum in https://github.com/RIOT-OS/RIOT/pull/11773#discussion_r299990171. Make sure `examples/gnrc_tftp` is still working according to its README.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #11772.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
