### PR TITLE
cpu/esp32: fix of conditional linker options for esp_idf_heap

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -111,3 +111,10 @@ else
         CFLAGS += -DFLASH_MODE_DOUT=1
     endif
 endif
+
+ifneq (,$(filter esp_idf_heap,$(USEMODULE)))
+    LINKFLAGS += -Wl,-wrap,_malloc_r
+    LINKFLAGS += -Wl,-wrap,_calloc_r
+    LINKFLAGS += -Wl,-wrap,_realloc_r
+    LINKFLAGS += -Wl,-wrap,_free_r
+endif

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -147,13 +147,6 @@ ifneq (,$(filter stdio_uart,$(USEMODULE)))
     LINKFLAGS += -Wl,-wrap,getchar
 endif
 
-ifneq (,$(filter esp_idf_heap,$(USEMODULE)))
-    LINKFLAGS += -Wl,-wrap,_malloc_r
-    LINKFLAGS += -Wl,-wrap,_calloc_r
-    LINKFLAGS += -Wl,-wrap,_realloc_r
-    LINKFLAGS += -Wl,-wrap,_free_r
-endif
-
 # The ELFFILE is the base one used for flashing
 FLASHFILE ?= $(ELFFILE)
 


### PR DESCRIPTION
### Contribution description

This PR fixes a problem that was introduced with the commit https://github.com/RIOT-OS/RIOT/pull/11967/commits/e4198542d13ea7df119824836a8afae0e64b903c. The problem happened for applications that are using the `esp_idf_heap` module which requires to override the memory management functions with wrappers, e.g., applications that are using the WiFi interface.

Module `esp_idf_heap` is enabled in `cpu/esp32/Makefile.dep` depending on other modules, like the `esp_wifi` module. Since `cpu/esp32/Makefile.dep` is read after `cpu/esp32/Makefile.include`, the conditional  definition of the linker options for the wrapper functions 
```make
ifneq (,$(filter esp_idf_heap,$(USEMODULE)))
    LINKFLAGS += -Wl,-wrap,_malloc_r
￼    LINKFLAGS += -Wl,-wrap,_calloc_r
    LINKFLAGS += -Wl,-wrap,_realloc_r
    LINKFLAGS += -Wl,-wrap,_free_r
endif
```
had to be moved from `cpu/esp32/Makefile.include` to `cpu/esp32/Makefile.dep`.

### Testing procedure

Flash and test `examples/gnrc_networking`:
```
USEMODULE=esp_wifi CFLAGS='-DESP_WIFI_SSID=\"<ssid>\" -DESP_WIFI_PASS=\"<passphrase>\"' make BOARD=esp32-wroom-32 -C examples/gnrc_networking flash
```

Without the changes in this PR, the application will crash. With the changes in this PR the application should work.

### Issues/PRs references

Fixes problem in issue #11941 