### PR TITLE
 sys/shell: refactor tokenizer code.

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -142,6 +142,8 @@ static void handle_input_line(const shell_command_t *command_list, char *line)
     enum PARSE_STATE pstate = PARSE_SPACE;
 
     while (*readpos != '\0') {
+        char wordbreak;
+
         switch (pstate) {
             case PARSE_SPACE:
                 if (*readpos != BLANK) {
@@ -159,35 +161,23 @@ static void handle_input_line(const shell_command_t *command_list, char *line)
                 }
                 goto parse_end;
             case PARSE_UNQUOTED:
-                if (*readpos == BLANK) {
-                    pstate = PARSE_SPACE;
-                    *writepos++ = '\0';
-                    goto parse_end;
-                } else if (*readpos == ESCAPECHAR) {
-                    pstate = escape_toggle(pstate);
-                    goto parse_end;
-                }
-                break;
+                wordbreak = BLANK;
+                goto break_word;
             case PARSE_SINGLEQUOTE:
-                if (*readpos == SQUOTE)  {
-                    pstate = PARSE_SPACE;
-                    *writepos++ = '\0';
-                    goto parse_end;
-                } else if (*readpos == ESCAPECHAR) {
-                    pstate = escape_toggle(pstate);
-                    goto parse_end;
-                }
-                break;
+                wordbreak = SQUOTE;
+                goto break_word;
             case PARSE_DOUBLEQUOTE:
-                if (*readpos == DQUOTE) {
+                wordbreak = DQUOTE;
+break_word:
+                if (*readpos == wordbreak) {
                     pstate = PARSE_SPACE;
                     *writepos++ = '\0';
-                    goto parse_end;
                 } else if (*readpos == ESCAPECHAR) {
                     pstate = escape_toggle(pstate);
-                    goto parse_end;
+                } else {
+                    break;
                 }
-                break;
+                goto parse_end;
             default: /* QUOTED state */
                 pstate = escape_toggle(pstate);
                 break;

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -47,9 +47,9 @@ static void _putchar(int c) {
 #endif
 
 #ifdef MODULE_SHELL_COMMANDS
-#define _use_builtin_cmds true
+#define _builtin_cmds _shell_command_list
 #else
-#define _use_builtin_cmds false
+#define _builtin_cmds NULL
 #endif
 
 static void flush_if_needed(void)
@@ -78,8 +78,8 @@ static shell_command_handler_t find_handler(const shell_command_t *command_list,
         handler = search_commands(command_list, command);
     }
 
-    if (handler == NULL && _use_builtin_cmds) {
-        handler = search_commands(_shell_command_list, command);
+    if (handler == NULL && _builtin_cmds != NULL) {
+        handler = search_commands(_builtin_cmds, command);
     }
 
     return handler;
@@ -100,8 +100,8 @@ static void print_help(const shell_command_t *command_list)
         print_commands(command_list);
     }
 
-    if (_use_builtin_cmds) {
-        print_commands(_shell_command_list);
+    if (_builtin_cmds != NULL) {
+        print_commands(_builtin_cmds);
     }
 }
 

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include "shell.h"
 #include "shell_commands.h"
 
@@ -109,107 +110,112 @@ static void print_help(const shell_command_t *command_list)
     }
 }
 
+enum PARSE_STATE {
+    PARSE_SPACE,
+    PARSE_UNQUOTED,
+    PARSE_SINGLEQUOTE,
+    PARSE_DOUBLEQUOTE,
+    PARSE_ESCAPE_MASK,
+    PARSE_UNQUOTED_ESC,
+    PARSE_SINGLEQUOTE_ESC,
+    PARSE_DOUBLEQUOTE_ESC,
+};
+
+static enum PARSE_STATE escape_toggle(enum PARSE_STATE s)
+{
+    return s ^ PARSE_ESCAPE_MASK;
+}
+
+#define SQUOTE '\''
+#define DQUOTE '"'
+#define ESCAPECHAR '\\'
+#define BLANK ' '
+
 static void handle_input_line(const shell_command_t *command_list, char *line)
 {
     static const char *INCORRECT_QUOTING = "shell: incorrect quoting";
 
     /* first we need to calculate the number of arguments */
-    unsigned argc = 0;
-    char *pos = line;
-    int contains_esc_seq = 0;
-    while (1) {
-        if ((unsigned char) *pos > ' ') {
-            /* found an argument */
-            if (*pos == '"' || *pos == '\'') {
-                /* it's a quoted argument */
-                const char quote_char = *pos;
-                do {
-                    ++pos;
-                    if (!*pos) {
-                        puts(INCORRECT_QUOTING);
-                        return;
-                    }
-                    else if (*pos == '\\') {
-                        /* skip over the next character */
-                        ++contains_esc_seq;
-                        ++pos;
-                        if (!*pos) {
-                            puts(INCORRECT_QUOTING);
-                            return;
-                        }
-                        continue;
-                    }
-                } while (*pos != quote_char);
-                if ((unsigned char) pos[1] > ' ') {
-                    puts(INCORRECT_QUOTING);
-                    return;
+    int argc = 0;
+    char *readpos = line;
+    char *writepos = readpos;
+    enum PARSE_STATE pstate = PARSE_SPACE;
+
+    while (*readpos != '\0') {
+        switch (pstate) {
+            case PARSE_SPACE:
+                if (*readpos != BLANK) {
+                    argc++;
                 }
-            }
-            else {
-                /* it's an unquoted argument */
-                do {
-                    if (*pos == '\\') {
-                        /* skip over the next character */
-                        ++contains_esc_seq;
-                        ++pos;
-                        if (!*pos) {
-                            puts(INCORRECT_QUOTING);
-                            return;
-                        }
-                    }
-                    ++pos;
-                    if (*pos == '"') {
-                        puts(INCORRECT_QUOTING);
-                        return;
-                    }
-                } while ((unsigned char) *pos > ' ');
-            }
-
-            /* count the number of arguments we got */
-            ++argc;
+                if (*readpos == SQUOTE) {
+                    pstate = PARSE_SINGLEQUOTE;
+                } else if (*readpos == DQUOTE) {
+                    pstate = PARSE_DOUBLEQUOTE;
+                } else if (*readpos == ESCAPECHAR) {
+                    pstate = PARSE_UNQUOTED_ESC;
+                } else if (*readpos != BLANK) {
+                    pstate = PARSE_UNQUOTED;
+                    break;
+                }
+                goto parse_end;
+            case PARSE_UNQUOTED:
+                if (*readpos == BLANK) {
+                    pstate = PARSE_SPACE;
+                    *writepos++ = '\0';
+                    goto parse_end;
+                } else if (*readpos == ESCAPECHAR) {
+                    pstate = escape_toggle(pstate);
+                    goto parse_end;
+                }
+                break;
+            case PARSE_SINGLEQUOTE:
+                if (*readpos == SQUOTE)  {
+                    pstate = PARSE_SPACE;
+                    *writepos++ = '\0';
+                    goto parse_end;
+                } else if (*readpos == ESCAPECHAR) {
+                    pstate = escape_toggle(pstate);
+                    goto parse_end;
+                }
+                break;
+            case PARSE_DOUBLEQUOTE:
+                if (*readpos == DQUOTE) {
+                    pstate = PARSE_SPACE;
+                    *writepos++ = '\0';
+                    goto parse_end;
+                } else if (*readpos == ESCAPECHAR) {
+                    pstate = escape_toggle(pstate);
+                    goto parse_end;
+                }
+                break;
+            default: /* QUOTED state */
+                pstate = escape_toggle(pstate);
+                break;
         }
-
-        /* zero out the current position (space or quotation mark) and advance */
-        if (*pos > 0) {
-            *pos = 0;
-            ++pos;
-        }
-        else {
-            break;
-        }
+        *writepos++ = *readpos;
+parse_end:
+        readpos++;
     }
-    if (!argc) {
+
+    *writepos = '\0';
+
+    if (pstate != PARSE_SPACE && pstate != PARSE_UNQUOTED) {
+        puts(INCORRECT_QUOTING);
+        return;
+    }
+
+    if (argc == 0) {
         return;
     }
 
     /* then we fill the argv array */
-    char *argv[argc + 1];
-    argv[argc] = NULL;
-    pos = line;
-    for (unsigned i = 0; i < argc; ++i) {
-        while (!*pos) {
-            ++pos;
-        }
-        if (*pos == '"' || *pos == '\'') {
-            ++pos;
-        }
-        argv[i] = pos;
-        while (*pos) {
-            ++pos;
-        }
-    }
-    for (char **arg = argv; contains_esc_seq && *arg; ++arg) {
-        for (char *c = *arg; *c; ++c) {
-            if (*c != '\\') {
-                continue;
-            }
-            for (char *d = c; *d; ++d) {
-                *d = d[1];
-            }
-            if (--contains_esc_seq == 0) {
-                break;
-            }
-        }
+    int collected;
+    char *argv[argc];
+
+    readpos = line;
+    for (collected = 0; collected < argc; collected++) {
+        argv[collected] = readpos;
+        readpos += strlen(readpos) + 1;
     }
 
     /* then we call the appropriate handler */

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -49,6 +49,11 @@ CMDS = (
     ('unknown_command', ('shell: command not found: unknown_command')),
     ('help', EXPECTED_HELP),
     ('echo a string', ('\"echo\"\"a\"\"string\"')),
+    ('echo "t\e st" "\\"" '"'\\'' a\ b", ('"echo""te st"""""\'""a b"')),
+    ('echo a\\', ('shell: incorrect quoting')),
+    ('echo "', ('shell: incorrect quoting')),
+    ("echo '", ('shell: incorrect quoting')),
+    ('echo "\'" \'"\'', ('"echo""\'""""')),
     ('ps', EXPECTED_PS),
     ('garbage1234'+CONTROL_C, ('>')),  # test cancelling a line
     ('help', EXPECTED_HELP),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The tokenizer (the code that breaks up the line given to the shell into strings to create argv) was quite a messy piece of code. This commit refactors it into a more traditional state-machine based parser.

This fixes the issues with quote handling exposed by the recently introduced test.

Not only is the code clearer now, it is also smaller:

In the SAMR-21, before:

```
   text	   data	    bss	    dec	    hex	filename
  10292	    140	   2612	  13044	   32f4	tests/shell/bin/samr21-xpro/tests_shell.elf
```

After 1st refactor commit:

```
   text    data     bss     dec     hex filename
  10268	    140	   2612	  13020	   32dc	tests/shell/bin/samr21-xpro/tests_shell.elf
```

After 2nd change:

```
   text	   data	    bss	    dec	    hex	filename
  10256	    140	   2612	  13008	   32d0	tests/shell/bin/samr21-xpro/tests_shell.elf
```

### Testing procedure

I added test vectors to the automated test. The old code could not handle this string:

```
> echo "t\e st" "\"" '\'' a\ b
shell: incorrect quoting
> echo "\""
shell: incorrect quoting
```

The new code handles it correctly.

### Issues/PRs references

To be continued....