### PR TITLE
makefiles: refactor the coloring and the use of echo.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -503,7 +503,7 @@ endif # BUILD_IN_DOCKER
 #   check_cmd 'command' 'description'
 define check_cmd
 	@command -v $1 >/dev/null 2>&1 || \
-	  { $(COLOR_ECHO) \
+	  { echo \
 	    '$(COLOR_RED)$2 $1 is required but not found in PATH.  Aborting.$(COLOR_RESET)'; \
 	    exit 1;}
 endef
@@ -512,8 +512,8 @@ endef
 	$(call check_cmd,$(CC),Compiler)
 
 ..build-message:
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
-	@$(COLOR_ECHO)
+	@echo '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
+	@echo
 
 # The `clean` needs to be serialized before everything else.
 all $(BASELIBS) $(BUILDDEPS) ..in-docker-container: | $(CLEAN)
@@ -644,7 +644,7 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
 
   # Test if there where dependencies against a module in DISABLE_MODULE.
   ifneq (, $(filter $(DISABLE_MODULE), $(USEMODULE)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Required modules were disabled using DISABLE_MODULE:$(COLOR_RESET)"\
+    $(shell echo "$(COLOR_RED)Required modules were disabled using DISABLE_MODULE:$(COLOR_RESET)"\
                           "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))" 1>&2)
     USEMODULE := $(filter-out $(DISABLE_MODULE), $(USEMODULE))
     EXPECT_ERRORS := 1
@@ -652,17 +652,17 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
 
   # Test if all feature requirements were met by the selected board.
   ifneq (,$(FEATURES_MISSING))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)There are unsatisfied feature requirements:$(COLOR_RESET)"\
+    $(shell echo "$(COLOR_RED)There are unsatisfied feature requirements:$(COLOR_RESET)"\
                           "$(FEATURES_MISSING)" 1>&2)
     EXPECT_ERRORS := 1
   endif
 
   # Test if any used feature conflict with another one.
   ifneq (,$(FEATURES_CONFLICTING))
-    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)The following features may conflict:$(COLOR_RESET)"\
+    $(shell echo "$(COLOR_YELLOW)The following features may conflict:$(COLOR_RESET)"\
                           "$(FEATURES_CONFLICTING)" 1>&2)
     ifneq (, $(FEATURES_CONFLICT_MSG))
-        $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Rationale: $(COLOR_RESET)$(FEATURES_CONFLICT_MSG)" 1>&2)
+        $(shell echo "$(COLOR_YELLOW)Rationale: $(COLOR_RESET)$(FEATURES_CONFLICT_MSG)" 1>&2)
     endif
     EXPECT_CONFLICT := 1
   endif
