### PR TITLE
add ARRAY_SIZE macro and make use of it

### DIFF
--- a/boards/acd52832/include/periph_conf.h
+++ b/boards/acd52832/include/periph_conf.h
@@ -61,7 +61,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -77,7 +77,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -53,7 +53,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -77,7 +77,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -120,7 +120,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -154,7 +154,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_sercom5
 #define UART_1_ISR          isr_sercom0
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -215,7 +215,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -235,7 +235,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -47,7 +47,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_SHARED_ISR_1            isr_dma1_channel4_5_6_7
 #define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 } /* Indexes 2, 3 and 4 of dma_config share the same isr */
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 /** @} */
 
@@ -93,7 +93,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -155,7 +155,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -87,7 +87,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_2_ISR  isr_dma1_channel4
 #define DMA_3_ISR  isr_dma2_channel3
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 /** @} */
 
@@ -107,7 +107,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -152,7 +152,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart1)
 #define UART_1_ISR          (isr_uart4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -172,7 +172,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -218,7 +218,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -253,7 +253,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_er
 #define I2C_1_ISR           isr_i2c2_er
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -54,7 +54,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -53,7 +53,7 @@ static const timer_conf_t timer_config[] = {
     },
 };
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 
 #define TIMER_IRQ_PRIO      1
 /** @} */
@@ -76,7 +76,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_uart0
 
 /* macros common across all UARTs */
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 
 /** @} */
 
@@ -94,7 +94,7 @@ static const i2c_conf_t i2c_config[] = {
     },
 };
 
-#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF               ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -111,7 +111,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -124,7 +124,7 @@ static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 6), /**< GPIO_PA6 = ADC_ALS_PIN */
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/cc2650-launchpad/include/periph_conf.h
+++ b/boards/cc2650-launchpad/include/periph_conf.h
@@ -62,7 +62,7 @@ static const timer_conf_t timer_config[] = {
  }
 };
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**

--- a/boards/cc2650stk/include/periph_conf.h
+++ b/boards/cc2650stk/include/periph_conf.h
@@ -60,7 +60,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**

--- a/boards/common/arduino-due/include/periph_conf.h
+++ b/boards/common/arduino-due/include/periph_conf.h
@@ -59,7 +59,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc0
 #define TIMER_1_ISR         isr_tc3
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -107,7 +107,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          isr_usart1
 #define UART_3_ISR          isr_usart3
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -125,7 +125,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -140,7 +140,7 @@ static const pwm_chan_conf_t pwm_chan[] = {
 };
 
 #define PWM_NUMOF           (1U)
-#define PWM_CHAN_NUMOF      (sizeof(pwm_chan) / sizeof(pwm_chan[0]))
+#define PWM_CHAN_NUMOF      ARRAY_SIZE(pwm_chan)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -118,7 +118,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -141,7 +141,7 @@ static const uart_conf_t uart_config[] = {
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom5
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -165,7 +165,7 @@ static const pwm_conf_t pwm_config[] = {
 };
 
 /* number of devices that are actually defined */
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -230,7 +230,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -248,7 +248,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
      }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -349,7 +349,7 @@ extern "C" {
 #endif
     };
 
-    #define PWM_NUMOF           (sizeof(pwm_conf) / sizeof(pwm_conf[0]))
+    #define PWM_NUMOF           ARRAY_SIZE(pwm_conf)
 #endif
 #endif /* PWM_NUMOF */
 /** @} */

--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -25,6 +25,7 @@
 
 /* include periph_cpu.h to make it visible in any case */
 #include "periph_cpu.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,7 +60,7 @@ static const gpio_t adc_channels[] = ADC_GPIOS;
  *
  * @note ADC_NUMOF definition must not be changed.
  */
-#define ADC_NUMOF   (sizeof(adc_channels) / sizeof(adc_channels[0]))
+#define ADC_NUMOF   ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**
@@ -91,7 +92,7 @@ static const gpio_t dac_channels[] = DAC_GPIOS;
  *
  * @note DAC_NUMOF definition must not be changed.
  */
-#define DAC_NUMOF   (sizeof(dac_channels) / sizeof(dac_channels[0]))
+#define DAC_NUMOF   ARRAY_SIZE(dac_channels)
 /** @} */
 
 /**
@@ -127,7 +128,7 @@ static const i2c_conf_t i2c_config[] = {
  *
  * @note I2C_NUMOF definition must not be changed.
  */
-#define I2C_NUMOF   (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF   ARRAY_SIZE(i2c_config)
 
 /** @} */
 
@@ -203,7 +204,7 @@ static const spi_conf_t spi_config[] = {
  *
  * @note SPI_NUMOF definition must not be changed.
  */
-#define SPI_NUMOF   (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF   ARRAY_SIZE(spi_config)
 
 /** @} */
 

--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -81,7 +81,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_0_ISR  isr_dma1_channel4
 #define DMA_1_ISR  isr_dma1_channel6
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 /** @} */
 
@@ -109,7 +109,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim3
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -146,7 +146,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart1)
 #define UART_1_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -183,7 +183,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/common/kw41z/include/cfg_i2c_default.h
+++ b/boards/common/kw41z/include/cfg_i2c_default.h
@@ -43,7 +43,7 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pcr = (PORT_PCR_MUX(3)),
     },
 };
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           (isr_i2c1)
 /** @} */
 

--- a/boards/common/kw41z/include/periph_conf_common.h
+++ b/boards/common/kw41z/include/periph_conf_common.h
@@ -116,7 +116,7 @@ static const uart_conf_t uart_config[] = {
         .type   = KINETIS_LPUART,
     },
 };
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define LPUART_0_ISR        isr_lpuart0
 /* Use MCGIRCLK (internal reference 4 MHz clock) */
 #define LPUART_0_SRC        3

--- a/boards/common/nrf51/include/cfg_timer_01.h
+++ b/boards/common/nrf51/include/cfg_timer_01.h
@@ -49,7 +49,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_timer0
 #define TIMER_1_ISR         isr_timer1
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nrf51/include/cfg_timer_012.h
+++ b/boards/common/nrf51/include/cfg_timer_012.h
@@ -56,7 +56,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_1_ISR         isr_timer1
 #define TIMER_2_ISR         isr_timer2
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nrf52/include/cfg_spi_default.h
+++ b/boards/common/nrf52/include/cfg_spi_default.h
@@ -39,7 +39,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nrf52/include/cfg_timer_default.h
+++ b/boards/common/nrf52/include/cfg_timer_default.h
@@ -48,7 +48,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_timer1
 #define TIMER_1_ISR         isr_timer2
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -38,7 +38,7 @@ extern "C" {
 static const pwm_conf_t pwm_config[] = {
     { NRF_PWM0, { 28, 29, 30, 31 } }
 };
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -89,7 +89,7 @@ static const motor_driver_config_t motor_driver_config[] = {
     },
 };
 
-#define MOTOR_DRIVER_NUMOF           (sizeof(motor_driver_config) / sizeof(motor_driver_config[0]))
+#define MOTOR_DRIVER_NUMOF           ARRAY_SIZE(motor_driver_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/particle-mesh/include/periph_conf_common.h
+++ b/boards/common/particle-mesh/include/periph_conf_common.h
@@ -43,7 +43,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/remote/include/periph_common.h
+++ b/boards/common/remote/include/periph_common.h
@@ -61,7 +61,7 @@ static const timer_conf_t timer_config[] = {
     },
 };
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 
 #define TIMER_IRQ_PRIO      1
 /** @} */
@@ -100,7 +100,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          isr_uart1
 
 /* macros common across all UARTs */
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 
 /** @} */
 

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -51,7 +51,7 @@ static const tc32_conf_t timer_config[] = {
 /* Timer 0 configuration */
 #define TIMER_0_CHANNELS    2
 #define TIMER_0_ISR         isr_tc0
-#define TIMER_NUMOF         (sizeof(timer_config)/sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -74,7 +74,7 @@ static const uart_conf_t uart_config[] = {
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom2_2
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -96,7 +96,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -115,7 +115,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
+++ b/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
@@ -71,7 +71,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1
 #endif
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/stm32/include/cfg_timer_tim2.h
+++ b/boards/common/stm32/include/cfg_timer_tim2.h
@@ -49,7 +49,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim2
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/stm32/include/cfg_timer_tim5.h
+++ b/boards/common/stm32/include/cfg_timer_tim5.h
@@ -41,7 +41,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/stm32f103c8/include/periph_conf.h
+++ b/boards/common/stm32f103c8/include/periph_conf.h
@@ -113,7 +113,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_1_ISR         isr_tim3
 #define TIMER_2_ISR         isr_tim4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -151,7 +151,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart2)
 #define UART_2_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -185,7 +185,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_ev
 #define I2C_1_ISR           isr_i2c2_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -205,7 +205,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -253,7 +253,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -160,7 +160,7 @@ static const spi_conf_t spi_confs[] = {
     },
 };
 
-#define SPI_NUMOF (sizeof(spi_confs) / sizeof(spi_confs[0]))
+#define SPI_NUMOF ARRAY_SIZE(spi_confs)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/f4vi1/include/periph_conf.h
+++ b/boards/f4vi1/include/periph_conf.h
@@ -52,7 +52,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -79,7 +79,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart6)
 #define UART_0_DMA_ISR      (isr_dma2_stream6)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -115,7 +115,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -138,7 +138,7 @@ static const uart_conf_t uart_config[] = {
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom0
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -225,7 +225,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -243,7 +243,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
      }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/firefly/include/periph_conf.h
+++ b/boards/firefly/include/periph_conf.h
@@ -70,7 +70,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -86,7 +86,7 @@ static const adc_conf_t adc_config[] = {
     GPIO_PIN(PORT_A, 2),    /**< GPIO_PA2 = ADC3_PIN */
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -83,7 +83,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim3
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -112,7 +112,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -151,7 +151,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -188,7 +188,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -132,7 +132,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart1_rx_tx)
 #define UART_1_ISR          (isr_uart0_rx_tx)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -159,7 +159,7 @@ static const adc_conf_t adc_config[] = {
     [ 9] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 27, .avg = ADC_AVG_MAX },
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /*
  * K22F ADC reference settings:
  * 0: VREFH/VREFL external pin pair
@@ -186,7 +186,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 
@@ -251,7 +251,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 
@@ -271,7 +271,7 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pcr = (PORT_PCR_MUX(2) | PORT_PCR_ODE_MASK),
     },
 };
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           (isr_i2c0)
 #define I2C_1_ISR           (isr_i2c1)
 /** @} */

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -119,7 +119,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_uart0_rx_tx)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -155,7 +155,7 @@ static const adc_conf_t adc_config[] = {
     [19] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 27, .avg = ADC_AVG_MAX },
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /*
  * K64F ADC reference settings:
  * 0: VREFH/VREFL external pin pair
@@ -183,7 +183,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 
@@ -248,7 +248,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 
@@ -268,7 +268,7 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pcr = (PORT_PCR_MUX(5) | PORT_PCR_ODE_MASK),
     },
 };
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           (isr_i2c0)
 #define I2C_1_ISR           (isr_i2c1)
 /** @} */

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -64,7 +64,7 @@ static const spi_conf_t spi_config[] = {
         .simmask  = SIM_SCGC6_SPI1_MASK
     }
 };
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -92,7 +92,7 @@ static const adc_conf_t adc_config[] = {
     /* internal: DCDC divided battery level */
     [ 6] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 23, .avg = ADC_AVG_MAX },
 };
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /*
  * KW41Z ADC reference settings:
  * 0: VREFH external pin or VREF_OUT 1.2 V signal (if VREF module is enabled)

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -150,7 +150,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -230,7 +230,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -248,7 +248,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
      }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 
 /**
  * @name Random Number Generator configuration

--- a/boards/i-nucleo-lrwan1/include/periph_conf.h
+++ b/boards/i-nucleo-lrwan1/include/periph_conf.h
@@ -49,7 +49,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_rng_lpuart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -89,7 +89,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -112,7 +112,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -28,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Internal macro to calculate *_NUMOF based on config.
- */
-#define PERIPH_NUMOF(config)    (sizeof(config) / sizeof(config[0]))
-
-/**
  * @name    Clock configuration
  * @{
  */
@@ -88,7 +83,7 @@ static const spi_dev_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           PERIPH_NUMOF(spi_config)
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -111,7 +106,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 /** @} */
 
@@ -134,7 +129,7 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_NUMOF          PERIPH_NUMOF(uart_config)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_usart0_rx
 /** @} */
 

--- a/boards/iotlab-a8-m3/include/periph_conf.h
+++ b/boards/iotlab-a8-m3/include/periph_conf.h
@@ -43,7 +43,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -49,7 +49,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/limifrog-v1/include/periph_conf.h
+++ b/boards/limifrog-v1/include/periph_conf.h
@@ -65,7 +65,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         (isr_tim5)
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -98,7 +98,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart3)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -148,7 +148,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -185,7 +185,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_ev
 #define I2C_1_ISR           isr_i2c2_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/lobaro-lorabox/include/periph_conf.h
+++ b/boards/lobaro-lorabox/include/periph_conf.h
@@ -101,7 +101,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart1)
 #define UART_1_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -158,7 +158,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -182,7 +182,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/lsn50/include/periph_conf.h
+++ b/boards/lsn50/include/periph_conf.h
@@ -46,7 +46,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_SHARED_ISR_1            isr_dma1_channel4_5_6_7
 #define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 } /* Indexes 2, 3 and 4 of dma_config share the same isr */
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 /** @} */
 
@@ -92,7 +92,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart1)
 #define UART_1_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -138,7 +138,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -161,7 +161,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/maple-mini/include/periph_conf.h
+++ b/boards/maple-mini/include/periph_conf.h
@@ -83,7 +83,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim3
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -121,7 +121,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          isr_usart1
 #define UART_2_ISR          isr_usart3
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -154,7 +154,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_ev
 #define I2C_1_ISR           isr_i2c2_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -205,7 +205,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -53,7 +53,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -51,7 +51,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -71,7 +71,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -98,7 +98,7 @@ static const dac_conf_t dac_config[] = {
     { .pin = GPIO_PIN(PORT_A,  5), .chan = 1 }
 };
 
-#define DAC_NUMOF           (sizeof(dac_config) / sizeof(dac_config[0]))
+#define DAC_NUMOF           ARRAY_SIZE(dac_config)
 /** @} */
 
 /**
@@ -159,7 +159,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_DMA_ISR      (isr_dma1_stream3)
 
 /* deduct number of defined UART interfaces */
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -179,7 +179,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -203,7 +203,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -156,7 +156,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart0_rx_tx)
 #define UART_1_ISR          (isr_uart1_rx_tx)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -202,7 +202,7 @@ static const adc_conf_t adc_config[] = {
     [16] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 11), .chan =  7, .avg = ADC_AVG_MAX },
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /*
  * K60D ADC reference settings:
  * 0: VREFH/VREFL external pin pair
@@ -224,7 +224,7 @@ static const dac_conf_t dac_config[] = {
     }
 };
 
-#define DAC_NUMOF           (sizeof(dac_config) / sizeof(dac_config[0]))
+#define DAC_NUMOF           ARRAY_SIZE(dac_config)
 /** @} */
 
 /**
@@ -256,7 +256,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -335,7 +335,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -354,7 +354,7 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pcr = (PORT_PCR_MUX(2) | PORT_PCR_ODE_MASK),
     },
 };
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           (isr_i2c0)
 #define I2C_1_ISR           (isr_i2c1)
 /** @} */

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -180,7 +180,7 @@ static const motor_driver_config_t motor_driver_config[] = {
     },
 };
 
-#define MOTOR_DRIVER_NUMOF           (sizeof(motor_driver_config) / sizeof(motor_driver_config[0]))
+#define MOTOR_DRIVER_NUMOF           ARRAY_SIZE(motor_driver_config)
 /** @} */
 
 #endif /* __cplusplus */

--- a/boards/nrf51dk/include/periph_conf.h
+++ b/boards/nrf51dk/include/periph_conf.h
@@ -54,7 +54,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -71,7 +71,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -48,7 +48,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_uart0)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf52840dk/include/periph_conf.h
+++ b/boards/nrf52840dk/include/periph_conf.h
@@ -38,7 +38,7 @@ static const spi_conf_t spi_config[] = {
         .miso = GPIO_PIN(1, 14),
     }
 };
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -67,7 +67,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart0)
 #define UART_1_ISR          (isr_uarte1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf52dk/include/periph_conf.h
+++ b/boards/nrf52dk/include/periph_conf.h
@@ -40,7 +40,7 @@ static const spi_conf_t spi_config[] = {
         .miso = GPIO_PIN(0, 24),
     }
 };
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -66,7 +66,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f030r8/include/periph_conf.h
+++ b/boards/nucleo-f030r8/include/periph_conf.h
@@ -71,7 +71,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         (isr_tim1_cc)
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -104,7 +104,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -134,7 +134,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -184,7 +184,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f031k6/include/periph_conf.h
+++ b/boards/nucleo-f031k6/include/periph_conf.h
@@ -74,7 +74,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -114,7 +114,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -154,7 +154,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f042k6/include/periph_conf.h
+++ b/boards/nucleo-f042k6/include/periph_conf.h
@@ -84,7 +84,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -124,7 +124,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -164,7 +164,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -73,7 +73,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim1_cc
 
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -117,7 +117,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 #define UART_2_ISR          (isr_usart3_8)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -147,7 +147,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f072rb/include/periph_conf.h
+++ b/boards/nucleo-f072rb/include/periph_conf.h
@@ -71,7 +71,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim1_cc
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -115,7 +115,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 #define UART_2_ISR          (isr_usart3_8)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -155,7 +155,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -205,7 +205,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -67,7 +67,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_SHARED_ISR_0            isr_dma1_ch2_3_dma2_ch1_2
 #define DMA_SHARED_ISR_0_STREAMS    { 0, 1 } /* Indexes 0 and 1 of dma_config share the same isr */
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 
 /**
@@ -86,7 +86,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim1_cc
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -142,7 +142,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 #define UART_2_ISR          (isr_usart3_8)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 
@@ -189,7 +189,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -219,7 +219,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -78,7 +78,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim3
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -116,7 +116,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 #define UART_2_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -165,7 +165,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_ev
 #define I2C_1_ISR           isr_i2c2_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -213,7 +213,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -50,7 +50,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_4_ISR  isr_dma2_stream6
 #define DMA_5_ISR  isr_dma1_stream6
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 /** @} */
 
