### PR TITLE
tests/pkg_semtech-loramac: disable rx thread for arduino-mega2560

### DIFF
--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -9,9 +9,9 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
 BOARD_BLACKLIST := msb-430 msb-430h pic32-clicker pic32-wifire \
                    telosb wsn430-v1_3b wsn430-v1_4 z1
 
-# waspmote-pro doesn't have enough RAM to support another thread dedicated to
-# RX messages
-BOARD_WITHOUT_LORAMAC_RX := waspmote-pro
+# waspmote-pro and arduino-meag2560 don't have enough RAM to support another
+# thread dedicated to RX messages
+BOARD_WITHOUT_LORAMAC_RX := arduino-mega2560 waspmote-pro
 
 LORA_DRIVER ?= sx1276
 LORA_REGION ?= EU868


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes #12071 by disabling the rx extra thread in the application for arduino-mega2560.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be ok

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #12071 and will help merging #11917 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
