### PR TITLE
sys/auto_init: Updated sht1x auto_init

### DIFF
--- a/drivers/include/sht1x.h
+++ b/drivers/include/sht1x.h
@@ -26,57 +26,40 @@
 #include <stdint.h>
 #include <periph/gpio.h>
 
+#include "sht1x_types.h"
+#include "sht1x_params.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifdef MODULE_AUTO_INIT_ACTUATORS_SENSORS_SHT1X
 /**
- * @brief Possible configuration (=status byte) values of the SHT10/11/15
+ * @brief   Array of all auto-initialized SHT1X device descriptors
  *
- * These values can be or'ed together to get the configuration.
+ * @note    Only available if module @ref sys_auto_init_actuators_sensors_sht1x
+ *          is used
  */
-typedef enum {
-    /** Use 8/12 bit resolution instead of 12/14 bit for temp/hum */
-    SHT1X_CONF_LOW_RESOLUTION   = 0x01,
-    /** Don't upload calibration data to register to safe 10 millisec */
-    SHT1X_CONF_SKIP_CALIBRATION = 0x02,
-    /** Waste 8mA at 5V to increase the sensor temperature up to 10°C */
-    SHT1X_CONF_ENABLE_HEATER    = 0x04,
-    /** Skip the CRC check (and reading the CRC byte) to safe time */
-    SHT1X_CONF_SKIP_CRC         = 0x08,
-} sht1x_conf_t;
+extern sht1x_dev_t sht1x_devs[SHT1X_NUMOF];
 
 /**
- * @brief Possible values for Vdd (measured temperature depends on it)
+ * @brief   If `sht1x` is auto-initialized, device descriptors can be retrieved by number
+ * @param   num     Number of the SHT1X device to retrieve the device descriptor of
+ * @return  The device descriptor of the device with number @p num
+ * @retval  `NULL`  @p num is out of range
+ *
+ * @note    Only available if module @ref sys_auto_init_actuators_sensors_sht1x
+ *          is used
  */
-typedef enum {
-    SHT1X_VDD_5_0V = 0,
-    SHT1X_VDD_4_0V = 1,
-    SHT1X_VDD_3_5V = 2,
-    SHT1X_VDD_3_0V = 3,
-    SHT1X_VDD_2_5V = 4,
-} sht1x_vdd_t;
+static inline sht1x_dev_t * sht1x_get_dev(unsigned num)
+{
+    if (num >= SHT1X_NUMOF) {
+        return NULL;
+    }
 
-/**
- * @brief SHT10/11/15 temperature humidity sensor
- */
-typedef struct {
-    gpio_t  clk;      /**< GPIO connected to the clock pin of the SHT1X */
-    gpio_t  data;     /**< GPIO connected to the data pin of the SHT1X */
-    int16_t temp_off; /**< Offset to add to the measured temperature */
-    int16_t hum_off;  /**< Offset to add to the measured humidity */
-    uint8_t conf;     /**< Status byte (containing configuration) of the SHT1X */
-    uint8_t vdd;      /**< Supply voltage of the SHT1X (as sht1x_vdd_t) */
-} sht1x_dev_t;
-
-/**
- * @brief Parameters required to set up the SHT10/11/15 device driver
- */
-typedef struct {
-    gpio_t      clk;  /**< GPIO connected to the clock pin of the SHT1X */
-    gpio_t      data; /**< GPIO connected to the data pin of the SHT1X */
-    sht1x_vdd_t vdd;  /**< The supply voltage of the SHT1X */
-} sht1x_params_t;
+    return &sht1x_devs[num];
+}
+#endif /* MODULE_AUTO_INIT_ACTUATORS_SENSORS_SHT1X */
 
 /**
  * @brief             Initialize the SHT10/11/15 sensor

--- a/drivers/sht1x/Makefile.dep
+++ b/drivers/sht1x/Makefile.dep
@@ -1,2 +1,5 @@
 FEATURES_REQUIRED += periph_gpio
 USEMODULE += xtimer
+ifneq (,$(filter auto_init_sensors_actuators_default,$(USEMODULE)))
+  USEMODULE += auto_init_actuators_sensors_sht1x
+endif

--- a/drivers/sht1x/include/sht1x_params.h
+++ b/drivers/sht1x/include/sht1x_params.h
@@ -20,7 +20,7 @@
 #define SHT1X_PARAMS_H
 
 #include "board.h"
-#include "sht1x.h"
+#include "sht1x_types.h"
 #include "saul_reg.h"
 
 #ifdef __cplusplus
@@ -84,6 +84,11 @@ static const saul_reg_info_t sht1x_saul_info[] =
 {
     SHT1X_SAULINFO
 };
+
+/**
+ * @brief   Number of SHT1x devices
+ */
+#define SHT1X_NUMOF             (sizeof(sht1x_params) / sizeof(sht1x_params[0]))
 
 #ifdef __cplusplus
 }

