### PR TITLE
makefiles/utils: functions for lowercase and uppercase

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -89,6 +89,7 @@ CLEAN = $(filter clean, $(MAKECMDGOALS))
 
 # include makefiles utils tools
 include $(RIOTMAKE)/utils/variables.mk
+include $(RIOTMAKE)/utils/strings.mk
 
 # get host operating system
 OS := $(shell uname)

--- a/makefiles/utils/strings.mk
+++ b/makefiles/utils/strings.mk
@@ -1,0 +1,8 @@
+# Make only version of string functions
+#
+# This replaces the pattern of using ':= $(shell echo $(var) | tr 'a-z-' 'A-Z_)'
+# On local tests the make version was ~100 times faster than the shell one
+
+lowercase = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
+uppercase = $(subst a,A,$(subst b,B,$(subst c,C,$(subst d,D,$(subst e,E,$(subst f,F,$(subst g,G,$(subst h,H,$(subst i,I,$(subst j,J,$(subst k,K,$(subst l,L,$(subst m,M,$(subst n,N,$(subst o,O,$(subst p,P,$(subst q,Q,$(subst r,R,$(subst s,S,$(subst t,T,$(subst u,U,$(subst v,V,$(subst w,W,$(subst x,X,$(subst y,Y,$(subst z,Z,$1))))))))))))))))))))))))))
+uppercase_and_underscore = $(call uppercase,$(subst -,_,$1))

--- a/makefiles/utils/test-strings.mk
+++ b/makefiles/utils/test-strings.mk
@@ -1,0 +1,14 @@
+include strings.mk
+
+STRING_LOWER = abcdefghijklmnopqrstuvwxyz-123456789
+STRING_UPPER = ABCDEFGHIJKLMNOPQRSTUVWXYZ-123456789
+STRING_MACRO = ABCDEFGHIJKLMNOPQRSTUVWXYZ_123456789
+
+test-lowercase:
+	$(Q)bash -c 'test "$(STRING_LOWER)" = "$(call lowercase,$(STRING_UPPER))" || { echo ERROR: "$(STRING_LOWER)" != "$(call lowercase,$(STRING_UPPER))"; exit 1; }'
+
+test-uppercase:
+	$(Q)bash -c 'test "$(STRING_UPPER)" = "$(call uppercase,$(STRING_LOWER))" || { echo ERROR: "$(STRING_UPPER)" != "$(call uppercase,$(STRING_LOWER))"; exit 1; }'
+
+test-uppercase_and_underscore:
+	$(Q)bash -c 'test "$(STRING_MACRO)" = "$(call uppercase_and_underscore,$(STRING_LOWER))" || { echo ERROR: "$(STRING_MACRO)" != "$(call uppercase_and_underscore,$(STRING_LOWER))"; exit 1; }'

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -19,6 +19,9 @@ MAKEFILES_UTILS = $(RIOTMAKE)/utils
 COMPILE_TESTS += test-ensure_value test-ensure_value-negative
 COMPILE_TESTS += test-exported-variables
 COMPILE_TESTS += test-memoized-variables
+COMPILE_TESTS += test-lowercase
+COMPILE_TESTS += test-uppercase
+COMPILE_TESTS += test-uppercase_and_underscore
 
 # Tests will be run both in the host machine and in `docker`
 all: build-system-utils-tests
@@ -39,3 +42,10 @@ test-exported-variables:
 
 test-memoized-variables:
 	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-variables.mk test-memoized-variables)
+
+test-lowercase:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-lowercase)
+test-uppercase:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-uppercase)
+test-uppercase_and_underscore:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-uppercase_and_underscore)


### PR DESCRIPTION
### Contribution description

Add make only function to convert strings to lowercase and uppercase.
This can replace the `$(shell echo $(var) | tr 'a-z-' 'A-Z_')` pattern.
Using the 'make' implementation results in being around 100 times faster.

I was inspired by wondering how faster was the `lc` implementation in `mips.inc.mk`.
https://github.com/RIOT-OS/RIOT/blob/e9ea6a02ed227328e446044e83e818754b5251f1/makefiles/arch/mips.inc.mk#L7

### Testing procedure

Running the test in `tests/build_system_utils` should work.

If you want to verify the test tests, you can also play with changing the functions implementation and replacing some characters.


#### Speed comparison.

I used this diff to compare the speed.

<details><summary>diff to get speed comparison</summary>

```diff
diff --git a/makefiles/utils/strings.mk b/makefiles/utils/strings.mk
index 2feedcff7..5c3e45b33 100644
--- a/makefiles/utils/strings.mk
+++ b/makefiles/utils/strings.mk
@@ -6,3 +6,28 @@
 lowercase = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 uppercase = $(subst a,A,$(subst b,B,$(subst c,C,$(subst d,D,$(subst e,E,$(subst f,F,$(subst g,G,$(subst h,H,$(subst i,I,$(subst j,J,$(subst k,K,$(subst l,L,$(subst m,M,$(subst n,N,$(subst o,O,$(subst p,P,$(subst q,Q,$(subst r,R,$(subst s,S,$(subst t,T,$(subst u,U,$(subst v,V,$(subst w,W,$(subst x,X,$(subst y,Y,$(subst z,Z,$1))))))))))))))))))))))))))
 uppercase_and_underscore = $(call uppercase,$(subst -,_,$1))
+
+
+# Local testing
+var = abcdefghijklmnopqrstuvwxyz-123456789
+VAR = ABCDEFGHIJKLMNOPQRSTUVWXYZ_123456789
+
+ifneq ($(call uppercase_and_underscore,$(var)),$(VAR))
+  $(error $(call uppercase_and_underscore,$(var)))
+endif
+
+NUM ?= 10000
+iters := $(shell seq $(NUM))
+
+d_0 := $(shell date +%s.%N)
+a := $(foreach i,$(iters),$(call uppercase_and_underscore,$(var)))
+d_end := $(shell date +%s.%N)
+d_diff := $(shell echo $(d_end) - $(d_0) | bc)
+$(warning makefile $(d_diff): $(d_0) - $(d_end))
+
+d_0 := $(shell date +%s.%N)
+$(foreach i,$(iters),$(shell echo $(var)| tr 'a-z-' 'A-Z_'>/dev/null))
+d_end := $(shell date +%s.%N)
+
+d_diff := $(shell echo $(d_end) - $(d_0) | bc)
+$(warning shell    $(d_diff): $(d_0) - $(d_end))
```
</details>

```
make --no-print-directory -C examples/hello-world/ clean
/home/harter/work/git/RIOT/makefiles/utils/strings.mk:26: makefile .165520482: 1567079757.710985849 - 1567079757.876506331
/home/harter/work/git/RIOT/makefiles/utils/strings.mk:33: shell    18.993786935: 1567079757.878182792 - 1567079776.871969727
```

I also ran it with `NUM=100000` to get a better average.
It got sometime from 80 to 150 times faster depending on local load.

```
NUM=100000 make --no-print-directory -C examples/hello-world/ clean
/home/harter/work/git/RIOT/makefiles/utils/strings.mk:26: makefile 1.510057258: 1567079987.770061777 - 1567079989.280119035
/home/harter/work/git/RIOT/makefiles/utils/strings.mk:33: shell    236.004733208: 1567079989.281896031 - 1567080225.286629239
```

```
echo 236.004733208 / 1.510057258 | bc -l
156.28859896384140951561
```

### Issues/PRs references

This work is done in the context of removing immediate variable evaluations and exports
https://github.com/RIOT-OS/RIOT/issues/10850

As when changing a variable from immediate to deferred, a `shell` call would be made at each evaluation. So better fix this first.
