### PR TITLE
boards/nrf52832-mdk: enable I2C and use default configuration

### DIFF
--- a/boards/nrf52832-mdk/Makefile.features
+++ b/boards/nrf52832-mdk/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = nrf52832xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_uart
 
 include $(RIOTBOARD)/common/nrf52/Makefile.nrf52832.features

--- a/boards/nrf52832-mdk/include/periph_conf.h
+++ b/boards/nrf52832-mdk/include/periph_conf.h
@@ -22,6 +22,7 @@
 
 #include "periph_cpu.h"
 #include "cfg_clock_32_1.h"
+#include "cfg_i2c_default.h"
 #include "cfg_rtt_default.h"
 #include "cfg_spi_default.h"
 #include "cfg_timer_default.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR enables I2C on nrf52832-mdk and use the I2C default configuration for nrf boards. The pinout of the nrf52832-mdk is the same as the nrf52840-mdk so we can do that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Plug an I2C sensor on P26/27 and verify that it works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #12143 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
