### PR TITLE
at86rf2xx: implement Basic Mode

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -85,9 +85,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,
                           &enable, sizeof(enable));
 
-    /* enable safe mode (protect RX FIFO until reading data starts) */
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
-                        AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
 #ifdef MODULE_AT86RF212B
     at86rf2xx_set_page(dev, AT86RF2XX_DEFAULT_PAGE);
 #endif

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -77,6 +77,8 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* set default options */
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_AUTOACK, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
+    at86rf2xx_set_option(dev, AT86RF2XX_OPT_EXT_MODE,
+            CONFIG_AT86RF2XX_DEFAULT_MODE);
 
     static const netopt_enable_t enable = NETOPT_ENABLE;
     netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -154,11 +154,11 @@ void at86rf2xx_fb_stop(const at86rf2xx_t *dev);
 uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev);
 
 /**
- * @brief   Make sure that device is not sleeping
+ * @brief   Wake up the device
  *
- * @param[in,out] dev   device to eventually wake up
+ * @param[in,out] dev   device to wake up
  */
-void at86rf2xx_assert_awake(at86rf2xx_t *dev);
+void at86rf2xx_wake_up(at86rf2xx_t *dev);
 
 /**
  * @brief   Trigger a hardware reset
@@ -167,6 +167,12 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev);
  */
 void at86rf2xx_hardware_reset(at86rf2xx_t *dev);
 
+/**
+ * @brief  Put the device to sleep
+ *
+ * @param[in] dev           device to sleep
+ */
+void at86rf2xx_sleep(at86rf2xx_t *dev);
 
 /**
  * @brief   Set PHY parameters based on channel and page number

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -151,7 +151,7 @@ void at86rf2xx_fb_stop(const at86rf2xx_t *dev);
  *
  * @return              internal status of the given device
  */
-uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev);
+uint8_t at86rf2xx_read_trx_status(const at86rf2xx_t *dev);
 
 /**
  * @brief   Wake up the device

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -158,6 +158,12 @@ extern "C" {
 #define AT86RF2XX_STATE_IN_PROGRESS    (0x1f)     /**< ongoing state conversion */
 /** @} */
 
+#define AT86RF2XX_PHY_RX               (0x0)      /**< device is in RX mode */
+#define AT86RF2XX_PHY_TX               (0x1)      /**< device is in TX mode */
+#define AT86RF2XX_PHY_TRX_OFF          (0x2)      /**< device transceiver is off */
+#define AT86RF2XX_PHY_FORCE_TRX_OFF    (0x3)      /**< device is forced to turn
+                                                       its transceiver off */
+
 /**
  * @name    Internal device option flags
  * @{

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -139,6 +139,20 @@ extern "C" {
 #define AT86RF2XX_SMART_IDLE_LISTENING     (0)
 #endif
 
+#define AT86RF2XX_MODE_BASIC               (0)    /**< Basic operation mode */
+#define AT86RF2XX_MODE_EXTENDED            (1)    /**< Extended operation mode */
+
+/**
+ * @brief   Default AT86RF2XX operation mode
+ *
+ * This configuration flag sets the default operation mode to be configured
+ * on radio startup. Note the operation mode is a runtime configuration and
+ * it's possible to change it setting the @ref AT86RF2XX_OPT_EXT_MODE option
+ */
+#ifndef CONFIG_AT86RF2XX_DEFAULT_MODE
+#define CONFIG_AT86RF2XX_DEFAULT_MODE AT86RF2XX_MODE_EXTENDED
+#endif
+
 /**
  * @name    Flags for device internal states (see datasheet)
  * @{
@@ -185,6 +199,8 @@ extern "C" {
                                                      *   pending */
 #define AT86RF2XX_OPT_SLEEP          (0x0200)       /**< Go back to sleep right
                                                          after any operation */
