### PR TITLE
tests/unittests: rename set_up/tear_down function

### DIFF
--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -253,9 +253,7 @@ Test *tests_<module>_<header>_tests(void)
         /* ... */
     };
 
-    EMB_UNIT_TESTCALLER(<module>_<header>_tests,
-                        tests_<module>_<header>_set_up,
-                        tests_<module>_<header>_tear_down, fixtures);
+    EMB_UNIT_TESTCALLER(<module>_<header>_tests, set_up, tear_down, fixtures);
     /* set up and tear down function can be NULL if omitted */
 
     return (Test *)&<module>_<header>;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Rename `setup()` and `tear_down()` in template code to mirror the name used in `tests_<module>_<header>_tests`.

### Testing procedure

This is just a small change in the README. It should not affect other code.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
