### PR TITLE
boards/pba-d-01-kw2x: rely on the common adapter selection code

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -9,7 +9,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 export OPENOCD_PRE_VERIFY_CMDS += \
   -c 'load_image $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin 0x20000000 bin' \
   -c 'resume 0x20000000'
-export OPENOCD_EXTRA_INIT
 export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield.sh
 
 DEBUG_ADAPTER ?= dap
@@ -18,7 +17,8 @@ DEBUG_ADAPTER ?= dap
 # Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
 #   Usage: SERIAL="0200..." BOARD="pba-d-01-kw2x" make flash
 ifneq (,$(SERIAL))
-  export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
+  # Trigger adapter selection on SERIAL in 'openocd-adapters'
+  DEBUG_ADAPTER_ID ?= $(SERIAL)
   SERIAL_TTY = $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh $(SERIAL)))
   ifeq (,$(SERIAL_TTY))
     $(error Did not find a device with serial $(SERIAL))


### PR DESCRIPTION
### Contribution description

Do not set 'OPENOCD_EXTRA_INIT' but rely on
'openocd/openocd-adapters/dap.inc.mk' to select the adapter.
Using 'OPENOCD_EXTRA_INIT' for this was deprecated.

When 'DEBUG_ADAPTER_ID' was set it was already the case but not with 'SERIAL'.
The compatibility with using 'SERIAL' is maintained.

### Review procedure

No other boards is setting `OPENOCD_EXTRA_INIT`:

<details><summary>git grep OPENOCD_EXTRA_INIT</summary>

```
git grep OPENOCD_EXTRA_INIT
boards/common/frdm/Makefile.include:export OPENOCD_EXTRA_INIT
dist/tools/openocd/openocd.sh:: ${OPENOCD_EXTRA_INIT:=}
dist/tools/openocd/openocd.sh:            ${OPENOCD_EXTRA_INIT} \
dist/tools/openocd/openocd.sh:            ${OPENOCD_EXTRA_INIT} \
dist/tools/openocd/openocd.sh:            ${OPENOCD_EXTRA_INIT} \
dist/tools/openocd/openocd.sh:            ${OPENOCD_EXTRA_INIT} \
```
</details>


The configuration of the adapter does end up in almost the same place with `OPENOCD_ADAPTER_INIT`

https://github.com/RIOT-OS/RIOT/blob/f74381c77b58b97e5c86a18cb162fe17a5df75ba/dist/tools/openocd/openocd.sh#L353-L355

And is the way we use for many other boards:

<details><summary>git grep '$(DEBUG_ADAPTER_ID)'</summary>

```
git grep '$(DEBUG_ADAPTER_ID)'
boards/mulle/Makefile.include:    ifneq ($(DEBUG_ADAPTER_ID),)
boards/mulle/Makefile.include:      PORT := $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh '^$(DEBUG_ADAPTER_ID)$$'))
boards/mulle/Makefile.include:    ifneq ($(DEBUG_ADAPTER_ID),)
boards/mulle/Makefile.include:      PORT := /dev/tty.usbserial-$(DEBUG_ADAPTER_ID)B
makefiles/tools/edbg.inc.mk:ifneq (,$(DEBUG_ADAPTER_ID))
makefiles/tools/edbg.inc.mk:  EDBG_ARGS += --serial $(DEBUG_ADAPTER_ID)
makefiles/tools/openocd-adapters/dap.inc.mk:ifneq (,$(DEBUG_ADAPTER_ID))
makefiles/tools/openocd-adapters/dap.inc.mk:  OPENOCD_ADAPTER_INIT += -c 'cmsis_dap_serial $(DEBUG_ADAPTER_ID)'
makefiles/tools/openocd-adapters/jlink.inc.mk:ifneq (,$(DEBUG_ADAPTER_ID))
makefiles/tools/openocd-adapters/jlink.inc.mk:  OPENOCD_ADAPTER_INIT += -c 'jlink serial $(DEBUG_ADAPTER_ID)'
makefiles/tools/openocd-adapters/mulle.inc.mk:ifneq (,$(DEBUG_ADAPTER_ID))
makefiles/tools/openocd-adapters/mulle.inc.mk:  ifeq "100" "$(word 1, $(sort 100 $(DEBUG_ADAPTER_ID)))"
makefiles/tools/openocd-adapters/mulle.inc.mk:    ifneq "149" "$(word 1, $(sort 149 $(DEBUG_ADAPTER_ID)))"
makefiles/tools/openocd-adapters/mulle.inc.mk:ifneq (,$(DEBUG_ADAPTER_ID))
makefiles/tools/openocd-adapters/mulle.inc.mk:  OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
makefiles/tools/openocd-adapters/stlink.inc.mk:ifneq (,$(DEBUG_ADAPTER_ID))
makefiles/tools/openocd-adapters/stlink.inc.mk:  OPENOCD_ADAPTER_INIT += -c 'hla_serial $(DEBUG_ADAPTER_ID)'
```
</details>


### Testing procedure

