### PR TITLE
credman: add documentation for enum credman_type_t

### DIFF
--- a/sys/include/net/credman.h
+++ b/sys/include/net/credman.h
@@ -90,9 +90,14 @@ typedef uint16_t credman_tag_t;
  * @brief Credential types
  */
 typedef enum {
+    /**
+     * @brief Empty type
+     *
+     * Used to detect uninitialized @ref credman_credential_t internally.
+     */
     CREDMAN_TYPE_EMPTY  = 0,
-    CREDMAN_TYPE_PSK    = 1,
-    CREDMAN_TYPE_ECDSA  = 2,
+    CREDMAN_TYPE_PSK    = 1,    /**< PSK credential type */
+    CREDMAN_TYPE_ECDSA  = 2,    /**< ECDSA credential type */
 } credman_type_t;
 
 /**


### PR DESCRIPTION
### Contribution description

This PR adds missing documentation for `credman_type_t` as mentioned in this [comment][1]. No other changes to the API are made here.

### Testing procedure

```
make doc
```
produces no warnings or errors.

### Issues/PRs references

[1]: https://github.com/RIOT-OS/RIOT/pull/11909#discussion_r310643894
