### PR TITLE
nanocbor: fix doc grouping of nanocbor_config

### DIFF
--- a/pkg/nanocbor/include/nanocbor/config.h
+++ b/pkg/nanocbor/include/nanocbor/config.h
@@ -8,6 +8,8 @@
 
 /**
  * @defgroup    nanocbor_config NanoCBOR configuration header
+ * @ingroup     pkg_nanocbor
+ * @ingroup     config
  * @brief       Provides compile-time configuration for nanocbor
  */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The configuration header for nanocbor currently shows up in the [top-level module list](https://doc.riot-os.org/modules.html). This puts it to the right sub-group.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
make -C doc/doxygen html
```

(anyone noticed that `make doc` does not work anymore as expected [builds malformed HTML and LaTeX] or is it just me?)

The `nanocbor_config` should not show up in `doc/doxygen/html/modules.html` anymore, but in `doc/doxygen/html/group__config.html` and `doc/doxygen/html/group__pkg__nanocbor.html`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
