### PR TITLE
cpu/esp*: fix of the error code for I2C address ACK errors

### DIFF
--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -288,23 +288,68 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-#define _i2c_return_on_error(dev) \
+/*
+ * This macro checks the result of a read transfer. In case of an error,
+ * the hardware is reset and returned with a corresponding error code.
+ *
+ * @note:
+ * In a read transfer, an ACK is only expected for the address field. Thus,
+ * an ACK error can only happen for the address field. Therefore, we always
+ * return -ENXIO in case of an ACK error.
+ */
+#define _i2c_return_on_error_read(dev) \
     if (_i2c_bus[dev].results & I2C_ARBITRATION_LOST_INT_ENA) { \
-        LOG_TAG_ERROR("i2c", "arbitration lost dev=%u\n", dev); \
+        LOG_TAG_DEBUG("i2c", "arbitration lost dev=%u\n", dev); \
         _i2c_reset_hw (dev); \
-__asm__ volatile ("isync"); \
+        __asm__ volatile ("isync"); \
         return -EAGAIN; \
     } \
     else if (_i2c_bus[dev].results & I2C_ACK_ERR_INT_ENA) { \
-        LOG_TAG_ERROR("i2c", "ack error dev=%u\n", dev); \
+        LOG_TAG_DEBUG("i2c", "ack error dev=%u\n", dev); \
         _i2c_reset_hw (dev); \
-__asm__ volatile ("isync"); \
-        return -EIO; \
+        __asm__ volatile ("isync"); \
+        return -ENXIO; \
     } \
     else if (_i2c_bus[dev].results & I2C_TIME_OUT_INT_ENA) { \
-        LOG_TAG_ERROR("i2c", "bus timeout dev=%u\n", dev); \
+        LOG_TAG_DEBUG("i2c", "bus timeout dev=%u\n", dev); \
         _i2c_reset_hw (dev); \
-__asm__ volatile ("isync"); \
+        __asm__ volatile ("isync"); \
+        return -ETIMEDOUT; \
+    }
+
+/*
+ * This macro checks the result of a write transfer. In case of an error,
+ * the hardware is reset and returned with a corresponding error code.
+ *
+ * @note:
+ * In a write transfer, an ACK error can happen for the address field
+ * as well as for data. If the FIFO still contains all data bytes,
+ * (i.e. _i2c_hw[dev].regs->status_reg.tx_fifo_cnt >= len), the ACK error
+ * happened in address field and we have to returen -ENXIO. Otherwise, the
+ * ACK error happened in data field and we have to return -EIO.
+ */
+#define _i2c_return_on_error_write(dev) \
+    if (_i2c_bus[dev].results & I2C_ARBITRATION_LOST_INT_ENA) { \
+        LOG_TAG_DEBUG("i2c", "arbitration lost dev=%u\n", dev); \
+        _i2c_reset_hw (dev); \
+        __asm__ volatile ("isync"); \
+        return -EAGAIN; \
+    } \
+    else if (_i2c_bus[dev].results & I2C_ACK_ERR_INT_ENA) { \
+        LOG_TAG_DEBUG("i2c", "ack error dev=%u\n", dev); \
+        _i2c_reset_hw (dev); \
+        __asm__ volatile ("isync"); \
+        if (_i2c_hw[dev].regs->status_reg.tx_fifo_cnt >= len) { \
+            return -ENXIO; \
+        } \
+        else { \
+            return -EIO; \
+        } \
+    } \
+    else if (_i2c_bus[dev].results & I2C_TIME_OUT_INT_ENA) { \
+        LOG_TAG_DEBUG("i2c", "bus timeout dev=%u\n", dev); \
+        _i2c_reset_hw (dev); \
+        __asm__ volatile ("isync"); \
         return -ETIMEDOUT; \
     }
 
@@ -350,7 +395,7 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, uint8_t fla
         _i2c_read_cmd (dev, data, I2C_MAX_DATA, false);
         _i2c_end_cmd (dev);
         _i2c_transfer (dev);
-        _i2c_return_on_error (dev);
+        _i2c_return_on_error_read (dev);
 
         /* if transfer was successful, fetch the data from I2C RAM */
         for (unsigned i = 0; i < I2C_MAX_DATA; i++) {
@@ -380,7 +425,7 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, uint8_t fla
 
     /* finish operation by executing the command pipeline */
     _i2c_transfer (dev);
-    _i2c_return_on_error (dev);
+    _i2c_return_on_error_read (dev);
 
     /* if transfer was successful, fetch data from I2C RAM */
     for (unsigned i = 0; i < len; i++) {
@@ -437,7 +482,7 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len, uint
         _i2c_write_cmd (dev, ((uint8_t*)data) + off, I2C_MAX_DATA);
         _i2c_end_cmd (dev);
         _i2c_transfer (dev);
-        _i2c_return_on_error (dev);
+        _i2c_return_on_error_write (dev);
 
         len -= I2C_MAX_DATA;
         off += I2C_MAX_DATA;
@@ -458,7 +503,7 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len, uint
 
     /* finish operation by executing the command pipeline */
     _i2c_transfer (dev);
-    _i2c_return_on_error (dev);
+    _i2c_return_on_error_write (dev);
 
     /* return 0 on success */
     return 0;

--- a/cpu/esp32/periph/i2c_sw.c
+++ b/cpu/esp32/periph/i2c_sw.c
@@ -225,7 +225,7 @@ int /* IRAM */ i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, 
                 (res = _i2c_write_byte (bus, addr2)) != 0) {
                 /* abort transfer */
                 _i2c_abort (bus, __func__);
-                return res;
+                return -ENXIO;
             }
         }
         else {
@@ -233,7 +233,7 @@ int /* IRAM */ i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, 
             if ((res = _i2c_write_byte (bus, (addr << 1 | I2C_READ))) != 0) {
                 /* abort transfer */
                 _i2c_abort (bus, __func__);
-                return res;
+                return -ENXIO;
             }
         }
     }
