### PR TITLE
sys/xtimer/xtimer.c: _mutex_timeout() cleanup

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -450,8 +450,6 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b);
 /**
  * @brief lock a mutex but with timeout
  *
- * @note this requires core_thread_flags to be enabled
- *
  * @param[in]    mutex  mutex to lock
  * @param[in]    us     timeout in microseconds relative
  *

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -261,7 +261,7 @@ static void _mutex_timeout(void *arg)
         }
         sched_set_status(mt->thread, STATUS_PENDING);
         irq_restore(irqstate);
-        thread_yield_higher();
+        sched_switch(mt->thread->priority);
         return;
     }
     irq_restore(irqstate);

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -253,12 +253,17 @@ static void _mutex_timeout(void *arg)
     mt->timeout = 1;
     list_node_t *node = list_remove(&mt->mutex->queue,
                                     (list_node_t *)&mt->thread->rq_entry);
-    if ((node != NULL) && (mt->mutex->queue.next == NULL)) {
-        mt->mutex->queue.next = MUTEX_LOCKED;
-    }
-    sched_set_status(mt->thread, STATUS_PENDING);
-    thread_yield_higher();
 
+    /* if thread was removed from the list */
+    if (node != NULL) {
+        if (mt->mutex->queue.next == NULL) {
+            mt->mutex->queue.next = MUTEX_LOCKED;
+        }
+        sched_set_status(mt->thread, STATUS_PENDING);
+        irq_restore(irqstate);
+        thread_yield_higher();
+        return;
+    }
     irq_restore(irqstate);
 }
 

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -239,6 +239,15 @@ int _xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout_ticks)
 
 static void _mutex_timeout(void *arg)
 {
+    /* interupts a disabled because xtimer can spin
+     * if xtimer_set spins the callback is executed
+     * in the thread context
+     *
+     * If the xtimer spin is fixed in the future
+     * interups disable/restore can be removed
+     */
+    unsigned irqstate = irq_disable();
+
     mutex_thread_t *mt = (mutex_thread_t *)arg;
 
     mt->timeout = 1;
@@ -249,6 +258,8 @@ static void _mutex_timeout(void *arg)
     }
     sched_set_status(mt->thread, STATUS_PENDING);
     thread_yield_higher();
+
+    irq_restore(irqstate);
 }
 
 int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t timeout)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This pr prepares for bug fixes and improvements of `xtimer.c:xtimer_mutex_lock_timeout() ` (the tracking pr: #11660 )

This pr improves the _mutex_timeout() function. 
It uses now `sched_switch` instead of `thread_yield_higher`. (https://github.com/RIOT-OS/RIOT/pull/11660#discussion_r298597694, #11759)
Only call `sched_switch` (`thread_yield_higher` before) when the thread was unlocked.
And ensure interrupt are disabled because it modifies a mutex. (if `xtimer_set` spins the callback is executed in the thread context.)

This pr also changes the comment of `sys/include/xtimer.h: xtimer_mutex_lock_timeout()`

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`BOARD=native make -C tests/xtimer_mutex_lock timeout/ flash test`
output:

```
...
> mutex_timeout_n_spin_unlocked
starting test: xtimer mutex lock timeout
OK
> mutex_timeout_n_spin_locked
mutex_timeout_n_spin_locked
starting test: xtimer mutex lock timeout
OK
> 
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
 the tracking pr: #11660
reason for sched_switch instead of thread_yield_higher: #11759, https://github.com/RIOT-OS/RIOT/pull/11660#discussion_r298597694