### PR TITLE
tools/doccheck: extend script to also check for Doxygen groups defined multiple times

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -50,6 +50,7 @@ DEFINED_GROUPS=$(echo "${ALL_RAW_DEFGROUP}" | \
                     sort)
 DEFINED_GROUPS_UNIQUE=$(echo "${DEFINED_GROUPS}" | sort -u)
 
+# Check for undefined groups
 UNDEFINED_GROUPS=$( \
     for group in $(echo "${ALL_RAW_INGROUP}" | \
                     grep -oE '[^ ]+$' | sort -u); \
@@ -58,21 +59,17 @@ UNDEFINED_GROUPS=$( \
     done \
     )
 
-UNDEFINED_GROUPS_PRINT=$( \
-    for group in ${UNDEFINED_GROUPS}; \
-    do \
-        echo -e "\n${CWARN}${group}${CRESET} found in:"; \
-        echo "${ALL_RAW_INGROUP}" | grep "\<${group}\>$" | sort -u | \
-                awk -F: '{ print "\t" $1 }'; \
-    done \
-    )
-
 if [ -n "${UNDEFINED_GROUPS}" ]
 then
     COUNT=$(echo "${UNDEFINED_GROUPS}" | wc -l)
     echo -ne "${CERROR}ERROR${CRESET} "
     echo -e "There are ${CWARN}${COUNT}${CRESET} undefined Doxygen groups:"
-    echo "${UNDEFINED_GROUPS_PRINT}"
+    for group in ${UNDEFINED_GROUPS};
+    do
+        echo -e "\n${CWARN}${group}${CRESET} found in:";
+        echo "${ALL_RAW_INGROUP}" | grep "\<${group}\>$" | sort -u |
+                awk -F: '{ print "\t" $1 }';
+    done
     exit 2
 fi
 

--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -40,22 +40,23 @@ exclude_filter() {
     grep -v -e vendor -e examples -e tests -e "\<dist/tools\>"
 }
 
-# Check all groups are defined
-DEFINED_GROUPS=$(git grep @defgroup -- '*.h' '*.c' '*.txt' | \
-                    exclude_filter | \
+# Check groups are correctly defined (e.g. no undefined groups and no group
+# defined multiple times)
+ALL_RAW_DEFGROUP=$(git grep @defgroup -- '*.h' '*.c' '*.txt' | exclude_filter)
+ALL_RAW_INGROUP=$(git grep '@ingroup' -- '*.h' '*.c' '*.txt' | exclude_filter)
+DEFINED_GROUPS=$(echo "${ALL_RAW_DEFGROUP}" | \
                     grep -oE '@defgroup[ ]+[^ ]+' | \
-                    grep -oE '[^ ]+$' | sort -u)
+                    grep -oE '[^ ]+$' | \
+                    sort)
+DEFINED_GROUPS_UNIQUE=$(echo "${DEFINED_GROUPS}" | sort -u)
 
 UNDEFINED_GROUPS=$( \
-    for group in $(git grep '@ingroup' -- '*.h' '*.c' '*.txt' | \
-                    exclude_filter | \
+    for group in $(echo "${ALL_RAW_INGROUP}" | \
                     grep -oE '[^ ]+$' | sort -u); \
     do \
-        echo "${DEFINED_GROUPS}" | grep -xq "${group}" || echo "${group}"; \
+        echo "${DEFINED_GROUPS_UNIQUE}" | grep -xq "${group}" || echo "${group}"; \
     done \
     )
-
-ALL_RAW_INGROUP=$(git grep '@ingroup' -- '*.h' '*.c' '*.txt' | exclude_filter)
 
 UNDEFINED_GROUPS_PRINT=$( \
     for group in ${UNDEFINED_GROUPS}; \
@@ -72,5 +73,24 @@ then
     echo -ne "${CERROR}ERROR${CRESET} "
     echo -e "There are ${CWARN}${COUNT}${CRESET} undefined Doxygen groups:"
     echo "${UNDEFINED_GROUPS_PRINT}"
+    exit 2
+fi
+
+# Check for groups defined multiple times:
+MULTIPLE_DEFINED_GROUPS=$(echo "${DEFINED_GROUPS}" | uniq -d)
+
+if [ -n "${MULTIPLE_DEFINED_GROUPS}" ]
+then
+    COUNT=$(echo "${MULTIPLE_DEFINED_GROUPS}" | wc -l)
+    echo -ne "${CERROR}ERROR${CRESET} "
+    echo -e "There are ${CWARN}${COUNT}${CRESET} Doxygen groups defined multiple times:"
+    for group in ${MULTIPLE_DEFINED_GROUPS};
+    do
+        echo -e "\n${CWARN}${group}${CRESET} defined in:";
+        echo "${ALL_RAW_DEFGROUP}" | \
+            awk -F@ '{ split($2, end, " "); printf("%s%s\n",$1,end[2]) }' |
+            grep "\<${group}\>$" | sort -u |
+            awk -F: '{ print "\t" $1 }';
+    done
     exit 2
 fi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While reworking #8939, I noticed several nucleo boards were having their Doxygen groups (e.g. `boards_nucleo-xxx`) defined in `doc.txt` and `periph_conf.h`.

After looking into it a bit more, it appears that some other Doxygen groups, in different parts of the code, have the same problem.

The idea of this PR is to extend the doccheck script to also check groups that are defined multiple times and to return the number of times and files where the groups are defined.

For the moment, the script doesn't exit with a return code != 0 in case of problem but simply prints the problematic groups with a warning. So it can be merged without bad consequences on static tests.

Previous checks still work (according to my local tests).

I'll open another PR with all reported doxygen group fixed and a change to make the script return an error if one or several groups are defined multiple times.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run `make static-test` and check the output
- Verify the listed groups are indeed problematic
- CI should not fail

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

~The PR containing all the fixes will arrive soon.~ All problems found are fixed by #11814 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
