### PR TITLE
makefiles/buildtest: always execute 'buildtest' loop on host machine

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -110,7 +110,7 @@ include $(RIOTMAKE)/info-nproc.inc.mk
 # List of boards variables
 include $(RIOTMAKE)/boards.inc.mk
 
-GLOBAL_GOALS += buildtest info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff
+GLOBAL_GOALS += buildtest buildtest-indocker info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
   BOARD=none
 endif

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -1,4 +1,4 @@
-.PHONY: buildtest
+.PHONY: buildtest buildtest-indocker
 
 BUILDTEST_MAKE_REDIRECT ?= >/dev/null 2>&1
 
@@ -24,4 +24,18 @@ buildtest:
 		fi; \
 	done ; \
 	$${RESULT}
+endif # BUILD_IN_DOCKER
+
+# Define 'buildtest-indocker' completely executed inside the container.
+# It prevents starting one container per compilation wich is slower but it
+# could hide errors where the host toolchain would be used
+ifeq ($(BUILD_IN_DOCKER),1)
+  buildtest-indocker: ..in-docker-container
+else
+ifeq ($(INSIDE_DOCKER),1)
+  buildtest-indocker: buildtest
+else
+  buildtest-indocker:
+	$(error $@ must be run with `BUILD_IN_DOCKER=1`)
+endif # INSIDE_DOCKER
 endif # BUILD_IN_DOCKER

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -2,9 +2,6 @@
 
 BUILDTEST_MAKE_REDIRECT ?= >/dev/null 2>&1
 
-ifeq ($(BUILD_IN_DOCKER),1)
-buildtest: ..in-docker-container
-else
 buildtest:
 	@ \
 	RESULT=true ; \
@@ -24,7 +21,6 @@ buildtest:
 		fi; \
 	done ; \
 	$${RESULT}
-endif # BUILD_IN_DOCKER
 
 # Define 'buildtest-indocker' completely executed inside the container.
 # It prevents starting one container per compilation wich is slower but it

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,6 @@ export DOCKER_FLAGS ?= --rm
 # List of Docker-enabled make goals
 export DOCKER_MAKECMDGOALS_POSSIBLE = \
   all \
-  buildtest \
   buildtest-indocker \
   scan-build \
   scan-build-analyze \

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -6,6 +6,7 @@ export DOCKER_FLAGS ?= --rm
 export DOCKER_MAKECMDGOALS_POSSIBLE = \
   all \
   buildtest \
+  buildtest-indocker \
   scan-build \
   scan-build-analyze \
   tests-% \


### PR DESCRIPTION
### Contribution description 

This remove executing buildtest `for` loop in docker.

When building completely in docker, 'buildtest' would hide issues when
the host toolchain would be used when doing `make all` directly.

A side effect is also that now `BUILDTEST_MAKE_REDIRECT` would work when
doing `buildtest` with docker.
This also now removes passing `BOARDS` as it was added and needed only
for 'buildtest', and should work without the specific handling. https://github.com/RIOT-OS/RIOT/pull/11385


The side effect is that now one `docker` instance should be started per compilation but makes it more consistent with  doing `BUILD_IN_DOCKER=1 BOARD=board_name make` for each board.

### Testing procedure

I locally used `DOCKER="sudo docker"` but did not include it in the tests commands displayed below.


#### Normal buildtest uses

Running `buildtest` with `BUILD_IN_DOCKER=1` still works.

```
BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/ buildtest
Building for acd52832 ... success.
Building for airfy-beacon ... success.
...
Building for wsn430-v1_3b ... success.
Building for wsn430-v1_4 ... success.
Building for yunjia-nrf51822 ... success.
Building for z1 ... success.
```

`BOARDS` can still be limited:

```
BUILD_IN_DOCKER=1 BOARDS='native samr21-xpro pic32-wifire' make --no-print-directory -C examples/hello-world/ buildtest
Building for native ... success.
Building for samr21-xpro ... success.
Building for pic32-wifire ... success.
```

