### PR TITLE
gcoap: allow for retransmission backoff to be turned off

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -341,6 +341,20 @@ extern "C" {
 #define GCOAP_RECV_TIMEOUT      (1 * US_PER_SEC)
 #endif
 
+#ifdef DOXYGEN
+/**
+ * @ingroup net_gcoap_conf
+ * @brief   Turns off retransmission backoff when defined (undefined per default)
+ *
+ * In normal operations the timeout between retransmissions doubles. When
+ * GCOAP_NO_RETRANS_BACKOFF is defined this doubling does not happen.
+ *
+ * @see COAP_ACK_TIMEOUT
+ * @see COAP_ACK_VARIANCE
+ */
+#define GCOAP_NO_RETRANS_BACKOFF
+#endif
+
 /**
  * @ingroup net_gcoap_conf
  * @brief   Default time to wait for a non-confirmable response [in usec]

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -132,7 +132,11 @@ static void *_event_loop(void *arg)
                 /* reduce retries remaining, double timeout and resend */
                 else {
                     memo->send_limit--;
+#ifdef GCOAP_NO_RETRANS_BACKOFF
+                    unsigned i        = 0;
+#else
                     unsigned i        = COAP_MAX_RETRANSMIT - memo->send_limit;
+#endif
                     uint32_t timeout  = ((uint32_t)COAP_ACK_TIMEOUT << i) * US_PER_SEC;
                     uint32_t variance = ((uint32_t)COAP_ACK_VARIANCE << i) * US_PER_SEC;
                     timeout = random_uint32_range(timeout, timeout + variance);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This allows for the backoff of CoAP retransmissions to be turned of. This is sometimes desirable for an experimental set-up as we used e.g. in [this paper](https://conferences.sigcomm.org/acm-icn/2018/proceedings/icn18-final46.pdf)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
To see the best effect it is recommended to merge #11784 first and compile `examples/gcoap` with `CFLAGS="-DCOAP_ACK_VARIANCE=0 -DGCOAP_NO_RETRANS_BACKOFF"`. This will turnoff the backoff *and* its randomization.

```
BOARD=iotlab-m3 CFLAGS="-DCOAP_ACK_VARIANCE=0 -DGCOAP_NO_RETRANS_BACKOFF" make -C examples/gcoap flash
```

Now with a sniffer activated, use a 6LoWPAN-enabled board (to circumvent neighbor discovery with link-local addresses) and type

```
coap get -c fe80::1155:4433:2211:00ff 5683 /.well-known/core
```

Packets now should come in ~2sec intervals.

When compiling just with 


```
BOARD=iotlab-m3 CFLAGS="-DCOAP_ACK_VARIANCE=0" make -C examples/gcoap flash
```

The time between each retransmission should roughly double.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#11784 recommended for testing.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
