### PR TITLE
pyterm: configuring repeating command on empty line

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -94,6 +94,9 @@ defaultnewline = "LF"
 # default prompt character
 defaultprompt = '>'
 
+# repeat command on empty line instead of sending the line
+defaultrepeat_cmd_empty_line = True
+
 
 class SerCmd(cmd.Cmd):
     """Main class for pyterm based on Python's Cmd class.
@@ -105,7 +108,8 @@ class SerCmd(cmd.Cmd):
     def __init__(self, port=None, baudrate=None, toggle=None, tcp_serial=None,
                  confdir=None, conffile=None, host=None, run_name=None,
                  log_dir_name=None, newline=None, formatter=None,
-                 set_rts=None, set_dtr=None, serprompt=None):
+                 set_rts=None, set_dtr=None, serprompt=None,
+                 repeat_command_on_empty_line=defaultrepeat_cmd_empty_line):
         """Constructor.
 
         Args:
@@ -134,6 +138,7 @@ class SerCmd(cmd.Cmd):
         self.log_dir_name = log_dir_name
         self.newline = newline
         self.serprompt = serprompt
+        self.repeat_command_on_empty_line = repeat_command_on_empty_line
         if formatter is not None:
             self.fmt_str = formatter
 
@@ -271,6 +276,16 @@ class SerCmd(cmd.Cmd):
         if (line.startswith("/")):
                 return "PYTERM_" + line[1:]
         return line
