### PR TITLE
sx127x: remove MULTIDIO and fix missing interrupt handling

### DIFF
--- a/boards/sensebox_samd21/Makefile.include
+++ b/boards/sensebox_samd21/Makefile.include
@@ -21,7 +21,5 @@ else
   include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
 
-CFLAGS += -DSX127X_USE_DIO_MULTI
-
 # setup the boards dependencies
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -121,7 +121,9 @@ extern "C" {
  * @name        SX127X
  *
  * SX127X configuration (on XBEE1 port). This particular board has
- * merged DIO0 and DIO1 interupt pins into one (defined as DIOMULTI).
+ * merged DIO0 and DIO1 interrupt pins into one. The driver will always
+ * check the interrupt type in the ISR handler, so it's enough to set
+ * the DIO0 pin in order to handle both DIO0 and DIO1.
  * @{
  */
 #define SX127X_PARAM_SPI                    (SPI_DEV(0))
@@ -130,15 +132,13 @@ extern "C" {
 
 #define SX127X_PARAM_RESET                  GPIO_UNDEF
 
-#define SX127X_PARAM_DIO0                   GPIO_UNDEF
+#define SX127X_PARAM_DIO0                   XBEE1_INT_PIN       /* D24 */
 
 #define SX127X_PARAM_DIO1                   GPIO_UNDEF
 
 #define SX127X_PARAM_DIO2                   GPIO_UNDEF
 
 #define SX127X_PARAM_DIO3                   GPIO_UNDEF
-
-#define SX127X_PARAM_DIO_MULTI              XBEE1_INT_PIN       /* D24 */
 
 #define SX127X_PARAM_PASELECT               (SX127X_PA_BOOST)
 /** @} */

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -92,9 +92,6 @@ extern "C" {
 #define SX127X_IRQ_DIO3                  (1<<3)  /**< DIO3 IRQ */
 #define SX127X_IRQ_DIO4                  (1<<4)  /**< DIO4 IRQ */
 #define SX127X_IRQ_DIO5                  (1<<5)  /**< DIO5 IRQ */
-#ifdef SX127X_USE_DIO_MULTI
-#define SX127X_IRQ_DIO_MULTI             (1<<6)  /**< DIO MULTI IRQ */
-#endif
 #ifndef SX127X_DIO_PULL_MODE
 #define SX127X_DIO_PULL_MODE             (GPIO_IN_PD) /**< pull down DIOx */
 #endif
@@ -214,9 +211,6 @@ typedef struct {
     gpio_t dio3_pin;                   /**< Interrupt line DIO3 (CAD done) */
     gpio_t dio4_pin;                   /**< Interrupt line DIO4 (not used) */
     gpio_t dio5_pin;                   /**< Interrupt line DIO5 (not used) */
-#ifdef SX127X_USE_DIO_MULTI
-    gpio_t dio_multi_pin;              /**< Interrupt line for multiple IRQs */
-#endif
 #if defined(SX127X_USE_TX_SWITCH) || defined(SX127X_USE_RX_SWITCH)
     gpio_t rx_switch_pin;              /**< Rx antenna switch */
     gpio_t tx_switch_pin;              /**< Tx antenna switch */

--- a/drivers/sx127x/include/sx127x_params.h
+++ b/drivers/sx127x/include/sx127x_params.h
@@ -60,10 +60,6 @@ extern "C" {
 #define SX127X_PARAM_DIO3                   GPIO_PIN(1, 4)       /* D5 */
 #endif
 
-#ifndef SX127X_PARAM_DIO_MULTI
-#define SX127X_PARAM_DIO_MULTI              GPIO_UNDEF
-#endif
-
 #ifndef SX127X_PARAM_PASELECT
 #define SX127X_PARAM_PASELECT               (SX127X_PA_RFO)
 #endif
@@ -77,17 +73,7 @@ extern "C" {
 #endif
 
 #ifndef SX127X_PARAMS
-#ifdef SX127X_USE_DIO_MULTI
-#define SX127X_PARAMS             { .spi       = SX127X_PARAM_SPI,          \
-                                    .nss_pin   = SX127X_PARAM_SPI_NSS,      \
-                                    .reset_pin = SX127X_PARAM_RESET,        \
-                                    .dio0_pin  = SX127X_PARAM_DIO0,         \
-                                    .dio1_pin  = SX127X_PARAM_DIO1,         \
-                                    .dio2_pin  = SX127X_PARAM_DIO2,         \
-                                    .dio3_pin  = SX127X_PARAM_DIO3,         \
-                                    .dio_multi_pin = SX127X_PARAM_DIO_MULTI,\
-                                    .paselect  = SX127X_PARAM_PASELECT }
-#elif defined(SX127X_USE_TX_SWITCH) || defined(SX127X_USE_RX_SWITCH)
+#if defined(SX127X_USE_TX_SWITCH) || defined(SX127X_USE_RX_SWITCH)
 #define SX127X_PARAMS             { .spi            = SX127X_PARAM_SPI,          \
                                     .nss_pin        = SX127X_PARAM_SPI_NSS,      \
                                     .reset_pin      = SX127X_PARAM_RESET,        \

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -48,14 +48,10 @@ static void _on_tx_timeout(void *arg);
 static void _on_rx_timeout(void *arg);
 
 /* SX127X DIO interrupt handlers initialization */
-#ifndef SX127X_USE_DIO_MULTI
 static void sx127x_on_dio0_isr(void *arg);
 static void sx127x_on_dio1_isr(void *arg);
 static void sx127x_on_dio2_isr(void *arg);
 static void sx127x_on_dio3_isr(void *arg);
-#else
-static void sx127x_on_dio_multi_isr(void *arg);
-#endif
 
 void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params)
 {
@@ -210,7 +206,6 @@ static void sx127x_on_dio_isr(sx127x_t *dev, sx127x_flags_t flag)
     sx127x_isr((netdev_t *)dev);
 }
 
-#ifndef SX127X_USE_DIO_MULTI
 static void sx127x_on_dio0_isr(void *arg)
 {
     sx127x_on_dio_isr((sx127x_t*) arg, SX127X_IRQ_DIO0);
@@ -230,19 +225,12 @@ static void sx127x_on_dio3_isr(void *arg)
 {
     sx127x_on_dio_isr((sx127x_t*) arg, SX127X_IRQ_DIO3);
 }
-#else
-static void sx127x_on_dio_multi_isr(void *arg)
-{
-    sx127x_on_dio_isr((sx127x_t*) arg, SX127X_IRQ_DIO_MULTI);
-}
-#endif
 
 /* Internal event handlers */
 static int _init_gpios(sx127x_t *dev)
 {
     int res;
 
-#ifndef SX127X_USE_DIO_MULTI
     /* Check if DIO0 pin is defined */
     if (dev->params.dio0_pin != GPIO_UNDEF) {
         res = gpio_init_int(dev->params.dio0_pin, SX127X_DIO_PULL_MODE,
@@ -287,24 +275,6 @@ static int _init_gpios(sx127x_t *dev)
             return res;
         }
     }
-#else
-    if (dev->params.dio_multi_pin != GPIO_UNDEF) {
-        DEBUG("[sx127x] info: Trying to initialize DIO MULTI pin\n");
-        res = gpio_init_int(dev->params.dio_multi_pin, SX127X_DIO_PULL_MODE,
-                            GPIO_RISING, sx127x_on_dio_multi_isr, dev);
-        if (res < 0) {
-            DEBUG("[sx127x] error: failed to initialize DIO MULTI pin\n");
-            return res;
-        }
-
-        DEBUG("[sx127x] info: DIO MULTI pin initialized successfully\n");
-    }
-    else {
-        DEBUG("[sx127x] error: no DIO MULTI pin defined\n");
-        DEBUG("[sx127x] error at least one interrupt should be defined\n");
-        return SX127X_ERR_GPIOS;
-    }
-#endif
 
     return res;
 }

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -225,55 +225,25 @@ static void _isr(netdev_t *netdev)
 {
     sx127x_t *dev = (sx127x_t *) netdev;
 
-    uint8_t irq = dev->irq;
+    uint8_t interruptReg = sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS);
 
-#ifdef SX127X_USE_DIO_MULTI
-    /* if the IRQ is from an OR'd pin check the actual IRQ on the registers */
-    if (irq == SX127X_IRQ_DIO_MULTI) {
-        uint8_t interruptReg = sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS);
-
-        switch (interruptReg) {
-            case SX127X_RF_LORA_IRQFLAGS_TXDONE:
-            case SX127X_RF_LORA_IRQFLAGS_RXDONE:
-                irq = SX127X_IRQ_DIO0;
-                break;
-
-            case SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT:
-                irq = SX127X_IRQ_DIO1;
-                break;
-
-            case SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL:
-                irq = SX127X_IRQ_DIO2;
-                break;
-
-            case SX127X_RF_LORA_IRQFLAGS_CADDETECTED:
-            case SX127X_RF_LORA_IRQFLAGS_CADDONE:
-            case SX127X_RF_LORA_IRQFLAGS_VALIDHEADER:
-                irq = SX127X_IRQ_DIO3;
-                break;
-
-            default:
-                break;
-        }
-    }
-#endif
-
-    dev->irq = 0;
-
-    switch (irq) {
-        case SX127X_IRQ_DIO0:
+    switch (interruptReg) {
+        case SX127X_RF_LORA_IRQFLAGS_TXDONE:
+        case SX127X_RF_LORA_IRQFLAGS_RXDONE:
             _on_dio0_irq(dev);
             break;
 
-        case SX127X_IRQ_DIO1:
+        case SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT:
             _on_dio1_irq(dev);
             break;
 
-        case SX127X_IRQ_DIO2:
+        case SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL:
             _on_dio2_irq(dev);
             break;
 
-        case SX127X_IRQ_DIO3:
+        case SX127X_RF_LORA_IRQFLAGS_CADDETECTED:
+        case SX127X_RF_LORA_IRQFLAGS_CADDONE:
+        case SX127X_RF_LORA_IRQFLAGS_VALIDHEADER:
             _on_dio3_irq(dev);
             break;
 

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -223,32 +223,27 @@ static int _init(netdev_t *netdev)
 
 static void _isr(netdev_t *netdev)
 {
-    sx127x_t *dev = (sx127x_t *) netdev;
+    sx127x_t *dev = (sx127x_t *)netdev;
 
     uint8_t interruptReg = sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS);
 
-    switch (interruptReg) {
-        case SX127X_RF_LORA_IRQFLAGS_TXDONE:
-        case SX127X_RF_LORA_IRQFLAGS_RXDONE:
-            _on_dio0_irq(dev);
-            break;
+    if (interruptReg & (SX127X_RF_LORA_IRQFLAGS_TXDONE |
+                        SX127X_RF_LORA_IRQFLAGS_RXDONE)) {
+        _on_dio0_irq(dev);
+    }
 
-        case SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT:
-            _on_dio1_irq(dev);
-            break;
+    if (interruptReg & SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT) {
+        _on_dio1_irq(dev);
+    }
 
-        case SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL:
-            _on_dio2_irq(dev);
-            break;
+    if (interruptReg & SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL) {
+        _on_dio2_irq(dev);
+    }
 
-        case SX127X_RF_LORA_IRQFLAGS_CADDETECTED:
-        case SX127X_RF_LORA_IRQFLAGS_CADDONE:
-        case SX127X_RF_LORA_IRQFLAGS_VALIDHEADER:
-            _on_dio3_irq(dev);
-            break;
-
-        default:
-            break;
+    if (interruptReg & (SX127X_RF_LORA_IRQFLAGS_CADDETECTED |
+                        SX127X_RF_LORA_IRQFLAGS_CADDONE |
+                        SX127X_RF_LORA_IRQFLAGS_VALIDHEADER)) {
+        _on_dio3_irq(dev);
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the MULTIDIO feature introduced in https://github.com/RIOT-OS/RIOT/pull/9815 and fixes a missing interrupt handling for some boards (sensebox_samd21).

Instead of having a dedicated case for boards that don't include all DIO lines, now the ISR flags are always read in the `netdev->driver->isr` function. Hence, the MULTIDIO feature is not needed anymore.

Since the SenseBox doesn't provide DIO3 the RX_STARTED event (introduced in #10932) was never triggered (but the corresponding ISR flag 0x4 was updated). When the RX_DONE triggered (0x1), the handler was not called because the ISR flags byte was (0x4 | 0x1) = 0x5 and was indeed not handled within the switch-case.
This PR changes this switch-case pattern to `if(isr & EVENT_FLAG) { handle_event(...)}`
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `tests/pkg_semtech_loramac` and `tests/driver_sx127x` and verify common LoRa and LoRaWAN stuff work (joining a network, changing frequency, etc).

Ideally test in `sensebox_samd21` and any other LoRaWAN board (e.g `b-l072z-lrwan1`)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
