### PR TITLE
make: do not locally export compilation variables

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -35,4 +35,4 @@ FLASHFILE ?= $(BINFILE)
 DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 RESET_FLAGS ?= $(BINDIR)
 
-export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
+OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -20,5 +20,4 @@ DEBUGSERVER_FLAGS = $(MSPDEBUGFLAGS) gdb
 DEBUGGER = $(PREFIX)gdb
 DEBUGGER_FLAGS = --tui --ex="target remote localhost:2000" --ex "monitor reset halt" --ex load -ex "monitor reset halt"  $(ELFFILE)
 
-# export common msb-430 includes
-export INCLUDES += -I$(RIOTBOARD)/common/msb-430/include
+INCLUDES += -I$(RIOTBOARD)/common/msb-430/include

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -19,13 +19,13 @@ PORT_DARWIN ?= /dev/tty.usbserial-ARM
 TERMFLAGS += -tg -p "$(PORT)"
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-export CFLAGS_CPU   = -mcpu=arm7tdmi-s
-export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
-export CFLAGS_DBG  ?= -ggdb -g3
-export CFLAGS_OPT  ?= -Os
+CFLAGS_CPU   = -mcpu=arm7tdmi-s
+CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+CFLAGS_DBG  ?= -ggdb -g3
+CFLAGS_OPT  ?= -Os
 
-export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
-export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
+ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU).ld
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
 export LINKFLAGS += -Wl,--gc-sections

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -23,10 +23,10 @@ endif
 OFLAGS = --gap-fill 0xff
 FLASHFILE ?= $(BINFILE)
 DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
-export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
+OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 
 # include common remote includes
-export INCLUDES += -I$(RIOTBOARD)/common/remote/include
+INCLUDES += -I$(RIOTBOARD)/common/remote/include
 
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/common/silabs/Makefile.include
+++ b/boards/common/silabs/Makefile.include
@@ -1,2 +1,2 @@
-export INCLUDES += -I$(RIOTBOARD)/common/silabs/include
-export INCLUDES += -I$(RIOTBOARD)/common/silabs/drivers/include
+INCLUDES += -I$(RIOTBOARD)/common/silabs/include
+INCLUDES += -I$(RIOTBOARD)/common/silabs/drivers/include

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -1,7 +1,7 @@
 # include this module in the build
 USEMODULE += boards_common_wsn430
 # use common wsn430 includes
-export INCLUDES += -I$(RIOTBOARD)/common/wsn430/include
+INCLUDES += -I$(RIOTBOARD)/common/wsn430/include
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0

--- a/boards/hamilton/Makefile.include
+++ b/boards/hamilton/Makefile.include
@@ -1,7 +1,7 @@
 # debugger config
 export JLINK_DEVICE := atsamr21e18a
-export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
-export OFLAGS := --gap-fill 0xff
+OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
+OFLAGS := --gap-fill 0xff
 
 # Configure terminal, hamilton doesn't provide any UART, thus use RTT
 TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -21,30 +21,30 @@ export CGANNOTATE ?= cg_annotate
 export GPROF ?= gprof
 
 # basic cflags:
-export CFLAGS += -Wall -Wextra -pedantic
+CFLAGS += -Wall -Wextra -pedantic
 # default std set to gnu99 of not overwritten by user
 ifeq (,$(filter -std=%, $(CFLAGS)))
-  export CFLAGS += -std=gnu99
+  CFLAGS += -std=gnu99
 endif
 
 ifeq ($(shell uname -m),x86_64)
-  export CFLAGS += -m32
+  CFLAGS += -m32
 endif
 ifneq (,$(filter -DDEVELHELP,$(CFLAGS)))
-  export CFLAGS += -fstack-protector-all
+  CFLAGS += -fstack-protector-all
 endif
 ifeq ($(shell uname -s),FreeBSD)
   ifeq ($(shell uname -m),amd64)
-    export CFLAGS += -m32 -DCOMPAT_32BIT -B/usr/lib32
+    CFLAGS += -m32 -DCOMPAT_32BIT -B/usr/lib32
   endif
 endif
 ifeq ($(shell uname -s),Darwin)
