### PR TITLE
cpu/lpc2387: Cleanup

### DIFF
--- a/boards/avsextrem/board_init.c
+++ b/boards/avsextrem/board_init.c
@@ -68,10 +68,6 @@ void init_clks1(void)
 
     /* Set clock divider to 4 (value+1) */
     CCLKCFG = CL_CPU_DIV - 1; // Fcpu = 72 MHz
-
-#if USE_USB
-    USBCLKCFG = USBCLKDivValue; /* usbclk = 288 MHz/6 = 48 MHz */
-#endif
 }
 
 /*---------------------------------------------------------------------------*/

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -72,8 +72,4 @@ void init_clks1(void)
 
     /* Set clock divider to 4 (value+1) */
     CCLKCFG = CL_CPU_DIV - 1;           /* Fcpu = 72 MHz */
-
-#if USE_USB
-    USBCLKCFG = USBCLKDivValue;     /* usbclk = 288 MHz/6 = 48 MHz */
-#endif
 }

--- a/cpu/arm7_common/arm7_init.c
+++ b/cpu/arm7_common/arm7_init.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2008-2009, Freie Universitaet Berlin (FUB). All rights reserved.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_arm7_common
+ * @{
+ *
+ * @file
+ * @brief       Common ARM7 boot up code
+ *
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Michael Baar <michael.baar@fu-berlin.de>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "thread.h"
+
+#include "log.h"
+
+static inline void
+_init_data(void)
+{
+    extern unsigned int _etext;
+    extern unsigned int _data;
+    extern unsigned int _edata;
+    extern unsigned int __bss_start;
+    extern unsigned int __bss_end;
+
+    register unsigned int *p1;
+    register unsigned int *p2;
+    register unsigned int *p3;
+
+    // initialize data from flash
+    // (linker script ensures that data is 32-bit aligned)
+    p1 = &_etext;
+    p2 = &_data;
+    p3 = &_edata;
+
+    while (p2 < p3) {
+        *p2++ = *p1++;
+    }
+
+    // clear bss
+    // (linker script ensures that bss is 32-bit aligned)
+    p1 = &__bss_start;
+    p2 = &__bss_end;
+
+    while (p1 < p2) {
+        *p1++ = 0;
+    }
+}
+
+void bootloader(void)
+{
+    extern void bl_init_ports(void);
+    extern void bl_init_clks(void);
+
+    /* board specific setup of clocks */
+    bl_init_clks();
+
+    /* initialize bss and data */
+    _init_data();
+
+    /* board specific setup of i/o pins */
+    bl_init_ports();
+
+#ifdef MODULE_NEWLIB
+    extern void __libc_init_array(void);
+    __libc_init_array();
+#endif
+}
+
+/** @} */

--- a/cpu/arm7_common/bootloader.c
+++ b/cpu/arm7_common/bootloader.c
@@ -34,12 +34,6 @@ void FIQ_Routine(void)   __attribute__((interrupt("FIQ")));
 //void SWI_Routine (void)   __attribute__((interrupt("SWI")));
 void UNDEF_Routine(void) __attribute__((interrupt("UNDEF")));
 
-void IRQ_Routine(void)
-{
-    LOG_ERROR("Kernel Panic,\nEarly IRQ call\n");
-
-    while (1) {};
-}
 /*-----------------------------------------------------------------------------------*/
 void FIQ_Routine(void)
 {
@@ -51,13 +45,6 @@ void FIQ_Routine(void)
 void SWI_Routine(void)
 {
     LOG_ERROR("Kernel Panic,\nEarly SWI call\n");
-
-    while (1) {};
-}
-/*-----------------------------------------------------------------------------------*/
-void DEBUG_Routine(void)
-{
-    LOG_ERROR("DEBUG hit.");
 
     while (1) {};
 }
@@ -164,19 +151,14 @@ bl_init_data(void)
 /*-----------------------------------------------------------------------------------*/
 void bootloader(void)
 {
-    extern void bl_uart_init(void);
     extern void bl_init_ports(void);
     extern void bl_init_clks(void);
-    extern void bl_blink(void);
-    extern void bl_config_init(void);
 
     /* board specific setup of clocks */
     bl_init_clks();
 
     /* initialize bss and data */
-#ifndef CPU_MC1322X
     bl_init_data();
-#endif
 
     /* board specific setup of i/o pins */
     bl_init_ports();

--- a/cpu/arm7_common/common.s
+++ b/cpu/arm7_common/common.s
@@ -33,7 +33,6 @@
   .extern  sched_active_thread
   .extern  sched_context_switch_request
   .extern  sched_run
-  .extern  DEBUG_Routine
 
 /* Public functions declared in this file */
   .global  arm_irq_handler

--- a/cpu/arm7_common/vectors.c
+++ b/cpu/arm7_common/vectors.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2009, Freie Universitaet Berlin (FUB). All rights reserved.
+ * Copyright (C) 2008-2009, Freie Universität Berlin (FUB). All rights reserved.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -9,19 +9,13 @@
 /**
  * @ingroup     cpu_arm7_common
  * @{
- */
-
-/**
+ *
  * @file
- * @internal
- * @brief       ARM bootloader
+ * @brief       Default implementations for ARM7 specific interrupt and
+ *              exception handlers
  *
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Michael Baar <michael.baar@fu-berlin.de>
- * @version     $Revision$
- * @since       19.08.2008
- *
- * @note        $Id$
  */
 
 #include <stdio.h>
@@ -30,26 +24,25 @@
 
 #include "log.h"
 
-void FIQ_Routine(void)   __attribute__((interrupt("FIQ")));
-//void SWI_Routine (void)   __attribute__((interrupt("SWI")));
-void UNDEF_Routine(void) __attribute__((interrupt("UNDEF")));
+void isr_fio(void)   __attribute__((interrupt("FIQ")));
+//void isr_swi (void)   __attribute__((interrupt("SWI")));
+void isr_undef(void) __attribute__((interrupt("UNDEF")));
 
-/*-----------------------------------------------------------------------------------*/
-void FIQ_Routine(void)
+volatile int arm_abortflag = 0;
+
+void isr_fio(void)
 {
     LOG_ERROR("Kernel Panic,\nEarly FIQ call\n");
 
     while (1) {};
 }
-/*-----------------------------------------------------------------------------------*/
-void SWI_Routine(void)
+
+void isr_swi(void)
 {
     LOG_ERROR("Kernel Panic,\nEarly SWI call\n");
 
     while (1) {};
 }
-/*-----------------------------------------------------------------------------------*/
-volatile int arm_abortflag = 0;
 
 void abtorigin(const char *vector, unsigned long *lnk_ptr1)
 {
@@ -70,8 +63,8 @@ void abtorigin(const char *vector, unsigned long *lnk_ptr1)
 
     while (1) {};
 }
-/*-----------------------------------------------------------------------------------*/
-void UNDEF_Routine(void)
+
+void isr_undef(void)
 {
     /* cppcheck-suppress variableScope
      * (reason: used within __asm__ which cppcheck doesn't pick up) */
@@ -85,8 +78,8 @@ void UNDEF_Routine(void)
 
     while (1) {};
 }
-/*-----------------------------------------------------------------------------------*/
-void PABT_Routine(void)
+
+void isr_pabt(void)
 {
     /* cppcheck-suppress variableScope
      * (reason: used within __asm__ which cppcheck doesn't pick up) */
@@ -100,8 +93,8 @@ void PABT_Routine(void)
 
     while (1) {};
 }
-/*-----------------------------------------------------------------------------------*/
-void DABT_Routine(void)
+
+void isr_dabt(void)
 {
     /* cppcheck-suppress variableScope
      * (reason: used within __asm__ which cppcheck doesn't pick up) */
@@ -115,58 +108,3 @@ void DABT_Routine(void)
 
     while (1) {};
 }
-/*-----------------------------------------------------------------------------------*/
-static inline void
-bl_init_data(void)
-{
-    extern unsigned int _etext;
-    extern unsigned int _data;
-    extern unsigned int _edata;
-    extern unsigned int __bss_start;
-    extern unsigned int __bss_end;
-
-    register unsigned int *p1;
-    register unsigned int *p2;
-    register unsigned int *p3;
-
-    // initialize data from flash
-    // (linker script ensures that data is 32-bit aligned)
-    p1 = &_etext;
-    p2 = &_data;
-    p3 = &_edata;
-
-    while (p2 < p3) {
-        *p2++ = *p1++;
-    }
-
-    // clear bss
-    // (linker script ensures that bss is 32-bit aligned)
-    p1 = &__bss_start;
-    p2 = &__bss_end;
-
-    while (p1 < p2) {
-        *p1++ = 0;
-    }
-}
-/*-----------------------------------------------------------------------------------*/
-void bootloader(void)
-{
-    extern void bl_init_ports(void);
-    extern void bl_init_clks(void);
-
-    /* board specific setup of clocks */
-    bl_init_clks();
-
-    /* initialize bss and data */
-    bl_init_data();
-
-    /* board specific setup of i/o pins */
-    bl_init_ports();
-
-#ifdef MODULE_NEWLIB
-    extern void __libc_init_array(void);
-    __libc_init_array();
-#endif
-}
-
-/** @} */

--- a/cpu/lpc2387/startup.s
+++ b/cpu/lpc2387/startup.s
@@ -47,25 +47,25 @@
 It is 64 bytes and can be mapped (see documentation 1.4.2). */
 .section .vectors
 /* Exception Vectors */
-                ldr     PC, Reset_Addr      /* Reset */
-                ldr     PC, Undef_Addr      /* Undefined Instruction */
-                ldr     PC, SWI_Addr        /* Software Interrupt */
-                ldr     PC, PAbt_Addr       /* Prefetch Abort */
-                ldr     PC, DAbt_Addr       /* Data Abort */
+                ldr     PC, reset_addr      /* Reset */
+                ldr     PC, undef_addr      /* Undefined Instruction */
+                ldr     PC, swi_addr        /* Software Interrupt */
+                ldr     PC, pabt_addr       /* Prefetch Abort */
+                ldr     PC, dabt_addr       /* Data Abort */
                 nop                         /* Reserved Vector (holds Philips ISP checksum) */
                 /* see page 71 of "Insiders Guide to the Philips ARM7-Based Microcontrollers" by Trevor Martin  */
 /*                ldr     PC, [PC,#-0x0120]     /* Interrupt Request Interrupt (load from VIC) */
-                ldr     PC, IRQ_Addr        /* Interrupt Request Interrupt (load from VIC) */
+                ldr     PC, irq_addr        /* Interrupt Request Interrupt (load from VIC) */
                 ldr     r0, =__fiq_handler  /* Fast Interrupt Request Interrupt */
                 ldr     pc, [r0]            /* jump to handler in pointer at __fiq_handler */
 
 /* Exception vector handlers branching table */
-Reset_Addr:     .word   Reset_Handler       /* defined in this module below  */
-Undef_Addr:     .word   UNDEF_Routine       /* defined in main.c  */
-SWI_Addr:       .word   ctx_switch          /* defined in main.c  */
-PAbt_Addr:      .word   PABT_Routine        /* defined in main.c  */
-DAbt_Addr:      .word   DABT_Routine        /* defined in main.c  */
-IRQ_Addr:       .word   arm_irq_handler      /* defined in main.c  */
+reset_addr:     .word   reset_handler       /* defined in this module below  */
+undef_addr:     .word   isr_undef           /* defined in arm7_common/vectors.c */
+swi_addr:       .word   ctx_switch          /* defined in arm7_common/common.s */
+pabt_addr:      .word   isr_pabt            /* defined in arm7_common/vectors.c */
+dabt_addr:      .word   isr_dabt            /* defined in arm7_common/vectors.c */
+irq_addr:       .word   arm_irq_handler     /* defined in arm7_common/common.s */
 
 /* Begin of boot code */
 .text
@@ -76,10 +76,10 @@ IRQ_Addr:       .word   arm_irq_handler      /* defined in main.c  */
 .func   _startup
 
 _startup:
-                ldr    pc, =Reset_Handler
+                ldr    pc, =reset_handler
 
-/*.func Reset_Handler */
-Reset_Handler:
+/*.func reset_handler */
+reset_handler:
 
 .section .init0
                 /* Setup a stack for each mode - note that this only sets up a usable stack


### PR DESCRIPTION
Note: The boot up sequence of the LPC2387 is quite weird, with clock setup in the `boards/` rather than in `cpu/`. I intend to clean this up with a series of PRs. A side effect from the code organization is that this PR touches files in seemingly unrelated subsystems...

### Contribution description
- Removed unused and defunct code from the clock configuration during boot up
- Removed obsolete ISR implementations that are not registered anywhere anymore and thus never get triggered
- Removed function declarations of functions that are neither used nor implemented anywhere
- Previously boot up code and ISR implementations where mixed together in `bootloader.c`
    - Moved ISR implementations to `vector.c` and applied naming scheme used by other modules in `cpu/`
    - Moved boot up code to `arm7_init.c`.


### Testing procedure
Try to build, flash, and run some applications and tests currently working on the MSB-A2. They should still work

### Issues/PRs references
One of many steps to address https://github.com/RIOT-OS/RIOT/issues/4693