### PR TITLE
boards with side-effect: move CPU/CPU_MODEL definition to Makefile.features

### DIFF
--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -1,3 +1,6 @@
+CPU = cc2538
+CPU_MODEL ?= cc2538nf53
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
@@ -8,5 +11,3 @@ FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += emulator_renode
-
-include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -1,7 +1,3 @@
-# Define the cpu used by the CC2538DK board:
-export CPU        = cc2538
-export CPU_MODEL ?= cc2538nf53
-
 # the SmartRF06 Evaluation Board serial numbers all begin with "06EB":
 PROGRAMMER_SERIAL ?= 06EB
 

--- a/boards/common/esp32/Makefile.dep
+++ b/boards/common/esp32/Makefile.dep
@@ -1,5 +1,3 @@
-include $(RIOTCPU)/esp32/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/boards/common/esp32/Makefile.features
+++ b/boards/common/esp32/Makefile.features
@@ -1,5 +1,5 @@
-# most board features results directly from ESP32 CPU features
-include $(RIOTCPU)/esp32/Makefile.features
+CPU = esp32
+CPU_MODEL = esp32
 
 # additional features provided by all boards are GPIOs and at least one UART
 FEATURES_PROVIDED += periph_gpio

--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -1,6 +1,6 @@
 # the cpu to build for
-export CPU ?= esp32
-export CPU_MODEL ?= esp32
+export CPU = esp32
+export CPU_MODEL = esp32
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0

--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -1,7 +1,3 @@
-# the cpu to build for
-export CPU = esp32
-export CPU_MODEL = esp32
-
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/common/esp8266/Makefile.dep
+++ b/boards/common/esp8266/Makefile.dep
@@ -1,5 +1,3 @@
-include $(RIOTCPU)/esp8266/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/boards/common/esp8266/Makefile.features
+++ b/boards/common/esp8266/Makefile.features
@@ -1,6 +1,5 @@
-# MCU defined features that are provided independent on board definitions
-
-include $(RIOTCPU)/esp8266/Makefile.features
+CPU = esp8266
+CPU_MODEL = esp8266
 
 # MCU defined peripheral features provided by all boards in alphabetical order
 

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -1,6 +1,6 @@
 # the cpu to build for
-export CPU ?= esp8266
-export CPU_MODEL ?= esp8266
+export CPU = esp8266
+export CPU_MODEL = esp8266
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -1,7 +1,3 @@
-# the cpu to build for
-export CPU = esp8266
-export CPU_MODEL = esp8266
-
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/common/nrf52/Makefile.dep
+++ b/boards/common/nrf52/Makefile.dep
@@ -1,5 +1,3 @@
-include $(RIOTCPU)/nrf52/Makefile.dep
-
 ifneq (,$(filter skald,$(USEMODULE)))
   USEMODULE += nrfble
 endif

--- a/boards/common/nrf52/Makefile.features
+++ b/boards/common/nrf52/Makefile.features
@@ -1,3 +1,5 @@
+CPU = nrf52
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
@@ -8,5 +10,3 @@ endif
 # Various other features (if any)
 FEATURES_PROVIDED += ble_nimble
 FEATURES_PROVIDED += radio_nrfble
-
-include $(RIOTCPU)/nrf52/Makefile.features

--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -1,6 +1,3 @@
-# this module contains shared code for all boards using the nrf52 CPU
-export CPU = nrf52
-
 # include this module into the build
 INCLUDES += -I$(RIOTBOARD)/common/nrf52/include
 

--- a/boards/ek-lm4f120xl/Makefile.features
+++ b/boards/ek-lm4f120xl/Makefile.features
@@ -1,8 +1,9 @@
+CPU = lm4f120
+CPU_MODEL = LM4F120H5QR
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/lm4f120/Makefile.features

--- a/boards/ek-lm4f120xl/Makefile.include
+++ b/boards/ek-lm4f120xl/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the ek-lm4f120xl board
-export CPU = lm4f120
-export CPU_MODEL = LM4F120H5QR
-
 #define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/hifive1/Makefile.dep