-  export CFLAGS += -Wno-deprecated-declarations
+  CFLAGS += -Wno-deprecated-declarations
 endif
 
 # unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
-export CXXUWFLAGS +=
-export CXXEXFLAGS +=
+CXXUWFLAGS +=
+CXXEXFLAGS +=
 
 ifeq ($(shell uname -m),x86_64)
   export LINKFLAGS += -m32
@@ -59,7 +59,7 @@ else
 endif
 
 # clean up unused functions
-export CFLAGS += -ffunction-sections -fdata-sections
+CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(shell uname -s),Darwin)
   export LINKFLAGS += -Wl,-dead_strip
 else
@@ -76,7 +76,7 @@ endif
 
 TERMFLAGS := $(PORT) $(TERMFLAGS)
 
-export ASFLAGS =
+ASFLAGS =
 ifeq ($(shell basename $(DEBUGGER)),lldb)
   DEBUGGER_FLAGS = -- $(ELFFILE) $(TERMFLAGS)
 else
@@ -92,23 +92,23 @@ debug-valgrind-server: export VALGRIND_FLAGS ?= --vgdb=yes --vgdb-error=0 -v \
 	--read-var-info=yes
 term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
 term-gprof: TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELFFILE)
-all-valgrind: export CFLAGS += -DHAVE_VALGRIND_H -g3
+all-valgrind: CFLAGS += -DHAVE_VALGRIND_H -g3
 all-valgrind: export NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
-all-debug: export CFLAGS += -g3
-all-cachegrind: export CFLAGS += -g3
-all-gprof: export CFLAGS += -pg
+all-debug: CFLAGS += -g3
+all-cachegrind: CFLAGS += -g3
+all-gprof: CFLAGS += -pg
 all-gprof: export LINKFLAGS += -pg
-all-asan: export CFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
-all-asan: export CFLAGS += -DNATIVE_IN_CALLOC
+all-asan: CFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
+all-asan: CFLAGS += -DNATIVE_IN_CALLOC
 all-asan: export LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
 
-export INCLUDES += $(NATIVEINCLUDES)
+INCLUDES += $(NATIVEINCLUDES)
 
-export CFLAGS += -DDEBUG_ASSERT_VERBOSE
+CFLAGS += -DDEBUG_ASSERT_VERBOSE
 
 # workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52624
 ifneq ($(shell gcc --version | head -1 | grep -E ' (4.6|4.7)'),)
-  export CFLAGS += -DHAVE_NO_BUILTIN_BSWAP16
+  CFLAGS += -DHAVE_NO_BUILTIN_BSWAP16
 endif
 
 # backward compatability with glibc <= 2.17 for native

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -26,7 +26,7 @@ else ifeq ($(PROGRAMMER),jlink)
   include $(RIOTMAKE)/tools/jlink.inc.mk
 endif
 
-export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
+OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/saml10-xpro/Makefile.include
+++ b/boards/saml10-xpro/Makefile.include
@@ -1,4 +1,4 @@
 export CPU_FAM  = saml10
-export CFLAGS += -D__SAML10E16A__
+CFLAGS += -D__SAML10E16A__
 
 include $(RIOTBOARD)/common/saml1x/Makefile.include

--- a/boards/saml11-xpro/Makefile.include
+++ b/boards/saml11-xpro/Makefile.include
@@ -1,4 +1,4 @@
 export CPU_FAM  = saml11
-export CFLAGS += -D__SAML11E16A__
+CFLAGS += -D__SAML11E16A__
 
 include $(RIOTBOARD)/common/saml1x/Makefile.include

--- a/boards/saml21-xpro/Makefile.include
+++ b/boards/saml21-xpro/Makefile.include
@@ -1,4 +1,4 @@
-export CFLAGS += -D__SAML21J18A__
+CFLAGS += -D__SAML21J18A__
 
 # set edbg device type
 EDBG_DEVICE_TYPE = atmel_cm0p

