### PR TITLE
cpu/native: default to GNRC_NETIF_NUMOF for the number of TAP interfaces

### DIFF
--- a/cpu/native/include/netdev_tap_params.h
+++ b/cpu/native/include/netdev_tap_params.h
@@ -32,7 +32,7 @@ extern "C" {
  *          more similar to actual boards
  */
 #ifndef NETDEV_TAP_MAX
-#define NETDEV_TAP_MAX              (1)
+#define NETDEV_TAP_MAX              (GNRC_NETIF_NUMOF)
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

When wanting to use multiple tap interfaces on the `native` board, both `NETDEV_TAP_MAX` and `GNRC_NETIF_NUMOF` have to be changed.

This makes creating a `native` instance with more than one tap interface more convenient.

### Testing procedure

In `examples/gnrc_networking`:

**before**

```
$ make GNRC_NETIF_NUMOF=2
$ bin/native/gnrc_networking.elf tap0 tap1
> ifconfig
Iface  6  HWaddr: 5E:66:78:C9:FA:43 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::5c66:78ff:fec9:fa43  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffc9:fa43
          
          Statistics for Layer 2
            RX packets 4  bytes 440
            TX packets 1 (Multicast: 1)  bytes 78
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 4  bytes 384
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0
>
```

**after**
```
$ make GNRC_NETIF_NUMOF=2
$ bin/native/gnrc_networking.elf tap0 tap1
> ifconfig
Iface  6  HWaddr: 5E:66:78:C9:FA:43 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::5c66:78ff:fec9:fa43  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffc9:fa43
          
          Statistics for Layer 2
            RX packets 4  bytes 440
            TX packets 1 (Multicast: 1)  bytes 78
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 4  bytes 384
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0

Iface  7  HWaddr: 76:61:7C:C4:DE:1A 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::7461:7cff:fec4:de1a  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffc4:de1a
          
          Statistics for Layer 2
            RX packets 4  bytes 440
            TX packets 1 (Multicast: 1)  bytes 78
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 4  bytes 384
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0
>
```

### Issues/PRs references
Makes reproducing #11980 easier.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
