### PR TITLE
 boards: move CPU/CPU_MODEL definition to Makefile.features

### DIFF
--- a/boards/acd52832/Makefile.features
+++ b/boards/acd52832/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf52832xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi

--- a/boards/acd52832/Makefile.include
+++ b/boards/acd52832/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the acd52832
-export CPU_MODEL = nrf52832xxaa
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 

--- a/boards/airfy-beacon/Makefile.features
+++ b/boards/airfy-beacon/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf51x22xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c

--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU model
-export CPU_MODEL = nrf51x22xxaa
-
 # include common nrf51 boards module into the build
 USEMODULE += boards_common_nrf51
 

--- a/boards/arduino-duemilanove/Makefile.features
+++ b/boards/arduino-duemilanove/Makefile.features
@@ -1,3 +1,3 @@
-include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
+CPU = atmega328p
 
-include $(RIOTCPU)/atmega328p/Makefile.features
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.features

--- a/boards/arduino-duemilanove/Makefile.include
+++ b/boards/arduino-duemilanove/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the ardudino duemilanove board
-export CPU = atmega328p
-
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-leonardo/Makefile.features
+++ b/boards/arduino-leonardo/Makefile.features
@@ -1,3 +1,3 @@
-include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
+CPU = atmega32u4
 
-include $(RIOTCPU)/atmega32u4/Makefile.features
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.features

--- a/boards/arduino-leonardo/Makefile.include
+++ b/boards/arduino-leonardo/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the arduino uno board
-export CPU = atmega32u4
-
 PORT_LINUX      ?= /dev/ttyUSB0
 AVRDUDE_PORT    ?= /dev/ttyACM0
 PORT_DARWIN     ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-mega2560/Makefile.features
+++ b/boards/arduino-mega2560/Makefile.features
@@ -1,4 +1,4 @@
+CPU = atmega2560
+
 FEATURES_PROVIDED += puf_sram
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
-
-include $(RIOTCPU)/atmega2560/Makefile.features

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the arduino mega2560 board
-export CPU = atmega2560
-
 USEMODULE += boards_common_arduino-atmega
 
 # configure the terminal program

--- a/boards/arduino-mkr1000/Makefile.features
+++ b/boards/arduino-mkr1000/Makefile.features
@@ -1,3 +1,1 @@
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.features
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/arduino-mkrfox1200/Makefile.features
+++ b/boards/arduino-mkrfox1200/Makefile.features
@@ -1,3 +1,1 @@
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.features
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/arduino-mkrzero/Makefile.features
+++ b/boards/arduino-mkrzero/Makefile.features
@@ -1,3 +1,1 @@
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.features
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/arduino-nano/Makefile.features
+++ b/boards/arduino-nano/Makefile.features
@@ -1,3 +1,3 @@
-include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
+CPU = atmega328p
 
-include $(RIOTCPU)/atmega328p/Makefile.features
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.features

--- a/boards/arduino-nano/Makefile.include
+++ b/boards/arduino-nano/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the Arduino Nano board
-export CPU = atmega328p
-
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-uno/Makefile.features
+++ b/boards/arduino-uno/Makefile.features
@@ -1,3 +1,3 @@
-include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
+CPU = atmega328p
 
-include $(RIOTCPU)/atmega328p/Makefile.features
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.features

--- a/boards/arduino-uno/Makefile.include
+++ b/boards/arduino-uno/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the arduino uno board
-export CPU = atmega328p
-
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-zero/Makefile.features
+++ b/boards/arduino-zero/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samd21g18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/arduino-zero/Makefile.include
+++ b/boards/arduino-zero/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by Arduino/Genuino Zero board
-export CPU = samd21
-export CPU_MODEL = samd21g18a
-
 # set edbg device type
 EDBG_DEVICE_TYPE = atmel_cm0p
 

--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l0
+CPU_MODEL = stm32l072cz
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
@@ -12,5 +15,3 @@ FEATURES_PROVIDED += periph_uart
 # The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
 # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32l0
-export CPU_MODEL = stm32l072cz
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/b-l475e-iot01a/Makefile.features
+++ b/boards/b-l475e-iot01a/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l4
+CPU_MODEL = stm32l475vg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/b-l475e-iot01a/Makefile.include
+++ b/boards/b-l475e-iot01a/Makefile.include
@@ -1,7 +1,3 @@
-# the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l475vg
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/calliope-mini/Makefile.features
+++ b/boards/calliope-mini/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf51x22xxab
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_uart

--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU
-export CPU_MODEL = nrf51x22xxab
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/cc2650-launchpad/Makefile.features
+++ b/boards/cc2650-launchpad/Makefile.features
@@ -1,7 +1,8 @@
+CPU = cc26x0
+CPU_MODEL = cc26x0f128
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_i2c
-
-include $(RIOTCPU)/cc26x0/Makefile.features

--- a/boards/cc2650-launchpad/Makefile.include
+++ b/boards/cc2650-launchpad/Makefile.include
@@ -1,5 +1,3 @@
-export CPU       = cc26x0
-export CPU_MODEL = cc26x0f128
 export XDEBUGGER = XDS110
 
 # set default port depending on operating system

--- a/boards/cc2650stk/Makefile.features
+++ b/boards/cc2650stk/Makefile.features
@@ -1,7 +1,8 @@
+CPU = cc26x0
+CPU_MODEL = cc26x0f128
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/cc26x0/Makefile.features

--- a/boards/cc2650stk/Makefile.include
+++ b/boards/cc2650stk/Makefile.include
@@ -1,5 +1,3 @@
-export CPU       = cc26x0
-export CPU_MODEL = cc26x0f128
 export XDEBUGGER = XDS110
 
 # set default port depending on operating system

--- a/boards/chronos/Makefile.features
+++ b/boards/chronos/Makefile.features
@@ -1,7 +1,8 @@
+CPU = cc430
+CPU_MODEL = cc430f6137
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_rtc
 
 # Various other features (if any)
-
-include $(RIOTCPU)/cc430/Makefile.features

--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = cc430
-export CPU_MODEL = cc430f6137
-
 # flasher configuration
 FLASHFILE ?= $(HEXFILE)
 FLASHER = mspdebug

--- a/boards/common/arduino-due/Makefile.features
+++ b/boards/common/arduino-due/Makefile.features
@@ -1,3 +1,6 @@
+CPU = sam3
+CPU_MODEL = sam3x8e
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
-
-include $(RIOTCPU)/sam3/Makefile.features

--- a/boards/common/arduino-due/Makefile.include
+++ b/boards/common/arduino-due/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the arduino due based boards
-export CPU = sam3
-export CPU_MODEL = sam3x8e
-
 # export this module and its includes
 USEMODULE += boards_common_arduino_due
 INCLUDES  += -I$(RIOTBOARD)/common/arduino-due/include

--- a/boards/common/arduino-mkr/Makefile.features
+++ b/boards/common/arduino-mkr/Makefile.features
@@ -1,3 +1,7 @@
+CPU = samd21
+CPU_MODEL = samd21g18a
+
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c

--- a/boards/common/arduino-mkr/Makefile.include
+++ b/boards/common/arduino-mkr/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by Arduino/Genuino MKR1000 board
-export CPU = samd21
-export CPU_MODEL = samd21g18a
-
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 

