### PR TITLE
boards: remove unused XTIMER_SHOOT_EARLY defines

### DIFF
--- a/boards/common/iotlab/include/board_common.h
+++ b/boards/common/iotlab/include/board_common.h
@@ -51,7 +51,6 @@ extern "C" {
  */
 #define XTIMER_WIDTH        (16U)
 #define XTIMER_OVERHEAD     (6U)
-#define XTIMER_SHOOT_EARLY  (3U)
 /** @} */
 
 /**

--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -38,7 +38,6 @@ extern "C" {
 #endif
 
 #if defined(CPU_MODEL_STM32F334R8)
-#define XTIMER_SHOOT_EARLY          (2)
 #define XTIMER_OVERHEAD             (5)
 #endif
 

--- a/boards/msba2/include/board.h
+++ b/boards/msba2/include/board.h
@@ -50,7 +50,6 @@ extern "C" {
  * @{
  */
 #define XTIMER_OVERHEAD     7
-#define XTIMER_SHOOT_EARLY  3
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR removes unused `XTIMER_SHOOT_EARLY`. This define is only present in 3 boards but not present in any code, can be verified with git grep. There is not documentation pointing to any use case for these defines either.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Green murdock should be enough.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
