### PR TITLE
gcoap: Add 'obs' attribute in example and extend documentation

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -43,7 +43,7 @@ static const coap_resource_t _resources[] = {
 };
 
 static const char *_link_params[] = {
-    ";ct=0;rt=\"count\"",
+    ";ct=0;rt=\"count\";obs",
     NULL
 };
 

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -96,7 +96,7 @@
  * ## Client Operation ##
  *
  * Client operation includes two phases: creating and sending a request, and
- * handling the response aynchronously in a client supplied callback. See
+ * handling the response asynchronously in a client supplied callback. See
  * `examples/gcoap/gcoap_cli.c` for a simple example of sending a request and
  * reading the response.
  *
@@ -146,6 +146,13 @@
  * an application has registered with gcoap. An application does not need to
  * take any action to support Observe client registration. However, gcoap
  * limits registration for a given resource to a _single_ observer.
+ *
+ * It is [suggested] (https://tools.ietf.org/html/rfc7641#section-6) that a
+ * server adds the 'obs' attribute to resources that are useful for observation
+ * (i.e. will produce notifications) as a hint. Keep in mind that this is not
+ * mandatory in order to enable the mechanism in RIOT, nor will prevent a client
+ * from observing a resource that does not have this attribute in the link
+ * description.
  *
  * An Observe notification is considered a response to the original client
  * registration request. So, the Observe server only needs to create and send


### PR DESCRIPTION
### Contribution description
As discussed in #11587, this adds the 'obs' attribute to the link description of the `/cli/stats` resource in the gcoap example application. This improves the description of the resource by giving a client a [hint](https://tools.ietf.org/html/rfc7641#section-6) that this resource is useful for observation.

Also a small paragraph regarding this is added to the gcoap documentation.

### Testing procedure
- Build documentation
- Run gcoap example application, you should get the 'obs' attribute when listing the resources (i.e. GET to `/.well-known/core`).

### Issues/PRs references
Related to #11587