### PR TITLE
cpu/sam0: update doc.txt with new MCU families

### DIFF
--- a/cpu/sam0_common/doc.txt
+++ b/cpu/sam0_common/doc.txt
@@ -4,5 +4,5 @@
  * @brief           Atmel SAM0 common
  *
  * This module contains all common code and definition to all Atmel SAM0 cpu
- * families supported by RIOT: @ref cpu_samd21, @ref cpu_saml21.
+ * families supported by RIOT: @ref cpu_samd21, @ref cpu_saml21, @ref cpu_saml1x, @ref cpu_samd5x.
  */


### PR DESCRIPTION
saml1x and samd5x make use of sam0_common.
Update the documentation accordingly. 