### PR TITLE
cpu/fe310: fixes for SW interrupt latency issues

### DIFF
--- a/cpu/fe310/periph/pm.c
+++ b/cpu/fe310/periph/pm.c
@@ -23,7 +23,7 @@
 
 void pm_set_lowest(void)
 {
-    /* __asm__("wfi"); */
+    __asm__ volatile ("wfi");
 }
 
 void pm_off(void)


### PR DESCRIPTION
Fix for latency in invoking SW interrupt for context switching

### Contribution description

FE310 uses a software interrupt to perform a context switch. This interrupt has a latency of 4-7 cycles, which can cause instructions to be executed after `thread_yield_higher` leading to unpredictable results. The bug is similar to that found in #8897.

Also added core panic support and fixed `cpu_switch_context_exit `logic.

### Testing procedure

Tested with all tests\thread_*  apps

### Issues/PRs references

Fixes: #12109
Fixes: #12110
