### PR TITLE
gnrc_cc110x: use gnrc_netif_hdr_set_netif()

### DIFF
--- a/drivers/cc110x/gnrc_cc110x/gnrc_cc110x.c
+++ b/drivers/cc110x/gnrc_cc110x/gnrc_cc110x.c
@@ -168,7 +168,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         gnrc_netif_hdr_set_dst_addr(netif_hdr->data, (uint8_t*)&cc110x_pkt->address, addr_len);
     }
 
-    ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = thread_getpid();
+    gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
     ((gnrc_netif_hdr_t *)netif_hdr->data)->lqi = cc110x->pkt_buf.lqi;
     ((gnrc_netif_hdr_t *)netif_hdr->data)->rssi = cc110x->pkt_buf.rssi;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This splits out the usage of gnrc_netif_hdr_set_netif() in the CC110x glue-code of GNRC out of #10661.

 @maribu informed me, that `gnrc_networking` is broken for `cc110x` on `master`, but is fixed with #10340. So I'm aware, that I'm basically shrouding corpses with this. However, I want to get to a point where `if_pid` is only accessed in the rarerest of cases outside of `gnrc_netif_hdr`, so depending how long it takes for #10340 (hopefully not so long), we have this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Exchanging packets with `examples/default` should still work (add `msba2` to `BOARD_PROVIDES_NETIF`).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Split out of #10661.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