@@ -670,7 +670,7 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   # If there is a whitelist, then test if the board is whitelisted.
   ifneq (, $(BOARD_WHITELIST))
     ifeq (, $(filter $(BOARD_WHITELIST), $(BOARD)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is not whitelisted:$(COLOR_RESET) $(BOARD_WHITELIST)" 1>&2)
+      $(shell echo "$(COLOR_RED)The selected BOARD=$(BOARD) is not whitelisted:$(COLOR_RESET) $(BOARD_WHITELIST)" 1>&2)
       EXPECT_ERRORS := 1
     endif
   endif
@@ -678,31 +678,31 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (, $(BOARD_BLACKLIST))
     ifneq (, $(filter $(BOARD_BLACKLIST), $(BOARD)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is blacklisted:$(COLOR_RESET) $(BOARD_BLACKLIST)" 1>&2)
+      $(shell echo "$(COLOR_RED)The selected BOARD=$(BOARD) is blacklisted:$(COLOR_RESET) $(BOARD_BLACKLIST)" 1>&2)
       EXPECT_ERRORS := 1
     endif
   endif
 
   #  test if toolchain is supported.
   ifeq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_SUPPORTED)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.$(COLOR_RESET)\nSupported toolchains: $(TOOLCHAINS_SUPPORTED)" 1>&2)
+    $(shell echo "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.$(COLOR_RESET)$(NEWLINE)Supported toolchains: $(TOOLCHAINS_SUPPORTED)" 1>&2)
     EXPECT_ERRORS := 1
   endif
 
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (,$(TOOLCHAINS_BLACKLIST))
     ifneq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_BLACKLIST)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:$(COLOR_RESET) $(TOOLCHAINS_BLACKLIST)" 1>&2)
+      $(shell echo "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:$(COLOR_RESET) $(TOOLCHAINS_BLACKLIST)" 1>&2)
       EXPECT_ERRORS := 1
     endif
   endif
 
   ifneq (, $(EXPECT_CONFLICT))
-    $(shell $(COLOR_ECHO) "\n$(COLOR_YELLOW)EXPECT undesired behaviour!$(COLOR_RESET)" 1>&2)
+    $(shell echo "$(NEWLINE)$(COLOR_YELLOW)EXPECT undesired behaviour!$(COLOR_RESET)" 1>&2)
   endif
 
   ifneq (, $(EXPECT_ERRORS))
-    $(shell $(COLOR_ECHO) "\n\n$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)\n\n" 1>&2)
+    $(shell echo "$(NEWLINE)$(NEWLINE)$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)$(NEWLINE)$(NEWLINE)" 1>&2)
   endif
 
 endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -512,8 +512,8 @@ endef
 	$(call check_cmd,$(CC),Compiler)
 
 ..build-message:
-	@echo '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
-	@echo
+	$(info $(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET))
+	@true
 
 # The `clean` needs to be serialized before everything else.
 all $(BASELIBS) $(BUILDDEPS) ..in-docker-container: | $(CLEAN)
@@ -644,25 +644,25 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
 
   # Test if there where dependencies against a module in DISABLE_MODULE.
   ifneq (, $(filter $(DISABLE_MODULE), $(USEMODULE)))
-    $(shell echo "$(COLOR_RED)Required modules were disabled using DISABLE_MODULE:$(COLOR_RESET)"\
-                          "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))" 1>&2)
+    $(warning $(COLOR_RED)Required modules were disabled using DISABLE_MODULE:$(COLOR_RESET)\
+                          $(sort $(filter $(DISABLE_MODULE), $(USEMODULE))))
     USEMODULE := $(filter-out $(DISABLE_MODULE), $(USEMODULE))
     EXPECT_ERRORS := 1
   endif
 
   # Test if all feature requirements were met by the selected board.
   ifneq (,$(FEATURES_MISSING))
-    $(shell echo "$(COLOR_RED)There are unsatisfied feature requirements:$(COLOR_RESET)"\
-                          "$(FEATURES_MISSING)" 1>&2)
+    $(warning $(COLOR_RED)There are unsatisfied feature requirements:$(COLOR_RESET)\
+                          $(FEATURES_MISSING))
     EXPECT_ERRORS := 1
   endif
 
   # Test if any used feature conflict with another one.
   ifneq (,$(FEATURES_CONFLICTING))
-    $(shell echo "$(COLOR_YELLOW)The following features may conflict:$(COLOR_RESET)"\
-                          "$(FEATURES_CONFLICTING)" 1>&2)
+    $(warning $(COLOR_YELLOW)The following features may conflict:$(COLOR_RESET)\
+                          $(FEATURES_CONFLICTING))
     ifneq (, $(FEATURES_CONFLICT_MSG))
-        $(shell echo "$(COLOR_YELLOW)Rationale: $(COLOR_RESET)$(FEATURES_CONFLICT_MSG)" 1>&2)
+        $(warning $(COLOR_YELLOW)Rationale: $(COLOR_RESET)$(FEATURES_CONFLICT_MSG))
     endif
     EXPECT_CONFLICT := 1
   endif
@@ -670,7 +670,7 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   # If there is a whitelist, then test if the board is whitelisted.
   ifneq (, $(BOARD_WHITELIST))
     ifeq (, $(filter $(BOARD_WHITELIST), $(BOARD)))
-      $(shell echo "$(COLOR_RED)The selected BOARD=$(BOARD) is not whitelisted:$(COLOR_RESET) $(BOARD_WHITELIST)" 1>&2)
+      $(warning $(COLOR_RED)The selected BOARD=$(BOARD) is not whitelisted:$(COLOR_RESET) $(BOARD_WHITELIST))
       EXPECT_ERRORS := 1
     endif
   endif
@@ -678,31 +678,31 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (, $(BOARD_BLACKLIST))
     ifneq (, $(filter $(BOARD_BLACKLIST), $(BOARD)))
-      $(shell echo "$(COLOR_RED)The selected BOARD=$(BOARD) is blacklisted:$(COLOR_RESET) $(BOARD_BLACKLIST)" 1>&2)
+      $(warning $(COLOR_RED)The selected BOARD=$(BOARD) is blacklisted:$(COLOR_RESET) $(BOARD_BLACKLIST))
       EXPECT_ERRORS := 1
     endif
   endif
 
   #  test if toolchain is supported.
   ifeq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_SUPPORTED)))
-    $(shell echo "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.$(COLOR_RESET)$(NEWLINE)Supported toolchains: $(TOOLCHAINS_SUPPORTED)" 1>&2)
+    $(warning $(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.$(COLOR_RESET)$(NEWLINE)Supported toolchains: $(TOOLCHAINS_SUPPORTED))
     EXPECT_ERRORS := 1
   endif
 
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (,$(TOOLCHAINS_BLACKLIST))
     ifneq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_BLACKLIST)))
-      $(shell echo "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:$(COLOR_RESET) $(TOOLCHAINS_BLACKLIST)" 1>&2)
+      $(warning $(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:$(COLOR_RESET) $(TOOLCHAINS_BLACKLIST))
       EXPECT_ERRORS := 1
     endif
   endif
 
   ifneq (, $(EXPECT_CONFLICT))
-    $(shell echo "$(NEWLINE)$(COLOR_YELLOW)EXPECT undesired behaviour!$(COLOR_RESET)" 1>&2)
+    $(warning $(NEWLINE)$(COLOR_YELLOW)EXPECT undesired behaviour!$(COLOR_RESET))
   endif
 
   ifneq (, $(EXPECT_ERRORS))
-    $(shell echo "$(NEWLINE)$(NEWLINE)$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)$(NEWLINE)$(NEWLINE)" 1>&2)
+    $(warning $(NEWLINE)$(NEWLINE)$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)$(NEWLINE)$(NEWLINE))
   endif
 
 endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -103,6 +103,7 @@ PYTHONPATH := $(RIOTBASE)/dist/pythonlibs/:$(PYTHONPATH)
 include $(RIOTMAKE)/docker.inc.mk
 
 # include color echo macros
+include $(RIOTMAKE)/utils/ansi.mk
 include $(RIOTMAKE)/color.inc.mk
 
 # include concurrency helpers

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -28,11 +28,12 @@ CFLAGS += -D$(CPU_LINE) -DCPU_LINE_$(CPU_LINE)
 CFLAGS += -DSTM32_FLASHSIZE=$(FLASHSIZE)U
 
 info-stm32:
