### PR TITLE
periph/timer: Fix return codes of timer API

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -140,7 +140,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     *ctx[tim].flag &= ~(1 << (channel + OCF1A));
     *ctx[tim].mask |= (1 << (channel + OCIE1A));
 
-    return 1;
+    return 0;
 }
 
 int timer_clear(tim_t tim, int channel)

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -177,7 +177,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     }
     dev(tim)->IMR |= chn_isr_cfg[channel].flag;
 
-    return 1;
+    return 0;
 }
 
 int timer_clear(tim_t tim, int channel)
@@ -190,7 +190,7 @@ int timer_clear(tim_t tim, int channel)
     /* clear interupt flags */
     dev(tim)->IMR &= ~(chn_isr_cfg[channel].flag);
 
-    return 1;
+    return 0;
 }
 
 /*

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -184,7 +184,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     }
     dev(tim)->IMR |= chn_isr_cfg[channel].flag;
 
-    return 1;
+    return 0;
 }
 
 int timer_clear(tim_t tim, int channel)

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -463,7 +463,7 @@ static inline int lptmr_set(uint8_t dev, uint16_t timeout)
         lptmr_reload(dev, timeout);
     }
     irq_restore(mask);
-    return 1;
+    return 0;
 }
 
 static inline int lptmr_set_absolute(uint8_t dev, uint16_t target)
@@ -498,7 +498,7 @@ static inline int lptmr_set_absolute(uint8_t dev, uint16_t target)
         lptmr_reload(dev, timeout);
     }
     irq_restore(mask);
-    return 1;
+    return 0;
 }
 
 static inline int lptmr_clear(uint8_t dev)
@@ -510,20 +510,20 @@ static inline int lptmr_clear(uint8_t dev)
     if (!lptmr[dev].running) {
         /* Already clear */
         irq_restore(mask);
-        return 1;
+        return 0;
     }
     lptmr[dev].running = 0;
     if (!(hw->CSR & LPTMR_CSR_TEN_MASK)) {
         /* Timer is stopped */
         irq_restore(mask);
-        return 1;
+        return 0;
     }
     /* Disable interrupt, enable timer */
     hw->CSR = LPTMR_CSR_TEN_MASK | LPTMR_CSR_TFC_MASK;
     /* Clear IRQ if it occurred during this function */
     NVIC_ClearPendingIRQ(lptmr_config[dev].irqn);
     irq_restore(mask);
-    return 1;
+    return 0;
 }
 
 static inline void lptmr_start(uint8_t dev)

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -80,7 +80,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     unsigned int timer_base;
     unsigned int timer_side = TIMER_A;
     unsigned int timer_cfg = TIMER_CFG_SPLIT_PAIR | TIMER_CFG_A_PERIODIC_UP | TIMER_TAMR_TAMIE;
-    unsigned int timer_max_val;
+    unsigned int timer_max_val = 0;
     unsigned int timer_intbit = TIMER_TIMA_TIMEOUT | TIMER_TIMA_MATCH;
 
     switch(dev){

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -163,7 +163,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
     ROM_TimerMatchSet(timer_base, timer_side, (unsigned long) (scaledv & 0xFFFFFFFF));
     ROM_TimerEnable(timer_base, timer_side);
 
-    return 1;
+    return 0;
 }
 
 int timer_clear(tim_t dev, int channel)
@@ -194,7 +194,7 @@ int timer_clear(tim_t dev, int channel)
     }
 
     ROM_TimerIntClear(timer_base, timer_intbit);
-    return 1;
+    return 0;
 }
 
 unsigned int timer_read(tim_t dev)

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -83,7 +83,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
                 return -1;
         }
         TIMER_0_DEV->MCR |= (1 << (channel * 3));
-        return 1;
+        return 0;
     }
     return -1;
 }
@@ -92,7 +92,7 @@ int timer_clear(tim_t dev, int channel)
 {
     if (dev == TIMER_0 && channel >= 0 && channel < TIMER_0_CHANNELS) {
         TIMER_0_DEV->MCR &= ~(1 << (channel * 3));
-        return 1;
+        return 0;
     }
     return -1;
 }

