### PR TITLE
boards/msba2: Added OpenOCD config

### DIFF
--- a/boards/msba2/Makefile.include
+++ b/boards/msba2/Makefile.include
@@ -1,3 +1,4 @@
 USEMODULE += boards_common_msba2
 
 include $(RIOTBOARD)/common/msba2/Makefile.include
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/msba2/dist/openocd.cfg
+++ b/boards/msba2/dist/openocd.cfg
@@ -1,0 +1,36 @@
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+
+# Every pin set as high impedance except TCK, TDI, TDO and TMS
+ftdi_layout_init 0x0008 0x000b
+
+# nSRST defined on pin CN2-13 of the MiniModule (pin ADBUS5 [AD5] on the FT2232H chip)
+# This choice is arbitrary. Use other GPIO pin if desired.
+ftdi_layout_signal nSRST -data 0x0020 -oe 0x0020
+
+ftdi_layout_signal nTRST -data 0x0010 -oe 0x0010
+transport select jtag
+
+# ADBUS 0 - 5 are used
+# 0 TCK
+# 1 TDI
+# 2 TDO
+# 3 TMS
+# 4 nTRST
+# 5 nSRST
+
+
+source [find target/lpc2xxx.cfg]
+# parameters:
+# - core_freq_khz - frequency of core in kHz during flashing, usually equal to connected crystal or internal oscillator, e.g. 12000
+# - adapter_freq_khz - frequency of debug adapter in kHz, should be 8x slower than core_freq_khz, e.g. 1000
+
+proc setup_lpc2387 {core_freq_khz adapter_freq_khz} {
+	# setup_lpc2xxx <chip_name> <cputapid> <flash_size> <flash_variant> <workarea_size> <core_freq_khz> <adapter_freq_khz>
+	setup_lpc2xxx lpc2387 0x4f1f0f0f 0x7d000 lpc2000_v2 0x10000 $core_freq_khz $adapter_freq_khz
+}
+
+proc init_targets {} {
+	# setup_lpc2387 <core_freq_khz> <adapter_freq_khz>
+	setup_lpc2387 4000 500
+}

--- a/boards/msba2/doc.txt
+++ b/boards/msba2/doc.txt
@@ -5,16 +5,15 @@
 
 ## Overview
 
-![MSBA2 image](https://raw.githubusercontent.com/wiki/RIOT-
-OS/RIOT/images/MSBA2_photo.jpg)
+![MSBA2 image](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/MSBA2_photo.jpg)
 
 
 ## Hardware
 
-| MCU: | LPC2387 ARM7-TDMI |
-|------|-------------------|
-| RAM: | 96kb |
-| Flash: | 512kb |
+| MCU:      | LPC2387 ARM7-TDMI |
+|-----------|-------------------|
+| RAM:      | 96kb              |
+| Flash:    | 512kb             |
 
 
 # More info
@@ -30,42 +29,67 @@ OS/RIOT/images/MSBA2_photo.jpg)
 [MSB-A2 page @ Freie Universität Berlin/CST](http://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/Z_Finished_Projects/ScatterWeb/modules/mod_MSB-A2.html)
 
 
-## Toolchains
+## Flashing
 
-See: [ARM](https://github.com/RIOT-OS/RIOT/wiki/Family:-ARM)
+The MSB-A2 is programmed via an ISP bootloader over UART. The board includes
+an FTDI USB-TTL converter, which is connected to the left USB Mini-B connector
+(see picture above). Connect the MSB-A2 using that connector to your PC and
+run from within the folder of your application to flash:
 
-Working:
- - CodeSourcery 2013.11
- - CodeSourcery 2014.05 (only hello-world tested)
- - CodeSourcery 2008q3
- - [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded) 5.2.1 20151202 (release) (only [`default`](https://github.com/RIOT-OS/RIOT/tree/master/examples/default) tested)
+    BOARD=msba2 make flash
 
-Not Working:
- - Arm launchpad 2013-2
- - [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded) 4.8.4 2014q2 (release)
+You'll notice that during the first invocation takes a bit longer, as the tool
+`lpc2k_pgm` used to flash the MSB-A2 is also compiled.
 
+You can connect to the shell by running:
 
-## Programming and Debugging
+    BOARD=msba2 make term
 
-Currently the MSBA2 boards only work properly™ with a CodeSourcery toolchain.
+## Debugging
 
-##### lpc2k_pgm
+Some rigorous hardware modification is needed to access the JTAG interface of
+the MSB-A2.
 
-In order to flash the MSBA2 board you also need the `lpc2k_pgm` tool. You can
-build it by navigating to the `boards/msba2-common/tools` directory and then
-running `make`. The tool will be created inside the `bin/` sub-directory and has
-to be copied to a directory inside the `$PATH`.
+![MSB-A2 modified to access JTAG](https://raw.githubusercontent.com/maribu/images/master/MSB-A2-JTAG.jpg)
 
-##### flashing/debugging
+The following wires need to be soldered on:
 
-Build using the following set of commands:
+| Signal        | Place                                                     |
+|:--------------|:----------------------------------------------------------|
+| JTAG-TDO      | IC2, Pin 1                                                |
+| JTAG-TDI      | IC2, Pin 2                                                |
+| JTAG-TMS      | IC2, Pin 3                                                |
+| JTAG-TRST     | IC2, Pin 4                                                |
+| JTAG-TCK      | IC2, Pin 5                                                |
+| JTAG-RTCK (*) | IC2, Pin 100                                              |
+| RESET         | right pad of R6 (easier to solder) **or** IC2, Pin 17     |
+| GND           | The bottom left through-hole pad                          |
 
- BOARD=msba2 make flash
- BOARD=msba2 make term
+(*) You can safely omit the connection to JTAG-RTCK.
 
+As debugger an FT2232HL is used, the cheapest version costs less 10€ (often
+nicknamed CJMCU-2232HL).
 
+Connect as fallows:
 
-## Known Issues
+| FT2232HL  | MSB-A2    |
+|:----------|:----------|
+| GND       | GND       |
+| AD0       | JTAG-TCK  |
+| AD1       | JTAG-TDI  |
+| AD2       | JTAG-TDO  |
+| AD3       | JTAG-TMS  |
+| AD4       | JTAG-TRST |
+| AD5       | RESET     |
 
-None
+Once this is done, debugging is as simple as running:
+
+    BOARD=msba2 make debug
+
+### Flashing via OpenOCD
+
+Theoretically you should be able to flash also via JTAG. But do not expect this
+to be faster. Also: Do you really want to risk bricking the MSB-A2 you spend so
+much time to modify? The author of this text surely didn't want to risk that...
+
  */


### PR DESCRIPTION
### Contribution description

- Added OpenOCD configuration for MSB-A2
- Updated MSB-A2 documentation
- Extended documentation to explain how debugging the board works

### Testing procedure

1. Grab a MSB-A2 board and modify as explained in the board documentation
2. Grab an FT2232HL that will be used as debugger (can be bought for less then 10€ as CJMCU-2232HL)
3. Connect the board to the debugger as documented
4. Run `make BOARD=msba2 flash` and `make BOARD=msba2 debug` in your favorite application
5. Try setting breakpoints, single-stepping etc.

### Issues/PRs references

None