### PR TITLE
pkg/semtech-loramac: handle rx started event in mac event callback

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -543,6 +543,10 @@ static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
             }
             break;
 
+        case NETDEV_EVENT_RX_STARTED:
+            DEBUG("[semtech-loramac] RX started\n");
+            break;
+
         case NETDEV_EVENT_RX_COMPLETE:
         {
             size_t len;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an extra case for "RX started" netdev event in semtech-loramac event callback function.

When enable debug, this avoids having the message `[semtech-loramac] unexpected netdev event received: 1` when the RX windows start.

Thanks to compiler optimization, the code size is unchanged by this PR when ENABLE_DEBUG is not set.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- enable debug in `semtech-loramac.c`
- flash `tests/pkg_semtech-loramac` application
- using the shell, configure the device, join a LoRaWAN network and send messages
- on master, you get the following output:
```
> loramac tx test
loramac tx test
[semtech-loramac] loramac cmd msg
[semtech-loramac] send frame test
[semtech-loramac] MCPS request: confirmed TX
[semtech-loramac] MCPS request: OK
[semtech-loramac] Transmission completed
[semtech-loramac] MAC timer timeout
[semtech-loramac] MAC timer timeout
[semtech-loramac] unexpected netdev event received: 1   <= unexpected event corresponding to rx started
[semtech-loramac] MCPS confirm event
[semtech-loramac] MCPS indication event
[semtech-loramac] MCPS confirm msg received
[semtech-loramac] MCPS confirm event OK
[semtech-loramac] saving uplink counter: 3
[semtech-loramac] MCPS confirm event: CONFIRMED
[semtech-loramac] forward TX status to sender thread
[semtech-loramac] MCPS indication msg received
[semtech-loramac] MCPS indication Unconfirmed
[semtech-loramac] MCPS indication: ACK received
[semtech-loramac] received something
Received ACK from network
Message sent with success

```
- with this PR:
```
> loramac tx test
loramac tx test
[semtech-loramac] loramac cmd msg
[semtech-loramac] send frame test
[semtech-loramac] MCPS request: confirmed TX
[semtech-loramac] MCPS request: OK
[semtech-loramac] Transmission completed
[semtech-loramac] MAC timer timeout
[semtech-loramac] MAC timer timeout
[semtech-loramac] RX started      <= new debug message here !!!
[semtech-loramac] MCPS confirm event
[semtech-loramac] MCPS indication event
[semtech-loramac] MCPS confirm msg received
[semtech-loramac] MCPS confirm event OK
[semtech-loramac] saving uplink counter: 4 
[semtech-loramac] MCPS confirm event: CONFIRMED
[semtech-loramac] forward TX status to sender thread
[semtech-loramac] MCPS indication msg received
[semtech-loramac] MCPS indication Unconfirmed
[semtech-loramac] MCPS indication: ACK received
[semtech-loramac] received something
Received ACK from network
Message sent with success
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Suggestion from @fjmolinas in https://github.com/RIOT-OS/RIOT/pull/11777#issuecomment-508530993

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
