### PR TITLE
 gnrc_ipv6: use gnrc_netif_hdr_get/set_netif()

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -211,8 +211,7 @@ static void _send(gnrc_pktsnip_t *pkt, const gnrc_pktsnip_t *orig_pkt,
         if (netif) {
             /* copy interface from original netif header to assure packet
              * goes out where it came from */
-            gnrc_netif_hdr_t *netif_hdr = netif->data;
-            kernel_pid_t netif_pid = netif_hdr->if_pid;
+            gnrc_netif_t *iface = gnrc_netif_hdr_get_netif(netif->data);
 
             netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
             if (netif == NULL) {
@@ -220,8 +219,7 @@ static void _send(gnrc_pktsnip_t *pkt, const gnrc_pktsnip_t *orig_pkt,
                 gnrc_pktbuf_release(pkt);
                 return;
             }
-            netif_hdr = netif->data;
-            netif_hdr->if_pid = netif_pid;
+            gnrc_netif_hdr_set_netif(netif->data, iface);
             LL_PREPEND(pkt, netif);
         }
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6,

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -630,7 +630,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
     netif_hdr = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
 
     if (netif_hdr != NULL) {
-        netif = gnrc_netif_get_by_pid(((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid);
+        netif = gnrc_netif_hdr_get_netif(netif_hdr->data);
 #ifdef MODULE_NETSTATS_IPV6
         assert(netif != NULL);
         netstats_t *stats = &netif->ipv6.stats;

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -232,7 +232,7 @@ static void _send_to_iface(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     const ipv6_hdr_t *hdr = pkt->next->data;
 
     assert(netif != NULL);
-    ((gnrc_netif_hdr_t *)pkt->data)->if_pid = netif->pid;
+    gnrc_netif_hdr_set_netif(pkt->data, netif);
     if (gnrc_pkt_len(pkt->next) > netif->ipv6.mtu) {
         DEBUG("ipv6: packet too big\n");
         gnrc_icmpv6_error_pkt_too_big_send(netif->ipv6.mtu, pkt);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -830,7 +830,7 @@ static void _send_delayed_nbr_adv(const gnrc_netif_t *netif,
     if ((pkt = _check_release_pkt(pkt, payload)) == NULL) {
         return;
     }
-    ((gnrc_netif_hdr_t *)pkt->data)->if_pid = netif->pid;
+    gnrc_netif_hdr_set_netif(pkt->data, netif);
     LL_PREPEND(payload, pkt);
     _evtimer_add(pkt, GNRC_IPV6_NIB_SND_NA, &nce->snd_na,
                  random_uint32_range(0, NDP_MAX_ANYCAST_MS_DELAY));
@@ -1196,7 +1196,7 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                             queue_entry->pkt = NULL;
                             return false;
                         }
-                        ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = netif->pid;
+                        gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
                         LL_PREPEND(queue_entry->pkt, netif_hdr);
                     }
                     gnrc_pktqueue_add(&entry->pktqueue, queue_entry);

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -609,7 +609,7 @@ static gnrc_pktsnip_t *_build_headers(gnrc_netif_t *netif,
         gnrc_pktbuf_remove_snip(iphdr, iphdr);
         return NULL;
     }
-    ((gnrc_netif_hdr_t *)l2hdr->data)->if_pid = netif->pid;
+    gnrc_netif_hdr_set_netif(l2hdr->data, netif);
     LL_PREPEND(iphdr, l2hdr);
     return l2hdr;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This splits out the usage of `gnrc_netif_hdr_get_netif()`/`gnrc_netif_hdr_set_netif()` of IPv6 related stuff of GNRC out of #10661 (except for ICMPv6 echo, see #11916).


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The following tests should still pass
- `tests/gnrc_ndp`
- `tests/gnrc_ipv6_nib`
- `tests/gnrc_ipv6_nib_6ln`

It also does not hurt to do all the tests in [Task 10 of the release specs](https://github.com/RIOT-OS/Release-Specs/blob/master/10-icmpv6-error/10-icmpv6-error.md), however one of subtask 1-9 should be enough as only the sending routine of the `gnrc_icmpv6_error` module is changed.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Split out of #10661.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
