### PR TITLE
cpu/esp32: lwIP netdev

### DIFF
--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -61,7 +61,7 @@
  * not provide an argument that could be used as pointer to the ESP WiFi
  * device which triggers the interrupt.
  */
-static esp_wifi_netdev_t _esp_wifi_dev;
+esp_wifi_netdev_t _esp_wifi_dev;
 static const netdev_driver_t _esp_wifi_driver;
 
 /* device thread stack */
@@ -202,7 +202,7 @@ static wifi_config_t wifi_config_sta = {
     }
 };
 
-static void esp_wifi_setup (esp_wifi_netdev_t* dev)
+void esp_wifi_setup (esp_wifi_netdev_t* dev)
 {
     DEBUG("%s: %p\n", __func__, dev);
 

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -408,7 +408,7 @@ static int _esp_wifi_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_l
 
     switch (opt) {
         case NETOPT_ADDRESS:
-            assert(max_len == ETHERNET_ADDR_LEN);
+            assert(max_len >= ETHERNET_ADDR_LEN);
             esp_wifi_get_mac(ESP_MAC_WIFI_STA,(uint8_t *)val);
             return ETHERNET_ADDR_LEN;
         case NETOPT_IS_WIRED:

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -143,6 +143,15 @@ extern "C" {
 
 #define TCPIP_THREAD_STACKSIZE  (THREAD_STACKSIZE_DEFAULT)
 
+#if defined(CPU_ESP32) && !defined(DOXYGEN)
+/**
+ * In ESP32, the thread that is dealing with hardware interrupts of the WiFi
+ * interface has a priority of 1. This thread should have a higher priority
+ * than lwIP's TCP/IP thread.
+ */
+#define TCPIP_THREAD_PRIO       (2)
+#endif
+
 #define MEM_ALIGNMENT           (4)
 #ifndef MEM_SIZE
 /* packet buffer size of GNRC + stack for TCP/IP */


### PR DESCRIPTION
### Contribution description

The changes in this PR allow to use an `esp_wifi` network device of ESP32 with lwIP.

### Testing procedure

Compile `tests/lwip` and flash an ESP32 node with:
```
USEMODULE=esp_wifi CFLAGS='-DESP_WIFI_SSID=\"<your_ssid>\" -DESP_WIFI_PASS=\"<your_passphrase>\"' make BOARD=esp32-wroom-32 -C tests/lwip flash
```

Start `netcat` on a Linux machine in same LAN:
```
nc -6l 12345
```

Use a terminal to connect to the ESP32 node and use the following commands
```
> tcp connect fe80::c73e:f07d:d95d:ebf9 12345
> tcp send 00
Success: send 1 byte over TCP to server
> tcp disconnect
```
where the address should be replaced with the address of your Linux machine.

### Issues/PRs references

Fixes #11910
~Depends on  PR #11964~
~Depends on PR #11967~