### PR TITLE
tests/log_printfnoformat: add test application & script

### DIFF
--- a/tests/log_printfnoformat/Makefile
+++ b/tests/log_printfnoformat/Makefile
@@ -1,0 +1,10 @@
+include ../Makefile.tests_common
+
+USEMODULE += log_printfnoformat
+
+TEST_ON_CI_WHITELIST += all
+
+# Enable debug log level
+CFLAGS += -DLOG_LEVEL=4
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/log_printfnoformat/main.c
+++ b/tests/log_printfnoformat/main.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Test logging with no format gives the expected output
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#include <inttypes.h>
+
+#include "log.h"
+
+int main(void)
+{
+    uint8_t value = 42;
+    const char *string = "test";
+    const char *format = "Logging value %d and string %s";
+
+    LOG_ERROR(format, value, string);
+    LOG_WARNING(format, value, string);
+    LOG_INFO(format, value, string);
+    LOG_DEBUG(format, value, string);
+
+    return 0;
+}

--- a/tests/log_printfnoformat/tests/01-run.py
+++ b/tests/log_printfnoformat/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Alexandre Abadie <alexandre.abadie@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    for _ in range(4):
+        child.expect_exact('Logging value %d and string %s')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR add a test application for log_printfnoformat submodule. In the current state it fails to build on native and requires #11572 for the fix.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Rebase this branch on top of #11572 
- Run make -C tests/printf_lognoformat flash test and verify the test succeeds.

Without the rebase it doesn't work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Adds a non regression tests for the fix provided in #11572 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
