### PR TITLE
sys/auto_init/can: cleanup for STM32 CAN controller driver

### DIFF
--- a/sys/auto_init/can/auto_init_can.c
+++ b/sys/auto_init/can/auto_init_can.c
@@ -63,9 +63,4 @@ void auto_init_candev(void)
     extern void auto_init_esp_can(void);
     auto_init_esp_can();
 #endif
-
-#ifdef MODULE_CAN_STM32
-    extern void auto_init_can_stm32(void);
-    auto_init_can_stm32();
-#endif
 }


### PR DESCRIPTION
### Contribution description

This PR removes the initialization code for the `can_stm32` module. The initialization became obsolete with PR #6178 because the STM32 CAN controller driver is no longer a module.

### Testing procedure

Compilation of application `tests/conn_can` for a STM32 board which provides `periph_can` feature has to be successful:
```
make BOARD=nucleo-f413zh -C tests/conn_can/
```

### Issues/PRs references

Related to PR #6178 