### PR TITLE
gnrc_sixlowpan_frag_stats: initial import of frag statistics

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -32,6 +32,7 @@ PSEUDOMODULES += gnrc_sixloenc
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default
 PSEUDOMODULES += gnrc_sixlowpan_frag_hint
+PSEUDOMODULES += gnrc_sixlowpan_frag_stats
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc
 PSEUDOMODULES += gnrc_sixlowpan_nd_border_router
 PSEUDOMODULES += gnrc_sixlowpan_router

--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -138,6 +138,31 @@ typedef struct {
 #endif /* MODULE_GNRC_SIXLOWPAN_FRAG_HINT */
 } gnrc_sixlowpan_msg_frag_t;
 
+#if defined(MODULE_GNRC_SIXLOWPAN_FRAG_STATS) || DOXYGEN
+/**
+ * @brief   Statistics on fragmentation and reassembly
+ *
+ * @note    Only available with the `gnrc_sixlowpan_frag_stats` module
+ */
+typedef struct {
+    unsigned rbuf_full;     /**< counts the number of events where the
+                             *   reassembly buffer is full */
+    unsigned frag_full;     /**< counts the number of events that there where
+                             *   no @ref gnrc_sixlowpan_msg_frag_t available */
+#if defined(MODULE_GNRC_SIXLOWPAN_FRAG_VRB) || DOXYGEN
+    unsigned vrb_full;      /**< counts the number of events where the virtual
+                             *   reassembly buffer is full */
+#endif
+} gnrc_sixlowpan_frag_stats_t;
+
+/**
+ * @brief   Get the current statistics on fragmentation and reassembly
+ *
+ * @return  The current statistics on fragmentation and reassembly
+ */
+gnrc_sixlowpan_frag_stats_t *gnrc_sixlowpan_frag_stats_get(void);
+#endif
+
 /**
  * @brief   Allocates a @ref gnrc_sixlowpan_msg_frag_t object
  *

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -274,6 +274,9 @@ gnrc_sixlowpan_msg_frag_t *gnrc_sixlowpan_msg_frag_get(void)
             return &_fragment_msg[i];
         }
     }
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+    gnrc_sixlowpan_frag_stats_get()->frag_full++;
+#endif
     return NULL;
 }
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -82,6 +82,15 @@ enum {
     RBUF_ADD_DUPLICATE,
 };
 
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+static gnrc_sixlowpan_frag_stats_t _stats;
+
+gnrc_sixlowpan_frag_stats_t *gnrc_sixlowpan_frag_stats_get(void)
+{
+    return &_stats;
+}
+#endif
+
 static int _check_fragments(gnrc_sixlowpan_rbuf_base_t *entry,
                             size_t frag_size, size_t offset)
 {
@@ -348,8 +357,15 @@ static gnrc_sixlowpan_rbuf_t *_rbuf_get(const void *src, size_t src_len,
             gnrc_pktbuf_release(oldest->pkt);
             rbuf_rm(oldest);
             res = oldest;
+#if GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE && \
+    defined(MODULE_GNRC_SIXLOWPAN_FRAG_STATS)
+            _stats.rbuf_full++;
+#endif
         }
         else {
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+            _stats.rbuf_full++;
+#endif
             return NULL;
         }
     }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -73,6 +73,11 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
             break;
         }
     }
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+    if (vrbe == NULL) {
+        gnrc_sixlowpan_frag_stats_get()->vrb_full++;
+    }
+#endif
     return vrbe;
 }
 

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -54,6 +54,9 @@ ifneq (,$(filter gnrc_ipv6_nib_6lbr,$(USEMODULE)))
     SRC += sc_gnrc_6ctx.c
 endif
 endif
+ifneq (,$(filter gnrc_sixlowpan_frag_stats,$(USEMODULE)))
+  SRC += sc_gnrc_6lo_frag_stats.c
+endif
 ifneq (,$(filter saul_reg,$(USEMODULE)))
   SRC += sc_saul_reg.c
 endif

--- a/sys/shell/commands/sc_gnrc_6lo_frag_stats.c
+++ b/sys/shell/commands/sc_gnrc_6lo_frag_stats.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include <stdio.h>
+
+#include "net/gnrc/sixlowpan/frag.h"
+
+int _gnrc_6lo_frag_stats(int argc, char **argv)
+{
+    gnrc_sixlowpan_frag_stats_t *stats = gnrc_sixlowpan_frag_stats_get();
+
+    (void)argc;
+    (void)argv;
+    printf("rbuf full: %u\n", stats->rbuf_full);
+    printf("frag full: %u\n", stats->frag_full);
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_VRB
+    printf("VRB full: %u\n", stats->vrb_full);
+#endif
+    return 0;
+}
+
+/** @} */

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -117,6 +117,12 @@ extern int _gnrc_6ctx(int argc, char **argv);
 #endif
 #endif
 
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+extern int _gnrc_6lo_frag_stats(int argc, char **argv);
+#endif
+#endif
+
 #ifdef MODULE_CCN_LITE_UTILS
 extern int _ccnl_open(int argc, char **argv);
 extern int _ccnl_content(int argc, char **argv);
