### PR TITLE
gnrc_icmpv6_echo: use gnrc_netif_hdr_set_netif()

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -100,7 +100,7 @@ void gnrc_icmpv6_echo_req_handle(gnrc_netif_t *netif, ipv6_hdr_t *ipv6_hdr,
     }
 
     if (netif != NULL) {
-        ((gnrc_netif_hdr_t *)hdr->data)->if_pid = netif->pid;
+        gnrc_netif_hdr_set_netif(hdr->data, netif);
     }
     else {
         /* ipv6_hdr->dst is loopback address */

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -67,7 +67,7 @@ typedef struct {
     BITFIELD(cktab, CKTAB_SIZE);
     uint32_t timeout;
     uint32_t interval;
-    kernel_pid_t iface;
+    gnrc_netif_t *netif;
     uint16_t id;
     uint8_t hoplimit;
     uint8_t pattern;
@@ -171,21 +171,23 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
     for (int i = 1; i < argc; i++) {
         char *arg = argv[i];
         if (arg[0] != '-') {
+            int iface;
+
             data->hostname = arg;
 #ifdef MODULE_SOCK_DNS
             if (sock_dns_query(data->hostname, &data->host, AF_INET6) == 0) {
                 continue;
             }
 #endif
-            data->iface = ipv6_addr_split_iface(data->hostname);
-            if (data->iface < KERNEL_PID_UNDEF) {
-#if GNRC_NETIF_NUMOF == 1
-                gnrc_netif_t *netif = gnrc_netif_iter(NULL);
-                if (netif != NULL) {
-                    data->iface = netif->pid;
-                }
-#endif
+            iface = ipv6_addr_split_iface(data->hostname);
+            if (iface > KERNEL_PID_UNDEF) {
+                data->netif = gnrc_netif_get_by_pid(iface);
             }
+#if GNRC_NETIF_NUMOF == 1
+            else {
+                data->netif = gnrc_netif_iter(NULL);
+            }
+#endif
             if (ipv6_addr_from_str(&data->host, data->hostname) == NULL) {
                 break;
             }
@@ -295,7 +297,7 @@ static void _pinger(_ping_data_t *data)
     ipv6 = pkt->data;
     /* if data->hoplimit is unset (i.e. 0) gnrc_ipv6 will select hop limit */
     ipv6->hl = data->hoplimit;
-    if (data->iface > KERNEL_PID_UNDEF) {
+    if (data->netif != NULL) {
         gnrc_netif_hdr_t *netif;
 
         tmp = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
@@ -304,7 +306,7 @@ static void _pinger(_ping_data_t *data)
             goto error_exit;
         }
         netif = tmp->data;
-        netif->if_pid = data->iface;
+        netif->if_pid = data->netif->pid;
         LL_PREPEND(pkt, tmp);
     }
     if (data->datalen >= sizeof(uint32_t)) {

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -298,15 +298,12 @@ static void _pinger(_ping_data_t *data)
     /* if data->hoplimit is unset (i.e. 0) gnrc_ipv6 will select hop limit */
     ipv6->hl = data->hoplimit;
     if (data->netif != NULL) {
-        gnrc_netif_hdr_t *netif;
-
         tmp = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
         if (tmp == NULL) {
             puts("error: packet buffer full");
             goto error_exit;
         }
-        netif = tmp->data;
-        netif->if_pid = data->netif->pid;
+        gnrc_netif_hdr_set_netif(tmp->data, data->netif);
         LL_PREPEND(pkt, tmp);
     }
     if (data->datalen >= sizeof(uint32_t)) {

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -180,7 +180,7 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
             }
 #endif
             iface = ipv6_addr_split_iface(data->hostname);
-            if (iface > KERNEL_PID_UNDEF) {
+            if (iface != -1) {
                 data->netif = gnrc_netif_get_by_pid(iface);
             }
 #if GNRC_NETIF_NUMOF == 1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This splits out the usage of `gnrc_netif_hdr_set_netif()` GNRC's ICMPv6 echo implentation out of #10661. 


### Testing procedure
`ping6` in `examples/gnrc_networking` and `examples/gnrc_border_router` should still work:

On two terminals:

```sh
BOARD="<your fav>" make -C examples/gnrc_networking flash term
```

```
ping6 <link-local address of other node>
ping6 <link-local address of other node>%<iface>
```

On one terminal:

```sh
BOARD="<your fav>" make -C examples/gnrc_border_router flash term
```

```
ping6 fe80::1%<wired iface>
```

On the linux host, with the border router still running:

```
ping6 fe80::2%tap0
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Split out of #10661
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
