### PR TITLE
uniflash.inc.mk: add variables for configuration files

### DIFF
--- a/makefiles/tools/uniflash.inc.mk
+++ b/makefiles/tools/uniflash.inc.mk
@@ -1,11 +1,15 @@
 # http://www.ti.com/tool/uniflash
 FLASHFILE ?= $(ELFFILE)
 
+UNIFLASH_CONFIG_CCXML ?= $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml
+UNIFLASH_CONFIG_DAT ?= $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).dat
+UNIFLASH_CONFIG_GDB ?= $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_gdb.conf
+
 export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
 # check which uniflash version is available, either 4.x or 3.x
 ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
-  FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(FLASHFILE)
+  FFLAGS  = --config $(UNIFLASH_CONFIG_CCXML) $(FLASHFILE)
   # configure uniflash for resetting target
   # xds110reset path changed in version UniFlash v4.4.0
   # Try to detect the newest one and fallback to only 'xds110reset'
@@ -15,15 +19,15 @@ ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   RESET ?= $(XDS110RESET)
 else
   FLASHER = $(UNIFLASH_PATH)/uniflash.sh
-  FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(FLASHFILE)
+  FFLAGS  = -ccxml $(UNIFLASH_CONFIG_CCXML) -program $(FLASHFILE)
   # configure uniflash for resetting target
   RESET ?= $(UNIFLASH_PATH)/uniflash.sh
-  RESET_FLAGS ?= -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset
+  RESET_FLAGS ?= -ccxml $(UNIFLASH_CONFIG_CCXML) -reset
 endif
 # configure the debug server
 DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console
-DEBUGSERVER_FLAGS = -p 3333 $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).dat
+DEBUGSERVER_FLAGS = -p 3333 $(UNIFLASH_CONFIG_DAT)
 
 # configure the debugging tool
 DEBUGGER = $(PREFIX)gdb
-DEBUGGER_FLAGS = -x $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_gdb.conf $(ELFFILE)
+DEBUGGER_FLAGS = -x $(UNIFLASH_CONFIG_GDB) $(ELFFILE)


### PR DESCRIPTION
### Contribution description

Refactoring to use common variables for the configuration files.

This will allow overwriting the files more easily from outside.

----

This allows to locally handle setting the board serial with a custom `ccxml` file. Generated from the graphical interface or with a `serial` manually written

https://e2e.ti.com/support/tools/ccs/f/81/p/784244/2900415

Doing a global handling is planned but will require more testing and `xml` patching.

### Testing procedure

The default value did not change from `master`:

```
touch dslite.sh
```

```
UNIFLASH_PATH=${PWD} BOARD=cc2650-launchpad make --no-print-directory -C examples/hello-world/ info-debug-variable-FFLAGS info-debug-variable-RESET_FLAGS info-debug-variable-DEBUGSERVER_FLAGS info-debug-variable-DEBUGGER_FLAGS
--config /home/harter/work/git/RIOT/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.ccxml /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf

-p 3333 /home/harter/work/git/RIOT/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.dat
-x /home/harter/work/git/RIOT/boards/cc2650-launchpad/dist/cc26x0f128_gdb.conf /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf
```

```
UNIFLASH_PATH=non_existent BOARD=cc2650-launchpad make --no-print-directory -C examples/hello-world/ info-debug-variable-FFLAGS info-debug-variable-RESET_FLAGS info-debug-variable-DEBUGSERVER_FLAGS info-debug-variable-DEBUGGER_FLAGS
-ccxml /home/harter/work/git/RIOT/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.ccxml -program /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf
-ccxml /home/harter/work/git/RIOT/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.ccxml -reset
-p 3333 /home/harter/work/git/RIOT/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.dat
-x /home/harter/work/git/RIOT/boards/cc2650-launchpad/dist/cc26x0f128_gdb.conf /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf
```

The values can indeed be overwritten:

```
UNIFLASH_CONFIG_CCXML=overwritten_ccxml UNIFLASH_CONFIG_DAT=overwritten_dat UNIFLASH_CONFIG_GDB=overwritten_gdb UNIFLASH_PATH=${PWD} BOARD=cc2650-launchpad make --no-print-directory -C examples/hello-world/ info-debug-variable-FFLAGS info-debug-variable-RESET_FLAGS info-debug-variable-DEBUGSERVER_FLAGS info-debug-variable-DEBUGGER_FLAGS
--config overwritten_ccxml /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf

-p 3333 overwritten_dat
-x overwritten_gdb /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf
```

```
UNIFLASH_CONFIG_CCXML=overwritten_ccxml UNIFLASH_CONFIG_DAT=overwritten_dat UNIFLASH_CONFIG_GDB=overwritten_gdb UNIFLASH_PATH=non_existent BOARD=cc2650-launchpad make --no-print-directory -C examples/hello-world/ info-debug-variable-FFLAGS info-debug-variable-RESET_FLAGS info-debug-variable-DEBUGSERVER_FLAGS info-debug-variable-DEBUGGER_FLAGS
-ccxml overwritten_ccxml -program /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf
-ccxml overwritten_ccxml -reset
-p 3333 overwritten_dat
-x overwritten_gdb /home/harter/work/git/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf
```


### Issues/PRs references

Part of handling multiple boards on the same machine https://github.com/RIOT-OS/RIOT/pull/10870