### PR TITLE
.murdock: blacklist the -gz (debug compression) compiler flag.

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -9,6 +9,23 @@ export CFLAGS_DBG=""
 export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 export ENABLE_TEST_CACHE=${ENABLE_TEST_CACHE:-1}
 
+# This is a work around for a bug in CCACHE which interacts very badly with
+# some features of RIOT and of murdock. The result is that ccache is
+# ineffective (i.e. objects are never reused, resulting in extreme cache miss
+# rate) and murdock becomes slow.
+#
+# - CCACHE thinks that -gz by itself enables debugging, which is not true.
+#   see https://github.com/ccache/ccache/issues/464
+#   - When debug info is included, CCACHE hashes the file paths, as these
+#     influence the debug information (the name of compile units and/or their
+#     "comp_dir" attribute)
+# - Riot does not set -fdebug-prefix-map. This is not that easy as it may not
+#   be supported in every toolchain (some are quite old).
+# - Murdock builds PRs in different directories each time.
+#
+# It is only the combination of these three factors which causes this bug.
+export OPTIONAL_CFLAGS_BLACKLIST="-gz"
+
 NIGHTLY=${NIGHTLY:-0}
 RUN_TESTS=${RUN_TESTS:-${NIGHTLY}}
 


### PR DESCRIPTION
### Contribution description

-gz enables DWARF section compression, though it is a no-op where debug is not enable, e.g. in murdock.

Due to a combination of factors, including a bug in CCACHE, this flag makes CCACHE ineffective and slows down murdock.

The alternative, of filtering the flags in our buid system (for example, by testing RIOT_CI_BUILD or CCACHE) are too much of a shotgun approach as the problem is quite specific to our CI setup.

<details>
 <summary>Read the comment in the file for a more in-depth description.</summary>

> This is a work around for a bug in CCACHE which interacts very badly with
> some features of RIOT and of murdock. The result is that ccache is
> ineffective (i.e. objects are never reused, resulting in extreme cache miss
> rate) and murdock becomes slow.
>
> - CCACHE thinks that -gz by itself enables debugging, which is not true.
>   see https://github.com/ccache/ccache/issues/464
>   - When debug info is included, CCACHE hashes the file paths, as these
>     influence the debug information (the name of compile units and/or their
>     "comp_dir" attribute)
> - Riot does not set -fdebug-prefix-map. This is not that easy as it may not
>   be supported in every toolchain (some are quite old).
> - Murdock builds PRs in different directories each time.
>
> It is only the combination of these three factors which causes this bug.

</details>

### Testing procedure

Run murdock, see if it goes fast.

### Issues/PRs references

Alternative to #12198 .
