### PR TITLE
dist/tools/pyocd: add PYOCD_ADAPTER_INIT and pass DEBUG_ADAPTER_ID to pyocd

### DIFF
--- a/dist/tools/pyocd/pyocd.sh
+++ b/dist/tools/pyocd/pyocd.sh
@@ -52,6 +52,8 @@
 : ${PYOCD_CMD:=pyocd}
 : ${PYOCD_FLASH:=${PYOCD_CMD} flash}
 : ${PYOCD_GDBSERVER:=${PYOCD_CMD} gdbserver}
+# Debugger interface initialization commands to pass to PyOCD
+: ${PYOCD_ADAPTER_INIT:=}
 # The setsid command is needed so that Ctrl+C in GDB doesn't kill PyOCD.
 : ${SETSID:=setsid}
 # GDB command, usually a separate command for each platform (e.g.
@@ -124,7 +126,7 @@ do_flash() {
     fi
 
     # flash device
-    sh -c "${PYOCD_FLASH} ${FLASH_TARGET_TYPE} -a ${IMAGE_OFFSET} \"${HEX_FILE}\"" &&
+    sh -c "${PYOCD_FLASH} ${FLASH_TARGET_TYPE} ${PYOCD_ADAPTER_INIT} -a ${IMAGE_OFFSET} \"${HEX_FILE}\"" &&
     echo 'Done flashing'
 }
 
