### PR TITLE
gnrc_tcp: Fix memory leak, potential DOS

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -219,6 +219,7 @@ static int _receive(gnrc_pktsnip_t *pkt)
             _pkt_build_reset_from_pkt(&reset, pkt);
             gnrc_netapi_send(gnrc_tcp_pid, reset);
         }
+        gnrc_pktbuf_release(pkt);
         return -ENOTCONN;
     }
     gnrc_pktbuf_release(pkt);


### PR DESCRIPTION
#### Description

I believe I found a memory leak in `gnrc_tcp` which occurs during a faulty TCP handshake, e.g. by sending an ACK instead of SYN as the first packet.

#### Steps to reproduce the issue

The sample packet used below contains a hard-coded IP address, thus it is important to configure RIOT to use that IP address. Otherwise it will reject the packet. On `native` start `tests/gnrc_tcp_server` as follows:

1. Make sure the IP address of your TAP interface is `fe80::e87d:b3ff:fe8b:4f01` and make sure RIOT uses `fe80::e87d:b3ff:fe8b:4f02`.
2. Add `USEMODULE += gnrc_pktbuf_malloc` to `tests/gnrc_tcp_server/Makefile`.
3. Compile `gnrc_tcp_server` using: `TCP_SERVER_ADDR=fe80::e87d:b3ff:fe8b:4f02 TCP_SERVER_PORT=4223 make -C tests/gnrc_tcp_server/ all-valgrind`
4. Invoke `gnrc_tcp_server`: `make -C tests/gnrc_tcp_server/`

Using `socat` send a packet to the `gnrc_tcp_server`. This will probably require superuser privileges as it creates a raw IP socket:

```
# echo rwsQf2pekYLaU+exUBBwgPDKAAA= | base64 -d | socat -u STDIN IP6-SENDTO:[fe80::e87d:b3ff:fe8b:4f02%tap0]:6
```

This can be repeated multiple times. Afterwards, terminate the `gnrc_tcp_server` application by sending it a SIGINT.

#### Expected results

valgrind shouldn't report any memory leaks.

#### Actual results

Depending on how often the aforementioned packet has been send to RIOT valgrind reports a memory leak. For example:

```
==16184== 420 (60 direct, 360 indirect) bytes in 3 blocks are definitely lost in loss record 6 of 6
==16184==    at 0x483463B: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-x86-linux.so)
==16184==    by 0x110DC3: _create_snip (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:276)
==16184==    by 0x1106EC: gnrc_pktbuf_add (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:97)
==16184==    by 0x124238: _recv (sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c:168)
==16184==    by 0x1100AB: _event_cb (sys/net/gnrc/netif/gnrc_netif.c:1425)
==16184==    by 0x124B8A: _isr (cpu/native/netdev_tap/netdev_tap.c:100)
==16184==    by 0x10FE83: _gnrc_netif_thread (sys/net/gnrc/netif/gnrc_netif.c:1329)
==16184==    by 0x499D53A: makecontext (/build/glibc-Stc26X/glibc-2.28/stdlib/../sysdeps/unix/sysv/linux/i386/makecontext.S:91
```

#### Impact

IMHO this is a potential DOS as it allows an attacker to consume all pktbuf memory.

#### Related Issues

#11999