### PR TITLE
drivers/periph/i2c: Updated i2c_release() to return void

### DIFF
--- a/cpu/atmega_common/periph/i2c.c
+++ b/cpu/atmega_common/periph/i2c.c
@@ -226,12 +226,11 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
 static void i2c_poweron(i2c_t dev)

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -159,7 +159,7 @@ static void _i2c_master_slave_addr(uint16_t addr, bool receive)
 {
     DEBUG("%s (%" PRIx16 ", %d)\n", __FUNCTION__, addr, (int)receive);
     assert(!(addr & 0x80));
-    I2CM_SA = (addr << 1) | receive;
+    I2CM_SA = (addr << 1) | (receive ? 0x1 : 0x0);
 }
 
 static void _i2c_master_data_put(uint8_t data)

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -241,14 +241,11 @@ int i2c_acquire(i2c_t dev)
     return -1;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
+    assert(dev < I2C_NUMOF);
     DEBUG("%s\n", __FUNCTION__);
-    if (dev < I2C_NUMOF) {
-        mutex_unlock(&lock);
-        return 0;
-    }
-    return -1;
+    mutex_unlock(&lock);
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t addr,

--- a/cpu/cc26x0/periph/i2c.c
+++ b/cpu/cc26x0/periph/i2c.c
@@ -21,6 +21,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
@@ -133,11 +134,10 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
     mutex_unlock(&_lock);
-    return 0;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t addr,

--- a/cpu/efm32/periph/i2c.c
+++ b/cpu/efm32/periph/i2c.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "cpu.h"
@@ -152,15 +153,15 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
+    assert(dev < I2C_NUMOF);
+
     /* disable peripheral */
     CMU_ClockEnable(i2c_config[dev].cmu, false);
 
     /* release lock */
     mutex_unlock(&i2c_lock[dev]);
-
-    return 0;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length, uint8_t flags)

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -39,6 +39,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <string.h>
@@ -277,15 +278,14 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
     DEBUG ("%s\n", __func__);
 
-    CHECK_PARAM_RET (dev < I2C_NUMOF, -1)
+    assert(dev < I2C_NUMOF);
 
     _i2c_reset_hw (dev);
     mutex_unlock(&_i2c_bus[dev].lock);
-    return 0;
 }
 
 #define _i2c_return_on_error(dev) \

--- a/cpu/esp32/periph/i2c_sw.c
+++ b/cpu/esp32/periph/i2c_sw.c
@@ -33,6 +33,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 
@@ -186,12 +187,11 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
-    CHECK_PARAM_RET (dev < I2C_NUMOF, -1)
+    assert(dev < I2C_NUMOF);
 
     mutex_unlock(&_i2c_bus[dev].lock);
-    return 0;
 }
 
 int /* IRAM */ i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, uint8_t flags)

--- a/cpu/esp8266/periph/i2c.c
+++ b/cpu/esp8266/periph/i2c.c
@@ -31,6 +31,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <errno.h>
 
@@ -201,12 +202,11 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
-    CHECK_PARAM_RET (dev < I2C_NUMOF, -1)
+    assert(dev < I2C_NUMOF);
 
     mutex_unlock(&i2c_bus_lock[dev]);
-    return 0;
 }
 
 int /* IRAM */ i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, uint8_t flags)

--- a/cpu/kinetis/periph/i2c.c
+++ b/cpu/kinetis/periph/i2c.c
@@ -23,6 +23,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <errno.h>
 
@@ -114,15 +115,15 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
+    assert(dev < I2C_NUMOF);
     /* Check that the bus was properly stopped before releasing */
     /* It is a programming error to release the bus after sending a start
      * condition but before sending a stop condition */
     assert(i2c_state[dev].active == 0);
 
     mutex_unlock(&i2c_state[dev].mtx);
-    return 0;
 }
 
 static uint8_t i2c_find_divider(unsigned freq, unsigned speed)

--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -28,6 +28,7 @@
  *
  * @}
  */
+#include <assert.h>
 #include <errno.h>
 #include "cpu.h"
 #include "mutex.h"
@@ -139,12 +140,11 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,

--- a/cpu/nrf52/periph/i2c.c
+++ b/cpu/nrf52/periph/i2c.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 #include <errno.h>
 
@@ -113,7 +114,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
@@ -121,7 +122,6 @@ int i2c_release(i2c_t dev)
     mutex_unlock(&locks[dev]);
 
     DEBUG("[i2c] released dev %i\n", (int)dev);
-    return 0;
 }
 
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <errno.h>
 
@@ -164,11 +165,10 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t addr,

--- a/cpu/stm32_common/periph/i2c_1.c
+++ b/cpu/stm32_common/periph/i2c_1.c
@@ -32,6 +32,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <errno.h>
 
@@ -145,14 +146,13 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
     periph_clk_dis(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
 
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,

--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -34,6 +34,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <errno.h>
 
@@ -195,7 +196,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
@@ -207,7 +208,6 @@ int i2c_release(i2c_t dev)
 #endif
 
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
 int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -231,10 +231,8 @@ int i2c_acquire(i2c_t dev);
  * @brief   Release the given I2C device to be used by others
  *
  * @param[in] dev           I2C device to release
- *
- * @return                  0 on success, -1 on error
  */
-int i2c_release(i2c_t dev);
+void i2c_release(i2c_t dev);
 
 /**
  * @brief   Convenience function for reading one byte from a given register

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -146,7 +146,6 @@ int cmd_i2c_acquire(int argc, char **argv)
 
 int cmd_i2c_release(int argc, char **argv)
 {
-    int res;
     int dev;
 
     dev = _check_param(argc, argv, 1, 1, "DEV");
@@ -155,13 +154,10 @@ int cmd_i2c_release(int argc, char **argv)
     }
 
     printf("Command: i2c_release(%i)\n", dev);
-    res = i2c_release(dev);
+    i2c_release(dev);
 
-    if (res == I2C_ACK) {
-        printf("Success: i2c_%i released\n", dev);
-        return 0;
-    }
-    return _print_i2c_error(res);
+    printf("Success: i2c_%i released\n", dev);
+    return 0;
 }
 
 int cmd_i2c_read_reg(int argc, char **argv)


### PR DESCRIPTION
### Contribution description

`i2c_release()` should not return any value, as:

- There is no reasonable error handling possible by the caller, so there is no value in indicating success/failure via the return value to the caller
- There is no legitimate reason to fail *unless* an invalid I2C bus was released or an I2C bus that was not previously acquired was released
    - --> This would indicate a bug in the code and should be tackled by an `assert()`

### Testing procedure

1. Murdock will do the most important part
2. Test if the I2C interface is still working

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/10673