### PR TITLE
board/nucleo-l031k6: Add i2c to periph_conf

### DIFF
--- a/boards/nucleo-l031k6/Makefile.features
+++ b/boards/nucleo-l031k6/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32l031k6
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -127,6 +127,29 @@ static const spi_conf_t spi_config[] = {
 #define ADC_NUMOF           (7U)
 /** @} */
 
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 6),
+        .sda_pin        = GPIO_PIN(PORT_B, 7),
+        .scl_af         = GPIO_AF1,
+        .sda_af         = GPIO_AF1,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .irqn           = I2C1_IRQn
+    }
+};
+
+#define I2C_0_ISR           isr_i2c1
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Contribution description

Enabled I2C for Nucleo L031K6 on PB_7 (D4) for SDA and PB_6 (D5) for SCL.

### Testing procedure

Connected TMP006 via I2C and used existing driver & test code to test communication:

<img width="514" alt="Screenshot 2019-08-16 at 8 56 55 PM" src="https://user-images.githubusercontent.com/151967/63191276-67ac7d00-c068-11e9-950a-7162a9494e4d.png">
