### PR TITLE
can/isotp: fix closing connection and improve flow control handling

### DIFF
--- a/sys/can/conn/isotp.c
+++ b/sys/can/conn/isotp.c
@@ -91,7 +91,7 @@ int conn_can_isotp_create(conn_can_isotp_t *conn, struct isotp_options *options,
     return 0;
 }
 
-int conn_can_isotp_bind(conn_can_isotp_t *conn)
+int conn_can_isotp_bind(conn_can_isotp_t *conn, struct isotp_fc_options *fc_options)
 {
     assert(conn != NULL);
     assert(conn->isotp.opt.tx_id != 0 || conn->isotp.opt.rx_id != 0);
@@ -126,7 +126,7 @@ int conn_can_isotp_bind(conn_can_isotp_t *conn)
         put_msg(conn, &msg);
     }
 
-    ret = isotp_bind(&conn->isotp, &entry, conn);
+    ret = isotp_bind(&conn->isotp, &entry, conn, fc_options);
     if (!ret) {
         conn->bound = 1;
     }

--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -878,6 +878,7 @@ int isotp_release(struct isotp *isotp)
         .can_mask = 0xFFFFFFFF,
     };
     raw_can_unsubscribe_rx(isotp->entry.ifnum, &filter, isotp_pid, isotp);
+    xtimer_remove(&isotp->rx_timer);
 
     if (isotp->rx.snip) {
         DEBUG("isotp_release: freeing rx buf\n");
@@ -886,6 +887,8 @@ int isotp_release(struct isotp *isotp)
     }
     isotp->rx.state = ISOTP_IDLE;
     isotp->entry.target.pid = KERNEL_PID_UNDEF;
+
+    xtimer_remove(&isotp->tx_timer);
 
     mutex_lock(&lock);
     LL_DELETE(isotp_list, isotp);

--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -33,18 +33,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#ifndef CAN_ISOTP_BS
-#define CAN_ISOTP_BS 10
-#endif
-
-#ifndef CAN_ISOTP_STMIN
-#define CAN_ISOTP_STMIN 5
-#endif
-
-#ifndef CAN_ISOTP_WFTMAX
-#define CAN_ISOTP_WFTMAX 0
-#endif
-
 #ifndef CAN_ISOTP_MSG_QUEUE_SIZE
 #define CAN_ISOTP_MSG_QUEUE_SIZE 64
 #endif
@@ -792,7 +780,8 @@ int isotp_send(struct isotp *isotp, const void *buf, int len, int flags)
     return len;
 }
 
