### PR TITLE
tests/driver_bmx280: cleanup temperature value display

### DIFF
--- a/tests/driver_bmx280/main.c
+++ b/tests/driver_bmx280/main.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -83,10 +84,6 @@ int main(void)
 
         /* Get temperature in centi degrees Celsius */
         temperature = bmx280_read_temperature(&dev);
-        bool negative = (temperature < 0);
-        if (negative) {
-            temperature = -temperature;
-        }
 
         /* Get pressure in Pa */
         pressure = bmx280_read_pressure(&dev);
@@ -96,14 +93,13 @@ int main(void)
         humidity = bme280_read_humidity(&dev);
 #endif
 
-        printf("Temperature [°C]:%c%d.%d\n"
+        printf("Temperature [°C]: %d.%d\n"
                "Pressure [Pa]: %lu\n"
 #if defined(MODULE_BME280)
                "Humidity [%%rH]: %u.%02u\n"
 #endif
                "\n+-------------------------------------+\n",
-               (negative) ? '-' : ' ',
-               temperature / 100, (temperature % 100) / 10,
+               temperature / 100, abs(temperature % 100) / 10,
 #if defined(MODULE_BME280)
                (unsigned long)pressure,
                (unsigned int)(humidity / 100), (unsigned int)(humidity % 100)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a minor cleanup of the `tests/drivers_bmx280` application. It was suggested by @keestux in #12140.

On samr21-xpro, this change also saves 16 bytes of ROM compared to master. 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Flash and run this application and verify temperature values are correctly displayed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Mentioned in https://github.com/RIOT-OS/RIOT/pull/12140#discussion_r320041743

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