--- a/boards/common/iotlab/Makefile.features
+++ b/boards/common/iotlab/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f1
+CPU_MODEL = stm32f103re
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt

--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -1,7 +1,3 @@
-# the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103re
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))

--- a/boards/common/kw41z/Makefile.dep
+++ b/boards/common/kw41z/Makefile.dep
@@ -2,5 +2,3 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_adc
   USEMODULE += saul_gpio
 endif
-
-include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/common/kw41z/Makefile.features
+++ b/boards/common/kw41z/Makefile.features
@@ -1,3 +1,6 @@
+CPU = kinetis
+CPU_MODEL = mkw41z512vht4
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_rtc
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/common/kw41z/Makefile.include
+++ b/boards/common/kw41z/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the board
-export CPU = kinetis
-export CPU_MODEL = mkw41z512vht4
-
 # include this module into the build
 INCLUDES += -I$(RIOTBOARD)/common/kw41z/include
 

--- a/boards/common/msb-430/Makefile.features
+++ b/boards/common/msb-430/Makefile.features
@@ -1,1 +1,2 @@
-include $(RIOTCPU)/msp430fxyz/Makefile.features
+CPU = msp430fxyz
+CPU_MODEL = msp430f1612

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = msp430fxyz
-export CPU_MODEL = msp430f1612
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/common/msba2/Makefile.features
+++ b/boards/common/msba2/Makefile.features
@@ -1,1 +1,1 @@
-include $(RIOTCPU)/lpc2387/Makefile.features
+CPU = lpc2387

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -1,8 +1,5 @@
 BOARDS_COMMON_MSBA2_DIR := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
-## the cpu to build for
-export CPU = lpc2387
-
 # Compile `lpc2k_pgm` when required
 # It is still compiling in `boards` as it was the case before introducing the
 # rule to autobuild

--- a/boards/common/nrf51/Makefile.features
+++ b/boards/common/nrf51/Makefile.features
@@ -1,8 +1,8 @@
+CPU = nrf51
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 
 # Various other features (if any)
 FEATURES_PROVIDED += ble_nimble
-
--include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/common/nrf51/Makefile.include
+++ b/boards/common/nrf51/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU
-export CPU = nrf51
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf52840xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi

--- a/boards/common/particle-mesh/Makefile.include
+++ b/boards/common/particle-mesh/Makefile.include
@@ -1,5 +1,3 @@
-export CPU_MODEL = nrf52840xxaa
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/common/remote/Makefile.features
+++ b/boards/common/remote/Makefile.features
@@ -1,1 +1,2 @@
-include $(RIOTCPU)/cc2538/Makefile.features
+CPU = cc2538
+CPU_MODEL = cc2538sf53

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the RE-mote board
-export CPU       =  cc2538
-export CPU_MODEL =  cc2538sf53
-
 # define the default flash-tool
 export PROGRAMMER ?= cc2538-bsl
 