--- a/drivers/sht1x/include/sht1x_types.h
+++ b/drivers/sht1x/include/sht1x_types.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_sht1x
+ *
+ * @{
+ * @file
+ * @brief       Data types of SHT10/SHT11/SHT15 Device Driver
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef SHT1X_TYPES_H
+#define SHT1X_TYPES_H
+
+#include <stdint.h>
+#include <periph/gpio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Possible configuration (=status byte) values of the SHT10/11/15
+ *
+ * These values can be or'ed together to get the configuration.
+ */
+typedef enum {
+    /** Use 8/12 bit resolution instead of 12/14 bit for temp/hum */
+    SHT1X_CONF_LOW_RESOLUTION   = 0x01,
+    /** Don't upload calibration data to register to safe 10 millisec */
+    SHT1X_CONF_SKIP_CALIBRATION = 0x02,
+    /** Waste 8mA at 5V to increase the sensor temperature up to 10°C */
+    SHT1X_CONF_ENABLE_HEATER    = 0x04,
+    /** Skip the CRC check (and reading the CRC byte) to safe time */
+    SHT1X_CONF_SKIP_CRC         = 0x08,
+} sht1x_conf_t;
+
+/**
+ * @brief Possible values for Vdd (measured temperature depends on it)
+ */
+typedef enum {
+    SHT1X_VDD_5_0V = 0,
+    SHT1X_VDD_4_0V = 1,
+    SHT1X_VDD_3_5V = 2,
+    SHT1X_VDD_3_0V = 3,
+    SHT1X_VDD_2_5V = 4,
+} sht1x_vdd_t;
+
+/**
+ * @brief SHT10/11/15 temperature humidity sensor
+ */
+typedef struct {
+    gpio_t  clk;      /**< GPIO connected to the clock pin of the SHT1X */
+    gpio_t  data;     /**< GPIO connected to the data pin of the SHT1X */
+    int16_t temp_off; /**< Offset to add to the measured temperature */
+    int16_t hum_off;  /**< Offset to add to the measured humidity */
+    uint8_t conf;     /**< Status byte (containing configuration) of the SHT1X */
+    uint8_t vdd;      /**< Supply voltage of the SHT1X (as sht1x_vdd_t) */
+} sht1x_dev_t;
+
+/**
+ * @brief Parameters required to set up the SHT10/11/15 device driver
+ */
+typedef struct {
+    gpio_t      clk;  /**< GPIO connected to the clock pin of the SHT1X */
+    gpio_t      data; /**< GPIO connected to the data pin of the SHT1X */
+    sht1x_vdd_t vdd;  /**< The supply voltage of the SHT1X */
+} sht1x_params_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHT1X_TYPES_H */
+/** @} */

--- a/makefiles/defaultmodules.inc.mk
+++ b/makefiles/defaultmodules.inc.mk
@@ -1,6 +1,7 @@
 DEFAULT_MODULE += board cpu core core_init core_msg core_panic sys
 
 DEFAULT_MODULE += auto_init
+DEFAULT_MODULE += auto_init_actuators_sensors_default
 
 # Initialize all used peripherals by default
 DEFAULT_MODULE += periph_init

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -308,6 +308,7 @@ PSEUDOMODULES += test_utils_interactive_sync_shell
 
 # All auto_init modules are pseudomodules
 PSEUDOMODULES += auto_init_%
+NO_PSEUDOMODULES += auto_init_actuators_sensors
 NO_PSEUDOMODULES += auto_init_can
 NO_PSEUDOMODULES += auto_init_loramac
 NO_PSEUDOMODULES += auto_init_multimedia

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -611,6 +611,10 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
     USEMODULE += netif
     USEMODULE += ipv6_addr
   endif
+
+  ifneq (,$(filter sht1x,$(USEMODULE)))
+    USEMODULE += auto_init_actuators_sensors_sht1x
+  endif
 endif
 
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -8,8 +8,6 @@ ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
   SKETCH_MODULE ?= arduino_sketches
   USEMODULE += $(SKETCH_MODULE)
-  USEMODULE += fmt
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter arduino_pwm,$(FEATURES_USED)))
@@ -22,6 +20,14 @@ endif
 
 ifneq (,$(filter congure_test,$(USEMODULE)))
   USEMODULE += fmt
