### PR TITLE
makefiles: documentation for hexfile binfile

### DIFF
--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -45,6 +45,7 @@ info-build:
 	@echo ''
 	@echo 'ELFFILE: $(ELFFILE)'
 	@echo 'HEXFILE: $(HEXFILE)'
+	@echo 'BINFILE: $(BINFILE)'
 	@echo 'FLASHFILE: $(FLASHFILE)'
 	@echo ''
 	@echo 'FEATURES_USED:'

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -76,7 +76,7 @@ export FLASH_ADDR            # Define an offset to flash code into ROM memory.
 # TERMFLAGS                  # Additional parameters to supply to TERMPROG.
 export PORT                  # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
-export HEXFILE               # The stripped result of the compilation.
+export HEXFILE               # The 'intel hex' stripped result of the compilation.
 # FLASHFILE                  # The output file used for flashing (transition phase: only if defined)
 # DEBUGGER                   # The command to call on "make debug", usually a script starting the GDB front-end.
 # DEBUGGER_FLAGS             # The parameters to supply to DEBUGGER.

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -58,7 +58,7 @@ export ASFLAGS               # Flags for the assembler.
 export LINK                  # The command used to link the files. Must take the same parameters as GCC, i.e. "ld" won't work.
 # LINKFLAGS                  # Flags to supply in the linking step.
 export LTOFLAGS              # extra CFLAGS for compiling with link time optimization
-export OBJCOPY               # The command used to create the HEXFILE.
+export OBJCOPY               # The command used to create the HEXFILE and BINFILE.
 export OFLAGS                # The parameter for OBJCOPY, e.g. to strip the debug information.
 export OBJDUMP               # The command used to create the assembly listing.
 export OBJDUMPFLAGS          # The parameter for OBJDUMP.
@@ -77,6 +77,7 @@ export FLASH_ADDR            # Define an offset to flash code into ROM memory.
 export PORT                  # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The 'intel hex' stripped result of the compilation.
+# BINFILE                    # The 'binary' stripped result of the compilation.
 # FLASHFILE                  # The output file used for flashing (transition phase: only if defined)
 # DEBUGGER                   # The command to call on "make debug", usually a script starting the GDB front-end.
 # DEBUGGER_FLAGS             # The parameters to supply to DEBUGGER.


### PR DESCRIPTION
### Contribution description

Now that `HEXFILE` is not overwritten to a `.bin` anymore and `BINFILE` always a binary file, the documentation can be clarified.

### Testing procedure

Review the new documentation in `makefiles/vars.inc.mk`.

The value of `HEXFILE` is not overwritten anymore (to BINFILE in particular)

```
git grep 'HEXFILE \?:\?=' '**' ':!boards/common/msba2/tools/flashutil.sh'
# empty
```

The value can be seen in the `info-build` output.

```
make -C examples/hello-world/ info-build | grep FILE:  | head -n 4
ELFFILE: /home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.elf
HEXFILE: /home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.hex
BINFILE: /home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.bin
FLASHFILE: /home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.elf
```

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/8838
