### PR TITLE
sys/arduino: Using Arduino libraries

### DIFF
--- a/pkg/talking_leds/Makefile
+++ b/pkg/talking_leds/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=talking_leds
+PKG_URL=https://github.com/fabriziop/TalkingLED
+PKG_VERSION=8ae4f2d0b736aa338f24e097dbaf876fbb385dbd
+PKG_LICENSE=MIT
+
+.PHONY: all
+
+all:
+	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.talking_leds
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/talking_leds/Makefile.dep
+++ b/pkg/talking_leds/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += arduino

--- a/pkg/talking_leds/Makefile.include
+++ b/pkg/talking_leds/Makefile.include
@@ -1,0 +1,3 @@
+INCLUDES += -I$(PKGDIRBASE)/talking_leds/src
+
+CXXEXFLAGS += -std=c++11

--- a/pkg/talking_leds/Makefile.talking_leds
+++ b/pkg/talking_leds/Makefile.talking_leds
@@ -1,0 +1,3 @@
+MODULE = talking_leds
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/talking_leds/doc.txt
+++ b/pkg/talking_leds/doc.txt
@@ -1,0 +1,6 @@
+/**
+ * @defgroup pkg_talking_leds Talking LEDs - Arduino library for demonstration
+ * @ingroup  pkg
+ * @brief    Demonstrates the usage of Arduino libraries as packages
+ * @see      https://github.com/fabriziop/TalkingLED
+ */

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -1,15 +1,18 @@
 # Add Arduino sketches to the application as a module
 
-# Define application sketches module, it will be generated into $(BINDIR)
-SKETCH_MODULE     ?= arduino_sketches
-SKETCH_MODULE_DIR ?= $(BINDIR)/$(SKETCH_MODULE)
-SKETCHES           = $(wildcard $(APPDIR)/*.sketch)
-include $(RIOTBASE)/sys/arduino/sketches.inc.mk
+SKETCHES = $(wildcard $(APPDIR)/*.sketch)
 
-# Depends on module
-USEMODULE += $(SKETCH_MODULE)
-DIRS      += $(SKETCH_MODULE_DIR)
-BUILDDEPS += $(SKETCH_GENERATED_FILES)
+ifneq (,$(SKETCHES))
+  # Define application sketches module, it will be generated into $(BINDIR)
+  SKETCH_MODULE     ?= arduino_sketches
+  SKETCH_MODULE_DIR ?= $(BINDIR)/$(SKETCH_MODULE)
+  include $(RIOTBASE)/sys/arduino/sketches.inc.mk
+
+  # Depends on module
+  USEMODULE += $(SKETCH_MODULE)
+  DIRS      += $(SKETCH_MODULE_DIR)
+  BUILDDEPS += $(SKETCH_GENERATED_FILES)
+endif
 
 # include the Arduino headers
 INCLUDES += -I$(RIOTBASE)/sys/arduino/include

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -30,12 +30,12 @@ extern "C" {
 #include "serialport.hpp"
 
 /**
- * @brief    Ardunio boolean data type definion
+ * @brief    Arduino boolean data type definion
  */
 typedef bool boolean;
 
 /**
- * @brief    Ardunio byte data type definion
+ * @brief    Arduino byte data type definion
  */
 typedef uint8_t byte;
 

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -22,11 +22,22 @@
 #define ARDUINO_HPP
 
 extern "C" {
+#include <stdint.h>
 #include "periph/gpio.h"
 #include "arduino_board.h"
 }
 
 #include "serialport.hpp"
+
+/**
+ * @brief    Ardunio boolean data type definion
+ */
+typedef bool boolean;
+
+/**
+ * @brief    Ardunio byte data type definion
+ */
+typedef uint8_t byte;
 
 /**
  * @brief   Possible pin configurations

--- a/tests/sys_arduino_lib/Makefile
+++ b/tests/sys_arduino_lib/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEPKG += talking_leds
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys_arduino_lib/Makefile.ci
+++ b/tests/sys_arduino_lib/Makefile.ci
@@ -1,0 +1,7 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    nucleo-f031k6 \
+    #

--- a/tests/sys_arduino_lib/main.cpp
+++ b/tests/sys_arduino_lib/main.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief    Demonstrates the use of an Arduino library imported as package
+ *
+ * @author   Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+
+#include "arduino_board.h"
+#include "TalkingLED.h"
+
+#ifndef ARDUINO_LED
+#define ARDUINO_LED (13)    /* Arduino Uno LED pin */
+#endif
+
+TalkingLED tled;
+
+int main(void)
+{
+    tled.begin(ARDUINO_LED);
+
+    while (1) {
+        /* message 2: short short */
+        tled.message(2);
+        tled.waitEnd();
+        /* message 8: long long */
+        tled.message(8);
+        tled.waitEnd();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR allows the use of an Arduino library in RIOT applications without the need for an Arduino sketch. For this purpose it introduces the pseudomodule `arduino_lib`. This pseudomodule enables implicitly module `arduino` but avoids that a sketch is required or generated and compiled. Thus, it becomes possible just to compile and use a package or a directory with some source files from an Arduino library in RIOT applications without having an Arduino sketch. The application has to enable the `arduino_lib` module instead of the `arduino` module.

The test app `tests/arduino_lib` demonstrates how to import and use Arduino libraries as packages using a very simple Arduino library. For this purpose, the PR contains the package `talking_leds` for on-board LED flashing sequences.

In addition, this PR introduces the Arduino standard header file `Arduino.h` and the data types `boolean` and `byte` to improvethe compatibility of `sys/arduino` with Arduino libraries and applications.

### Testing procedure

Compile and flash `tests/sys_arduino_lib`:

```
make -C tests/sys_arduino_lib BOARD=... flash
```
The integrated LED should flash in a loop twice short and twice long.

### Issues/PRs references