--- a/boards/slwstk6000b/Makefile.include
+++ b/boards/slwstk6000b/Makefile.include
@@ -1,7 +1,7 @@
 include $(RIOTBOARD)/slwstk6000b/module-info.mk
 
 # add module specific includes
-export INCLUDES += -I$(RIOTBOARD)/slwstk6000b/modules/$(BOARD_MODULE)/include
+INCLUDES += -I$(RIOTBOARD)/slwstk6000b/modules/$(BOARD_MODULE)/include
 
 # define the cpu used by SLWSTK6000B
 export CPU = efm32

--- a/cpu/arm7_common/Makefile
+++ b/cpu/arm7_common/Makefile
@@ -1,5 +1,3 @@
-CFLAGS += $(CFLAGS_BASIC)
-
 DIRS = periph
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/atmega32u4/Makefile.include
+++ b/cpu/atmega32u4/Makefile.include
@@ -1,5 +1,5 @@
 # this CPU implementation is using the new core/CPU interface
-export CFLAGS += -DCOREIF_NG=1
+CFLAGS += -DCOREIF_NG=1
 
 # tell the build system that the CPU depends on the atmega common files
 USEMODULE += atmega_common

--- a/cpu/atmega_common/Makefile.include
+++ b/cpu/atmega_common/Makefile.include
@@ -1,7 +1,7 @@
 # include module specific includes
-export INCLUDES += -I$(RIOTCPU)/atmega_common/include \
-                   -isystem$(RIOTCPU)/atmega_common/avr_libc_extra/include \
-                   -isystem$(RIOTCPU)/atmega_common/avr_libc_extra/include/vendor
+INCLUDES += -I$(RIOTCPU)/atmega_common/include \
+            -isystem$(RIOTCPU)/atmega_common/avr_libc_extra/include \
+            -isystem$(RIOTCPU)/atmega_common/avr_libc_extra/include/vendor
 
 # avr libc needs some RIOT-specific support code
 USEMODULE += avr_libc_extra

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -12,7 +12,7 @@ ifeq (1,$(EFM32_TNRG))
 endif
 
 ifeq (1,$(EFM32_UART_MODES))
-  export CFLAGS += -DEFM32_UART_MODES=1
+  CFLAGS += -DEFM32_UART_MODES=1
 endif
 
 include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/efm32/Makefile.include
+++ b/cpu/efm32/Makefile.include
@@ -4,7 +4,7 @@ export CPU_ARCH = $(EFM32_ARCHITECTURE)
 export CPU_FAM = $(EFM32_FAMILY)
 
 # the em_device.h header requires a global define with the cpu model
