### PR TITLE
tools/openocd: check if variable for extra reset_config is set

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -121,7 +121,7 @@
 # The single quotes are important on the line above, or it will not work.
 
 # Handle OPENOCD_RESET_USE_CONNECT_ASSERT_SRST
-if [ "${OPENOCD_RESET_USE_CONNECT_ASSERT_SRST}" -eq 1 ]; then
+if [ "${OPENOCD_RESET_USE_CONNECT_ASSERT_SRST}" = "1" ]; then
   OPENOCD_EXTRA_RESET_INIT+="-c 'reset_config connect_assert_srst'"
 fi
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a warning message raised by OpenOCD when flashing without `OPENOCD_RESET_USE_CONNECT_ASSERT_SRST = 1` so on almost all boards flashed by OpenOCD except `nucleo-f091rc`.
The message is: `openocd.sh: line 124: [: : integer expression expected`

The fix is simply to also check if the variable is set.

Another solution could be to assign a default value of `0`, e.g. [here](https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/openocd/openocd.sh#L77). I don't know what's best.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Use OpenOCD to flash a board other than nucleo-f091. With this PR the mentioned warning message is not displayed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Cleanup of #11976 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
