### PR TITLE
at86rf2xx: remove SLEEP from phy states

### DIFF
--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -154,11 +154,11 @@ void at86rf2xx_fb_stop(const at86rf2xx_t *dev);
 uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev);
 
 /**
- * @brief   Make sure that device is not sleeping
+ * @brief   Wake up the device
  *
- * @param[in,out] dev   device to eventually wake up
+ * @param[in,out] dev   device to wake up
  */
-void at86rf2xx_assert_awake(at86rf2xx_t *dev);
+void at86rf2xx_wake_up(at86rf2xx_t *dev);
 
 /**
  * @brief   Trigger a hardware reset
@@ -167,6 +167,12 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev);
  */
 void at86rf2xx_hardware_reset(at86rf2xx_t *dev);
 
+/**
+ * @brief  Put the device to sleep
+ *
+ * @param[in] dev           device to sleep
+ */
+void at86rf2xx_sleep(at86rf2xx_t *dev);
 
 /**
  * @brief   Set PHY parameters based on channel and page number

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -177,6 +177,8 @@ extern "C" {
 #define AT86RF2XX_OPT_AUTOACK        (0x0080)       /**< Auto ACK active */
 #define AT86RF2XX_OPT_ACK_PENDING    (0x0100)       /**< ACK frames with data
                                                      *   pending */
+#define AT86RF2XX_OPT_SLEEP          (0x0200)       /**< Go back to sleep right
+                                                         after any operation */
 
 /** @} */
 


### PR DESCRIPTION
# Contribution description
This commit changes the representation of the SLEEP state in the `at86rf2xx` driver.

I'm trying to make a distinction between PHY states (RX_ON, TRX_OFF, TX_ON/PLL_ON) and hardware states (P_ON, RESET, SLEEP). This will simplify a lot the state handling of radios, and also add some mechanism to prevent race conditions when changing between RX, BUSY_RX, TX and BUSY_TX (I will open a PR soon that show this in action).

The first step then is to remove the SLEEP state from `at86rf2xx_set_state` and add some dedicated functions for turning the radio on and off (inspired in the Linux at86rf2xx driver).

The API of netdev is the same (NETOPT_STATE set with NETOPT_STATE_SLEEP sets the radio to sleep), but the behavior of the driver changes a bit because of the `dev->idle_state` variable. In current master, it's possible to send data while the device is sleeping, and then the device will do a TX->SLEEP transition. With this change, if the device was sleeping it will end in TRX_OFF.

In any case, the `idle_state` logic shouldn't be in the driver (e.g in TSCH networks the MAC layer needs to set the state of the radio without cooperation from the driver. Same applies for LoRaWAN). So I hope it's OK ;)

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Test it with the `default` example:
- Set the devices to sleep (e.g `ifconfig 4 set state SLEEP`)
- Try to send data with `txtsnd`. The device should be able to send data and go back to STANDBY state (TRX_OFF)
- Wake up the devices (`ifconfig 4 set state IDLE`).
- Send data again. Verify nodes can still receive data after wake up.

It would be possible to verify that the device is actually sleeping measuring the power consumption of the node (I know this is possible with not so much efforts on IoT-LAB)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Related to #11483
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
