### PR TITLE
nrfusb: Check chip revision before enabling

### DIFF
--- a/cpu/nrf52/periph/usbdev.c
+++ b/cpu/nrf52/periph/usbdev.c
@@ -269,6 +269,9 @@ void usbdev_init_lowlevel(void)
 static void _init(usbdev_t *dev)
 {
     DEBUG("nrfusb: initializing\n");
+    /* Engineering revision version A is affected by errata 94, crash *
+     * instead of pretending to have functional USB                   */
+    assert(NRF_FICR->INFO.VARIANT != 0x41414141);
     nrfusb_t *usbdev = (nrfusb_t*)dev;
     poweron(usbdev);
     usbdev->used = 0;


### PR DESCRIPTION
### Contribution description

Engineering sample A doesn't have a functional USB peripheral (errata
issue 94). This commit adds an assertion check for this revision to
prevent some developer headaches.

### Testing procedure

Find an engineering revision A board and flash `examples/usbus_minimal` on it. It should throw an assertion failure on boot. It must not throw an assertion failure on any other version.

### Issues/PRs references

None