### PR TITLE
Cifra: initial import of package

### DIFF
--- a/pkg/cifra/Makefile
+++ b/pkg/cifra/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=cifra
+PKG_URL=https://github.com/ctz/cifra
+PKG_VERSION=cfa6df9ca0007abe3c70409d02b3779ac1742297
+PKG_LICENSE=CC-0
+
+.PHONY: all
+
+all:
+	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.cifra
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cifra/Makefile.cifra
+++ b/pkg/cifra/Makefile.cifra
@@ -1,0 +1,30 @@
+MODULE := cifra
+
+CFLAGS += -Wno-pedantic
+
+SRC += aes.c
+SRC += sha256.c
+SRC += sha512.c
+SRC += chash.c
+SRC += hmac.c
+SRC += pbkdf2.c
+SRC += modes.c
+SRC += eax.c
+SRC += gf128.c
+SRC += blockwise.c
+SRC += cmac.c
+SRC += salsa20.c
+SRC += chacha20.c
+SRC += curve25519.c
+SRC += gcm.c
+SRC += cbcmac.c
+SRC += ccm.c
+SRC += sha3.c
+SRC += sha1.c
+SRC += poly1305.c
+SRC += norx.c
+SRC += chacha20poly1305.c
+SRC += drbg.c
+SRC += ocb.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/cifra/Makefile.include
+++ b/pkg/cifra/Makefile.include
@@ -1,0 +1,2 @@
+INCLUDES += -I$(PKGDIRBASE)/cifra/src
+INCLUDES += -I$(PKGDIRBASE)/cifra/src/ext

--- a/pkg/cifra/doc.txt
+++ b/pkg/cifra/doc.txt
@@ -1,0 +1,26 @@
+/**
+ * @defgroup pkg_cifra Cifra cryptographic library
+ * @ingroup  pkg
+ * @brief    Provides the Cifra cryptographic library.
+ *
+ * # Cifra RIOT package
+ *
+ * Cifra is a collection of cryptographic primitives targeted at embedded use.
+ *
+ * You can find the API and more information
+ * [here](https://cifra.readthedocs.org/en/latest/)
+ *
+ * ## Requirements
+ *
+ * @note    Cifra only supports 32bit platforms.
+ *
+ * ## Usage
+ *
+ * Just add it as a package in your application:
+ *
+ * ```makefile
+ * USEPKG += cifra
+ * ```
+ *
+ * @see		https://github.com/ctz/cifra
+ */

