### PR TITLE
pkg/nimble/scanner: pass adv pkt type to callback

### DIFF
--- a/pkg/nimble/scanlist/include/nimble_scanlist.h
+++ b/pkg/nimble/scanlist/include/nimble_scanlist.h
@@ -52,6 +52,7 @@ typedef struct {
     uint32_t adv_msg_cnt;           /**< number of adv packets by a node */
     uint32_t first_update;          /**< first packet timestamp */
     uint32_t last_update;           /**< last packet timestamp */
+    uint8_t type;                   /**< advertising packet type */
 } nimble_scanlist_entry_t;
 
 /**
@@ -64,12 +65,13 @@ void nimble_scanlist_init(void);
  *
  * If the list is already full, the scanned node is simply ignored.
  *
+ * @param[in]  type     type of the advertising packet received
  * @param[in]  addr     BLE address of the scanned node
  * @param[in]  rssi     RSSI of the received advertising packet
  * @param[in]  ad       the payload of the advertising packet
  * @param[in]  len      length of @p ad
  */
-void nimble_scanlist_update(const ble_addr_t *addr, int8_t rssi,
+void nimble_scanlist_update(uint8_t type, const ble_addr_t *addr, int8_t rssi,
                             const uint8_t *ad, size_t len);
 
 /**

--- a/pkg/nimble/scanlist/nimble_scanlist.c
+++ b/pkg/nimble/scanlist/nimble_scanlist.c
@@ -64,7 +64,7 @@ nimble_scanlist_entry_t *nimble_scanlist_get_by_pos(unsigned pos)
     return e;
 }
 
-void nimble_scanlist_update(const ble_addr_t *addr, int8_t rssi,
+void nimble_scanlist_update(uint8_t type, const ble_addr_t *addr, int8_t rssi,
                             const uint8_t *ad, size_t len)
 {
     assert(addr);
@@ -87,6 +87,7 @@ void nimble_scanlist_update(const ble_addr_t *addr, int8_t rssi,
         e->last_rssi = rssi;
         e->first_update = now;
         e->adv_msg_cnt = 1;
+        e->type = type;
         clist_rpush(&_list, (clist_node_t *)e);
     }
     else {

--- a/pkg/nimble/scanlist/nimble_scanlist_print.c
+++ b/pkg/nimble/scanlist/nimble_scanlist_print.c
@@ -21,6 +21,7 @@
 
 #include "net/bluetil/ad.h"
 #include "nimble_scanlist.h"
+#include "nimble/hci_common.h"
 
 static void _print_addr(const ble_addr_t *addr)
 {
@@ -29,11 +30,35 @@ static void _print_addr(const ble_addr_t *addr)
         printf(":%02x", addr->val[i]);
     }
     switch (addr->type) {
-        case BLE_ADDR_PUBLIC:       printf(" (PUBLIC) ");   break;
-        case BLE_ADDR_RANDOM:       printf(" (RANDOM) ");   break;
-        case BLE_ADDR_PUBLIC_ID:    printf(" (PUB_ID) ");   break;
+        case BLE_ADDR_PUBLIC:       printf(" (PUBLIC)");   break;
+        case BLE_ADDR_RANDOM:       printf(" (RANDOM)");   break;
+        case BLE_ADDR_PUBLIC_ID:    printf(" (PUB_ID)");   break;
         case BLE_ADDR_RANDOM_ID:    printf(" (RAND_ID)");  break;
         default:                    printf(" (UNKNOWN)");  break;
+    }
+}
+
+static void _print_type(uint8_t type)
+{
+    switch (type) {
+        case BLE_HCI_ADV_TYPE_ADV_IND:
+            printf(" [IND]");
+            break;
+        case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_HD:
+            printf(" [DIRECT_IND_HD]");
+            break;
+        case BLE_HCI_ADV_TYPE_ADV_SCAN_IND:
+            printf(" [SCAN_IND]");
+            break;
+        case BLE_HCI_ADV_TYPE_ADV_NONCONN_IND:
+            printf(" [NONCONN_IND]");
+            break;
+        case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD:
+            printf(" [DIRECT_IND_LD]");
+            break;
+        default:
+            printf(" [INVALID]");
+            break;
     }
 }
 
@@ -65,6 +90,7 @@ void nimble_scanlist_print_entry(nimble_scanlist_entry_t *e)
     }
 
     _print_addr(&e->addr);
+    _print_type(e->type);
     unsigned adv_int = ((e->last_update - e->first_update) / e->adv_msg_cnt);
     printf(" \"%s\", adv_msg_cnt: %u, adv_int: %uus, last_rssi: %i\n",
            name, (unsigned)e->adv_msg_cnt, adv_int, (int)e->last_rssi);

--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -42,8 +42,15 @@ enum {
 /**
  * @brief   Callback signature triggered by this module for each discovered
  *          advertising packet
+ *
+ * @param[in] type      type of advertising packet, e.g BLE_HCI_ADV_TYPE_ADV_IND
+ * @param[in] addr      advertising address of the source node
+ * @param[in] rssi      RSSI value for the received packet
+ * @param[in] ad        advertising data
+ * @param[in] ad_len    length of @p ad in bytes
  */
-typedef void(*nimble_scanner_cb)(const ble_addr_t *addr, int8_t rssi,
+typedef void(*nimble_scanner_cb)(uint8_t type,
+                                 const ble_addr_t *addr, int8_t rssi,
                                  const uint8_t *ad, size_t ad_len);
 
 /**

--- a/pkg/nimble/scanner/nimble_scanner.c
+++ b/pkg/nimble/scanner/nimble_scanner.c
@@ -35,7 +35,7 @@ static int _on_scan_evt(struct ble_gap_event *event, void *arg)
 {
     /* only interested in the DISC event */
     if (event->type == BLE_GAP_EVENT_DISC) {
-        _disc_cb(&event->disc.addr, event->disc.rssi,
+        _disc_cb(event->disc.event_type, &event->disc.addr, event->disc.rssi,
                  event->disc.data, (size_t)event->disc.length_data);
     }
     else {


### PR DESCRIPTION
### Contribution description
The NimBLE GAP event triggered on receiving advertising packets (`BLE_GAP_EVENT_DISC`) includes a field denoting the actual type of the advertising message received. This could be a simple `ADV_IND`, but also includes packets like `SCAN_IND` or `NONCONN_IND`. Passing this information to the callback registered with the `nimble_scanner` is quite useful to filter out a certain group of packets before starting to actually looking at their payload, and therefore saving some energy.

This PR adds this packet type field as parameter to the callback function passed to the `nimble_scanner` module. The PR also includes the corresponding adaptation for the `nimble_scanlist` module, so this new information is also saved in the scanlist and printed on demand.

### Testing procedure
Build, flash, and run the `examples/nimble_scanner` application: you should see the pkt type printed out with the scan results.

### Issues/PRs references
none