### PR TITLE
emcute: fix length field calculation

### DIFF
--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -63,7 +63,9 @@ static volatile int result;
 
 static size_t set_len(uint8_t *buf, size_t len)
 {
-    if (len < (0xff - 7)) {
+    /* - `len` field minimum length == 1
+     * - `((len + 1) <= 0xff) == len < 0xff` */
+    if (len < 0xff) {
         buf[0] = len + 1;
         return 1;
     }


### PR DESCRIPTION
The length field in an MQTT packet carries the _total_ length of the packet. If it is below 256 (i.e. fits in one byte) only one byte is used for the length field. If it is larger than that 3 bytes are used, with the first byte having the value `0x01` and the remaining bytes representing the length in as a 2 byte unsigned integer in network byte order. Resulting from that it can be assessed that the check in `emcutes`'s `set_len()` function is wrong as it needs to be checked if `len` is lesser or equal to `0xff - 1` (-1 for the length field itself). `len <= (0xff - 1)` can be simplified to `len < 0xff`. For some larger packages this safes 2 bytes of wasted packet space.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
Merge #11823 and run its testing procedure.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Split out of #11823 to stream-line the review.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
