### PR TITLE
board/nucleo-l432kc: Implementing I2C for board

### DIFF
--- a/boards/nucleo-l432kc/Makefile.features
+++ b/boards/nucleo-l432kc/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -170,6 +170,29 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 6),
+        .sda_pin        = GPIO_PIN(PORT_B, 7),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR1_I2C1EN,
+        .irqn           = I2C1_ER_IRQn
+    }
+};
+
+#define I2C_0_ISR           isr_i2c1_er
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

Trying to enable I2C for Nucleo-L432KC, however it doesn't seem to be working yet, as I'm seeing scrambled data on a I2C 7-segment LED display that I'm testing this with. Creating this PR in the hope that maybe someone with a better understanding of the board's internal workings could give a hint on what could be wrong with the periph config.

### Testing procedure

Connect I2C device to board's D4 (SDA) and D5 (SCL) pins and try to talk to it.