-export CFLAGS += -D$(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
+CFLAGS += -D$(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
 
 # include Gecko SDK package
 USEPKG += gecko_sdk

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -1,4 +1,4 @@
-export INCLUDES += -I$(RIOTCPU)/mips32r2_common/include
+INCLUDES += -I$(RIOTCPU)/mips32r2_common/include
 
 export USEMODULE += mips32r2_common
 export USEMODULE += mips32r2_common_periph

--- a/cpu/mips_pic32_common/Makefile.include
+++ b/cpu/mips_pic32_common/Makefile.include
@@ -1,6 +1,6 @@
 include $(RIOTCPU)/mips32r2_common/Makefile.include
 
-export INCLUDES += -I$(RIOTCPU)/mips_pic32_common/include
+INCLUDES += -I$(RIOTCPU)/mips_pic32_common/include
 
 USEMODULE += mips_pic32_common
 USEMODULE += mips_pic32_common_periph

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -4,14 +4,14 @@ include $(RIOTCPU)/mips_pic32_common/Makefile.include
 include $(RIOTMAKE)/arch/mips.inc.mk
 
 # define build specific options
-export CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM
+CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM
 
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
 export LINKFLAGS += -Tpic32mx512_12_128_uhi.ld
 
 # the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
-export OBJCOPY = objcopy #use system objcopy as toolchain one is broken.
-export OFLAGS += \
+OBJCOPY = objcopy #use system objcopy as toolchain one is broken.
+OFLAGS += \
     --change-section-lma .bootflash-0xA0000000 \
     --change-section-lma .exception_vector-0x80000000 \
     --change-section-lma .text-0x80000000 \

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -4,15 +4,15 @@ include $(RIOTCPU)/mips_pic32_common/Makefile.include
 include $(RIOTMAKE)/arch/mips.inc.mk
 
 # define build specific options
-export CFLAGS += -march=m5101 -mmicromips -DSKIP_COPY_TO_RAM
-export CFLAGS += -DMIPS_MICROMIPS
+CFLAGS += -march=m5101 -mmicromips -DSKIP_COPY_TO_RAM
+CFLAGS += -DMIPS_MICROMIPS
 
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
 export LINKFLAGS += -Tpic32mz2048_uhi.ld
 
 # the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
-export OBJCOPY = objcopy #use system objcopy as toolchain one is broken.
-export OFLAGS += \
+OBJCOPY = objcopy #use system objcopy as toolchain one is broken.
+OFLAGS += \
     --change-section-lma .lowerbootflashalias-0xA0000000 \
     --change-section-lma .bootflash1-0xA0000000 \
     --change-section-lma .bootflash2-0xA0000000 \

--- a/cpu/msp430_common/Makefile.include
+++ b/cpu/msp430_common/Makefile.include
@@ -2,9 +2,8 @@ PSEUDOMODULES += msp430_malloc
 
 INCLUDES += -I$(RIOTCPU)/msp430_common/include/
 
-# export the CPU model
 MODEL = $(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
-export CFLAGS += -DCPU_MODEL_$(MODEL)
+CFLAGS += -DCPU_MODEL_$(MODEL)
 
 export UNDEF += $(BINDIR)/msp430_common/startup.o
 export USEMODULE += msp430_common msp430_common_periph msp430_malloc

--- a/cpu/nrf5x_common/Makefile.include
+++ b/cpu/nrf5x_common/Makefile.include
@@ -1,6 +1,5 @@
-# export the CPU family so we can differentiate between them in the code
 FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
-export CFLAGS += -DCPU_FAM_$(FAM)
+CFLAGS += -DCPU_FAM_$(FAM)
 
 # include nrf5x common periph drivers
 USEMODULE += nrf5x_common_periph
@@ -8,5 +7,4 @@ USEMODULE += nrf5x_common_periph
 # link common cpu code
 USEMODULE += cpu_common
 
-# export the common include directory
-export INCLUDES += -I$(RIOTCPU)/nrf5x_common/include
+INCLUDES += -I$(RIOTCPU)/nrf5x_common/include

--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -19,9 +19,9 @@ ROM_START_ADDR ?= 0x00000000
 RAM_START_ADDR ?= 0x20000000
 
 # this CPU implementation doesn't use CMSIS initialization
-export CFLAGS += -DDONT_USE_CMSIS_INIT
-export CFLAGS += -DDONT_USE_PREDEFINED_CORE_HANDLERS
-export CFLAGS += -DDONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
+CFLAGS += -DDONT_USE_CMSIS_INIT
+CFLAGS += -DDONT_USE_PREDEFINED_CORE_HANDLERS
+CFLAGS += -DDONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
 
 # For Cortex-M cpu we use the common cortexm.ld linker script
 LINKER_SCRIPT ?= cortexm.ld
@@ -29,5 +29,4 @@ LINKER_SCRIPT ?= cortexm.ld
 # include sam0 common periph drivers
 USEMODULE += sam0_common_periph
 
-# export the common include directory
-export INCLUDES += -I$(RIOTCPU)/sam0_common/include
+INCLUDES += -I$(RIOTCPU)/sam0_common/include

--- a/cpu/sam_common/Makefile.include
+++ b/cpu/sam_common/Makefile.include
@@ -2,10 +2,9 @@
 CFLAGS += -DCPU_FAM_$(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
 
 # this CPU implementation doesn't use CMSIS initialization
-export CFLAGS += -DDONT_USE_CMSIS_INIT
+CFLAGS += -DDONT_USE_CMSIS_INIT
 
 # for the sam[drl] CPUs we hold all linkerscripts in the sam0 common folder
 export LINKFLAGS += -L$(RIOTCPU)/sam_common/ldscripts
 
-# export the common include directory
-export INCLUDES += -I$(RIOTCPU)/sam_common/include
+INCLUDES += -I$(RIOTCPU)/sam_common/include

--- a/cpu/stellaris_common/Makefile.include
+++ b/cpu/stellaris_common/Makefile.include
@@ -1,4 +1,4 @@
 # define stellaris specific flags and includes
 export STELLARISWARE = $(RIOTCPU)/stellaris_common/include/vendor
 # define build specific options
-export CFLAGS += -I$(STELLARISWARE) -DPART_$(CPU_MODEL) -c -DTARGET_IS_BLIZZARD_RA1
+CFLAGS += -I$(STELLARISWARE) -DPART_$(CPU_MODEL) -c -DTARGET_IS_BLIZZARD_RA1

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -1,6 +1,5 @@
-# export the CPU family so we can differentiate between them in the code
 FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
-export CFLAGS += -DCPU_FAM_$(FAM)
+CFLAGS += -DCPU_FAM_$(FAM)
 
 # All stm32 families provide pm support
 USEMODULE += pm_layered
@@ -12,8 +11,7 @@ USEMODULE += stm32_common stm32_common_periph
 export LINKFLAGS += -L$(RIOTCPU)/stm32_common/ldscripts
 LINKER_SCRIPT ?= stm32_common.ld
 
-# export the common include directory
-export INCLUDES += -I$(RIOTCPU)/stm32_common/include
+INCLUDES += -I$(RIOTCPU)/stm32_common/include
 
 # Compute ROM_LEN and RAM_LEN
 include $(RIOTCPU)/stm32_common/stm32_mem_lengths.mk
@@ -26,8 +24,8 @@ FLASHSIZE := $(shell echo $$(( $(LEN) * $(KB) )) )
 CPU_LINE ?= $(shell echo $(CPU_MODEL) | cut -c -9 | tr 'a-z-' 'A-Z_')xx
 
 # Set CFLAGS
-export CFLAGS += -D$(CPU_LINE) -DCPU_LINE_$(CPU_LINE)
-export CFLAGS += -DSTM32_FLASHSIZE=$(FLASHSIZE)U
+CFLAGS += -D$(CPU_LINE) -DCPU_LINE_$(CPU_LINE)
+CFLAGS += -DSTM32_FLASHSIZE=$(FLASHSIZE)U
 
 info-stm32:
 	@$(COLOR_ECHO) "CPU: $(CPU_MODEL)"

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -41,7 +41,7 @@ QUIET ?= 1
 
 #DISABLE_MODULE += core_msg
 
-#export INCLUDES += -Iapplication_include
+#INCLUDES += -Iapplication_include
 
 # Specify custom dependencies for your application here ...
 # APPDEPS = app_data.h config.h

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -2,12 +2,12 @@
 export TARGET_ARCH ?= arm-none-eabi
 
 # define build specific options
-export CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)
+CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)
 
 ifneq (llvm,$(TOOLCHAIN))
 # Clang (observed with v3.7) does not understand  -mno-thumb-interwork, only add if
 # not building with LLVM
-export CFLAGS      += -mno-thumb-interwork
+CFLAGS      += -mno-thumb-interwork
 
 # work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85606
 ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
@@ -15,13 +15,13 @@ ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
 endif
 endif
 
-export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
-export CFLAGS_DBG  ?= -ggdb -g3
-export CFLAGS_OPT  ?= -Os
+CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+CFLAGS_DBG  ?= -ggdb -g3
+CFLAGS_OPT  ?= -Os
 
-export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
+CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 
-export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
 export LINKER_SCRIPT ?= $(CPU_MODEL).ld
 export LINKFLAGS += -T$(LINKER_SCRIPT) -Wl,--fatal-warnings
@@ -81,24 +81,23 @@ endif
 endif
 endif
 
-# export the CPU model and architecture
 MODEL = $(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
-export CFLAGS += -DCPU_MODEL_$(MODEL)
+CFLAGS += -DCPU_MODEL_$(MODEL)
 ARCH = $(shell echo $(CPU_ARCH) | tr 'a-z-' 'A-Z_')
-export CFLAGS += -DCPU_ARCH_$(ARCH)
+CFLAGS += -DCPU_ARCH_$(ARCH)
 
 # set the compiler specific CPU and FPU options
 ifneq (,$(filter $(CPU_ARCH),cortex-m4f cortex-m7))
     ifneq (,$(filter cortexm_fpu,$(DISABLE_MODULE)))
-        export CFLAGS_FPU ?= -mfloat-abi=soft
+        CFLAGS_FPU ?= -mfloat-abi=soft
     else
         USEMODULE += cortexm_fpu
         # clang assumes there is an FPU
         ifneq (llvm,$(TOOLCHAIN))
             ifeq ($(CPU_ARCH),cortex-m7)
-                export CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-d16
+                CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-d16
             else
-                export CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
+                CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
             endif
         endif
     endif
@@ -116,19 +115,19 @@ endif
 ifneq (,$(filter cmsis-dsp,$(USEPKG)))
 # definition needed to use cmsis-dsp headers
 ifeq ($(CPU_ARCH),cortex-m0)
-export CFLAGS += -DARM_MATH_CM0
+CFLAGS += -DARM_MATH_CM0
 else ifeq ($(CPU_ARCH),cortex-m0plus)
-export CFLAGS += -DARM_MATH_CM0PLUS
+CFLAGS += -DARM_MATH_CM0PLUS
 else ifeq ($(CPU_ARCH),cortex-m3)
-export CFLAGS += -DARM_MATH_CM3
+CFLAGS += -DARM_MATH_CM3
 else ifeq ($(CPU_ARCH),cortex-m4)
-export CFLAGS += -DARM_MATH_CM4
+CFLAGS += -DARM_MATH_CM4
 else ifeq ($(CPU_ARCH),cortex-m4f)
-export CFLAGS += -DARM_MATH_CM4
+CFLAGS += -DARM_MATH_CM4
 else ifeq ($(CPU_ARCH),cortex-m7)
-export CFLAGS += -DARM_MATH_CM7
+CFLAGS += -DARM_MATH_CM7
 else ifeq ($(CPU_ARCH),cortex-m23)
-export CFLAGS += -DARM_MATH_CM23
+CFLAGS += -DARM_MATH_CM23
 endif
 endif
 

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -33,34 +33,34 @@ endif
 # https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=commitdiff;h=81c17949f0419d1c4fee421c60987ea1149522ae
 # Otherwise we get an error about a missing declaration of strnlen in some parts.
 ifeq (, $(filter -std=%, $(CFLAGS)))
-  export CFLAGS += -std=gnu99
+  CFLAGS += -std=gnu99
 endif
-export CFLAGS_CPU   = -EL -mabi=$(ABI)
-export CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums -fdata-sections
-export CFLAGS_DBG   = -g3
-export CFLAGS_OPT   = -Os
+CFLAGS_CPU   = -EL -mabi=$(ABI)
+CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums -fdata-sections
+CFLAGS_DBG   = -g3
+CFLAGS_OPT   = -Os
 
-export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_OPT) $(CFLAGS_DBG)
+CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_OPT) $(CFLAGS_DBG)
 
 ifeq ($(USE_HARD_FLOAT),1)
-    export CFLAGS += -mhard-float -DMIPS_HARD_FLOAT
+    CFLAGS += -mhard-float -DMIPS_HARD_FLOAT
 else
     #hard-float is the default so we must set soft-float
-    export CFLAGS += -msoft-float
+    CFLAGS += -msoft-float
     export LINKFLAGS += -msoft-float
 endif
 
 ifeq ($(USE_DSP),1)
-    export CFLAGS += -mdsp -DMIPS_DSP
+    CFLAGS += -mdsp -DMIPS_DSP
 endif
 
 ifeq ($(TOOLCHAIN),llvm)
 # The MIPS toolchain headers in assembly mode are not compatible with Clang
-export CCAS = $(PREFIX)gcc
-export CCASUWFLAGS += -target $(TARGET_ARCH)
+CCAS = $(PREFIX)gcc
+CCASUWFLAGS += -target $(TARGET_ARCH)
 endif
 
-export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_OPT) $(CFLAGS_DBG)
+ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_OPT) $(CFLAGS_DBG)
 
 export LINKFLAGS += $(MIPS_HAL_LDFLAGS)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts

