### PR TITLE
cpu/nrf5x: fix bitrate doc for nrfmin driver

### DIFF
--- a/cpu/nrf5x_common/include/nrfmin.h
+++ b/cpu/nrf5x_common/include/nrfmin.h
@@ -21,7 +21,7 @@
  *    -> we define host byte order := network byte order
  *
  * The driver is using a Nordic proprietary physical layer, configured to a
- * bitrate of 2Mbit. The maximum payload length can be freely configured, but
+ * bitrate of 1 Mbit/s. The maximum payload length can be freely configured, but
  * the maximal supported value is 250 byte (default is 200 byte).
  *
  * We define the nrfmin link layer to use 16-bit addresses. On the physical


### PR DESCRIPTION
# Contribution description
The documentation of the `nrfmin` driver contained an error: the driver is per default configured to a bitrate of 1 Mbit/s, and not 2 (-> see https://github.com/RIOT-OS/RIOT/blob/master/cpu/nrf5x_common/radio/nrfmin/nrfmin.c#L45)

### Testing procedure
None needed, just verify the doc.

### Issues/PRs references
none