### PR TITLE
cpu/stm32: Fix read bytes flag for i2c_2

### DIFF
--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -218,6 +218,10 @@ int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,
     I2C_TypeDef *i2c = i2c_config[dev].dev;
     DEBUG("[i2c] read_bytes: Starting\n");
 
+    /* Do not support repeated start reading */
+    if ((i2c->SR2 & I2C_SR2_BUSY) && !(flags & I2C_NOSTART)) {
+        return -EOPNOTSUPP;
+    }
     int ret = _start(i2c, (address << 1) | I2C_FLAG_READ, flags, length);
     if (ret < 0) {
         if (ret == -ETIMEDOUT) {


### PR DESCRIPTION
#Contribution description

This commit stops a repeated start read which causes slave bus lockup.
When trying to do a repeated start read on i2c_read_bytes it returns -EOPNOTSUPP error.
This fixes the problem of trying to read, getting a timeout error and the slave still thinks it needs to send data holding the sda line.


### Testing procedure

Run the `tests/periph_i2c` HiL test.  The CI should show the fix in all STM32 F1, F2, L1, and F4 families.

### Issues/PRs references
