### PR TITLE
drivers/include/periph/eeprom: Changed uint8_t* to void* in API

### DIFF
--- a/cpu/atmega_common/periph/eeprom.c
+++ b/cpu/atmega_common/periph/eeprom.c
@@ -27,7 +27,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
+size_t eeprom_read(uint32_t pos, void *data, size_t len)
 {
     assert(pos + len <= EEPROM_SIZE);
 
@@ -50,7 +50,7 @@ size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
     return len;
 }
 
-size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len)
+size_t eeprom_write(uint32_t pos, const void *data, size_t len)
 {
     assert(pos + len <= EEPROM_SIZE);
 

--- a/cpu/stm32_common/periph/eeprom.c
+++ b/cpu/stm32_common/periph/eeprom.c
@@ -85,7 +85,7 @@ static void _write_byte(uint32_t addr, uint8_t data)
 #endif
 }
 
-size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
+size_t eeprom_read(uint32_t pos, void *data, size_t len)
 {
     assert(pos + len <= EEPROM_SIZE);
 
@@ -102,7 +102,7 @@ size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
     return len;
 }
 
-size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len)
+size_t eeprom_write(uint32_t pos, const void *data, size_t len)
 {
     assert(pos + len <= EEPROM_SIZE);
 

--- a/drivers/include/periph/eeprom.h
+++ b/drivers/include/periph/eeprom.h
@@ -57,12 +57,12 @@ uint8_t eeprom_read_byte(uint32_t pos);
  * EEPROM.
  *
  * @param[in]  pos      start position in eeprom
- * @param[out] data     output byte array to write to
+ * @param[out] data     output memory location to write to
  * @param[in]  len      the number of bytes to read
  *
  * @return  the number of bytes read
  */
-size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len);
+size_t eeprom_read(uint32_t pos, void *data, size_t len);
 
 /**
  * @brief   Write a byte at the given position
@@ -79,12 +79,12 @@ void eeprom_write_byte(uint32_t pos, uint8_t data);
  * EEPROM.
  *
  * @param[in] pos       start position in eeprom
- * @param[in] data      input byte array to read into
+ * @param[in] data      input memory location to read into
  * @param[in] len       the number of bytes to read
  *
  * @return the number of bytes written
  */
-size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len);
+size_t eeprom_write(uint32_t pos, const void *data, size_t len);
 
 /**
  * @brief   Set @p len bytes from the given position @p pos with value @p val


### PR DESCRIPTION
### Contribution description
This tiny PR changes the EEPROM API for eeprom_read and eeprom_write
to expect void* data instead of uint8_t* data. This suggests a more general interface.

### Testing procedure
I executed tests/eepreg and tests/periph_eeprom on arduino-mega2560.

### Issues/PRs references
This PR has emerged from PR #11929 .
