### PR TITLE
cpu/sam0_common/periph/uart: implement non-blocking write

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -976,6 +976,11 @@ ifneq (,$(filter suit_%,$(USEMODULE)))
   USEMODULE += suit
 endif
 
+# Enable periph_uart when periph_uart_nonblocking is enabled
+ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_uart
+endif
+
 # Enable periph_gpio when periph_gpio_irq is enabled
 ifneq (,$(filter periph_gpio_irq,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -73,6 +73,7 @@ static const uart_conf_t uart_config[] = {
 
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom2_2
+#define UART_0_ISR_TX       isr_sercom2_0
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -88,6 +88,7 @@ static const uart_conf_t uart_config[] = {
 
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom2_2
+#define UART_0_ISR_TX       isr_sercom2_0
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */

--- a/cpu/sam0_common/Makefile.dep
+++ b/cpu/sam0_common/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
+  USEMODULE += tsrb
+endif

--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -4,6 +4,7 @@ FEATURES_PROVIDED += periph_flashpage_raw
 FEATURES_PROVIDED += periph_flashpage_rwee
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_uart_modecfg
+FEATURES_PROVIDED += periph_uart_nonblocking
 FEATURES_PROVIDED += periph_wdt periph_wdt_cb
 
 -include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -196,6 +196,14 @@ typedef enum {
 /** @} */
 #endif /* ndef DOXYGEN */
 
+
+/**
+ * @brief   Size of the UART TX buffer for non-blocking mode.
+ */
+#ifndef SAM0_UART_TXBUF_SIZE
+#define SAM0_UART_TXBUF_SIZE    (64)
+#endif
+
 /**
  * @brief   UART device configuration
  */

--- a/cpu/samd21/Makefile.dep
+++ b/cpu/samd21/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.dep

--- a/cpu/samd5x/Makefile.dep
+++ b/cpu/samd5x/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.dep

--- a/cpu/saml1x/Makefile.dep
+++ b/cpu/saml1x/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.dep

--- a/cpu/saml21/Makefile.dep
+++ b/cpu/saml21/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.dep

--- a/tests/periph_uart_nonblocking/Makefile
+++ b/tests/periph_uart_nonblocking/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += periph_uart_nonblocking
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_uart_nonblocking/main.c
+++ b/tests/periph_uart_nonblocking/main.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Simple test application for non-blocking UART functionality
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <xtimer.h>
+
+#define LINE_DELAY_MS   100
+
+static inline uint32_t puts_delay(const char* str)
+{
+    puts(str);
+    xtimer_usleep(LINE_DELAY_MS * 1000);
+    return LINE_DELAY_MS * 1000;
+}
+
+int main(void)
+{
+    uint32_t total_us = 0;
+    xtimer_ticks32_t counter = xtimer_now();
+
+    /* Richard Stallman and the Free Software Foundation
+       claim no copyright on this song. */
+    total_us += puts_delay("");
+    total_us += puts_delay("Join us now and share the software;");
+    total_us += puts_delay("You'll be free, hackers, you'll be free.");
+    total_us += puts_delay("Join us now and share the software;");
+    total_us += puts_delay("You'll be free, hackers, you'll be free.");
+    total_us += puts_delay("");
+    total_us += puts_delay("Hoarders can get piles of money,");
+    total_us += puts_delay("That is true, hackers, that is true.");
+    total_us += puts_delay("But they cannot help their neighbors;");
+    total_us += puts_delay("That's not good, hackers, that's not good.");
+    total_us += puts_delay("");
+    total_us += puts_delay("When we have enough free software");
+    total_us += puts_delay("At our call, hackers, at our call,");
+    total_us += puts_delay("We'll kick out those dirty licenses");
+    total_us += puts_delay("Ever more, hackers, ever more.");
+    total_us += puts_delay("");
+    total_us += puts_delay("Join us now and share the software;");
+    total_us += puts_delay("You'll be free, hackers, you'll be free.");
+    total_us += puts_delay("Join us now and share the software;");
+    total_us += puts_delay("You'll be free, hackers, you'll be free.");
+    total_us += puts_delay("");
+
+    counter.ticks32 = xtimer_now().ticks32 - counter.ticks32;
+
+    printf("== printed in %" PRIu32 "/%" PRIu32 " µs ==\n", xtimer_usec_from_ticks(counter), total_us);
+
+    puts("[SUCCESS]");
+
+    return 0;
+}

--- a/tests/periph_uart_nonblocking/tests/01-run.py
+++ b/tests/periph_uart_nonblocking/tests/01-run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Benjamin Valentin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'== printed in (\d+)/(\d+) µs ==')
+    time_actual = int(child.match.group(1))
+    time_expect = int(child.match.group(2))
+
+    assert time_actual / time_expect < 1.0015
+
+    child.expect_exact("[SUCCESS]")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This replaces the polling based UART TX implementation on the sam0 platform with an interrupt based one.
Thread-safe Ringbuffer is used for the TX buffer with a compile-time configurable buffer size. (May be tweaked.)

~~**This violates the specification of `uart_write()`** as this makes [`uart_write()`](https://riot-os.org/api/group__drivers__periph__uart.html#gae2360fb0e880c387cfc02dd0cbd1c113) non-blocking.~~

The non-blocking mode is now only used if the module `periph_uart_nonblocking` is used.

I wanted to have a non-blocking debug output when debugging a race condition, so I implemented this. Maybe a non-blocking uart_write could be generally useful though.

### Testing procedure

add `USEMODULE += periph_uart_nonblocking` to your application.

Everything should behave as before, although the console output feels more snappy.
Only the shell / debug output have been tested.

### Issues/PRs references
none
