### PR TITLE
pthread_cond.h: use 'sys/types.h' value of 'clockid_t' for avr. Enables pthread on AVR.

### DIFF
--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -25,13 +25,17 @@
 #   include "msp430_types.h"
 #endif
 
+#if defined(__WITH_AVRLIBC__)
+/* avr-libc 'time.h' does not include 'sys/types.h' but we need 'clockid_t' */
+#   include <sys/types.h>
+#endif
+
 #ifdef __MACH__
 /* needed for AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER */
 #include <AvailabilityMacros.h>
-#endif
-
-#if defined(__WITH_AVRLIBC__) || (defined(__MACH__) && !defined(AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER))
+#if !defined(AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER)
 typedef int clockid_t;
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/tests/pthread/Makefile
+++ b/tests/pthread/Makefile
@@ -1,12 +1,5 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno jiminy-mega256rfr2 mega-xplained \
-                   waspmote-pro
-# arduino mega2560 uno duemilanove : unknown type name: clockid_t
-# jiminy-mega256rfr2: unknown type name: clockid_t
-# mega-xplained: unknown type name: clockid_t
-
 USEMODULE += posix_headers
 USEMODULE += pthread
 

--- a/tests/pthread_barrier/Makefile
+++ b/tests/pthread_barrier/Makefile
@@ -1,12 +1,10 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno i-nucleo-lrwan1 jiminy-mega256rfr2 \
-                   mega-xplained stm32l0538-disco waspmote-pro
-# AVR platform: unknown type name: clockid_t
-
-# exclude boards with insufficient memory
-BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY = \
+	i-nucleo-lrwan1 \
+	nucleo-f031k6 \
+	stm32l0538-disco \
+	#
 
 # Modules to include.
 USEMODULE += pthread

--- a/tests/pthread_cleanup/Makefile
+++ b/tests/pthread_cleanup/Makefile
@@ -1,12 +1,5 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno jiminy-mega256rfr2 mega-xplained \
-                   waspmote-pro
-# arduino mega2560 uno duemilanove : unknown type name: clockid_t
-# jiminy-mega256rfr2: unknown type name: clockid_t
-# mega-xplained: unknown type name: clockid_t
-
 USEMODULE += pthread
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_condition_variable/Makefile
+++ b/tests/pthread_condition_variable/Makefile
@@ -1,12 +1,5 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno jiminy-mega256rfr2 mega-xplained \
-                   waspmote-pro
-# arduino mega2560 uno duemilanove : unknown type name: clockid_t
-# jiminy-mega256rfr2: unknown type name: clockid_t
-# mega-xplained: unknown type name: clockid_t
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += posix_headers

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -1,13 +1,25 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno hifive1 hifive1b i-nucleo-lrwan1 \
-                   jiminy-mega256rfr2 mega-xplained stm32l0538-disco waspmote-pro
+BOARD_INSUFFICIENT_MEMORY := \
+	arduino-duemilanove \
+	arduino-nano \
+	arduino-uno \
+	nucleo-f031k6 \
+	hifive1 \
+	hifive1b \
+	i-nucleo-lrwan1 \
+	stm32l0538-disco \
+	#
 
-# AVR platform: unknown type name: clockid_t
-# hifive1: not enough memory for thread stacks
-
-BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
+# The test reboots on 'arduino-mega2560' because it mallocs too much memory.
+# So I disabled all the other avr boards. Re-enable after success test.
+BOARD_INSUFFICIENT_MEMORY += \
+	arduino-leonardo \
+	arduino-mega2560 \
+	jiminy-mega256rfr2 \
+	mega-xplained \
+	waspmote-pro \
+	#
 
 USEMODULE += posix_headers
 USEMODULE += pthread

--- a/tests/pthread_flood/Makefile
+++ b/tests/pthread_flood/Makefile
@@ -1,13 +1,11 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
-
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno jiminy-mega256rfr2 mega-xplained \
-                   waspmote-pro
-# arduino mega2560 uno duemilanove : unknown type name: clockid_t
-# jiminy-mega256rfr2: unknown type name: clockid_t
-# mega-xplained: unknown type name: clockid_t
+BOARD_INSUFFICIENT_MEMORY = \
+	arduino-duemilanove \
+	arduino-nano \
+	arduino-uno \
+	nucleo-f031k6 \
+	#
 
 USEMODULE += posix_headers
 USEMODULE += pthread

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -1,21 +1,28 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno jiminy-mega256rfr2 mega-xplained \
-                   waspmote-pro
-# arduino mega2560 uno duemilanove : unknown type name: clockid_t
-# jiminy-mega256rfr2: unknown type name: clockid_t
-# mega-xplained: unknown type name: clockid_t
-
 USEMODULE += pthread
 USEMODULE += xtimer
 USEMODULE += random
 
-BOARD_INSUFFICIENT_MEMORY += chronos i-nucleo-lrwan1 \
-                             msb-430 msb-430h nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery stm32l0538-disco
+BOARD_INSUFFICIENT_MEMORY = \
+	arduino-duemilanove \
+	arduino-leonardo \
+	arduino-nano \
+	arduino-uno \
+	chronos \
+	i-nucleo-lrwan1 \
+	msb-430 \
+	msb-430h \
+	nucleo-f030r8 \
+	nucleo-f031k6 \
+	nucleo-f042k6 \
+	nucleo-f303k8 \
+	nucleo-f334r8 \
+	nucleo-l031k6 \
+	nucleo-l053r8 \
+	stm32f0discovery \
+	stm32l0538-disco \
+	#
 
 # HACK Blacklist native as `murdock` fails on utf-8 characters for native tests
 TEST_ON_CI_BLACKLIST += native

