### PR TITLE
pkg/ccn-lite: remove dependency on tlsf-malloc.

### DIFF
--- a/examples/ccn-lite-relay/main.c
+++ b/examples/ccn-lite-relay/main.c
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 
-#include "tlsf-malloc.h"
 #include "msg.h"
 #include "shell.h"
 #include "ccn-lite-riot.h"
@@ -31,13 +30,8 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-/* 10kB buffer for the heap should be enough for everyone */
-#define TLSF_BUFFER     (10240 / sizeof(uint32_t))
-static uint32_t _tlsf_heap[TLSF_BUFFER];
-
 int main(void)
 {
-    tlsf_add_global_pool(_tlsf_heap, sizeof(_tlsf_heap));
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
     puts("Basic CCN-Lite example");

--- a/pkg/ccn-lite/Makefile.dep
+++ b/pkg/ccn-lite/Makefile.dep
@@ -3,6 +3,5 @@ ifneq (,$(filter ccn-lite,$(USEPKG)))
   USEMODULE += evtimer
   USEMODULE += random
   USEMODULE += timex
-  USEMODULE += tlsf-malloc
   USEMODULE += posix_headers
 endif


### PR DESCRIPTION
### Contribution description

There is no reason why this package would need tlsf. Using tlsf as system malloc is not known to work in all platforms.

With this patch CCN-Lite will use the default malloc provided by the target's C library.

### Testing procedure

The test procedure is described in the `examples/ccn-lite-relay/README.md`.

### Issues/PRs references

Works around the need for #12021 .
See #12031 for an explanation of why it is not such a good idea to use TLSF as the system-wide malloc.