### PR TITLE
NDN-over-BLE: enable CCN-lite to use BLE as link layer

### DIFF
--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -3,7 +3,8 @@ APPLICATION = ccn-lite-relay
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
 
-BOARD_WHITELIST := fox iotlab-m3 msba2 mulle native pba-d-01-kw2x samr21-xpro
+BOARD_WHITELIST := fox iotlab-m3 msba2 mulle native nrf52dk nrf52840dk \
+                   pba-d-01-kw2x samr21-xpro
 
 
 # This has to be the absolute path to the RIOT base directory:

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -69,8 +69,11 @@ static int _conn_dump(nimble_netif_conn_t *conn, int handle, void *arg)
 
     printf("[%2i] ", handle);
     bluetil_addr_print(conn->addr);
-    printf(" (%c) -> ", role);
+    printf(" (%c)", role);
+#ifdef MODULE_GNRC_IPV6
+    printf(" -> ");
     bluetil_addr_ipv6_l2ll_print(conn->addr);
+#endif
     puts("");
 
     return 0;
@@ -121,8 +124,10 @@ static void _cmd_info(void)
     bluetil_addr_swapped_cp(tmp_addr, own_addr);
     printf("Own Address: ");
     bluetil_addr_print(own_addr);
+#ifdef MODULE_GNRC_IPV6
     printf(" -> ");
     bluetil_addr_ipv6_l2ll_print(own_addr);
+#endif
     puts("");
 
     printf(" Free slots: %u/%u\n", free, MYNEWT_VAL_BLE_MAX_CONNECTIONS);

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -30,7 +30,7 @@
 #include "net/bluetil/ad.h"
 #include "net/bluetil/addr.h"
 
-#define DEFAULT_NODE_NAME           "RIOT-GNRC"
+#define DEFAULT_NODE_NAME           "bleRIOT"
 #define DEFAULT_SCAN_DURATION       (500U)      /* 500ms */
 #define DEFAULT_CONN_TIMEOUT        (500U)      /* 500ms */
 


### PR DESCRIPTION
# Contribution description
This PR enables RIOT to run NDN-over-BLE using NimBLE and CCN-lite. It allows this by simply allowing the `ccn-lite-relay` example to be build for some BLE boards. As the CCN-lite port in RIOT is build around the GNRC `netif` interface, all needed wrapper code to tie in NimBLE is already provided in #11578. So all that is left for this PR is to whitelist boards...

This PR also contains a pure cosmetic fix to the `ble` shell command provided by `sc_nimble_netif`: the output of link local IPv6 addresses is now tied to the existence to the `gnrc_ipv6` module, as there is not use for these addresses in a non-IP context...

Note: this PR will work for all boards using a `nrf52` family CPU. But for the sake of taking a little bit of workload of the CI, I decided only to add one board per nrf52 variant for now. We might want to change this later on at some point...

### Testing procedure
- flash this application to any number of `nrf52`-based boards (the `iotlab` can be of help here...)
- connect the boards in any topology you feel fit (´ble adv` to start advertising, `ble scan` and `ble connect` to connect to advertising nodes)
- fill the content store of one or more boards with data (e.g. `ccnl_cs /your/name/here "some content")
- ask for that content from any node (e.g. `ccnl_int /your/name/here`)

This should work for single and for any multi-hop topology!

### Issues/PRs references
EDIT
~~based on #11578~~ -> was merged.