### PR TITLE
periph/gpio: add gpio_set_cb() function

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -416,6 +416,25 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int8_t int_num = _int_num(pin);
+
+    if (int_num < 0) {
+        return -1;
+    }
+
+    if (cb) {
+        config[int_num].cb = cb;
+    }
+
+    if (arg) {
+        config[int_num].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     EIFR |= (1 << _int_num(pin));

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -416,7 +416,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+int gpio_update_cb(gpio_t pin, gpio_cb_t cb)
 {
     int8_t int_num = _int_num(pin);
 
@@ -424,13 +424,20 @@ int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
         return -1;
     }
 
-    if (cb) {
-        config[int_num].cb = cb;
+    _gpio_update_cb(pin, &config[int_num].cb, cb);
+
+    return 0;
+}
+
+int gpio_update_cb_arg(gpio_t pin, void *arg)
+{
+    int8_t int_num = _int_num(pin);
+
+    if (int_num < 0) {
+        return -1;
     }
 
-    if (arg) {
-        config[int_num].arg = arg;
-    }
+    config[int_num].arg = arg;
 
     return 0;
 }

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -196,6 +196,19 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    if (cb) {
+        isr_ctx[_port_num(pin)][_pin_num(pin)].cb = cb;
+    }
+
+    if (arg) {
+        isr_ctx[_port_num(pin)][_pin_num(pin)].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     gpio(pin)->IE |= _pin_mask(pin);

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -196,15 +196,16 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+int gpio_update_cb(gpio_t pin, gpio_cb_t cb)
 {
-    if (cb) {
-        isr_ctx[_port_num(pin)][_pin_num(pin)].cb = cb;
-    }
+    _gpio_update_cb(pin, &isr_ctx[_port_num(pin)][_pin_num(pin)].cb, cb);
 
-    if (arg) {
-        isr_ctx[_port_num(pin)][_pin_num(pin)].arg = arg;
-    }
+    return 0;
+}
+
+int gpio_update_cb_arg(gpio_t pin, void arg)
+{
+    isr_ctx[_port_num(pin)][_pin_num(pin)].arg = arg;
 
     return 0;
 }

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -110,6 +110,19 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    if (cb) {
+        gpio_chan[pin].cb = cb;
+    }
+
+    if (arg) {
+        gpio_chan[pin].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     IOC->CFG[pin] |= IOCFG_EDGEIRQ_ENABLE;

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -137,8 +137,8 @@ void isr_edge(void)
 {
     for (unsigned pin = 0; pin < GPIO_ISR_CHAN_NUMOF; pin++) {
         /* doc claims EVFLAGS will only be set for pins that have edge detection enabled */
-        if (GPIO->EVFLAGS & (1 << pin)) {
-            GPIO->EVFLAGS |= (1 << pin);
+        if (GPIO->EVFLAGS & (1U << pin)) {
+            GPIO->EVFLAGS |= (1U << pin);
             gpio_chan[pin].cb(gpio_chan[pin].arg);
         }
     }

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -134,6 +134,23 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    if (pin == GPIO_UNDEF) {
+        return -1;
+    }
+
+    if (cb) {
+        isr_ctx[_pin_num(pin)].cb = cb;
+    }
+
+    if (arg) {
+        isr_ctx[_pin_num(pin)].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     GPIO_IntEnable(_pin_mask(pin));

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -428,6 +428,23 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    if (pin >= GPIO_PIN_NUMOF) {
+        return -1;
+    }
+
+    if (cb) {
+        gpio_isr_ctx_table[pin].cb = cb;
+    }
+
+    if (arg) {
+        gpio_isr_ctx_table[pin].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable (gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);

--- a/cpu/esp8266/periph/gpio.c
+++ b/cpu/esp8266/periph/gpio.c
@@ -214,6 +214,21 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
+
+    if (cb) {
+        gpio_isr_ctx_table[pin].cb = cb;
+    }
+
+    if (arg) {
+        gpio_isr_ctx_table[pin].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable (gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -140,6 +140,21 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    uint32_t pin_pos = _pin_pos(pin);
+
+    if (cb) {
+        isr_ctx[pin_pos].cb = cb;
+    }
+
+    if (arg) {
+        isr_ctx[pin_pos].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     GPIO->IEN |= _pin_mask(pin);

--- a/cpu/fe310/periph/gpio.c
+++ b/cpu/fe310/periph/gpio.c
@@ -162,6 +162,23 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    if (pin >= GPIO_NUMOF) {
+        return -1;
+    }
+
+    if (cb) {
+        isr_ctx[pin].cb = cb;
+    }
+
+    if (arg) {
+        isr_ctx[pin].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     /* Check for valid pin */

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -313,6 +313,24 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int ctx = get_ctx(port_num(pin), pin_num(pin));
+    if (ctx < 0) {
+        return -1;
+    }
+
+    if (cb) {
+        isr_ctx[ctx].cb = cb;
+    }
+
+    if (arg) {
+        isr_ctx[ctx].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     int ctx = get_ctx(port_num(pin), pin_num(pin));

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -254,6 +254,22 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    const uint8_t port_num = _port_num(pin);
+    const uint8_t pin_num = _pin_num(pin);
+
+    if (cb) {
+        gpio_config[port_num][pin_num].cb = cb;
+    }
+
+    if (arg) {
+        gpio_config[port_num][pin_num].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -202,6 +202,24 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    /* only certain pins can be used as interrupt pins */
+    if (_port(pin) != 0 && _port(pin) != 2) {
+        return -1;
+    }
+
+    if (cb) {
+        isr_ctx[_pin(pin)].cb = cb;
+    }
+
+    if (arg) {
+        isr_ctx[_pin(pin)].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     assert(_port(pin) == 0 || _port(pin) == 2);

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -249,7 +249,7 @@ void isr_eint3(void)
 
     /* invoke all handlers */
     for (int i = 0; i < NUMOF_IRQS; i++) {
-        if (status & (1 << i)) {
+        if (status & (1U << i)) {
             isr_ctx[i].cb(isr_ctx[i].arg);
 
             LPC_GPIOINT->IO0IntClr |= (1 << i);

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -247,6 +247,26 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int isr_map_entry =_isr_map_entry(pin);
+    int _state_index = _gpio_isr_map[isr_map_entry];
+
+    if (_state_index == 0xff) {
+        return -1;
+    }
+
+    if (cb) {
+        _gpio_states[_state_index].cb = cb;
+    }
+
+    if (arg) {
+        _gpio_states[_state_index].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     int isr_map_entry =_isr_map_entry(pin);

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -187,6 +187,19 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    if (cb) {
+        isr_ctx[_ctx(pin)].cb = cb;
+    }
+
+    if (arg) {
+        isr_ctx[_ctx(pin)].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     msp_port_isr_t *port = _isr_port(pin);

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -186,6 +186,31 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int idx = -1;
+    for (unsigned int i = 0; i < _gpiote_next_index; i++) {
+        if (_exti_pins[i] == pin) {
+            idx = i;
+            break;
+        }
+    }
+
+    if (idx < 0) {
+        return -1;
+    }
+
+    if (cb) {
+        exti_chan[idx].cb = cb;
+    }
+
+    if (arg) {
+        exti_chan[idx].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     for (unsigned int i = 0; i < _gpiote_next_index; i++) {

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -226,6 +226,26 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int exti = _exti(pin);
+
+    /* make sure EIC channel is valid */
+    if (exti == -1) {
+        return -1;
+    }
+
+    if (cb) {
+        gpio_config[exti].cb = cb;
+    }
+
+    if (arg) {
+        gpio_config[exti].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     int exti = _exti(pin);

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -329,7 +329,7 @@ static inline void isr_handler(Pio *port, int port_num)
     uint32_t status = (port->PIO_ISR & port->PIO_IMR);
 
     for (int i = 0; i < 32; i++) {
-        if (status & (1 << i)) {
+        if (status & (1U << i)) {
             int ctx = _ctx(port_num, i);
             exti_ctx[ctx].cb(exti_ctx[ctx].arg);
         }

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -308,6 +308,21 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    unsigned ctx_num = _ctx(_port_num(pin), _pin_num(pin));
+
+    if (cb) {
+        exti_ctx[ctx_num].cb = cb;
+    }
+
+    if (arg) {
+        exti_ctx[ctx_num].arg = arg;
+    }
+
+    return 0;
+}
+
 static inline void isr_handler(Pio *port, int port_num)
 {
     /* take interrupt flags only from pins which interrupt is enabled */

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -239,6 +239,22 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 
     return 0;
 }
+
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int pin_num = _pin_num(pin);
+
+    if (cb) {
+        isr_ctx[pin_num].cb = cb;
+    }
+
+    if (arg) {
+        isr_ctx[pin_num].arg = arg;
+    }
+
+    return 0;
+}
+
 void isr_exti(void)
 {
     /* only generate interrupts against lines which have their IMR set */

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -218,6 +218,21 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int pin_num = _pin_num(pin);
+
+    if (cb) {
+        exti_ctx[pin_num].cb = cb;
+    }
+
+    if (arg) {
+        exti_ctx[pin_num].arg = arg;
+    }
+
+    return 0;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     EXTI->IMR |= (1 << _pin_num(pin));

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -173,6 +173,28 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
                   gpio_cb_t cb, void *arg);
 
 /**
+ * @brief   Change the callback and/or argument of an external interrupt GPIO
+ *
+ * The registered callback function will be called in interrupt context every
+ * time the defined flank(s) configured in `gpio_init_int()` are detected.
+ *
+ * This assumes `gpio_init_int()` has been called at least once before on `pin`.
+ *
+ * @note    You have to add the module `periph_gpio_irq` to your project to
+ *          enable this function
+ *
+ * @param[in] pin       pin to re-configure
+ * @param[in] cb        callback that is called from interrupt context
+ *                      May be NULL, in which case the previous value is kept.
+ * @param[in] arg       optional argument passed to the callback
+ *                      May be NULL, in which case the previous value is kept.
+ *
+ * @return              0 on success
+ * @return              -1 on error
+ */
+int gpio_set_cb(gpio_t pin, gpio_cb_t cb, void *arg);
+
+/**
  * @brief   Enable pin interrupt if configured as interrupt source
  *
  * @note    You have to add the module `periph_gpio_irq` to your project to


### PR DESCRIPTION
### Contribution description

It can be desirable to change the function or behavior associated with a GPIO interrupt.
Currently this can only be achieved by calling `gpio_init_int()` again, which not only does lots of unnecessary and possibly time-consuming work, but also forces to expose the GPIO configuration to callers that only want to change the callback argument.

Error handling is done (if at all) following the style of the respective GPIO driver. That is, if the rest of the driver did not check if `pin` is valid, I didn't add such checks for `gpio_set_cb()`. If it did contain such checks, I copied them.

As this function only makes sense to call after `gpio_init_int()` had been called on `pin`, it could be argued to drop the checks entirely. 

### Testing procedure

The following program should alternate between the two messages with each press of a button.

```C
#include <stdio.h>
#include "periph/gpio.h"
#include "board.h"

static char* messages[] = {
    "Hello IRQ!",
    "Goodby IRQ!"
};

static void _irq_handler(void *arg)
{
    puts(arg);
    gpio_set_cb(BTN0_PIN, NULL, arg == messages[0] ? messages[1] : messages[0]);
}

int main(void)
{
    gpio_init_int(BTN0_PIN, GPIO_IN, GPIO_RISING, _irq_handler, messages[0]);
    return 0;
}
```

(Only tested on samr21-xpro)

### Issues/PRs references
none

(this will be used by the at86rf215 driver, a device which contains two basebands but only exposes one GPIO pin. As an optimization, the context points to the netdev that last called `send()`.)
