### PR TITLE
murdock: do not compile with different CFLAGS

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -5,7 +5,6 @@
 
 export RIOT_CI_BUILD=1
 export STATIC_TESTS=${STATIC_TESTS:-1}
-export CFLAGS_DBG=""
 export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 export ENABLE_TEST_CACHE=${ENABLE_TEST_CACHE:-1}
 


### PR DESCRIPTION
### Contribution description

murdock compilation results in different `CFLAGS` than when compiling
with `RIOT_CI_BUILD=1` locally.

Why does CI compile with different compiler options ?

### Testing procedure

```
git grep 'CFLAGS_DBG[[:space:]][[:space:]]*?\?.*'
boards/common/msba2/Makefile.include:export CFLAGS_DBG  ?= -ggdb -g3
makefiles/arch/atmega.inc.mk:CFLAGS_DBG  ?= -ggdb -g3
makefiles/arch/cortexm.inc.mk:export CFLAGS_DBG  ?= -ggdb -g3
makefiles/arch/mips.inc.mk:export CFLAGS_DBG   = -g3
makefiles/arch/msp430.inc.mk:CFLAGS_DBG  ?= -gdwarf-2
makefiles/arch/riscv.inc.mk:CFLAGS_DBG  ?= -g3 -Og
```

This would result in different build size at least for `riscv` boards that have `-Og` in there:

<details><summary>`examples/hello-world` size when removing `CFLAGS_DBG`: `447c`</summary>

```
DOCKER_ENV_VARS=CFLAGS_DBG CFLAGS_DBG= BOARD=hifive1 RIOT_CI_BUILD=1 BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/hello-world/
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'CFLAGS_DBG=' -e 'BOARD=hifive1' -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make
[sudo] password for harter:
Building application "hello-world" for "hifive1" with MCU "fe310".

   text    data     bss     dec     hex filename
  14244     112    3176   17532    447c /data/riotbuild/riotbase/examples/hello-world/bin/hifive1/hello-world.elf
make: Leaving directory '/home/harter/work/git/RIOT/examples/hello-world'
```
</details>

<details><summary>`examples/hello-world` size when compiling normally: `36a6`</summary>

```
BOARD=hifive1 RIOT_CI_BUILD=1 BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/hello-world/
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'BOARD=hifive1' -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotbase/examples/hello-world/' \
    'riot/riotbuild:latest' make
Building application "hello-world" for "hifive1" with MCU "fe310".

   text    data     bss     dec     hex filename
  10702     112    3176   13990    36a6 /data/riotbuild/riotbase/examples/hello-world/bin/hifive1/hello-world.elf
```
</details>

### Issues/PRs references

None