--- a/boards/common/saml1x/Makefile.features
+++ b/boards/common/saml1x/Makefile.features
@@ -1,3 +1,5 @@
+CPU = saml1x
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -9,5 +11,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features on these boards (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/saml1x/Makefile.features

--- a/boards/common/saml1x/Makefile.include
+++ b/boards/common/saml1x/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the saml11 board
-export CPU = saml1x
-
 # set edbg device type
 EDBG_DEVICE_TYPE = mchp_cm23
 

--- a/boards/common/wsn430/Makefile.features
+++ b/boards/common/wsn430/Makefile.features
@@ -1,7 +1,8 @@
+CPU = msp430fxyz
+CPU_MODEL = msp430f1611
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -1,7 +1,3 @@
-# select the used CPU
-export CPU = msp430fxyz
-export CPU_MODEL = msp430f1611
-
 # include this module in the build
 USEMODULE += boards_common_wsn430
 # use common wsn430 includes

--- a/boards/f4vi1/Makefile.features
+++ b/boards/f4vi1/Makefile.features
@@ -1,5 +1,7 @@
+CPU = stm32f4
+CPU_MODEL = stm32f415rg
+
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the stm32f4-discovery board
-export CPU = stm32f4
-export CPU_MODEL = stm32f415rg
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samd21g18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -8,5 +11,3 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by Adafruit Feather M0 boards
-export CPU = samd21
-export CPU_MODEL = samd21g18a
-
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -1,8 +1,9 @@
+CPU = stm32f1
+CPU_MODEL = stm32f103re
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/fox/Makefile.include
+++ b/boards/fox/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103re
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/frdm-k22f/Makefile.dep
+++ b/boards/frdm-k22f/Makefile.dep
@@ -2,5 +2,3 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += saul_adc
 endif
-
-include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/frdm-k22f/Makefile.features
+++ b/boards/frdm-k22f/Makefile.features
@@ -1,3 +1,6 @@
+CPU = kinetis
+CPU_MODEL = mk22fn512vlh12
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/frdm-k22f/Makefile.include
+++ b/boards/frdm-k22f/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the board
-export CPU = kinetis
-export CPU_MODEL = mk22fn512vlh12
-
 # Include default FRDM board config
 include $(RIOTBOARD)/common/frdm/Makefile.include

--- a/boards/frdm-k64f/Makefile.dep
+++ b/boards/frdm-k64f/Makefile.dep
@@ -1,5 +1,3 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_adc
 endif
-
-include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -1,3 +1,6 @@
+CPU = kinetis
+CPU_MODEL = mk64fn1m0vll12
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/frdm-k64f/Makefile.include
+++ b/boards/frdm-k64f/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the FRDM-K64F board
-export CPU = kinetis
-export CPU_MODEL = mk64fn1m0vll12
-
 # Include default FRDM board config
 include $(RIOTBOARD)/common/frdm/Makefile.include

--- a/boards/hamilton/Makefile.features
+++ b/boards/hamilton/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samr21e18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-
--include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/hamilton/Makefile.include
+++ b/boards/hamilton/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by Hamilton
-export CPU = samd21
-export CPU_MODEL = samr21e18a
-
 # debugger config
 export JLINK_DEVICE := atsamr21e18a
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb

--- a/boards/i-nucleo-lrwan1/Makefile.features
+++ b/boards/i-nucleo-lrwan1/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l0
+CPU_MODEL = stm32l052t8
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
@@ -6,5 +9,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/i-nucleo-lrwan1/Makefile.include
+++ b/boards/i-nucleo-lrwan1/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32l0
-export CPU_MODEL = stm32l052t8
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/ikea-tradfri/Makefile.dep
+++ b/boards/ikea-tradfri/Makefile.dep
@@ -1,5 +1,3 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
-
-include $(RIOTCPU)/efm32/Makefile.dep

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -1,3 +1,6 @@
+CPU = efm32
+CPU_MODEL = efr32mg1p132f256gm32
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtc
@@ -5,5 +8,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by ikea-tradfri
-export CPU = efm32
-export CPU_MODEL = efr32mg1p132f256gm32
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/iotlab-a8-m3/Makefile.features
+++ b/boards/iotlab-a8-m3/Makefile.features
@@ -1,3 +1,1 @@
 include $(RIOTBOARD)/common/iotlab/Makefile.features
-
-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/iotlab-m3/Makefile.features
+++ b/boards/iotlab-m3/Makefile.features
@@ -1,5 +1,3 @@
 include $(RIOTBOARD)/common/iotlab/Makefile.features
 
 FEATURES_PROVIDED += periph_dma
-
-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/jiminy-mega256rfr2/Makefile.features
+++ b/boards/jiminy-mega256rfr2/Makefile.features
@@ -1,8 +1,8 @@
+CPU = atmega256rfr2
+
 # This board is based on an atmega CPU, thus import the features from it
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
 
 # Put defined MCU peripherals here (in alphabetical order)
 # Peripherals are defined in common/arduino-atmega/Makefile.features
 # Add only additional Peripherals
-
--include $(RIOTCPU)/atmega256rfr2/Makefile.features

--- a/boards/jiminy-mega256rfr2/Makefile.include
+++ b/boards/jiminy-mega256rfr2/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the jiminy board
-export CPU = atmega256rfr2
-
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/limifrog-v1/Makefile.features
+++ b/boards/limifrog-v1/Makefile.features
@@ -1,7 +1,8 @@
+CPU = stm32l1
+CPU_MODEL = stm32l151rc
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/limifrog-v1/Makefile.include
+++ b/boards/limifrog-v1/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32l1
-export CPU_MODEL = stm32l151rc
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/lobaro-lorabox/Makefile.features
+++ b/boards/lobaro-lorabox/Makefile.features
@@ -1,8 +1,9 @@
+CPU = stm32l1
+CPU_MODEL = stm32l151cb_a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32l1
-export CPU_MODEL = stm32l151cb_a
-
 # add the common header files to the include path
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/lsn50/Makefile.features
+++ b/boards/lsn50/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l0
+CPU_MODEL = stm32l072cz
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
@@ -12,5 +15,3 @@ FEATURES_PROVIDED += periph_uart
 # The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
 # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/lsn50/Makefile.include
+++ b/boards/lsn50/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32l0
-export CPU_MODEL = stm32l072cz
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/maple-mini/Makefile.features
+++ b/boards/maple-mini/Makefile.features
@@ -1,7 +1,8 @@
+CPU = stm32f1
+CPU_MODEL = stm32f103cb
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/maple-mini/Makefile.include
+++ b/boards/maple-mini/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the maple-mini board
-export CPU = stm32f1
-export CPU_MODEL = stm32f103cb
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/mbed_lpc1768/Makefile.features
+++ b/boards/mbed_lpc1768/Makefile.features
@@ -1,6 +1,6 @@
+CPU = lpc1768
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/lpc1768/Makefile.features

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the mbed_lpx1768 board
-export CPU = lpc1768
-
 FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
 DEBUGGER =
 DEBUGSERVER =

--- a/boards/mega-xplained/Makefile.features
+++ b/boards/mega-xplained/Makefile.features
@@ -1,3 +1,5 @@
+CPU = atmega1284p
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -7,5 +9,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-
--include $(RIOTCPU)/atmega1284p/Makefile.features

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the Mega Xplained board
-export CPU = atmega1284p
-
 # Found by checking fuse settings (2048 words so 4KB)
 # https://www.microchip.com/DevelopmentTools/ProductDetails/atmega1284p-xpld
 BOOTLOADER_SIZE ?= 4K

--- a/boards/microbit/Makefile.features
+++ b/boards/microbit/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf51x22xxab
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_uart

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU
-export CPU_MODEL = nrf51x22xxab
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f415rg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
@@ -6,5 +9,3 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/msbiot/Makefile.include
+++ b/boards/msbiot/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the msb-iot board
-export CPU = stm32f4
-export CPU_MODEL = stm32f415rg
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -1,3 +1,5 @@
+CPU = native
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
@@ -9,5 +11,3 @@ FEATURES_PROVIDED += periph_qdec
 # Various other features (if any)
 FEATURES_PROVIDED += ethernet
 FEATURES_PROVIDED += motor_driver
-
-include $(RIOTCPU)/native/Makefile.features

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -3,8 +3,6 @@ export NATIVEINCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 export NATIVEINCLUDES += -I$(RIOTBASE)/core/include/
 export NATIVEINCLUDES += -I$(RIOTBASE)/drivers/include/
 
-export CPU = native
-
 USEMODULE += native-drivers
 
 ifeq ($(shell uname -s),Darwin)

--- a/boards/nrf51dk/Makefile.features
+++ b/boards/nrf51dk/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf51x22xxac
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi

--- a/boards/nrf51dk/Makefile.include
+++ b/boards/nrf51dk/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU
-export CPU_MODEL = nrf51x22xxac
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/nrf51dongle/Makefile.features
+++ b/boards/nrf51dongle/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf51x22xxab
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nrf51dongle/Makefile.include
+++ b/boards/nrf51dongle/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU
-export CPU_MODEL = nrf51x22xxab
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/nrf52832-mdk/Makefile.features
+++ b/boards/nrf52832-mdk/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf52832xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nrf52832-mdk/Makefile.include
+++ b/boards/nrf52832-mdk/Makefile.include
@@ -1,5 +1,3 @@
-export CPU_MODEL = nrf52832xxaa
-
 # This board uses a DAP-Link programmer
 # Flashing support is provided through pyocd (default) and openocd.
 # For openocd, a version built against the development branch and containing

--- a/boards/nrf52840-mdk/Makefile.features
+++ b/boards/nrf52840-mdk/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf52840xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi

--- a/boards/nrf52840-mdk/Makefile.include
+++ b/boards/nrf52840-mdk/Makefile.include
@@ -1,5 +1,3 @@
-export CPU_MODEL = nrf52840xxaa
-
 # This board uses a DAP-Link programmer
 # Flashing support is provided through pyocd (default) and openocd.
 # For openocd, a version built against the development branch and containing

--- a/boards/nrf52840dk/Makefile.features
+++ b/boards/nrf52840dk/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf52840xxaa
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features
 
 # Various other features (if any)

--- a/boards/nrf52840dk/Makefile.include
+++ b/boards/nrf52840dk/Makefile.include
@@ -1,3 +1,1 @@
-export CPU_MODEL = nrf52840xxaa
-
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/nrf52dk/Makefile.features
+++ b/boards/nrf52dk/Makefile.features
@@ -1,2 +1,4 @@
+CPU_MODEL = nrf52832xxaa
+
 include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.features
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features

--- a/boards/nrf52dk/Makefile.include
+++ b/boards/nrf52dk/Makefile.include
@@ -1,3 +1,1 @@
-export CPU_MODEL = nrf52832xxaa
-
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/nucleo-f030r8/Makefile.features
+++ b/boards/nucleo-f030r8/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f0
+CPU_MODEL = stm32f030r8
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_pwm
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f030r8/Makefile.include
+++ b/boards/nucleo-f030r8/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f0
-export CPU_MODEL = stm32f030r8
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f031k6/Makefile.features
+++ b/boards/nucleo-f031k6/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f0
+CPU_MODEL = stm32f031k6
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_pwm
@@ -8,5 +11,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
-
-include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f031k6/Makefile.include
+++ b/boards/nucleo-f031k6/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f0
-export CPU_MODEL = stm32f031k6
-
 # load the common Makefile.include for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.include

--- a/boards/nucleo-f042k6/Makefile.features
+++ b/boards/nucleo-f042k6/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f0
+CPU_MODEL = stm32f042k6
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_pwm
@@ -8,5 +11,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
-
-include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f042k6/Makefile.include
+++ b/boards/nucleo-f042k6/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f0
-export CPU_MODEL = stm32f042k6
-
 # load the common Makefile.include for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.include

--- a/boards/nucleo-f070rb/Makefile.features
+++ b/boards/nucleo-f070rb/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f0
+CPU_MODEL = stm32f070rb
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -11,5 +14,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f070rb/Makefile.include
+++ b/boards/nucleo-f070rb/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f0
-export CPU_MODEL = stm32f070rb
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f072rb/Makefile.features
+++ b/boards/nucleo-f072rb/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f0
+CPU_MODEL = stm32f072rb
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -12,5 +15,3 @@ FEATURES_PROVIDED += periph_spi
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f072rb/Makefile.include
+++ b/boards/nucleo-f072rb/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f0
-export CPU_MODEL = stm32f072rb
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f091rc/Makefile.features
+++ b/boards/nucleo-f091rc/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f0
+CPU_MODEL = stm32f091rc
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
@@ -13,5 +16,3 @@ FEATURES_PROVIDED += periph_spi
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f091rc/Makefile.include
+++ b/boards/nucleo-f091rc/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f0
-export CPU_MODEL = stm32f091rc
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f103rb/Makefile.features
+++ b/boards/nucleo-f103rb/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f1
+CPU_MODEL = stm32f103rb
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/nucleo-f103rb/Makefile.include
+++ b/boards/nucleo-f103rb/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103rb
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f2
+CPU_MODEL = stm32f207zg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
@@ -12,5 +15,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f2/Makefile.features

--- a/boards/nucleo-f207zg/Makefile.include
+++ b/boards/nucleo-f207zg/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f207 board
-export CPU = stm32f2
-export CPU_MODEL = stm32f207zg
-
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f302r8/Makefile.features
+++ b/boards/nucleo-f302r8/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f3
+CPU_MODEL = stm32f302r8
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -11,5 +14,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f302r8/Makefile.include
+++ b/boards/nucleo-f302r8/Makefile.include
@@ -1,6 +1,2 @@
-# the cpu to build for
-export CPU = stm32f3
-export CPU_MODEL = stm32f302r8
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f303k8/Makefile.features
+++ b/boards/nucleo-f303k8/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f3
+CPU_MODEL = stm32f303k8
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
-
-include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303k8/Makefile.include
+++ b/boards/nucleo-f303k8/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f3
-export CPU_MODEL = stm32f303k8
-
 # load the common Makefile.include for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.include

--- a/boards/nucleo-f303re/Makefile.features
+++ b/boards/nucleo-f303re/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f3
+CPU_MODEL = stm32f303re
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -11,5 +14,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303re/Makefile.include
+++ b/boards/nucleo-f303re/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f3
-export CPU_MODEL = stm32f303re
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f303ze/Makefile.features
+++ b/boards/nucleo-f303ze/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f3
+CPU_MODEL = stm32f303ze
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo 144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303ze/Makefile.include
+++ b/boards/nucleo-f303ze/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f303ze board
-export CPU = stm32f3
-export CPU_MODEL = stm32f303ze
-
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f334r8/Makefile.features
+++ b/boards/nucleo-f334r8/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f3
+CPU_MODEL = stm32f334r8
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f334r8/Makefile.include
+++ b/boards/nucleo-f334r8/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f3
-export CPU_MODEL = stm32f334r8
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f401re/Makefile.features
+++ b/boards/nucleo-f401re/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f401re
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += periph_qdec
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f401re/Makefile.include
+++ b/boards/nucleo-f401re/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f401re board
-export CPU = stm32f4
-export CPU_MODEL = stm32f401re
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f410rb/Makefile.features
+++ b/boards/nucleo-f410rb/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f410rb
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -5,5 +8,3 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f410rb/Makefile.include
+++ b/boards/nucleo-f410rb/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f401 board
-export CPU = stm32f4
-export CPU_MODEL = stm32f410rb
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f411re/Makefile.features
+++ b/boards/nucleo-f411re/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f411re
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -6,5 +9,3 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f411re/Makefile.include
+++ b/boards/nucleo-f411re/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f411re board
-export CPU = stm32f4
-export CPU_MODEL = stm32f411re
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f412zg/Makefile.features
+++ b/boards/nucleo-f412zg/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f412zg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f412zg/Makefile.include
+++ b/boards/nucleo-f412zg/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f412 board
-export CPU = stm32f4
-export CPU_MODEL = stm32f412zg
-
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f413zh/Makefile.features
+++ b/boards/nucleo-f413zh/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f413zh
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_can
@@ -12,5 +15,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f413zh/Makefile.include
+++ b/boards/nucleo-f413zh/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f446 board
-export CPU = stm32f4
-export CPU_MODEL = stm32f413zh
-
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f429zi
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f429zi/Makefile.include
+++ b/boards/nucleo-f429zi/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f429zi board
-export CPU = stm32f4
-export CPU_MODEL = stm32f429zi
-
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f446re/Makefile.features
+++ b/boards/nucleo-f446re/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f446re
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -14,5 +17,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f446re/Makefile.include
+++ b/boards/nucleo-f446re/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f446re board
-export CPU = stm32f4
-export CPU_MODEL = stm32f446re
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f446ze/Makefile.features
+++ b/boards/nucleo-f446ze/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f446ze
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -8,5 +11,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f446ze/Makefile.include
+++ b/boards/nucleo-f446ze/Makefile.include
@@ -1,6 +1,2 @@
-# define the cpu used by the nucleo-f446ze board
-export CPU = stm32f4
-export CPU_MODEL = stm32f446ze
-
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f722ze/Makefile.features
+++ b/boards/nucleo-f722ze/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f7
+CPU_MODEL = stm32f722ze
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-f722ze/Makefile.include
+++ b/boards/nucleo-f722ze/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f7
-export CPU_MODEL = stm32f722ze
-
 # load the common Makefile.include for Nucleo144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f746zg/Makefile.features
+++ b/boards/nucleo-f746zg/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f7
+CPU_MODEL = stm32f746zg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
@@ -10,5 +13,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-f746zg/Makefile.include
+++ b/boards/nucleo-f746zg/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f7
-export CPU_MODEL = stm32f746zg
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f7
+CPU_MODEL = stm32f767zi
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
@@ -13,5 +16,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-f767zi/Makefile.include
+++ b/boards/nucleo-f767zi/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32f7
-export CPU_MODEL = stm32f767zi
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-l031k6/Makefile.features
+++ b/boards/nucleo-l031k6/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l0
+CPU_MODEL = stm32l031k6
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_pwm
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
-
-include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l031k6/Makefile.include
+++ b/boards/nucleo-l031k6/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32l0
-export CPU_MODEL = stm32l031k6
-
 # load the common Makefile.include for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.include

--- a/boards/nucleo-l053r8/Makefile.features
+++ b/boards/nucleo-l053r8/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l0
+CPU_MODEL = stm32l053r8
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -8,5 +11,3 @@ FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l053r8/Makefile.include
+++ b/boards/nucleo-l053r8/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32l0
-export CPU_MODEL = stm32l053r8
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-l073rz/Makefile.features
+++ b/boards/nucleo-l073rz/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l0
+CPU_MODEL = stm32l073rz
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -17,5 +20,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l073rz/Makefile.include
+++ b/boards/nucleo-l073rz/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32l0
-export CPU_MODEL = stm32l073rz
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-l152re/Makefile.features
+++ b/boards/nucleo-l152re/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l1
+CPU_MODEL = stm32l152re
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
@@ -14,5 +17,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/nucleo-l152re/Makefile.include
+++ b/boards/nucleo-l152re/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32l1
-export CPU_MODEL = stm32l152re
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-l432kc/Makefile.features
+++ b/boards/nucleo-l432kc/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l4
+CPU_MODEL = stm32l432kc
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -15,5 +18,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.features
-
-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l432kc/Makefile.include
+++ b/boards/nucleo-l432kc/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l432kc
-
 # load the common Makefile.include for Nucleo-32 boards
 include $(RIOTBOARD)/common/nucleo32/Makefile.include

--- a/boards/nucleo-l433rc/Makefile.features
+++ b/boards/nucleo-l433rc/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l4
+CPU_MODEL = stm32l433rc
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
@@ -17,5 +20,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l433rc/Makefile.include
+++ b/boards/nucleo-l433rc/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l433rc
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-l452re/Makefile.features
+++ b/boards/nucleo-l452re/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l4
+CPU_MODEL = stm32l452re
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -11,5 +14,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l452re/Makefile.include
+++ b/boards/nucleo-l452re/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l452re
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-l476rg/Makefile.features
+++ b/boards/nucleo-l476rg/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l4
+CPU_MODEL = stm32l476rg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
@@ -14,5 +17,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
-
-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l476rg/Makefile.include
+++ b/boards/nucleo-l476rg/Makefile.include
@@ -1,6 +1,2 @@
-## the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l476rg
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l4
+CPU_MODEL = stm32l496zg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -12,5 +15,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l496zg/Makefile.include
+++ b/boards/nucleo-l496zg/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l496zg
-
 # stdio is not available over st-link but on the Arduino TX/RX pins
 # A serial to USB converter plugged to the host is required
 PORT_LINUX ?= /dev/ttyACM0

--- a/boards/nucleo-l4r5zi/Makefile.features
+++ b/boards/nucleo-l4r5zi/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l4
+CPU_MODEL = stm32l4r5zi
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
@@ -12,5 +15,3 @@ FEATURES_PROVIDED += riotboot
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features
-
--include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l4r5zi/Makefile.include
+++ b/boards/nucleo-l4r5zi/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l4r5zi
-
 # stdio is available over st-link
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/nz32-sc151/Makefile.features
+++ b/boards/nz32-sc151/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l1
+CPU_MODEL = stm32l151rc
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32l1
-export CPU_MODEL = stm32l151rc
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/opencm904/Makefile.features
+++ b/boards/opencm904/Makefile.features
@@ -1,5 +1,6 @@
+CPU = stm32f1
+CPU_MODEL = stm32f103cb
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -1,7 +1,3 @@
-# the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103cb
-
 # custom flasher to use with the bootloader
 FLASHER = $(RIOTBOARD)/$(BOARD)/dist/robotis-loader.py
 DEBUGGER =

--- a/boards/openmote-b/Makefile.features
+++ b/boards/openmote-b/Makefile.features
@@ -1,3 +1,6 @@
+CPU = cc2538
+CPU_MODEL = cc2538sf53
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -5,5 +8,3 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the OpenMote-B board
-export CPU = cc2538
-export CPU_MODEL = cc2538sf53
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/openmote-cc2538/Makefile.features
+++ b/boards/openmote-cc2538/Makefile.features
@@ -1,3 +1,6 @@
+CPU = cc2538
+CPU_MODEL = cc2538sf53
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
@@ -5,5 +8,3 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
-
-include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the OpenMote-cc2538 board
-export CPU = cc2538
-export CPU_MODEL = cc2538sf53
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/pba-d-01-kw2x/Makefile.dep
+++ b/boards/pba-d-01-kw2x/Makefile.dep
@@ -11,5 +11,3 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += tcs37727
   USEMODULE += tmp006
 endif
-
-include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -1,3 +1,9 @@
+CPU = kinetis
+# the pba-d-01-kw2x board can embed either a kw21d256, kw21d512 or kw22d512 cpu.
+# The default set up is kw21d256, the variable is overrideable to use the other
+# cpu if needed.
+CPU_MODEL ?= mkw21d256vha5
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -10,5 +16,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -1,11 +1,3 @@
-# define the cpu used by the phyWAVE-KW22 board
-export CPU = kinetis
-
-# the pba-d-01-kw2x board can embed either a kw21d256, kw21d512 or kw22d512 cpu.
-# The default set up is kw21d256, the variable is overrideable to use the other
-# cpu if needed.
-export CPU_MODEL ?= mkw21d256vha5
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/pyboard/Makefile.features
+++ b/boards/pyboard/Makefile.features
@@ -1,8 +1,9 @@
+CPU = stm32f4
+CPU_MODEL = stm32f405rg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/pyboard/Makefile.include
+++ b/boards/pyboard/Makefile.include
@@ -1,7 +1,3 @@
-# the cpu to build for
-export CPU = stm32f4
-export CPU_MODEL = stm32f405rg
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/reel/Makefile.features
+++ b/boards/reel/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf52840xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi

--- a/boards/reel/Makefile.include
+++ b/boards/reel/Makefile.include
@@ -1,6 +1,3 @@
-# specific CPU model used
-CPU_MODEL = nrf52840xxaa
-
 # set programming environment
 DEBUG_ADAPTER ?= dap
 PROGRAMMER ?= openocd

--- a/boards/ruuvitag/Makefile.features
+++ b/boards/ruuvitag/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf52832xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart

--- a/boards/ruuvitag/Makefile.include
+++ b/boards/ruuvitag/Makefile.include
@@ -1,6 +1,3 @@
-# CPU configuration
-CPU_MODEL = nrf52832xxaa
-
 # for this board, we are using Segger's RTT as default terminal interface
 USEMODULE += stdio_rtt
 TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh

--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samd21j18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/samd21-xpro/Makefile.include
+++ b/boards/samd21-xpro/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by SAMD21 Xplained Pro board
-export CPU = samd21
-export CPU_MODEL = samd21j18a
-
 # set edbg device type
 EDBG_DEVICE_TYPE = atmel_cm0p
 

--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd5x
+CPU_MODEL = same54p20a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/samd5x/Makefile.features

--- a/boards/same54-xpro/Makefile.include
+++ b/boards/same54-xpro/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by SAME54 Xplained Pro board
-export CPU = samd5x
-export CPU_MODEL = same54p20a
-
 # set edbg device type
 EDBG_DEVICE_TYPE = atmel_cm4v2
 

--- a/boards/saml10-xpro/Makefile.features
+++ b/boards/saml10-xpro/Makefile.features
@@ -1,1 +1,3 @@
+CPU_MODEL = saml10e16a
+
 include $(RIOTBOARD)/common/saml1x/Makefile.features

--- a/boards/saml10-xpro/Makefile.include
+++ b/boards/saml10-xpro/Makefile.include
@@ -1,5 +1,4 @@
 export CPU_FAM  = saml10
-export CPU_MODEL = saml10e16a
 export CFLAGS += -D__SAML10E16A__
 
 include $(RIOTBOARD)/common/saml1x/Makefile.include

--- a/boards/saml11-xpro/Makefile.features
+++ b/boards/saml11-xpro/Makefile.features
@@ -1,1 +1,3 @@
+CPU_MODEL = saml11e16a
+
 include $(RIOTBOARD)/common/saml1x/Makefile.features

--- a/boards/saml11-xpro/Makefile.include
+++ b/boards/saml11-xpro/Makefile.include
@@ -1,5 +1,4 @@
 export CPU_FAM  = saml11
-export CPU_MODEL = saml11e16a
 export CFLAGS += -D__SAML11E16A__
 
 include $(RIOTBOARD)/common/saml1x/Makefile.include

--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -1,3 +1,6 @@
+CPU = saml21
+CPU_MODEL = saml21j18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/saml21/Makefile.features

--- a/boards/saml21-xpro/Makefile.include
+++ b/boards/saml21-xpro/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the saml21 board
-export CPU = saml21
-export CPU_MODEL = saml21j18a
 export CFLAGS += -D__SAML21J18A__
 
 # set edbg device type

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samr21g18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -11,5 +14,3 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by SAMR21 Xplained Pro board
-export CPU = samd21
-export CPU_MODEL = samr21g18a
-
 # set edbg device type
 EDBG_DEVICE_TYPE = atmel_cm0p
 

--- a/boards/samr30-xpro/Makefile.features
+++ b/boards/samr30-xpro/Makefile.features
@@ -1,3 +1,6 @@
+CPU = saml21
+CPU_MODEL = samr30g18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -6,6 +9,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# samr30 is a specific flavor of saml21
-include $(RIOTCPU)/saml21/Makefile.features

--- a/boards/samr30-xpro/Makefile.include
+++ b/boards/samr30-xpro/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the samr30-xpro board (based on saml21)
-export CPU = saml21
-export CPU_MODEL = samr30g18a
-
 # set edbg device type
 EDBG_DEVICE_TYPE = atmel_cm0p
 

--- a/boards/seeeduino_arch-pro/Makefile.features
+++ b/boards/seeeduino_arch-pro/Makefile.features
@@ -1,6 +1,6 @@
+CPU = lpc1768
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/lpc1768/Makefile.features

--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU
-export CPU = lpc1768
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/sensebox_samd21/Makefile.features
+++ b/boards/sensebox_samd21/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samd21g18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -6,5 +9,3 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sensebox_samd21/Makefile.include
+++ b/boards/sensebox_samd21/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by SenseBox board
-export CPU = samd21
-export CPU_MODEL = samd21g18a
-
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 

--- a/boards/slstk3401a/Makefile.dep
+++ b/boards/slstk3401a/Makefile.dep
@@ -5,5 +5,3 @@ endif
 
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep
-
-include $(RIOTCPU)/efm32/Makefile.dep

--- a/boards/slstk3401a/Makefile.features
+++ b/boards/slstk3401a/Makefile.features
@@ -1,3 +1,6 @@
+CPU = efm32
+CPU_MODEL = efm32pg1b200f256gm48
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 include $(RIOTBOARD)/common/silabs/Makefile.features
-
-include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slstk3401a/Makefile.include
+++ b/boards/slstk3401a/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by SLSTK3401A
-export CPU = efm32
-export CPU_MODEL = efm32pg1b200f256gm48
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/slstk3402a/Makefile.dep
+++ b/boards/slstk3402a/Makefile.dep
@@ -5,5 +5,3 @@ endif
 
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep
-
-include $(RIOTCPU)/efm32/Makefile.dep

--- a/boards/slstk3402a/Makefile.features
+++ b/boards/slstk3402a/Makefile.features
@@ -1,3 +1,6 @@
+CPU = efm32
+CPU_MODEL = efm32pg12b500f1024gl125
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 include $(RIOTBOARD)/common/silabs/Makefile.features
-
-include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slstk3402a/Makefile.include
+++ b/boards/slstk3402a/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by SLSTK3402A
-export CPU = efm32
-export CPU_MODEL = efm32pg12b500f1024gl125
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/sltb001a/Makefile.dep
+++ b/boards/sltb001a/Makefile.dep
@@ -6,5 +6,3 @@ endif
 
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep
-
-include $(RIOTCPU)/efm32/Makefile.dep

--- a/boards/sltb001a/Makefile.features
+++ b/boards/sltb001a/Makefile.features
@@ -1,3 +1,6 @@
+CPU = efm32
+CPU_MODEL = efr32mg1p132f256gm48
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 include $(RIOTBOARD)/common/silabs/Makefile.features
-
-include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by SLTB001A
-export CPU = efm32
-export CPU_MODEL = efr32mg1p132f256gm48
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/slwstk6220a/Makefile.features
+++ b/boards/slwstk6220a/Makefile.features
@@ -1,6 +1,7 @@
+CPU = ezr32wg
+CPU_MODEL = ezr32wg330f256r60
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/ezr32wg/Makefile.features

--- a/boards/slwstk6220a/Makefile.include
+++ b/boards/slwstk6220a/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by WSTK6220
-export CPU = ezr32wg
-export CPU_MODEL = ezr32wg330f256r60
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/sodaq-autonomo/Makefile.features
+++ b/boards/sodaq-autonomo/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samd21j18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-autonomo/Makefile.include
+++ b/boards/sodaq-autonomo/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by SODAQ Autonomo board
-export CPU = samd21
-export CPU_MODEL = samd21j18a
-
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 

--- a/boards/sodaq-explorer/Makefile.features
+++ b/boards/sodaq-explorer/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samd21j18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-explorer/Makefile.include
+++ b/boards/sodaq-explorer/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the SODAQ ExpLoRer board
-export CPU = samd21
-export CPU_MODEL = samd21j18a
-
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 

--- a/boards/sodaq-one/Makefile.features
+++ b/boards/sodaq-one/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samd21g18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-one/Makefile.include
+++ b/boards/sodaq-one/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the SODAQ ONE board
-export CPU = samd21
-export CPU_MODEL = samd21g18a
-
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 

--- a/boards/sodaq-sara-aff/Makefile.features
+++ b/boards/sodaq-sara-aff/Makefile.features
@@ -1,3 +1,6 @@
+CPU = samd21
+CPU_MODEL = samd21j18a
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
-
-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-sara-aff/Makefile.include
+++ b/boards/sodaq-sara-aff/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the SODAQ SARA AFF boards
-export CPU = samd21
-export CPU_MODEL = samd21j18a
-
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 

--- a/boards/spark-core/Makefile.features
+++ b/boards/spark-core/Makefile.features
@@ -1,6 +1,7 @@
+CPU = stm32f1
+CPU_MODEL = stm32f103cb
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103cb
-
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/stk3600/Makefile.dep
+++ b/boards/stk3600/Makefile.dep
@@ -4,5 +4,3 @@ endif
 
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep
-
-include $(RIOTCPU)/efm32/Makefile.dep

--- a/boards/stk3600/Makefile.features
+++ b/boards/stk3600/Makefile.features
@@ -1,3 +1,6 @@
+CPU = efm32
+CPU_MODEL = efm32lg990f256
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
@@ -11,5 +14,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 include $(RIOTBOARD)/common/silabs/Makefile.features
-
-include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/stk3600/Makefile.include
+++ b/boards/stk3600/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by STK3600
-export CPU = efm32
-export CPU_MODEL = efm32lg990f256
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/stk3700/Makefile.dep
+++ b/boards/stk3700/Makefile.dep
@@ -4,5 +4,3 @@ endif
 
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep
-
-include $(RIOTCPU)/efm32/Makefile.dep

--- a/boards/stk3700/Makefile.features
+++ b/boards/stk3700/Makefile.features
@@ -1,3 +1,6 @@
+CPU = efm32
+CPU_MODEL = efm32gg990f1024
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
@@ -11,5 +14,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 include $(RIOTBOARD)/common/silabs/Makefile.features
-
-include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/stk3700/Makefile.include
+++ b/boards/stk3700/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by STK3700
-export CPU = efm32
-export CPU_MODEL = efm32gg990f1024
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/stm32f0discovery/Makefile.features
+++ b/boards/stm32f0discovery/Makefile.features
@@ -1,8 +1,9 @@
+CPU = stm32f0
+CPU_MODEL = stm32f051r8
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the stm32f0-discovery board
-export CPU = stm32f0
-export CPU_MODEL = stm32f051r8
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/stm32f3discovery/Makefile.features
+++ b/boards/stm32f3discovery/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f3
+CPU_MODEL = stm32f303vc
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
@@ -6,5 +9,3 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the stm32f3-discovery board
-export CPU = stm32f3
-export CPU_MODEL = stm32f303vc
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f429zi
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
@@ -6,5 +9,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/stm32f429i-disc1/Makefile.include
+++ b/boards/stm32f429i-disc1/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the stm32f4-discovery board
-export CPU = stm32f4
-export CPU_MODEL = stm32f429zi
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f407vg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
@@ -14,5 +17,3 @@ FEATURES_PROVIDED += arduino
 # TODO: re-think concept for conflicts based on actual used peripherals...
 FEATURES_CONFLICT += periph_spi:periph_dac
 FEATURES_CONFLICT_MSG += "On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0."
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the stm32f4-discovery board
-export CPU = stm32f4
-export CPU_MODEL = stm32f407vg
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/stm32f769i-disco/Makefile.features
+++ b/boards/stm32f769i-disco/Makefile.features
@@ -1,7 +1,8 @@
+CPU = stm32f7
+CPU_MODEL = stm32f769ni
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/stm32f769i-disco/Makefile.include
+++ b/boards/stm32f769i-disco/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the stm32f769-discovery board
-export CPU = stm32f7
-export CPU_MODEL = stm32f769ni
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/stm32l0538-disco/Makefile.features
+++ b/boards/stm32l0538-disco/Makefile.features
@@ -1,7 +1,8 @@
+CPU = stm32l0
+CPU_MODEL = stm32l053c8
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/stm32l0538-disco/Makefile.include
+++ b/boards/stm32l0538-disco/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the stm32l0538-disco board
-export CPU = stm32l0
-export CPU_MODEL = stm32l053c8
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32l4
+CPU_MODEL = stm32l476vg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
@@ -6,5 +9,3 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-
-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/stm32l476g-disco/Makefile.include
+++ b/boards/stm32l476g-disco/Makefile.include
@@ -1,7 +1,3 @@
-# the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l476vg
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/teensy31/Makefile.dep
+++ b/boards/teensy31/Makefile.dep
@@ -1,1 +1,0 @@
-include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/teensy31/Makefile.features
+++ b/boards/teensy31/Makefile.features
@@ -1,8 +1,9 @@
+CPU = kinetis
+CPU_MODEL = mk20dx256vlh7
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the Teensy3.1 & 3.2 board
-CPU = kinetis
-CPU_MODEL = mk20dx256vlh7
-
 # custom flasher to use with the bootloader
 TEENSY_LOADER = $(RIOTTOOLS)/teensy-loader-cli/teensy_loader
 FLASHER = $(TEENSY_LOADER)

--- a/boards/telosb/Makefile.features
+++ b/boards/telosb/Makefile.features
@@ -1,3 +1,6 @@
+CPU = msp430fxyz
+CPU_MODEL = msp430f1611
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_spi
@@ -5,5 +8,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-
-include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = msp430fxyz
-export CPU_MODEL = msp430f1611
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-MXV*)))

