### PR TITLE
 sys/shell: refactor readline function.

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -35,17 +35,6 @@
 #include "shell_commands.h"
 
 #define ETX '\x03'  /** ASCII "End-of-Text", or ctrl-C */
-#if !defined(SHELL_NO_ECHO) || !defined(SHELL_NO_PROMPT)
-#ifdef MODULE_NEWLIB
-/* use local copy of putchar, as it seems to be inlined,
- * enlarging code by 50% */
-static void _putchar(int c) {
-    putchar(c);
-}
-#else
-#define _putchar putchar
-#endif
-#endif
 
 static void flush_if_needed(void)
 {
@@ -283,8 +272,8 @@ static int readline(char *buf, size_t size)
 
             buf[curr_pos] = '\0';
 #ifndef SHELL_NO_ECHO
-            _putchar('\r');
-            _putchar('\n');
+            putchar('\r');
+            putchar('\n');
 #endif
 
             return (length_exceeded)? -READLINE_TOOLONG : curr_pos;
@@ -304,9 +293,9 @@ static int readline(char *buf, size_t size)
             }
             /* white-tape the character */
 #ifndef SHELL_NO_ECHO
-            _putchar('\b');
-            _putchar(' ');
-            _putchar('\b');
+            putchar('\b');
+            putchar(' ');
+            putchar('\b');
 #endif
         }
         else {
@@ -318,7 +307,7 @@ static int readline(char *buf, size_t size)
                 length_exceeded = true;
             }
 #ifndef SHELL_NO_ECHO
-            _putchar(c);
+            putchar(c);
 #endif
         }
         flush_if_needed();
