### PR TITLE
make: disable dwarf compression on CI builds

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -39,9 +39,13 @@ endif
 CFLAGS += -fno-common
 
 # Compress debug info. This saves approximately 50% of disk usage.
-# It has no effect if debugging information is not emitted, so it can be left
-# on unconditionally.
-OPTIONAL_CFLAGS += -gz
+# A bug in ccache <= 3.7.3 makes ccache needlessly include the CWD in a
+# compilation hash when using "-gz" even if no debug symbols are generated,
+# thus disable for CI builds.
+# See https://github.com/ccache/ccache/issues/464 for more info.
+ifneq (1, $(RIOT_CI_BUILD))
+  OPTIONAL_CFLAGS += -gz
+endif
 
 # Enable all default warnings and all extra warnings
 CFLAGS += -Wall -Wextra


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If enabled, ccache on CI becomes almost ineffective.

This PR guards the CFLAG with RIOT_CI_BUILD.

From #12110 

```
This somehow makes ccache almost ineffective on CI. Maybe you noticed almost doubled build times today? My first thought turned out to be wrong. During the day, I cleared the cache on one of the workers, but build times stayed double. So cache thrashing was no issue, (and should't be actually as even the oldest PRs get rebased to master and are thus not much different).

Then I ran a script that ran a limited build (samr21-xpro only) on one worker, once with clean cache, then one more time with hot cache, on all merged commits since the last nightly.

Long story short, 3aa8bc0 (this PR's merge commit) somehow makes ccache ineffective.
```

I tried to reproduce locally with this:

```
cd examples/gnrc_networking; hyperfine -w1 "RIOT_CI_BUILD=1 BOARD=samr21-xpro make clean all -j8"
```

On my laptop, master takes ~2.6s, this PR ~2.2s, so the difference is not so drastic. Let's see how quickly this PR builds on CI. Might need two builds (cold vs hot cache) to see the difference.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#12150 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
