### PR TITLE
pkg: ccn-lite: version bump

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
 PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
-PKG_VERSION=b9e22be23ab534015061b03c39348445a2e9bb4b
+PKG_VERSION=e37b02c5cb20e9acccea2394be40f7e570a66a4b
 PKG_LICENSE=ISC
 
 .PHONY: all ..cmake_version_supported


### PR DESCRIPTION
### Contribution description
Bumps the ccn-lite vesion.

### Testing procedure
1. A simple Interest-Data exchange test with `native` should suffice.
2. The ccn-lite example should compile for `arduino-uno`(after adding it to the `Makefile`'s whitelist for boards. Note that linking will fail due to the memory limits of the uno, though.

### Issues/PRs references
 Fixes #8598 .