+++ b/boards/hifive1/Makefile.dep
@@ -1,1 +1,0 @@
-include $(RIOTCPU)/fe310/Makefile.dep

--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -1,3 +1,6 @@
+CPU = fe310
+CPU_MODEL = fe310_g000
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 #FEATURES_PROVIDED += periph_pwm
@@ -6,5 +9,3 @@ FEATURES_PROVIDED += periph_rtt
 #FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/fe310/Makefile.features

--- a/boards/hifive1/Makefile.include
+++ b/boards/hifive1/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the HiFive1 board
-export CPU = fe310
-export CPU_MODEL = fe310_g000
-
 # Uses UART0 for stdio input/output (comment out to disable)
 USEMODULE += stdio_uart
 

--- a/boards/hifive1b/Makefile.dep
+++ b/boards/hifive1b/Makefile.dep
@@ -1,1 +1,0 @@
-include $(RIOTCPU)/fe310/Makefile.dep

--- a/boards/hifive1b/Makefile.features
+++ b/boards/hifive1b/Makefile.features
@@ -1,3 +1,6 @@
+CPU = fe310
+CPU_MODEL = fe310_g002
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 #FEATURES_PROVIDED += periph_i2c
@@ -7,5 +10,3 @@ FEATURES_PROVIDED += periph_rtt
 #FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/fe310/Makefile.features

--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the HiFive1 board
-export CPU = fe310
-export CPU_MODEL = fe310_g002
-
 # Uses UART0 for stdio input/output (comment out to disable)
 USEMODULE += stdio_uart
 

--- a/boards/mulle/Makefile.dep
+++ b/boards/mulle/Makefile.dep
@@ -19,5 +19,3 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += saul_adc
 endif
-
-include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/mulle/Makefile.features
+++ b/boards/mulle/Makefile.features
@@ -1,3 +1,13 @@
+CPU = kinetis
+
+### CPU part number (must have a specific linker script for each part)
+# Note that MK60DN256ZVLL10 (version 1.x) and MK60DN256VLL10 (version 2.x, no Z)
+# only differ in some register locations etc, not in the actual memory layout,
+# so it is safe to use the same linker script for both version 1.x and version
+# 2.x silicon.
+# The linker script needs to know the flash and RAM sizes of the device.
+CPU_MODEL ?= mk60dn512vll10
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
@@ -8,5 +18,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -1,23 +1,7 @@
-# define the cpu used by the Mulle board
-export CPU = kinetis
-
 # MULLE_SERIAL is used to select which specific Mulle board we are compiling for.
 ifdef MULLE_SERIAL
   CFLAGS += -DMULLE_SERIAL=$(MULLE_SERIAL)
 endif
-
-### CPU part number (must have a specific linker script for each part)
-# Note that MK60DN256ZVLL10 (version 1.x) and MK60DN256VLL10 (version 2.x, no Z)
-# only differ in some register locations etc, not in the actual memory layout,
-# so it is safe to use the same linker script for both version 1.x and version
-# 2.x silicon.
-# The linker script needs to know the flash and RAM sizes of the device.
-
-ifeq ($(CPU_MODEL),)
-  CPU_MODEL = mk60dn512vll10
-endif
-
-export CPU_MODEL
 
 # Default debug adapter choice is to use the Mulle programmer board
 DEBUG_ADAPTER ?= mulle

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -1,8 +1,8 @@
+CPU_MODEL = nrf51x22xxaa
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
 # include common nrf51 based boards features
 include $(RIOTBOARD)/common/nrf51/Makefile.features
-
-include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/nrf6310/Makefile.include
+++ b/boards/nrf6310/Makefile.include
@@ -1,6 +1,3 @@
-# define the used CPU
-export CPU_MODEL = nrf51x22xxaa
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/pic32-clicker/Makefile.features
+++ b/boards/pic32-clicker/Makefile.features
@@ -1,6 +1,7 @@
+CPU = mips_pic32mx
+CPU_MODEL = p32mx470f512h
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/mips_pic32mx/Makefile.features

