### PR TITLE
tests,examples/usb: PID, VID warning only when building.

### DIFF
--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -16,8 +16,10 @@ USEMODULE += usbus
 USEMODULE += auto_init_usbus
 
 # USB device vendor and product ID
-USB_VID ?= 1209
-USB_PID ?= 0001
+DEFAULT_VID = 1209
+DEFAULT_PID = 0001
+USB_VID ?= $(DEFAULT_VID)
+USB_PID ?= $(DEFAULT_PID)
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
@@ -26,7 +28,11 @@ CFLAGS += -DUSB_CONFIG_VID=0x$(USB_VID) -DUSB_CONFIG_PID=0x$(USB_PID)
 
 include $(RIOTBASE)/Makefile.include
 
-ifeq ($(USB_VID):$(USB_PID), 1209:0001)
-  $(shell $(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2)
-  $(shell $(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2)
-endif
+.PHONY: usb_id_check
+usb_id_check:
+	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
+		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+	fi
+
+all: | usb_id_check

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -15,14 +15,20 @@ CFLAGS += -DGNRC_NETIF_NUMOF=2
 
 # USB device vendor and product ID
 # pid.codes test VID/PID, not globally unique
-USB_VID ?= 1209
-USB_PID ?= 0001
+DEFAULT_VID = 1209
+DEFAULT_PID = 0001
+USB_VID ?= $(DEFAULT_VID)
+USB_PID ?= $(DEFAULT_PID)
 
 CFLAGS += -DUSB_CONFIG_VID=0x$(USB_VID) -DUSB_CONFIG_PID=0x$(USB_PID)
 
 include $(RIOTBASE)/Makefile.include
 
-ifeq ($(USB_VID):$(USB_PID), 1209:0001)
-  $(shell $(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2)
-  $(shell $(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2)
-endif
+.PHONY: usb_id_check
+usb_id_check:
+	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
+		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+	fi
+
+all: | usb_id_check


### PR DESCRIPTION
### Contribution description

The warning issued when the PID and VID are set to the default values should not be printed on `make clean` and other targets, only with `make all` and it should be a proper target.

### Testing procedure

Run:

```
$ make -C tests/usbus_cdc_ecm clean
$ make -C examples/usbus_minimal/ clean
```

With this pr: no warnings. With master: red warning messages.

Run:
```
$ make -C tests/usbus_cdc_ecm
$ make -C examples/usbus_minimal
```

Warnings are still there.

Run:

```
$ USB_VID=1 USB_PID=1 make -C tests/usbus_cdc_ecm
$ USB_VID=1 USB_PID=1 make -C examples/usbus_minimal
```

Warnings go away.

### Issues/PRs references

To do: replace shell echos with proper $(warning ..) calls once #12126 is in.