--- a/pkg/cifra/patches/0001-Replace-typeof-with-__typeof__-for-compatibility.patch
+++ b/pkg/cifra/patches/0001-Replace-typeof-with-__typeof__-for-compatibility.patch
@@ -1,0 +1,53 @@
+From 16a6d98096f5cc15a5716b665341fd22d04ec426 Mon Sep 17 00:00:00 2001
+From: Koen Zandberg <koen@bergzand.net>
+Date: Thu, 5 Sep 2019 09:45:50 +0200
+Subject: [PATCH 1/2] Replace typeof with __typeof__ for compatibility
+
+---
+ src/ext/handy.h | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/ext/handy.h b/src/ext/handy.h
+index a9b2d9d..d7d9dd4 100644
+--- a/src/ext/handy.h
++++ b/src/ext/handy.h
+@@ -15,14 +15,14 @@
+ /* Normal MIN/MAX macros.  Evaluate argument expressions only once. */
+ #ifndef MIN
+   #define MIN(x, y) \
+-    ({ typeof (x) __x = (x); \
+-       typeof (y) __y = (y); \
++    ({ __typeof__ (x) __x = (x); \
++       __typeof__ (y) __y = (y); \
+        __x < __y ? __x : __y; })
+ #endif
+ #ifndef MAX
+   #define MAX(x, y) \
+-    ({ typeof (x) __x = (x); \
+-       typeof (y) __y = (y); \
++    ({ __typeof__ (x) __x = (x); \
++       __typeof__ (y) __y = (y); \
+        __x > __y ? __x : __y; })
+ #endif
+ 
+@@ -30,7 +30,7 @@
+ #ifndef SWAP
+   #define SWAP(x, y) \
+     do { \
+-      typeof (x) __tmp = (x); \
++      __typeof__ (x) __tmp = (x); \
+       (x) = (y); \
+       (y) = __tmp; \
+     } while (0)
+@@ -48,7 +48,7 @@
+ /** Error: return. 
+  *  
+  *  If the expression fails, return the error from this function. */
+-#define ER(expr) do { typeof (expr) err_ = (expr); if (err_) return err_; } while (0)
++#define ER(expr) do { __typeof__ (expr) err_ = (expr); if (err_) return err_; } while (0)
+ 
+ /** Error: goto.
+  *
+-- 
+2.21.0
+

--- a/pkg/cifra/patches/0002-replace-struct-initializer-for-c99-compatibility.patch
+++ b/pkg/cifra/patches/0002-replace-struct-initializer-for-c99-compatibility.patch
@@ -1,0 +1,26 @@
+From 4d3f2070b013036f0d936cda0b9262e8a8445b2e Mon Sep 17 00:00:00 2001
+From: Koen Zandberg <koen@bergzand.net>
+Date: Thu, 5 Sep 2019 09:46:10 +0200
+Subject: [PATCH 2/2] replace struct initializer for c99 compatibility
+
+---
+ src/ocb.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/ocb.c b/src/ocb.c
+index 3d244d4..fb6d822 100644
+--- a/src/ocb.c
++++ b/src/ocb.c
+@@ -163,7 +163,8 @@ static void ocb_hash_block(void *vctx, const uint8_t *block)
+ static void ocb_process_header(ocb *o, const uint8_t *header, size_t nheader,
+                                uint8_t out[BLOCK])
+ {
+-  ocb_hash ctx = { o };
++  ocb_hash ctx = { 0 };
++  ctx.o = o;
+   ocb_hash_init(&ctx);
+ 
+   uint8_t partial[BLOCK];
+-- 
+2.21.0
+

--- a/tests/pkg_cifra/Makefile
+++ b/tests/pkg_cifra/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.tests_common
+
+# No 8 bit and 16 bit support
+BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
+                   arduino-mega2560 arduino-nano \
+                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
+                   wsn430-v1_4 z1
+
+USEMODULE += embunit
+USEMODULE += random
+USEPKG += cifra
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_cifra/main.c
+++ b/tests/pkg_cifra/main.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Tests cifra package
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "embUnit.h"
+#include "random.h"
+#include "aes.h"
+#include "modes.h"
+
+#define SECRET_KEY_LEN  32
+
+static uint8_t message[] = "0123456789abcdef";
+static uint8_t nonce[] = "0123456789abcdef";
+
+static uint8_t cipher[sizeof(message)];
+static uint8_t tag[16];
+
+static uint8_t decrypted[sizeof(message)];
+
+static uint8_t key[SECRET_KEY_LEN];
+
+static void setUp(void)
+{
+    /* Initialize */
+    random_init(0);
+
+    random_bytes(key, SECRET_KEY_LEN);
+}
+
+static void test_cifra_gcm(void)
+{
+    cf_aes_context aes;
+    cf_aes_init(&aes, key, SECRET_KEY_LEN);
+
+    cf_gcm_encrypt(&cf_aes, &aes,
+                   message, sizeof(message),
+                   NULL, 0,
+                   nonce, sizeof(nonce),
+                   cipher,
+                   tag, 16);
+
+    int res = cf_gcm_decrypt(&cf_aes, &aes,
+                             cipher, sizeof(message),
+                             NULL, 0,
+                             nonce, sizeof(nonce),
+                             tag, 16,
+                             decrypted);
+
+    TEST_ASSERT(res == 0);
+    TEST_ASSERT_EQUAL_STRING((char *)message, (char *)decrypted);
+
+    /* Flip bit in the ciphertext */
+    cipher[0] ^= 0x01;
+
+    res = cf_gcm_decrypt(&cf_aes, &aes,
+                         cipher, sizeof(message),
+                         NULL, 0,
+                         nonce, sizeof(nonce),
+                         tag, 16,
+                         decrypted);
+
+    TEST_ASSERT(res == 1);
+
+    /* Flip bit in the ciphertext back */
+    cipher[0] ^= 0x01;
+
+    /* Flip bit in the key */
+    key[0] ^= 0x01;
+
+    /* Reimport the key */
+    cf_aes_init(&aes, key, SECRET_KEY_LEN);
+
+    res = cf_gcm_decrypt(&cf_aes, &aes,
+                         cipher, sizeof(message),
+                         NULL, 0,
+                         nonce, sizeof(nonce),
+                         tag, 16,
+                         decrypted);
+
+    TEST_ASSERT(res == 1);
+}
+
+Test *tests_cifra(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_cifra_gcm),
+    };
+
+    EMB_UNIT_TESTCALLER(cifra_tests, setUp, NULL, fixtures);
+    return (Test*)&cifra_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_cifra());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/pkg_cifra/tests/01-run.py
+++ b/tests/pkg_cifra/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r"OK \(\d+ tests\)")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
Another PR, another crypto package.

### Contribution description

[Cifra] is a cryptographic library providing AES, including a number of authenticated modes, SHA2, SHA3, chacha20poly1305 and NORX authenticated encryption modes.

Initial measurements show low flash usage, 3.8KB on a samr21-xpro for the full AES-GCM implementation.

### Testing procedure

Test provided in `tests/pkg_cifra`. Only aes-gcm is validated at the moment.

### Issues/PRs references

None

[Cifra]: https://github.com/ctz/cifra