### PR TITLE
cpu/fe310: don't call thread_yield when sched_active_thread is invalid

### DIFF
--- a/cpu/fe310/cpu.c
+++ b/cpu/fe310/cpu.c
@@ -334,8 +334,8 @@ void cpu_switch_context_exit(void)
     /* enable interrupts */
     irq_enable();
 
-    /* start the thread */
-    thread_yield();
+    /* start the thread by triggering a context switch */
+    thread_yield_higher();
     UNREACHABLE();
 }
 


### PR DESCRIPTION
### Contribution description

As the comment above `cpu_switch_context_exit` notes:

	sched_active_thread is not valid when cpu_switch_context_exit() is called.

Unfortunately, `thread_yield()`, which is called directly by
`cpu_switch_context_exit()`, uses `sched_active_thread` possibly resulting
in a null pointer dereference.

Solution: Trigger a software interrupt to perform a context switch and
let `sched_run()` determine the next valid thread from there.

### Testing procedure

I personally noticed this while trying to use RIOT with a [riscv simulator](https://github.com/agra-uni-bremen/riscv-vp). However, since this might as well be a bug in the simulator is probably best to "test this" by reading the code. 

**Disclaimer:** I am not a riscv expert, but I think it's pretty obvious that calling `thread_yield()` with an invalid `sched_active_thread` is a bad idea, unless you want to rely on the cpu not raising a trap/exception.
