### PR TITLE
cpu/esp32: esp_wifi improvements and cleanups

### DIFF
--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -18,8 +18,6 @@
 
 #ifdef MODULE_ESP_WIFI
 
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 #include "log.h"
 #include "tools.h"
 
@@ -32,7 +30,7 @@
 #include "net/gnrc.h"
 #include "net/ethernet.h"
 #include "net/netdev/eth.h"
-
+#include "od.h"
 #include "xtimer.h"
 
 #include "esp_common.h"
@@ -49,8 +47,8 @@
 #include "esp_wifi_params.h"
 #include "esp_wifi_netdev.h"
 
-#include "net/ipv6/hdr.h"
-#include "net/gnrc/ipv6/nib.h"
+#define ENABLE_DEBUG (0)
+#include "debug.h"
 
 #define SYSTEM_EVENT_WIFI_RX_DONE    (SYSTEM_EVENT_MAX + 3)
 #define SYSTEM_EVENT_WIFI_TX_DONE    (SYSTEM_EVENT_MAX + 4)

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -72,6 +72,9 @@ extern esp_err_t esp_system_event_add_handler (system_event_cb_t handler,
 
 esp_err_t _esp_wifi_rx_cb(void *buffer, uint16_t len, void *eb)
 {
+    assert(buffer);
+    assert(eb);
+
     /*
      * This callback function is executed in interrupt context but in the
      * context of the wifi thread. That is, mutex_lock or msg_send can block.
@@ -303,8 +306,8 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
 {
     DEBUG("%s: netdev=%p iolist=%p\n", __func__, netdev, iolist);
 
-    CHECK_PARAM_RET (netdev != NULL, -ENODEV);
-    CHECK_PARAM_RET (iolist != NULL, -EINVAL);
+    assert(netdev != NULL);
+    assert(iolist != NULL);
 
     esp_wifi_netdev_t* dev = (esp_wifi_netdev_t*)netdev;
 
@@ -355,9 +358,8 @@ static int _esp_wifi_recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
     DEBUG("%s: %p %p %u %p\n", __func__, netdev, buf, len, info);
 
-    CHECK_PARAM_RET (netdev != NULL, -ENODEV);
 
-    esp_wifi_netdev_t* dev = (esp_wifi_netdev_t*)netdev;
+    assert(netdev != NULL);
 
     mutex_lock(&dev->dev_lock);
 
@@ -403,8 +405,8 @@ static int _esp_wifi_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_l
 {
     DEBUG("%s: %s %p %p %u\n", __func__, netopt2str(opt), netdev, val, max_len);
 
-    CHECK_PARAM_RET (netdev != NULL, -ENODEV);
-    CHECK_PARAM_RET (val != NULL, -EINVAL);
+    assert(netdev != NULL);
+    assert(val != NULL);
 
     esp_wifi_netdev_t* dev = (esp_wifi_netdev_t*)netdev;
 
@@ -429,8 +431,8 @@ static int _esp_wifi_set(netdev_t *netdev, netopt_t opt, const void *val, size_t
 {
     DEBUG("%s: %s %p %p %u\n", __func__, netopt2str(opt), netdev, val, max_len);
 
-    CHECK_PARAM_RET (netdev != NULL, -ENODEV);
-    CHECK_PARAM_RET (val != NULL, -EINVAL);
+    assert(netdev != NULL);
+    assert(val != NULL);
 
     switch (opt) {
         case NETOPT_ADDRESS:
@@ -446,7 +448,7 @@ static void _esp_wifi_isr(netdev_t *netdev)
 {
     DEBUG("%s: %p\n", __func__, netdev);
 
-    CHECK_PARAM (netdev != NULL);
+    assert(netdev != NULL);
 
     esp_wifi_netdev_t *dev = (esp_wifi_netdev_t *) netdev;
 

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -66,12 +66,14 @@
 
 #define MAC_STR                         "%02x:%02x:%02x:%02x:%02x:%02x"
 #define MAC_STR_ARG(m)                  m[0], m[1], m[2], m[3], m[4], m[5]
+
+/*
  * There is only one ESP WiFi device. We define it as static device variable
  * to have accesss to the device inside ESP WiFi interrupt routines which do
  * not provide an argument that could be used as pointer to the ESP WiFi
  * device which triggers the interrupt.
  */
-esp_wifi_netdev_t _esp_wifi_dev;
+static esp_wifi_netdev_t _esp_wifi_dev;
 static const netdev_driver_t _esp_wifi_driver;
 
 /*
@@ -334,8 +336,6 @@ void esp_wifi_setup (esp_wifi_netdev_t* dev)
 
     /* initialize netdev data structure */
     dev->connected = false;
-
-    mutex_init(&dev->dev_lock);
 }
 
 static int _esp_wifi_init(netdev_t *netdev)

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.h
@@ -37,18 +37,10 @@ typedef struct
 {
     netdev_t netdev;                   /**< netdev parent struct */
 
-    uint16_t rx_len;                   /**< number of bytes received */
-    uint8_t rx_buf[ETHERNET_MAX_LEN];  /**< receive buffer */
-
-    uint16_t tx_len;                   /**< number of bytes in transmit buffer */
-    uint8_t tx_buf[ETHERNET_MAX_LEN];  /**< transmit buffer */
-
     uint32_t event;                    /**< received event */
     bool connected;                    /**< indicates whether connected to AP */
 
     gnrc_netif_t* netif;               /**< reference to the corresponding netif */
-
-    mutex_t dev_lock;                  /**< device is already in use */
 
 } esp_wifi_netdev_t;
 


### PR DESCRIPTION
### Contribution description

This PR provides several improvements and cleanups that

- reduces packet loss rate
- increases stability
- provides code similarity with `esp_wifi` of ESP8266 for future code deduplication

In detail the PR provides the following changes:

1. Receive call back function `_esp_wifi_rx_cb` is called from WiFi hardware driver with a pointer to a frame buffer that is allocated in the WiFi hardware driver. This frame buffer was freed immediately after copying its content to a single local receive buffer of the `esp_wifi` netdev. The local receive buffer then remained occupied until the protocol stack had processed it. Further incoming packets were dropped. 
  Very often, however, multiple consecutive WiFi frames are received simultaneously before the first is fully processed. Having the local receive buffer to hold only one received frame, led to a number of lost packets, even at low network load.
   Therefore, a ringbuffer of `rx_buf` elements was introduced which doesn't store the frames directly but only references to the frame buffers allocated in WiFi hardware driver. Since there is enough memory for a number of such frames, the frames buffers allocated in the WiFi hardware driver are no longer freed immediately, but are kept until the frame has been processed by the protocol stack. This leads to a much lower loss rate of packets.
2. Instead of having a send buffer as member `esp_wifi` netdev, a local variable is now used as send buffer. This avoids the need for a locking mechanism and reduces the risk of deadlocks.
3. Events of different types can be pending at the same time. Therefore it is not possible to use ascending identifiers for the presence of pending events. Rather, each event type has to be represented by one bit. Thes bits ORed identify all types of pending events. In the `esp_wifi_isr` function all pending events are then handled in one call. Otherwise, some events might be lost.
4. Parameter checks were replaced by assertions.
5. Some small cleanups.

### Testing procedure

Compile and flash `examples/gnrc_networking` to one ESP32 node.
```
USEMODULE='esp_wifi' CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"passphrase\"' make BOARD=esp32-wroom-32 -C examples/gnrc_networking flash
```
1. Simultaneously ping the ESP32 node from different terminals or machines with very high, but different rates and different payload sizes:
   ```
   term 1> ping6 <ipv6_address>%eth0 -i 0.001
   ```
   ```
   term 2> ping6 <ipv6_address>%eth0 -i 0.004 -s 1200
   ```
   ```
   term 3> ping6 <ipv6_address>%eth0 -i 0.008 -s 1392
   ```
   The loss rate should be 0 % for all pings.

   Compare with current master, where the loss rates is already 20 % with only one ping.
   ```
   term 1> ping6 <ipv6_address>%eth0 -i 0.08
   ```
   The reason is the missing ring buffer for simultaneous incoming WiFi frames.

2. Again, simultaneously ping the ESP32 node from different terminals or machines with high, but different rates and different payload sizes. Additionally, send UDP packets from the ESP32 node:

   ```
   term 1> ping6 <ipv6_address>%eth0 -i 0.02
   ```
   ```
   term 2> ping6 <ipv6_address>%eth0 -i 0.03 -s 1200
   ```
   ```
   term 3> ping6 <ipv6_address>%eth0 -i 0.04 -s 1392
   ```
   ```
   term 4> nc -6ul 12345
   ```
   ```
   esp32> udp send <ipv6_address of term4> 12345 "." 10000 10000
   ```
   Once the udp command has been finished, stop `nc` with
   ```
   term 5> killall -TERM nc
   ```
   and check the number of characters received by `nc`. It should be 10.000, that is 0 % loss rate. Also the ping commands should still have a loss rate of 0 %.
  
### Issues/PRs references

Depends on PR #11947 