### PR TITLE
cpu/sam0_common/gpio: don't hard-code number of ports

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -157,9 +157,9 @@ void gpio_write(gpio_t pin, int value)
 #ifdef MODULE_PERIPH_GPIO_IRQ
 static int _exti(gpio_t pin)
 {
-    int port_num = ((pin >> 7) & 0x03);
+    unsigned port_num = ((pin >> 7) & 0x03);
 
-    if (port_num > 1) {
+    if (port_num >= ARRAY_SIZE(exti_config)) {
         return -1;
     }
     return exti_config[port_num][_pin_pos(pin)];


### PR DESCRIPTION
### Contribution description

`_exti()` assumes only 2 ports, so it will always fail when using e.g. port C or port D on same54.

Instead, determine the number of ports from the dimensions of the `exti_config` array.

### Testing procedure
- Configure a pin on port C or port D as interrupt. I will always fail. With this patch it will work as expected.

But it's already obvious by looking at the code: `port_num` is used as an index for `exti_config`, so the check should take the dimensions of that array into account instead of hard-coding a number.

### Issues/PRs references
none