### PR TITLE
dist/jlink.sh: Allow overwriting the 'reset' commands

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -54,6 +54,8 @@
 
 # Set IMAGE_OFFSET to zero by default.
 : ${IMAGE_OFFSET:=0}
+# Allow overwriting the reset commands.
+: ${JLINK_RESET_FILE:=${RIOTTOOLS}/jlink/reset.seg}
 
 # default GDB port
 _GDB_PORT=3333
@@ -167,7 +169,7 @@ do_flash() {
     if [ ! -z "${JLINK_POST_FLASH}" ]; then
         printf "${JLINK_POST_FLASH}\n" >> ${BINDIR}/burn.seg
     fi
-    cat ${RIOTTOOLS}/jlink/reset.seg >> ${BINDIR}/burn.seg
+    cat ${JLINK_RESET_FILE} >> ${BINDIR}/burn.seg
     # flash device
     sh -c "${JLINK} ${JLINK_SERIAL} \
                     -ExitOnError 1 \
@@ -224,7 +226,7 @@ do_reset() {
                     -speed '${JLINK_SPEED}' \
                     -if '${JLINK_IF}' \
                     -jtagconf -1,-1 \
-                    -commandfile '${RIOTTOOLS}/jlink/reset.seg'"
+                    -commandfile '${JLINK_RESET_FILE}'"
 }
 
 do_term() {


### PR DESCRIPTION
### Contribution description

Add a variable to configure the reset commands.
This is required for board that need a hardware reset.

### Testing procedure

Flashing an resetting with a JLink board did not change.
For example

```
BOARD=nrf52dk make -C tests/bloom_bytes/ reset flash test
```

And the file can be overwritten, here with a non existing one to show the error:
```
JLINK_RESET_FILE=lala BOARD=nrf52dk make -C tests/bloom_bytes/ clean reset flash test
make: Entering directory '/home/harter/work/git/RIOT/tests/bloom_bytes'
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh reset
### Resetting Target ###
SEGGER J-Link Commander V6.42d (Compiled Feb 15 2019 13:56:53)
DLL version V6.42d, compiled Feb 15 2019 13:56:43

J-Link Commander will now exit on Error
Could not open J-Link Command File 'lala'
/home/harter/work/git/RIOT/tests/bloom_bytes/../../Makefile.include:592: recipe for target 'reset' failed
make: *** [reset] Error 1
make: Leaving directory '/home/harter/work/git/RIOT/tests/bloom_bytes'
```


### Issues/PRs references

This is a change required for #11833 