### PR TITLE
tests/driver_io1_xplained: remove printf_float dependency

### DIFF
--- a/tests/driver_io1_xplained/Makefile
+++ b/tests/driver_io1_xplained/Makefile
@@ -2,6 +2,5 @@ include ../Makefile.tests_common
 
 USEMODULE += io1_xplained
 USEMODULE += xtimer
-USEMODULE += printf_float
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_io1_xplained/main.c
+++ b/tests/driver_io1_xplained/main.c
@@ -67,9 +67,10 @@ int main(void)
     while (1) {
         /* Get temperature in degrees celsius */
         at30tse75x_get_temperature(&dev.temp, &temperature);
-        printf("Temperature [°C]: %.2f\n"
+        printf("Temperature [°C]: %i.%03u\n"
                "+-------------------------------------+\n",
-               temperature);
+               (int)temperature,
+               (unsigned)((temperature - (int)temperature) * 1000));
         xtimer_sleep(DELAY_1S);
 
         /* Card detect pin is inverted */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This removes the `printf_float` dependency from the `tests/driver_io1_xplained` application. It was used to print the temperature measured by the extension which is returned as float by the driver.
Using the same arithmetic computation than the one in the sensor shell command works and allows removing this dependency.
This saves ~42% ROM usage (33256B before, 19604B now) and is fixing the CI issue raised by Murdock in #12025.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This PR can be tested on IoT-LAB:
- Start an experiment:
```
$ iotlab-experiment submit -n test -d 60 -l saclay,samr21,1
```
- Build and flash
```
$ make IOTLAB_NODE=auto-ssh -C tests/driver_io1_xplained/ flash term
```
- Verify the temperature displayed is correct (compare against master)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will avoid to blacklist the nucleo-l031k6 board in #12025 because of insufficient memory.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
