### PR TITLE
cpu/atmega_common: wrappers for memory management function to avoid preemption

### DIFF
--- a/cpu/atmega_common/avr_libc_extra/posix_unistd.c
+++ b/cpu/atmega_common/avr_libc_extra/posix_unistd.c
@@ -21,6 +21,7 @@
 
 #ifdef MODULE_VFS
 #include <fcntl.h>
+#include "irq.h"
 #include "vfs.h"
 #elif defined(MODULE_STDIO_UART)
 #include "stdio_uart.h"
@@ -173,6 +174,47 @@ ssize_t write(int fd, const void *src, size_t count)
     errno = ENODEV;
     return -1;
 #endif
+}
+
+/*
+ * Following functions are wrappers around the according avr-libc system
+ * functions to avoid their preemption by disabling the interrupts for the
+ * time of their execution.
+ */
+extern void *__real_malloc(size_t size);
+extern void __real_free(void *ptr);
+extern void *__real_calloc(size_t nmemb, size_t size);
+extern void *__real_realloc(void *ptr, size_t size);
+
+void *__wrap_malloc(size_t size)
+{
+    unsigned state = irq_disable();
+    void *ptr = __real_malloc(size);
+    irq_restore(state);
+    return ptr;
+}
+
+void __wrap_free(void *ptr)
+{
+    unsigned state = irq_disable();
+    __real_free(ptr);
+    irq_restore(state);
+}
+
+void *__wrap_calloc(size_t nmemb, size_t size)
+{
+    unsigned state = irq_disable();
+    void *ptr = __real_calloc(nmemb, size);
+    irq_restore(state);
+    return ptr;
+}
+
+void *__wrap_realloc(void *ptr, size_t size)
+{
+    unsigned state = irq_disable();
+    void *new = __real_realloc(ptr, size);
+    irq_restore(state);
+    return new;
 }
 
 /** @} */

--- a/makefiles/arch/atmega.inc.mk
+++ b/makefiles/arch/atmega.inc.mk
@@ -41,6 +41,9 @@ LDSCRIPT_COMPAT = $(if $(shell $(TARGET_ARCH)-ld --verbose | grep __TEXT_REGION_
                     -T$(RIOTCPU)/$(CPU)/ldscripts_compat/avr_2.26.ld)
 LINKFLAGS += $(LDSCRIPT_COMPAT)
 
+# use the wrapper functions for following avr-libc functions
+LINKFLAGS += -Wl,-wrap=malloc -Wl,-wrap=calloc -Wl,-wrap=realloc -Wl,-wrap=free
+
 ifeq ($(LTO),1)
   # avr-gcc <4.8.3 has a bug when using LTO which causes a warning to be printed always:
   # '_vector_25' appears to be a misspelled signal handler [enabled by default]


### PR DESCRIPTION
### Contribution description

This PR is an aproach to fix the problem described in #10842.

Memory management function like `malloc`, `calloc`, `realloc` and `free` must not be preempted when they operate on allocator structures. To avoid such a preemption, wrappers around these functions are used which simply disable all interrupts for the time of their execution.

This approach produces 78 additional bytes of code.

### Testing procedure

Flash and run `tests/malloc`.

### Issues/PRs references

Fixes #10842 