### PR TITLE
cpu/cortexm_common: replace irq_restore by __set_PRIMASK for stm32l152re

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -171,10 +171,11 @@ static inline void cortexm_sleep(int deep)
     __DSB();
     __WFI();
 #if defined(CPU_MODEL_STM32L152RE)
-    /* STM32L152RE crashes without this __NOP(). See #8518. */
-    __NOP();
-#endif
+    /* STM32L152RE crashes if branching to irq_restore(state). See #11830. */
+    __set_PRIMASK(state);
+#else
     irq_restore(state);
+#endif
 }
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR was split from #11830.

When #7385 was introduced when going to sleep (i.e. calling `__WFI()`), `irq_enable` was changed to `irq_restore` and that broke `stm32l152re`. 

#8518 fixed the issue by introducing a `__NOP()` after `__WFI()`. This fixed the issue until #11159 where the call to `cortexm_sleep` was changed and now `__NOP()` didn't fix the issue but instead somehow triggered it.

After debugging in #11820 it was discovered that the changes in #7385 didn't actually break the code, but broke the code only when `DBGMCU_CR_DBG_STANDBY | DBGMCU_CR_DBG_STOP | DBGMCU_CR_DBG_SLEEP` where enabled. By default openocd sets these bits after an `examine-end` event. This is done by default for all stm32 boards.

https://github.com/ntfreak/openocd/blob/263deb3802a515ba8155b6c59146f0f539de4e43/tcl/target/stm32l1.cfg#L93-L100

This could be fixed by 510ffce so those bits are set only when `gdb` is launched. No need to enable debugging in other cases. When debugging this issue was still present.

Multiple changes/fixes where attempted in #11820 to fix the issue. Non of them sufficiently consistent or un-intrusive.

As for all I can tell, and as stated in #8518, the issue was the loss of the content of `r0` when jumping to `irq_restore` which resulted in a corrupted `pc` trying to execute instructions out of the flash region. 

```
2019-07-09 17:38:58,314 - INFO # Attempting to reconstruct state for debugging...
2019-07-09 17:38:58,315 - INFO # In GDB:
2019-07-09 17:38:58,316 - INFO #   set $pc=0x7822d5e
2019-07-09 17:38:58,317 - INFO #   frame 0
2019-07-09 17:38:58,317 - INFO #   bt
2019-07-09 17:38:58,318 - INFO # 
2019-07-09 17:38:58,319 - INFO # ISR stack overflowed by at least 16 bytes.

```

Since the problem was the branch, with 5d96127  `irq_restore` was replaced by `__set_PRIMASK(state);` which inlines the function call avoiding the jump and the whole issue all together.

The disassembly:

```
 80006e6:       f023 0304       bic.w   r3, r3, #4
 80006ea:       6113            str     r3, [r2, #16]
 80006ec:       f7ff ffac       bl      8000648 <irq_disable>
 80006f0:       f3bf 8f4f       dsb     sy
 80006f4:       bf30            wfi
 80006f6:       f380 8810       msr     PRIMASK, r0
 80006fa:       b33c            cbz     r4, 800074c <pm_set+0x74>
 80006fc:       e8bd 4010       ldmia.w sp!, {r4, lr}
 8000700:       f000 bc82       b.w     8001008 <stmclk_init_sysclk>
 8000704:       4b13            ldr     r3, [pc, #76]   ; (8000754 <pm_set+0x7c>)
```

Original disassembly:

```
 80006e4:       6913            ldr     r3, [r2, #16]
 80006e6:       f023 0304       bic.w   r3, r3, #4
 80006ea:       6113            str     r3, [r2, #16]
 80006ec:       f7ff ffac       bl      8000648 <irq_disable>
 80006f0:       f3bf 8f4f       dsb     sy
 80006f4:       bf30            wfi
 80006f6:       bf00            nop
 80006f8:       f7ff ffae       bl      8000658 <irq_restore>
 80006fc:       b33c            cbz     r4, 800074e <pm_set+0x76>
 80006fe:       e8bd 4010       ldmia.w sp!, {r4, lr}
 8000702:       f000 bc85       b.w     8001010 <stmclk_init_sysclk>
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

- To a simple check to verify the issue is fixed.

In master this hardfaults:

`
make -C tests/xtimer_drift BOARD=nucleo-l152re -j3 flash term
`

- For the same command, verify the change robustness:
   - Change optimization to -O2
   - Add/Remove __NOP( )
  -  checkout #8518 ~1 and see that this fix also works at that time.

- to be safe run `python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --jobs 4 . nucleo-l152re`, I got the following tests fails (expected fails)

```
ERROR:nucleo-l152re:Tests failed: 7
Failures during test:
- [tests/driver_grove_ledbar](tests/driver_grove_ledbar/test.failed)
- [tests/driver_my9221](tests/driver_my9221/test.failed)
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/pkg_fatfs_vfs](tests/pkg_fatfs_vfs/test.failed)
- [tests/pkg_qdsa](tests/pkg_qdsa/test.failed)
```

### Issues/PRs references

Fixes #11820 
See also #8518 & #8024

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
