### PR TITLE
periph/hwrng: Introduce generic hwrng_read(), allow for leaner HWRNG implementations

### DIFF
--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -326,6 +326,12 @@ typedef gpio_t adc_conf_t;
 #define SOCADC_12_BIT_RSHIFT    (4U) /**< Mask for getting data(12 bits ENOB) */
 /** @} */
 
+/**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_INIT   (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc2538/periph/hwrng.c
+++ b/cpu/cc2538/periph/hwrng.c
@@ -79,6 +79,24 @@ void hwrng_init(void)
     RFCORE_SFR_RFST = ISRFOFF;
 }
 
+uint32_t hwrng_uint32(void)
+{
+    union {
+        uint16_t half[2];
+        uint32_t val;
+    } rnd;
+
+    /* Clock the RNG LSFR once: */
+    soc_adc->ADCCON1 = soc_adc->ADCCON1 | (1UL << SOC_ADC_ADCCON1_RCTRL_S);
+    rnd.half[0] = soc_adc->RNDL | (soc_adc->RNDH << 8);
+
+    /* Clock the RNG LSFR again: */
+    soc_adc->ADCCON1 = soc_adc->ADCCON1 | (1UL << SOC_ADC_ADCCON1_RCTRL_S);
+    rnd.half[1] = soc_adc->RNDL | (soc_adc->RNDH << 8);
+
+    return rnd.val;
+}
+
 void hwrng_read(void *buf, unsigned int num)
 {
     uint8_t *b = (uint8_t *)buf;

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -398,6 +398,13 @@ typedef struct {
 } uart_conf_t;
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_GENERIC_READ (1)
+#define HWRNG_HAS_INIT         (1)
+
+/**
  * @brief   CPU provides own pm_off() function
  */
 #define PROVIDES_PM_LAYERED_OFF

--- a/cpu/efm32/periph/hwrng.c
+++ b/cpu/efm32/periph/hwrng.c
@@ -49,21 +49,3 @@ uint32_t hwrng_uint32(void)
 {
     return TRNG0->FIFO;
 }
-
-void hwrng_read(void *buf, unsigned int num)
-{
-    uint32_t *out_buf = (uint32_t *) buf;
-    uint32_t tmp;
-
-    /* read known good available data */
-    while (num >= 4) {
-        *out_buf++ = TRNG0->FIFO;
-        num -= 4;
-    }
-
-    /* read remaining data (not multiple of 4) */
-    if (num) {
-        tmp = TRNG0->FIFO;
-        memcpy((uint8_t *)out_buf, (const uint8_t *) &tmp, num);
-    }
-}

--- a/cpu/efm32/periph/hwrng.c
+++ b/cpu/efm32/periph/hwrng.c
@@ -45,6 +45,11 @@ void hwrng_init(void)
     while (TRNG0->FIFOLEVEL == 0) {}
 }
 
+uint32_t hwrng_uint32(void)
+{
+    return TRNG0->FIFO;
+}
+
 void hwrng_read(void *buf, unsigned int num)
 {
     uint32_t *out_buf = (uint32_t *) buf;

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -35,6 +35,12 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_GENERIC_READ (1)
+
+/**
  * @brief   Length of the CPU_ID in octets
  */
 #define CPUID_LEN           (7U)

--- a/cpu/esp32/periph/hwrng.c
+++ b/cpu/esp32/periph/hwrng.c
@@ -23,33 +23,9 @@
 #include "periph_conf.h"
 #include "periph/hwrng.h"
 
-static const uint32_t* RNG_DATA_REG = (uint32_t*)0x3ff75144;
+#define RNG_DATA_REG (*(volatile uint32_t *)0x3ff75144)
 
-void hwrng_init(void)
+uint32_t hwrng_uint32(void)
 {
-    /* no need for initialization */
-}
-#include "rom/ets_sys.h"
-void hwrng_read(void *buf, unsigned int num)
-{
-    unsigned int count = 0;
-    uint8_t *b = (uint8_t *)buf;
-
-    while (count < num) {
-        /* read next 4 bytes of random data */
-        uint32_t tmp = *RNG_DATA_REG;
-
-        /* copy data into result vector */
-        for (int i = 0; i < 4 && count < num; i++) {
-            b[count++] = (uint8_t)tmp;
-            tmp = tmp >> 8;
-        }
-    }
-}
-
-uint32_t hwrand (void)
-{
-    uint32_t _tmp;
-    hwrng_read(&_tmp, sizeof(uint32_t));
-    return _tmp;
+    return RNG_DATA_REG;
 }

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -39,6 +39,7 @@
 #include "periph/cpuid.h"
 #include "periph/init.h"
 #include "periph/rtc.h"
+#include "periph/hwrng.h"
 
 #include "driver/periph_ctrl.h"
 #include "esp/common_macros.h"
@@ -88,7 +89,6 @@ extern void esp_reent_init(struct _reent* r);
 extern void esp_panic_wdt_stop (void);
 extern void spi_ram_init(void);
 extern void spi_ram_heap_init(void);
-extern uint32_t hwrand (void);
 extern void bootloader_clock_configure(void);
 
 /* forward declarations */
@@ -286,7 +286,7 @@ static NORETURN void IRAM system_init (void)
     system_wdt_init();
 
     /* init random number generator */
-    srand(hwrand());
+    srand(hwrng_uint32());
 
     /*
      * initialization as it should be called from newlibc (includes the

--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -33,6 +33,12 @@ extern "C" {
 #define CPUID_LEN           (4U)
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_GENERIC_READ (1)
+
+/**
  * @name    GPIO configuration of ESP8266
  * @{
  */

--- a/cpu/esp8266/periph/hwrng.c
+++ b/cpu/esp8266/periph/hwrng.c
@@ -47,9 +47,7 @@ void hwrng_read(void *buf, unsigned int num)
     }
 }
 
