### PR TITLE
pkg/libcose: update crypto support

### DIFF
--- a/pkg/libcose/Makefile.dep
+++ b/pkg/libcose/Makefile.dep
@@ -2,9 +2,6 @@ USEPKG += nanocbor
 
 USEMODULE += libcose_crypt
 
-ifneq (,$(filter libcose_crypt_tweetnacl,$(USEMODULE)))
-  USEPKG += tweetnacl
-endif
 ifneq (,$(filter libcose_crypt_hacl,$(USEMODULE)))
   USEPKG += hacl
 endif

--- a/pkg/libcose/Makefile.dep
+++ b/pkg/libcose/Makefile.dep
@@ -2,6 +2,14 @@ USEPKG += nanocbor
 
 USEMODULE += libcose_crypt
 
+USEMODULE += random
+
 ifneq (,$(filter libcose_crypt_hacl,$(USEMODULE)))
   USEPKG += hacl
+endif
+ifneq (,$(filter libcose_crypt_monocypher,$(USEMODULE)))
+  USEPKG += monocypher
+endif
+ifneq (,$(filter libcose_crypt_c25519,$(USEMODULE)))
+  USEPKG += c25519
 endif

--- a/pkg/libcose/Makefile.include
+++ b/pkg/libcose/Makefile.include
@@ -4,6 +4,12 @@ CFLAGS += -DUSE_CBOR_CONTEXT
 ifneq (,$(filter libcose_crypt_hacl,$(USEMODULE)))
   CFLAGS += -DCRYPTO_HACL
 endif
+ifneq (,$(filter libcose_crypt_monocypher,$(USEMODULE)))
+  CFLAGS += -DCRYPTO_MONOCYPHER
+endif
+ifneq (,$(filter libcose_crypt_c25519,$(USEMODULE)))
+  CFLAGS += -DCRYPTO_C25519
+endif
 
 # Declare pseudomodules here to be selfcontained
 PSEUDOMODULES += libcose_crypt_%

--- a/pkg/libcose/Makefile.include
+++ b/pkg/libcose/Makefile.include
@@ -1,9 +1,6 @@
 INCLUDES += -I$(PKGDIRBASE)/libcose/include
 CFLAGS += -DUSE_CBOR_CONTEXT
 
-ifneq (,$(filter libcose_crypt_tweetnacl,$(USEMODULE)))
-  CFLAGS += -DCRYPTO_TWEETNACL
-endif
 ifneq (,$(filter libcose_crypt_hacl,$(USEMODULE)))
   CFLAGS += -DCRYPTO_HACL
 endif

--- a/pkg/libcose/patches/0001-RIOT-Use-RIOT-random_bytes-function-instead-of-rando.patch
+++ b/pkg/libcose/patches/0001-RIOT-Use-RIOT-random_bytes-function-instead-of-rando.patch
@@ -1,14 +1,39 @@
-From ed69076abbe83ed256f1e1fbdf74726961c9071e Mon Sep 17 00:00:00 2001
+From 0104f8d1558fbd40d25dc48291508b3eac9965fa Mon Sep 17 00:00:00 2001
 From: Kaspar Schleiser <kaspar@schleiser.de>
 Date: Fri, 5 Jul 2019 14:51:09 +0200
 Subject: [PATCH] RIOT: Use RIOT random_bytes function instead of randombytes
 
 ---
- src/crypt/hacl.c | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ src/crypt/c25519.c     | 5 ++---
+ src/crypt/hacl.c       | 6 +++---
+ src/crypt/monocypher.c | 7 +++----
+ 3 files changed, 8 insertions(+), 10 deletions(-)
 
