### PR TITLE
cpu/esp32: critcial section handling changed in FreeRTOS adaptation layer

### DIFF
--- a/cpu/esp32/Makefile
+++ b/cpu/esp32/Makefile
@@ -4,7 +4,6 @@ MODULE = cpu
 # Add a list of subdirectories, that should also be built:
 DIRS += $(RIOTCPU)/esp_common
 DIRS += periph
-DIRS += freertos
 DIRS += vendor
 
 ifneq (, $(filter esp_can, $(USEMODULE)))
@@ -17,6 +16,10 @@ endif
 
 ifneq (, $(filter esp_wifi, $(USEMODULE)))
     DIRS += esp-wifi
+endif
+
+ifneq (, $(filter riot_freertos, $(USEMODULE)))
+    DIRS += freertos
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -75,6 +75,7 @@ USEMODULE += periph_hwrng
 USEMODULE += periph_flash
 USEMODULE += periph_rtc
 USEMODULE += periph_uart
+USEMODULE += riot_freertos
 USEMODULE += random
 USEMODULE += stdio_uart
 USEMODULE += xtensa

--- a/cpu/esp32/include/freertos/portmacro.h
+++ b/cpu/esp32/include/freertos/portmacro.h
@@ -30,8 +30,8 @@ extern "C" {
 #define portMUX_TYPE                    mutex_t
 #define portMUX_INITIALIZER_UNLOCKED    MUTEX_INIT
 
-#define portENTER_CRITICAL(pm)          mutex_lock(pm)
-#define portEXIT_CRITICAL(pm)           mutex_unlock(pm)
+#define portENTER_CRITICAL(mux)         vTaskEnterCritical(mux)
+#define portEXIT_CRITICAL(mux)          vTaskExitCritical(mux)
 #define portENTER_CRITICAL_NESTED       irq_disable
 #define portEXIT_CRITICAL_NESTED        irq_restore
 
@@ -47,6 +47,9 @@ extern "C" {
 #define portNUM_PROCESSORS              2
 
 #define xPortGetCoreID()                PRO_CPU_NUM
+
+extern void vTaskEnterCritical(portMUX_TYPE *mux);
+extern void vTaskExitCritical(portMUX_TYPE *mux);
 
 #ifdef __cplusplus
 }

--- a/cpu/esp32/include/freertos/portmacro.h
+++ b/cpu/esp32/include/freertos/portmacro.h
@@ -39,9 +39,9 @@ extern "C" {
 #define portEXIT_CRITICAL_ISR(mux)      vTaskExitCritical(mux)
 
 #define taskENTER_CRITICAL(mux)         portENTER_CRITICAL(mux)
-#define taskENTER_CRITICAL_ISR(mux)        portENTER_CRITICAL_ISR(mux)
+#define taskENTER_CRITICAL_ISR(mux)     portENTER_CRITICAL_ISR(mux)
 #define taskEXIT_CRITICAL(mux)          portEXIT_CRITICAL(mux)
-#define taskEXIT_CRITICAL_ISR(mux)        portEXIT_CRITICAL_ISR(mux)
+#define taskEXIT_CRITICAL_ISR(mux)      portEXIT_CRITICAL_ISR(mux)
 
 #define portYIELD_FROM_ISR              thread_yield_higher
 #define portNUM_PROCESSORS              2


### PR DESCRIPTION
### Contribution description

This PR changes the critical section handling of the FreeRTOS adaptation layer that is required by ESP32 SDK libraries for the WiFi interface.

#### Background

ESP32 SDK libraries for the WiFi interface require a number of FreeRTOS functions to work, e.g., crittical section handling, queues, mutexes and semaphores. To provide the ESP SDK libraries with these required FreeRTOS functions, an adaptation layer module in `cpu/esp32/freertos` realizes a mapping of these functions to RIOT's mechansims.

#### Critical section handling

The critical section handling of FreeRTOS for ESP32 realized by the `portENTER_CRITICAL`, `taskENTER_CRITICAL`, `portEXIT_CRITICAL` and `taskEXIT_CRITICAL`  macros/functions uses mutexes. However, since these macros/functions are also called in interrupt context, the mutex based implementation of critical section handling does not work in RIOT.

This led to a number of instability problems when the WiFi interface was used (modules `esp_wifi` and/or `esp_now`), e.g., the problem with the multiheap corruption described in issue #11941. Therefore, the former mutex based implementation of critical section handling had to be changed. 

#### Change

The mutex that is given as parameter for critical section handling macros/function is not used any longer. Instead,  the basic default FreeRTOS mechanism for critical sections is realized by simply disabling interrupts. Once the interrupt is disabled by calling `portENTER_CRITICAL` or `taskENTER_CRITICAL`, the execution in critical section can't be interrupted. Since context switches for the ESP32 are also based on interrupts, there is no possibility that another thread will enter the critical section once the interrupts are disabled, even if an action within the critical section would trigger a `thread_yield_higher`.

I have tested the changes with ESP32 border router test configuration as described in #10929. While the CORRUPT multiheap error message as described in #11941 occured within several minutes without these changes, the configuration is working with the changes since more than one day without any error message.

### Testing procedure

Setup an ESP-NOW network of two ESP32 nodes. For that purpose compile and flash two nodes with:
```
USEMODULE=esp_now make BOARD=esp32-wroom-32 -C examples/gnrc_networking flash
```
After that, connect to the nodes with a terminal program and use some commands like `ifconfig` and `ping6` and wait. Without the changes in this PR, a `CORRUPT` message should come after several minutes. With the changes the same configuration should work stable.

### Issues/PRs references

Fixes issue #11941.
Makes PR #11942 obsolete.