### PR TITLE
 tapsetup: require to be executed with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ you can use to create a network of tap interfaces.
 
 To create a bridge and two (or `count` at your option) tap interfaces:
 
-    ./dist/tools/tapsetup/tapsetup [-c [<count>]]
+    sudo ./dist/tools/tapsetup/tapsetup [-c [<count>]]
 
 ## CONTRIBUTE
 

--- a/cpu/native/README.md
+++ b/cpu/native/README.md
@@ -53,17 +53,17 @@ can use to create a network of tap interfaces.
 Usage:
 To create a bridge and two (or count at your option) tap interfaces:
 
-    ../../dist/tools/tapsetup/tapsetup [-c [<count>]]
+    sudo ../../dist/tools/tapsetup/tapsetup [-c [<count>]]
 
 On OSX you need to start the RIOT instance at some point during the script's
 execution. The script will instruct you when to do that.
 
 To delete the bridge and all tap interfaces:
 
-    ../../dist/tools/tapsetup/tapsetup -d
+    sudo ../../dist/tools/tapsetup/tapsetup -d
 
 For OSX you **have** to run this after killing your RIOT instance and rerun
-`../../dist/tools/tapsetup [-c [<count>]]` before restarting.
+`sudo ../../dist/tools/tapsetup [-c [<count>]]` before restarting.
 
 **Please note:** If you want to communicate between RIOT and your host
 operating system, you must not use the `tapsetup` script, but create and

--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -35,15 +35,15 @@ create_bridge() {
 
     case "${PLATFORM}" in
         FreeBSD)
-            sudo kldload if_bridge
-            sudo ifconfig ${BRNAME} create || exit 1 ;;
+            kldload if_bridge
+            ifconfig ${BRNAME} create || exit 1 ;;
         Linux)
-            sudo ip link add name ${BRNAME} type bridge || exit 1
+            ip link add name ${BRNAME} type bridge || exit 1
             if [ -n "${DEACTIVATE_IPV6}" ]; then
-                sudo -s sh -c "echo 1  > /proc/sys/net/ipv6/conf/${BRNAME}/disable_ipv6" || exit 1
+                echo 1 > /proc/sys/net/ipv6/conf/${BRNAME}/disable_ipv6 || exit 1
             fi ;;
         OSX)
-            sudo ifconfig ${BRNAME} create || exit 1 ;;
+            ifconfig ${BRNAME} create || exit 1 ;;
         *)
             ;;
     esac
@@ -52,9 +52,9 @@ create_bridge() {
 up_bridge() {
     case "${PLATFORM}" in
         FreeBSD|OSX)
-            sudo ifconfig ${BRNAME} up || exit 1 ;;
+            ifconfig ${BRNAME} up || exit 1 ;;
         Linux)
-            sudo ip link set ${BRNAME} up || exit 1 ;;
+            ip link set ${BRNAME} up || exit 1 ;;
         *)
             ;;
     esac
@@ -65,17 +65,17 @@ delete_bridge() {
 
     case "${PLATFORM}" in
         FreeBSD)
-            sudo sysctl net.link.tap.user_open=0
-            sudo kldunload if_tap || exit 1
-            sudo kldunload if_bridge || exit 1 ;;
+            sysctl net.link.tap.user_open=0
+            kldunload if_tap || exit 1
+            kldunload if_bridge || exit 1 ;;
         Linux)
             for IF in $(ls /sys/class/net/${BRNAME}/brif); do
-                sudo ip link delete "${IF}"
+                ip link delete "${IF}"
             done
 
-            sudo ip link delete ${BRNAME} || exit 1 ;;
+            ip link delete ${BRNAME} || exit 1 ;;
         OSX)
-            sudo ifconfig ${BRNAME} destroy || exit 1 ;;
+            ifconfig ${BRNAME} destroy || exit 1 ;;
         *)
             ;;
     esac
@@ -84,8 +84,8 @@ delete_bridge() {
 begin_tap() {
     case "${PLATFORM}" in
         FreeBSD)
-            sudo kldload if_tap || exit 1
-            sudo sysctl net.link.tap.user_open=1 ;;
+            kldload if_tap || exit 1
+            sysctl net.link.tap.user_open=1 ;;
         *)
             ;;
     esac
@@ -95,24 +95,24 @@ create_tap() {
     case "${PLATFORM}" in
         FreeBSD)
             echo "creating ${TAPNAME}${N}" || exit 1
-            sudo ifconfig tap${N} create || exit 1
-            sudo chown ${USER} /dev/tap${N} || exit 1
-            sudo ifconfig ${BRNAME} addm tap${N} || exit 1
-            sudo ifconfig tap${N} up || exit 1 ;;
+            ifconfig tap${N} create || exit 1
+            chown ${SUDO_USER} /dev/tap${N} || exit 1
+            ifconfig ${BRNAME} addm tap${N} || exit 1
+            ifconfig tap${N} up || exit 1 ;;
         Linux)
             echo "creating ${TAPNAME}${N}"
-            sudo ip tuntap add dev ${TAPNAME}${N} mode tap user ${USER} || exit 1
+            ip tuntap add dev ${TAPNAME}${N} mode tap user ${SUDO_USER} || exit 1
             if [ -n "${DEACTIVATE_IPV6}" ]; then
-                sudo -s sh -c "echo 1  > /proc/sys/net/ipv6/conf/${TAPNAME}${N}/disable_ipv6" || exit 1
+                echo 1 > /proc/sys/net/ipv6/conf/${TAPNAME}${N}/disable_ipv6 || exit 1
             fi
-            sudo ip link set dev ${TAPNAME}${N} master ${BRNAME} || exit 1
-            sudo ip link set ${TAPNAME}${N} up || exit 1 ;;
+            ip link set dev ${TAPNAME}${N} master ${BRNAME} || exit 1
+            ip link set ${TAPNAME}${N} up || exit 1 ;;
         OSX)
