### PR TITLE
boards/hamilton: remove OFLAGS '-O binary'

### DIFF
--- a/boards/hamilton/Makefile.include
+++ b/boards/hamilton/Makefile.include
@@ -5,7 +5,7 @@ export CPU_MODEL = samr21e18a
 # debugger config
 export JLINK_DEVICE := atsamr21e18a
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
-export OFLAGS := -O binary --gap-fill 0xff
+export OFLAGS := --gap-fill 0xff
 
 # Configure terminal, hamilton doesn't provide any UART, thus use RTT
 TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh


### PR DESCRIPTION
### Contribution description

The 'binary' output format is now given by default to .bin files creation

This was changed before `hamilton` board integration but not updated in the PR.

### Testing procedure

The `-O binary` flag is only once in the `objcopy` output and compilation gives the same `.bin` file.

#### objcopy
```
RIOT_CI_BUILD=1 BOARD=hamilton QUIET=0 make --no-print-directory -C examples/hello-world/ | grep objcopy
/opt/gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-objcopy --gap-fill 0xff -Obinary /data/riotbuild/riotbase/examples/hello-world/bin/hamilton/hello-world.elf /data/riotbuild/riotbase/examples/hello-world/bin/hamilton/hello-world.bin
```
In master it had two times `-O binary`.

```
BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 BOARD=hamilton make --no-print-directory -C examples/hello-world/ QUIET=0 | grep objcopy
/opt/gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-objcopy -O binary --gap-fill 0xff -Obinary /data/riotbuild/riotbase/examples/hello-world/bin/hamilton/hello-world.elf /data/riotbuild/riotbase/examples/hello-world/bin/hamilton/hello-world.bin
```

#### binary output

The binary is the same for both

```
sha256sum examples/hello-world/bin/hamilton/hello-world.bin
a8283b86d7e4a87bcaebde1447a3f419d968317044d2880aeb4b2b2a9d66fdec  examples/hello-world/bin/hamilton/hello-world.bin
```


### Issues/PRs references

Part of the https://github.com/RIOT-OS/RIOT/pull/8838 changes