### PR TITLE
nanocoap: make coap_get_block2() actually fill struct

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -641,30 +641,33 @@ size_t coap_put_option_block1(uint8_t *buf, uint16_t lastonum, unsigned blknum, 
     return coap_put_option_block(buf, lastonum, blknum, szx, more, COAP_OPT_BLOCK1);
 }
 
-int coap_get_block1(coap_pkt_t *pkt, coap_block1_t *block1)
+int coap_get_block(coap_pkt_t *pkt, coap_block1_t *block, uint16_t blkopt)
 {
     uint32_t blknum;
     unsigned szx;
 
-    block1->more = coap_get_blockopt(pkt, COAP_OPT_BLOCK1, &blknum, &szx);
-    if (block1->more >= 0) {
-        block1->offset = blknum << (szx + 4);
+    block->more = coap_get_blockopt(pkt, blkopt, &blknum, &szx);
+    if (block->more >= 0) {
+        block->offset = blknum << (szx + 4);
     }
     else {
-        block1->offset = 0;
+        block->offset = 0;
     }
 
-    block1->blknum = blknum;
-    block1->szx = szx;
+    block->blknum = blknum;
+    block->szx = szx;
 
-    return (block1->more >= 0);
+    return (block->more >= 0);
 }
 
-int coap_get_block2(coap_pkt_t *pkt, coap_block1_t *block2)
+int coap_get_block1(coap_pkt_t *pkt, coap_block1_t *block)
 {
-    block2->more = coap_get_blockopt(pkt, COAP_OPT_BLOCK2, &block2->blknum,
-                                     &block2->szx);
-    return (block2->more >= 0);
+    return coap_get_block(pkt, block, COAP_OPT_BLOCK1);
+}
+
+int coap_get_block2(coap_pkt_t *pkt, coap_block1_t *block)
+{
+    return coap_get_block(pkt, block, COAP_OPT_BLOCK2);
 }
 
 size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t lastonum)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, coap_get_block2() did not fill the passed structure, making it unusable.

 This refactors coap_get_block1() into a shared coap_get_block() function and implements both coap_get_block1() and coap_get_block2() using that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- ckeck if the coap test applications still work as expected

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