--- a/makefiles/arch/msp430.inc.mk
+++ b/makefiles/arch/msp430.inc.mk
@@ -5,14 +5,12 @@ export TARGET_ARCH ?= msp430
 CFLAGS_CPU   = -mmcu=$(CPU_MODEL)
 # default std set to gnu99 of not overwritten by user
 ifeq (, $(filter -std=%, $(CFLAGS)))
-  export CFLAGS += -std=gnu99
+  CFLAGS += -std=gnu99
 endif
 CFLAGS_LINK  = -ffunction-sections -fdata-sections
 CFLAGS_DBG  ?= -gdwarf-2
 CFLAGS_OPT  ?= -Os
-# export compiler flags
-export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
-# export assmebly flags
-export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
+CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
+ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 # export linker flags
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -11,9 +11,7 @@ export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
 export LINKER_SCRIPT ?= $(CPU_MODEL).ld
 export LINKFLAGS += -T$(LINKER_SCRIPT)
 
-# export compiler flags
-export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) $(CFLAGS_LINK)
-# export assmebly flags
-export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+CFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) $(CFLAGS_LINK)
+ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 # export linker flags
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -47,6 +47,7 @@ export CC                    # The C compiler to use.
 export CXX                   # The CXX compiler to use.
 export CCAS                  # The C compiler to use for assembler files, typically the same as CC.
 export CFLAGS                # The compiler flags. Must only ever be used with `+=`.