-            sudo chown ${USER} /dev/tap${N} || exit 1
+            chown ${SUDO_USER} /dev/tap${N} || exit 1
             echo "start RIOT instance for tap${N} now and hit enter"
             read
-            sudo ifconfig ${BRNAME} addm tap${N} || exit 1
-            sudo ifconfig tap${N} up || exit 1 ;;
+            ifconfig ${BRNAME} addm tap${N} || exit 1
+            ifconfig tap${N} up || exit 1 ;;
         *)
             ;;
     esac
@@ -174,12 +174,9 @@ while true ; do
     esac
 done
 
-if [ -z "${USER}" ]; then
-    export USER=$(id -un)
-    if [ -z "${USER}" ]; then
-        echo 'need to export $USER'
-        exit 1
-    fi
+if [ -z "${SUDO_USER}" ]; then
+    echo 'Environment variable $SUDO_USER required; Please run with `sudo`'
+    exit 1
 fi
 if [ -z "${COMMAND}" ]; then
     COMMAND="create"

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -62,7 +62,7 @@ call this the `native` port). Try it right now in your terminal window:
 git clone git://github.com/RIOT-OS/RIOT.git # assumption: git is pre-installed
 cd RIOT
 git checkout <LATEST_RELEASE>
-./dist/tools/tapsetup/tapsetup              # create virtual Ethernet
+sudo ./dist/tools/tapsetup/tapsetup         # create virtual Ethernet
                                             # interfaces to connect multiple
                                             # RIOT instances
 cd examples/default/

--- a/examples/ccn-lite-relay/README.md
+++ b/examples/ccn-lite-relay/README.md
@@ -39,7 +39,7 @@ RIOT provides three shell to interact with the CCN-Lite stack:
 
 An example usage of this application could be setup like this:
 1. Open a terminal window, navigate to the RIOT directory, and enter
-   `dist/tools/tapsetup/tapsetup -c`.
+   `sudo dist/tools/tapsetup/tapsetup -c`.
 2. Open a second terminal window and navigate to this directory in both of
    windows.
 3. Call `make -B clean all term` in the first terminal and `PORT=tap1 make

--- a/examples/dtls-echo/README.md
+++ b/examples/dtls-echo/README.md
@@ -12,7 +12,7 @@ Linux version of TinyDTLS. However, this is not tested yet.
 
 Preparing the logical interfaces:
 
-    ./../../dist/tools/tapsetup/tapsetup --create 2
+    sudo ./../../dist/tools/tapsetup/tapsetup --create 2
 
 For the server instance:
 

--- a/examples/emcute_mqttsn/README.md
+++ b/examples/emcute_mqttsn/README.md
@@ -58,7 +58,7 @@ single RIOT native instance, we can do the following:
 
 1. Setup `tap` and `tapbr` devices using RIOT's `tapsetup` script:
 ```
-./RIOTDIR/dist/tools/tapsetup/tapsetup
+sudo ./RIOTDIR/dist/tools/tapsetup/tapsetup
 ```
 
 2. Assign a site-global prefix to the `tapbr0` interface (the name could be

--- a/examples/gnrc_networking/README.md
+++ b/examples/gnrc_networking/README.md
@@ -104,7 +104,7 @@ you first need to set up two tap devices and a bridge that connects
 them. This constitutes a virtual network that the RIOT instances can
 use to communicate.
 
-    ./../../dist/tools/tapsetup/tapsetup --create 2
+    sudo ./../../dist/tools/tapsetup/tapsetup --create 2
 
 Then, make sure you've compiled the application by calling `make` and
 start the first RIOT instance by invoking `make term`. In the RIOT

--- a/examples/gnrc_tftp/README.md
+++ b/examples/gnrc_tftp/README.md
@@ -12,7 +12,7 @@ however show up in Wireshark, which can be confusing). So be sure to adjust your
 
 First, create a tap interface (to which RIOT will connect) and a bridge (to which Linux will connect) from the RIOT main directory run:
 
-    ./dist/tools/tapsetup/tapsetup -c 1
+    sudo ./dist/tools/tapsetup/tapsetup -c 1
 
 Now you can start the `gnrc_tftp` example by invoking `make term`. This should automatically connect to the `tap0` interface. If
 this doesn't work for some reason, run `make` without any arguments, and then run the binary manually like so (assuming you are in the `examples/gnrc_tftp` directory):

--- a/examples/ndn-ping/README.md
+++ b/examples/ndn-ping/README.md
@@ -8,7 +8,7 @@ Any board with a default netdev can be used to run this example.
 
 Create `tap` and `tapbr` devices using RIOT's `tapsetup` script before stating the application:
 ```bash
-./RIOTDIR/dist/tools/tapsetup/tapsetup
+sudo ./RIOTDIR/dist/tools/tapsetup/tapsetup
 ```
 
 Then run the application on 2 different terminals :


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
It is somewhat unlucky, that `tapsetup` basically executes sudo without the user potentially knowing about it (e.g. if they had NOPASSWD configured in their sudoers). Let's not do that and require the script to be executed with `sudo`. The executing user required for the ownership of the TAP interfaces can still be acquired via the `SUDO_USER` environment variable.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `dist/tools/tapsetup/tapsetup` with and without `sudo` (given output assumes you did not create a TAP bridge before):

```
$ dist/tools/tapsetup/tapsetup
need to export $SUDO_USER
$ sudo dist/tools/tapsetup/tapsetup
creating tapbr0
creating tap0
creating tap1
$ sudo dist/tools/tapsetup/tapsetup -d
deleting tapbr0
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
