### PR TITLE
boards/stm32: introduce and use shared i2c config with I2C1 on PB6/PB7

### DIFF
--- a/boards/common/stm32/include/cfg_i2c1_pb6_pb7.h
+++ b/boards/common/stm32/include/cfg_i2c1_pb6_pb7.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Common configuration for STM32 I2C
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef CFG_I2C1_PB6_PB7_H
+#define CFG_I2C1_PB6_PB7_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 6),
+        .sda_pin        = GPIO_PIN(PORT_B, 7),
+#if CPU_FAM_STM32L4
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+#else /* CPU_FAM_STM32L0 */
+        .scl_af         = GPIO_AF1,
+        .sda_af         = GPIO_AF1,
+#endif
+        .bus            = APB1,
+#if CPU_FAM_STM32L4
+        .rcc_mask       = RCC_APB1ENR1_I2C1EN,
+        .irqn           = I2C1_ER_IRQn,
+#else /* CPU_FAM_STM32L0 */
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .irqn           = I2C1_IRQn
+#endif
+    }
+};
+
+#if CPU_FAM_STM32L4
+#define I2C_0_ISR           isr_i2c1_er
+#else /* CPU_FAM_STM32L0 */
+#define I2C_0_ISR           isr_i2c1
+#endif
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_I2C1_PB6_PB7_H */
+/** @} */

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -23,6 +23,7 @@
 
 #include "periph_cpu.h"
 #include "l0/cfg_clock_32_16_1.h"
+#include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
 
@@ -125,29 +126,6 @@ static const spi_conf_t spi_config[] = {
     { GPIO_PIN(PORT_A, 7), 7 },  /* Pin A6 */  \
 }
 #define ADC_NUMOF           (7U)
-/** @} */
-
-/**
- * @name I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev            = I2C1,
-        .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 6),
-        .sda_pin        = GPIO_PIN(PORT_B, 7),
-        .scl_af         = GPIO_AF1,
-        .sda_af         = GPIO_AF1,
-        .bus            = APB1,
-        .rcc_mask       = RCC_APB1ENR_I2C1EN,
-        .irqn           = I2C1_IRQn
-    }
-};
-
-#define I2C_0_ISR           isr_i2c1
-
-#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -22,6 +22,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
 
@@ -168,29 +169,6 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
-/** @} */
-
-/**
- * @name I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev            = I2C1,
-        .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 6),
-        .sda_pin        = GPIO_PIN(PORT_B, 7),
-        .scl_af         = GPIO_AF4,
-        .sda_af         = GPIO_AF4,
-        .bus            = APB1,
-        .rcc_mask       = RCC_APB1ENR1_I2C1EN,
-        .irqn           = I2C1_ER_IRQn
-    }
-};
-
-#define I2C_0_ISR           isr_i2c1_er
-
-#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Following #12025 and #12068, this PR is factorizing the configuration for those boards since they are very similar.
iotlab-m3 could also use the new common file but that would first require to provide a shared clock configuration.

@mrusme has the hardware so maybe he could test and report his results here.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test an I2C device on nucleo-l031k6 and nucleo-l432kc

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Factorization of configurations introduced in #12025 and #12068.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