@@ -81,7 +81,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -108,7 +108,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -164,7 +164,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart6)
 #define UART_2_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -226,7 +226,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f302r8/include/periph_conf.h
+++ b/boards/nucleo-f302r8/include/periph_conf.h
@@ -100,7 +100,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 #define UART_2_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -120,7 +120,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -160,7 +160,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -197,7 +197,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_er
 #define I2C_1_ISR           isr_i2c3_er
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f303k8/include/periph_conf.h
+++ b/boards/nucleo-f303k8/include/periph_conf.h
@@ -85,7 +85,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -115,7 +115,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -155,7 +155,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f303re/include/periph_conf.h
+++ b/boards/nucleo-f303re/include/periph_conf.h
@@ -98,7 +98,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 #define UART_2_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -118,7 +118,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -178,7 +178,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -215,7 +215,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_er
 #define I2C_1_ISR           isr_i2c3_er
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f303ze/include/periph_conf.h
+++ b/boards/nucleo-f303ze/include/periph_conf.h
@@ -111,7 +111,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -141,7 +141,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -181,7 +181,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f334r8/include/periph_conf.h
+++ b/boards/nucleo-f334r8/include/periph_conf.h
@@ -97,7 +97,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 #define UART_2_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -117,7 +117,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -157,7 +157,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -84,7 +84,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart6)
 #define UART_2_DMA_ISR      (isr_dma1_stream6)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -104,7 +104,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -137,7 +137,7 @@ static const qdec_conf_t qdec_config[] = {
 #define QDEC_0_ISR         isr_tim3
 #define QDEC_1_ISR         isr_tim4
 
-#define QDEC_NUMOF           (sizeof(qdec_config) / sizeof(qdec_config[0]))
+#define QDEC_NUMOF           ARRAY_SIZE(qdec_config)
 /** @} */
 
 /**
@@ -197,7 +197,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f410rb/include/periph_conf.h
+++ b/boards/nucleo-f410rb/include/periph_conf.h
@@ -86,7 +86,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_DMA_ISR      (isr_dma2_stream7)
 
 /* deduct number of defined UART interfaces */
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -126,7 +126,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f411re/include/periph_conf.h
+++ b/boards/nucleo-f411re/include/periph_conf.h
@@ -86,7 +86,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_DMA_ISR      isr_dma1_stream6
 
 /* deduct number of defined UART interfaces */
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /** @name    PWM configuration
@@ -115,7 +115,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -155,7 +155,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f412zg/include/periph_conf.h
+++ b/boards/nucleo-f412zg/include/periph_conf.h
@@ -86,7 +86,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -116,7 +116,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -156,7 +156,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -49,7 +49,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_3_ISR  isr_dma2_stream2
 #define DMA_4_ISR  isr_dma2_stream0
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 /** @} */
 
@@ -109,7 +109,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -139,7 +139,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -185,7 +185,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -85,7 +85,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -115,7 +115,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -135,7 +135,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f446re/include/periph_conf.h
+++ b/boards/nucleo-f446re/include/periph_conf.h
@@ -85,7 +85,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart3)
 #define UART_2_DMA_ISR      (isr_dma1_stream5)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -115,7 +115,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -148,7 +148,7 @@ static const qdec_conf_t qdec_config[] = {
 #define QDEC_0_ISR         isr_tim3
 #define QDEC_1_ISR         isr_tim4
 
-#define QDEC_NUMOF           (sizeof(qdec_config) / sizeof(qdec_config[0]))
+#define QDEC_NUMOF           ARRAY_SIZE(qdec_config)
 /** @} */
 
 /**
@@ -191,7 +191,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -85,7 +85,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -115,7 +115,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -135,7 +135,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f722ze/include/periph_conf.h
+++ b/boards/nucleo-f722ze/include/periph_conf.h
@@ -85,7 +85,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -85,7 +85,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -47,7 +47,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_2_ISR  isr_dma1_stream6
 #define DMA_3_ISR  isr_dma2_stream0
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 /** @} */
 
@@ -104,7 +104,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart6)
 #define UART_2_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -137,7 +137,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -51,7 +51,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -71,7 +71,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -108,7 +108,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-l053r8/include/periph_conf.h
+++ b/boards/nucleo-l053r8/include/periph_conf.h
@@ -64,7 +64,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -84,7 +84,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -124,7 +124,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -82,7 +82,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_rng_lpuart1)
 #endif
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -102,7 +102,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -142,7 +142,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -193,7 +193,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1
 #define I2C_1_ISR           isr_i2c2
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -78,7 +78,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_2_ISR  isr_dma1_ch7
 #define DMA_3_ISR  isr_dma1_ch4
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
 /** @} */
 
@@ -135,7 +135,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 #define UART_2_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -165,7 +165,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -211,7 +211,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -248,7 +248,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_ev
 #define I2C_1_ISR           isr_i2c2_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -276,7 +276,7 @@ static const dac_conf_t dac_config[] = {
     { .pin = GPIO_PIN(PORT_A,  5), .chan = 1 }
 };
 
-#define DAC_NUMOF           (sizeof(dac_config) / sizeof(dac_config[0]))
+#define DAC_NUMOF           ARRAY_SIZE(dac_config)
 /** @} */
 
 

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -107,7 +107,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -127,7 +127,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -167,7 +167,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l433rc/include/periph_conf.h
+++ b/boards/nucleo-l433rc/include/periph_conf.h
@@ -120,7 +120,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_lpuart1)
 #define UART_1_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -140,7 +140,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -180,7 +180,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -203,7 +203,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1_er
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l452re/include/periph_conf.h
+++ b/boards/nucleo-l452re/include/periph_conf.h
@@ -121,7 +121,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -141,7 +141,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -181,7 +181,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -105,7 +105,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_2_ISR  isr_dma1_channel4
 #define DMA_3_ISR  isr_dma1_channel7
 
-#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif /* MODULE_PERIPH_DMA */
 /** @} */
 
@@ -126,7 +126,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -188,7 +188,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart3)
 #define UART_2_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -228,7 +228,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -274,7 +274,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -106,7 +106,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -148,7 +148,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart3)
 #define UART_1_DMA_ISR      (isr_dma1_stream5)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -178,7 +178,7 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -218,7 +218,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l4r5zi/include/periph_conf.h
+++ b/boards/nucleo-l4r5zi/include/periph_conf.h
@@ -84,7 +84,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -125,7 +125,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_lpuart1)
 #define UART_1_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -165,7 +165,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nz32-sc151/include/periph_conf.h
+++ b/boards/nz32-sc151/include/periph_conf.h
@@ -91,7 +91,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart2)
 #define UART_2_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -111,7 +111,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -171,7 +171,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -195,7 +195,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -224,7 +224,7 @@ static const dac_conf_t dac_config[] = {
     { .pin = GPIO_PIN(PORT_A,  5), .chan = 1 }
 };
 
-#define DAC_NUMOF           (sizeof(dac_config) / sizeof(dac_config[0]))
+#define DAC_NUMOF           ARRAY_SIZE(dac_config)
 /** @} */
 
 

--- a/boards/opencm904/include/periph_conf.h
+++ b/boards/opencm904/include/periph_conf.h
@@ -83,7 +83,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim3
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -121,7 +121,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          isr_usart1
 #define UART_2_ISR          isr_usart3
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -63,7 +63,7 @@ static const timer_conf_t timer_config[] = {
     },
 };
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_IRQ_PRIO      1
 /** @} */
 
@@ -83,7 +83,7 @@ static const adc_conf_t adc_config[] = {
 
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**
@@ -104,7 +104,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_uart0
 
 /* macros common across all UARTs */
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -121,7 +121,7 @@ static const i2c_conf_t i2c_config[] = {
     },
 };
 
-#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF               ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -138,7 +138,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -61,7 +61,7 @@ static const timer_conf_t timer_config[] = {
     },
 };
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_IRQ_PRIO      1
 /** @} */
 
@@ -79,7 +79,7 @@ static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 6), /**< GPIO_PA6 = ON_SLEEP_PIN */
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**
@@ -100,7 +100,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_uart0
 
 /* macros common across all UARTs */
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -117,7 +117,7 @@ static const i2c_conf_t i2c_config[] = {
     },
 };
 
-#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF               ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -134,7 +134,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/particle-argon/include/periph_conf.h
+++ b/boards/particle-argon/include/periph_conf.h
@@ -53,7 +53,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart0)
 #define UART_1_ISR          (isr_uarte1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/particle-boron/include/periph_conf.h
+++ b/boards/particle-boron/include/periph_conf.h
@@ -53,7 +53,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart0)
 #define UART_1_ISR          (isr_uarte1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 #ifdef __cplusplus
 }

--- a/boards/particle-xenon/include/periph_conf.h
+++ b/boards/particle-xenon/include/periph_conf.h
@@ -44,7 +44,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_uart0)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -127,7 +127,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart2_rx_tx)
 #define UART_1_ISR          (isr_uart0_rx_tx)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -143,7 +143,7 @@ static const adc_conf_t adc_config[] = {
     [ 5] = { .dev = ADC0, .pin = GPIO_PIN(PORT_E, 1), .chan = 11, .avg = ADC_AVG_MAX }
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /*
  * KW2xD ADC reference settings:
  * 0: VREFH/VREFL external pin pair
@@ -170,7 +170,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 
@@ -250,7 +250,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 
@@ -270,7 +270,7 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pcr = (PORT_PCR_MUX(6) | PORT_PCR_ODE_MASK),
     },
 };
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           (isr_i2c1)
 /** @} */
 

--- a/boards/phynode-kw41z/include/periph_conf.h
+++ b/boards/phynode-kw41z/include/periph_conf.h
@@ -51,7 +51,7 @@ static const spi_conf_t spi_config[] = {
         .simmask  = SIM_SCGC6_SPI1_MASK
     }
 };
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -71,7 +71,7 @@ static const adc_conf_t adc_config[] = {
     /* internal: DCDC divided battery level */
     [ 2] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 23, .avg = ADC_AVG_MAX },
 };
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /*
  * KW41Z ADC reference settings:
  * 0: VREFH external pin or VREF_OUT 1.2 V signal (if VREF module is enabled)

--- a/boards/pyboard/include/periph_conf.h
+++ b/boards/pyboard/include/periph_conf.h
@@ -74,7 +74,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -100,7 +100,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -146,7 +146,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -170,7 +170,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c2_er
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/reel/include/periph_conf.h
+++ b/boards/reel/include/periph_conf.h
@@ -47,7 +47,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_uart0)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -63,7 +63,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -42,7 +42,7 @@ static const i2c_conf_t i2c_config[] = {
     },
 };
 
-#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF               ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -66,7 +66,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -80,7 +80,7 @@ static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 7), /**< GPIO_PA7 = ADC3_PIN */
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -42,7 +42,7 @@ static const i2c_conf_t i2c_config[] = {
     },
 };
 
-#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF               ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -66,7 +66,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -82,7 +82,7 @@ static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 2), /**< GPIO_PA2 = ADC3_PIN */
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -45,7 +45,7 @@ static const i2c_conf_t i2c_config[] = {
     },
 };
 
-#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF               ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -68,7 +68,7 @@ static const spi_conf_t spi_config[] = {
         .cs_pin   = GPIO_PIN(0, 7)
     }
 };
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -84,7 +84,7 @@ static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 2), /**< GPIO_PA2 = ADC3_PIN */
 };
 
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/ruuvitag/include/periph_conf.h
+++ b/boards/ruuvitag/include/periph_conf.h
@@ -42,7 +42,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -126,7 +126,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -171,7 +171,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          isr_sercom4
 #define UART_2_ISR          isr_sercom5
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -256,7 +256,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -274,7 +274,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
      }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -66,7 +66,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_1_CHANNELS    2
 #define TIMER_1_ISR         isr_tc2
 
-#define TIMER_NUMOF         (sizeof(timer_config)/sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -89,7 +89,7 @@ static const uart_conf_t uart_config[] = {
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom2_2
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -111,7 +111,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -130,7 +130,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -54,7 +54,7 @@ static const tc32_conf_t timer_config[] = {
 /* Timer 0 configuration */
 #define TIMER_0_CHANNELS    2
 #define TIMER_0_ISR         isr_tc0
-#define TIMER_NUMOF         (sizeof(timer_config)/sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -88,7 +88,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_sercom3
 #define UART_1_ISR          isr_sercom4
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -110,7 +110,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -129,7 +129,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -126,7 +126,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -160,7 +160,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_sercom0
 #define UART_1_ISR          isr_sercom5
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -227,7 +227,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -245,7 +245,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
      }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -50,7 +50,7 @@ static const tc32_conf_t timer_config[] = {
 /* Timer 0 configuration */
 #define TIMER_0_CHANNELS    2
 #define TIMER_0_ISR         isr_tc0
-#define TIMER_NUMOF         (sizeof(timer_config)/sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -73,7 +73,7 @@ static const uart_conf_t uart_config[] = {
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom0
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -94,7 +94,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -112,7 +112,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
      }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -116,7 +116,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -150,7 +150,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_sercom3
 #define UART_1_ISR          isr_sercom4
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -171,7 +171,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 
 /**
  * @name    I2C configuration
@@ -198,7 +198,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 
 /**
  * @name    RTC configuration

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Internal macro to calculate *_NUMOF based on config.
- */
-#define PERIPH_NUMOF(config)    (sizeof(config) / sizeof(config[0]))
-
-/**
  * @name    Clock configuration
  * @{
  */
@@ -89,8 +84,8 @@ static const adc_chan_conf_t adc_channel_config[] = {
     }
 };
 
-#define ADC_DEV_NUMOF       PERIPH_NUMOF(adc_config)
-#define ADC_NUMOF           PERIPH_NUMOF(adc_channel_config)
+#define ADC_DEV_NUMOF       ARRAY_SIZE(adc_config)
+#define ADC_NUMOF           ARRAY_SIZE(adc_channel_config)
 /** @} */
 
 /**
@@ -110,7 +105,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           PERIPH_NUMOF(i2c_config)
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           isr_i2c0
 /** @} */
 
@@ -147,7 +142,7 @@ static const spi_dev_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           PERIPH_NUMOF(spi_config)
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -170,7 +165,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 /** @} */
 
@@ -217,7 +212,7 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_NUMOF          PERIPH_NUMOF(uart_config)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_usart0_rx
 #define UART_1_ISR_RX       isr_usart1_rx
 #define UART_2_ISR_RX       isr_leuart0

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Internal macro to calculate *_NUMOF based on config.
- */
-#define PERIPH_NUMOF(config)    (sizeof(config) / sizeof(config[0]))
-
-/**
  * @name    Clock configuration
  * @{
  */
@@ -80,8 +75,8 @@ static const adc_chan_conf_t adc_channel_config[] = {
     }
 };
 
-#define ADC_DEV_NUMOF       PERIPH_NUMOF(adc_config)
-#define ADC_NUMOF           PERIPH_NUMOF(adc_channel_config)
+#define ADC_DEV_NUMOF       ARRAY_SIZE(adc_config)
+#define ADC_NUMOF           ARRAY_SIZE(adc_channel_config)
 /** @} */
 
 /**
@@ -101,7 +96,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           PERIPH_NUMOF(i2c_config)
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           isr_i2c0
 /** @} */
 
@@ -138,7 +133,7 @@ static const spi_dev_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           PERIPH_NUMOF(spi_config)
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -161,7 +156,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_wtimer1
 /** @} */
 
@@ -196,7 +191,7 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_NUMOF          PERIPH_NUMOF(uart_config)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_usart0_rx
 #define UART_1_ISR_RX       isr_leuart0
 /** @} */

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Internal macro to calculate *_NUMOF based on config.
- */
-#define PERIPH_NUMOF(config)    (sizeof(config) / sizeof(config[0]))
-
-/**
  * @name    Clock configuration
  * @{
  */
@@ -89,8 +84,8 @@ static const adc_chan_conf_t adc_channel_config[] = {
     }
 };
 
-#define ADC_DEV_NUMOF       PERIPH_NUMOF(adc_config)
-#define ADC_NUMOF           PERIPH_NUMOF(adc_channel_config)
+#define ADC_DEV_NUMOF       ARRAY_SIZE(adc_config)
+#define ADC_NUMOF           ARRAY_SIZE(adc_channel_config)
 /** @} */
 
 /**
@@ -110,7 +105,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           PERIPH_NUMOF(i2c_config)
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           isr_i2c0
 /** @} */
 
@@ -147,7 +142,7 @@ static const spi_dev_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           PERIPH_NUMOF(spi_config)
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -170,7 +165,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 /** @} */
 
@@ -217,7 +212,7 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_NUMOF          PERIPH_NUMOF(uart_config)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_usart0_rx
 #define UART_1_ISR_RX       isr_usart1_rx
 #define UART_2_ISR_RX       isr_leuart0

--- a/boards/slwstk6000b/include/periph_conf.h
+++ b/boards/slwstk6000b/include/periph_conf.h
@@ -31,11 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Internal macro to calculate *_NUMOF based on config.
- */
-#define PERIPH_NUMOF(config)    (sizeof(config) / sizeof(config[0]))
-
-/**
  * @name    Clock configuration
  * @{
  */
@@ -82,8 +77,8 @@ static const adc_chan_conf_t adc_channel_config[] = {
     }
 };
 
-#define ADC_DEV_NUMOF       PERIPH_NUMOF(adc_config)
-#define ADC_NUMOF           PERIPH_NUMOF(adc_channel_config)
+#define ADC_DEV_NUMOF       ARRAY_SIZE(adc_config)
+#define ADC_NUMOF           ARRAY_SIZE(adc_channel_config)
 /** @} */
 
 /**
@@ -103,7 +98,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           PERIPH_NUMOF(i2c_config)
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           isr_i2c0
 /** @} */
 
@@ -140,7 +135,7 @@ static const spi_dev_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           PERIPH_NUMOF(spi_config)
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -163,7 +158,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 /** @} */
 
@@ -186,7 +181,7 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_NUMOF          PERIPH_NUMOF(uart_config)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_usart0_rx
 /** @} */
 

