### PR TITLE
boards/reel: add missing radio_nrf52840 feature

### DIFF
--- a/boards/reel/Makefile.features
+++ b/boards/reel/Makefile.features
@@ -6,4 +6,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrf802154
+
 include $(RIOTBOARD)/common/nrf52/Makefile.features


### PR DESCRIPTION
### Contribution description
The `reel` board features a `nrf52840` SoC and hence has also support for the `nrf802154` radio. So this PR adds this feature to the board.

I stumbled upon this when cleaning up the shared code for nrf52-based boards, so a follow up PR moving this dep into the CPU tree is next...

### Testing procedure
Compile `gnrc_networking` for the `reel`. The `nrf802154` driver should be compiled in, and there should be no warnings complaining about missing features.

### Issues/PRs references
none