### PR TITLE
gnrc_tcp: fix integer underflow in option parser

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
@@ -64,6 +64,12 @@ int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
                 DEBUG("gnrc_tcp_option.c : _option_parse() : Unknown option found.\
                       KIND=%"PRIu8", LENGTH=%"PRIu8"\n", option->kind, option->length);
         }
+
+        if (option->length > opt_left) {
+            DEBUG("gnrc_tcp_option.c : _option_parse() : invalid option length\n");
+            return 0;
+        }
+
         opt_ptr += option->length;
         opt_left -= option->length;
     }


### PR DESCRIPTION
### Contribution description

`opt_left` is an `8 bit` unsigned integer which underflows if `option->length` > `opt_left`.

### Testing procedure

None, read the code.