### PR TITLE
examples/default: PoC user/password login for the terminal

### DIFF
--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -38,6 +38,7 @@ USEMODULE += ps
 USEMODULE += saul_default
 USEMODULE += xtimer
 USEMODULE += crypto
+USEMODULE += hashes
 
 BOARD_PROVIDES_NETIF := acd52832 airfy-beacon b-l072z-lrwan1 cc2538dk fox \
         iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -36,6 +36,7 @@ USEMODULE += shell_commands
 USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
+USEMODULE += xtimer
 
 BOARD_PROVIDES_NETIF := acd52832 airfy-beacon b-l072z-lrwan1 cc2538dk fox \
         iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -37,6 +37,7 @@ USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 USEMODULE += xtimer
+USEMODULE += crypto
 
 BOARD_PROVIDES_NETIF := acd52832 airfy-beacon b-l072z-lrwan1 cc2538dk fox \
         iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \

--- a/examples/default/login.c
+++ b/examples/default/login.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Proof of concept of user/password protection for the serial
+ *              interface (shell).
+ *
+ * @author      Juan I Carrano <j.carrano@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdbool.h>
+#include "xtimer.h"
+
+const char user[] = "admin";
+const char pass[] = "Passw0rd!";
+
+static bool is_line_delim(char c)
+{
+    return c == '\r' || c == '\n';
+}
+
+static bool is_line_cancel(char c)
+{
+    return c == 0x03 || c == 0x04;
+}
+
+enum INPUT_STATE {
+    INPUT_OK,
+    INPUT_ERR,
+};
+
+static bool input_compare(const char *target, char mask_char)
+{
+    enum INPUT_STATE status = INPUT_OK;
+    char cmp_this;
+
+    do {
+        int c = getchar();
+
+        if (c == EOF || is_line_cancel(c)) {
+            cmp_this = '\0';
+            status = INPUT_ERR;
+        } else if (is_line_delim(c)) {
+            cmp_this = '\0';
+        } else {
+            cmp_this = c;
+            putchar(mask_char? mask_char: c);
+            fflush(stdout);
+        }
+
+        if (*target != cmp_this) {
+            status = INPUT_ERR;
+        }
+
+        if (*target != '\0') {
+            target++;
+        }
+    } while (cmp_this != '\0');
+
+    return status == INPUT_OK;
+}
+
+enum LOGIN_STATE {
+    LOGIN_WRONG,
+    LOGIN_OK_ONE,
+    LOGIN_OK_BOTH,
+};
+
+static bool login(void)
+{
+    int state = LOGIN_WRONG;
+
+    fputs("Username: ", stdout);
+    fflush(stdout);
+
+    state += !!input_compare(user, 0);
+
+    fputs("\r\nPassword: ", stdout);
+    fflush(stdout);
+
+    state += !!input_compare(pass, '*');
+
+    putchar('\r');
+    putchar('\n');
+
+    return state == LOGIN_OK_BOTH;
+}
+
+#define N_ATTEMPTS 3
+
+/**
+ * Repeatedly prompt for the user and password.
+ *
+ * This function won't return until the correct user-pass pair has been
+ * introduced.
+ */
+void secure_login(void)
+{
+    while (1) {
+        int attempts = N_ATTEMPTS;
+
+        while (attempts--) {
+            if (login()) {
+                return;
+            }
+            puts("Wrong user/pass");
+            xtimer_sleep(1);
+        }
+        xtimer_sleep(7);
+    }
+}

--- a/examples/default/login.c
+++ b/examples/default/login.c
@@ -18,7 +18,9 @@
  * @}
  */
 
+#include <stdio.h>
 #include <stdbool.h>
+
 #include "xtimer.h"
 
 const char user[] = "admin";
@@ -34,14 +36,9 @@ static bool is_line_cancel(char c)
     return c == 0x03 || c == 0x04;
 }
 
