### PR TITLE
tests/test_tools: add a test for the testing tools environment

### DIFF
--- a/tests/test_tools/Makefile
+++ b/tests/test_tools/Makefile
@@ -1,0 +1,11 @@
+DEVELHELP = 0
+include ../Makefile.tests_common
+
+USEMODULE += shell
+
+TEST_ON_CI_WHITELIST += all
+
+# Disable shell echo and prompt to not have them in the way for testing
+CFLAGS += -DSHELL_NO_ECHO=1 -DSHELL_NO_PROMPT=1
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/test_tools/README.md
+++ b/tests/test_tools/README.md
@@ -1,0 +1,8 @@
+`test_tools`
+============
+
+This test is here to verify the test tools integration with your board and test
+setup.
+
+It verify the assumptions required for testing on the board behaviour
+through make term.

--- a/tests/test_tools/main.c
+++ b/tests/test_tools/main.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Specific shell implementation for testing the testing tools.
+ *
+ * @author      Gaëtan Harter <gaetan.harter@fu-berlin.de>
+ *
+ */
+
+#include <stdio.h>
+
+#include "shell_commands.h"
+#include "shell.h"
+
+#if !defined(SHELL_NO_ECHO) || !defined(SHELL_NO_PROMPT)
+#error This test assumes no shell echo or shell prompt
+#endif
+
+
+/**
+ * @brief true - do nothing, successfully
+ *
+ * true [ignored command line arguments]
+ *
+ * Description taken from `man true` in coreutils.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0
+ *
+ */
+static int cmd_true(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    return 0;
+}
+
+
+/**
+ * @brief shellping, replies shellpong
+ *
+ * Test if the shell is ready to take commands
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0
+ *
+ */
+static int cmd_shellping(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("shellpong");
+    return 0;
+}
+
+
+static const shell_command_t shell_commands[] = {
+    { "shellping", "Just print 'shellpong'", cmd_shellping },
+    { "true", "do nothing, successfully", cmd_true },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("Running 'tests_tools' application");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/test_tools/tests/01-run.py
+++ b/tests/test_tools/tests/01-run.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Test behaviour of the test running and the term program interaction."""
+
+import sys
+import pexpect
+from testrunner import run
+
+
+def _shellping(child, timeout=1):
+    """Issue a 'shellping' command.
+
+    Raises a pexpect exception on failure.
+    :param timeout: timeout for the answer
+    """
+    child.sendline('shellping')
+    child.expect_exact('shellpong\r\n', timeout=timeout)
+
+
+def _wait_shell_ready(child, numtries=5):
+    """Wait until the shell is ready by using 'shellping'."""
+    for _ in range(numtries - 1):
+        try:
+            _shellping(child)
+        except pexpect.TIMEOUT:
+            pass
+        else:
+            break
+    else:
+        # This one should fail
+        _shellping(child)
+
+
+def _test_no_local_echo(child):
+    """Verify that there is not local echo while testing."""
+    msg = 'true this should not be echoed'
+    child.sendline(msg)
+    res = child.expect_exact([pexpect.TIMEOUT, msg], timeout=1)
+    assert res == 0, "There should have been a timeout and not match stdin"
+
+
+def testfunc(child):
+    """Run some tests to verify the board under test behaves correctly.
+
+    It currently tests:
+
+    * local echo
+    """
+    child.expect_exact("Running 'tests_tools' application")
+
+    _wait_shell_ready(child)
+
+    # Verify there is no local and remote echo as it is disabled
+    _test_no_local_echo(child)
+
+    # The node should still answer after the previous one
+    _shellping(child)
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

Check the interaction with a board through make term.
It is using a shell without echo or prompt for reference.

It currently checks that there is no local echo.


Now that the issue in `testrunner` and the `RIOT_TERMINAL` is fixed, it is more a sanity check/regression test to verify your environment or a board configuration does not mess up with what is required for testing.


### Testing procedure

Run `BOARD=your_board make -C tests/test_tools/ flash test` with different `RIOT_TERMINAL`, currently supported (not on all boards) `pyterm`, `socat`, `picocom`.

The test should succeed in all cases.

<details><summary><code>RIOT_TERMINAL=pyterm samr21-xpro</code></summary>

```
RIOT_TERMINAL=pyterm  BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
   9144     140    2612   11896    2e78 /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming........................................ done.
Verification........................................ done.
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-08-23 18:08:58,892 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2019-08-23 18:09:02,136 - INFO # main(): This is RIOT! (Version: buildtest)
2019-08-23 18:09:02,139 - INFO # Running 'tests_tools' application
shellping
2019-08-23 18:09:02,192 - INFO # shellpong
true this should not be echoed
shellping
2019-08-23 18:09:03,297 - INFO # shellpong
```
</details>

<details><summary><code>RIOT_TERMINAL=picocom samr21-xpro</code></summary>

```
RIOT_TERMINAL=picocom BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
   9144     140    2612   11896    2e78 /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming........................................ done.
Verification........................................ done.
picocom --nolock --imap lfcrlf --baud "115200" "/dev/ttyACM0"
picocom v2.2

port is        : /dev/ttyACM0
flowcontrol    : none
baudrate is    : 115200
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
nolock is      : yes
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        : lfcrlf,
omap is        : 
emap is        : crcrlf,delbs,

Type [C-a] [C-h] to see available commands

Terminal ready
main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' applicationshellping

shellpong
true this should not be echoed
shellping
shellpong

```
</details>

<details><summary><code>RIOT_TERMINAL=socat samr21-xpro</code></summary>

```
RIOT_TERMINAL=socat BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
   9144     140    2612   11896    2e78 /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming........................................ done.
Verification........................................ done.
socat - open:/dev/ttyACM0,b115200,echo=0,raw
main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' applicationshellping

shellpong
true this should not be echoed
shellping
shellpong

```
</details>

<details><summary><code>native</code></summary>

```
RIOT_CI_BUILD=1 BOARD=native make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "native" with MCU "native".

   text    data     bss     dec     hex filename
  22506     628   47652   70786   11482 /home/harter/work/git/RIOT/tests/test_tools/bin/native/tests_test_tools.elf
true 
/home/harter/work/git/RIOT/tests/test_tools/bin/native/tests_test_tools.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong

```
</details>

<details><summary><code>On IoT-LAB it works too</code></summary>

```
IOTLAB_NODE=auto-ssh RIOT_CI_BUILD=1 BOARD=iotlab-m3 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "iotlab-m3" with MCU "stm32f1".

   text    data     bss     dec     hex filename
   8800     140    2620   11560    2d28 /home/harter/work/git/RIOT/tests/test_tools/bin/iotlab-m3/tests_test_tools.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list grenoble,m3,58 --update /home/harter/work/git/RIOT/tests/test_tools/bin/iotlab-m3/tests_test_tools.elf | grep 0
0
ssh -t harter@grenoble.iot-lab.info 'socat - tcp:m3-58.grenoble.iot-lab.info:20000'
�main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
�main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
```
</details>

### Issues/PRs references

Split out of 
* [WIP] tests/test_tools: add a test for the testing tools environment #11094 "
