### PR TITLE
pkg/semtech-loramac: add uplink_counter get/set functions

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -203,17 +203,7 @@ static size_t _write_uint32(size_t pos, uint32_t value)
     return eeprom_write(pos, array, sizeof(uint32_t));
 }
 
-static inline void _set_uplink_counter(semtech_loramac_t *mac, uint32_t counter)
-{
-    DEBUG("[semtech-loramac] reading uplink counter: %" PRIu32 " \n", counter);
 
-    mutex_lock(&mac->lock);
-    MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_UPLINK_COUNTER;
-    mibReq.Param.UpLinkCounter = counter;
-    LoRaMacMibSetRequestConfirm(&mibReq);
-    mutex_unlock(&mac->lock);
-}
 
 static inline void _set_join_state(semtech_loramac_t *mac, bool joined)
 {
@@ -260,7 +250,7 @@ static inline void _read_loramac_config(semtech_loramac_t *mac)
     /* Read uplink counter */
     uint32_t ul_counter;
     pos += _read_uint32(pos, &ul_counter);
-    _set_uplink_counter(mac, ul_counter);
+    semtech_loramac_set_uplink_counter(mac, ul_counter);
 
     /* Read RX2 freq */
     uint32_t rx2_freq;

--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -385,3 +385,27 @@ uint8_t semtech_loramac_get_rx2_dr(semtech_loramac_t *mac)
     mutex_unlock(&mac->lock);
     return datarate;
 }
+
+void semtech_loramac_set_uplink_counter(semtech_loramac_t *mac, uint32_t counter)
+{
+    DEBUG("[semtech-loramac] reading uplink counter: %" PRIu32 " \n", counter);
+    mutex_lock(&mac->lock);
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_UPLINK_COUNTER;
+    mibReq.Param.UpLinkCounter = counter;
+    LoRaMacMibSetRequestConfirm(&mibReq);
+    mutex_unlock(&mac->lock);
+}
+
+uint32_t semtech_loramac_get_uplink_counter(semtech_loramac_t *mac)
+{
+    mutex_lock(&mac->lock);
+    uint32_t counter;
+    DEBUG("[semtech-loramac] getting uplink counter\n");
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_UPLINK_COUNTER;
+    LoRaMacMibGetRequestConfirm(&mibReq);
+    counter = mibReq.Param.UpLinkCounter;
+    mutex_unlock(&mac->lock);
+    return counter;
+}

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -497,6 +497,22 @@ void semtech_loramac_set_rx2_dr(semtech_loramac_t *mac, uint8_t dr);
  */
 uint8_t semtech_loramac_get_rx2_dr(semtech_loramac_t *mac);
 
