### PR TITLE
boards/common/nrf52: add common nrf52 i2c config

### DIFF
--- a/boards/common/nrf52/include/cfg_i2c_default.h
+++ b/boards/common/nrf52/include/cfg_i2c_default.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_nrf52
+ * @{
+ *
+ * @file
+ * @brief       Default I2C config for nRF52 based boards
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef CFG_I2C_DEFAULT_H
+#define CFG_I2C_DEFAULT_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = 27,
+        .sda = 26,
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_I2C_DEFAULT_H */
+/** @} */

--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -23,27 +23,13 @@
 
 #include "periph_cpu.h"
 #include "cfg_clock_32_1.h"
+#include "cfg_i2c_default.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev = NRF_TWIM1,
-        .scl = 27,
-        .sda = 26,
-        .speed = I2C_SPEED_NORMAL
-    }
-};
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
-/** @} */
 
 /**
  * @name   PWM configuration

--- a/boards/common/particle-mesh/include/periph_conf_common.h
+++ b/boards/common/particle-mesh/include/periph_conf_common.h
@@ -22,6 +22,7 @@
 
 #include "periph_cpu.h"
 #include "cfg_clock_32_1.h"
+#include "cfg_i2c_default.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_default.h"
 
@@ -43,21 +44,6 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev = NRF_TWIM1,
-        .scl = 27,
-        .sda = 26,
-        .speed = I2C_SPEED_NORMAL
-    }
-};
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -22,6 +22,7 @@
 
 #include "periph_cpu.h"
 #include "cfg_clock_32_1.h"
+#include "cfg_i2c_default.h"
 #include "cfg_rtt_default.h"
 #include "cfg_spi_default.h"
 #include "cfg_timer_default.h"
@@ -48,21 +49,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_uart0)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev = NRF_TWIM1,
-        .scl = 27,
-        .sda = 26,
-        .speed = I2C_SPEED_NORMAL
-    }
-};
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -56,7 +56,7 @@ static const uart_conf_t uart_config[] = {
  */
 static const i2c_conf_t i2c_config[] = {
     {
-        .dev = NRF_TWIM0,
+        .dev = NRF_TWIM1,
         .scl = 27,
         .sda = 26,
         .speed = I2C_SPEED_NORMAL

--- a/boards/reel/include/periph_conf.h
+++ b/boards/reel/include/periph_conf.h
@@ -22,6 +22,7 @@
 
 #include "periph_cpu.h"
 #include "cfg_clock_32_1.h"
+#include "cfg_i2c_default.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_default.h"
 
@@ -63,21 +64,6 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
-/** @} */
-
-/**
- * @name    I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev = NRF_TWIM1,
-        .scl = GPIO_PIN(0, 27),
-        .sda = GPIO_PIN(0, 26),
-        .speed = I2C_SPEED_NORMAL
-    }
-};
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds a common i2c config file for nrf52 based board and uses it when possible. It also changes the default config for `nrf52840-mdk` i2c to make it compatible with the new config (change TWIM0 to TWIM1) and to avoid conflicts with spi.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I tested the new config on `nrf52840-mdk` with bmx280 application:

```make -C tests/driver_bmx280/ BOARD=nrf52840-mdk flash -j3 term```

```
2019-07-31 10:27:35,934 - INFO # main(): This is RIOT! (Version: 2019.10-deve<DAPLink:Overflow>
2019-07-31 10:27:35,936 - INFO # Initialization successful
2019-07-31 10:27:35,937 - INFO # 
2019-07-31 10:27:35,940 - INFO # +------------Calibration Data------------+
2019-07-31 10:27:35,942 - INFO # dig_T1: 28090
2019-07-31 10:27:35,943 - INFO # dig_T2: 26242
2019-07-31 10:27:35,944 - INFO # dig_T3: 50
2019-07-31 10:27:35,945 - INFO # dig_P1: 36405
2019-07-31 10:27:35,946 - INFO # dig_P2: -10604
2019-07-31 10:27:35,947 - INFO # dig_P3: 3024
2019-07-31 10:27:35,949 - INFO # dig_P4: 7539
2019-07-31 10:27:35,950 - INFO # dig_P5: -80
2019-07-31 10:27:35,951 - INFO # dig_P6: -7
2019-07-31 10:27:35,952 - INFO # dig_P7: 12300
2019-07-31 10:27:35,953 - INFO # dig_P8: -12000
2019-07-31 10:27:35,954 - INFO # dig_P9: 5000
2019-07-31 10:27:35,955 - INFO # dig_H1: 75
2019-07-31 10:27:35,956 - INFO # dig_H2: 344
2019-07-31 10:27:35,957 - INFO # dig_H3: 0
2019-07-31 10:27:35,958 - INFO # dig_H4: 363
2019-07-31 10:27:35,959 - INFO # dig_H5: 50
2019-07-31 10:27:35,960 - INFO # dig_H6: 30
2019-07-31 10:27:35,960 - INFO # 
2019-07-31 10:27:35,964 - INFO # +--------Starting Measurements--------+
2019-07-31 10:27:35,972 - INFO # Temperature [°C]: 30.4
2019-07-31 10:27:35,974 - INFO # Pressure [Pa]: 100071
2019-07-31 10:27:35,976 - INFO # Humidity [%rH]: 37.36
2019-07-31 10:27:35,976 - INFO # 
2019-07-31 10:27:35,980 - INFO # +-------------------------------------+
2019-07-31 10:27:37,988 - INFO # Temperature [°C]: 30.4
2019-07-31 10:27:37,990 - INFO # Pressure [Pa]: 100060
2019-07-31 10:27:37,992 - INFO # Humidity [%rH]: 37.38
2019-07-31 10:27:37,992 - INFO # 
2019-07-31 10:27:37,996 - INFO # +-------------------------------------+

```

A green murdock should be enough for the rest.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
