### PR TITLE
gnrc/pktbuf: remove obsolete sys/uio.h include

### DIFF
--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -13,8 +13,6 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
-#include <sys/uio.h>
-
 #include "net/gnrc/pktbuf.h"
 
 gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt,


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This was previously used by gnrc_pktbuf_get_iovec() for the definitions
of "struct iovec", which has been removed a while ago.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
