### PR TITLE
boards/stm32: generalize use of connect_assert_srst for flashing

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -11,8 +11,9 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # this board has an on-board ST-link adapter
 DEBUG_ADAPTER ?= stlink
 
-# call a 'reset halt' command before starting the debugger
-export OPENOCD_DBG_START_CMD = -c 'reset halt'
+# this board can become un-flashable after a hardfault,
+# use connect_assert_srst to always be able to flash or reset the board.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -12,6 +12,10 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# nucleo boards can become un-flashable after a hardfault,
+# use connect_assert_srst to always be able to flash or reset the boards.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
+
 # all Nucleo boards have an on-board ST-link adapter
 DEBUG_ADAPTER ?= stlink
 

--- a/boards/common/stm32/dist/stm32l0.cfg
+++ b/boards/common/stm32/dist/stm32l0.cfg
@@ -5,5 +5,5 @@ try {
     puts "WARNING: Your Openocd version does not support dual bank flash on your board. Falling back to single bank flashing."
     source [find target/stm32l0.cfg]
 }
-reset_config srst_only connect_assert_srst
+reset_config srst_only
 $_TARGETNAME configure -rtos auto

--- a/boards/i-nucleo-lrwan1/Makefile.include
+++ b/boards/i-nucleo-lrwan1/Makefile.include
@@ -11,8 +11,9 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # to flash this board, use an ST-link adapter
 DEBUG_ADAPTER ?= stlink
 
-# call a 'reset halt' command before starting the debugger
-export OPENOCD_DBG_START_CMD = -c 'reset halt'
+# this board can become un-flashable after a hardfault,
+# use connect_assert_srst to always be able to flash or reset the boards.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/lsn50/Makefile.include
+++ b/boards/lsn50/Makefile.include
@@ -11,8 +11,9 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # By default, flash this board using an ST-link adapter
 DEBUG_ADAPTER ?= stlink
 
-# call a 'reset halt' command before starting the debugger
-export OPENOCD_DBG_START_CMD = -c 'reset halt'
+# this board can become un-flashable after a hardfault,
+# use connect_assert_srst to always be able to flash or reset the boards.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/nucleo-f091rc/Makefile.include
+++ b/boards/nucleo-f091rc/Makefile.include
@@ -1,6 +1,2 @@
-# nucleo-f091rc can become un-flashable after a hardfault, use connect_assert_srst
-# to always be able to flash or reset the board.
-export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a follow-up and generalization of #11976 to all nucleo. The common OpenOCD confguration for stm32l0 based boards is also adapted (removed use of connect_assert_srst) and related boards (b-l072z-lrwan1, lsn50, i-nucleo-lrwan1) are adapted as well.

There are other boards using stlink that could be also adapted: stm32 discovery boards, stm32f108, b-l475e-iot01a and ublox-c030-u201.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Same testing procedure as the one in #11976 but for all mentioned boards (all nucleo + stm32l0 based boards)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #11976.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
