### PR TITLE
cpu/esp32: add compile option when module ssp is used

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -138,6 +138,10 @@ ifeq ($(QEMU), 1)
     CFLAGS += -DQEMU
 endif
 
+ifneq (,$(filter ssp,$(USEMODULE)))
+    CFLAGS  += -fstack-protector-strong
+endif
+
 # LINKFLAGS += -Wl,--verbose
 
 LINKFLAGS += -L$(ESP32_SDK_DIR)/components/esp32


### PR DESCRIPTION
### Contribution description

Add compile option `-fstack-protector-strong` to `CFLAGS` when module ssp is enabled.

### Testing procedure

Compile `tests/ssp` with command
```
make BOARD=esp32-wroom-32 -C tests/ssp QUIET=0
```
and check that option `-fstack-protector-strong` is in the command line for `xtensa-esp32-elf-gcc`.

Compile `examples/hello-world` with command
```
make BOARD=esp32-wroom-32 -C examples/hello-world QUIET=0
```
and check that option `-fstack-protector-strong` isn't in the command line for `xtensa-esp32-elf-gcc`.

### Issues/PRs references
