### PR TITLE
pyterm: Disable repeating command on empty line

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -105,7 +105,8 @@ class SerCmd(cmd.Cmd):
     def __init__(self, port=None, baudrate=None, toggle=None, tcp_serial=None,
                  confdir=None, conffile=None, host=None, run_name=None,
                  log_dir_name=None, newline=None, formatter=None,
-                 set_rts=None, set_dtr=None, serprompt=None):
+                 set_rts=None, set_dtr=None, serprompt=None,
+                 repeat_command_on_empty_line=False):
         """Constructor.
 
         Args:
@@ -134,6 +135,7 @@ class SerCmd(cmd.Cmd):
         self.log_dir_name = log_dir_name
         self.newline = newline
         self.serprompt = serprompt
+        self.repeat_command_on_empty_line = repeat_command_on_empty_line
         if formatter is not None:
             self.fmt_str = formatter
 
@@ -273,11 +275,14 @@ class SerCmd(cmd.Cmd):
         return line
 
     def emptyline(self):
-        """Disable repeating command on empty line.
+        """Either send empty line or repeat previous command.
 
-        Just send a newline.
+        Behavior can be configured with `repeat_command_on_empty_line`.
         """
-        self.default('')
+        if self.repeat_command_on_empty_line:
+            super().emptyline()
+        else:
+            self.default('')
 
     def default(self, line):
         """In case of no Pyterm specific prefix is detected, split
@@ -798,6 +803,9 @@ if __name__ == "__main__":
                         "of CR and LF. Examples: -nl=LF, -nl=CRLF. "
                         "(Default is %s)" % defaultnewline,
                         default=defaultnewline)
+    parser.add_argument("--repeat-command-on-empty-line",
+                        help="Enable repeating command on empty line",
+                        action="store_true", default=False)
     parser.add_argument("-pr", "--prompt",
                         help="The expected prompt character, default is %c"
                         % defaultprompt,
@@ -810,7 +818,8 @@ if __name__ == "__main__":
     myshell = SerCmd(args.port, args.baudrate, args.toggle, args.tcp_serial,
                      args.directory, args.config, args.host, args.run_name,
                      args.log_dir_name, args.newline, args.format,
-                     args.set_rts, args.set_dtr, args.prompt)
+                     args.set_rts, args.set_dtr, args.prompt,
+                     args.repeat_command_on_empty_line)
     myshell.prompt = ''
 
     try:

--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -272,6 +272,13 @@ class SerCmd(cmd.Cmd):
                 return "PYTERM_" + line[1:]
         return line
 
+    def emptyline(self):
+        """Disable repeating command on empty line.
+
+        Just send a newline.
+        """
+        self.default('')
+
     def default(self, line):
         """In case of no Pyterm specific prefix is detected, split
         string by colons and send it to the node.

--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -805,7 +805,7 @@ if __name__ == "__main__":
                         default=defaultnewline)
     parser.add_argument("--repeat-command-on-empty-line",
                         help="Enable repeating command on empty line",
-                        action="store_true", default=False)
+                        action="store_true")
     parser.add_argument("-pr", "--prompt",
                         help="The expected prompt character, default is %c"
                         % defaultprompt,

--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -803,13 +803,20 @@ if __name__ == "__main__":
                         "of CR and LF. Examples: -nl=LF, -nl=CRLF. "
                         "(Default is %s)" % defaultnewline,
                         default=defaultnewline)
-    parser.add_argument("--repeat-command-on-empty-line",
-                        help="Enable repeating command on empty line",
-                        action="store_true")
     parser.add_argument("-pr", "--prompt",
                         help="The expected prompt character, default is %c"
                         % defaultprompt,
                         default=defaultprompt)
+
+    parser.add_argument("--repeat-command-on-empty-line",
+                        dest='repeat_command_on_empty_line',
+                        action='store_true',
+                        help="Repeat command on empty line (Default)")
+    parser.add_argument("--no-repeat-command-on-empty-line",
+                        dest='repeat_command_on_empty_line',
+                        action="store_false",
+                        help="Do not repeat command on empty line")
+    parser.set_defaults(repeat_command_on_empty_line=True)
 
     args = parser.parse_args()
 

--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -94,6 +94,9 @@ defaultnewline = "LF"
 # default prompt character
 defaultprompt = '>'
 
+# repeat command on empty line instead of sending the line
+defaultrepeat_cmd_empty_line = True
+
 
 class SerCmd(cmd.Cmd):
     """Main class for pyterm based on Python's Cmd class.
@@ -106,7 +109,7 @@ class SerCmd(cmd.Cmd):
                  confdir=None, conffile=None, host=None, run_name=None,
                  log_dir_name=None, newline=None, formatter=None,
                  set_rts=None, set_dtr=None, serprompt=None,
-                 repeat_command_on_empty_line=False):
+                 repeat_command_on_empty_line=defaultrepeat_cmd_empty_line):
         """Constructor.
 
         Args:
@@ -808,6 +811,7 @@ if __name__ == "__main__":
                         % defaultprompt,
                         default=defaultprompt)
 
+    # Keep help message in sync if changing the default
     parser.add_argument("--repeat-command-on-empty-line",
                         dest='repeat_command_on_empty_line',
                         action='store_true',
@@ -816,7 +820,8 @@ if __name__ == "__main__":
                         dest='repeat_command_on_empty_line',
                         action="store_false",
                         help="Do not repeat command on empty line")
