### PR TITLE
pkg/nimble: fix doxygen group name prefix

### DIFF
--- a/pkg/nimble/addr/include/nimble_addr.h
+++ b/pkg/nimble/addr/include/nimble_addr.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    ble_nimble_addr Address Helper
- * @ingroup     ble_nimble
+ * @defgroup    pkg_nimble_addr Address Helper
+ * @ingroup     pkg_nimble
  * @brief       NimBLE specific helper functions for handling addresses
  * @{
  *

--- a/pkg/nimble/addr/nimble_addr.c
+++ b/pkg/nimble/addr/nimble_addr.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     ble_nimble_addr
+ * @ingroup     pkg_nimble_addr
  * @{
  *
  * @file

--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    ble_nimble_contrib RIOT Integration
- * @ingroup     ble_nimble
+ * @defgroup    pkg_nimble_contrib RIOT Integration
+ * @ingroup     pkg_nimble
  * @brief       Basic RIOT integration of NimBLE, including e.g. stack
  *              configuration and (auto)initialization code
  * @{

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     ble_nimble
+ * @ingroup     pkg_nimble
  * @{
  *
  * @file

--- a/pkg/nimble/doc.txt
+++ b/pkg/nimble/doc.txt
@@ -1,5 +1,5 @@
 /**
- * @defgroup ble_nimble NimBLE
+ * @defgroup pkg_nimble NimBLE
  * @ingroup  pkg
  * @ingroup  ble
  * @brief    RIOT port of the NimBLE BLE stack

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    pkg_nimble_netif GNRC netif Implementation
- * @ingroup     ble_nimble
+ * @ingroup     pkg_nimble
  * @brief       GNRC netif implementation for NimBLE, enabling the integration
  *              of NimBLE into GNRC
  *

--- a/pkg/nimble/scanlist/include/nimble_scanlist.h
+++ b/pkg/nimble/scanlist/include/nimble_scanlist.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    ble_nimble_scanlist Scan Result Helper
- * @ingroup     ble_nimble
+ * @defgroup    pkg_nimble_scanlist Scan Result Helper
+ * @ingroup     pkg_nimble
  * @brief       List for storing and printing BLE scan results
  *
  * @note        This scanlist implementation is not thread safe. So calling

--- a/pkg/nimble/scanlist/nimble_scanlist.c
+++ b/pkg/nimble/scanlist/nimble_scanlist.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     ble_nimble_scanlist
+ * @ingroup     pkg_nimble_scanlist
  * @{
  *
  * @file

--- a/pkg/nimble/scanlist/nimble_scanlist_print.c
+++ b/pkg/nimble/scanlist/nimble_scanlist_print.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     ble_nimble_scanlist
+ * @ingroup     pkg_nimble_scanlist
  * @{
  *
  * @file

--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    ble_nimble_scanner Scanner Helper
- * @ingroup     ble_nimble
+ * @defgroup    pkg_nimble_scanner Scanner Helper
+ * @ingroup     pkg_nimble
  * @brief       Helper module to simplify the usage of NimBLE in scanning mode
  * @{
  *

--- a/pkg/nimble/scanner/nimble_scanner.c
+++ b/pkg/nimble/scanner/nimble_scanner.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     ble_nimble_scanner
+ * @ingroup     pkg_nimble_scanner
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description
Follow up on #11578: as discussed there, the prefix for the main doxygen group of the NimBLE package and its sumodules should be `pkg_`.

### Testing procedure
Verify the doxygen output (it should not change...).

### Issues/PRs references
Follow up on #11578 