--- a/tests/pthread_tls/Makefile
+++ b/tests/pthread_tls/Makefile
@@ -1,13 +1,12 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
-                   arduino-nano arduino-uno jiminy-mega256rfr2 mega-xplained \
-                   waspmote-pro
-# arduino mega2560 uno duemilanove : unknown type name: clockid_t
-# jiminy-mega256rfr2: unknown type name: clockid_t
-# mega-xplained: unknown type name: clockid_t
-
 USEMODULE += posix_headers
 USEMODULE += pthread
+
+BOARD_INSUFFICIENT_MEMORY = \
+	arduino-duemilanove \
+	arduino-nano \
+	arduino-uno \
+	#
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

This enables 'pthread' support on avr
    
avr-libc C90 'time.h' does not include 'sys/types.h' as POSIX expects it.
However, the type previously defined conflicts with the one in
'cpu/atmega_common/avr_libc_extra/include/sys/types.h' when both are
included, so include 'sys/types.h'.
    
Maybe it should alway be included by 'time.h' but this would need its specific review.

### Testing procedure

Run the `pthread*` tests on `avr` boards.

I could run all the tests on `arduino-mega2560`.

(except the disabled 'pthread_cooperation' that rashes due to lack of ram (and does not check the pthread_create return value))

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . arduino-mega2560 --applications="tests/pthread  tests/pthread_barrier  tests/pthread_cleanup  tests/pthread_condition_variable  tests/pthread_cooperation  tests/pthread_flood  tests/pthread_rwlock
tests/pthread_tls"
INFO:arduino-mega2560:Saving toolchain
INFO:arduino-mega2560.tests/pthread:Board supported: True
INFO:arduino-mega2560.tests/pthread:Board has enough memory: True
INFO:arduino-mega2560.tests/pthread:Application has test: True
INFO:arduino-mega2560.tests/pthread:Run compilation
INFO:arduino-mega2560.tests/pthread:Run test
INFO:arduino-mega2560.tests/pthread:Run test.flash
INFO:arduino-mega2560.tests/pthread:Success
INFO:arduino-mega2560.tests/pthread_barrier:Board supported: True
INFO:arduino-mega2560.tests/pthread_barrier:Board has enough memory: True
INFO:arduino-mega2560.tests/pthread_barrier:Application has test: True
INFO:arduino-mega2560.tests/pthread_barrier:Run compilation
INFO:arduino-mega2560.tests/pthread_barrier:Run test
INFO:arduino-mega2560.tests/pthread_barrier:Run test.flash
INFO:arduino-mega2560.tests/pthread_barrier:Success
INFO:arduino-mega2560.tests/pthread_cleanup:Board supported: True
INFO:arduino-mega2560.tests/pthread_cleanup:Board has enough memory: True
INFO:arduino-mega2560.tests/pthread_cleanup:Application has test: True
INFO:arduino-mega2560.tests/pthread_cleanup:Run compilation
INFO:arduino-mega2560.tests/pthread_cleanup:Run test
INFO:arduino-mega2560.tests/pthread_cleanup:Run test.flash
INFO:arduino-mega2560.tests/pthread_cleanup:Success
INFO:arduino-mega2560.tests/pthread_condition_variable:Board supported: True
INFO:arduino-mega2560.tests/pthread_condition_variable:Board has enough memory: True
INFO:arduino-mega2560.tests/pthread_condition_variable:Application has test: True
INFO:arduino-mega2560.tests/pthread_condition_variable:Run compilation
INFO:arduino-mega2560.tests/pthread_condition_variable:Run test
INFO:arduino-mega2560.tests/pthread_condition_variable:Run test.flash
INFO:arduino-mega2560.tests/pthread_condition_variable:Success
INFO:arduino-mega2560.tests/pthread_cooperation:Board supported: True
INFO:arduino-mega2560.tests/pthread_cooperation:Board has enough memory: False
INFO:arduino-mega2560.tests/pthread_flood:Board supported: True
INFO:arduino-mega2560.tests/pthread_flood:Board has enough memory: True
INFO:arduino-mega2560.tests/pthread_flood:Application has test: True
INFO:arduino-mega2560.tests/pthread_flood:Run compilation
INFO:arduino-mega2560.tests/pthread_flood:Run test
INFO:arduino-mega2560.tests/pthread_flood:Run test.flash
INFO:arduino-mega2560.tests/pthread_flood:Success
INFO:arduino-mega2560.tests/pthread_rwlock:Board supported: True
INFO:arduino-mega2560.tests/pthread_rwlock:Board has enough memory: True
INFO:arduino-mega2560.tests/pthread_rwlock:Application has test: True
INFO:arduino-mega2560.tests/pthread_rwlock:Run compilation
INFO:arduino-mega2560.tests/pthread_rwlock:Run test
INFO:arduino-mega2560.tests/pthread_rwlock:Run test.flash
INFO:arduino-mega2560.tests/pthread_rwlock:Success
INFO:arduino-mega2560.tests/pthread_tls:Board supported: True
INFO:arduino-mega2560.tests/pthread_tls:Board has enough memory: True
INFO:arduino-mega2560.tests/pthread_tls:Application has test: True
INFO:arduino-mega2560.tests/pthread_tls:Run compilation
INFO:arduino-mega2560.tests/pthread_tls:Run test
INFO:arduino-mega2560.tests/pthread_tls:Run test.flash
INFO:arduino-mega2560.tests/pthread_tls:Success
INFO:arduino-mega2560:Tests successful
```


### Issues/PRs references

Found the compiler error while talking with @JulianHolzwarth while testing #12056 