### PR TITLE
dist/tools: add Coccinelle check for ARRAYSIZE

### DIFF
--- a/dist/tools/coccinelle/warn/arraysize.cocci
+++ b/dist/tools/coccinelle/warn/arraysize.cocci
@@ -1,0 +1,58 @@
+// Use the macro ARRAY_SIZE when possible
+//
+// Confidence: High
+// Copyright: (C) Gilles Muller, Julia Lawall, EMN, INRIA, DIKU.  GPLv2.
+// URL: http://coccinelle.lip6.fr/rules/array.html
+// Options: -I ... -all_includes can give more complete results
+
+// This is a modified version for RIOT-OS.
+// At first it was used to help with Pull Request 11865
+// Now it helps to warn when it is possible to use the macro
+// in new code.
+
+@@
+type T;
+T[] E;
+@@
+
+- (sizeof(E)/sizeof(*E))
++ ARRAY_SIZE(E)
+
+@@
+type T;
+T[] E;
+T E2;
+@@
+
+- (sizeof(E)/sizeof(E2))
++ ARRAY_SIZE(E)
+
+@@
+type T;
+T[] E;
+@@
+
+- (sizeof(E)/sizeof(E[...]))
++ ARRAY_SIZE(E)
+
+@@
+type T;
+T[] E;
+@@
+
+- (sizeof(E)/sizeof(T))
++ ARRAY_SIZE(E)
+
+@n@
+identifier AS,E;
+@@
+
+- #define AS(E) ARRAY_SIZE(E)
+
+@@
+expression E;
+identifier n.AS;
+@@
+
+- AS(E)
++ ARRAY_SIZE(E)


### PR DESCRIPTION
### Contribution description

This Coccinelle script will warn when new code has the potential to use
the macro ARRAYSIZE instead of something like this
```
     sizeof(some_array) / sizeof(some_array[0])
```

The script is placed in `dist/tools/coccinelle/warn` and it will automatically be picked up by  `check.sh`.

### Testing procedure

The script can be tested separately with this command:
```
spatch --in-place --macro-file-builtins dist/tools/coccinelle/include/riot-standard.h --cocci-file dist/tools/coccinelle/warn/arraysize.cocci --dir .
```
It will go through the whole RIOT code (which may be overkill), but it shows its potential. Today's run modified three files.
```
	modified:   cpu/atmega_common/periph/gpio.c
	modified:   cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/dh_groups.c
	modified:   cpu/esp8266/vendor/esp-gdbstub/gdbstub.c
```
Two of these are vendor files, so they should probably be skipped. The other one shows that the `ARRAYSIZE` macro could have been used.
```
@@ -310,7 +310,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
         uint8_t pin_num = _pin_num(pin);
 
         for (unsigned i = 0;
-             i < sizeof(pcint_mapping) / sizeof(pcint_mapping[0]); i++) {
+             i < ARRAY_SIZE(pcint_mapping); i++) {
             if (pin != GPIO_UNDEF && pin == pcint_mapping[i]) {
                 offset = i;
                 break;
```


### Issues/PRs references

This script is useful after merging PR #11865 