-enum INPUT_STATE {
-    INPUT_OK,
-    INPUT_ERR,
-};
-
 static bool input_compare(const char *target, char mask_char)
 {
-    enum INPUT_STATE status = INPUT_OK;
+    bool login_ok = true;
     char cmp_this;
 
     do {
@@ -49,7 +46,7 @@ static bool input_compare(const char *target, char mask_char)
 
         if (c == EOF || is_line_cancel(c)) {
             cmp_this = '\0';
-            status = INPUT_ERR;
+            login_ok = false;
         } else if (is_line_delim(c)) {
             cmp_this = '\0';
         } else {
@@ -59,7 +56,7 @@ static bool input_compare(const char *target, char mask_char)
         }
 
         if (*target != cmp_this) {
-            status = INPUT_ERR;
+            login_ok = false;
         }
 
         if (*target != '\0') {
@@ -67,7 +64,7 @@ static bool input_compare(const char *target, char mask_char)
         }
     } while (cmp_this != '\0');
 
-    return status == INPUT_OK;
+    return login_ok;
 }
 
 enum LOGIN_STATE {

--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -34,6 +34,9 @@
 #include "net/gnrc.h"
 #endif
 
+/* I'm too lazy to write a proper header. */
+extern void secure_login(void);
+
 int main(void)
 {
 #ifdef MODULE_NETIF
@@ -45,7 +48,12 @@ int main(void)
     (void) puts("Welcome to RIOT!");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    while (1) {
+        secure_login();
+        shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+        puts("\r\nExiting shell");
+    }
 
     return 0;
 }

--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -35,7 +35,7 @@
 #endif
 
 /* I'm too lazy to write a proper header. */
-extern void secure_login(void);
+extern void secure_login(char *line_buf, size_t buf_size);
 
 int main(void)
 {
@@ -50,7 +50,7 @@ int main(void)
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 
     while (1) {
-        secure_login();
+        secure_login(line_buf, SHELL_DEFAULT_BUFSIZE);
         shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
         puts("\r\nExiting shell");
     }

--- a/examples/default/pbkdf2.c
+++ b/examples/default/pbkdf2.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       PBKDF2 key derivation implementation- this is quite probably
+ *              wrong, I'm no crypto expert.
+ *
+ * @author      Juan I Carrano <j.carrano@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "hashes/sha256.h"
+
+#include "pbkdf2.h"
+
+static void inplace_xor_scalar(uint8_t *bytes, size_t len, uint8_t c)
+{
+    while (len--) {
+        *bytes ^= c;
+        bytes++;
+    }
+}
+
+static void inplace_xor_digests(uint8_t *d1, uint8_t *d2)
+{
+    int len = SHA256_DIGEST_LENGTH;
+
+    while (len--) {
+        *d1 ^= *d2;
+        d1++;
+        d2++;
+    }
+}
+
+void pbkdf2_sha256(const uint8_t *password, size_t password_len,
+                   const uint8_t *salt, size_t salt_len,
+                   int iterations,
+                   uint8_t *output)
+{
+    sha256_context_t inner;
+    sha256_context_t outer;
+    uint8_t tmp_digest[SHA256_DIGEST_LENGTH];
+    int first_iter = 1;
+
+    {
+        uint8_t processed_pass[SHA256_INTERNAL_BLOCK_SIZE];
+
+        memset(processed_pass, 0,  sizeof(processed_pass));
+
+        if (password_len > sizeof(processed_pass)) {
+            sha256_init(&inner);
+            sha256_update(&inner, password, password_len);
+            sha256_final(&inner, processed_pass);
+        } else {
+            memcpy(processed_pass, password, password_len);
+        }
+
+        sha256_init(&inner);
+        sha256_init(&outer);
+
+        /* Trick: doing inner.update(processed_pass XOR 0x36) followed by
+         * inner.update(processed_pass XOR 0x5C) requires remembering
+         * processed_pass. Instead undo the first XOR while doing the second.
+         */
+        inplace_xor_scalar(processed_pass, sizeof(processed_pass), 0x36);
+        sha256_update(&inner, processed_pass, sizeof(processed_pass));
+
+        inplace_xor_scalar(processed_pass, sizeof(processed_pass), 0x36 ^ 0x5C);
+        sha256_update(&outer, processed_pass, sizeof(processed_pass));
+    }
+
+    memset(output, 0, SHA256_DIGEST_LENGTH);
+
+    while (iterations--) {
+        sha256_context_t inner_copy = inner, outer_copy = outer;
+
+        if (first_iter) {
+            sha256_update(&inner_copy, salt, salt_len);
+            sha256_update(&inner_copy, "\x00\x00\x00\x01", 4);
+            first_iter = 0;
+        } else {
+            sha256_update(&inner_copy, tmp_digest, sizeof(tmp_digest));
+        }
+
+        sha256_final(&inner_copy, tmp_digest);
+
+        sha256_update(&outer_copy, tmp_digest, sizeof(tmp_digest));
+        sha256_final(&outer_copy, tmp_digest);
+
+        inplace_xor_digests(output, tmp_digest);
+    }
+}

--- a/examples/default/pbkdf2.h
+++ b/examples/default/pbkdf2.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       PBKDF2 key derivation implementation- this is quite probably
+ *              wrong, I'm no crypto expert.
+ *
+ * @author      Juan I Carrano <j.carrano@fu-berlin.de>
+ *
+ * @}
+ */
+
+#ifndef PBKDF2_H
+#define PBKDF2_H
+
+#include "hashes/sha256.h"
+
+#define PBKDF2_KEY_SIZE SHA256_DIGEST_LENGTH
+
+/**
+ * Create a key from a password and hash using PBKDF2.
+ *
+ * @param[out]   output  Array of size PBKDF2_KEY_SIZE
+ */
+void pbkdf2_sha256(const uint8_t *password, size_t password_len,
+                   const uint8_t *salt, size_t salt_len,
+                   int iterations,
+                   uint8_t *output);
+
+#endif /* PBKDF2_H */

--- a/examples/default/pbkdf2.py
+++ b/examples/default/pbkdf2.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Derive a key from a password using pbkdf2/sha256.
+"""
+
+import os
+import hashlib
+import textwrap
+
+password = b"Passw0rd!"
+salt = os.urandom(64)
+iterations = 1000
+
+def _inner_array(a):
+    return ", ".join(f"0x{c:X}" for c in a)
+
+def _to_array(name, a):
+    return f"static const uint8_t {name}[] = {{{_inner_array(a)}}};"
+
+def pretty_indent(s):
+    initial_brace = " " * (1 + s.index("{"))
+    wrapper = textwrap.TextWrapper(width=79, subsequent_indent=initial_brace)
+
+    return "\n".join(wrapper.wrap(s))
+
+def my_pbkdf(password, salt, iterations):
+    """This is derived from the implementation in python's hashlib, heavily
+    simplified. The C version is a translation of this code.
+    """
+    first = True
+
+    # Fast inline HMAC implementation
+    inner = hashlib.new('sha256')
+    outer = hashlib.new('sha256')
+    blocksize = inner.block_size
+
+    if len(password) > blocksize:
+        password = hashlib.new('sha256', password).digest()
+
+    password = password + b'\x00' * (blocksize - len(password))
+
+    password = bytes((x ^ 0x36) for x in password)
+    inner.update(password)
+
+    password = bytes((x ^ 0x36 ^ 0x5C) for x in password)
+    outer.update(password)
+
+    dklen = outer.digest_size
+
+    rkey = b"\x00"*dklen
+
+    for _ in range(iterations):
+        icpy = inner.copy()
+        ocpy = outer.copy()
+
+        if first:
+            icpy.update(salt)
+            icpy.update(b'\x00\x00\x00\x01')
+            first = False
+        else:
+            icpy.update(prev)
+
+        prev = icpy.digest()
+        ocpy.update(prev)
+        prev = ocpy.digest()
+        rkey = bytes(x^y for x, y in zip(rkey,prev))
+
+    return rkey
+
+key = hashlib.pbkdf2_hmac('sha256', password, salt, iterations)
+key2 = my_pbkdf(password, salt, iterations)
+
+print(f"#define PBKDF2_ITERS {iterations}")
+print(pretty_indent(_to_array('salt', salt)))
+print(pretty_indent(_to_array('key', key)))
+print(pretty_indent(_to_array('key2', key2)))
+
+# Check that my ugly version gives the same results as the official one.
+print(key==key2)
+print(len(key))

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -33,6 +33,8 @@
 #include "shell_commands.h"
 
 #define ETX '\x03'  /** ASCII "End-of-Text", or ctrl-C */
+#define EOT '\x04'  /** ASCII "End-of-Transmission", or ctrl-D */
+
 #if !defined(SHELL_NO_ECHO) || !defined(SHELL_NO_PROMPT)
 #ifdef MODULE_NEWLIB
 /* use local copy of putchar, as it seems to be inlined,
@@ -237,7 +239,7 @@ static int readline(char *buf, size_t size)
         }
 
         int c = getchar();
-        if (c < 0) {
+        if (c < 0 || c == EOT) {
             return EOF;
         }
 

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -78,6 +78,14 @@ int main(void)
     /* define own shell commands */
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
+    puts("shell exited (1)");
+
+    /* Restart the shell after the previous one exits, so that we can test
+     * ctrl-D exit */
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    puts("shell exited (2)");
+
     /* or use only system shell commands */
     /*
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -50,6 +50,8 @@ CMDS = (
     ('help', EXPECTED_HELP),
     ('echo a string', ('\"echo\"\"a\"\"string\"')),
     ('ps', EXPECTED_PS),
+    ('reboot', ('test_shell.')),
+    (CONTROL_D, ('shell exited (1)')),
     ('garbage1234'+CONTROL_C, ('>')),  # test cancelling a line
     ('help', EXPECTED_HELP),
     ('reboot', ('test_shell.'))


### PR DESCRIPTION
### Contribution description

This is a _very_ rough proof of concept showing how a simple user/password prompt can be used at the serial terminal to protect the shell.

The password is hashed and salted with **PBKDF2-sha256**.

To be effective, this requires a **shell that can be exited**, in order to be able to log off.

The login prompt has a built in delay between attempts (7 seconds each three failed attempts, plus the delay inherent to the key derivation function.).

### Testing procedure

This won't work quite right in native because the serial/pty handling isdifferent there (we are not turning off the OS' line bufering and that gets in the way, as well as ctrl-d)

I get the best experience using miniterm.py (I used a samr21):

```
miniterm.py --eol LF /dev/ttyACM0 115200
```

The credentials are `admin`, `Passw0rd!`.

### Issues/PRs references

Built on top of #10788 .