--- a/boards/slwstk6220a/include/periph_conf.h
+++ b/boards/slwstk6220a/include/periph_conf.h
@@ -63,7 +63,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_timer1
 #define TIMER_0_MAX_VALUE   (0xffff)            /* 16-bit timer */
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -82,7 +82,7 @@ static const uart_conf_t uart_config[] = {
 };
 
 #define UART_0_ISR_RX       isr_usart2_rx
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -116,7 +116,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -173,7 +173,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          isr_sercom4
 #define UART_3_ISR          isr_sercom1
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -229,7 +229,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -247,7 +247,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
      }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -113,7 +113,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -158,7 +158,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          isr_sercom4
 #define UART_2_ISR          isr_sercom0
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -212,7 +212,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -239,7 +239,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
     }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 
 /** @} */
 

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -116,7 +116,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -151,7 +151,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_sercom5
 #define UART_1_ISR          isr_sercom2
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -214,7 +214,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -232,7 +232,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
     }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 
 /** @} */
 

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -118,7 +118,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tc3
 #define TIMER_1_ISR         isr_tc4
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -153,7 +153,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_sercom5
 #define UART_1_ISR          isr_sercom0
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -211,7 +211,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -229,7 +229,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
     }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 
 /** @} */
 

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -83,7 +83,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim3
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -103,7 +103,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -142,7 +142,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Internal macro to calculate *_NUMOF based on config.
- */
-#define PERIPH_NUMOF(config)    (sizeof(config) / sizeof(config[0]))
-
-/**
  * @name    Clock configuration
  * @{
  */
@@ -77,8 +72,8 @@ static const adc_chan_conf_t adc_channel_config[] = {
     }
 };
 
-#define ADC_DEV_NUMOF       PERIPH_NUMOF(adc_config)
-#define ADC_NUMOF           PERIPH_NUMOF(adc_channel_config)
+#define ADC_DEV_NUMOF       ARRAY_SIZE(adc_config)
+#define ADC_NUMOF           ARRAY_SIZE(adc_channel_config)
 /** @} */
 
 /**
@@ -100,8 +95,8 @@ static const dac_chan_conf_t dac_channel_config[] = {
     }
 };
 
-#define DAC_DEV_NUMOF       PERIPH_NUMOF(dac_config)
-#define DAC_NUMOF           PERIPH_NUMOF(dac_channel_config)
+#define DAC_DEV_NUMOF       ARRAY_SIZE(dac_config)
+#define DAC_NUMOF           ARRAY_SIZE(dac_channel_config)
 /** @} */
 
 /**
@@ -129,7 +124,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           PERIPH_NUMOF(i2c_config)
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           isr_i2c0
 #define I2C_1_ISR           isr_i2c1
 /** @} */
@@ -156,8 +151,8 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_DEV_NUMOF       PERIPH_NUMOF(pwm_config)
-#define PWM_NUMOF           PERIPH_NUMOF(pwm_channel_config)
+#define PWM_DEV_NUMOF       ARRAY_SIZE(pwm_config)
+#define PWM_NUMOF           ARRAY_SIZE(pwm_channel_config)
 /** @} */
 
 /**
@@ -202,7 +197,7 @@ static const spi_dev_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           PERIPH_NUMOF(spi_config)
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -225,7 +220,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 /** @} */
 
@@ -269,7 +264,7 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_NUMOF          PERIPH_NUMOF(uart_config)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_uart0_rx
 #define UART_1_ISR_RX       isr_usart1_rx
 #define UART_2_ISR_RX       isr_leuart0

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Internal macro to calculate *_NUMOF based on config.
- */
-#define PERIPH_NUMOF(config)    (sizeof(config) / sizeof(config[0]))
-
-/**
  * @name    Clock configuration
  * @{
  */
@@ -77,8 +72,8 @@ static const adc_chan_conf_t adc_channel_config[] = {
     }
 };
 
-#define ADC_DEV_NUMOF       PERIPH_NUMOF(adc_config)
-#define ADC_NUMOF           PERIPH_NUMOF(adc_channel_config)
+#define ADC_DEV_NUMOF       ARRAY_SIZE(adc_config)
+#define ADC_NUMOF           ARRAY_SIZE(adc_channel_config)
 /** @} */
 
 /**
@@ -100,8 +95,8 @@ static const dac_chan_conf_t dac_channel_config[] = {
     }
 };
 
-#define DAC_DEV_NUMOF       PERIPH_NUMOF(dac_config)
-#define DAC_NUMOF           PERIPH_NUMOF(dac_channel_config)
+#define DAC_DEV_NUMOF       ARRAY_SIZE(dac_config)
+#define DAC_NUMOF           ARRAY_SIZE(dac_channel_config)
 /** @} */
 
 /**
@@ -129,7 +124,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           PERIPH_NUMOF(i2c_config)
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 #define I2C_0_ISR           isr_i2c0
 #define I2C_1_ISR           isr_i2c1
 /** @} */
@@ -156,8 +151,8 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_DEV_NUMOF       PERIPH_NUMOF(pwm_config)
-#define PWM_NUMOF           PERIPH_NUMOF(pwm_channel_config)
+#define PWM_DEV_NUMOF       ARRAY_SIZE(pwm_config)
+#define PWM_NUMOF           ARRAY_SIZE(pwm_channel_config)
 /** @} */
 
 /**
@@ -202,7 +197,7 @@ static const spi_dev_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           PERIPH_NUMOF(spi_config)
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -225,7 +220,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 /** @} */
 
@@ -269,7 +264,7 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_NUMOF          PERIPH_NUMOF(uart_config)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_uart0_rx
 #define UART_1_ISR_RX       isr_usart1_rx
 #define UART_2_ISR_RX       isr_leuart0

--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -69,7 +69,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim2
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -102,7 +102,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart1)
 #define UART_1_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -168,7 +168,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -62,7 +62,7 @@ static const dac_conf_t dac_config[] = {
     { .pin = GPIO_PIN(PORT_A,  4), .chan = 0 }
 };
 
-#define DAC_NUMOF           (sizeof(dac_config) / sizeof(dac_config[0]))
+#define DAC_NUMOF           ARRAY_SIZE(dac_config)
 /** @} */
 
 /**
@@ -81,7 +81,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim2
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -125,7 +125,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart2)
 #define UART_2_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -155,7 +155,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -202,7 +202,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -239,7 +239,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_er
 #define I2C_1_ISR           isr_i2c2_er
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f429i-disc1/include/periph_conf.h
+++ b/boards/stm32f429i-disc1/include/periph_conf.h
@@ -52,7 +52,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart1)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -75,7 +75,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -99,7 +99,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c3_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -52,7 +52,7 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -95,7 +95,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart3)
 #define UART_1_DMA_ISR      (isr_dma1_stream3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -124,7 +124,7 @@ static const dac_conf_t dac_config[] = {
     { .pin = GPIO_PIN(PORT_A,  5), .chan = 1 }
 };
 
-#define DAC_NUMOF           (sizeof(dac_config) / sizeof(dac_config[0]))
+#define DAC_NUMOF           ARRAY_SIZE(dac_config)
 /** @} */
 
 /**
@@ -154,7 +154,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**
@@ -184,7 +184,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -208,7 +208,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c1_ev
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f769i-disco/include/periph_conf.h
+++ b/boards/stm32f769i-disco/include/periph_conf.h
@@ -82,7 +82,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart1)
 #define UART_0_DMA_ISR      (isr_dma1_stream4)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32l0538-disco/include/periph_conf.h
+++ b/boards/stm32l0538-disco/include/periph_conf.h
@@ -66,7 +66,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim2
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -90,7 +90,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart1)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -140,7 +140,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -86,7 +86,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim5
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -114,7 +114,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart2)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/teensy31/include/periph_conf.h
+++ b/boards/teensy31/include/periph_conf.h
@@ -132,7 +132,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart0_rx_tx)
 #define UART_1_ISR          (isr_uart1_rx_tx)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -164,7 +164,7 @@ static const pwm_conf_t pwm_config[] = {
     }
 };
 
-#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/ublox-c030-u201/include/periph_conf.h
+++ b/boards/ublox-c030-u201/include/periph_conf.h
@@ -133,7 +133,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_2_ISR          (isr_usart6)
 #define UART_3_ISR          (isr_usart3)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -173,7 +173,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -210,7 +210,7 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_0_ISR           isr_i2c1_ev
 #define I2C_1_ISR           isr_i2c3_ev
 
-#define I2C_NUMOF (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/usb-kw41z/include/periph_conf.h
+++ b/boards/usb-kw41z/include/periph_conf.h
@@ -48,7 +48,7 @@ static const spi_conf_t spi_config[] = {
         .simmask  = SIM_SCGC6_SPI1_MASK
     }
 };
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -68,7 +68,7 @@ static const adc_conf_t adc_config[] = {
     /* internal: DCDC divided battery level */
     [ 2] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 23, .avg = ADC_AVG_MAX },
 };
-#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /*
  * KW41Z ADC reference settings:
  * 0: VREFH external pin or VREF_OUT 1.2 V signal (if VREF module is enabled)

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -57,7 +57,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -74,7 +74,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -109,6 +109,16 @@
 #endif
 
 /**
+ * @def ARRAY_SIZE(a)
+ * @brief       Calculate the number of elements in a static array.
+ * @param[in]   a   Array to examine
+ * @returns     The number of elements in the array a.
+ */
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(a) (sizeof((a)) / sizeof((a)[0]))
+#endif
+
+/**
  * @def         ALIGN_OF(T)
  * @brief       Calculate the minimal alignment for type T.
  * @param[in]   T   Type to examine

--- a/core/sched.c
+++ b/core/sched.c
@@ -65,7 +65,7 @@ static uint32_t runqueue_bitcache = 0;
 #endif
 
 FORCE_USED_SECTION
-const uint8_t max_threads = sizeof(sched_threads) / sizeof(thread_t*);
+const uint8_t max_threads = ARRAY_SIZE(sched_threads);
 
 #ifdef DEVELHELP
 /* OpenOCD can't determine struct offsets and additionally this member is only

--- a/cpu/esp32/irq_arch.c
+++ b/cpu/esp32/irq_arch.c
@@ -129,7 +129,7 @@ static const struct _irq_alloc_table_t _irq_alloc_table[] = {
 
 typedef void (*intr_handler_t)(void *arg);
 
-#define IRQ_ALLOC_TABLE_SIZE (sizeof(_irq_alloc_table)/sizeof(struct _irq_alloc_table_t))
+#define IRQ_ALLOC_TABLE_SIZE ARRAY_SIZE(_irq_alloc_table)
 #define ESP_INTR_FLAG_INTRDISABLED    (1<<11)
 
 /**

--- a/cpu/esp32/periph/pwm.c
+++ b/cpu/esp32/periph/pwm.c
@@ -100,7 +100,7 @@ static const struct _pwm_hw_t _pwm_hw[] =
         .mod = PERIPH_PWM0_MODULE,
         .int_src = ETS_PWM0_INTR_SOURCE,
         .signal_group = PWM0_OUT0A_IDX,
-        .gpio_num = sizeof(pwm0_channels) / sizeof(pwm0_channels[0]),
+        .gpio_num = ARRAY_SIZE(pwm0_channels),
         .gpios = pwm0_channels,
     },
     #endif
@@ -110,7 +110,7 @@ static const struct _pwm_hw_t _pwm_hw[] =
         .mod = PERIPH_PWM1_MODULE,
         .int_src = ETS_PWM1_INTR_SOURCE,
         .signal_group = PWM1_OUT0A_IDX,
-        .gpio_num = sizeof(pwm1_channels) / sizeof(pwm1_channels[0]),
+        .gpio_num = ARRAY_SIZE(pwm1_channels),
         .gpios = pwm1_channels,
     },
     #endif

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -113,7 +113,7 @@ static const struct station_config station_cfg = {
  */
 static const struct softap_config softap_cfg = {
         .ssid = ESP_WIFI_SSID,
-        .ssid_len = sizeof(ESP_WIFI_SSID) / sizeof(ESP_WIFI_SSID[0]),
+        .ssid_len = ARRAY_SIZE(ESP_WIFI_SSID),
         .ssid_hidden = 1,               /* don't make the AP visible */
         .password = ESP_WIFI_PASS,
         .authmode = AUTH_WPA2_PSK,

--- a/cpu/esp8266/periph/i2c.c
+++ b/cpu/esp8266/periph/i2c.c
@@ -137,10 +137,10 @@ static void _i2c_clear (_i2c_bus_t* bus);
 /* implementation of i2c interface */
 void i2c_init(i2c_t dev)
 {
-    if (I2C_NUMOF != sizeof(_i2c_bus)/sizeof(_i2c_bus_t)) {
+    if (I2C_NUMOF != ARRAY_SIZE(_i2c_bus)) {
         LOG_INFO("I2C_NUMOF does not match number of I2C_SDA_x/I2C_SCL_x definitions\n");
         LOG_INFO("Please check your board configuration in 'board.h'\n");
-        assert(I2C_NUMOF < sizeof(_i2c_bus)/sizeof(_i2c_bus_t));
+        assert(I2C_NUMOF < ARRAY_SIZE(_i2c_bus));
 
         return;
     }

--- a/cpu/esp8266/periph/timer.c
+++ b/cpu/esp8266/periph/timer.c
@@ -297,7 +297,7 @@ void timer_print_config(void)
 {
     for (int i = 0; i < HW_TIMER_NUMOF; i++) {
         LOG_INFO("\tTIMER_DEV(%d): %d channel(s)\n", i,
-                 sizeof(timers[i].channels) / sizeof(struct hw_channel_t));
+                 ARRAY_SIZE(timers[i].channels));
     }
 }
 
@@ -562,7 +562,7 @@ void timer_print_config(void)
 {
     for (int i = 0; i < OS_TIMER_NUMOF; i++) {
         LOG_INFO("\tTIMER_DEV(%d): %d channel(s)\n", i,
-                 sizeof(timers[i].channels) / sizeof(struct phy_channel_t));
+                 ARRAY_SIZE(timers[i].channels));
     }
 }
 

--- a/cpu/kinetis/dist/calc_spi_scalers/calc_spi_scalers.c
+++ b/cpu/kinetis/dist/calc_spi_scalers/calc_spi_scalers.c
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 
     puts("static const uint32_t spi_clk_config[] = {");
 
-    for (i = 0; i < (sizeof(targets) / sizeof(targets[0])); i++) {
+    for (i = 0; i < ARRAY_SIZE(targets); i++) {
         uint8_t tmp, ptmp;
         long res;
         /* bus clock */
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
         }
         printf("        SPI_CTAR_PDT(%i) | SPI_CTAR_DT(%i)\n", (int)ptmp, (int)tmp);
 
-        if (i == (sizeof(targets) / sizeof(targets[0])) - 1) {
+        if (i == ARRAY_SIZE(targets) - 1) {
             puts("    )");
         }
         else {

--- a/cpu/kinetis/doc.txt
+++ b/cpu/kinetis/doc.txt
@@ -22,7 +22,7 @@
         { .dev = ADC0, .pin = GPIO_PIN(PORT_C,  1), .chan = 15 }, // PTC1
         { .dev = ADC0, .pin = GPIO_PIN(PORT_C,  2), .chan =  4 }, // PTC2
     };
-    #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+    #define ADC_NUMOF           ARRAYSIZE(adc_config)
 
 
 @defgroup    cpu_kinetis_cpuid Kinetis CPUID
@@ -59,7 +59,7 @@ No configuration is necessary.
             .sda_pcr = (PORT_PCR_MUX(2) | PORT_PCR_ODE_MASK),
         },
     };
-    #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+    #define I2C_NUMOF           ARRAYSIZE(i2c_config)
     #define I2C_0_ISR           (isr_i2c0)
 
 
@@ -195,7 +195,7 @@ because of the additional overhead of calling gpio_set/clear at every transfer.
             .simmask  = SIM_SCGC6_SPI1_MASK
         }
     };
-    #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+    #define SPI_NUMOF           ARRAYSIZE(spi_config)
 
 
 @defgroup    cpu_kinetis_timer Kinetis Timer
@@ -281,6 +281,6 @@ available.
             .mode   = UART_MODE_8N1,
         },
     };
-    #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+    #define UART_NUMOF          ARRAYSIZE(uart_config)
 
 */

