### PR TITLE
cpu/atmega32u4: Fixed external interrupts; boards/arduino-leonardo: Fixed dependency tracking

### DIFF
--- a/boards/arduino-leonardo/Makefile.dep
+++ b/boards/arduino-leonardo/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_arduino-atmega
+
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.dep

--- a/cpu/atmega32u4/include/periph_cpu.h
+++ b/cpu/atmega32u4/include/periph_cpu.h
@@ -45,8 +45,7 @@ enum {
 #define CPU_ATMEGA_EXT_INTS    { GPIO_PIN(PORT_D, 0), \
                                  GPIO_PIN(PORT_D, 1), \
                                  GPIO_PIN(PORT_D, 2), \
-                                 GPIO_PIN(PORT_D, 3), \
-                                 GPIO_PIN(PORT_E, 7) }
+                                 GPIO_PIN(PORT_D, 3) }
 
 /**
  * @name   Defines for the I2C interface


### PR DESCRIPTION
### Contribution description

- Removes incorrect entry for external interrupt on non-existing pin PE7 for MCU ATmega32U4
- Adds missing Makefile.dep to Arduino Leonardo board

### Testing procedure

- Everything should still build
- The non-existing pin PE7 should no longer be configured as interrupt in the test added in https://github.com/RIOT-OS/RIOT/pull/11923
- `make BOARD=arduino-leonardo info-modules` e.g. in `examples/hello_world` should now list `boards_common_arduino-atmega`

### Issues/PRs references

Found bug while testing https://github.com/RIOT-OS/RIOT/pull/11923