### PR TITLE
at86rf2xx: fix race conditions and PHY states representation

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -85,9 +85,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,
                           &enable, sizeof(enable));
 
-    /* enable safe mode (protect RX FIFO until reading data starts) */
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
-                        AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
 #ifdef MODULE_AT86RF212B
     at86rf2xx_set_page(dev, AT86RF2XX_DEFAULT_PAGE);
 #endif

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -110,10 +110,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     tmp |= (AT86RF2XX_TRX_CTRL_0_CLKM_CTRL__OFF);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_0, tmp);
 
-    /* enable interrupts */
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK,
-                        AT86RF2XX_IRQ_STATUS_MASK__TRX_END
-                        | AT86RF2XX_IRQ_STATUS_MASK__RX_START);
     /* clear interrupt flags */
     at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
 

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -154,11 +154,11 @@ void at86rf2xx_fb_stop(const at86rf2xx_t *dev);
 uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev);
 
 /**
- * @brief   Make sure that device is not sleeping
+ * @brief   Wake up the device
  *
- * @param[in,out] dev   device to eventually wake up
+ * @param[in,out] dev   device to wake up
  */
-void at86rf2xx_assert_awake(at86rf2xx_t *dev);
+void at86rf2xx_wake_up(at86rf2xx_t *dev);
 
 /**
  * @brief   Trigger a hardware reset
@@ -167,6 +167,12 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev);
  */
 void at86rf2xx_hardware_reset(at86rf2xx_t *dev);
 
+/**
+ * @brief  Put the device to sleep
+ *
+ * @param[in] dev           device to sleep
+ */
+void at86rf2xx_sleep(at86rf2xx_t *dev);
 
 /**
  * @brief   Set PHY parameters based on channel and page number

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -151,7 +151,7 @@ void at86rf2xx_fb_stop(const at86rf2xx_t *dev);
  *
  * @return              internal status of the given device
  */
-uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev);
+uint8_t at86rf2xx_read_trx_status(const at86rf2xx_t *dev);
 
 /**
  * @brief   Wake up the device

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -158,6 +158,12 @@ extern "C" {
 #define AT86RF2XX_STATE_IN_PROGRESS    (0x1f)     /**< ongoing state conversion */
 /** @} */
 
+#define AT86RF2XX_PHY_RX               (0x0)      /**< device is in RX mode */
+#define AT86RF2XX_PHY_TX               (0x1)      /**< device is in TX mode */
+#define AT86RF2XX_PHY_TRX_OFF          (0x2)      /**< device transceiver is off */
+#define AT86RF2XX_PHY_FORCE_TRX_OFF    (0x3)      /**< device is forced to turn
+                                                       its transceiver off */
+
 /**
  * @name    Internal device option flags
  * @{

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -177,6 +177,8 @@ extern "C" {
 #define AT86RF2XX_OPT_AUTOACK        (0x0080)       /**< Auto ACK active */
 #define AT86RF2XX_OPT_ACK_PENDING    (0x0100)       /**< ACK frames with data
                                                      *   pending */
+#define AT86RF2XX_OPT_SLEEP          (0x0200)       /**< Go back to sleep right
+                                                         after any operation */
 
 /** @} */
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -211,6 +211,7 @@ typedef struct {
     at86rf2xx_params_t params;              /**< parameters for initialization */
     uint16_t flags;                         /**< Device specific flags */
     uint8_t state;                          /**< current state of the radio */
+    bool busy;                              /**< radio is busy */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */
 #ifdef MODULE_AT86RF212B
     /* Only AT86RF212B supports multiple pages (PHY modes) */
@@ -535,6 +536,18 @@ void at86rf2xx_tx_exec(const at86rf2xx_t *dev);
  * @return                  false if channel is determined busy
  */
 bool at86rf2xx_cca(at86rf2xx_t *dev);
+
+/**
+ * @brief Internal function to change state
+ * @details For all cases but AT86RF2XX_STATE_FORCE_TRX_OFF state and
+ *          cmd parameter are the same.
+ *
+ * @param dev       device to operate on
+ * @param state     target state
+ * @param cmd       command to initiate state transition
+ */
+
+void at86rf2xx_write_trx_state(at86rf2xx_t *dev, uint8_t state, uint8_t cmd);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR summarizes in:
### 1. Define PHY states for the at86rf2xx.
 Now the at86rf2xx_set_state function receives a PHY state instead of an internal AT86RF2XX representation.This simplifies the state machine and integration of Basic Mode:

E.g `at86rf2xx_set_state(dev, AT86RF2XX_PHY_RX)` will internally set the transceiver to AT86RF2XX_STATE_RX_AACK_ON in Extended Mode but to AT86RF2XX_STATE_RX_ON in Basic Mode.

### 2. Now it's possible to retrieve the TRX state with a variable, instead of polling via `at86rf2xx_get_status`.

This variable is synchronized with the transceiver via interrupts (e.g RX_START interrupt set `dev->state=AT86RF2XX_PHY_RX_BUSY`. Then, the RX_DONE event sets the variable back to a non BUSY event).

See how this simplifies the _isr function and how this prevents race conditions (send command is rejected if "dev->state" is in one of the BUSY states. No need to poll the device).

### 3. Move from Dynamic buffer protection to Static buffer protection:
Dynamic buffer protection is released on at86rf2xx_fb_stop. The current work around was to go set the transceiver state to PLL_ON before reading the frame buffer.
With static buffer protection the detection of SFD is disabled on RX_END, and re-enabled on packet read/drop.

This changes fix the issue described on https://github.com/RIOT-OS/RIOT/pull/11256 (it makes @miri64 tests pass), so it's an alternative to https://github.com/RIOT-OS/RIOT/pull/11264

Basic Mode support comes next :)

## Discussion/RFC
 In practice, the RX_START event tells the PHY layer that the SFD was detected. Thus, this event is mandatory for synchronizing the dev->state variable.

Also, the transmission (regardless of Basic or Extended mode) always ends with the TX_DONE event. So, RX_START and TRX_END must be mandatory if a PHY layer is present (so far, the `at86rf2xx_netdev.c` is the PHY layer implementation of the driver).

**The question is, do we still want the TELL_RX_START, TELL_RX_DONE and TELL_TX_DONE configurations?**
If yes, they MUST be activated in the at86rf2xx_netdev layer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run https://github.com/RIOT-OS/RIOT/pull/11256. Check the test passes (that means no "Unexpected payload. This test failed!").

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/pull/11256
Alternative to https://github.com/RIOT-OS/RIOT/pull/11264
Depends on #12062 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