+export CFLAGS_CPU            # CPU architecture specific compiler flags
 export CXXUWFLAGS            # (Patterns of) flags in CFLAGS that should not be passed to CXX.
 export CXXEXFLAGS            # Additional flags that should be passed to CXX.
 export CCASUWFLAGS           # (Patterns of) flags in CFLAGS that should not be passed to CCAS.

--- a/pkg/oonf_api/patches/0002-port-tests-to-riot.patch
+++ b/pkg/oonf_api/patches/0002-port-tests-to-riot.patch
@@ -45,7 +45,7 @@ index 0000000..afbaf0f
 +# this has to be the absolute path of the RIOT-base dir
 +export RIOTBASE =$(CURDIR)/../../../../../..
 +
-+export CFLAGS = -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
++CFLAGS = -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
 +
 +## Modules to include.
 +
@@ -59,7 +59,7 @@ index 0000000..afbaf0f
 +	error daemonize is not supported on RIOT
 +endif
 +
-+export INCLUDES += -I$(CURDIR)/../..
++INCLUDES += -I$(CURDIR)/../..
 +
 +QUIET ?= 1
 +
@@ -141,14 +141,14 @@ index 0000000..e472545
 +# this has to be the absolute path of the RIOT-base dir
 +export RIOTBASE =$(CURDIR)/../../../../../..
 +