-int isotp_bind(struct isotp *isotp, can_reg_entry_t *entry, void *arg)
+int isotp_bind(struct isotp *isotp, can_reg_entry_t *entry, void *arg,
+               struct isotp_fc_options *fc_options)
 {
     int ret;
 
@@ -816,13 +805,13 @@ int isotp_bind(struct isotp *isotp, can_reg_entry_t *entry, void *arg)
     memset(&isotp->rx, 0, sizeof(struct tpcon));
     memset(&isotp->tx, 0, sizeof(struct tpcon));
 
-    isotp->rxfc.bs = CAN_ISOTP_BS;
-    isotp->rxfc.stmin = CAN_ISOTP_STMIN;
+    isotp->rxfc.bs = fc_options ? fc_options->bs : CAN_ISOTP_BS;
+    isotp->rxfc.stmin = fc_options ? fc_options->stmin : CAN_ISOTP_STMIN;
     isotp->rxfc.wftmax = 0;
 
     isotp->txfc.bs = 0;
     isotp->txfc.stmin = 0;
-    isotp->txfc.wftmax = CAN_ISOTP_WFTMAX;
+    isotp->txfc.wftmax = fc_options ? fc_options->wftmax : CAN_ISOTP_WFTMAX;
 
     isotp->entry.ifnum = entry->ifnum;
 #ifdef MODULE_CAN_MBOX

--- a/sys/include/can/conn/isotp.h
+++ b/sys/include/can/conn/isotp.h
@@ -112,10 +112,10 @@ static inline void conn_can_isotp_init_slave(conn_can_isotp_t *master, conn_can_
  * @brief   ISOTP connection
  */
 typedef struct conn_can_isotp {
-    struct isotp isotp;  /**< ISO-TP connection */
-    int ifnum;           /**< interface number */
-    int bound;           /**< 1 if connection is bound */
-    mbox_t mbox;         /**< mbox */
+    struct isotp isotp; /**< ISO-TP connection */
+    int ifnum;          /**< interface number */
+    int bound;          /**< 1 if connection is bound */
+    mbox_t mbox;        /**< mbox */
     /** message queue */
     msg_t mbox_queue[CONN_CAN_ISOTP_MBOX_SIZE];
 } conn_can_isotp_t;
@@ -137,11 +137,12 @@ int conn_can_isotp_create(conn_can_isotp_t *conn, struct isotp_options *options,
  * @brief Bind a can isotp connection
  *
  * @param[inout] conn       ISO-TP connection
+ * @param[in] fc_options    ISO-TP flow control options, can be NULL for default parameters
  *
  * @return 0 on success
  * @return any other negative number in case of an error
  */
-int conn_can_isotp_bind(conn_can_isotp_t *conn);
+int conn_can_isotp_bind(conn_can_isotp_t *conn, struct isotp_fc_options *fc_options);
 
 /**
  * @brief  Close can isotp connection socket

--- a/sys/include/can/isotp.h
+++ b/sys/include/can/isotp.h
@@ -31,6 +31,26 @@ extern "C" {
 #include "xtimer.h"
 #include "net/gnrc/pktbuf.h"
 
+#ifndef CAN_ISOTP_BS
+/**
+ * @brief   Default Block Size for RX Flow Control frames
+ */
+#define CAN_ISOTP_BS        (10)
+#endif
+
+#ifndef CAN_ISOTP_STMIN
+/**
+ * @brief   Default STmin for RX Flow Control frames
+ */
+#define CAN_ISOTP_STMIN     (5)
+#endif
+
+#ifndef CAN_ISOTP_WFTMAX
+/**
+ * @brief   Default maximum WFT for TX Flow Control
+ */
+#define CAN_ISOTP_WFTMAX    (1)
+#endif
 
 /**
  * @brief The isotp_fc_options struct
@@ -160,11 +180,14 @@ int isotp_send(struct isotp *isotp, const void *buf, int len, int flags);
  * @param isotp           the channel to bind
  * @param entry           entry identifying the CAN ifnum and the upper layer
  *                        either by its pid or its mailbox
+ * @param fc_options      flow control parameters, bs and stmin for rx, wftmax for tx,
+ *                        if NULL, default values will be used
  * @param arg             upper layer private parameter
  *
  * @return 0 on success, < 0 on error
  */
-int isotp_bind(struct isotp *isotp, can_reg_entry_t *entry, void *arg);
+int isotp_bind(struct isotp *isotp, can_reg_entry_t *entry, void *arg,
+               struct isotp_fc_options *fc_options);
 
 /**
  * @brief Release a bound isotp channel

--- a/tests/conn_can/main.c
+++ b/tests/conn_can/main.c
@@ -227,7 +227,7 @@ static int _bind_isotp(int argc, char **argv)
 #endif
     ret = conn_can_isotp_create(&conn_isotp[thread_nb], &isotp_opt, ifnum);
     if (ret == 0) {
-        ret = conn_can_isotp_bind(&conn_isotp[thread_nb]);
+        ret = conn_can_isotp_bind(&conn_isotp[thread_nb], NULL);
     }
     if (ret < 0) {
         puts("Error when binding connection");


### PR DESCRIPTION

### Contribution description

This PR fixes closing an ISO TP connection if the user-supplied timeout is shorter than `CAN_ISOTP_TIMEOUT_N_Ar`.  In short, xtimers were not removed properly when closing.

This also add the ability to customize the flow control frame from the upper layers. We discovered some weird behavior with some vehicles that do not implement the protocol properly, so tweaking the flow control for a given connection can be useful.


### Testing procedure

The bug was reproduced with the given configuration:

1. RIOT node opens a connection and waits for reception with a timeout < 1s
1. remote node sends a "first frame"
1. RIOT node sends the "flow control"
1. remote node doesn't send a "consecutive frame" -> timeout on the RIOT node, crash after `CAN_ISOTP_TIMEOUT_N_Ar` s (1s)


