### PR TITLE
cpu/stm32_common: fix STM32F7 LSI_CLOCK definition

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -33,11 +33,10 @@ extern "C" {
 #if defined(CPU_FAM_STM32F0) || defined (CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3)
 #define CLOCK_LSI           (40000U)
-#elif defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
-      defined(CPU_FAM_STM32L1)
+#elif defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
 #define CLOCK_LSI           (37000U)
 #elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
-      defined(CPU_FAM_STM32L4)
+      defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L4)
 #define CLOCK_LSI           (32000U)
 #else
 #error "error: LSI clock speed not defined for your target CPU"


### PR DESCRIPTION

### Contribution description

This PR fixes the frequency of the LSI clock oscilator in `STM32F7` boards which is `~32Khz` and not `~37Khz`.

### Testing procedure

No feature is using the LSI so just checking the RM for `STM32F7` should suffice.

### Issues/PRs references

Found while testing #11252 

