### PR TITLE
net/gnrc/udp: Adding Null pointer check in gnrc_netif_hdr_build 

### DIFF
--- a/tests/gnrc_udp/udp.c
+++ b/tests/gnrc_udp/udp.c
@@ -138,6 +138,11 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
         if (iface > 0) {
             gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
+            if(netif == NULL) {
+                puts("Error: unable to allocate NETIF header");
+                gnrc_pktbuf_release(ip);
+                return;
+            }
             ((gnrc_netif_hdr_t *)netif->data)->if_pid = (kernel_pid_t)iface;
             LL_PREPEND(ip, netif);
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR contains the fix for issue #11631 :

1. Check for Null pointer has been added in **tests/gnrc_udp/udp.c** file where the node was crashing when tried sending a payload over 5992 bytes MTU. By checking the return value of the function **gnrc_netif_hdr_build** before sending the payload to the destination address we avoid the Null pointer Dereferencing.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
The fix has been tested in "native"

    

1. Have a udps server running and make a note of it's IPv6 address
2. From the tests/gnrc_udp/ folder, build and run the program and try sending a large payload in the following format:
> udp send [dest_addr] [port] [payload in bytes]

`udp send fe80::2806:1aff:fedd:f6d8 8888 5993`

The node will not send the message but will return an error message
    `Error: unable to allocate NETIF header`

Edit by @miri64: Use `pktbuf` to check if packet buffer is cleared in error case.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes #11631