### PR TITLE
sys/Makefile.include: check for newlib_nano instead of USE_NANO_SPECS  [backport 2019.07]

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -144,8 +144,6 @@ include $(RIOTCPU)/cortexm_common/Makefile.include
 
 # use the nano-specs of Newlib when available
 USEMODULE += newlib_nano
-export USE_NANO_SPECS = 1
-
 # Avoid overriding the default rule:
 all:
 

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -72,13 +72,13 @@ ifneq (,$(filter arduino,$(USEMODULE)))
 endif
 
 ifneq (,$(filter printf_float,$(USEMODULE)))
-  ifeq (1,$(USE_NANO_SPECS))
+  ifneq (,$(filter newlib_nano,$(USEMODULE)))
     export LINKFLAGS += -u _printf_float
   endif
 endif
 
 ifneq (,$(filter scanf_float,$(USEMODULE)))
-  ifeq (1,$(USE_NANO_SPECS))
+  ifneq (,$(filter newlib_nano,$(USEMODULE)))
     export LINKFLAGS += -u _scanf_float
   endif
 endif


### PR DESCRIPTION
# Backport of #11883

### Contribution description

Check for the usage of `newlib_nano` module instead of the
`USE_NANO_SPECS` variable.

This allows also benefiting from the `printf_float` and `scanf_float`
behaviour on `arm7` and `riscv` cpus.


### Testing procedure

Verify it is actually handled correctly on `arm7` and `riscv` boards.


Run the `tests/unittests tests-scanf_float` on `arm7` and `riscv` boards.

```
BOARD=msba2 make --no-print-directory -C tests/unittests/ tests-scanf_float flash-only test

Booting (hardware reset)...

Reset CPU (into user code)
Programming done.
ssh -t vaduz.imp.fu-berlin.de 'source /srv/ilab-builds/workspace/workspace.rc && BOARD=msba2 QUIET=0 make --no-print-directory -C /srv/ilab-builds/boards term'
/srv/ilab-builds/boards/RIOT/dist/tools/pyterm/pyterm -tg -p "/dev/riot/ttyMSBA2"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-07-22 16:37:43,181 - INFO # Connect to serial port /dev/riot/ttyMSBA2
Welcome to pyterm!
Type '/exit' to exit.
2019-07-22 16:37:44,187 - INFO # main(): This is RIOT! (Version: 2019.10-devel-104-g294fb-HEAD)
2019-07-22 16:37:44,187 - INFO # ......
2019-07-22 16:37:44,188 - INFO # OK (6 tests)
```

Run other relevant tests:

* msba2
  * [x] tests/unittests tests-scanf_float @cladmi 
  * [x] tests/libfixmath_unittests
* hifive1
  * [x] tests/unittests tests-scanf_float

### Issues/PRs references

General fix for https://github.com/RIOT-OS/RIOT/pull/11882

`USE_NANO_SPECS` was added in https://github.com/RIOT-OS/RIOT/pull/5094
Not sure why it was not set with `newlib_nano` at the end.
