### PR TITLE
dist/tools/git/git-cache: bump version

### DIFF
--- a/dist/tools/git/git-cache
+++ b/dist/tools/git/git-cache
@@ -136,8 +136,9 @@ _check_tag_or_commit() {
     local REMOTE_NAME=$2
 
     if _check_commit $SHA1 ; then
-        git_cache tag commit$SHA1 $SHA1 2> /dev/null || true # ignore possibly already existing tag
-        echo "commit$SHA1"
+        local tag=commit$SHA1-$$
+        git_cache tag $tag $SHA1 2> /dev/null || true # ignore possibly already existing tag
+        echo "$tag"
     elif _tag_to_sha1 ${REMOTE_NAME}/$SHA1 > /dev/null; then
         echo "${REMOTE_NAME}/$SHA1"
     fi
@@ -187,7 +188,23 @@ clone() {
         if [ -n "$tag" ]; then
             echo "git-cache: cloning from cache. tag=$tag"
             git -c advice.detachedHead=false clone $Q --reference "${GIT_CACHE_DIR}" --shared "${GIT_CACHE_DIR}" "${TARGET_PATH}" --branch $tag
+
+            # rename tags from <remote-hash>/* to *
             git -C "${TARGET_PATH}" fetch $Q origin "refs/tags/${REMOTE_NAME}/*:refs/tags/*"
+
+            # remove all commit* and <remote-hash>/* tags
+            git -C "${TARGET_PATH}" tag -l \
+                | grep -P '(^[a-f0-9]{40}/|^commit[a-f0-9]{40}(-\d+)?$)' \
+                | xargs git -C "${TARGET_PATH}" tag -d > /dev/null
+
+            # cleanup possibly created helper tag
+            case $tag in
+                commit*)
+                    git_cache tag -d $tag 2>&1 > /dev/null || true
+                    ;;
+            esac
+
+
             if [ $pull -eq 1 ]; then
                 git -C "${TARGET_PATH}" fetch $Q $REMOTE $SHA1:$SHA1
                 git -C "${TARGET_PATH}" checkout $Q $SHA1
@@ -201,6 +218,12 @@ clone() {
             git clone "${REMOTE}" "${TARGET_PATH}"
             git -c advice.detachedHead=false -C "${TARGET_PATH}" checkout $SHA1
     fi
+}
+
+cleanup() {
+    git_cache tag -l \
+        | grep -P '(^commit[a-f0-9]{40}(-\d+)?$)' \
+        | xargs git -C "${GIT_CACHE_DIR}" tag -d > /dev/null
 }
 
 usage() {
@@ -217,6 +240,9 @@ usage() {
     echo "    git cache clone <url> <SHA1>  clone repository <url> from cache"
     echo "    git cache show-path           print's the path that can be used as "
     echo "                                  '--reference' parameter"
+    echo "    git cache cleanup             cleanup dangling temporary tags"
+    echo "                                  (appear if git-cache gets inter-"
+    echo "                                   rupted, but are harmless)"
     echo ""
     echo "To retrieve objects from cache (will use remote repository if needed):"
     echo '    git clone --reference $(git cache show-path) <repo>'
@@ -253,6 +279,9 @@ case $ACTION in
         ;;
     clone)
         clone $*
+        ;;
+    cleanup)
+        cleanup
         ;;
     *)
         usage


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Upstream contains important fixes:

- improve tag handling

Previously, a checkout from cache included all tags from all cached repositories, but with a repository-hash in front.
This lead to duplicate tag entries:

```
    $ cd tests/pkg_libcose
    $ make
    $ cd bin/pkg/native/libcose
    $ git describe
```

master:
```
[kaspar@ng libcose ((542ba36478...))]$ git describe
warning: tag 'v0.3.1' is really '4b5e2db9542f5884bab62b37b874bbdeafbe9c62/v0.3.1' here
v0.3.1-1-g542ba36478
[kaspar@ng libcose ((542ba36478...))]$
```

this PR:
```
[kaspar@ng libcose ((62e41ab711...))]$ git describe
v0.3.1-1-g62e41ab711
[kaspar@ng libcose ((62e41ab711...))]$ 
```

Not the missing "warning: tag X is really Y here" warning. The warning broke anything within a package depending on "git describe" output, e.g., the micropython Makefiles.

(the actual commit hash differs, as a patch is applied on top using git am.)

- improve concurrent use

previously, git-cache would, if a commit hash was requested for checkout create a temporary tag ```commit<hash>``` so it has a named ref. The logic wouldn't work with multiple concurrent calls.
This has been fixed by appending the PID of git-cache to the temporary tag.

- clean up temporary tags

Well, previously the tags weren't really temporary, cluttering the tag space with leftovers. Now they get properly cleaned after checkout.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI has been using this since a long time (it is part of the murdock container), so I don't expect much trouble.
Anyhow, for testing, try building ```tests/pkg_*``` for all tests using git, especially those using tags instead of commit hashes.
(Ensure git-cache is enabled: ```git-cache init```).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