-uint32_t hwrand (void)
+uint32_t hwrng_uint32(void)
 {
-    uint32_t _tmp;
-    hwrng_read(&_tmp, sizeof(uint32_t));
-    return _tmp;
+    return WDEV.HWRNG;
 }

--- a/cpu/esp8266/periph/hwrng.c
+++ b/cpu/esp8266/periph/hwrng.c
@@ -25,28 +25,6 @@
 
 #include "esp/wdev_regs.h"
 
-void hwrng_init(void)
-{
-    /* no need for initialization */
-}
-
-void hwrng_read(void *buf, unsigned int num)
-{
-    unsigned int count = 0;
-    uint8_t *b = (uint8_t *)buf;
-
-    while (count < num) {
-        /* read next 4 bytes of random data */
-        uint32_t tmp = WDEV.HWRNG;
-
-        /* copy data into result vector */
-        for (int i = 0; i < 4 && count < num; i++) {
-            b[count++] = (uint8_t)tmp;
-            tmp = tmp >> 8;
-        }
-    }
-}
-
 uint32_t hwrng_uint32(void)
 {
     return WDEV.HWRNG;

--- a/cpu/esp8266/startup.c
+++ b/cpu/esp8266/startup.c
@@ -26,6 +26,7 @@
 #include "kernel_init.h"
 #include "log.h"
 #include "periph/init.h"
+#include "periph/hwrng.h"
 
 #include "c_types.h"
 #include "spi_flash.h"
@@ -48,8 +49,6 @@
 
 extern void board_init(void);
 extern void board_print_config(void);
-
-uint32_t hwrand (void);
 
 #ifdef MODULE_NEWLIB_SYSCALLS_DEFAULT
 /* initialization as it should be called from newlibc */
@@ -153,7 +152,7 @@ void system_init(void)
     init_exceptions ();
 
     /* init random number generator */
-    srand(hwrand());
+    srand(hwrng_uint32());
 
     /* init flash drive */
     extern void flash_drive_init (void);
@@ -687,7 +686,7 @@ void __attribute__((noreturn)) IRAM cpu_user_start (void)
     /* PHASE 3: start RIOT-OS kernel */
 
     /* init random number generator */
-    srand(hwrand());
+    srand(hwrng_uint32());
 
     /* init flash drive */
     extern void flash_drive_init (void);

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -51,6 +51,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_GENERIC_READ (1)
+#define HWRNG_HAS_POWERONOFF   (1)
+
+/**
  * @name    CPU specific gpio_t type definition
  * @{
  */

--- a/cpu/mips_pic32_common/include/periph_cpu_common.h
+++ b/cpu/mips_pic32_common/include/periph_cpu_common.h
@@ -39,6 +39,12 @@ extern "C" {
 #define CPUID_LEN           (4U)
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_INIT   (1)
+
+/**
  * @brief   Override GPIO pin selection macro
  */
 #define GPIO_PIN(x,y)       ((x << 4) | (y & 0xf))

--- a/cpu/mips_pic32_common/periph/hwrng.c
+++ b/cpu/mips_pic32_common/periph/hwrng.c
@@ -43,6 +43,20 @@ void hwrng_init(void)
     RNGCON |= _RNGCON_CONT_MASK;
 }
 
+uint32_t hwrng_uint32(void)
+{
+    uint32_t tmp;
+
+    RNGCON |= _RNGCON_PRNGEN_MASK;
+
+    wait_plen_cycles();
+    tmp = RNGNUMGEN1;
+
+    RNGCON &= ~_RNGCON_PRNGEN_MASK;
+
+    return tmp;
+}
+
 void hwrng_read(void *buf, unsigned int num)
 {
     unsigned int i = 0;

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -33,6 +33,12 @@ extern "C" {
 #endif
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_INIT   (1)
+
+/**
  * @brief   Prevent shared timer functions from being used
  */
 #define PERIPH_TIMER_PROVIDES_SET

--- a/cpu/native/periph/hwrng.c
+++ b/cpu/native/periph/hwrng.c
@@ -94,6 +94,13 @@ void hwrng_read(void *buf, unsigned int num)
     }
 }
 
+uint32_t hwrng_uint32(void)
+{
+    uint32_t tmp;
+    hwrng_read(&tmp, sizeof(tmp));
+    return tmp;
+}
+
 /**********************************************************************
  * internal API implementation
  **********************************************************************/

--- a/cpu/nrf5x_common/periph/hwrng.c
+++ b/cpu/nrf5x_common/periph/hwrng.c
@@ -28,11 +28,6 @@
 #include "assert.h"
 #endif
 
-void hwrng_init(void)
-{
-    /* nothing to do here */
-}
-
 /*
  * The hardware peripheral is used by the SoftDevice. When the SoftDevice is
  * enabled, it shall only be accessed through the SoftDevice API

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -33,6 +33,13 @@ extern "C" {
 #define CPUID_LEN           (16U)
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_GENERIC_READ (1)
+#define HWRNG_HAS_INIT         (1)
+
+/**
  * @brief   Use shared SPI functions
  * @{
  */

--- a/cpu/sam0_common/periph/hwrng.c
+++ b/cpu/sam0_common/periph/hwrng.c
@@ -32,25 +32,8 @@ void hwrng_init(void)
     TRNG->CTRLA.bit.ENABLE = 1;
 }
 
