### PR TITLE
pkg/nanocbor: bump version to resolve 8/16 bit compilation issue

### DIFF
--- a/pkg/nanocbor/Makefile
+++ b/pkg/nanocbor/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nanocbor
 PKG_URL     = https://github.com/bergzand/nanocbor
-PKG_VERSION = 44d9b1cfaa6829c5d1063f3c0e4a1733cfa409e3
+PKG_VERSION = 3a672f79b2458a96393447e50a41174f741eadc5
 PKG_LICENSE = LGPL-2.1
 
 .PHONY: all

--- a/pkg/nanocbor/doc.txt
+++ b/pkg/nanocbor/doc.txt
@@ -7,9 +7,6 @@
  * This package contains the NanoCBOR library for a small CBOR encoder and
  * decoder. Flash footprint for encoding and decoding should be below 1K each.
  *
- * At the moment 8 bit and 16 bit MCU support is broken by upstream, see the
- * [issue](https://github.com/bergzand/NanoCBOR/issues/18).
- *
  * ## Usage
  *
  * Just add it as a package in your application:

--- a/tests/pkg_nanocbor/Makefile
+++ b/tests/pkg_nanocbor/Makefile
@@ -2,13 +2,6 @@ include ../Makefile.tests_common
 
 TEST_ON_CI_WHITELIST += all
 
-# No 8 bit and 16 bit support
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano \
-                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
-                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
-                   wsn430-v1_4 z1
-
 USEPKG += nanocbor
 # Used for verification
 USEMODULE += embunit


### PR DESCRIPTION
### Contribution description

upstream claims to have fixed the compilation issue with 8 and 16 bit platforms. This PR contains the version bump and removes the blacklist for the test application

### Testing procedure

Check if the CI shows green

### Issues/PRs references

None