### PR TITLE
stm32_common/stm32_mem_length: fix RAM_LEN for stm32l1xx-A/X cpu's

### DIFF
--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -1,6 +1,6 @@
 ## the cpu to build for
 export CPU = stm32l1
-export CPU_MODEL = stm32l151cb
+export CPU_MODEL = stm32l151cb_a
 
 # add the common header files to the include path
 INCLUDES  += -I$(RIOTBOARD)/lobaro-lorabox/include

--- a/cpu/stm32_common/stm32_mem_lengths.mk
+++ b/cpu/stm32_common/stm32_mem_lengths.mk
@@ -5,7 +5,7 @@ RAM_START_ADDR ?= 0x20000000
 # The next block takes care of setting the rigth lengths of RAM and ROM
 # for the stm32 family. Most of the CPUs should have been taken into
 # account here, so no need to assign the lengths per model.
-STM32_INFO := $(shell printf '%s' '$(CPU_MODEL)' | tr 'a-z' 'A-Z' | sed -E -e 's/^STM32(F|L)(0|1|2|3|4|7)([A-Z0-9])([0-9])(.)(.)/\1 \2 \2\3\4 \3 \4 \5 \6/')
+STM32_INFO := $(shell printf '%s' '$(CPU_MODEL)' | tr 'a-z' 'A-Z' | sed -E -e 's/^STM32(F|L)(0|1|2|3|4|7)([A-Z0-9])([0-9])(.)(.)(_A)?/\1 \2 \2\3\4 \3 \4 \5 \6 \7/')
 STM32_TYPE     := $(word 1, $(STM32_INFO))
 STM32_FAMILY   := $(word 2, $(STM32_INFO))
 STM32_MODEL    := $(word 3, $(STM32_INFO))
@@ -13,6 +13,7 @@ STM32_MODEL2   := $(word 4, $(STM32_INFO))
 STM32_MODEL3   := $(word 5, $(STM32_INFO))
 STM32_PINCOUNT := $(word 6, $(STM32_INFO))
 STM32_ROMSIZE  := $(word 7, $(STM32_INFO))
+STM32_RAMMOD   := $(word 8, $(STM32_INFO))
 
 ifeq ($(STM32_TYPE), F)
   ifeq ($(STM32_FAMILY), 0)
@@ -202,14 +203,18 @@ else ifeq ($(STM32_TYPE), L)
         RAM_LEN = 4K
       else ifeq ($(STM32_ROMSIZE), 8)
         RAM_LEN = 8K
-      else ifneq (, $(filter $(STM32_ROMSIZE), B C))
+      else ifeq ($(STM32_ROMSIZE)$(STM32_RAMMOD), B)
+        RAM_LEN = 10K
+      else ifneq (, $(filter $(STM32_ROMSIZE)$(STM32_RAMMOD), B_A C))
         RAM_LEN = 16K
       endif
     else ifneq (, $(filter $(STM32_MODEL), 151 152))
       ifneq (, $(filter $(STM32_PINCOUNT), C Q U V Z))
-        ifeq ($(STM32_ROMSIZE), 6)
+        ifneq (, $(filter $(STM32_ROMSIZE)$(STM32_RAMMOD), 6 8))
+          RAM_LEN = 10K
+        else ifneq (, $(filter $(STM32_ROMSIZE)$(STM32_RAMMOD), 6_A B))
           RAM_LEN = 16K
-        else ifneq (, $(filter $(STM32_ROMSIZE), 8 B C))
+        else ifneq (, $(filter $(STM32_ROMSIZE)$(STM32_RAMMOD), 8_A B_A C C_A))
           RAM_LEN = 32K
         else ifeq ($(STM32_ROMSIZE), D)
           RAM_LEN = 48K
@@ -217,15 +222,15 @@ else ifeq ($(STM32_TYPE), L)
           RAM_LEN = 80K
         endif
       else ifeq ($(STM32_PINCOUNT), R)
-        ifeq ($(STM32_ROMSIZE), 6)
-          RAM_LEN = 16K
-        else ifneq (, $(filter $(STM32_ROMSIZE), 8 C))
+        ifeq ($(STM32_ROMSIZE)$(STM32_RAMMOD), 6)
+          RAM_LEN = 10K
+        else ifneq (, $(filter $(STM32_ROMSIZE)$(STM32_RAMMOD), 8_A B_A C C_A))
           RAM_LEN = 32K