+endif
+
+ifneq (,$(filter auto_init_actuators_sensors_%,$(filter-out auto_init_actuators_sensors_default,$(USEMODULE))))
+  USEMODULE += auto_init_actuators_sensors
+endif
+
+ifneq (,$(filter auto_init_saul,$(USEMODULE)))
+  USEMODULE += auto_init_actuators_sensors_default
 endif
 
 ifneq (,$(filter eepreg,$(USEMODULE)))

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -1,3 +1,7 @@
+ifneq (,$(filter auto_init_actuators_sensors,$(USEMODULE)))
+  DIRS += actuators_sensors
+endif
+
 ifneq (,$(filter gnrc_netif_init,$(USEMODULE)))
   DIRS += netif
 endif

--- a/sys/auto_init/actuators_sensors/Makefile
+++ b/sys/auto_init/actuators_sensors/Makefile
@@ -1,0 +1,7 @@
+MODULE = auto_init_actuators_sensors
+
+SRC := $(MODULE).c
+
+SUBMODULES := 1
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/actuators_sensors/auto_init_actuators_sensors.c
+++ b/sys/auto_init/actuators_sensors/auto_init_actuators_sensors.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup sys_auto_init_actuators_sensors
+ *
+ * @{
+ * @file
+ * @brief   Implementation of the auto initialization of actuators and sensors
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+#include <stdint.h>
+#include <stdio.h>
+
+#include "auto_init.h"
+
+void auto_init_actuators_sensors(void)
+{
+}

--- a/sys/auto_init/actuators_sensors/doc.txt
+++ b/sys/auto_init/actuators_sensors/doc.txt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup sys_auto_init_actuators_sensors Actuator & Sensor Auto Initialisation
+ * @ingroup sys_auto_init
+ * @brief Auto initialisation of actuator and sensor drivers
+ *
+ * This module contains auto init functions for actuator and sensor drivers.
+ *
+ * # Architecture / Usage
+ * Each actuator/sensor driver "foo" capable of auto initialization must provide
+ * the (pseudo) module `auto_init_actuators_sensors_foo` that provides the
+ * auto initialization. The module `auto_init_actuators_sensors` provides the
+ * function `void auto_init_actuators_sensors(void)` that will call the auto
+ * initialisation hooks of the individual actuator and sensor drivers.
+ *
+ * Note that the auto initialization of each actuator and sensor driver must
+ * be individually enabled to allow the user maximum flexibility. However,
+ * the pseudo module `auto_init_sensors_actuators_default` will pull in the auto
+ * initialization hooks of all used actuator and sensor drivers.
+ *
+ * # SAUL Integration
+ * Each actuator driver and sensor driver auto-init hook must also register the
+ * SAUL endpoints (if present) if and only if the module `auto_init_saul` is
+ * used.
+ */

--- a/sys/auto_init/actuators_sensors/sht1x.c
+++ b/sys/auto_init/actuators_sensors/sht1x.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @defgroup    sys_auto_init_actuators_sensors_sht1x Auto-initialization for SHT1X sensors
+ * @ingroup     sys_auto_init_actuators_sensors
+ *
+ * This sub-module contains the auto-initialization hook for SHT1X temperature
+ * and humidity sensors.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for SHT1X temperature/humidity sensors
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include "log.h"
+#include "sht1x_params.h"
+#include "sht1x.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+sht1x_dev_t sht1x_devs[SHT1X_NUMOF];
+
+#ifdef MODULE_AUTO_INIT_SAUL
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[SHT1X_NUMOF * 2];
+
+/**
+ * @name    Import SAUL endpoints
+ * @{
+ */
+extern const saul_driver_t sht1x_saul_temp_driver;
+extern const saul_driver_t sht1x_saul_hum_driver;
+/** @} */
+
+#endif /* MODULE_AUTO_INIT_SAUL */
+
+static void sht1x_error(unsigned int num, const char *reason)
+{
+    LOG_ERROR("[auto_init] error initializing SHT10/SHT11/SHT15 sensor "
+              "#%u: %s\n", num, reason);
+}
+
+void auto_init_sht1x(void)
+{
+    for (unsigned int i = 0; i < SHT1X_NUMOF; i++) {
+        DEBUG("[auto_init_sht1x] Initializing SHT1X sensor #%u\n", i);
+
+        switch (sht1x_init(&sht1x_devs[i], &sht1x_params[i])) {
+        case 0:
+            break;
+        case -EIO:
+            sht1x_error(i, "Failed to initialize GPIOs");
+            continue;
+        case -EINVAL:
+            sht1x_error(i, "Invalid configuration for VDD");
+            continue;
+        case -EPROTO:
+            sht1x_error(i, "Reset command not acknowledged");
+            continue;
+        default:
+            /* Should not happen, but better safe than sorry */
+            sht1x_error(i, "?");
+            continue;
+        }
+
+#ifdef MODULE_AUTO_INIT_SAUL
+        saul_entries[(i * 2)    ].dev = &(sht1x_devs[i]);
+        saul_entries[(i * 2) + 1].dev = &(sht1x_devs[i]);
+        saul_entries[(i * 2)    ].name = sht1x_saul_info[(i * 2)    ].name;
+        saul_entries[(i * 2) + 1].name = sht1x_saul_info[(i * 2) + 1].name;
+        saul_entries[(i * 2)    ].driver = &sht1x_saul_temp_driver;
+        saul_entries[(i * 2) + 1].driver = &sht1x_saul_hum_driver;
+        saul_reg_add(&(saul_entries[(i * 2)    ]));
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
+#endif /* MODULE_AUTO_INIT_SAUL */
+    }
+}

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -213,6 +213,12 @@ void auto_init(void)
         auto_init_sht1x();
     }
 
