### PR TITLE
cpu/stm32l1: optimize power consumption

### DIFF
--- a/cpu/stm32_common/cpu_init.c
+++ b/cpu/stm32_common/cpu_init.c
@@ -45,11 +45,16 @@
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F3) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7) || \
+    defined(CPU_FAM_STM32L1)
 
 #define STM32_CPU_MAX_GPIOS    (12U)
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+#if defined(CPU_FAM_STM32L1)
+#define GPIO_CLK              (AHB)
+#define GPIO_CLK_ENR          (RCC->AHBENR)
+#define GPIO_CLK_ENR_MASK     (0x0000FFFF)
+#elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
 #define GPIO_CLK              (AHB)
 #define GPIO_CLK_ENR          (RCC->AHBENR)
 #define GPIO_CLK_ENR_MASK     (0xFFFF0000)
@@ -147,7 +152,8 @@ void cpu_init(void)
     stmclk_init_sysclk();
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F3) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7)
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7) || \
+    defined(CPU_FAM_STM32L1)
     _gpio_init_ain();
 #endif
 #ifdef MODULE_PERIPH_DMA


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR is based on previous work in #8403 & #10052. On start-up it configures all GPIO's as AIN.
On other boards of the STM32 family (L0 & L4) this is done by default. In #11758 this was done for STM32F0-7, with #11830 that solves #11820, it can now be done for STM32L1.

As stated in this [AN](https://comm.eefocus.com/media/download/index/id-1013834), doing this saves the consumption of the input Schmitt trigger. The only case where this shouldn't be done is when the pin is connected to an external driver that has a pull-up or pull-down setting, this should be handled by pertinent drivers.

### Testing procedure

Supply voltage for all the below measurement was 3.3V. ASupply was measured directly threw the IDD pin either with a multi meter or NUCLEO-LPM01A power measurement extension.

As of know when entering STOP mode consumption on stm32l1 is around 500uA, with this PR it drops to **1.5uA** (datasheet typ 1.4uA for l152re). To test run:

`make BOARD=nucleo-l152re -C tests/periph_pm/ flash`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on #11830 and #11489
Closes #11359 & #10052

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
