### PR TITLE
cpu/stm32l4/stmclk: fix HSE overwride when MSI is enabled

### DIFF
--- a/cpu/stm32l4/stmclk.c
+++ b/cpu/stm32l4/stmclk.c
@@ -133,7 +133,7 @@ void stmclk_init_sysclk(void)
 
 #if ((CLOCK_HSE == 0) || CLOCK_MSI_ENABLE)
     /* reset clock to MSI with 48MHz, disables all other clocks */
-    RCC->CR = (RCC_CR_MSIRANGE_11 | RCC_CR_MSION | RCC_CR_MSIRGSEL);
+    RCC->CR |= (RCC_CR_MSIRANGE_11 | RCC_CR_MSION | RCC_CR_MSIRGSEL);
     while (!(RCC->CR & RCC_CR_MSIRDY)) {}
     /* select the MSI clock for the 48MHz clock tree (USB, RNG) */
     RCC->CCIPR = (RCC_CCIPR_CLK48SEL_0 | RCC_CCIPR_CLK48SEL_1);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

For `stm32l4` if `HSE` and `MSI` are enabled, when `MSI` is configured it overrides the `HSE` clock configuration. This causes `stmclk_init_sysclk` to hang since `PLL` is to be setup with `HSE` but it was disabled when setting `MSI`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Find a `stm32l4` board that has an `HSE` clock (or provide one yourself), enable both `MSI` and `HSE` in `periph_conf.h` for that board. In master flashing whatever application will result in no terminal output since it get stuck at https://github.com/fjmolinas/RIOT/blob/51bc33de973295d6952349a185b5f2bd2f4e3160/cpu/stm32l4/stmclk.c#L152.

With this PR the clk initialization succeeds.

I don't now of any nucleo-board that provides `HSE`, but  #11895 support a `stm32wb` which uses the same `stmclk` function, testing can be performed on that PR and verifying the described behaviour.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
