### PR TITLE
stm32_common/gpio: remove unused guard

### DIFF
--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -196,11 +196,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     isr_ctx[pin_num].arg = arg;
 
     /* enable clock of the SYSCFG module for EXTI configuration */
-#ifdef CPU_FAN_STM32F0
-    periph_clk_en(APB2, RCC_APB2ENR_SYSCFGCOMPEN);
-#else
     periph_clk_en(APB2, RCC_APB2ENR_SYSCFGEN);
-#endif
 
     /* initialize pin as input */
     gpio_init(pin, mode);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR removes an unneeded guard for stm32f0, there was a typo in the ifdef and since `RCC_APB2ENR_SYSCFGCOMPEN` is mapped to `RCC_APB2ENR_SYSCFGEN` in the CMSIS this is not needed (if it ever was).

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

A green murdock should be enough.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