-	@echo "CPU: $(CPU_MODEL)"
-	@echo "$(TAB)Line: $(CPU_LINE)"
-	@echo "$(TAB)Pin count:$(TAB)$(STM32_PINCOUNT)"
-	@echo "$(TAB)ROM size:$(TAB)$(ROM_LEN) ($(FLASHSIZE) Bytes)"
-	@echo "$(TAB)RAM size:$(TAB)$(RAM_LEN)"
+	$(info CPU: $(CPU_MODEL))
+	$(info $(TAB)Line: $(CPU_LINE))
+	$(info $(TAB)Pin count:$(TAB)$(STM32_PINCOUNT))
+	$(info $(TAB)ROM size:$(TAB)$(ROM_LEN) ($(FLASHSIZE) Bytes))
+	$(info $(TAB)RAM size:$(TAB)$(RAM_LEN))
+	@true
 
 ifneq (,$(CCMRAM_LEN))
   LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ccmram_length=$(CCMRAM_LEN)

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -28,11 +28,11 @@ CFLAGS += -D$(CPU_LINE) -DCPU_LINE_$(CPU_LINE)
 CFLAGS += -DSTM32_FLASHSIZE=$(FLASHSIZE)U
 
 info-stm32:
-	@$(COLOR_ECHO) "CPU: $(CPU_MODEL)"
-	@$(COLOR_ECHO) "\tLine: $(CPU_LINE)"
-	@$(COLOR_ECHO) "\tPin count:\t$(STM32_PINCOUNT)"
-	@$(COLOR_ECHO) "\tROM size:\t$(ROM_LEN) ($(FLASHSIZE) Bytes)"
-	@$(COLOR_ECHO) "\tRAM size:\t$(RAM_LEN)"
+	@echo "CPU: $(CPU_MODEL)"
+	@echo "$(TAB)Line: $(CPU_LINE)"
+	@echo "$(TAB)Pin count:$(TAB)$(STM32_PINCOUNT)"
+	@echo "$(TAB)ROM size:$(TAB)$(ROM_LEN) ($(FLASHSIZE) Bytes)"
+	@echo "$(TAB)RAM size:$(TAB)$(RAM_LEN)"
 
 ifneq (,$(CCMRAM_LEN))
   LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ccmram_length=$(CCMRAM_LEN)

--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -31,8 +31,8 @@ include $(RIOTBASE)/Makefile.include
 .PHONY: usb_id_check
 usb_id_check:
 	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
-		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+		echo "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
+		echo "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi
 
 all: | usb_id_check

--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -28,11 +28,13 @@ CFLAGS += -DUSB_CONFIG_VID=0x$(USB_VID) -DUSB_CONFIG_PID=0x$(USB_PID)
 
 include $(RIOTBASE)/Makefile.include
 
+define PID_VID_WARNING
+$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)
+$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)
+endef
+
 .PHONY: usb_id_check
 usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
-		echo "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		echo "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
-	fi
+	$(if $(filter-out $(USB_VID):$(USB_PID),$(DEFAULT_VID):$(DEFAULT_PID)),,$(warning $(PID_VID_WARNING)))
 
 all: | usb_id_check

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -7,14 +7,14 @@ buildtest:
 	RESULT=true ; \
 	for board in $(BOARDS); do \
 		if BOARD=$${board} $(MAKE) check-toolchain-supported > /dev/null 2>&1; then \
