### PR TITLE
tests: fix tests for nucleo-f303k8

### DIFF
--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -13,6 +13,12 @@ BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f334r8 spark-core \
 # to CXXEXFLAGS variable
 CXXEXFLAGS += -std=c++11
 
+# nucleo-f303k8 doesn't have enough RAM to run the test so we reduce the stack
+# size for every thread
+ifneq (,$(filter nucleo-f303k8,$(BOARD)))
+  CFLAGS += -DTHREAD_STACKSIZE_DEFAULT=512
+endif
+
 USEMODULE += cpp11-compat
 USEMODULE += xtimer
 USEMODULE += timex

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -21,6 +21,12 @@ BOARD_INSUFFICIENT_MEMORY += \
 	waspmote-pro \
 	#
 
+# nucleo-f303k8 doesn't have enough RAM to run the test so we reduce the stack
+# size for every thread
+ifneq (,$(filter nucleo-f303k8,$(BOARD)))
+  CFLAGS += -DTHREAD_STACKSIZE_DEFAULT=512
+endif
+
 USEMODULE += posix_headers
 USEMODULE += pthread
 

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              arduino-uno chronos i-nucleo-lrwan1 msb-430 \
-                             msb-430h nucleo-f031k6 nucleo-f303k8 stm32l0538-disco
+                             msb-430h nucleo-f031k6 stm32l0538-disco
 
 DISABLE_MODULE += auto_init
 
@@ -11,6 +11,9 @@ ifneq (,$(filter nucleo-f042k6,$(BOARD)))
 endif
 ifneq (,$(filter nucleo-f030r8 nucleo-l031k6 nucleo-l053r8 stm32f0discovery stm32l0538-disco,$(BOARD)))
   PROBLEM ?= 5
+endif
+ifneq (,$(filter nucleo-f303k8,$(BOARD)))
+  PROBLEM ?= 7
 endif
 ifneq (,$(filter nucleo-f334r8,$(BOARD)))
   PROBLEM ?= 9


### PR DESCRIPTION
- Descrease defualt stack size for pthread_cooperation and
  cp11_condition_variable
- Reduce number of problems for thread cooperation and remove
  from inssuficient memmory list

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

While testing #11809 I realized the following tests where failing for nucleo-f303k8:

```
Failures during test:
- [tests/cpp11_condition_variable](tests/cpp11_condition_variable/test.failed)
- [tests/driver_grove_ledbar](tests/driver_grove_ledbar/test.failed)
- [tests/driver_my9221](tests/driver_my9221/test.failed)
- [tests/pkg_fatfs_vfs](tests/pkg_fatfs_vfs/test.failed)
- [tests/pthread_cooperation](tests/pthread_cooperation/test.failed)
```

Two of them and another test that wasn't run can be enabled by changing the `stack size` so there is no RAM issues.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->



<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --jobs 0 . nucleo-f303k8 --applications "tests/pthread_cooperation tests/cpp11_condition_variable tests/thread_cooperation"</summary>

```
INFO:nucleo-f303k8:Saving toolchain
INFO:nucleo-f303k8.tests/cpp11_condition_variable:Board supported: True
INFO:nucleo-f303k8.tests/cpp11_condition_variable:Board has enough memory: True
INFO:nucleo-f303k8.tests/cpp11_condition_variable:Application has test: True
INFO:nucleo-f303k8.tests/cpp11_condition_variable:Run compilation
INFO:nucleo-f303k8.tests/cpp11_condition_variable:Run test
INFO:nucleo-f303k8.tests/cpp11_condition_variable:Run test.flash
INFO:nucleo-f303k8.tests/cpp11_condition_variable:Success
INFO:nucleo-f303k8.tests/pthread_cooperation:Board supported: True
INFO:nucleo-f303k8.tests/pthread_cooperation:Board has enough memory: True
INFO:nucleo-f303k8.tests/pthread_cooperation:Application has test: True
INFO:nucleo-f303k8.tests/pthread_cooperation:Run compilation
INFO:nucleo-f303k8.tests/pthread_cooperation:Run test
INFO:nucleo-f303k8.tests/pthread_cooperation:Run test.flash
INFO:nucleo-f303k8.tests/pthread_cooperation:Success
INFO:nucleo-f303k8.tests/thread_cooperation:Board supported: True
INFO:nucleo-f303k8.tests/thread_cooperation:Board has enough memory: True
INFO:nucleo-f303k8.tests/thread_cooperation:Application has test: True
INFO:nucleo-f303k8.tests/thread_cooperation:Run compilation
INFO:nucleo-f303k8.tests/thread_cooperation:Run test
INFO:nucleo-f303k8.tests/thread_cooperation:Run test.flash
INFO:nucleo-f303k8.tests/thread_cooperation:Success
INFO:nucleo-f303k8:Tests successful
```

</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
