### PR TITLE
test_utils_interactive_sync: add a helper for synchronizing tests

### DIFF
--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -14,6 +14,7 @@ import pexpect
 
 from .spawn import find_exc_origin, setup_child, teardown_child
 from .unittest import PexpectTestCase   # noqa, F401 expose to users
+from .utils import test_utils_interactive_sync # noqa, F401 expose to users
 
 # Timeout for tests can be changed by setting RIOT_TEST_TIMEOUT to the desired
 # value in the environment variables

--- a/dist/pythonlibs/testrunner/utils.py
+++ b/dist/pythonlibs/testrunner/utils.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2019 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+"""Utility functions for writing tests."""
+
+import pexpect
+
+
+def test_utils_interactive_sync(child, retries=5, delay=1):
+    """Synchronisation for 'test_utils_interactive_sync' function.
+
+    Interacts through input to wait for node being ready.
+    """
+    for _ in range(0, retries):
+        child.sendline('r')
+        ret = child.expect_exact(['READY', pexpect.TIMEOUT], timeout=delay)
+        if ret == 0:
+            break
+    else:
+        # Last call to make it fail her,
+        child.expect_exact('READY', timeout=0)
+
+    child.sendline('s')
+    child.expect_exact('START')

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -25,6 +25,9 @@ endif
 ifneq (,$(filter shell_commands,$(USEMODULE)))
   DIRS += shell/commands
 endif
+ifneq (,$(filter test_utils_interactive_sync,$(USEMODULE)))
+  DIRS += test_utils/interactive_sync
+endif
 ifneq (,$(filter net_help,$(USEMODULE)))
   DIRS += net/crosslayer/net_help
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -9,3 +9,5 @@ endif
 ifneq (,$(filter prng_fortuna,$(USEMODULE)))
   CFLAGS += -DCRYPTO_AES
 endif
+
+include $(RIOTBASE)/sys/test_utils/Makefile.dep

--- a/sys/include/test_utils/interactive_sync.h
+++ b/sys/include/test_utils/interactive_sync.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    test_utils_interactive_sync Test interactive synchronization
+ * @ingroup     sys
+ * @brief       Utility function for synchronizing before a test
+ *
+ * @{
+ * @file
+ * @brief       Synchronization for normally non interactive tests
+ *
+ * @author      Gaëtan Harter <gaetan.harter@fu-berlin.de>
+ */
+
+#ifndef TEST_UTILS_INTERACTIVE_SYNC_H
+#define TEST_UTILS_INTERACTIVE_SYNC_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Wait for the tester to start test
+ *
+ * @details Wait for a 's' character to return
+ *
+ */
+void test_utils_interactive_sync(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* TEST_UTILS_INTERACTIVE_SYNC_H */
+/** @} */

--- a/sys/test_utils/Makefile.dep
+++ b/sys/test_utils/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter test_utils_interactive_sync,$(USEMODULE)))
+  USEMODULE += stdin
+endif

--- a/sys/test_utils/interactive_sync/Makefile
+++ b/sys/test_utils/interactive_sync/Makefile
@@ -1,0 +1,3 @@
+MODULE = test_utils_interactive_sync
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/test_utils/interactive_sync/interactive_sync.c
+++ b/sys/test_utils/interactive_sync/interactive_sync.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include "test_utils/interactive_sync.h"
+
+void test_utils_interactive_sync(void)
+{
+    char c = '\0'; /* Print help on first loop */
+    do {
+        if (c == 'r') {
+            /* This one should have a different case than the help message
+             * otherwise we match it when using 'expect' */
+            puts("READY");
+        }
+        else if (c != '\n' && c != '\r') {
+            puts("Help: Press s to start test, r to print it is ready");
+        }
+        c = getchar();
+    } while (c != 's');
+
+    puts("START");
+}

--- a/tests/cond_order/Makefile
+++ b/tests/cond_order/Makefile
@@ -7,4 +7,6 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              nucleo-l031k6 nucleo-l053 nucleo-l053r8 \
                              stm32f0discovery stm32l0538-disco
 
+USEMODULE += test_utils_interactive_sync
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/cond_order/main.c
+++ b/tests/cond_order/main.c
@@ -24,6 +24,7 @@
 #include "cond.h"
 #include "mutex.h"
 #include "thread.h"
+#include "test_utils/interactive_sync.h"
 
 #define THREAD_NUMOF            (5U)
 #define THREAD_FIRSTGROUP_NUMOF (3U)