-+export CFLAGS = -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
++CFLAGS = -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
 +
 +## Modules to include.
 +USEMODULE += oonf_cunit
 +USEMODULE += oonf_common
 +USEMODULE += oonf_rfc5444
 +
-+export INCLUDES += -I$(CURDIR)/../..
++INCLUDES += -I$(CURDIR)/../..
 +
 +QUIET ?= 1
 +

--- a/pkg/oonf_api/patches/0003-port-example-to-riot.patch
+++ b/pkg/oonf_api/patches/0003-port-example-to-riot.patch
@@ -31,7 +31,7 @@ index 0000000..9d5653d
 +# this has to be the absolute path of the RIOT-base dir
 +export RIOTBASE =$(CURDIR)/../../../../..
 +
-+export CFLAGS = -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
++CFLAGS = -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
 +
 +## Modules to include.
 +


### PR DESCRIPTION
### Contribution description

These are already exported by `makefiles/vars.inc.mk`.
It is a prerequisite to allow handling compilation without global exports.

This currently does not un-export them from `makefiles/toolchain`.

### Testing procedure

All the removed export are exported in `makefiles/vars.inc.mk` or not needed in sub-execution.
I newly exported `CFLAGS_CPU` as it is needed by `pkg/openthread`.

```
git diff $(git merge-base HEAD master) | grep '^-' | grep -v -e '--- a/' -e '#' \
   | grep -v -e 'CFLAGS ' -e 'OBJCOPY'  -e CCAS -e ASFLAGS -e INCLUDES -e OFLAGS -e OBJDUMPFLAGS -e CXXEXFLAGS -e CXXUWFLAGS -e CFLAGS_CPU
-export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
-export CFLAGS_DBG  ?= -ggdb -g3
-export CFLAGS_OPT  ?= -Os
-
-export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
-export CFLAGS_DBG  ?= -ggdb -g3
-export CFLAGS_OPT  ?= -Os
-        export CFLAGS_FPU ?= -mfloat-abi=soft
-                export CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-d16
-                export CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
-export CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums -fdata-sections
-export CFLAGS_DBG   = -g3
-export CFLAGS_OPT   = -Os
```

