### PR TITLE
sys: add schedstatistics module

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -203,29 +203,6 @@ extern clist_node_t sched_runqueues[SCHED_PRIO_LEVELS];
  */
 NORETURN void sched_task_exit(void);
 
-#ifdef MODULE_SCHEDSTATISTICS
-/**
- *  Scheduler statistics
- */
-typedef struct {
-    uint32_t laststart;      /**< Time stamp of the last time this thread was
-                                  scheduled to run */
-    unsigned int schedules;  /**< How often the thread was scheduled to run */
-    uint64_t runtime_ticks;  /**< The total runtime of this thread in ticks */
-} schedstat_t;
-
-/**
- *  Thread statistics table
- */
-extern schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
-
-/**
- *  @brief  Registers the sched statistics callback and sets laststart for
- *          caller thread
- */
-void init_schedstatistics(void);
-#endif /* MODULE_SCHEDSTATISTICS */
-
 #ifdef MODULE_SCHED_CB
 /**
  *  @brief  Register a callback that will be called on every scheduler run

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -71,7 +71,6 @@ PSEUDOMODULES += saul_default
 PSEUDOMODULES += saul_gpio
 PSEUDOMODULES += saul_nrf_temperature
 PSEUDOMODULES += scanf_float
-PSEUDOMODULES += schedstatistics
 PSEUDOMODULES += sched_cb
 PSEUDOMODULES += semtech_loramac_rx
 PSEUDOMODULES += sock

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -93,7 +93,7 @@
 #endif
 
 #ifdef MODULE_SCHEDSTATISTICS
-#include "sched.h"
+#include "schedstatistics.h"
 #endif
 
 #define ENABLE_DEBUG (0)

--- a/sys/include/schedstatistics.h
+++ b/sys/include/schedstatistics.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *               2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    schedstatistics Schedstatistics
+ * @ingroup     sys
+ * @brief       When including this module scheduler statistics
+ *              (@ref schedstat_t) for a thread will be updated on every
+ *              @ref sched_run().
+ *
+ * @note        If auto_init is disabled `init_schedstatistics()` needs to be
+ *              called as well as xtimer_init().
+ * @{
+ *
+ * @file
+ * @brief       Scheduler statisctics
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ */
+
+#ifndef SCHEDSTATISTICS_H
+#define SCHEDSTATISTICS_H
+
+#include <stdint.h>
+#include "kernel_types.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ *  Scheduler statistics
+ */
+typedef struct {
+    uint32_t laststart;      /**< Time stamp of the last time this thread was
+                                  scheduled to run */
+    unsigned int schedules;  /**< How often the thread was scheduled to run */
+    uint64_t runtime_ticks;  /**< The total runtime of this thread in ticks */
+} schedstat_t;
+
+/**
+ *  Thread statistics table
+ */
+extern schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
+
+/**
+ *  @brief  Registers the sched statistics callback and sets laststart for
+ *          caller thread
+ */
+void init_schedstatistics(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SCHEDSTATISTICS_H */
+/** @} */

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -22,6 +22,10 @@
 #include "thread.h"
 #include "kernel_types.h"
 
+#ifdef MODULE_SCHEDSTATISTICS
+#include "schedstatistics.h"
+#endif
+
 #ifdef MODULE_TLSF_MALLOC
 #include "tlsf.h"
 #include "tlsf-malloc.h"

--- a/sys/schedstatistics/Makefile
+++ b/sys/schedstatistics/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/schedstatistics/schedstatistics.c
+++ b/sys/schedstatistics/schedstatistics.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *               2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       Scheduler statistics implementation
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      René Kijewski <rene.kijewski@fu-berlin.de>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+#include "sched.h"
+#include "xtimer.h"
+#include "schedstatistics.h"
+
+schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
+
+void sched_statistics_cb(kernel_pid_t active_thread, kernel_pid_t next_thread)
+{
+    uint32_t now = xtimer_now().ticks32;
+
+    /* Update active thread runtime, there is allways an active thread since
+       first sched_run happens when main_trampoline gets scheduled */
+    schedstat_t *active_stat = &sched_pidlist[active_thread];
+    active_stat->runtime_ticks += now - active_stat->laststart;
+
+    /* Update next_thread stats */
+    schedstat_t *next_stat = &sched_pidlist[next_thread];
+    next_stat->laststart = now;
+    next_stat->schedules++;
+}
+
+void init_schedstatistics(void)
+{
+    /* Init laststart for the thread starting schedstatistics since the callback
+       wasn't registered when it was first scheduled */
+    schedstat_t *active_stat = &sched_pidlist[sched_active_pid];
+    active_stat->laststart = xtimer_now().ticks32;
+    active_stat->schedules = 1;
+    sched_register_cb(sched_statistics_cb);
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR extends on #11781, it moves all `schedstatistics` code to an external module so the dependency in core with `xtimer` is removed.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

- For a couple of boards run:

`make -C tests/ps_schedstatistics BOARD=samr21-xpro clean all flash test`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#11781
