### PR TITLE
gnrc_netif_ieee802154: release TX packet on TX_DONE

### DIFF
--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -97,6 +97,12 @@ typedef struct {
 #endif
 
     /**
+     * @brief   Pointer to pending pkt.
+     *          This should be used for retransmissions.
+     */
+    iolist_t *pending_pkt;
+
+    /**
      * @brief   PAN ID in network byte order
      */
     uint16_t pan;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1283,7 +1283,9 @@ static void *_gnrc_netif_thread(void *args)
     /* setup the link-layer's message queue */
     msg_init_queue(msg_queue, GNRC_NETIF_MSG_QUEUE_SIZE);
     /* register the event callback with the device driver */
-    dev->event_callback = _event_cb;
+    if(!dev->event_callback) {
+        dev->event_callback = _event_cb;
+    }
     dev->context = netif;
     /* initialize low-level driver */
     res = dev->driver->init(dev);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
    
If the IEEE802.15.4 device doesn't support automatic retransmissions, the MAC layer should keep the outgoing packet until it's safe to release. As an intermediary step, the packet is now freed upon TX_DONE.

This is required in order to add driver independent ACK support.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Send IEEE802.15.4 packets between devices (e.g `samr21-xpro`). Use the `gnrc_pktbuf_cmd` module to ensure the pktbuf is empty after sending packets.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
