### PR TITLE
tests/driver_hts221: cleanup temperature display logic

### DIFF
--- a/tests/driver_hts221/main.c
+++ b/tests/driver_hts221/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <stdlib.h>
 #include <stdio.h>
 
 #include "hts221.h"
@@ -52,12 +53,8 @@ int main(void)
         if (hts221_read_temperature(&dev, &temp) != HTS221_OK) {
             puts(" -- failed to read temperature!");
         }
-        bool negative = (temp < 0);
-        if (negative) {
-            temp = -temp;
-        }
-        printf("H: %u.%u%%, T:%c%u.%u°C\n", (hum / 10), (hum % 10),
-               (negative ? '-' : ' '), (temp / 10), (temp % 10));
+        printf("H: %d.%d%%, T: %d.%d°C\n", (hum / 10), (hum % 10),
+               (temp / 10), abs(temp % 10));
         xtimer_sleep(SLEEP_S);
     }
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is not solving a bug but just saving some bytes for the `tests/driver_hts221` application with a similar change from #12140 and #12162.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This PR can be tested on IoT-LAB using one of the nrf52dk/nrf51dk/nrf52840dk/b-l475e-iot01a boards.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Similar cleanup than the ones in #12140, #12162 and others.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
