### PR TITLE
cpu/arm7_common: Cleaned up IRQ code

### DIFF
--- a/cpu/arm7_common/irq_arch.c
+++ b/cpu/arm7_common/irq_arch.c
@@ -8,8 +8,6 @@
 #include <stdbool.h>
 
 #define IRQ_MASK 0x00000080
-#define FIQ_MASK 0x00000040
-#define INT_MASK (IRQ_MASK | FIQ_MASK)
 
 static inline unsigned __get_cpsr(void)
 {
@@ -48,46 +46,11 @@ unsigned irq_restore(unsigned oldCPSR)
     return _cpsr;
 }
 
-unsigned IRQenabled(void)
-{
-    unsigned _cpsr;
-
-    _cpsr = __get_cpsr();
-    return (_cpsr & IRQ_MASK);
-}
-
 unsigned irq_enable(void)
 {
     unsigned _cpsr;
 
     _cpsr = __get_cpsr();
     __set_cpsr(_cpsr & ~IRQ_MASK);
-    return _cpsr;
-}
-
-unsigned disableFIQ(void)
-{
-    unsigned _cpsr;
-
-    _cpsr = __get_cpsr();
-    __set_cpsr(_cpsr | FIQ_MASK);
-    return _cpsr;
-}
-
-unsigned restoreFIQ(unsigned oldCPSR)
-{
-    unsigned _cpsr;
-
-    _cpsr = __get_cpsr();
-    __set_cpsr((_cpsr & ~FIQ_MASK) | (oldCPSR & FIQ_MASK));
-    return _cpsr;
-}
-
-unsigned enableFIQ(void)
-{
-    unsigned _cpsr;
-
-    _cpsr = __get_cpsr();
-    __set_cpsr(_cpsr & ~FIQ_MASK);
     return _cpsr;
 }


### PR DESCRIPTION
### Contribution description

- Moved VIC.c to irq_arch.c for consistent naming scheme
- Removed unused functions IRQenabled, disableFIQ, restoreFIQ, enableFIQ
    - There is not header for those functions, so they *cannot* be used
    - These is obviously no user, as they *cannot* be used
    - There is absolutely no documentation what they would be used for

### Testing procedure

Build, flash and run some randomly selected examples/tests for the MSB-A2. If there were running before, they should still do so.

### Issues/PRs references

One of many steps to address https://github.com/RIOT-OS/RIOT/issues/4693