@@ -147,6 +149,7 @@ do_debug() {
     # start PyOCD as GDB server
     ${SETSID} sh -c "${PYOCD_GDBSERVER} \
             ${FLASH_TARGET_TYPE} \
+            ${PYOCD_ADAPTER_INIT} \
             -p ${GDB_PORT} \
             -T ${TELNET_PORT} & \
             echo \$! > $OCD_PIDFILE" &
@@ -164,13 +167,14 @@ do_debugserver() {
     # start PyOCD as GDB server
     sh -c "${PYOCD_GDBSERVER} \
             ${FLASH_TARGET_TYPE} \
+            ${PYOCD_ADAPTER_INIT} \
             -p ${GDB_PORT} \
             -T ${TELNET_PORT}"
 }
 
 do_reset() {
     # start PyOCD and invoke board reset
-    sh -c "${PYOCD_CMD} cmd -c reset ${FLASH_TARGET_TYPE}"
+    sh -c "${PYOCD_CMD} cmd -c reset ${FLASH_TARGET_TYPE} ${PYOCD_ADAPTER_INIT}"
 }
 
 #

--- a/makefiles/tools/pyocd.inc.mk
+++ b/makefiles/tools/pyocd.inc.mk
@@ -8,3 +8,8 @@ FFLAGS ?= flash $(FLASHFILE)
 DEBUGGER_FLAGS ?= debug $(ELFFILE)
 DEBUGSERVER_FLAGS ?= debug-server
 RESET_FLAGS ?= reset
+
+# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
+ifneq (,$(DEBUG_ADAPTER_ID))
+  export PYOCD_ADAPTER_INIT += -u $(DEBUG_ADAPTER_ID)
+endif


### PR DESCRIPTION
### Contribution description

This PR adds `PYOCD_ADAPTER_INIT` which is used before flash, term and debug in `pyocd`, in the same way as `openocd`. It is used to pass `DEBUG_ADAPTER_ID` to `pyocd`.

This allows differentiating when multiple debuggers are connected.

### Testing procedure

Test reset, debug and flash with two debuggers recognized by pyocd connected:

- This PR:

<details><summary>DEBUG_ADAPTER_ID=10260000033adcbb00000000000000000000000097969902 make -C examples/hello-world/ BOARD=nrf52840-mdk flash</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
Building application "hello-world" for "nrf52840-mdk" with MCU "nrf52".

"make" -C /home/francisco/workspace/RIOT/boards/nrf52840-mdk
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common/periph
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
   text    data     bss     dec     hex filename
   8196     116    2556   10868    2a74 /home/francisco/workspace/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.elf
/home/francisco/workspace/RIOT/dist/tools/pyocd/pyocd.sh flash /home/francisco/workspace/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.hex
### Flashing Target ###
[====================] 100%
0001856:INFO:loader:Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 12288 bytes (3 pages) at 9.67 kB/s
Done flashing
make: Leaving directory '/home/francisco/workspace/RIOT/examples/hello-world'

```
</details>

<details><summary>DEBUG_ADAPTER_ID=10260000033adcbb00000000000000000000000097969902 make -C examples/hello-world/ BOARD=nrf52840-mdk debug</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/dist/tools/pyocd/pyocd.sh debug /home/francisco/workspace/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.elf
### Starting Debugging ###
Reading symbols from /home/francisco/workspace/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.elf...
0000326:INFO:board:Target type is nrf52840
0000418:INFO:dap:DP IDR = 0x2ba01477 (v1 rev2)
0000440:INFO:ap:AP#0 IDR = 0x24770011 (AHB-AP var1 rev2)
0000481:INFO:ap:AP#1 IDR = 0x02880000 (proprietary)
0000565:INFO:rom_table:AP#0 ROM table #0 @ 0xe00ff000 (designer=244 part=008)
0000605:INFO:rom_table:[0]<e000e000:SCS-M4 class=14 designer=43b part=00c>
0000612:INFO:rom_table:[1]<e0001000:DWT class=14 designer=43b part=002>
0000618:INFO:rom_table:[2]<e0002000:FPB class=14 designer=43b part=003>
0000625:INFO:rom_table:[3]<e0000000:ITM class=14 designer=43b part=001>
0000632:INFO:rom_table:[4]<e0040000:TPIU-M4 class=9 designer=43b part=9a1 devtype=11 archid=0000 devid=0:0:ca1>
0000642:INFO:rom_table:[5]<e0041000:ETM-M4 class=9 designer=43b part=925 devtype=13 archid=0000 devid=0:0:0>
0000649:INFO:cortex_m:CPU core #0 is Cortex-M4 r0p1
0000660:INFO:cortex_m:FPU present: FPv4-SP
0000668:INFO:dwt:4 hardware watchpoints
0000677:INFO:fpb:6 hardware breakpoints, 4 literal comparators
0000700:INFO:server:Semihost server started on port 4444
0000701:INFO:gdbserver:GDB server started on port 3333
Remote debugging using :3333
0001365:INFO:gdbserver:One client connected!
pm_set_lowest () at /home/francisco/workspace/RIOT/cpu/cortexm_common/include/cpu.h:177
177         irq_restore(state);
0001501:INFO:gdbserver:Attempting to load Argon
0001502:INFO:gdbserver:Attempting to load FreeRTOS
0001502:INFO:gdbserver:Attempting to load Zephyr
```
</details>

<details><summary>DEBUG_ADAPTER_ID=10260000033adcbb00000000000000000000000097969902 make -C examples/hello-world/ BOARD=nrf52840-mdk reset</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/dist/tools/pyocd/pyocd.sh reset
### Resetting Target ###
Resetting target
make: Leaving directory '/home/francisco/workspace/RIOT/examples/hello-world'
### Issues/PRs references
```
</details>

- master:

<details><summary>DEBUG_ADAPTER_ID=10260000033adcbb00000000000000000000000097969902 make -C examples/hello-world/ BOARD=nrf52840-mdk flash</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
Building application "hello-world" for "nrf52840-mdk" with MCU "nrf52".

"make" -C /home/francisco/workspace/RIOT/boards/nrf52840-mdk
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common/periph
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
   text    data     bss     dec     hex filename
   8176     116    2556   10848    2a60 /home/francisco/workspace/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.elf
/home/francisco/workspace/RIOT/dist/tools/pyocd/pyocd.sh flash /home/francisco/workspace/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.hex
### Flashing Target ###
## => Board Name | Unique ID
-- -- ----------------------
 0 => ARM DAPLink CMSIS-DAP | 10260000033adcbb00000000000000000000000097969902
 1 => Atmel Corp. EDBG CMSIS-DAP | ATML2127031800011523
 q => Quit

Enter the number of the debug probe to connect:

```
</details>

<details><summary>DEBUG_ADAPTER_ID=10260000033adcbb00000000000000000000000097969902 make -C examples/hello-world/ BOARD=nrf52840-mdk debug</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/dist/tools/pyocd/pyocd.sh debug /home/francisco/workspace/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.elf
### Starting Debugging ###
Reading symbols from /home/francisco/workspace/RIOT/examples/hello-world/bin/nrf52840-mdk/hello-world.elf...
## => Board Name | Unique ID
-- -- ----------------------
 0 => ARM DAPLink CMSIS-DAP | 10260000033adcbb00000000000000000000000097969902
 1 => Atmel Corp. EDBG CMSIS-DAP | ATML2127031800011523
 q => Quit

Enter the number of the debug probe to connect:
> 0000305:CRITICAL:__main__:uncaught exception: EOF when reading a line
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/pyocd/__main__.py", line 338, in run
    self._COMMANDS[self._args.cmd](self)
  File "/usr/local/lib/python3.6/dist-packages/pyocd/__main__.py", line 562, in do_gdbserver
    options=sessionOptions)
  File "/usr/local/lib/python3.6/dist-packages/pyocd/core/helpers.py", line 232, in session_with_chosen_probe
    unique_id=unique_id,
  File "/usr/local/lib/python3.6/dist-packages/pyocd/core/helpers.py", line 165, in choose_probe
    line = six.moves.input("> ")
EOFError: EOF when reading a line
```
</details>

<details><summary>DEBUG_ADAPTER_ID=10260000033adcbb00000000000000000000000097969902 make -C examples/hello-world/ BOARD=nrf52840-mdk reset</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/dist/tools/pyocd/pyocd.sh reset
### Resetting Target ###
## => Board Name | Unique ID
-- -- ----------------------
 0 => ARM DAPLink CMSIS-DAP | 10260000033adcbb00000000000000000000000097969902
 1 => Atmel Corp. EDBG CMSIS-DAP | ATML2127031800011523
 q => Quit

Enter the number of the debug probe to connect:
```
</details>
