### PR TITLE
arduino-due: add riotboot support

### DIFF
--- a/boards/common/arduino-due/Makefile.features
+++ b/boards/common/arduino-due/Makefile.features
@@ -12,3 +12,4 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += riotboot

--- a/cpu/sam3/Makefile.include
+++ b/cpu/sam3/Makefile.include
@@ -1,5 +1,10 @@
 export CPU_ARCH = cortex-m3
 export CPU_FAM  = sam3
 
+ROM_LEN ?= 512K
+RAM_LEN ?= 96K
+ROM_START_ADDR ?= 0x00080000
+RAM_START_ADDR ?= 0x20000000
+
 include $(RIOTCPU)/sam_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/sam_common/Makefile.include
+++ b/cpu/sam_common/Makefile.include
@@ -4,8 +4,8 @@ CFLAGS += -DCPU_FAM_$(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
 # this CPU implementation doesn't use CMSIS initialization
 export CFLAGS += -DDONT_USE_CMSIS_INIT
 
-# for the sam[drl] CPUs we hold all linkerscripts in the sam0 common folder
-export LINKFLAGS += -L$(RIOTCPU)/sam_common/ldscripts
+# For Cortex-M cpu we use the common cortexm.ld linker script
+LINKER_SCRIPT ?= cortexm.ld
 
 # export the common include directory
 export INCLUDES += -I$(RIOTCPU)/sam_common/include

--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -1,6 +1,9 @@
 FLASHFILE ?= $(BINFILE)
 FLASHER ?= $(RIOTTOOLS)/bossa/bossac
-FFLAGS  ?= -p $(PORT) -e -i -w -v -b -R $(FLASHFILE)
+BOSSA_ARGS += -p $(PORT)
+BOSSA_ARGS += -i -w -v -b -R
+BOSSA_ARGS += $(if $(IMAGE_OFFSET),--offset $(IMAGE_OFFSET))
+FFLAGS ?= $(BOSSA_ARGS) $(FLASHFILE)
 
 # some arduino boards need to toggle the serial interface a little bit to get
 # them ready for flashing...

--- a/tests/cortexm_common_ldscript/Makefile
+++ b/tests/cortexm_common_ldscript/Makefile
@@ -7,6 +7,7 @@ include ../Makefile.tests_common
 BOARD_WHITELIST += iotlab-a8-m3
 BOARD_WHITELIST += iotlab-m3
 BOARD_WHITELIST += samr21-xpro
+BOARD_WHITELIST += arduino-due
 # Normally all boards using `kinetis/ldscripts/kinetis.ld` linkerscript
 BOARD_WHITELIST += frdm-kw41z
 BOARD_WHITELIST += frdm-k64f


### PR DESCRIPTION
### Contribution description

This PR attempts to add riotboot requirements for the arduino due board.

### Testing procedure

Still needs some preparatory work, but ultimately the test below should succeed:

make -C tests/riotboot BOARD=arduino-due flash test