-        else ifeq ($(STM32_ROMSIZE), B)
+        else ifneq (, $(filter $(STM32_ROMSIZE)$(STM32_RAMMOD), B 6_A))
           RAM_LEN = 16K
-        else ifeq ($(STM32_ROMSIZE), D)
+        else ifneq (, $(filter $(STM32_ROMSIZE)$(STM32_RAMMOD), D))
           RAM_LEN = 48K
-        else ifeq ($(STM32_ROMSIZE), E)
+        else ifneq (, $(filter $(STM32_ROMSIZE)$(STM32_RAMMOD), D_X E))
           RAM_LEN = 80K
         endif
       endif

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -46,7 +46,8 @@
  * * STM32L1XX_XL: Ultra Low Power XL-density devices: STM32L151xExx,
  *   STM32L152xExx and STM32L162xExx
  */
-#if defined(CPU_MODEL_STM32L151RBA) || defined(CPU_MODEL_STM32L151CB)
+#if defined(CPU_MODEL_STM32L151RB_A) || defined(CPU_MODEL_STM32L151CB) || \
+    defined(CPU_MODEL_STM32L151CB_A)
 #define STM32L1XX_MD (1U)
 #elif defined(CPU_MODEL_STM32L151RC)
 #define STM32L1XX_MDP (1U)
@@ -64,7 +65,8 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32L151RBA) || defined(CPU_MODEL_STM32L151CB)
+#if defined(CPU_MODEL_STM32L151RB_A) || defined(CPU_MODEL_STM32L151CB) || \
+    defined(CPU_MODEL_STM32L151CB_A)
 #define CPU_IRQ_NUMOF                   (45U)
 #else
 #define CPU_IRQ_NUMOF                   (57U)

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -30,7 +30,8 @@ extern "C" {
 /**
  * @name    Starting address of the CPU ID
  */
-#if defined(CPU_MODEL_STM32L151RBA) || defined(CPU_MODEL_STM32L151CB)
+#if defined(CPU_MODEL_STM32L151RB_A) || defined(CPU_MODEL_STM32L151CB) || \
+    defined(CPU_MODEL_STM32L151CB_A)
 #define CPUID_ADDR          (0x1ff80050)
 #else
 #define CPUID_ADDR          (0x1ff800d0)
@@ -82,7 +83,7 @@ typedef enum {
 #define EEPROM_SIZE                (16384UL)  /* 16kB */
 #elif defined(CPU_MODEL_STM32L151RC)
 #define EEPROM_SIZE                (8192U)    /* 8kB */
-#elif defined(CPU_MODEL_STM32L151CB)
+#elif defined(CPU_MODEL_STM32L151CB) || defined(CPU_MODEL_STM32L151CB_A)
 #define EEPROM_SIZE                (4096U)    /* 4kB */
 #endif
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

STM32L1 cpu's sometimes have a `-A/X` in the product name, this changes the amount of RAM on some of these boards. Currently some product names are incorrectly defined according to the specification, e.g: `lobaro-lorabox` `CPU_MODEL=stm32l151cb` when it is actually `stm32l151cb-a`, the first version having 16kB and the second 32 kB (NOTE: since in master the RAM for stm32l151cb is wrongly defined there isn't any functional problem, but incorrect definitions). The parsing script has been updated to include the suffix.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Check STM32 documentation to verify the combinations:

https://www.st.com/en/microcontrollers-microprocessors/stm32l151-152.html
https://www.st.com/content/st_com/en/products/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus/stm32-ultra-low-power-mcus/stm32l1-series/stm32l100-value-line.html

To verify `RAM_LEN` you can change the `CPU_MODEL` variable while running:

```
CPU_MODEL=stm32l151cb_a RIOT_MAKEFILES_GLOBAL_POST="\$(RIOTBASE)/cpu/stm32_common/Makefile.include" make -C examples/hello-world/ info-stm32
```

This is just including the info-stm32 recipe while allowing to set the `CPU_MODEL` externally (just a bodged command to test). Then check the output is correct:

```
CPU: stm32l151cb_a
        Line: STM32L151xx
        Pin count:      48
        ROM size:       128K (131072 Bytes)
        RAM size:       32K
```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Re-opened #11794 because I had mistakenly pushed to upstream.