### PR TITLE
makefiles/docker.inc.mk: allow setting more things from environment

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -88,6 +88,9 @@ DOCKER_OVERRIDE_CMDLINE += $(strip $(DOCKER_OVERRIDE_CMDLINE_AUTO))
 # Overwrite if you want to use `docker` with sudo
 DOCKER ?= docker
 
+# 'make' arguments inside docker
+DOCKER_MAKE_ARGS += $(DOCKER_MAKECMDGOALS) $(DOCKER_OVERRIDE_CMDLINE)
+
 # Resolve symlink of /etc/localtime to its real path
 # This is a workaround for docker on macOS, for more information see:
 # https://github.com/docker/for-mac/issues/2396
@@ -272,4 +275,4 @@ DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):
 	    $(DOCKER_VOLUMES_AND_ENV) \
 	    $(DOCKER_ENVIRONMENT_CMDLINE) \
 	    -w '$(DOCKER_APPDIR)' \
-	    '$(DOCKER_IMAGE)' make $(DOCKER_MAKECMDGOALS) $(DOCKER_OVERRIDE_CMDLINE)
+	    '$(DOCKER_IMAGE)' make $(DOCKER_MAKE_ARGS)

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -70,18 +70,20 @@ export DOCKER_ENV_VARS += \
 # DOCKER_ENVIRONMENT_CMDLINE must be immediately assigned (:=) or otherwise some
 # of the environment variables will be overwritten by Makefile.include and their
 # origin is changed to "file"