Note: I will set `SERIAL_TTY` from the command line to not trigger the usb listing when using random serial number.

With this PR, the selection to `OPENOCD_ADAPTER_INIT` works with both `SERIAL` and `DEBUG_ADAPTER_ID`:

```
DEBUG_ADAPTER_ID=anything BOARD=pba-d-01-kw2x make --no-print-directory -C examples/hello-world/ info-debug-variable-OPENOCD_ADAPTER_INIT SERIAL_TTY=/dev/null
-c source [find interface/cmsis-dap.cfg] -c cmsis_dap_serial anything
```

```
SERIAL=anything BOARD=pba-d-01-kw2x make --no-print-directory -C examples/hello-world/ info-debug-variable-OPENOCD_ADAPTER_INIT SERIAL_TTY=/dev/null
-c source [find interface/cmsis-dap.cfg] -c cmsis_dap_serial anything
```

In master we had the same behavior with `DEBUG_ADAPTER_ID`

```
DEBUG_ADAPTER_ID=anything BOARD=pba-d-01-kw2x make --no-print-directory -C examples/hello-world/ info-debug-variable-OPENOCD_ADAPTER_INIT SERIAL_TTY=/dev/null
-c source [find interface/cmsis-dap.cfg] -c cmsis_dap_serial anything
```

And when using `SERIAL` this was handled through `OPENOCD_EXTRA_INIT` instead of `OPENOCD_ADAPTER_INIT`

```
SERIAL=anything BOARD=pba-d-01-kw2x make --no-print-directory -C examples/hello-world/ info-debug-variable-OPENOCD_EXTRA_INIT SERIAL_TTY=/dev/null
-c cmsis_dap_serial anything
```

#### When multiple boards are connected, flashing is correctly handled:

<details><summary>No serial configuration fails (for reference)</summary>

```
BOARD=pba-d-01-kw2x BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make --no-print-directory -C examples/hello-world/ flash
...
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:37)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
Info : add flash_bank kinetis kx.pflash
adapter speed: 1000 kHz
none separate
cortex_m reset_config sysresetreq
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: JTAG Supported
Info : CMSIS-DAP: FW Version = 1.2.0
Info : CMSIS-DAP: Serial# = L1000973
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 0 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz


/srv/ilab-builds/workspace/git/RIOT/examples/hello-world/../../Makefile.include:556: recipe for target 'flash' failed
```

<details><summary>The SERIAL handling works</summary>

```
SERIAL=02000203C37B4E073E87B3FF BOARD=pba-d-01-kw2x BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make --no-print-directory -C examples/hello-world/ flash
...
cortex_m reset_config sysresetreq
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 1.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : MDM: Chip is unsecured. Continuing.
Info : kx.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 46489 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* kx.cpu             cortex_m   little kx.cpu             unknown
Info : MDM: Chip is unsecured. Continuing.
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000740 msp: 0x1fffc200
auto erase enabled
Info : Kinetis MK21DN512xxx5 detected: 2 flash blocks
Info : 2 PFlash banks: 512k total
wrote 10240 bytes from file /srv/ilab-builds/workspace/git/RIOT/examples/hello-world/bin/pba-d-01-kw2x/hello-world.elf in 0.389989s (25.642 KiB/s)
34 bytes written at address 0x20000000
downloaded 34 bytes in 0.004008s (8.284 KiB/s)
target halted due to breakpoint, current mode: Thread 
xPSR: 0x01000000 pc: 0x20000020 msp: 0x1fffc200
verified 9424 bytes in 0.399987s (23.009 KiB/s)
Info : MDM: Chip is unsecured. Continuing.
shutdown command invoked
```
</details>

<details><summary>And it still works with `DEBUG_ADAPTER_ID`</summary>

```
DEBUG_ADAPTER_ID=02000203C37B4E073E87B3FF BOARD=pba-d-01-kw2x BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make --no-print-directory -C examples/hello-world/ flash
...
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 1.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : MDM: Chip is unsecured. Continuing.
Info : kx.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 34461 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* kx.cpu             cortex_m   little kx.cpu             unknown
Info : MDM: Chip is unsecured. Continuing.
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000740 msp: 0x1fffc200
auto erase enabled
Info : Kinetis MK21DN512xxx5 detected: 2 flash blocks
Info : 2 PFlash banks: 512k total
wrote 10240 bytes from file /srv/ilab-builds/workspace/git/RIOT/examples/hello-world/bin/pba-d-01-kw2x/hello-world.elf in 0.389948s (25.644 KiB/s)
34 bytes written at address 0x20000000
downloaded 34 bytes in 0.004008s (8.284 KiB/s)
target halted due to breakpoint, current mode: Thread 
xPSR: 0x01000000 pc: 0x20000020 msp: 0x1fffc200
verified 9424 bytes in 0.400029s (23.006 KiB/s)
Info : MDM: Chip is unsecured. Continuing.
shutdown command invoked
Done flashing
```
</details>

### Issues/PRs references

Found while reviewing https://github.com/RIOT-OS/RIOT/pull/11976