### PR TITLE
cpu/stm32_common: uniformize define alignments

### DIFF
--- a/cpu/stm32_common/cpu_common.c
+++ b/cpu/stm32_common/cpu_common.c
@@ -91,13 +91,13 @@ void periph_clk_en(bus_t bus, uint32_t mask)
         case IOP:
             RCC->IOPENR |= mask;
             break;
-#elif defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32F1) \
-      || defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+#elif defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32F1) || \
+      defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
         case AHB:
             RCC->AHBENR |= mask;
             break;
-#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) \
-      || defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
+#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
+      defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
         case AHB1:
             RCC->AHB1ENR |= mask;
             break;
@@ -144,13 +144,13 @@ void periph_clk_dis(bus_t bus, uint32_t mask)
         case IOP:
             RCC->IOPENR &= ~(mask);
             break;
-#elif defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32F1) \
-      || defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+#elif defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32F1) || \
+      defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
         case AHB:
             RCC->AHBENR &= ~(mask);
             break;
-#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) \
-      || defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
+#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
+      defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
         case AHB1:
             RCC->AHB1ENR &= ~(mask);
             break;

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -34,10 +34,10 @@ extern "C" {
     defined(CPU_FAM_STM32F3)
 #define CLOCK_LSI           (40000U)
 #elif defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
-    defined(CPU_FAM_STM32L1)
+      defined(CPU_FAM_STM32L1)
 #define CLOCK_LSI           (37000U)
 #elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
-    defined(CPU_FAM_STM32L4)
+      defined(CPU_FAM_STM32L4)
 #define CLOCK_LSI           (32000U)
 #else
 #error "error: LSI clock speed not defined for your target CPU"

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -34,9 +34,9 @@
 #include "periph/gpio.h"
 #include "pm_layered.h"
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) \
-    || defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) \
-    || defined(CPU_FAM_STM32F7)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) || \
+    defined(CPU_FAM_STM32F7)
 #define ISR_REG     ISR
 #define ISR_TXE     USART_ISR_TXE
 #define ISR_TC      USART_ISR_TC
@@ -368,9 +368,9 @@ void uart_poweroff(uart_t uart)
 
 static inline void irq_handler(uart_t uart)
 {
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) \
-    || defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) \
-    || defined(CPU_FAM_STM32F7)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) || \
+    defined(CPU_FAM_STM32F7)
 
     uint32_t status = dev(uart)->ISR;
 

--- a/cpu/stm32_common/stmclk.c
+++ b/cpu/stm32_common/stmclk.c
@@ -19,8 +19,9 @@
  * @}
  */
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) \
-    || defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F3) || \
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7)
 
 #include "cpu.h"
 #include "stmclk.h"
@@ -41,7 +42,8 @@
  * @name    PLL configuration
  * @{
  */
-#if defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7)
+#if defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
+    defined(CPU_FAM_STM32F7)
 /* figure out which input to use */
 #if (CLOCK_HSE)
 #define PLL_SRC                  RCC_PLLCFGR_PLLSRC_HSE
@@ -147,7 +149,8 @@
  * @name    Deduct the needed flash wait states from the core clock frequency
  * @{
  */
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || defined(STM32F3)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F3)
 #define FLASH_WAITSTATES        ((CLOCK_CORECLOCK - 1) / 24000000U)
 #else
 #define FLASH_WAITSTATES        (CLOCK_CORECLOCK / 30000000U)
@@ -158,7 +161,8 @@
 #define FLASH_ACR_CONFIG        (FLASH_ACR_ICEN | FLASH_ACR_DCEN | FLASH_ACR_PRFTEN | FLASH_WAITSTATES)
 #elif defined(CPU_FAM_STM32F7)
 #define FLASH_ACR_CONFIG        (FLASH_ACR_ARTEN | FLASH_ACR_PRFTEN | FLASH_WAITSTATES)
-#elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F3)
+#elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+      defined(CPU_FAM_STM32F3)
 #define FLASH_ACR_CONFIG        (FLASH_ACR_PRFTBE | FLASH_WAITSTATES)
 #endif
 /** @} */
@@ -208,9 +212,11 @@ void stmclk_init_sysclk(void)
     RCC->DCKCFGR2 |= RCC_DCKCFGR2_CK48MSEL;
 #endif
     /* now we can safely configure and start the PLL */
-#if defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7)
+#if defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
+    defined(CPU_FAM_STM32F7)
     RCC->PLLCFGR = (PLL_SRC | PLL_M | PLL_N | PLL_P | PLL_Q | PLL_R);
-#elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F3)
+#elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+      defined(CPU_FAM_STM32F3)
     /* reset PLL configuration bits */
     RCC->CFGR &= ~(RCC_CFGR_PLLSRC | RCC_CFGR_PLLXTPRE | RCC_CFGR_PLLMUL);
     /* set PLL configuration */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR uniformize the define alignment in cpu/stm32_common.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Checking the code so no obvious mistake has been made and a Green murdock should be enough.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