@@ -286,7 +286,7 @@ int /* IRAM */ i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_
                 (res = _i2c_write_byte (bus, addr2)) != 0) {
                 /* abort transfer */
                 _i2c_abort (bus, __func__);
-                return res;
+                return -ENXIO;
             }
         }
         else {
@@ -294,7 +294,7 @@ int /* IRAM */ i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_
             if ((res = _i2c_write_byte (bus, addr << 1)) != 0) {
                 /* abort transfer */
                 _i2c_abort (bus, __func__);
-                return res;
+                return -ENXIO;
             }
         }
     }

--- a/cpu/esp8266/periph/i2c.c
+++ b/cpu/esp8266/periph/i2c.c
@@ -240,7 +240,7 @@ int /* IRAM */ i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, 
                 (res = _i2c_write_byte (bus, addr2)) != 0) {
                 /* abort transfer */
                 _i2c_abort (bus, __func__);
-                return res;
+                return -ENXIO;
             }
         }
         else {
@@ -248,7 +248,7 @@ int /* IRAM */ i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, 
             if ((res = _i2c_write_byte (bus, (addr << 1 | I2C_READ))) != 0) {
                 /* abort transfer */
                 _i2c_abort (bus, __func__);
-                return res;
+                return -ENXIO;
             }
         }
     }
@@ -301,7 +301,7 @@ int /* IRAM */ i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_
                 (res = _i2c_write_byte (bus, addr2)) != 0) {
                 /* abort transfer */
                 _i2c_abort (bus, __func__);
-                return res;
+                return -ENXIO;
             }
         }
         else {
@@ -309,7 +309,7 @@ int /* IRAM */ i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_
             if ((res = _i2c_write_byte (bus, addr << 1)) != 0) {
                 /* abort transfer */
                 _i2c_abort (bus, __func__);
-                return res;
+                return -ENXIO;
             }
         }
     }


### PR DESCRIPTION
### Contribution description

This PR fixes the problem described in issue #12125.

`-EIO` was returned on all ACK errors. However, according to the [API doc](http://doc.riot-os.org/group__drivers__periph__i2c.html#ga196b4508511c41822eddf6b43b008e90), `-ENXIO` has to be returned when no devices respond on the address sent on the bus. That is, in case of an ACK error for the address field, `-ENXIO` has to be returned instead of `-EIO`.

This PR fixes this problem for ESP8266, ESP32 software and hardware implementation.

### Testing procedure

Flash and test `examples/default` with enabled module `i2c_scan`  with following commands.
- ESP8266:
   ```
   USEMODULE='i2c_scan' make BOARD=esp8266-esp-12x -C examples/default flash term
   ```
- ESP32 software implementation, and 
   ```
   USEMODULE='i2c_scan' make BOARD=esp32-wroom-32 -C examples/default flash term
   ```
- ESP32 hardware implementation, and 
   ```
   USEMODULE='i2c_scan esp_i2c_hw' make BOARD=esp32-wroom-32 -C examples/default flash term
   ```

Without this PR the output should look like for all platforms:
```
> i2c_scan 0
2019-08-31 14:21:33,249 - INFO #  i2c_scan 0
2019-08-31 14:21:33,252 - INFO # Scanning I2C device 0...
2019-08-31 14:21:33,257 - INFO # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2019-08-31 14:21:33,260 - INFO #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2019-08-31 14:21:33,263 - INFO # 0x00 R R R R R R R R R R R R R R E E
2019-08-31 14:21:33,266 - INFO # 0x10 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,271 - INFO # 0x20 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,274 - INFO # 0x30 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,277 - INFO # 0x40 E E E E E X E E E E E E E E E E
2019-08-31 14:21:33,280 - INFO # 0x50 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,283 - INFO # 0x60 E E E E E E E E E E E E E E E E
2019-08-31 14:21:33,287 - INFO # 0x70 E E E E E E E E R R R R R R R R
```
With this PR the output should look like for all platforms:
```
> i2c_scan 0
2019-08-31 14:42:36,555 - INFO #  i2c_scan 0
2019-08-31 14:42:36,581 - INFO # Scanning I2C device 0...
2019-08-31 14:42:36,583 - INFO # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2019-08-31 14:42:36,585 - INFO #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2019-08-31 14:42:36,588 - INFO # 0x00 R R R R R R R R R R R R R R - -
2019-08-31 14:42:36,591 - INFO # 0x10 - - - - - - - - - - - - - - - -
2019-08-31 14:42:36,592 - INFO # 0x20 - - - - - - - - - - - - - - - -
2019-08-31 14:42:36,596 - INFO # 0x30 - - - - - - - - - - - - - - - -
2019-08-31 14:42:36,597 - INFO # 0x40 - - - - - X - - - - - - - - - -
2019-08-31 14:42:36,599 - INFO # 0x50 - - - - - - - - - - - - - - - -
2019-08-31 14:42:36,601 - INFO # 0x60 - - - - - - - - - - - - - - - -
2019-08-31 14:42:36,602 - INFO # 0x70 - - - - - - - X R R R R R R R R
```

**Note:** The output of `i2c_scan` for ESP8266 works only correctly with PR #12133.

### Issues/PRs references

Depends on PR #12133.
Fixes issue #12125.