### PR TITLE
cpu/stm32: Fix 16 bit reg endianness for i2c_1

### DIFF
--- a/cpu/stm32_common/periph/i2c_1.c
+++ b/cpu/stm32_common/periph/i2c_1.c
@@ -37,6 +37,7 @@
 
 #include "cpu.h"
 #include "mutex.h"
+#include "byteorder.h"
 
 #include "cpu_conf_stm32_common.h"
 
@@ -168,6 +169,10 @@ int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
     /* As a higher level function we know the bus should be free */
     if (i2c->ISR & I2C_ISR_BUSY) {
         return -EAGAIN;
+    }
+    /* Handle endianess of register if 16 bit */
+    if (flags & I2C_REG16) {
+        reg = htons(reg); /* Make sure register is in big-endian on I2C bus */
     }
     /* First set ADDR and register with no stop */
     /* No RELOAD should be set so repeated start is valid */


### PR DESCRIPTION


### Contribution description

Since i2c_1 i2c_write_regs is cpu specific reg endianness must be swapped there
Change reg from little endian to big endian

### Testing procedure
Use any STM32 F0, F3, F7, L0 and L4 board.
Read a 16 bit register and make sure it is big endian and not little endian.
You can use [PHiLIP](https://github.com/riot-appstore/PHiLIP/) as the slave device since it can be set to 16 bit register mode and have the endianness controlled.


### Issues/PRs references

Fixes #11544
