### PR TITLE
cpu/saml21: enable 48mhz clock for usbdev

### DIFF
--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -197,6 +197,21 @@ static const adc_conf_chan_t adc_channels[] = {
 #define DAC_VREF            DAC_CTRLB_REFSEL_VDDANA
 /** @} */
 
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_48MHZ,
+    }
+};
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samr30-xpro/Makefile.features
+++ b/boards/samr30-xpro/Makefile.features
@@ -9,6 +9,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -180,6 +180,20 @@ static const adc_conf_chan_t adc_channels[] = {
 #define ADC_NUMOF                               ARRAY_SIZE(adc_channels)
 /** @} */
 
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_48MHZ,
+    }
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samr34-xpro/Makefile.features
+++ b/boards/samr34-xpro/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -169,6 +169,21 @@ static const adc_conf_chan_t adc_channels[] = {
 #define ADC_NUMOF                               ARRAY_SIZE(adc_channels)
 /** @} */
 
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm       = GPIO_PIN(PA, 24),
+        .dp       = GPIO_PIN(PA, 25),
+        .d_mux    = GPIO_MUX_G,
+        .device   = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_48MHZ,
+    }
+};
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -82,8 +82,14 @@ static void _xosc32k_setup(void)
 
 void sam0_gclk_enable(uint8_t id)
 {
-    (void) id;
-    /* clocks are always running */
+    switch(id) {
+        case SAM0_GCLK_48MHZ:
+            _gclk_setup(SAM0_GCLK_48MHZ, GCLK_GENCTRL_GENEN |
+                        GCLK_GENCTRL_SRC_DFLL48M);
+            break;
+        default:
+            break;
+    }
 }
 
 uint32_t sam0_gclk_freq(uint8_t id)
@@ -95,6 +101,8 @@ uint32_t sam0_gclk_freq(uint8_t id)
         return 8000000;
     case SAM0_GCLK_32KHZ:
         return 32768;
+    case SAM0_GCLK_48MHZ:
+        return 48000000;
     default:
         return 0;
     }

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -46,6 +46,7 @@ enum {
     SAM0_GCLK_MAIN  = 0,                 /**< Main clock */
     SAM0_GCLK_8MHZ  = 1,                 /**< 8MHz clock */
     SAM0_GCLK_32KHZ = 2,                 /**< 32 kHz clock */
+    SAM0_GCLK_48MHZ = 3,                 /**< 48MHz clock */
 };
 /** @} */
 


### PR DESCRIPTION
### Contribution description

This patch for SAML21 boards enables the 48MHz clock used by the usbdev driver, and the adds the driver configuration for a couple of boards (saml21-xpro, samr30-xpro).

### Testing procedure

I've tested a SAML21 board with both example/usbus_minimal and tests/usbus_cdc_ecm, and it works correctly. Also tested on samr34-xpro using PR #11250.

### Issues/PRs references

Closes #12077. Code adapted from #10075 as suggested by @dylad.
