### PR TITLE
cpu/esp32: fix of gpio_read for output ports

### DIFF
--- a/boards/esp32-wemos-lolin-d32-pro/include/arduino_board.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/arduino_board.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   The on-board LED is connected to pin 2 on this board
+ * @brief   The on-board LED is connected to Arduino pin 10 on this board
  */
 #define ARDUINO_LED         (10)
 


### PR DESCRIPTION
### Contribution description

Although it isn't explicitly specified in API, `gpio_read` should return the last written output value for output ports. Since the handling of inputs and outputs is strictly separated by several registers in ESP32, `gpio_read` returned always the initial value of the input register. Therefore, `gpio_read` always returned `0` for output ports.

This PR fixes this problem. For this purpose, a case distinction is made in `gpio_read`. While for input ports the real value are read from the ESP32 input register, the last written value for the output port is read from the ESP32 output register.

### Testing procedure

Flash `tests/periph_gpio` with to ESP32 board, for example:
```
make BOARD=esp32-wroom-32 -C tests/periph_gpio flash term
```
Use the following commands:
```
> init_out 0 4
> read 0 4
GPIO_PIN(0.04) is LOW
> set 0 4
> read 0 4
GPIO_PIN(0.04) is HIGH
> clear 0 4
> read 0 4
GPIO_PIN(0.04) is LOW
```
Without this fix `read 0 4` would always return `GPIO_PIN(0.04) is LOW`.

### Issues/PRs references
