### PR TITLE
tests/driver_sx127x: Add reset command

### DIFF
--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -368,6 +368,17 @@ int rx_timeout_cmd(int argc, char **argv)
     return 0;
 }
 
+int reset_cmd(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    netdev_t *netdev = (netdev_t *)&sx127x;
+    puts("resetting sx127x...");
+    netopt_state_t state = NETOPT_STATE_RESET;
+    netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(netopt_state_t));
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
     { "setup",    "Initialize LoRa modulation settings",     lora_setup_cmd },
     { "random",   "Get random number from sx127x",           random_cmd },
@@ -377,6 +388,7 @@ static const shell_command_t shell_commands[] = {
     { "register", "Get/Set value(s) of registers of sx127x", register_cmd },
     { "send",     "Send raw payload string",                 send_cmd },
     { "listen",   "Start raw payload listener",              listen_cmd },
+    { "reset",    "Reset the sx127x device",                 reset_cmd},
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds the reset command to the SX127X driver test application. It performs a reset on the device, by setting `NETOPT_STATE` to `NETOPT_STATE_RESET` on the interface. It is useful to test the reset sequence on the device.

### Testing procedure
Flash the driver test application:
```
BOARD=b-l072z-lrwan1 make all flash term -C tests/driver_sx127x
```
Set some value that will we restored on reset, such as the syncword:
```
> syncword set 12
2019-07-26 15:13:54,790 - INFO #  syncword set 12
2019-07-26 15:13:54,792 - INFO # Syncword set to 12
```
Use the reset command and verify the value goes back to the default:
```
> reset
2019-07-26 15:13:58,564 - INFO #  reset
2019-07-26 15:13:58,565 - INFO # resetting sx127x...
> syncword get
2019-07-26 15:14:00,265 - INFO #  syncword get
2019-07-26 15:14:00,267 - INFO # Syncword: 0xf5
```

### Issues/PRs references
Useful for testing fix proposed in #11913