### PR TITLE
pkg/tinydtls: documents usage and configuration options

### DIFF
--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -1,6 +1,7 @@
 PKG_BUILDDIR ?= $(PKGDIRBASE)/tinydtls
 
 INCLUDES += -I$(PKG_BUILDDIR)
+INCLUDES += -I$(RIOTPKG)/tinydtls/include
 
 ifeq ($(TOOLCHAIN), llvm)
   CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function

--- a/pkg/tinydtls/doc.txt
+++ b/pkg/tinydtls/doc.txt
@@ -4,4 +4,33 @@
  * @ingroup  net
  * @brief    Provides the Eclipse TinyDTLS to RIOT
  * @see      https://projects.eclipse.org/projects/iot.tinydtls
+ *
+ * Usage
+ * -----
+ *
+ * Add as a package in your application Makefile:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ * USEPKG += tinydtls
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * Supported Cipher Suites
+ * -----------------------
+ *
+ * TinyDTLS only has support for `TLS_PSK_WITH_AES_128_CCM_8` and
+ * `TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8`. The cipher suites to be used can be
+ * chosen at compile time by adding `DTLS_PSK` or `DTLS_ECC` to the CFLAGS as
+ * follows:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ * # Uncomment to enable
+ * # This adds support for TLS_PSK_WITH_AES_128_CCM_8
+ * # CFLAGS += -DDTLS_PSK
+ * # This adds support for TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
+ * # CFLAGS += -DDTLS_ECC
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * If neither `DTLS_PSK` nor `DTLS_ECC` are specified, then tinyDTLS will
+ * enable `DTLS_PSK` by default.
+ *
  */

--- a/pkg/tinydtls/include/tinydtls/config.h
+++ b/pkg/tinydtls/include/tinydtls/config.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    tinydtls_config Tinydtls configuration header
+ * @ingroup     pkg_tinydtls config
+ * @brief       Provides compile-time configuration for tinydtls
+ *
+ * @{
+ *
+ * @file
+ * @brief       TinyDTLS configuration
+ *
+ * @author      Aiman Ismail <muhammadaimanbin.ismail@haw-hamburg.de>
+ */
+
+#ifndef TINYDTLS_CONFIG_H
+#define TINYDTLS_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief The maximum number of DTLS context at the same time
+ */
+#ifndef DTLS_CONTEXT_MAX
+#define DTLS_CONTEXT_MAX    (2)
+#endif
+
+/**
+ * @brief The maximum number DTLS peers (i.e. sessions)
+ */
+#ifndef DTLS_PEER_MAX
+#define DTLS_PEER_MAX       (1)
+#endif
+
+/**
+ * @brief The maximum number of concurrent DTLS handshakes
+ */
+#ifndef DTLS_HANDSHAKE_MAX
+#define DTLS_HANDSHAKE_MAX  (2)
+#endif
+
+/**
+ * @brief The maximum number of concurrently used cipher keys
+ */
+#ifndef DTLS_SECURITY_MAX
+#define DTLS_SECURITY_MAX   (DTLS_HANDSHAKE_MAX + DTLS_PEER_MAX)
+#endif
+
+/**
+ * @brief The maximum number of hash functions that can be used in parallel
+ */
+#ifndef DTLS_HASH_MAX
+#define DTLS_HASH_MAX       (3 * DTLS_PEER_MAX)
+#endif
+
+/**
+ * @brief The number of retransmissions of any DTLS record
+ *
+ * The 802.15.4 ACK can provoke very fast re-transmissions with a value
+ * higher than one. This is a temporary bad behavior for the RIOT MAC
+ */
+#ifndef DTLS_DEFAULT_MAX_RETRANSMIT
+#define DTLS_DEFAULT_MAX_RETRANSMIT     (1)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TINYDTLS_CONFIG_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR documents the usage of tinydtls in RIOT and the configuration options available.
No new options are defined, the values and its explanations are taken from [examples/dtls-echo README.md][1] and [RIOT-specific options in tinydtls][2].

### Testing procedure

```bash
$ make doc
```

produces no warning or errors.

### Issues/PRs references

Partially addresses this [comment][3].

[1]: https://github.com/RIOT-OS/RIOT/blob/master/examples/dtls-echo/README.md#handling-the-static-memory-allocation
[2]: https://github.com/eclipse/tinydtls/blob/develop/platform-specific/riot_boards.h
[3]: https://github.com/RIOT-OS/RIOT/pull/11909#issuecomment-516058452