And the `CFLAGS_` variables are only used by included files:


```
git grep '$(CFLAGS_.*)'  | grep -v -e 'pkg/openthread/Makefile'  -e 'dist/tools/uhcpd/Makefile'
Makefile.include:       $(Q)'$(RIOTTOOLS)/genconfigheader/genconfigheader.sh' $(CFLAGS_WITH_MACROS) \
boards/common/msba2/Makefile.include:CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
boards/common/msba2/Makefile.include:ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
boards/common/msba2/Makefile.include:export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
makefiles/arch/atmega.inc.mk:CFLAGS_CPU   = -mmcu=$(CPU) $(CFLAGS_FPU)
makefiles/arch/atmega.inc.mk:CFLAGS    += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
makefiles/arch/atmega.inc.mk:ASFLAGS   += $(CFLAGS_CPU) $(CFLAGS_DBG)
makefiles/arch/atmega.inc.mk:LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -e reset_handler -Wl,--gc-sections
makefiles/arch/cortexm.inc.mk:CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)
makefiles/arch/cortexm.inc.mk:CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
makefiles/arch/cortexm.inc.mk:ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
makefiles/arch/cortexm.inc.mk:export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
makefiles/arch/mips.inc.mk:CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_OPT) $(CFLAGS_DBG)
makefiles/arch/mips.inc.mk:eASFLAGS += $(CFLAGS_CPU) $(CFLAGS_OPT) $(CFLAGS_DBG)
makefiles/arch/mips.inc.mk:export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT)
makefiles/arch/msp430.inc.mk:CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
makefiles/arch/msp430.inc.mk:ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
makefiles/arch/msp430.inc.mk:export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
makefiles/arch/riscv.inc.mk:CFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) $(CFLAGS_LINK)
makefiles/arch/riscv.inc.mk:ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
makefiles/arch/riscv.inc.mk:export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
makefiles/eclipse.inc.mk:       $(Q)printf "%s\n" $(CC) $(CFLAGS_WITH_MACROS) $(INCLUDES) | \
makefiles/toolchain/llvm.inc.mk:    $(shell $(PREFIX)gcc $(CFLAGS_CPU) -v -x $1 -E /dev/null 2>&1 | \
makefiles/toolchain/llvm.inc.mk:  ifeq (,$(CFLAGS_CPU))
```

And there should not be any other changes than these variables and comments except the first two commits changes and the `dist/Makefile` comment.

``` diff
git diff --word-diff $(git merge-base HEAD master) | sed 's/\[-export-\]//g' | sed 's/\[-#.*\]//' | grep -e '{' -e '\[-'
[-CFLAGS += $(CFLAGS_BASIC)-]
{+#INCLUDES+} += -Iapplication_include
{+export CFLAGS_CPU            # CPU architecture specific compiler flags+}
```

### Issues/PRs references

Part of removing exporting everything everywhere https://github.com/RIOT-OS/RIOT/issues/10850