### PR TITLE
cpu/arm7_common: Fix thread_yield_higher in ISR

### DIFF
--- a/cpu/arm7_common/arm_cpu.c
+++ b/cpu/arm7_common/arm_cpu.c
@@ -18,6 +18,8 @@
 
 #include <stdio.h>
 #include "arm_cpu.h"
+#include "irq.h"
+#include "sched.h"
 #include "thread.h"
 
 #define STACK_MARKER    (0x77777777)
@@ -25,7 +27,12 @@
 
 void thread_yield_higher(void)
 {
-    __asm__("svc 0\n");
+    if (irq_is_in()) {
+        sched_context_switch_request = 1;
+    }
+    else {
+        __asm__("svc 0\n");
+    }
 }
 
 /*----------------------------------------------------------------------------


### PR DESCRIPTION
### Contribution description
`thread_yield_higher()` in interrupt context must not yield immediately, but at the end of the ISR. This PR fixes the behavior.

### Testing procedure
- The test in https://github.com/RIOT-OS/RIOT/pull/11759 should pass when this PR is applied.
- Other tests related to scheduling and multithreading should still pass

### Issues/PRs references
Addresses the issue identified in https://github.com/RIOT-OS/RIOT/pull/11759