### PR TITLE
core/thread.c: thread_create fix priority type

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -341,7 +341,7 @@ struct _thread {
 */
 kernel_pid_t thread_create(char *stack,
                   int stacksize,
-                  char priority,
+                  uint8_t priority,
                   int flags,
                   thread_task_func_t task_func,
                   void *arg,

--- a/core/thread.c
+++ b/core/thread.c
@@ -143,7 +143,7 @@ uintptr_t thread_measure_stack_free(char *stack)
 }
 #endif
 
-kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags, thread_task_func_t function, void *arg, const char *name)
+kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority, int flags, thread_task_func_t function, void *arg, const char *name)
 {
     if (priority >= SCHED_PRIO_LEVELS) {
         return -EINVAL;


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The priority type in `thread_create` is now consistent with the `struct _thread `.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Create a thread with a priority of -1:
```
main(): This is RIOT! (Version: 2019.10-devel-445-g1d16b-pr/core/thread/hotfix_prio_type)
	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x565a9400 | 0x565a9400
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x565a7120 | 0x565a8f90 
	  2 | main                 | running  Q |   7 |  12288 ( 2556) | 0x565a4120 | 0x565a6f90 
	  3 | nr2                  | sleeping _ | 255 |  12288 (  420) | 0x565a1120 | 0x565a3f90 
	    | SUM 
```
After fix it it returns `-EINVAL` and does not create a thread.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
