### PR TITLE
pkg/nimble: init GATT svr during sys init

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -53,6 +53,7 @@ PSEUDOMODULES += netstats_l2
 PSEUDOMODULES += netstats_ipv6
 PSEUDOMODULES += netstats_rpl
 PSEUDOMODULES += nimble
+PSEUDOMODULES += nimble_gatts_init
 PSEUDOMODULES += newlib
 PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -3,6 +3,8 @@ PKG_URL     = https://github.com/apache/mynewt-nimble.git
 PKG_VERSION = 997dad8c9fc549e64b6c54eafcec109d92789418
 PKG_LICENSE = Apache-2.0
 
+PKG_SOURCE_LOCAL = /home/hauke/dev/ble/mynewt-nimble
+
 TDIR = $(RIOTPKG)/$(PKG_NAME)
 PDIR = $(PKG_BUILDDIR)
 
@@ -18,7 +20,8 @@ else
   CFLAGS += -Wno-unused-but-set-variable
 endif
 
-SUBMODS := $(filter nimble_%,$(USEMODULE))
+PSEUDOMODS := nimble_gatts_init
+SUBMODS := $(filter-out $(PSEUDOMODS),$(filter nimble_%,$(USEMODULE)))
 
 .PHONY: all
 

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -26,6 +26,10 @@ ifneq (,$(filter nimble_host,$(USEMODULE)))
   USEMODULE += nimble_host_store_ram
 endif
 
+ifneq (,$(filter nimble_svc_%,$(USEMODULE)))
+  USEMODULE += nimble_gatts_init
+endif
+
 # nimble controller dependencies
 ifneq (,$(filter nimble_controller,$(USEMODULE)))
   USEMODULE += nimble_transport_ram

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -110,4 +110,7 @@ void nimble_riot_init(void)
 #ifdef MODULE_NIMBLE_SVC_IPSS
     ble_svc_ipss_init();
 #endif
+#ifdef MODULE_NIMBLE_GATTS_INIT
+    ble_gatts_start();
+#endif
 }


### PR DESCRIPTION
# Contribution description
When using build-in GATT service in NimBLE, it makes sense to initialize them during system initialization. Otherwise users have to always call `ble_gatts_start()` in their user application. This is now only needed, if custom services are added (see e.g. `examples/nimble_gatt`).

NOTE: this PR currently leads to a hard-fault in the `examples/nimble_heart_rate_sensor` application. This seems to be a potential bug in the NimBLE code -> https://github.com/apache/mynewt-nimble/issues/556. So we need to resolve that issue until we can merge this PR... 


### Testing procedure
For example: remove the custom services and the `ble_gatts_start()` call from `examples/nimble_gatt/main.c`, connect to the device with a smartphone and verify that the build-in services (GATT, GAP) are present.

Or run the `nimble_gnrc` example from https://github.com/RIOT-OS/RIOT/pull/11578 combined with this PR and verify that the `IPSP` GATT service is present.

### Issues/PRs references
#11578 will make use of this PR