### PR TITLE
makefiles/cflags.inc.mk: handle optional cflags

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -105,6 +105,10 @@ CFLAGS  += -DLOG_TAG_IN_BRACKETS
 CFLAGS  += -Wno-unused-parameter -Wformat=0
 CFLAGS  += -mlongcalls -mtext-section-literals -fstrict-volatile-bitfields
 CFLAGS  += -fdata-sections -ffunction-sections -fzero-initialized-in-bss
+
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
+
 ASFLAGS += --longcalls --text-section-literals
 
 ifneq ($(CONFIGS),)

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -158,3 +158,7 @@ else
     FFLAGS += 0 $(FLASHFILE)-0x00000.bin
     FFLAGS += 0x10000 $(FLASHFILE)-0x10000.bin; esptool.py -p $(PORT) run
 endif
+
+OPTIONAL_CFLAGS_BLACKLIST += -fdiagnostics-color
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation

--- a/makefiles/arch/atmega.inc.mk
+++ b/makefiles/arch/atmega.inc.mk
@@ -50,3 +50,6 @@ ifeq ($(LTO),1)
   # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59396
   LINKFLAGS += -Wno-error
 endif
+
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -66,3 +66,6 @@ export LINKFLAGS += $(MIPS_HAL_LDFLAGS)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export LINKFLAGS += -Wl,--gc-sections
+
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation

--- a/makefiles/arch/msp430.inc.mk
+++ b/makefiles/arch/msp430.inc.mk
@@ -14,3 +14,7 @@ CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 # export linker flags
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
+
+OPTIONAL_CFLAGS_BLACKLIST += -fdiagnostics-color
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -70,6 +70,9 @@ ifeq (,$(filter -DDEVELHELP,$(CFLAGS)))
   endif
 endif
 
+# Add the optional flags that are not architecture/toolchain blacklisted
+CFLAGS += $(filter-out $(OPTIONAL_CFLAGS_BLACKLIST),$(OPTIONAL_CFLAGS))
+
 # Default ARFLAGS for platforms which do not specify it.
 # Note: make by default provides ARFLAGS=rv which we want to override
 ifeq ($(origin ARFLAGS),default)

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -11,37 +11,19 @@ endif
 # 0x0 might be a sane memory location for embedded systems, so the test must not be removed.
 # Right now clang does not use the *delete-null-pointer* optimization, and does not understand the parameter.
 # Related issues: #628, #664.
