### PR TITLE
drivers/cc110x: Default channel configuration

### DIFF
--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -347,19 +347,18 @@ static int cc110x_init(netdev_t *netdev)
     /* Apply configuration (if non-NULL) and channel map, which also calls
      * cc110x_full_calibration
      */
-    retval = cc110x_apply_config(dev, dev->params.config, dev->params.channels);
+    retval = cc110x_apply_config(dev, dev->params.config, dev->params.channels,
+                                 CC110X_DEFAULT_CHANNEL);
     if (retval) {
         gpio_irq_disable(dev->params.gdo0);
         gpio_irq_disable(dev->params.gdo2);
         DEBUG("[cc110x] netdev_driver_t::init(): cc110x_apply_config() "
               "failed\n");
-        /* Pass through received error code  */
+        /* Pass through received error code */
         return retval;
     }
-    else {
-        DEBUG("[cc110x] netdev_driver_t::init(): Success\n");
-    }
 
+    DEBUG("[cc110x] netdev_driver_t::init(): Success\n");
     return 0;
 }
 

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -240,6 +240,13 @@ extern "C" {
 #define CC110X_DEFAULT_PROTOCOL         (GNRC_NETTYPE_UNDEF)
 #endif
 
+#ifndef CC110X_DEFAULT_CHANNEL
+/**
+ * @brief The default channel to set up after initializing the device
+ */
+#define CC110X_DEFAULT_CHANNEL      (0U)
+#endif
+
 /**
  * @brief   The state of the CC1100/CC1101 transceiver
  *
@@ -558,10 +565,12 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params);
  * @param   dev     Device descriptor of the transceiver
  * @param   conf    Configuration to apply or `NULL` to only change channel map
  * @param   chanmap Channel map to apply (must be compatible with @p conf)
+ * @param   channel The channel to tune in after applying the config
  *
  * @retval  0       Success
  * @retval  -EINVAL Called with invalid argument
  * @retval  -EIO    Communication with the transceiver failed
+ * @retval  -ERANGE Channel out of range or not supported by channel map
  *
  * @pre     The application developer checked in the documentation that the
  *          channel map in @p chanmap is compatible with the configuration in
@@ -574,7 +583,7 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params);
  * @ref cc110x_full_calibration is called to update it.
  */
 int cc110x_apply_config(cc110x_t *dev, const cc110x_config_t *conf,
-                        const cc110x_chanmap_t *chanmap);
+                        const cc110x_chanmap_t *chanmap, uint8_t channel);
 
 /**
  * @brief   Perform a calibration of the frequency generator for each supported

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -71,10 +71,4 @@ endif
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed
-ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-  DEFAULT_CHANNEL ?= 5
-  CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-else                                          # radio is IEEE 802.15.4 2.4 GHz
-  DEFAULT_CHANNEL ?= 26
-  CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-endif
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -116,10 +116,4 @@ host-tools:
 	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)
 
 # Set a custom channel if needed
-ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-  DEFAULT_CHANNEL ?= 5
-  CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-else                                          # radio is IEEE 802.15.4 2.4 GHz
-  DEFAULT_CHANNEL ?= 26
-  CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-endif
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -36,10 +36,4 @@ QUIET ?= 1
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed
-ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-  DEFAULT_CHANNEL ?= 5
-  CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-else                                          # radio is IEEE 802.15.4 2.4 GHz
-  DEFAULT_CHANNEL ?= 26
-  CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-endif
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -65,10 +65,4 @@ QUIET ?= 1
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed
-ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-  DEFAULT_CHANNEL ?= 5
-  CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-else                                          # radio is IEEE 802.15.4 2.4 GHz
-  DEFAULT_CHANNEL ?= 26
-  CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-endif
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/examples/gnrc_networking_mac/Makefile
+++ b/examples/gnrc_networking_mac/Makefile
@@ -60,6 +60,5 @@ QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
 
-# Set a custom channel
-DEFAULT_CHANNEL ?= 26
-CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+# Set a custom channel if needed
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -49,3 +49,6 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -61,10 +61,4 @@ QUIET ?= 1
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed
-ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-  DEFAULT_CHANNEL ?= 5
-  CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-else                                          # radio is IEEE 802.15.4 2.4 GHz
-  DEFAULT_CHANNEL ?= 26
-  CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-endif
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/makefiles/default-channel.inc.mk
+++ b/makefiles/default-channel.inc.mk
@@ -1,0 +1,13 @@
+# Set a custom channel if needed
+ifneq (,$(filter cc110x,$(USEMODULE)))          # radio is cc110x sub-GHz
+  DEFAULT_CHANNEL ?= 0
+  CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+else
+  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
+    DEFAULT_CHANNEL ?= 5
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  else                                          # radio is IEEE 802.15.4 2.4 GHz
+    DEFAULT_CHANNEL ?= 26
+    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+  endif
+endif

--- a/tests/gnrc_gomach/Makefile
+++ b/tests/gnrc_gomach/Makefile
@@ -42,8 +42,7 @@ USEMODULE += gnrc_gomach
 # reduce the size of the packet buffer a bit
 CFLAGS += -DGNRC_PKTBUF_SIZE=1024
 
-# Set a custom channel if needed
-DEFAULT_CHANNEL ?= 26
-CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-
 include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/tests/gnrc_lwmac/Makefile
+++ b/tests/gnrc_lwmac/Makefile
@@ -34,8 +34,7 @@ USEMODULE += gnrc_lwmac
 # reduce the size of the packet buffer a bit
 CFLAGS += -DGNRC_PKTBUF_SIZE=512
 
-# Set a custom channel if needed
-DEFAULT_CHANNEL ?= 26
-CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-
 include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -31,10 +31,4 @@ USEMODULE += netstats_ipv6
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed
-ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-  DEFAULT_CHANNEL ?= 5
-  CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-else                                          # radio is IEEE 802.15.4 2.4 GHz
-  DEFAULT_CHANNEL ?= 26
-  CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-endif
+include $(RIOTMAKE)/default-channel.inc.mk

--- a/tests/riotboot_flashwrite/Makefile
+++ b/tests/riotboot_flashwrite/Makefile
@@ -65,15 +65,4 @@ QUIET ?= 1
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed
-ifneq (,$(filter cc110x,$(USEMODULE)))          # radio is cc110x sub-GHz
-  DEFAULT_CHANNEL ?= 0
-  CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-else
-  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-    DEFAULT_CHANNEL ?= 5
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-  else                                          # radio is IEEE 802.15.4 2.4 GHz
-    DEFAULT_CHANNEL ?= 26
-    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-  endif
-endif
+include $(RIOTMAKE)/default-channel.inc.mk


### PR DESCRIPTION
### Contribution description

- Reintroduced the `CC110X_DEFAULT_CHANNEL` preprocessor macro, as there are still users of it from the old driver (bugfix)
- Moved the default channel configuration copy-pasted into various Makefiles to `makefiles/default-channel.inc.mk` and included that instead in the various Makefiles (cleanup)

### Testing procedure

Run `BOARD=<foo> DEFAULT_CHANNEL=<bar> make -C examples/default flash` for some boards (e.g. one with a 802.15.4 transceiver and the MSB-A2). Check with `ifconfig` that the default channel (`<bar>`) was applied.

### Issues/PRs references

None