### PR TITLE
dist/pythonlibs/testrunner: dynamic changing of test timeout

### DIFF
--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -15,8 +15,13 @@ import pexpect
 from .spawn import find_exc_origin, setup_child, teardown_child
 from .unittest import PexpectTestCase   # noqa, F401 expose to users
 
+# Timeout for tests can be changed by setting RIOT_TEST_TIMEOUT to the desired
+# value in the environment variables
+# default value (10)
+TIMEOUT = int(os.environ.get('RIOT_TEST_TIMEOUT') or 10)
 
-def run(testfunc, timeout=10, echo=True, traceback=False):
+
+def run(testfunc, timeout=TIMEOUT, echo=True, traceback=False):
     child = setup_child(timeout, env=os.environ,
                         logfile=sys.stdout if echo else None)
     try:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Few flashers require a longer time to flash code and reset the device and require the test script to wait for a long time before timing out. This PR adds an environment variable that can be set by the user to vary the timeout in accordance with the requirements of the system


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
- export RIOT_TEST_TIMEOUT environment variable with the desired timeout
- run any test from the test directory
- The tests that were already working should succeed as usual

