### PR TITLE
cpu/nrf5x_common: add flashpage_raw_support

### DIFF
--- a/cpu/nrf51/include/cpu_conf.h
+++ b/cpu/nrf51/include/cpu_conf.h
@@ -49,6 +49,12 @@ extern "C" {
 #elif defined(CPU_MODEL_NRF51X22XXAB)
 #define FLASHPAGE_NUMOF         (128U)
 #endif
+/* The minimum block size which can be written is 4B. However, the erase
+ * block is always FLASHPAGE_SIZE.
+ */
+#define FLASHPAGE_RAW_BLOCKSIZE    (4U)
+/* Writing should be always 4 bytes aligned */
+#define FLASHPAGE_RAW_ALIGNMENT    (4U)
 /** @} */
 
 /**

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -62,6 +62,13 @@ extern "C" {
 #elif defined(CPU_MODEL_NRF52840XXAA)
 #define FLASHPAGE_NUMOF                 (256U)
 #endif
+
+/* The minimum block size which can be written is 4B. However, the erase
+ * block is always FLASHPAGE_SIZE.
+ */
+#define FLASHPAGE_RAW_BLOCKSIZE    (4U)
+/* Writing should be always 4 bytes aligned */
+#define FLASHPAGE_RAW_ALIGNMENT    (4U)
 /** @} */
 
 /**

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_flashpage_raw
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_temperature

--- a/cpu/nrf5x_common/periph/flashpage.c
+++ b/cpu/nrf5x_common/periph/flashpage.c
@@ -23,12 +23,37 @@
 #include "assert.h"
 #include "periph/flashpage.h"
 
+void flashpage_write_raw(void *target_addr, const void *data, size_t len)
+{
+    /* assert multiples of FLASHPAGE_RAW_BLOCKSIZE are written and no less of
+       that length. */
+    assert(!(len % FLASHPAGE_RAW_BLOCKSIZE));
+
+    /* ensure writes are aligned */
+    assert(!(((unsigned)target_addr % FLASHPAGE_RAW_ALIGNMENT) ||
+            ((unsigned)data % FLASHPAGE_RAW_ALIGNMENT)));
+
+    /* ensure the length doesn't exceed the actual flash size */
+    assert(((unsigned)target_addr + len) <
+           (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)) + 1);
+
+    uint32_t *page_addr = target_addr;
+    const uint32_t *data_addr = data;
+
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
+    for (unsigned i = 0; i < (len / FLASHPAGE_RAW_BLOCKSIZE); i++) {
+        *page_addr++ = data_addr[i];
+    }
+
+    /* finish up */
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+}
+
 void flashpage_write(int page, const void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
 
     uint32_t *page_addr = (uint32_t *)flashpage_addr(page);
-    const uint32_t *data_addr = data;
 
     /* erase given page */
     NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een;
@@ -37,12 +62,6 @@ void flashpage_write(int page, const void *data)
 
     /* write data to page */
     if (data != NULL) {
-        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
-        for (unsigned i = 0; i < (FLASHPAGE_SIZE / 4); i++) {
-            *page_addr++ = data_addr[i];
-        }
+        flashpage_write_raw(page_addr, data, FLASHPAGE_SIZE);
     }
-
-    /* finish up */
-    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds `flashpage_raw` support for nrf5x.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run: `make -C tests/periph_flashpage/ BOARD=nrf52840dk flash test`

Tested locally on `nrf52840dk`, `nrf52840-mdk` and over iotlab on `microbit` and `nrf51dk`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