--- a/boards/thingy52/Makefile.features
+++ b/boards/thingy52/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf52832xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -1,6 +1,3 @@
-# CPU configuration for the Thingy:52
-CPU_MODEL = nrf52832xxaa
-
 # for this board, we are using Segger's RTT as default terminal interface
 USEMODULE += stdio_rtt
 TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh

--- a/boards/ublox-c030-u201/Makefile.features
+++ b/boards/ublox-c030-u201/Makefile.features
@@ -1,3 +1,6 @@
+CPU = stm32f4
+CPU_MODEL = stm32f437vg
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
@@ -5,5 +8,3 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/ublox-c030-u201/Makefile.include
+++ b/boards/ublox-c030-u201/Makefile.include
@@ -1,7 +1,3 @@
-## the cpu to build for
-export CPU = stm32f4
-export CPU_MODEL = stm32f437vg
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 

--- a/boards/waspmote-pro/Makefile.features
+++ b/boards/waspmote-pro/Makefile.features
@@ -1,3 +1,5 @@
+CPU = atmega1281
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -7,5 +9,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-
--include $(RIOTCPU)/atmega1281/Makefile.features

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -1,6 +1,3 @@
-# define the cpu used by the waspmote pro board
-export CPU = atmega1281
-
 # Bootloader uses stk500v1 protocol, which usually is implemented in
 # bootloaders of 2K size.
 # http://www.libelium.com/products/waspmote/hardware/

