### PR TITLE
core: use irq_disable()/irq_restore() instead of atomics

### DIFF
--- a/core/include/rmutex.h
+++ b/core/include/rmutex.h
@@ -24,7 +24,6 @@
 #define RMUTEX_H
 
 #include <stdint.h>
-#include <stdatomic.h>
 
 #include "mutex.h"
 #include "kernel_types.h"
@@ -54,18 +53,17 @@ typedef struct rmutex_t {
     /**
      * @brief   Owner thread of the mutex.
      * @details Owner is written by the mutex holder, and read
-     *          concurrently to ensure consistency,
-     *          atomic_int_least16_t is used. Note @ref kernel_pid_t is an int16
+     *          in critical section to ensure consistency.
      * @internal
      */
-    atomic_int_least16_t owner;
+    kernel_pid_t owner;
 } rmutex_t;
 
 /**
  * @brief Static initializer for rmutex_t.
  * @details This initializer is preferable to rmutex_init().
  */
-#define RMUTEX_INIT { MUTEX_INIT, 0, ATOMIC_VAR_INIT(KERNEL_PID_UNDEF) }
+#define RMUTEX_INIT { MUTEX_INIT, 0, KERNEL_PID_UNDEF }
 
 /**
  * @brief Initializes a recursive mutex object.

--- a/core/rmutex.c
+++ b/core/rmutex.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 
+#include "irq.h"
 #include "rmutex.h"
 #include "thread.h"
 #include "assert.h"
@@ -51,9 +52,10 @@ static int _lock(rmutex_t *rmutex, int trylock)
          *     mutex_lock(). However the read access to owner is not
          *     locked, and owner can be changed by a thread that is
          *     holding the lock (e.g.: holder unlocks the mutex, new
-         *     holder aquired the lock). The atomic access strategy
-         *     'relaxed' ensures, that the value of rmutex->owner is read
-         *     consistent.
+         *     holder aquired the lock). Enclosing the access within
+         *     irq_disable()/irq_restore() ensures that the value of
+         *     rmutex->owner is read correctly WRT read/modify/write of the
+         *     shared 16bit memory.
          *
          *     It is not necessary to synchronize (make written values
          *     visible) read/write with other threads, because every
@@ -78,7 +80,9 @@ static int _lock(rmutex_t *rmutex, int trylock)
          */
 
         /* ensure that owner is read atomically, since I need a consistent value */
-        owner = atomic_load_explicit(&rmutex->owner, memory_order_relaxed);
+        unsigned state = irq_disable();
+        owner = rmutex->owner;
+        irq_restore(state);
         DEBUG("rmutex %" PRIi16" : mutex held by %" PRIi16" \n", thread_getpid(), owner);
 
         /* Case 1: Mutex is not held by me */
@@ -103,7 +107,9 @@ static int _lock(rmutex_t *rmutex, int trylock)
     DEBUG("rmutex %" PRIi16" : settting the owner\n", thread_getpid());
 
     /* ensure that owner is written atomically, since others need a consistent value */
-    atomic_store_explicit(&rmutex->owner, thread_getpid(), memory_order_relaxed);
+    unsigned state = irq_disable();
+    rmutex->owner = thread_getpid();
+    irq_restore(state);
 
     DEBUG("rmutex %" PRIi16" : increasing refs\n", thread_getpid());
 
@@ -125,7 +131,7 @@ int rmutex_trylock(rmutex_t *rmutex)
 
 void rmutex_unlock(rmutex_t *rmutex)
 {
-    assert(atomic_load_explicit(&rmutex->owner,memory_order_relaxed) == thread_getpid());
+    assert(rmutex->owner == thread_getpid());
     assert(rmutex->refcount > 0);
 
     DEBUG("rmutex %" PRIi16" : decrementing refs refs\n", thread_getpid());
@@ -139,8 +145,10 @@ void rmutex_unlock(rmutex_t *rmutex)
 
         DEBUG("rmutex %" PRIi16" : resetting owner\n", thread_getpid());
 
-        /* ensure that owner is written only once */
-        atomic_store_explicit(&rmutex->owner, KERNEL_PID_UNDEF, memory_order_relaxed);
+        /* ensure that owner is written atomically */
+        unsigned state = irq_disable();
+        rmutex->owner = thread_getpid();
+        irq_restore(state);
 
         DEBUG("rmutex %" PRIi16" : releasing mutex\n", thread_getpid());
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR replaces C11 atomics with plain irq_disable()/irq_restore() calls. Please see #12048 for some background.

As irq_*() includes compiler and memory barriers, this should have the same protective effect.

Size-wise, when compiling tests/rmutex for samr21-xpro, this reduces size by 56 / 40 bytes for gcc / llvm.

### Testing procedure

- CI runs rmutix basic tests
- please re-think the reason for using atomics in the first place and whether just using a critical section serves the same purpose

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #12048.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
