### PR TITLE
netstats: add counter for retransmissions

### DIFF
--- a/sys/include/net/netstats.h
+++ b/sys/include/net/netstats.h
@@ -48,6 +48,7 @@ typedef struct {
                                      (either acknowledged or unconfirmed
                                      sending operation, e.g. multicast) */
     uint32_t tx_failed;         /**< failed sending operations */
+    uint32_t tx_retrans;        /**< total number of retransmissions */
     uint32_t tx_bytes;          /**< sent bytes */
     uint32_t rx_count;          /**< received (data) packets */
     uint32_t rx_bytes;          /**< received bytes */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1417,6 +1417,9 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
                 }
                 break;
 #ifdef MODULE_NETSTATS_L2
+            case NETDEV_EVENT_TX_NOACK:
+                netif->stats.tx_retrans++;
+                break;
             case NETDEV_EVENT_TX_MEDIUM_BUSY:
                 /* we are the only ones supposed to touch this variable,
                  * so no acquire necessary */

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -126,7 +126,7 @@ static int _netif_stats(kernel_pid_t iface, unsigned module, bool reset)
         printf("          Statistics for %s\n"
                "            RX packets %u  bytes %u\n"
                "            TX packets %u (Multicast: %u)  bytes %u\n"
-               "            TX succeeded %u errors %u\n",
+               "            TX succeeded %u errors %u retransmissions %u\n",
                _netstats_module_to_str(module),
                (unsigned) stats->rx_count,
                (unsigned) stats->rx_bytes,
@@ -134,7 +134,8 @@ static int _netif_stats(kernel_pid_t iface, unsigned module, bool reset)
                (unsigned) stats->tx_mcast_count,
                (unsigned) stats->tx_bytes,
                (unsigned) stats->tx_success,
-               (unsigned) stats->tx_failed);
+               (unsigned) stats->tx_failed,
+               (unsigned) stats->tx_retrans);
         res = 0;
     }
     return res;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This was cherry-picked out of #11068 (which became a huge mess during my experiment phase in preparation for [the 6LoWPAN fragment forwarding paper](https://arxiv.org/abs/1905.08089).

This adds a retransmission counter to `netstats`. It also adds an implementation of that counter to `gnrc_netif` to count `NETDEV_EVENT_TX_NOACK` events as retransmissions in the interface's netstats (as no ACK from the receiver implies a retransmission). Lastly, the shell command is extended to print out the new counter.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash `gnrc_networking` to two boards that have network devices that support retransmissions (I used two `samr21-xpro`

```
make -C examples/gnrc_networking flash # to two boards
```

`make term` to both of them in two different terminals.

Check if the retransmission counter for Layer 2 is 0

```
> ifconfig
[…]
Statistics for Layer 2
  RX packets 0  bytes 0
  TX packets 3 (Multicast: 3)  bytes 115
  TX succeeded 3 errors 0 retransmissions 0
[…]
```

Let them ping each other with unicast addresses in short intervals to stress the medium:

```
ping6 -i 10 -c 1000 "<the respective other node's link-local address>"
```

`ifconfig` should show `retransmissions` > 0 for Layer 2

```
[…]
Statistics for Layer 2
  RX packets 1162  bytes 41923
  TX packets 2103 (Multicast: 16)  bytes 75806
  TX succeeded 1173 errors 50 retransmissions 880
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Cherry-picked from #11068, but this PR has no dependencies.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
