### PR TITLE
cpu/stm32_common: disable i2c in release

### DIFF
--- a/cpu/stm32/periph/i2c_1.c
+++ b/cpu/stm32/periph/i2c_1.c
@@ -143,12 +143,20 @@ int i2c_acquire(i2c_t dev)
 
     periph_clk_en(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
 
+    /* enable device */
+    i2c_config[dev].dev->CR1 |= I2C_CR1_PE;
+
     return 0;
 }
 
 void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
+
+    /* disable device */
+    i2c_config[dev].dev->CR1 &= ~(I2C_CR1_PE);
+
+    _wait_for_bus(i2c_config[dev].dev);
 
     periph_clk_dis(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
 

--- a/cpu/stm32/periph/i2c_2.c
+++ b/cpu/stm32/periph/i2c_2.c
@@ -193,12 +193,20 @@ int i2c_acquire(i2c_t dev)
 
     periph_clk_en(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
 
+    /* enable device */
+    i2c_config[dev].dev->CR1 |= I2C_CR1_PE;
+
     return 0;
 }
 
 void i2c_release(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
+
+    /* disable device */
+    i2c_config[dev].dev->CR1 &= ~(I2C_CR1_PE);
+
+    _wait_for_bus(i2c_config[dev].dev);
 
     periph_clk_dis(i2c_config[dev].bus, i2c_config[dev].rcc_mask);
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The hardware peripheral should be disabled before stopping the peripheral clock. With the uart driver we found that there could be some wrong behaviour otherwise.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
use periph_i2c test app
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
