### PR TITLE
pkg/libb2: rename config.h to avoid conflicts in the global namespace, set HAVE_ALIGNED_ACCESS_REQUIRED based on CPU (fixes build on esp8266)

### DIFF
--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -27,6 +27,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   The CPU supports unaligned memory access.
+ *          Even if the underlying architecture does not support it, the kernel will take care of it.
+ */
+#define CPU_HAS_UNALIGNED_ACCESS
+
+/**
  * @brief   Prints the address the callee will return to
  */
 __attribute__((always_inline)) static inline void cpu_print_last_instruction(void)

--- a/pkg/libb2/include/config.h
+++ b/pkg/libb2/include/config.h
@@ -1,6 +1,8 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include "cpu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -11,6 +13,10 @@ extern "C" {
 /* Test for a little-endian machine */
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define NATIVE_LITTLE_ENDIAN
+#endif
+
+#ifndef CPU_HAS_UNALIGNED_ACCESS
+#define HAVE_ALIGNED_ACCESS_REQUIRED
 #endif
 
 #ifdef __cplusplus

--- a/pkg/libb2/include/libb2_config.h
+++ b/pkg/libb2/include/libb2_config.h
@@ -1,5 +1,5 @@
-#ifndef CONFIG_H
-#define CONFIG_H
+#ifndef LIBB2_CONFIG_H
+#define LIBB2_CONFIG_H
 
 #include "cpu.h"
 
@@ -22,4 +22,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* CONFIG_H */
+#endif /* LIBB2_CONFIG_H */

--- a/pkg/libb2/patches/0001-rename-config.h-to-libb2_config.h.patch
+++ b/pkg/libb2/patches/0001-rename-config.h-to-libb2_config.h.patch
@@ -1,0 +1,26 @@
+From 213f6bb69962154a890925124d44aa8f3361270e Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@googlemail.com>
+Date: Sun, 1 Sep 2019 17:21:06 +0200
+Subject: [PATCH] rename config.h  to libb2_config.h
+
+This avoids conflics with other config.h files
+---
+ src/blake2-impl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/blake2-impl.h b/src/blake2-impl.h
+index c99e3de..a8622e7 100644
+--- a/src/blake2-impl.h
++++ b/src/blake2-impl.h
+@@ -17,7 +17,7 @@
+ #include <stddef.h>
+ #include <stdint.h>
+ #include <string.h>
+-#include "config.h"
++#include "libb2_config.h"
+ 
+ #define BLAKE2_IMPL_CAT(x,y) x ## y
+ #define BLAKE2_IMPL_EVAL(x,y)  BLAKE2_IMPL_CAT(x,y)
+-- 
+2.20.1
+


### PR DESCRIPTION
### Contribution description
`tests/pkg_libb2` fails to build on esp8266 targets. The `SUFFIX` is used to select a CPU specific optimized implementation, e.g. `SUFFIX=_avx` enables the AVX code path, `SUFFIX=_ssse3` builds with SSE3 instructions and so on. Since we do not evaluate `src/Makefile.am`, `SUFFIX` is never set and the preprocessor just pasts it literal, resulting in function names like `blake2bSUFFIX` for which no implementation exists.

To fix this, set `SUFFIX` to empty string to select the generic implementation.

### Testing procedure
Build `tests/pkg_libb2`

### Issues/PRs references
Discovered in #12133
