### PR TITLE
release/11-lorawan: add tests to target applications

### DIFF
--- a/examples/lorawan/README.md
+++ b/examples/lorawan/README.md
@@ -36,3 +36,22 @@ Finally, to join a LoRaWAN network using OTAA activation, edit the application
     DEVEUI ?= 0000000000000000
     APPEUI ?= 0000000000000000
     APPKEY ?= 00000000000000000000000000000000
+
+## Automatic test
+
+The automatic test replicates 11-lorawan release specs test:
+
+- [11-lorawan](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md)
+  - [Task #01 - LoRaWAN example](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md#task-01---lorawan-example)
+
+
+### Assumptions
+
+- The tests assumes that there is a gateway in all DR distance to the device and the
+device was flashed with the correct keys.
+
+### Usage
+
+On a board with a lora radio device run:
+
+    $ make BOARD=b-l072z-lrwan1 -C examples/lorawan test

--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -70,7 +70,7 @@ static void _send_message(void)
     /* Try to send the message */
     uint8_t ret = semtech_loramac_send(&loramac,
                                        (uint8_t *)message, strlen(message));
-    if (ret != SEMTECH_LORAMAC_TX_OK) {
+    if ((ret != SEMTECH_LORAMAC_TX_OK) && (ret != SEMTECH_LORAMAC_TX_DONE))  {
         printf("Cannot send message '%s', ret code: %d\n", message, ret);
         return;
     }

--- a/examples/lorawan/tests/01-run.py
+++ b/examples/lorawan/tests/01-run.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import time
+
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("LoRaWAN Class A low-power application")
+    child.expect_exact("Starting join procedure")
+    child.expect_exact("Join procedure succeeded")
+
+    for _ in range(0, 5):
+        child.expect_exact("Sending: This is RIOT!")
+        time.sleep(20)
+
+    print("TESST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -206,3 +206,33 @@ The node will also print the data received:
 
     > loramac tx test
     Data received: This is RIOT!
+
+## Automatic test
+
+The automatic test replicates 11-lorawan release specs tests:
+
+- [11-lorawan](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md)
+  - [Task #02 - OTAA join procedure](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md#task-02---otaa-join-procedure)
+  - [Task #03 - ABP join procedure](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md#task-03---abp-join-procedure)
+  - [Task #04 - LoRaWAN device parameters persistence](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md#task-03---lorawan-device-parameters-persistence)
+
+
+### Assumptions
+
+- The tests assumes that there is a gateway in all DR distance to the device and
+that the correct keys are provided. DEVEUI and APPEUI must be the same for OTAA
+and ABP.
+
+- The DR duty cycling time-offs values are for EU863-870
+
+- The frame counters must be reset on the LoRaWAN backend at the beginning of the
+test since the eeprom is erased at the beginning of the test.
+
+- Requires eeprom support or ABP test will fail because it wont have the right frame
+counter saved.
+
+### Usage
+
+On a board with a lora radio device run:
+
+    $ DEVEUI=<...> APPEUI=<...> APPKEY=<...> DEVADDR=<...> NWKSKEY=<...> APPSKEY=<...> RX2_DR= <...> make BOARD=b-l072z-lrwan1 -C tests/pkg_semtech-loramac test

--- a/tests/pkg_semtech-loramac/tests/01-run.py
+++ b/tests/pkg_semtech-loramac/tests/01-run.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+import time
+
+from testrunner import run
+
+
+# It's assumed that the same DEVEUI & APPEUI is used for abp and otaa
+DEVEUI = os.getenv('DEVEUI', '00EA17067F596D18')
+APPEUI = os.getenv('APPEUI', '70B3D57ED000B02F')
+APPKEY = os.getenv('APPKEY', 'C91870835C73F5E36EDF6E5DBD1445D0')
+DEVADDR = os.getenv('DEVADDR', '26011C28')
+NWKSKEY = os.getenv('NWKSKEY', 'C89D06AB37D58373FA50B69B7D288B1C')
+APPSKEY = os.getenv('APPSKEY', 'E38E70FD74D768BE36EA753D96D5030C')
+
+# Default to things network RX2_DR
+TEST_RX2_DR = os.getenv('RX2_DR', 3)
+
+# Theoretical duty cycling timeoff for EU863-870
+# https://www.semtech.com/uploads/documents/LoraDesignGuide_STD.pdf#page=7
+TEST_DATA_RATES = {"0": 164.6, "3": 20.6, "5": 6.2}
+
+# Dummy Message
+MSG = "This is RIOT"
+
+
+def _send_line_echo(child, line):
+    child.sendline(line)
+    child.expect_exact(line)
+    child.expect_exact(">")
+
+
+def _send_line(child, line, expect_line):
+    child.sendline(line)
+    child.expect_exact(expect_line)
+    child.expect_exact(">")
+
+
+def _reset_config(child):
+    # Start with a clean config
+    child.sendline("loramac erase")
+    child.expect("loramac erase")
+    child.expect_exact(">")
+    child.sendline("reboot")
+    child.expect_exact("reboot")
+    child.expect_exact("All up, running the shell now")
+    child.expect_exact(">")
+
+
+def _reboot(child):
+    child.sendline("reboot")
+    child.expect_exact("All up, running the shell now")
+    child.expect_exact(">")
+
+
+def _loramac_setup(child, join):
+    if join == "abp":
+        _send_line_echo(child, "loramac set deveui {}".format(DEVEUI))
+        _send_line_echo(child, "loramac set appeui {}".format(APPEUI))
+        _send_line_echo(child, "loramac set devaddr {}".format(DEVADDR))
+        _send_line_echo(child, "loramac set nwkskey {}".format(NWKSKEY))
+        _send_line_echo(child, "loramac set appskey {}".format(APPSKEY))
+        _send_line_echo(child, "loramac set rx2_dr {}".format(TEST_RX2_DR))
+    else:
+        _send_line_echo(child, "loramac set deveui {}".format(DEVEUI))
+        _send_line_echo(child, "loramac set appeui {}".format(APPEUI))
+        _send_line_echo(child, "loramac set appkey {}".format(APPKEY))
+
+
+def loramac_tx_test(child, join):
+
+    _reset_config(child)
+
+    # test all data rates
+    for key, time_off in TEST_DATA_RATES.items():
+        # Setup keys and rx2_dr
+        _loramac_setup(child, join)
+        # Set DR and join
+        _send_line_echo(child, "loramac set dr {}".format(key))
+        child.sendline("loramac join {}".format(join))
+        child.expect_exact(["Join procedure succeeded!",
+                            "Warning: already joined!"])
+        child.expect_exact(">")
+        # Transmit cnf message
+        child.sendline("loramac tx \"{}\" cnf 123".format(MSG))
+        child.expect_exact("Received ACK from network", timeout=30)
+        child.expect_exact("Message sent with success")
+        child.expect_exact(">")
+        # Wake-up just before time_off, fail to send
+        time.sleep(time_off)
+        # Send uncnf message with success
+        child.sendline("loramac tx \"{}\" uncnf 42".format(MSG))
+        child.expect_exact("Message sent with success")
+        child.expect_exact(">")
+        # ave config
+        _send_line_echo(child, "loramac save")
+        _reboot(child)
+
+
+def test_task02(child):
+    loramac_tx_test(child, "otaa")
+
+
+def test_task03(child):
+    loramac_tx_test(child, "abp")
+
+
+def test_task04(child):
+    # Erase eeprom
+    _reset_config(child)
+
+    # Verify start from erased state
+    _send_line(child, "loramac get deveui", "DEVEUI: 0000000000000000")
+    _send_line(child, "loramac get appeui", "APPEUI: 0000000000000000")
+    _send_line(child, "loramac get appkey",
+               "APPKEY: 00000000000000000000000000000000")
+    _send_line(child, "loramac get devaddr", "DEVADDR: 00000000")
+    _send_line(child, "loramac get nwkskey",
+               "NWKSKEY: 00000000000000000000000000000000")
+    _send_line(child, "loramac get appskey",
+               "APPSKEY: 00000000000000000000000000000000")
+
+    # Save and verify otaa keys
+    _loramac_setup(child, "otaa")
+    _send_line_echo(child, "loramac save")
+    child.sendline("reboot")
+    child.expect_exact("All up, running the shell now")
+    child.expect_exact(">")
+    _send_line(child, "loramac get deveui", "DEVEUI: {}".format(DEVEUI))
+    _send_line(child, "loramac get appeui", "APPEUI: {}".format(APPEUI))
+    _send_line(child, "loramac get appkey", "APPKEY: {}".format(APPKEY))
+    _reset_config(child)
+
+    # Save and verify abp keys
+    _loramac_setup(child, "abp")
+    _send_line_echo(child, "loramac save")
+    child.sendline("reboot")
+    child.expect_exact("All up, running the shell now")
+    child.expect_exact(">")
+    _send_line(child, "loramac get devaddr", "DEVADDR: {}".format(DEVADDR))
+    _send_line(child, "loramac get nwkskey", "NWKSKEY: {}".format(NWKSKEY))
+    _send_line(child, "loramac get appskey", "APPSKEY: {}".format(APPSKEY))
+
+
+def testfunc(child):
+
+    def run(func):
+        if child.logfile == sys.stdout:
+            func(child)
+        else:
+            try:
+                func(child)
+                print(".", end="", flush=True)
+            except Exception as e:
+                print("FAILED")
+                raise e
+
+    run(test_task02)
+    run(test_task03)
+    run(test_task04)
+
+    print("TEST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds two tests replicating Task01-04 for release testing lorawan. In both cases valid
keys and identifiers must be provided for a device registers in DR 0-5 distance of a LoRa gateway.

The tests also require eeprom support to pass since it loops over the DR's for ABP join procedure and
the frame counter must match.

I'm tagging it as WIP since the following is missing:

- [ ] verify duty cycling is respected (I have found that this isnt very deterministic, maybe @aabadie has a suggestion on how to do it)
- [ ] setup so it tests on iotlab by default

I still wanted to open the PR since it can be used for release testing.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

- Run :

`$ make BOARD=<board> DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> -C examples/lorawan flash test`

The test will wait for 5 successful transmission and pass, i.e.:

 [Task #01 - LoRaWAN example](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md#task-01---lorawan-example).

- Run :

`$ make BOARD=<board> DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> DEVADDR=<device address > NWKSKEY=<nwk session key> APPSKEY=<app session key> -Ctests/pkg_semtech-loramac flash test`

The test will send a cnf and uncnf message over DR 0, 3 and 5 for OTAA and ABP. It will also verify device persistence, i.e:

  - [Task #02 - OTAA join procedure](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md#task-02---otaa-join-procedure)
  - [Task #03 - ABP join procedure](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md#task-03---abp-join-procedure)
  - [Task #04 - LoRaWAN device parameters persistence](https://github.com/RIOT-OS/Release-Specs/blob/ba236c4a1d1258ab63d21b0a860d0f5a5935bbd4/11-lorawan/11-lorawan.md#task-03---lorawan-device-parameters-persistence)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
