### PR TITLE
cpu/esp32: fixes printf and puts

### DIFF
--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -91,8 +91,12 @@ int IRAM puts(const char *s)
     if (!s) {
         return EOF;
     }
-    ets_printf("%s\n", s);
-    return strlen(s);
+    int len = strlen(s);
+    for (int i = 0; i < len; i++) {
+        __wrap_putchar(s[i]);
+    }
+    __wrap_putchar('\n');
+    return len;
 }
 
 char _printf_buf[PRINTF_BUFSIZ];
@@ -105,7 +109,9 @@ int IRAM printf(const char* format, ...)
     int ret = vsnprintf(_printf_buf, PRINTF_BUFSIZ, format, arglist);
 
     if (ret > 0) {
-        ets_printf (_printf_buf);
+        for (int i = 0; i < ret; i++) {
+            __wrap_putchar(_printf_buf[i]);
+        }
     }
 
     va_end(arglist);


### PR DESCRIPTION
### Contribution description

This PR fixes `printf` and `puts` functions. These functions used `ets_printf` before. Unfortunately, `ets_printf` adds an additional `\r` for each `\n` which is inconsistent with other RIOT platforms. As one result some automatic tests failed as described in PR #11449. Therefore, both functions write now character-wise directly to the UART interface.

### Testing procedure

Flash `examples/hello-world` with:
```
make BOARD=esp32-wroom-32 -C examples/hello-world flash test
```
The output should still be:
```
Hello World!
You are running RIOT on a(n) esp32-wroom-32 board.
This board features a(n) esp32 MCU.
```
The output can be written to a file with:
```
tail -f /dev/ttyUSB0 >& file.txt
```
In the hexdump of the file there should be only a single `0x0a` character as line endings.
```
hexdump -C file.txt
...
00000a80  30 29 0d 0a 48 65 6c 6c  6f 20 57 6f 72 6c 64 21  |0)..Hello World!|
00000a90  0a 59 6f 75 20 61 72 65  20 72 75 6e 6e 69 6e 67  |.You are running|
00000aa0  20 52 49 4f 54 20 6f 6e  20 61 28 6e 29 20 65 73  | RIOT on a(n) es|
00000ab0  70 33 32 2d 77 72 6f 6f  6d 2d 33 32 20 62 6f 61  |p32-wroom-32 boa|
00000ac0  72 64 2e 0a 54 68 69 73  20 62 6f 61 72 64 20 66  |rd..This board f|
00000ad0  65 61 74 75 72 65 73 20  61 28 6e 29 20 65 73 70  |eatures a(n) esp|
00000ae0  33 32 20 4d 43 55 2e 0a                           |32 MCU..|
```

### Issues/PRs references

Fixes probably the problem described in PR #11449.
