### PR TITLE
xtimer/xtimer.c: xtimer_rmutex_lock_timeout

### DIFF
--- a/sys/include/c11_atomics_compat.hpp
+++ b/sys/include/c11_atomics_compat.hpp
@@ -36,7 +36,9 @@
  * atomic_int foo = ATOMIC_VAR_INIT(42);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
+#ifndef ATOMIC_VAR_INIT
 #define ATOMIC_VAR_INIT(x) { x }
+#endif
 
 /**
   * @brief Type with the same alignment and size as `atomic_bool`

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -58,9 +58,7 @@
  * see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60932
  */
 #ifdef __cplusplus
-#include <atomic>
-/* Make atomic_int available without namespace specifier */
-using std::atomic_int;
+#include "c11_atomics_compat.hpp"
 #else
 #include <stdatomic.h> /* for atomic_int */
 #endif

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -37,6 +37,7 @@
 #endif /* MODULE_CORE_MSG */
 #include "mutex.h"
 #include "kernel_types.h"
+#include "rmutex.h"
 
 #ifdef MODULE_ZTIMER_XTIMER_COMPAT
 #include "ztimer/xtimer_compat.h"
@@ -413,7 +414,19 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b);
  */
 int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
 
+/**
+ * @brief lock a rmutex but with timeout
+ *
+ * @param[in]    rmutex  rmutex to lock
+ * @param[in]    us     timeout in microseconds relative
+ *
+ * @return       0, when returned after rmutex was locked
+ * @return       -1, when the timeout occcured
+ */
+int xtimer_rmutex_lock_timeout(rmutex_t *rmutex, uint64_t us);
+
 #if defined(MODULE_CORE_THREAD_FLAGS) || defined(DOXYGEN)