-DOCKER_ENVIRONMENT_CMDLINE := $(foreach varname,$(DOCKER_ENV_VARS), \
+DOCKER_ENVIRONMENT_CMDLINE_AUTO := $(foreach varname,$(DOCKER_ENV_VARS), \
   $(if $(filter environment command,$(origin $(varname))), \
   -e '$(varname)=$(subst ','\'',$($(varname)))', \
   ))
-DOCKER_ENVIRONMENT_CMDLINE := $(strip $(DOCKER_ENVIRONMENT_CMDLINE))
+DOCKER_ENVIRONMENT_CMDLINE += $(strip $(DOCKER_ENVIRONMENT_CMDLINE_AUTO))
+
+
 # The variables set on the command line will also be passed on the command line
 # in Docker
-DOCKER_OVERRIDE_CMDLINE := $(foreach varname,$(DOCKER_ENV_VARS), \
+DOCKER_OVERRIDE_CMDLINE_AUTO := $(foreach varname,$(DOCKER_ENV_VARS), \
     $(if $(filter command,$(origin $(varname))), \
     '$(varname)=$($(varname))', \
     ))
-DOCKER_OVERRIDE_CMDLINE := $(strip $(DOCKER_OVERRIDE_CMDLINE))
+DOCKER_OVERRIDE_CMDLINE += $(strip $(DOCKER_OVERRIDE_CMDLINE_AUTO))
 
 # Overwrite if you want to use `docker` with sudo
 DOCKER ?= docker

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -25,7 +25,7 @@ export DOCKER_MAKECMDGOALS ?= all
 # List of all exported environment variables that shall be passed on to the
 # Docker container, they will only be passed if they are set from the
 # environment, not if they are only default Makefile values.
-export DOCKER_ENV_VARS = \
+export DOCKER_ENV_VARS += \
   APPDIR \
   AR \
   ARFLAGS \


### PR DESCRIPTION
### Contribution description

This allows setting a base value for more variables from the environment:

* `DOCKER_ENV_VARS` to add variables that must be automatically detected by docker handling
* `DOCKER_ENVIRONMENT_CMDLINE` and `DOCKER_OVERRIDE_CMDLINE` to directly define variables to the environment or the command line by bypassing the automatic handling with the `origin`. (this must use docker syntax)
* Add a new `DOCKER_MAKE_ARGS` to pass variables as `make` arguments in docker. It could be done with `DOCKER_OVERRIDE_CMDLINE` but it would be a hack.


### Testing procedure


#### Current behavior unchanged

I can still set `RIOT_CI_BUILD` from env and command line for example:

<details><summary>From env it is set with `-e 'RIOT_CI_BUILD=1'`</summary>

```
 RIOT_CI_BUILD=1 DOCKER="sudo docker" BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make   
Building application "hello-world" for "native" with MCU "native".

   text	   data	    bss	    dec	    hex	filename
  22918	    568	  47652	  71138	  115e2	/data/riotbuild/riotbase/examples/hello-world/bin/native/hello-world.elf
```
</details>

<details><summary>From command line it is set after `make`</summary>

```
DOCKER="sudo docker" BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/ RIOT_CI_BUILD=1
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache  -v /home/harter/work/git/RIOT/.git:/home/harter/work/git/RIOT/.git \
    -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make  'RIOT_CI_BUILD=1' 
Building application "hello-world" for "native" with MCU "native".

   text	   data	    bss	    dec	    hex	filename
  22918	    568	  47652	  71138	  115e2	/data/riotbuild/riotbase/examples/hello-world/bin/native/hello-world.elf
```
</details>

I noticed it is also set as `-e` even if it does nothing as it is overwritten.
This was present in master.


#### Adding variables to `DOCKER_ENV_VARS`.

It works both from 

<details><summary>command line, it has `-e BEER_TYPE`</summary>

```
DOCKER_ENV_VARS=BEER_TYPE BEER_TYPE="imperial stout" DOCKER="sudo docker" BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'BEER_TYPE=imperial stout' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make   
```
</details>

<details><summary>from environment, it has make BEER_TYPE=</summary>

```
DOCKER_ENV_VARS=BEER_TYPE BEER_TYPE="imperial stout" DOCKER="sudo docker" BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/
DOCKER_ENV_VARS=BEER_TYPE DOCKER="sudo docker" BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/ BEER_TYPE="imperial stout"
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'BEER_TYPE=imperial stout' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make  'BEER_TYPE=imperial stout' 
```
</details>

Note that `DOCKER_ENV_VARS` must be set from the environment to add to the list, otherwise it will override the internal value as expected.

It does not work in `master`.


#### Adding to the `CMDLINE` variables directly:

Details both the variable from the command line, the override from the command line and the exported variables are taken into account.

`-e 'beer=good'`, `BEER_TYPE='imperial stout'`

<details><summary>Both `CMDLINE` are taken into account</summary>

```
DOCKER_OVERRIDE_CMDLINE="BEER_TYPE='imperial stout'" DOCKER_ENVIRONMENT_CMDLINE="-e 'beer=good'" DOCKER="sudo docker" BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/ RIOT_CI_BUILD=1
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'beer=good' -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make  BEER_TYPE='imperial stout' 'RIOT_CI_BUILD=1' 
```
</details>

Note that `DOCKER_OVERRIDE_CMDLINE` must be set from the environment to not override the value as expected. Was not working in master.

#### The make command args

<details><summary>Passing '-j 2' to make in docker</summary>

```
DOCKER_MAKE_ARGS="-j 2" DOCKER="sudo docker" BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/ 
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
     \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make -j 2   
```
</details>

Not supported in master and is new.

#### All at once with the previous behaviour

In case you want, you can see that all is working at once

`-e 'beer=good'`, `-e 'RIOT_VERSION=1'` and `BEER_TYPE='imperial stout'` with `'RIOT_CI_BUILD=1'` and `-j 2`

<details><summary>Can we handle all this, YES</summary>

```
DOCKER_MAKE_ARGS="-j 2" DOCKER_OVERRIDE_CMDLINE="BEER_TYPE='imperial stout'" DOCKER_ENVIRONMENT_CMDLINE="-e 'beer=good'" RIOT_VERSION=1 DOCKER="sudo docker" BUILD_IN_DOCKER=1 make --no-print-directory -C examples/hello-world/ RIOT_CI_BUILD=1 
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'beer=good' -e 'RIOT_CI_BUILD=1' -e 'RIOT_VERSION=1' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make -j 2  BEER_TYPE='imperial stout' 'RIOT_CI_BUILD=1' 
Building application "hello-world" for "native" with MCU "native".

   text	   data	    bss	    dec	    hex	filename
  22918	    568	  47652	  71138	  115e2	/data/riotbuild/riotbase/examples/hello-world/bin/native/hello-world.elf
```
</details>

### Issues/PRs references

Allow bypassing default handling for the command line setting when they do not work, and add other variables:

https://github.com/RIOT-OS/RIOT/issues/12027

This is also something I need to locally give `-j` to docker. I was using

```
# Extract parallel option
# The number of jobs is only available after make 4.2
# The value will not be available in make but in the targets body
MAKE_PARALLEL = $(filter -j -j%,$(MAKEFLAGS))
DOCKER_MAKECMDGOALS += $(MAKE_PARALLEL)
```
in a `RIOT_MAKEFILES_GLOBAL_POST`
