### PR TITLE
cpu/atmega_common/gpio: use ARRAY_SIZE macro

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -309,8 +309,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
         int8_t offset = -1;
         uint8_t pin_num = _pin_num(pin);
 
-        for (unsigned i = 0;
-             i < sizeof(pcint_mapping) / sizeof(pcint_mapping[0]); i++) {
+        for (unsigned i = 0; i < ARRAY_SIZE(pcint_mapping); i++) {
             if (pin != GPIO_UNDEF && pin == pcint_mapping[i]) {
                 offset = i;
                 break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

After #11865 and #11973 were merged, I tried the coccinnelle check script locally (and directly) and it found one remaining place where the ARRAY_SIZE macro could be used. This PR is changing that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I guess a successful build of `tests/periph_gpio` for an atmega board is ok:
```
make BOARD=arduino-mega2560 -C tests/periph_gpio
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Leftover from #11865, found thanks to #11973 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
