### PR TITLE
toolchain/cflags: enable dwarf compression (save 50% HDD)

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -108,6 +108,7 @@ CFLAGS  += -fdata-sections -ffunction-sections -fzero-initialized-in-bss
 
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
+OPTIONAL_CFLAGS_BLACKLIST += -gz
 
 ASFLAGS += --longcalls --text-section-literals
 

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -162,3 +162,4 @@ endif
 OPTIONAL_CFLAGS_BLACKLIST += -fdiagnostics-color
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
+OPTIONAL_CFLAGS_BLACKLIST += -gz

--- a/makefiles/arch/atmega.inc.mk
+++ b/makefiles/arch/atmega.inc.mk
@@ -53,3 +53,4 @@ endif
 
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
+OPTIONAL_CFLAGS_BLACKLIST += -gz

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -69,3 +69,4 @@ export LINKFLAGS += -Wl,--gc-sections
 
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
+OPTIONAL_CFLAGS_BLACKLIST += -gz

--- a/makefiles/arch/msp430.inc.mk
+++ b/makefiles/arch/msp430.inc.mk
@@ -18,3 +18,4 @@ export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections 
 OPTIONAL_CFLAGS_BLACKLIST += -fdiagnostics-color
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
+OPTIONAL_CFLAGS_BLACKLIST += -gz

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -38,6 +38,11 @@ endif
 # Forbid common symbols to prevent accidental aliasing.
 CFLAGS += -fno-common
 
+# Compress debug info. This saves approximately 50% of disk usage.
+# It has no effect if debugging information is not emitted, so it can be left
+# on unconditionally.
+OPTIONAL_CFLAGS += -gz
+
 # Enable all default warnings and all extra warnings
 CFLAGS += -Wall -Wextra
 # Enable additional checks for printf/scanf format strings


### PR DESCRIPTION
### Contribution description

Use the `-gz` option to compress ELF sections containing DWARF information.

**This saves around 50% of disk space, without any side effects.**

See https://gcc.gnu.org/onlinedocs/gcc-9.2.0/gcc/Debugging-Options.html#Debugging-Options for more infomation on this option.

Some platforms have an outdated toolchain that does not support `-gz` sothe flag is blacklisted there. Even then, the results are quite impressive.

It would be super-awesome if the AVR, MSP and ESP toolchains could be updated to a version with support for this feature. AFAIK those versions are out there, it is just that we are not using them.

### Testing procedure


I used @cladmi's [`buildtest` branch](https://github.com/cladmi/RIOT/tree/wip/du/buildtest) with this change and compiled the `examples/default` application:

```
$ BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/default buildtest-indocker
```

The size was obtained with:

```
$ find output -name "*.bin.bindirsize" -type f -exec tail  -n1 '{}' \; | cut -f 1 | awk '{s+=$1} END {printf "%.0f", s}'
```

Results:

- Vanilla: 10328112 KB (**~10GB**).
- with -gz: 4982788 KB (**~5GB**).

### Issues/PRs references

This was inspired by #8496.
See #10195 for another 50% savings (TODO: combine the two and see if we get 75% savings)