### PR TITLE
pkg/oonf_api: deprecate package

### DIFF
--- a/pkg/oonf_api/doc.txt
+++ b/pkg/oonf_api/doc.txt
@@ -1,0 +1,11 @@
+/**
+ * @defgroup    pkg_oonf_api   OLSR.org Network Framework
+ * @ingroup     pkg
+ * @ingroup     net
+ * @brief       The OLSR.org Network Framework (OONF) is a collection of libraries
+ *              that can be used as the building blocks for networking daemons
+ *
+ * @deprecated  The package has not been updated in 6 years, tests were never integrated
+ *              into CI and with NHDP the only user of this package is being deprecated too.
+ *              Will be removed after the 2020.04 release.
+ */


### PR DESCRIPTION
### Contribution description
`tests/pkg_oonf_api` is a no-op. oonf_api contains it's own suite of test that were also ported to RIOT.
When I fixed them up and thought about how they could be integrated into CI, I was seriously wondering if the package is still used by anymore.

 - [oonf_api](https://github.com/OLSR/OONF) has not been updated in 6 years, it's still at 0.3.0 from 2013.
 - tests were never integrated into CI
 - With NHDP the only upstream user of the package is [about to be removed](https://github.com/RIOT-OS/RIOT/pull/11987).
 - Possible downstream users would probably rather prefer a less vintage version of the library.

So unless someone actually still has a use for this vintage pkg, I think we should better do away with it entirely. To be useful it would need to be updated to a more recent version and the unit tests would need to be integrated into our CI.

### Testing procedure
Make sure you have no use for the package anymore.

### Issues/PRs references
obsoletes #12184