### PR TITLE
pkg/oonf_api: Use MRI script to combine archives.

### DIFF
--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -8,14 +8,34 @@ MODULE:=$(PKG_NAME)
 # GCC 7.x fails on (intentional) fallthrough, thus disable implicit-fallthrough.
 CFLAGS += -Wno-implicit-fallthrough
 
+COMBINED_ARCHIVE = $(BINDIR)/$(MODULE).a
+
 .PHONY: all
 
 all:
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-	"$(MAKE)" $(BINDIR)/$(MODULE).a
+	"$(MAKE)" $(COMBINED_ARCHIVE)
 
-$(BINDIR)/$(MODULE).a: $(BINDIR)/oonf_*.a
-	mkdir -p $(BINDIR)/$(MODULE); cd $(BINDIR)/$(MODULE); for var in $?; do ar -x $$var; done; ar -r -c -s $(BINDIR)/$(MODULE).a *.o
+PARTIAL_ARCHIVES = $(wildcard $(BINDIR)/oonf_*.a)
+
+$(COMBINED_ARCHIVE): $(BINDIR)/$(MODULE).mri $(PARTIAL_ARCHIVES)
+	ar -M < $<
+
+define ADDLIB_TEMPLATE
+addlib $1
+
+endef
+
+define MRI_TEMPLATE
+create $1
+$(foreach a,$2,$(call ADDLIB_TEMPLATE,$a))
+save
+end
+endef
+
+$(BINDIR)/$(MODULE).mri:
+	$(file >$@,$(call MRI_TEMPLATE,$(COMBINED_ARCHIVE),$(PARTIAL_ARCHIVES)))
+	@true
 
 include $(RIOTBASE)/pkg/pkg.mk
 ifneq (,$(filter -Wformat-nonliteral -Wformat=2, $(CFLAGS)))


### PR DESCRIPTION
### Contribution description

The OONF package is combining multiple ".a" file into a single archive. The way it was being done involved creating and changing directories, unpacking the original archives and repacking them into a combined one.

Theis has a couple of issues:

- It is untidy and wasteful.
- It breaks when thin archives are enabled, as a thin archive cannot be unpacked.

This commit uses a MRI script to do the combining step. It works both with and without thin archives and is cleaner overall.

An issue that remains to be soved is that make is calling itself to create the archive, as the PARTIAL_ARCHIVES are not known before hand. This is hacky. It can be solved but it is a subject for another PR.

### Testing procedure

The OONF example should still compile.

### Issues/PRs references

needed for #10195 .