--- a/boards/yunjia-nrf51822/Makefile.features
+++ b/boards/yunjia-nrf51822/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = nrf51x22xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU model
-export CPU_MODEL = nrf51x22xxaa
-
 # include common nrf51 boards module into the build
 USEMODULE += boards_common_nrf51
 

--- a/boards/z1/Makefile.features
+++ b/boards/z1/Makefile.features
@@ -1,3 +1,6 @@
+CPU = msp430fxyz
+CPU_MODEL = msp430f2617
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_spi
@@ -5,5 +8,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-
-include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -1,7 +1,3 @@
-# CPU used by this board
-export CPU = msp430fxyz
-export CPU_MODEL = msp430f2617
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))


### PR DESCRIPTION
### Contribution description

This moves CPU and CPU_MODEL to Makefile.features for a selection of board that currently cause no difference at all in the dependency parsing.

This was accepted in "Tracking: move CPU/CPU_MODEL to Makefile.features" #11477 and more precisely by this PR "Makefile.features: prerequisites for moving CPU/CPU_MODEL to boards/Makefile.features" #11478

cpu/$(CPU)/Makefile.features and cpu/$(CPU)/Makefile.dep are
automatically included

Part of moving CPU/CPU_MODEL definition to Makefile.features to have it
available before Makefile.include.

