### PR TITLE
dist/tools/build_system_sanity_check: check BOARD set as ?=

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -126,6 +126,19 @@ check_deprecated_vars_patterns() {
         | error_with_message 'Deprecated variables or patterns:'
 }
 
+# Applications Makefile must not set 'BOARD =' unconditionally
+check_not_setting_board_equal() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e '^[[:space:]]*BOARD[[:space:]]*=')
+
+    pathspec+=('**/Makefile')
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message 'Applications Makefile should use "BOARD ?="'
+}
+
 error_on_input() {
     ! grep ''
 }
@@ -134,6 +147,7 @@ all_checks() {
     check_not_parsing_features
     check_not_exporting_variables
     check_deprecated_vars_patterns
+    check_not_setting_board_equal
 }
 
 main() {

--- a/tests/board_microbit/Makefile
+++ b/tests/board_microbit/Makefile
@@ -1,6 +1,6 @@
-include ../Makefile.tests_common
+BOARD ?= microbit
 
-BOARD = microbit
+include ../Makefile.tests_common
 
 # This test application is for the BBC micro:bit only
 BOARD_WHITELIST := microbit

--- a/tests/cpu_efm32_features/Makefile
+++ b/tests/cpu_efm32_features/Makefile
@@ -1,6 +1,5 @@
+BOARD ?= sltb001a
 include ../Makefile.tests_common
-
-BOARD = sltb001a
 
 BOARD_WHITELIST := ikea-tradfri \
                    slstk3401a \


### PR DESCRIPTION
### Contribution description

Applications Makefile must not set 'BOARD =' unconditionally but
'BOARD ?='.

Also fix the two tests that were wrong.

### Testing procedure

The check executes without error:


```
./dist/tools/buildsystem_sanity_check/check.sh
```


Without the fix it found the errors:

```
git revert HEAD^ --no-commit
./dist/tools/buildsystem_sanity_check/check.sh
Invalid build system patterns found by ./dist/tools/buildsystem_sanity_check/check.sh:
Applications Makefile should use "BOARD ?="
        tests/board_microbit/Makefile:BOARD = microbit
        tests/cpu_efm32_features/Makefile:BOARD = sltb001a
```

This also led to not honoring the board configuration from the environment in master:

```
BOARD=ikea-tradfri make --no-print-directory -C tests/cpu_efm32_features/ info-debug-variable-BOARD
sltb001a
```

And now fixed with this PR:

```
BOARD=ikea-tradfri make --no-print-directory -C tests/cpu_efm32_features/ info-debug-variable-BOARD
ikea-tradfri
```

### Issues/PRs references

Found while debugging https://github.com/RIOT-OS/RIOT/pull/11477