### PR TITLE
gnrc_netif: allow for wait of minimum time between sends

### DIFF
--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -137,6 +137,17 @@ extern "C" {
 #define GNRC_NETIF_DEFAULT_HL      (64U)   /**< default hop limit */
 #endif
 
+/**
+ * @brief   Minimum wait time in microseconds after a send operation
+ *
+ * @experimental
+ *
+ * This is purely meant as a debugging feature to slow down a radios sending.
+ */
+#ifndef GNRC_NETIF_MIN_WAIT_AFTER_SEND_US
+#define GNRC_NETIF_MIN_WAIT_AFTER_SEND_US   (0U)
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This was cherry-picked out of #11068 (which became a huge mess during my experiment phase in preparation for [the 6LoWPAN fragment forwarding paper](https://arxiv.org/abs/1905.08089).

This adds a minimum sleep between every send, to allow for slowing down the send operations of  a device.

To be perfectly honest, I don't know if and how useful this could be in production operation or beyond experimentation in general, but it helped me to confirm some things during my experimentation. However, I kept it optional and marked it as experimental so I think it does not harm to merge.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
First compile and flash `gnrc_networking` normally with `GNRC_NETIF_MIN_WAIT_AFTER_SEND_US=0`. Ping another node with the same configuration. There should be no significant changes to to master.

Now compile with a higher delay e.g. `GNRC_NETIF_MIN_WAIT_AFTER_SEND_US=5000`. The RTT when pinging should now significantly increase (maybe even timeout), if you have access to a sniffer: the time different between two transmissions (ignoring L2 retransmissions) should now be at minimum at the configured time interval.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Cherry-picked from #11068, but this PR has no dependencies.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
