### PR TITLE
makefiles: add support for raspi debug adapter

### DIFF
--- a/makefiles/tools/openocd-adapters/raspi.inc.mk
+++ b/makefiles/tools/openocd-adapters/raspi.inc.mk
@@ -1,0 +1,13 @@
+# Raspberry Pi debug adapter over sysfs gpio's
+SWDCLK_PIN ?= 21
+SWDIO_PIN ?= 20
+SRST_PIN ?= 16
+
+OPENOCD_ADAPTER_INIT ?= \
+  -c 'source [find interface/sysfsgpio-raspberrypi.cfg]'
+  -c 'transport select swd' \
+  -c 'adapter_nsrst_assert_width 100'
+  -c 'sysfsgpio_swd_nums $(SWDCLK_PIN) $(SWDIO_PIN)'\
+  -c 'sysfsgpio_srst_num $(SRST_PIN)'
+export OPENOCD_ADAPTER_INIT
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds support for using GPIO's on a Raspberry Pi as an SWD debug adapter. The pin configuration can be overridden by defining SWDCLK_PIN, SWDIO_PIN and SRST_PIN in your board's `Makefile.include`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The correct pins should be defined.
OpenOCD should be configured with `--enable-sysfsgpio`.
Test by flashing a device with the SWD pins connected to the raspberry PI pins with:
```
DEBUG_ADAPTER=raspi make flash
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
