### PR TITLE
tests/xtimer_mutex_lock_timeout: New test

### DIFF
--- a/tests/xtimer_mutex_lock_timeout/Makefile
+++ b/tests/xtimer_mutex_lock_timeout/Makefile
@@ -1,6 +1,16 @@
 include ../Makefile.tests_common
 
+# copied from shell test
+BOARD_INSUFFICIENT_MEMORY = arduino-duemilanove \
+                             arduino-leonardo \
+                             arduino-nano \
+                             arduino-uno
+
 USEMODULE += xtimer
 USEMODULE += shell
+
+#for testing
+#USEMODULE += ps
+#USEMODULE += shell_commands
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_mutex_lock_timeout/main.c
+++ b/tests/xtimer_mutex_lock_timeout/main.c
@@ -19,7 +19,6 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include "shell.h"
 #include "xtimer.h"
 

--- a/tests/xtimer_mutex_lock_timeout/main.c
+++ b/tests/xtimer_mutex_lock_timeout/main.c
@@ -77,6 +77,9 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
         puts("error: mutex timed out");
     }
 
+    /* to make the test easier to read */
+    printf("\n");
+
     return 0;
 }
 
@@ -113,6 +116,9 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
             puts("error mutex not locked");
         }
     }
+
+    /* to make the test easier to read */
+    printf("\n");
 
     return 0;
 }