+    if (IS_USED(MODULE_AUTO_INIT_ACTUATORS_SENSORS)) {
+        LOG_DEBUG("Auto init sensors / actuators.\n");
+        extern void auto_init_actuators_sensors(void);
+        auto_init_actuators_sensors();
+    }
+
     if (IS_USED(MODULE_AUTO_INIT_SAUL)) {
         LOG_DEBUG("Auto init SAUL.\n");
         extern void saul_init_devs(void);

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -213,12 +213,6 @@ void auto_init(void)
         auto_init_sht1x();
     }
 
-    if (IS_USED(MODULE_AUTO_INIT_ACTUATORS_SENSORS)) {
-        LOG_DEBUG("Auto init sensors / actuators.\n");
-        extern void auto_init_actuators_sensors(void);
-        auto_init_actuators_sensors();
-    }
-
     if (IS_USED(MODULE_AUTO_INIT_SAUL)) {
         LOG_DEBUG("Auto init SAUL.\n");
         extern void saul_init_devs(void);

--- a/sys/shell/commands/sc_sht1x.c
+++ b/sys/shell/commands/sc_sht1x.c
@@ -27,23 +27,19 @@
 #include "sht1x.h"
 #include "sht1x_params.h"
 
-#define SHT1X_NUM     ARRAY_SIZE(sht1x_params)
-
-extern sht1x_dev_t sht1x_devs[SHT1X_NUM];
-
 static sht1x_dev_t *get_dev(int argc, char **argv)
 {
     switch (argc) {
     case 1:
-        return &sht1x_devs[0];
+        return sht1x_get_dev(0);
     case 2:
     {
-        int pos = atoi(argv[1]);
-        if ((pos < 0) || (pos >= (int)SHT1X_NUM)) {
-            printf("No SHT10/SHT11/SHT15 device with number %i\n", pos);
-            return NULL;
+        unsigned num = (unsigned)atoi(argv[1]);
+        sht1x_dev_t *dev = sht1x_get_dev(num);
+        if (!dev) {
+            printf("No SHT10/SHT11/SHT15 device with number %u\n", num);
         }
-        return &sht1x_devs[pos];
+        return dev;
     }
     default:
         break;
@@ -215,7 +211,7 @@ int _sht_config_handler(int argc, char **argv)
                 return -1;
             }
             dev_num = atoi(argv[i]);
-            if ((dev_num < 0) || (dev_num >= (int)SHT1X_NUM)) {
+            if ((dev_num < 0) || (dev_num >= (int)SHT1X_NUMOF)) {
                 printf("No SHT10/11/15 sensor with number %i\n", dev_num);
                 return -1;
             }


### PR DESCRIPTION
### Contribution description

This PR adapts the SHT1X auto init code to match the new API suggested in https://github.com/RIOT-OS/RIOT/pull/11871.

### Testing procedure

- Grab an MSB-A2 and check if the SHT1X driver is properly auto initialized e.g. in `/examples/saul`.
- Check if auto-initialization can be properly disabled

### Issues/PRs references

- Depends and includes https://github.com/RIOT-OS/RIOT/pull/11871
- The new auto initialization of sensors/actuators was discussed in https://github.com/RIOT-OS/RIOT/issues/11826