### PR TITLE
driver/cc110x: Fixed indent/alignment in doc

### DIFF
--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Implementation for the "public" API of the CC1100/CC1101 driver
+ * @brief       Implementation for the "public" API of the CC1100/CC1101 driver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 

--- a/drivers/cc110x/cc110x_calibration.c
+++ b/drivers/cc110x/cc110x_calibration.c
@@ -7,14 +7,14 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Implementation of the manual calibration facility of the
- *            CC1100/CC1101 driver
+ * @brief       Implementation of the manual calibration facility of the
+ *              CC1100/CC1101 driver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -31,11 +31,11 @@
 #include "debug.h"
 
 /**
- * @brief Read the calibration data from the transceiver and store it
+ * @brief   Read the calibration data from the transceiver and store it
  *
- * @param dev      Device descriptor of the transceiver
+ * @param   dev     Device descriptor of the transceiver
  *
- * @pre @p dev is acquired using @p cc110x_acquire
+ * @pre     @p dev is acquired using @p cc110x_acquire
  */
 static inline void get_calibration_data(cc110x_t *dev)
 {

--- a/drivers/cc110x/cc110x_chanmaps.c
+++ b/drivers/cc110x/cc110x_chanmaps.c
@@ -7,14 +7,14 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Channel maps that translate "virtual" channels to "physical"
- *            channels.
+ * @brief       Channel maps that translate "virtual" channels to "physical"
+ *              channels.
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 

--- a/drivers/cc110x/cc110x_communication.c
+++ b/drivers/cc110x/cc110x_communication.c
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Functions to communicate with the CC1100/CC1101 transceiver
+ * @brief       Functions to communicate with the CC1100/CC1101 transceiver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 

--- a/drivers/cc110x/cc110x_configs.c
+++ b/drivers/cc110x/cc110x_configs.c
@@ -7,14 +7,14 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Transceiver configuration for different base bands, modulation
- *            rate and channel bandwidth.
+ * @brief       Transceiver configuration for different base bands, modulation
+ *              rate and channel bandwidth.
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -7,14 +7,14 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Implementation of RIOT's netdev_driver API for the CC1100/CC1101
- *            transceiver
+ * @brief       Implementation of RIOT's netdev_driver API for the CC1100/CC1101
+ *              transceiver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -45,8 +45,8 @@ static int cc110x_set(netdev_t *netdev, netopt_t opt,
                       const void *val, size_t len);
 
 /**
- * @brief A lookup table to convert from dBm value to the best matching
- *        @ref cc110x_tx_power_t value
+ * @brief   A lookup table to convert from dBm value to the best matching
+ *          @ref cc110x_tx_power_t value
  */
 static const int8_t tx_power_from_dbm[] = {
     [CC110X_TX_POWER_MINUS_30_DBM]  = -25,
@@ -59,7 +59,7 @@ static const int8_t tx_power_from_dbm[] = {
 };
 
 /**
- * @brief A lookup table to convert an @ref cc110x_tx_power_t value to dBm
+ * @brief   A lookup table to convert an @ref cc110x_tx_power_t value to dBm
  */
 static const int8_t dbm_from_tx_power[] = {
     [CC110X_TX_POWER_MINUS_30_DBM]  = -30,
@@ -496,13 +496,13 @@ static int cc110x_send(netdev_t *netdev, const iolist_t *iolist)
 }
 
 /**
- * @brief Generate an IPv6 interface identifier for a CC110X transceiver
+ * @brief   Generate an IPv6 interface identifier for a CC110X transceiver
  *
- * @param dev   Transceiver to create the IPv6 interface identifier (IID)
- * @param iid   Store the generated IID here
+ * @param   dev     Transceiver to create the IPv6 interface identifier (IID)
+ * @param   iid     Store the generated IID here
  *
- * @return      Returns the size of @ref eui64_t to confirm with the API
- *              in @ref netdev_driver_t::get
+ * @return  Returns the size of @ref eui64_t to confirm with the API
+ *          in @ref netdev_driver_t::get
  */
 static int cc110x_get_iid(cc110x_t *dev, eui64_t *iid)
 {
@@ -562,10 +562,10 @@ static int cc110x_get(netdev_t *netdev, netopt_t opt,
 }
 
 /**
- * @brief Set the given address as the device's layer 2 address
+ * @brief   Set the given address as the device's layer 2 address
  *
- * @param dev    Device descripter of the transceiver
- * @param addr   Address to set
+ * @param   dev     Device descripter of the transceiver
+ * @param   addr    Address to set
  */
 static int cc110x_set_addr(cc110x_t *dev, uint8_t addr)
 {

--- a/drivers/cc110x/cc110x_patables.c
+++ b/drivers/cc110x/cc110x_patables.c
@@ -7,17 +7,17 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Default configuration of the transceiver output power for the
- *            different frequency bands
+ * @brief       Default configuration of the transceiver output power for the
+ *              different frequency bands
  *
  * See Section "24 Output Power Programming" on page 59 in the data sheet for
  * details.
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 

--- a/drivers/cc110x/cc110x_rx_tx.c
+++ b/drivers/cc110x/cc110x_rx_tx.c
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Functions to manage sending/receiving frames with the CC110x
+ * @brief       Functions to manage sending/receiving frames with the CC110x
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -49,9 +49,9 @@ void cc110x_enter_rx_mode(cc110x_t *dev)
 }
 
 /**
- * @brief Function to run when frame is fully received
+ * @brief   Function to run when frame is fully received
  *
- * @param dev     Device descriptor of the transceiver
+ * @param   dev     Device descriptor of the transceiver
  *
  * Intended to be called from @ref cc110x_rx_continue
  */
@@ -87,9 +87,9 @@ static netdev_event_t cc110x_rx_done(cc110x_t *dev)
 }
 
 /**
- * @brief Read a chunk of data from the RX-FIFO
+ * @brief   Read a chunk of data from the RX-FIFO
  *
- * @param dev     Device descriptor of the transceiver
+ * @param   dev     Device descriptor of the transceiver
  *
  * This function should be called from the ISR when data in the RX-FIFO is
  * available or the last byte of the frame was received
@@ -187,9 +187,9 @@ static netdev_event_t cc110x_rx_continue(cc110x_t *dev)
 }
 
 /**
- * @brief Function to run when frame is fully send
+ * @brief   Function to run when frame is fully send
  *
- * @param dev     Device descriptor of the transceiver
+ * @param   dev     Device descriptor of the transceiver
  */
 static netdev_event_t cc110x_tx_done(cc110x_t *dev)
 {
@@ -218,9 +218,9 @@ static netdev_event_t cc110x_tx_done(cc110x_t *dev)
 }
 
 /**
- * @brief Refill the TX-FIFO
+ * @brief   Refill the TX-FIFO
  *
- * @param dev     Device descriptor of the transceiver
+ * @param   dev     Device descriptor of the transceiver
  */
 static netdev_event_t cc110x_tx_continue(cc110x_t *dev)
 {

--- a/drivers/cc110x/cc110x_settings.c
+++ b/drivers/cc110x/cc110x_settings.c
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     On-chip settings for the TI CC1100/CC1101 transceiver
+ * @brief       On-chip settings for the TI CC1100/CC1101 transceiver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 

--- a/drivers/cc110x/include/cc110x_calibration.h
+++ b/drivers/cc110x/include/cc110x_calibration.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Calibration related functions of the CC110x transceiver driver
+ * @brief       Calibration related functions of the CC110x transceiver driver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -25,19 +25,19 @@ extern "C" {
 #endif
 
 /**
- * @brief Perform a recalibration of the transceiver
+ * @brief   Perform a recalibration of the transceiver
  *
- * @param dev     The device descriptor of the transceiver
+ * @param   dev     The device descriptor of the transceiver
  *
- * @retval 0      Success
- * @retval -EIO   Failed
+ * @retval  0       Success
+ * @retval  -EIO    Failed
  *
- * @pre           @p dev has been acquired using @ref cc110x_acquire
- * @pre           Transceiver is in IDLE state
- * @post          On success @p dev is still acquired, the caller has to release
- *                it. On failure the SPI bus is **already** **released**
- * @post          Transceiver is again in IDLE state, calibration has been
- *                performed and calibration data has been backed up on MCU.
+ * @pre     @p dev has been acquired using @ref cc110x_acquire
+ * @pre     Transceiver is in IDLE state
+ * @post    On success @p dev is still acquired, the caller has to release
+ *          it. On failure the SPI bus is **already** **released**
+ * @post    Transceiver is again in IDLE state, calibration has been
+ *          performed and calibration data has been backed up on MCU.
  */
 int cc110x_recalibrate(cc110x_t *dev);
 

--- a/drivers/cc110x/include/cc110x_communication.h
+++ b/drivers/cc110x/include/cc110x_communication.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Functions to communicate with the CC1100/CC1101 transceiver
+ * @brief       Functions to communicate with the CC1100/CC1101 transceiver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -30,14 +30,14 @@ extern "C" {
 #endif
 
 /**
- * @brief Acquire the SPI interface of the transceiver and configure it
+ * @brief   Acquire the SPI interface of the transceiver and configure it
  *
- * @retval SPI_OK       Success
- * @retval SPI_NOMODE   SPI mode 0 not supported by MCU
- * @retval SPI_NOCLK    SPI clock given in @ref cc110x_params_t is not supported
+ * @retval  SPI_OK      Success
+ * @retval  SPI_NOMODE  SPI mode 0 not supported by MCU
+ * @retval  SPI_NOCLK   SPI clock given in @ref cc110x_params_t is not supported
  *
- * @pre @ref cc110x_power_on has be called before calling this function.
- *      (Only needed *once* when the driver initializes.)
+ * @pre     @ref cc110x_power_on has be called before calling this function.
+ *          (Only needed *once* when the driver initializes.)
  */
 static inline int cc110x_acquire(cc110x_t *dev)
 {
@@ -46,7 +46,7 @@ static inline int cc110x_acquire(cc110x_t *dev)
 }
 
 /**
- * @brief Release the SPI interface of the transceiver
+ * @brief   Release the SPI interface of the transceiver
  */
 static inline void cc110x_release(cc110x_t *dev)
 {
@@ -54,133 +54,135 @@ static inline void cc110x_release(cc110x_t *dev)
 }
 
 /**
- * @brief Read a single configuration/status register from the transceiver
+ * @brief   Read a single configuration/status register from the transceiver
  *
- * @param dev   Device descriptor of the transceiver to read the register from
- * @param addr  Address of the register to read
- * @param dest  Where to store the received register content
+ * @param   dev     Device descriptor of the transceiver to read the register
+ *                  from
+ * @param   addr    Address of the register to read
+ * @param   dest    Where to store the received register content
  *
- * @return      The received status byte
+ * @return  The received status byte
  *
- * @pre         @p dest points to one byte of writeable memory
- * @warning     Race condition: SPI access to status registers can occur while
- *              their content is changed, resulting in corrupted data being
- *              retrieved. @ref cc110x_read_reliable provides reliable access
- *              to status registers and should be used to read the TXBYTES,
- *              RXBYTES, MARCSTATE, LQI, RSSI, WORTIME1 and WORTIME0 status
- *              registers. (See Silicon Errata from 2015 at pages 4ff.)
- *              (In IDLE state LQI and RSSI can be read safely using this
- *              function.)
- * @warning     The received status byte is occasionally corrupted. (See
- *              Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
- *              To get the status byte in a reliable way.
+ * @pre     @p dest points to one byte of writeable memory
+ * @warning Race condition: SPI access to status registers can occur while
+ *          their content is changed, resulting in corrupted data being
+ *          retrieved. @ref cc110x_read_reliable provides reliable access
+ *          to status registers and should be used to read the TXBYTES,
+ *          RXBYTES, MARCSTATE, LQI, RSSI, WORTIME1 and WORTIME0 status
+ *          registers. (See Silicon Errata from 2015 at pages 4ff.)
+ *          (In IDLE state LQI and RSSI can be read safely using this
+ *          function.)
+ * @warning The received status byte is occasionally corrupted. (See
+ *          Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
+ *          To get the status byte in a reliable way.
  */
 uint8_t cc110x_read(cc110x_t *dev, uint8_t addr, uint8_t *dest);
 
 /**
- * @brief Read a single status register from the transceiver reliable
+ * @brief   Read a single status register from the transceiver reliable
  *
  * This function has more overhead than @ref cc110x_read, but it is the only
  * reliable way to access frequently updated status registers.
  *
- * @param dev   Device descriptor of the transceiver to read the register from
- * @param addr  Address of the register to read
- * @param dest  Where to store the received register content
+ * @param   dev     Device descriptor of the transceiver to read the register
+ *                  from
+ * @param   addr    Address of the register to read
+ * @param   dest    Where to store the received register content
  *
- * @return      The received status byte
+ * @return  The received status byte
  *
- * @pre         @p dest points to one byte of writeable memory
- * @warning     The received status byte is occasionally corrupted. (See
- *              Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
- *              To get the status byte in a reliable way.
+ * @pre     @p dest points to one byte of writeable memory
+ * @warning The received status byte is occasionally corrupted. (See
+ *          Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
+ *          To get the status byte in a reliable way.
  */
 uint8_t cc110x_read_reliable(cc110x_t *dev, uint8_t addr, uint8_t *dest);
 
 /**
- * @brief Write to a single configuration register on the transceiver
+ * @brief   Write to a single configuration register on the transceiver
  *
- * @param dev   Device descriptor of the transceiver to write byte to
- * @param addr  Address of the register to write to
- * @param data  Data to write
+ * @param   dev     Device descriptor of the transceiver to write byte to
+ * @param   addr    Address of the register to write to
+ * @param   data    Data to write
  *
- * @return      The received status byte
+ * @return  The received status byte
  *
- * @pre         @p addr <= 0x2e (@ref CC110X_REG_TEST0)
- * @warning     Writing to status registers is impossible (==> precondition)
- * @warning     The received status byte is occasionally corrupted. (See
- *              Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
- *              To get the status byte in a reliable way.
+ * @pre     @p addr <= 0x2e (@ref CC110X_REG_TEST0)
+ * @warning Writing to status registers is impossible (==> precondition)
+ * @warning The received status byte is occasionally corrupted. (See
+ *          Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
+ *          To get the status byte in a reliable way.
  */
 uint8_t cc110x_write(cc110x_t *dev, uint8_t addr, uint8_t data);
 
 /**
- * @brief Burst-read a bunch of configuration registers from the transceiver
+ * @brief   Burst-read a bunch of configuration registers from the transceiver
  *
- * @param dev   Device descriptor of the transceiver to read from
- * @param addr  Address to start reading from
- * @param dest  Destination buffer to store the received data to
- * @param len   Number of bytes to read starting from @p addr
+ * @param   dev     Device descriptor of the transceiver to read from
+ * @param   addr    Address to start reading from
+ * @param   dest    Destination buffer to store the received data to
+ * @param   len     Number of bytes to read starting from @p addr
  *
- * @return      The received status byte
+ * @return  The received status byte
  *
- * @pre         @p dest points to a pre-allocated buffer of >= @p len bytes
- * @pre         @p addr + @p len <= 0x2e (@ref CC110X_REG_TEST0)
- * @warning     Burst read access from status registers is impossible
- *              (==> second precondition)
- * @warning     The received status byte is occasionally corrupted. (See
- *              Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
- *              To get the status byte in a reliable way.
+ * @pre     @p dest points to a pre-allocated buffer of >= @p len bytes
+ * @pre     @p addr + @p len <= 0x2e (@ref CC110X_REG_TEST0)
+ * @warning Burst read access from status registers is impossible
+ *          (==> second precondition)
+ * @warning The received status byte is occasionally corrupted. (See
+ *          Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
+ *          To get the status byte in a reliable way.
  */
 uint8_t cc110x_burst_read(cc110x_t *dev, uint8_t addr, void *dest, size_t len);
 
 /**
- * @brief Burst-write to a bunch of configuration registers on the transceiver
+ * @brief   Burst-write to a bunch of configuration registers on the transceiver
  *
- * @param dev   Device descriptor of the transceiver to write
- * @param addr  Address to start writing to
- * @param src   Buffer holding the configuration to write
- * @param len   Number of registers to write to
+ * @param   dev     Device descriptor of the transceiver to write
+ * @param   addr    Address to start writing to
+ * @param   src     Buffer holding the configuration to write
+ * @param   len     Number of registers to write to
  *
- * @return      The received status byte
+ * @return  The received status byte
  *
- * @pre         @p src points to @p len bytes of readable memory
- * @pre         @p addr + @p len <= 0x2e (@ref CC110X_REG_TEST0)
- * @warning     Writes to status registers is impossible
- *              (==> second precondition)
- * @warning     The received status byte is occasionally corrupted. (See
- *              Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
- *              to get the status byte in a reliable way.
+ * @pre     @p src points to @p len bytes of readable memory
+ * @pre     @p addr + @p len <= 0x2e (@ref CC110X_REG_TEST0)
+ * @warning Writes to status registers is impossible
+ *          (==> second precondition)
+ * @warning The received status byte is occasionally corrupted. (See
+ *          Silicon Errata from 2015 at pages 4ff.) Use @ref cc110x_status
+ *          to get the status byte in a reliable way.
  */
 uint8_t cc110x_burst_write(cc110x_t *dev, uint8_t addr,
                            const void *src, size_t len);
 
 /**
- * @brief Send a command to the transceiver
+ * @brief   Send a command to the transceiver
  *
- * @param dev        Device descriptor of the transceiver to send the command to
- * @param cmd_strobe Command to send
+ * @param   dev     Device descriptor of the transceiver to send the command to
+ * @param   cmd     Command to send
  *
- * @return           The received status byte
+ * @return  The received status byte
  *
- * @warning          The received status byte is occasionally corrupted. (See
- *                   Silicon Errata from 2015 at pages 4ff.) Use
- *                   @ref cc110x_status to get the status byte in a reliable
- *                   way.
+ * @warning The received status byte is occasionally corrupted. (See
+ *          Silicon Errata from 2015 at pages 4ff.) Use
+ *          @ref cc110x_status to get the status byte in a reliable
+ *          way.
  */
-uint8_t cc110x_cmd(cc110x_t *dev, uint8_t cmd_strobe);
+uint8_t cc110x_cmd(cc110x_t *dev, uint8_t cmd);
 
 /**
- * @brief Get the transceivers status byte in a reliable way
+ * @brief   Get the transceivers status byte in a reliable way
  *
- * @param dev        Device descriptor of the transceiver to get the status from
+ * @param   dev     Device descriptor of the transceiver to get the status from
  *
- * @return           The received status byte
+ * @return  The received status byte
  */
 uint8_t cc110x_status(cc110x_t *dev);
 
 /**
- * @brief Wakes up the transceiver from "Sleep" or "Crystal oscillator off"
- *        state and waits until the crystal has stabilized
+ * @brief   Wakes up the transceiver from "Sleep" or "Crystal oscillator off"
+ *          state and waits until the crystal has stabilized
  *
  * Thus function clears the CS pin, which triggers a transition from the "Sleep"
  * or "Crystal oscillator off" states (see Figure 13 on page 28 in the data
@@ -199,8 +201,8 @@ uint8_t cc110x_status(cc110x_t *dev);
  * of messing with the SPI interface, this driver simply waits for this upper
  * bound, as suggested in the note below Table 22 on page 30 in the data sheet.
  *
- * @retval 0       Success
- * @retval -EIO    Couldn't pull the CS pin down (@ref cc110x_params_t::cs)
+ * @retval  0       Success
+ * @retval  -EIO    Couldn't pull the CS pin down (@ref cc110x_params_t::cs)
  */
 int cc110x_power_on(cc110x_t *dev);
 

--- a/drivers/cc110x/include/cc110x_constants.h
+++ b/drivers/cc110x/include/cc110x_constants.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Constants for the CC1100/CC1101 driver
+ * @brief       Constants for the CC1100/CC1101 driver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 /**
- * @name Command strobes of the CC1100/CC1101 transceiver
+ * @name    Command strobes of the CC1100/CC1101 transceiver
  *
  * See Table 42 on page 67 in the data sheet. Only values relevant to the
  * driver are listed.
@@ -34,62 +34,62 @@ extern "C" {
  */
 
 /**
- * @brief Reset chip (SRES)
+ * @brief   Reset chip (SRES)
  */
 #define CC110X_STROBE_RESET       0x30
 
 /**
- * @brief Calibrate frequency synthesizer and turn it off (SCAL)
+ * @brief   Calibrate frequency synthesizer and turn it off (SCAL)
  */
 #define CC110X_STROBE_CALIBRATE   0x33
 
 /**
- * @brief Go to RX state (SRX)
+ * @brief   Go to RX state (SRX)
  *
  * Requires frequency calibration first
  */
 #define CC110X_STROBE_RX          0x34
 
 /**
- * @brief Go to TX state (STX)
+ * @brief   Go to TX state (STX)
  *
  * Requires frequency calibration first
  */
 #define CC110X_STROBE_TX          0x35
 
 /**
- * @brief Go to IDLE state (SIDLE)
+ * @brief   Go to IDLE state (SIDLE)
  */
 #define CC110X_STROBE_IDLE        0x36
 
 /**
- * @brief Go to power down state once CS goes high (SPWD)
+ * @brief   Go to power down state once CS goes high (SPWD)
  */
 #define CC110X_STROBE_OFF         0x39
 
 /**
- * @brief Flush RX fifo (SFRX)
+ * @brief   Flush RX fifo (SFRX)
  *
  * Only valid in IDLE or in RXFIO_OVERFLOW states
  */
 #define CC110X_STROBE_FLUSH_RX    0x3A
 
 /**
- * @brief Flush TX fifo (SFTX)
+ * @brief   Flush TX fifo (SFTX)
  *
  * Only valid in IDLE or in TXFIO_OVERFLOW states
  */
 #define CC110X_STROBE_FLUSH_TX    0x3B
 
 /**
- * @brief Get the status byte (SNOP)
+ * @brief   Get the status byte (SNOP)
  */
 #define CC110X_STROBE_STATUS      0x3D
 
 /** @} */
 
 /**
- * @name Access modifies for accessing configuration/status registers
+ * @name    Access modifies for accessing configuration/status registers
  *
  * See Table 45 on pages 69ff in the data sheet. These modifies need to be
  * xor'ed with the address of the register.
@@ -98,7 +98,7 @@ extern "C" {
  */
 
 /**
- * @brief Access modifier to write a single byte to a configuration register
+ * @brief   Access modifier to write a single byte to a configuration register
  *
  * | read bit (`0x80`) | burst access bit (`0x40`) |
  * |-------------------|---------------------------|
@@ -107,8 +107,8 @@ extern "C" {
 #define CC110X_SINGLE_BYTE_WRITE  0x00
 
 /**
- * @brief Access modifier to write multiple bytes at once to configuration
- *        registers
+ * @brief   Access modifier to write multiple bytes at once to configuration
+ *          registers
  *
  * | read bit (`0x80`) | burst access bit (`0x40`) |
  * |-------------------|---------------------------|
@@ -117,7 +117,7 @@ extern "C" {
 #define CC110X_BURST_WRITE        0x40
 
 /**
- * @brief Access modifier to read a single byte from a configuration register
+ * @brief   Access modifier to read a single byte from a configuration register
  *
  * | read bit (`0x80`) | burst access bit (`0x40`) |
  * |-------------------|---------------------------|
@@ -126,8 +126,8 @@ extern "C" {
 #define CC110X_SINGLE_BYTE_READ   0x80
 
 /**
- * @brief Access modifier to read multiple bytes at once from configuration
- *        registers
+ * @brief   Access modifier to read multiple bytes at once from configuration
+ *          registers
  *
  * | read bit (`0x80`) | burst access bit (`0x40`) |
  * |-------------------|---------------------------|
@@ -138,7 +138,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name "Multi byte registers" of the CC1100/CC1101 transceiver
+ * @name    "Multi byte registers" of the CC1100/CC1101 transceiver
  *
  * See Table 45 on pages 69ff in the data sheet. These multi byte registers
  * have a special semantics, which is documented for each multi byte register
@@ -147,7 +147,7 @@ extern "C" {
  */
 
 /**
- * @brief Access to the PATABLE as multi byte register
+ * @brief   Access to the PATABLE as multi byte register
  *
  * It is most convenient to read/write the whole 8 bytes of the PATABLE using a
  * burst access. The first single byte access after the CS pin is pulled low
@@ -159,7 +159,7 @@ extern "C" {
 #define CC110X_MULTIREG_PATABLE   0x3E
 
 /**
- * @brief Access to the TX and RX FIFO as multi byte register
+ * @brief   Access to the TX and RX FIFO as multi byte register
  *
  * A single byte read using @ref cc110x_read from the FIFO multi byte register
  * will retrieve and remove the next byte from the RX FIFO. A burst of *n* bytes
@@ -178,7 +178,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name Configuration registers of the CC1100/CC1101 transceiver
+ * @name    Configuration registers of the CC1100/CC1101 transceiver
  *
  * See Table 43 on pages 68ff in the data sheet. Only values relevant to the
  * driver are listed.
@@ -187,80 +187,80 @@ extern "C" {
  */
 
 /**
- * @brief First configuration register on the transceiver, used for burst
- *        access to the whole configuration
+ * @brief   First configuration register on the transceiver, used for burst
+ *          access to the whole configuration
  */
 #define CC110X_CONF_START         0x00
 
 /**
- * @brief GDO2 output pin configuration
+ * @brief   GDO2 output pin configuration
  */
 #define CC110X_REG_IOCFG2         0x00
 
 /**
- * @brief GDO1 output pin configuration
+ * @brief   GDO1 output pin configuration
  */
 #define CC110X_REG_IOCFG1         0x01
 
 /**
- * @brief GDO0 output pin configuration
+ * @brief   GDO0 output pin configuration
  */
 #define CC110X_REG_IOCFG0         0x02
 
 /**
- * @brief Device address
+ * @brief   Device address
  */
 #define CC110X_REG_ADDR           0x09
 
 /**
- * @brief Channel number
+ * @brief   Channel number
  */
 #define CC110X_REG_CHANNR         0x0A
 
 /**
- * @brief Intermediate frequency to use
+ * @brief   Intermediate frequency to use
  */
 #define CC110X_REG_FSCTRL1        0x0B
 
 /**
- * @brief Frequency control word, high byte
+ * @brief   Frequency control word, high byte
  */
 #define CC110X_REG_FREQ2          0x0D
 
 /**
- * @brief Frequency control word, middle byte
+ * @brief   Frequency control word, middle byte
  */
 #define CC110X_REG_FREQ1          0x0E
 
 /**
- * @brief Frequency control word, low byte
+ * @brief   Frequency control word, low byte
  */
 #define CC110X_REG_FREQ0          0x0F
 
 /**
- * @brief Modem configuration (channel filter bandwidth and data rate)
+ * @brief   Modem configuration (channel filter bandwidth and data rate)
  */
 #define CC110X_REG_MDMCFG4        0x10
 
 /**
- * @brief Modem configuration (data rate)
+ * @brief   Modem configuration (data rate)
  */
 #define CC110X_REG_MDMCFG3        0x11
 
 /**
- * @brief Modem deviation setting
+ * @brief   Modem deviation setting
  */
 #define CC110X_REG_DEVIATN        0x15
 
 /**
- * @brief Front End TX Configuration
+ * @brief   Front End TX Configuration
  *
  * Least three significant bits contain the current PA power setting.
  */
 #define CC110X_REG_FREND0         0x22
 
 /**
- * @brief Charge pump current calibration
+ * @brief   Charge pump current calibration
  *
  * This value depends on the environment (e.g. temperature, supply voltage,
  * etc.), but not on the frequency. Thus, this value does not become obsolete
@@ -269,7 +269,7 @@ extern "C" {
 #define CC110X_REG_FSCAL3         0x23
 
 /**
- * @brief VCO current calibration
+ * @brief   VCO current calibration
  *
  * This value depends on the environment (e.g. temperature, supply voltage,
  * etc.), but not on the frequency. Thus, this value does not become obsolete
@@ -278,7 +278,7 @@ extern "C" {
 #define CC110X_REG_FSCAL2         0x24
 
 /**
- * @brief VCO capacitance calibration
+ * @brief   VCO capacitance calibration
  *
  * This value is frequency depended. Thus, for fast channel hopping it has to
  * be obtained for each channel (by performing a calibration on that channel
@@ -288,7 +288,7 @@ extern "C" {
 #define CC110X_REG_FSCAL1         0x25
 
 /**
- * @brief Undocumented frequency calibration value
+ * @brief   Undocumented frequency calibration value
  *
  * For fast channel hopping this value can be ignored (see page 64ff in the
  * data sheet) - so it has to be frequency independent.
@@ -296,34 +296,34 @@ extern "C" {
 #define CC110X_REG_FSCAL0         0x26
 
 /**
- * @brief Unlock the temperature sensor by writing 0xBF to it
+ * @brief   Unlock the temperature sensor by writing 0xBF to it
  *
  * Intended for production test, but who would complain about getting an
  * temperature sensor for free :-)
  *
- * @see @ref CC110X_GDO0_ANALOG_TEMPERATURE for details
+ * @see     @ref CC110X_GDO0_ANALOG_TEMPERATURE for details
  */
 #define CC110X_REG_PTEST          0x2A
 
 /**
- * @brief Magic value obtained with SmartRF Studio software
+ * @brief   Magic value obtained with SmartRF Studio software
  */
 #define CC110X_REG_TEST2          0x2C
 
 /**
- * @brief Magic value obtained with SmartRF Studio software
+ * @brief   Magic value obtained with SmartRF Studio software
  */
 #define CC110X_REG_TEST1          0x2D
 
 /**
- * @brief Magic value obtained with SmartRF Studio software
+ * @brief   Magic value obtained with SmartRF Studio software
  */
 #define CC110X_REG_TEST0          0x2E
 
 /** @} */
 
 /**
- * @name Status registers of the CC1100/CC1101 transceiver
+ * @name    Status registers of the CC1100/CC1101 transceiver
  *
  * See Table 43 on pages 68ff in the data sheet. Only values relevant to the
  * driver are listed.
@@ -336,42 +336,42 @@ extern "C" {
  */
 
 /**
- * @brief Part number
+ * @brief   Part number
  *
  * @warning Not accessible using burst reads
  */
 #define CC110X_REG_PARTNUM        (0x30 | 0x40)
 
 /**
- * @brief Version
+ * @brief   Version
  *
  * @warning Not accessible using burst reads
  */
 #define CC110X_REG_VERSION        (0x31 | 0x40)
 
 /**
- * @brief Estimated link quality
+ * @brief   Estimated link quality
  *
  * @warning Not accessible using burst reads
  */
 #define CC110X_REG_LQI            (0x33 | 0x40)
 
 /**
- * @brief Received signal strength indication
+ * @brief   Received signal strength indication
  *
  * @warning Not accessible using burst reads
  */
 #define CC110X_REG_RSSI           (0x34 | 0x40)
 
 /**
- * @brief Packet status, GDOx status
+ * @brief   Packet status, GDOx status
  *
  * @warning Not accessible using burst reads
  */
 #define CC110X_REG_PKTSTATUS      (0x38 | 0x40)
 
 /**
- * @brief Number of bytes in the TX FIFO
+ * @brief   Number of bytes in the TX FIFO
  *
  * @warning Not accessible using burst reads
  * @warning The received value could be corrupted when reading it while it is
@@ -381,7 +381,7 @@ extern "C" {
 #define CC110X_REG_TXBYTES        (0x3A | 0x40)
 
 /**
- * @brief Number of bytes available in the RX FIFO
+ * @brief   Number of bytes available in the RX FIFO
  *
  * @warning Not accessible using burst reads
  * @warning The received value could be corrupted when reading it while it is
@@ -393,7 +393,8 @@ extern "C" {
 /** @} */
 
 /**
- * @name Possible values for the IOCFG2, IOCFG1, and IOCFG0 configuration registers
+ * @name    Possible values for the IOCFG2, IOCFG1, and IOCFG0 configuration
+ *          registers
  *
  * See Table 41 on page 62 in the data sheet. Only values relevant to the
  * driver are listed.
@@ -402,8 +403,8 @@ extern "C" {
  */
 
 /**
- * @brief GDOx goes HIGH when data has to be read from RX FIFO or when a packet
- *        is fully received
+ * @brief   GDOx goes HIGH when data has to be read from RX FIFO or when a
+ *          packet is fully received
  *
  * Depends on the threshold set for the RX-FIFO in the FIFOTHR configuration
  * register
@@ -411,7 +412,7 @@ extern "C" {
 #define CC110X_GDO_ON_RX_DATA           0x01
 
 /**
- * @brief GDOx goes LOW when data should be written to the TX FIFO
+ * @brief   GDOx goes LOW when data should be written to the TX FIFO
  *
  * Depends on the threshold set for the TX-FIFO in the FIFOTHR configuration
  * register
@@ -419,37 +420,37 @@ extern "C" {
 #define CC110X_GDO_ON_TX_DATA           0x02
 
 /**
- * @brief GDOx goes HIGH when a packet is received/send and back LOW when the
- *        transmission is completed/aborted (e.g. wrong destination address)
+ * @brief   GDOx goes HIGH when a packet is received/send and back LOW when the
+ *          transmission is completed/aborted (e.g. wrong destination address)
  */
 #define CC110X_GDO_ON_TRANSMISSION      0x06
 
 /**
- * @brief GDOx goes HIGH when channel is clear for sending
+ * @brief   GDOx goes HIGH when channel is clear for sending
  *
  * Depends on the CCA_MODE setting in the MCSM1 configuration register
  */
 #define CC110X_GDO_ON_CHANNEL_CLEAR     0x09
 
 /**
- * @brief GDOx goes HIGH when PLL is in lock
+ * @brief   GDOx goes HIGH when PLL is in lock
  *
  */
 #define CC110X_GDO_ON_PLL_IN_LOCK       0x0A
 
 
 /**
- * @brief GDOx remains constantly LOW
+ * @brief   GDOx remains constantly LOW
  */
 #define CC110X_GDO_CONSTANT_LOW         0x2F
 
 /**
- * @brief GDOx remains constantly HIGH
+ * @brief   GDOx remains constantly HIGH
  */
 #define CC110X_GDO_CONSTANT_HIGH        0x6F
 
 /**
- * @brief Repurpose GDO0 as analog temperature sensor in IDLE state
+ * @brief   Repurpose GDO0 as analog temperature sensor in IDLE state
  *
  * This only works with GDO0 and only in IDLE state! Additionally, 0xBF has
  * to be written to configuration register PTEST when in IDLE state. Before
@@ -460,57 +461,59 @@ extern "C" {
 /** @} */
 
 /**
- * @name Bitmasks to access entries in the PKTSTATUS status register
+ * @name    Bitmasks to access entries in the PKTSTATUS status register
  *
  * See page 94 in the data sheet.
  *
  * @{
  */
 /**
- * @brief Bitmask to get the GDO0 state from the PKTSTATUS status register value
+ * @brief   Bitmask to get the GDO0 state from the PKTSTATUS status register
+ *          value
  */
 #define CC110X_PKTSTATUS_GDO0           0x01
 /**
- * @brief Bitmask to get the GDO2 state from the PKTSTATUS status register value
+ * @brief   Bitmask to get the GDO2 state from the PKTSTATUS status register
+ *          value
  */
 #define CC110X_PKTSTATUS_GDO2           0x04
 /**
- * @brief Bitmask to get the SFD bit from the PKTSTATUS status register value
- *        which is set while receiving a frame
+ * @brief   Bitmask to get the SFD bit from the PKTSTATUS status register value
+ *          which is set while receiving a frame
  */
 #define CC110X_PKTSTATUS_RECEIVING      0x08
 /**
- * @brief Bitmask to get the CCA bit from the PKTSTATUS status register value
+ * @brief   Bitmask to get the CCA bit from the PKTSTATUS status register value
  */
 #define CC110X_PKTSTATUS_CCA            0x10
 /**
- * @brief Bitmask to get the Carrier Sense bit from the PKTSTATUS status
- *        register value
+ * @brief   Bitmask to get the Carrier Sense bit from the PKTSTATUS status
+ *          register value
  */
 #define CC110X_PKTSTATUS_CS             0x40
 /** @} */
 
 /**
- * @name Values to write into the PTEST configuration register
+ * @name    Values to write into the PTEST configuration register
  *
  * See page 91 in the data sheet. Only the two documented values are specified.
  *
  * @{
  */
 /**
- * @brief Default value of the PTEST configuration register.
+ * @brief   Default value of the PTEST configuration register.
  */
 #define CC110X_PTEST_DEFAULT            0x7F
 /**
- * @brief Value to write in PTEST when reading the temperature.
+ * @brief   Value to write in PTEST when reading the temperature.
  *
- * @see CC110X_GDO0_ANALOG_TEMPERATURE
+ * @see     CC110X_GDO0_ANALOG_TEMPERATURE
  */
 #define CC110X_PTEST_TEMPERATURE        0xBF
 /** @} */
 
 /**
- * @brief Size of the RX and TX FIFO
+ * @brief   Size of the RX and TX FIFO
  */
 #define CC110X_FIFO_SIZE                64
 

--- a/drivers/cc110x/include/cc110x_internal.h
+++ b/drivers/cc110x/include/cc110x_internal.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Internal functions of the CC110x transceiver driver
+ * @brief       Internal functions of the CC110x transceiver driver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 

--- a/drivers/cc110x/include/cc110x_netdev.h
+++ b/drivers/cc110x/include/cc110x_netdev.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Functions related to the netdev interface of the CC110x driver
+ * @brief       Functions related to the netdev interface of the CC110x driver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -25,14 +25,14 @@ extern "C" {
 #endif
 
 /**
- * @brief RIOT's API to interact with the CC1100/CC1101 driver
+ * @brief   RIOT's API to interact with the CC1100/CC1101 driver
  */
 extern const netdev_driver_t cc110x_driver;
 
 /**
- * @brief Interrupt handler to call on both edges of the GDO0 and GDO2 pins
+ * @brief   Interrupt handler to call on both edges of the GDO0 and GDO2 pins
  *
- * @param dev     The device descriptor of the transceiver
+ * @param   dev     The device descriptor of the transceiver
  *
  * This interrupt handler requests that the cc110x ISR is called in thread
  * context

--- a/drivers/cc110x/include/cc110x_params.h
+++ b/drivers/cc110x/include/cc110x_params.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     cc110x board specific configuration
+ * @brief       cc110x board specific configuration
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
 #ifndef CC110X_PARAMS_H

--- a/drivers/cc110x/include/cc110x_rx_tx.h
+++ b/drivers/cc110x/include/cc110x_rx_tx.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Functions to related to RX/TX of the CC110x transceiver driver
+ * @brief       Functions to related to RX/TX of the CC110x transceiver driver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -25,17 +25,17 @@ extern "C" {
 #endif
 
 /**
- * @brief ISR to be called via @ref netdev_driver_t::isr
+ * @brief   ISR to be called via @ref netdev_driver_t::isr
  */
 void cc110x_isr(netdev_t *dev);
 
 /**
- * @brief Bring transceiver into RX mode
+ * @brief   Bring transceiver into RX mode
  *
- * @param dev     The device descriptor of the transceiver
+ * @param   dev     The device descriptor of the transceiver
  *
- * @pre           @p dev has been acquired using @ref cc110x_acquire
- * @post          @p dev is still acquired, the caller has to release it
+ * @pre     @p dev has been acquired using @ref cc110x_acquire
+ * @post    @p dev is still acquired, the caller has to release it
  */
 void cc110x_enter_rx_mode(cc110x_t *dev);
 

--- a/drivers/cc110x/include/cc110x_settings.h
+++ b/drivers/cc110x/include/cc110x_settings.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @ingroup   drivers_cc110x
+ * @ingroup     drivers_cc110x
  * @{
  *
  * @file
- * @brief     Default settings of the TI CC1100/CC1101 transceiver
+ * @brief       Default settings of the TI CC1100/CC1101 transceiver
  *
- * @author    Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @}
  */
 
@@ -27,23 +27,23 @@ extern "C" {
 #endif
 
 /**
- * @brief The size of the configuration array for CC110X in bytes
+ * @brief   The size of the configuration array for CC110X in bytes
  */
 #define CC110X_CONF_SIZE 41
 
 /**
- * @brief Length of the PATABLE
+ * @brief   Length of the PATABLE
  */
 #define CC110X_PATABLE_LEN 8
 
 /**
- * @brief Configuration register values for CC1100/CC1101 transceivers
+ * @brief   Configuration register values for CC1100/CC1101 transceivers
  */
 extern const char cc110x_conf[CC110X_CONF_SIZE];
 
 /**
- * @brief Magic numbers to write to the TEST2, TEST1 and TEST0 configuration
- *        registers
+ * @brief   Magic numbers to write to the TEST2, TEST1 and TEST0 configuration
+ *          registers
  *
  * Those registers are poorly documented. The data sheet refers to SmartRF
  * Studio to obtain the correct magic numbers. Those values were identical
@@ -55,7 +55,7 @@ extern const char cc110x_conf[CC110X_CONF_SIZE];
 extern const char cc110x_magic_registers[3];
 
 /**
- * @name   Configuration data that specify the 8 available output power levels
+ * @name    Configuration data that specify the 8 available output power levels
  *
  * Source: Table 39 in the data sheet on page 60.
  *
@@ -73,22 +73,22 @@ extern const char cc110x_magic_registers[3];
  * @{
  */
 /**
- * @brief PATABLE values for the 433 MHz band
+ * @brief   PATABLE values for the 433 MHz band
  *
  * Source: Table 39 in the data sheet on page 60.
  */
 extern const cc110x_patable_t cc110x_patable_433mhz;
 /**
- * @brief PATABLE values for the 868 MHz band
+ * @brief   PATABLE values for the 868 MHz band
  *
- * @note  This is the default PATABLE. There is no need to upload this table
- *        unless switching between different PATABLEs is required.
+ * @note    This is the default PATABLE. There is no need to upload this table
+ *          unless switching between different PATABLEs is required.
  *
  * Source: Table 39 in the data sheet on page 60.
  */
 extern const cc110x_patable_t cc110x_patable_868mhz;
 /**
- * @brief PATABLE values for the 915 MHz band
+ * @brief   PATABLE values for the 915 MHz band
  *
  * Source: Table 39 in the data sheet on page 60.
  */
@@ -97,13 +97,13 @@ extern const cc110x_patable_t cc110x_patable_915mhz;
 
 
 /**
- * @name Channel mappings for CC110x transceivers
+ * @name    Channel mappings for CC110x transceivers
  *
  * @{
  */
 /**
- * @brief Channel map for 50 kHz channels with a distance of 200 kHz in the
- *        433 MHz band
+ * @brief   Channel map for 50 kHz channels with a distance of 200 kHz in the
+ *          433 MHz band
  *
  * This channel mapping assumes @ref cc110x_config_433mhz_38kbps_50khz is
  * used as configuration. @ref cc110x_chanmap_433mhz_50khz_alt is an alternative
@@ -113,16 +113,16 @@ extern const cc110x_patable_t cc110x_patable_915mhz;
  */
 extern const cc110x_chanmap_t cc110x_chanmap_433mhz_50khz;
 /**
- * @brief Alternative channel map for 50 kHz channels with a distance of 200 kHz
- *        in the 433 MHz band
- * @see cc110x_chanmap_433mhz_50khz
+ * @brief   Alternative channel map for 50 kHz channels with a distance of 200 kHz
+ *          in the 433 MHz band
+ * @see     cc110x_chanmap_433mhz_50khz
  *
  * This channel mapping assumes @ref cc110x_config_433mhz_38kbps_50khz is
  * used as configuration.
  */
 extern const cc110x_chanmap_t cc110x_chanmap_433mhz_50khz_alt;
 /**
- * @brief Channel map for 5 non-overlapping 300 kHz channels in the 433 MHz band
+ * @brief   Channel map for 5 non-overlapping 300 kHz channels in the 433 MHz band
  *
  * This channel mapping assumes @ref cc110x_config_433mhz_250kbps_300khz is
  * used as configuration. (Note: The distance between channels is in fact
@@ -132,7 +132,7 @@ extern const cc110x_chanmap_t cc110x_chanmap_433mhz_50khz_alt;
  */
 extern const cc110x_chanmap_t cc110x_chanmap_433mhz_300khz;
 /**
- * @brief Channel map for LoRa 868MHz channels 10 to 17 (available as 0 to 7).
+ * @brief   Channel map for LoRa 868MHz channels 10 to 17 (available as 0 to 7).
  *
  * This channel mapping assumes @ref cc110x_config_868mhz_250kbps_300khz is used
  * as configuration.
@@ -141,23 +141,24 @@ extern const cc110x_chanmap_t cc110x_chanmap_868mhz_lora;
 /** @} */
 
 /**
- * @name Base frequency, channel bandwidth and data rate configurations for CC110x transceivers
+ * @name    Base frequency, channel bandwidth and data rate configurations for
+ *          CC110x transceivers
  *
  * @{
  */
 /**
- * @brief CC110x configuration: 433MHz band, 38.4kbps data rate, 50 kHz channel
- *        width
+ * @brief   CC110x configuration: 433MHz band, 38.4kbps data rate, 50 kHz
+ *          channel width
  */
 extern const cc110x_config_t cc110x_config_433mhz_38kbps_50khz;
 /**
- * @brief CC110x configuration: 433MHz band, 250kbps data rate, 300 kHz channel
- *        width
+ * @brief   CC110x configuration: 433MHz band, 250kbps data rate, 300 kHz
+ *          channel width
  */
 extern const cc110x_config_t cc110x_config_433mhz_250kbps_300khz;
 /**
- * @brief CC110x configuration: 868MHz band, 250kbps data rate, 300 kHz channel
- *        width
+ * @brief   CC110x configuration: 868MHz band, 250kbps data rate, 300 kHz
+ *          channel width
  */
 extern const cc110x_config_t cc110x_config_868mhz_250kbps_300khz;
 /** @} */

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -209,30 +209,30 @@ extern "C" {
 #endif
 
 /**
- * @brief Length of a layer 2 frame
+ * @brief   Length of a layer 2 frame
  *
  * This does not include the preamble, sync word, CRC field, and length field.
  */
 #define CC110X_MAX_FRAME_SIZE           0xFF
 
 /**
- * @brief Maximum (layer 2) payload size supported by the driver
+ * @brief   Maximum (layer 2) payload size supported by the driver
  */
 #define CC110X_MAX_PAYLOAD_SIZE         (CC110X_MAX_FRAME_SIZE - CC1XXX_HEADER_SIZE)
 
 /**
- * @brief Maximum number of channels supported by the driver
+ * @brief   Maximum number of channels supported by the driver
  */
 #define CC110X_MAX_CHANNELS             8
 
 /**
- * @brief Special value to indicate that layer 2 address should be derived
- *        from the CPU-ID
+ * @brief   Special value to indicate that layer 2 address should be derived
+ *          from the CPU-ID
  */
 #define CC110X_L2ADDR_AUTO              0x00
 
 /**
- * @brief Default protocol for data that is coming in
+ * @brief   Default protocol for data that is coming in
  */
 #ifdef MODULE_GNRC_SIXLOWPAN
 #define CC110X_DEFAULT_PROTOCOL         (GNRC_NETTYPE_SIXLOWPAN)
@@ -241,7 +241,7 @@ extern "C" {
 #endif
 
 /**
- * @brief The state of the CC1100/CC1101 transceiver
+ * @brief   The state of the CC1100/CC1101 transceiver
  *
  * The three least significant bytes match the representation of the matching
  * transceiver state given in the status byte of the hardware. See Table 32 on
@@ -250,13 +250,13 @@ extern "C" {
 typedef enum {
     CC110X_STATE_IDLE               = 0b00000000,   /**< IDLE state */
     /**
-     * @brief Frame received, waiting for upper layer to retrieve it
+     * @brief   Frame received, waiting for upper layer to retrieve it
      *
      * Transceiver is in IDLE state.
      */
     CC110X_STATE_FRAME_READY        = 0b00001000,
     /**
-     * @brief Frame received, waiting for upper layer to retrieve it
+     * @brief   Frame received, waiting for upper layer to retrieve it
      *
      * Transceiver is in SLEEP state. There is no matching representation in the
      * status byte, as reading the status byte will power up the transceiver in
@@ -266,14 +266,14 @@ typedef enum {
     CC110X_STATE_OFF                = 0b00010000,
     CC110X_STATE_RX_MODE            = 0b00000001,   /**< Listening for frames */
     /**
-     * @brief Receiving a frame just now
+     * @brief   Receiving a frame just now
      *
      * Transceiver is in RX state.
      */
     CC110X_STATE_RECEIVING          = 0b00001001,
     CC110X_STATE_TX_MODE            = 0b00000010,   /**< Transmit mode */
     /**
-     * @brief Waiting for transceiver to complete outgoing transmission
+     * @brief   Waiting for transceiver to complete outgoing transmission
      *
      * Transceiver is in TX state
      */
@@ -301,8 +301,8 @@ typedef enum {
 } cc110x_tx_power_t;
 
 /**
- * @brief Structure that holds the PATABLE, which allows to configure the
- *        8 available output power levels using a magic number for each level.
+ * @brief   Structure that holds the PATABLE, which allows to configure the
+ *          8 available output power levels using a magic number for each level.
  *
  * See Section "24 Output Power Programming" on page 59ff in the data sheet.
  * The values suggested in Table 39 on page 60 in the data sheet are already
@@ -319,7 +319,7 @@ typedef struct {
 
 
 /**
- * @brief Configuration of the transceiver to use
+ * @brief   Configuration of the transceiver to use
  *
  * @warning Two transceivers with different configurations will be unable
  *          to communicate.
@@ -344,9 +344,9 @@ typedef struct {
 typedef struct {
     uint8_t base_freq[3]; /**< Base frequency to use */
     /**
-     * @brief FSCTRL1 configuration register value that affects the
-     *        intermediate frequency of the transceiver to use
-     * @note The 4 most significant bits have to be 0.
+     * @brief   FSCTRL1 configuration register value that affects the
+     *          intermediate frequency of the transceiver to use
+     * @note    The 4 most significant bits have to be 0.
      *
      * Assuming a 26 MHz crystal the IF is calculated as follows (in kHz):
      *
@@ -356,8 +356,8 @@ typedef struct {
      */
     uint8_t fsctrl1;
     /**
-     * @brief MDMCFG4 configuration register value that affects channel filter
-     *        bandwidth and the data rate
+     * @brief   MDMCFG4 configuration register value that affects channel filter
+     *          bandwidth and the data rate
      *
      * See page 76 in the data sheet.
      *
@@ -372,9 +372,9 @@ typedef struct {
      */
     uint8_t mdmcfg4;
     /**
-     * @brief MDMCFG3 configuration register value that affects the data rate
+     * @brief   MDMCFG3 configuration register value that affects the data rate
      *
-     * @see   cc110x_config_t::mdmcfg4
+     * @see     cc110x_config_t::mdmcfg4
      *
      * See page 76 in the data sheet.
      *
@@ -388,8 +388,8 @@ typedef struct {
      */
     uint8_t mdmcfg3;
     /**
-     * @brief DEVIANT configuration register that affects the amount by which
-     *        the radio frequency is shifted in FSK/GFSK modulation
+     * @brief   DEVIANT configuration register that affects the amount by which
+     *          the radio frequency is shifted in FSK/GFSK modulation
      *
      * @see cc110x_config_t::mdmcfg4
      *
@@ -413,7 +413,7 @@ typedef struct {
 } cc110x_config_t;
 
 /**
- * @brief Structure to hold mapping between virtual and physical channel numbers
+ * @brief   Structure to hold mapping between virtual and physical channel numbers
  *
  * This driver will provide "virtual" channel numbers 0 to 7, which will be
  * translated to "physical" channel numbers before being send to the
@@ -442,13 +442,13 @@ typedef struct {
 } cc110x_chanmap_t;
 
 /**
- * @brief Structure holding all parameter for driver initialization
+ * @brief   Structure holding all parameter for driver initialization
  */
 typedef struct {
     const cc110x_patable_t *patable;  /**< Pointer to the PATABLE to use */
     /**
-     * @brief Pointer to the configuration of the base frequency, data rate and
-     *        channel bandwidth; or `NULL` to keep the default.
+     * @brief   Pointer to the configuration of the base frequency, data rate
+     *          and channel bandwidth; or `NULL` to keep the default.
      */
     const cc110x_config_t *config;
     const cc110x_chanmap_t *channels;   /**< Pointer to the default channel map */
@@ -465,12 +465,12 @@ typedef struct {
 } cc110x_params_t;
 
 /**
- * @brief Structure holding the calibration data of the frequency synthesizer
+ * @brief   Structure holding the calibration data of the frequency synthesizer
  */
 typedef struct {
     /**
-     * @brief VCO capacitance calibration, which depends on the frequency and,
-     *        thus, has to be stored for each channel
+     * @brief   VCO capacitance calibration, which depends on the frequency and,
+     *          thus, has to be stored for each channel
      */
     char fscal1[CC110X_MAX_CHANNELS];
     char fscal2;    /**< VCO current calibration, independent of channel */
@@ -478,7 +478,7 @@ typedef struct {
 } cc110x_fs_calibration_t;
 
 /**
- * @brief Buffer to temporary store incoming/outgoing packet
+ * @brief   Buffer to temporary store incoming/outgoing packet
  *
  * The CC1100/CC1101 transceiver's FIFO sadly is only 64 bytes in size. To
  * support frames bigger than that, chunks of the frame have to be
@@ -488,23 +488,24 @@ typedef struct {
 typedef struct __attribute__((packed)) {
     uint8_t len;            /**< Length of the frame in bytes */
     /**
-     * @brief The payload data of the frame
+     * @brief   The payload data of the frame
      */
     uint8_t data[CC110X_MAX_FRAME_SIZE];
     /**
-     * @brief Index of the next @ref cc110x_framebuf_t::data element to transfer
+     * @brief   Index of the next @ref cc110x_framebuf_t::data element to
+     *          transfer
      *
-     * In RX mode: Index of the next @ref cc110x_framebuf_t::data element to store
-     * data read from the RX-FIFO into.
+     * In RX mode: Index of the next @ref cc110x_framebuf_t::data element to
+     * store data read from the RX-FIFO into.
      *
-     * In TX mode: Index of the next @ref cc110x_framebuf_t::data element to write
-     * to the TX-FIFO.
+     * In TX mode: Index of the next @ref cc110x_framebuf_t::data element to
+     * write to the TX-FIFO.
      */
     uint8_t pos;
 } cc110x_framebuf_t;
 
 /**
- * @brief Device descriptor for CC1100/CC1101 transceivers
+ * @brief   Device descriptor for CC1100/CC1101 transceivers
  */
 typedef struct {
     netdev_t netdev;                    /**< RIOT's interface to this driver */
@@ -518,11 +519,11 @@ typedef struct {
     cc110x_params_t params;             /**< Configuration of the driver */
     cc110x_framebuf_t buf;              /**< Temporary frame buffer */
     /**
-     * @brief RSSI and LQI of the last received frame
+     * @brief   RSSI and LQI of the last received frame
      */
     cc1xxx_rx_info_t rx_info;
     /**
-     * @brief Frequency synthesizer calibration data
+     * @brief   Frequency synthesizer calibration data
      */
     cc110x_fs_calibration_t fscal;
     /**
@@ -537,16 +538,16 @@ typedef struct {
 } cc110x_t;
 
 /**
- * @brief Setup the CC1100/CC1101 driver, but perform no initialization
+ * @brief   Setup the CC1100/CC1101 driver, but perform no initialization
  *
  * @ref netdev_driver_t::init can be used after this call to initialize the
  * transceiver.
  *
- * @param dev    Device descriptor to use
- * @param params Parameter of the device to setup
+ * @param   dev     Device descriptor to use
+ * @param   params  Parameter of the device to setup
  *
- * @retval 0       Device successfully set up
- * @retval -EINVAL @p dev or @p params is `NULL`, or @p params is invalid
+ * @retval  0       Device successfully set up
+ * @retval  -EINVAL @p dev or @p params is `NULL`, or @p params is invalid
  */
 int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params);
 
@@ -554,16 +555,17 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params);
  * @brief Apply the given configuration and the given channel map and performs
  *        a recalibration
  *
- * @param dev        Device descriptor of the transceiver
- * @param conf       Configuration to apply or `NULL` to only change channel map
- * @param chanmap    Channel map to apply (must be compatible with @p conf)
+ * @param   dev     Device descriptor of the transceiver
+ * @param   conf    Configuration to apply or `NULL` to only change channel map
+ * @param   chanmap Channel map to apply (must be compatible with @p conf)
  *
- * @retval 0         Success
- * @retval -EINVAL   Called with invalid argument
- * @retval -EIO      Communication with the transceiver failed
+ * @retval  0       Success
+ * @retval  -EINVAL Called with invalid argument
+ * @retval  -EIO    Communication with the transceiver failed
  *
- * @pre The application developer checked in the documentation that the channel
- *      map in @p chanmap is compatible with the configuration in @p conf
+ * @pre     The application developer checked in the documentation that the
+ *          channel map in @p chanmap is compatible with the configuration in
+ *          @p conf
  *
  * Because the configuration (potentially) changes the channel bandwidth, the
  * old channel map is rendered invalid. This API therefore asks for both to make
@@ -575,15 +577,15 @@ int cc110x_apply_config(cc110x_t *dev, const cc110x_config_t *conf,
                         const cc110x_chanmap_t *chanmap);
 
 /**
- * @brief Perform a calibration of the frequency generator for each supported
- *        channel
+ * @brief   Perform a calibration of the frequency generator for each supported
+ *          channel
  *
- * @param dev        Device descriptor of the transceiver
+ * @param   dev     Device descriptor of the transceiver
  *
- * @retval 0         Success
- * @retval -EINVAL   Called with invalid argument
- * @retval -EAGAIN   Current state prevents deliberate calibration
- * @retval -EIO      Communication with the transceiver failed
+ * @retval  0       Success
+ * @retval  -EINVAL Called with invalid argument
+ * @retval  -EAGAIN Current state prevents deliberate calibration
+ * @retval  -EIO    Communication with the transceiver failed
  *
  * Tunes in each supported channel and calibrates the transceiver. The
  * calibration data is stored so that @ref cc110x_set_channel can skip the
@@ -594,16 +596,16 @@ int cc110x_full_calibration(cc110x_t *dev);
 /**
  * @brief Hops to the specified channel
  *
- * @param dev        Device descriptor of the transceiver
- * @param channel    Channel to hop to
+ * @param   dev     Device descriptor of the transceiver
+ * @param   channel Channel to hop to
  *
- * @retval 0         Success
- * @retval -EINVAL   Called with `NULL` as @p dev
- * @retval -ERANGE   Channel out of range or not supported by channel map
- * @retval -EAGAIN   Currently in a state that does not allow hopping, e.g.
- *                   sending/receiving a packet, calibrating or handling
- *                   transmission errors
- * @retval -EIO      Communication with the transceiver failed
+ * @retval  0       Success
+ * @retval  -EINVAL Called with `NULL` as @p dev
+ * @retval  -ERANGE Channel out of range or not supported by channel map
+ * @retval  -EAGAIN Currently in a state that does not allow hopping, e.g.
+ *                  sending/receiving a packet, calibrating or handling
+ *                  transmission errors
+ * @retval  -EIO    Communication with the transceiver failed
  *
  * This function implements the fact channel hopping approach outlined in
  * section 28.2 on page 64 in the data sheet, which skips the calibration phase
@@ -612,16 +614,16 @@ int cc110x_full_calibration(cc110x_t *dev);
 int cc110x_set_channel(cc110x_t *dev, uint8_t channel);
 
 /**
- * @brief Set the TX power to the specified value
+ * @brief   Set the TX power to the specified value
  *
- * @param dev        Device descriptor of the transceiver
- * @param power      Output power to apply
+ * @param   dev     Device descriptor of the transceiver
+ * @param   power   Output power to apply
  *
- * @retval 0         Success
- * @retval -EINVAL   Called with `NULL` as @p dev
- * @retval -ERANGE   Called with an invalid value for @p power
- * @retval -EAGAIN   Changing the TX power is in the current state not possible
- * @retval -EIO      Communication with the transceiver failed
+ * @retval  0       Success
+ * @retval  -EINVAL Called with `NULL` as @p dev
+ * @retval  -ERANGE Called with an invalid value for @p power
+ * @retval  -EAGAIN Changing the TX power is in the current state not possible
+ * @retval  -EIO    Communication with the transceiver failed
  */
 int cc110x_set_tx_power(cc110x_t *dev, cc110x_tx_power_t power);
 


### PR DESCRIPTION
### Contribution description

The Doxygen documentation blocks have not been correctly aligned. This commit fixes this.

### Testing procedure

Check that this PR indeed only touches comments. (And one parameter is renamed, as it was to long.) If no code has been touched, this PR will not break anything.

and/or

Build some network application, e.g. `examples/gnrc_networking` with the `cc110x` module used (e.g. by building for the `msba2` or the `msbiot`). The binary before and after applying this PR should be identical, as no code was changed.

### Issues/PRs references

None