--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -135,7 +135,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
     compares[channel] = counter + timeout;
     irq_restore(status);
 
-    return 1;
+    return 0;
 }
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
@@ -152,7 +152,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
     compares[channel] = value;
     irq_restore(status);
 
-    return 1;
+    return 0;
 }
 
 int timer_clear(tim_t dev, int channel)
@@ -166,7 +166,7 @@ int timer_clear(tim_t dev, int channel)
     compares[channel] = 0;
     irq_restore(status);
 
-    return 1;
+    return 0;
 }
 
 unsigned int timer_read(tim_t dev)

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -141,7 +141,7 @@ int timer_set(tim_t dev, int channel, unsigned int offset)
 
     do_timer_set(offset);
 
-    return 1;
+    return 0;
 }
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
@@ -157,7 +157,7 @@ int timer_clear(tim_t dev, int channel)
 
     do_timer_set(0);
 
-    return 1;
+    return 0;
 }
 
 void timer_start(tim_t dev)

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -103,7 +103,7 @@ int timer_set_absolute(tim_t tim, int chan, unsigned int value)
     dev(tim)->CC[chan] = value;
     dev(tim)->INTENSET = (TIMER_INTENSET_COMPARE0_Msk << chan);
 
-    return 1;
+    return 0;
 }
 
 int timer_clear(tim_t tim, int chan)
@@ -116,7 +116,7 @@ int timer_clear(tim_t tim, int chan)
     dev(tim)->INTENCLR = (TIMER_INTENSET_COMPARE0_Msk << chan);
     ctx[tim].flags &= ~(1 << chan);
 
-    return 1;
+    return 0;
 }
 
 unsigned int timer_read(tim_t tim)

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -164,7 +164,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
         return -1;
      }
 
-    return 1;
+    return 0;
 }
 
 int timer_clear(tim_t tim, int channel)
@@ -182,7 +182,7 @@ int timer_clear(tim_t tim, int channel)
         return -1;
     }
 
-    return 1;
+    return 0;
 }
 
 unsigned int timer_read(tim_t tim)

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -141,7 +141,7 @@ int timer_clear(tim_t tim, int channel)
 
     dev(tim)->TC_CHANNEL[0].TC_IDR = (TC_IDR_CPAS << channel);
 
-    return 1;
+    return 0;
 }
 
 unsigned int timer_read(tim_t tim)

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -108,7 +108,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg);
  * @param[in] timeout       timeout in ticks after that the registered callback
  *                          is executed
  *
- * @return                  1 on success
+ * @return                  0 on success
  * @return                  -1 on error
  */
 int timer_set(tim_t dev, int channel, unsigned int timeout);
@@ -121,7 +121,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout);
  * @param[in] value         the absolute compare value when the callback will be
  *                          triggered
  *
- * @return                  1 on success
+ * @return                  0 on success
  * @return                  -1 on error
  */
 int timer_set_absolute(tim_t dev, int channel, unsigned int value);
@@ -132,7 +132,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value);
  * @param[in] dev           the timer device to clear
  * @param[in] channel       the channel on the given device to clear
  *
- * @return                  1 on success
+ * @return                  0 on success
  * @return                  -1 on error
  */
 int timer_clear(tim_t dev, int channel);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR changes the documentation of the periph/timer API to reflect most implementations, i.e., changing the return codes for `timer_set`, `timer_set_absolute`, and `timer_clear` to always use `0` on success instead of `1`. Rational is as follows: 
- most (if not all) C API commonly use `0` for success
- its confusing that `timer_init` returns `0` on success and `-1` on error, but other functions (see above) return `1` for success while still returning `-1` on error. So no bool logic could be used either. 
- most of our implementation already do this (bc. the original contributed assumed said default, or/and just didn't read the documentation)
- the impact of this change is minimal (or even none) for code in RIOT main tree, as return codes are hardly (or never) used - at least for the functions changed here.

### Testing procedure

run `tests/periph_timer` or any other timer test on your favourite board and verify it still works.

I will add a link to our HIL test results in the comments below, after this PR is open.

### Issues/PRs references

#4371