### PR TITLE
boards/nucleo*: move doxygen group definition to doc.txt

### DIFF
--- a/boards/nucleo-f412zg/doc.txt
+++ b/boards/nucleo-f412zg/doc.txt
@@ -1,2 +1,5 @@
 /**
+ @defgroup    boards_nucleo-f412zg STM32 Nucleo-F412ZG
+ @ingroup     boards_common_nucleo144
+ @brief       Support for the STM32 Nucleo-F412ZG
  */

--- a/boards/nucleo-f412zg/include/periph_conf.h
+++ b/boards/nucleo-f412zg/include/periph_conf.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f412zg STM32 Nucleo-F412ZG
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-F412ZG
+ * @ingroup     boards_nucleo-f412zg
  * @{
  *
  * @file

--- a/boards/nucleo-f413zh/doc.txt
+++ b/boards/nucleo-f413zh/doc.txt
@@ -1,2 +1,5 @@
 /**
+ @defgroup    boards_nucleo-f413zh STM32 Nucleo-F413ZH
+ @ingroup     boards_common_nucleo144
+ @brief       Support for the STM32 Nucleo-F413ZH
  */

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f413zh STM32 Nucleo-F413ZH
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-F413ZH
+ * @ingroup     boards_nucleo-f413zh
  * @{
  *
  * @file

--- a/boards/nucleo-f429zi/doc.txt
+++ b/boards/nucleo-f429zi/doc.txt
@@ -1,2 +1,5 @@
 /**
+@defgroup    boards_nucleo-f429zi STM32 Nucleo-F429ZI
+@ingroup     boards_common_nucleo144
+@brief       Support for the STM32 Nucleo-F429ZI
  */

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f429zi STM32 Nucleo-F429ZI
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-F429ZI
+ * @ingroup     boards_nucleo-f429zi
  * @{
  *
  * @file

--- a/boards/nucleo-f722ze/doc.txt
+++ b/boards/nucleo-f722ze/doc.txt
@@ -1,2 +1,5 @@
 /**
+@defgroup    boards_nucleo-f722ze STM32 Nucleo-F722ZE
+@ingroup     boards_common_nucleo144
+@brief       Support for the STM32 Nucleo-F722ZE
  */

--- a/boards/nucleo-f722ze/include/periph_conf.h
+++ b/boards/nucleo-f722ze/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f722ze STM32 Nucleo-F722ZE
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-F722ZE
+ * @ingroup     boards_nucleo-f722ze
  * @{
  *
  * @file

--- a/boards/nucleo-f746zg/doc.txt
+++ b/boards/nucleo-f746zg/doc.txt
@@ -1,2 +1,5 @@
 /**
+@defgroup    boards_nucleo-f746zg STM32 Nucleo-F746ZG
+@ingroup     boards_common_nucleo144
+@brief       Support for the STM32 Nucleo-F746ZG
  */

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f746zg STM32 Nucleo-F746ZG
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-F746ZG
+ * @ingroup     boards_nucleo-f746zg
  * @{
  *
  * @file

--- a/boards/nucleo-f767zi/doc.txt
+++ b/boards/nucleo-f767zi/doc.txt
@@ -1,2 +1,5 @@
 /**
+@defgroup    boards_nucleo-f767zi STM32 Nucleo-F767ZI
+@ingroup     boards_common_nucleo144
+@brief       Support for the STM32 Nucleo-F767ZI
  */

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f767zi STM32 Nucleo-F767ZI
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-F767ZI
+ * @ingroup     boards_nucleo-f767zi
  * @{
  *
  * @file

--- a/boards/nucleo-l031k6/doc.txt
+++ b/boards/nucleo-l031k6/doc.txt
@@ -1,2 +1,5 @@
 /**
+@defgroup    boards_nucleo-l031k6 STM32 Nucleo-L031K6
+@ingroup     boards_common_nucleo32
+@brief       Support for the STM32 Nucleo-L031K6
  */

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l031k6 STM32 Nucleo-L031K6
- * @ingroup     boards_common_nucleo32
- * @brief       Support for the STM32 Nucleo-L031K6
+ * @ingroup     boards_nucleo-l031k6
  * @{
  *
  * @file

--- a/boards/nucleo-l432kc/doc.txt
+++ b/boards/nucleo-l432kc/doc.txt
@@ -1,2 +1,5 @@
 /**
+@defgroup    boards_nucleo-l432kc STM32 Nucleo-L432KC
+@ingroup     boards_common_nucleo32
+@brief       Support for the STM32 Nucleo-L432KC
  */

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l432kc STM32 Nucleo-L432KC
- * @ingroup     boards_common_nucleo32
- * @brief       Support for the STM32 Nucleo-L432KC
+ * @ingroup     boards_nucleo-l432kc
  * @{
  *
  * @file

--- a/boards/nucleo-l433rc/doc.txt
+++ b/boards/nucleo-l433rc/doc.txt
@@ -1,0 +1,5 @@
+/**
+@defgroup    boards_nucleo-l433rc STM32 Nucleo-L433RC
+@ingroup     boards_common_nucleo64
+@brief       Support for the STM32 Nucleo-L433RC
+ */

--- a/boards/nucleo-l433rc/include/periph_conf.h
+++ b/boards/nucleo-l433rc/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l433rc STM32 Nucleo-L433RC
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-L433RC
+ * @ingroup     boards_nucleo-l433rc
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up some nucleo boards Doxygen group definitions: for the modified boards, there's an empty doc.txt (or no doc.txt) and the doxygen groups are defined in the `periph_conf.h` file.

For consistence with other boards, this PR is moving the Doxygen group definition and description to the doc.txt file.

The doc.txt are empty (like for many other nucleo boards) but there are future plans to extend the documentation of these boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run `make doc` and check the generated documentation is the same
- `make static-test` should return no error

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

I think the empty doc.txt files are leftover from #8516

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
