### PR TITLE
shell_commands: check ICMPv6 echo reply sender

### DIFF
--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -338,7 +338,8 @@ static void _print_reply(_ping_data_t *data, gnrc_pktsnip_t *icmpv6,
         uint16_t recv_seq;
 
         /* not our ping */
-        if (byteorder_ntohs(icmpv6_hdr->id) != data->id) {
+        if ((byteorder_ntohs(icmpv6_hdr->id) != data->id) &&
+            !ipv6_addr_equal(from, &data->host)) {
             return;
         }
         recv_seq = byteorder_ntohs(icmpv6_hdr->seq);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fix for #11519 by checking the source address when an echo reply is
received by the `ping6` command.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
See #11519 for testing procedures
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fix for #11519.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
