### PR TITLE
 examples/lorawan: fix semtech_loramac_send TX ret code [backport 2019.07]

### DIFF
--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -70,7 +70,7 @@ static void _send_message(void)
     /* Try to send the message */
     uint8_t ret = semtech_loramac_send(&loramac,
                                        (uint8_t *)message, strlen(message));
-    if (ret != SEMTECH_LORAMAC_TX_OK) {
+    if (ret != SEMTECH_LORAMAC_TX_DONE)  {
         printf("Cannot send message '%s', ret code: %d\n", message, ret);
         return;
     }

--- a/pkg/semtech-loramac/doc.txt
+++ b/pkg/semtech-loramac/doc.txt
@@ -88,7 +88,7 @@
  *     /* 4. send some data */
  *     char *message = "This is RIOT";
  *     if (semtech_loramac_send(&loramac,
- *                              (uint8_t *)message, strlen(message)) != SEMTECH_LORAMAC_TX_OK) {
+ *                              (uint8_t *)message, strlen(message)) != SEMTECH_LORAMAC_TX_DONE) {
            printf("Cannot send message '%s'\n", message);
  *         return 1;
  *     }

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -159,7 +159,7 @@ uint8_t semtech_loramac_join(semtech_loramac_t *mac, uint8_t type);
  * This function returns after TX status is replied from the MAC. To receive
  * potential messages sent from the network an explicit call to
  * @ref semtech_loramac_recv must be done after this function if it returned
- * @ref SEMTECH_LORAMAC_TX_OK and within the RX windows delays.
+ * @ref SEMTECH_LORAMAC_TX_DONE and within the RX windows delays.
  *
  * @see semtech_loramac_recv
  *
@@ -167,7 +167,7 @@ uint8_t semtech_loramac_join(semtech_loramac_t *mac, uint8_t type);
  * @param[in] data         The TX data
  * @param[in] len          The length of the TX data
  *
- * @return SEMTECH_LORAMAC_TX_OK when the message can be transmitted
+ * @return SEMTECH_LORAMAC_TX_DONE when the message was transmitted
  * @return SEMTECH_LORAMAC_NOT_JOINED when the network is not joined
  * @return SEMTECH_LORAMAC_BUSY when the mac is already active (join or tx in progress)
  * @return SEMTECH_LORAMAC_DUTYCYCLE_RESTRICTED when the send is rejected because of dutycycle restriction


### PR DESCRIPTION
# Backport of #11869

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

With #11541 (b7890b3031a653bde2d33afb54b9aa819e29af53) TX notification messages are only sent after mcps confirm event, and the code sent is `SEMTECH_LORAMAC_TX_DONE` instead of `SEMTECH_LORAMAC_TX_OK`. This PR fixes the documentation and the example accordingly.


### Testing procedure

Compile and flash `examples/lorawan` with valid keys:

`make BOARD=b-l072z-lrwan1 DEVEUI=00BD35DEE58FF9CB APPEUI=70B3D57ED000B02F APPKEY=C91870835C73F5E36EDF6E5DBD1445D0 -C examples/lorawan flash term`

Without this PR TX actually succeeds but SEMTECH_LORAMAC_TX_DONE return value is perceived as error:

```
2019-07-19 11:54:38,531 - INFO # nding: This is Rmain(): This is RIOT! (Version: 2019.10-devel-71-ga9e72c5-pr_lorawan_retcode)
2019-07-19 11:54:38,535 - INFO # LoRaWAN Class A low-power application
2019-07-19 11:54:38,538 - INFO # =====================================
2019-07-19 11:54:38,604 - INFO # Starting join procedure
2019-07-19 11:54:43,784 - INFO # Join procedure succeeded
2019-07-19 11:54:43,786 - INFO # Sending: This is RIOT!
2019-07-19 11:54:44,902 - INFO # Cannot send message 'This is RIOT!', ret code: 6
```

With this PR everything is OK.

```
2019-07-19 11:52:59,595 - INFO # main(): This is RIOT! (Version: 2019.10-devel-71-ga9e72c5-pr_lorawan_retcode)
2019-07-19 11:52:59,599 - INFO # LoRaWAN Class A low-power application
2019-07-19 11:52:59,602 - INFO # =====================================
2019-07-19 11:52:59,668 - INFO # Starting join procedure
2019-07-19 11:53:04,849 - INFO # Join procedure succeeded
2019-07-19 11:53:04,852 - INFO # Sending: This is RIOT!
2019-07-19 11:53:25,966 - INFO # Sending: This is RIOT!
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
