### PR TITLE
cpu/arm7_common: Moved compiler flags here

### DIFF
--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -19,23 +19,7 @@ PORT_DARWIN ?= /dev/tty.usbserial-ARM
 PYTERMFLAGS += -tg
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-CFLAGS_CPU   = -mcpu=arm7tdmi-s
-CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
-CFLAGS_DBG  ?= -ggdb -g3
-CFLAGS_OPT  ?= -Os
-
-CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
-ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
-export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU).ld
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
-export LINKFLAGS += -Wl,--gc-sections
-
-# use the nano-specs of Newlib when available
-USEMODULE += newlib_nano
-
 FLASHFILE ?= $(HEXFILE)
 FFLAGS = $(PORT) $(FLASHFILE)
 
 INCLUDES += -I$(RIOTBOARD)/common/msba2/include
-
-export UNDEF += $(BINDIR)/cpu/startup.o

--- a/cpu/arm7_common/Makefile.include
+++ b/cpu/arm7_common/Makefile.include
@@ -1,6 +1,26 @@
 # Target architecture for the build. Use arm-none-eabi if you are unsure.
 export TARGET_ARCH ?= arm-none-eabi
 
-USEMODULE += arm7_common_periph
-
 INCLUDES += -I$(RIOTBASE)/cpu/arm7_common/include/
+
+# use common ARM7 periph code
+USEMODULE += arm7_common_periph
+# use the nano-specs of Newlib when available
+USEMODULE += newlib_nano
+
+# currently only arm7tdmi-s is supported by RIOT, but allow overriding MCPU
+# if someone wants to add support for other ARM7 CPUs
+MCPU ?= arm7tdmi-s
+
+CFLAGS_CPU  = -mcpu=$(MCPU)
+CFLAGS_LINK = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+CFLAGS_DBG  ?= -ggdb -g3
+CFLAGS_OPT  ?= -Os
+
+CFLAGS      += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
+ASFLAGS     += $(CFLAGS_CPU) $(CFLAGS_DBG)
+export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU).ld
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
+export LINKFLAGS += -Wl,--gc-sections
+
+export UNDEF += $(BINDIR)/cpu/startup.o


### PR DESCRIPTION
### Contribution description
- Moved compiler & linker flags from `boards/common/msba2` to `cpu/arm7_common`
- Moved dependency to newlib nano to `cpu/arm7_common`
- Moved config to link in `cpu/startup.o` to `cpu/arm7_common`

### Testing procedure
1. Select a few random example applications and check if the still build, flash and run as expected

### Issues/PRs references
This PR is a response to issue https://github.com/RIOT-OS/RIOT/issues/11861, the actual fix for issue https://github.com/RIOT-OS/RIOT/issues/11861 was done in https://github.com/RIOT-OS/RIOT/pull/11883