### PR TITLE
sys/xtimer/xtimer.c: _mutex_timeout() bug fix

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -250,7 +250,8 @@ static void _mutex_timeout(void *arg)
 
     mutex_thread_t *mt = (mutex_thread_t *)arg;
 
-    if (mt->mutex->queue.next != MUTEX_LOCKED) {
+    if (mt->mutex->queue.next != MUTEX_LOCKED &&
+        mt->mutex->queue.next != NULL) {
         mt->timeout = 1;
         list_node_t *node = list_remove(&mt->mutex->queue,
                                         (list_node_t *)&mt->thread->rq_entry);
@@ -266,7 +267,6 @@ static void _mutex_timeout(void *arg)
             return;
         }
     }
-
     irq_restore(irqstate);
 }
 

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -250,20 +250,23 @@ static void _mutex_timeout(void *arg)
 
     mutex_thread_t *mt = (mutex_thread_t *)arg;
 
-    mt->timeout = 1;
-    list_node_t *node = list_remove(&mt->mutex->queue,
-                                    (list_node_t *)&mt->thread->rq_entry);
+    if (mt->mutex->queue.next != MUTEX_LOCKED) {
+        mt->timeout = 1;
+        list_node_t *node = list_remove(&mt->mutex->queue,
+                                        (list_node_t *)&mt->thread->rq_entry);
 
-    /* if thread was removed from the list */
-    if (node != NULL) {
-        if (mt->mutex->queue.next == NULL) {
-            mt->mutex->queue.next = MUTEX_LOCKED;
+        /* if thread was removed from the list */
+        if (node != NULL) {
+            if (mt->mutex->queue.next == NULL) {
+                mt->mutex->queue.next = MUTEX_LOCKED;
+            }
+            sched_set_status(mt->thread, STATUS_PENDING);
+            irq_restore(irqstate);
+            sched_switch(mt->thread->priority);
+            return;
         }
-        sched_set_status(mt->thread, STATUS_PENDING);
-        irq_restore(irqstate);
-        sched_switch(mt->thread->priority);
-        return;
     }
+
     irq_restore(irqstate);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
HAS "REMOVE ME" COMMIT TO SHOW BUG
This includes pr:  #10872 
Tracking: pr #11660 

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Fixes **BUG**. 

The function `_mutex_timeout` removes a thread from the waiting list of a mutex and unblocks the thread (sets status to `STATUS_PENDING`) when the thread is waiting for the mutex. This is used for `xtimer_mutex_lock_timeout` a mutex lock function with timeout. This pr fixes a bug that happens because the function `_mutex_timeout` never checks if the mutex has a waiting list. This pr adds this check.

When the Timer triggers after the mutex is acquired but before the timer is removed.. You can see the bug with the "REMOVE ME" commit (asserts when the mutex  is acquired and the timer triggers after).
The Function (`_mutex_timeout`) does nothing when the thread got the mutex (and no thread is waiting for it `mutex->queue.next == MUTEX_LOCKED` ) and when the mutex is free (`mutex->queue.next == NULL`).

`list_remove` should not be called with a mutex where `mutex->queue.next == MUTEX_LOCKED`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
`BOARD=native make -C tests/xtimer_mutex_lock_timeout/ flash test`
output:

```
...
> mutex_timeout_long_unlocked
mutex_timeout_long_unlocked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked
mutex_timeout_long_locked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked_low
mutex_timeout_long_locked_low
starting test: xtimer mutex lock timeout with thread
threads = 2
THREAD low prio: start
MAIN THREAD: calling xtimer_mutex_lock_timeout
OK
threads = 3
MAIN THREAD: waiting for created thread to end
THREAD low prio: exiting low
threads = 2


```
Revert the `Revert "REMOVE ME" `commit to see it work after fix.
output:

```
...
> mutex_timeout_long_unlocked
mutex_timeout_long_unlocked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked
mutex_timeout_long_locked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked_low
mutex_timeout_long_locked_low
starting test: xtimer mutex lock timeout with thread
threads = 2
THREAD low prio: start
MAIN THREAD: calling xtimer_mutex_lock_timeout
OK
threads = 3
MAIN THREAD: waiting for created thread to end
THREAD low prio: exiting low
threads = 2

```

Revert to `REMOVE ME` commit and run the test to see the bug.
output:
```
...
> mutex_timeout_long_unlocked
mutex_timeout_long_unlocked
starting test: xtimer mutex lock timeout
sys/xtimer/xtimer.c:252 => 0x565b8323
*** RIOT kernel panic:
FAILED ASSERTION.

*** halted.

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on PR #11807 
Tracking PR #11660 
Includes PR #10872 
my old pr fixing same bug: #11543