### PR TITLE
pkg/ccn-lite: bump version and adapt shell functions accordingly

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -10,6 +10,10 @@ CMAKE_MINIMAL_VERSION = 3.6.0
 
 RIOT_CFLAGS = $(INCLUDES)
 
+ifeq (llvm,$(TOOLCHAIN))
+  RIOT_CFLAGS += -Wno-char-subscripts
+endif
+
 TOOLCHAIN_FILE=$(PKG_BUILDDIR)/xcompile-toolchain.cmake
 
 all: $(PKG_BUILDDIR)/src/Makefile

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
 PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
-PKG_VERSION=f85a2a055db92b5978f2d4f92b830b5b6b9acb42
+PKG_VERSION=b9e22be23ab534015061b03c39348445a2e9bb4b
 PKG_LICENSE=ISC
 
 .PHONY: all ..cmake_version_supported

--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -113,24 +113,25 @@ int _ccnl_content(int argc, char **argv)
     arg_len = strlen(buf);
 
     struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[1], CCNL_SUITE_NDNTLV, NULL);
-    int offs = CCNL_MAX_PACKET_SIZE;
-    arg_len = ccnl_ndntlv_prependContent(prefix, (unsigned char*) buf, arg_len, NULL, NULL, &offs, _out);
+    size_t offs = CCNL_MAX_PACKET_SIZE;
+    size_t reslen = 0;
+    arg_len = ccnl_ndntlv_prependContent(prefix, (unsigned char*) buf, arg_len, NULL, NULL, &offs, _out, &reslen);
 
     ccnl_prefix_free(prefix);
 
     unsigned char *olddata;
     unsigned char *data = olddata = _out + offs;
 
-    int len;
-    unsigned typ;
+    size_t len;
+    uint64_t typ;
 
-    if (ccnl_ndntlv_dehead(&data, &arg_len, (int*) &typ, &len) ||
+    if (ccnl_ndntlv_dehead(&data, &reslen, &typ, &len) ||
         typ != NDN_TLV_Data) {
         return -1;
     }
 
     struct ccnl_content_s *c = 0;
-    struct ccnl_pkt_s *pk = ccnl_ndntlv_bytes2pkt(typ, olddata, &data, &arg_len);
+    struct ccnl_pkt_s *pk = ccnl_ndntlv_bytes2pkt(typ, olddata, &data, &reslen);
     c = ccnl_content_new(&pk);
     c->flags |= CCNL_CONTENT_FLAGS_STATIC;
     msg_t m = { .type = CCNL_MSG_CS_ADD, .content.ptr = c };


### PR DESCRIPTION
### Contribution description

This PR bumps the CCN-lite pkg version and adapts to recent API changes in the `sc_ccnl` shell command handler. I've tested the new version briefly in small multi-hop setups under native and in the FIT IoT-LAB testbed on iotlab-m3 nodes. Thereby I did some requests to differently named content items that (i) exist (ii) don't exist (iii) are generated during retransmission procedure. Everything went as expected.

### Testing procedure
(follow description in #11948)

### Issues/PRs references
Fixes #11948