+/**
+ * @brief   Sets the Uplink Frame Counter
+ *
+ * @param[in] mac          Pointer to the mac
+ * @param[in] counter      Frame counter to set
+ */
+void semtech_loramac_set_uplink_counter(semtech_loramac_t *mac, uint32_t counter);
+
+/**
+ * @brief   Gets the Uplink Frame Counter
+ *
+ * @param[in] mac          Pointer to the mac
+ * @return                 Uplink frame counter
+ */
+uint32_t semtech_loramac_get_uplink_counter(semtech_loramac_t *mac);
+
 #ifdef MODULE_PERIPH_EEPROM
 /**
  * @brief   The magic number used to identify the LoRaWAN configuration

--- a/sys/shell/commands/sc_loramac.c
+++ b/sys/shell/commands/sc_loramac.c
@@ -57,13 +57,13 @@ static void _loramac_tx_usage(void)
 static void _loramac_set_usage(void)
 {
     puts("Usage: loramac set <deveui|appeui|appkey|appskey|nwkskey|devaddr|"
-         "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr> <value>");
+         "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr|ul_cnt> <value>");
 }
 
 static void _loramac_get_usage(void)
 {
     puts("Usage: loramac get <deveui|appeui|appkey|appskey|nwkskey|devaddr|"
-         "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr>");
+         "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr|ul_cnt>");
 }
 
 int _loramac_handler(int argc, char **argv)
@@ -161,6 +161,9 @@ int _loramac_handler(int argc, char **argv)
         }
         else if (strcmp("rx2_dr", argv[2]) == 0) {
             printf("RX2 dr: %d\n", semtech_loramac_get_rx2_dr(&loramac));
+        }
+        else if (strcmp("ul_cnt", argv[2]) == 0) {
+            printf("Uplink Counter: %"PRIu32"\n", semtech_loramac_get_uplink_counter(&loramac));
         }
         else {
             _loramac_get_usage();
@@ -334,6 +337,14 @@ int _loramac_handler(int argc, char **argv)
                 return 1;
             }
             semtech_loramac_set_rx2_dr(&loramac, dr);
+        }
+        else if (strcmp("ul_cnt", argv[2]) == 0) {
+            if (argc < 4) {
+                puts("Usage: loramac set ul_cnt <value>");
+                return 1;
+            }
+            uint32_t counter = atoi(argv[3]);
+            semtech_loramac_set_uplink_counter(&loramac, counter);
         }
         else {
             _loramac_set_usage();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR exposes` _set_uplink_counter()` as part of the public api for `semtech_loramac`. It also adds it as a shell command. 

This is used by #11915 to be able to save and set the frame counter after a reboot on a node that doesn't have eeprom support. The use case for exposing the function is similar, being able to set the uplink counter to user defined values so there is no need to reset the network server.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

- Basic check:

`make BOARD=b-l072z-lrwan1 -C tests/pkg_semtech-loramac/ flash term`

Get and set the up link counter.

```
loramac get ul_ctr
2019-07-25 15:32:41,771 - INFO # loramac get ul_ctr
2019-07-25 15:32:41,773 - INFO # Uplink Counter: 3
> loramac set ul_ctr 8
2019-07-25 15:32:54,262 - INFO #  loramac set ul_ctr 8
loramac get ul_ctr
2019-07-25 15:32:59,406 - INFO #  loramac get ul_ctr
2019-07-25 15:32:59,408 - INFO # Uplink Counter: 8
```

- Functionality check: 

`make BOARD=b-l072z-lrwan1 -C tests/pkg_semtech-loramac/ flash term`

Set proper keys, and a high datarate. Manipulate the ul_ctr so the network server rejecs the incoming packets and then set it to a higher value so it accepts them again:

```
> 2019-07-25 15:40:56,624 - INFO #  main(): This is RIOT! (Version: 2019.10-devel-118-gb6999-pr_loramac_uplink_setget)
2019-07-25 15:40:56,627 - INFO # All up, running the shell now
>  loramac set deveui 00EB7BF2F1B8D06C
2019-07-25 15:41:07,073 - INFO #  loramac set deveui 00EB7BF2F1B8D06C
loramac set appeui 70B3D57ED001FD5FCA
2019-07-25 15:41:13,747 - INFO #  loramac set appeui 70B3D57ED001FD5F
: loramac set appskey 24C03C182530A3C70F1F9702A49939CA
2019-07-25 15:41:18,724 - INFO #  loramac set appskey 24C03C182530A3C70F1F9702A49939CA
: loramac set nwkskey 14601248D522BCD93C2DDFA6BF86B496
2019-07-25 15:41:23,085 - INFO #  loramac set nwkskey 14601248D522BCD93C2DDFA6BF86B496
: loramac set devaddr 26011847
2019-07-25 15:41:26,144 - INFO #  loramac set devaddr 26011847
: loramac set rx2_dr 3
2019-07-25 15:41:29,152 - INFO #  loramac set rx2_dr 3
: loramac set dr 5
2019-07-25 15:41:32,877 - INFO #  loramac set dr 5
: loramac join abp
2019-07-25 15:41:35,280 - INFO #  loramac join abp
2019-07-25 15:41:35,282 - INFO # Join procedure succeeded!
: loramac tx hello cnf
2019-07-25 15:41:46,408 - INFO #  loramac tx hello cnf
2019-07-25 15:41:47,538 - INFO # Received ACK from network
2019-07-25 15:41:47,540 - INFO # Message sent with success
> loramac tx hello cnf
2019-07-25 15:41:49,665 - INFO #  loramac tx hello cnf
2019-07-25 15:41:49,670 - INFO # Cannot send: dutycycle restriction
> loramac tx hello cnf
2019-07-25 15:41:52,583 - INFO #  loramac tx hello cnf
2019-07-25 15:41:53,713 - INFO # Received ACK from network
2019-07-25 15:41:53,715 - INFO # Message sent with success
: loramac set ul_ctr 0
2019-07-25 15:42:01,926 - INFO #  loramac set ul_ctr 0
> loramatx hello cnf
2019-07-25 15:42:06,386 - INFO #  loramac tx hello cnf
2019-07-25 15:42:21,888 - INFO # Fail to send: no ACK received
> loramaset ul_ctr 8
2019-07-25 15:42:29,362 - INFO #  loramac set ul_ctr 8
> loramatx hello cnf 8
2019-07-25 15:42:31,193 - INFO #  loramac tx hello cnf
2019-07-25 15:42:32,323 - INFO # Received ACK from network
2019-07-25 15:42:32,325 - INFO # Message sent with success

```
- Run the test in #11915 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Required by #11915.