### PR TITLE
cpu/esp32: fix of the return code in esp_wifi_send

### DIFF
--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -336,6 +336,7 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
 
     /* send the the packet to the peer(s) mac address */
     if (esp_wifi_internal_tx(ESP_IF_WIFI_STA, dev->tx_buf, dev->tx_len) == ESP_OK) {
+        ret = dev->tx_len;
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
     }
     else {


### PR DESCRIPTION
### Contribution description

`_send` function of the `esp_wifi` netdev driver always returned 0 instead of the number of sent bytes. This led to problems when using it with `lwip`, see https://github.com/RIOT-OS/RIOT/pull/11946#issuecomment-517302147

This PR fixes the problem.

### Testing procedure

Should be not necessary to test it explicitly.

### Issues/PRs references

Prerequisite for PR #11946.