### PR TITLE
boards/common/nucleo: increase XTIMER_BACKOFF for STM32F103

### DIFF
--- a/boards/blackpill/include/board.h
+++ b/boards/blackpill/include/board.h
@@ -67,7 +67,7 @@ void board_init(void);
  * @{
  */
 #define XTIMER_WIDTH        (16)
-#define XTIMER_BACKOFF      5
+#define XTIMER_BACKOFF      (19)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/bluepill/include/board.h
+++ b/boards/bluepill/include/board.h
@@ -61,7 +61,7 @@ void board_init(void);
  * @{
  */
 #define XTIMER_WIDTH        (16)
-#define XTIMER_BACKOFF      5
+#define XTIMER_BACKOFF      (19)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -44,7 +44,7 @@ extern "C" {
 
 #if defined(CPU_FAM_STM32F1)
 #define XTIMER_WIDTH                (16)
-#define XTIMER_BACKOFF              (5)
+#define XTIMER_BACKOFF              (19)
 #endif
 
 #if defined(CPU_FAM_STM32L1)

--- a/boards/maple-mini/include/board.h
+++ b/boards/maple-mini/include/board.h
@@ -29,7 +29,7 @@ extern "C" {
  * @{
  */
 #define XTIMER_WIDTH        (16)
-#define XTIMER_BACKOFF      5
+#define XTIMER_BACKOFF      (19)
 /** @} */
 
 /**

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -29,7 +29,7 @@ extern "C" {
  * @{
  */
 #define XTIMER_WIDTH        (16)
-#define XTIMER_BACKOFF      5
+#define XTIMER_BACKOFF      (19)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

This PR increases XTIMER_BACKOFF for all `stm32f103` based board that are using custom `XTIMER_BACKOFF` definitions. While testing #11809 it was seen that for `nucleo-f103rb`  2 tests where failing because of too small `XTIMER_BACKOFF` definitions. This PR fixes this for all `stm32f103` based board running on the same timer with the same `CORE_CLOCK`

```
- [tests/xtimer_periodic_wakeup](tests/xtimer_periodic_wakeup/test.failed)
- [tests/xtimer_usleep_short](tests/xtimer_usleep_short/test.failed)
```

### Testing procedure

Tested on `nucleo-f103rb` and `bluepill`:

<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --jobs 2 . nucleo-f103rb --applications="tests/xtimer_usleep_short tests/xtimer_periodic_wakeup"</summary>

```
INFO:nucleo-f103rb:Saving toolchain
INFO:nucleo-f103rb.tests/xtimer_periodic_wakeup:Board supported: True
INFO:nucleo-f103rb.tests/xtimer_periodic_wakeup:Board has enough memory: True
INFO:nucleo-f103rb.tests/xtimer_periodic_wakeup:Application has test: True
INFO:nucleo-f103rb.tests/xtimer_periodic_wakeup:Run compilation
INFO:nucleo-f103rb.tests/xtimer_periodic_wakeup:Run test
INFO:nucleo-f103rb.tests/xtimer_periodic_wakeup:Run test.flash
INFO:nucleo-f103rb.tests/xtimer_periodic_wakeup:Success
INFO:nucleo-f103rb.tests/xtimer_usleep_short:Board supported: True
INFO:nucleo-f103rb.tests/xtimer_usleep_short:Board has enough memory: True
INFO:nucleo-f103rb.tests/xtimer_usleep_short:Application has test: True
INFO:nucleo-f103rb.tests/xtimer_usleep_short:Run compilation
INFO:nucleo-f103rb.tests/xtimer_usleep_short:Run test
INFO:nucleo-f103rb.tests/xtimer_usleep_short:Run test.flash
INFO:nucleo-f103rb.tests/xtimer_usleep_short:Success
INFO:nucleo-f103rb:Tests successful
```
</details>

<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --jobs 2 . bluepill --applications="tests/xtimer_usleep_short tests/xtimer_usleep_short/"</summary>

```
INFO:bluepill:Saving toolchain
INFO:bluepill.tests/xtimer_usleep_short:Board supported: True
INFO:bluepill.tests/xtimer_usleep_short:Board has enough memory: True
INFO:bluepill.tests/xtimer_usleep_short:Application has test: True
INFO:bluepill.tests/xtimer_usleep_short:Run compilation
INFO:bluepill.tests/xtimer_usleep_short:Run test
INFO:bluepill.tests/xtimer_usleep_short:Run test.flash
INFO:bluepill.tests/xtimer_usleep_short:Success
INFO:bluepill.tests/xtimer_usleep_short/:Board supported: True
INFO:bluepill.tests/xtimer_usleep_short/:Board has enough memory: True
INFO:bluepill.tests/xtimer_usleep_short/:Application has test: True
INFO:bluepill.tests/xtimer_usleep_short/:Run compilation
INFO:bluepill.tests/xtimer_usleep_short/:Run test
INFO:bluepill.tests/xtimer_usleep_short/:Run test.flash
INFO:bluepill.tests/xtimer_usleep_short/:Success
INFO:bluepill:Tests successful
```
</details>

### Issues/PRs references

