### PR TITLE
sys/riotboot: misc fixes

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -22,8 +22,8 @@ else
 endif
 
 # Final target for slot 0 with riot_hdr
-SLOT0_RIOT_BIN = $(BINDIR_APP)-slot0.riot.bin
-SLOT1_RIOT_BIN = $(BINDIR_APP)-slot1.riot.bin
+SLOT0_RIOT_BIN = $(BINDIR_APP)-slot0.$(APP_VER).riot.bin
+SLOT1_RIOT_BIN = $(BINDIR_APP)-slot1.$(APP_VER).riot.bin
 SLOT_RIOT_BINS = $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 
 # if RIOTBOOT_SKIP_COMPILE is set to 1, "make riotboot/slot[01](-flash)"
@@ -54,7 +54,7 @@ link: $(SLOT_RIOT_ELFS)
 endif
 
 # Create binary target with RIOT header
-$(SLOT_RIOT_BINS): %.riot.bin: %.hdr %.bin
+$(SLOT_RIOT_BINS): %.$(APP_VER).riot.bin: %.hdr %.bin
 	@echo "creating $@..."
 	$(Q)cat $^ > $@
 

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -17,7 +17,8 @@ export SLOT0_OFFSET SLOT0_LEN SLOT1_OFFSET SLOT1_LEN
 ifeq (1, RIOT_CI_BUILD)
   APP_VER ?= 0
 else
-  APP_VER ?= $(shell date +%s)
+  EPOCH := $(shell date +%s)
+  APP_VER ?= $(EPOCH)
 endif
 
 # Final target for slot 0 with riot_hdr


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR contains two fixes for the riotboot makefiles:

1. ensure that the call to "date" that sets the epoch is not done multiple times due to Makefile's lazy evaluation
2. add APP_VER to resulting binar filenames, so multiple versions can be created simultaneously.

This PR depends on "add_riotboot_test_script".

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- ensure the RIOTBOOT test is still completing correctly
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Waiting for #11707 (automatic tests).
This is not really a dependency, but the same files are touched, and testing should be easier with a test application.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