@@ -61,6 +62,8 @@ int main(void)
 {
     puts("Condition variable order test");
     puts("Please refer to the README.md for more information\n");
+
+    test_utils_interactive_sync();
 
     mutex_init(&testlock);
     cond_init(&testcond);

--- a/tests/cond_order/tests/01-run.py
+++ b/tests/cond_order/tests/01-run.py
@@ -10,6 +10,8 @@
 import os
 import sys
 
+from testrunner import test_utils_interactive_sync
+
 thread_prio = {
         3:  6,
         4:  4,
@@ -21,6 +23,8 @@ first_group_size = 3
 
 
 def testfunc(child):
+    test_utils_interactive_sync(child)
+
     for k in thread_prio.keys():
         child.expect(u"T%i \(prio %i\): waiting on condition variable now" % (k, thread_prio[k]))
 

--- a/tests/libfixmath/Makefile
+++ b/tests/libfixmath/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 USEPKG += libfixmath
 USEMODULE += libfixmath
-USEMODULE += xtimer
+USEMODULE += test_utils_interactive_sync
 
 TEST_ON_CI_WHITELIST += all
 

--- a/tests/libfixmath/main.c
+++ b/tests/libfixmath/main.c
@@ -30,6 +30,7 @@
 
 #include <stdio.h>
 
+#include "kernel_defines.h"
 #include "xtimer.h"
 #include "fix16.h"
 

--- a/tests/libfixmath/main.c
+++ b/tests/libfixmath/main.c
@@ -31,8 +31,8 @@
 #include <stdio.h>
 
 #include "kernel_defines.h"
-#include "xtimer.h"
 #include "fix16.h"
+#include "test_utils/interactive_sync.h"
 
 #ifndef M_PI
 #   define M_PI 3.14159265359
@@ -186,8 +186,9 @@ static void unary_ops(void)
 
 int main(void)
 {
-    /* Delay output to prevent flooding of buffer */
-    xtimer_sleep(1);
+    /* Sync to prevent flooding of buffer */
+    test_utils_interactive_sync();
+
     puts("Unary.");
     unary_ops();
 

--- a/tests/libfixmath/tests/01-run.py
+++ b/tests/libfixmath/tests/01-run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
-from testrunner import run
+from testrunner import run, test_utils_interactive_sync
 
 
 def expect_unary(child):
@@ -31,6 +31,7 @@ def expect_binary(child):
 
 
 def testfunc(child):
+    test_utils_interactive_sync(child)
     child.expect_exact('Unary.')
     expect_unary(child)
     child.expect_exact('Binary.')

--- a/tests/posix_time/Makefile
+++ b/tests/posix_time/Makefile
@@ -2,8 +2,7 @@ include ../Makefile.tests_common
 
 USEMODULE += posix_time
 
-# This application uses getchar and thus expects input from stdio
-USEMODULE += stdin
+USEMODULE += test_utils_interactive_sync
 
 TEST_ON_CI_WHITELIST += all
 

--- a/tests/posix_time/main.c
+++ b/tests/posix_time/main.c
@@ -26,11 +26,11 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include "test_utils/interactive_sync.h"
 
 int main(void)
 {
-    puts("Please hit any key and then ENTER to continue");
-    getchar();
+    test_utils_interactive_sync();
     puts("5 x usleep(i++ * 500000)");
     for (unsigned i = 0; i < 5; i++) {
         useconds_t us = i * 500000u;

--- a/tests/posix_time/tests/01-run.py
+++ b/tests/posix_time/tests/01-run.py
@@ -10,7 +10,7 @@
 
 import sys
 import time
-from testrunner import run
+from testrunner import run, test_utils_interactive_sync
 
 US_PER_SEC = 1000000
 EXTERNAL_JITTER = 0.15
@@ -22,8 +22,7 @@ class InvalidTimeout(Exception):
 
 def testfunc(child):
     try:
-        child.expect_exact("Please hit any key and then ENTER to continue")
-        child.sendline("a")
+        test_utils_interactive_sync(child)
         start_test = time.time()
         child.expect_exact("5 x usleep(i++ * 500000)")
         for i in range(5):

--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -6,8 +6,7 @@ TEST_ON_CI_WHITELIST += all
 # This test randomly fails on `native` so disable it from CI
 TEST_ON_CI_BLACKLIST += native
 
-# This application uses getchar and thus expects input from stdio
-USEMODULE += stdin
+USEMODULE += test_utils_interactive_sync
 
 # Port and pin configuration for probing with oscilloscope
 # Port number should be found in port enum e.g in cpu/include/periph_cpu.h

--- a/tests/xtimer_usleep/main.c
+++ b/tests/xtimer_usleep/main.c
@@ -27,6 +27,7 @@
 
 #include "xtimer.h"
 #include "timex.h"
+#include "test_utils/interactive_sync.h"
 
 #define RUNS                (5U)
 #define SLEEP_TIMES_NUMOF   ARRAY_SIZE(sleep_times)
@@ -61,8 +62,7 @@ int main(void)
 
     printf("Running test %u times with %u distinct sleep times\n", RUNS,
            (unsigned)SLEEP_TIMES_NUMOF);
-    puts("Please hit any key and then ENTER to continue");
-    getchar();
+    test_utils_interactive_sync();
     start_test = xtimer_now_usec();
     for (unsigned m = 0; m < RUNS; m++) {
         for (unsigned n = 0;

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -11,7 +11,7 @@
 
 import sys
 import time
-from testrunner import run
+from testrunner import run, test_utils_interactive_sync
 
 
 US_PER_SEC = 1000000
@@ -28,8 +28,7 @@ def testfunc(child):
     RUNS = int(child.match.group(1))
     SLEEP_TIMES_NUMOF = int(child.match.group(2))
     try:
-        child.expect_exact(u"Please hit any key and then ENTER to continue")
-        child.sendline(u"a")
+        test_utils_interactive_sync(child)
         start_test = time.time()
         for m in range(RUNS):
             for n in range(SLEEP_TIMES_NUMOF):


### PR DESCRIPTION
### Contribution description

Add an implementation that waits for 's' to print 'START' and return.
If 'r' is given is prints 'READY' to allow querying for state.

This also provides a helper to use it in `testrunner` tests.

It should allow fixing tests where the input before reset is matched and on boards that cannot reset.


I used the function for `tests/cond_order` as example as it was failing on `cc2650-launchpad` during 2019.07-RC1 testing.


### Testing procedure

Run the `tests/cond_order` on a board that:
* would have printed the output to `pexpect` before `reset`
* where RESET does not work
* setups where the first bytes would be lost https://github.com/RIOT-OS/RIOT/issues/8211 

This broke the test on `cc2650-launchpad` as shown on this output as the lines before resetting are already matched by the test and then the board resets:

<details><summary><code>make RIOT_CI_BUILD=1 --no-print-directory -C /srv/ilab-builds/workspace/git/RIOT/tests/cond_order test</code></sumamry>

```
make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C /srv/ilab-builds/workspace/git/RIOT/tests/cond_order test
/srv/ilab-builds/workspace/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/ttyCC2650_LAUNCHPAD" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-07-18 19:29:49,793 - INFO # Connect to serial port /dev/riot/ttyCC2650_LAUNCHPAD
2019-07-18 19:29:50,796 - INFO # est)
Welcome to pyterm!
Type '/exit' to exit.
2019-07-18 19:29:50,798 - INFO # Condition variable order test
2019-07-18 19:29:50,800 - INFO # Please refer to the README.md for more information
2019-07-18 19:29:50,801 - INFO # 
2019-07-18 19:29:50,802 - INFO # T3 (prio 6): waiting on condition variable now
2019-07-18 19:29:50,804 - INFO # T4 (prio 4): waiting on condition variable now
2019-07-18 19:29:50,806 - INFO # T5 (prio 0): waiting on condition variable now
2019-07-18 19:29:50,808 - INFO # T6 (prio 2): waiting on condition variable now
2019-07-18 19:29:50,810 - INFO # T7 (prio 1): waiting on condition variable now
2019-07-18 19:29:50,811 - INFO # First batch was signaled
2019-07-18 19:29:50,812 - INFO # T5 (prio 0): condition variable was signaled now
2019-07-18 19:29:50,814 - INFO # T7 (prio 1): condition variable was signaled now
2019-07-18 19:29:50,816 - INFO # T6 (prio 2): condition variable was signaled now
2019-07-18 19:29:50,817 - INFO # First batch has woken up
2019-07-18 19:29:50,818 - INFO # Second batch was signaled
2019-07-18 19:29:52,829 - INFO # T4 (prio 4): condition variablmain(): This is RIOT! (Version: buildtest)
2019-07-18 19:29:52,831 - INFO # Condition variable order test
2019-07-18 19:29:52,836 - INFO # Please refer to the README.md for more information
2019-07-18 19:29:52,836 - INFO # 
2019-07-18 19:29:52,840 - INFO # T3 (prio 6): waiting on condition variable now
2019-07-18 19:29:52,844 - INFO # T4 (prio 4): waiting on condition variable now
2019-07-18 19:29:52,848 - INFO # T5 (prio 0): waiting on condition variable now
2019-07-18 19:29:52,852 - INFO # T6 (prio 2): waiting on condition variable now
2019-07-18 19:29:52,856 - INFO # T7 (prio 1): waiting on condition variable now
2019-07-18 19:29:52,858 - INFO # First batch was signaled
2019-07-18 19:29:52,863 - INFO # T5 (prio 0): condition variable was signaled now

Traceback (most recent call last):
  File "/srv/ilab-builds/workspace/git/RIOT/tests/cond_order/tests/01-run.py", line 44, in <module>
    sys.exit(run(testfunc))
  File "/srv/ilab-builds/workspace/git/RIOT/dist/pythonlibs/testrunner/__init__.py", line 23, in run
    testfunc(child)
  File "/srv/ilab-builds/workspace/git/RIOT/tests/cond_order/tests/01-run.py", line 32, in testfunc
    assert(int(child.match.group(1)) > last)
AssertionError
/srv/ilab-builds/workspace/git/RIOT/tests/cond_order/../../Makefile.include:604: recipe for target 'test' failed
make: *** [test] Error 1

Return value: 2
```
</details>

This also allows testing on `esp32` (when disabling `RESET` as it gets locked).
The test fails due to a different priority on T3 but at least can run (test does not handle that `THREAD_PRIORITY_MAIN` can be different.

<details><summary><code>RIOT_CI_BUILD=1 RESET=true BOARD=esp32-wroom-32 make -C tests/cond_order/ flash test</code></summary>

```
Welcome to pyterm!
Type '/exit' to exit.
2019-07-19 16:05:08,789 - INFO # READY
s
2019-07-19 16:05:08,847 - INFO # START
2019-07-19 16:05:08,850 - INFO # T3 (prio 14): waiting on condition variable now
2019-07-19 16:05:08,853 - INFO # T4 (prio 4): waiting on condition variable now
2019-07-19 16:05:08,858 - INFO # T5 (prio 0): waiting on condition variable now
2019-07-19 16:05:08,864 - INFO # T6 (prio 2): waiting on condition variable now
2019-07-19 16:05:08,865 - INFO # T7 (prio 1): waiting on condition variable now
2019-07-19 16:05:08,869 - INFO # First batch was signaled
2019-07-19 16:05:08,875 - INFO # T5 (prio 0): condition variable was signaled now
2019-07-19 16:05:08,875 - INFO # T7 (prio 1): condition variable was signaled now
2019-07-19 16:05:08,881 - INFO # T6 (prio 2): condition variable was signaled now
2019-07-19 16:05:08,886 - INFO # First batch has woken up
2019-07-19 16:05:08,886 - INFO # Second batch was signaled
2019-07-19 16:05:08,891 - INFO # T4 (prio 4): condition variable was signaled now
2019-07-19 16:05:08,897 - INFO # T3 (prio 14): condition variable was signaled now
2019-07-19 16:05:08,897 - INFO # Second batch has woken up
2019-07-19 16:05:08,897 - INFO #
2019-07-19 16:05:08,900 - INFO # Test END, check the order of priorities above.
Timeout in expect script at "child.expect(u"T%i \(prio %i\): waiting on condition variable now" % (k, thread_prio[k]))" (tests/cond_order/tests/01-run.py:29)
```
</details>

Where in master the output was completely missed:

```
2019-07-19 16:06:29,141 - INFO # Connect to serial port /dev/riot/ttyESP32_WROOM_32
Welcome to pyterm!
Type '/exit' to exit.
Timeout in expect script at "child.expect(u"T%i \(prio %i\): waiting on condition variable now" % (k, thread_prio[k]))" (tests/cond_order/tests/01-run.py:25)
```

All the modified tests still work (would be checked by murdock when running tests).

### Issues/PRs references

Running tests on boards for `2019.07-RC1` tests https://github.com/RIOT-OS/Release-Specs/issues/128#issuecomment-513172986

Work with @MrKevinWeiss to allow running tests on `esp32` that cannot reset using `esptool` when `term` is open.