### PR TITLE
Implementation of PCA9685

### DIFF
--- a/drivers/pca9685/Makefile
+++ b/drivers/pca9685/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/pca9685/include/pca9685.h
+++ b/drivers/pca9685/include/pca9685.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2019 Marius <marius@twostairs.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_pca9685 PCA9685 16-channel, 12-bit PWM Fm+ I²C-bus controller
+ * @ingroup     drivers_pca9685
+ * @brief       Device driver interface for the PCA9685 16-channel, 12-bit PWM Fm+ I²C-bus controller
+ * Implementation based on https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library
+  * @{
+ *
+ * @file
+ * @brief       Device driver interface for the PCA9685 16-channel, 12-bit PWM Fm+ I²C-bus controller.
+ *
+ * @author      Marius <marius@twostairs.com>
+ *
+ * @}
+ */
+
+#ifndef PCA9685_H
+#define PCA9685_H
+
+#include <stdio.h>
+
+#include "periph/i2c.h"
+
+#define PCA9685_ADDR (0x43)
+
+#define PCA9685_SUBADR1 (0x2) /**< i2c bus address 1 */
+#define PCA9685_SUBADR2 (0x3) /**< i2c bus address 2 */
+#define PCA9685_SUBADR3 (0x4) /**< i2c bus address 3 */
+
+#define PCA9685_MODE1 (0x0) /**< Mode Register 1 */
+#define PCA9685_MODE2 (0x1) /**< Mode Register 2 */
+#define PCA9685_PRESCALE (0xFE) /**< Prescaler for PWM output frequency */
+
+#define LED0_ON_L (0x6) /**< LED0 output and brightness control byte 0 */
+#define LED0_ON_H (0x7) /**< LED0 output and brightness control byte 1 */
+#define LED0_OFF_L (0x8) /**< LED0 output and brightness control byte 2 */
+#define LED0_OFF_H (0x9) /**< LED0 output and brightness control byte 3 */
+
+#define ALLLED_ON_L (0xFA) /**< load all the LEDn_ON registers, byte 0 */
+#define ALLLED_ON_H (0xFB) /**< load all the LEDn_ON registers, byte 1 */
+#define ALLLED_OFF_L (0xFC) /**< load all the LEDn_OFF registers, byte 0 */
+#define ALLLED_OFF_H (0xFD) /**< load all the LEDn_OFF registers, byte 1 */
+
+#ifndef PCA9685_PARAM_I2C_DEV
+#define PCA9685_PARAM_I2C_DEV         I2C_DEV(0)
+#endif
+#ifndef PCA9685_PARAM_I2C_ADDR
+#define PCA9685_PARAM_I2C_ADDR        PCA9685_ADDR
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    i2c_t i2c_dev;                              /**< I2C device which is used */
+    uint8_t i2c_addr;                           /**< I2C address */
+    float pwm_freq;                             /**< PWM frequency */
+} pca9685_params_t;
+
+/**
+ * @brief   Device descriptor for the PCA9685
+ */
+typedef struct {
+    pca9685_params_t      params;               /**< Device initialization parameters */
+} pca9685_t;
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    PCA9685_OK = 0,                              /**< everything was fine */
+    PCA9685_ERR_NODEV,                           /**< did not detect device */
+    PCA9685_ERR_SETFREQ,                         /**< error when setting the frequency */
+    PCA9685_ERR_SETEXTCLK,                       /**< error when setting the external clock */
+    PCA9685_ERR_SETPWM,                          /**< error when setting the PWM */
+    PCA9685_ERR_WAKEUP,                          /**< error when waking up */
+    PCA9685_ERR_SLEEP,                           /**< error when putting to sleep */
+};
+
+int pca9685_init(pca9685_t *dev, const pca9685_params_t *params);
+int pca9685_set_ext_clk(pca9685_t *dev, uint8_t prescale);
+int pca9685_set_pwm_freq(pca9685_t *dev, float freq);
+
+int pca9685_set_output_mode(pca9685_t *dev, bool totempole);
+
+int pca9685_set_pwm(pca9685_t *dev, uint8_t num, uint16_t on, uint16_t off, bool acquire, bool keep_acquired);
+uint16_t pca9685_get_pwm(pca9685_t *dev, uint8_t num);
+
+int pca9685_wakeup(pca9685_t *dev);
+int pca9685_sleep(pca9685_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/drivers/pca9685/pca9685.c
+++ b/drivers/pca9685/pca9685.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2019 Marius <marius@twostairs.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_pca9685
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the PCA9685 16-channel, 12-bit PWM Fm+ I²C-bus controller.
+ * Implementation based on https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library
+ *
+ * @author      Marius <marius@twostairs.com>
+ *
+ * @}
+ */
+
+#include <math.h>
+
+#include "pca9685.h"
+
+#include "xtimer.h"
+#include "periph_conf.h"
+#include "periph/i2c.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define DEV_I2C      (dev->params.i2c_dev)
+#define DEV_ADDR     (dev->params.i2c_addr)
+
+int pca9685_init(pca9685_t *dev, const pca9685_params_t *params) {
+    dev->params = *params;
+
+    DEBUG("Acquiring I2C ...\n");
+    i2c_acquire(DEV_I2C);
+
+    DEBUG("Reading reg ...\n");
+    uint8_t oldmode;
+    if(i2c_read_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, &oldmode, 0) != 0) {
+        DEBUG("Failed ...\n");
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_NODEV;
+    }
+
+    DEBUG("Releasing I2C ...\n");
+    i2c_release(DEV_I2C);
+
+    DEBUG("Setting PWM ...\n");
+    int setfreq = pca9685_set_pwm_freq(dev, dev->params.pwm_freq);
+    if(setfreq != PCA9685_OK) {
+        return setfreq;
+    }
+
+    return PCA9685_OK;
+}
+
+int pca9685_set_ext_clk(pca9685_t *dev, uint8_t prescale) {
+
+    i2c_acquire(DEV_I2C);
+
+    uint8_t oldmode;
+    if(i2c_read_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, &oldmode, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETEXTCLK;
+    }
+    uint8_t newmode = (oldmode & 0x7F) | 0x10; // sleep
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, newmode, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETEXTCLK;
+    }
+
+    // This sets both the SLEEP and EXTCLK bits of the MODE1 register to switch to
+    // use the external clock.
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, (newmode|=0x40), 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETEXTCLK;
+    }
+
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_PRESCALE, prescale, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETEXTCLK;
+    }
+
+    xtimer_usleep(5);
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, (newmode & ~(0x10)) | 0xa0, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETEXTCLK;
+    }
+
+    i2c_release(DEV_I2C);
+
+    return PCA9685_OK;
+}
+
+int pca9685_set_pwm_freq(pca9685_t *dev, float freq) {
+    freq *= 0.9; //Correct for overshoot in the frequency setting (see issue https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library/issues/11)
+    float prescaleval = 25000000;
+    prescaleval /= 4096;
+    prescaleval /= freq;
+    prescaleval -= 1;
+    uint8_t prescale = floor(prescaleval + 0.5);
+
+    i2c_acquire(DEV_I2C);
+
+    uint8_t oldmode;
+    if(i2c_read_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, &oldmode, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETFREQ;
+    }
+
+    uint8_t newmode = (oldmode & 0x7F) | 0x10;
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, newmode, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETFREQ;
+    }
+
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_PRESCALE, prescale, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETFREQ;
+    }
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, oldmode, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETFREQ;
+    }
+
+    xtimer_usleep(5);
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, oldmode|0xa0, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETFREQ;
+    }
+
+    i2c_release(DEV_I2C);
+    return PCA9685_OK;
+}
+
+int pca9685_set_output_mode(pca9685_t *dev, bool totempole) {
+    uint8_t oldmode;
+
+    i2c_acquire(DEV_I2C);
+
+    if(i2c_read_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE2, &oldmode, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETFREQ;
+    }
+
+    uint8_t newmode;
+    if (totempole) {
+        newmode = (oldmode&0x7F) | 0x04;
+    }
+    else {
+        newmode = (oldmode&0x7F) & ~0x04;
+    }
+
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE2, newmode, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SETFREQ;
+    }
+
+    i2c_release(DEV_I2C);
+    return PCA9685_OK;
+}
+
+int pca9685_set_pwm(pca9685_t *dev, uint8_t num, uint16_t on, uint16_t off, bool acquire, bool keep_acquired) {
+    uint8_t onoff[4];
+    onoff[0] = (uint8_t)on;
+    onoff[1] = (uint8_t)((uint16_t)on >> 8);
+    onoff[2] = (uint8_t)off;
+    onoff[3] = (uint8_t)((uint16_t)off >> 8);
+
+    if(acquire == true) {
+        i2c_acquire(DEV_I2C);
+    }
+
+    if(i2c_write_regs(DEV_I2C, DEV_ADDR, LED0_ON_L + 4 * num, &onoff, 4, 0) != 0) {
+        if(keep_acquired == false) {
+            i2c_release(DEV_I2C);
+        }
+
+        return -PCA9685_ERR_SETPWM;
+    }
+
+    if(keep_acquired == false) {
+        i2c_release(DEV_I2C);
+    }
+    return PCA9685_OK;
+}
+
+uint16_t pca9685_get_pwm(pca9685_t *dev, uint8_t num) {
+    uint8_t buffer[4] = {0, 0, 0, 0};
+
+    i2c_acquire(DEV_I2C);
+
+    i2c_read_regs(DEV_I2C, DEV_ADDR, LED0_ON_L + 4 * num, &buffer, 4, 0);
+
+    i2c_release(DEV_I2C);
+    return ((buffer[0] & 0xff) | (buffer[1] << 8));
+}
+
+int pca9685_wakeup(pca9685_t *dev) {
+    uint8_t sleep;
+
+    i2c_acquire(DEV_I2C);
+
+    if(i2c_read_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, &sleep, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_WAKEUP;
+    }
+
+    uint8_t wakeup = sleep & ~0x10; // set sleep bit low
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, wakeup, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_WAKEUP;
+    }
+
+    i2c_release(DEV_I2C);
+    return PCA9685_OK;
+}
+
+int pca9685_sleep(pca9685_t *dev) {
+    uint8_t awake;
+
+    i2c_acquire(DEV_I2C);
+
+    if(i2c_read_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, &awake, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SLEEP;
+    }
+
+    uint8_t sleep = awake | 0x10; // set sleep bit high
+    if(i2c_write_reg(DEV_I2C, DEV_ADDR, PCA9685_MODE1, sleep, 0) != 0) {
+        i2c_release(DEV_I2C);
+        return -PCA9685_ERR_SLEEP;
+    }
+
+    xtimer_usleep(5);
+    i2c_release(DEV_I2C);
+    return PCA9685_OK;
+}