@@ -328,8 +317,8 @@ static int readline(char *buf, size_t size)
 static inline void print_prompt(void)
 {
 #ifndef SHELL_NO_PROMPT
-    _putchar('>');
-    _putchar(' ');
+    putchar('>');
+    putchar(' ');
 #endif
 
     flush_if_needed();

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -276,6 +276,11 @@ static int readline(char *buf, size_t size)
         /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
         /* Ctrl-C cancels the current line. */
         if (c == '\r' || c == '\n' || c == ETX) {
+            if (c == ETX) {
+                curr_pos = 0;
+                length_exceeded = 0;
+            }
+
             buf[curr_pos] = '\0';
 #ifndef SHELL_NO_ECHO
             _putchar('\r');

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -384,8 +384,6 @@ void shell_run(const shell_command_t *shell_commands, char *line_buf, int len)
             case -READLINE_TOOLONG:
                 puts(TOOLONG_MESSAGE);
                 break;
-            case 0:
-                break;
             default:
                 handle_input_line(shell_commands, state);
                 break;

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -329,8 +329,6 @@ static int readline(struct shell_state *state, size_t size)
 
     assert((size_t)size > 0);
 
-    print_prompt(state);
-
     while (1) {
         int c = getchar();
 
@@ -385,6 +383,7 @@ void shell_run(const shell_command_t *shell_commands, char *line_buf, int len)
     len = shell_state_init(state, len);
 
     while (1) {
+        print_prompt(state);
         int res = readline(state, len);
 
         switch (res) {

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -68,10 +68,14 @@ struct shell_state {
     char line[];
 };
 
-static void shell_state_init(struct shell_state *state)
+static int shell_state_init(struct shell_state *state, int len)
 {
+    assert(len >= sizeof(struct shell_state));
+
     state->echo_on = ECHO_ON;
     state->prompt_char = PROMPT_CHAR;
+
+    return len - sizeof(struct shell_state);
 }
 
 /**
@@ -371,9 +375,7 @@ void shell_run(const shell_command_t *shell_commands, char *line_buf, int len)
 {
     struct shell_state *state = (void*)line_buf;
 
-    assert(len >= sizeof(struct shell_state));
-
-    shell_state_init(state);
+    len = shell_state_init(state, len);
 
     while (1) {
         int res = readline(state, len);

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -21,4 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
 
 APP_SHELL_FMT ?= NONE
 
+# needed to correctly test long lines
+RIOT_TERMINAL ?= socat
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -56,7 +56,17 @@ static int print_echo(int argc, char **argv)
     return 0;
 }
 
+static int print_shell_bufsize(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    printf("%d\n", SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
+    { "bufsize", "Get the shell's buffer size", print_shell_bufsize },
     { "start_test", "starts a test", print_teststart },
     { "end_test", "ends a test", print_testend },
     { "echo", "prints the input command", print_echo },

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -7,6 +7,7 @@
 # directory for more details.
 
 import sys
+import os
 from testrunner import run
 
 
@@ -50,21 +51,36 @@ CMDS = (
     ('help', EXPECTED_HELP),
     ('echo a string', ('\"echo\"\"a\"\"string\"')),
     ('ps', EXPECTED_PS),
-    ('garbage1234'+CONTROL_C, ('>')),  # test cancelling a line
     ('help', EXPECTED_HELP),
     ('reboot', ('test_shell.'))
 )
 
+PROMPT = '> '
+
+ON_NATIVE = os.environ['BOARD'] == 'native'
+
 
 def check_cmd(child, cmd, expected):
+    child.expect(PROMPT)
     child.sendline(cmd)
     for line in expected:
         child.expect_exact(line)
 
 
 def testfunc(child):
+    # Avoid sending en extra empty line on native.
+    if ON_NATIVE:
+        child.crlf = '\n'
+
     # check startup message
     child.expect('test_shell.')
+
+    # test cancelling a line
+    child.expect(PROMPT)
+    child.sendline('garbage1234'+CONTROL_C)
+    garbage_expected = 'garbage1234\r\r\n> '
+    garbage_received = child.read(len(garbage_expected))
+    assert garbage_expected == garbage_received
 
     # loop other defined commands and expected output
     for cmd, expected in CMDS:

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -73,7 +73,21 @@ def testfunc(child):
         child.crlf = '\n'
 
     # check startup message
-    child.expect('test_shell.')
+    child.expect('test_shell.\r\n')
+    child.sendline('')
+
+    child.sendline('bufsize')
+    child.expect('([0-9]+)\r\n')
+
+    bufsize = int(child.match[1])
+
+    child.expect(PROMPT)
+
+    # check a long line
+    child.sendline("_"*bufsize + "verylong")
+    # this is dirty hack to work around a bug in the uart (#10634)
+    child.sendline()
+    child.expect('shell: maximum line length exceeded')
 
     # test cancelling a line
     child.expect(PROMPT)

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -84,9 +84,17 @@ def testfunc(child):
     child.expect(PROMPT)
 
     # check a long line
-    child.sendline("_"*bufsize + "verylong")
-    # this is dirty hack to work around a bug in the uart (#10634)
-    child.sendline()
+    longline = "_"*bufsize + "verylong"
+    if ON_NATIVE:
+        child.sendline(longline)
+    else:
+        # this is dirty hack to work around a bug in the uart (#10634)
+        for c in longline:
+            child.write(c)
+            child.flush()
+        child.sendline()
+        child.sendline()
+
     child.expect('shell: maximum line length exceeded')
 
     # test cancelling a line


### PR DESCRIPTION
### Contribution description

This makes the code of `readline()` clearer and shorter. It also fixes a minor artifact of the long line handling.

Previously it was not possible to recover from a long line. That is, if too many characters were sent, the line would be invalidated and pressing backspace would not fix it- the only option was to discard the line. It is now possible to bring the line back to size. Note that visual effects when deleting characters will still depend on the host's terminal.

The new code is written in a way that all writes to memory are guarded by bounds check, so an assertion was removed.

The main commit in this PR is b7294a6d9a783dad1076a8d7d7d0f1e397e5db36 .

### Testing procedure

I added test vectors to `tests/shell`. The tests is not really testing a lot right now because the host is still line buffering.

### Issues/PRs references

Depends on:
- [ ] #10635 
- [ ] #12087 

Related to: #12085 , #10994 . In a way I'm kind of rewriting the shell little by little.
