### PR TITLE
makefiles/color: detect if writing to terminal.

### DIFF
--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -8,12 +8,8 @@ COLOR_RESET  :=
 COLOR_ECHO   := /bin/echo
 
 ifeq ($(CC_NOCOLOR),)
-  available_colors:=$(shell tput colors 2> /dev/null)
-  ifeq ($(available_colors),)
-    CC_NOCOLOR = 1
-  else ifeq ($(available_colors),-1)
-    CC_NOCOLOR = 1
-  else ifeq ($(available_colors),0)
+  IS_TERMINAL = $(if $(MAKE_TERMOUT),$(MAKE_TERMERR),)
+  ifeq ($(IS_TERMINAL),)
     CC_NOCOLOR = 1
   else
     CC_NOCOLOR = 0


### PR DESCRIPTION

### Contribution description

The current code for detecting whether colors should be used by default was not working. Normally what programs such as git or grep do is check if they are writing to a pipe.

### Testing procedure

To see the issue by yourself:

$ BOARD=samr21-xpro make -C tests/periph_qdec > I_SHOULD_NOT_HAVE_COLORS 2>&1

This commit uses MAKE_TERMOUT, MAKE_TERMERR and if ANY of them is NOT a terminal, colors are disabled.


