### PR TITLE
Fixed AF_INET6 number to match C-library defines

### DIFF
--- a/sys/include/net/af.h
+++ b/sys/include/net/af.h
@@ -33,14 +33,11 @@ enum {
 #define AF_UNIX     AF_UNIX     /**< unspecified address family (as macro) */
     AF_PACKET,                  /**< packet family */
 #define AF_PACKET   AF_PACKET   /**< packet family (as macro) */
-    AF_INET,                    /**< internetwork address family: UDP, TCP, etc. */
+    AF_INET = 4,                    /**< internetwork address family: UDP, TCP, etc. */
 #define AF_INET     AF_INET     /**< internetwork address family: UDP, TCP, etc. (as macro) */
-    AF_INET6,                   /**< internetwork address family with IPv6: UDP, TCP, etc. */
+    AF_INET6  = 10,                   /**< internetwork address family with IPv6: UDP, TCP, etc. */
 #define AF_INET6    AF_INET6    /**< internetwork address family with IPv6: UDP, TCP, etc.
                                  *    (as macro) */
-    AF_NUMOF,                   /**< maximum number of address families on this system */
-#define AF_NUMOF    AF_NUMOF    /**< maximum number of address families on this system (as macro) */
-#define AF_MAX      AF_NUMOF    /**< alias for @ref AF_NUMOF */
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

AF_INET and AF_INET6 have POSIX-wide accepted numbers across different systems (4 and 10 respectively).

Violating this assignment may cause library calls related, e.g. to IP address handling, to fail.

This patch keeps the enum type, but assigns the right numbers to AF_INET and AF_INET6 so that libraries are not confused by the label mismatch.

### Testing procedure

Simply calling `inet_pton()` with the wrong address family on native triggers the problem.
`inet_pton()` returns '0' (error) and sets errno to 97 (EAFNOSUPPORT).

See simple test to reproduce:
https://github.com/danielinux/RIOT-OS-posix-tcp-socket-example

### Issues/PRs references

This defect has been discovered while working on PR #10308 - but it's not related to TLS sockets.

See also: #12130 which can be blocking for the test.

cc: @miri64 