### PR TITLE
net/mqttsn: fix client ID length to comply to the standard

### DIFF
--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -95,15 +95,6 @@ extern "C" {
 #define ASYMCUTE_LISTENER_STACKSIZE (THREAD_STACKSIZE_DEFAULT)
 #endif
 
-#ifndef ASYMCUTE_ID_MAXLEN
-/**
- * @brief   Maximum client ID length
- *
- * @note    Must be less than (256 - 8) and less than (ASYMCUTE_BUFSIZE - 8)
- */
-#define ASYMCUTE_ID_MAXLEN          (32U)
-#endif
-
 #ifndef ASYMCUTE_TOPIC_MAXLEN
 /**
  * @brief   Maximum topic length
@@ -273,7 +264,7 @@ struct asymcute_con {
     uint8_t keepalive_retry_cnt;        /**< keep alive transmission counter */
     uint8_t state;                      /**< connection state */
     uint8_t rxbuf[ASYMCUTE_BUFSIZE];    /**< connection specific receive buf */
-    char cli_id[ASYMCUTE_ID_MAXLEN + 1];/**< buffer to store client ID */
+    char cli_id[MQTTSN_CLI_ID_MAXLEN + 1];  /**< buffer to store client ID */
 };
 
 /**

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -114,16 +114,6 @@ extern "C" {
 #define EMCUTE_BUFSIZE          (512U)
 #endif
 
-#ifndef EMCUTE_ID_MAXLEN
-/**
- * @brief   Maximum client ID length
- *
- * @note    **Must** be less than (256 - 6) AND less than
- *          (@ref EMCUTE_BUFSIZE - 6).
- */
-#define EMCUTE_ID_MAXLEN        (196U)
-#endif
-
 #ifndef EMCUTE_TOPIC_MAXLEN
 /**
  * @brief   Maximum topic length

--- a/sys/include/net/mqttsn.h
+++ b/sys/include/net/mqttsn.h
@@ -36,6 +36,16 @@ extern "C" {
 #endif
 
 /**
+ * @name    The client ID must contain 1-23 characters
+ *
+ * @see MQTT-SN spec v1.2, section 5.3.1
+ * @{
+ */
+#define MQTTSN_CLI_ID_MINLEN    (1U)
+#define MQTTSN_CLI_ID_MAXLEN    (23U)
+/** @} */
+
+/**
  * @brief   MQTT-SN flags
  *
  * All MQTT-SN functions only support a sub-set of the available flags. It is up

--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -712,7 +712,7 @@ int asymcute_connect(asymcute_con_t *con, asymcute_req_t *req,
         return ASYMCUTE_NOTSUP;
     }
     /* make sure the client ID will fit into the dedicated buffer */
-    if (id_len > ASYMCUTE_ID_MAXLEN) {
+    if ((id_len < MQTTSN_CLI_ID_MINLEN) || (id_len > MQTTSN_CLI_ID_MAXLEN)) {
         return ASYMCUTE_OVERFLOW;
     }
     /* check if the context is not already connected to any gateway */

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -28,6 +28,7 @@
 #include "thread_flags.h"
 
 #include "net/emcute.h"
+#include "net/mqttsn.h"
 #include "emcute_internal.h"
 
 #define ENABLE_DEBUG        (0)
@@ -490,7 +491,8 @@ int emcute_willupd_msg(const void *data, size_t len)
 
 void emcute_run(uint16_t port, const char *id)
 {
-    assert(strlen(id) < EMCUTE_ID_MAXLEN);
+    assert(strlen(id) >= MQTTSN_CLI_ID_MINLEN &&
+           strlen(id) <= MQTTSN_CLI_ID_MAXLEN);
 
     sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
     sock_udp_ep_t remote;


### PR DESCRIPTION
# Contribution description
The MQTT-SN standard explicitly states, that the client ID must contain 1-23 characters (see section 5.3.1 and also the cli ID field description in 5.4.4). This PR adapts the existing implementations to adhere to these values.

### Testing procedure
Build `asymcute` and `emcute` using client ID strings that are larger/smaller then 1-23 chars, this should make the application return an error for calling connect() (`asymcute`) or throw an assertion (`emcute`).

### Issues/PRs references
none