+diff --git a/src/crypt/c25519.c b/src/crypt/c25519.c
+index c23749b..f30e92a 100644
+--- a/src/crypt/c25519.c
++++ b/src/crypt/c25519.c
+@@ -17,8 +17,7 @@
+ #include "cose/crypto.h"
+ #include "cose/crypto/c25519.h"
+ #include "cose/crypto/selectors.h"
+-
+-extern void randombytes(uint8_t *target, uint64_t n);
++#include "random.h"
+ 
+ #ifdef CRYPTO_C25519_INCLUDE_ED25519
+ int cose_crypto_sign_ed25519(const cose_key_t *key, uint8_t *sign, size_t *signlen, uint8_t *msg, unsigned long long int msglen)
+@@ -38,7 +37,7 @@ int cose_crypto_verify_ed25519(const cose_key_t *key, const uint8_t *sign, size_
+ 
+ void cose_crypto_keypair_ed25519(cose_key_t *key)
+ {
+-    randombytes(key->d, EDSIGN_SECRET_KEY_SIZE);
++    random_bytes(key->d, EDSIGN_SECRET_KEY_SIZE);
+     edsign_sec_to_pub(key->x, key->d);
+ }
+ 
 diff --git a/src/crypt/hacl.c b/src/crypt/hacl.c
-index c24d751732..3bdcabf95e 100644
+index c24d751..3bdcabf 100644
 --- a/src/crypt/hacl.c
 +++ b/src/crypt/hacl.c
 @@ -19,10 +19,10 @@
@@ -41,6 +66,38 @@ index c24d751732..3bdcabf95e 100644
      return COSE_CRYPTO_AEAD_CHACHA20POLY1305_NONCEBYTES;
  }
  #endif /* CRYPTO_HACL_INCLUDE_CHACHAPOLY */
+diff --git a/src/crypt/monocypher.c b/src/crypt/monocypher.c
+index 9e4dcbc..d1fcac1 100644
+--- a/src/crypt/monocypher.c
++++ b/src/crypt/monocypher.c
+@@ -17,8 +17,7 @@
+ #include <monocypher.h>
+ #include "cose/crypto.h"
+ #include "cose/crypto/selectors.h"
+-
+-extern void randombytes(uint8_t *target, uint64_t n);
++#include "random.h"
+ 
+ #ifdef CRYPTO_MONOCYPHER_INCLUDE_CHACHAPOLY
+ static uint32_t load32_le(const uint8_t *u)
+@@ -105,7 +104,7 @@ COSE_ssize_t cose_crypto_keygen_chachapoly(uint8_t *sk, size_t len)
+     if (len < 64) {
+         return COSE_ERR_NOMEM;
+     }
+-    randombytes((unsigned char*)sk, 64);
++    random_bytes((unsigned char*)sk, 64);
+     return 64;
+ }
+ #endif /* CRYPTO_MONOCYPHER_INCLUDE_CHACHAPOLY */
+@@ -133,7 +132,7 @@ static void _ed25519_clamp(uint8_t *key)
+ 
+ void cose_crypto_keypair_ed25519(cose_key_t *key)
+ {
+-    randombytes(key->d, COSE_CRYPTO_SIGN_ED25519_SECRETKEYBYTES);
++    random_bytes(key->d, COSE_CRYPTO_SIGN_ED25519_SECRETKEYBYTES);
+     _ed25519_clamp(key->d);
+     crypto_sign_public_key(key->x, key->d);
+ }
 -- 
-2.22.0
+2.21.0
 

--- a/tests/pkg_libcose/Makefile
+++ b/tests/pkg_libcose/Makefile
@@ -14,11 +14,20 @@ BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 \
 
 TEST_ON_CI_WHITELIST += native
 
-CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(4*THREAD_STACKSIZE_DEFAULT\)
 
 USEPKG += libcose
+# By default we use hacl as crypto backend, uncomment to use a different
+# crypto backend.
 USEMODULE += libcose_crypt_hacl
+# USEMODULE += libcose_crypt_c25519
+# USEMODULE += libcose_crypt_monocypher
 USEMODULE += memarray
 USEMODULE += embunit