-			$(COLOR_ECHO) -n "Building for $$board ... " ; \
+			printf "Building for $$board ... " ; \
 			BOARD=$${board} RIOT_CI_BUILD=1 \
 				$(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \
 			RES=$$? ; \
 			if [ $$RES -eq 0 ]; then \
-				$(COLOR_ECHO) "$(COLOR_GREEN)success.$(COLOR_RESET)" ; \
+				echo "$(COLOR_GREEN)success.$(COLOR_RESET)" ; \
 			else \
-				$(COLOR_ECHO) "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
+				echo "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
 				RESULT=false ; \
 			fi ; \
 			BOARD=$${board} $(MAKE) clean-intermediates >/dev/null 2>&1 || true; \

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -3,6 +3,7 @@
 
 COLOR_GREEN  :=
 COLOR_RED    :=
+COLOR_YELLOW :=
 COLOR_PURPLE :=
 COLOR_RESET  :=
 COLOR_ECHO   := /bin/echo
@@ -17,11 +18,12 @@ ifeq ($(CC_NOCOLOR),)
 endif
 
 ifeq ($(CC_NOCOLOR),0)
-  COLOR_GREEN  := \033[1;32m
-  COLOR_RED    := \033[1;31m
-  COLOR_YELLOW := \033[1;33m
-  COLOR_PURPLE := \033[1;35m
-  COLOR_RESET  := \033[0m
+  _ANSI_ESC := $(shell printf "\033")
+  COLOR_GREEN  := $(_ANSI_ESC)[1;32m
+  COLOR_RED    := $(_ANSI_ESC)[1;31m
+  COLOR_YELLOW := $(_ANSI_ESC)[1;33m
+  COLOR_PURPLE := $(_ANSI_ESC)[1;35m
+  COLOR_RESET  := $(_ANSI_ESC)[0m
   ifeq ($(OS),Darwin)
     COLOR_ECHO   := echo -e
     SHELL=bash

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -6,7 +6,6 @@ COLOR_RED    :=
 COLOR_YELLOW :=
 COLOR_PURPLE :=
 COLOR_RESET  :=
-COLOR_ECHO   := /bin/echo
 
 ifeq ($(CC_NOCOLOR),)
   IS_TERMINAL = $(if $(MAKE_TERMOUT),$(MAKE_TERMERR),)
@@ -23,10 +22,4 @@ ifeq ($(CC_NOCOLOR),0)
   COLOR_YELLOW := $(ANSI_YELLOW)
   COLOR_PURPLE := $(ANSI_PURPLE)
   COLOR_RESET  := $(ANSI_RESET)
-  ifeq ($(OS),Darwin)
-    COLOR_ECHO   := echo -e
-    SHELL=bash
-  else
-    COLOR_ECHO   := /bin/echo -e
-  endif
 endif

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -18,12 +18,11 @@ ifeq ($(CC_NOCOLOR),)
 endif
 
 ifeq ($(CC_NOCOLOR),0)
-  _ANSI_ESC := $(shell printf "\033")
-  COLOR_GREEN  := $(_ANSI_ESC)[1;32m
-  COLOR_RED    := $(_ANSI_ESC)[1;31m
-  COLOR_YELLOW := $(_ANSI_ESC)[1;33m
-  COLOR_PURPLE := $(_ANSI_ESC)[1;35m
-  COLOR_RESET  := $(_ANSI_ESC)[0m
+  COLOR_GREEN  := $(ANSI_GREEN)
+  COLOR_RED    := $(ANSI_RED)
+  COLOR_YELLOW := $(ANSI_YELLOW)
+  COLOR_PURPLE := $(ANSI_PURPLE)
+  COLOR_RESET  := $(ANSI_RESET)
   ifeq ($(OS),Darwin)
     COLOR_ECHO   := echo -e
     SHELL=bash

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -269,7 +269,7 @@ DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):
 # The `flash`, `term`, `debugserver` etc. targets usually require access to
 # hardware which may not be reachable from inside the container.
 ..in-docker-container:
-	@echo '$(COLOR_GREEN)Launching build container using image "$(DOCKER_IMAGE)".$(COLOR_RESET)'
+	$(info $(COLOR_GREEN)Launching build container using image "$(DOCKER_IMAGE)".$(COLOR_RESET))
 	@# HACK: Handle directory creation here until it is provided globally
 	$(Q)mkdir -p $(BUILD_DIR)
 	$(DOCKER) run $(DOCKER_FLAGS) -t -u "$$(id -u)" \

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -269,7 +269,7 @@ DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):
 # The `flash`, `term`, `debugserver` etc. targets usually require access to
 # hardware which may not be reachable from inside the container.
 ..in-docker-container:
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Launching build container using image "$(DOCKER_IMAGE)".$(COLOR_RESET)'
+	@echo '$(COLOR_GREEN)Launching build container using image "$(DOCKER_IMAGE)".$(COLOR_RESET)'
 	@# HACK: Handle directory creation here until it is provided globally
 	$(Q)mkdir -p $(BUILD_DIR)
 	$(DOCKER) run $(DOCKER_FLAGS) -t -u "$$(id -u)" \

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -52,14 +52,14 @@ BOARDS := $(filter-out $(BOARDS_WITH_MISSING_FEATURES), $(BOARDS))
 
 info-buildsizes: SHELL=bash
 info-buildsizes:
-	@echo -e "   text\t   data\t    bss\t    dec\tboard"; \
+	@echo "   text$(TAB)   data$(TAB)    bss$(TAB)    dec$(TAB)board"; \
 	for board in $(BOARDS); do \
 	    echo "$$(BOARD=$${board} $(MAKE) --no-print-directory info-buildsize 2>/dev/null | tail -n-1 | cut -f-4)" "$${board}"; \
 	done;
 
 info-buildsizes-diff: SHELL=bash
 info-buildsizes-diff:
-	@echo -e "text\tdata\tbss\tdec\tBOARD/BINDIRBASE\n"; \
+	@echo "text$(TAB)data$(TAB)bss$(TAB)dec$(TAB)BOARD/BINDIRBASE$(NEWLINE)"; \
 	for board in $(BOARDS); do \
 	  for BINDIRBASE in $${OLDBIN} $${NEWBIN}; do \
 	      BINDIRBASE=$${BINDIRBASE} BOARD=$${board} $(MAKE) info-buildsize --no-print-directory 2>/dev/null | tail -n-1 | cut -f-4; \
@@ -68,16 +68,16 @@ info-buildsizes-diff:
 	    for I in 0 1 2 3; do \
 	      if [[ -n "$${NEW[I]}" && -n "$${OLD[I]}" ]]; then \
 	        DIFF=$$(($${NEW[I]} - $${OLD[I]})); \
-	        if [[ "$${DIFF}" -gt 0 ]]; then $(COLOR_ECHO) -n "$(COLOR_RED)"; fi; \
-	        if [[ "$${DIFF}" -lt 0 ]]; then $(COLOR_ECHO) -n "$(COLOR_GREEN)"; fi; \
+	        if [[ "$${DIFF}" -gt 0 ]]; then printf "$(COLOR_RED)"; fi; \
+	        if [[ "$${DIFF}" -lt 0 ]]; then printf -n "$(COLOR_GREEN)"; fi; \
 	      else \
 	        DIFF="$(COLOR_RED)ERR"; \
 	      fi; \
-	      echo -ne "$${DIFF}\t$(COLOR_RESET)"; \
+	      echo -ne "$${DIFF}$(TAB)$(COLOR_RESET)"; \
 	    done; \
 	    echo "$${board}"; \
-	    for I in 0 1 2 3; do echo -ne "$${OLD[I]-$(COLOR_RED)ERR$(COLOR_RESET)}\t"; done; echo -e "$${OLDBIN}"; \
-	    for I in 0 1 2 3; do echo -ne "$${NEW[I]-$(COLOR_RED)ERR$(COLOR_RESET)}\t"; done; echo -e "$${NEWBIN}\n"; \
+	    for I in 0 1 2 3; do echo -n "$${OLD[I]-$(COLOR_RED)ERR$(COLOR_RESET)}$(TAB)"; done; echo "$${OLDBIN}"; \
+	    for I in 0 1 2 3; do echo -n "$${NEW[I]-$(COLOR_RED)ERR$(COLOR_RESET)}$(TAB)"; done; echo "$${NEWBIN}$(NEWLINE)"; \
 	  done; \
 	done;
 

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -24,84 +24,85 @@ info-buildsize:
 	@$(SIZE) -d -B $(ELFFILE) || echo ''
 
 info-build:
-	@echo 'APPLICATION: $(APPLICATION)'
-	@echo 'APPDIR:      $(APPDIR)'
-	@echo ''
-	@echo 'supported boards:'
-	@echo $$($(MAKE) info-boards-supported)
-	@echo ''
-	@echo 'BOARD:   $(BOARD)'
-	@echo 'CPU:     $(CPU)'
-	@echo 'MCU:     $(MCU)'
-	@echo ''
-	@echo 'RIOTBASE:  $(RIOTBASE)'
-	@echo 'RIOTBOARD: $(RIOTBOARD)'
-	@echo 'RIOTCPU:   $(RIOTCPU)'
-	@echo 'RIOTPKG:   $(RIOTPKG)'
-	@echo ''
-	@echo 'DEFAULT_MODULE: $(sort $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE)))'
-	@echo 'DISABLE_MODULE: $(sort $(DISABLE_MODULE))'
-	@echo 'USEMODULE:      $(sort $(filter-out $(DEFAULT_MODULE), $(USEMODULE)))'
-	@echo ''
-	@echo 'ELFFILE: $(ELFFILE)'
-	@echo 'HEXFILE: $(HEXFILE)'
-	@echo 'BINFILE: $(BINFILE)'
-	@echo 'FLASHFILE: $(FLASHFILE)'
-	@echo ''
-	@echo 'FEATURES_USED:'
-	@echo '         $(or $(FEATURES_USED), -none-)'
-	@echo 'FEATURES_REQUIRED:'
-	@echo '         $(or $(sort $(FEATURES_REQUIRED)), -none-)'
-	@echo 'FEATURES_OPTIONAL_ONLY (optional that are not required, strictly "nice to have"):'
-	@echo '         $(or $(FEATURES_OPTIONAL_ONLY), -none-)'
-	@echo 'FEATURES_OPTIONAL_MISSING (missing optional features):'
-	@echo '         $(or $(FEATURES_OPTIONAL_MISSING), -none-)'
-	@echo 'FEATURES_PROVIDED (by the board or USEMODULE'"'"'d drivers):'
-	@echo '         $(or $(sort $(FEATURES_PROVIDED)), -none-)'
-	@echo 'FEATURES_MISSING (only non optional features):'
-	@echo '         $(or $(FEATURES_MISSING), -none-)'
-	@echo ''
-	@echo 'FEATURES_CONFLICT:     $(FEATURES_CONFLICT)'
-	@echo 'FEATURES_CONFLICT_MSG: $(FEATURES_CONFLICT_MSG)'
-	@echo 'FEATURES_CONFLICTING:'
-	@echo '         $(or $(FEATURES_CONFLICTING), -none-)'
-	@echo ''
-	@echo 'INCLUDES:$(patsubst %, $(NEWLINE)$(TAB)%, $(INCLUDES))'
-	@echo ''
-	@echo 'CC:      $(CC)'
-	@echo 'CFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CFLAGS))'
-	@echo ''
-	@echo 'CXX:     $(CXX)'
-	@echo 'CXXUWFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CXXUWFLAGS))'
-	@echo 'CXXEXFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CXXEXFLAGS))'
-	@echo ''
-	@echo 'LINK:    $(LINK)'
-	@echo 'LINKFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(LINKFLAGS))'
-	@echo ''
-	@echo 'OBJCOPY: $(OBJCOPY)'
-	@echo 'OFLAGS:  $(OFLAGS)'
-	@echo ''
-	@echo 'FLASHER: $(FLASHER)'
-	@echo 'FFLAGS:  $(FFLAGS)'
-	@echo ''
-	@echo 'TERMPROG:  $(TERMPROG)'
-	@echo 'TERMFLAGS: $(TERMFLAGS)'
-	@echo 'PORT:      $(PORT)'
-	@echo ''
-	@echo 'DEBUGGER:       $(DEBUGGER)'
-	@echo 'DEBUGGER_FLAGS: $(DEBUGGER_FLAGS)'
-	@echo
-	@echo 'DOWNLOAD_TO_FILE:   $(DOWNLOAD_TO_FILE)'
-	@echo 'DOWNLOAD_TO_STDOUT: $(DOWNLOAD_TO_STDOUT)'
-	@echo 'UNZIP_HERE:         $(UNZIP_HERE)'
-	@echo ''
-	@echo 'DEBUGSERVER:       $(DEBUGSERVER)'
-	@echo 'DEBUGSERVER_FLAGS: $(DEBUGSERVER_FLAGS)'
-	@echo ''
-	@echo 'RESET:       $(RESET)'
-	@echo 'RESET_FLAGS: $(RESET_FLAGS)'
-	@echo ''
-	@echo 'MAKEFILE_LIST:$(patsubst %, $(NEWLINE)$(TAB)%, $(abspath $(MAKEFILE_LIST)))'
+	$(info APPLICATION: $(APPLICATION))
+	$(info APPDIR:      $(APPDIR))
+	$(info )
+	$(info supported boards:)
+	$(info $($(MAKE) info-boards-supported))
+	$(info )
+	$(info BOARD:   $(BOARD))
+	$(info CPU:     $(CPU))
+	$(info MCU:     $(MCU))
+	$(info )
+	$(info RIOTBASE:  $(RIOTBASE))
+	$(info RIOTBOARD: $(RIOTBOARD))
+	$(info RIOTCPU:   $(RIOTCPU))
+	$(info RIOTPKG:   $(RIOTPKG))
+	$(info )
+	$(info DEFAULT_MODULE: $(sort $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))))
+	$(info DISABLE_MODULE: $(sort $(DISABLE_MODULE)))
+	$(info USEMODULE:      $(sort $(filter-out $(DEFAULT_MODULE), $(USEMODULE))))
+	$(info )
+	$(info ELFFILE: $(ELFFILE))
+	$(info HEXFILE: $(HEXFILE))
+	$(info BINFILE: $(BINFILE))
+	$(info FLASHFILE: $(FLASHFILE))
+	$(info )
+	$(info FEATURES_USED:)
+	$(info          $(or $(FEATURES_USED), -none-))
+	$(info FEATURES_REQUIRED:)
+	$(info          $(or $(sort $(FEATURES_REQUIRED)), -none-))
+	$(info FEATURES_OPTIONAL_ONLY (optional that are not required, strictly "nice to have"):)
+	$(info          $(or $(FEATURES_OPTIONAL_ONLY), -none-))
+	$(info FEATURES_OPTIONAL_MISSING (missing optional features):)
+	$(info          $(or $(FEATURES_OPTIONAL_MISSING), -none-))
+	$(info FEATURES_PROVIDED (by the board or USEMODULE'd drivers):)
+	$(info          $(or $(sort $(FEATURES_PROVIDED)), -none-))
+	$(info FEATURES_MISSING (only non optional features):)
+	$(info          $(or $(FEATURES_MISSING), -none-))
+	$(info )
+	$(info FEATURES_CONFLICT:     $(FEATURES_CONFLICT))
+	$(info FEATURES_CONFLICT_MSG: $(FEATURES_CONFLICT_MSG))
+	$(info FEATURES_CONFLICTING:)
+	$(info          $(or $(FEATURES_CONFLICTING), -none-))
+	$(info )
+	$(info INCLUDES:$(patsubst %, $(NEWLINE)$(TAB)%, $(INCLUDES)))
+	$(info )
+	$(info CC:      $(CC))
+	$(info CFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CFLAGS)))
+	$(info )
+	$(info CXX:     $(CXX))
+	$(info CXXUWFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CXXUWFLAGS)))
+	$(info CXXEXFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CXXEXFLAGS)))
+	$(info )
+	$(info LINK:    $(LINK))
+	$(info LINKFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(LINKFLAGS)))
+	$(info )
+	$(info OBJCOPY: $(OBJCOPY))
+	$(info OFLAGS:  $(OFLAGS))
+	$(info )
+	$(info FLASHER: $(FLASHER))
+	$(info FFLAGS:  $(FFLAGS))
+	$(info )
+	$(info TERMPROG:  $(TERMPROG))
+	$(info TERMFLAGS: $(TERMFLAGS))
+	$(info PORT:      $(PORT))
+	$(info )
+	$(info DEBUGGER:       $(DEBUGGER))
+	$(info DEBUGGER_FLAGS: $(DEBUGGER_FLAGS))
+	$(info )
+	$(info DOWNLOAD_TO_FILE:   $(DOWNLOAD_TO_FILE))
+	$(info DOWNLOAD_TO_STDOUT: $(DOWNLOAD_TO_STDOUT))
+	$(info UNZIP_HERE:         $(UNZIP_HERE))
+	$(info )
+	$(info DEBUGSERVER:       $(DEBUGSERVER))
+	$(info DEBUGSERVER_FLAGS: $(DEBUGSERVER_FLAGS))
+	$(info )
+	$(info RESET:       $(RESET))
+	$(info RESET_FLAGS: $(RESET_FLAGS))
+	$(info )
+	$(info MAKEFILE_LIST:$(patsubst %, $(NEWLINE)$(TAB)%, $(abspath $(MAKEFILE_LIST))))
+	@true
 
 info-files: QUIET := 0
 info-files:
@@ -140,10 +141,12 @@ info-features-used:
 	@for i in $(FEATURES_USED); do echo $$i; done
 
 info-debug-variable-%:
-	@echo $($*)
+	$(info $($*))
+	@true
 
 info-toolchains-supported:
-	@echo $(filter-out $(TOOLCHAINS_BLACKLIST),$(TOOLCHAINS_SUPPORTED))
+	$(info $(filter-out $(TOOLCHAINS_BLACKLIST),$(TOOLCHAINS_SUPPORTED)))
+	@true
 
 check-toolchain-supported:
 	@exit $(if $(filter $(TOOLCHAIN),$(filter-out $(TOOLCHAINS_BLACKLIST),$(TOOLCHAINS_SUPPORTED))),0,1)

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -14,7 +14,7 @@ info-objsize:
 	  "") SORTROW=4 ;; \
 	  *) echo "Usage: $(MAKE) info-objsize SORTROW=[text|data|bss|dec]" ; return ;; \
 	esac; \
-	printf '   text\t   data\t    bss\t    dec\t    hex\tfilename\n'; \
+	printf '   text$(TAB)   data$(TAB)    bss$(TAB)    dec$(TAB)    hex$(TAB)filename$(NEWLINE)'; \
 	$(SIZE) -d -B $(BASELIBS) | \
 	  tail -n+2 | \
 	  sed -e 's#$(BINDIR)##' | \
@@ -66,17 +66,17 @@ info-build:
 	@echo 'FEATURES_CONFLICTING:'
 	@echo '         $(or $(FEATURES_CONFLICTING), -none-)'
 	@echo ''
-	@echo -e 'INCLUDES:$(patsubst %, \n\t%, $(INCLUDES))'
+	@echo 'INCLUDES:$(patsubst %, $(NEWLINE)$(TAB)%, $(INCLUDES))'
 	@echo ''
 	@echo 'CC:      $(CC)'
-	@echo -e 'CFLAGS:$(patsubst %, \n\t%, $(CFLAGS))'
+	@echo 'CFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CFLAGS))'
 	@echo ''
 	@echo 'CXX:     $(CXX)'
-	@echo -e 'CXXUWFLAGS:$(patsubst %, \n\t%, $(CXXUWFLAGS))'
-	@echo -e 'CXXEXFLAGS:$(patsubst %, \n\t%, $(CXXEXFLAGS))'
+	@echo 'CXXUWFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CXXUWFLAGS))'
+	@echo 'CXXEXFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(CXXEXFLAGS))'
 	@echo ''
 	@echo 'LINK:    $(LINK)'
-	@echo -e 'LINKFLAGS:$(patsubst %, \n\t%, $(LINKFLAGS))'
+	@echo 'LINKFLAGS:$(patsubst %, $(NEWLINE)$(TAB)%, $(LINKFLAGS))'
 	@echo ''
 	@echo 'OBJCOPY: $(OBJCOPY)'
 	@echo 'OFLAGS:  $(OFLAGS)'
@@ -101,12 +101,12 @@ info-build:
 	@echo 'RESET:       $(RESET)'
 	@echo 'RESET_FLAGS: $(RESET_FLAGS)'
 	@echo ''
-	@echo -e 'MAKEFILE_LIST:$(patsubst %, \n\t%, $(abspath $(MAKEFILE_LIST)))'
+	@echo 'MAKEFILE_LIST:$(patsubst %, $(NEWLINE)$(TAB)%, $(abspath $(MAKEFILE_LIST)))'
 
 info-files: QUIET := 0
 info-files:
 	@( \
-	  echo "$(abspath $(shell echo "$(MAKEFILE_LIST)"))" | tr ' ' '\n'; \
+	  echo "$(abspath $(shell echo "$(MAKEFILE_LIST)"))" | tr ' ' '$(NEWLINE)'; \
 	  CSRC="$$($(MAKE) USEPKG="" -Bn | grep -o -e "[^ ]\+\.[csS]$$" -e "[^ ]\+\.[csS][ \']" | grep -v -e "^\s*-D")"; \
 	  echo "$$CSRC"; \
 	  echo "$(RIOTBASE)/Makefile.base"; \

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -24,17 +24,17 @@ endif
 
 mcuboot: ROM_OFFSET=$$(($(MCUBOOT_SLOT0_SIZE) + $(IMAGE_HDR_SIZE)))
 mcuboot: mcuboot-create-key link
-	@$(COLOR_ECHO)
-	@$(COLOR_ECHO) '$(COLOR_PURPLE)Re-linking for MCUBoot at $(MCUBOOT_SLOT0_SIZE)...$(COLOR_RESET)'
-	@$(COLOR_ECHO)
+	@echo
+	@echo '$(COLOR_PURPLE)Re-linking for MCUBoot at $(MCUBOOT_SLOT0_SIZE)...$(COLOR_RESET)'
+	@echo
 	$(Q)$(_LINK) -o $(ELFFILE) && \
 	$(OBJCOPY) $(OFLAGS) -Obinary $(ELFFILE) $(BINFILE) && \
 	$(IMGTOOL) sign --key $(MCUBOOT_KEYFILE) --version $(IMAGE_VERSION) --align \
 	$(MCUBOOT_IMAGE_ALIGN) -H $(IMAGE_HDR_SIZE) $(BINFILE) $(SIGN_BINFILE)
-	@$(COLOR_ECHO)
-	@$(COLOR_ECHO) '$(COLOR_PURPLE)Signed with $(MCUBOOT_KEYFILE) for version $(IMAGE_VERSION)\
+	@echo
+	@echo '$(COLOR_PURPLE)Signed with $(MCUBOOT_KEYFILE) for version $(IMAGE_VERSION)\
 	$(COLOR_RESET)'
-	@$(COLOR_ECHO)
+	@echo
 
 $(MCUBOOT_BIN):
 	$(Q)$(DLCACHE) $(MCUBOOT_BIN_URL) $(MCUBOOT_BIN_MD5) $@

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -24,17 +24,12 @@ endif
 
 mcuboot: ROM_OFFSET=$$(($(MCUBOOT_SLOT0_SIZE) + $(IMAGE_HDR_SIZE)))
 mcuboot: mcuboot-create-key link
-	@echo
-	@echo '$(COLOR_PURPLE)Re-linking for MCUBoot at $(MCUBOOT_SLOT0_SIZE)...$(COLOR_RESET)'
-	@echo
+	$(info $(COLOR_PURPLE)Re-linking for MCUBoot at $(MCUBOOT_SLOT0_SIZE)...$(COLOR_RESET))
 	$(Q)$(_LINK) -o $(ELFFILE) && \
 	$(OBJCOPY) $(OFLAGS) -Obinary $(ELFFILE) $(BINFILE) && \
 	$(IMGTOOL) sign --key $(MCUBOOT_KEYFILE) --version $(IMAGE_VERSION) --align \
 	$(MCUBOOT_IMAGE_ALIGN) -H $(IMAGE_HDR_SIZE) $(BINFILE) $(SIGN_BINFILE)
-	@echo
-	@echo '$(COLOR_PURPLE)Signed with $(MCUBOOT_KEYFILE) for version $(IMAGE_VERSION)\
-	$(COLOR_RESET)'
-	@echo
+	$(info '$(COLOR_PURPLE)Signed with $(MCUBOOT_KEYFILE) for version $(IMAGE_VERSION)$(COLOR_RESET))
 
 $(MCUBOOT_BIN):
 	$(Q)$(DLCACHE) $(MCUBOOT_BIN_URL) $(MCUBOOT_BIN_MD5) $@

--- a/makefiles/scan-build.inc.mk
+++ b/makefiles/scan-build.inc.mk
@@ -82,7 +82,7 @@ endif # BUILD_IN_DOCKER
 
 
 ..scan-build-analyze: clean
-	@echo '$(COLOR_GREEN)Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".$(COLOR_RESET)'
+	$(info $(COLOR_GREEN)Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".$(COLOR_RESET))
 # ccc-analyzer needs to be told the proper -target setting for best results,
 # otherwise false error reports about unknown register names etc will be produced.
 # These kinds of errors can be safely ignored as long as they only come from LLVM
@@ -96,7 +96,7 @@ endif # BUILD_IN_DOCKER
 	      make -C $(CURDIR) all $(strip $(CMDVARS)) FORCE_ASSERTS=1
 
 ..scan-build-view: scan-build-analyze
-	@echo "Showing most recent report in your web browser..."
+	$(info Showing most recent report in your web browser...")
 	@REPORT_FILE="$$(find '$(SCANBUILD_OUTPUTDIR)' -maxdepth 2 -mindepth 2 \
 	            -type f -name 'index.html' 2>/dev/null | sort | tail -n 1)"; \
 	  if [ -n "$${REPORT_FILE}" ]; then \

--- a/makefiles/scan-build.inc.mk
+++ b/makefiles/scan-build.inc.mk
@@ -82,13 +82,13 @@ endif # BUILD_IN_DOCKER
 
 
 ..scan-build-analyze: clean
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".$(COLOR_RESET)'
+	@echo '$(COLOR_GREEN)Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".$(COLOR_RESET)'
 # ccc-analyzer needs to be told the proper -target setting for best results,
 # otherwise false error reports about unknown register names etc will be produced.
 # These kinds of errors can be safely ignored as long as they only come from LLVM
 	@if [ "$${TOOLCHAIN}" != "llvm" -a "$${BOARD}" != "native" ]; then \
-	  $(COLOR_ECHO) '$(COLOR_YELLOW)Recommend using TOOLCHAIN=llvm for best results.$(COLOR_RESET)'; \
-	  $(COLOR_ECHO) '$(COLOR_YELLOW)Ignore any "error: unknown register name '\''rX'\'' in asm" messages.$(COLOR_RESET)'; \
+	  echo '$(COLOR_YELLOW)Recommend using TOOLCHAIN=llvm for best results.$(COLOR_RESET)'; \
+	  echo '$(COLOR_YELLOW)Ignore any "error: unknown register name '\''rX'\'' in asm" messages.$(COLOR_RESET)'; \
 	fi
 	$(Q)mkdir -p '$(SCANBUILD_OUTPUTDIR)'
 	$(Q)env -i $(ENVVARS) \

--- a/makefiles/utils/ansi.mk
+++ b/makefiles/utils/ansi.mk
@@ -1,0 +1,11 @@
+# ANSI Terminal codes and other escape sequences.
+# The objective of this definitions is to be able to write special characters
+# without resorting to shell commands like echo.
+
+include $(RIOTMAKE)/utils/ansi_special.mk
+
+ANSI_GREEN  := $(ANSI_ESC)[1;32m
+ANSI_RED    := $(ANSI_ESC)[1;31m
+ANSI_YELLOW := $(ANSI_ESC)[1;33m
+ANSI_PURPLE := $(ANSI_ESC)[1;35m
+ANSI_RESET  := $(ANSI_ESC)[0m

--- a/makefiles/utils/ansi_special.mk
+++ b/makefiles/utils/ansi_special.mk
@@ -1,0 +1,16 @@
+# Make does not recognize escaped characters (e.g. \t, \033, etc).
+# The following variables contain the characters themselves.
+# This file is inherently fragile (i.e. your editor could destroy the tab
+# without you realizing, to be careful when editing this.
+
+# To generate this: $ printf "ANSI_ESC := \033# comment"
+ANSI_ESC := # you may or may not be able to see that character in your editor
+
+# The third parameter to the subst is a tab - be careful not to replace it with
+# spaces!
+TAB := $(subst ,,	)
+
+define NEWLINE
+
+
+endef

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -24,11 +24,13 @@ CFLAGS += -DUSB_CONFIG_VID=0x$(USB_VID) -DUSB_CONFIG_PID=0x$(USB_PID)
 
 include $(RIOTBASE)/Makefile.include
 
+define PID_VID_WARNING
+$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)
+$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)
+endef
+
 .PHONY: usb_id_check
 usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
-		echo "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		echo "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
-	fi
+	$(if $(filter-out $(USB_VID):$(USB_PID),$(DEFAULT_VID):$(DEFAULT_PID)),,$(warning $(PID_VID_WARNING)))
 
 all: | usb_id_check

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -27,8 +27,8 @@ include $(RIOTBASE)/Makefile.include
 .PHONY: usb_id_check
 usb_id_check:
 	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
-		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+		echo "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
+		echo "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi
 
 all: | usb_id_check


### PR DESCRIPTION
### Contribution description

This consists of several changes. I can split as necessary or remove some commits.

The whole idea of this is to reduce the reliance on the shell and on echo- for efficiency (calling external commands is slow) and for improved portability.

With this change,s not only can color messages be printed using normal `echo` with no switches: colors also work with the `info` and `warning` builtins of make.

The `@true` are added to prevent `make: Nothing to be done for 'xxxx'` messages.

This fixes the discrepancy between the output with and without CC_NOCOLOR, where disabling colors would also lead to tabs and newlines not being interpreted.

### Testing procedure

The CI will check that nothing is broken. The usual ways of causing errors and warning can be used to check that the colors show up as intended.

### Issues/PRs references

Rewrites part of #10405 .
