### PR TITLE
drivers/at86rf2xx: add support for configuring PHY modes

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -48,10 +48,14 @@ ifneq (,$(filter at86rf2%,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
-  USEMODULE += gnrc_netif_phy_oqpsk
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_gpio_irq
   FEATURES_REQUIRED += periph_spi
+
+  ifneq (,$(filter gnrc,$(USEMODULE)))
+    # Pull in `ifconfig` support for BPSK/O-QPSK
+    USEMODULE += gnrc_netif_cmd_oqpsk
+  endif
 endif
 
 ifneq (,$(filter ata8520e,$(USEMODULE)))

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -48,6 +48,7 @@ ifneq (,$(filter at86rf2%,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  USEMODULE += gnrc_netif_phy_oqpsk
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_gpio_irq
   FEATURES_REQUIRED += periph_spi

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -213,6 +213,20 @@ void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page)
 #endif
 }
 
+uint8_t at86rf2xx_get_phy_mode(at86rf2xx_t *dev)
+{
+#ifdef MODULE_AT86RF212B
+    switch (dev->page) {
+        case  0: return IEEE802154_PHY_BPSK;
+        case  2: return IEEE802154_PHY_OQPSK;
+        default: return IEEE802154_PHY_DISABLED;
+    }
+#else
+    (void) dev;
+    return IEEE802154_PHY_OQPSK;
+#endif
+}
+
 uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev)
 {
     return dev->netdev.pan;

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -216,14 +216,89 @@ void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page)
 uint8_t at86rf2xx_get_phy_mode(at86rf2xx_t *dev)
 {
 #ifdef MODULE_AT86RF212B
-    switch (dev->page) {
-        case  0: return IEEE802154_PHY_BPSK;
-        case  2: return IEEE802154_PHY_OQPSK;
-        default: return IEEE802154_PHY_DISABLED;
+    uint8_t ctrl2;
+    ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    if (ctrl2 & AT86RF2XX_TRX_CTRL_2_MASK__BPSK_OQPSK) {
+        return IEEE802154_PHY_OQPSK;
+    } else {
+        return IEEE802154_PHY_BPSK;
     }
 #else
     (void) dev;
     return IEEE802154_PHY_OQPSK;
+#endif
+}
+
+int at86rf2xx_set_rate(at86rf2xx_t *dev, uint8_t rate)
+{
+    uint8_t ctrl2;
+
+    if (rate > 3) {
+        return -ERANGE;
+    }
+
+    ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    ctrl2 &= AT86RF2XX_TRX_CTRL_2_MASK__OQPSK_DATA_RATE;
+    ctrl2 |= rate;
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2, ctrl2);
+
+    return 0;
+}
+
+uint8_t at86rf2xx_get_rate(at86rf2xx_t *dev)
+{
+    uint8_t rate;
+
+    rate = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    rate &= AT86RF2XX_TRX_CTRL_2_MASK__OQPSK_DATA_RATE;
+
+    return rate | IEEE802154_OQPSK_FLAG_LEGACY;
+}
+
+uint16_t at86rf2xx_get_chips(at86rf2xx_t *dev)
+{
+#ifdef MODULE_AT86RF212B
+    uint8_t ctrl2;
+    ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    ctrl2 &= AT86RF2XX_TRX_CTRL_2_MASK__SUB_MODE | AT86RF2XX_TRX_CTRL_2_MASK__BPSK_OQPSK;
+    switch (ctrl2) {
+    /* O-QPSK, 1000 kChip/s */
+    case (AT86RF2XX_TRX_CTRL_2_MASK__SUB_MODE | AT86RF2XX_TRX_CTRL_2_MASK__BPSK_OQPSK):
+        return 1000;
+    /* BPSK, 600 kChip/s */
+    case (AT86RF2XX_TRX_CTRL_2_MASK__SUB_MODE):
+        return 600;
+    /* O-QPSK, 400 kChip/s */
+    case (AT86RF2XX_TRX_CTRL_2_MASK__BPSK_OQPSK):
+        return 400;
+    /* BPSK, 300 kChip/s */
+    default:
+        return 300;
+    }
+#else
+    (void) dev;
+    /* device only supports 2000 kChip/s */
+    return 2000;
+#endif
+}
+
+int at86rf2xx_set_chips(at86rf2xx_t *dev, uint16_t chips)
+{
+#ifdef MODULE_AT86RF212B
+    uint8_t ctrl2;
+    ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    ctrl2 &= ~AT86RF2XX_TRX_CTRL_2_MASK__SUB_MODE;
+
+    /* device only supports two chip rates - select the nearest one */
+    if (chips > 500) {
+        ctrl2 |= AT86RF2XX_TRX_CTRL_2_MASK__SUB_MODE;
+    }
+
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2, ctrl2);
+
+    return 0;
+#else
+    return -ENOTSUP;
 #endif
 }
 

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -349,6 +349,11 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
                 !!(dev->flags & AT86RF2XX_OPT_CSMA);
             return sizeof(netopt_enable_t);
 
+        case NETOPT_IEEE802154_PHY:
+            assert(max_len >= sizeof(int8_t));
+            *(uint8_t *)val = at86rf2xx_get_phy_mode(dev);
+            return sizeof(uint8_t);
+
 /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
 #if AT86RF2XX_HAVE_RETRIES
         case NETOPT_TX_RETRIES_NEEDED:

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -349,11 +349,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
                 !!(dev->flags & AT86RF2XX_OPT_CSMA);
             return sizeof(netopt_enable_t);
 