+
+    def emptyline(self):
+        """Either send empty line or repeat previous command.
+
+        Behavior can be configured with `repeat_command_on_empty_line`.
+        """
+        if self.repeat_command_on_empty_line:
+            super().emptyline()
+        else:
+            self.default('')
 
     def default(self, line):
         """In case of no Pyterm specific prefix is detected, split
@@ -796,6 +811,18 @@ if __name__ == "__main__":
                         % defaultprompt,
                         default=defaultprompt)
 
+    # Keep help message in sync if changing the default
+    parser.add_argument("--repeat-command-on-empty-line",
+                        dest='repeat_command_on_empty_line',
+                        action='store_true',
+                        help="Repeat command on empty line (Default)")
+    parser.add_argument("--no-repeat-command-on-empty-line",
+                        dest='repeat_command_on_empty_line',
+                        action="store_false",
+                        help="Do not repeat command on empty line")
+    parser.set_defaults(
+        repeat_command_on_empty_line=defaultrepeat_cmd_empty_line)
+
     args = parser.parse_args()
 
     if args.noprefix:
@@ -803,7 +830,8 @@ if __name__ == "__main__":
     myshell = SerCmd(args.port, args.baudrate, args.toggle, args.tcp_serial,
                      args.directory, args.config, args.host, args.run_name,
                      args.log_dir_name, args.newline, args.format,
-                     args.set_rts, args.set_dtr, args.prompt)
+                     args.set_rts, args.set_dtr, args.prompt,
+                     args.repeat_command_on_empty_line)
     myshell.prompt = ''
 
     try:


### PR DESCRIPTION
### Contribution description

Allow configuring that it sends an empty newline when it receives a newline.

Alternative to https://github.com/RIOT-OS/RIOT/pull/12096

Toggle implementation based on https://stackoverflow.com/a/15008806/395687

### Testing procedure

Run the shell and execute 'help' then just send an empty line with 'enter'.

It repeats the command as in master without options:

<details><summary>Default behavior</summary>

```
BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C examples/default/ flash term
Building application "default" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
  40864     508    6048   47420    b93c /home/harter/work/git/RIOT/examples/default/bin/samr21-xpro/default.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/examples/default/bin/samr21-xpro/default.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming..................................................................................................................................................................... done.
Verification..................................................................................................................................................................... done.
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-08-29 15:18:57,560 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
help
2019-08-29 15:19:00,699 - INFO # help
2019-08-29 15:19:00,702 - INFO # Command              Description
2019-08-29 15:19:00,705 - INFO # ---------------------------------------
2019-08-29 15:19:00,709 - INFO # reboot               Reboot the node
2019-08-29 15:19:00,714 - INFO # ps                   Prints information about running threads.
2019-08-29 15:19:00,718 - INFO # random_init          initializes the PRNG
2019-08-29 15:19:00,723 - INFO # random_get           returns 32 bit of pseudo randomness
2019-08-29 15:19:00,728 - INFO # rtc                  control RTC peripheral interface
2019-08-29 15:19:00,732 - INFO # ifconfig             Configure network interfaces
2019-08-29 15:19:00,738 - INFO # txtsnd               Sends a custom string as is over the link layer
2019-08-29 15:19:00,744 - INFO # saul                 interact with sensors and actuators using SAUL
>
2019-08-29 15:19:07,002 - INFO #  help
2019-08-29 15:19:07,005 - INFO # Command              Description
2019-08-29 15:19:07,008 - INFO # ---------------------------------------
2019-08-29 15:19:07,012 - INFO # reboot               Reboot the node
2019-08-29 15:19:07,017 - INFO # ps                   Prints information about running threads.
2019-08-29 15:19:07,021 - INFO # random_init          initializes the PRNG
2019-08-29 15:19:07,026 - INFO # random_get           returns 32 bit of pseudo randomness
2019-08-29 15:19:07,031 - INFO # rtc                  control RTC peripheral interface
2019-08-29 15:19:07,035 - INFO # ifconfig             Configure network interfaces
2019-08-29 15:19:07,041 - INFO # txtsnd               Sends a custom string as is over the link layer
2019-08-29 15:19:07,048 - INFO # saul                 interact with sensors and actuators using SAUL
> 2019-08-29 15:19:10,513 - INFO # Exiting Pyterm
/home/harter/work/git/RIOT/examples/default/../../Makefile.include:566: recipe for target 'term' failed
make: *** [term] Interrupt
```
</details>

The new behavior can be used by setting `PYTERMFLAGS=" --no-repeat-command-on-empty-line"` in the environment:


<details><summary>Sending the newline, just sends the newline to the shell</summary>

```
PYTERMFLAGS=" --no-repeat-command-on-empty-line" BOARD=samr21-xpro RIOT_CI_BUILD=1 make --no-print-directory -C examples/default/ flash term
Building application "default" for "samr21-xpro" with MCU "samd21".

   text    data     bss     dec     hex filename
  40864     508    6048   47420    b93c /home/harter/work/git/RIOT/examples/default/bin/samr21-xpro/default.elf
/home/harter/work/git/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/harter/work/git/RIOT/examples/default/bin/samr21-xpro/default.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004678 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming..................................................................................................................................................................... done.
Verification..................................................................................................................................................................... done.
/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  --no-repeat-command-on-empty-line
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-08-29 15:20:45,250 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
help
2019-08-29 15:20:52,803 - INFO # help
2019-08-29 15:20:52,806 - INFO # Command              Description
2019-08-29 15:20:52,809 - INFO # ---------------------------------------
2019-08-29 15:20:52,812 - INFO # reboot               Reboot the node
2019-08-29 15:20:52,818 - INFO # ps                   Prints information about running threads.
2019-08-29 15:20:52,822 - INFO # random_init          initializes the PRNG
2019-08-29 15:20:52,827 - INFO # random_get           returns 32 bit of pseudo randomness
2019-08-29 15:20:52,832 - INFO # rtc                  control RTC peripheral interface
2019-08-29 15:20:52,836 - INFO # ifconfig             Configure network interfaces
2019-08-29 15:20:52,842 - INFO # txtsnd               Sends a custom string as is over the link layer
2019-08-29 15:20:52,848 - INFO # saul                 interact with sensors and actuators using SAUL
>
2019-08-29 15:20:53,683 - INFO #

```
</details>

### Issues/PRs references

Alternative to https://github.com/RIOT-OS/RIOT/pull/12096