-ifeq ($(shell $(CC) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-  ifeq ($(shell LANG=C $(CC) -fno-delete-null-pointer-checks -E - 2>&1 1>/dev/null </dev/null | grep warning: | grep -- -fno-delete-null-pointer-checks),)
-    CFLAGS += -fno-delete-null-pointer-checks
+OPTIONAL_CFLAGS += -fno-delete-null-pointer-checks
 
-    ifneq ($(shell $(CXX) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-      CXXUWFLAGS += -fno-delete-null-pointer-checks
-    else
-      ifneq ($(shell LANG=C $(CXX) -fno-delete-null-pointer-checks -E - 2>&1 1>/dev/null </dev/null | grep warning: | grep -- -fno-delete-null-pointer-checks),)
-        CXXUWFLAGS += -fno-delete-null-pointer-checks
-      endif
-    endif
-  endif
-endif
-
-# Template for testing a compiler flag and adding it to CFLAGS (errors usually
-# happens when using older toolchains which do not support the given flags)
-define cflags_test_and_add
-  ifeq ($(shell $(CC) -Werror $(1) -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-    CFLAGS += $(1)
-  endif
-endef
 # Use colored compiler output if the compiler supports this and if this is not
 # disabled by the user
 ifeq ($(CC_NOCOLOR),0)
-  $(eval $(call cflags_test_and_add,-fdiagnostics-color))
+  OPTIONAL_CFLAGS += -fdiagnostics-color
 endif
 
 # Fast-out on old style function definitions.
 # They cause unreadable error compiler errors on missing semicolons.
 # Worse yet they hide errors by accepting wildcard argument types.
-$(foreach flag,-Wstrict-prototypes -Wold-style-definition,$(eval $(call cflags_test_and_add,$(flag))))
+OPTIONAL_CFLAGS += -Wstrict-prototypes
+OPTIONAL_CFLAGS += -Wold-style-definition
 
 # Unwanted flags for c++
 CXXUWFLAGS += -std=%
@@ -59,7 +41,9 @@ CFLAGS += -fno-common
 # Enable all default warnings and all extra warnings
 CFLAGS += -Wall -Wextra
 # Enable additional checks for printf/scanf format strings
-$(foreach flag,-Wformat=2 -Wformat-overflow -Wformat-truncation,$(eval $(call cflags_test_and_add,$(flag))))
+OPTIONAL_CFLAGS += -Wformat=2
+OPTIONAL_CFLAGS += -Wformat-overflow
+OPTIONAL_CFLAGS += -Wformat-truncation
 
 # Warn if a user-supplied include directory does not exist.
 CFLAGS += -Wmissing-include-dirs

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -71,3 +71,7 @@ ifneq (,$(TARGET_ARCH))
   INCLUDES    += $(GCC_C_INCLUDES)
   CXXINCLUDES += $(GCC_CXX_INCLUDES)
 endif
+
+OPTIONAL_CFLAGS_BLACKLIST += -fno-delete-null-pointer-checks
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation


### PR DESCRIPTION
### Contribution description

Handle declaring OPTIONAL_CFLAGS and blacklisting them with
OPTIONAL_CFLAGS_BLACKLIST.

This should replace checking everytime if options are supported.

The idea, is that these optional options are toolchain specific. So can be saved for the reference platform and allow users to still define other ones.

The BLACKLIST was defined in the docker image to match the previous in CFLAGS.

I did not add them to `docker` exported variables are they are supposed to be qualified in the docker image.


### Testing procedure

All examples must correctly compile in CI as it is the reference toolchain.


I compared the value of `CFLAGS` and got the same value.

I did not re-do the handling for `CXXUWFLAGS += -fno-delete-null-pointer-checks` but if everything compiles correctly, in docker it should be ok.


For testing I used this diff to compare the sorted value of `CFLAGS_WITH_MACROS` as it is the full value.

<details><summary>buildtest print CFLAGS</summary>

``` diff
diff --git a/makefiles/buildtests.inc.mk b/makefiles/buildtests.inc.mk
index 734176baa..cdee194e3 100644
--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -1,23 +1,14 @@
 .PHONY: buildtest buildtest-indocker

-BUILDTEST_MAKE_REDIRECT ?= >/dev/null 2>&1
+BUILDTEST_MAKE_REDIRECT ?=

 buildtest:
        @ \
        RESULT=true ; \
        for board in $(BOARDS); do \
                if BOARD=$${board} $(MAKE) check-toolchain-supported > /dev/null 2>&1; then \
-                       $(COLOR_ECHO) -n "Building for $$board ... " ; \
                        BOARD=$${board} RIOT_CI_BUILD=1 \
-                               $(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \
-                       RES=$$? ; \
-                       if [ $$RES -eq 0 ]; then \
-                               $(COLOR_ECHO) "$(COLOR_GREEN)success.$(COLOR_RESET)" ; \
-                       else \
-                               $(COLOR_ECHO) "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
-                               RESULT=false ; \
-                       fi ; \
-                       BOARD=$${board} $(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
+                               $(MAKE) --no-print-directory info-debug-variable-CFLAGS_WITH_MACROS | xargs -n1 | sort -u | xargs; \
                fi; \
        done ; \
        $${RESULT}
```
</details>

And compared the value in `examples/hello-world` with  both `TOOLCHAIN=gnu` and `TOOLCHAIN=llvm`.
The output was the same with this PR and in master.

```
time BUILD_IN_DOCKER=1 DOCKER="sudo docker" make --no-print-directory -C examples/hello-world/ buildtest-indocker
```


#### Timing impact

The execution time  was of course lower without re-checking the toolchain support, and even more with `llvm`.

| toolchain | master | pull request | 
|-----------|--------|--------------|
| gnu       | 1m4    | 50s          |
| llvm      | 2m12   | 1m6          |

### Issues/PRs references

This work is done in the context of removing immediate variable evaluations and exports
#10850