### PR TITLE
gitignore: add clangd compile flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ results/
 
 # mypy artifacts
 .mypy_cache/
+
+# Clangd compile flags (language server)
+compile_commands.json
+compile_flags.txt


### PR DESCRIPTION
### Contribution description
This PR modifies `.gitignore` to add ignores for `compile_commands.json` and `compile_flags.txt`.

These files are used by [Clangd](https://clang.llvm.org/extra/clangd/) language server. They contain compilation flags, and Clangd uses them to provide context-aware autocompletion and linting.

The file can exist in any parent folder, but generally exists in the root of RIOT-OS. While it's not the best/easiest/fool-proof setup, I find it very useful (here is my [compile-flags.txt](https://gist.github.com/basilfx/9ea37dc119c873b33f7737f9bf79fbb3)).

I guess that it would even be possible to generate this file, but that would be another PR (and you still wouldn't want it in the repo).

### Testing procedure
This shouldn't affect anything.

### Issues/PRs references
None