When setting `BUILDTEST_MAKE_REDIRECT=` in the environment it will be taken into account

<details><summary><code>BUILDTEST_MAKE_REDIRECT= BUILD_IN_DOCKER=1 BOARDS='native samr21-xpro' make --no-print-directory -C examples/default buildtest</code></summary>

```
BUILDTEST_MAKE_REDIRECT= BUILD_IN_DOCKER=1 BOARDS='native samr21-xpro' make --no-print-directory -C examples/default buildtest
Building for native ... Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'BOARD=native' -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotbase/examples/default/' \
    'riot/riotbuild:latest' make all
Building application "default" for "native" with MCU "native".

   text    data     bss     dec     hex filename
  90210    1104   72024  163338   27e0a /data/riotbuild/riotbase/examples/default/bin/native/default.elf
success.
Building for samr21-xpro ... Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'BOARD=samr21-xpro' -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotbase/examples/default/' \
    'riot/riotbuild:latest' make all
Building application "default" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
  40856     508    6048   47412    b934 /data/riotbuild/riotbase/examples/default/bin/samr21-xpro/default.elf
success.
```
</details>


In master it was showing the `docker` command first to run `buildtest` now `all` is run with `docker` for each board.

<details><summary>Master: <code>BUILDTEST_MAKE_REDIRECT= BUILD_IN_DOCKER=1 BOARDS='native samr21-xpro' make --no-print-directory -C examples/hello-world/ buildtest</code></summary>

```
BUILDTEST_MAKE_REDIRECT= BUILD_IN_DOCKER=1 BOARDS='native samr21-xpro' make --no-print-directory -C examples/hello-world/ buildtest
Launching build container using image "riot/riotbuild:latest".
mkdir -p /home/harter/work/git/worktree/riot_master/build
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache  -v /home/harter/work/git/RIOT/.git:/home/harter/work/git/RIOT/.git \
    -e 'BOARDS=native samr21-xpro' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make buildtest  
Building for native ... success.
Building for samr21-xpro ... success.
```
</details>

#### Removes errors hiding

Use a PATH where you do not have `arm-none-eabi-gcc`
```
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin arm-none-eabi-gcc

Command 'arm-none-eabi-gcc' not found, but can be installed with:

sudo apt install gcc-arm-none-eabi
```

It now correctly fails with `buildtest` with `BUILD_IN_DOCKER=1` as the host toolchain is used by that application.


<details><summary><code>BOARDS="iotlab-m3 samr21-xpro" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 BUILDTEST_MAKE_REDIRECT='>/dev/null' make -C tests/riotboot buildtest</code></summary>

```
BOARDS="iotlab-m3 samr21-xpro" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 BUILDTEST_MAKE_REDIRECT='>/dev/null' make -C tests/riotboot buildtest
make: Entering directory '/home/harter/work/git/RIOT/tests/riotboot'
Building for iotlab-m3 ... /bin/sh: 1: arm-none-eabi-gcc: not found
make[1]: *** [/home/harter/work/git/RIOT/tests/riotboot/bin/iotlab-m3/tests_riotboot-slot0.elf] Error 127
failed!
Building for samr21-xpro ... /bin/sh: 1: arm-none-eabi-gcc: not found
make[1]: *** [/home/harter/work/git/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.elf] Error 127
failed!
/home/harter/work/git/RIOT/makefiles/buildtests.inc.mk:6: recipe for target 'buildtest' failed
make: *** [buildtest] Error 1
make: Leaving directory '/home/harter/work/git/RIOT/tests/riotboot'
```

</details>

When it was hiding the error and correctly compiling in `master`

<details><summary><code>DOCKER="sudo docker" BOARDS="iotlab-m3 samr21-xpro" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 BUILDTEST_MAKE_REDIRECT='>/dev/null' make -C tests/riotboot buildtest</code></summary>

