### PR TITLE
tests/driver_bmp180: cleanup application

### DIFF
--- a/tests/driver_bmp180/Makefile
+++ b/tests/driver_bmp180/Makefile
@@ -2,7 +2,6 @@ include ../Makefile.tests_common
 
 USEMODULE += bmp180
 USEMODULE += xtimer
-USEMODULE += printf_float
 
 # set default altitude
 TEST_ALTITUDE ?= 158 # altitude in Polytechnique School campus

--- a/tests/driver_bmp180/main.c
+++ b/tests/driver_bmp180/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -73,12 +74,12 @@ int main(void)
         /* Get altitude in meters */
         int16_t altitude = bmp180_altitude(&dev, pressure_0);
 
-        printf("Temperature [°C]: %d.%d\n"
+        printf("Temperature [°C]: %i.%d\n"
                "Pressure [hPa]: %lu.%d\n"
                "Pressure at see level [hPa]: %lu.%d\n"
               "Altitude [m]: %i\n"
                "\n+-------------------------------------+\n",
-               (int)(temperature / 10), (int)(temperature % 10),
+               (int)(temperature / 10), abs(temperature % 10),
                (unsigned long)pressure / 100, (int)(pressure % 100),
                (unsigned long)pressure_0 / 100, (int)(pressure_0 % 100),
                (int)altitude);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up the bmp180 driver test application:
- it removes an unnecessary dependency to printf_float: there is no use of float formatter in calls to printf
- it fixes how negative temperature are displayed

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

- Verify the removal of printf_float decreases significantly the ROM size
- Verify negative temperatures are correctly displayed (might be difficult now) or otherwise compare to the hts221 driver application which uses the same logic

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None so far

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
