### PR TITLE
cpu/mips32r2: remove nomips16 attribute from _mips_handle_exception

### DIFF
--- a/cpu/mips32r2_common/thread_arch.c
+++ b/cpu/mips32r2_common/thread_arch.c
@@ -182,11 +182,21 @@ mem_rw(const void *vaddr)
 extern int _dsp_save(struct dspctx *ctx);
 extern int _dsp_load(struct dspctx *ctx);
 #endif
+
 /*
- * The nomips16 attribute should not really be needed, it works around a toolchain
- * issue in 2016.05-03.
+ * The official mips toolchain version 2016.05-03 needs this attribute.
+ * Newer versions (>=2017.10-05) don't. Those started being based on gcc 6,
+ * thus use that to guard the attribute.
+ *
+ * See https://github.com/RIOT-OS/RIOT/pull/11986.
  */
+#if __GNUC__ <= 4
 void __attribute__((nomips16))
+#else
+void
+#endif
+
+/* note return type from above #ifdef */
 _mips_handle_exception(struct gpctx *ctx, int exception)
 {
     unsigned int syscall_num = 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
A note says "The nomips16 attribute should not really be needed,
it works around a toolchain issue in 2016.05-03."

In fact, in 2018.09-03, the attribute leads to this error:

```cpu/mips32r2_common/thread_arch.c:191:1: error: ‘_mips_handle_exception’ redeclared with conflicting ‘nomips16’ attributes```

This this commit removes the attribute.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Successful build and basic test on any mips32r2 board should suffice.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Needed for https://github.com/RIOT-OS/riotdocker/pull/76

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