--- a/boards/pic32-clicker/Makefile.include
+++ b/boards/pic32-clicker/Makefile.include
@@ -1,5 +1,3 @@
-export CPU = mips_pic32mx
-export CPU_MODEL=p32mx470f512h
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
 

--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -1,6 +1,7 @@
+CPU = mips_pic32mz
+CPU_MODEL = p32mz2048efg100
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/mips_pic32mz/Makefile.features

--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -1,5 +1,3 @@
-export CPU = mips_pic32mz
-export CPU_MODEL=p32mz2048efg100
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -59,7 +59,6 @@ PSEUDOMODULES += esp_spi_ram
 PSEUDOMODULES += esp_spiffs
 PSEUDOMODULES += esp_wifi_any
 
-export CPU ?= esp32
 export TARGET_ARCH ?= xtensa-esp32-elf
 export ESPTOOL ?= $(ESP32_SDK_DIR)/components/esptool_py/esptool/esptool.py
 


### PR DESCRIPTION
### Contribution description

This moves CPU and CPU_MODEL to Makefile.features for a selection of board that only cause harmless side-effects in the dependency parsing like

* de-duplication
* ordering change
* `?=` replaced by `=` and spacing

#### Review procedure

I would advise to look at each commit individually and the global output comparison.

This PR modifications are, like the first PR
* moving `CPU`, `CPU_MODEL` to a different file
* removing the `include $(RIOTCPU)/cpu_name`
* Removing the `export CPU` and `export CPU_MODEL` as they are globally exported in https://github.com/RIOT-OS/RIOT/blob/3e753834e793928d2ee0946c25d6bd1232ad69c6/makefiles/vars.inc.mk#L11-L12
* It removed the comment saying "we set the cpu" as it is quite obvious. If it is not it should be part of a board porting guide.

And also the "side-effects":
* removing duplicate file inclusion that remove duplicates in the variables
* files `include` order when moved to the global include location which change order in the variables
* Some not needed `?=` in esp
* spacing changes

I can split in several PRs if wanted, it was just easier for me to run the validation once.

The dependency to #12004 is only for testing and could be merged without it.

### Testing procedure

<details><summary>All the modified boards for this change are the following</summary>

```
# esp change to remove ?=
esp32-mh-et-live-minikit
esp32-olimex-evb
esp32-wemos-lolin-d32-pro
esp32-wroom-32
esp32-wrover-kit
esp8266-esp-12x
esp8266-olimex-mod
esp8266-sparkfun-thing
# nrf6310, de-duplication
nrf6310
# nrf52, order changes
# git grep -l -e common/nrf52 -e common/nrf52xxxdk -e common/particle-mesh '**' ':!boards/common'  | cut -f 2 -d/ | sort -u
acd52832
nrf52832-mdk
nrf52840dk
nrf52840-mdk
nrf52dk
particle-argon
particle-boron
particle-xenon
reel
ruuvitag
thingy52
# hifive* order changes
hifive1
hifive1b
# pic32*, space change
pic32-clicker
pic32-wifire
# ek-lm4f120xl, uppercase CPU
ek-lm4f120xl
# cc2538dk, keep the ?=
cc2538dk
# mulle, adapt to ?=
mulle
```
</details>

So to run the comparison, it is easier to first limit the testing to these boards.

```
export ALLBOARDS="esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing nrf6310 acd52832 nrf52832-mdk nrf52840dk nrf52840-mdk nrf52dk particle-argon particle-boron particle-xenon reel ruuvitag thingy52 hifive1 hifive1b pic32-clicker pic32-wifire ek-lm4f120xl cc2538dk mulle"
```

In the PR run

```
./dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh  build/deps/cpu_model
...
# This takes 17 minutes on my machine
```

On the second commit: "squash! make: add targets to debug dependencies variables " run the same generation: (it is shown at last on github, but is not locally)

```
./dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh  build/deps/ref
```

And generate the aggregated result

```
./generate_aggregated.sh build/deps/cpu_model
./generate_aggregated.sh build/deps/ref
```

<details><summary><code>generate_aggregated.sh</code></summary>