--- a/tests/xtimer_mutex_lock_timeout/main.c
+++ b/tests/xtimer_mutex_lock_timeout/main.c
@@ -45,9 +45,9 @@ static int cmd_test_xtimer_mutex_lock_timeout_low_prio_thread(int argc,
  * @brief   List of command for this application.
  */
 static const shell_command_t shell_commands[] = {
-    { "mutex_timeout_long_unlocked", "unlocked mutex with long timeout",
+    { "mutex_timeout_long_unlocked", "unlocked mutex (no-spin timeout)",
       cmd_test_xtimer_mutex_lock_timeout_long_unlocked, },
-    { "mutex_timeout_long_locked", "locked mutex with long timeout",
+    { "mutex_timeout_long_locked", "locked mutex (no-spin timeout)",
       cmd_test_xtimer_mutex_lock_timeout_long_locked, },
     { "mutex_timeout_long_locked_low",
       "lock low-prio-locked-mutex from high-prio-thread (no-spin timeout)",

--- a/tests/xtimer_mutex_lock_timeout/main.c
+++ b/tests/xtimer_mutex_lock_timeout/main.c
@@ -21,9 +21,15 @@
 #include <stdio.h>
 #include "shell.h"
 #include "xtimer.h"
+#include "thread.h"
+#include "msg.h"
+#include "irq.h"
 
 /* timeout at one millisecond (1000 us) to make sure it does not spin. */
 #define LONG_MUTEX_TIMEOUT 1000
+
+/* main Thread PID */
+static kernel_pid_t main_thread_pid;
 
 /**
  * Foward declarations
@@ -32,6 +38,8 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
                                                             char **argv);
 static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
                                                           char **argv);
+static int cmd_test_xtimer_mutex_lock_timeout_low_prio_thread(int argc,
+                                                              char **argv);
 
 /**
  * @brief   List of command for this application.
@@ -41,8 +49,40 @@ static const shell_command_t shell_commands[] = {
       cmd_test_xtimer_mutex_lock_timeout_long_unlocked, },
     { "mutex_timeout_long_locked", "locked mutex with long timeout",
       cmd_test_xtimer_mutex_lock_timeout_long_locked, },
+    { "mutex_timeout_long_locked_low",
+      "lock low-prio-locked-mutex from high-prio-thread (no-spin timeout)",
+      cmd_test_xtimer_mutex_lock_timeout_low_prio_thread, },
     { NULL, NULL, NULL }
 };
+
+/**
+ * @brief   stack for
+ *          cmd_test_xtimer_mutex_lock_timeout_low_prio_thread
+ *          not enough stack for doing printf only use puts
+ */
+static char t_stack[THREAD_STACKSIZE_DEFAULT];
+
+/**
+ * @brief   thread function for
+ *          cmd_test_xtimer_mutex_lock_timeout_low_prio_thread
+ */
+void *thread_low_prio_test(void *arg)
+{
+    mutex_t *test_mutex = (mutex_t *)arg;
+    msg_t msg;
+
+    puts("THREAD low prio: start");
+
+    mutex_lock(test_mutex);
+    thread_wakeup(main_thread_pid);
+
+    mutex_unlock(test_mutex);
+    (void)irq_disable();
+    puts("THREAD low prio: exiting low");
+    msg_send_int(&msg, main_thread_pid);
+
+    sched_task_exit();
+}
 
 /**
  * @brief   shell command to test xtimer_mutex_lock_timeout
@@ -76,7 +116,6 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
     else {
         puts("error: mutex timed out");
     }
-
     /* to make the test easier to read */
     printf("\n");
 
@@ -116,6 +155,73 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
             puts("error mutex not locked");
         }
     }
+    /* to make the test easier to read */
+    printf("\n");
+
+    return 0;
+}
+
+/**
+ * @brief   shell command to test xtimer_mutex_lock_timeout
+ *
+ * This function will create a new thread with lower prio
+ * than the main thread (this function should be called from
+ * the main thread). The new thread will get a mutex and will
+ * lock it. This function (main thread) calls xtimer_mutex_lock_timeout.
+ * The other thread will then unlock the mutex. The main
+ * thread gets the mutex and wakes up. The timer will not
+ * trigger because the main threads gets the mutex.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return 0 always
+ */
+static int cmd_test_xtimer_mutex_lock_timeout_low_prio_thread(int argc,
+                                                              char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("starting test: xtimer mutex lock timeout with thread");
+    mutex_t test_mutex = MUTEX_INIT;
+    main_thread_pid = thread_getpid();
+    int current_thread_count = sched_num_threads;
+    printf("threads = %d\n", current_thread_count);
+    kernel_pid_t test_thread = thread_create(t_stack, sizeof(t_stack),
+                                             THREAD_PRIORITY_MAIN + 1,
+                                             THREAD_CREATE_STACKTEST,
+                                             thread_low_prio_test,
+                                             (void *)&test_mutex,
+                                             "thread_low_prio_test");
+    (void)test_thread;
+
+    thread_sleep();
+
+    puts("MAIN THREAD: calling xtimer_mutex_lock_timeout");
+
+    if (xtimer_mutex_lock_timeout(&test_mutex, LONG_MUTEX_TIMEOUT) == 0) {
+        /* mutex has to be locked */
+        if (mutex_trylock(&test_mutex) == 0) {
+            puts("OK");
+        }
+        else {
+            puts("error mutex not locked");
+        }
+    }
+    else {
+        puts("error: mutex timed out");
+    }
+
+    current_thread_count = sched_num_threads;
+    printf("threads = %d\n", current_thread_count);
+
+    /* to end the created thread */
+    msg_t msg;
+    puts("MAIN THREAD: waiting for created thread to end");
+    msg_receive(&msg);
+
+    current_thread_count = sched_num_threads;
+    printf("threads = %d\n", current_thread_count);
 
     /* to make the test easier to read */
     printf("\n");

--- a/tests/xtimer_mutex_lock_timeout/tests/01-run.py
+++ b/tests/xtimer_mutex_lock_timeout/tests/01-run.py
@@ -27,6 +27,17 @@ def testfunc(child):
     child.expect("starting test: xtimer mutex lock timeout")
     child.expect("OK")
     child.expect_exact("> ")
+    child.sendline("mutex_timeout_long_locked_low")
+    child.expect("starting test: xtimer mutex lock timeout with thread")
+    child.expect("threads = 2")
+    child.expect("THREAD low prio: start")
+    child.expect("MAIN THREAD: calling xtimer_mutex_lock_timeout")
+    child.expect("OK")
+    child.expect("threads = 3")
+    child.expect("MAIN THREAD: waiting for created thread to end")
+    child.expect("THREAD low prio: exiting low")
+    child.expect("threads = 2")
+    child.expect_exact("> ")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
Tracking: pr #11660

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Implements a new function for `xtimer_mutex_lock_timeout` to make sure the function works with threads. The new function tests `xtimer_mutex_lock_timeout` by locking the mutex from another thread, calling `xtimer_mutex_lock_timeout` and unlocking the mutex from the other thread before the timeout ends. 

(The test also shows that the created thread exits/ends)

The test also prints a empty line after each test function to make it easier to read and removes a wrong include.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
`BOARD=native make -C tests/xtimer_mutex_lock_timeout/ flash test`
it outputs:
```
...
> mutex_timeout_long_unlocked
mutex_timeout_long_unlocked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked
mutex_timeout_long_locked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked_low
mutex_timeout_long_locked_low
starting test: xtimer mutex lock timeout with thread
threads = 2
THREAD low prio: start
MAIN THREAD: calling xtimer_mutex_lock_timeout
OK
threads = 3
MAIN THREAD: waiting for created thread to end
THREAD low prio: exiting low
threads = 2

> 
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
tracking #11660
