### PR TITLE
sys/tlsf: move heap intialization for tlsf-malloc to auto-init

### DIFF
--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -14,12 +14,15 @@ RIOTBASE ?= $(CURDIR)/../..
 # development process:
 DEVELHELP ?= 1
 
+# Configure CCN-lite
 CFLAGS += -DUSE_LINKLAYER
 CFLAGS += -DUSE_RONR
 CFLAGS += -DCCNL_UAPI_H_
 CFLAGS += -DUSE_SUITE_NDNTLV
 CFLAGS += -DNEEDS_PREFIX_MATCHING
 CFLAGS += -DNEEDS_PACKET_CRAFTING
+# 10kB buffer for the heap should be enough for everyone
+CFLAGS += -DTLSF_MALLOC_HEAPSIZE=10240
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/examples/ccn-lite-relay/main.c
+++ b/examples/ccn-lite-relay/main.c
@@ -31,13 +31,8 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-/* 10kB buffer for the heap should be enough for everyone */
-#define TLSF_BUFFER     (10240 / sizeof(uint32_t))
-static uint32_t _tlsf_heap[TLSF_BUFFER];
-
 int main(void)
 {
-    tlsf_add_global_pool(_tlsf_heap, sizeof(_tlsf_heap));
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
     puts("Basic CCN-Lite example");

--- a/pkg/tlsf/contrib/include/tlsf-malloc.h
+++ b/pkg/tlsf/contrib/include/tlsf-malloc.h
@@ -44,6 +44,14 @@ extern "C" {
 #endif
 
 /**
+ * @brief   The global pool will be initialized with a buffer of this size
+ *          during system initialization (auto-init)
+ */
+#ifndef TLSF_MALLOC_HEAPSIZE
+#define TLSF_MALLOC_HEAPSIZE        (4096U)
+#endif
+
+/**
  * @brief Struct to hold the total sizes of free and used blocks
  * Used for @ref tlsf_size_walker()
  */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -20,6 +20,11 @@
 
 #include "auto_init.h"
 
+#ifdef MODULE_TLSF_MALLOC
+#include "tlsf-malloc.h"
+static uint8_t _tlsf_pool[TLSF_MALLOC_HEAPSIZE];
+#endif
+
 #ifdef MODULE_MCI
 #include "diskio.h"
 #endif
@@ -93,6 +98,10 @@
 
 void auto_init(void)
 {
+#ifdef MODULE_TLSF_MALLOC
+    /* NOTE: this should be initialized before any other modules */
+    tlsf_add_global_pool(_tlsf_pool, sizeof(_tlsf_pool));
+#endif
 #ifdef MODULE_PRNG
     void auto_init_random(void);
     auto_init_random();


### PR DESCRIPTION
# Contribution description
Currently, when `tlsf-malloc` is used, the initialization of the heap memory is left to the application. This poses a problem when modules/packages use `malloc` and if they are initialized from auto-init -> this leads to `tlsf-malloc` crashing, as not memory is allocated to it at that point.

This PR solves this issue by moving the buffer allocation for `tlsf-malloc` into auto-init, before any other modules are initialized. The buffer size is determined by `TLSF_MALLOC_HEAPSIZE`, which is per default set to 4k, but can simply be redefined from the build system...

### Testing procedure
As of now, `examples/ccn-lite-relay` is the only application in RIOT using `tlsf-malloc`. For verification, simply compile this PR and compare the used memory with master, it should be identical. Next you can alter the value for `TLSF_MALLOC_HEAPSIZE`, and the RAM usage of the build should change by the difference of the new value and 10240.

Reproducing the crash behavior pointed out above is slightly more difficult, as the code is not yet PRed. I found it when using NimBLE and CCN-lite at the same time, as NimBLE has some rare `malloc´ calls in its initialization code, and those fail once `tlsf-malloc` is used...

### Issues/PRs references

See issues #4490, #5796.