-    parser.set_defaults(repeat_command_on_empty_line=True)
+    parser.set_defaults(
+        repeat_command_on_empty_line=defaultrepeat_cmd_empty_line)
 
     args = parser.parse_args()
 

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -15,7 +15,7 @@ export BAUD ?= 115200
 RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
   TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
-  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
+  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)" $(PYTERMFLAGS)
 else ifeq ($(RIOT_TERMINAL),socat)
   SOCAT_OUTPUT ?= -
   TERMPROG ?= $(RIOT_TERMINAL)

--- a/tests/test_tools/main.c
+++ b/tests/test_tools/main.c
@@ -64,10 +64,29 @@ static int cmd_shellping(int argc, char **argv)
     return 0;
 }
 
+/**
+ * @brief getchar, read one character
+ *
+ * Read one character and print its hex value
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0
+ *
+ */
+static int cmd_getchar(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    printf("%s 0x%02x\n", argv[0], getchar());
+    return 0;
+}
 
 static const shell_command_t shell_commands[] = {
     { "shellping", "Just print 'shellpong'", cmd_shellping },
     { "true", "do nothing, successfully", cmd_true },
+    { "getchar", "Get one character and print the hex value", cmd_getchar },
     { NULL, NULL, NULL }
 };
 

--- a/tests/test_tools/tests/01-run.py
+++ b/tests/test_tools/tests/01-run.py
@@ -37,6 +37,14 @@ def _test_no_local_echo(child):
     res = child.expect_exact([pexpect.TIMEOUT, msg], timeout=1)
     assert res == 0, "There should have been a timeout and not match stdin"
 
+def _test_sending_newline(child):
+    """Verify that a empty line can be send to the node.
+
+    The local terminal must NOT repeat the previous command.
+    """
+    child.sendline('getchar')
+    child.sendline('')  # send only one newline character
+    child.expect_exact('getchar 0x0a\r\n')
 
 def testfunc(child):
     """Run some tests to verify the board under test behaves correctly.
@@ -54,6 +62,9 @@ def testfunc(child):
 
     # The node should still answer after the previous one
     _shellping(child)
+
+    # It is possible to send an empty newline
+    _test_sending_newline(child)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

Just send a empty newline when it receives a newline.
This is the behavior of all the other terminals.

This also works when applied in conjunction with https://github.com/RIOT-OS/RIOT/pull/12094

### Testing procedure

Run `BOARD=your_board make -C tests/test_tools/ flash test` with different RIOT_TERMINAL, currently supported (not on all boards) `pyterm`, `socat`, `picocom`. If possible one with `term_rtt`. But as it is internally using `pyterm` it will benefit from the changes automatically.


<details><summary><code>RIOT_TERMINAL=pyterm samr21-xpro</code></summary>

```
RIOT_TERMINAL=pyterm  BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
   9244     140    2612   11996    2edc /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming........................................ done.
Verification........................................ done.
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-08-27 15:16:55,257 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2019-08-27 15:16:58,394 - INFO # main(): This is RIOT! (Version: buildtest)
2019-08-27 15:16:58,398 - INFO # Running 'tests_tools' application
shellping
2019-08-27 15:16:58,452 - INFO # shellpong
true this should not be echoed
shellping
2019-08-27 15:16:59,557 - INFO # shellpong
getchar

2019-08-27 15:16:59,660 - INFO # getchar 0x0a

```
</details>

<details><summary><code>RIOT_TERMINAL=picocom samr21-xpro</code></summary>

```
RIOT_TERMINAL=picocom  BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test

```
</details>

<details><summary><code>RIOT_TERMINAL=socat samr21-xpro</code></summary>

```
RIOT_TERMINAL=picocom  BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
   9244     140    2612   11996    2edc /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming........................................ done.
Verification........................................ done.
picocom --nolock --imap lfcrlf --baud "115200" "/dev/ttyACM0"
picocom v2.2

port is        : /dev/ttyACM0
flowcontrol    : none
baudrate is    : 115200
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
nolock is      : yes
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        : lfcrlf,
omap is        : 
emap is        : crcrlf,delbs,

Type [C-a] [C-h] to see available commands

Terminal ready
main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
getchar

getchar 0x0a

```
</details>

<details><summary><code>native</code></summary>

```
RIOT_CI_BUILD=1 BOARD=native make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "native" with MCU "native".

   text    data     bss     dec     hex filename
  22682     640   47652   70974   1153e /home/harter/work/git/RIOT/tests/test_tools/bin/native/tests_test_tools.elf
true
/home/harter/work/git/RIOT/tests/test_tools/bin/native/tests_test_tools.elf
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
getchar

getchar 0x0a

```
</details>

<details><summary><code>On IoT-LAB it works too</code></summary>

```
IOTLAB_NODE=auto-ssh RIOT_CI_BUILD=1 BOARD=iotlab-m3 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "iotlab-m3" with MCU "stm32f1".

   text    data     bss     dec     hex filename
   8896     140    2620   11656    2d88 /home/harter/work/git/RIOT/tests/test_tools/bin/iotlab-m3/tests_test_tools.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list grenoble,m3,58 --update /home/harter/work/git/RIOT/tests/test_tools/bin/iotlab-m3/tests_test_tools.elf | grep 0
0
ssh -t harter@grenoble.iot-lab.info 'socat - tcp:m3-58.grenoble.iot-lab.info:20000'
�main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
�main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
getchar

getchar 0x0a

```
</details>


### Issues/PRs references

Different behavior between testing locally and in `CI`.
Also repeating the last command was always a pain when testing.
