### PR TITLE
shell/commands: fix, only accept proper pong response to icmpv6_echo

### DIFF
--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -338,7 +338,7 @@ static void _print_reply(_ping_data_t *data, gnrc_pktsnip_t *icmpv6,
         uint16_t recv_seq;
 
         /* not our ping */
-        if ((byteorder_ntohs(icmpv6_hdr->id) != data->id) &&
+        if ((byteorder_ntohs(icmpv6_hdr->id) != data->id) ||
             !ipv6_addr_equal(from, &data->host)) {
             return;
         }


### PR DESCRIPTION
### Contribution description

This PR fixes the Bug introduced in #11933. 

### Testing procedure

Follow the testing procedure in #11519. To test in a controlled setting follow the testing procedure sugested by @benemorius:

To test this in a controlled setting I captured and injected ping replies with a Linux node connected via a border router to a Riot node using this procedure:
1) Prepare Linux node to capture its own outgoing ping reply:
`tcpdump -i eth0 "icmp6 && ip6[40] == 129" -n -c1 -w icmp-reply.pcap`
1) Use the border router to block the genuine ping reply from reaching the Riot node:
`ip6tables -I FORWARD -o lowpan0 -p icmpv6 --icmpv6-type echo-reply -j DROP`
1) Ping Linux node from Riot node using 1 ping and a 60 second timeout:
`ping6 2001:470:4bb0:ffff::1 -c 1 -W 60000`
1) On Linux node modify the source address of the captured packet:
`tcprewrite --infile=icmp-reply.pcap --outfile=icmp-reply2.pcap --pnat=[2001:470:4bb0:ffff::1]:[2001:470:4bb0:ffff::2]`
1) On border router unblock ping replies:
`ip6tables -D FORWARD -o lowpan0 -p icmpv6 --icmpv6-type echo-reply -j DROP`
1) On Linux node send modified ping reply:
`tcpreplay --intf1=eth0 icmp-reply2.pcap`
1) Observe whether the Riot node prints the reply. It should not.
`12 bytes from 2001:470:4bb0:ffff::2 id:0xbe45/0xbe45 icmp_seq=0 ttl=63 rssi=-85 dBm time=13823.374 ms`
1) As before, block ping replies at the border router:
`ip6tables -I FORWARD -o lowpan0 -p icmpv6 --icmpv6-type echo-reply -j DROP`
1) As before, send a ping from the Riot node:
`ping6 2001:470:4bb0:ffff::1 -c 1 -W 60000`
1) As before, unblock ping replies:
`ip6tables -D FORWARD -o lowpan0 -p icmpv6 --icmpv6-type echo-reply -j DROP`
1) From the Linux node send the unmodified ping reply captured earlier:
`tcpreplay --intf1=eth0 icmp-reply.pcap`
1) Observe whether the Riot node prints the reply. It should not.
`12 bytes from 2001:470:4bb0:ffff::1 id:0xbe45/0x2e08 icmp_seq=0 ttl=63 rssi=-86 dBm time=52156.860 ms`


### Issues/PRs references

Fixes #11519