-uint32_t hwrand(void)
+uint32_t hwrng_uint32(void)
 {
     while (!TRNG->INTFLAG.bit.DATARDY) {}
     return TRNG->DATA.reg;
-}
-
-void hwrng_read(void *buf, unsigned int num)
-{
-    unsigned int count = 0;
-    uint8_t *b = (uint8_t *)buf;
-
-    while (count < num) {
-        /* read next 4 bytes of random data */
-        uint32_t tmp = hwrand();
-
-        /* copy data into result vector */
-        for (int i = 0; i < 4 && count < num; i++) {
-            b[count++] = (uint8_t)tmp;
-            tmp = tmp >> 8;
-        }
-    }
 }

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -61,6 +61,13 @@ typedef uint32_t gpio_t;
 #define CPUID_LEN           (16U)
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_GENERIC_READ (1)
+#define HWRNG_HAS_POWERONOFF   (1)
+
+/**
  * @brief   All SAM3 timers are 32-bit wide
  */
 #define TIMER_MAX_VAL       (0xffffffff)

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -51,6 +51,13 @@ extern "C" {
 #define CPUID_LEN           (12U)
 
 /**
+ * @name    HWRNG configuration
+ * @{
+ */
+#define HWRNG_HAS_GENERIC_READ (1)
+#define HWRNG_HAS_POWERONOFF   (1)
+
+/**
  * @brief   We provide our own pm_off() function for all STM32-based CPUs
  */
 #define PROVIDES_PM_LAYERED_OFF

--- a/cpu/stm32_common/periph/hwrng.c
+++ b/cpu/stm32_common/periph/hwrng.c
@@ -28,12 +28,7 @@
 /* only build if the CPU actually provides a RNG peripheral */
 #ifdef RNG
 
-void hwrng_init(void)
-{
-    /* no need for initialization */
-}
-
-static void poweron(void)
+void hwrng_poweron(void)
 {
     /* power on and enable the device */
 #if defined(CPU_LINE_STM32F410Rx)
@@ -46,7 +41,7 @@ static void poweron(void)
     RNG->CR = RNG_CR_RNGEN;
 }
 
-static void poweroff(void)
+void hwrng_poweroff(void)
 {
     /* finally disable the device again */
     RNG->CR = 0;
@@ -61,36 +56,9 @@ static void poweroff(void)
 
 uint32_t hwrng_uint32(void)
 {
-    poweron();
-
     /* wait for random data to be ready to read */
     while (!(RNG->SR & RNG_SR_DRDY)) {}
     return RNG->DR;
-
-    poweroff();
-}
-
-void hwrng_read(void *buf, unsigned int num)
-{
-    unsigned int count = 0;
-    uint8_t *b = (uint8_t *)buf;
-
-    poweron();
-
-    /* get random data */
-    while (count < num) {
-        /* wait for random data to be ready to read */
-        while (!(RNG->SR & RNG_SR_DRDY)) {}
-        /* read next 4 bytes */
-        uint32_t tmp = RNG->DR;
-        /* copy data into result vector */
-        for (int i = 0; i < 4 && count < num; i++) {
-            b[count++] = (uint8_t)tmp;
-            tmp = tmp >> 8;
-        }
-    }
-
-    poweroff();
 }
 
 #endif /* RNG */

--- a/drivers/include/periph/hwrng.h
+++ b/drivers/include/periph/hwrng.h
@@ -39,6 +39,15 @@ extern "C" {
 #endif
 
 /**
+ * @def     HWRNG_HAS_INIT
+ *
+ * @brief   Set to 1 if the platform implements hwrng_init(), 0 otherwise
+ */
+#ifndef HWRNG_HAS_INIT
+#define HWRNG_HAS_INIT            (0)
+#endif
+
+/**
  * @def     HWRNG_HAS_POWERONOFF
  *
  * @brief   Set to 1 if the platform implements hwrng_poweron() / hwrng_poweroff(), 0 otherwise
@@ -64,6 +73,9 @@ extern "C" {
  * if it would impose too much overhead to do this everytime the hwrng_read
  * function is called. The device should however be put into power-off mode
  * after initialization and will be powered on and of when hwrng_read is called.
+ *
+ * @note     Only implemented and called for platforms with HWRNG_HAS_INIT = 1.
+ *
  */
 void hwrng_init(void);
 

--- a/drivers/include/periph/hwrng.h
+++ b/drivers/include/periph/hwrng.h
@@ -32,9 +32,28 @@
 #define PERIPH_HWRNG_H
 
 #include <stdint.h>
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/**
+ * @def     HWRNG_HAS_POWERONOFF
+ *
+ * @brief   Set to 1 if the platform implements hwrng_poweron() / hwrng_poweroff(), 0 otherwise
+ */
+#ifndef HWRNG_HAS_POWERONOFF
+#define HWRNG_HAS_POWERONOFF      (0)
+#endif
+
+/**
+ * @def     HWRNG_HAS_GENERIC_READ
+ *
+ * @brief   Set to 1 if the platform does not implement a custom hwrng_read() function, 0 otherwise
+ */
+#ifndef HWRNG_HAS_GENERIC_READ
+#define HWRNG_HAS_GENERIC_READ    (0)
 #endif
 
 /**
@@ -49,6 +68,22 @@ extern "C" {
 void hwrng_init(void);
 
 /**
+ * @brief    Power on the HWRNG module
+ *
+ * @note     Only implemented and called for platforms with HWRNG_HAS_POWERONOFF = 1.
+ *
+ */
+void hwrng_poweron(void);
+
+/**
+ * @brief    Power off the HWRNG module
+ *
+ * @note     Only implemented and called for platforms with HWRNG_HAS_POWERONOFF = 1.
+ *
+ */
+void hwrng_poweroff(void);
+
+/**
  * @brief   Read N bytes of random data from the hardware device
  *
  * The read function should power on the HWRNG MCU peripheral, read the given
@@ -61,6 +96,10 @@ void hwrng_read(void *buf, unsigned int num);
 
 /**
  * @brief   Read a single random word.
+ *
+ * The read function does not power on the HWRNG MCU peripheral, the caller
+ * is responsible for calling hwrng_poweron() / hwrng_poweroff() manually if
+ * HWRNG_HAS_POWERONOFF = 1.
  *
  * @return  The random number.
  */

--- a/drivers/include/periph/hwrng.h
+++ b/drivers/include/periph/hwrng.h
@@ -59,6 +59,13 @@ void hwrng_init(void);
  */
 void hwrng_read(void *buf, unsigned int num);
 
+/**
+ * @brief   Read a single random word.
+ *
+ * @return  The random number.
+ */
+uint32_t hwrng_uint32(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/periph_common/hwrng.c
+++ b/drivers/periph_common/hwrng.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_periph_hwrng
+ * @{
+ *
+ * @file        hwrng.c
+ * @brief       Copy random values to buffer
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include "periph_cpu.h"
+#include "periph/hwrng.h"
+
+#if defined(MODULE_PERIPH_HWRNG) && HWRNG_HAS_GENERIC_READ
+
+void hwrng_read(void *buf, unsigned int num)
+{
+    uint32_t *b32 = (uint32_t *)buf;
+
+#if HWRNG_HAS_POWERONOFF
+    hwrng_poweron();
+#endif
+
+    while (num >= sizeof(uint32_t)) {
+        *b32++ = hwrng_uint32();
+        num -= sizeof(uint32_t);
+    }
+
+    if (!num) {
+        goto out;
+    }
+
+    uint32_t tmp = hwrng_uint32();
+    uint8_t *b = (uint8_t *)b32;
+    uint8_t *r = (uint8_t *)&tmp;
+
+    switch (num) {
+    case 3:
+        *b++ = *r++;
+        /* fall-through */
+    case 2:
+        *b++ = *r++;
+        /* fall-through */
+    case 1:
+        *b++ = *r++;
+        /* fall-through */
+    }
+
+out:
+#if HWRNG_HAS_POWERONOFF
+    hwrng_poweroff();
+#else
+    ;
+#endif
+}
+
+#endif

--- a/drivers/periph_common/hwrng.c
+++ b/drivers/periph_common/hwrng.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <stddef.h>
 #include "periph_cpu.h"
 #include "periph/hwrng.h"
 

--- a/drivers/periph_common/hwrng.c
+++ b/drivers/periph_common/hwrng.c
@@ -62,15 +62,13 @@ void hwrng_read(void *buf, unsigned int num)
     b32 = ROUND_UP_PTR(buf);
     unaligned = (uintptr_t)b32 - (uintptr_t)buf;
 
-    if (unaligned) {
-        tmp = hwrng_uint32();
-        if (num < unaligned) {
-            unaligned = num;
-        }
-
-        copy_bytewise(buf, &tmp, unaligned);
-        num -= unaligned;
+    tmp = hwrng_uint32();
+    if (num < unaligned) {
+        unaligned = num;
     }
+
+    copy_bytewise(buf, &tmp, unaligned);
+    num -= unaligned;
 
 fast:
     while (num >= sizeof(uint32_t)) {

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#include "periph_conf.h"
+
 #ifdef MODULE_PERIPH_I2C
 #include "periph/i2c.h"
 #endif
@@ -66,7 +68,9 @@ void periph_init(void)
 #endif
 
 #ifdef MODULE_PERIPH_HWRNG
+#if HWRNG_HAS_INIT
     hwrng_init();
+#endif
 #endif
 
 #ifdef MODULE_PERIPH_USBDEV

--- a/tests/rng/test.c
+++ b/tests/rng/test.c
@@ -41,7 +41,7 @@ static void test_init(char *name)
     if (source == RNG_PRNG) {
         random_init(seed);
     }
-#ifdef MODULE_PERIPH_HWRNG
+#if defined(MODULE_PERIPH_HWRNG) && HWRNG_HAS_INIT
     else if (source == RNG_HWRNG) {
         hwrng_init();
     }


### PR DESCRIPTION
### Contribution description
Most HWRNGs are pretty simple. They provide a register that contains random data. Some HWRNG implementations already expose this single register by providing a `hwrand(void)` function that returns a 32 bit value.

The `hwrng_read()` API function expects a buffer, so currently many implementations invent (or copy & paste) their way to fill a buffer of arbitrary size with 32 bit values.

This PR does the following things:
 - add the `hwrand(void)` function to the hwrng API. Not only is it often more convenient, it also allows for a generic `hwrng_read()` implementation.
 - implement `hwrand()` for all drivers that didn't have it yet
 - implement a generic `hwrng_read()` that uses `hwrand()` and is a bit more efficient than the current implementation
 - Introduce `HWRNG_HAS_INIT` & `HWRNG_HAS_POWERONOFF` analogous to the watchdog API so we don't have to call empty functions if they are not needed.

### Testing procedure

All platforms should still build & run `tests/rng` and `tests/periph_hwrng` as they did before.

On same54 a small speedup can be observed using the `speed` test in `tests/rng` (set `source 2` to select the HWRNG):

before: `Collected 11009147 samples in 10.000008 seconds (4300 KiB/s).`
after: `Collected 12244868 samples in 10.000009 seconds (4783 KiB/s).`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