--- a/tests/driver_pca9685/Makefile
+++ b/tests/driver_pca9685/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += pca9685
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_pca9685/README.md
+++ b/tests/driver_pca9685/README.md
@@ -1,0 +1,2 @@
+# About
+This application is a test for the PCA9685 16-channel, 12-bit PWM Fm+ I²C-bus controller.

--- a/tests/driver_pca9685/main.c
+++ b/tests/driver_pca9685/main.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Marius <marius@twostairs.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the PCA9685 16-channel, 12-bit PWM Fm+ I²C-bus controller driver.
+ *
+ * @author      Marius <marius@twostairs.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+
+#include "pca9685.h"
+
+int main(void)
+{
+    pca9685_t pca9685;
+    pca9685_params_t pca9685_params;
+
+    pca9685_params.pwm_freq = 50.0;
+    pca9685_params.i2c_dev = PCA9685_PARAM_I2C_DEV;
+    pca9685_params.i2c_addr = PCA9685_PARAM_I2C_ADDR;
+
+    printf("Initializing ...\n");
+    if(pca9685_init(&pca9685, &pca9685_params) != PCA9685_OK) {
+        printf("Error initializing PCA9685!\n");
+        return -1;
+    }
+
+    printf("Setting output mode ...\n");
+    if(pca9685_set_output_mode(&pca9685, true) != 0) {
+        printf("Error setting output mode of pca9685!\n");
+        return 0;
+    }
+
+    printf("Waking up ...\n");
+    if(pca9685_wakeup(&pca9685) != PCA9685_OK) {
+        printf("Error waking up PCA9685!\n");
+        return -1;
+    }
+
+    printf("Setting PWM ...\n");
+    if(pca9685_set_pwm(&pca9685, 0, 200, 200, true, false) != PCA9685_OK) {
+        printf("Error setting PWM on PCA9685!\n");
+        return -1;
+    }
+
+    if(pca9685_get_pwm(&pca9685, 0) != 200) {
+        printf("Something is odd here.\n");
+        return -1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

Added new driver for PCA9685, which is commonly found on PWM breakouts.

### Testing procedure

See `tests/driver_pca9685`. Simply connect a PCA9685 breakout to your board, set the correct I2C address and make it lighten up an LED attached to PWM & GND for example by calling `pca9685_set_pwm(&pca9685, 0, 4096, 0, true, false);`.

### Info

Retry of #12033. @benpicco please check again!