### PR TITLE
tests/driver_sht2x: avoid negative number after decimal dot

### DIFF
--- a/tests/driver_sht2x/Makefile
+++ b/tests/driver_sht2x/Makefile
@@ -5,6 +5,5 @@ FEATURES_REQUIRED = periph_i2c
 
 USEMODULE += sht2x
 USEMODULE += xtimer
-USEMODULE += printf_float
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_sht2x/main.c
+++ b/tests/driver_sht2x/main.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
 
@@ -88,7 +89,7 @@ int main(void)
             printf("Temperature [°C]: %d.%d\n"
                    "Humidity [%%RH]: %u.%02u\n"
                    "\n+-------------------------------------+\n",
-                   temperature / 100, (temperature % 100) / 10,
+                   temperature / 100, abs(temperature % 100) / 10,
                    (unsigned int)(humidity / 100), (unsigned int)(humidity % 100)
                    );
         }


### PR DESCRIPTION
This is a similar fix as in #12162  and #12140.