+
 /**
  * @brief    Set timeout thread flag after @p timeout
  *

--- a/tests/xtimer_rmutex_lock_timeout/Makefile
+++ b/tests/xtimer_rmutex_lock_timeout/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_rmutex_lock_timeout/main.c
+++ b/tests/xtimer_rmutex_lock_timeout/main.c
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin,
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       testing xtimer_rmutex_lock_timeout function
+ *
+ *
+ * @author      Julian Holzwarth <julian.holzwarth@fu-berlin.de>
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "shell.h"
+#include "xtimer.h"
+#include "thread.h"
+#include "msg.h"
+#include "irq.h"
+
+/* timeout at one millisecond (1000 us) to make sure it does not spin. */
+#define LONG_RMUTEX_TIMEOUT 1000
+
+/* timeout smaller than XTIMER_BACKOFF to make sure it spins. */
+#define SHORT_RMUTEX_TIMEOUT ((1 << XTIMER_SHIFT) + 1)
+
+/**
+ * Forward declarations
+ */
+static int cmd_test_xtimer_rmutex_lock_timeout_long_unlocked(int argc,
+                                                             char **argv);
+static int cmd_test_xtimer_rmutex_lock_timeout_long_locked(int argc,
+                                                           char **argv);
+static int cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread(
+    int argc, char **argv);
+
+static int cmd_test_xtimer_rmutex_lock_timeout_short_unlocked(int argc,
+                                                              char **argv);
+static int cmd_test_xtimer_rmutex_lock_timeout_short_locked(int argc,
+                                                            char **argv);
+
+#define error_wrong_variables "Error: rmutex wrong variables in struct"
+#define error_rmutex_taken "Error: rmutex taken"
+#define error_timeout "Error: rmutex timed out"
+#define shell_help_output "See main.c"
+
+/**
+ * @brief   List of command for this application.
+ */
+static const shell_command_t shell_commands[] = {
+    { "t1", shell_help_output,
+      cmd_test_xtimer_rmutex_lock_timeout_long_unlocked, },
+    { "t2", shell_help_output,
+      cmd_test_xtimer_rmutex_lock_timeout_long_locked, },
+    { "t3", shell_help_output,
+      cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread, },
+    { "t4", shell_help_output,
+      cmd_test_xtimer_rmutex_lock_timeout_short_unlocked, },
+    { "t5", shell_help_output,
+      cmd_test_xtimer_rmutex_lock_timeout_short_locked, },
+    { NULL, NULL, NULL }
+};
+
+/* main Thread PID */
+static kernel_pid_t main_thread_pid;
+
+/**
+ * @brief   stack for
+ *          cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread
+ */
+static char t_stack[THREAD_STACKSIZE_SMALL];
+
+/**
+ * @brief   send message and suicide thread
+ *
+ * This function will send a message to a thread without yielding
+ * and terminates the calling thread. This can be used to wakeup a
+ * thread and terminating yourself.
+ * This function calls sched_task_exit()
+ *
+ * @param[in] m Pointer to preallocated @ref msg_t structure, must
+ * not be NULL.
+ * @param[in] target_pid PID of target thread
+ *
+ */
+static NORETURN void msg_send_sched_task_exit(msg_t *m, kernel_pid_t target_pid)
+{
+    (void)irq_disable();
+    msg_send_int(m, target_pid);
+    sched_task_exit();
+}
+
+/**
+ * @brief   this thread locks a rmutex
+ */
+static void *lock_rmutex_thread(void *arg)
+{
+    rmutex_t *test_rmutex = (rmutex_t *)arg;
+
+    rmutex_lock(test_rmutex);
+    return NULL;
+}
+
+/**
+ * @brief   thread function for
+ *          cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread
+ */
+void *test_thread(void *arg)
+{
+    rmutex_t *test_rmutex = (rmutex_t *)arg;
+    msg_t msg;
+
+    rmutex_lock(test_rmutex);
+    thread_wakeup(main_thread_pid);
+
+    rmutex_unlock(test_rmutex);
+
+    msg_send_sched_task_exit(&msg, main_thread_pid);
+}
+
+/**
+ * @brief   shell command to test xtimer_rmutex_lock_timeout
+ *
+ * the rmutex is not locked before the function call and
+ * the timer long. Meaning the timer will get removed
+ * before triggering.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return 0 on success
+ */
+static int cmd_test_xtimer_rmutex_lock_timeout_long_unlocked(int argc,
+                                                             char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    rmutex_t test_rmutex = RMUTEX_INIT;
+
+    if (xtimer_rmutex_lock_timeout(&test_rmutex, LONG_RMUTEX_TIMEOUT) == 0) {
+        /* rmutex has to be locked once */
+        if (atomic_load_explicit(&test_rmutex.owner,
+                                 memory_order_relaxed) == thread_getpid() &&
+            test_rmutex.refcount == 1 &&
+            mutex_trylock(&test_rmutex.mutex) == 0) {
+            puts("OK");
+        }
+        else {
+            puts(error_wrong_variables);
+        }
+    }
+    else {
+        puts(error_timeout);
+    }
+    /* to make the test easier to read */
+    printf("\n");
+
+    return 0;
+}
+
+/**
+ * @brief   shell command to test xtimer_rmutex_lock_timeout
+ *
+ * the rmutex is locked from another thread before the
+ * function call and the timer is long.
+ * Meaning the timer will trigger
+ * and remove the thread from the rmutex waiting list.
+ * To loc
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return 0 on success
+ */
+static int cmd_test_xtimer_rmutex_lock_timeout_long_locked(int argc,
+                                                           char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    rmutex_t test_rmutex = RMUTEX_INIT;
+
+    /* lock rmutex from different thread */
+    kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
+                                               THREAD_PRIORITY_MAIN - 1,
+                                               THREAD_CREATE_STACKTEST,
+                                               lock_rmutex_thread,
+                                               (void *)&test_rmutex,
+                                               "lock_thread");
+
+    if (xtimer_rmutex_lock_timeout(&test_rmutex, LONG_RMUTEX_TIMEOUT) == 0) {
+        puts(error_rmutex_taken);
+    }
+    else {
+        /* rmutex has to be locked once */
+        if (atomic_load_explicit(&test_rmutex.owner,
+                                 memory_order_relaxed) == second_t_pid &&
+            test_rmutex.refcount == 1 &&
+            mutex_trylock(&test_rmutex.mutex) == 0) {
+            puts("OK");
+        }
+        else {
+            puts(error_wrong_variables);
+        }
+    }
+    /* to make the test easier to read */
+    printf("\n");
+
+    return 0;
+}
+
+/**
+ * @brief   shell command to test xtimer_rmutex_lock_timeout
+ *
+ * This function will create a new thread with lower prio
+ * than the main thread (this function should be called from
+ * the main thread). The new thread will get a rmutex and will
+ * lock it. This function (main thread) calls xtimer_rmutex_lock_timeout.
+ * The other thread will then unlock the rmutex. The main
+ * thread gets the rmutex and wakes up. The timer will not
+ * trigger because the main threads gets the rmutex.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return 0 on success
+ */
+static int cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread(
+    int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    main_thread_pid = thread_getpid();
+    rmutex_t test_rmutex = RMUTEX_INIT;
+
+    kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
+                                               THREAD_PRIORITY_MAIN + 1,
+                                               THREAD_CREATE_STACKTEST,
+                                               test_thread,
+                                               (void *)&test_rmutex,
+                                               "test_thread");
+    (void)second_t_pid;
+    thread_sleep();
+
+    if (xtimer_rmutex_lock_timeout(&test_rmutex, LONG_RMUTEX_TIMEOUT) == 0) {
+        /* rmutex has to be locked once */
+        if (atomic_load_explicit(&test_rmutex.owner,
+                                 memory_order_relaxed) == thread_getpid() &&
+            test_rmutex.refcount == 1 &&
+            mutex_trylock(&test_rmutex.mutex) == 0) {
+            puts("OK");
+        }
+        else {
+            puts(error_wrong_variables);
+        }
+    }
+    else {
+        puts(error_timeout);
+    }
+
+    /* to end the created thread */
+    msg_t msg;
+    msg_receive(&msg);
+
+    /* to make the test easier to read */
+    printf("\n");
+
+    return 0;
+}
+
+/**
+ * @brief   shell command to test xtimer_rmutex_lock_timeout when spinning
+ *
+ * The rmutex is locked before the function call and
+ * the timer long. Meaning the timer will trigger before
+ * xtimer_rmutex_lock_timeout tries to acquire the rmutex.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return 0 on success
+ */
+static int cmd_test_xtimer_rmutex_lock_timeout_short_locked(int argc,
+                                                            char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    rmutex_t test_rmutex = RMUTEX_INIT;
+
+    kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
+                                               THREAD_PRIORITY_MAIN - 1,
+                                               THREAD_CREATE_STACKTEST,
+                                               lock_rmutex_thread,
+                                               (void *)&test_rmutex,
+                                               "lock_thread");
+
+    if (xtimer_rmutex_lock_timeout(&test_rmutex, SHORT_RMUTEX_TIMEOUT) == 0) {
+        puts(error_rmutex_taken);
+    }
+    else {
+        /* rmutex has to be locked once */
+        if (atomic_load_explicit(&test_rmutex.owner,
+                                 memory_order_relaxed) == second_t_pid &&
+            test_rmutex.refcount == 1 &&
+            mutex_trylock(&test_rmutex.mutex) == 0) {
+            puts("OK");
+        }
+        else {
+            puts(error_wrong_variables);
+        }
+    }
+    /* to make the test easier to read */
+    printf("\n");
+
+    return 0;
+}
+
+/**
+ * @brief   shell command to test xtimer_rmutex_lock_timeout when spinning
+ *
+ * the rmutex is not locked before the function is called and
+ * the timer is short. Meaning the timer will trigger before
+ * xtimer_rmutex_lock_timeout tries to acquire the rmutex.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return 0 on success
+ */
+static int cmd_test_xtimer_rmutex_lock_timeout_short_unlocked(int argc,
+                                                              char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    rmutex_t test_rmutex = RMUTEX_INIT;
+
+    if (xtimer_rmutex_lock_timeout(&test_rmutex, SHORT_RMUTEX_TIMEOUT) == 0) {
+        /* rmutex has to be locked once */
+        if (atomic_load_explicit(&test_rmutex.owner,
+                                 memory_order_relaxed) == thread_getpid() &&
+            test_rmutex.refcount == 1 &&
+            mutex_trylock(&test_rmutex.mutex) == 0) {
+            puts("OK");
+        }
+        else {
+            puts(error_wrong_variables);
+        }
+    }
+    else {
+        puts(error_timeout);
+    }
+    /* to make the test easier to read */
+    printf("\n");
+
+    return 0;
+}
+
+/**
+ * @brief   main function starting shell
+ *
+ * @return 0 on success
+ */
+int main(void)
+{
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/xtimer_rmutex_lock_timeout/tests/01-run.py
+++ b/tests/xtimer_rmutex_lock_timeout/tests/01-run.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2020 Freie Universität Berlin,
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Julian Holzwarth <julian.holzwarth@fu-berlin.de>
+
+import sys
+import pexpect
+from testrunner import run
+
+
+def testfunc(child):
+    # Try to wait for the shell
+    for _ in range(0, 10):
+        child.sendline("help")
+        if child.expect_exact(["> ", pexpect.TIMEOUT], timeout=1) == 0:
+            break
+    child.sendline("t1")
+    child.expect("OK")
+    child.expect_exact("> ")
+    child.sendline("t2")
+    child.expect("OK")
+    child.expect_exact("> ")
+    child.sendline("t3")
+    child.expect("OK")
+    child.expect_exact("> ")
+    child.sendline("t4")
+    child.expect("OK")
+    child.expect_exact("> ")
+    child.sendline("t5")
+    child.expect("OK")
+    child.expect_exact("> ")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This pr adds a new function  `xtimer_rmutex_lock_timeout`. The function tries to acquire a `rmutex` within  a timeout and returns if it was successful. The function uses `xtimer_mutex_lock_timeout`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
`BOARD=native make -C tests/xtimer_rmutex_lock_timeout/ flash test`
it outputs before  #11660:
```

...
> rmutex_timeout_long_unlocked
rmutex_timeout_long_unlocked
starting test: xtimer rmutex lock timeout
OK

> rmutex_timeout_long_locked
rmutex_timeout_long_locked
starting test: xtimer rmutex lock timeout
OK

> rmutex_timeout_long_lower_unlock_locked
rmutex_timeout_long_lower_unlock_locked
starting test: xtimer rmutex lock timeout
MAIN THREAD: created thread
THREAD low prio: locked and waiting
MAIN THREAD: locking
THREAD low prio: unlocking
OK
MAIN THREAD: waiting for created thread to end
THREAD low prio: exiting

> rmutex_timeout_short_locked
rmutex_timeout_short_locked
starting test: xtimer rmutex lock timeout with short timeout and locked rmutex
...
Unexpected end of file in expect script at "child.expect("OK")" (tests/xtimer_rmutex_lock_timeout/tests/01-run.py:36)
```


after  #11660 output:


```
...
> rmutex_timeout_long_unlocked
rmutex_timeout_long_unlocked
starting test: xtimer rmutex lock timeout
OK

> rmutex_timeout_long_locked
rmutex_timeout_long_locked
starting test: xtimer rmutex lock timeout
OK

> rmutex_timeout_long_lower_unlock_locked
rmutex_timeout_long_lower_unlock_locked
starting test: xtimer rmutex lock timeout
MAIN THREAD: created thread
THREAD low prio: locked and waiting
MAIN THREAD: locking
THREAD low prio: unlocking
OK
MAIN THREAD: waiting for created thread to end
THREAD low prio: exiting

> rmutex_timeout_short_locked
rmutex_timeout_short_locked
starting test: xtimer rmutex lock timeout with short timeout and locked rmutex
OK

> rmutex_timeout_short_unlocked
rmutex_timeout_short_unlocked
starting test: xtimer rmutex lock timeout with short timeout and unlocked rmutex
OK

> 

```



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
depends on #11660

