### PR TITLE
Corrected random range when bounds are equal

### DIFF
--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -77,7 +77,8 @@ void random_bytes(uint8_t *target, size_t n)
 
 uint32_t random_uint32_range(uint32_t a, uint32_t b)
 {
-    assert(a < b);
+    assert(a <= b);
+    if(a==b) return a;
 
     uint32_t divisor, rand_val, range = b - a;
     uint8_t range_msb = bitarithm_msb(range);


### PR DESCRIPTION
### Contribution description
This is a bug fix affecting the [random](https://github.com/RIOT-OS/RIOT/tree/master/sys/random) module in RIOT. The function [random_uint32_t_range](https://github.com/RIOT-OS/RIOT/blob/f802bbb5ae096502cdaf9ad9975fb1611162f455/sys/random/random.c#L78) fails when the parameter bounds are equal. A fallback is to simply return the bound parameter in this case. 

This behaviour was observed when using LoraMac in the AU915 band. More precisely, the bug manifested in LoRaMac-node function [RegionAU915NextChannel](https://github.com/Lora-net/LoRaMac-node/blob/3655dae44f36dbdf4540968a1f462f2d8711f0c8/src/mac/region/RegionAU915.c#L903).
Indeed, when the variable [nbEnabledChannels](https://github.com/Lora-net/LoRaMac-node/blob/3655dae44f36dbdf4540968a1f462f2d8711f0c8/src/mac/region/RegionAU915.c#L947) reduces to 1, the randr function is asked for a random int between 0 and 0 and is expected to return 0.

### Testing procedure
Attached a simple test file [test-randr.zip](https://github.com/RIOT-OS/RIOT/files/3482850/test-randr.zip). Unzip and run on native using `make all term`.

- Result on current master
```
main(): This is RIOT! (Version: 2019.10-devel-341-gf802bb-HEAD)
Random range test
random_uint32_t_range(0,30)=28
sys/random/random.c:80 => 0x566139c3
*** RIOT kernel panic:
FAILED ASSERTION.

*** halted.
```
- Result on this PR
```
main(): This is RIOT! (Version: 2019.10-devel-341-gf802bb-randomr)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
random_uint32_t_range(0,30)=18
random_uint32_t_range(1,1)=1
Done
```

### Issues/PRs references
Fixes #11978. Related to PR #8864, PR #9410 and PR #9528.