```
DOCKER="sudo docker" BOARDS="iotlab-m3 samr21-xpro" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 BUILDTEST_MAKE_REDIRECT='>/dev/null' make -C tests/riotboot buildtest
make: Entering directory '/home/harter/work/git/RIOT/tests/riotboot'
Launching build container using image "riot/riotbuild:latest".
mkdir -p /home/harter/work/git/RIOT/build
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'BOARDS=iotlab-m3 samr21-xpro' \
    -w '/data/riotbuild/riotbase/tests/riotboot/' \
    'riot/riotbuild:latest' make buildtest
Building for iotlab-m3 ... «success.
Building for samr21-xpro ... success.
make: Leaving directory '/home/harter/work/git/RIOT/tests/riotboot'
```
</details>

and also hiding the error and correctly compiling in with `buildtest-indocker`.

<details><summary><code>BOARDS="iotlab-m3 samr21-xpro" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 BUILDTEST_MAKE_REDIRECT='>/dev/null' make -C tests/riotboot buildtest-indocker</code></summary>
```
BOARDS="iotlab-m3 samr21-xpro" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 BUILDTEST_MAKE_REDIRECT='>/dev/null' make -C tests/riotboot buildtest-indocker
make: Entering directory '/home/harter/work/git/RIOT/tests/riotboot'
Launching build container using image "riot/riotbuild:latest".
mkdir -p /home/harter/work/git/RIOT/build
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'BOARDS=iotlab-m3 samr21-xpro' \
    -w '/data/riotbuild/riotbase/tests/riotboot/' \
    'riot/riotbuild:latest' make buildtest-indocker
Building for iotlab-m3 ... success.
Building for samr21-xpro ... success.
make: Leaving directory '/home/harter/work/git/RIOT/tests/riotboot'
```
</details>

<details><summary>mcuboot is now working since https://github.com/RIOT-OS/RIOT/pull/11083</summary>

<details><summary><code>PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 BUILDTEST_MAKE_REDIRECT='>/dev/null' make -C tests/mcuboot/ buildtest</code></summary>

```
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 BUILDTEST_MAKE_REDIRECT='>/dev/null' make -C tests/mcuboot/ buildtest
make: Entering directory '/home/harter/work/git/RIOT/tests/mcuboot'
Building for nrf52dk ... /bin/sh: 1: arm-none-eabi-gcc: not found
make[1]: *** [mcuboot] Error 127
failed!
/home/harter/work/git/RIOT/makefiles/buildtests.inc.mk:6: recipe for target 'buildtest' failed
make: *** [buildtest] Error 1
make: Leaving directory '/home/harter/work/git/RIOT/tests/mcuboot'
```
</details>

When it was hiding the error and correctly compiling in `master`

<details><summary><code>PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 make -C tests/mcuboot/ buildtest</code></summary>

```
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUILD_IN_DOCKER=1 make -C tests/mcuboot/ buildtest
make: Entering directory '/home/harter/work/git/worktree/riot_master/tests/mcuboot'
Launching build container using image "riot/riotbuild:latest".
mkdir -p /home/harter/work/git/worktree/riot_master/build
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache  -v /home/harter/work/git/RIOT/.git:/home/harter/work/git/RIOT/.git \
     \
    -w '/data/riotbuild/riotbase/tests/mcuboot/' \
    'riot/riotbuild:latest' make buildtest  
Building for nrf52dk ... success.
make: Leaving directory '/home/harter/work/git/worktree/riot_master/tests/mcuboot'
```
</details>

</details>


### Issues/PRs references

Found that `BUILD_IN_DOCKER=1 make buildtest` was hiding expected errors during 2019.07-RC1 testing https://github.com/RIOT-OS/Release-Specs/issues/128#issuecomment-511388172

Fixes https://github.com/RIOT-OS/RIOT/issues/11842
