### PR TITLE
drivers/cc110x: Fixed documentaion

### DIFF
--- a/drivers/cc110x/include/cc110x_calibration.h
+++ b/drivers/cc110x/include/cc110x_calibration.h
@@ -14,7 +14,6 @@
  * @brief       Calibration related functions of the CC110x transceiver driver
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
- * @}
  */
 
 #ifndef CC110X_CALIBRATION_H

--- a/drivers/cc110x/include/cc110x_communication.h
+++ b/drivers/cc110x/include/cc110x_communication.h
@@ -14,7 +14,6 @@
  * @brief       Functions to communicate with the CC1100/CC1101 transceiver
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
- * @}
  */
 
 #ifndef CC110X_COMMUNICATION_H

--- a/drivers/cc110x/include/cc110x_constants.h
+++ b/drivers/cc110x/include/cc110x_constants.h
@@ -14,7 +14,6 @@
  * @brief       Constants for the CC1100/CC1101 driver
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
- * @}
  */
 
 #ifndef CC110X_CONSTANTS_H

--- a/drivers/cc110x/include/cc110x_internal.h
+++ b/drivers/cc110x/include/cc110x_internal.h
@@ -14,7 +14,6 @@
  * @brief       Internal functions of the CC110x transceiver driver
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
- * @}
  */
 
 #ifndef CC110X_INTERNAL_H

--- a/drivers/cc110x/include/cc110x_netdev.h
+++ b/drivers/cc110x/include/cc110x_netdev.h
@@ -14,7 +14,6 @@
  * @brief       Functions related to the netdev interface of the CC110x driver
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
- * @}
  */
 
 #ifndef CC110X_NETDEV_H

--- a/drivers/cc110x/include/cc110x_params.h
+++ b/drivers/cc110x/include/cc110x_params.h
@@ -33,42 +33,64 @@ extern "C" {
  * @{
  */
 #ifndef CC110X_PARAM_SPI
-#define CC110X_PARAM_SPI            SPI_DEV(0)
+#define CC110X_PARAM_SPI            SPI_DEV(0)      /**< SPI bus connected to CC110x */
 #endif
 
 #ifndef CC110X_PARAM_CS
-#define CC110X_PARAM_CS             GPIO_PIN(1, 21)
+#define CC110X_PARAM_CS             GPIO_PIN(1, 21) /**< SPI-CS connected to CC110x */
 #endif
 
 #ifndef CC110X_PARAM_GDO0
-#define CC110X_PARAM_GDO0           GPIO_PIN(0, 27)
+#define CC110X_PARAM_GDO0           GPIO_PIN(0, 27) /**< GPIO connected to CC110x' GDO0 pin */
 #endif
 
 #ifndef CC110X_PARAM_GDO2
-#define CC110X_PARAM_GDO2           GPIO_PIN(0, 28)
+#define CC110X_PARAM_GDO2           GPIO_PIN(0, 28) /**< GPIO connected to CC110x's GDO2 pin */
 #endif
 
 #ifndef CC110X_PARAM_SPI_CLOCK
-#define CC110X_PARAM_SPI_CLOCK      SPI_CLK_5MHZ
+#define CC110X_PARAM_SPI_CLOCK      SPI_CLK_5MHZ    /**< SPI clock frequence to use */
 #endif
 
 #ifndef CC110X_PARAM_L2ADDR
+/**
+ * @brief   L2 address configure when the driver is initialized
+ */
 #define CC110X_PARAM_L2ADDR         CC110X_L2ADDR_AUTO
 #endif
 
 #ifndef CC110X_PARAM_PATABLE
+/**
+ * @brief   PA table to use
+ *
+ * Choose the one matching the base frequency your transceiver uses, otherwise
+ * the TX power setting will be incorrect.
+ */
 #define CC110X_PARAM_PATABLE        (&cc110x_patable_868mhz)
 #endif
 
 #ifndef CC110X_PARAM_CONFIG
+/**
+ * @brief   Default config to apply
+ *
+ * If 868 MHz is used as base frequency, you can set this to `NULL`
+ */
 #define CC110X_PARAM_CONFIG         NULL
 #endif
 
 #ifndef CC110X_PARAM_CHANNELS
+/**
+ * @brief   Default channel map to use
+ *
+ * This must match to configuration you have chosen
+ */
 #define CC110X_PARAM_CHANNELS       (&cc110x_chanmap_868mhz_lora)
 #endif
 
 #ifndef CC110X_PARAMS
+/**
+ * @brief   Default initialization parameters of the CC110x driver
+ */
 #define CC110X_PARAMS               { \
         .spi      = CC110X_PARAM_SPI,  \
         .spi_clk  = CC110X_PARAM_SPI_CLOCK, \
@@ -85,8 +107,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name    CC110X configuration
- * @brief   Specifies the SPI bus and GPIOs connected to the CC110X transceiver
+ * @brief   CC110X initialization parameters
  */
 static const cc110x_params_t cc110x_params[] = {
     CC110X_PARAMS

--- a/drivers/cc110x/include/cc110x_rx_tx.h
+++ b/drivers/cc110x/include/cc110x_rx_tx.h
@@ -14,7 +14,6 @@
  * @brief       Functions to related to RX/TX of the CC110x transceiver driver
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
- * @}
  */
 
 #ifndef CC110X_RX_TX_H

--- a/drivers/cc110x/include/cc110x_settings.h
+++ b/drivers/cc110x/include/cc110x_settings.h
@@ -14,7 +14,6 @@
  * @brief       Default settings of the TI CC1100/CC1101 transceiver
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
- * @}
  */
 
 #ifndef CC110X_SETTINGS_H


### PR DESCRIPTION
### Contribution description

- Fixed unbalanced Doxygen "open doc group" (`@{`) and "close doc group" (`@}`) commands
- Added missing documentation the current release of Doxygen complains about

### Testing procedure

Run `make doc` with the current doxygen release. There should be no warnings related to `drivers/cc110x` anymore. (Be prepared to receive a **lot** of warnings unrelated to this PR.)

### Issues/PRs references

None