### PR TITLE
cpu/esp32: fix documentation about toolchain installation

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -332,11 +332,11 @@ ESP-IDF, the official SDK from Espressif, can be downloaded and installed as GIT
 
 ```
 cd $HOME/esp
-git clone --recursive https://github.com/espressif/esp-idf.git
+git clone https://github.com/espressif/esp-idf.git
 cd esp-idf
-git checkout -q f198339ec09e90666150672884535802304d23ec
-cd components/esp32/lib
-git checkout -q 534a9b14101af90231d40a4f94924d67bc848d5f
+git checkout f198339ec09e90666150672884535802304d23ec
+git submodule init
+git submodule update
 ```
 
 @note Please take care to checkout correct branches which were used for the port. Newer versions might also work but were not tested.


### PR DESCRIPTION
### Contribution description

It looks like the submodule folders in esp-idf got renamed, this breaks the instructions in the documentation as it instructs the user to get them all to the latest state immediately (`git clone --recursive`):

```
$ git clone --recursive https://github.com/espressif/esp-idf.git # checks out all the submodules to the current state/name
$ cd esp-idf
$ git checkout -q f198339ec09e90666150672884535802304d23ec # uh oh
warning: unable to rmdir 'components/asio/asio': Directory not empty
warning: unable to rmdir 'components/bootloader/subproject/components/micro-ecc/micro-ecc': Directory not empty
warning: unable to rmdir 'components/bt/controller/lib': Directory not empty
warning: unable to rmdir 'components/bt/host/nimble/nimble': Directory not empty
warning: unable to rmdir 'components/cbor/tinycbor': Directory not empty
warning: unable to rmdir 'components/esp_wifi/lib_esp32': Directory not empty
warning: unable to rmdir 'components/expat/expat': Directory not empty
warning: unable to rmdir 'components/lwip/lwip': Directory not empty
warning: unable to rmdir 'components/mqtt/esp-mqtt': Directory not empty
warning: unable to rmdir 'components/protobuf-c/protobuf-c': Directory not empty
warning: unable to rmdir 'components/unity/unity': Directory not empty
warning: unable to rmdir 'examples/build_system/cmake/import_lib/main/lib/tinyxml2': Directory not empty
$ cd components/esp32/lib
$ git checkout -q 534a9b14101af90231d40a4f94924d67bc848d5f

fatal: reference is not a tree: 534a9b14101af90231d40a4f94924d67bc848d5f
```

Now when trying to build e.g. `examples/gnrc_networking`, this results in errors that the libraries can not be found for linking, the build fails.

If instead we checkout the submodules *after* bringing the main repo to a known state, things work again

### Testing procedure
Follow the instructions for installing the toolchain:

```bash
mkdir -p $HOME/esp
cd $HOME/esp
git clone https://github.com/gschorcht/xtensa-esp32-elf.git

git clone https://github.com/espressif/esp-idf.git
cd esp-idf
git checkout f198339ec09e90666150672884535802304d23ec
git submodule init
git submodule update
# the submodule are now already in a known good state, no extra checkout needed
```

In RIOT, do
```bash
export PATH=$HOME/esp/xtensa-esp32-elf/bin:$PATH
export ESP32_SDK_DIR=$HOME/esp/esp-idf

sed -i '1iUSEMODULE += esp_wifi' examples/gnrc_networking/Makefile
make -j BOARD=esp32-wroom-32 -C examples/gnrc_networking
```

### Issues/PRs references
discovered when testing #11997