### PR TITLE
Makefile.include: add cleanterm target and use it for tests

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -632,7 +632,7 @@ term: $(filter flash flash-only, $(MAKECMDGOALS)) $(TERMDEPS)
 
 # Term without the pyterm added logging
 # TERMFLAGS must be exported for `jlink.sh term_rtt`.
-cleanterm: export PYTERMFLAGS += --noprefix
+cleanterm: export PYTERMFLAGS += --noprefix --no-repeat-command-on-empty-line
 cleanterm: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)

--- a/Makefile.include
+++ b/Makefile.include
@@ -630,6 +630,13 @@ term: $(filter flash flash-only, $(MAKECMDGOALS)) $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
 
+# Term without the pyterm added logging
+# TERMFLAGS must be exported for `jlink.sh term_rtt`.
+cleanterm: export PYTERMFLAGS += --noprefix
+cleanterm: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
+	$(call check_cmd,$(TERMPROG),Terminal program)
+	$(TERMPROG) $(TERMFLAGS)
+
 list-ttys:
 	$(Q)$(RIOTTOOLS)/usb-serial/list-ttys.sh
 

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -36,7 +36,7 @@ def find_exc_origin(exc_info):
 
 
 def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
-    child = spawnclass("make term", env=env, timeout=timeout,
+    child = spawnclass("make cleanterm", env=env, timeout=timeout,
                        codec_errors='replace', echo=False)
 
     # on many platforms, the termprog needs a short while to be ready...

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -68,7 +68,7 @@ _JLINK_IF=SWD
 _JLINK_SPEED=2000
 # default terminal frontend
 _JLINK_TERMPROG=${RIOTTOOLS}/pyterm/pyterm
-_JLINK_TERMFLAGS="-ts 19021"
+_JLINK_TERMFLAGS="-ts 19021 ${PYTERMFLAGS}"
 
 #
 # a couple of tests for certain configuration options

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,3 +27,18 @@ An automated way of knowing if a test is available is to execute the
 It executes without error if tests run by 'make test' are present.
 
     make test/available
+
+
+Interaction through the uart
+----------------------------
+
+Tests implemented with `testrunner` use the `cleanterm` target that
+provides an interaction without adding extra text output or input handling.
+It can currently be expected to have unmodified line based interaction with the
+board.
+
+The expected behavior is verified with the test in `tests/test_tools`.
+
+Tests cannot rely on having on all boards and terminal programs:
+* unbuffered input
+* allowing sending special characters like `ctrl+c/ctrl+d`

--- a/tests/test_tools/main.c
+++ b/tests/test_tools/main.c
@@ -66,7 +66,6 @@ static int cmd_shellping(int argc, char **argv)
     return 0;
 }
 
-
 /**
  * @brief Uppercase the first word
  *
@@ -98,11 +97,31 @@ static int cmd_toupper(int argc, char **argv)
     return 0;
 }
 
+/**
+ * @brief getchar, read one character
+ *
+ * Read one character and print its hex value
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0
+ *
+ */
+static int cmd_getchar(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    printf("%s 0x%02x\n", argv[0], getchar());
+    return 0;
+}
+
 
 static const shell_command_t shell_commands[] = {
     { "shellping", "Just print 'shellpong'", cmd_shellping },
     { "true", "do nothing, successfully", cmd_true },
     { "toupper", "uppercase first argument", cmd_toupper },
+    { "getchar", "Get one character and print the hex value", cmd_getchar },
     { NULL, NULL, NULL }
 };
 

--- a/tests/test_tools/main.c
+++ b/tests/test_tools/main.c
@@ -15,6 +15,8 @@
  */
 
 #include <stdio.h>
+#include <string.h>
+#include <ctype.h>
 
 #include "shell_commands.h"
 #include "shell.h"
@@ -65,9 +67,42 @@ static int cmd_shellping(int argc, char **argv)
 }
 
 
