### PR TITLE
pkg/semtech_loramac: fix memcpy to uninitialized pointer [backport 2019.07]

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -64,7 +64,7 @@ void semtech_loramac_set_appskey(semtech_loramac_t *mac, const uint8_t *skey)
     mutex_lock(&mac->lock);
     MibRequestConfirm_t mibReq;
     mibReq.Type = MIB_APP_SKEY;
-    memcpy(mibReq.Param.AppSKey, skey, LORAMAC_APPSKEY_LEN);
+    mibReq.Param.AppSKey = (uint8_t *) skey;
     LoRaMacMibSetRequestConfirm(&mibReq);
     mutex_unlock(&mac->lock);
 }
@@ -84,7 +84,7 @@ void semtech_loramac_set_nwkskey(semtech_loramac_t *mac, const uint8_t *skey)
     mutex_lock(&mac->lock);
     MibRequestConfirm_t mibReq;
     mibReq.Type = MIB_NWK_SKEY;
-    memcpy(mibReq.Param.NwkSKey, skey, LORAMAC_NWKSKEY_LEN);
+    mibReq.Param.NwkSKey = (uint8_t *) skey;
     LoRaMacMibSetRequestConfirm(&mibReq);
     mutex_unlock(&mac->lock);
 }


### PR DESCRIPTION
# Backport of #11847

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

 #11552 introduced an illegal memcpy to an uni-initialized pointers. This broke loramac for some boards e.g: lobaro-lorabox and broke ABP for most of them. This pr fixes the illegal access.

The PR should be backported to Release 2019.07.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

- On im880b (using #11315) or lobaro-lorabox on master the following causes a hardfault:

`BOARD=lobaro-lorabox LORA_DRIVER=sx1272 make -C tests/pkg_semtech-loramac/ flash term`

```
loramac save
2019-07-16 11:05:16,557 - INFO #  loramac save
2019-07-16 11:05:16,562 - INFO # [semtech-loramac] saving configuration on EEPROM
2019-07-16 11:05:17,010 - INFO # [semtech-loramac] saving uplink counter: 0 
2019-07-16 11:05:17,042 - INFO # [semtech-loramac] saving rx2 freq: 869525000
2019-07-16 11:05:17,070 - INFO # [semtech-loramac] saving rx2 dr: 3
reboot
```

with this PR it works as expected.

- On b-l072z-lrwan1 and other boards in master trying to set session keys fails or hangs:

```
loramac set appskey 1EBB10A1AE58065BB4540A4181DC7BB8
2019-07-15 17:16:52,784 - INFO #  loramac set appskey 1EBB10A1AE58065BB4540A4181DC7BB8
loramac get appskey
2019-07-15 17:16:55,244 - INFO #  loramac get appskey
2019-07-15 17:16:55,248 - INFO # APPSKEY: E9030008000000000000000000000000
```

With this PR it succeeds.


- Release tasks `11-lorawan` succeed with b-l072z-lrwan1:
 - [x] Task #01 - LoRaWAN example
 - [x] Task #02 - OTAA join procedure
 - [x] Task #03 - ABP join procedure
 - [x] Task #04 - LoRaWAN device parameters persistence

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

fixes #11626
alternative to #11783 