### PR TITLE
sys/event: fix of compilation problems

### DIFF
--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -121,7 +121,7 @@ extern "C" {
 /**
  * @brief   static initializer for detached event queues
  */
-#define EVENT_QUEUE_INIT_DETACHED   { 0 }
+#define EVENT_QUEUE_INIT_DETACHED   { .waiter = NULL }
 
 /**
  * @brief   event structure forward declaration

--- a/tests/events/main.c
+++ b/tests/events/main.c
@@ -128,7 +128,7 @@ int main(void)
     puts("[START] event test application.\n");
 
     /* test creation of delayed claiming of a detached event queue */
-    event_queue_t dq;
+    event_queue_t dq = EVENT_QUEUE_INIT_DETACHED;
     printf("initializing detached event queue %p\n", (void *)&dq);
     event_queue_init_detached(&dq);
 


### PR DESCRIPTION
### Contribution description

Unstructured static initializers of the form { 0 } lead to compilation errors on ESP8266, MSP430 and MIPS platforms. Therefore, the following compilation errors occur when  `EVENT_QUEUE_INIT_DETACHED` is used for initialization of event queues.
```
error: (near initialization for 'queue.event_list') [-Werror=missing-braces]
error: (near initialization for 'queue.waiter') [-Werror=missing-field-initializers]
```
This PR fixes the compilation problem.

### Testing procedure

Compilation of `tests/events` should work on any of the platforms ESP8266, MSP430 or MIPS. Without the change in [`sys/include/event.h`](https://github.com/RIOT-OS/RIOT/blob/9028be5e08857d9e34436fe8370d2bf89d5f0d72/sys/include/event.h#L124) it should not compile for these platforms.

### Issues/PRs references

Required by #10555 