### PR TITLE
cpu/saml1x: update periph status implementation in board doc.txt

### DIFF
--- a/boards/saml10-xpro/doc.txt
+++ b/boards/saml10-xpro/doc.txt
@@ -51,14 +51,14 @@ memory.
 | Low-level driver | GPIO    | yes       | |
 |        | PWM       | no            | |
 |        | UART      | yes           | |
-|        | I2C       | no        | |
-|        | SPI       | no        | |
+|        | I2C       | yes        | |
+|        | SPI       | yes        | |
 |        | USB       | no        | |
-|        | RTT       | no        | |
-|        | RTC       | no       |  |
-|        | RNG       | no        |  |
+|        | RTT       | yes        | |
+|        | RTC       | yes      |  |
+|        | RNG       | yes        |  |
 |        | Timer     | yes           | |
-|        | ADC       | no          | |
+|        | ADC       | yes         | |
 
 ## Flashing the device
 

--- a/boards/saml11-xpro/doc.txt
+++ b/boards/saml11-xpro/doc.txt
@@ -51,14 +51,14 @@ memory. In addition, this SoC features the ARM TrustZone technology.
 | Low-level driver | GPIO    | yes       | |
 |        | PWM       | no            | |
 |        | UART      | yes           | |
-|        | I2C       | no        | |
-|        | SPI       | no        | |
+|        | I2C       | yes        | |
+|        | SPI       | yes        | |
 |        | USB       | no        | |
-|        | RTT       | no        | |
-|        | RTC       | no       |  |
-|        | RNG       | no        |  |
+|        | RTT       | yes       | |
+|        | RTC       | yes      |  |
+|        | RNG       | yes        |  |
 |        | Timer     | yes           | |
-|        | ADC       | no          | |
+|        | ADC       | yes         | |
 
 
 


### PR DESCRIPTION
### Contribution description
Updated the implementation status of the boards saml10-xpro and saml11-xpro.
Before only support of low-level drivers GPIO, UART and Timer was documented.
Testing showed that I2C, SPI, RTT, RTC, RNG and ADC also work on both boards.

### Testing procedure

I ran the following tests:
periph_i2c
periph_spi
periph_rtt
periph_rtc
periph_adc
rng