### PR TITLE
boards/slstk340*a: Add reset before flashing

### DIFF
--- a/boards/slstk3401a/Makefile.include
+++ b/boards/slstk3401a/Makefile.include
@@ -7,6 +7,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup JLink for flashing
 export JLINK_DEVICE := $(CPU_MODEL)
+export JLINK_PRE_FLASH = r
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # add board common drivers

--- a/boards/slstk3402a/Makefile.include
+++ b/boards/slstk3402a/Makefile.include
@@ -7,6 +7,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup JLink for flashing
 export JLINK_DEVICE := $(CPU_MODEL)
+export JLINK_PRE_FLASH = r
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # add board common drivers


### PR DESCRIPTION
### Contribution description

It seems that this board needs a reset command before flashing with JLinkExe
This adds the reset - r - to the JLINK_PRE_FLASH

This bug was found while setting up the HiL CI rack

### Testing procedure

Flash with and without this PR:

`BOARD=slstk3401a make flash -C examples/hello-world`
and
`BOARD=slstk3402a make flash -C examples/hello-world`

### Issues/PRs references

Similar to #11548