### PR TITLE
cpu/kinetis: enable HWRNG for k64f

### DIFF
--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -3,8 +3,6 @@ FEATURES_PROVIDED += periph_cpuid
 # HACK Do not define 'hwrng' if the board does not supports it
 # A whitelist on CPU_MODEL would be better but this information/variable is not
 # available yet.
-# HWRNG uses the wrong hwrng register for the frdm-k64f board/cpu_model
-_KINETIS_BOARDS_WITHOUT_HWRNG += frdm-k64f
 # TRNG driver is not implemented for 'CPU_MODEL == mkw41z512vht4'
 _KINETIS_BOARDS_WITHOUT_HWRNG += frdm-kw41z phynode-kw41z usb-kw41z
 # No HWRNG in MK20D7 devices

--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -154,15 +154,19 @@ extern "C"
  * @name Hardware random number generator module configuration
  * @{
  */
-#if !defined(HWRNG_CLKEN) && defined(RNG) && !defined(RNG_CMD_ST_MASK)
-#define KINETIS_RNGA RNG
+#if !defined(HWRNG_CLK_REG) && !defined(HWRNG_CLK_REG_SHIFT)
 #if defined(SIM_SCGC3_RNGA_SHIFT)
-#define HWRNG_CLKEN()       (bit_set32(&SIM->SCGC3, SIM_SCGC3_RNGA_SHIFT))
-#define HWRNG_CLKDIS()      (bit_clear32(&SIM->SCGC3, SIM_SCGC3_RNGA_SHIFT))
+#define HWRNG_CLK_REG           SIM->SCGC3
+#define HWRNG_CLK_REG_SHIFT     SIM_SCGC3_RNGA_SHIFT
 #elif defined(SIM_SCGC6_RNGA_SHIFT)
-#define HWRNG_CLKEN()       (bit_set32(&SIM->SCGC6, SIM_SCGC6_RNGA_SHIFT))
-#define HWRNG_CLKDIS()      (bit_clear32(&SIM->SCGC6, SIM_SCGC6_RNGA_SHIFT))
+#define HWRNG_CLK_REG           SIM->SCGC6
+#define HWRNG_CLK_REG_SHIFT     SIM_SCGC6_RNGA_SHIFT
 #endif
+#endif
+#if defined(RNG)
+#define KINETIS_RNGA RNG
+#define HWRNG_CLKEN()       (bit_set32(&HWRNG_CLK_REG, HWRNG_CLK_REG_SHIFT))
+#define HWRNG_CLKDIS()      (bit_clear32(&HWRNG_CLK_REG, HWRNG_CLK_REG_SHIFT))
 #endif /* KINETIS_RNGA */
 /** @} */
 

--- a/cpu/kinetis/include/cpu_conf_kinetis_k.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis_k.h
@@ -119,6 +119,19 @@
     defined(CPU_MODEL_MK64FX512VLQ12) || \
     defined(CPU_MODEL_MK64FX512VMD12)
 #include "vendor/MK64F12.h"
+
+/**
+ * @name Hardware random number generator module configuration
+ *
+ *       For K64F SCG3 or SCG6 can be used depending on if the the
+ *       peripheral is accessed through AIPS-lite0 or AIPS-lite1.
+ *       For K64F RNGA is only mapped to SCG6.
+ * @{
+ */
+#define HWRNG_CLK_REG           (SIM->SCGC6)
+#define HWRNG_CLK_REG_SHIFT     (SIM_SCGC6_RNGA_SHIFT)
+/** @} */
+
 #endif
 #endif /* (KINETIS_SUBFAMILY == y) */
 #endif /* (KINETIS_FAMILY == x) */


### PR DESCRIPTION

### Contribution description

HWRNG was disabled for `frdm-k64f` in #11454 because 925a908 broke the support. 

When looking at `kinetis k64` reference manual under (`AIPS-Lite0` and `AIPS-Lite1`):

> Modules that are disabled via their clock gate control bits in the SIM registers disable the
> associated AIPS slots. Access to any address within an unimplemented or disabled
> peripheral bridge slot results in a transfer error termination.

If the peripheral Bridge for `AIPS-Lite-0` and `AIPS-Lite-1`, `RNGA` is only mapped in `SCGC6`, so it shouldn't use `SCGC3` for `k64`.

See **4.5** and **4.5.2** in [RM](https://cdn.sparkfun.com/datasheets/Dev/Arduino/Boards/K64P144M120SF5RM.pdf).

This PR changes the SCGx register used for RNGA to SCG3.

_note: this PR doesn't address the fact that the hwrng implementation for kinetis is flawed since it returns 32 bits of a register with 1 bit of entropy_

### Testing procedure

- Test the features:

<details><summary>make -C tests/periph_hwrng/ BOARD=frdm-k64f clean flash -j term
</summary>

```
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-08-09 09:15:56,520 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2019-08-09 09:15:57,524 - INFO # 3b 0x4a 0x17
2019-08-09 09:15:57,525 - INFO # generating 18 random byte(s)
2019-08-09 09:15:57,527 - INFO # Got: 0x35 0xa8 0x6c 0xgenerating 1 random byte(s)
2019-08-09 09:15:57,527 - INFO # Got: 0x2b
2019-08-09 09:15:57,529 - INFO # generating 2 random byte(s)
2019-08-09 09:15:57,531 - INFO # Got: 0x20 0x62
2019-08-09 09:15:57,533 - INFO # generating 3 random byte(s)
2019-08-09 09:15:57,533 - INFO # Got: 0xe8 0xea 0xf3
2019-08-09 09:15:57,533 - INFO # generating 4 random byte(s)
2019-08-09 09:15:57,534 - INFO # Got: 0xc8 0x88 0xbd 0x31
2019-08-09 09:15:57,534 - INFO # generating 5 random byte(s)
2019-08-09 09:15:57,534 - INFO # Got: 0x51 0x86 0xf6 0xd3 0xbf
2019-08-09 09:15:57,534 - INFO # generating 6 random byte(s)
2019-08-09 09:15:57,535 - INFO # Got: 0x07 0x0c 0x10 0xea 0x9c 0xc9
2019-08-09 09:15:57,535 - INFO # generating 7 random byte(s)
2019-08-09 09:15:57,535 - INFO # Got: 0x68 0x0d 0xe0 0xd7 0xbb 0xb8 0xd5
2019-08-09 09:15:57,536 - INFO # generating 8 random byte(s)
2019-08-09 09:15:57,536 - INFO # Got: 0x31 0x3b 0xa0 0xa9 0x1d 0x49 0xbe 0x25
2019-08-09 09:15:57,536 - INFO # generating 9 random byte(s)
2019-08-09 09:15:57,537 - INFO # Got: 0xcf 0xfc 0xaa 0x97 0x20 0x9e 0x39 0x67 0xbd
2019-08-09 09:15:57,537 - INFO # generating 10 random byte(s)
2019-08-09 09:15:57,539 - INFO # Got: 0x94 0xc2 0x3b 0x3f 0xff 0x56 0xa3 0x6c 0x79 0x94
2019-08-09 09:15:57,542 - INFO # generating 11 random byte(s)
2019-08-09 09:15:57,547 - INFO # Got: 0x7a 0x5c 0x64 0x74 0xcf 0xe1 0xa9 0xb9 0xb1 0x14 0xf6
2019-08-09 09:15:57,549 - INFO # generating 12 random byte(s)
2019-08-09 09:15:57,555 - INFO # Got: 0x62 0xd7 0xaf 0x4e 0x01 0xb5 0x76 0xde 0x94 0x56 0x78 0x40
2019-08-09 09:15:57,558 - INFO # generating 13 random byte(s)
2019-08-09 09:15:57,564 - INFO # Got: 0x1b 0x1f 0xed 0x4c 0x52 0x42 0x08 0x3a 0x2a 0x81 0x1c 0x50 0x36
2019-08-09 09:15:57,566 - INFO # generating 14 random byte(s)
2019-08-09 09:15:57,572 - INFO # Got: 0x2b 0xb8 0x3c 0x6b 0x40 0x20 0xf2 0xf5 0x7e 0xab 0xbb 0x9f 0x42 0x02
2019-08-09 09:15:57,575 - INFO # generating 15 random byte(s)
2019-08-09 09:15:57,582 - INFO # Got: 0x84 0xa0 0xb9 0xbf 0x83 0x0c 0x47 0xe0 0xd7 0xbd 0xfe 0xac 0x49 0x81 0x52
2019-08-09 09:15:57,584 - INFO # generating 16 random byte(s)
2019-08-09 09:15:57,592 - INFO # Got: 0xf9 0x93 0xd0 0x58 0xb5 0xe0 0xd4 0x90 0x14 0x6d 0x82 0x52 0x25 0x95 0xb3 0x28
2019-08-09 09:15:57,594 - INFO # generating 17 random byte(s)
2019-08-09 09:15:57,602 - INFO # Got: 0xf4 0xbf 0xe9 0x72 0x10 0xbe 0x5b 0xcc 0xc9 0x71 0x8b 0x82 0xba 0x74 0xa7 0x06 0xf6
2019-08-09 09:15:57,605 - INFO # generating 18 random byte(s)
2019-08-09 09:15:57,613 - INFO # Got: 0x67 0xa2 0x53 0xc6 0xf5 0xd2 0x09 0x62 0xcb 0x66 0x9d 0x91 0xa3 0x17 0x7d 0x64 0x31 0x9b
2019-08-09 09:15:57,616 - INFO # generating 19 random byte(s)
2019-08-09 09:15:57,624 - INFO # Got: 0xe0 0x4f 0x8c 0x12 0x34 0x3d 0xed 0x5e 0xa0 0x17 0x70 0x1c 0x75 0xb9 0x82 0xf1 0xb5 0x2c 0x9e
2019-08-09 09:15:57,627 - INFO # generating 20 random byte(s)
2019-08-09 09:15:57,636 - INFO # Got: 0x3f 0x74 0x66 0x45 0x2f 0x22 0xae 0x31 0x06 0x7b 0x19 0x97 0x34 0xea 0x9c 0x05 0x29 0x7d 0xc0 0xf6
2019-08-09 09:15:58,638 - INFO # generating 1 random byte(s)
2019-08-09 09:15:58,639 - INFO # Got: 0x4f
2019-08-09 09:15:58,641 - INFO # generating 2 random byte(s)
2019-08-09 09:15:58,642 - INFO # Got: 0xcd 0xad
2019-08-09 09:15:58,645 - INFO # generating 3 random byte(s)
2019-08-09 09:15:58,647 - INFO # Got: 0xb1 0xf5 0xfe
2019-08-09 09:15:58,648 - INFO # generating 4 random byte(s)
2019-08-09 09:15:58,651 - INFO # Got: 0xdd 0x9c 0xf4 0xf8
2019-08-09 09:15:58,654 - INFO # generating 5 random byte(s)
2019-08-09 09:15:58,656 - INFO # Got: 0x2a 0x9d 0xf9 0xaa 0x5d
2019-08-09 09:15:58,658 - INFO # generating 6 random byte(s)
2019-08-09 09:15:58,662 - INFO # Got: 0xa0 0xbe 0x2d 0x30 0x64 0x52
2019-08-09 09:15:58,664 - INFO # generating 7 random byte(s)
2019-08-09 09:15:58,667 - INFO # Got: 0xd1 0x9d 0x8a 0x39 0x7e 0x11 0x26
2019-08-09 09:15:58,670 - INFO # generating 8 random byte(s)
2019-08-09 09:15:58,674 - INFO # Got: 0x97 0x40 0x4c 0xd1 0xeb 0xa0 0x32 0x4e
2019-08-09 09:15:58,676 - INFO # generating 9 random byte(s)
2019-08-09 09:15:58,680 - INFO # Got: 0x5b 0x01 0xf5 0x86 0x89 0x88 0xff 0xbc 0x87
2019-08-09 09:15:58,682 - INFO # generating 10 random byte(s)
2019-08-09 09:15:58,687 - INFO # Got: 0x24 0x4c 0x9b 0xfc 0xd6 0x21 0x84 0xe2 0xf6 0x70
2019-08-09 09:15:58,690 - INFO # generating 11 random byte(s)
2019-08-09 09:15:58,695 - INFO # Got: 0x51 0x0e 0xe0 0x90 0xed 0x26 0x7f 0x9f 0xed 0x3b 0x03
2019-08-09 09:15:58,697 - INFO # generating 12 random byte(s)
2019-08-09 09:15:58,703 - INFO # Got: 0xc5 0xe8 0xc4 0xfd 0x3a 0x54 0x40 0xe1 0x22 0x58 0xf2 0xde
2019-08-09 09:15:58,706 - INFO # generating 13 random byte(s)
2019-08-09 09:15:58,712 - INFO # Got: 0x8d 0x3c 0xe7 0x40 0x28 0x98 0x41 0x33 0x2a 0xbe 0x3d 0x23 0x3f
2019-08-09 09:15:58,714 - INFO # generating 14 random byte(s)
2019-08-09 09:15:58,721 - INFO # Got: 0xd6 0xec 0x15 0xb3 0xb3 0x49 0x2a 0x84 0xa6 0xf0 0x50 0xec 0x9c 0x8e
2019-08-09 09:15:58,723 - INFO # generating 15 random byte(s)
2019-08-09 09:15:58,731 - INFO # Got: 0xb8 0x82 0x0b 0xb1 0x7f 0x47 0x83 0x82 0x46 0xe2 0x38 0xbc 0xd4 0xb0 0x8a
2019-08-09 09:15:58,734 - INFO # generating 16 random byte(s)
2019-08-09 09:15:58,741 - INFO # Got: 0x57 0x8a 0x02 0x8e 0x02 0xf8 0x2f 0xfa 0xe9 0x6c 0x29 0x7e 0x5f 0x9e 0x24 0x54
2019-08-09 09:15:58,743 - INFO # generating 17 random byte(s)
2019-08-09 09:15:58,750 - INFO # Got: 0x8c 0xf3 0x8e 0x3f 0x3e 0xee 0x7f 0x58 0x41 0xd9 0x7c 0x0c 0x49 0x6a 0xbb 0xcb 0x92
2019-08-09 09:15:58,753 - INFO # generating 18 random byte(s)
2019-08-09 09:15:58,762 - INFO # Got: 0x8c 0x8a 0x5d 0xf4 0xd2 0x8d 0x1f 0x06 0xc7 0xde 0x2a 0xe2 0xab 0x1c 0x4f 0xec 0xf2 0x0a
2019-08-09 09:15:58,764 - INFO # generating 19 random byte(s)
2019-08-09 09:15:58,772 - INFO # Got: 0x8f 0x46 0xfd 0x2c 0xa7 0xcc 0x0b 0xa6 0xb8 0x04 0x3c 0x96 0x35 0xfa 0x49 0x06 0x36 0x0e 0x59
2019-08-09 09:15:58,775 - INFO # generating 20 random byte(s)
2019-08-09 09:15:58,784 - INFO # Got: 0x91 0x56 0x3d 0xf3 0x4a 0x0e 0x22 0x5d 0xb5 0x2a 0x88 0x8e 0xbc 0x21 0xc5 0x13 0xd9 0x2e 0x2b 0x24
2019-08-09 09:15:59,724 - INFO # main(): This is RIOT! (Version: 2019.10-devel-305-gb9f5f-pr_k64f_hwrng)
2019-08-09 09:15:59,725 - INFO # 
2019-08-09 09:15:59,727 - INFO # HWRNG peripheral driver test
2019-08-09 09:15:59,727 - INFO # 
2019-08-09 09:15:59,732 - INFO # This test will print from 1 to 20 random bytes about every second
2019-08-09 09:15:59,732 - INFO # 
2019-08-09 09:15:59,734 - INFO # generating 1 random byte(s)
2019-08-09 09:15:59,735 - INFO # Got: 0xb4
2019-08-09 09:15:59,738 - INFO # generating 2 random byte(s)
2019-08-09 09:15:59,739 - INFO # Got: 0x85 0x9a
2019-08-09 09:15:59,742 - INFO # generating 3 random byte(s)
2019-08-09 09:15:59,744 - INFO # Got: 0x4b 0xfb 0x0d
2019-08-09 09:15:59,746 - INFO # generating 4 random byte(s)
2019-08-09 09:15:59,748 - INFO # Got: 0xb8 0xfc 0x35 0xa9
2019-08-09 09:15:59,751 - INFO # generating 5 random byte(s)
2019-08-09 09:15:59,753 - INFO # Got: 0x17 0xc7 0xcd 0xad 0x88
2019-08-09 09:15:59,756 - INFO # generating 6 random byte(s)
2019-08-09 09:15:59,759 - INFO # Got: 0xd4 0xb0 0xc0 0x60 0xaa 0xae
2019-08-09 09:15:59,761 - INFO # generating 7 random byte(s)
2019-08-09 09:15:59,765 - INFO # Got: 0x3f 0xfc 0xee 0x7a 0xe2 0x6a 0xbe
2019-08-09 09:15:59,767 - INFO # generating 8 random byte(s)
2019-08-09 09:15:59,771 - INFO # Got: 0xe8 0xa6 0x4b 0x4a 0x75 0x63 0x4a 0x1b
2019-08-09 09:15:59,774 - INFO # generating 9 random byte(s)
2019-08-09 09:15:59,778 - INFO # Got: 0x6a 0xde 0xeb 0x5a 0xe8 0x72 0xa4 0x10 0x50
2019-08-09 09:15:59,780 - INFO # generating 10 random byte(s)
2019-08-09 09:15:59,785 - INFO # Got: 0xbe 0xdd 0xba 0x5a 0xea 0x4c 0x9e 0x3c 0x01 0x47
2019-08-09 09:15:59,787 - INFO # generating 11 random byte(s)
2019-08-09 09:15:59,793 - INFO # Got: 0x0d 0xfa 0xb2 0x50 0xdf 0x99 0xda 0x24 0xc3 0xf6 0xf4
2019-08-09 09:15:59,795 - INFO # generating 12 random byte(s)
2019-08-09 09:15:59,801 - INFO # Got: 0x0a 0xf2 0x79 0x34 0x6b 0xdb 0x28 0x38 0x3d 0x54 0xfe 0x1e
2019-08-09 09:15:59,803 - INFO # generating 13 random byte(s)
2019-08-09 09:15:59,809 - INFO # Got: 0x90 0x7f 0x83 0x16 0x03 0xcb 0xcd 0x08 0xdb 0xf6 0x51 0x3c 0xc5
2019-08-09 09:15:59,812 - INFO # generating 14 random byte(s)
2019-08-09 09:15:59,818 - INFO # Got: 0xcf 0x6d 0x89 0x84 0xc6 0xa4 0xf2 0xd3 0xd8 0x72 0x94 0x1f 0x75 0x38
2019-08-09 09:15:59,821 - INFO # generating 15 random byte(s)
2019-08-09 09:15:59,829 - INFO # Got: 0xb9 0x41 0x3f 0x4f 0xbe 0xe2 0x14 0x97 0x8c 0xc7 0x25 0x72 0x75 0x98 0x9d
2019-08-09 09:15:59,830 - INFO # generating 16 random byte(s)
2019-08-09 09:15:59,838 - INFO # Got: 0x7f 0xdc 0x74 0xf1 0x85 0xaf 0xec 0x77 0x98 0x13 0x64 0xe8 0xf1 0xd8 0x3a 0x44
2019-08-09 09:15:59,840 - INFO # generating 17 random byte(s)
2019-08-09 09:15:59,848 - INFO # Got: 0x0b 0x63 0x8b 0xe4 0x09 0xa7 0x94 0x41 0x68 0x7d 0x97 0x8d 0xd2 0x23 0x7a 0xa4 0xe9
2019-08-09 09:15:59,851 - INFO # generating 18 random byte(s)
2019-08-09 09:15:59,859 - INFO # Got: 0x05 0xf9 0x4f 0xca 0x5f 0x14 0xda 0xb5 0xca 0x33 0xc7 0x98 0x1b 0x6d 0x07 0x26 0x7e 0xd9
2019-08-09 09:15:59,863 - INFO # generating 19 random byte(s)
2019-08-09 09:15:59,870 - INFO # Got: 0x4b 0x05 0x3e 0x4f 0x0e 0x30 0x98 0x7b 0x85 0xde 0x7f 0x26 0xed 0xd2 0x49 0x09 0xd2 0x50 0xab
2019-08-09 09:15:59,873 - INFO # generating 20 random byte(s)
2019-08-09 09:15:59,883 - INFO # Got: 0xdd 0xc6 0x20 0xbe 0x68 0x29 0x0f 0x32 0x04 0xd1 0xf3 0x5e 0xc9 0xbb 0xfe 0x58 0xe2 0xf2 0xec 0x14

```
</details>

- Launch tests depeing on RNG

<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --jobs 2 . frdm-k64f --applications="tests/gnrc_ipv6_nib tests/gnrc_ipv6_nib_6ln tests/gnrc_ndp tests/gnrc_netif tests/gnrc_sixlowpan tests/gnrc_sock_ip tests/gnrc_sock_udp tests/nhdp tests/pkg_c25519 tests/pkg_hacl tests/pkg_libcoap tests/pkg_libcose tests/pkg_libhydrogen tests/pkg_micro-ecc-with-hwrng tests/pkg_monocypher tests/pkg_qdsa tests/pkg_tweetnacl tests/pthread_barrier tests/pthread_rwlock tests/rng tests/trickle"

</summary>

```
INFO:frdm-k64f:Saving toolchain
INFO:frdm-k64f.tests/gnrc_ipv6_nib:Board supported: True
INFO:frdm-k64f.tests/gnrc_ipv6_nib:Board has enough memory: True
INFO:frdm-k64f.tests/gnrc_ipv6_nib:Application has test: True
INFO:frdm-k64f.tests/gnrc_ipv6_nib:Run compilation
INFO:frdm-k64f.tests/gnrc_ipv6_nib:Run test
INFO:frdm-k64f.tests/gnrc_ipv6_nib:Run test.flash
INFO:frdm-k64f.tests/gnrc_ipv6_nib:Success
INFO:frdm-k64f.tests/gnrc_ipv6_nib_6ln:Board supported: True
INFO:frdm-k64f.tests/gnrc_ipv6_nib_6ln:Board has enough memory: True
INFO:frdm-k64f.tests/gnrc_ipv6_nib_6ln:Application has test: True
INFO:frdm-k64f.tests/gnrc_ipv6_nib_6ln:Run compilation
INFO:frdm-k64f.tests/gnrc_ipv6_nib_6ln:Run test
INFO:frdm-k64f.tests/gnrc_ipv6_nib_6ln:Run test.flash
INFO:frdm-k64f.tests/gnrc_ipv6_nib_6ln:Success
INFO:frdm-k64f.tests/gnrc_ndp:Board supported: True
INFO:frdm-k64f.tests/gnrc_ndp:Board has enough memory: True
INFO:frdm-k64f.tests/gnrc_ndp:Application has test: True
INFO:frdm-k64f.tests/gnrc_ndp:Run compilation
INFO:frdm-k64f.tests/gnrc_ndp:Run test
INFO:frdm-k64f.tests/gnrc_ndp:Run test.flash
INFO:frdm-k64f.tests/gnrc_ndp:Success
INFO:frdm-k64f.tests/gnrc_netif:Board supported: True
INFO:frdm-k64f.tests/gnrc_netif:Board has enough memory: True
INFO:frdm-k64f.tests/gnrc_netif:Application has test: True
INFO:frdm-k64f.tests/gnrc_netif:Run compilation
INFO:frdm-k64f.tests/gnrc_netif:Run test
INFO:frdm-k64f.tests/gnrc_netif:Run test.flash
INFO:frdm-k64f.tests/gnrc_netif:Success
INFO:frdm-k64f.tests/gnrc_sixlowpan:Board supported: True
INFO:frdm-k64f.tests/gnrc_sixlowpan:Board has enough memory: True
INFO:frdm-k64f.tests/gnrc_sixlowpan:Application has test: True
INFO:frdm-k64f.tests/gnrc_sixlowpan:Run compilation
INFO:frdm-k64f.tests/gnrc_sixlowpan:Run test
INFO:frdm-k64f.tests/gnrc_sixlowpan:Run test.flash
INFO:frdm-k64f.tests/gnrc_sixlowpan:Success
INFO:frdm-k64f.tests/gnrc_sock_ip:Board supported: True
INFO:frdm-k64f.tests/gnrc_sock_ip:Board has enough memory: True
INFO:frdm-k64f.tests/gnrc_sock_ip:Application has test: True
INFO:frdm-k64f.tests/gnrc_sock_ip:Run compilation
INFO:frdm-k64f.tests/gnrc_sock_ip:Run test
INFO:frdm-k64f.tests/gnrc_sock_ip:Run test.flash
INFO:frdm-k64f.tests/gnrc_sock_ip:Success
INFO:frdm-k64f.tests/gnrc_sock_udp:Board supported: True
INFO:frdm-k64f.tests/gnrc_sock_udp:Board has enough memory: True
INFO:frdm-k64f.tests/gnrc_sock_udp:Application has test: True
INFO:frdm-k64f.tests/gnrc_sock_udp:Run compilation
INFO:frdm-k64f.tests/gnrc_sock_udp:Run test
INFO:frdm-k64f.tests/gnrc_sock_udp:Run test.flash
INFO:frdm-k64f.tests/gnrc_sock_udp:Success
INFO:frdm-k64f.tests/nhdp:Board supported: True
INFO:frdm-k64f.tests/nhdp:Board has enough memory: True
INFO:frdm-k64f.tests/nhdp:Application has test: True
INFO:frdm-k64f.tests/nhdp:Run compilation
INFO:frdm-k64f.tests/nhdp:Run test
INFO:frdm-k64f.tests/nhdp:Run test.flash
INFO:frdm-k64f.tests/nhdp:Success
INFO:frdm-k64f.tests/pkg_c25519:Board supported: True
INFO:frdm-k64f.tests/pkg_c25519:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_c25519:Application has test: True
INFO:frdm-k64f.tests/pkg_c25519:Run compilation
INFO:frdm-k64f.tests/pkg_c25519:Run test
INFO:frdm-k64f.tests/pkg_c25519:Run test.flash
INFO:frdm-k64f.tests/pkg_c25519:Success
INFO:frdm-k64f.tests/pkg_hacl:Board supported: True
INFO:frdm-k64f.tests/pkg_hacl:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_hacl:Application has test: True
INFO:frdm-k64f.tests/pkg_hacl:Run compilation
INFO:frdm-k64f.tests/pkg_hacl:Run test
INFO:frdm-k64f.tests/pkg_hacl:Run test.flash
INFO:frdm-k64f.tests/pkg_hacl:Success
INFO:frdm-k64f.tests/pkg_libcoap:Board supported: True
INFO:frdm-k64f.tests/pkg_libcoap:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_libcoap:Application has test: True
INFO:frdm-k64f.tests/pkg_libcoap:Run compilation
INFO:frdm-k64f.tests/pkg_libcoap:Run test
INFO:frdm-k64f.tests/pkg_libcoap:Run test.flash
INFO:frdm-k64f.tests/pkg_libcoap:Success
INFO:frdm-k64f.tests/pkg_libcose:Board supported: True
INFO:frdm-k64f.tests/pkg_libcose:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_libcose:Application has test: True
INFO:frdm-k64f.tests/pkg_libcose:Run compilation
INFO:frdm-k64f.tests/pkg_libcose:Run test
INFO:frdm-k64f.tests/pkg_libcose:Run test.flash
INFO:frdm-k64f.tests/pkg_libcose:Success
INFO:frdm-k64f.tests/pkg_libhydrogen:Board supported: True
INFO:frdm-k64f.tests/pkg_libhydrogen:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_libhydrogen:Application has test: True
INFO:frdm-k64f.tests/pkg_libhydrogen:Run compilation
INFO:frdm-k64f.tests/pkg_libhydrogen:Run test
INFO:frdm-k64f.tests/pkg_libhydrogen:Run test.flash
INFO:frdm-k64f.tests/pkg_libhydrogen:Success
INFO:frdm-k64f.tests/pkg_micro-ecc-with-hwrng:Board supported: True
INFO:frdm-k64f.tests/pkg_micro-ecc-with-hwrng:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_micro-ecc-with-hwrng:Application has test: True
INFO:frdm-k64f.tests/pkg_micro-ecc-with-hwrng:Run compilation
INFO:frdm-k64f.tests/pkg_micro-ecc-with-hwrng:Run test
INFO:frdm-k64f.tests/pkg_micro-ecc-with-hwrng:Run test.flash
INFO:frdm-k64f.tests/pkg_micro-ecc-with-hwrng:Success
INFO:frdm-k64f.tests/pkg_monocypher:Board supported: True
INFO:frdm-k64f.tests/pkg_monocypher:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_monocypher:Application has test: True
INFO:frdm-k64f.tests/pkg_monocypher:Run compilation
INFO:frdm-k64f.tests/pkg_monocypher:Run test
INFO:frdm-k64f.tests/pkg_monocypher:Run test.flash
INFO:frdm-k64f.tests/pkg_monocypher:Success
INFO:frdm-k64f.tests/pkg_qdsa:Board supported: True
INFO:frdm-k64f.tests/pkg_qdsa:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_qdsa:Application has test: True
INFO:frdm-k64f.tests/pkg_qdsa:Run compilation
INFO:frdm-k64f.tests/pkg_qdsa:Run test
INFO:frdm-k64f.tests/pkg_qdsa:Run test.flash
INFO:frdm-k64f.tests/pkg_qdsa:Success
INFO:frdm-k64f.tests/pkg_tweetnacl:Board supported: True
INFO:frdm-k64f.tests/pkg_tweetnacl:Board has enough memory: True
INFO:frdm-k64f.tests/pkg_tweetnacl:Application has test: True
INFO:frdm-k64f.tests/pkg_tweetnacl:Run compilation
INFO:frdm-k64f.tests/pkg_tweetnacl:Run test
INFO:frdm-k64f.tests/pkg_tweetnacl:Run test.flash
INFO:frdm-k64f.tests/pkg_tweetnacl:Success
INFO:frdm-k64f.tests/pthread_barrier:Board supported: True
INFO:frdm-k64f.tests/pthread_barrier:Board has enough memory: True
INFO:frdm-k64f.tests/pthread_barrier:Application has test: True
INFO:frdm-k64f.tests/pthread_barrier:Run compilation
INFO:frdm-k64f.tests/pthread_barrier:Run test
INFO:frdm-k64f.tests/pthread_barrier:Run test.flash
INFO:frdm-k64f.tests/pthread_barrier:Success
INFO:frdm-k64f.tests/pthread_rwlock:Board supported: True
INFO:frdm-k64f.tests/pthread_rwlock:Board has enough memory: True
INFO:frdm-k64f.tests/pthread_rwlock:Application has test: True
INFO:frdm-k64f.tests/pthread_rwlock:Run compilation
INFO:frdm-k64f.tests/pthread_rwlock:Run test
INFO:frdm-k64f.tests/pthread_rwlock:Run test.flash
INFO:frdm-k64f.tests/pthread_rwlock:Success
INFO:frdm-k64f.tests/rng:Board supported: True
INFO:frdm-k64f.tests/rng:Board has enough memory: True
INFO:frdm-k64f.tests/rng:Application has test: True
INFO:frdm-k64f.tests/rng:Run compilation
INFO:frdm-k64f.tests/rng:Run test
INFO:frdm-k64f.tests/rng:Run test.flash
INFO:frdm-k64f.tests/rng:Success
INFO:frdm-k64f.tests/trickle:Board supported: True
INFO:frdm-k64f.tests/trickle:Board has enough memory: True
INFO:frdm-k64f.tests/trickle:Application has test: True
INFO:frdm-k64f.tests/trickle:Run compilation
INFO:frdm-k64f.tests/trickle:Run test
INFO:frdm-k64f.tests/trickle:Run test.flash
INFO:frdm-k64f.tests/trickle:Success
INFO:frdm-k64f:Tests successful

```
</details>

### Issues/PRs references

Related to #11454
Fixes #11447