### PR TITLE
cpu/stm32f2: add riotboot requirements

### DIFF
--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -7,6 +7,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
 

--- a/cpu/stm32f2/Makefile.include
+++ b/cpu/stm32f2/Makefile.include
@@ -1,5 +1,23 @@
 export CPU_ARCH = cortex-m3
 export CPU_FAM  = stm32f2
 
+# STM32F2 uses sectors instead of pages, where the minimum sector length is 16KB
+# (the first sector), therefore RIOTBOOT_LEN must be 16KB to cover a whole sector.
+RIOTBOOT_LEN ?= 0x4000
+
+# CPU_IRQ_NUMOF for STM32F2 boards is < 81+16 so (97*4 bytes = 388 bytes ~= 0x200)
+# RIOTBOOT_HDR_LEN can be set to 0x200.
+# Details on alignment requirements for M3 in `cpu/cortexm_common/Makefile.include`.
+RIOTBOOT_HDR_LEN ?= 0x200
+
+# Sectors don't have the same length. Per bank there can be up to 12 sectors. The
+# first 4 sectors are 16kB long, the 5th is 64kB and the remaining 7 are 128kB.
+# Since flash can only be erased by sector, slots can't overlap over sectors.
+# The most efficient layout comes from removing RIOTBOOT_LEN twice, once at the
+# start of the flash for the bootloader, and a second time at the end of the
+# flash, to get evenly sized and distributed slots.
+SLOT0_LEN ?= $(shell printf "0x%x" $$((($(ROM_LEN:%K=%*1024)-2*$(RIOTBOOT_LEN)) / $(NUM_SLOTS))))
+SLOT1_LEN ?= $(SLOT0_LEN)
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds riotboot for stm32f2. Since F2 works with sectors for riotboot to work each slot must start at the beginning of a sector. For stm32f2 the smallest sector is of length 16kB therefore that must be the length of the bootloader and the same amount must be taken from the second half of the flash to optimize flash usage.

This PR is part of 3, since just adding riotboot doesn't make much sense if it can't perform ota. Although it doesn't depend on them but it is highly related to:

* Support flashpage: https://github.com/RIOT-OS/RIOT/pull/11681
* Support flashpage raw for flashwrite: https://github.com/RIOT-OS/RIOT/pull/11705

Also pulling https://github.com/RIOT-OS/RIOT/pull/11808 can ease testing significantly.

### Testing procedure

It has been tested on the supported boards: `nucleo-f207zg`

1.- Test riotboot:

`BOARD=nucleo-f207zg FEATURES_REQUIRED+=riotboot make -C tests/xtimer_usleep riotboot/flash-extended-slot0 term`

`BOARD=nucleo-f207zg FEATURES_REQUIRED+=riotboot make -C tests/xtimer_usleep riotboot/flash-slot1 term`

In both cases it should run without issues.

2.- Since the sector division is important when updating the slots by writing to flash directly it would be ideal to rebase on top off flashpage: https://github.com/RIOT-OS/RIOT/pull/11681 and https://github.com/RIOT-OS/RIOT/pull/11705, as well as https://github.com/RIOT-OS/RIOT/pull/11808

and run `tests/riotboot_flashwrite`

The following patch can be applied to the test Makefile

`make -C tests/riotboot_flashwrite/ BOARD=nucleo-f207zg flash test`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

* Support flashpage: https://github.com/RIOT-OS/RIOT/pull/11681
* Support flashpage raw for flashwrite: https://github.com/RIOT-OS/RIOT/pull/11705

* Also pulling https://github.com/RIOT-OS/RIOT/pull/11808 can ease testing significantly.