### PR TITLE
sys/riotboot: add missing assert.h

### DIFF
--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "riotboot/flashwrite.h"


### PR DESCRIPTION
### Contribution description

It seems that `assert()` is provided via some include, but this is not the case for all boards. This PR adds it.

Here is a part of the log, for my (custom) board:

```
/RIOT/sys/riotboot/flashwrite.c: In function 'riotboot_flashwrite_init_raw':
/RIOT/sys/riotboot/flashwrite.c:51:5: error: implicit declaration of function 'assert' [-Werror=implicit-function-declaration]
     assert(offset <= FLASHPAGE_SIZE);
     ^~~~~~
/RIOT/sys/riotboot/flashwrite.c:51:5: note: 'assert' is defined in header '<assert.h>'; did you forget to '#include <assert.h>'?
/RIOT/sys/riotboot/flashwrite.c:31:1:
+#include <assert.h>

/RIOT/sys/riotboot/flashwrite.c:51:5:
     assert(offset <= FLASHPAGE_SIZE);
     ^~~~~~
cc1: all warnings being treated as errors
```

### Testing procedure

Run `cd tests/riotboot_flashwrite && make`. Compilation should still be fine.

### Issues/PRs references

None