### PR TITLE
[gnrc_icmpv6_error] Fixed multicast detection

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -243,7 +243,7 @@ static gnrc_pktsnip_t *_check_ipv6_hdr(const gnrc_pktsnip_t *orig_pkt)
     const ipv6_hdr_t *ipv6_hdr = ipv6->data;
 
     if (ipv6_addr_is_unspecified(&ipv6_hdr->src) ||
-        ipv6_addr_is_multicast(&ipv6_hdr->src)) {
+        ipv6_addr_is_multicast(&ipv6_hdr->dst)) {
         ipv6 = NULL;
     }
     return ipv6;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixed gnrc_icmpv6_error.c multicast detection.
When sending a multicast udp packet, icmpv6_errors shouldn't be reported back to the sender.
Currently the src address is being checked for multicast, but it should be the dst address.


### Testing procedure

Send UDP packet to ff02::1 without having a receiver registered/the UDP server started in gnrc_networking on the other nodes. This will lead to errors being send back. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
