### PR TITLE
boards/openmote-b: Fix flashing issues

### DIFF
--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -16,19 +16,20 @@ ifeq ($(PROGRAMMER),cc2538-bsl)
   else ifeq ($(OS),Darwin)
     PORT_BSL ?= $(PORT_DARWIN)
   endif
+  FLASHFILE ?= $(HEXFILE)
   FLASHER = $(RIOTBASE)/dist/tools/cc2538-bsl/cc2538-bsl.py
   FFLAGS  = -p "$(PORT_BSL)" --bootloader-invert-lines -e -w -v -b 460800 $(FLASHFILE)
+  RESET ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
+  RESET_FLAGS ?= -p "$(PORT_BSL)" --bootloader-invert-lines
 else ifeq ($(PROGRAMMER),jlink)
-  FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
-  FFLAGS  = $(BINDIR) $(FLASHFILE)
-  DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
-  DEBUGSERVER = JLinkGDBServer -device CC2538SF53
-  RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+  # Special flashing and reset scripts are required due to board hardware
+  export FLASH_ADDR = 0x200000
+  export JLINK_DEVICE = CC2538SF53
+  export JLINK_IF = JTAG
+  export JLINK_RESET_FILE = $(RIOTBOARD)/$(BOARD)/dist/hw_reset.seg
+  include $(RIOTMAKE)/tools/jlink.inc.mk
 endif
 
-FLASHFILE ?= $(BINFILE)
-DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
-RESET_FLAGS ?= $(BINDIR)
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 
 # setup serial terminal

--- a/boards/openmote-b/board.c
+++ b/boards/openmote-b/board.c
@@ -29,6 +29,9 @@ void board_init(void)
     gpio_init(LED1_PIN, GPIO_OUT);
     gpio_init(LED2_PIN, GPIO_OUT);
     gpio_init(LED3_PIN, GPIO_OUT);
+    /* The boot pin must be set to input otherwise it may lock the bootloader */
+    gpio_init(BOOT_PIN, GPIO_IN);
+
     gpio_init(USER_BUTTON_PIN, GPIO_IN);
     gpio_init(RF_SWITCH_2_4_GHZ_PIN, GPIO_OUT);
     gpio_init(RF_SWITCH_SUB_GHZ_PIN, GPIO_OUT);

--- a/boards/openmote-b/dist/hw_reset.seg
+++ b/boards/openmote-b/dist/hw_reset.seg
@@ -1,0 +1,4 @@
+r0
+sleep 100
+r1
+exit

--- a/boards/openmote-b/doc.txt
+++ b/boards/openmote-b/doc.txt
@@ -40,11 +40,6 @@ RIOT support flashing with USB by default.
 You may have to specify the flashing port with
 `PORT_BSL=<my_openmote_port> make flash`
 
-@note       On some boards the MSP430 chip responsible for controlling
-the bootloading pins may not be functioning.  If you are only able to flash
-when there is no image (either the first time after purchase or after erasing
-with the jtag).  Please contact the manufacturer to provide a fix.
-
 ### Flashing via JTAG
 
 To be able to flash the board via JTAG you need to install Seggers JLinkExe
@@ -56,4 +51,11 @@ from your application folder.
 
 Mac OS users may experiment a command line expecting `connect`. Just type it
 and the process will continue.
+
+### Debugging
+
+The JTAG interface is required for debugging.  On some board revisions the
+debug may not be able to run. To debug use:
+
+`make debug`
  */

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -96,6 +96,8 @@
 #define CCA_BACKDOOR_ENABLE       (1)
 #define CCA_BACKDOOR_PORT_A_PIN   (6) /**< BSL_BOOT Pin */
 #define CCA_BACKDOOR_ACTIVE_LEVEL (0) /**< Active low */
+
+#define BOOT_PIN    GPIO_PIN(0, CCA_BACKDOOR_PORT_A_PIN) /**< BSL_BOOT Pin */
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

Some boards seem to lock the bootloader if the boot pin is high.
It must be set to input to prevent contention from the msp430 line controller.
Also the JTAG path seems incorrect since there is no dist/ for the board.
We can just use the common remote to fix it.
Also it is using bin file which requires the whole amount for flash to be flashed since the config is at the end.  By switching to HEX it works

### Testing procedure

You must have a board that can only flash once before getting sync problems when connecting to the bootloader.  Try flashing twice without (you may need to erase with a jtag interface) then flash with and it should be able to reflash.

The flashing should be much faster now.

Also try flashing with the jtag and getting into the debugger.


### Issues/PRs references
Finally fixing the problem for #11684 and #11031