### PR TITLE
net/gnrc/tcp: fix invalid read

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -162,6 +162,7 @@ static int _receive(gnrc_pktsnip_t *pkt)
             return -ENOMSG;
         }
         pkt->type = GNRC_NETTYPE_UNDEF;
+        hdr = (tcp_hdr_t *)tcp->data;
     }
 
     /* Validate checksum */


### PR DESCRIPTION
### Contribution description

From the `gnrc_pktbuf_mark` documentation:

	    It's not guaranteed that `result->data` points to the same address as the original `pkt->data.

Thus it should be necessary to update the `hdr` pointer.

### Testing procedure

1. Add `USEMODULE += gnrc_pktbuf_malloc` to `tests/gnrc_tcp_server/Makefile`
2. Compile `gnrc_tcp_server` using `make -C tests/gnrc_tcp_server/ all-valgrind`
3. Start `gnrc_tcp_server` using `make -C tests/gnrc_tcp_server/ term-valgrind`
4. Send a short packet e.g. using `echo f | nc <ip> <port>`

**Expect output:** Valgrind shouldn't report any out-out-bounds memory access.

**Actual output:** Valgrind reports an `Invalid read of size 2` during checksum comparison.

```
==4765== Invalid read of size 2
==4765==    at 0x114859: _receive (sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c:168)
==4765==    by 0x114B01: _event_loop (sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c:255)
==4765==    by 0x499D53A: makecontext (/build/glibc-Stc26X/glibc-2.28/stdlib/../sysdeps/unix/sysv/linux/i386/makecontext.S:91)
==4765==  Address 0x4b41ac0 is 16 bytes inside a block of size 22 free'd
==4765==    at 0x4836C47: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-x86-linux.so)
==4765==    by 0x110853: _mark (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:134)
==4765==    by 0x11092C: gnrc_pktbuf_mark (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:153)
==4765==    by 0x114824: _receive (sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c:158)
==4765==    by 0x114B01: _event_loop (sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c:255)
==4765==    by 0x499D53A: makecontext (/build/glibc-Stc26X/glibc-2.28/stdlib/../sysdeps/unix/sysv/linux/i386/makecontext.S:91)
==4765==  Block was alloc'd at
==4765==    at 0x483463B: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-x86-linux.so)
==4765==    by 0x1107F9: _mark (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:127)
==4765==    by 0x11092C: gnrc_pktbuf_mark (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:153)
==4765==    by 0x11C181: _receive (sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c:706)
==4765==    by 0x11B5F9: _event_loop (sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c:188)
==4765==    by 0x499D53A: makecontext (/build/glibc-Stc26X/glibc-2.28/stdlib/../sysdeps/unix/sysv/linux/i386/makecontext.S:91)
```