### PR TITLE
doc/doxygen: Use python3 in generate-changelog.py

### DIFF
--- a/doc/doxygen/generate-changelog.py
+++ b/doc/doxygen/generate-changelog.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 #


### PR DESCRIPTION
### Contribution description

Updated `generate-changelog.py` in `doc/doxygen` to use Python3 instead of Python2. On my system this was the last dependency on Python2, so I assume other will sooner or later face the same issue. Updating it to use Python3 allows removing Python2 in that sitation.

### Testing procedure

Running `make doc` should still work. It should be safe to rely on the CI for this.

### Issues/PRs references

None