### PR TITLE
murdock: nordic_softdevice_ble: softdevice.hex is a test input

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -24,6 +24,12 @@ ifeq (jlink,$(PROGRAMMER))
     export JLINK_PRE_FLASH := erase\nloadfile $(BINDIR)/softdevice.hex
     export FLASH_ADDR := 0x1f000
     export LINKER_SCRIPT ?= $(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL)_sd.ld
+    # murdock: softdevice.hex file is used for flashing
+    # It must be taken into account for the test input hash and
+    # be sent to the separated testing boards
+    TEST_EXTRA_FILES += $(BINDIR)/softdevice.hex
+    # Files in TEST_EXTRA_FILES need to have an explicit target
+    $(BINDIR)/softdevice.hex: | $(ELFFILE)
   endif
   include $(RIOTMAKE)/tools/jlink.inc.mk
 else ifeq (openocd,$(PROGRAMMER))


### PR DESCRIPTION


### Contribution description


When running tests using 'nordic_softdevice_ble', the 'softdevice.hex'
file must also be taken into account for the test hashing and be
uploaded to the separated murdock testing boards.


### Testing procedure

Running test `tests/nordic_softdevice` with `nrf52dk` should now work on `murdock`.

### Issues/PRs references

https://ci.riot-os.org/RIOT-OS/RIOT/master/700b121936dc4f39d66d84468fbd31398c9f1ec8/output/run_test/tests/nordic_softdevice/nrf52dk:gnu.txt

https://github.com/RIOT-OS/RIOT/pull/11797#issuecomment-519835097
https://github.com/RIOT-OS/RIOT/pull/11697#issuecomment-503077236