### PR TITLE
doc: remove duplicate definitions of Doxygen groups

### DIFF
--- a/boards/arduino-leonardo/include/board.h
+++ b/boards/arduino-leonardo/include/board.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_arduino-leonardo Arduino Leonardo
- * @ingroup     boards
- * @brief       Support for the Arduino Leonardo board
+ * @ingroup     boards_arduino-leonardo
  * @{
  *
  * @file

--- a/boards/common/esp32/board_common.c
+++ b/boards/common/esp32/board_common.c
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_common_esp32 ESP32 Board Commons
- * @ingroup     boards_common
- * @brief       Common definitions for all ESP32 boards
+ * @ingroup     boards_common_esp32
  * @{
  *
  * @file

--- a/boards/common/esp8266/board_common.c
+++ b/boards/common/esp8266/board_common.c
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_common_esp8266 ESP8266 Common
- * @ingroup     boards_common
- * @brief       Common files for the esp8266 board.
+ * @ingroup     boards_common_esp8266
  * @{
  *
  * @file

--- a/boards/esp8266-esp-12x/include/board.h
+++ b/boards/esp8266-esp-12x/include/board.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    boards_esp8266_esp-12x  ESP-12x based boards
- * @ingroup     boards_esp8266
+ * @ingroup     boards_esp8266_esp-12x
  */
 
 /**

--- a/boards/esp8266-olimex-mod/include/board.h
+++ b/boards/esp8266-olimex-mod/include/board.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    boards_esp8266_olimex-mod Olimex MOD-WIFI-ESP8266-DEV
- * @ingroup     boards_esp8266
+ * @ingroup     boards_esp8266_olimex-mod
  */
 
 /**

--- a/boards/esp8266-sparkfun-thing/include/board.h
+++ b/boards/esp8266-sparkfun-thing/include/board.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    boards_esp8266_sparkfun-thing SparkFun ESP8266 Thing
- * @ingroup     boards_esp8266
+ * @ingroup     boards_esp8266_sparkfun-thing
  */
 
 /**

--- a/boards/nucleo-f030r8/include/periph_conf.h
+++ b/boards/nucleo-f030r8/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f030r8 STM32 Nucleo-F030R8
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F030R8
+ * @ingroup     boards_nucleo-f030r8
  * @{
  *
  * @file

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f070rb STM32 Nucleo-F070RB
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F070RB
+ * @ingroup     boards_nucleo-f070rb
  * @{
  *
  * @file

--- a/boards/nucleo-f072rb/include/periph_conf.h
+++ b/boards/nucleo-f072rb/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f072rb STM32 Nucleo-F072RB
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F072RB
+ * @ingroup     boards_nucleo-f072rb
  * @{
  *
  * @file

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f091rc STM32 Nucleo-F091RC
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F091RC
+ * @ingroup     boards_nucleo-f091rc
  * @{
  *
  * @file

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f103rb STM32 Nucleo-F103RB
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F103RB
+ * @ingroup     boards_nucleo-f103rb
  * @{
  *
  * @file

--- a/boards/nucleo-f302r8/include/periph_conf.h
+++ b/boards/nucleo-f302r8/include/periph_conf.h
@@ -9,9 +9,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f302r8 STM32 Nucleo-F302R8
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F302R8
+ * @ingroup     boards_nucleo-f302r8
  * @{
  *
  * @file

--- a/boards/nucleo-f303k8/include/periph_conf.h
+++ b/boards/nucleo-f303k8/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f303k8 STM32 Nucleo-F303K8
- * @ingroup     boards_common_nucleo32
- * @brief       Support for the STM32 Nucleo-F303K8
+ * @ingroup     boards_nucleo-f303k8
  * @{
  *
  * @file

--- a/boards/nucleo-f303re/include/periph_conf.h
+++ b/boards/nucleo-f303re/include/periph_conf.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f303re STM32 Nucleo-F303RE
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F303RE
+ * @ingroup     boards_nucleo-f303re
  * @{
  *
  * @file

--- a/boards/nucleo-f303ze/include/periph_conf.h
+++ b/boards/nucleo-f303ze/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f303ze STM32 Nucleo-F303ZE
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-F303ZE
+ * @ingroup     boards_nucleo-f303ze
  * @{
  *
  * @file

--- a/boards/nucleo-f334r8/include/periph_conf.h
+++ b/boards/nucleo-f334r8/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f334r8 STM32 Nucleo-F334R8
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F334R8
+ * @ingroup     boards_nucleo-f334r8
  * @{
  *
  * @file

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f401re STM32 Nucleo-F401RE
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F401RE
+ * @ingroup     boards_nucleo-f401re
  * @{
  *
  * @file

--- a/boards/nucleo-f410rb/include/periph_conf.h
+++ b/boards/nucleo-f410rb/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f410rb STM32 Nucleo-F410RB
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F410RB
+ * @ingroup     boards_nucleo-f410rb
  * @{
  *
  * @file

--- a/boards/nucleo-f411re/include/periph_conf.h
+++ b/boards/nucleo-f411re/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f411re STM32 Nucleo-F411RE
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F411RE
+ * @ingroup     boards_nucleo-f411re
  * @{
  *
  * @file

--- a/boards/nucleo-f446re/include/periph_conf.h
+++ b/boards/nucleo-f446re/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f446re STM32 Nucleo-F446RE
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-F446RE
+ * @ingroup     boards_nucleo-f446re
  * @{
  *
  * @file

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f446ze STM32 Nucleo-F446ZE
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-F446ZE
+ * @ingroup     boards_nucleo-f446ze
  * @{
  *
  * @file

--- a/boards/nucleo-l053r8/include/periph_conf.h
+++ b/boards/nucleo-l053r8/include/periph_conf.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l053r8 STM32 Nucleo-L053R8
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-L053R8
+ * @ingroup     boards_nucleo-l053r8
  * @{
  *
  * @file

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -8,9 +8,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l073rz STM32 Nucleo-L073RZ
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-L073RZ
+ * @ingroup     boards_nucleo-l073rz
  * @{
  *
  * @file

--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l152re STM32 Nucleo-L152RE
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-L152RE
+ * @ingroup     boards_nucleo-l152re
  * @{
  *
  * @file

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -9,9 +9,7 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l476rg STM32 Nucleo-L476RG
- * @ingroup     boards_common_nucleo64
- * @brief       Support for the STM32 Nucleo-L476RG
+ * @ingroup     boards_nucleo-l476rg
  * @{
  *
  * @file

--- a/boards/stm32f769i-disco/include/board.h
+++ b/boards/stm32f769i-disco/include/board.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_stm32f769i-disco STM32F769I-DISCO board
- * @ingroup     boards
- * @brief       Support for the STM32F769I-DISCO board
+ * @ingroup     boards_stm32f769i-disco
  * @{
  *
  * @file

--- a/core/include/native_sched.h
+++ b/core/include/native_sched.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    core_sched Scheduler
- * @ingroup     core
- * @brief       The RIOT scheduler
+ * @defgroup    core_sched_native Scheduler for native
+ * @ingroup     core_sched
+ * @brief       The RIOT scheduler for the native platform
  * @details
  *
  * @{

--- a/cpu/efm32/include/cpu_conf.h
+++ b/cpu/efm32/include/cpu_conf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    cpu_efm32 Silicon Labs EFM32/EFR32/EZR32
- * @ingroup     cpu
- * @brief       Support for Silicon Labs EFM32/EFR32/EZR32 CPUs
+ * @ingroup     cpu_efm32
  * @{
  *
  * @file

--- a/pkg/lwip/doc.txt
+++ b/pkg/lwip/doc.txt
@@ -4,4 +4,7 @@
  * @ingroup  net
  * @brief    Provides the lwIP network stack
  * @see      http://savannah.nongnu.org/projects/lwip/
+ *
+ * lwIP is a lightweight TCP/IP stack primarily for usage with Ethernet.
+ * It can be used with the @ref sock API.
  */

--- a/pkg/lwip/include/lwip.h
+++ b/pkg/lwip/include/lwip.h
@@ -7,13 +7,7 @@
  */
 
 /**
- * @defgroup    pkg_lwip    lwIP
- * @ingroup     pkg
- * @brief       A lightweight TCP/IP stack
- * @see         http://savannah.nongnu.org/projects/lwip/
- *
- * lwIP is a lightweight TCP/IP stack primarily for usage with Ethernet.
- * It can be used with the the @ref conn.
+ * @ingroup     pkg_lwip
  *
  * @{
  *

--- a/sys/hashes/sha1.c
+++ b/sys/hashes/sha1.c
@@ -11,14 +11,12 @@
  */
 
 /**
- * @defgroup    sys_hashes_sha1 SHA-1
- * @ingroup     sys_hashes
- * @brief       Implementation of the SHA-1 hashing function
+ * @ingroup     sys_hashes_sha1
 
  * @{
  *
  * @file
- * @brief       SHA-1 interface definition
+ * @brief       Implementation of the SHA-1 hashing function
  *
  * @author      Wei Dai and others
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's TCP implementation for the GNRC network stack.
+ * @ingroup     net_gnrc_tcp
  *
  * @{
  *

--- a/sys/include/net/gnrc/tcp/tcb.h
+++ b/sys/include/net/gnrc/tcp/tcb.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's TCP implementation for the GNRC network stack.
+ * @ingroup     net_gnrc_tcp
  *
  * @{
  *

--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -7,15 +7,12 @@
  */
 
 /**
- * @defgroup    net_gnrc_sock   GNRC-specific implementation of the sock API
- * @ingroup     net_gnrc
- * @brief       Provides an implementation of the @ref net_sock by the
- *              @ref net_gnrc
+ * @ingroup     net_gnrc_sock
  *
  * @{
  *
  * @file
- * @brief   GNRC-specific types and function definitions
+ * @brief   Internal GNRC-specific types and function definitions
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/net/gnrc/transport_layer/tcp/internal/common.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/common.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's TCP implementation for the GNRC network stack.
+ * @ingroup     net_gnrc_tcp
  *
  * @{
  *

--- a/sys/net/gnrc/transport_layer/tcp/internal/eventloop.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/eventloop.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's TCP implementation for the GNRC network stack.
+ * @ingroup     net_gnrc_tcp
  *
  * @{
  *

--- a/sys/net/gnrc/transport_layer/tcp/internal/fsm.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/fsm.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's TCP implementation for the GNRC network stack.
+ * @ingroup     net_gnrc_tcp
  *
  * @{
  *

--- a/sys/net/gnrc/transport_layer/tcp/internal/option.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/option.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's TCP implementation for the GNRC network stack.
+ * @ingroup     net_gnrc_tcp
  *
  * @{
  *

--- a/sys/net/gnrc/transport_layer/tcp/internal/pkt.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/pkt.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's TCP implementation for the GNRC network stack.
+ * @ingroup     net_gnrc_tcp
  *
  * @{
  *

--- a/sys/net/gnrc/transport_layer/tcp/internal/rcvbuf.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/rcvbuf.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's TCP implementation for the GNRC network stack.
+ * @ingroup     net_gnrc_tcp
  *
  * @{
  *

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup pthread POSIX threads
- * POSIX conforming multi-threading features.
- * @ingroup posix
+ * @ingroup pthread
  * @{
  * @file
  * @brief   Thread creation features.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing all duplicate definitions of Doxygen groups reported by the doccheck script PRed in #11813.

The last commit of this PR is updating the script so that it returns an error when duplicate Doxygen group definitions are reported by the script.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI: `make static-test` returns with no error
- Doxygen documentation is correct: run `make doc` and verify

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

~Based on #11813 but~ can also be merged directly.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
