### PR TITLE
makefiles: add new target is-board-supported

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -146,8 +146,10 @@ include $(RIOTMAKE)/boards.inc.mk
 
 # Debug targets for build system migration
 include $(RIOTMAKE)/dependencies_debug.inc.mk
+# save env variable BOARD for global targets
+ENV_BOARD := $(BOARD)
 
-GLOBAL_GOALS += buildtest buildtest-indocker info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff
+GLOBAL_GOALS += buildtest buildtest-indocker info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff is-board-supported
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
   BOARD=none
 endif

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -109,6 +109,11 @@ info-boards-supported:
 info-boards-features-missing:
 	@for f in $(BOARDS_FEATURES_MISSING); do echo $${f}; done | column -t
 
+IS_BOARD_SUPPORTED ?= $(filter $(ENV_BOARD), $(BOARDS))
+.PHONY: is-board-supported
+is-board-supported:
+	$(Q)test -n "$(IS_BOARD_SUPPORTED)"
+
 # Reset BOARDSDIR so unchanged for makefiles included after, for now only
 # needed for buildtests.inc.mk
 BOARDSDIR := $(BOARDSDIR_GLOBAL)


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Addding a new target to check whether a given board is supported by
the given application. Return 0 for yes and 1 for no.

Basically it is a short hand for `make -C <path/to/app> info-boards-supported | grep $BOARD`.
However, this might be handy for distributed automated builds, with workers that handle only a specific board and need to check if that is supported by the app.

### Testing procedure

Run `BOARD=<name> make -C <path/to/app> info-board-supported` then run `echo $?` which should give `0` if the board is supported by the app and `1` if not.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->