+#define AT86RF2XX_OPT_EXT_MODE       (0x0400)       /**< Enable extended
+                                                         operation */
 
 /** @} */
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -177,6 +177,8 @@ extern "C" {
 #define AT86RF2XX_OPT_AUTOACK        (0x0080)       /**< Auto ACK active */
 #define AT86RF2XX_OPT_ACK_PENDING    (0x0100)       /**< ACK frames with data
                                                      *   pending */
+#define AT86RF2XX_OPT_SLEEP          (0x0200)       /**< Go back to sleep right
+                                                         after any operation */
 
 /** @} */
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -211,6 +211,7 @@ typedef struct {
     at86rf2xx_params_t params;              /**< parameters for initialization */
     uint16_t flags;                         /**< Device specific flags */
     uint8_t state;                          /**< current state of the radio */
+    bool busy;                              /**< radio is busy */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */
 #ifdef MODULE_AT86RF212B
     /* Only AT86RF212B supports multiple pages (PHY modes) */
@@ -535,6 +536,18 @@ void at86rf2xx_tx_exec(const at86rf2xx_t *dev);
  * @return                  false if channel is determined busy
  */
 bool at86rf2xx_cca(at86rf2xx_t *dev);
+
+/**
+ * @brief Internal function to change state
+ * @details For all cases but AT86RF2XX_STATE_FORCE_TRX_OFF state and
+ *          cmd parameter are the same.
+ *
+ * @param dev       device to operate on
+ * @param state     target state
+ * @param cmd       command to initiate state transition
+ */
+
+void at86rf2xx_write_trx_state(at86rf2xx_t *dev, uint8_t state, uint8_t cmd);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This adds support for Basic Mode operation (no auto-ack, no
auto-retrans with CSMA).
A new configuration flag is added for setting the default
operation mode. However, the device can switch between modes
on runtime (see `AT86RF2XX_OPT_EXT_MODE` option).

By default, the device is set to Extended Operation.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Test with a couple of nodes. Set one to extended mode and the other one to basic:
E.g
```
CFLAGS=-DCONFIG_AT86RF2XX_DEFAULT_MODE=AT86RF2XX_MODE_BASIC BOARD=iotlab-m3 make all flash term
```
and
```
BOARD=iotlab-m3 make all flash term
```
Send packets from BASIC->EXTENDED. You should see an ACK packet (8 bytes with netif_hdr) in the BASIC node:
```
1566572302.955737;m3-11;> txtsnd 4 15:11:6B:10:65:FC:BD:52 holi
1566572302.957690;m3-11;> PKTDUMP: data received:
1566572302.957966;m3-10;> PKTDUMP: data received:
1566572302.958641;m3-11;~~ SNIP  0 - size:   0 byte, type: NETTYPE_UNDEF (0)
1566572302.960005;m3-10;~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
1566572302.960198;m3-10;00000000  68  6F  6C  69
1566572302.960334;m3-10;~~ SNIP  1 - size:  18 byte, type: NETTYPE_NETIF (-1)
1566572302.961037;m3-10;if_pid: 4  rssi: -46  lqi: 255
1566572302.961192;m3-10;flags: 0x0
1566572302.961774;m3-11;00000000~~ SNIP  1 - size:   8 byte, type: NETTYPE_NETIF (-1)
1566572302.961953;m3-11;if_pid: 4  rssi: -46  lqi: 255
1566572302.962089;m3-11;flags: 0x0
1566572302.962249;m3-10;src_l2addr: AD:56
1566572302.962370;m3-10;dst_l2addr: 15:11:6B:10:65:FC:BD:52
1566572302.963227;m3-11;src_l2addr: (nil)
1566572302.963729;m3-11;dst_l2addr: (nil)
1566572302.964136;m3-11;~~ PKT    -  2 snips, total size:   8 byte
1566572302.964533;m3-10;~~ PKT    -  2 snips, total size:  22 byte

```

Send from EXTENDED->BASIC. You should see the retransmission packets on BASIC:
```m3-10;txtsnd 4 15:11:6B:10:65:FC:AD:56 holi
1566572246.940421;m3-10;> txtsnd 4 15:11:6B:10:65:FC:AD:56 holi
1566572246.944401;m3-11;> PKTDUMP: data received:
1566572246.944594;m3-11;~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
1566572246.944733;m3-11;00000000  68  6F  6C  69
1566572246.945702;m3-11;~~ SNIP  1 - size:  18 byte, type: NETTYPE_NETIF (-1)
1566572246.946942;m3-11;if_pid: 4  rssi: -45  lqi: 255
1566572246.947133;m3-11;flags: 0x0
1566572246.948295;m3-11;src_l2addr: BD:52
1566572246.948472;m3-11;dst_l2addr: 15:11:6B:10:65:FC:AD:56
1566572246.949881;m3-11;~~ PKT    -  2 snips, total size:  22 byte
1566572246.950059;m3-11;PKTDUMP: data received:
1566572246.950551;m3-11;~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
1566572246.951460;m3-11;00000000  68  6F  6C  69
1566572246.952444;m3-11;~~ SNIP  1 - size:  18 byte, type: NETTYPE_NETIF (-1)
1566572246.953410;m3-11;if_pid: 4  rssi: -45  lqi: 255
1566572246.953588;m3-11;flags: 0x0
1566572246.953713;m3-11;src_l2addr: BD:52
1566572246.954456;m3-11;dst_l2addr: 15:11:6B:10:65:FC:AD:56
1566572246.955447;m3-11;~~ PKT    -  2 snips, total size:  22 byte
1566572246.956426;m3-11;PKTDUMP: data received:
1566572246.957399;m3-11;~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
1566572246.957578;m3-11;00000000  68  6F  6C  69
1566572246.958500;m3-11;~~ SNIP  1 - size:  18 byte, type: NETTYPE_NETIF (-1)
1566572246.959442;m3-11;if_pid: 4  rssi: -45  lqi: 255
1566572246.959607;m3-11;flags: 0x0
1566572246.960428;m3-11;src_l2addr: BD:52
1566572246.961398;m3-11;dst_l2addr: 15:11:6B:10:65:FC:AD:56
1566572246.962408;m3-11;~~ PKT    -  2 snips, total size:  22 byte
1566572246.962574;m3-11;PKTDUMP: data received:
1566572246.963450;m3-11;~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
1566572246.964425;m3-11;00000000  68  6F  6C  69
1566572246.965401;m3-11;~~ SNIP  1 - size:  18 byte, type: NETTYPE_NETIF (-1)
1566572246.966344;m3-11;if_pid: 4  rssi: -45  lqi: 255
1566572246.966780;m3-11;flags: 0x0
1566572246.967168;m3-11;src_l2addr: BD:52
1566572246.967685;m3-11;dst_l2addr: 15:11:6B:10:65:FC:AD:56
1566572246.968635;m3-11;~~ PKT    -  2 snips, total size:  22 byte


```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #12069 
Partially addresses https://github.com/RIOT-OS/RIOT/issues/8213
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
