### PR TITLE
dist/tools/ethos: add setup_network.sh script

### DIFF
--- a/dist/tools/ethos/README.md
+++ b/dist/tools/ethos/README.md
@@ -13,3 +13,19 @@ To use, add
 
 to app Makefile, "make clean all flash", then run this tool as follows:
     # sudo ./ethos <tap-device> <serial>
+
+## setup_network.sh
+
+This script sets up a tap device, configures a prefix and starts a uhcpd server
+serving that prefix towards the tap device.
+The tap device will be owned by the calling user, or if called with sudo, with
+the user that uses sudo. That way, ethos can use it without being root / using
+sudo.
+
+E.g., use as follows:
+
+    $ sudo ./setup_network.sh riot0 2001:db8::0/64
+
+Keep that running, then in another shell start ethos:
+
+    $ ethos riot0 <serial>

--- a/dist/tools/ethos/setup_network.sh
+++ b/dist/tools/ethos/setup_network.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+create_tap() {
+    ip tuntap add ${TAP} mode tap user ${_USER}
+    sysctl -w net.ipv6.conf.${TAP}.forwarding=1
+    sysctl -w net.ipv6.conf.${TAP}.accept_ra=0
+    ip link set ${TAP} up
+    ip a a fe80::1/64 dev ${TAP}
+    ip a a fd00:dead:beef::1/128 dev lo
+    ip route add ${PREFIX} via fe80::2 dev ${TAP}
+}
+
+remove_tap() {
+    ip tuntap del ${TAP} mode tap
+}
+
+cleanup() {
+    echo "Cleaning up..."
+    remove_tap
+    ip a d fd00:dead:beef::1/128 dev lo
+    trap "" INT QUIT TERM EXIT
+}
+
+start_uhcpd() {
+    ${UHCPD} ${TAP} ${PREFIX}
+}
+
+TAP=$1
+PREFIX=$2
+_USER=$3
+: ${UHCPD:="$(readlink -f $(dirname $0)"/../uhcpd/bin")/uhcpd"}
+
+[ -z "${TAP}" -o -z "${PREFIX}" ] && {
+    echo "usage: $0 <tap-device> <prefix> [<user>]"
+    exit 1
+}
+
+if [ -z "$_USER" ]; then
+    if [ -n "$SUDO_USER" ] ; then
+        _USER=$SUDO_USER
+    else
+        _USER=$USER
+    fi
+fi
+
+trap "cleanup" INT QUIT TERM EXIT
+
+
+create_tap && start_uhcpd


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides an alternative to start_network.sh.

start_network.sh is supposed to be use as TERMPROG and needs to be started as root.
It sets up a tap device, starts uhcpd in background, then launches ethos.

This PR's setup_network.sh drops starting ethos and starts uhcpd in foreground.

The use-case is:
- run ```sudo setup_network.sh <params>``` in one terminal, keep running
- run ```make term/test``` in another terminal, re-using the existing network

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This is used in the soon-to-be-openened SUIT PR. I suggest using that PR as testbed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