@@ -224,6 +230,9 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_GNRC_IPV6_NIB_6LBR
     {"6ctx", "6LoWPAN context configuration tool", _gnrc_6ctx },
 #endif
+#endif
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+    {"6lo_frag", "6LoWPAN fragment statistics", _gnrc_6lo_frag_stats },
 #endif
 #ifdef MODULE_SAUL_REG
     {"saul", "interact with sensors and actuators using SAUL", _saul },


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This was cherry-picked out of #11068 (which became a huge mess during my experiment phase in preparation for [the 6LoWPAN fragment forwarding paper](https://arxiv.org/abs/1905.08089).

This provides analytical tools for 6LoWPAN fragmentation and reassembly. A counter is introduced for

- reassembly buffer full events,
- fragmentation buffer full events, and
- VRB full events

Furthermore a shell command is introduced that prints these counters out.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The fragmentation buffer full counter and VRB full counter are not testable without a fragment forwarding scheme (e.g. #11068).

The reassembly buffer full counter can be tested by including the module `gnrc_sixlowpan_frag_stats` to `gnrc_networking`, configuring the reassembly buffer size to 1, building that application for a 6Lo-capable board (I used the `samr21-xpro`), and flashing it to two nodes:

```sh
USEMODULE=gnrc_sixlowpan_frag_stats CFLAGS=-DGNRC_SIXLOWPAN_FRAG_RBUF_SIZE=1 \
    make -C examples/gnrc_networking flash # to two nodes
```

`make term` to both of them in two different terminals.

On **node 1** check if the command was compiled in. Both available counters should be set to 0.

```
> help
2019-07-12 16:08:34,988 - INFO #  help
2019-07-12 16:08:34,991 - INFO # Command              Description
2019-07-12 16:08:34,994 - INFO # ---------------------------------------
2019-07-12 16:08:35,000 - INFO # udp                  send data over UDP and listen on UDP ports
2019-07-12 16:08:35,003 - INFO # reboot               Reboot the node
2019-07-12 16:08:35,009 - INFO # ps                   Prints information about running threads.
2019-07-12 16:08:35,012 - INFO # ping6                Ping via ICMPv6
2019-07-12 16:08:35,016 - INFO # random_init          initializes the PRNG
2019-07-12 16:08:35,021 - INFO # random_get           returns 32 bit of pseudo randomness
2019-07-12 16:08:35,026 - INFO # nib                  Configure neighbor information base
2019-07-12 16:08:35,031 - INFO # ifconfig             Configure network interfaces
2019-07-12 16:08:35,038 - INFO # rpl                  rpl configuration tool ('rpl help' for more information)
2019-07-12 16:08:35,042 - INFO # 6lo_frag             6LoWPAN fragment statistics
> 6lo_frag
2019-07-12 16:08:37,340 - INFO #  6lo_frag
2019-07-12 16:08:37,341 - INFO # rbuf full: 0
2019-07-12 16:08:37,342 - INFO # frag full: 0
```

Get the link-local address of **node 1**:

```
> ifconfig
[…]
2019-07-12 16:09:28,096 - INFO #           inet6 addr: fe80::7b65:822:8693:9d5a  scope: local  VAL
[…]
```

On **node 2** ping node 1 with a small interval (e.g. 10 ms) but larg-ish packet size (just require fragmentation, e.g. 128 bytes):

```
ping6 -i 10 -s 128 fe80::7b65:822:8693:9d5a
2019-07-12 16:12:38,078 - INFO #  ping6 -i 10 -s 128 fe80::7b65:822:8693:9d5a
2019-07-12 16:12:38,171 - INFO # 136 bytes from fe80::7b65:822:8693:9d5a: icmp_seq=2 ttl=64 rssi=-34 dBm time=44.766 ms
2019-07-12 16:12:39,118 - INFO # 
2019-07-12 16:12:39,122 - INFO # --- fe80::7b65:822:8693:9d5a PING statistics ---
2019-07-12 16:12:39,128 - INFO # 3 packets transmitted, 1 packets received, 66% packet loss
2019-07-12 16:12:39,132 - INFO # round-trip min/avg/max = 44.766/44.766/44.766 ms
```

It is expected for the success rate not to be that great, as we only have one reassembly buffer entry on node 1 (+ other effects like might interfere with this short amount of interval).

Check the `6lo_frag` command on **node 1**. `rbuf_full` should now be >0:

```
> 6lo_frag
2019-07-12 16:13:21,489 - INFO #  6lo_frag
2019-07-12 16:13:21,490 - INFO # rbuf full: 1
2019-07-12 16:13:21,492 - INFO # frag full: 0
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Cherry-picked from #11068

Depends on #11000 as the statistics module was already ported for that in #11068.

![Route to 6Lo minimal fragment forwarding](http://page.mi.fu-berlin.de/mlenders/sixlo_minfwd.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
