### PR TITLE
Revert "shell/commands: fix, only accept proper pong response"

### DIFF
--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -338,7 +338,7 @@ static void _print_reply(_ping_data_t *data, gnrc_pktsnip_t *icmpv6,
         uint16_t recv_seq;
 
         /* not our ping */
-        if ((byteorder_ntohs(icmpv6_hdr->id) != data->id) ||
+        if ((byteorder_ntohs(icmpv6_hdr->id) != data->id) &&
             !ipv6_addr_equal(from, &data->host)) {
             return;
         }


### PR DESCRIPTION
### Contribution description
This reverts commit 5e1558ba57e2a8e925474ebdd3332ac9076d9c50 as it breaks brodcast ping.


### Testing procedure

Run `ping6 ff02::1` with at least one other node in the same PAN.

#### Expected results
```
2019-09-10 19:20:39,932 - INFO #  ping6 ff02::1%7
2019-09-10 19:20:39,955 - INFO # 12 bytes from fe80::8d1b:3202:ae20:bb66: icmp_seq=0 ttl=64 rssi=-34 dBm time=7.861 ms
2019-09-10 19:20:39,960 - INFO # 12 bytes from fe80::3030:81da:f70c:5e06: icmp_seq=0 ttl=64 rssi=-66 dBm time=16.176 ms (DUP!)
2019-09-10 19:20:40,947 - INFO # 12 bytes from fe80::8d1b:3202:ae20:bb66: icmp_seq=1 ttl=64 rssi=-37 dBm time=6.931 ms
2019-09-10 19:20:41,949 - INFO # 12 bytes from fe80::3030:81da:f70c:5e06: icmp_seq=2 ttl=64 rssi=-70 dBm time=7.988 ms
2019-09-10 19:20:41,952 - INFO # 
2019-09-10 19:20:41,956 - INFO # --- ff02::1 PING statistics ---
2019-09-10 19:20:41,961 - INFO # 3 packets transmitted, 3 packets received, 1 duplicates, 0% packet loss
```

#### Actual results
```
2019-09-10 19:21:48,467 - INFO #  ping6 ff02::1%7
2019-09-10 19:21:51,469 - INFO # 
2019-09-10 19:21:51,473 - INFO # --- ff02::1 PING statistics ---
2019-09-10 19:21:51,478 - INFO # 3 packets transmitted, 0 packets received, 100% packet loss
```

### Issues/PRs references
this reverts #12159 but the real culprit was #11933 😉 
