### PR TITLE
2019.07-RC1: run all tests on murdock

### DIFF
--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -15,6 +15,11 @@ test-murdock:
 		"$(BOARD):$(TOOLCHAIN)" \
 		$(FLASHFILE)
 
+# TEST CHANGE
+# Enable all tests by default
+TEST_ON_CI_WHITELIST ?= all
+# TEST CHANGE
+
 # don't whitelist tests if there's no binary
 ifeq (1,$(RIOTNOLINK))
   TEST_ON_CI_WHITELIST:=

--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -16,8 +16,8 @@ test-murdock:
 		$(FLASHFILE)
 
 # TEST CHANGE
-# Enable all tests by default
-TEST_ON_CI_WHITELIST ?= all
+# Enable all tests by default, if there are tests
+TEST_ON_CI_WHITELIST ?= $(if $(TESTS),all)
 # TEST CHANGE
 
 # don't whitelist tests if there's no binary


### PR DESCRIPTION
### Contribution description

This enables running all tests by default (unless TEST_ON_CI_WHITELIST is already set).
Get the Murdock testing output for the current release branch.

Test commit, not meant to be merged.

### Testing procedure

Get the tests results output as an information for the release testing.


### Issues/PRs references

https://github.com/RIOT-OS/Release-Specs/issues/128