### PR TITLE
dist/tools/openocd: add OPENOCD_EXTRA_INIT_RESET use for nucleo-f091rc

### DIFF
--- a/boards/nucleo-f091rc/Makefile.include
+++ b/boards/nucleo-f091rc/Makefile.include
@@ -1,2 +1,6 @@
+# nucleo-f091rc can become un-flashable after a hardfault, use connect_assert_srst
+# to always be able to flash or reset the board.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
+
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -73,6 +73,8 @@
 : ${OPENOCD_EXTRA_INIT:=}
 # Debugger interface initialization commands to pass to OpenOCD
 : ${OPENOCD_ADAPTER_INIT:=}
+# If set to 1 'reset_config' will use 'connect_assert_srst' before 'flash' or 'reset.
+: ${OPENOCD_RESET_USE_CONNECT_ASSERT_SRST:=}
 # The setsid command is needed so that Ctrl+C in GDB doesn't kill OpenOCD
 : ${SETSID:=setsid}
 # GDB command, usually a separate command for each platform (e.g. arm-none-eabi-gdb)
@@ -106,7 +108,6 @@
 #
 # Examples of alternative debugger configurations
 #
-
 # Using the GDB text UI:
 # DBG_EXTRA_FLAGS=-tui make debug
 # or to always use TUI, put in your .profile:
@@ -118,6 +119,11 @@
 # export DBG=ddd
 # export DBG_FLAGS='--debugger "${GDB} ${DBG_DEFAULT_FLAGS}"'
 # The single quotes are important on the line above, or it will not work.
+
+# Handle OPENOCD_RESET_USE_CONNECT_ASSERT_SRST
+if [ "${OPENOCD_RESET_USE_CONNECT_ASSERT_SRST}" -eq 1 ]; then
+  OPENOCD_EXTRA_RESET_INIT+="-c 'reset_config connect_assert_srst'"
+fi
 
 #
 # a couple of tests for certain configuration options
@@ -205,6 +211,7 @@ _flash_list_raw() {
     sh -c "${OPENOCD} \
             ${OPENOCD_ADAPTER_INIT} \
             -f '${OPENOCD_CONFIG}' \
+            ${OPENOCD_EXTRA_RESET_INIT} \
             -c 'init' \
             -c 'flash probe 0' \
             -c 'flash list' \
@@ -274,6 +281,7 @@ do_flash() {
             ${OPENOCD_ADAPTER_INIT} \
             -f '${OPENOCD_CONFIG}' \
             ${OPENOCD_EXTRA_INIT} \
+            ${OPENOCD_EXTRA_RESET_INIT} \
             -c 'tcl_port 0' \
             -c 'telnet_port 0' \
             -c 'gdb_port 0' \
@@ -353,6 +361,7 @@ do_reset() {
             ${OPENOCD_ADAPTER_INIT} \
             -f '${OPENOCD_CONFIG}' \
             ${OPENOCD_EXTRA_INIT} \
+            ${OPENOCD_EXTRA_RESET_INIT} \
             -c 'tcl_port 0' \
             -c 'telnet_port 0' \
             -c 'gdb_port 0' \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

When testing #11809 I realized that after flashing `tests/ssp` on `nucleo-f091rc` the board becomes un-flashable which caused all subsequent tests to fail. This can be avoided if `connect_assert_srst` is added to the reset configuration.

To avoid this also being called when debugging a new configuration parameter is introduced to only call this when reseting or flashing the board but not on debug actions. Since not all platforms support `connect_assert_srst` this is not used as default.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

#### Reproducing

To reproduce on master executing the following will fail on the second try:

`make -C tests/ssp/ BOARD=nucleo-f091rc flash`

The following also fails

`make -C tests/ssp/ BOARD=nucleo-f091rc flash reset`

#### Testing

With this PR it succeeds. Also the following succeeds:

2x `make -C tests/ssp/ BOARD=nucleo-f091rc flash`

`make -C tests/ssp/ BOARD=nucleo-f091rc flash reset`

`make -C tests/xtimer_usleep/ BOARD=nucleo-f091rc flash debug`

### Issues/PRs references

Related to #8976, #10479