### PR TITLE
cpu/esp32: activate cpp feature

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -1,5 +1,10 @@
 # additional modules dependencies
 
+ifneq (,$(filter cpp,$(FEATURES_USED)))
+    USEMODULE += pthread
+    BASELIBS += -lstdc++
+endif
+
 ifneq (,$(filter esp_eth,$(USEMODULE)))
     USEMODULE += esp_idf_eth
     USEMODULE += esp_idf_eth_phy

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -1,4 +1,5 @@
-# Features that are provided by CPU independent on the board
+# Features that are provided by the CPU independent on the board
+FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm


### PR DESCRIPTION
### Contribution description

This PR activates the C++ feature for ESP32 boards. It simply adds the pthread module and libstdc++ to linked libraries to solve the problem of unresolved symbols when feature cpp is required.

### Testing procedure

Compile and flash  `examples/riot_and_cpp`, for example
```
make BOARD=esp32-wroom-32 -C examples/riot_and_cpp flash
```
to test the device with a C++ application.

### Issues/PRs references