### Review procedure

This PR modifications are only

* moving `CPU`, `CPU_MODEL` to a different file
* removing the `include $(RIOTCPU)/cpu_name/...`
* Removing the `export CPU` and `export CPU_MODEL` as they are globally exported in https://github.com/RIOT-OS/RIOT/blob/3e753834e793928d2ee0946c25d6bd1232ad69c6/makefiles/vars.inc.mk#L11-L12
* It removed the comment saying "we set the cpu" as it is quite obvious. If it is not it should be part of a board porting guide.


The testing procedure dumps all variables used for dependency parsing and compare that the new value is consistent.

The dependency to #12004 is only for testing and could be merged without it.

### Testing procedure

#### Review of the new state

In the PR run

```
./dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh  build/deps/cpu_model
...
# This takes more than 2 hours on my machine
```

Then run the aggregation script:
<details><summary><code>generate_aggregated.sh</code></summary>

```bash
#! /bin/bash

set -ue

readonly DIRECTORY=$1

set -v
rm -f ${DIRECTORY}/tests/nordic_softdevice/info-global/dependencies_info-boards-supported_reel  # Remove as not generated by normal compilation
rm -rf ${DIRECTORY}/tests/cpu_efm32_features # Remove as issues with BOARD being unconditionally set https://github.com/RIOT-OS/RIOT/pull/12009
find "${DIRECTORY}" -type f -name 'dependencies_info_*' | sort | xargs cat > ${DIRECTORY}/deps_info
find "${DIRECTORY}" -type f -name 'dependencies_info-boards-supported_*' | sort | xargs cat > ${DIRECTORY}/deps_info-boards-supported
```
</details>

