### PR TITLE
makefiles: add support for sysfs gpio debug adapter

### DIFF
--- a/makefiles/tools/openocd-adapters/sysfs_gpio.inc.mk
+++ b/makefiles/tools/openocd-adapters/sysfs_gpio.inc.mk
@@ -1,0 +1,15 @@
+# sysfs GPIO debug adapter
+
+SWCLK_PIN ?= 21
+SWDIO_PIN ?= 20
+SRST_PIN ?= 16
+
+OPENOCD_ADAPTER_INIT ?= \
+  -c 'interface sysfsgpio' \
+  -c 'transport select swd' \
+  -c 'sysfsgpio_swd_nums $(SWCLK_PIN) $(SWDIO_PIN)' \
+  -c 'sysfsgpio_srst_num $(SRST_PIN)' \
+  -c 'adapter_nsrst_delay 100' \
+  -c 'adapter_nsrst_assert_width 100'
+
+export OPENOCD_ADAPTER_INIT


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Adds support for using GPIO's as an SWD debug adapter via sysfs. The pin configuration can be overridden by defining SWCLK_PIN, SWDIO_PIN and SRST_PIN in your board's Makefile.include.
This adds some minor improvements on #11175
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
1. Connect RPi pins to swd pins on <board_of_your_choice>
2. Add yourself to the gpio group on the system or run as root
3. Run BOARD=<board_of_your_choice> DEBUG_ADAPTER=sysfs_gpio make flash -C <app_of_your_choice>


### Issues/PRs references
Minor improvement on #11175, slightly related to #11311 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
