### PR TITLE
 boards/msba2/lobaro-lorabox: change TERMFLAGS to PYTERMFLAGS

### DIFF
--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -16,7 +16,7 @@ PORT_LINUX ?= /dev/ttyUSB0
 # This does not make a lot of sense, but it has the same value as the previous code
 PORT_DARWIN ?= /dev/tty.usbserial-ARM
 
-TERMFLAGS += -tg
+PYTERMFLAGS += -tg
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 export CFLAGS_CPU   = -mcpu=arm7tdmi-s

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -16,7 +16,7 @@ PORT_LINUX ?= /dev/ttyUSB0
 # This does not make a lot of sense, but it has the same value as the previous code
 PORT_DARWIN ?= /dev/tty.usbserial-ARM
 
-TERMFLAGS += -tg -p "$(PORT)"
+TERMFLAGS += -tg
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 export CFLAGS_CPU   = -mcpu=arm7tdmi-s

--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -17,4 +17,4 @@ FLASHFILE ?= $(BINFILE)
 # -l 0x1ff: amount of sectors to erase
 FFLAGS += -p $(PORT) -e -u -S -l 0x1ff -w $(FLASHFILE)
 
-TERMFLAGS +=  --set-rts 0
+PYTERMFLAGS +=  --set-rts 0

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -15,7 +15,7 @@ export BAUD ?= 115200
 RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
   TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
-  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
+  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)" $(PYTERMFLAGS)
 else ifeq ($(RIOT_TERMINAL),socat)
   SOCAT_OUTPUT ?= -
   TERMPROG ?= $(RIOT_TERMINAL)


### PR DESCRIPTION
### Contribution description

The boards are using `pyterm` specific options that do not work on any
other `RIOT_TERMINAL`. It is a shame this is required but at least do
not pass arbitrary arguments to the other RIOT_TERMINAL.
So use the new PYTERMFLAGS for this.

This addresses setting the TERMFLAGS in an incompatible way to the other `RIOT_TERMINAL` in https://github.com/RIOT-OS/RIOT/issues/12089  https://github.com/RIOT-OS/RIOT/issues/12090

However, `term` would still not work with `socat` or `picocom`.

### Testing procedure

Testing still works on `msba2`. For example `tests/bloom_bytes`

```
BOARD=msba2 RIOT_CI_BUILD=1 make --no-print-directory -C tests/bloom_bytes/ flash >/dev/null; BOARD=msba2 RIOT_CI_BUILD=1 make --no-print-directory -C tests/bloom_bytes/  test
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyUSB0" -b "115200" -tg
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
main(): This is RIOT! (Version: buildtest)
Testing Bloom filter.

m: 4096 k: 8

adding 512 elements took 188ms
checking 10000 elements took 1801ms

267 elements probably in the filter.
9733 elements not in the filter.
0.026700 false positive rate.

All done!
```

##### `tests/shell` using `socat`

It does not fail on invalid arguments

```
Reset CPU (into user code)
Programming done.
socat - open:/dev/ttyUSB0,b115200,echo=0,raw
Timeout in expect script at "child.expect('test_shell.')" (tests/shell/tests/01-run.py:67)

/home/harter/work/git/RIOT/tests/shell/../../Makefile.include:605: recipe for target 'test' failed
make: *** [test] Error 1
make: Leaving directory '/home/harter/work/git/RIOT/tests/shell'
```

Where in master, `socat` was called with incompatible arguments

```
BOARD=msba2 make -C tests/shell/ test
make: Entering directory '/home/harter/work/git/RIOT/tests/shell'
socat -tg -p "/dev/ttyUSB0"
2019/08/27 14:23:55 socat[7360] E unknown option "-p"; use option "-h" for help
/home/harter/work/git/RIOT/Makefile.include:566: recipe for target 'term' failed
make[1]: *** [term] Error 1
Unexpected end of file in expect script at "child.expect('test_shell.')" (tests/shell/tests/01-run.py:67)
```
#### `lobaro-lorabox`

The `term` command is still the same for `lobaro-lorabox` as in `master`
I do not have a board to do the real test

```
BOARD=lobaro-lorabox RIOT_CI_BUILD=1 make --no-print-directory -C tests/bloom_bytes/ info-debug-variable-TERMFLAGS
-p /dev/ttyUSB0 -b 115200 --set-rts 0
```

Which gives this execution

```
BOARD=lobaro-lorabox RIOT_CI_BUILD=1 make --no-print-directory -C tests/bloom_bytes/ term | head -n 3
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyUSB0" -b "115200" --set-rts 0
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyUSB0
Cannot connect to serial port /dev/ttyUSB0: could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
```


### Issues/PRs references

* https://github.com/RIOT-OS/RIOT/issues/12089
* https://github.com/RIOT-OS/RIOT/issues/12090
* Used as base for https://github.com/RIOT-OS/RIOT/pull/12094