### PR TITLE
sys/riotboot: add initial image digest verification

### DIFF
--- a/sys/include/riotboot/flashwrite.h
+++ b/sys/include/riotboot/flashwrite.h
@@ -169,6 +169,20 @@ static inline int riotboot_flashwrite_finish(riotboot_flashwrite_t *state)
  */
 size_t riotboot_flashwrite_slotsize(const riotboot_flashwrite_t *state);
 
+/**
+ * @brief       Verify the digest of an image
+ *
+ * @param[in]   sha256_digest   content of the image digest
+ * @param[in]   img_size        the size of the image
+ * @param[in]   target_slot     the image slot number
+ *
+ * @returns     -1 when image is too small
+ * @returns     0 if the digest is valid
+ * @returns     1 if the digest is invalid
+ */
+int riotboot_flashwrite_verify_sha256(const uint8_t *sha256_digest,
+                                      size_t img_size, int target_slot);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/riotboot/flashwrite_verify_sha256.c
+++ b/sys/riotboot/flashwrite_verify_sha256.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 Inria
+ *               2019 Freie Universität Berlin
+ *               2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_riotboot_flashwrite
+ * @{
+ *
+ * @file
+ * @brief       Firmware update sha256 verification helper functions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "hashes/sha256.h"
+#include "log.h"
+#include "riotboot/slot.h"
+
+int riotboot_flashwrite_verify_sha256(const uint8_t *sha256_digest, size_t img_len, int target_slot)
+{
+    char digest[SHA256_DIGEST_LENGTH];
+
+    sha256_context_t sha256;
+
+    if (img_len < 4) {
+        LOG_INFO("riotboot: verify_sha256(): image too small\n");
+        return -1;
+    }
+
+    uint8_t *img_start = (uint8_t *)riotboot_slot_get_hdr(target_slot);
+
+    LOG_INFO("riotboot: verifying digest at %p (img at: %p size: %u)\n", sha256_digest, img_start, img_len);
+
+    sha256_init(&sha256);
+
+    /* add RIOTBOOT_MAGIC since it isn't written into flash until
+     * riotboot_flashwrite_finish()" */
+    sha256_update(&sha256, "RIOT", 4);
+
+    /* account for injected RIOTBOOT_MAGIC by skipping RIOTBOOT_MAGIC_LEN */
+    sha256_update(&sha256, img_start + 4, img_len - 4);
+
+    sha256_final(&sha256, digest);
+
+    return memcmp(sha256_digest, digest, SHA256_DIGEST_LENGTH) != 0;
+}


### PR DESCRIPTION
### Contribution description

This PR adds image verification using sha256 to riotboot.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

As is, this code is never compiled. It has been split out from a large SUIT pr which will be opened soon. I suggest reviewing the code here and use the SUIT PR as testbed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#11818 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
