### PR TITLE
github: add configuration for stale-bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Number of days of inactivity before an issue becomes stale (185 days > 1/2 year)
+daysUntilStale: 185
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 31
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "Area: security"
+  - "State: demonstrator"
+  - "State: don't stale"
+  - "Type: tracking"
+# Label to use when marking an issue as stale
+staleLabel: "State: stale"
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+  If you want me to ignore this issue, please mark it with the
+  "State: don't stale" label. Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds a configuration for the [probot stale app](https://probot.github.io/apps/stale/). It basically implements what we already do by hand / with comments: If there is no activity in an issue/PR for > 1/2 year, mark it as stale (using the new `State: stale` label) and if there is still no activity then, close it. Excempt from this are the issues/PRs marked with the following labels:

- `Area: security`
- `State: demonstator`
- `State: don't stale`
- `Type: tracking`

Maybe this somewhat increases the productivity.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Not sure this can be tested without the file being merged :-/.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