-        case NETOPT_IEEE802154_PHY:
-            assert(max_len >= sizeof(int8_t));
-            *(uint8_t *)val = at86rf2xx_get_phy_mode(dev);
-            return sizeof(uint8_t);
-
 /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
 #if AT86RF2XX_HAVE_RETRIES
         case NETOPT_TX_RETRIES_NEEDED:
@@ -425,6 +420,21 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             *((netopt_enable_t *)val) = (tmp & AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK) ? false : true;
             res = sizeof(netopt_enable_t);
             break;
+
+        case NETOPT_IEEE802154_PHY:
+            assert(max_len >= sizeof(int8_t));
+            *(uint8_t *)val = at86rf2xx_get_phy_mode(dev);
+            return sizeof(uint8_t);
+
+        case NETOPT_OQPSK_RATE:
+            assert(max_len >= sizeof(int8_t));
+            *(uint8_t *)val = at86rf2xx_get_rate(dev);
+            return sizeof(uint8_t);
+
+        case NETOPT_OQPSK_CHIPS:
+            assert(max_len >= sizeof(int16_t));
+            *(uint16_t *)val = at86rf2xx_get_chips(dev);
+            return sizeof(uint16_t);
 
         default:
             res = -ENOTSUP;
@@ -598,6 +608,24 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             assert(len <= sizeof(int8_t));
             at86rf2xx_set_cca_threshold(dev, *((const int8_t *)val));
             res = sizeof(int8_t);
+            break;
+
+        case NETOPT_OQPSK_CHIPS:
+            assert(len <= sizeof(int16_t));
+            if (at86rf2xx_set_chips(dev, *((const uint16_t *)val)) < 0) {
+                res = -EINVAL;
+            } else {
+                res = sizeof(uint16_t);
+            }
+            break;
+
+        case NETOPT_OQPSK_RATE:
+            assert(len <= sizeof(int8_t));
+            if (at86rf2xx_set_rate(dev, *((const uint8_t *)val)) < 0) {
+                res = -EINVAL;
+            } else {
+                res = sizeof(uint8_t);
+            }
             break;
 
         default:

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -311,6 +311,47 @@ void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page);
 uint8_t at86rf2xx_get_phy_mode(at86rf2xx_t *dev);
 
 /**
+ * @brief   Get the current O-QPSK rate mode of the PHY
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  the currenty set rate mode
+ */
+uint8_t at86rf2xx_get_rate(at86rf2xx_t *dev);
+
+/**
+ * @brief   Set the current O-QPSK rate mode of the PHY
+ *          refer to OQPSK_DATA_RATE in the data sheet.
+ *          Rate Modes > 0 are proprietary.
+ *
+ * @param[in] dev           device to write to
+ * @param[in] rate          the selected data rate mode (0-3)
+ *
+ * @return                  0 on success, otherwise error value
+ */
+int at86rf2xx_set_rate(at86rf2xx_t *dev, uint8_t rate);
+
+/**
+ * @brief   Get the current O-QPSK/BPSK chip rate
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  the currenty chip rate in kChip/s
+ */
+uint16_t at86rf2xx_get_chips(at86rf2xx_t *dev);
+
+/**
+ * @brief   Set the current O-QPSK/BPSK chip rate.
+ *          Depending on the device, only selected rates are supported.
+ *
+ * @param[in] dev           device to write to
+ * @param[in] chips         the selected chip rate in kChip/s
+ *
+ * @return                  0 on success, otherwise error value
+ */
+int at86rf2xx_set_chips(at86rf2xx_t *dev, uint16_t chips);
+
+/**
  * @brief   Get the configured PAN ID of the given device
  *
  * @param[in] dev           device to read from

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -303,6 +303,14 @@ uint8_t at86rf2xx_get_page(const at86rf2xx_t *dev);
 void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page);
 
 /**
+ * @brief   Get the PHY mode of the given device
+ *
+ * @param[in,out] dev       device to read from
+ * @return                  the currently set phy mode
+ */
+uint8_t at86rf2xx_get_phy_mode(at86rf2xx_t *dev);
+
+/**
  * @brief   Get the configured PAN ID of the given device
  *
  * @param[in] dev           device to read from


### PR DESCRIPTION
### Contribution description

This implements getting & setting O-QPSK options with #12171
This allows for setting the rate mode (values 0-4, for 250, 500, 1000 & 2000 kbit/s operation) as well as chip rate (1000 kchip/s and 400 kchip/s for O-QPSK and 600 kchip/s and 300 kchip/s for BPSK).

The proprietary rate mode 2 on at86rf233 is compatible with the legacy high data rate mode on at86rf215.

### Testing procedure
Or on `samr30-xpro` you should now be able to to the following:
```
ifconfig 7 set rate_mode 2
ifconfig 7 set chip_rate 400
```

You should get
```
 Iface  7  HWaddr: 34:82  Channel: 0  Page: 2  NID: 0x23 PHY: O-QPSK 
            chip rate: 400 rate mode: 2 (legacy) 
           Long HWaddr: 79:7A:34:2F:9D:73:B4:82
```

On `samr21-xpro`, setting the chip_rate  should fail.

### Issues/PRs references
depends on #12171