```
./generate_aggregated.sh build/deps/cpu_model
```


Now the value of `CPU` and `CPU_MODEL` `info-boards-supported` and the normal dependency parsing are the same except for boards that are not migrated by this PR:


<details><summary>Difference in `CPU/CPU_MODEL/BOARD`</summary>

```
diff -W 80 -y --suppress-common-lines build/deps/cpu_model/deps_info-boards-supported build/deps/cpu_model/deps_info | grep -e BOARD -e 'CPU ' -e CPU_MODEL | awk '!x[$0]++'
CPU =                                 | CPU = nrf52
CPU =                                 | CPU = nrf51
CPU =                                 | CPU = stm32f1
CPU_MODEL =                           | CPU_MODEL = stm32f103c8
CPU =                                 | CPU = cc2538
CPU_MODEL =                           | CPU_MODEL = cc2538nf53
CPU =                                 | CPU = lm4f120
CPU_MODEL =                           | CPU_MODEL = LM4F120H5QR
CPU =                                 | CPU = esp32
CPU_MODEL =                           | CPU_MODEL = esp32
CPU =                                 | CPU = esp8266
CPU_MODEL =                           | CPU_MODEL = esp8266
CPU =                                 | CPU = fe310
CPU_MODEL =                           | CPU_MODEL = fe310_g000
CPU_MODEL =                           | CPU_MODEL = fe310_g002
CPU_MODEL =                           | CPU_MODEL = lpc1768
CPU =                                 | CPU = kinetis
CPU_MODEL =                           | CPU_MODEL = mk60dn512vll10
CPU_MODEL =                           | CPU_MODEL = nrf51x22xxaa
CPU =                                 | CPU = mips_pic32mx
CPU_MODEL =                           | CPU_MODEL = p32mx470f512h
CPU =                                 | CPU = mips_pic32mz
CPU_MODEL =                           | CPU_MODEL = p32mz2048efg100
CPU =                                 | CPU = efm32
CPU_MODEL =                           | CPU_MODEL = efr32mg12p332f1024gl125
```
</details>

