### PR TITLE
cpu/esp32: disable multiheap memory management

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -90,7 +90,7 @@ endif
 # if SPI RAM is enabled, ESP-IDF heap and quot flash mode have to be used
 ifneq (,$(filter esp_spi_ram,$(USEMODULE)))
     # USEMODULE += esp_idf_heap
-    $(error Module esp_spi_ram can't be use with current implementation)    
+    $(error Module esp_spi_ram can't be used with current implementation)    
     export FLASH_MODE = qout
     CFLAGS += -DFLASH_MODE_QOUT=1
 else

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -28,7 +28,7 @@ endif
 
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     # add additional modules used for any WiFi interface
-    USEMODULE += esp_idf_heap
+    # USEMODULE += esp_idf_heap
     USEMODULE += esp_idf_wpa_supplicant_crypto
     USEMODULE += esp_idf_wpa_supplicant_port
     USEMODULE += esp_idf_nvs_flash
@@ -89,7 +89,8 @@ endif
 
 # if SPI RAM is enabled, ESP-IDF heap and quot flash mode have to be used
 ifneq (,$(filter esp_spi_ram,$(USEMODULE)))
-    USEMODULE += esp_idf_heap
+    # USEMODULE += esp_idf_heap
+    $(error Module esp_spi_ram can't be use with current implementation)    
     export FLASH_MODE = qout
     CFLAGS += -DFLASH_MODE_QOUT=1
 else

--- a/cpu/esp32/vendor/esp-idf/Makefile
+++ b/cpu/esp32/vendor/esp-idf/Makefile
@@ -2,7 +2,6 @@ MODULE=esp_idf
 
 DIRS += driver
 DIRS += esp32
-DIRS += heap
 DIRS += soc
 DIRS += spi_flash
 DIRS += wpa_supplicant
@@ -10,6 +9,10 @@ DIRS += wpa_supplicant
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     DIRS += nvs_flash
     INCLUDES += -I$(ESP32_SDK_DIR)/components/smartconfig_ack/include
+endif
+
+ifneq (,$(filter esp_idf_heap,$(USEMODULE)))
+    DIRS += heap
 endif
 
 ifneq (,$(filter esp_eth,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

This PR disables the multiheap memory management as a temporary workaround for issue #11941.

### Testing procedure

Setup a ESP-NOW network of two ESP32 nodes. For that purpose compile and flash two nodes with:
```
USEMODULE=esp_now make BOARD=esp32-wroom-32 -C examples/gnrc_networking flash
```
After that, connect to the nodes with a terminal program and use some commands like `ifconfig` and `ping6` to check whether it works and wait for 1 hour or so. There should no `CORRUPT` message anymore.

### Issues/PRs references

Temporary workaround for #11941.