### PR TITLE
drivers/periph_wdt: small doxygen fixes

### DIFF
--- a/drivers/include/periph/wdt.h
+++ b/drivers/include/periph/wdt.h
@@ -135,7 +135,7 @@
  *
  * int main(void)
  * {
- *     wdt_setup_callback(0, MAX_TIME, wdt_cb, arg);
+ *     wdt_setup_reboot_with_callback(0, MAX_TIME, wdt_cb, arg);
  *     wdt_start();
  *     while (1) {
  *         xtimer_usleep(time);

--- a/drivers/include/periph/wdt.h
+++ b/drivers/include/periph/wdt.h
@@ -54,7 +54,6 @@
  *
  * int main(void)
  * {
- *
  *     wdt_setup_reboot(0, MAX_TIME);
  *     wdt_start();
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing inline code snippets provided in the WDT peripheral interface:
- renamed `wdt_setup_callback` to `wdt_setup_reboot_with_callback`
- removed a useless blankline in one of the example

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read the doc and compare with the API functions

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while updating #11556 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
