### PR TITLE
cpu/esp8266: fix stdio problems

### DIFF
--- a/cpu/esp8266/Makefile.dep
+++ b/cpu/esp8266/Makefile.dep
@@ -25,38 +25,7 @@ ifneq (, $(filter esp_wifi, $(USEMODULE)))
     USEMODULE += netdev_eth
 endif
 
-ifneq (, $(filter lua, $(USEPKG)))
-    USEMODULE += newlib_syscalls_default
-    USEMODULE += xtimer
-endif
-
-ifneq (, $(filter lwip%, $(USEMODULE)))
-    USEMODULE += newlib_syscalls_default
-endif
-
 ifneq (,$(filter ndn-riot,$(USEPKG)))
     USEMODULE += crypto
     USEMODULE += cipher_modes
-endif
-
-ifneq (, $(filter posix%, $(USEMODULE)))
-    USEMODULE += newlib_syscalls_default
-endif
-
-ifneq (, $(filter shell, $(USEMODULE)))
-    USEMODULE += newlib_syscalls_default
-    USEMODULE += xtimer
-endif
-
-ifneq (, $(filter xtimer, $(USEMODULE)))
-    USEMODULE += newlib_syscalls_default
-endif
-
-ifneq (, $(filter vfs, $(USEMODULE)))
-    USEMODULE += newlib_syscalls_default
-    USEMODULE += xtimer
-endif
-
-ifneq (, $(filter newlib_syscalls_default, $(USEMODULE)))
-    USEMODULE += stdio_uart
 endif

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -61,10 +61,13 @@ PSEUDOMODULES += esp_spiffs
 
 USEMODULE += esp
 USEMODULE += mtd
+USEMODULE += newlib
+USEMODULE += newlib_syscalls_default
 USEMODULE += periph
 USEMODULE += ps
 USEMODULE += random
 USEMODULE += sdk
+USEMODULE += stdio_uart
 USEMODULE += xtensa
 
 ifneq (, $(filter pthread, $(USEMODULE)))

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -85,7 +85,7 @@ INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/espressif
 CFLAGS  += -DESP_OPEN_SDK -DSCHED_PRIO_LEVELS=32 -DCONTEXT_SWITCH_BY_INT
 CFLAGS  += -Wno-unused-parameter -Wformat=0
 CFLAGS  += -mlongcalls -mtext-section-literals
-CFLAGS  += -fdata-sections -fzero-initialized-in-bss
+CFLAGS  += -ffunction-sections -fdata-sections -fzero-initialized-in-bss
 ASFLAGS += --longcalls --text-section-literals
 
 ifneq (, $(filter esp_sdk, $(USEMODULE)))
@@ -135,7 +135,6 @@ endif
 
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/eagle.rom.addr.v6.ld
 LINKFLAGS += -nostdlib -lgcc -u ets_run -Wl,-gc-sections # -Wl,--print-gc-sections
-LINKFLAGS += -Wl,--warn-unresolved-symbols
 
 # The ELFFILE is the base one used for flashing
 FLASHFILE ?= $(ELFFILE)

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -62,6 +62,7 @@ PSEUDOMODULES += esp_spiffs
 USEMODULE += esp
 USEMODULE += mtd
 USEMODULE += newlib
+USEMODULE += newlib_nano
 USEMODULE += newlib_syscalls_default
 USEMODULE += periph
 USEMODULE += ps

--- a/cpu/esp8266/periph/uart.c
+++ b/cpu/esp8266/periph/uart.c
@@ -127,7 +127,7 @@ void IRAM __uart_intr_handler (void *arg)
 }
 
 /* RX/TX FIFO capacity is 128 byte */
-#define UART_FIFO_MAX 127
+#define UART_FIFO_MAX 1
 
 /* receive one data byte with wait */
 static uint8_t IRAM __uart_rx_one_char (uart_t uart)

--- a/cpu/esp8266/sdk/main.c
+++ b/cpu/esp8266/sdk/main.c
@@ -35,7 +35,7 @@
 #include "sdk/main.h"
 #include "sdk/rom.h"
 
