### PR TITLE
unittests/sht1x: decrease the amount of tested values on board

### DIFF
--- a/tests/unittests/tests-sht1x/tests-sht1x.c
+++ b/tests/unittests/tests-sht1x/tests-sht1x.c
@@ -16,6 +16,25 @@ static const int16_t max_diff_temp = 1;
 /** @brief Maximum difference from correct humidity value [in e-02 %] */
 static const int16_t max_diff_hum = 10;
 
+/*
+ * Configure tested values steps
+ *
+ * Verify less values on boards as without hwfloat it takes minutes to test.
+ * Checking that the trend is valid is enough to find int overflow
+ * or similar errors.
+ *
+ * Keep the full range test on native as it is "instant"
+ */
+
+#ifdef CPU_NATIVE
+#define TEMPERATURE_TEST_STEPS      1
+/* Use 0.13°c steps. */
+#define HUMIDITY_TEST_TEMP_STEPS    13
+#else /* CPU_NATIVE */
+#define TEMPERATURE_TEST_STEPS      100
+#define HUMIDITY_TEST_TEMP_STEPS    1300
+#endif /* CPU_NATIVE */
+
 static int16_t expected_temp(const sht1x_dev_t *dev, uint16_t _raw)
 {
     static const double d1_table[] = { -40.1, -39.8, -39.7, -39.6, -39.4 };
@@ -68,7 +87,8 @@ static void test_sht1x_conversion(void)
         uint16_t max_raw_hum = max_raw_hums[i_res];
         for (size_t i_vdd = 0; i_vdd < ARRAY_SIZE(vdds); i_vdd++) {
             dev.vdd = vdds[i_vdd];
-            for (uint16_t raw_temp = 0; raw_temp <= max_raw_temp; raw_temp++) {
+            for (uint16_t raw_temp = 0; raw_temp <= max_raw_temp;
+                    raw_temp += TEMPERATURE_TEST_STEPS) {
                 int16_t got_temp = sht1x_temperature(&dev, raw_temp);
                 int16_t exp_temp = expected_temp(&dev, raw_temp);
 
@@ -77,8 +97,9 @@ static void test_sht1x_conversion(void)
             }
         }
 
-        /* Testing for temperatures in -10.00°C and 65.00°C in steps of 0.13°C */
-        for (int16_t temp = -1000; temp < 6500; temp += 13) {
+        /* Testing for temperatures between -10.00°C and 65.00°C */
+        for (int16_t temp = -1000; temp < 6500;
+                temp += HUMIDITY_TEST_TEMP_STEPS) {
             for (uint16_t raw_hum = 0; raw_hum <= max_raw_hum; raw_hum++) {
                 int16_t exp_hum = expected_hum(&dev, raw_hum, temp);
                 if ((exp_hum < 0) || (exp_hum > 10000)) {


### PR DESCRIPTION
### Contribution description

Reduce the amount of tested values by a 100.
This makes the testing time go from 3 minutes to 2 seconds on `frdm-kw41z`.

Testing that the integer calculation matches the float one does not need
to be performed on the full range on boards. Checking some values should
be enough to detect overflow issues.
The full range checking is kept on native.

Fixes #12042

### Testing procedure

Running the `unittests` on `frdm-kw41z` now goes to the end of the test in time:

```
2019-08-21 15:00:31,531 - INFO # ��˙����main(): This is RIOT! (Version: 2019.10-devel-445-g2a24-pr/unittests/sht1x/limit_test_vectors_on_board)
2019-08-21 15:00:50,676 - INFO # .............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
2019-08-21 15:00:50,676 - INFO # OK (957 tests)
2019-08-21 15:00:50,676 - INFO # *** RIOT kernel panic:
```

I noticed the `RIOT kernel panic`, but this is also in `master`

On master the test was failing:

```
BOARD=frdm-kw41z make tests-sht1x flash test

Type '/exit' to exit.                                                                                                                                                                      
2019-08-20 17:21:58,190 - INFO # t�G�   main(): This is RIOT! (Version: 2019.10-devel-444-gd6356)                                                                                     
Timeout in expect script at "child.expect(u"OK \\([0-9]+ tests\\)")" (tests/unittests/tests/01-run.py:14)
```

But when run with `term` we could get the output after 3:30 minutes (with the `HARD FAULT`.

```
2019-08-21 15:03:34,907 - INFO # main(): This is RIOT! (Version: 2019.10-devel-444-gd6356)


2019-08-21 15:06:56,170 - INFO # .............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
2019-08-21 15:06:56,175 - INFO # OK (957 tests)
2019-08-21 15:06:56,176 - INFO # *** RIOT kernel panic:
2019-08-21 15:06:56,176 - INFO # HARD FAULT HANDLER
2019-08-21 15:06:56,176 - INFO #
2019-08-21 15:06:56,185 - INFO # *** rebooting...main(): This is RIOT! (Version: 2019.10-devel-444-gd6356)
```

### Issues/PRs references

* Fixes #12042 tests/unittests/tests-sht1x breaks on `frdm-kw41z

The test was failing during release too https://github.com/RIOT-OS/Release-Specs/issues/128#issuecomment-513172986