```
#! /bin/bash

set -ue

readonly DIRECTORY=$1

set -v
rm -f ${DIRECTORY}/tests/nordic_softdevice/info-global/dependencies_info-boards-supported_reel  # Remove as not generated by normal compilation
find "${DIRECTORY}" -type f -name 'dependencies_info_*' | sort | xargs cat > ${DIRECTORY}/deps_info
find "${DIRECTORY}" -type f -name 'dependencies_info-boards-supported_*' | sort | xargs cat > ${DIRECTORY}/deps_info-boards-supported
```
</details>

#### Difference between normal and "global" dependency parsing

<details><summary>Both dependency parsing now have the same values for `FEATURES_PROVIDED`, `CPU`, `CPU_MODEL` for these boards</summary>

```
diff -W 80 -y --suppress-common-lines build/deps/cpu_model/deps_info-boards-supported build/deps/cpu_model/deps_info -I USEMODULE -I FEATURES_USED -I FEATURES_REQUIRED -I FEATURES_OPTIONAL -I CPU_FAM
# empty diff
```
</details>

You can see that most differences have been fixed with this PR by checking the previous state with all `CPU` and `CPU_MODEL` that were not defined in `info-boards-supported`.

```
diff -W 80 -y --suppress-common-lines build/deps/ref/deps_info-boards-supported build/deps/ref/deps_info -I USEMODULE -I FEATURES_USED -I FEATURES_REQUIRED -I FEATURES_OPTIONAL -I CPU_FAM
```

There are still currently differences in some variables, so they are excluded, but this is out of this PR scope and was the case before too.

#### The difference between before and now for normal parsing

As the normal parsing already had `CPU` and `CPU_MODEL`, there are only difference in `FEATURES_REQUIRED` and `FEATURES_PROVIDED` but the actual value is unchanged as the value of the sorted ones is the same.

<details><summary>Looking in the difference in `examples/default`</summary>

