### PR TITLE
drivers/at86rf2xx: do not hang on no dev

### DIFF
--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -90,6 +90,7 @@ int main(void)
     puts("AT86RF2xx device driver test");
     xtimer_init();
 
+    unsigned dev_success = 0;
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
         netopt_enable_t en = NETOPT_ENABLE;
         const at86rf2xx_params_t *p = &at86rf2xx_params[i];
@@ -98,8 +99,16 @@ int main(void)
         printf("Initializing AT86RF2xx radio at SPI_%d\n", p->spi);
         at86rf2xx_setup(&devs[i], p);
         dev->event_callback = _event_cb;
-        dev->driver->init(dev);
+        if (dev->driver->init(dev) < 0) {
+            continue;
+        }
         dev->driver->set(dev, NETOPT_RX_END_IRQ, &en, sizeof(en));
+        dev_success++;
+    }
+
+    if (!dev_success) {
+        puts("No device could be initialized");
+        return 1;
     }
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,


### PR DESCRIPTION
### Contribution description

The device driver was hanging, if no device was connected.
`_init()` ->
`at86rf2xx_reset` ->
`at86rf2xx_set_state` ->
`_set_state(dev, AT86RF2XX_STATE_TRX_OFF, state)`

Since no state transition was happening, MISO never returned the expect state AT86RF2XX_STATE_TRX_OFF. (endless loop)

To prevent this, the driver checks the configured part number, before it resets the device.
If the part number matches, you can assume that the expected device is connected.
Additionally check if SPI bus can be acquired once, because `getbus()` ignores the return value. 

### Testing procedure

Start default test application tests/at86rf2xx.
With an at86rf2xx connected everything is as before.
Without an at86rf2xx connected the program prints 
`No device could be initialized`

### Issues/PRs references

None
