### PR TITLE
pkg/semtech-loramac: update documentation

### DIFF
--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -150,6 +150,7 @@ int semtech_loramac_init(semtech_loramac_t *mac);
  * @return SEMTECH_LORAMAC_JOIN_SUCCEEDED on success
  * @return SEMTECH_LORAMAC_JOIN_FAILED on failure
  * @return SEMTECH_LORAMAC_BUSY when the mac is already active (join or tx in progress)
+ * @return SEMTECH_LORAMAC_ALREADY_JOINED if network was already joined
  */
 uint8_t semtech_loramac_join(semtech_loramac_t *mac, uint8_t type);
 
@@ -172,6 +173,7 @@ uint8_t semtech_loramac_join(semtech_loramac_t *mac, uint8_t type);
  * @return SEMTECH_LORAMAC_BUSY when the mac is already active (join or tx in progress)
  * @return SEMTECH_LORAMAC_DUTYCYCLE_RESTRICTED when the send is rejected because of dutycycle restriction
  * @return SEMTECH_LORAMAC_TX_ERROR when an invalid parameter is given
+ * @return SEMTECH_LORAMAC_TX_CNF_FAILED when message was transmitted but no ACK was received
  */
 uint8_t semtech_loramac_send(semtech_loramac_t *mac, uint8_t *data, uint8_t len);
 

--- a/sys/shell/commands/sc_loramac.c
+++ b/sys/shell/commands/sc_loramac.c
@@ -430,6 +430,10 @@ int _loramac_handler(int argc, char **argv)
             case SEMTECH_LORAMAC_TX_ERROR:
                 puts("Cannot send: error");
                 return 1;
+
+            case SEMTECH_LORAMAC_TX_CNF_FAILED:
+                puts("Fail to send: no ACK received");
+                return 1;
         }
 
         puts("Message sent with success");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds SEMTECH_LORAMAC_TX_CNF_FAILED when an ACK is not received on a `cnf` transmission. It also adds the debug message to the shell so it doesn't print "Message sent with success".

It also adds SEMTECH_LORAMAC_ALREADY_JOINED as a return code for `semtech_loramac_join`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run:

```BOARD=b-l072z-lrwan1 make -C tests/pkg_semtech-loramac/ flash term```

Set dr to 5 to reduce time between re-transmissions.  Set an invalid parameter for the keys or set no parameter.

``` loramac set dr 5```

without this PR:

```
2019-07-22 14:23:18,476 - INFO #  loramac tx "This is RIOT" cnf 123
2019-07-22 14:23:36,000 - INFO # Message sent with success
```

with this PR:

```
2019-07-22 14:23:18,476 - INFO #  loramac tx "This is RIOT" cnf 123
2019-07-22 14:23:36,000 - INFO #  Fail to send: no ACK received

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
