### PR TITLE
cpu/esp32: esp_wifi and crypto module fix

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -40,10 +40,6 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     USEMODULE += esp_idf_nvs_flash
     USEMODULE += riot_freertos
     USEMODULE += xtimer
-
-    # crypto and hashes produce symbol conflicts with esp_idf_wpa_supplicant_crypto
-    DISABLE_MODULE += crypto
-    DISABLE_MODULE += hashes
 endif
 
 ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -192,7 +192,6 @@ The RIOT-OS for ESP32 SoCs supports the following features at the moment:
 The implementation of RIOT-OS for ESP32 SOCs has the following limitations at the moment:
 
 - Only <b>one core</b> (the PRO CPU) is used because RIOT does not support running multiple threads  simultaneously.
-- RIOT modules <b>crypto</b> and <b>hashes</b> cannot be used together with modules <b>esp_now</b> and <b>esp_wifi</b>
 - <b>Bluetooth</b> cannot be used at the moment.
 - <b>Flash encryption</b> is not yet supported.
 
@@ -942,12 +941,9 @@ The board has to have one of the supported PHY modules to be able to use the Eth
 The RIOT port for ESP32 implements in module `esp_wifi` a `netdev` driver for
 the built-in WiFi interface.
 
-@note Due to symbol conflicts with the `crypto` and `hash` modules of RIOT
-in module `esp_idf_wpa_supplicant_crypto`, which is required by module
-`esp_wifi`, `esp_wifi` cannot be used for applications that use these modules.
-Therefore, module `esp_wifi` is not automatically enabled when module
-`netdev_default` is used. Instead, if necessary, the application has to add
-the module `esp_wifi` in the Makefile.
+@note Module `esp_wifi` is not enabled automatically when the `netdev_default`
+module is used. Instead, if necessary, the application has to add the
+`esp_wifi` module in the Makefile.
 
 ```
 USEMODULE += esp_wifi
@@ -987,7 +983,9 @@ With ESP-NOW, the ESP32 provides a connectionless communication technology, feat
 
 The RIOT port for ESP32 implements in module ```esp_now``` a ```netdev``` driver which uses ESP-NOW to provide a link layer interface to a meshed network of ESP32 nodes. In this network, each node can send short packets with up to 250 data bytes to all other nodes that are visible in its range.
 
-@note Due to symbol conflicts in the ```esp_idf_wpa_supplicant_crypto``` module used by the ```esp_now``` with RIOT's ```crypto``` and ```hashes``` modules, ESP-NOW cannot be used for application that use these modules. Therefore, the module ```esp_now``` is not enabled automatically if the ```netdev_default``` module is used. Instead, the application has to add the ```esp_now``` module in its makefile when needed.<br>
+@note Module `esp_now`module is not enabled automatically if the
+`netdev_default` module is used. Instead, the application has to add the
+`esp_now` module in its makefile when needed.<br>
 ```
 USEMODULE += esp_now
 ```

--- a/cpu/esp32/vendor/esp-idf/esp32/Makefile
+++ b/cpu/esp32/vendor/esp-idf/esp32/Makefile
@@ -3,6 +3,7 @@ MODULE=esp_idf_esp32
 include $(RIOTBASE)/Makefile.base
 
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
+INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/wpa_supplicant/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/wpa_supplicant/port/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp32
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp32/include
@@ -10,5 +11,4 @@ INCLUDES += -I$(ESP32_SDK_DIR)/components/nvs_flash/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/esp32/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/smartconfig_ack/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/include/crypto
 INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/port/include

--- a/cpu/esp32/vendor/esp-idf/esp32/fast_crypto_ops.c
+++ b/cpu/esp32/vendor/esp-idf/esp32/fast_crypto_ops.c
@@ -136,25 +136,25 @@ const mesh_crypto_funcs_t g_wifi_default_mesh_crypto_funcs = {
 const wpa_crypto_funcs_t g_wifi_default_wpa_crypto_funcs = {
     .size = sizeof(wpa_crypto_funcs_t),
     .version = ESP_WIFI_CRYPTO_VERSION,
-    .aes_wrap = (esp_aes_wrap_t)aes_wrap,
-    .aes_unwrap = (esp_aes_unwrap_t)aes_unwrap,
-    .hmac_sha256_vector = (esp_hmac_sha256_vector_t)hmac_sha256_vector,
-    .sha256_prf = (esp_sha256_prf_t)sha256_prf,
-    .hmac_md5 = (esp_hmac_md5_t)hmac_md5,
-    .hamc_md5_vector = (esp_hmac_md5_vector_t)hmac_md5_vector,
-    .hmac_sha1 = (esp_hmac_sha1_t)hmac_sha1,
-    .hmac_sha1_vector = (esp_hmac_sha1_vector_t)hmac_sha1_vector,
-    .sha1_prf = (esp_sha1_prf_t)sha1_prf,
-    .sha1_vector = (esp_sha1_vector_t)sha1_vector,
-    .pbkdf2_sha1 = (esp_pbkdf2_sha1_t)pbkdf2_sha1,
-    .rc4_skip = (esp_rc4_skip_t)rc4_skip,
-    .md5_vector = (esp_md5_vector_t)md5_vector,
-    .aes_encrypt = (esp_aes_encrypt_t)aes_encrypt,
-    .aes_encrypt_init = (esp_aes_encrypt_init_t)aes_encrypt_init,
-    .aes_encrypt_deinit = (esp_aes_encrypt_deinit_t)aes_encrypt_deinit,
-    .aes_decrypt = (esp_aes_decrypt_t)aes_decrypt,
-    .aes_decrypt_init = (esp_aes_decrypt_init_t)aes_decrypt_init,
-    .aes_decrypt_deinit = (esp_aes_decrypt_deinit_t)aes_decrypt_deinit
+    .aes_wrap = (esp_aes_wrap_t)wpa_aes_wrap,
+    .aes_unwrap = (esp_aes_unwrap_t)wpa_aes_unwrap,
+    .hmac_sha256_vector = (esp_hmac_sha256_vector_t)wpa_hmac_sha256_vector,
+    .sha256_prf = (esp_sha256_prf_t)wpa_sha256_prf,
+    .hmac_md5 = (esp_hmac_md5_t)wpa_hmac_md5,
+    .hamc_md5_vector = (esp_hmac_md5_vector_t)wpa_hmac_md5_vector,
+    .hmac_sha1 = (esp_hmac_sha1_t)wpa_hmac_sha1,
+    .hmac_sha1_vector = (esp_hmac_sha1_vector_t)wpa_hmac_sha1_vector,
+    .sha1_prf = (esp_sha1_prf_t)wpa_sha1_prf,
+    .sha1_vector = (esp_sha1_vector_t)wpa_sha1_vector,
+    .pbkdf2_sha1 = (esp_pbkdf2_sha1_t)wpa_pbkdf2_sha1,
+    .rc4_skip = (esp_rc4_skip_t)wpa_rc4_skip,
+    .md5_vector = (esp_md5_vector_t)wpa_md5_vector,
+    .aes_encrypt = (esp_aes_encrypt_t)wpa_aes_encrypt,
+    .aes_encrypt_init = (esp_aes_encrypt_init_t)wpa_aes_encrypt_init,
+    .aes_encrypt_deinit = (esp_aes_encrypt_deinit_t)wpa_aes_encrypt_deinit,
+    .aes_decrypt = (esp_aes_decrypt_t)wpa_aes_decrypt,
+    .aes_decrypt_init = (esp_aes_decrypt_init_t)wpa_aes_decrypt_init,
+    .aes_decrypt_deinit = (esp_aes_decrypt_deinit_t)wpa_aes_decrypt_deinit
 };
 #if 0 /* WPS not supported at the moment */
 const wps_crypto_funcs_t g_wifi_default_wps_crypto_funcs = {
@@ -218,7 +218,7 @@ const wpa2_crypto_funcs_t g_wifi_default_wpa2_crypto_funcs = {
 #endif
 
 const mesh_crypto_funcs_t g_wifi_default_mesh_crypto_funcs = {
-    .aes_128_encrypt = (esp_aes_128_encrypt_t)aes_128_cbc_encrypt,
-    .aes_128_decrypt = (esp_aes_128_decrypt_t)aes_128_cbc_decrypt,
+    .aes_128_encrypt = (esp_aes_128_encrypt_t)wpa_aes_128_cbc_encrypt,
+    .aes_128_decrypt = (esp_aes_128_decrypt_t)wpa_aes_128_cbc_decrypt,
 };
 #endif

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/aes.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/aes.h
@@ -1,0 +1,35 @@
+/*
+ * AES functions
+ * Copyright (c) 2003-2006, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef AES_H
+#define AES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define AES_BLOCK_SIZE 16
+
+void *wpa_aes_encrypt_init(const u8 *key, size_t len);
+void wpa_aes_encrypt(void *ctx, const u8 *plain, u8 *crypt);
+void wpa_aes_encrypt_deinit(void *ctx);
+void *wpa_aes_decrypt_init(const u8 *key, size_t len);
+void wpa_aes_decrypt(void *ctx, const u8 *crypt, u8 *plain);
+void wpa_aes_decrypt_deinit(void *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AES_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/aes_i.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/aes_i.h
@@ -1,0 +1,139 @@
+/*
+ * AES (Rijndael) cipher
+ * Copyright (c) 2003-2005, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef AES_I_H
+#define AES_I_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "aes.h"
+
+/* #define FULL_UNROLL */
+#define AES_SMALL_TABLES
+
+extern const u32 Te0[256];
+extern const u32 Te1[256];
+extern const u32 Te2[256];
+extern const u32 Te3[256];
+extern const u32 Te4[256];
+extern const u32 Td0[256];
+extern const u32 Td1[256];
+extern const u32 Td2[256];
+extern const u32 Td3[256];
+extern const u32 Td4[256];
+extern const u32 rcon[10];
+extern const u8 Td4s[256];
+extern const u8 rcons[10];
+
+#ifndef AES_SMALL_TABLES
+
+#define RCON(i) rcon[(i)]
+
+#define TE0(i) Te0[((i) >> 24) & 0xff]
+#define TE1(i) Te1[((i) >> 16) & 0xff]
+#define TE2(i) Te2[((i) >> 8) & 0xff]
+#define TE3(i) Te3[(i) & 0xff]
+#define TE41(i) (Te4[((i) >> 24) & 0xff] & 0xff000000)
+#define TE42(i) (Te4[((i) >> 16) & 0xff] & 0x00ff0000)
+#define TE43(i) (Te4[((i) >> 8) & 0xff] & 0x0000ff00)
+#define TE44(i) (Te4[(i) & 0xff] & 0x000000ff)
+#define TE421(i) (Te4[((i) >> 16) & 0xff] & 0xff000000)
+#define TE432(i) (Te4[((i) >> 8) & 0xff] & 0x00ff0000)
+#define TE443(i) (Te4[(i) & 0xff] & 0x0000ff00)
+#define TE414(i) (Te4[((i) >> 24) & 0xff] & 0x000000ff)
+#define TE411(i) (Te4[((i) >> 24) & 0xff] & 0xff000000)
+#define TE422(i) (Te4[((i) >> 16) & 0xff] & 0x00ff0000)
+#define TE433(i) (Te4[((i) >> 8) & 0xff] & 0x0000ff00)
+#define TE444(i) (Te4[(i) & 0xff] & 0x000000ff)
+#define TE4(i) (Te4[(i)] & 0x000000ff)
+
+#define TD0(i) Td0[((i) >> 24) & 0xff]
+#define TD1(i) Td1[((i) >> 16) & 0xff]
+#define TD2(i) Td2[((i) >> 8) & 0xff]
+#define TD3(i) Td3[(i) & 0xff]
+#define TD41(i) (Td4[((i) >> 24) & 0xff] & 0xff000000)
+#define TD42(i) (Td4[((i) >> 16) & 0xff] & 0x00ff0000)
+#define TD43(i) (Td4[((i) >> 8) & 0xff] & 0x0000ff00)
+#define TD44(i) (Td4[(i) & 0xff] & 0x000000ff)
+#define TD0_(i) Td0[(i) & 0xff]
+#define TD1_(i) Td1[(i) & 0xff]
+#define TD2_(i) Td2[(i) & 0xff]
+#define TD3_(i) Td3[(i) & 0xff]
+
+#else /* AES_SMALL_TABLES */
+
+#define RCON(i) (rcons[(i)] << 24)
+
+static inline u32 rotr(u32 val, int bits)
+{
+	return (val >> bits) | (val << (32 - bits));
+}
+
+#define TE0(i) Te0[((i) >> 24) & 0xff]
+#define TE1(i) rotr(Te0[((i) >> 16) & 0xff], 8)
+#define TE2(i) rotr(Te0[((i) >> 8) & 0xff], 16)
+#define TE3(i) rotr(Te0[(i) & 0xff], 24)
+#define TE41(i) ((Te0[((i) >> 24) & 0xff] << 8) & 0xff000000)
+#define TE42(i) (Te0[((i) >> 16) & 0xff] & 0x00ff0000)
+#define TE43(i) (Te0[((i) >> 8) & 0xff] & 0x0000ff00)
+#define TE44(i) ((Te0[(i) & 0xff] >> 8) & 0x000000ff)
+#define TE421(i) ((Te0[((i) >> 16) & 0xff] << 8) & 0xff000000)
+#define TE432(i) (Te0[((i) >> 8) & 0xff] & 0x00ff0000)
+#define TE443(i) (Te0[(i) & 0xff] & 0x0000ff00)
+#define TE414(i) ((Te0[((i) >> 24) & 0xff] >> 8) & 0x000000ff)
+#define TE411(i) ((Te0[((i) >> 24) & 0xff] << 8) & 0xff000000)
+#define TE422(i) (Te0[((i) >> 16) & 0xff] & 0x00ff0000)
+#define TE433(i) (Te0[((i) >> 8) & 0xff] & 0x0000ff00)
+#define TE444(i) ((Te0[(i) & 0xff] >> 8) & 0x000000ff)
+#define TE4(i) ((Te0[(i)] >> 8) & 0x000000ff)
+
+#define TD0(i) Td0[((i) >> 24) & 0xff]
+#define TD1(i) rotr(Td0[((i) >> 16) & 0xff], 8)
+#define TD2(i) rotr(Td0[((i) >> 8) & 0xff], 16)
+#define TD3(i) rotr(Td0[(i) & 0xff], 24)
+#define TD41(i) (Td4s[((i) >> 24) & 0xff] << 24)
+#define TD42(i) (Td4s[((i) >> 16) & 0xff] << 16)
+#define TD43(i) (Td4s[((i) >> 8) & 0xff] << 8)
+#define TD44(i) (Td4s[(i) & 0xff])
+#define TD0_(i) Td0[(i) & 0xff]
+#define TD1_(i) rotr(Td0[(i) & 0xff], 8)
+#define TD2_(i) rotr(Td0[(i) & 0xff], 16)
+#define TD3_(i) rotr(Td0[(i) & 0xff], 24)
+
+#endif /* AES_SMALL_TABLES */
+
+#ifdef _MSC_VER
+#define SWAP(x) (_lrotl(x, 8) & 0x00ff00ff | _lrotr(x, 8) & 0xff00ff00)
+#define GETU32(p) SWAP(*((u32 *)(p)))
+#define PUTU32(ct, st) { *((u32 *)(ct)) = SWAP((st)); }
+#else
+#define GETU32(pt) (((u32)(pt)[0] << 24) ^ ((u32)(pt)[1] << 16) ^ \
+((u32)(pt)[2] <<  8) ^ ((u32)(pt)[3]))
+#define PUTU32(ct, st) { \
+(ct)[0] = (u8)((st) >> 24); (ct)[1] = (u8)((st) >> 16); \
+(ct)[2] = (u8)((st) >>  8); (ct)[3] = (u8)(st); }
+#endif
+
+#define AES_PRIV_SIZE (4 * 4 * 15 + 4)
+#define AES_PRIV_NR_POS (4 * 15)
+
+int wpa_rijndaelKeySetupEnc(u32 rk[], const u8 cipherKey[], int keyBits);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AES_I_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/aes_wrap.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/aes_wrap.h
@@ -1,0 +1,62 @@
+/*
+ * AES-based functions
+ *
+ * - AES Key Wrap Algorithm (128-bit KEK) (RFC3394)
+ * - One-Key CBC MAC (OMAC1) hash with AES-128
+ * - AES-128 CTR mode encryption
+ * - AES-128 EAX mode encryption/decryption
+ * - AES-128 CBC
+ *
+ * Copyright (c) 2003-2007, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef AES_WRAP_H
+#define AES_WRAP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int __must_check wpa_aes_wrap(const u8 *kek, int n, const u8 *plain, u8 *cipher);
+int __must_check wpa_aes_unwrap(const u8 *kek, int n, const u8 *cipher, u8 *plain);
+int __must_check wpa_omac1_aes_128_vector(const u8 *key, size_t num_elem,
+				                          const u8 *addr[], const size_t *len,
+				      u8 *mac);
+int __must_check wpa_omac1_aes_128(const u8 *key, const u8 *data, size_t data_len,
+			                       u8 *mac);
+int __must_check wpa_aes_128_encrypt_block(const u8 *key, const u8 *in, u8 *out);
+int __must_check wpa_aes_128_ctr_encrypt(const u8 *key, const u8 *nonce,
+				                         u8 *data, size_t data_len);
+int __must_check wpa_aes_128_eax_encrypt(const u8 *key,
+				                         const u8 *nonce, size_t nonce_len,
+				                         const u8 *hdr, size_t hdr_len,
+				                         u8 *data, size_t data_len, u8 *tag);
+int __must_check wpa_aes_128_eax_decrypt(const u8 *key,
+				                         const u8 *nonce, size_t nonce_len,
+				                         const u8 *hdr, size_t hdr_len,
+				     u8 *data, size_t data_len, const u8 *tag);
+int __must_check wpa_aes_128_cbc_encrypt(const u8 *key, const u8 *iv, u8 *data,
+				                         size_t data_len);
+int __must_check wpa_aes_128_cbc_decrypt(const u8 *key, const u8 *iv, u8 *data,
+				                         size_t data_len);
+int __must_check wpa_fast_aes_wrap(const uint8_t *kek, int n, const uint8_t *plain, uint8_t *cipher);
+int __must_check wpa_fast_aes_unwrap(const uint8_t *kek, int n, const uint8_t *cipher, uint8_t *plain);
+int __must_check wpa_fast_aes_128_cbc_encrypt(const uint8_t *key, const uint8_t *iv, uint8_t *data,
+				                              size_t data_len);
+int __must_check wpa_fast_aes_128_cbc_decrypt(const uint8_t *key, const uint8_t *iv, uint8_t *data,
+				                              size_t data_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AES_WRAP_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/base64.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/base64.h
@@ -1,0 +1,31 @@
+/*
+ * Base64 encoding/decoding (RFC1341)
+ * Copyright (c) 2005, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef BASE64_H
+#define BASE64_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+unsigned char * wpa_base64_encode(const unsigned char *src, size_t len,
+			                      size_t *out_len);
+unsigned char * wpa_base64_decode(const unsigned char *src, size_t len,
+			                      size_t *out_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BASE64_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/common.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/common.h
@@ -1,0 +1,489 @@
+/*
+ * wpa_supplicant/hostapd / common helper functions, etc.
+ * Copyright (c) 2002-2007, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "os.h"
+
+#if defined(__XTENSA__)
+#include <machine/endian.h>
+#define __BYTE_ORDER     BYTE_ORDER
+#define __LITTLE_ENDIAN  LITTLE_ENDIAN
+#define __BIG_ENDIAN     BIG_ENDIAN
+#endif /*__XTENSA__*/
+
+#if defined(__linux__) || defined(__GLIBC__)
+#include <endian.h>
+#include <byteswap.h>
+#endif /* __linux__ */
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || \
+    defined(__OpenBSD__)
+#include <sys/types.h>
+#include <sys/endian.h>
+#define __BYTE_ORDER	_BYTE_ORDER
+#define	__LITTLE_ENDIAN	_LITTLE_ENDIAN
+#define	__BIG_ENDIAN	_BIG_ENDIAN
+#ifdef __OpenBSD__
+#define bswap_16 swap16
+#define bswap_32 swap32
+#define bswap_64 swap64
+#else /* __OpenBSD__ */
+#define bswap_16 bswap16
+#define bswap_32 bswap32
+#define bswap_64 bswap64
+#endif /* __OpenBSD__ */
+#endif /* defined(__FreeBSD__) || defined(__NetBSD__) ||
+	* defined(__DragonFly__) || defined(__OpenBSD__) */
+
+#ifdef __APPLE__
+#include <sys/types.h>
+#include <machine/endian.h>
+#define __BYTE_ORDER	_BYTE_ORDER
+#define __LITTLE_ENDIAN	_LITTLE_ENDIAN
+#define __BIG_ENDIAN	_BIG_ENDIAN
+static inline unsigned short bswap_16(unsigned short v)
+{
+	return ((v & 0xff) << 8) | (v >> 8);
+}
+
+static inline unsigned int bswap_32(unsigned int v)
+{
+	return ((v & 0xff) << 24) | ((v & 0xff00) << 8) |
+		((v & 0xff0000) >> 8) | (v >> 24);
+}
+#endif /* __APPLE__ */
+
+#ifdef CONFIG_TI_COMPILER
+#define __BIG_ENDIAN 4321
+#define __LITTLE_ENDIAN 1234
+#ifdef __big_endian__
+#define __BYTE_ORDER __BIG_ENDIAN
+#else
+#define __BYTE_ORDER __LITTLE_ENDIAN
+#endif
+#endif /* CONFIG_TI_COMPILER */
+
+#ifdef __SYMBIAN32__
+#define __BIG_ENDIAN 4321
+#define __LITTLE_ENDIAN 1234
+#define __BYTE_ORDER __LITTLE_ENDIAN
+#endif /* __SYMBIAN32__ */
+
+#ifdef CONFIG_NATIVE_WINDOWS
+#include <winsock.h>
+
+typedef int socklen_t;
+
+#ifndef MSG_DONTWAIT
+#define MSG_DONTWAIT 0 /* not supported */
+#endif
+
+#endif /* CONFIG_NATIVE_WINDOWS */
+
+#ifdef _MSC_VER
+#define inline __inline
+
+#undef vsnprintf
+#define vsnprintf _vsnprintf
+#undef close
+#define close closesocket
+#endif /* _MSC_VER */
+
+
+/* Define platform specific integer types */
+
+#ifdef _MSC_VER
+typedef UINT64 u64;
+typedef UINT32 u32;
+typedef UINT16 u16;
+typedef UINT8 u8;
+typedef INT64 s64;
+typedef INT32 s32;
+typedef INT16 s16;
+typedef INT8 s8;
+#define WPA_TYPES_DEFINED
+#endif /* _MSC_VER */
+
+#ifdef __vxworks
+typedef unsigned long long u64;
+typedef UINT32 u32;
+typedef UINT16 u16;
+typedef UINT8 u8;
+typedef long long s64;
+typedef INT32 s32;
+typedef INT16 s16;
+typedef INT8 s8;
+#define WPA_TYPES_DEFINED
+#endif /* __vxworks */
+
+#ifdef CONFIG_TI_COMPILER
+#ifdef _LLONG_AVAILABLE
+typedef unsigned long long u64;
+#else
+/*
+ * TODO: 64-bit variable not available. Using long as a workaround to test the
+ * build, but this will likely not work for all operations.
+ */
+typedef unsigned long u64;
+#endif
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+#define WPA_TYPES_DEFINED
+#endif /* CONFIG_TI_COMPILER */
+
+#ifdef __SYMBIAN32__
+#define __REMOVE_PLATSEC_DIAGNOSTICS__
+#include <e32def.h>
+typedef TUint64 u64;
+typedef TUint32 u32;
+typedef TUint16 u16;
+typedef TUint8 u8;
+#define WPA_TYPES_DEFINED
+#endif /* __SYMBIAN32__ */
+
+#ifndef WPA_TYPES_DEFINED
+#ifdef CONFIG_USE_INTTYPES_H
+#include <inttypes.h>
+#else
+#include <stdint.h>
+#endif
+
+typedef uint64_t u64;
+typedef uint32_t u32;
+typedef uint16_t u16;
+typedef uint8_t u8;
+typedef int64_t s64;
+typedef int32_t s32;
+typedef int16_t s16;
+typedef int8_t s8;
+#define WPA_TYPES_DEFINED
+#endif /* !WPA_TYPES_DEFINED */
+
+
+/* Define platform specific byte swapping macros */
+
+#if defined(__CYGWIN__) || defined(CONFIG_NATIVE_WINDOWS)
+
+static inline unsigned short wpa_swap_16(unsigned short v)
+{
+	return ((v & 0xff) << 8) | (v >> 8);
+}
+
+static inline unsigned int wpa_swap_32(unsigned int v)
+{
+	return ((v & 0xff) << 24) | ((v & 0xff00) << 8) |
+		((v & 0xff0000) >> 8) | (v >> 24);
+}
+
+#define le_to_host16(n) (n)
+#define host_to_le16(n) (n)
+#define be_to_host16(n) wpa_swap_16(n)
+#define host_to_be16(n) wpa_swap_16(n)
+#define le_to_host32(n) (n)
+#define be_to_host32(n) wpa_swap_32(n)
+#define host_to_be32(n) wpa_swap_32(n)
+
+#define WPA_BYTE_SWAP_DEFINED
+
+#endif /* __CYGWIN__ || CONFIG_NATIVE_WINDOWS */
+
+
+#ifndef WPA_BYTE_SWAP_DEFINED
+
+#ifndef __BYTE_ORDER
+#ifndef __LITTLE_ENDIAN
+#ifndef __BIG_ENDIAN
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
+#if defined(sparc)
+#define __BYTE_ORDER __BIG_ENDIAN
+#endif
+#endif /* __BIG_ENDIAN */
+#endif /* __LITTLE_ENDIAN */
+#endif /* __BYTE_ORDER */
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define le_to_host16(n) ((__force u16) (le16) (n))
+#define host_to_le16(n) ((__force le16) (u16) (n))
+#define be_to_host16(n) bswap_16((__force u16) (be16) (n))
+#define host_to_be16(n) ((__force be16) bswap_16((n)))
+#define le_to_host32(n) ((__force u32) (le32) (n))
+#define host_to_le32(n) ((__force le32) (u32) (n))
+#define be_to_host32(n) bswap_32((__force u32) (be32) (n))
+#define host_to_be32(n) ((__force be32) bswap_32((n)))
+#define le_to_host64(n) ((__force u64) (le64) (n))
+#define host_to_le64(n) ((__force le64) (u64) (n))
+#define be_to_host64(n) bswap_64((__force u64) (be64) (n))
+#define host_to_be64(n) ((__force be64) bswap_64((n)))
+#elif __BYTE_ORDER == __BIG_ENDIAN
+#define le_to_host16(n) bswap_16(n)
+#define host_to_le16(n) bswap_16(n)
+#define be_to_host16(n) (n)
+#define host_to_be16(n) (n)
+#define le_to_host32(n) bswap_32(n)
+#define be_to_host32(n) (n)
+#define host_to_be32(n) (n)
+#define le_to_host64(n) bswap_64(n)
+#define host_to_le64(n) bswap_64(n)
+#define be_to_host64(n) (n)
+#define host_to_be64(n) (n)
+#ifndef WORDS_BIGENDIAN
+#define WORDS_BIGENDIAN
+#endif
+#else
+#error Could not determine CPU byte order
+#endif
+
+#define WPA_BYTE_SWAP_DEFINED
+#endif /* !WPA_BYTE_SWAP_DEFINED */
+
+
+/* Macros for handling unaligned memory accesses */
+
+#define WPA_GET_BE16(a) ((u16) (((a)[0] << 8) | (a)[1]))
+#define WPA_PUT_BE16(a, val)			\
+	do {					\
+		(a)[0] = ((u16) (val)) >> 8;	\
+		(a)[1] = ((u16) (val)) & 0xff;	\
+	} while (0)
+
+#define WPA_GET_LE16(a) ((u16) (((a)[1] << 8) | (a)[0]))
+#define WPA_PUT_LE16(a, val)			\
+	do {					\
+		(a)[1] = ((u16) (val)) >> 8;	\
+		(a)[0] = ((u16) (val)) & 0xff;	\
+	} while (0)
+
+#define WPA_GET_BE24(a) ((((u32) (a)[0]) << 16) | (((u32) (a)[1]) << 8) | \
+			 ((u32) (a)[2]))
+#define WPA_PUT_BE24(a, val)					\
+	do {							\
+		(a)[0] = (u8) ((((u32) (val)) >> 16) & 0xff);	\
+		(a)[1] = (u8) ((((u32) (val)) >> 8) & 0xff);	\
+		(a)[2] = (u8) (((u32) (val)) & 0xff);		\
+	} while (0)
+
+#define WPA_GET_BE32(a) ((((u32) (a)[0]) << 24) | (((u32) (a)[1]) << 16) | \
+			 (((u32) (a)[2]) << 8) | ((u32) (a)[3]))
+#define WPA_PUT_BE32(a, val)					\
+	do {							\
+		(a)[0] = (u8) ((((u32) (val)) >> 24) & 0xff);	\
+		(a)[1] = (u8) ((((u32) (val)) >> 16) & 0xff);	\
+		(a)[2] = (u8) ((((u32) (val)) >> 8) & 0xff);	\
+		(a)[3] = (u8) (((u32) (val)) & 0xff);		\
+	} while (0)
+
+#define WPA_GET_LE32(a) ((((u32) (a)[3]) << 24) | (((u32) (a)[2]) << 16) | \
+			 (((u32) (a)[1]) << 8) | ((u32) (a)[0]))
+#define WPA_PUT_LE32(a, val)					\
+	do {							\
+		(a)[3] = (u8) ((((u32) (val)) >> 24) & 0xff);	\
+		(a)[2] = (u8) ((((u32) (val)) >> 16) & 0xff);	\
+		(a)[1] = (u8) ((((u32) (val)) >> 8) & 0xff);	\
+		(a)[0] = (u8) (((u32) (val)) & 0xff);		\
+	} while (0)
+
+#define WPA_GET_BE64(a) ((((u64) (a)[0]) << 56) | (((u64) (a)[1]) << 48) | \
+			 (((u64) (a)[2]) << 40) | (((u64) (a)[3]) << 32) | \
+			 (((u64) (a)[4]) << 24) | (((u64) (a)[5]) << 16) | \
+			 (((u64) (a)[6]) << 8) | ((u64) (a)[7]))
+#define WPA_PUT_BE64(a, val)				\
+	do {						\
+		(a)[0] = (u8) (((u64) (val)) >> 56);	\
+		(a)[1] = (u8) (((u64) (val)) >> 48);	\
+		(a)[2] = (u8) (((u64) (val)) >> 40);	\
+		(a)[3] = (u8) (((u64) (val)) >> 32);	\
+		(a)[4] = (u8) (((u64) (val)) >> 24);	\
+		(a)[5] = (u8) (((u64) (val)) >> 16);	\
+		(a)[6] = (u8) (((u64) (val)) >> 8);	\
+		(a)[7] = (u8) (((u64) (val)) & 0xff);	\
+	} while (0)
+
+#define WPA_GET_LE64(a) ((((u64) (a)[7]) << 56) | (((u64) (a)[6]) << 48) | \
+			 (((u64) (a)[5]) << 40) | (((u64) (a)[4]) << 32) | \
+			 (((u64) (a)[3]) << 24) | (((u64) (a)[2]) << 16) | \
+			 (((u64) (a)[1]) << 8) | ((u64) (a)[0]))
+
+
+#ifndef ETH_ALEN
+#define ETH_ALEN 6
+#endif
+#ifndef IFNAMSIZ
+#define IFNAMSIZ 16
+#endif
+#ifndef ETH_P_ALL
+#define ETH_P_ALL 0x0003
+#endif
+#ifndef ETH_P_PAE
+#define ETH_P_PAE 0x888E /* Port Access Entity (IEEE 802.1X) */
+#endif /* ETH_P_PAE */
+#ifndef ETH_P_EAPOL
+#define ETH_P_EAPOL ETH_P_PAE
+#endif /* ETH_P_EAPOL */
+#ifndef ETH_P_RSN_PREAUTH
+#define ETH_P_RSN_PREAUTH 0x88c7
+#endif /* ETH_P_RSN_PREAUTH */
+#ifndef ETH_P_RRB
+#define ETH_P_RRB 0x890D
+#endif /* ETH_P_RRB */
+
+
+#ifdef __GNUC__
+#define PRINTF_FORMAT(a,b) __attribute__ ((format (printf, (a), (b))))
+#define STRUCT_PACKED __attribute__ ((packed))
+#else
+#define PRINTF_FORMAT(a,b)
+#define STRUCT_PACKED
+#endif
+
+#ifdef CONFIG_ANSI_C_EXTRA
+
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+/* snprintf - used in number of places; sprintf() is _not_ a good replacement
+ * due to possible buffer overflow; see, e.g.,
+ * http://www.ijs.si/software/snprintf/ for portable implementation of
+ * snprintf. */
+int snprintf(char *str, size_t size, const char *format, ...);
+
+/* vsnprintf - only used for wpa_msg() in wpa_supplicant.c */
+int vsnprintf(char *str, size_t size, const char *format, va_list ap);
+#endif /* !defined(_MSC_VER) || _MSC_VER < 1400 */
+
+/* getopt - only used in main.c */
+int getopt(int argc, char *const argv[], const char *optstring);
+extern char *optarg;
+extern int optind;
+
+#ifndef CONFIG_NO_SOCKLEN_T_TYPEDEF
+#ifndef __socklen_t_defined
+typedef int socklen_t;
+#endif
+#endif
+
+/* inline - define as __inline or just define it to be empty, if needed */
+#ifdef CONFIG_NO_INLINE
+#define inline
+#else
+#define inline __inline
+#endif
+
+#ifndef __func__
+#define __func__ "__func__ not defined"
+#endif
+
+#ifndef bswap_16
+#define bswap_16(a) ((((u16) (a) << 8) & 0xff00) | (((u16) (a) >> 8) & 0xff))
+#endif
+
+#ifndef bswap_32
+#define bswap_32(a) ((((u32) (a) << 24) & 0xff000000) | \
+		     (((u32) (a) << 8) & 0xff0000) | \
+     		     (((u32) (a) >> 8) & 0xff00) | \
+     		     (((u32) (a) >> 24) & 0xff))
+#endif
+
+#ifndef MSG_DONTWAIT
+#define MSG_DONTWAIT 0
+#endif
+
+#ifdef _WIN32_WCE
+void perror(const char *s);
+#endif /* _WIN32_WCE */
+
+#endif /* CONFIG_ANSI_C_EXTRA */
+
+#ifndef MAC2STR
+#define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
+#define MACSTR "%02x:%02x:%02x:%02x:%02x:%02x"
+#endif
+
+#ifndef BIT
+#define BIT(x) (1 << (x))
+#endif
+
+/*
+ * Definitions for sparse validation
+ * (http://kernel.org/pub/linux/kernel/people/josh/sparse/)
+ */
+#ifdef __CHECKER__
+#define __force __attribute__((force))
+#define __bitwise __attribute__((bitwise))
+#else
+#define __force
+#define __bitwise
+#endif
+
+typedef u16 __bitwise be16;
+typedef u16 __bitwise le16;
+typedef u32 __bitwise be32;
+typedef u32 __bitwise le32;
+typedef u64 __bitwise be64;
+typedef u64 __bitwise le64;
+
+#ifndef __must_check
+#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
+#define __must_check __attribute__((__warn_unused_result__))
+#else
+#define __must_check
+#endif /* __GNUC__ */
+#endif /* __must_check */
+
+int hwaddr_aton(const char *txt, u8 *addr);
+int hwaddr_aton2(const char *txt, u8 *addr);
+int hexstr2bin(const char *hex, u8 *buf, size_t len);
+void inc_byte_array(u8 *counter, size_t len);
+void wpa_get_ntp_timestamp(u8 *buf);
+int wpa_snprintf_hex(char *buf, size_t buf_size, const u8 *data, size_t len);
+int wpa_snprintf_hex_uppercase(char *buf, size_t buf_size, const u8 *data,
+			                   size_t len);
+
+#ifdef CONFIG_NATIVE_WINDOWS
+void wpa_unicode2ascii_inplace(TCHAR *str);
+TCHAR * wpa_strdup_tchar(const char *str);
+#else /* CONFIG_NATIVE_WINDOWS */
+#define wpa_unicode2ascii_inplace(s) do { } while (0)
+#define wpa_strdup_tchar(s) strdup((s))
+#endif /* CONFIG_NATIVE_WINDOWS */
+
+const char * wpa_ssid_txt(const u8 *ssid, size_t ssid_len);
+
+static inline int is_zero_ether_addr(const u8 *a)
+{
+	return !(a[0] | a[1] | a[2] | a[3] | a[4] | a[5]);
+}
+
+/*
+ * gcc 4.4 ends up generating strict-aliasing warnings about some very common
+ * networking socket uses that do not really result in a real problem and
+ * cannot be easily avoided with union-based type-punning due to struct
+ * definitions including another struct in system header files. To avoid having
+ * to fully disable strict-aliasing warnings, provide a mechanism to hide the
+ * typecast from aliasing for now. A cleaner solution will hopefully be found
+ * in the future to handle these cases.
+ */
+void * __hide_aliasing_typecast(void *foo);
+#define aliasing_hide_typecast(a,t) (t *) __hide_aliasing_typecast((a))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COMMON_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/crypto.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/crypto.h
@@ -1,0 +1,617 @@
+/*
+ * WPA Supplicant / wrapper functions for crypto libraries
+ * Copyright (c) 2004-2009, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ *
+ * This file defines the cryptographic functions that need to be implemented
+ * for wpa_supplicant and hostapd. When TLS is not used, internal
+ * implementation of MD5, SHA1, and AES is used and no external libraries are
+ * required. When TLS is enabled (e.g., by enabling EAP-TLS or EAP-PEAP), the
+ * crypto library used by the TLS implementation is expected to be used for
+ * non-TLS needs, too, in order to save space by not implementing these
+ * functions twice.
+ *
+ * Wrapper code for using each crypto library is in its own file (crypto*.c)
+ * and one of these files is build and linked in to provide the functions
+ * defined here.
+ */
+
+#ifndef CRYPTO_H
+#define CRYPTO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "common.h"
+
+/**
+ * md4_vector - MD4 hash for data vector
+ * @num_elem: Number of elements in the data vector
+ * @addr: Pointers to the data areas
+ * @len: Lengths of the data blocks
+ * @mac: Buffer for the hash
+ * Returns: 0 on success, -1 on failure
+ */
+int wpa_md4_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac);
+
+/**
+ * md5_vector - MD5 hash for data vector
+ * @num_elem: Number of elements in the data vector
+ * @addr: Pointers to the data areas
+ * @len: Lengths of the data blocks
+ * @mac: Buffer for the hash
+ * Returns: 0 on success, -1 on failure
+ */
+int wpa_md5_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac);
+
+#ifdef CONFIG_FIPS
+/**
+ * md5_vector_non_fips_allow - MD5 hash for data vector (non-FIPS use allowed)
+ * @num_elem: Number of elements in the data vector
+ * @addr: Pointers to the data areas
+ * @len: Lengths of the data blocks
+ * @mac: Buffer for the hash
+ * Returns: 0 on success, -1 on failure
+ */
+int wpa_md5_vector_non_fips_allow(size_t num_elem, const u8 *addr[],
+			                      const size_t *len, u8 *mac);
+#else /* CONFIG_FIPS */
+#define md5_vector_non_fips_allow md5_vector
+#endif /* CONFIG_FIPS */
+
+
+/**
+ * sha1_vector - SHA-1 hash for data vector
+ * @num_elem: Number of elements in the data vector
+ * @addr: Pointers to the data areas
+ * @len: Lengths of the data blocks
+ * @mac: Buffer for the hash
+ * Returns: 0 on success, -1 on failure
+ */
+int wpa_sha1_vector(size_t num_elem, const u8 *addr[], const size_t *len,
+		            u8 *mac);
+
+/**
+ * fips186_2-prf - NIST FIPS Publication 186-2 change notice 1 PRF
+ * @seed: Seed/key for the PRF
+ * @seed_len: Seed length in bytes
+ * @x: Buffer for PRF output
+ * @xlen: Output length in bytes
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function implements random number generation specified in NIST FIPS
+ * Publication 186-2 for EAP-SIM. This PRF uses a function that is similar to
+ * SHA-1, but has different message padding.
+ */
+int __must_check wpa_fips186_2_prf(const u8 *seed, size_t seed_len, u8 *x,
+			       size_t xlen);
+
+/**
+ * sha256_vector - SHA256 hash for data vector
+ * @num_elem: Number of elements in the data vector
+ * @addr: Pointers to the data areas
+ * @len: Lengths of the data blocks
+ * @mac: Buffer for the hash
+ * Returns: 0 on success, -1 on failure
+ */
+int wpa_sha256_vector(size_t num_elem, const u8 *addr[], const size_t *len,
+		              u8 *mac);
+
+/**
+ * fast_sha256_vector - fast SHA256 hash for data vector
+ * @num_elem: Number of elements in the data vector
+ * @addr: Pointers to the data areas
+ * @len: Lengths of the data blocks
+ * @mac: Buffer for the hash
+ * Returns: 0 on success, -1 on failure
+ */
+int wpa_fast_sha256_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
+		       uint8_t *mac);
+
+/**
+ * des_encrypt - Encrypt one block with DES
+ * @clear: 8 octets (in)
+ * @key: 7 octets (in) (no parity bits included)
+ * @cypher: 8 octets (out)
+ */
+void wpa_des_encrypt(const u8 *clear, const u8 *key, u8 *cypher);
+
+/**
+ * aes_encrypt_init - Initialize AES for encryption
+ * @key: Encryption key
+ * @len: Key length in bytes (usually 16, i.e., 128 bits)
+ * Returns: Pointer to context data or %NULL on failure
+ */
+void * wpa_aes_encrypt_init(const u8 *key, size_t len);
+
+/**
+ * aes_encrypt - Encrypt one AES block
+ * @ctx: Context pointer from aes_encrypt_init()
+ * @plain: Plaintext data to be encrypted (16 bytes)
+ * @crypt: Buffer for the encrypted data (16 bytes)
+ */
+void wpa_aes_encrypt(void *ctx, const u8 *plain, u8 *crypt);
+
+/**
+ * aes_encrypt_deinit - Deinitialize AES encryption
+ * @ctx: Context pointer from aes_encrypt_init()
+ */
+void wpa_aes_encrypt_deinit(void *ctx);
+
+/**
+ * aes_decrypt_init - Initialize AES for decryption
+ * @key: Decryption key
+ * @len: Key length in bytes (usually 16, i.e., 128 bits)
+ * Returns: Pointer to context data or %NULL on failure
+ */
+void * wpa_aes_decrypt_init(const u8 *key, size_t len);
+
+/**
+ * aes_decrypt - Decrypt one AES block
+ * @ctx: Context pointer from aes_encrypt_init()
+ * @crypt: Encrypted data (16 bytes)
+ * @plain: Buffer for the decrypted data (16 bytes)
+ */
+void wpa_aes_decrypt(void *ctx, const u8 *crypt, u8 *plain);
+
+/**
+ * aes_decrypt_deinit - Deinitialize AES decryption
+ * @ctx: Context pointer from aes_encrypt_init()
+ */
+void wpa_aes_decrypt_deinit(void *ctx);
+
+
+enum crypto_hash_alg {
+        CRYPTO_HASH_ALG_MD5, CRYPTO_HASH_ALG_SHA1,
+        CRYPTO_HASH_ALG_HMAC_MD5, CRYPTO_HASH_ALG_HMAC_SHA1,
+        CRYPTO_HASH_ALG_SHA256, CRYPTO_HASH_ALG_HMAC_SHA256
+};
+
+struct crypto_hash;
+
+/**
+ * crypto_hash_init - Initialize hash/HMAC function
+ * @alg: Hash algorithm
+ * @key: Key for keyed hash (e.g., HMAC) or %NULL if not needed
+ * @key_len: Length of the key in bytes
+ * Returns: Pointer to hash context to use with other hash functions or %NULL
+ * on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+struct crypto_hash * crypto_hash_init(enum crypto_hash_alg alg, const u8 *key,
+				                      size_t key_len);
+
+/**
+ * fast_crypto_hash_init - Initialize hash/HMAC function
+ * @alg: Hash algorithm
+ * @key: Key for keyed hash (e.g., HMAC) or %NULL if not needed
+ * @key_len: Length of the key in bytes
+ * Returns: Pointer to hash context to use with other hash functions or %NULL
+ * on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+struct crypto_hash * fast_crypto_hash_init(enum crypto_hash_alg alg, const uint8_t *key,
+				                           size_t key_len);
+
+/**
+ * crypto_hash_update - Add data to hash calculation
+ * @ctx: Context pointer from crypto_hash_init()
+ * @data: Data buffer to add
+ * @len: Length of the buffer
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+void crypto_hash_update(struct crypto_hash *ctx, const u8 *data, size_t len);
+
+/**
+ * fast_crypto_hash_update - Add data to hash calculation
+ * @ctx: Context pointer from crypto_hash_init()
+ * @data: Data buffer to add
+ * @len: Length of the buffer
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+void fast_crypto_hash_update(struct crypto_hash *ctx, const uint8_t *data, size_t len);
+
+/**
+ * crypto_hash_finish - Complete hash calculation
+ * @ctx: Context pointer from crypto_hash_init()
+ * @hash: Buffer for hash value or %NULL if caller is just freeing the hash
+ * context
+ * @len: Pointer to length of the buffer or %NULL if caller is just freeing the
+ * hash context; on return, this is set to the actual length of the hash value
+ * Returns: 0 on success, -1 if buffer is too small (len set to needed length),
+ * or -2 on other failures (including failed crypto_hash_update() operations)
+ *
+ * This function calculates the hash value and frees the context buffer that
+ * was used for hash calculation.
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int crypto_hash_finish(struct crypto_hash *ctx, u8 *hash, size_t *len);
+
+/**
+ * fast_crypto_hash_finish - Complete hash calculation
+ * @ctx: Context pointer from crypto_hash_init()
+ * @hash: Buffer for hash value or %NULL if caller is just freeing the hash
+ * context
+ * @len: Pointer to length of the buffer or %NULL if caller is just freeing the
+ * hash context; on return, this is set to the actual length of the hash value
+ * Returns: 0 on success, -1 if buffer is too small (len set to needed length),
+ * or -2 on other failures (including failed crypto_hash_update() operations)
+ *
+ * This function calculates the hash value and frees the context buffer that
+ * was used for hash calculation.
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int fast_crypto_hash_finish(struct crypto_hash *ctx, uint8_t *hash, size_t *len);
+
+
+enum crypto_cipher_alg {
+	CRYPTO_CIPHER_NULL = 0, CRYPTO_CIPHER_ALG_AES, CRYPTO_CIPHER_ALG_3DES,
+	CRYPTO_CIPHER_ALG_DES, CRYPTO_CIPHER_ALG_RC2, CRYPTO_CIPHER_ALG_RC4
+};
+
+struct crypto_cipher;
+
+/**
+ * crypto_cipher_init - Initialize block/stream cipher function
+ * @alg: Cipher algorithm
+ * @iv: Initialization vector for block ciphers or %NULL for stream ciphers
+ * @key: Cipher key
+ * @key_len: Length of key in bytes
+ * Returns: Pointer to cipher context to use with other cipher functions or
+ * %NULL on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+struct crypto_cipher * crypto_cipher_init(enum crypto_cipher_alg alg,
+					                      const u8 *iv, const u8 *key,
+					                      size_t key_len);
+
+/**
+ * fast_crypto_cipher_init - Initialize block/stream cipher function
+ * @alg: Cipher algorithm
+ * @iv: Initialization vector for block ciphers or %NULL for stream ciphers
+ * @key: Cipher key
+ * @key_len: Length of key in bytes
+ * Returns: Pointer to cipher context to use with other cipher functions or
+ * %NULL on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+struct crypto_cipher * fast_crypto_cipher_init(enum crypto_cipher_alg alg,
+					                           const uint8_t *iv, const uint8_t *key,
+					                           size_t key_len);
+/**
+ * crypto_cipher_encrypt - Cipher encrypt
+ * @ctx: Context pointer from crypto_cipher_init()
+ * @plain: Plaintext to cipher
+ * @crypt: Resulting ciphertext
+ * @len: Length of the plaintext
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check crypto_cipher_encrypt(struct crypto_cipher *ctx,
+				                       const u8 *plain, u8 *crypt, size_t len);
+
+/**
+ * fast_crypto_cipher_encrypt - Cipher encrypt
+ * @ctx: Context pointer from crypto_cipher_init()
+ * @plain: Plaintext to cipher
+ * @crypt: Resulting ciphertext
+ * @len: Length of the plaintext
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check fast_crypto_cipher_encrypt(struct crypto_cipher *ctx,
+				                            const uint8_t *plain, uint8_t *crypt, size_t len);
+
+/**
+ * crypto_cipher_decrypt - Cipher decrypt
+ * @ctx: Context pointer from crypto_cipher_init()
+ * @crypt: Ciphertext to decrypt
+ * @plain: Resulting plaintext
+ * @len: Length of the cipher text
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check crypto_cipher_decrypt(struct crypto_cipher *ctx,
+				                       const u8 *crypt, u8 *plain, size_t len);
+
+/**
+ * fast_crypto_cipher_decrypt - Cipher decrypt
+ * @ctx: Context pointer from crypto_cipher_init()
+ * @crypt: Ciphertext to decrypt
+ * @plain: Resulting plaintext
+ * @len: Length of the cipher text
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check fast_crypto_cipher_decrypt(struct crypto_cipher *ctx,
+				                            const uint8_t *crypt, uint8_t *plain, size_t len);
+
+/**
+ * crypto_cipher_decrypt - Free cipher context
+ * @ctx: Context pointer from crypto_cipher_init()
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+void crypto_cipher_deinit(struct crypto_cipher *ctx);
+
+/**
+ * fast_crypto_cipher_decrypt - Free cipher context
+ * @ctx: Context pointer from crypto_cipher_init()
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+void fast_crypto_cipher_deinit(struct crypto_cipher *ctx);
+
+struct crypto_public_key;
+struct crypto_private_key;
+
+/**
+ * crypto_public_key_import - Import an RSA public key
+ * @key: Key buffer (DER encoded RSA public key)
+ * @len: Key buffer length in bytes
+ * Returns: Pointer to the public key or %NULL on failure
+ *
+ * This function can just return %NULL if the crypto library supports X.509
+ * parsing. In that case, crypto_public_key_from_cert() is used to import the
+ * public key from a certificate.
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+struct crypto_public_key * crypto_public_key_import(const u8 *key, size_t len);
+
+/**
+ * crypto_private_key_import - Import an RSA private key
+ * @key: Key buffer (DER encoded RSA private key)
+ * @len: Key buffer length in bytes
+ * @passwd: Key encryption password or %NULL if key is not encrypted
+ * Returns: Pointer to the private key or %NULL on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+struct crypto_private_key * crypto_private_key_import(const u8 *key,
+						                              size_t len,
+						                              const char *passwd);
+
+/**
+ * crypto_public_key_from_cert - Import an RSA public key from a certificate
+ * @buf: DER encoded X.509 certificate
+ * @len: Certificate buffer length in bytes
+ * Returns: Pointer to public key or %NULL on failure
+ *
+ * This function can just return %NULL if the crypto library does not support
+ * X.509 parsing. In that case, internal code will be used to parse the
+ * certificate and public key is imported using crypto_public_key_import().
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+struct crypto_public_key * crypto_public_key_from_cert(const u8 *buf,
+						                               size_t len);
+
+/**
+ * crypto_public_key_encrypt_pkcs1_v15 - Public key encryption (PKCS #1 v1.5)
+ * @key: Public key
+ * @in: Plaintext buffer
+ * @inlen: Length of plaintext buffer in bytes
+ * @out: Output buffer for encrypted data
+ * @outlen: Length of output buffer in bytes; set to used length on success
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check crypto_public_key_encrypt_pkcs1_v15(
+	struct crypto_public_key *key, const u8 *in, size_t inlen,
+	u8 *out, size_t *outlen);
+
+/**
+ * crypto_private_key_decrypt_pkcs1_v15 - Private key decryption (PKCS #1 v1.5)
+ * @key: Private key
+ * @in: Encrypted buffer
+ * @inlen: Length of encrypted buffer in bytes
+ * @out: Output buffer for encrypted data
+ * @outlen: Length of output buffer in bytes; set to used length on success
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check crypto_private_key_decrypt_pkcs1_v15(
+	struct crypto_private_key *key, const u8 *in, size_t inlen,
+	u8 *out, size_t *outlen);
+
+/**
+ * crypto_private_key_sign_pkcs1 - Sign with private key (PKCS #1)
+ * @key: Private key from crypto_private_key_import()
+ * @in: Plaintext buffer
+ * @inlen: Length of plaintext buffer in bytes
+ * @out: Output buffer for encrypted (signed) data
+ * @outlen: Length of output buffer in bytes; set to used length on success
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check crypto_private_key_sign_pkcs1(struct crypto_private_key *key,
+					                           const u8 *in, size_t inlen,
+					                           u8 *out, size_t *outlen);
+
+/**
+ * crypto_public_key_free - Free public key
+ * @key: Public key
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+void crypto_public_key_free(struct crypto_public_key *key);
+
+/**
+ * crypto_private_key_free - Free private key
+ * @key: Private key from crypto_private_key_import()
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+void crypto_private_key_free(struct crypto_private_key *key);
+
+/**
+ * crypto_public_key_decrypt_pkcs1 - Decrypt PKCS #1 signature
+ * @key: Public key
+ * @crypt: Encrypted signature data (using the private key)
+ * @crypt_len: Encrypted signature data length
+ * @plain: Buffer for plaintext (at least crypt_len bytes)
+ * @plain_len: Plaintext length (max buffer size on input, real len on output);
+ * Returns: 0 on success, -1 on failure
+ */
+int __must_check crypto_public_key_decrypt_pkcs1(
+	struct crypto_public_key *key, const u8 *crypt, size_t crypt_len,
+	u8 *plain, size_t *plain_len);
+
+/**
+ * crypto_global_init - Initialize crypto wrapper
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check crypto_global_init(void);
+
+/**
+ * crypto_global_deinit - Deinitialize crypto wrapper
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+void crypto_global_deinit(void);
+
+/**
+ * crypto_mod_exp - Modular exponentiation of large integers
+ * @base: Base integer (big endian byte array)
+ * @base_len: Length of base integer in bytes
+ * @power: Power integer (big endian byte array)
+ * @power_len: Length of power integer in bytes
+ * @modulus: Modulus integer (big endian byte array)
+ * @modulus_len: Length of modulus integer in bytes
+ * @result: Buffer for the result
+ * @result_len: Result length (max buffer size on input, real len on output)
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function calculates result = base ^ power mod modulus. modules_len is
+ * used as the maximum size of modulus buffer. It is set to the used size on
+ * success.
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check crypto_mod_exp(const u8 *base, size_t base_len,
+				                const u8 *power, size_t power_len,
+				                const u8 *modulus, size_t modulus_len,
+				                u8 *result, size_t *result_len);
+
+/**
+ * fast_crypto_mod_exp - Modular exponentiation of large integers
+ * @base: Base integer (big endian byte array)
+ * @base_len: Length of base integer in bytes
+ * @power: Power integer (big endian byte array)
+ * @power_len: Length of power integer in bytes
+ * @modulus: Modulus integer (big endian byte array)
+ * @modulus_len: Length of modulus integer in bytes
+ * @result: Buffer for the result
+ * @result_len: Result length (max buffer size on input, real len on output)
+ * Returns: 0 on success, -1 on failure
+ *
+ * This function calculates result = base ^ power mod modulus. modules_len is
+ * used as the maximum size of modulus buffer. It is set to the used size on
+ * success.
+ *
+ * This function is only used with internal TLSv1 implementation
+ * (CONFIG_TLS=internal). If that is not used, the crypto wrapper does not need
+ * to implement this.
+ */
+int __must_check fast_crypto_mod_exp(const uint8_t *base, size_t base_len,
+				                     const uint8_t *power, size_t power_len,
+				                     const uint8_t *modulus, size_t modulus_len,
+				                     uint8_t *result, size_t *result_len);
+
+/**
+ * rc4_skip - XOR RC4 stream to given data with skip-stream-start
+ * @key: RC4 key
+ * @keylen: RC4 key length
+ * @skip: number of bytes to skip from the beginning of the RC4 stream
+ * @data: data to be XOR'ed with RC4 stream
+ * @data_len: buf length
+ * Returns: 0 on success, -1 on failure
+ *
+ * Generate RC4 pseudo random stream for the given key, skip beginning of the
+ * stream, and XOR the end result with the data buffer to perform RC4
+ * encryption/decryption.
+ */
+int wpa_rc4_skip(const u8 *key, size_t keylen, size_t skip,
+	             u8 *data, size_t data_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CRYPTO_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/dh_group5.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/dh_group5.h
@@ -1,0 +1,33 @@
+/*
+ * Diffie-Hellman group 5 operations
+ * Copyright (c) 2009, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef DH_GROUP5_H
+#define DH_GROUP5_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "wpa/wpabuf.h"
+
+void * wpa_dh5_init(struct wpabuf **priv, struct wpabuf **publ);
+struct wpabuf * wpa_dh5_derive_shared(void *ctx, const struct wpabuf *peer_public,
+				                      const struct wpabuf *own_private);
+void wpa_dh5_free(void *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DH_GROUP5_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/dh_groups.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/dh_groups.h
@@ -1,0 +1,40 @@
+/*
+ * Diffie-Hellman groups
+ * Copyright (c) 2007, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef DH_GROUPS_H
+#define DH_GROUPS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct dh_group {
+	int id;
+	const u8 *generator;
+	size_t generator_len;
+	const u8 *prime;
+	size_t prime_len;
+};
+
+const struct dh_group * wpa_dh_groups_get(int id);
+struct wpabuf * wpa_dh_init(const struct dh_group *dh, struct wpabuf **priv);
+struct wpabuf * wpa_dh_derive_shared(const struct wpabuf *peer_public,
+				                     const struct wpabuf *own_private,
+				                     const struct dh_group *dh);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DH_GROUPS_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/includes.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/includes.h
@@ -1,0 +1,73 @@
+/*
+ * wpa_supplicant/hostapd - Default include files
+ * Copyright (c) 2005-2006, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ *
+ * This header file is included into all C files so that commonly used header
+ * files can be selected with OS specific ifdef blocks in one place instead of
+ * having to have OS/C library specific selection in many files.
+ */
+
+#ifndef INCLUDES_H
+#define INCLUDES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Include possible build time configuration before including anything else */
+//#include "build_config.h"  //don't need anymore
+#ifndef __ets__
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#ifndef _WIN32_WCE
+#ifndef CONFIG_TI_COMPILER
+#include <signal.h>
+#include <sys/types.h>
+#endif /* CONFIG_TI_COMPILER */
+#include <errno.h>
+#endif /* _WIN32_WCE */
+#include <ctype.h>
+#include <time.h>
+
+#ifndef CONFIG_TI_COMPILER
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif /* _MSC_VER */
+#endif /* CONFIG_TI_COMPILER */
+
+#ifndef CONFIG_NATIVE_WINDOWS
+#ifndef CONFIG_TI_COMPILER
+//#include <sys/socket.h>
+//#include <netinet/in.h>
+//#include <arpa/inet.h>
+#ifndef __vxworks
+#ifndef __SYMBIAN32__
+//#include <sys/uio.h>
+#endif /* __SYMBIAN32__ */
+#include <sys/time.h>
+#endif /* __vxworks */
+#endif /* CONFIG_TI_COMPILER */
+#endif /* CONFIG_NATIVE_WINDOWS */
+
+#else
+
+#include "rom/ets_sys.h"
+
+#endif /* !__ets__ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INCLUDES_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/md5.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/md5.h
@@ -1,0 +1,43 @@
+/*
+ * MD5 hash implementation and interface functions
+ * Copyright (c) 2003-2009, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef MD5_H
+#define MD5_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MD5_MAC_LEN 16
+
+int wpa_hmac_md5_vector(const uint8_t *key, size_t key_len, size_t num_elem,
+		                const uint8_t *addr[], const size_t *len, uint8_t *mac);
+int wpa_hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data, size_t data_len,
+	             uint8_t *mac);
+#ifdef CONFIG_FIPS
+int wpa_hmac_md5_vector_non_fips_allow(const uint8_t *key, size_t key_len,
+				                       size_t num_elem, const uint8_t *addr[],
+				                       const size_t *len, uint8_t *mac);
+int wpa_hmac_md5_non_fips_allow(const uint8_t *key, size_t key_len, const uint8_t *data,
+			                    size_t data_len, uint8_t *mac);
+#else /* CONFIG_FIPS */
+#define wpa_hmac_md5_vector_non_fips_allow hmac_md5_vector
+#define wpa_hmac_md5_non_fips_allow hmac_md5
+#endif /* CONFIG_FIPS */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MD5_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/md5_i.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/md5_i.h
@@ -1,0 +1,37 @@
+/*
+ * MD5 internal definitions
+ * Copyright (c) 2003-2005, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef MD5_I_H
+#define MD5_I_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct MD5Context {
+	u32 buf[4];
+	u32 bits[2];
+	u8 in[64];
+};
+
+void wpa_MD5Init(struct MD5Context *context);
+void wpa_MD5Update(struct MD5Context *context, unsigned char const *buf,
+	               unsigned len);
+void wpa_MD5Final(unsigned char digest[16], struct MD5Context *context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MD5_I_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/ms_funcs.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/ms_funcs.h
@@ -1,0 +1,68 @@
+/*
+ * WPA Supplicant / shared MSCHAPV2 helper functions
+ *
+ *
+ */
+
+#ifndef MS_FUNCS_H
+#define MS_FUNCS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int generate_nt_response(const u8 *auth_challenge, const u8 *peer_challenge,
+			             const u8 *username, size_t username_len,
+			             const u8 *password, size_t password_len,
+			             u8 *response);
+
+int generate_nt_response_pwhash(const u8 *auth_challenge,
+				                const u8 *peer_challenge,
+				                const u8 *username, size_t username_len,
+				                const u8 *password_hash,
+				                u8 *response);
+int generate_authenticator_response(const u8 *password, size_t password_len,
+				                    const u8 *peer_challenge,
+				                    const u8 *auth_challenge,
+				                    const u8 *username, size_t username_len,
+				                    const u8 *nt_response, u8 *response);
+int generate_authenticator_response_pwhash(
+	const u8 *password_hash,
+	const u8 *peer_challenge, const u8 *auth_challenge,
+	const u8 *username, size_t username_len,
+	const u8 *nt_response, u8 *response);
+int nt_challenge_response(const u8 *challenge, const u8 *password,
+			              size_t password_len, u8 *response);
+
+void challenge_response(const u8 *challenge, const u8 *password_hash,
+			            u8 *response);
+int nt_password_hash(const u8 *password, size_t password_len,
+		             u8 *password_hash);
+int hash_nt_password_hash(const u8 *password_hash, u8 *password_hash_hash);
+int get_master_key(const u8 *password_hash_hash, const u8 *nt_response,
+		           u8 *master_key);
+int get_asymetric_start_key(const u8 *master_key, u8 *session_key,
+			    size_t session_key_len, int is_send,
+			    int is_server);
+int encrypt_pw_block_with_password_hash(
+	const u8 *password, size_t password_len,
+	const u8 *password_hash, u8 *pw_block);
+int __must_check encry_pw_block_with_password_hash(
+	const u8 *password, size_t password_len,
+	const u8 *password_hash, u8 *pw_block);
+int __must_check new_password_encrypted_with_old_nt_password_hash(
+	const u8 *new_password, size_t new_password_len,
+	const u8 *old_password, size_t old_password_len,
+	u8 *encrypted_pw_block);
+void nt_password_hash_encrypted_with_block(const u8 *password_hash,
+					                       const u8 *block, u8 *cypher);
+int old_nt_password_hash_encrypted_with_new_nt_password_hash(
+	const u8 *new_password, size_t new_password_len,
+	const u8 *old_password, size_t old_password_len,
+	u8 *encrypted_password_hash);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MS_FUNCS_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/random.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/random.h
@@ -1,0 +1,42 @@
+/*
+ * Random number generator
+ * Copyright (c) 2010-2011, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef RANDOM_H
+#define RANDOM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CONFIG_NO_RANDOM_POOL
+
+#ifdef CONFIG_NO_RANDOM_POOL
+#define random_init(e) do { } while (0)
+#define random_deinit() do { } while (0)
+#define random_add_randomness(b, l) do { } while (0)
+#define random_get_bytes(b, l) os_get_random((b), (l))
+#define random_pool_ready() 1
+#define random_mark_pool_ready() do { } while (0)
+#else /* CONFIG_NO_RANDOM_POOL */
+void random_init(const char *entropy_file);
+void random_deinit(void);
+void random_add_randomness(const void *buf, size_t len);
+int random_get_bytes(void *buf, size_t len);
+#endif /* CONFIG_NO_RANDOM_POOL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RANDOM_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/sha1.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/sha1.h
@@ -1,0 +1,42 @@
+/*
+ * SHA1 hash implementation and interface functions
+ * Copyright (c) 2003-2009, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef SHA1_H
+#define SHA1_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SHA1_MAC_LEN 20
+
+int wpa_hmac_sha1_vector(const uint8_t *key, size_t key_len, size_t num_elem,
+		                 const uint8_t *addr[], const size_t *len, uint8_t *mac);
+int wpa_hmac_sha1(const uint8_t *key, size_t key_len, const uint8_t *data, size_t data_len,
+	              uint8_t *mac);
+int wpa_sha1_prf(const uint8_t *key, size_t key_len, const char *label,
+	             const uint8_t *data, size_t data_len, uint8_t *buf, size_t buf_len);
+int wpa_sha1_t_prf(const uint8_t *key, size_t key_len, const char *label,
+	               const uint8_t *seed, size_t seed_len, uint8_t *buf, size_t buf_len);
+//int __must_check wpa_tls_prf(const uint8_t *secret, size_t secret_len,
+//			                   const char *label, const uint8_t *seed, size_t seed_len,
+//			                   uint8_t *out, size_t outlen);
+int wpa_pbkdf2_sha1(const char *passphrase, const char *ssid, size_t ssid_len,
+		            int iterations, uint8_t *buf, size_t buflen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHA1_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/sha1_i.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/sha1_i.h
@@ -1,0 +1,37 @@
+/*
+ * SHA1 internal definitions
+ * Copyright (c) 2003-2005, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef SHA1_I_H
+#define SHA1_I_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct SHA1Context {
+	u32 state[5];
+	u32 count[2];
+	unsigned char buffer[64];
+};
+
+void wpa_SHA1Init(struct SHA1Context *context);
+void wpa_SHA1Update(struct SHA1Context *context, const void *data, u32 len);
+void wpa_SHA1Final(unsigned char digest[20], struct SHA1Context *context);
+void wpa_SHA1Transform(u32 state[5], const unsigned char buffer[64]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHA1_I_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/sha256.h
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/include/crypto/sha256.h
@@ -1,0 +1,42 @@
+/*
+ * SHA256 hash implementation and interface functions
+ * Copyright (c) 2003-2006, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#ifndef SHA256_H
+#define SHA256_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SHA256_MAC_LEN 32
+
+void wpa_hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+		                    const u8 *addr[], const size_t *len, u8 *mac);
+void wpa_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+		             size_t data_len, u8 *mac);
+void wpa_sha256_prf(const u8 *key, size_t key_len, const char *label,
+	                const u8 *data, size_t data_len, u8 *buf, size_t buf_len);
+
+void wpa_fast_hmac_sha256_vector(const uint8_t *key, size_t key_len, size_t num_elem,
+		                         const uint8_t *addr[], const size_t *len, uint8_t *mac);
+void wpa_fast_hmac_sha256(const uint8_t *key, size_t key_len, const uint8_t *data,
+		                  size_t data_len, uint8_t *mac);
+void wpa_fast_sha256_prf(const uint8_t *key, size_t key_len, const char *label,
+	                     const uint8_t *data, size_t data_len, uint8_t *buf, size_t buf_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHA256_H */

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
@@ -4,7 +4,8 @@ include $(RIOTBASE)/Makefile.base
 
 # we have to do it in that way to avoid that $(RIOTBASE)/sys/include/crypto
 # is found first
-INCLUDES  = -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/wpa_supplicant/port/include
+INCLUDES  = -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/wpa_supplicant/include
+INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/wpa_supplicant/port/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/port/include
 CFLAGS += -D__ets__ -DESPRESSIF_USE -DESP32_IDF_CODE=1

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-cbc.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-cbc.c
@@ -28,14 +28,14 @@
  * Returns: 0 on success, -1 on failure
  */
 int
-aes_128_cbc_encrypt(const u8 *key, const u8 *iv, u8 *data, size_t data_len)
+wpa_aes_128_cbc_encrypt(const u8 *key, const u8 *iv, u8 *data, size_t data_len)
 {
     void *ctx;
     u8 cbc[AES_BLOCK_SIZE];
     u8 *pos = data;
     int i, j, blocks;
 
-    ctx = aes_encrypt_init(key, 16);
+    ctx = wpa_aes_encrypt_init(key, 16);
     if (ctx == NULL)
         return -1;
     os_memcpy(cbc, iv, AES_BLOCK_SIZE);
@@ -44,11 +44,11 @@ aes_128_cbc_encrypt(const u8 *key, const u8 *iv, u8 *data, size_t data_len)
     for (i = 0; i < blocks; i++) {
         for (j = 0; j < AES_BLOCK_SIZE; j++)
             cbc[j] ^= pos[j];
-        aes_encrypt(ctx, cbc, cbc);
+        wpa_aes_encrypt(ctx, cbc, cbc);
         os_memcpy(pos, cbc, AES_BLOCK_SIZE);
         pos += AES_BLOCK_SIZE;
     }
-    aes_encrypt_deinit(ctx);
+    wpa_aes_encrypt_deinit(ctx);
     return 0;
 }
 
@@ -62,14 +62,14 @@ aes_128_cbc_encrypt(const u8 *key, const u8 *iv, u8 *data, size_t data_len)
  * Returns: 0 on success, -1 on failure
  */
 int
-aes_128_cbc_decrypt(const u8 *key, const u8 *iv, u8 *data, size_t data_len)
+wpa_aes_128_cbc_decrypt(const u8 *key, const u8 *iv, u8 *data, size_t data_len)
 {
     void *ctx;
     u8 cbc[AES_BLOCK_SIZE], tmp[AES_BLOCK_SIZE];
     u8 *pos = data;
     int i, j, blocks;
 
-    ctx = aes_decrypt_init(key, 16);
+    ctx = wpa_aes_decrypt_init(key, 16);
     if (ctx == NULL)
         return -1;
     os_memcpy(cbc, iv, AES_BLOCK_SIZE);
@@ -77,12 +77,12 @@ aes_128_cbc_decrypt(const u8 *key, const u8 *iv, u8 *data, size_t data_len)
     blocks = data_len / AES_BLOCK_SIZE;
     for (i = 0; i < blocks; i++) {
         os_memcpy(tmp, pos, AES_BLOCK_SIZE);
-        aes_decrypt(ctx, pos, pos);
+        wpa_aes_decrypt(ctx, pos, pos);
         for (j = 0; j < AES_BLOCK_SIZE; j++)
             pos[j] ^= cbc[j];
         os_memcpy(cbc, tmp, AES_BLOCK_SIZE);
         pos += AES_BLOCK_SIZE;
     }
-    aes_decrypt_deinit(ctx);
+    wpa_aes_decrypt_deinit(ctx);
     return 0;
 }

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-internal-dec.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-internal-dec.c
@@ -36,13 +36,13 @@
  *
  * @return    the number of rounds for the given cipher key size.
  */
-static int  rijndaelKeySetupDec(u32 rk[], const u8 cipherKey[], int keyBits)
+static int  wpa_rijndaelKeySetupDec(u32 rk[], const u8 cipherKey[], int keyBits)
 {
     int Nr, i, j;
     u32 temp;
 
     /* expand the cipher key: */
-    Nr = rijndaelKeySetupEnc(rk, cipherKey, keyBits);
+    Nr = wpa_rijndaelKeySetupEnc(rk, cipherKey, keyBits);
     if (Nr < 0)
         return Nr;
     /* invert the order of the round keys: */
@@ -67,14 +67,14 @@ static int  rijndaelKeySetupDec(u32 rk[], const u8 cipherKey[], int keyBits)
     return Nr;
 }
 
-void *  aes_decrypt_init(const u8 *key, size_t len)
+void *  wpa_aes_decrypt_init(const u8 *key, size_t len)
 {
     u32 *rk;
     int res;
     rk = os_malloc(AES_PRIV_SIZE);
     if (rk == NULL)
         return NULL;
-    res = rijndaelKeySetupDec(rk, key, len * 8);
+    res = wpa_rijndaelKeySetupDec(rk, key, len * 8);
     if (res < 0) {
         os_free(rk);
         return NULL;
@@ -83,7 +83,7 @@ void *  aes_decrypt_init(const u8 *key, size_t len)
     return rk;
 }
 
-static void  rijndaelDecrypt(const u32 rk[/*44*/], int Nr, const u8 ct[16],
+static void  wpa_rijndaelDecrypt(const u32 rk[/*44*/], int Nr, const u8 ct[16],
                 u8 pt[16])
 {
     u32 s0, s1, s2, s3, t0, t1, t2, t3;
@@ -158,14 +158,14 @@ d##3 = TD0(s##3) ^ TD1(s##2) ^ TD2(s##1) ^ TD3(s##0) ^ rk[4 * i + 3]
     PUTU32(pt + 12, s3);
 }
 
-void  aes_decrypt(void *ctx, const u8 *crypt, u8 *plain)
+void  wpa_aes_decrypt(void *ctx, const u8 *crypt, u8 *plain)
 {
     u32 *rk = ctx;
-    rijndaelDecrypt(ctx, rk[AES_PRIV_NR_POS], crypt, plain);
+    wpa_rijndaelDecrypt(ctx, rk[AES_PRIV_NR_POS], crypt, plain);
 }
 
 
-void  aes_decrypt_deinit(void *ctx)
+void  wpa_aes_decrypt_deinit(void *ctx)
 {
     os_memset(ctx, 0, AES_PRIV_SIZE);
     os_free(ctx);

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-internal-enc.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-internal-enc.c
@@ -28,7 +28,7 @@
 
 #include "os.h"
 
-void  rijndaelEncrypt(const u32 rk[], int Nr, const u8 pt[16], u8 ct[16])
+void  wpa_rijndaelEncrypt(const u32 rk[], int Nr, const u8 pt[16], u8 ct[16])
 {
     u32 s0, s1, s2, s3, t0, t1, t2, t3;
 #ifndef FULL_UNROLL
@@ -103,14 +103,14 @@ d##3 = TE0(s##3) ^ TE1(s##0) ^ TE2(s##1) ^ TE3(s##2) ^ rk[4 * i + 3]
 }
 
 
-void *  aes_encrypt_init(const u8 *key, size_t len)
+void *  wpa_aes_encrypt_init(const u8 *key, size_t len)
 {
     u32 *rk;
     int res;
     rk = os_malloc(AES_PRIV_SIZE);
     if (rk == NULL)
         return NULL;
-    res = rijndaelKeySetupEnc(rk, key, len * 8);
+    res = wpa_rijndaelKeySetupEnc(rk, key, len * 8);
     if (res < 0) {
         os_free(rk);
         return NULL;
@@ -120,14 +120,14 @@ void *  aes_encrypt_init(const u8 *key, size_t len)
 }
 
 
-void  aes_encrypt(void *ctx, const u8 *plain, u8 *crypt)
+void  wpa_aes_encrypt(void *ctx, const u8 *plain, u8 *crypt)
 {
     u32 *rk = ctx;
-    rijndaelEncrypt(ctx, rk[AES_PRIV_NR_POS], plain, crypt);
+    wpa_rijndaelEncrypt(ctx, rk[AES_PRIV_NR_POS], plain, crypt);
 }
 
 
-void  aes_encrypt_deinit(void *ctx)
+void  wpa_aes_encrypt_deinit(void *ctx)
 {
     os_memset(ctx, 0, AES_PRIV_SIZE);
     os_free(ctx);

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-internal.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-internal.c
@@ -785,7 +785,7 @@ const u8 rcons[] /* ICACHE_RODATA_ATTR */ = {
  *
  * @return    the number of rounds for the given cipher key size.
  */
-int rijndaelKeySetupEnc(u32 rk[], const u8 cipherKey[], int keyBits)
+int wpa_rijndaelKeySetupEnc(u32 rk[], const u8 cipherKey[], int keyBits)
 {
     int i;
     u32 temp;

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-unwrap.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-unwrap.c
@@ -29,7 +29,7 @@
  * Returns: 0 on success, -1 on failure (e.g., integrity verification failed)
  */
 int
-aes_unwrap(const u8 *kek, int n, const u8 *cipher, u8 *plain)
+wpa_aes_unwrap(const u8 *kek, int n, const u8 *cipher, u8 *plain)
 {
     u8 a[8], *r, b[16];
     int i, j;
@@ -40,7 +40,7 @@ aes_unwrap(const u8 *kek, int n, const u8 *cipher, u8 *plain)
     r = plain;
     os_memcpy(r, cipher + 8, 8 * n);
 
-    ctx = aes_decrypt_init(kek, 16);
+    ctx = wpa_aes_decrypt_init(kek, 16);
     if (ctx == NULL)
         return -1;
 
@@ -58,13 +58,13 @@ aes_unwrap(const u8 *kek, int n, const u8 *cipher, u8 *plain)
             b[7] ^= n * j + i;
 
             os_memcpy(b + 8, r, 8);
-            aes_decrypt(ctx, b, b);
+            wpa_aes_decrypt(ctx, b, b);
             os_memcpy(a, b, 8);
             os_memcpy(r, b + 8, 8);
             r -= 8;
         }
     }
-    aes_decrypt_deinit(ctx);
+    wpa_aes_decrypt_deinit(ctx);
 
     /* 3) Output results.
      *

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-wrap.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/aes-wrap.c
@@ -22,7 +22,7 @@
  * @cipher: Wrapped key, (n + 1) * 64 bits
  * Returns: 0 on success, -1 on failure
  */
-int  aes_wrap(const u8 *kek, int n, const u8 *plain, u8 *cipher)
+int  wpa_aes_wrap(const u8 *kek, int n, const u8 *plain, u8 *cipher)
 {
     u8 *a, *r, b[16];
     int i, j;
@@ -35,7 +35,7 @@ int  aes_wrap(const u8 *kek, int n, const u8 *plain, u8 *cipher)
     os_memset(a, 0xa6, 8);
     os_memcpy(r, plain, 8 * n);
 
-    ctx = aes_encrypt_init(kek, 16);
+    ctx = wpa_aes_encrypt_init(kek, 16);
     if (ctx == NULL)
         return -1;
 
@@ -51,14 +51,14 @@ int  aes_wrap(const u8 *kek, int n, const u8 *plain, u8 *cipher)
         for (i = 1; i <= n; i++) {
             os_memcpy(b, a, 8);
             os_memcpy(b + 8, r, 8);
-            aes_encrypt(ctx, b, b);
+            wpa_aes_encrypt(ctx, b, b);
             os_memcpy(a, b, 8);
             a[7] ^= n * j + i;
             os_memcpy(r, b + 8, 8);
             r += 8;
         }
     }
-    aes_encrypt_deinit(ctx);
+    wpa_aes_encrypt_deinit(ctx);
 
     /* 3) Output the results.
      *

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/crypto_internal.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/crypto_internal.c
@@ -49,21 +49,21 @@ struct crypto_hash *  crypto_hash_init(enum crypto_hash_alg alg, const u8 *key,
 
     switch (alg) {
     case CRYPTO_HASH_ALG_MD5:
-        MD5Init(&ctx->u.md5);
+        wpa_MD5Init(&ctx->u.md5);
         break;
     case CRYPTO_HASH_ALG_SHA1:
-        SHA1Init(&ctx->u.sha1);
+        wpa_SHA1Init(&ctx->u.sha1);
         break;
 #ifdef CONFIG_SHA256
     case CRYPTO_HASH_ALG_SHA256:
-        sha256_init(&ctx->u.sha256);
+        wpa_sha256_init(&ctx->u.sha256);
         break;
 #endif /* CONFIG_SHA256 */
     case CRYPTO_HASH_ALG_HMAC_MD5:
         if (key_len > sizeof(k_pad)) {
-            MD5Init(&ctx->u.md5);
-            MD5Update(&ctx->u.md5, key, key_len);
-            MD5Final(tk, &ctx->u.md5);
+            wpa_MD5Init(&ctx->u.md5);
+            wpa_MD5Update(&ctx->u.md5, key, key_len);
+            wpa_MD5Final(tk, &ctx->u.md5);
             key = tk;
             key_len = 16;
         }
@@ -75,14 +75,14 @@ struct crypto_hash *  crypto_hash_init(enum crypto_hash_alg alg, const u8 *key,
             os_memset(k_pad + key_len, 0, sizeof(k_pad) - key_len);
         for (i = 0; i < sizeof(k_pad); i++)
             k_pad[i] ^= 0x36;
-        MD5Init(&ctx->u.md5);
-        MD5Update(&ctx->u.md5, k_pad, sizeof(k_pad));
+        wpa_MD5Init(&ctx->u.md5);
+        wpa_MD5Update(&ctx->u.md5, k_pad, sizeof(k_pad));
         break;
     case CRYPTO_HASH_ALG_HMAC_SHA1:
         if (key_len > sizeof(k_pad)) {
-            SHA1Init(&ctx->u.sha1);
-            SHA1Update(&ctx->u.sha1, key, key_len);
-            SHA1Final(tk, &ctx->u.sha1);
+            wpa_SHA1Init(&ctx->u.sha1);
+            wpa_SHA1Update(&ctx->u.sha1, key, key_len);
+            wpa_SHA1Final(tk, &ctx->u.sha1);
             key = tk;
             key_len = 20;
         }
@@ -94,15 +94,15 @@ struct crypto_hash *  crypto_hash_init(enum crypto_hash_alg alg, const u8 *key,
             os_memset(k_pad + key_len, 0, sizeof(k_pad) - key_len);
         for (i = 0; i < sizeof(k_pad); i++)
             k_pad[i] ^= 0x36;
-        SHA1Init(&ctx->u.sha1);
-        SHA1Update(&ctx->u.sha1, k_pad, sizeof(k_pad));
+        wpa_SHA1Init(&ctx->u.sha1);
+        wpa_SHA1Update(&ctx->u.sha1, k_pad, sizeof(k_pad));
         break;
 #ifdef CONFIG_SHA256
     case CRYPTO_HASH_ALG_HMAC_SHA256:
         if (key_len > sizeof(k_pad)) {
-            sha256_init(&ctx->u.sha256);
-            sha256_process(&ctx->u.sha256, key, key_len);
-            sha256_done(&ctx->u.sha256, tk);
+            wpa_sha256_init(&ctx->u.sha256);
+            wpa_sha256_process(&ctx->u.sha256, key, key_len);
+            wpa_sha256_done(&ctx->u.sha256, tk);
             key = tk;
             key_len = 32;
         }
@@ -114,8 +114,8 @@ struct crypto_hash *  crypto_hash_init(enum crypto_hash_alg alg, const u8 *key,
             os_memset(k_pad + key_len, 0, sizeof(k_pad) - key_len);
         for (i = 0; i < sizeof(k_pad); i++)
             k_pad[i] ^= 0x36;
-        sha256_init(&ctx->u.sha256);
-        sha256_process(&ctx->u.sha256, k_pad, sizeof(k_pad));
+        wpa_sha256_init(&ctx->u.sha256);
+        wpa_sha256_process(&ctx->u.sha256, k_pad, sizeof(k_pad));
         break;
 #endif /* CONFIG_SHA256 */
     default:
@@ -135,16 +135,16 @@ void  crypto_hash_update(struct crypto_hash *ctx, const u8 *data, size_t len)
     switch (ctx->alg) {
     case CRYPTO_HASH_ALG_MD5:
     case CRYPTO_HASH_ALG_HMAC_MD5:
-        MD5Update(&ctx->u.md5, data, len);
+        wpa_MD5Update(&ctx->u.md5, data, len);
         break;
     case CRYPTO_HASH_ALG_SHA1:
     case CRYPTO_HASH_ALG_HMAC_SHA1:
-        SHA1Update(&ctx->u.sha1, data, len);
+        wpa_SHA1Update(&ctx->u.sha1, data, len);
         break;
 #ifdef CONFIG_SHA256
     case CRYPTO_HASH_ALG_SHA256:
     case CRYPTO_HASH_ALG_HMAC_SHA256:
-        sha256_process(&ctx->u.sha256, data, len);
+        wpa_sha256_process(&ctx->u.sha256, data, len);
         break;
 #endif /* CONFIG_SHA256 */
     default:
@@ -174,7 +174,7 @@ int  crypto_hash_finish(struct crypto_hash *ctx, u8 *mac, size_t *len)
             return -1;
         }
         *len = 16;
-        MD5Final(mac, &ctx->u.md5);
+        wpa_MD5Final(mac, &ctx->u.md5);
         break;
     case CRYPTO_HASH_ALG_SHA1:
         if (*len < 20) {
@@ -183,7 +183,7 @@ int  crypto_hash_finish(struct crypto_hash *ctx, u8 *mac, size_t *len)
             return -1;
         }
         *len = 20;
-        SHA1Final(mac, &ctx->u.sha1);
+        wpa_SHA1Final(mac, &ctx->u.sha1);
         break;
 #ifdef CONFIG_SHA256
     case CRYPTO_HASH_ALG_SHA256:
@@ -193,7 +193,7 @@ int  crypto_hash_finish(struct crypto_hash *ctx, u8 *mac, size_t *len)
             return -1;
         }
         *len = 32;
-        sha256_done(&ctx->u.sha256, mac);
+        wpa_sha256_done(&ctx->u.sha256, mac);
         break;
 #endif /* CONFIG_SHA256 */
     case CRYPTO_HASH_ALG_HMAC_MD5:
@@ -204,17 +204,17 @@ int  crypto_hash_finish(struct crypto_hash *ctx, u8 *mac, size_t *len)
         }
         *len = 16;
 
-        MD5Final(mac, &ctx->u.md5);
+        wpa_MD5Final(mac, &ctx->u.md5);
 
         os_memcpy(k_pad, ctx->key, ctx->key_len);
         os_memset(k_pad + ctx->key_len, 0,
               sizeof(k_pad) - ctx->key_len);
         for (i = 0; i < sizeof(k_pad); i++)
             k_pad[i] ^= 0x5c;
-        MD5Init(&ctx->u.md5);
-        MD5Update(&ctx->u.md5, k_pad, sizeof(k_pad));
-        MD5Update(&ctx->u.md5, mac, 16);
-        MD5Final(mac, &ctx->u.md5);
+        wpa_MD5Init(&ctx->u.md5);
+        wpa_MD5Update(&ctx->u.md5, k_pad, sizeof(k_pad));
+        wpa_MD5Update(&ctx->u.md5, mac, 16);
+        wpa_MD5Final(mac, &ctx->u.md5);
         break;
     case CRYPTO_HASH_ALG_HMAC_SHA1:
         if (*len < 20) {
@@ -224,17 +224,17 @@ int  crypto_hash_finish(struct crypto_hash *ctx, u8 *mac, size_t *len)
         }
         *len = 20;
 
-        SHA1Final(mac, &ctx->u.sha1);
+        wpa_SHA1Final(mac, &ctx->u.sha1);
 
         os_memcpy(k_pad, ctx->key, ctx->key_len);
         os_memset(k_pad + ctx->key_len, 0,
               sizeof(k_pad) - ctx->key_len);
         for (i = 0; i < sizeof(k_pad); i++)
             k_pad[i] ^= 0x5c;
-        SHA1Init(&ctx->u.sha1);
-        SHA1Update(&ctx->u.sha1, k_pad, sizeof(k_pad));
-        SHA1Update(&ctx->u.sha1, mac, 20);
-        SHA1Final(mac, &ctx->u.sha1);
+        wpa_SHA1Init(&ctx->u.sha1);
+        wpa_SHA1Update(&ctx->u.sha1, k_pad, sizeof(k_pad));
+        wpa_SHA1Update(&ctx->u.sha1, mac, 20);
+        wpa_SHA1Final(mac, &ctx->u.sha1);
         break;
 #ifdef CONFIG_SHA256
     case CRYPTO_HASH_ALG_HMAC_SHA256:
@@ -245,17 +245,17 @@ int  crypto_hash_finish(struct crypto_hash *ctx, u8 *mac, size_t *len)
         }
         *len = 32;
 
-        sha256_done(&ctx->u.sha256, mac);
+        wpa_sha256_done(&ctx->u.sha256, mac);
 
         os_memcpy(k_pad, ctx->key, ctx->key_len);
         os_memset(k_pad + ctx->key_len, 0,
               sizeof(k_pad) - ctx->key_len);
         for (i = 0; i < sizeof(k_pad); i++)
             k_pad[i] ^= 0x5c;
-        sha256_init(&ctx->u.sha256);
-        sha256_process(&ctx->u.sha256, k_pad, sizeof(k_pad));
-        sha256_process(&ctx->u.sha256, mac, 32);
-        sha256_done(&ctx->u.sha256, mac);
+        wpa_sha256_init(&ctx->u.sha256);
+        wpa_sha256_process(&ctx->u.sha256, k_pad, sizeof(k_pad));
+        wpa_sha256_process(&ctx->u.sha256, mac, 32);
+        wpa_sha256_done(&ctx->u.sha256, mac);
         break;
 #endif /* CONFIG_SHA256 */
     default:

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/des-internal.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/des-internal.c
@@ -396,7 +396,7 @@ static void desfunc(u32 *block, const u32 *keys)
 
 /* wpa_supplicant/hostapd specific wrapper */
 
-void des_encrypt(const u8 *clear, const u8 *key, u8 *cypher)
+void wpa_des_encrypt(const u8 *clear, const u8 *key, u8 *cypher)
 {
     u8 pkey[8], next, tmp;
     int i;
@@ -424,14 +424,14 @@ void des_encrypt(const u8 *clear, const u8 *key, u8 *cypher)
 }
 
 /*
-void des_key_setup(const u8 *key, u32 *ek, u32 *dk)
+void wpa_des_key_setup(const u8 *key, u32 *ek, u32 *dk)
 {
     deskey(key, 0, ek);
     deskey(key, 1, dk);
 }
 
 
-void des_block_encrypt(const u8 *plain, const u32 *ek, u8 *crypt)
+void wpa_des_block_encrypt(const u8 *plain, const u32 *ek, u8 *crypt)
 {
     u32 work[2];
     work[0] = WPA_GET_BE32(plain);
@@ -442,7 +442,7 @@ void des_block_encrypt(const u8 *plain, const u32 *ek, u8 *crypt)
 }
 
 
-void des_block_decrypt(const u8 *crypt, const u32 *dk, u8 *plain)
+void wpa_des_block_decrypt(const u8 *crypt, const u32 *dk, u8 *plain)
 {
     u32 work[2];
     work[0] = WPA_GET_BE32(crypt);
@@ -453,7 +453,7 @@ void des_block_decrypt(const u8 *crypt, const u32 *dk, u8 *plain)
 }
 
 
-void des3_key_setup(const u8 *key, struct des3_key_s *dkey)
+void wpa_des3_key_setup(const u8 *key, struct des3_key_s *dkey)
 {
     deskey(key, 0, dkey->ek[0]);
     deskey(key + 8, 1, dkey->ek[1]);
@@ -465,7 +465,7 @@ void des3_key_setup(const u8 *key, struct des3_key_s *dkey)
 }
 
 
-void des3_encrypt(const u8 *plain, const struct des3_key_s *key, u8 *crypt)
+void wpa_des3_encrypt(const u8 *plain, const struct des3_key_s *key, u8 *crypt)
 {
     u32 work[2];
 
@@ -479,7 +479,7 @@ void des3_encrypt(const u8 *plain, const struct des3_key_s *key, u8 *crypt)
 }
 
 
-void des3_decrypt(const u8 *crypt, const struct des3_key_s *key, u8 *plain)
+void wpa_des3_decrypt(const u8 *crypt, const struct des3_key_s *key, u8 *plain)
 {
     u32 work[2];
 

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/dh_group5.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/dh_group5.c
@@ -20,9 +20,9 @@
 
 
 void *
-dh5_init(struct wpabuf **priv, struct wpabuf **publ)
+wpa_dh5_init(struct wpabuf **priv, struct wpabuf **publ)
 {
-    *publ = dh_init(dh_groups_get(5), priv);
+    *publ = wpa_dh_init(wpa_dh_groups_get(5), priv);
     if (*publ == 0)
         return NULL;
     return (void *) 1;
@@ -30,14 +30,14 @@ dh5_init(struct wpabuf **priv, struct wpabuf **publ)
 
 
 struct wpabuf *
-dh5_derive_shared(void *ctx, const struct wpabuf *peer_public,
+wpa_dh5_derive_shared(void *ctx, const struct wpabuf *peer_public,
                   const struct wpabuf *own_private)
 {
-    return dh_derive_shared(peer_public, own_private, dh_groups_get(5));
+    return wpa_dh_derive_shared(peer_public, own_private, wpa_dh_groups_get(5));
 }
 
 
 void
-dh5_free(void *ctx)
+wpa_dh5_free(void *ctx)
 {
 }

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/md4-internal.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/md4-internal.c
@@ -17,25 +17,25 @@ typedef struct MD4Context {
     u8 buffer[MD4_BLOCK_LENGTH];
 } MD4_CTX;
 
-static void MD4Init(MD4_CTX *ctx);
-static void MD4Update(MD4_CTX *ctx, const unsigned char *input, size_t len);
-static void MD4Final(unsigned char digest[MD4_DIGEST_LENGTH], MD4_CTX *ctx);
+static void wpa_MD4Init(MD4_CTX *ctx);
+static void wpa_MD4Update(MD4_CTX *ctx, const unsigned char *input, size_t len);
+static void wpa_MD4Final(unsigned char digest[MD4_DIGEST_LENGTH], MD4_CTX *ctx);
 
-int md4_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
+int wpa_md4_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
 {
     MD4_CTX ctx;
     size_t i;
 
-    MD4Init(&ctx);
+    wpa_MD4Init(&ctx);
     for (i = 0; i < num_elem; i++)
-        MD4Update(&ctx, addr[i], len[i]);
-    MD4Final(mac, &ctx);
+        wpa_MD4Update(&ctx, addr[i], len[i]);
+    wpa_MD4Final(mac, &ctx);
     return 0;
 }
 
 #define MD4_DIGEST_STRING_LENGTH    (MD4_DIGEST_LENGTH * 2 + 1)
 
-static void MD4Transform(u32 state[4], const u8 block[MD4_BLOCK_LENGTH]);
+static void wpa_MD4Transform(u32 state[4], const u8 block[MD4_BLOCK_LENGTH]);
 
 #define PUT_64BIT_LE(cp, value) do {    \
     (cp)[7] = (value) >> 56;    \
@@ -60,7 +60,7 @@ static u8 PADDING[MD4_BLOCK_LENGTH] = {
     0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
-static void MD4Init(MD4_CTX *ctx)
+static void wpa_MD4Init(MD4_CTX *ctx)
 {
     ctx->count = 0;
     ctx->state[0] = 0x67452301;
@@ -69,7 +69,7 @@ static void MD4Init(MD4_CTX *ctx)
     ctx->state[3] = 0x10325476;
 }
 
-static void MD4Update(MD4_CTX *ctx, const unsigned char *input, size_t len)
+static void wpa_MD4Update(MD4_CTX *ctx, const unsigned char *input, size_t len)
 {
     size_t have, need;
 
@@ -81,14 +81,14 @@ static void MD4Update(MD4_CTX *ctx, const unsigned char *input, size_t len)
     if (len >= need) {
         if (have != 0) {
             os_memcpy(ctx->buffer + have, input, need);
-            MD4Transform(ctx->state, ctx->buffer);
+            wpa_MD4Transform(ctx->state, ctx->buffer);
             input += need;
             len -= need;
             have = 0;
         }
 
         while (len >= MD4_BLOCK_LENGTH) {
-            MD4Transform(ctx->state, input);
+            wpa_MD4Transform(ctx->state, input);
             input += MD4_BLOCK_LENGTH;
             len -= MD4_BLOCK_LENGTH;
         }
@@ -98,7 +98,7 @@ static void MD4Update(MD4_CTX *ctx, const unsigned char *input, size_t len)
         os_memcpy(ctx->buffer + have, input, len);
 }
 
-static void MD4Pad(MD4_CTX *ctx)
+static void wpa_MD4Pad(MD4_CTX *ctx)
 {
     u8 count[8];
     size_t padlen;
@@ -109,15 +109,15 @@ static void MD4Pad(MD4_CTX *ctx)
         ((ctx->count >> 3) & (MD4_BLOCK_LENGTH - 1));
     if (padlen < 1 + 8)
         padlen += MD4_BLOCK_LENGTH;
-    MD4Update(ctx, PADDING, padlen - 8);
-    MD4Update(ctx, count, 8);
+    wpa_MD4Update(ctx, PADDING, padlen - 8);
+    wpa_MD4Update(ctx, count, 8);
 }
 
-static void MD4Final(unsigned char digest[MD4_DIGEST_LENGTH], MD4_CTX *ctx)
+static void wpa_MD4Final(unsigned char digest[MD4_DIGEST_LENGTH], MD4_CTX *ctx)
 {
     int i;
 
-    MD4Pad(ctx);
+    wpa_MD4Pad(ctx);
     if (digest != NULL) {
         for (i = 0; i < 4; i ++)
             PUT_32BIT_LE(digest + i * 4, ctx->state[i]);
@@ -132,7 +132,7 @@ static void MD4Final(unsigned char digest[MD4_DIGEST_LENGTH], MD4_CTX *ctx)
 #define MD4SETP(f, w, x, y, z, data, s)    \
     ( w += f(x, y, z) + data, w = w<<s | w>>(32-s) )
 
-static void MD4Transform(u32 state[4], const u8 block[MD4_BLOCK_LENGTH])
+static void wpa_MD4Transform(u32 state[4], const u8 block[MD4_BLOCK_LENGTH])
 {
     u32 a, b, c, d, in[MD4_BLOCK_LENGTH / 4];
 

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/md5-internal.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/md5-internal.c
@@ -20,7 +20,7 @@
 #include "crypto/crypto.h"
 
 
-static void MD5Transform(u32 buf[4], u32 const in[16]);
+static void wpa_MD5Transform(u32 buf[4], u32 const in[16]);
 
 
 typedef struct MD5Context MD5_CTX;
@@ -35,15 +35,15 @@ typedef struct MD5Context MD5_CTX;
  * Returns: 0 on success, -1 of failure
  */
 int
-md5_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
+wpa_md5_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
 {
     MD5_CTX ctx;
     size_t i;
 
-    MD5Init(&ctx);
+    wpa_MD5Init(&ctx);
     for (i = 0; i < num_elem; i++)
-        MD5Update(&ctx, addr[i], len[i]);
-    MD5Final(mac, &ctx);
+        wpa_MD5Update(&ctx, addr[i], len[i]);
+    wpa_MD5Final(mac, &ctx);
     return 0;
 }
 
@@ -89,7 +89,7 @@ static void byteReverse(unsigned char *buf, unsigned longs)
  * initialization constants.
  */
 void
-MD5Init(struct MD5Context *ctx)
+wpa_MD5Init(struct MD5Context *ctx)
 {
     ctx->buf[0] = 0x67452301;
     ctx->buf[1] = 0xefcdab89;
@@ -105,7 +105,7 @@ MD5Init(struct MD5Context *ctx)
  * of bytes.
  */
 void
-MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
+wpa_MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
 {
     u32 t;
 
@@ -130,7 +130,7 @@ MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
     }
     os_memcpy(p, buf, t);
     byteReverse(ctx->in, 16);
-    MD5Transform(ctx->buf, (u32 *) ctx->in);
+    wpa_MD5Transform(ctx->buf, (u32 *) ctx->in);
     buf += t;
     len -= t;
     }
@@ -139,7 +139,7 @@ MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
     while (len >= 64) {
     os_memcpy(ctx->in, buf, 64);
     byteReverse(ctx->in, 16);
-    MD5Transform(ctx->buf, (u32 *) ctx->in);
+    wpa_MD5Transform(ctx->buf, (u32 *) ctx->in);
     buf += 64;
     len -= 64;
     }
@@ -154,7 +154,7 @@ MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
  * 1 0* (64-bit count of bits processed, MSB-first)
  */
 void
-MD5Final(unsigned char digest[16], struct MD5Context *ctx)
+wpa_MD5Final(unsigned char digest[16], struct MD5Context *ctx)
 {
     unsigned count;
     unsigned char *p;
@@ -175,7 +175,7 @@ MD5Final(unsigned char digest[16], struct MD5Context *ctx)
     /* Two lots of padding:  Pad the first block to 64 bytes */
     os_memset(p, 0, count);
     byteReverse(ctx->in, 16);
-    MD5Transform(ctx->buf, (u32 *) ctx->in);
+    wpa_MD5Transform(ctx->buf, (u32 *) ctx->in);
 
     /* Now fill the next block with 56 bytes */
     os_memset(ctx->in, 0, 56);
@@ -189,7 +189,7 @@ MD5Final(unsigned char digest[16], struct MD5Context *ctx)
     ((u32 *) ctx->in)[14] = ctx->bits[0];
     ((u32 *) ctx->in)[15] = ctx->bits[1];
 
-    MD5Transform(ctx->buf, (u32 *) ctx->in);
+    wpa_MD5Transform(ctx->buf, (u32 *) ctx->in);
     byteReverse((unsigned char *) ctx->buf, 4);
     os_memcpy(digest, ctx->buf, 16);
     os_memset(ctx, 0, sizeof(struct MD5Context));    /* In case it's sensitive */
@@ -213,7 +213,7 @@ MD5Final(unsigned char digest[16], struct MD5Context *ctx)
  * the data and converts bytes into longwords for this routine.
  */
 static void
-MD5Transform(u32 buf[4], u32 const in[16])
+wpa_MD5Transform(u32 buf[4], u32 const in[16])
 {
     register u32 a, b, c, d;
 

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/md5.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/md5.c
@@ -30,7 +30,7 @@
  * Returns: 0 on success, -1 on failure
  */
 int
-hmac_md5_vector(const u8 *key, size_t key_len, size_t num_elem,
+wpa_hmac_md5_vector(const u8 *key, size_t key_len, size_t num_elem,
             const u8 *addr[], const size_t *len, u8 *mac)
 {
     u8 k_pad[64]; /* padding - key XORd with ipad/opad */
@@ -48,7 +48,7 @@ hmac_md5_vector(const u8 *key, size_t key_len, size_t num_elem,
 
         /* if key is longer than 64 bytes reset it to key = MD5(key) */
         if (key_len > 64) {
-        if (md5_vector(1, &key, &key_len, tk))
+        if (wpa_md5_vector(1, &key, &key_len, tk))
             return -1;
         key = tk;
         key_len = 16;
@@ -78,7 +78,7 @@ hmac_md5_vector(const u8 *key, size_t key_len, size_t num_elem,
         _addr[i + 1] = addr[i];
         _len[i + 1] = len[i];
     }
-    if (md5_vector(1 + num_elem, _addr, _len, mac))
+    if (wpa_md5_vector(1 + num_elem, _addr, _len, mac))
         return -1;
 
     os_memset(k_pad, 0, sizeof(k_pad));
@@ -92,7 +92,7 @@ hmac_md5_vector(const u8 *key, size_t key_len, size_t num_elem,
     _len[0] = 64;
     _addr[1] = mac;
     _len[1] = MD5_MAC_LEN;
-    return md5_vector(2, _addr, _len, mac);
+    return wpa_md5_vector(2, _addr, _len, mac);
 }
 
 
@@ -106,8 +106,8 @@ hmac_md5_vector(const u8 *key, size_t key_len, size_t num_elem,
  * Returns: 0 on success, -1 on failure
  */
 int
-hmac_md5(const u8 *key, size_t key_len, const u8 *data, size_t data_len,
+wpa_hmac_md5(const u8 *key, size_t key_len, const u8 *data, size_t data_len,
           u8 *mac)
 {
-    return hmac_md5_vector(key, key_len, 1, &data, &data_len, mac);
+    return wpa_hmac_md5_vector(key, key_len, 1, &data, &data_len, mac);
 }

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/ms_funcs.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/ms_funcs.c
@@ -93,7 +93,7 @@ static int challenge_hash(const u8 *peer_challenge, const u8 *auth_challenge,
     addr[2] = username;
     len[2] = username_len;
 
-    if (sha1_vector(3, addr, len, hash))
+    if (wpa_sha1_vector(3, addr, len, hash))
         return -1;
     os_memcpy(challenge, hash, 8);
     return 0;
@@ -119,7 +119,7 @@ int nt_password_hash(const u8 *password, size_t password_len,
 
     len *= 2;
     pos = buf;
-    return md4_vector(1, (const u8 **) &pos, &len, password_hash);
+    return wpa_md4_vector(1, (const u8 **) &pos, &len, password_hash);
 }
 
 
@@ -132,7 +132,7 @@ int nt_password_hash(const u8 *password, size_t password_len,
 int hash_nt_password_hash(const u8 *password_hash, u8 *password_hash_hash)
 {
     size_t len = 16;
-    return md4_vector(1, &password_hash, &len, password_hash_hash);
+    return wpa_md4_vector(1, &password_hash, &len, password_hash_hash);
 }
 
 
@@ -146,12 +146,12 @@ void challenge_response(const u8 *challenge, const u8 *password_hash,
            u8 *response)
 {
     u8 zpwd[7];
-    des_encrypt(challenge, password_hash, response);
-    des_encrypt(challenge, password_hash + 7, response + 8);
+    wpa_des_encrypt(challenge, password_hash, response);
+    wpa_des_encrypt(challenge, password_hash + 7, response + 8);
     zpwd[0] = password_hash[14];
     zpwd[1] = password_hash[15];
     os_memset(zpwd + 2, 0, 5);
-    des_encrypt(challenge, zpwd, response + 16);
+    wpa_des_encrypt(challenge, zpwd, response + 16);
 }
 
 
@@ -259,13 +259,13 @@ int generate_authenticator_response_pwhash(
 
     if (hash_nt_password_hash(password_hash, password_hash_hash))
         return -1;
-    if (sha1_vector(3, addr1, len1, response))
+    if (wpa_sha1_vector(3, addr1, len1, response))
         return -1;
 
     if (challenge_hash(peer_challenge, auth_challenge, username,
                username_len, challenge))
         return -1;
-    return sha1_vector(3, addr2, len2, response);
+    return wpa_sha1_vector(3, addr2, len2, response);
 }
 
 
@@ -339,7 +339,7 @@ int get_master_key(const u8 *password_hash_hash, const u8 *nt_response,
     addr[1] = nt_response;
     addr[2] = magic1;
 
-    if (sha1_vector(3, addr, len, hash))
+    if (wpa_sha1_vector(3, addr, len, hash))
         return -1;
     os_memcpy(master_key, hash, 16);
     return 0;
@@ -407,7 +407,7 @@ int get_asymetric_start_key(const u8 *master_key, u8 *session_key,
     }
     addr[3] = shs_pad2;
 
-    if (sha1_vector(4, addr, len, digest))
+    if (wpa_sha1_vector(4, addr, len, digest))
         return -1;
 
     if (session_key_len > SHA1_MAC_LEN)
@@ -454,7 +454,7 @@ int encrypt_pw_block_with_password_hash(
      */
     pos = &pw_block[2 * 256];
     WPA_PUT_LE16(pos, password_len * 2);
-    rc4_skip(password_hash, 16, 0, pw_block, PWBLOCK_LEN);
+    wpa_rc4_skip(password_hash, 16, 0, pw_block, PWBLOCK_LEN);
     return 0;
 }
 
@@ -494,8 +494,8 @@ int new_password_encrypted_with_old_nt_password_hash(
 void nt_password_hash_encrypted_with_block(const u8 *password_hash,
                       const u8 *block, u8 *cypher)
 {
-    des_encrypt(password_hash, block, cypher);
-    des_encrypt(password_hash + 8, block + 7, cypher + 8);
+    wpa_des_encrypt(password_hash, block, cypher);
+    wpa_des_encrypt(password_hash + 8, block + 7, cypher + 8);
 }
 
 

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/rc4.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/rc4.c
@@ -20,7 +20,7 @@
 #define S_SWAP(a,b) do { u8 t = S[a]; S[a] = S[b]; S[b] = t; } while(0)
 
 int
-rc4_skip(const u8 *key, size_t keylen, size_t skip,
+wpa_rc4_skip(const u8 *key, size_t keylen, size_t skip,
          u8 *data, size_t data_len)
 {
     u32 i, j, k;

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha1-internal.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha1-internal.c
@@ -22,7 +22,7 @@
 
 typedef struct SHA1Context SHA1_CTX;
 
-void SHA1Transform(u32 state[5], const unsigned char buffer[64]);
+void wpa_SHA1Transform(u32 state[5], const unsigned char buffer[64]);
 
 
 /**
@@ -34,15 +34,15 @@ void SHA1Transform(u32 state[5], const unsigned char buffer[64]);
  * Returns: 0 on success, -1 of failure
  */
 int
-sha1_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
+wpa_sha1_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
 {
     SHA1_CTX ctx;
     size_t i;
 
-    SHA1Init(&ctx);
+    wpa_SHA1Init(&ctx);
     for (i = 0; i < num_elem; i++)
-        SHA1Update(&ctx, addr[i], len[i]);
-    SHA1Final(mac, &ctx);
+        wpa_SHA1Update(&ctx, addr[i], len[i]);
+    wpa_SHA1Final(mac, &ctx);
     return 0;
 }
 
@@ -160,7 +160,7 @@ A million repetitions of "a"
 
 
 #ifdef VERBOSE  /* SAK */
-void SHAPrintContext(SHA1_CTX *context, char *msg)
+void wpa_SHAPrintContext(SHA1_CTX *context, char *msg)
 {
     printf("%s (%d,%d) %x %x %x %x %x\n",
            msg,
@@ -176,7 +176,7 @@ void SHAPrintContext(SHA1_CTX *context, char *msg)
 /* Hash a single 512-bit block. This is the core of the algorithm. */
 
 void
-SHA1Transform(u32 state[5], const unsigned char buffer[64])
+wpa_SHA1Transform(u32 state[5], const unsigned char buffer[64])
 {
     u32 a, b, c, d, e;
     typedef union {
@@ -235,7 +235,7 @@ SHA1Transform(u32 state[5], const unsigned char buffer[64])
 /* SHA1Init - Initialize new context */
 
 void
-SHA1Init(SHA1_CTX* context)
+wpa_SHA1Init(SHA1_CTX* context)
 {
     /* SHA1 initialization constants */
     context->state[0] = 0x67452301;
@@ -250,13 +250,13 @@ SHA1Init(SHA1_CTX* context)
 /* Run your data through this. */
 
 void
-SHA1Update(SHA1_CTX* context, const void *_data, u32 len)
+wpa_SHA1Update(SHA1_CTX* context, const void *_data, u32 len)
 {
     u32 i, j;
     const unsigned char *data = _data;
 
 #ifdef VERBOSE
-    SHAPrintContext(context, "before");
+    wpa_SHAPrintContext(context, "before");
 #endif
     j = (context->count[0] >> 3) & 63;
     if ((context->count[0] += len << 3) < (len << 3))
@@ -264,16 +264,16 @@ SHA1Update(SHA1_CTX* context, const void *_data, u32 len)
     context->count[1] += (len >> 29);
     if ((j + len) > 63) {
         os_memcpy(&context->buffer[j], data, (i = 64-j));
-        SHA1Transform(context->state, context->buffer);
+        wpa_SHA1Transform(context->state, context->buffer);
         for ( ; i + 63 < len; i += 64) {
-            SHA1Transform(context->state, &data[i]);
+            wpa_SHA1Transform(context->state, &data[i]);
         }
         j = 0;
     }
     else i = 0;
     os_memcpy(&context->buffer[j], &data[i], len - i);
 #ifdef VERBOSE
-    SHAPrintContext(context, "after ");
+    wpa_SHAPrintContext(context, "after ");
 #endif
 }
 
@@ -281,7 +281,7 @@ SHA1Update(SHA1_CTX* context, const void *_data, u32 len)
 /* Add padding and return the message digest. */
 
 void
-SHA1Final(unsigned char digest[20], SHA1_CTX* context)
+wpa_SHA1Final(unsigned char digest[20], SHA1_CTX* context)
 {
     u32 i;
     unsigned char finalcount[8];
@@ -291,11 +291,11 @@ SHA1Final(unsigned char digest[20], SHA1_CTX* context)
             ((context->count[(i >= 4 ? 0 : 1)] >>
               ((3-(i & 3)) * 8) ) & 255);  /* Endian independent */
     }
-    SHA1Update(context, (unsigned char *) "\200", 1);
+    wpa_SHA1Update(context, (unsigned char *) "\200", 1);
     while ((context->count[0] & 504) != 448) {
-        SHA1Update(context, (unsigned char *) "\0", 1);
+        wpa_SHA1Update(context, (unsigned char *) "\0", 1);
     }
-    SHA1Update(context, finalcount, 8);  /* Should cause a SHA1Transform()
+    wpa_SHA1Update(context, finalcount, 8);  /* Should cause a SHA1Transform()
                           */
     for (i = 0; i < 20; i++) {
         digest[i] = (unsigned char)

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha1-pbkdf2.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha1-pbkdf2.c
@@ -19,7 +19,7 @@
 #include "crypto/crypto.h"
 
 static int
-pbkdf2_sha1_f(const char *passphrase, const char *ssid,
+wpa_pbkdf2_sha1_f(const char *passphrase, const char *ssid,
              size_t ssid_len, int iterations, unsigned int count,
              u8 *digest)
 {
@@ -45,13 +45,13 @@ pbkdf2_sha1_f(const char *passphrase, const char *ssid,
     count_buf[1] = (count >> 16) & 0xff;
     count_buf[2] = (count >> 8) & 0xff;
     count_buf[3] = count & 0xff;
-    if (hmac_sha1_vector((u8 *) passphrase, passphrase_len, 2, addr, len,
+    if (wpa_hmac_sha1_vector((u8 *) passphrase, passphrase_len, 2, addr, len,
                  tmp))
         return -1;
     os_memcpy(digest, tmp, SHA1_MAC_LEN);
 
     for (i = 1; i < iterations; i++) {
-        if (hmac_sha1((u8 *) passphrase, passphrase_len, tmp,
+        if (wpa_hmac_sha1((u8 *) passphrase, passphrase_len, tmp,
                   SHA1_MAC_LEN, tmp2))
             return -1;
         os_memcpy(tmp, tmp2, SHA1_MAC_LEN);
@@ -78,7 +78,7 @@ pbkdf2_sha1_f(const char *passphrase, const char *ssid,
  * IEEE Std 802.11-2004, Clause H.4. The main construction is from PKCS#5 v2.0.
  */
 int
-pbkdf2_sha1(const char *passphrase, const char *ssid, size_t ssid_len,
+wpa_pbkdf2_sha1(const char *passphrase, const char *ssid, size_t ssid_len,
         int iterations, u8 *buf, size_t buflen)
 {
     unsigned int count = 0;
@@ -88,7 +88,7 @@ pbkdf2_sha1(const char *passphrase, const char *ssid, size_t ssid_len,
 
     while (left > 0) {
         count++;
-        if (pbkdf2_sha1_f(passphrase, ssid, ssid_len, iterations,
+        if (wpa_pbkdf2_sha1_f(passphrase, ssid, ssid_len, iterations,
                   count, digest))
             return -1;
         plen = left > SHA1_MAC_LEN ? SHA1_MAC_LEN : left;

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha1.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha1.c
@@ -30,7 +30,7 @@
  * Returns: 0 on success, -1 on failure
  */
 int
-hmac_sha1_vector(const u8 *key, size_t key_len, size_t num_elem,
+wpa_hmac_sha1_vector(const u8 *key, size_t key_len, size_t num_elem,
              const u8 *addr[], const size_t *len, u8 *mac)
 {
     unsigned char k_pad[64]; /* padding - key XORd with ipad/opad */
@@ -48,7 +48,7 @@ hmac_sha1_vector(const u8 *key, size_t key_len, size_t num_elem,
 
         /* if key is longer than 64 bytes reset it to key = SHA1(key) */
         if (key_len > 64) {
-        if (sha1_vector(1, &key, &key_len, tk))
+        if (wpa_sha1_vector(1, &key, &key_len, tk))
             return -1;
         key = tk;
         key_len = 20;
@@ -77,7 +77,7 @@ hmac_sha1_vector(const u8 *key, size_t key_len, size_t num_elem,
         _addr[i + 1] = addr[i];
         _len[i + 1] = len[i];
     }
-    if (sha1_vector(1 + num_elem, _addr, _len, mac))
+    if (wpa_sha1_vector(1 + num_elem, _addr, _len, mac))
         return -1;
 
     os_memset(k_pad, 0, sizeof(k_pad));
@@ -91,7 +91,7 @@ hmac_sha1_vector(const u8 *key, size_t key_len, size_t num_elem,
     _len[0] = 64;
     _addr[1] = mac;
     _len[1] = SHA1_MAC_LEN;
-    return sha1_vector(2, _addr, _len, mac);
+    return wpa_sha1_vector(2, _addr, _len, mac);
 }
 
 
@@ -105,10 +105,10 @@ hmac_sha1_vector(const u8 *key, size_t key_len, size_t num_elem,
  * Returns: 0 on success, -1 of failure
  */
 int
-hmac_sha1(const u8 *key, size_t key_len, const u8 *data, size_t data_len,
+wpa_hmac_sha1(const u8 *key, size_t key_len, const u8 *data, size_t data_len,
            u8 *mac)
 {
-    return hmac_sha1_vector(key, key_len, 1, &data, &data_len, mac);
+    return wpa_hmac_sha1_vector(key, key_len, 1, &data, &data_len, mac);
 }
 
 /**
@@ -126,7 +126,7 @@ hmac_sha1(const u8 *key, size_t key_len, const u8 *data, size_t data_len,
  * given key (e.g., PMK in IEEE 802.11i).
  */
 int
-sha1_prf(const u8 *key, size_t key_len, const char *label,
+wpa_sha1_prf(const u8 *key, size_t key_len, const char *label,
          const u8 *data, size_t data_len, u8 *buf, size_t buf_len)
 {
     u8 counter = 0;
@@ -147,12 +147,12 @@ sha1_prf(const u8 *key, size_t key_len, const char *label,
     while (pos < buf_len) {
         plen = buf_len - pos;
         if (plen >= SHA1_MAC_LEN) {
-            if (hmac_sha1_vector(key, key_len, 3, addr, len,
+            if (wpa_hmac_sha1_vector(key, key_len, 3, addr, len,
                          &buf[pos]))
                 return -1;
             pos += SHA1_MAC_LEN;
         } else {
-            if (hmac_sha1_vector(key, key_len, 3, addr, len,
+            if (wpa_hmac_sha1_vector(key, key_len, 3, addr, len,
                          hash))
                 return -1;
             os_memcpy(&buf[pos], hash, plen);

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha256-internal.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha256-internal.c
@@ -26,10 +26,10 @@ struct sha256_state {
     u8 buf[SHA256_BLOCK_SIZE];
 };
 
-static void sha256_init(struct sha256_state *md);
-static int sha256_process(struct sha256_state *md, const unsigned char *in,
+static void wpa_sha256_init(struct sha256_state *md);
+static int wpa_sha256_process(struct sha256_state *md, const unsigned char *in,
               unsigned long inlen);
-static int sha256_done(struct sha256_state *md, unsigned char *out);
+static int wpa_sha256_done(struct sha256_state *md, unsigned char *out);
 
 
 /**
@@ -41,17 +41,17 @@ static int sha256_done(struct sha256_state *md, unsigned char *out);
  * Returns: 0 on success, -1 of failure
  */
 int
-sha256_vector(size_t num_elem, const u8 *addr[], const size_t *len,
+wpa_sha256_vector(size_t num_elem, const u8 *addr[], const size_t *len,
           u8 *mac)
 {
     struct sha256_state ctx;
     size_t i;
 
-    sha256_init(&ctx);
+    wpa_sha256_init(&ctx);
     for (i = 0; i < num_elem; i++)
-        if (sha256_process(&ctx, addr[i], len[i]))
+        if (wpa_sha256_process(&ctx, addr[i], len[i]))
             return -1;
-    if (sha256_done(&ctx, mac))
+    if (wpa_sha256_done(&ctx, mac))
         return -1;
     return 0;
 }
@@ -98,7 +98,7 @@ static const unsigned long K[64] = {
 
 /* compress 512-bits */
 static int
-sha256_compress(struct sha256_state *md, unsigned char *buf)
+wpa_sha256_compress(struct sha256_state *md, unsigned char *buf)
 {
     u32 S[8], W[64], t0, t1;
     u32 t;
@@ -142,7 +142,7 @@ sha256_compress(struct sha256_state *md, unsigned char *buf)
 
 /* Initialize the hash state */
 static void
-sha256_init(struct sha256_state *md)
+wpa_sha256_init(struct sha256_state *md)
 {
     md->curlen = 0;
     md->length = 0;
@@ -164,7 +164,7 @@ sha256_init(struct sha256_state *md)
    @return CRYPT_OK if successful
 */
 static int
-sha256_process(struct sha256_state *md, const unsigned char *in,
+wpa_sha256_process(struct sha256_state *md, const unsigned char *in,
               unsigned long inlen)
 {
     unsigned long n;
@@ -174,7 +174,7 @@ sha256_process(struct sha256_state *md, const unsigned char *in,
 
     while (inlen > 0) {
         if (md->curlen == 0 && inlen >= SHA256_BLOCK_SIZE) {
-            if (sha256_compress(md, (unsigned char *) in) < 0)
+            if (wpa_sha256_compress(md, (unsigned char *) in) < 0)
                 return -1;
             md->length += SHA256_BLOCK_SIZE * 8;
             in += SHA256_BLOCK_SIZE;
@@ -186,7 +186,7 @@ sha256_process(struct sha256_state *md, const unsigned char *in,
             in += n;
             inlen -= n;
             if (md->curlen == SHA256_BLOCK_SIZE) {
-                if (sha256_compress(md, md->buf) < 0)
+                if (wpa_sha256_compress(md, md->buf) < 0)
                     return -1;
                 md->length += 8 * SHA256_BLOCK_SIZE;
                 md->curlen = 0;
@@ -205,7 +205,7 @@ sha256_process(struct sha256_state *md, const unsigned char *in,
    @return CRYPT_OK if successful
 */
 static int
-sha256_done(struct sha256_state *md, unsigned char *out)
+wpa_sha256_done(struct sha256_state *md, unsigned char *out)
 {
     int i;
 
@@ -226,7 +226,7 @@ sha256_done(struct sha256_state *md, unsigned char *out)
         while (md->curlen < SHA256_BLOCK_SIZE) {
             md->buf[md->curlen++] = (unsigned char) 0;
         }
-        sha256_compress(md, md->buf);
+        wpa_sha256_compress(md, md->buf);
         md->curlen = 0;
     }
 
@@ -237,7 +237,7 @@ sha256_done(struct sha256_state *md, unsigned char *out)
 
     /* store length */
     WPA_PUT_BE64(md->buf + 56, md->length);
-    sha256_compress(md, md->buf);
+    wpa_sha256_compress(md, md->buf);
 
     /* copy output */
     for (i = 0; i < 8; i++)

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha256.c
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/sha256.c
@@ -29,7 +29,7 @@
  * @mac: Buffer for the hash (32 bytes)
  */
 void
-hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+wpa_hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
             const u8 *addr[], const size_t *len, u8 *mac)
 {
     unsigned char k_pad[64]; /* padding - key XORd with ipad/opad */
@@ -47,7 +47,7 @@ hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 
         /* if key is longer than 64 bytes reset it to key = SHA256(key) */
         if (key_len > 64) {
-        sha256_vector(1, &key, &key_len, tk);
+        wpa_sha256_vector(1, &key, &key_len, tk);
         key = tk;
         key_len = 32;
         }
@@ -75,7 +75,7 @@ hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
         _addr[i + 1] = addr[i];
         _len[i + 1] = len[i];
     }
-    sha256_vector(1 + num_elem, _addr, _len, mac);
+    wpa_sha256_vector(1 + num_elem, _addr, _len, mac);
 
     os_memset(k_pad, 0, sizeof(k_pad));
     os_memcpy(k_pad, key, key_len);
@@ -88,7 +88,7 @@ hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
     _len[0] = 64;
     _addr[1] = mac;
     _len[1] = SHA256_MAC_LEN;
-    sha256_vector(2, _addr, _len, mac);
+    wpa_sha256_vector(2, _addr, _len, mac);
 }
 
 
@@ -101,10 +101,10 @@ hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
  * @mac: Buffer for the hash (20 bytes)
  */
 void
-hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+wpa_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
          size_t data_len, u8 *mac)
 {
-    hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
+    wpa_hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
 }
 
 
@@ -122,7 +122,7 @@ hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
  * given key.
  */
 void
-sha256_prf(const u8 *key, size_t key_len, const char *label,
+wpa_sha256_prf(const u8 *key, size_t key_len, const char *label,
         const u8 *data, size_t data_len, u8 *buf, size_t buf_len)
 {
     u16 counter = 1;
@@ -147,11 +147,11 @@ sha256_prf(const u8 *key, size_t key_len, const char *label,
         plen = buf_len - pos;
         WPA_PUT_LE16(counter_le, counter);
         if (plen >= SHA256_MAC_LEN) {
-            hmac_sha256_vector(key, key_len, 4, addr, len,
+            wpa_hmac_sha256_vector(key, key_len, 4, addr, len,
                        &buf[pos]);
             pos += SHA256_MAC_LEN;
         } else {
-            hmac_sha256_vector(key, key_len, 4, addr, len, hash);
+            wpa_hmac_sha256_vector(key, key_len, 4, addr, len, hash);
             os_memcpy(&buf[pos], hash, plen);
             break;
         }


### PR DESCRIPTION
### Contribution description

This PR fixes the problem that the `esp_wifi` module cannot be used together with RIOT's `crypto` and `hashes` module. This problem was described in #10787.

**Background**

The `esp_wifi` module requires a number of crypto functions to realize WPA/WPA2. For that purpose it uses the crypt functions from the `wpa-supplicant` which is part of the ESP32 SDK. Unfortunately, these crypto functions can't be replaced by the crypto functions of modules `crypto` and `hashes` since

- a number of crypto functions are missing and
- the signatures of the functions in these modules are slightly different.

Furthermore, the use of `wpa_supplicant` together with modules `crypto` or `hashes` leads to multiple definitions of several functions.

**Solution**

To resolve these problems, crypto function headers from ESP32 SDK are added to ESP32 vendor code, and the crypto functions are renamed using the prefix `wpa_` by this PR.

### Testing procedure

Compile `examples/dtls-echo` with enabled `esp_wifi`, `crypto` and `hashes` modules.
```
USEMODULE='esp_wifi crypto hashes' CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"passphrase\"' make BOARD=esp32-wroom-32 -C examples/dtls-echo/
```

### Issues/PRs references

Fixes #10787 
