### PR TITLE
stm32_common/flash_common: fix _wait_for_pending_isr()

### DIFF
--- a/cpu/stm32_common/periph/flash_common.c
+++ b/cpu/stm32_common/periph/flash_common.c
@@ -65,8 +65,11 @@ void _wait_for_pending_operations(void)
         while (FLASH->SR & FLASH_SR_BSY) {}
     }
 
-    /* Clear 'end of operation' bit in status register */
-    if (FLASH->SR & FLASH_SR_EOP) {
-        FLASH->SR &= ~(FLASH_SR_EOP);
-    }
+    /* Clear 'end of operation' bit in status register, for other STM32 boards
+       this bit is set only if EOPIE is set, which is currently not done */
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1)
+    FLASH->SR |= FLASH_SR_EOP;
+#endif
 }

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -175,6 +175,9 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     /* unlock the flash module */
     _unlock_flash();
 
+    /* make sure no flash operation is ongoing */
+    _wait_for_pending_operations();
+
     DEBUG("[flashpage_raw] write: now writing the data\n");
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR fixes a flashpage implementation.

- In `flash_common` `FLASH_SR_EOP` is cleared by writing to 0, when RM states that it is cleared by writing 1 (check any STM32 `FLASH_SR` register description).
- It guards clearing  `FLASH_SR_EOP` for platforms that don't make use of it since  `FLASH_SR_EOP` is never set for them (STM32F2, STM32F4, STM32F7 & STM32L4).
- When writing to flash the first operation is performed before checking if there was any ongoing operation. This should also be done according to the RM.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Verify my statement in the RM.

Run for stm32x boards:

`make -C tests/periph_flashpage/ BOARD=nucleo-l476rg flash -j3 test`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