+
+ifneq (,$(filter libcose_crypt_monocypher,$(USEMODULE)))
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(6*THREAD_STACKSIZE_DEFAULT\)
+else
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(4*THREAD_STACKSIZE_DEFAULT\)
+endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_libcose/main.c
+++ b/tests/pkg_libcose/main.c
@@ -40,16 +40,21 @@ static unsigned char pk[COSE_CRYPTO_SIGN_ED25519_PUBLICKEYBYTES];
 static unsigned char sk[COSE_CRYPTO_SIGN_ED25519_SECRETKEYBYTES];
 static unsigned char pk2[COSE_CRYPTO_SIGN_ED25519_PUBLICKEYBYTES];
 static unsigned char sk2[COSE_CRYPTO_SIGN_ED25519_SECRETKEYBYTES];
-static unsigned char symmkey[COSE_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES];
-static uint8_t nonce[COSE_CRYPTO_AEAD_CHACHA20POLY1305_NONCEBYTES] = { 0 };
 /* COSE structs */
 static cose_sign_enc_t sign;
 static cose_sign_dec_t verify;
 static cose_signature_t signature1, signature2;
-static cose_key_t signer1, signer2, symm;
+static cose_key_t signer1, signer2;
+
+#if defined(MODULE_LIBCOSE_CRYPT_HACL) || defined(MODULE_LIBCOSE_CRYPT_MONOCYPHER)
+static unsigned char symmkey[COSE_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES];
+static uint8_t nonce[COSE_CRYPTO_AEAD_CHACHA20POLY1305_NONCEBYTES] = { 0 };
+static cose_key_t symm;
 static cose_encrypt_t test_encrypt;
 static cose_encrypt_dec_t test_decrypt;
 static cose_recp_dec_t test_derecp;
+#endif
+
 /* COSE sign buffer */
 static uint8_t buf[2048];
 /* Signature Verification buffer */
@@ -179,6 +184,7 @@ static void test_libcose_02(void)
                                            sizeof(vbuf)));
 }
 
+#if defined(MODULE_LIBCOSE_CRYPT_HACL) || defined(MODULE_LIBCOSE_CRYPT_MONOCYPHER)
 /* Untagged 1 encrypt test with chacha20poly1305*/
 static void test_libcose_03(void)
 {
@@ -207,13 +213,16 @@ static void test_libcose_03(void)
                                                vbuf, &plaintext_len));
     TEST_ASSERT_EQUAL_INT( sizeof(payload) - 1, plaintext_len);
 }
+#endif
 
 Test *tests_libcose(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_libcose_01),
         new_TestFixture(test_libcose_02),
+#if defined(MODULE_LIBCOSE_CRYPT_HACL) || defined(MODULE_LIBCOSE_CRYPT_MONOCYPHER)
         new_TestFixture(test_libcose_03),
+#endif
     };
 
     EMB_UNIT_TESTCALLER(libcose_tests, setUp, NULL, fixtures);


### PR DESCRIPTION

### Contribution description

This PR adds the required RIOT glue code for monocypher and c25519 support already present in libcose to work with RIOT.

- The patch has been updated to also replace random on the mentioned crypto libraries. 
- monocypher require more RAM to operate so the test stack is increased when using monocypher
- c25519 doesn't support cacha20poly135 so we don't compile that last test when using this crypto

### Testing procedure

For all crypto libraries (uncomment in the test Makefile) do:

<details><summary> make -C tests/pkg_libcose/ BOARD=samr21-xpro -j3 flash test</summary>

```
2019-08-12 14:36:42,228 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2019-08-12 14:36:45,347 - INFO # main(): This is RIOT! (Version: 2019.10-devel-374-g28bbba-pr_libcose_crypto_up)

2019-08-12 14:38:26,985 - INFO # ...
2019-08-12 14:38:26,987 - INFO # OK (3 tests)

make: Leaving directory '/home/francisco/workspace/RIOT/tests/pkg_libcose'
```
</details>

Except for c25519 (2 tests) 3 tests should pass. With some crypto-lib the test takes quite some time to run.

### Issues/PRs references

Although not needed by the PR #11818 can benefit from a ~10Kb size reduction from moving from `hacl` to `c25519`, the thread stack needs to be increased to be able to use `monocypher`.

