### PR TITLE
tests: add Nordic SoftDevice test app

### DIFF
--- a/tests/nordic_softdevice/Makefile
+++ b/tests/nordic_softdevice/Makefile
@@ -1,0 +1,19 @@
+BOARD ?= nrf52dk
+include ../Makefile.tests_common
+
+# Use the Nordic SoftDevice
+USEPKG += nordic_softdevice_ble
+
+# use a minimal GNRC configuration
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_ipv6
+USEMODULE += gnrc_icmpv6_echo
+# also add the shell with some basic shell commands
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+TEST_ON_CI_WHITELIST += nrf52dk
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/nordic_softdevice/README.md
+++ b/tests/nordic_softdevice/README.md
@@ -1,0 +1,13 @@
+# Nordic SoftDevice Test Application
+The main purpose of this test application is to ensure the inclusion of the
+Nordic SoftDevice package in RIOTs build test.
+
+In addition, this example includes a minimal GNRC configuration and the
+corresponding shell commands, so it can be used for some simple tests of
+network functionality. Please refer to `pkg/nordic_softdevice_ble/README.md`
+and `pkg/nordic_softdevice_ble/README-BLE-6LoWPAN.md` for more information on
+how to setup an IPv6 connection to your device.
+
+For more features, you can use the SoftDevice with RIOTs `gnrc_networking`
+example application. Simply build `gnrc_networking` for a SoftDevice-capable
+device, e.g. `USEPKG=nordic_softdevice_ble BOARD=nrf52dk make ...`.

--- a/tests/nordic_softdevice/main.c
+++ b/tests/nordic_softdevice/main.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       This test application ensures that the Nordic SoftDevice
+ *              integration is included in the build test
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("Test for the RIOT integration of the Nordic SoftDevice");
+
+    /* start shell */
+    puts("All up, running the shell now");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}

--- a/tests/nordic_softdevice/tests/01-run.py
+++ b/tests/nordic_softdevice/tests/01-run.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("All up, running the shell now")
+    child.sendline("ifconfig")
+    child.expect(r"Iface\s+(\d+)\s+HWaddr:")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=1, echo=False))


### PR DESCRIPTION
## Contribution description
This is the next step towards making NimBLE the default IP-over-BLE solution for Nordic boards.

This PR adds a simple test application to verify that the Nordic SoftDevice package is still working. Though meant mainly for keeping the SoftDevice in the built-test, it also includes a (very shallow) test script, that simply checks if a device boots ok and that the SoftDevice registers a network device with GNRC.

### Testing procedure
Build test should pass, and `make test` on any supported boards should succeed.

### Issues/PRs references
loosely related to #11578