### PR TITLE
cpu/esp32: cleanup of Makefile.include to fix undefined symbols

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -147,6 +147,13 @@ ifneq (,$(filter stdio_uart,$(USEMODULE)))
     LINKFLAGS += -Wl,-wrap,getchar
 endif
 
+ifneq (,$(filter esp_idf_heap,$(USEMODULE)))
+    LINKFLAGS += -Wl,-wrap,_malloc_r
+    LINKFLAGS += -Wl,-wrap,_calloc_r
+    LINKFLAGS += -Wl,-wrap,_realloc_r
+    LINKFLAGS += -Wl,-wrap,_free_r
+endif
+
 # The ELFFILE is the base one used for flashing
 FLASHFILE ?= $(ELFFILE)
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -132,7 +132,8 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     BASELIBS += -lwps -lwpa -lwpa2 -lespnow -lmesh -lphy -lstdc++
 endif
 
-LINKFLAGS += -lhal -lg -lc
+BASELIBS += -lhal -lg -lc
+
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ld/
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.common.ld

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -140,8 +140,12 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.common.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.peripherals.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
-LINKFLAGS += -nostdlib -lgcc -u putchar -Wl,-gc-sections
+LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections
 
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+    LINKFLAGS += -Wl,-wrap,putchar
+    LINKFLAGS += -Wl,-wrap,getchar
+endif
 
 # The ELFFILE is the base one used for flashing
 FLASHFILE ?= $(ELFFILE)

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -100,7 +100,7 @@ CFLAGS  += -DSDK_NOT_USED -DCONFIG_FREERTOS_UNICORE=1 -DESP_PLATFORM
 CFLAGS  += -DLOG_TAG_IN_BRACKETS
 CFLAGS  += -Wno-unused-parameter -Wformat=0
 CFLAGS  += -mlongcalls -mtext-section-literals -fstrict-volatile-bitfields
-CFLAGS  += -fdata-sections -fzero-initialized-in-bss
+CFLAGS  += -fdata-sections -ffunction-sections -fzero-initialized-in-bss
 ASFLAGS += --longcalls --text-section-literals
 
 ifneq ($(CONFIGS),)
@@ -140,7 +140,7 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.peripherals.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
 LINKFLAGS += -nostdlib -lgcc -u putchar -Wl,-gc-sections
-LINKFLAGS += -Wl,--warn-unresolved-symbols
+
 
 # The ELFFILE is the base one used for flashing
 FLASHFILE ?= $(ELFFILE)

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -243,22 +243,22 @@ void IRAM _lock_release_recursive(_lock_t *lock)
 extern void *heap_caps_malloc_default( size_t size );
 extern void *heap_caps_realloc_default( void *ptr, size_t size );
 
-void* IRAM_ATTR _malloc_r(struct _reent *r, size_t size)
+void* IRAM_ATTR __wrap__malloc_r(struct _reent *r, size_t size)
 {
     return heap_caps_malloc_default( size );
 }
 
-void IRAM_ATTR _free_r(struct _reent *r, void* ptr)
+void IRAM_ATTR __wrap__free_r(struct _reent *r, void* ptr)
 {
     heap_caps_free( ptr );
 }
 
-void* IRAM_ATTR _realloc_r(struct _reent *r, void* ptr, size_t size)
+void* IRAM_ATTR __wrap__realloc_r(struct _reent *r, void* ptr, size_t size)
 {
     return heap_caps_realloc_default( ptr, size );
 }
 
