### PR TITLE
pkg/openthread: remove openthread config header from contrib

### DIFF
--- a/pkg/openthread/contrib/platform_logging.c
+++ b/pkg/openthread/contrib/platform_logging.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "openthread/config.h"
 #include "openthread/platform/logging.h"
 
 /* adapted from OpenThread posix example:

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -27,7 +27,6 @@
 #include "net/ieee802154.h"
 #include "net/l2util.h"
 #include "net/netdev/ieee802154.h"
-#include "openthread/config.h"
 #include "openthread/platform/diag.h"
 #include "openthread/platform/radio.h"
 #include "ot.h"


### PR DESCRIPTION
### Contribution description

This PR removes the inclusion of the OpenThread config file in `openthread/contrib` C files.
The internal Openthread config file is not needed for the contrib
files, since it only includes internal OpenThread configuration
(use by the Openthread build system). Under certain cases some
macros defined in Openthread collide with RIOT internals or vendor
headers (see #11770). So it's important to keep the dependencies consistent.
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile the Openthread example with `samr21-xpro` or `iotlab-m3`. Check there are no compilation errors.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#11770
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
