### PR TITLE
boards/nrf52: cleanup shared Makefile.deps

### DIFF
--- a/boards/acd52832/Makefile.dep
+++ b/boards/acd52832/Makefile.dep
@@ -1,1 +1,2 @@
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.dep

--- a/boards/common/nrf52/Makefile.dep
+++ b/boards/common/nrf52/Makefile.dep
@@ -1,5 +1,3 @@
-include $(RIOTCPU)/nrf52/Makefile.dep
-
 ifneq (,$(filter skald,$(USEMODULE)))
   USEMODULE += nrfble
 endif
@@ -8,8 +6,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_nrf_temperature
 endif
 
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  ifeq (,$(filter nordic_softdevice_ble nrfmin nrf802154,$(USEMODULE) $(USEPKG)))
-    USEMODULE += nimble_netif
-  endif
-endif
+include $(RIOTCPU)/nrf52/Makefile.dep

--- a/boards/common/nrf52/Makefile.nrf52832.dep
+++ b/boards/common/nrf52/Makefile.nrf52832.dep
@@ -1,0 +1,7 @@
+ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+  ifeq (,$(filter nordic_softdevice_ble nrfmin nrf802154,$(USEMODULE) $(USEPKG)))
+    USEMODULE += nimble_netif
+  endif
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/common/nrf52/Makefile.nrf52840.dep
+++ b/boards/common/nrf52/Makefile.nrf52840.dep
@@ -1,0 +1,7 @@
+ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+  ifeq (,$(filter nimble_netif nrfmin,$(USEMODULE)))
+    USEMODULE += nrf802154
+  endif
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/common/nrf52xxxdk/Makefile.dep
+++ b/boards/common/nrf52xxxdk/Makefile.dep
@@ -1,5 +1,3 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
-
-include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/common/particle-mesh/Makefile.dep
+++ b/boards/common/particle-mesh/Makefile.dep
@@ -2,10 +2,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
-  ifeq (,$(filter nrfmin,$(USEMODULE)))
-    USEMODULE += nrf802154
-  endif
-endif
-
-include $(RIOTBOARD)/common/nrf52/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52840.dep

--- a/boards/nrf52832-mdk/Makefile.dep
+++ b/boards/nrf52832-mdk/Makefile.dep
@@ -2,4 +2,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-include $(RIOTBOARD)/common/nrf52/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.dep

--- a/boards/nrf52840-mdk/Makefile.dep
+++ b/boards/nrf52840-mdk/Makefile.dep
@@ -2,10 +2,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
-  ifeq (,$(filter nrfmin,$(USEMODULE)))
-    USEMODULE += nrf802154
-  endif
-endif
-
-include $(RIOTBOARD)/common/nrf52/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52840.dep

--- a/boards/nrf52840dk/Makefile.dep
+++ b/boards/nrf52840dk/Makefile.dep
@@ -1,7 +1,2 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
-  ifeq (,$(filter nrfmin,$(USEMODULE)))
-    USEMODULE += nrf802154
-  endif
-endif
-
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52840.dep

--- a/boards/nrf52dk/Makefile.dep
+++ b/boards/nrf52dk/Makefile.dep
@@ -1,1 +1,2 @@
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.dep

--- a/boards/reel/Makefile.dep
+++ b/boards/reel/Makefile.dep
@@ -3,10 +3,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += mma8x5x
 endif
 
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
-  ifeq (,$(filter nrfmin,$(USEMODULE)))
-    USEMODULE += nrf802154
-  endif
-endif
-
-include $(RIOTBOARD)/common/nrf52/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52840.dep

--- a/boards/ruuvitag/Makefile.dep
+++ b/boards/ruuvitag/Makefile.dep
@@ -5,8 +5,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   # USEMODULE += bme280_spi
 endif
 
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  USEMODULE += nrfmin
-endif
-
-include $(RIOTBOARD)/common/nrf52/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.dep

--- a/boards/thingy52/Makefile.dep
+++ b/boards/thingy52/Makefile.dep
@@ -1,5 +1,1 @@
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  USEMODULE += nrfmin
-endif
-
-include $(RIOTBOARD)/common/nrf52/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.dep


### PR DESCRIPTION
### Contribution description
The `nrf52832` and the `nrf52840`-based platforms have different default radio modes (`nimble_netif` and `nrf802154`, respectively). But the according `Makefile.dep`s were a little messy, so this PR should improve on this...

### Testing procedure
For `gnrc_networking`, verify that all `nrf52840` boards are now being build with the 802.15.4 support (`nrf802154`) and all `nrf52832` baords with IP-over-BLE support (`nimble_netif`). Also, all boards should flawlessly build with `nrfmin`.

### Issues/PRs references
none