Note that currently there are still differences in both parsing with

```
DISABLE_MODULE DEFAULT_MODULE USEMODULE FEATURES_REQUIRED FEATURES_USED FEATURES_OPTIONAL FEATURES_CONFLICT FEATURES_MISSING CPU_FAM
```


#### Comparison with the previous state

On the commit: `"squash! make: add targets to debug dependencies variables "` run the same generation:

```
./dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh  build/deps/ref
# This takes more than 2 hours on my machine
./generate_aggregated.sh build/deps/ref
```

It did not change the variables used when normal dependency parsing:

```
diff build/deps/ref/deps_info build/deps/cpu_model/deps_info
# no difference
```

And in general nothing changed except `CPU` and `CPU_MODEL` values being now declared in `info-boards-supported`:

```
diff -r -W 80 -y  --suppress-common-lines build/deps/ref/ build/deps/cpu_model/ -I 'CPU ' -I 'CPU_MODEL ' --exclude='deps_info*'
```

I need to exclude the aggregated file as diff reports a few lines with `CPU` / `CPU_MODEL` even if I asked to ignore them.</summary>

<details><summary>For reference without excluding the aggregated files</summary>

```diff
$ diff -r -W 80 -y  --suppress-common-lines build/deps/ref/ build/deps/cpu_model/ -I 'CPU ' -I 'CPU_MODEL '
diff -r -W 80 -y --suppress-common-lines -I 'CPU ' -I 'CPU_MODEL ' build/deps/ref/deps_info-boards-supported build/deps/cpu_model/deps_info-boards-supported
BOARD = opencm904                     | BOARD = opencm904
CPU =                                 | CPU = stm32f1
CPU_MODEL =                           | CPU_MODEL = stm32f103cb
BOARD = nz32-sc151                    | BOARD = nz32-sc151
CPU =                                 | CPU = stm32l1
CPU_MODEL =                           | CPU_MODEL = stm32l151rc
BOARD = pba-d-01-kw2x                 | BOARD = pba-d-01-kw2x
CPU =                                 | CPU = kinetis
CPU_MODEL =                           | CPU_MODEL = mkw21d256vha5
BOARD = slwstk6220a                   | BOARD = slwstk6220a
CPU =                                 | CPU = ezr32wg
CPU_MODEL =                           | CPU_MODEL = ezr32wg330f256r60
BOARD = stm32f0discovery              | BOARD = stm32f0discovery
CPU =                                 | CPU = stm32f0
CPU_MODEL =                           | CPU_MODEL = stm32f051r8
BOARD = saml21-xpro                   | BOARD = saml21-xpro
CPU =                                 | CPU = saml21
CPU_MODEL =                           | CPU_MODEL = saml21j18a
BOARD = remote-reva                   | BOARD = remote-reva
CPU =                                 | CPU = cc2538
CPU_MODEL =                           | CPU_MODEL = cc2538sf53
```
</details>


### Issues/PRs references

* Tracking: move CPU/CPU_MODEL to Makefile.features #11477
* Depends on the debug targets from: make: add targets to debug dependencies variables #12004 (could be removed before merging if it can get it sooner through)