-void* IRAM_ATTR _calloc_r(struct _reent *r, size_t count, size_t size)
+void* IRAM_ATTR __wrap__calloc_r(struct _reent *r, size_t count, size_t size)
 {
     void* result = heap_caps_malloc_default(count * size);
     if (result) {

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -67,7 +67,7 @@
 #ifdef MODULE_STDIO_UART
 #include "stdio_uart.h"
 
-int IRAM putchar(int c)
+int IRAM __wrap_putchar(int c)
 {
     char tmp = c;
     if (stdio_write(&tmp, 1) > 0) {
@@ -76,7 +76,7 @@ int IRAM putchar(int c)
     return -EOF;
 }
 
-int IRAM getchar(void)
+int IRAM __wrap_getchar(void)
 {
     char tmp;
     if (stdio_read(&tmp, 1) > 0) {

--- a/cpu/esp32/vendor/esp-idf/Makefile
+++ b/cpu/esp32/vendor/esp-idf/Makefile
@@ -2,13 +2,16 @@ MODULE=esp_idf
 
 DIRS += driver
 DIRS += esp32
-DIRS += heap
 DIRS += soc
 DIRS += spi_flash
-DIRS += wpa_supplicant
+
+ifneq (,$(filter esp_idf_heap,$(USEMODULE)))
+    DIRS += heap
+endif
 
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     DIRS += nvs_flash
+    DIRS += wpa_supplicant
     INCLUDES += -I$(ESP32_SDK_DIR)/components/smartconfig_ack/include
 endif
 


### PR DESCRIPTION
### Contribution description

This PR fixes the following compilation problems:

1. The compilation of an application could throw unknown symbol errors for functions that aren't use at all, for example:
   ```
   make BOARD=esp32-wroom-32 -C tests/lwip
   ...
   lwip_api.a(tcpip.o): In function `tcpip_callback':
   tcpip.c:(.text+0x2cc): warning: undefined reference to `sys_mbox_trypost_fromisr'
   ```
   To solve this problem, each function is now placed in its own section.

2. Since the linker handled unknown symbols as warnings, the compilation of an application did not fail on unknown symbols. Instead, the application crashed silently if these unknown symbols were required.

   To solve this problem, the linker option for handling unknown symbols as warnings has been removed. Now, the compilation fails if there are real unknown symbols. 

3. Symbol `pthread_setcancelstate` was not known in standard C libraries, even if the `pthread` module is linked.

   To solve this problem, standard C libraries are also added to `BASELIBS` to group them with all other modules.

4. When the standard C libraries were added to `BASELIBS` to group them together with all other modules, there were multiple definitions for the putchar function. The one that was defined to write to the UART as standard output and the one that was provided by the standard C libraries.

   To solve this symbol conflict, `putchar` and `getchar` functions that use the UART as standard output/input were renamed to `__wrap_putchar` and `__wrap_getchar` and the linker options were extended by `-Wl,-wrap` options.

5. A number of subdirectories in `cpu/esp32/vendor/esp-idf` were compiled ony even if the according module were not required by the application.

6. If module `esp_idf_heap` is used, the memory management functions `_malloc_r`, `_realloc_r`, `_calloc_r` and `_free_r` have to be overridden by wrapper functions to use the corresponding `heap_*` functions of module `esp_idf_heap`. However, this can lead to multiple symbol errors for these functions for some applications.

   To solve this symbol conflict, `_malloc_r`, `_realloc_r`, `_calloc_r` and `_free_r` functions are renamed to `__wrap_*` and the linker options are extended by `-Wl,-wrap` option when module `esp_idf_heap` is used.

### Testing procedure

1. Compilation with murdock should be successful for all applications.

2. Compile `tests/lwip` with and without this PR:
   ```
   make BOARD=esp32-wroom-32 -C tests/lwip
   ```
   There should be undefined symbols without this PR, but no undefined symbols with this PR.

3. To test the compilation of ESP32 specific modules, the following commands should succeed:
   ```
   USEMODULE=esp_eth make BOARD=esp32-olimex-evb -C examples/gnrc_networking
   ```
   ```
   USEMODULE=esp_wifi make BOARD=esp32-wroom-32 -C examples/gnrc_networking
   ```
   ```
   USEMODULE=esp_spi_ram make BOARD=esp32-wrover-kit -C tests/shell
   ```

4. Flash `tests/shell` to check that the prompt (printed with `putchar`) and the command line input work:
   ```
   make BOARD=esp32-wroom-32 -C tests/shell flash
   ```

### Issues/PRs references

Prerequisite for #11946 