### PR TITLE
boards/{blue,black}pill: Fixed flashing

### DIFF
--- a/boards/common/stm32f103c8/dist/openocd.cfg
+++ b/boards/common/stm32f103c8/dist/openocd.cfg
@@ -1,5 +1,3 @@
-set WORKAREASIZE 0x5000
-
 set CHIPNAME STM32F103C8Tx
 
 # Enable debug when in low power modes


### PR DESCRIPTION
### Contribution description

A new blue pill variant with only 32 KiB of flash (secretly coming with 64 KiB flash) instead of the use 64 KiB flash (secretly coming with 128 KiB) is not compatible with `make flash`. This PR changes the OpenOCD config so that both variants can be flashed.

### Testing procedure

Check if `make flash` still works with the 64 KiB (with inoffical 128 KiB) variant of the Blue Pill / Black Pill.

### Issues/PRs references
None