-extern char* _printf_buf;
+static char _printf_buf[PRINTF_BUFSIZ];
 
 int IRAM os_printf_plus (const char* format, ...)
 {

--- a/cpu/esp8266/syscalls.c
+++ b/cpu/esp8266/syscalls.c
@@ -52,42 +52,6 @@
 
 #include "sdk/sdk.h"
 
-int IRAM puts(const char * str)
-{
-    char c;
-    while ((c = *str) != 0) {
-        ets_putc(c);
-        ++str;
-    }
-    ets_putc('\n');
-    return true;
-}
-
-int IRAM putchar(int c)
-{
-    /* function is neccessary to avoid unproducable results */
-    ets_putc(c);
-    return true;
-}
-
-char _printf_buf[PRINTF_BUFSIZ];
-
-int /* IRAM */ printf(const char* format, ...)
-{
-    va_list arglist;
-    va_start(arglist, format);
-
-    int ret = vsnprintf(_printf_buf, PRINTF_BUFSIZ, format, arglist);
-
-    if (ret > 0) {
-        ets_printf (_printf_buf);
-    }
-
-    va_end(arglist);
-
-    return ret;
-}
-
 #ifdef MODULE_ESP_SDK
 /**
  * Map memory management functions to SDK memory management functions.

--- a/cpu/esp8266/syscalls.c
+++ b/cpu/esp8266/syscalls.c
@@ -339,53 +339,11 @@ void IRAM _lock_release_recursive(_lock_t *lock)
     rmutex_unlock ((rmutex_t*)*lock);
 }
 
-
-#ifdef MODULE_NEWLIB_SYSCALLS_DEFAULT
-
 #define _cheap heap_top
 
 extern char *heap_top;
 extern char _eheap;     /* end of heap (defined in esp8266.riot-os.app.ld) */
 extern char _sheap;     /* start of heap (defined in esp8266.riot-os.app.ld) */
-
-#else /* MODULE_NEWLIB_SYSCALLS_DEFAULT */
-
-static uint8_t* _cheap = 0; /* last allocated chunk of heap */
-extern uint8_t  _eheap;     /* end of heap (defined in esp8266.riot-os.app.ld) */
-extern uint8_t  _sheap;     /* start of heap (defined in esp8266.riot-os.app.ld) */
-
-void* IRAM _sbrk_r (struct _reent *r, ptrdiff_t incr)
-{
-    uint8_t* _cheap_old;
-
-    /* initial _cheap */
-    if (_cheap == NULL) {
-        _cheap = &_sheap;
-    }
-
-    /* save old _cheap */
-    _cheap_old = _cheap;
-
-    /* check whether _cheap + incr overflows the heap */
-    if (_cheap + incr >= &_eheap) {
-        r->_errno = ENOMEM;
-        return (caddr_t)-1;
-    }
-
-    /* set new _cheap */
-    _cheap += incr;
-
-    #if ENABLE_DEBUG
-    uint32_t remaining = &_eheap - _cheap;
-    printf ("%s %lu byte allocated in %p .. %p, remaining %u\n",
-            __func__, incr, _cheap_old, _cheap, remaining);
-    #endif
-
-    /* return allocated memory */
-    return (void*) _cheap_old;
-}
-
-#endif  /* MODULE_NEWLIB_SYSCALLS_DEFAULT */
 
 unsigned int IRAM get_free_heap_size (void)
 {
@@ -401,70 +359,6 @@ void heap_stats(void)
 }
 
 #endif /* MODULE_ESP_SDK */
-
-#if !defined(MODULE_NEWLIB_SYSCALLS_DEFAULT)
-
-NORETURN void _exit(int status)
-{
-    UNREACHABLE();
-}
-
-static int _no_sys_func (struct _reent *r, const char* f)
-{
-    LOG_ERROR("system function %s does not exist\n", f);
-    r->_errno = ENOSYS;
-    return -1;
-}
-
-int _open_r(struct _reent *r, const char *path, int flag, int m)
-{
-    return _no_sys_func (r, __func__);
-}
-
-int _close_r(struct _reent *r, int fd)
-{
-    return _no_sys_func (r, __func__);
-}
-
-int _fstat_r(struct _reent *r, int fdes, struct stat *stat)
-{
-    return _no_sys_func (r, __func__);
-}
-
-int _stat_r(struct _reent *r, const char *path, struct stat *buff)
-{
-    return _no_sys_func (r, __func__);
-}
-
-int _lseek_r(struct _reent *r, int fdes, int off, int w)
-{
-    return _no_sys_func (r, __func__);
-}
-
-int _write_r(struct _reent *r, int fd, const void *buff, size_t cnt)
-{
-    return _no_sys_func (r, __func__);
-}
-
-int _read_r(struct _reent *r, int fd, void *buff, size_t cnt)
-{
-    return _no_sys_func (r, __func__);
-}
-
-#include <sys/time.h>
-
-int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
-{
-    (void) tz;
-    if (tv) {
-        uint32_t microseconds = system_get_time();
-        tv->tv_sec = microseconds / 1000000;
-        tv->tv_usec = microseconds % 1000000;
-    }
-    return 0;
-}
-
-#endif /* MODULE_NEWLIB_SYSCALLS_DEFAULT */
 
 int _rename_r (struct _reent *r, const char* old, const char* new)
 {


### PR DESCRIPTION
### Contribution description

This PR fixes a problem with the standard output that arose in conjunction with the `i2c_scan` problem described in issue #12125.

The problem occurs when stdio functions `puts`, `putchar` and `printf` are used together with `fputs` or `fprintf` and `stdout` as file parameter. While outputs with `puts` are printed out immediately, 
outputs with `fputs` are not printed out on linefeed but when the internal buffer of 128 bytes is full. As a result, mixing these functions scrambles the output completely.

The problem is fixed by removing the overridden stdio functions `puts`, `putchar` and `printf`. Instead, the corresponding newlib functions are used always. For this purpose, modules `newlib`, `newlib_syscalls_default` and `stdio_uart` are now enabled by default which also reduces the number of module dependency rules in `Makefile.dep`.

### Testing procedure

Flash and test `examples/default` with enabled module `i2c_scan`  with command
```
USEMODULE='i2c_scan' make BOARD=esp8266-esp-12x -C examples/default flash term
```
Without this PR the output should look like:
```
2019-08-31 14:17:35,993 - INFO #  i2c_scan 0
2019-08-31 14:17:35,996 - INFO # Scanning I2C device 0...
2019-08-31 14:17:36,002 - INFO # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2019-08-31 14:17:36,006 - INFO #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2019-08-31 14:17:36,006 - INFO # 
2019-08-31 14:17:36,007 - INFO # 
2019-08-31 14:17:36,007 - INFO # 
2019-08-31 14:17:36,019 - INFO # 0x00 R R R R R R R R R R R R R R E E0x10 E E E E E E E E E E E E E E E E0x20 E E E E E E E E E E E E E E E E0x30 E E E E E E E E
2019-08-31 14:17:36,020 - INFO # 
2019-08-31 14:17:36,020 - INFO # 
2019-08-31 14:17:36,021 - INFO # 
2019-08-31 14:17:36,030 - INFO #  E E E E E E E E0x40 E E E E E X E E E E E E E E E E0x50 E E E E E E E E E E E E E E E E0x60 E E E E E E E E E E E E E E E E0x70
```
With this PR the output should look like:
```
> i2c_scan 0
2019-08-31 14:21:33,249 - INFO #  i2c_scan 0
2019-08-31 14:21:33,252 - INFO # Scanning I2C device 0...
2019-08-31 14:21:33,257 - INFO # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2019-08-31 14:21:33,260 - INFO #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2019-08-31 14:21:33,263 - INFO # 0x00 R R R R R R R R R R R R R R E E
2019-08-31 14:21:33,266 - INFO # 0x10 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,271 - INFO # 0x20 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,274 - INFO # 0x30 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,277 - INFO # 0x40 E E E E E X E E E E E E E E E E
2019-08-31 14:21:33,280 - INFO # 0x50 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,283 - INFO # 0x60 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,287 - INFO # 0x70 E E E E E E E E R R R R R R R R
```

### Issues/PRs references

Related to issue #12125.