+/**
+ * @brief Uppercase the first word
+ *
+ * First argument is read, converted to uppercase and printed with a newline.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ *
+ */
+static int cmd_toupper(int argc, char **argv)
+{
+    if (argc != 2) {
+        puts("Invalid number of argument");
+        printf("Usage: %s <word>\n", argv[0]);
+        return 1;
+    }
+
+    size_t len = strlen(argv[1]);
+    for (size_t i = 0; i < len; i++) {
+        /* Cast to 'int' as llvm and some compilers complain about
+         *     array subscript has type 'char' */
+        char c = toupper((int)argv[1][i]);
+        putchar(c);
+    }
+    putchar('\n');
+
+    return 0;
+}
+
+
 static const shell_command_t shell_commands[] = {
     { "shellping", "Just print 'shellpong'", cmd_shellping },
     { "true", "do nothing, successfully", cmd_true },
+    { "toupper", "uppercase first argument", cmd_toupper },
     { NULL, NULL, NULL }
 };
 

--- a/tests/test_tools/tests/01-run.py
+++ b/tests/test_tools/tests/01-run.py
@@ -38,12 +38,20 @@ def _test_no_local_echo(child):
     assert res == 0, "There should have been a timeout and not match stdin"
 
 
+def _test_clean_output(child):
+    """Verify that only what the node sends is received."""
+    child.sendline('toupper lowercase')
+    retline = child.readline()
+    assert retline.strip() == 'LOWERCASE'
+
+
 def testfunc(child):
     """Run some tests to verify the board under test behaves correctly.
 
     It currently tests:
 
     * local echo
+    * getting some test output without other messages
     """
     child.expect_exact("Running 'tests_tools' application")
 
@@ -54,6 +62,9 @@ def testfunc(child):
 
     # The node should still answer after the previous one
     _shellping(child)
+
+    # Check that the output is clean without extra terminal output
+    _test_clean_output(child)
 
 
 if __name__ == "__main__":

--- a/tests/test_tools/tests/01-run.py
+++ b/tests/test_tools/tests/01-run.py
@@ -38,6 +38,16 @@ def _test_no_local_echo(child):
     assert res == 0, "There should have been a timeout and not match stdin"
 
 
+def _test_sending_newline(child):
+    """Verify that a empty line can be send to the node.
+
+    The local terminal must NOT repeat the previous command.
+    """
+    child.sendline('getchar')
+    child.sendline('')  # send only one newline character
+    child.expect_exact('getchar 0x0a\r\n')
+
+
 def _test_clean_output(child):
     """Verify that only what the node sends is received."""
     child.sendline('toupper lowercase')
@@ -52,6 +62,7 @@ def testfunc(child):
 
     * local echo
     * getting some test output without other messages
