### PR TITLE
make: introduce $(CLEAN)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -80,6 +80,13 @@ MAKEOVERRIDES += $(foreach v,$(__DIRECTORY_VARIABLES),$(v)=$($(v)))
 # trailing '/' is important when RIOTPROJECT == CURDIR
 BUILDRELPATH ?= $(patsubst $(RIOTPROJECT)/%,%,$(CURDIR)/)
 
+# Set CLEAN to "clean" if that target was requested.
+# Allows recipes to be run after cleaning, without triggering it implicitly:
+#
+# all: | $(CLEAN)
+#
+CLEAN = $(filter clean, $(MAKECMDGOALS))
+
 # include makefiles utils tools
 include $(RIOTMAKE)/utils/variables.mk
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -518,9 +518,7 @@ endef
 	@$(COLOR_ECHO)
 
 # The `clean` needs to be serialized before everything else.
-ifneq (, $(filter clean, $(MAKECMDGOALS)))
-    all $(BASELIBS) $(BUILDDEPS) ..in-docker-container: clean
-endif
+all $(BASELIBS) $(BUILDDEPS) ..in-docker-container: | $(CLEAN)
 
 .PHONY: pkg-prepare pkg-build pkg-build-%
 pkg-prepare:


### PR DESCRIPTION
### Contribution description

Currently, some targets are serialized before "clean" by conditionally
adding a dependency.

Make does allow ordering using "|" syntax in prerequisites, but for
"clean" that would always trigger the clean target.
By only conditionally setting $(CLEAN) to clean, that can be
circumvented.

The new CLEAN allows any recipe to be run after "clean" by specifying "|
$(CLEAN)" as prerequisite.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try ```make clean all -j``` and ```make all -j```, ensuring both still work as expected (both with existing and non-existing ```bin/```.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
