### PR TITLE
dist/tools/ethos: deduplicate setup_network.sh, start_network.sh

### DIFF
--- a/dist/tools/ethos/README.md
+++ b/dist/tools/ethos/README.md
@@ -13,3 +13,19 @@ To use, add
 
 to app Makefile, "make clean all flash", then run this tool as follows:
     # sudo ./ethos <tap-device> <serial>
+
+## setup_network.sh
+
+This script sets up a tap device, configures a prefix and starts a uhcpd server
+serving that prefix towards the tap device.
+The tap device will be owned by the calling user, or if called with sudo, with
+the user that uses sudo. That way, ethos can use it without being root / using
+sudo.
+
+E.g., use as follows:
+
+    $ sudo ./setup_network.sh riot0 2001:db8::0/64
+
+Keep that running, then in another shell start ethos:
+
+    $ ethos riot0 <serial>

--- a/dist/tools/ethos/setup_network.sh
+++ b/dist/tools/ethos/setup_network.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+create_tap() {
+    ip tuntap add ${TAP} mode tap user ${_USER}
+    sysctl -w net.ipv6.conf.${TAP}.forwarding=1
+    sysctl -w net.ipv6.conf.${TAP}.accept_ra=0
+    ip link set ${TAP} up
+    ip a a fe80::1/64 dev ${TAP}
+    ip a a fd00:dead:beef::1/128 dev lo
+    ip route add ${PREFIX} via fe80::2 dev ${TAP}
+}
+
+remove_tap() {
+    ip tuntap del ${TAP} mode tap
+}
+
+cleanup() {
+    echo "Cleaning up..."
+    remove_tap
+    ip a d fd00:dead:beef::1/128 dev lo
+    trap "" INT QUIT TERM EXIT
+}
+
+start_uhcpd() {
+    ${UHCPD} ${TAP} ${PREFIX}
+}
+
+TAP=$1
+PREFIX=$2
+_USER=$3
+: ${UHCPD:="$(readlink -f $(dirname $0)"/../uhcpd/bin")/uhcpd"}
+
+[ -z "${TAP}" -o -z "${PREFIX}" ] && {
+    echo "usage: $0 <tap-device> <prefix> [<user>]"
+    exit 1
+}
+
+if [ -z "$_USER" ]; then
+    if [ -n "$SUDO_USER" ] ; then
+        _USER=$SUDO_USER
+    else
+        _USER=$USER
+    fi
+fi
+
+trap "cleanup" INT QUIT TERM EXIT
+
+
+create_tap && start_uhcpd

--- a/dist/tools/ethos/setup_network.sh
+++ b/dist/tools/ethos/setup_network.sh
@@ -15,10 +15,10 @@ remove_tap() {
 }
 
 cleanup() {
-    echo "Cleaning up..."
+    trap "" INT QUIT TERM EXIT
+    echo "Cleaning up network..."
     remove_tap
     ip a d fd00:dead:beef::1/128 dev lo
-    trap "" INT QUIT TERM EXIT
 }
 
 start_uhcpd() {
@@ -44,6 +44,5 @@ if [ -z "$_USER" ]; then
 fi
 
 trap "cleanup" INT QUIT TERM EXIT
-
 
 create_tap && start_uhcpd

--- a/dist/tools/ethos/start_network.sh
+++ b/dist/tools/ethos/start_network.sh
@@ -2,31 +2,14 @@
 
 ETHOS_DIR="$(dirname $(readlink -f $0))"
 
-create_tap() {
-    ip tuntap add ${TAP} mode tap user ${USER}
-    sysctl -w net.ipv6.conf.${TAP}.forwarding=1
-    sysctl -w net.ipv6.conf.${TAP}.accept_ra=0
-    ip link set ${TAP} up
-    ip a a fe80::1/64 dev ${TAP}
-    ip a a fd00:dead:beef::1/128 dev lo
-    ip route add ${PREFIX} via fe80::2 dev ${TAP}
-}
-
-remove_tap() {
-    ip tuntap del ${TAP} mode tap
-}
-
 cleanup() {
-    echo "Cleaning up..."
-    remove_tap
-    ip a d fd00:dead:beef::1/128 dev lo
-    kill ${UHCPD_PID}
+    [ -n "${SETUP_NETWORK_PID}" ] && kill -TERM ${SETUP_NETWORK_PID}
     trap "" INT QUIT TERM EXIT
 }
 
-start_uhcpd() {
-    ${UHCPD} ${TAP} ${PREFIX} > /dev/null &
-    UHCPD_PID=$!
+setup_network() {
+    ${ETHOS_DIR}/setup_network.sh $1 $2 &
+    SETUP_NETWORK_PID=$!
 }
 
 PORT=$1
@@ -46,5 +29,4 @@ UHCPD="$(readlink -f "${ETHOS_DIR}/../uhcpd/bin")/uhcpd"
 
 trap "cleanup" INT QUIT TERM EXIT
 
-
-create_tap && start_uhcpd && "${ETHOS_DIR}/ethos" ${TAP} ${PORT} ${BAUDRATE}
+setup_network ${TAP} ${PREFIX} && "${ETHOS_DIR}/ethos" ${TAP} ${PORT} ${BAUDRATE}

--- a/dist/tools/ethos/start_network.sh
+++ b/dist/tools/ethos/start_network.sh
@@ -8,7 +8,7 @@ cleanup() {
 }
 
 setup_network() {
-    ${ETHOS_DIR}/setup_network.sh $1 $2 &
+    ${ETHOS_DIR}/setup_network.sh $* &
     SETUP_NETWORK_PID=$!
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

#11816 introduced setup_network.sh, introducing some duplication with start_network.sh.
This PR aims to remove the duplications.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- ensure examples/suit_update (#11818) still works (using setup_network.sh)
- ensure users of start_network.sh still work

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