+    * sending empty lines
     """
     child.expect_exact("Running 'tests_tools' application")
 
@@ -65,6 +76,9 @@ def testfunc(child):
 
     # Check that the output is clean without extra terminal output
     _test_clean_output(child)
+
+    # It is possible to send an empty newline
+    _test_sending_newline(child)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

It is similar to 'term' but with removing possible additional behaviors
from pyterm.

It currently removes the logging decorators and allow sending empty lines.

Use a clean terminal without added decoration on the output for testing.

### Review procedure

`pyterm` logging and special behavior are required features that cannot be removed as said in https://github.com/RIOT-OS/RIOT/pull/12094

This introduces a new target that handles it.

This is completely similar to `rawterm` from https://github.com/RIOT-OS/RIOT/pull/11099 except that it only works around the `pyterm` issues and will do nothing against line buffering.

### Testing procedure

Run `BOARD=your_board make -C tests/test_tools/ flash test` with different RIOT_TERMINAL, currently supported (not on all boards) `pyterm`, `socat`, `picocom`. If possible one with `term_rtt`. But as it is internally using `pyterm` it will benefit from the changes automatically.



<details><summary><code>RIOT_TERMINAL=pyterm samr21-xpro</code></summary>

```
RIOT_TERMINAL=pyterm BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
   9944     504    2612   13060    3304 /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming............................................ done.
Verification............................................ done.
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --noprefix --no-repeat-command-on-empty-line
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
toupper lowercase
LOWERCASE
getchar

getchar 0x0a

```
</details>

<details><summary><code>RIOT_TERMINAL=picocom samr21-xpro</code></summary>

```
RIOT_TERMINAL=picocom  BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
   9848     504    2612   12964    32a4 /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming............................................ done.
Verification............................................ done.
picocom --nolock --imap lfcrlf --baud "115200" "/dev/ttyACM0"
picocom v2.2

port is        : /dev/ttyACM0
flowcontrol    : none
baudrate is    : 115200
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
nolock is      : yes
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        : lfcrlf,
omap is        : 
emap is        : crcrlf,delbs,

Type [C-a] [C-h] to see available commands

Terminal ready
main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
toupper lowercase
LOWERCASE
getchar

getchar 0x0a

```
</details>

<details><summary><code>RIOT_TERMINAL=socat samr21-xpro</code></summary>

```
RIOT_TERMINAL=socat  BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
   9848     504    2612   12964    32a4 /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/tests/test_tools/bin/samr21-xpro/tests_test_tools.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming............................................ done.
Verification............................................ done.
socat - open:/dev/ttyACM0,b115200,echo=0,raw
main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
toupper lowercase
LOWERCASE
getchar

getchar 0x0a

```
</details>

<details><summary><code>native</code></summary>

```
RIOT_CI_BUILD=1 BOARD=native make --no-print-directory -C tests/test_tools/ flash test

Building application "tests_test_tools" for "native" with MCU "native".

   text    data     bss     dec     hex filename
  22892     644   47652   71188   11614 /home/harter/work/git/RIOT/tests/test_tools/bin/native/tests_test_tools.elf
true 
/home/harter/work/git/RIOT/tests/test_tools/bin/native/tests_test_tools.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
toupper lowercase
LOWERCASE
getchar

getchar 0x0a

```
</details>

<details><summary><code>On IoT-LAB it works too</code></summary>

```
IOTLAB_NODE=auto-ssh RIOT_CI_BUILD=1 BOARD=iotlab-m3 make --no-print-directory -C tests/test_tools/ flash test
Building application "tests_test_tools" for "iotlab-m3" with MCU "stm32f1".

   text    data     bss     dec     hex filename
   9504     504    2620   12628    3154 /home/harter/work/git/RIOT/tests/test_tools/bin/iotlab-m3/tests_test_tools.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list grenoble,m3,58 --update /home/harter/work/git/RIOT/tests/test_tools/bin/iotlab-m3/tests_test_tools.elf | grep 0
0
ssh -t harter@grenoble.iot-lab.info 'socat - tcp:m3-58.grenoble.iot-lab.info:20000'
�main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
�main(): This is RIOT! (Version: buildtest)
Running 'tests_tools' application
shellping
shellpong
true this should not be echoed
shellping
shellpong
toupper lowercase
LOWERCASE
getchar

getchar 0x0a

```
</details>


#### The configuration is handled by `jlink.sh term_rtt`:

Tested without a board, we can see the logging format difference from `pyterm`.

<details><summary>BOARD=hamilton make -C examples/hello-world/ term</summary>

```
BOARD=hamilton make -C examples/hello-world/ term
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh term_rtt
### Starting RTT terminal ###
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-08-28 17:42:27,813 - WARNING # Host name for TCP connection is missing, defaulting to "localhost"
2019-08-28 17:42:27,813 - INFO # Connect to localhost:19021
2019-08-28 17:42:27,815 - ERROR # Something went wrong connecting to localhost:19021
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh: 243: kill: No such process
```
</details>

<details><summary>BOARD=hamilton make -C examples/hello-world/ cleanterm</summary>

```
BOARD=hamilton make -C examples/hello-world/ cleanterm
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh term_rtt
### Starting RTT terminal ###
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Host name for TCP connection is missing, defaulting to "localhost"Host name for TCP connection is missing, defaulting to "localhost"
Connect to localhost:19021Connect to localhost:19021
Something went wrong connecting to localhost:19021Something went wrong connecting to localhost:19021
/home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh: 243: kill: No such process
```
</details>


### term behaves as before

<details><summary>BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ term</summary>

```
BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C tests/test_tools/ term
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-08-28 17:55:03,695 - INFO # Connect to serial port /dev/ttyACM0
helWelcome to pyterm!
Type '/exit' to exit.
help
2019-08-28 17:55:04,889 - INFO # Command              Description
2019-08-28 17:55:04,892 - INFO # ---------------------------------------
2019-08-28 17:55:04,896 - INFO # shellping            Just print 'shellpong'
2019-08-28 17:55:04,900 - INFO # true                 do nothing, successfully
2019-08-28 17:55:04,904 - INFO # toupper              uppercase first argument
```
</details>

### Issues/PRs references

Replacement of https://github.com/RIOT-OS/RIOT/pull/12094
This is completely similar to `rawterm` from https://github.com/RIOT-OS/RIOT/pull/11099 except that it only works around the `pyterm` issues and will do nothing against line buffering.