### PR TITLE
makefiles/openocd: use stlink.cfg by default

### DIFF
--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -1,10 +1,16 @@
 # ST-Link debug adapter
-# Use st-link v2-1 by default
-STLINK_VERSION ?= 2-1
 
-# Use STLINK_VERSION to select which stlink version is used
+ifeq (,$(STLINK_VERSION))
+    # Use stlink.cfg by default
+    STLINK_CFG = stlink.cfg
+else
+    # Use STLINK_VERSION to select which stlink version is used.
+    # deprecated in OpenOCD since Jan 26, 2017
+    STLINK_CFG = stlink-v$(STLINK_VERSION).cfg
+endif
+
 OPENOCD_ADAPTER_INIT ?= \
-  -c 'source [find interface/stlink-v$(STLINK_VERSION).cfg]' \
+  -c 'source [find interface/$(STLINK_CFG)]' \
   -c 'transport select hla_swd'
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
stlink-v2-1.cfg is deprecated in openocd. Since 26 Jan 2017 openocd has a common config for all st-links. 

This change might break flashing for people who are using stlink with an old openocd and don't define STLINK_VERSION. Is it acceptable to assume RIOT users are using more recent openocd's?
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash on an stm board using stlink debugger.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
