### PR TITLE
shell_commands/ping6: mix-in current time into ID

### DIFF
--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -242,8 +242,9 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
     if (res != 0) {
         _usage(cmdname);
     }
+    data->id ^= (xtimer_now_usec() & UINT16_MAX);
 #ifdef MODULE_LUID
-    luid_custom(&data->id, sizeof(data->id), DEFAULT_ID);
+    luid_custom(&data->id, sizeof(data->id), data->id);
 #endif
     return res;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This prevents two fast executions of `ping6` behind each other to confuse their respective responses.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
From #11519

* Set up two devices A and B that can exchange messages
* Modify device B to send multiple responses over some extended period of time (e.g. seconds)
* On A: ping6 node B more than once
* ping6 ignores any pongs not matching a ping it send and filters out duplicates
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses

> On A: ping6 node B more than once

of #11519
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
