### PR TITLE
board/l031k6: Implement missing secondary (LP)UART

### DIFF
--- a/boards/nucleo-l031k6/Makefile.features
+++ b/boards/nucleo-l031k6/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = stm32l031k6
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -46,10 +46,23 @@ static const uart_conf_t uart_config[] = {
         .irqn       = USART2_IRQn,
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
-    }
+    },
+    {
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB1ENR_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF4,
+        .tx_af      = GPIO_AF4,
+        .bus        = APB1,
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0, /* Use APB clock */
+    },
 };
 
 #define UART_0_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_lpuart1)
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */


### PR DESCRIPTION
### Contribution description

Another feature that hasn't been implemented as it seems, is the secondary (LP)UART on this STM32 board. This is a draft of how this could look, unfortunately I cannot seem to get it running properly. `uart_init` seems to panic.

### Testing procedure

Create an application with the following features:

```
FEATURES_REQUIRED += periph_lpuart
FEATURES_REQUIRED += periph_uart
FEATURES_OPTIONAL += periph_uart_modecfg
```

Try to deply the `periph_uart` test.
