### PR TITLE
tests/pkg_qdsa: increase timeout

### DIFF
--- a/tests/pkg_qdsa/tests/01-run.py
+++ b/tests/pkg_qdsa/tests/01-run.py
@@ -9,9 +9,12 @@
 import sys
 from testrunner import run
 
+# It takes ~11s on nucleo-l152re, so add some margin
+TIMEOUT = 15
+
 
 def testfunc(child):
-    child.expect('OK \(\d+ tests\)')
+    child.expect('OK \(\d+ tests\)', timeout=TIMEOUT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

This PR increases the timeout for `tests/pkg_qdsa`. On `nucleo-l152re` the test was falining because
the timeout happened before the board could finish executing the test.

### Testing procedure

Run:

`make -C tests/pkg_qdsa/ BOARD=nucleo-l152re flash test`

Fails in master, succeeds with this PR.

### Issues/PRs references
