### PR TITLE
sys/arduino: Added millis()

### DIFF
--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -59,7 +59,7 @@ int digitalRead(int pin)
 
 void delay(unsigned long msec)
 {
-    xtimer_usleep(1000 * msec);
+    xtimer_usleep(msec * US_PER_MS);
 }
 
 void delayMicroseconds(unsigned long usec)

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -72,6 +72,11 @@ unsigned long micros()
     return xtimer_now_usec();
 }
 
+unsigned long millis()
+{
+    return xtimer_now_usec() / US_PER_MS;
+}
+
 int analogRead(int arduino_pin)
 {
     /*

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -104,6 +104,13 @@ void delayMicroseconds(unsigned long usec);
 unsigned long micros();
 
 /**
+ * @brief   Returns the number of milliseconds since start
+ *
+ * @return value of milliseconds since start
+ */
+unsigned long millis();
+
+/**
  * @brief   Read the current value of the given analog pin
  *
  * @param[in] pin       pin to read


### PR DESCRIPTION
### Contribution description

Added arduino-compatilbe `unsigned long millis()`

### Testing procedure

Apply the following patch

```patch
diff --git a/examples/arduino_hello-world/hello-world.sketch b/examples/arduino_hello-world/hello-world.sketch
index bdf414c0fd..4766fbb9e2 100644
--- a/examples/arduino_hello-world/hello-world.sketch
+++ b/examples/arduino_hello-world/hello-world.sketch
@@ -62,6 +62,8 @@ void loop(void)
             Serial.write('\n');
             // reset the count variable
             count = 0;
+            Serial.write("millis(): ");
+            Serial.println((int)millis());
         }
         // else we just remember the incoming char
         else {
```

And flash and run `examples/arduino_hello-world` on your favorite Arduino compatible board. When you type ´<FOO>\n` in the shell, in addition to the `ECHO: <FOO>` you should get the time since the boot of the board in milli seconds.

### Issues/PRs references

None