--- a/cpu/kinetis/periph/i2c.c
+++ b/cpu/kinetis/periph/i2c.c
@@ -129,7 +129,7 @@ static uint8_t i2c_find_divider(unsigned freq, unsigned speed)
 {
     unsigned diff = UINT_MAX;
     /* Use maximum divider if nothing matches */
-    uint8_t F = sizeof(i2c_dividers) / sizeof(i2c_dividers[0]) - 1;
+    uint8_t F = ARRAY_SIZE(i2c_dividers) - 1;
     /* We avoid using the MULT field to simplify the driver and avoid having to
      * work around hardware errata on some Kinetis parts
      *
@@ -151,7 +151,7 @@ static uint8_t i2c_find_divider(unsigned freq, unsigned speed)
      *    the I2Cx_F [MULT] field to the original value after the repeated start
      *    has occurred
      */
-    for (unsigned k = 0; k < sizeof(i2c_dividers) / sizeof(i2c_dividers[0]); ++k) {
+    for (unsigned k = 0; k < ARRAY_SIZE(i2c_dividers); ++k) {
         /* Test dividers until we find one that gives a good match */
         unsigned lim = (speed * i2c_dividers[k]);
         if (lim >= freq) {

--- a/cpu/mips_pic32_common/periph/gpio.c
+++ b/cpu/mips_pic32_common/periph/gpio.c
@@ -116,7 +116,7 @@ static PIC32_GPIO_T base_address[] = {
 
 static inline int check_valid_port(uint8_t port)
 {
-    return port < (sizeof(base_address)/sizeof(base_address[0]))
+    return port < ARRAY_SIZE(base_address)
         && base_address[port].gpio != NULL;
 }
 

--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -158,7 +158,7 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
 uint8_t pwm_channels(pwm_t dev)
 {
-    return sizeof(pwm_config[dev].chan) / sizeof(pwm_config[dev].chan[0]);
+    return ARRAY_SIZE(pwm_config[dev].chan);
 }
 
 void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)

--- a/cpu/stm32_common/dist/spi_divtable/spi_divtable.c
+++ b/cpu/stm32_common/dist/spi_divtable/spi_divtable.c
@@ -72,7 +72,7 @@ static int real_clk(int bus, int br)
 
 int main(int argc, char **argv)
 {
-    int tnum = sizeof(targets) / sizeof(targets[0]);
+    int tnum = ARRAY_SIZE(targets);
     int apb[2];
 
     if (argc != 3) {
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
 
     printf("static const uint8_t spi_divtable[2][%i] = {\n", tnum);
 
-    for (int bus = 0; bus < (sizeof(apb) / sizeof(apb[0])); bus ++) {
+    for (int bus = 0; bus < ARRAY_SIZE(apb); bus ++) {
         printf("    {       /* for APB%i @ %iHz */\n", (bus + 1), apb[bus]);
         for (int t = 0; t < tnum; t++) {
             int br = find_best(apb[bus], targets[t]);

--- a/cpu/stm32_common/periph/dma.c
+++ b/cpu/stm32_common/periph/dma.c
@@ -586,7 +586,7 @@ static void shared_isr(uint8_t *streams, size_t nb)
 void DMA_SHARED_ISR_0(void)
 {
     uint8_t streams[] = DMA_SHARED_ISR_0_STREAMS;
-    shared_isr(streams, sizeof(streams) / sizeof(streams[0]));
+    shared_isr(streams, ARRAY_SIZE(streams));
 }
 #endif
 
@@ -594,6 +594,6 @@ void DMA_SHARED_ISR_0(void)
 void DMA_SHARED_ISR_1(void)
 {
     uint8_t streams[] = DMA_SHARED_ISR_1_STREAMS;
-    shared_isr(streams, sizeof(streams) / sizeof(streams[0]));
+    shared_isr(streams, ARRAY_SIZE(streams));
 }
 #endif

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -72,12 +72,12 @@ static int16_t _tx_pow_to_dbm_212b(uint8_t channel, uint8_t page, uint8_t reg)
         if (channel == 0) {
             /* Channel 0 is 868.3 MHz */
             dbm_to_tx_pow = &dbm_to_tx_pow_868[0];
-            nelem = sizeof(dbm_to_tx_pow_868) / sizeof(dbm_to_tx_pow_868[0]);
+            nelem = ARRAY_SIZE(dbm_to_tx_pow_868);
         }
         else {
             /* Channels 1+ are 915 MHz */
             dbm_to_tx_pow = &dbm_to_tx_pow_915[0];
-            nelem = sizeof(dbm_to_tx_pow_915) / sizeof(dbm_to_tx_pow_915[0]);
+            nelem = ARRAY_SIZE(dbm_to_tx_pow_915);
         }
 
         for (size_t i = 0; i < nelem; ++i) {

--- a/drivers/bmx280/include/bmx280_params.h
+++ b/drivers/bmx280/include/bmx280_params.h
@@ -69,7 +69,7 @@ static const bmx280_params_t bmx280_params[] =
 /**
  * @brief   The number of configured sensors
  */
-#define BMX280_NUMOF    (sizeof(bmx280_params) / sizeof(bmx280_params[0]))
+#define BMX280_NUMOF    ARRAY_SIZE(bmx280_params)
 
 /**
  * @brief   Configuration details of SAUL registry entries

--- a/drivers/kw2xrf/kw2xrf_intern.c
+++ b/drivers/kw2xrf/kw2xrf_intern.c
@@ -45,7 +45,7 @@ void kw2xrf_disable_interrupts(kw2xrf_t *dev)
 void kw2xrf_update_overwrites(kw2xrf_t *dev)
 {
     kw2xrf_write_dreg(dev, MKW2XDM_OVERWRITE_VER, overwrites_direct[0].data);
-    for (uint8_t i = 0; i < sizeof(overwrites_indirect)/sizeof(overwrites_t); i++) {
+    for (uint8_t i = 0; i < ARRAY_SIZE(overwrites_indirect); i++) {
         kw2xrf_write_iregs(dev, overwrites_indirect[i].address,
                            (uint8_t *)&(overwrites_indirect[i].data), 1);
     }

--- a/drivers/ltc4150/ltc4150_last_minute.c
+++ b/drivers/ltc4150/ltc4150_last_minute.c
@@ -50,7 +50,7 @@ static void update_ringbuffer(ltc4150_last_minute_data_t *data,
         data->last_rotate_sec += 10;
         data->charged += data->buf_charged[data->ring_pos];
         data->discharged += data->buf_discharged[data->ring_pos];
-        if (++data->ring_pos >= sizeof(data->buf_charged)/sizeof(data->buf_charged[0])) {
+        if (++data->ring_pos >= ARRAY_SIZE(data->buf_charged)) {
             data->ring_pos = 0;
         }
         data->charged -= data->buf_charged[data->ring_pos];

--- a/drivers/sht1x/sht1x.c
+++ b/drivers/sht1x/sht1x.c
@@ -422,7 +422,7 @@ int sht1x_init(sht1x_dev_t *dev, const sht1x_params_t *params)
     if (
         !dev ||
         !params ||
-        (((uint8_t)params->vdd) >= sizeof(sht1x_d1) / sizeof(sht1x_d1[0]))
+        (((uint8_t)params->vdd) >= ARRAY_SIZE(sht1x_d1))
         ) {
         return -EINVAL;
     }
@@ -443,7 +443,7 @@ int sht1x_init(sht1x_dev_t *dev, const sht1x_params_t *params)
 /*---------------------------------------------------------------------------*/
 int16_t sht1x_temperature(const sht1x_dev_t *dev, uint16_t raw)
 {
-    if (!dev || (dev->vdd >= sizeof(sht1x_d1) / sizeof(sht1x_d1[0]))) {
+    if (!dev || (dev->vdd >= ARRAY_SIZE(sht1x_d1))) {
         return INT16_MIN;
     }
 
@@ -520,7 +520,7 @@ int sht1x_read(const sht1x_dev_t *dev, int16_t *temp, int16_t *rel_hum)
 
     if (
         !dev ||
-        (dev->vdd >= sizeof(sht1x_d1) / sizeof(sht1x_d1[0])) ||
+        (dev->vdd >= ARRAY_SIZE(sht1x_d1)) ||
         (!temp && !rel_hum)
         ) {
         return -EINVAL;

--- a/drivers/sht2x/include/sht2x_params.h
+++ b/drivers/sht2x/include/sht2x_params.h
@@ -77,7 +77,7 @@ static const sht2x_params_t sht2x_params[] =
 /**
  * @brief   Get the number of configured SHT2X devices
  */
-#define SHT2X_NUMOF       (sizeof(sht2x_params) / sizeof(sht2x_params[0]))
+#define SHT2X_NUMOF       ARRAY_SIZE(sht2x_params)
 
 /**
  * @brief   Configuration details of SAUL registry entries

--- a/drivers/sht3x/sht3x_saul.c
+++ b/drivers/sht3x/sht3x_saul.c
@@ -22,7 +22,7 @@
 #include "sht3x.h"
 #include "sht3x_params.h"
 
-#define SHT3X_NUM      (sizeof(sht3x_params) / sizeof(sht3x_params[0]))
+#define SHT3X_NUM      ARRAY_SIZE(sht3x_params)
 extern sht3x_dev_t sht3x_devs[SHT3X_NUM];
 
 /**

--- a/drivers/soft_spi/soft_spi.c
+++ b/drivers/soft_spi/soft_spi.c
@@ -39,7 +39,7 @@ static inline bool soft_spi_bus_is_valid(soft_spi_t bus)
 {
     unsigned int soft_spi_num = (unsigned int) bus;
 
-    if (sizeof(soft_spi_config) / sizeof(soft_spi_config[0]) < soft_spi_num) {
+    if (ARRAY_SIZE(soft_spi_config) < soft_spi_num) {
         return false;
     }
     return true;

--- a/drivers/srf04/include/srf04_params.h
+++ b/drivers/srf04/include/srf04_params.h
@@ -55,7 +55,7 @@ static const srf04_params_t srf04_params[] = {
 /**
  * @brief   Number of SRF04 devices
  */
-#define SRF04_NUMOF     (sizeof(srf04_params) / sizeof(srf04_params[0]))
+#define SRF04_NUMOF     ARRAY_SIZE(srf04_params)
 
 #ifdef __cplusplus
 }

--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -83,7 +83,7 @@ static const coap_resource_t _resources[] = {
 
 static gcoap_listener_t _listener = {
     .resources     = (coap_resource_t *)&_resources[0],
-    .resources_len = sizeof(_resources) / sizeof(_resources[0]),
+    .resources_len = ARRAY_SIZE(_resources),
     .next          = NULL
 };
 

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -61,7 +61,7 @@ static const coap_resource_t resources[] = {
 
 static gcoap_listener_t listener = {
     .resources     = &resources[0],
-    .resources_len = sizeof(resources) / sizeof(resources[0]),
+    .resources_len = ARRAY_SIZE(resources),
     .next          = NULL
 };
 

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -210,7 +210,7 @@ static int _peer_get_psk_info_handler(struct dtls_context_t *ctx, const session_
 
     if (id) {
         uint8_t i;
-        for (i = 0; i < sizeof(psk) / sizeof(struct keymap_t); i++) {
+        for (i = 0; i < ARRAY_SIZE(psk); i++) {
             if (id_len == psk[i].id_length && memcmp(id, psk[i].id, id_len) == 0) {
                 if (result_length < psk[i].key_length) {
                     dtls_warn("buffer too small for PSK");

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -268,7 +268,7 @@ static int _peer_verify_ecdsa_key_handler(struct dtls_context_t *ctx,
 /* DTLS variables and register are initialized. */
 dtls_context_t *_server_init_dtls(dtls_remote_peer_t *remote_peer)
 {
-    dtls_context_t *new_context = NULL;
+    dtls_context_t *new_context;
 
     static dtls_handler_t cb = {
         .write = _send_to_peer_handler,

--- a/examples/emcute_mqttsn/main.c
+++ b/examples/emcute_mqttsn/main.c
@@ -265,7 +265,7 @@ int main(void)
          "information.");
 
     /* the main thread needs a msg queue to be able to run `ping6`*/
-    msg_init_queue(queue, (sizeof(queue) / sizeof(msg_t)));
+    msg_init_queue(queue, ARRAY_SIZE(queue));
 
     /* initialize our subscription buffers */
     memset(subscriptions, 0, (NUMOFSUBS * sizeof(emcute_sub_t)));

--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -98,7 +98,7 @@ static constfs_file_t constfs_files[] = {
 
 /* this is the constfs specific descriptor */
 static constfs_t constfs_desc = {
-    .nfiles = sizeof(constfs_files) / sizeof(constfs_files[0]),
+    .nfiles = ARRAY_SIZE(constfs_files),
     .files = constfs_files,
 };
 

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -49,7 +49,7 @@ static const char *_link_params[] = {
 
 static gcoap_listener_t _listener = {
     &_resources[0],
-    sizeof(_resources) / sizeof(_resources[0]),
+    ARRAY_SIZE(_resources),
     _encode_link,
     NULL
 };
@@ -253,7 +253,7 @@ int gcoap_cli_cmd(int argc, char **argv)
 
     /* if not 'info', must be a method code */
     int code_pos = -1;
-    for (size_t i = 0; i < sizeof(method_codes) / sizeof(char*); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(method_codes); i++) {
         if (strcmp(argv[1], method_codes[i]) == 0) {
             code_pos = i;
         }

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -169,4 +169,4 @@ const coap_resource_t coap_resources[] = {
     { "/sha256", COAP_POST, _sha256_handler, NULL },
 };
 
-const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);
+const unsigned coap_resources_numof = ARRAY_SIZE(coap_resources);

--- a/pkg/lua/contrib/lua_loadlib.c
+++ b/pkg/lua/contrib/lua_loadlib.c
@@ -30,6 +30,7 @@
 #define LUA_LIB
 
 #include "lprefix.h"
+#include "kernel_defines.h"
 
 #include "lua.h"
 #include "lauxlib.h"
@@ -239,7 +240,7 @@ LUAMOD_API int luaopen_package(lua_State *L)
     luaL_newlib(L, pk_funcs); /* create 'package' table */
 
     /* create 'searchers' table */
-    lua_createtable(L, sizeof(searchers) / sizeof(searchers[0]) - 1, 0);
+    lua_createtable(L, ARRAY_SIZE(searchers) - 1, 0);
     /* fill it with predefined searchers */
     for (i = 0; searchers[i] != NULL; i++) {
         lua_pushvalue(L, -2); /* set 'package' as upvalue for all searchers */

--- a/pkg/lua/contrib/lua_run.c
+++ b/pkg/lua/contrib/lua_run.c
@@ -272,7 +272,7 @@ LUALIB_API int lua_riot_do_buffer(const uint8_t *buf, size_t buflen, void *memor
                                      modmask, retval);
 }
 
-#define MAX_ERR_STRING ((sizeof(lua_riot_str_errors) / sizeof(*lua_riot_str_errors)) - 1)
+#define MAX_ERR_STRING (ARRAY_SIZE(lua_riot_str_errors) - 1)
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 LUALIB_API const char *lua_riot_strerror(int errn)

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -48,15 +48,15 @@
 #endif
 
 #ifdef MODULE_AT86RF2XX     /* is mutual exclusive with above ifdef */
-#define LWIP_NETIF_NUMOF        (sizeof(at86rf2xx_params) / sizeof(at86rf2xx_params[0]))
+#define LWIP_NETIF_NUMOF        ARRAY_SIZE(at86rf2xx_params)
 #endif
 
 #ifdef MODULE_MRF24J40     /* is mutual exclusive with above ifdef */
-#define LWIP_NETIF_NUMOF        (sizeof(mrf24j40_params) / sizeof(mrf24j40_params[0]))
+#define LWIP_NETIF_NUMOF        ARRAY_SIZE(mrf24j40_params)
 #endif
 
 #ifdef MODULE_SOCKET_ZEP   /* is mutual exclusive with above ifdef */
-#define LWIP_NETIF_NUMOF        (sizeof(socket_zep_params) / sizeof(socket_zep_params[0]))
+#define LWIP_NETIF_NUMOF        ARRAY_SIZE(socket_zep_params)
 #endif
 
 #ifdef LWIP_NETIF_NUMOF

--- a/pkg/nimble/scanlist/nimble_scanlist.c
+++ b/pkg/nimble/scanlist/nimble_scanlist.c
@@ -50,7 +50,7 @@ static nimble_scanlist_entry_t *_find(const ble_addr_t *addr)
 
 void nimble_scanlist_init(void)
 {
-    for (unsigned i = 0; i < (sizeof(_mem) / sizeof(_mem[0])); i++) {
+    for (unsigned i = 0; i < ARRAY_SIZE(_mem); i++) {
         clist_rpush(&_pool, &_mem[i].node);
     }
 }

--- a/pkg/nordic_softdevice_ble/src/ble-core.c
+++ b/pkg/nordic_softdevice_ble/src/ble-core.c
@@ -149,7 +149,7 @@ ble_advertising_init(const char *name)
 
   advdata.name_type = BLE_ADVDATA_FULL_NAME;
   advdata.flags = flags;
-  advdata.uuids_complete.uuid_cnt = sizeof(adv_uuids) / sizeof(adv_uuids[0]);
+  advdata.uuids_complete.uuid_cnt = ARRAY_SIZE(adv_uuids);
   advdata.uuids_complete.p_uuids = adv_uuids;
 
   err_code = ble_advdata_set(&advdata, NULL);

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -34,7 +34,7 @@
 #include "debug.h"
 
 #ifdef MODULE_AT86RF2XX     /* is mutual exclusive with above ifdef */
-#define OPENTHREAD_NETIF_NUMOF        (sizeof(at86rf2xx_params) / sizeof(at86rf2xx_params[0]))
+#define OPENTHREAD_NETIF_NUMOF        ARRAY_SIZE(at86rf2xx_params)
 #endif
 
 #ifdef MODULE_AT86RF2XX

--- a/pkg/openthread/contrib/platform_functions_wrapper.c
+++ b/pkg/openthread/contrib/platform_functions_wrapper.c
@@ -81,7 +81,7 @@ uint8_t ot_exec_command(otInstance *ot_instance, const char* command, void *arg,
     uint8_t res = 0xFF;
     /* Check running thread */
     if (openthread_get_pid() == thread_getpid()) {
-        for (uint8_t i = 0; i < sizeof(otCommands) / sizeof(otCommands[0]); i++) {
+        for (uint8_t i = 0; i < ARRAY_SIZE(otCommands); i++) {
             if (strcmp(command, otCommands[i].name) == 0) {
                 res = (*otCommands[i].function)(ot_instance, arg, answer);
                 break;

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -72,15 +72,14 @@ unsigned long micros()
     return xtimer_now_usec();
 }
 
-/*
- * Bitfield for the state of the ADC-channels.
- * 0: Not initialized
- * 1: Successfully initialized
- */
-static uint16_t adc_line_state = 0;
-
 int analogRead(int arduino_pin)
 {
+    /*
+    * Bitfield for the state of the ADC-channels.
+    * 0: Not initialized
+    * 1: Successfully initialized
+    */
+    static uint16_t adc_line_state;
     int adc_value;
 
     /* Check if the ADC line is valid */
@@ -92,7 +91,7 @@ int analogRead(int arduino_pin)
             return -1;
         }
         /* The ADC channel is initialized */
-        adc_line_state |= 1 << arduino_pin;
+        adc_line_state |= (1 << arduino_pin);
     }
 
     /* Read the ADC channel */

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -26,7 +26,7 @@ extern "C" {
 
 #include "arduino.hpp"
 
-#define ANALOG_PIN_NUMOF     (sizeof(arduino_analog_map) / sizeof(arduino_analog_map[0]))
+#define ANALOG_PIN_NUMOF     (ARRAY_SIZE(arduino_analog_map))
 
 void pinMode(int pin, int mode)
 {

--- a/sys/auto_init/can/auto_init_can_native.c
+++ b/sys/auto_init/can/auto_init_can_native.c
@@ -20,7 +20,7 @@
 #include "can/device.h"
 #include "candev_linux_params.h"
 
-#define CANDEV_LINUX_NUMOF ((sizeof(candev_linux_params) / sizeof(candev_params_t)))
+#define CANDEV_LINUX_NUMOF ARRAY_SIZE(candev_linux_params)
 
 #ifndef CANDEV_LINUX_STACKSIZE
 #define CANDEV_LINUX_STACKSIZE (THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)

--- a/sys/auto_init/can/auto_init_periph_can.c
+++ b/sys/auto_init/can/auto_init_periph_can.c
@@ -20,7 +20,7 @@
 #include "can/device.h"
 #include "can_params.h"
 
-#define CANDEV_NUMOF ((sizeof(candev_params) / sizeof(candev_params[0])))
+#define CANDEV_NUMOF (ARRAY_SIZE(candev_params))
 
 #ifndef CANDEV_STACKSIZE
 #define CANDEV_STACKSIZE (THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)

--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -42,7 +42,7 @@
 #define AT86RF2XX_MAC_PRIO          (GNRC_NETIF_PRIO)
 #endif
 
-#define AT86RF2XX_NUM (sizeof(at86rf2xx_params) / sizeof(at86rf2xx_params[0]))
+#define AT86RF2XX_NUM ARRAY_SIZE(at86rf2xx_params)
 
 static at86rf2xx_t at86rf2xx_devs[AT86RF2XX_NUM];
 static char _at86rf2xx_stacks[AT86RF2XX_NUM][AT86RF2XX_MAC_STACKSIZE];

--- a/sys/auto_init/netif/auto_init_cc110x.c
+++ b/sys/auto_init/netif/auto_init_cc110x.c
@@ -38,7 +38,7 @@
 #define CC110X_MAC_PRIO          (GNRC_NETIF_PRIO)
 #endif
 
-#define CC110X_NUM (sizeof(cc110x_params)/sizeof(cc110x_params[0]))
+#define CC110X_NUM ARRAY_SIZE(cc110x_params)
 
 static netdev_cc110x_t cc110x_devs[CC110X_NUM];
 static char _stacks[CC110X_NUM][CC110X_MAC_STACKSIZE];

--- a/sys/auto_init/netif/auto_init_cc2420.c
+++ b/sys/auto_init/netif/auto_init_cc2420.c
@@ -42,7 +42,7 @@
 /**
  * @brief   Get the number of configured CC2420 devices
  */
-#define CC2420_NUMOF        (sizeof(cc2420_params) / sizeof(cc2420_params[0]))
+#define CC2420_NUMOF        ARRAY_SIZE(cc2420_params)
 
 /**
  * @brief   Allocate memory for dev descriptors, stacks, and 802.15.4 adaption

--- a/sys/auto_init/netif/auto_init_enc28j60.c
+++ b/sys/auto_init/netif/auto_init_enc28j60.c
@@ -39,7 +39,7 @@
 /**
  * @brief   Find out how many of these devices we need to care for
  */
-#define ENC28J60_NUM    (sizeof(enc28j60_params) / sizeof(enc28j60_params[0]))
+#define ENC28J60_NUM    ARRAY_SIZE(enc28j60_params)
 
 /**
  * @brief   Allocate memory for the device descriptors

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -39,7 +39,7 @@
 #define KW2XRF_MAC_PRIO          (GNRC_NETIF_PRIO)
 #endif
 
-#define KW2XRF_NUM (sizeof(kw2xrf_params)/sizeof(kw2xrf_params[0]))
+#define KW2XRF_NUM ARRAY_SIZE(kw2xrf_params)
 
 static kw2xrf_t kw2xrf_devs[KW2XRF_NUM];
 static char _kw2xrf_stacks[KW2XRF_NUM][KW2XRF_MAC_STACKSIZE];

--- a/sys/auto_init/netif/auto_init_mrf24j40.c
+++ b/sys/auto_init/netif/auto_init_mrf24j40.c
@@ -36,7 +36,7 @@
 #define MRF24J40_MAC_PRIO          (GNRC_NETIF_PRIO)
 #endif
 
-#define MRF24J40_NUM (sizeof(mrf24j40_params) / sizeof(mrf24j40_params[0]))
+#define MRF24J40_NUM ARRAY_SIZE(mrf24j40_params)
 
 static mrf24j40_t mrf24j40_devs[MRF24J40_NUM];
 static char _mrf24j40_stacks[MRF24J40_NUM][MRF24J40_MAC_STACKSIZE];

--- a/sys/auto_init/netif/auto_init_slipdev.c
+++ b/sys/auto_init/netif/auto_init_slipdev.c
@@ -27,7 +27,7 @@
 #include "slipdev.h"
 #include "slipdev_params.h"
 
-#define SLIPDEV_NUM (sizeof(slipdev_params)/sizeof(slipdev_params_t))
+#define SLIPDEV_NUM ARRAY_SIZE(slipdev_params)
 
 /**
  * @brief   Define stack parameters for the MAC layer thread

--- a/sys/auto_init/netif/auto_init_sx127x.c
+++ b/sys/auto_init/netif/auto_init_sx127x.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Calculate the number of configured SX127x devices
  */
-#define SX127X_NUMOF        (sizeof(sx127x_params) / sizeof(sx127x_params_t))
+#define SX127X_NUMOF        ARRAY_SIZE(sx127x_params)
 
 /**
  * @brief   Define stack parameters for the MAC layer thread

--- a/sys/auto_init/netif/auto_init_w5100.c
+++ b/sys/auto_init/netif/auto_init_w5100.c
@@ -35,7 +35,7 @@
 /**
  * @brief   Find out how many of these devices we need to care for
  */
-#define W5100_NUM    (sizeof(w5100_params) / sizeof(w5100_params[0]))
+#define W5100_NUM    ARRAY_SIZE(w5100_params)
 
 /**
  * @brief   Allocate memory for the device descriptors

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Calculate the number of configured XBee devices
  */
-#define XBEE_NUM        (sizeof(xbee_params) / sizeof(xbee_params_t))
+#define XBEE_NUM        ARRAY_SIZE(xbee_params)
 
 /**
  * @brief   Define stack parameters for the MAC layer thread

--- a/sys/auto_init/saul/auto_init_ad7746.c
+++ b/sys/auto_init/saul/auto_init_ad7746.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define AD7746_NUM   (sizeof(ad7746_params) / sizeof(ad7746_params[0]))
+#define AD7746_NUM   ARRAY_SIZE(ad7746_params)
 
 /**
  * @brief   Allocate memory for the device descriptors.
@@ -47,7 +47,7 @@ static saul_reg_t saul_entries[AD7746_NUM * 3];
 /**
  * @brief   Define the number of saul info
  */
-#define AD7746_INFO_NUM (sizeof(ad7746_saul_info) / sizeof(ad7746_saul_info[0]))
+#define AD7746_INFO_NUM ARRAY_SIZE(ad7746_saul_info)
 
 /**
  * @brief   Reference the driver structs

--- a/sys/auto_init/saul/auto_init_adc.c
+++ b/sys/auto_init/saul/auto_init_adc.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define SAUL_ADC_NUMOF    (sizeof(saul_adc_params)/sizeof(saul_adc_params[0]))
+#define SAUL_ADC_NUMOF    ARRAY_SIZE(saul_adc_params)
 
 /**
  * @brief   Allocate memory for pointers to the ADC parameter structs

--- a/sys/auto_init/saul/auto_init_adcxx1c.c
+++ b/sys/auto_init/saul/auto_init_adcxx1c.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define ADCXX1C_NUM   (sizeof(adcxx1c_params) / sizeof(adcxx1c_params[0]))
+#define ADCXX1C_NUM   ARRAY_SIZE(adcxx1c_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -46,7 +46,7 @@ static saul_reg_t saul_entries[ADCXX1C_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define ADCXX1C_INFO_NUM (sizeof(adcxx1c_saul_info) / sizeof(adcxx1c_saul_info[0]))
+#define ADCXX1C_INFO_NUM ARRAY_SIZE(adcxx1c_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_ads101x.c
+++ b/sys/auto_init/saul/auto_init_ads101x.c
@@ -33,7 +33,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define ADS101X_NUM   (sizeof(ads101x_params) / sizeof(ads101x_params[0]))
+#define ADS101X_NUM   ARRAY_SIZE(ads101x_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -48,7 +48,7 @@ static saul_reg_t saul_entries[ADS101X_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define ADS101X_INFO_NUM (sizeof(ads101x_saul_info) / sizeof(ads101x_saul_info[0]))
+#define ADS101X_INFO_NUM ARRAY_SIZE(ads101x_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_adxl345.c
+++ b/sys/auto_init/saul/auto_init_adxl345.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define ADXL345_NUM    (sizeof(adxl345_params) / sizeof(adxl345_params[0]))
+#define ADXL345_NUM    ARRAY_SIZE(adxl345_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[ADXL345_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define ADXL345_INFO_NUM (sizeof(adxl345_saul_info) / sizeof(adxl345_saul_info[0]))
+#define ADXL345_INFO_NUM ARRAY_SIZE(adxl345_saul_info)
 
 /**
  * @brief   Reference the driver structs

--- a/sys/auto_init/saul/auto_init_bmp180.c
+++ b/sys/auto_init/saul/auto_init_bmp180.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define BMP180_NUM      (sizeof(bmp180_params) / sizeof(bmp180_params[0]))
+#define BMP180_NUM      ARRAY_SIZE(bmp180_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -44,7 +44,7 @@ static saul_reg_t saul_entries[BMP180_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define BMP180_INFO_NUM (sizeof(bmp180_saul_info) / sizeof(bmp180_saul_info[0]))
+#define BMP180_INFO_NUM ARRAY_SIZE(bmp180_saul_info)
 
 /**
  * @name    Reference the driver structs.

--- a/sys/auto_init/saul/auto_init_bmx055.c
+++ b/sys/auto_init/saul/auto_init_bmx055.c
@@ -28,7 +28,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define BMX055_NUM          (sizeof(bmx055_params) / sizeof(bmx055_params[0]))
+#define BMX055_NUM          ARRAY_SIZE(bmx055_params)
 
 /**
  * @brief   Each sensor contains 3 individual i2c modules

--- a/sys/auto_init/saul/auto_init_ccs811.c
+++ b/sys/auto_init/saul/auto_init_ccs811.c
@@ -25,7 +25,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define CCS811_NUM      (sizeof(ccs811_params) / sizeof(ccs811_params[0]))
+#define CCS811_NUM      ARRAY_SIZE(ccs811_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -40,7 +40,7 @@ static saul_reg_t saul_entries[CCS811_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define CCS811_INFO_NUM (sizeof(ccs811_saul_info) / sizeof(ccs811_saul_info[0]))
+#define CCS811_INFO_NUM ARRAY_SIZE(ccs811_saul_info)
 
 /**
  * @name    Reference the driver structs.

--- a/sys/auto_init/saul/auto_init_dht.c
+++ b/sys/auto_init/saul/auto_init_dht.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define DHT_NUM     (sizeof(dht_params) / sizeof(dht_params[0]))
+#define DHT_NUM     ARRAY_SIZE(dht_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[DHT_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define DHT_INFO_NUM (sizeof(dht_saul_info) / sizeof(dht_saul_info[0]))
+#define DHT_INFO_NUM ARRAY_SIZE(dht_saul_info)
 
 /**
  * @name    Import SAUL endpoints

--- a/sys/auto_init/saul/auto_init_ds18.c
+++ b/sys/auto_init/saul/auto_init_ds18.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define DS18_NUMOF    (sizeof(ds18_params) / sizeof(ds18_params[0]))
+#define DS18_NUMOF    ARRAY_SIZE(ds18_params)
 
 /**
  * @brief   Allocation of memory for device descriptors

--- a/sys/auto_init/saul/auto_init_ds75lx.c
+++ b/sys/auto_init/saul/auto_init_ds75lx.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define DS75LX_NUM      (sizeof(ds75lx_params) / sizeof(ds75lx_params[0]))
+#define DS75LX_NUM      ARRAY_SIZE(ds75lx_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -44,7 +44,7 @@ static saul_reg_t saul_entries[DS75LX_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define DS75LX_INFO_NUM (sizeof(ds75lx_saul_info) / sizeof(ds75lx_saul_info[0]))
+#define DS75LX_INFO_NUM ARRAY_SIZE(ds75lx_saul_info)
 
 /**
  * @name    Reference the driver structs.

--- a/sys/auto_init/saul/auto_init_fxos8700.c
+++ b/sys/auto_init/saul/auto_init_fxos8700.c
@@ -28,7 +28,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define FXOS8700_NUM    (sizeof(fxos8700_params)/sizeof(fxos8700_params[0]))
+#define FXOS8700_NUM    ARRAY_SIZE(fxos8700_params)
 
 /**
  * @brief   Allocate memory for the device descriptors

--- a/sys/auto_init/saul/auto_init_gpio.c
+++ b/sys/auto_init/saul/auto_init_gpio.c
@@ -26,6 +26,7 @@
 #include "saul/periph.h"
 #include "gpio_params.h"
 #include "periph/gpio.h"
+#include "kernel_defines.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -37,7 +38,7 @@ void auto_init_gpio(void)
     LOG_DEBUG("[auto_init_saul] no SAUL GPIO configured!\n");
 }
 #else
-#define SAUL_GPIO_NUMOF (sizeof(saul_gpio_params)/sizeof(saul_gpio_params[0]))
+#define SAUL_GPIO_NUMOF ARRAY_SIZE(saul_gpio_params)
 
 
 /**

--- a/sys/auto_init/saul/auto_init_grove_ledbar.c
+++ b/sys/auto_init/saul/auto_init_grove_ledbar.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define GROVE_LEDBAR_NUM     (sizeof(grove_ledbar_params) / sizeof(grove_ledbar_params[0]))
+#define GROVE_LEDBAR_NUM     ARRAY_SIZE(grove_ledbar_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -46,7 +46,7 @@ static saul_reg_t saul_entries[GROVE_LEDBAR_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define GROVE_LEDBAR_INFO_NUM (sizeof(grove_ledbar_saul_info) / sizeof(grove_ledbar_saul_info[0]))
+#define GROVE_LEDBAR_INFO_NUM ARRAY_SIZE(grove_ledbar_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_hdc1000.c
+++ b/sys/auto_init/saul/auto_init_hdc1000.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define HDC1000_NUM    (sizeof(hdc1000_params) / sizeof(hdc1000_params[0]))
+#define HDC1000_NUM    ARRAY_SIZE(hdc1000_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[HDC1000_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define HDC1000_INFO_NUM    (sizeof(hdc1000_saul_info) / sizeof(hdc1000_saul_info[0]))
+#define HDC1000_INFO_NUM    ARRAY_SIZE(hdc1000_saul_info)
 
 /**
  * @name    Reference the driver struct

--- a/sys/auto_init/saul/auto_init_hts221.c
+++ b/sys/auto_init/saul/auto_init_hts221.c
@@ -30,9 +30,9 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define HTS221_NUM      (sizeof(hts221_params)/sizeof(hts221_params[0]))
+#define HTS221_NUM      ARRAY_SIZE(hts221_params)
 
-#define HTS221_SAUL_NUM (sizeof(hts221_saul_info)/sizeof(hts221_saul_info[0]))
+#define HTS221_SAUL_NUM ARRAY_SIZE(hts221_saul_info)
 /**
  * @brief   Allocate memory for the device descriptors
  */

--- a/sys/auto_init/saul/auto_init_io1_xplained.c
+++ b/sys/auto_init/saul/auto_init_io1_xplained.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define IO1_XPLAINED_NUM    (sizeof(io1_xplained_params) / sizeof(io1_xplained_params[0]))
+#define IO1_XPLAINED_NUM    ARRAY_SIZE(io1_xplained_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -44,7 +44,7 @@ static saul_reg_t saul_entries[IO1_XPLAINED_NUM * 4];
 /**
  * @brief   Define the number of saul info
  */
-#define IO1_XPLAINED_INFO_NUM    (sizeof(io1_xplained_saul_info) / sizeof(io1_xplained_saul_info[0]))
+#define IO1_XPLAINED_INFO_NUM    ARRAY_SIZE(io1_xplained_saul_info)
 
 /**
  * @name    Reference the driver structs.
@@ -74,7 +74,7 @@ void auto_init_io1_xplained(void)
 
         /* GPIOs */
         for (unsigned j = 0;
-             j < sizeof(io1_xplained_saul_gpios) / sizeof(io1_xplained_saul_gpios[0]);
+             j < ARRAY_SIZE(io1_xplained_saul_gpios);
              j++) {
             saul_reg_t *entry = &saul_entries[i * 4 + j + 1];
             entry->dev = &(io1_xplained_saul_gpios[j]);

--- a/sys/auto_init/saul/auto_init_isl29020.c
+++ b/sys/auto_init/saul/auto_init_isl29020.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define ISL29020_NUM    (sizeof(isl29020_params) / sizeof(isl29020_params[0]))
+#define ISL29020_NUM    ARRAY_SIZE(isl29020_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[ISL29020_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define ISL29020_INFO_NUM    (sizeof(isl29020_saul_info) / sizeof(isl29020_saul_info[0]))
+#define ISL29020_INFO_NUM    ARRAY_SIZE(isl29020_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_jc42.c
+++ b/sys/auto_init/saul/auto_init_jc42.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define JC42_NUM      (sizeof(jc42_params) / sizeof(jc42_params[0]))
+#define JC42_NUM      ARRAY_SIZE(jc42_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -44,7 +44,7 @@ static saul_reg_t saul_entries[JC42_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define JC42_INFO_NUM    (sizeof(jc42_saul_info) / sizeof(jc42_saul_info[0]))
+#define JC42_INFO_NUM    ARRAY_SIZE(jc42_saul_info)
 
 /**
  * @brief   Reference the driver structs.

--- a/sys/auto_init/saul/auto_init_l3g4200d.c
+++ b/sys/auto_init/saul/auto_init_l3g4200d.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define L3G4200D_NUM    (sizeof(l3g4200d_params) / sizeof(l3g4200d_params[0]))
+#define L3G4200D_NUM    ARRAY_SIZE(l3g4200d_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[L3G4200D_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define L3G4200D_INFO_NUM    (sizeof(l3g4200d_saul_info) / sizeof(l3g4200d_saul_info[0]))
+#define L3G4200D_INFO_NUM    ARRAY_SIZE(l3g4200d_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_lis2dh12.c
+++ b/sys/auto_init/saul/auto_init_lis2dh12.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Number of configured sensors
  */
-#define LIS2DH12_NUM    (sizeof(lis2dh12_params) / sizeof(lis2dh12_params[0]))
+#define LIS2DH12_NUM    ARRAY_SIZE(lis2dh12_params)
 
 
 /**

--- a/sys/auto_init/saul/auto_init_lis3dh.c
+++ b/sys/auto_init/saul/auto_init_lis3dh.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define LIS3DH_NUM    (sizeof(lis3dh_params) / sizeof(lis3dh_params[0]))
+#define LIS3DH_NUM    ARRAY_SIZE(lis3dh_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[LIS3DH_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define LIS3DH_INFO_NUM    (sizeof(lis3dh_saul_info) / sizeof(lis3dh_saul_info[0]))
+#define LIS3DH_INFO_NUM    ARRAY_SIZE(lis3dh_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_lis3mdl.c
+++ b/sys/auto_init/saul/auto_init_lis3mdl.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define LIS3MDL_NUM    (sizeof(lis3mdl_params)/sizeof(lis3mdl_params[0]))
+#define LIS3MDL_NUM    ARRAY_SIZE(lis3mdl_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[LIS3MDL_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define LIS3MDL_INFO_NUM    (sizeof(lis3mdl_saul_info)/sizeof(lis3mdl_saul_info[0]))
+#define LIS3MDL_INFO_NUM    ARRAY_SIZE(lis3mdl_saul_info)
 
 /**
  * @brief   Reference the driver structs

--- a/sys/auto_init/saul/auto_init_lpsxxx.c
+++ b/sys/auto_init/saul/auto_init_lpsxxx.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define LPSXXX_NUM      (sizeof(lpsxxx_params) / sizeof(lpsxxx_params[0]))
+#define LPSXXX_NUM      ARRAY_SIZE(lpsxxx_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[LPSXXX_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define LPSXXX_INFO_NUM    (sizeof(lpsxxx_saul_info) / sizeof(lpsxxx_saul_info[0]))
+#define LPSXXX_INFO_NUM    ARRAY_SIZE(lpsxxx_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_lsm303dlhc.c
+++ b/sys/auto_init/saul/auto_init_lsm303dlhc.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define LSM303DLHC_NUM    (sizeof(lsm303dlhc_params) / sizeof(lsm303dlhc_params[0]))
+#define LSM303DLHC_NUM    ARRAY_SIZE(lsm303dlhc_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[LSM303DLHC_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define LSM303DLHC_INFO_NUM    (sizeof(lsm303dlhc_saul_info) / sizeof(lsm303dlhc_saul_info[0]))
+#define LSM303DLHC_INFO_NUM    ARRAY_SIZE(lsm303dlhc_saul_info)
 
 /**
  * @name    Reference the driver structs

--- a/sys/auto_init/saul/auto_init_lsm6dsl.c
+++ b/sys/auto_init/saul/auto_init_lsm6dsl.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define LSM6DSL_NUM    (sizeof(lsm6dsl_params) / sizeof(lsm6dsl_params[0]))
+#define LSM6DSL_NUM    ARRAY_SIZE(lsm6dsl_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[LSM6DSL_NUM * 3];
 /**
  * @brief   Define the number of saul info
  */
-#define LSM6DSL_INFO_NUM    (sizeof(lsm6dsl_saul_info) / sizeof(lsm6dsl_saul_info[0]))
+#define LSM6DSL_INFO_NUM    ARRAY_SIZE(lsm6dsl_saul_info)
 
 /**
  * @name    Reference the driver structs

--- a/sys/auto_init/saul/auto_init_ltc4150.c
+++ b/sys/auto_init/saul/auto_init_ltc4150.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define LTC4150_NUM     (sizeof(ltc4150_params) / sizeof(ltc4150_params[0]))
+#define LTC4150_NUM     ARRAY_SIZE(ltc4150_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[LTC4150_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define LTC4150_INFO_NUM (sizeof(ltc4150_saul_info) / sizeof(ltc4150_saul_info[0]))
+#define LTC4150_INFO_NUM ARRAY_SIZE(ltc4150_saul_info)
 
 /**
  * @name    Import SAUL endpoints

--- a/sys/auto_init/saul/auto_init_mag3110.c
+++ b/sys/auto_init/saul/auto_init_mag3110.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define MAG3110_NUM     (sizeof(mag3110_params) / sizeof(mag3110_params[0]))
+#define MAG3110_NUM     ARRAY_SIZE(mag3110_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -46,7 +46,7 @@ static saul_reg_t saul_entries[MAG3110_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define MAG3110_INFO_NUM    (sizeof(mag3110_saul_info) / sizeof(mag3110_saul_info[0]))
+#define MAG3110_INFO_NUM    ARRAY_SIZE(mag3110_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_mma7660.c
+++ b/sys/auto_init/saul/auto_init_mma7660.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define MMA7660_NUM       (sizeof(mma7660_params) / sizeof(mma7660_params[0]))
+#define MMA7660_NUM       ARRAY_SIZE(mma7660_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[MMA7660_NUM];
 /**
  * @brief   Define the number of configured sensors
  */
-#define MMA7660_INFO_NUM  (sizeof(mma7660_saul_info) / sizeof(mma7660_saul_info[0]))
+#define MMA7660_INFO_NUM  ARRAY_SIZE(mma7660_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_mma8x5x.c
+++ b/sys/auto_init/saul/auto_init_mma8x5x.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define MMA8X5X_NUM     (sizeof(mma8x5x_params) / sizeof(mma8x5x_params[0]))
+#define MMA8X5X_NUM     ARRAY_SIZE(mma8x5x_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -46,7 +46,7 @@ static saul_reg_t saul_entries[MMA8X5X_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define MMA8X5X_INFO_NUM    (sizeof(mma8x5x_saul_info) / sizeof(mma8x5x_saul_info[0]))
+#define MMA8X5X_INFO_NUM    ARRAY_SIZE(mma8x5x_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_mpl3115a2.c
+++ b/sys/auto_init/saul/auto_init_mpl3115a2.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define MPL3115A2_NUM     (sizeof(mpl3115a2_params) / sizeof(mpl3115a2_params[0]))
+#define MPL3115A2_NUM     ARRAY_SIZE(mpl3115a2_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -46,7 +46,7 @@ static saul_reg_t saul_entries[MPL3115A2_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define MPL3115A2_INFO_NUM    (sizeof(mpl3115a2_saul_info) / sizeof(mpl3115a2_saul_info[0]))
+#define MPL3115A2_INFO_NUM    ARRAY_SIZE(mpl3115a2_saul_info)
 
 /**
  * @name    Reference the driver struct

--- a/sys/auto_init/saul/auto_init_mpu9150.c
+++ b/sys/auto_init/saul/auto_init_mpu9150.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define MPU9150_NUM         (sizeof(mpu9150_params) / sizeof(mpu9150_params[0]))
+#define MPU9150_NUM         ARRAY_SIZE(mpu9150_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[MPU9150_NUM * 3];
 /**
  * @brief   Define the number of saul info
  */
-#define MPU9150_INFO_NUM    (sizeof(mpu9150_saul_info) / sizeof(mpu9150_saul_info[0]))
+#define MPU9150_INFO_NUM    ARRAY_SIZE(mpu9150_saul_info)
 
 /**
  * @name    Reference the driver structs

--- a/sys/auto_init/saul/auto_init_pir.c
+++ b/sys/auto_init/saul/auto_init_pir.c
@@ -28,7 +28,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define PIR_NUM    (sizeof(pir_params)/sizeof(pir_params[0]))
+#define PIR_NUM    ARRAY_SIZE(pir_params)
 
 /**
  * @brief   Allocate memory for the device descriptors

--- a/sys/auto_init/saul/auto_init_pulse_counter.c
+++ b/sys/auto_init/saul/auto_init_pulse_counter.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define PULSE_COUNTER_NUM    (sizeof(pulse_counter_params) / sizeof(pulse_counter_params[0]))
+#define PULSE_COUNTER_NUM    ARRAY_SIZE(pulse_counter_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -44,7 +44,7 @@ static saul_reg_t saul_entries[PULSE_COUNTER_NUM];
 /**
  * @brief   Define the number of configured sensors
  */
-#define PULSE_COUNTER_INFO_NUM    (sizeof(pulse_counter_saul_info) / sizeof(pulse_counter_saul_info[0]))
+#define PULSE_COUNTER_INFO_NUM    ARRAY_SIZE(pulse_counter_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_sds011.c
+++ b/sys/auto_init/saul/auto_init_sds011.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define SDS011_NUM     (sizeof(sds011_params) / sizeof(sds011_params[0]))
+#define SDS011_NUM     ARRAY_SIZE(sds011_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[SDS011_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define SDS011_INFO_NUM (sizeof(sds011_saul_info) / sizeof(sds011_saul_info[0]))
+#define SDS011_INFO_NUM ARRAY_SIZE(sds011_saul_info)
 
 /**
  * @name    Import SAUL endpoint

--- a/sys/auto_init/saul/auto_init_sht1x.c
+++ b/sys/auto_init/saul/auto_init_sht1x.c
@@ -36,7 +36,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define SHT1X_NUM     (sizeof(sht1x_params) / sizeof(sht1x_params[0]))
+#define SHT1X_NUM     ARRAY_SIZE(sht1x_params)
 
 /**
  * @brief   Allocate memory for the device descriptors

--- a/sys/auto_init/saul/auto_init_sht3x.c
+++ b/sys/auto_init/saul/auto_init_sht3x.c
@@ -24,7 +24,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define SHT3X_NUM      (sizeof(sht3x_params) / sizeof(sht3x_params[0]))
+#define SHT3X_NUM      ARRAY_SIZE(sht3x_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -39,7 +39,7 @@ static saul_reg_t saul_entries[SHT3X_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define SHT3X_INFO_NUM (sizeof(sht3x_saul_info) / sizeof(sht3x_saul_info[0]))
+#define SHT3X_INFO_NUM ARRAY_SIZE(sht3x_saul_info)
 
 /**
  * @name    Reference the driver structs.

--- a/sys/auto_init/saul/auto_init_si114x.c
+++ b/sys/auto_init/saul/auto_init_si114x.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define SI114X_NUMOF    (sizeof(si114x_params) / sizeof(si114x_params[0]))
+#define SI114X_NUMOF    ARRAY_SIZE(si114x_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[SI114X_NUMOF * 4];
 /**
  * @brief   Define the number of saul info
  */
-#define SI114X_INFO_NUMOF    (sizeof(si114x_saul_reg_info) / sizeof(si114x_saul_reg_info[0]))
+#define SI114X_INFO_NUMOF    ARRAY_SIZE(si114x_saul_reg_info)
 
 /**
  * @name    Reference the driver structs

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define SI70XX_NUM    (sizeof(si70xx_params) / sizeof(si70xx_params[0]))
+#define SI70XX_NUM    ARRAY_SIZE(si70xx_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -44,7 +44,7 @@ static saul_reg_t saul_entries[SI70XX_NUM * 2];
 /**
  * @brief   Define the number of saul info
  */
-#define SI70XX_INFO_NUM    (sizeof(si70xx_saul_info) / sizeof(si70xx_saul_info[0]))
+#define SI70XX_INFO_NUM    ARRAY_SIZE(si70xx_saul_info)
 
 /**
  * @name    Reference the driver structs.

--- a/sys/auto_init/saul/auto_init_tcs37727.c
+++ b/sys/auto_init/saul/auto_init_tcs37727.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define TCS37727_NUM    (sizeof(tcs37727_params) / sizeof(tcs37727_params[0]))
+#define TCS37727_NUM    ARRAY_SIZE(tcs37727_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -45,7 +45,7 @@ static saul_reg_t saul_entries[TCS37727_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define TCS37727_INFO_NUM    (sizeof(tcs37727_saul_info) / sizeof(tcs37727_saul_info[0]))
+#define TCS37727_INFO_NUM    ARRAY_SIZE(tcs37727_saul_info)
 
 /**
  * @brief   Export the sensor's SAUL interface

--- a/sys/auto_init/saul/auto_init_tmp006.c
+++ b/sys/auto_init/saul/auto_init_tmp006.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define TMP006_NUM     (sizeof(tmp006_params) / sizeof(tmp006_params[0]))
+#define TMP006_NUM     ARRAY_SIZE(tmp006_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -46,7 +46,7 @@ static saul_reg_t saul_entries[TMP006_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define TMP006_INFO_NUM    (sizeof(tmp006_saul_info) / sizeof(tmp006_saul_info[0]))
+#define TMP006_INFO_NUM    ARRAY_SIZE(tmp006_saul_info)
 
 /**
  * @brief   Reference the driver struct

--- a/sys/auto_init/saul/auto_init_tsl2561.c
+++ b/sys/auto_init/saul/auto_init_tsl2561.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define TSL2561_NUMOF    (sizeof(tsl2561_params) / sizeof(tsl2561_params[0]))
+#define TSL2561_NUMOF    ARRAY_SIZE(tsl2561_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -44,7 +44,7 @@ static saul_reg_t saul_entries[TSL2561_NUMOF];
 /**
  * @brief   Define the number of saul info
  */
-#define TSL2561_INFO_NUMOF    (sizeof(tsl2561_saul_info) / sizeof(tsl2561_saul_info[0]))
+#define TSL2561_INFO_NUMOF    ARRAY_SIZE(tsl2561_saul_info)
 
 /**
  * @brief   Reference the driver structs.

--- a/sys/auto_init/saul/auto_init_tsl4531x.c
+++ b/sys/auto_init/saul/auto_init_tsl4531x.c
@@ -32,7 +32,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define TSL4531X_NUMOF    (sizeof(tsl4531x_params) / sizeof(tsl4531x_params[0]))
+#define TSL4531X_NUMOF    ARRAY_SIZE(tsl4531x_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -48,7 +48,7 @@ static saul_reg_t saul_entries[TSL4531X_NUMOF];
 /**
  * @brief   Define the number of saul info
  */
-#define TSL4531X_INFO_NUMOF    (sizeof(tsl4531x_saul_info) / sizeof(tsl4531x_saul_info[0]))
+#define TSL4531X_INFO_NUMOF    ARRAY_SIZE(tsl4531x_saul_info)
 
 /**
  * @brief   Reference the driver structs.

--- a/sys/auto_init/saul/auto_init_vcnl40x0.c
+++ b/sys/auto_init/saul/auto_init_vcnl40x0.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define VCNL40X0_NUMOF    (sizeof(vcnl40x0_params) / sizeof(vcnl40x0_params[0]))
+#define VCNL40X0_NUMOF    ARRAY_SIZE(vcnl40x0_params)
 
 /**
  * @brief   Allocation of memory for device descriptors

--- a/sys/auto_init/saul/auto_init_veml6070.c
+++ b/sys/auto_init/saul/auto_init_veml6070.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define VEML6070_NUM    (sizeof(veml6070_params) / sizeof(veml6070_params[0]))
+#define VEML6070_NUM    ARRAY_SIZE(veml6070_params)
 
 /**
  * @brief   Allocation of memory for device descriptors
@@ -44,7 +44,7 @@ static saul_reg_t saul_entries[VEML6070_NUM];
 /**
  * @brief   Define the number of saul info
  */
-#define VEML6070_INFO_NUM    (sizeof(veml6070_saul_info) / sizeof(veml6070_saul_info[0]))
+#define VEML6070_INFO_NUM    ARRAY_SIZE(veml6070_saul_info)
 
 /**
  * @brief   Reference the driver structs.

--- a/sys/auto_init/storage/auto_init_sdcard_spi.c
+++ b/sys/auto_init/storage/auto_init_sdcard_spi.c
@@ -29,7 +29,7 @@
  * @brief   number of used sd cards
  * @{
  */
-#define SDCARD_SPI_NUM (sizeof(sdcard_spi_params) / sizeof(sdcard_spi_params[0]))
+#define SDCARD_SPI_NUM ARRAY_SIZE(sdcard_spi_params)
 /** @} */
 
 /**

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -46,7 +46,7 @@ static const uint32_t _tenmap[] = {
     10000000LU,
 };
 
-#define TENMAP_SIZE  (sizeof(_tenmap) / sizeof(_tenmap[0]))
+#define TENMAP_SIZE  ARRAY_SIZE(_tenmap)
 
 static inline int _is_digit(char c)
 {

--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -22,6 +22,7 @@
 #define EMBUNIT_H
 
 #include "embUnit/embUnit.h"
+#include "kernel_defines.h"
 
 #ifdef OUTPUT
 #   define OUTPUT_XML       (1)

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -36,6 +36,7 @@
 #define PHYDAT_H
 
 #include <stdint.h>
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -62,7 +62,7 @@ const coap_resource_t _default_resources[] = {
 
 static gcoap_listener_t _default_listener = {
     &_default_resources[0],
-    sizeof(_default_resources) / sizeof(_default_resources[0]),
+    ARRAY_SIZE(_default_resources),
     NULL,
     NULL
 };

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -53,7 +53,6 @@ static kernel_pid_t _tftp_kernel_pid;
 #endif
 
 #define MIN(a, b)                   ((a) > (b) ? (b) : (a))
-#define ARRAY_LEN(x)                (sizeof(x) / sizeof(x[0]))
 
 #define TFTP_TIMEOUT_MSG            0x4000
 #define TFTP_STOP_SERVER_MSG        0x4001
@@ -1079,7 +1078,7 @@ int _tftp_decode_start(tftp_context_t *ctxt, gnrc_pktsnip_t *inpkt, gnrc_pktsnip
     DEBUG("tftp: incoming request '%s', mode: %s\n", ctxt->file_name, str_mode);
 
     /* decode the TFTP transfer mode */
-    for (uint32_t idx = 0; idx < ARRAY_LEN(_tftp_modes); ++idx) {
+    for (uint32_t idx = 0; idx < ARRAY_SIZE(_tftp_modes); ++idx) {
         if (_tftp_modes[idx].len > (inpkt->size - sizeof(*hdr) - fnlen)) {
             continue;
         }
@@ -1110,7 +1109,7 @@ int _tftp_decode_options(tftp_context_t *ctxt, gnrc_pktsnip_t *buf, uint32_t sta
         offset += strlen(value) + 1;
 
         /* check what option we are parsing */
-        for (uint32_t idx = 0; idx < ARRAY_LEN(_tftp_options); ++idx) {
+        for (uint32_t idx = 0; idx < ARRAY_SIZE(_tftp_options); ++idx) {
             if (memcmp(name, _tftp_options[idx].name, _tftp_options[idx].len) == 0) {
                 /* set the option value of the known options */
                 switch (idx) {

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -129,7 +129,7 @@ static void* uhcp_client_thread(void *arg)
 {
     (void)arg;
 
-    msg_init_queue(_uhcp_msg_queue, sizeof(_uhcp_msg_queue)/sizeof(msg_t));
+    msg_init_queue(_uhcp_msg_queue, ARRAY_SIZE(_uhcp_msg_queue));
     uhcp_client(gnrc_border_interface);
     return NULL;
 }

--- a/sys/net/routing/nhdp/nhdp_reader.c
+++ b/sys/net/routing/nhdp/nhdp_reader.c
@@ -108,9 +108,9 @@ void nhdp_reader_init(void)
 
     /* Register HELLO message consumer */
     rfc5444_reader_add_message_consumer(&reader, &_nhdp_msg_consumer,
-                                        _nhdp_msg_tlvs, ARRAYSIZE(_nhdp_msg_tlvs));
+                                        _nhdp_msg_tlvs, ARRAY_SIZE(_nhdp_msg_tlvs));
     rfc5444_reader_add_message_consumer(&reader, &_nhdp_address_consumer,
-                                        _nhdp_addr_tlvs, ARRAYSIZE(_nhdp_addr_tlvs));
+                                        _nhdp_addr_tlvs, ARRAY_SIZE(_nhdp_addr_tlvs));
 }
 
 int nhdp_reader_handle_packet(kernel_pid_t rcvg_if_pid, void *buffer, size_t length)

--- a/sys/net/routing/nhdp/nhdp_writer.c
+++ b/sys/net/routing/nhdp/nhdp_writer.c
@@ -90,7 +90,7 @@ void nhdp_writer_init(void)
 
     /* Register HELLO msg with 16 byte addresses and content provider */
     rfc5444_writer_register_msgcontentprovider(&nhdp_writer,
-            &_nhdp_message_content_provider, _nhdp_addrtlvs, ARRAYSIZE(_nhdp_addrtlvs));
+            &_nhdp_message_content_provider, _nhdp_addrtlvs, ARRAY_SIZE(_nhdp_addrtlvs));
     _hello_msg = rfc5444_writer_register_message(&nhdp_writer, RFC5444_MSGTYPE_HELLO, false, 16);
     _hello_msg->addMessageHeader = _nhdp_add_hello_msg_header_cb;
 

--- a/sys/phydat/phydat.c
+++ b/sys/phydat/phydat.c
@@ -56,11 +56,11 @@ static const uint32_t divisors[] = {
     10,
 };
 
-#define LOOKUP_LEN (sizeof(lookup_table_positive) / sizeof(int32_t))
+#define LOOKUP_LEN ARRAY_SIZE(lookup_table_positive)
 
 void phydat_fit(phydat_t *dat, const int32_t *values, unsigned int dim)
 {
-    assert(dim <= (sizeof(dat->val) / sizeof(dat->val[0])));
+    assert(dim <= ARRAY_SIZE(dat->val));
     uint32_t divisor = 0;
     uint32_t max = 0;
     const uint32_t *lookup = lookup_table_positive;

--- a/sys/riotboot/slot.c
+++ b/sys/riotboot/slot.c
@@ -40,7 +40,7 @@ const riotboot_hdr_t * const riotboot_slots[] = {
 };
 
 /* Calculate the number of slots */
-const unsigned riotboot_slot_numof = sizeof(riotboot_slots) / sizeof(riotboot_hdr_t*);
+const unsigned riotboot_slot_numof = ARRAY_SIZE(riotboot_slots);
 
 static void _riotboot_slot_jump_to_image(const riotboot_hdr_t *hdr)
 {

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -45,11 +45,6 @@
 #define _LINE_THRESHOLD                 (8U)
 
 /**
- * @brief   Determine length of array in elements
- */
-#define _ARRAY_LEN(x)                   (sizeof(x) / sizeof(x[0]))
-
-/**
  * @brief   Flag command mapping
  *
  * @note    Add options that are changed with netopt_enable_t here
@@ -177,9 +172,9 @@ static void _set_usage(char *cmd_name)
 static void _flag_usage(char *cmd_name)
 {
     printf("usage: %s <if_id> [-]{", cmd_name);
-    for (unsigned i = 0; i < _ARRAY_LEN(flag_cmds); i++) {
+    for (unsigned i = 0; i < ARRAY_SIZE(flag_cmds); i++) {
         printf("%s", flag_cmds[i].name);
-        if (i < (_ARRAY_LEN(flag_cmds) - 1)) {
+        if (i < (ARRAY_SIZE(flag_cmds) - 1)) {
             printf("|");
         }
     }
@@ -1073,7 +1068,7 @@ static int _netif_flag(char *cmd, kernel_pid_t iface, char *flag)
         set = NETOPT_DISABLE;
         flag++;
     }
-    for (unsigned i = 0; i < _ARRAY_LEN(flag_cmds); i++) {
+    for (unsigned i = 0; i < ARRAY_SIZE(flag_cmds); i++) {
         if (strcmp(flag_cmds[i].name, flag) == 0) {
             return _netif_set_flag(iface, flag_cmds[i].opt, set);
         }

--- a/sys/shell/commands/sc_sht1x.c
+++ b/sys/shell/commands/sc_sht1x.c
@@ -27,7 +27,7 @@
 #include "sht1x.h"
 #include "sht1x_params.h"
 
-#define SHT1X_NUM     (sizeof(sht1x_params) / sizeof(sht1x_params[0]))
+#define SHT1X_NUM     ARRAY_SIZE(sht1x_params)
 
 extern sht1x_dev_t sht1x_devs[SHT1X_NUM];
 

--- a/sys/shell/commands/sc_sht1x.c
+++ b/sys/shell/commands/sc_sht1x.c
@@ -225,14 +225,14 @@ int _sht_config_handler(int argc, char **argv)
                     missing_argument(i - 1, argv);
                     return -1;
                 }
-                temp_off = (int16_t)atoi(argv[i]);
+                temp_off = atoi(argv[i]);
                 break;
             case 'h':
                 if (++i >= argc) {
                     missing_argument(i - 1, argv);
                     return -1;
                 }
-                hum_off = (int16_t)atoi(argv[i]);
+                hum_off = atoi(argv[i]);
                 break;
             case 'r':
                 if (++i >= argc) {

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -60,10 +60,11 @@ static shell_command_handler_t find_handler(const shell_command_t *command_list,
 #endif
     };
 
-    const shell_command_t *entry;
-
     /* iterating over command_lists */
     for (unsigned int i = 0; i < ARRAY_SIZE(command_lists); i++) {
+
+        const shell_command_t *entry;
+
         if ((entry = command_lists[i])) {
             /* iterating over commands in command_lists entry */
             while (entry->name != NULL) {
@@ -92,10 +93,11 @@ static void print_help(const shell_command_t *command_list)
 #endif
     };
 
-    const shell_command_t *entry;
-
     /* iterating over command_lists */
     for (unsigned int i = 0; i < ARRAY_SIZE(command_lists); i++) {
+
+        const shell_command_t *entry;
+
         if ((entry = command_lists[i])) {
             /* iterating over commands in command_lists entry */
             while (entry->name != NULL) {

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -63,7 +63,7 @@ static shell_command_handler_t find_handler(const shell_command_t *command_list,
     const shell_command_t *entry;
 
     /* iterating over command_lists */
-    for (unsigned int i = 0; i < sizeof(command_lists) / sizeof(entry); i++) {
+    for (unsigned int i = 0; i < ARRAY_SIZE(command_lists); i++) {
         if ((entry = command_lists[i])) {
             /* iterating over commands in command_lists entry */
             while (entry->name != NULL) {
@@ -95,7 +95,7 @@ static void print_help(const shell_command_t *command_list)
     const shell_command_t *entry;
 
     /* iterating over command_lists */
-    for (unsigned int i = 0; i < sizeof(command_lists) / sizeof(entry); i++) {
+    for (unsigned int i = 0; i < ARRAY_SIZE(command_lists); i++) {
         if ((entry = command_lists[i])) {
             /* iterating over commands in command_lists entry */
             while (entry->name != NULL) {

--- a/tests/bench_timers/main.c
+++ b/tests/bench_timers/main.c
@@ -617,10 +617,10 @@ static void estimate_cpu_overhead(void)
 int main(void)
 {
     print_str("\nStatistical benchmark for timers\n");
-    for (unsigned int k = 0; k < (sizeof(ref_states) / sizeof(ref_states[0])); ++k) {
+    for (unsigned int k = 0; k < ARRAY_SIZE(ref_states); ++k) {
         matstat_clear(&ref_states[k]);
     }
-    for (unsigned int k = 0; k < (sizeof(int_states) / sizeof(int_states[0])); ++k) {
+    for (unsigned int k = 0; k < ARRAY_SIZE(int_states); ++k) {
         matstat_clear(&int_states[k]);
     }
     /* print test overview */
@@ -661,7 +661,7 @@ int main(void)
     print_u32_dec(log2test);
     print("\n", 1);
     print_str("state vector elements per variant = ");
-    print_u32_dec(sizeof(ref_states) / sizeof(ref_states[0]) / TEST_VARIANT_NUMOF);
+    print_u32_dec(ARRAY_SIZE(ref_states) / TEST_VARIANT_NUMOF);
     print("\n", 1);
     print_str("number of variants = ");
     print_u32_dec(TEST_VARIANT_NUMOF);

--- a/tests/can_trx/main.c
+++ b/tests/can_trx/main.c
@@ -47,7 +47,7 @@ static int help(int argc, char **argv)
     puts("Help:");
     puts("\tinit [trx_id] - initialize a trx");
     puts("\tset_mode [trx_id] [mode] - set a mode on the trx");
-    printf("trx_id: 0..%u\n", (unsigned)(sizeof(devs) / sizeof(devs[0])));
+    printf("trx_id: 0..%u\n", (unsigned)ARRAY_SIZE(devs));
     puts("modes:");
     puts("\t0: normal mode");
     puts("\t1: silent mode");
@@ -67,7 +67,7 @@ static int init(int argc, char **argv) {
     }
 
     unsigned trx = atoi(argv[1]);
-    if (trx < (sizeof(devs) / sizeof(devs[0]))) {
+    if (trx < ARRAY_SIZE(devs)) {
         int res = can_trx_init(devs[trx]);
         if (res >= 0) {
             puts("Trx successfully initialized");
@@ -93,7 +93,7 @@ static int set_mode(int argc, char **argv) {
     }
     unsigned trx = atoi(argv[1]);
     unsigned mode = atoi(argv[2]);
-    if ((trx < (sizeof(devs) / sizeof(devs[0]))) &&
+    if ((trx < ARRAY_SIZE(devs)) &&
             (mode <= TRX_HIGH_VOLTAGE_WAKE_UP_MODE)) {
         int res = can_trx_set_mode(devs[trx], mode);
         if (res >= 0) {

--- a/tests/driver_at86rf2xx/common.h
+++ b/tests/driver_at86rf2xx/common.h
@@ -23,6 +23,7 @@
 #include "at86rf2xx.h"
 #include "at86rf2xx_params.h"
 #include "net/netdev.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,7 +34,7 @@ extern "C" {
  * @internal
  * @{
  */
-#define AT86RF2XX_NUM   (sizeof(at86rf2xx_params) / sizeof(at86rf2xx_params[0]))
+#define AT86RF2XX_NUM   ARRAY_SIZE(at86rf2xx_params)
 
 extern at86rf2xx_t devs[AT86RF2XX_NUM];
 

--- a/tests/driver_ds3234/main.c
+++ b/tests/driver_ds3234/main.c
@@ -23,12 +23,13 @@
 #include "board.h"
 #include "ds3234.h"
 #include "ds3234_params.h"
+#include "kernel_defines.h"
 
 int main(void)
 {
     puts("DS3234 RTC PPS test application\n");
 
-    for (unsigned k = 0; k < (sizeof(ds3234_params) / sizeof(ds3234_params[0])); ++k) {
+    for (unsigned k = 0; k < ARRAY_SIZE(ds3234_params); ++k) {
         printf("Init #%u... ", k);
         int res = ds3234_pps_init(&ds3234_params[k]);
         if (res == 0) {

--- a/tests/driver_dynamixel/main.c
+++ b/tests/driver_dynamixel/main.c
@@ -16,8 +16,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#define ARRAY_LEN(array) (sizeof(array)/sizeof(array[0]))
-
 typedef struct {
     const char *name;
     int addr;
@@ -112,7 +110,7 @@ static int32_t parse_baud(char *arg)
 {
     int32_t baud = atoi(arg);
 
-    for (size_t i = 0 ; i < ARRAY_LEN(baudrates) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(baudrates); i++) {
         if (baud == baudrates[i]) {
             return baud;
         }
@@ -137,14 +135,14 @@ static void parse_reg(char *arg, int *reg8, int *reg16)
     *reg8 = -1;
     *reg16 = -1;
 
-    for (size_t i = 0 ; i < ARRAY_LEN(regs8) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(regs8); i++) {
         if (strcmp(arg, regs8[i].name) == 0) {
             *reg8 = regs8[i].addr;
             return;
         }
     }
 
-    for (size_t i = 0 ; i < ARRAY_LEN(regs16) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(regs16); i++) {
         if (strcmp(arg, regs16[i].name) == 0) {
             *reg16 = regs16[i].addr;
             return;
@@ -157,12 +155,12 @@ static void parse_reg(char *arg, int *reg8, int *reg16)
 void print_registers(void)
 {
     puts("available 8bits registers :");
-    for (size_t i = 0 ; i < ARRAY_LEN(regs8) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(regs8); i++) {
         printf("\t%s\n", regs8[i].name);
     }
 
     puts("available 16bits registers :");
-    for (size_t i = 0 ; i < ARRAY_LEN(regs16) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(regs16); i++) {
         printf("\t%s\n", regs16[i].name);
     }
 }
@@ -176,7 +174,7 @@ static int cmd_init(int argc, char **argv)
     if (argc != 3 && argc != 4) {
         printf("usage; %s <uart> <baudrate> [<timeout_us>]\n", argv[0]);
         puts("available baudrates :");
-        for (size_t i = 0 ; i < ARRAY_LEN(baudrates) ; i++) {
+        for (size_t i = 0 ; i < ARRAY_SIZE(baudrates); i++) {
             printf("\t%ld\n", (long int)baudrates[i]);
         }
         return 1;
@@ -207,7 +205,8 @@ static int cmd_init(int argc, char **argv)
         .dir = { dir_init, dir_enable_tx, dir_disable_tx },
     };
 
-    int ret = uart_half_duplex_init(&stream, dynamixel_buffer, ARRAY_LEN(dynamixel_buffer), &params);
+    int ret = uart_half_duplex_init(&stream, dynamixel_buffer,
+                                    ARRAY_SIZE(dynamixel_buffer), &params);
 
     if (argc == 4) {
         stream.timeout_us = timeout;

--- a/tests/driver_feetech/main.c
+++ b/tests/driver_feetech/main.c
@@ -14,8 +14,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#define ARRAY_LEN(array) (sizeof(array)/sizeof(array[0]))
-
 typedef struct {
     const char *name;
     int addr;
@@ -97,7 +95,7 @@ static int32_t parse_baud(char *arg)
 {
     int32_t baud = atoi(arg);
 
-    for (size_t i = 0 ; i < ARRAY_LEN(baudrates) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(baudrates); i++) {
         if (baud == baudrates[i]) {
             return baud;
         }
@@ -122,14 +120,14 @@ static void parse_reg(char *arg, int *reg8, int *reg16)
     *reg8 = -1;
     *reg16 = -1;
 
-    for (size_t i = 0 ; i < ARRAY_LEN(regs8) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(regs8); i++) {
         if (strcmp(arg, regs8[i].name) == 0) {
             *reg8 = regs8[i].addr;
             return;
         }
     }
 
-    for (size_t i = 0 ; i < ARRAY_LEN(regs16) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(regs16); i++) {
         if (strcmp(arg, regs16[i].name) == 0) {
             *reg16 = regs16[i].addr;
             return;
@@ -141,12 +139,12 @@ static void parse_reg(char *arg, int *reg8, int *reg16)
 
 void print_registers(void) {
     puts("available 8bits registers :");
-    for (size_t i = 0 ; i < ARRAY_LEN(regs8) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(regs8); i++) {
         printf("\t%s\n", regs8[i].name);
     }
 
     puts("available 16bits registers :");
-    for (size_t i = 0 ; i < ARRAY_LEN(regs16) ; i++) {
+    for (size_t i = 0 ; i < ARRAY_SIZE(regs16); i++) {
         printf("\t%s\n", regs16[i].name);
     }
 }
@@ -159,7 +157,7 @@ static int cmd_init(int argc, char **argv) {
     if (argc != 3 && argc != 4) {
         printf("usage; %s <uart> <baudrate> [<timeout_us>]\n", argv[0]);
         puts("available baudrates :");
-        for (size_t i = 0 ; i < ARRAY_LEN(baudrates) ; i++) {
+        for (size_t i = 0 ; i < ARRAY_SIZE(baudrates); i++) {
             printf("\t%ld\n", (long int)baudrates[i]);
         }
         return 1;
@@ -190,7 +188,7 @@ static int cmd_init(int argc, char **argv) {
         .dir = UART_HALF_DUPLEX_DIR_NONE,
     };
 
-    int ret = uart_half_duplex_init(&stream, feetech_buffer, ARRAY_LEN(feetech_buffer), &params);
+    int ret = uart_half_duplex_init(&stream, feetech_buffer, ARRAY_SIZE(feetech_buffer), &params);
 
     if (argc == 4) {
         stream.timeout_us = timeout;

--- a/tests/driver_isl29125/main.c
+++ b/tests/driver_isl29125/main.c
@@ -76,7 +76,7 @@ int main(void)
         "ISL29125_MODE_R", "ISL29125_MODE_G", "ISL29125_MODE_B",
         "ISL29125_MODE_RG", "ISL29125_MODE_GB"};
 
-    for (size_t i = 0; i < sizeof(modes) / sizeof(modes[0]); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(modes); i++) {
         printf("Setting mode %s\n", mode_names[i]);
         isl29125_set_mode(&dev, modes[i]);
         xtimer_usleep(SLEEP);

--- a/tests/driver_sdcard_spi/main.c
+++ b/tests/driver_sdcard_spi/main.c
@@ -36,7 +36,7 @@
 
 /* this is provided by the sdcard_spi driver
  * see sys/auto_init/storage/auto_init_sdcard_spi.c */
-extern sdcard_spi_t sdcard_spi_devs[sizeof(sdcard_spi_params) / sizeof(sdcard_spi_params[0])];
+extern sdcard_spi_t sdcard_spi_devs[ARRAY_SIZE(sdcard_spi_params)];
 sdcard_spi_t *card = &sdcard_spi_devs[0];
 
 uint8_t buffer[SD_HC_BLOCK_SIZE * MAX_BLOCKS_IN_BUFFER];

--- a/tests/driver_sht1x/main.c
+++ b/tests/driver_sht1x/main.c
@@ -25,7 +25,7 @@
 #include "shell_commands.h"
 #include "sht1x_params.h"
 
-#define SHT1X_NUM     (sizeof(sht1x_params) / sizeof(sht1x_params[0]))
+#define SHT1X_NUM     ARRAY_SIZE(sht1x_params)
 extern sht1x_dev_t sht1x_devs[SHT1X_NUM];
 static sht1x_dev_t *dev = &sht1x_devs[0];
 

--- a/tests/evtimer_underflow/main.c
+++ b/tests/evtimer_underflow/main.c
@@ -40,7 +40,7 @@ static evtimer_msg_event_t events[] = {
     { .event = { .offset = 0 }, .msg = { .content = { .ptr = "8" } } },
 };
 
-#define NEVENTS (sizeof(events) / sizeof(evtimer_msg_event_t))
+#define NEVENTS ARRAY_SIZE(events)
 
 /* This thread will print the drift to stdout once per second */
 void *worker_thread(void *arg)

--- a/tests/libfixmath/main.c
+++ b/tests/libfixmath/main.c
@@ -65,7 +65,7 @@ static void binary_ops(void)
             }
 
 
-            for (unsigned o = 0; o < sizeof(ops) / sizeof(*ops); ++o) {
+            for (unsigned o = 0; o < ARRAY_SIZE(ops); ++o) {
                 fix16_t c = ops[o].fun(a, b);
 
                 char buf[3][14];
@@ -96,7 +96,7 @@ static void unary_ops(void)
         };
 
         for (fix16_t input = fix16_from_dbl(-10.0); input < fix16_from_dbl(+10.0); input += fix16_from_dbl(0.25)) {
-            for (unsigned o = 0; o < sizeof(ops) / sizeof(*ops); ++o) {
+            for (unsigned o = 0; o < ARRAY_SIZE(ops); ++o) {
                 fix16_t result = ops[o].fun(input);
 
                 char buf[2][14];
@@ -121,7 +121,7 @@ static void unary_ops(void)
         };
 
         for (fix16_t input = fix16_from_dbl(-M_PI/2); input < fix16_from_dbl(+M_PI/2); input += fix16_from_dbl(0.05)) {
-            for (unsigned o = 0; o < sizeof(ops) / sizeof(*ops); ++o) {
+            for (unsigned o = 0; o < ARRAY_SIZE(ops); ++o) {
                 fix16_t result = ops[o].fun(input);
 
                 char buf[2][14];
@@ -144,7 +144,7 @@ static void unary_ops(void)
         };
 
         for (fix16_t input = fix16_from_dbl(-1.0); input < fix16_from_dbl(+1.0); input += fix16_from_dbl(0.05)) {
-            for (unsigned o = 0; o < sizeof(ops) / sizeof(*ops); ++o) {
+            for (unsigned o = 0; o < ARRAY_SIZE(ops); ++o) {
                 fix16_t result = ops[o].fun(input);
 
                 char buf[2][14];
@@ -170,7 +170,7 @@ static void unary_ops(void)
         };
 
         for (fix16_t input = fix16_from_dbl(0.05); input < fix16_from_dbl(+10.0); input += fix16_from_dbl(0.25)) {
-            for (unsigned o = 0; o < sizeof(ops) / sizeof(*ops); ++o) {
+            for (unsigned o = 0; o < ARRAY_SIZE(ops); ++o) {
                 fix16_t result = ops[o].fun(input);
 
                 char buf[2][14];

--- a/tests/lua_loader/main.c
+++ b/tests/lua_loader/main.c
@@ -64,9 +64,9 @@ const struct lua_riot_builtin_lua *const lua_riot_builtin_lua_table = _lua_riot_
 const struct lua_riot_builtin_c *const lua_riot_builtin_c_table = _lua_riot_builtin_c_table;
 
 const size_t lua_riot_builtin_lua_table_len =
-    sizeof(_lua_riot_builtin_lua_table) / sizeof(*_lua_riot_builtin_lua_table);
+    ARRAY_SIZE(_lua_riot_builtin_lua_table);
 const size_t lua_riot_builtin_c_table_len =
-    sizeof(_lua_riot_builtin_c_table) / sizeof(*_lua_riot_builtin_c_table);
+    ARRAY_SIZE(_lua_riot_builtin_c_table);
 
 #define LUA_MEM_SIZE (11000)
 static char lua_mem[LUA_MEM_SIZE] __attribute__ ((aligned(__BIGGEST_ALIGNMENT__)));

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -92,7 +92,7 @@ int nanotest_client_cmd(int argc, char **argv)
     }
 
     int code_pos = -1;
-    for (size_t i = 0; i < sizeof(method_codes) / sizeof(char*); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(method_codes); i++) {
         if (strcmp(argv[1], method_codes[i]) == 0) {
             code_pos = i;
         }

--- a/tests/nanocoap_cli/request_handlers.c
+++ b/tests/nanocoap_cli/request_handlers.c
@@ -77,4 +77,4 @@ const coap_resource_t coap_resources[] = {
     { "/value", COAP_GET | COAP_PUT | COAP_POST, _value_handler, NULL },
 };
 
-const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);
+const unsigned coap_resources_numof = ARRAY_SIZE(coap_resources);

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -56,10 +56,10 @@ static char printer_stack[THREAD_STACKSIZE_MAIN];
 #ifdef MODULE_PERIPH_UART_MODECFG
 static uart_data_bits_t data_bits_lut[] = { UART_DATA_BITS_5, UART_DATA_BITS_6,
                                             UART_DATA_BITS_7, UART_DATA_BITS_8 };
-static int data_bits_lut_len = sizeof(data_bits_lut)/sizeof(data_bits_lut[0]);
+static int data_bits_lut_len = ARRAY_SIZE(data_bits_lut);
 
 static uart_stop_bits_t stop_bits_lut[] = { UART_STOP_BITS_1, UART_STOP_BITS_2 };
-static int stop_bits_lut_len = sizeof(stop_bits_lut)/sizeof(stop_bits_lut[0]);
+static int stop_bits_lut_len = ARRAY_SIZE(stop_bits_lut);
 #endif
 
 static int parse_dev(char *arg)

--- a/tests/pkg_cn-cbor/main.c
+++ b/tests/pkg_cn-cbor/main.c
@@ -134,7 +134,7 @@ static void test_parse(void)
         "bf61610161629f0203ffff",   // {_ "a": 1, "b": [_ 2, 3]}
     };
 
-    for (test = 0; test < sizeof(tests) / sizeof(char*); test++) {
+    for (test = 0; test < ARRAY_SIZE(tests); test++) {
         unsigned char buf[64] = {0};
         TEST_ASSERT((strlen(tests[test])/2) <= sizeof(buf));
 
@@ -172,7 +172,7 @@ static void test_errors(void)
     TEST_ASSERT_EQUAL_INT(-1, cn_cbor_encoder_write(ebuf, 0, sizeof(ebuf),
             &inv));
 
-    for (offs = 0; offs < sizeof(tests) / sizeof(cbor_failure); offs++) {
+    for (offs = 0; offs < ARRAY_SIZE(tests); offs++) {
         unsigned char buf[32] = {0};
         TEST_ASSERT((strlen(tests[offs].hex)/2) <= sizeof(buf));
 

--- a/tests/pkg_fatfs/main.c
+++ b/tests/pkg_fatfs/main.c
@@ -57,14 +57,14 @@ mtd_dev_t *fatfs_mtd_devs[1];
 #elif MODULE_MTD_SDCARD
 #include "mtd_sdcard.h"
 #include "sdcard_spi_params.h"
-#define SDCARD_SPI_NUM (sizeof(sdcard_spi_params) / sizeof(sdcard_spi_params[0]))
+#define SDCARD_SPI_NUM ARRAY_SIZE(sdcard_spi_params)
 /* sdcard devs are provided by sys/auto_init/storage/auto_init_sdcard_spi.c */
 extern sdcard_spi_t sdcard_spi_devs[SDCARD_SPI_NUM];
 mtd_sdcard_t mtd_sdcard_devs[SDCARD_SPI_NUM];
 mtd_dev_t *fatfs_mtd_devs[SDCARD_SPI_NUM];
 #endif
 
-#define MTD_NUM (sizeof(fatfs_mtd_devs) / sizeof(fatfs_mtd_devs[0]))
+#define MTD_NUM ARRAY_SIZE(fatfs_mtd_devs)
 
 static int _mount(int argc, char **argv)
 {

--- a/tests/pkg_fatfs_vfs/main.c
+++ b/tests/pkg_fatfs_vfs/main.c
@@ -26,6 +26,8 @@
 #include "vfs.h"
 #include "mtd.h"
 
+#include "kernel_defines.h"
+
 #ifdef MODULE_MTD_SDCARD
 #include "mtd_sdcard.h"
 #include "sdcard_spi.h"
@@ -68,7 +70,7 @@ mtd_dev_t *fatfs_mtd_devs[FF_VOLUMES];
 /* mtd device for native is provided in boards/native/board_init.c */
 extern mtd_dev_t *mtd0;
 #elif MODULE_MTD_SDCARD
-#define SDCARD_SPI_NUM (sizeof(sdcard_spi_params) / sizeof(sdcard_spi_params[0]))
+#define SDCARD_SPI_NUM ARRAY_SIZE(sdcard_spi_params)
 extern sdcard_spi_t sdcard_spi_devs[SDCARD_SPI_NUM];
 mtd_sdcard_t mtd_sdcard_devs[SDCARD_SPI_NUM];
 /* always default to first sdcard*/

--- a/tests/pkg_jsmn/simple.c
+++ b/tests/pkg_jsmn/simple.c
@@ -31,6 +31,10 @@
 
 #include "jsmn.h"
 
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(*a))
+#endif
+
 /*
  * A small example of jsmn parsing when JSON structure is known and number of
  * tokens is predictable.
@@ -57,7 +61,7 @@ int main(void)
     jsmntok_t t[16]; /* We expect no more than 16 tokens */
 
     jsmn_init(&p);
-    r = jsmn_parse(&p, JSON_STRING, strlen(JSON_STRING), t, sizeof(t) / sizeof(t[0]));
+    r = jsmn_parse(&p, JSON_STRING, strlen(JSON_STRING), t, ARRAY_SIZE(t));
     if (r < 0) {
         printf("Failed to parse JSON: %d\n", r);
         return 1;

--- a/tests/pkg_tinycbor/main.c
+++ b/tests/pkg_tinycbor/main.c
@@ -71,7 +71,7 @@ const char *tests[] = {
 static void test_parse(void)
 {
     static size_t idx;
-    for (idx = 0; idx < sizeof(tests) / sizeof(char*); idx++) {
+    for (idx = 0; idx < ARRAY_SIZE(tests); idx++) {
         CborParser parser;
         CborValue it;
         unsigned char buf[64] = {0};

--- a/tests/riotboot_flashwrite/coap_handler.c
+++ b/tests/riotboot_flashwrite/coap_handler.c
@@ -78,4 +78,4 @@ const coap_resource_t coap_resources[] = {
     { "/flashwrite", COAP_POST, _flashwrite_handler, &_writer },
 };
 
-const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);
+const unsigned coap_resources_numof = ARRAY_SIZE(coap_resources);

--- a/tests/unittests/tests-analog_util/tests-analog_util.c
+++ b/tests/unittests/tests-analog_util/tests-analog_util.c
@@ -44,7 +44,7 @@ static test_values_t test_data[] = {
     {  3972L,  9876,      10000L,          0L, ADC_RES_14BIT},
 };
 
-#define TEST_DATA_NUMOF (sizeof(test_data) / sizeof(test_data[0]))
+#define TEST_DATA_NUMOF ARRAY_SIZE(test_data)
 
 static void test_adc_util_map(void)
 {

--- a/tests/unittests/tests-core/tests-core-priority-queue.c
+++ b/tests/unittests/tests-core/tests-core-priority-queue.c
@@ -21,7 +21,7 @@ static priority_queue_node_t qe[Q_LEN];
 static void set_up(void)
 {
     priority_queue_init(&q);
-    for (unsigned i = 0; i < sizeof(qe)/sizeof(priority_queue_node_t); ++i) {
+    for (unsigned i = 0; i < ARRAY_SIZE(qe); ++i) {
         priority_queue_node_init(&(qe[i]));
     }
 }

--- a/tests/unittests/tests-div/tests-div.c
+++ b/tests/unittests/tests-div/tests-div.c
@@ -65,8 +65,8 @@ static const uint64_t u64_15625_512_expected_values[] = {
     302231454903657293,
 };
 
-#define N_U32_VALS (sizeof(u32_test_values)/sizeof(u32_test_values[0]))
-#define N_U64_VALS (sizeof(u64_test_values)/sizeof(u64_test_values[0]))
+#define N_U32_VALS ARRAY_SIZE(u32_test_values)
+#define N_U64_VALS ARRAY_SIZE(u64_test_values)
 
 static void test_div_u64_by_15625(void)
 {

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -37,14 +37,14 @@ static const coap_resource_t resources_second[] = {
 
 static gcoap_listener_t listener = {
     .resources     = &resources[0],
-    .resources_len = (sizeof(resources) / sizeof(resources[0])),
+    .resources_len = ARRAY_SIZE(resources),
     .link_encoder  = NULL,
     .next          = NULL
 };
 
 static gcoap_listener_t listener_second = {
     .resources     = &resources_second[0],
-    .resources_len = (sizeof(resources_second) / sizeof(resources_second[0])),
+    .resources_len = ARRAY_SIZE(resources_second),
     .link_encoder  = NULL,
     .next          = NULL
 };

--- a/tests/unittests/tests-matstat/tests-matstat.c
+++ b/tests/unittests/tests-matstat/tests-matstat.c
@@ -212,7 +212,7 @@ static void test_matstat_merge_variance_regr1(void)
         { .count = 2414, .sum = 4859, .sum_sq = 1074, .min = 1, .max = 3, .mean = 2 },
     };
     matstat_state_t merged = MATSTAT_STATE_INIT;
-    for (unsigned k = 0; k < sizeof(inputs) / sizeof(inputs[0]); ++k) {
+    for (unsigned k = 0; k < ARRAY_SIZE(inputs); ++k) {
         matstat_merge(&merged, &inputs[k]);
     }
     int64_t var = (int64_t)matstat_variance(&merged);

--- a/tests/unittests/tests-phydat/tests-phydat.c
+++ b/tests/unittests/tests-phydat/tests-phydat.c
@@ -99,7 +99,7 @@ static void test_phydat_fit(void)
         { .val = { -32766, -32766, -32766 }, .unit = UNIT_NONE, .scale =  0 },
     };
 
-    for (unsigned int i = 0; i < sizeof(dims) / sizeof(dims[0]); i++) {
+    for (unsigned int i = 0; i < ARRAY_SIZE(dims); i++) {
         phydat_t dat = {
             .val = { -1, -1, -1 },
             .scale = scales[i],

--- a/tests/unittests/tests-sht1x/tests-sht1x.c
+++ b/tests/unittests/tests-sht1x/tests-sht1x.c
@@ -62,11 +62,11 @@ static void test_sht1x_conversion(void)
     const uint16_t max_raw_hums[] = { 0xff, 0xfff };
     sht1x_dev_t dev = { .conf = 0 };
 
-    for (size_t i_res = 0; i_res < sizeof(confs) / sizeof(confs[0]); i_res++) {
+    for (size_t i_res = 0; i_res < ARRAY_SIZE(confs); i_res++) {
         dev.conf = confs[i_res];
         uint16_t max_raw_temp = max_raw_temps[i_res];
         uint16_t max_raw_hum = max_raw_hums[i_res];
-        for (size_t i_vdd = 0; i_vdd < sizeof(vdds) / sizeof(vdds[0]); i_vdd++) {
+        for (size_t i_vdd = 0; i_vdd < ARRAY_SIZE(vdds); i_vdd++) {
             dev.vdd = vdds[i_vdd];
             for (uint16_t raw_temp = 0; raw_temp <= max_raw_temp; raw_temp++) {
                 int16_t got_temp = sht1x_temperature(&dev, raw_temp);

--- a/tests/unittests/tests-vfs/tests-vfs-mount-constfs.c
+++ b/tests/unittests/tests-vfs/tests-vfs-mount-constfs.c
@@ -52,7 +52,7 @@ static const constfs_file_t _files[] = {
 
 static const constfs_t fs_data = {
     .files = _files,
-    .nfiles = sizeof(_files) / sizeof(_files[0]),
+    .nfiles = ARRAY_SIZE(_files),
 };
 
 static vfs_mount_t _test_vfs_mount_invalid_mount = {

--- a/tests/xtimer_usleep/main.c
+++ b/tests/xtimer_usleep/main.c
@@ -29,7 +29,7 @@
 #include "timex.h"
 
 #define RUNS                (5U)
-#define SLEEP_TIMES_NUMOF   (sizeof(sleep_times) / sizeof(sleep_times[0]))
+#define SLEEP_TIMES_NUMOF   ARRAY_SIZE(sleep_times)
 
 static const uint32_t sleep_times[] = { 10000, 50000, 10234, 56780, 12122, 98765, 75000 };
 
@@ -66,7 +66,7 @@ int main(void)
     start_test = xtimer_now_usec();
     for (unsigned m = 0; m < RUNS; m++) {
         for (unsigned n = 0;
-             n < sizeof(sleep_times) / sizeof(sleep_times[0]);
+             n < ARRAY_SIZE(sleep_times);
              n++) {
 
             uint32_t start_sleep, diff;


### PR DESCRIPTION
### Contribution description
All throughout RIOT the construct `sizeof(a) / sizeof(a[0])` is used to determine the number of elements in an array `a`.

For the sake of DRY and readability, this introduces an `ARRAYSIZE` macro that does just that, without having to spell out the formula each time.

### Testing procedure
Conversion was done with `sed -ri 's/sizeof\((.*)\)\ \/ sizeof\(\1\[0\]\)/ARRAYSIZE\(\1\)/g'`

No functional change is expected.
