### PR TITLE
efm32: add support for riotboot 

### DIFF
--- a/boards/common/silabs/Makefile.features
+++ b/boards/common/silabs/Makefile.features
@@ -1,2 +1,3 @@
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += riotboot

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -8,3 +8,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart periph_uart_modecfg
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot

--- a/boards/ikea-tradfri/board.c
+++ b/boards/ikea-tradfri/board.c
@@ -26,7 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
+#ifndef RIOTBOOT
     /* initialize the LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/slstk3401a/board.c
+++ b/boards/slstk3401a/board.c
@@ -28,6 +28,7 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
+#ifndef RIOTBOOT
     /* perform common board initialization */
     board_common_init();
 
@@ -35,5 +36,6 @@ void board_init(void)
     /* initialize the Si7021 sensor */
     gpio_init(SI7021_EN_PIN, GPIO_OUT);
     gpio_set(SI7021_EN_PIN);
+#endif
 #endif
 }

--- a/boards/slstk3402a/board.c
+++ b/boards/slstk3402a/board.c
@@ -28,6 +28,7 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
+#ifndef RIOTBOOT
     /* perform common board initialization */
     board_common_init();
 
@@ -35,5 +36,6 @@ void board_init(void)
     /* initialize the Si7021 sensor */
     gpio_init(SI7021_EN_PIN, GPIO_OUT);
     gpio_set(SI7021_EN_PIN);
+#endif
 #endif
 }

--- a/boards/sltb001a/board.c
+++ b/boards/sltb001a/board.c
@@ -32,6 +32,7 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
+#ifndef RIOTBOOT
     /* perform common board initialization */
     board_common_init();
 
@@ -59,6 +60,7 @@ void board_init(void)
               (RGB_LED2_ENABLED << RGB_LED2_EN_BIT) |
               (RGB_LED3_ENABLED << RGB_LED3_EN_BIT) |
               (RGB_LED4_ENABLED << RGB_LED4_EN_BIT));
+#endif
 #endif
 #endif
 }

--- a/boards/slwstk6000b/board.c
+++ b/boards/slwstk6000b/board.c
@@ -28,6 +28,7 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
+#ifndef RIOTBOOT
     /* perform common board initialization */
     board_common_init();
 
@@ -35,5 +36,6 @@ void board_init(void)
     /* initialize the Si7021 sensor */
     gpio_init(SI7021_EN_PIN, GPIO_OUT);
     gpio_set(SI7021_EN_PIN);
+#endif
 #endif
 }

--- a/boards/stk3600/board.c
+++ b/boards/stk3600/board.c
@@ -27,6 +27,8 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
+#ifndef RIOTBOOT
     /* perform common board initialization */
     board_common_init();
+#endif
 }

--- a/boards/stk3700/board.c
+++ b/boards/stk3700/board.c
@@ -27,6 +27,8 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
+#ifndef RIOTBOOT
     /* perform common board initialization */
     board_common_init();
+#endif
 }

--- a/cpu/efm32/Makefile.include
+++ b/cpu/efm32/Makefile.include
@@ -3,6 +3,9 @@ include $(RIOTCPU)/efm32/efm32-info.mk
 export CPU_ARCH = $(EFM32_ARCHITECTURE)
 export CPU_FAM = $(EFM32_FAMILY)
 
+# the size of riotboot on the EFM32 exceeds the default value
+RIOTBOOT_LEN ?= 0x2000
+
 # the em_device.h header requires a global define with the cpu model
 CFLAGS += -D$(call uppercase_and_underscore,$(CPU_MODEL))
 

--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -51,6 +51,8 @@
 #define EMU_EM4INIT         EMU_EM4INIT_DEFAULT
 #endif
 
+#ifndef RIOTBOOT
+
 #ifdef _SILICON_LABS_32B_SERIES_1
 /**
  * @brief   Initialize integrated DC-DC regulator
@@ -154,13 +156,19 @@ static void pm_init(void)
 #endif
 }
 
+#endif
+
 void cpu_init(void)
 {
+#ifndef RIOTBOOT
     /* apply errata that may be applicable (see em_chip.h) */
     CHIP_Init();
+#endif
 
     /* initialize the Cortex-M core */
     cortexm_init();
+
+#ifndef RIOTBOOT
 
 #ifdef _SILICON_LABS_32B_SERIES_1
     /* initialize dc-dc */
@@ -178,4 +186,5 @@ void cpu_init(void)
 
     /* trigger static peripheral initialization */
     periph_init();
+#endif
 }


### PR DESCRIPTION
### Contribution description
This PR adds support for `riotboot` for EFM32 and all boards.

#### RFC
~~There is still one part that needs discussion (and should move to a different PR). 8ea2d1d exposes a global define that can be used to skip certain parts of the bootloader, when building the bootloader.~~

~~I need that for several reasons:~~

* ~~reducing the size of the bootloader (EFM32 `cpu_init()` does a lot more)~~
* ~~skipping parts in `cpu_init()` that are not relevant during boot~~
  * ~~configuring clock sources~~
    * ~~example: I could have an updated firmware that uses another source/configuration~~
  * ~~e.g. chip applying errata~~
    * ~~example: there can be new (conflicting) [EFM32 errata](https://github.com/RIOT-OS/RIOT/blob/master/cpu/efm32/cpu.c#L159)~~
  * ~~configuring DC-DC parameters~~
    * ~~example: I decide to update [DC-DC parameters](https://github.com/RIOT-OS/RIOT/blob/master/cpu/efm32/cpu.c#L59) to make my board more efficient or stable~~
  * ~~peripheral initialization~~

~~My goal is to boot as quick as possible to the actual firmware on the defaults, and then do proper initialization.~~

~~I don't know if there is a better way to detect if I'm building the firmware, and I am happy to adapt if there is a way.~~

Resolved by #12297.

### Testing procedure
`cd tests/riotboot && BOARD=ikea-tradfri make test` should work (or other EFM32 board, e.g. SLTB001a).

### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/8902#issuecomment-410159021