### PR TITLE
boards/iotlab: rely on OPENOCD_RESET_USE_CONNECT_ASSERT_SRST

### DIFF
--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -6,9 +6,8 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))
 export BAUD = 500000
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# call a 'reset halt' command before starting the debugger
-# it is required as `connect_assert_srst` is set
-export OPENOCD_DBG_START_CMD = -c 'reset halt'
+# Using connect_assert_srst removes errors on flash from invalid state
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/iotlab-a8-m3/dist/openocd.cfg
+++ b/boards/iotlab-a8-m3/dist/openocd.cfg
@@ -2,7 +2,6 @@ source [find interface/ftdi/iotlab-usb.cfg]
 source [find target/stm32f1x.cfg]
 
 # use combined on interfaces or targets that can't set TRST/SRST separately
-# Using connect_assert_srst removes errors on first flash
-reset_config trst_and_srst connect_assert_srst
+reset_config trst_and_srst
 
 $_TARGETNAME configure -rtos auto

--- a/boards/iotlab-m3/dist/openocd.cfg
+++ b/boards/iotlab-m3/dist/openocd.cfg
@@ -2,7 +2,6 @@ source [find interface/ftdi/iotlab-usb.cfg]
 source [find target/stm32f1x.cfg]
 
 # use combined on interfaces or targets that can't set TRST/SRST separately
-# Using connect_assert_srst removes errors on first flash
-reset_config trst_and_srst connect_assert_srst
+reset_config trst_and_srst
 
 $_TARGETNAME configure -rtos auto


### PR DESCRIPTION
### Contribution description

Use the new OPENOCD_RESET_USE_CONNECT_ASSERT_SRST to configure
'reset_config connect_assert_srst' when flashing and resetting only.

This removes the need for a special debug configuration and should allow
connecting to a running target again.


### Testing procedure

When flashing the reset configuration used is the same (see the last line displayed in the output):


```
BOARD=iotlab-m3 RIOT_CI_BUILD=1 make --no-print-directory -C examples/hello-world/ flash
```

<details><summary>Output in the PR, the configuration is changed to the same as in master</summary>

```
BOARD=iotlab-m3 RIOT_CI_BUILD=1 make --no-print-directory -C examples/hello-world/ flash
Building application "hello-world" for "iotlab-m3" with MCU "stm32f1".

   text    data     bss     dec     hex filename
   8168     120    2556   10844    2a5c /home/harter/work/git/worktree/riot_master/examples/hello-world/bin/iotlab-m3/hello-world.elf
/home/harter/work/git/worktree/riot_master/dist/tools/openocd/openocd.sh flash /home/harter/work/git/worktree/riot_master/examples/hello-world/bin/iotlab-m3/hello-world.elf
### Flashing Target ###
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:37)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
adapter speed: 1000 kHz
adapter_nsrst_delay: 100
jtag_ntrst_delay: 100
none separate
cortex_m reset_config sysresetreq
trst_and_srst separate srst_nogate trst_push_pull srst_open_drain connect_deassert_srst
trst_and_srst separate srst_nogate trst_push_pull srst_open_drain connect_assert_srst
```
</details>

<details><summary>Output in master until the reset configuration</summary>

```
Building application "hello-world" for "iotlab-m3" with MCU "stm32f1".                                                                                                                                                                                                                    

   text    data     bss     dec     hex filename
   8168     120    2556   10844    2a5c /home/harter/work/git/worktree/riot_master/examples/hello-world/bin/iotlab-m3/hello-world.elf
/home/harter/work/git/worktree/riot_master/dist/tools/openocd/openocd.sh flash /home/harter/work/git/worktree/riot_master/examples/hello-world/bin/iotlab-m3/hello-world.elf
/home/harter/work/git/worktree/riot_master/dist/tools/openocd/openocd.sh: line 124: [: : integer expression expected
### Flashing Target ###
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:37)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
adapter speed: 1000 kHz
adapter_nsrst_delay: 100
jtag_ntrst_delay: 100
none separate
cortex_m reset_config sysresetreq
trst_and_srst separate srst_nogate trst_push_pull srst_open_drain connect_assert_srst
```
</details>


<details><summary>Debug works</summary>

```
BOARD=iotlab-m3 RIOT_CI_BUILD=1 make --no-print-directory -C examples/hello-world/ debug
/home/harter/work/git/worktree/riot_master/dist/tools/openocd/openocd.sh debug /home/harter/work/git/worktree/riot_master/examples/hello-world/bin/iotlab-m3/hello-world.elf
### Starting Debugging ###
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:37)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Reading symbols from /home/harter/work/git/worktree/riot_master/examples/hello-world/bin/iotlab-m3/hello-world.elf...done.
Remote debugging using :3333
cortexm_sleep (deep=<optimized out>) at /home/harter/work/git/worktree/riot_master/cpu/cortexm_common/include/cpu.h:177
177         irq_restore(state);
(gdb) 
```
</details>


### Issues/PRs references

Alternative way of doing https://github.com/RIOT-OS/RIOT/pull/8977 that restores debug on a running target now that we have https://github.com/RIOT-OS/RIOT/pull/11976