``` diff
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_esp32-mh-et-live-minikit build/deps/cpu_model/examples/default/info/dependencies_info_esp32-mh-et-live-minikit
--- build/deps/ref/examples/default/info/dependencies_info_esp32-mh-et-live-minikit	2019-08-26 19:20:04.214279364 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_esp32-mh-et-live-minikit	2019-08-26 19:20:09.238320779 +0200
@@ -2,7 +2,7 @@
 CPU = esp32
 CPU_MODEL = esp32
 CPU_FAM =
-FEATURES_PROVIDED = cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_adc periph_dac periph_i2c periph_pwm periph_spi arduino
+FEATURES_PROVIDED = periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_adc periph_dac periph_i2c periph_pwm periph_spi arduino cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer
 _FEATURES_PROVIDED_SORTED = arduino cpp esp_now esp_spiffs esp_wifi periph_adc periph_cpuid periph_dac periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_pwm periph_rtc periph_spi periph_timer periph_uart periph_uart_modecfg
 FEATURES_REQUIRED = periph_uart periph_timer periph_gpio periph_uart periph_timer periph_gpio
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_timer periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_esp32-olimex-evb build/deps/cpu_model/examples/default/info/dependencies_info_esp32-olimex-evb
--- build/deps/ref/examples/default/info/dependencies_info_esp32-olimex-evb	2019-08-26 19:20:04.262279760 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_esp32-olimex-evb	2019-08-26 19:20:09.278321110 +0200
@@ -2,7 +2,7 @@
 CPU = esp32
 CPU_MODEL = esp32
 CPU_FAM =
-FEATURES_PROVIDED = cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_i2c periph_pwm periph_spi periph_eth esp_can periph_ir arduino
+FEATURES_PROVIDED = periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_i2c periph_pwm periph_spi periph_eth esp_can periph_ir arduino cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer
 _FEATURES_PROVIDED_SORTED = arduino cpp esp_can esp_now esp_spiffs esp_wifi periph_cpuid periph_eth periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_ir periph_pm periph_pwm periph_rtc periph_spi periph_timer periph_uart periph_uart_modecfg
 FEATURES_REQUIRED = periph_uart periph_timer periph_gpio periph_uart periph_timer periph_gpio
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_timer periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_esp32-wemos-lolin-d32-pro build/deps/cpu_model/examples/default/info/dependencies_info_esp32-wemos-lolin-d32-pro
--- build/deps/ref/examples/default/info/dependencies_info_esp32-wemos-lolin-d32-pro	2019-08-26 19:20:04.310280155 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_esp32-wemos-lolin-d32-pro	2019-08-26 19:20:09.322321472 +0200
@@ -2,7 +2,7 @@
 CPU = esp32
 CPU_MODEL = esp32
 CPU_FAM =
-FEATURES_PROVIDED = cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_adc periph_dac periph_i2c periph_pwm periph_spi esp_spi_ram arduino
+FEATURES_PROVIDED = periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_adc periph_dac periph_i2c periph_pwm periph_spi esp_spi_ram arduino cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer
 _FEATURES_PROVIDED_SORTED = arduino cpp esp_now esp_spi_ram esp_spiffs esp_wifi periph_adc periph_cpuid periph_dac periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_pwm periph_rtc periph_spi periph_timer periph_uart periph_uart_modecfg
 FEATURES_REQUIRED = periph_uart periph_timer periph_gpio periph_uart periph_timer periph_gpio
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_timer periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_esp32-wroom-32 build/deps/cpu_model/examples/default/info/dependencies_info_esp32-wroom-32
--- build/deps/ref/examples/default/info/dependencies_info_esp32-wroom-32	2019-08-26 19:20:04.354280518 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_esp32-wroom-32	2019-08-26 19:20:09.370321868 +0200
@@ -2,7 +2,7 @@
 CPU = esp32
 CPU_MODEL = esp32
 CPU_FAM =
-FEATURES_PROVIDED = cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_adc periph_dac periph_i2c periph_pwm periph_spi arduino
+FEATURES_PROVIDED = periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_adc periph_dac periph_i2c periph_pwm periph_spi arduino cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer
 _FEATURES_PROVIDED_SORTED = arduino cpp esp_now esp_spiffs esp_wifi periph_adc periph_cpuid periph_dac periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_pwm periph_rtc periph_spi periph_timer periph_uart periph_uart_modecfg
 FEATURES_REQUIRED = periph_uart periph_timer periph_gpio periph_uart periph_timer periph_gpio
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_timer periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_esp32-wrover-kit build/deps/cpu_model/examples/default/info/dependencies_info_esp32-wrover-kit
--- build/deps/ref/examples/default/info/dependencies_info_esp32-wrover-kit	2019-08-26 19:20:04.402280913 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_esp32-wrover-kit	2019-08-26 19:20:09.414322230 +0200
@@ -2,7 +2,7 @@
 CPU = esp32
 CPU_MODEL = esp32
 CPU_FAM =
-FEATURES_PROVIDED = cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_adc periph_i2c periph_pwm periph_spi sdcard_spi esp_spi_ram arduino
+FEATURES_PROVIDED = periph_gpio periph_gpio_irq periph_uart periph_uart_modecfg esp_spiffs esp_wifi esp_now periph_adc periph_i2c periph_pwm periph_spi sdcard_spi esp_spi_ram arduino cpp periph_cpuid periph_hwrng periph_pm periph_rtc periph_timer
 _FEATURES_PROVIDED_SORTED = arduino cpp esp_now esp_spi_ram esp_spiffs esp_wifi periph_adc periph_cpuid periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_pwm periph_rtc periph_spi periph_timer periph_uart periph_uart_modecfg sdcard_spi
 FEATURES_REQUIRED = periph_uart periph_timer periph_gpio periph_uart periph_timer periph_gpio
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_timer periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_esp8266-esp-12x build/deps/cpu_model/examples/default/info/dependencies_info_esp8266-esp-12x
--- build/deps/ref/examples/default/info/dependencies_info_esp8266-esp-12x	2019-08-26 19:20:04.446281277 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_esp8266-esp-12x	2019-08-26 19:20:09.462322626 +0200
@@ -2,7 +2,7 @@
 CPU = esp8266
 CPU_MODEL = esp8266
 CPU_FAM =
-FEATURES_PROVIDED = periph_cpuid periph_hwrng periph_pm periph_timer periph_adc periph_gpio periph_gpio_irq periph_i2c periph_pwm periph_spi periph_uart
+FEATURES_PROVIDED = periph_adc periph_gpio periph_gpio_irq periph_i2c periph_pwm periph_spi periph_uart periph_cpuid periph_hwrng periph_pm periph_timer
 _FEATURES_PROVIDED_SORTED = periph_adc periph_cpuid periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_pwm periph_spi periph_timer periph_uart
 FEATURES_REQUIRED = periph_uart periph_timer periph_gpio periph_uart periph_timer periph_gpio
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_timer periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_esp8266-olimex-mod build/deps/cpu_model/examples/default/info/dependencies_info_esp8266-olimex-mod
--- build/deps/ref/examples/default/info/dependencies_info_esp8266-olimex-mod	2019-08-26 19:20:04.490281639 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_esp8266-olimex-mod	2019-08-26 19:20:09.506322990 +0200
@@ -2,7 +2,7 @@
 CPU = esp8266
 CPU_MODEL = esp8266
 CPU_FAM =
-FEATURES_PROVIDED = periph_cpuid periph_hwrng periph_pm periph_timer periph_adc periph_gpio periph_gpio_irq periph_i2c periph_pwm periph_spi periph_uart
+FEATURES_PROVIDED = periph_adc periph_gpio periph_gpio_irq periph_i2c periph_pwm periph_spi periph_uart periph_cpuid periph_hwrng periph_pm periph_timer
 _FEATURES_PROVIDED_SORTED = periph_adc periph_cpuid periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_pwm periph_spi periph_timer periph_uart
 FEATURES_REQUIRED = periph_uart periph_timer periph_gpio periph_uart periph_timer periph_gpio
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_timer periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_esp8266-sparkfun-thing build/deps/cpu_model/examples/default/info/dependencies_info_esp8266-sparkfun-thing
--- build/deps/ref/examples/default/info/dependencies_info_esp8266-sparkfun-thing	2019-08-26 19:20:04.534282002 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_esp8266-sparkfun-thing	2019-08-26 19:20:09.550323352 +0200
@@ -2,7 +2,7 @@
 CPU = esp8266
 CPU_MODEL = esp8266
 CPU_FAM =
-FEATURES_PROVIDED = periph_cpuid periph_hwrng periph_pm periph_timer periph_adc periph_gpio periph_gpio_irq periph_i2c periph_pwm periph_spi periph_uart
+FEATURES_PROVIDED = periph_adc periph_gpio periph_gpio_irq periph_i2c periph_pwm periph_spi periph_uart periph_cpuid periph_hwrng periph_pm periph_timer
 _FEATURES_PROVIDED_SORTED = periph_adc periph_cpuid periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_pwm periph_spi periph_timer periph_uart
 FEATURES_REQUIRED = periph_uart periph_timer periph_gpio periph_uart periph_timer periph_gpio
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_timer periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_hifive1 build/deps/cpu_model/examples/default/info/dependencies_info_hifive1
--- build/deps/ref/examples/default/info/dependencies_info_hifive1	2019-08-26 19:20:06.154295356 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_hifive1	2019-08-26 19:20:11.178336772 +0200
@@ -4,7 +4,7 @@
 CPU_FAM =
 FEATURES_PROVIDED = periph_gpio periph_gpio_irq periph_rtc periph_rtt periph_timer periph_uart periph_cpuid periph_pm
 _FEATURES_PROVIDED_SORTED = periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_rtc periph_rtt periph_timer periph_uart
-FEATURES_REQUIRED = periph_uart periph_rtt periph_rtt periph_uart periph_rtt periph_rtt periph_uart
+FEATURES_REQUIRED = periph_uart periph_rtt periph_uart periph_rtt periph_uart
 _FEATURES_REQUIRED_SORTED = periph_rtt periph_uart
 FEATURES_OPTIONAL = periph_rtc periph_gpio periph_pm periph_gpio periph_pm periph_gpio periph_pm
 FEATURES_USED = periph_gpio periph_pm periph_rtc periph_rtt periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_hifive1b build/deps/cpu_model/examples/default/info/dependencies_info_hifive1b
--- build/deps/ref/examples/default/info/dependencies_info_hifive1b	2019-08-26 19:20:06.194295686 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_hifive1b	2019-08-26 19:20:11.230337201 +0200
@@ -4,7 +4,7 @@
 CPU_FAM =
 FEATURES_PROVIDED = periph_gpio periph_gpio_irq periph_rtc periph_rtt periph_timer periph_uart periph_cpuid periph_pm
 _FEATURES_PROVIDED_SORTED = periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_rtc periph_rtt periph_timer periph_uart
-FEATURES_REQUIRED = periph_uart periph_rtt periph_rtt periph_uart periph_rtt periph_rtt periph_uart
+FEATURES_REQUIRED = periph_uart periph_rtt periph_uart periph_rtt periph_uart
 _FEATURES_REQUIRED_SORTED = periph_rtt periph_uart
 FEATURES_OPTIONAL = periph_rtc periph_gpio periph_pm periph_gpio periph_pm periph_gpio periph_pm
 FEATURES_USED = periph_gpio periph_pm periph_rtc periph_rtt periph_uart
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_nrf52840dk build/deps/cpu_model/examples/default/info/dependencies_info_nrf52840dk
--- build/deps/ref/examples/default/info/dependencies_info_nrf52840dk	2019-08-26 19:20:05.070286420 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_nrf52840dk	2019-08-26 19:20:10.074327672 +0200
@@ -2,9 +2,9 @@
 CPU = nrf52
 CPU_MODEL = nrf52840xxaa
 CPU_FAM = nrf52
-FEATURES_PROVIDED = periph_i2c periph_pwm periph_spi periph_uart periph_rtt periph_timer riotboot ble_nimble radio_nrfble periph_adc periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_temperature periph_uart_modecfg radio_nrfmin puf_sram periph_pm cpp cpu_check_address radio_nrf802154 periph_pwm periph_usbdev
+FEATURES_PROVIDED = periph_i2c periph_pwm periph_spi periph_uart periph_rtt periph_timer riotboot ble_nimble radio_nrfble radio_nrf802154 periph_pwm periph_usbdev periph_adc periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_temperature periph_uart_modecfg radio_nrfmin puf_sram periph_pm cpp cpu_check_address
 _FEATURES_PROVIDED_SORTED = ble_nimble cpp cpu_check_address periph_adc periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_pwm periph_rtt periph_spi periph_temperature periph_timer periph_uart periph_uart_modecfg periph_usbdev puf_sram radio_nrf802154 radio_nrfble radio_nrfmin riotboot
-FEATURES_REQUIRED = periph_timer radio_nrf802154 periph_timer radio_nrf802154 periph_uart periph_gpio periph_temperature periph_timer radio_nrf802154 periph_timer radio_nrf802154 periph_uart periph_gpio periph_temperature
+FEATURES_REQUIRED = periph_timer radio_nrf802154 periph_uart periph_gpio periph_temperature periph_timer radio_nrf802154 periph_uart periph_gpio periph_temperature
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_temperature periph_timer periph_uart radio_nrf802154
 FEATURES_OPTIONAL = periph_rtc periph_cpuid periph_hwrng periph_cpuid periph_gpio periph_pm periph_cpuid periph_hwrng periph_cpuid periph_gpio periph_pm
 FEATURES_USED = periph_cpuid periph_gpio periph_hwrng periph_pm periph_temperature periph_timer periph_uart radio_nrf802154
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_nrf52840-mdk build/deps/cpu_model/examples/default/info/dependencies_info_nrf52840-mdk
--- build/deps/ref/examples/default/info/dependencies_info_nrf52840-mdk	2019-08-26 19:20:05.202287509 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_nrf52840-mdk	2019-08-26 19:20:10.198328694 +0200
@@ -4,7 +4,7 @@
 CPU_FAM = nrf52
 FEATURES_PROVIDED = periph_i2c periph_spi periph_uart periph_usbdev radio_nrf802154 periph_rtt periph_timer riotboot ble_nimble radio_nrfble periph_adc periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_temperature periph_uart_modecfg radio_nrfmin puf_sram periph_pm cpp cpu_check_address
 _FEATURES_PROVIDED_SORTED = ble_nimble cpp cpu_check_address periph_adc periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_i2c periph_pm periph_rtt periph_spi periph_temperature periph_timer periph_uart periph_uart_modecfg periph_usbdev puf_sram radio_nrf802154 radio_nrfble radio_nrfmin riotboot
-FEATURES_REQUIRED = periph_timer radio_nrf802154 periph_timer radio_nrf802154 periph_timer radio_nrf802154 periph_uart periph_gpio periph_temperature periph_timer radio_nrf802154 periph_timer radio_nrf802154 periph_uart periph_gpio periph_temperature
+FEATURES_REQUIRED = periph_timer radio_nrf802154 periph_uart periph_gpio periph_temperature periph_timer radio_nrf802154 periph_uart periph_gpio periph_temperature
 _FEATURES_REQUIRED_SORTED = periph_gpio periph_temperature periph_timer periph_uart radio_nrf802154
 FEATURES_OPTIONAL = periph_rtc periph_cpuid periph_hwrng periph_cpuid periph_gpio periph_pm periph_cpuid periph_hwrng periph_cpuid periph_gpio periph_pm
 FEATURES_USED = periph_cpuid periph_gpio periph_hwrng periph_pm periph_temperature periph_timer periph_uart radio_nrf802154
diff -u -r '--exclude=dependencies_info-boards*' '--exclude=deps_info-boards-supported' build/deps/ref/examples/default/info/dependencies_info_nrf6310 build/deps/cpu_model/examples/default/info/dependencies_info_nrf6310
--- build/deps/ref/examples/default/info/dependencies_info_nrf6310	2019-08-26 19:20:04.662283057 +0200
+++ build/deps/cpu_model/examples/default/info/dependencies_info_nrf6310	2019-08-26 19:20:09.678324408 +0200
@@ -2,7 +2,7 @@
 CPU = nrf51
 CPU_MODEL = nrf51x22xxaa
 CPU_FAM = nrf51
-FEATURES_PROVIDED = periph_spi periph_uart periph_rtt periph_timer ble_nimble periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_temperature periph_uart_modecfg radio_nrfmin puf_sram periph_pm cpp cpu_check_address periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_temperature periph_uart_modecfg radio_nrfmin puf_sram periph_pm cpp cpu_check_address
+FEATURES_PROVIDED = periph_spi periph_uart periph_rtt periph_timer ble_nimble periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_temperature periph_uart_modecfg radio_nrfmin puf_sram periph_pm cpp cpu_check_address
 _FEATURES_PROVIDED_SORTED = ble_nimble cpp cpu_check_address periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_hwrng periph_pm periph_rtt periph_spi periph_temperature periph_timer periph_uart periph_uart_modecfg puf_sram radio_nrfmin
 FEATURES_REQUIRED = radio_nrfmin periph_cpuid periph_uart periph_temperature radio_nrfmin periph_cpuid periph_uart periph_temperature
 _FEATURES_REQUIRED_SORTED = periph_cpuid periph_temperature periph_uart radio_nrfmin
```
</details>

And when excluding `^FEATURES_REQUIRED ` and `^FEATURES_PROVIDED `, so keeping the `sorted` ones we have the same values after migration.

```
diff  -r build/deps/ref/ build/deps/cpu_model/ --exclude='dependencies_info-boards*' --exclude=deps_info-boards-supported -I '^FEATURES_PROVIDED ' -I '^FEATURES_REQUIRED '
# empty diff
```


### Issues/PRs references

* Tracking: move CPU/CPU_MODEL to Makefile.features #11477
* Depends on the debug targets from: make: add targets to debug dependencies variables #12004 (could be removed before merging if it can get it sooner through)

