### PR TITLE
sys/ps: show free stack space in addition to used and total

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -59,7 +59,7 @@ void ps(void)
 #endif
             "%-9sQ | pri "
 #ifdef DEVELHELP
-           "| stack  ( used) | base addr  | current     "
+           "| stack  ( used) ( free) | base addr  | current     "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
            "| runtime  | switches"
@@ -75,7 +75,9 @@ void ps(void)
     void *isr_start = thread_isr_stack_start();
     void *isr_sp = thread_isr_stack_pointer();
     printf("\t  - | isr_stack            | -        - |"
-           "   - | %6i (%5i) | %10p | %10p\n", ISR_STACKSIZE, isr_usage, isr_start, isr_sp);
+           "   - | %6i (%5i) (%5i) | %10p | %10p\n",
+           ISR_STACKSIZE, isr_usage, ISR_STACKSIZE - isr_usage,
+           isr_start, isr_sp);
     overall_stacksz += ISR_STACKSIZE;
     if (isr_usage > 0) {
         overall_used += isr_usage;
@@ -102,7 +104,8 @@ void ps(void)
 #ifdef DEVELHELP
             int stacksz = p->stack_size;                                           /* get stack size */
             overall_stacksz += stacksz;
-            stacksz -= thread_measure_stack_free(p->stack_start);
+            int stack_free = thread_measure_stack_free(p->stack_start);
+            stacksz -= stack_free;
             overall_used += stacksz;
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
@@ -118,7 +121,7 @@ void ps(void)
 #endif
                    " | %-8s %.1s | %3i"
 #ifdef DEVELHELP
-                   " | %6i (%5i) | %10p | %10p "
+                   " | %6i (%5i) (%5i) | %10p | %10p "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
                    " | %2d.%03d%% |  %8u"
@@ -130,7 +133,8 @@ void ps(void)
 #endif
                    sname, queued, p->priority
 #ifdef DEVELHELP
-                   , p->stack_size, stacksz, (void *)p->stack_start, (void *)p->sp
+                   , p->stack_size, stacksz, stack_free,
+                   (void *)p->stack_start, (void *)p->sp
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
                    , runtime_major, runtime_minor, switches
@@ -140,8 +144,8 @@ void ps(void)
     }
 
 #ifdef DEVELHELP
-    printf("\t%5s %-21s|%13s%6s %6i (%5i)\n", "|", "SUM", "|", "|",
-           overall_stacksz, overall_used);
+    printf("\t%5s %-21s|%13s%6s %6i (%5i) (%5i)\n", "|", "SUM", "|", "|",
+           overall_stacksz, overall_used, overall_stacksz - overall_used);
 #   ifdef MODULE_TLSF_MALLOC
     puts("\nHeap usage:");
     tlsf_size_container_t sizes = { .free = 0, .used = 0 };


### PR DESCRIPTION

### Contribution description

This adds a new column to `ps` output showing unused stack space.

I find that this makes it easier to notice problems at a glance, as small numbers tend to stand out from everything else. Especially a zero.


### Testing procedure
Before:
```shell
> ps
        pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
          - | isr_stack            | -        - |   - |   1024 (  464) | 0x1fffc000 | 0x1fffc3b8
          1 | idle                 | pending  Q |  15 |    768 (  156) | 0x1fffcbe8 | 0x1fffce4c 
          2 | main                 | running  Q |   7 |   2560 (  888) | 0x1fffcee8 | 0x1fffd6cc 
          3 | pktdump              | bl rx    _ |   6 |   2560 (  248) | 0x20008aec | 0x200093f4 
          4 | 6lo                  | bl rx    _ |   3 |   1024 (  444) | 0x200094f0 | 0x200097cc 
          5 | ipv6                 | bl rx    _ |   4 |   1024 (  432) | 0x20006658 | 0x2000693c 
          6 | udp                  | bl rx    _ |   5 |   1024 (  280) | 0x20009ccc | 0x20009fb4 
          7 | kw41zrf-lwmac        | bl rx    _ |   2 |   1024 ( 1024) | 0x20005cd4 | 0x200060d4 
            | SUM                  |            |     |  12032 ( 3732)

```
After:
```shell
> ps
        pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
          - | isr_stack            | -        - |   - |   1024 (  464) (  560) | 0x1fffc000 | 0x1fffc3b8
          1 | idle                 | pending  Q |  15 |    768 (  156) (  612) | 0x1fffcbe8 | 0x1fffce4c 
          2 | main                 | running  Q |   7 |   2560 (  896) ( 1664) | 0x1fffcee8 | 0x1fffd6cc 
          3 | pktdump              | bl rx    _ |   6 |   2560 (  248) ( 2312) | 0x20008aec | 0x200093f4 
          4 | 6lo                  | bl rx    _ |   3 |   1024 (  444) (  580) | 0x200094f0 | 0x200097cc 
          5 | ipv6                 | bl rx    _ |   4 |   1024 (  432) (  592) | 0x20006658 | 0x2000693c 
          6 | udp                  | bl rx    _ |   5 |   1024 (  280) (  744) | 0x20009ccc | 0x20009fb4 
          7 | kw41zrf-lwmac        | bl rx    _ |   2 |   1024 ( 1024) (    0) | 0x20005cd4 | 0x200060d4 
            | SUM                  |            |     |  12032 ( 3684) ( 8348)
```
