### PR TITLE
usbus: rename setup request to control request

### DIFF
--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -137,17 +137,18 @@ typedef enum {
 } usbus_state_t;
 
 /**
- * @brief USBUS setup request state machine
+ * @brief USBUS control request state machine
  */
 typedef enum {
-    USBUS_SETUPRQ_READY,        /**< Ready for new setup request */
-    USBUS_SETUPRQ_INDATA,       /**< Request received with expected DATA IN stage */
-    USBUS_SETUPRQ_OUTACK,       /**< Expecting a zero-length ack out request
-                                     from the host */
-    USBUS_SETUPRQ_OUTDATA,      /**< Data OUT expected */
-    USBUS_SETUPRQ_INACK,        /**< Expecting a zero-length ack in request
-                                     from the host */
-} usbus_setuprq_state_t;
+    USBUS_CONTROL_REQUEST_STATE_READY,    /**< Ready for new control request */
+    USBUS_CONTROL_REQUEST_STATE_INDATA,   /**< Request received with expected
+                                               DATA IN stage */
+    USBUS_CONTROL_REQUEST_STATE_OUTACK,   /**< Expecting a zero-length ack OUT
+                                               request from the host */
+    USBUS_CONTROL_REQUEST_STATE_OUTDATA,  /**< Data OUT expected */
+    USBUS_CONTROL_REQUEST_STATE_INACK,    /**< Expecting a zero-length ack IN
+                                               request from the host */
+} usbus_control_request_state_t;
 
 /**
  * @brief USBUS string type
@@ -314,13 +315,13 @@ typedef struct usbus_handler_driver {
                              usbdev_ep_t *ep, usbus_event_transfer_t event);
 
     /**
-     * @brief setup request handler function
+     * @brief control request handler function
      *
-     * This function receives USB setup requests from the USBUS stack.
+     * This function receives USB control requests from the USBUS stack.
      *
      * @param usbus     USBUS context
      * @param handler   handler context
-     * @param state     setup request state
+     * @param state     control request state
      * @param setup     setup packet
      *
      * @return          Size of the returned data when the request is handled
@@ -328,8 +329,9 @@ typedef struct usbus_handler_driver {
      *                  host
      * @return          zero when the request is not handled by this handler
      */
-    int (*setup_handler)(usbus_t * usbus, struct usbus_handler *handler,
-                         usbus_setuprq_state_t state, usb_setup_t *request);
+    int (*control_handler)(usbus_t * usbus, struct usbus_handler *handler,
+                           usbus_control_request_state_t state,
+                           usb_setup_t *request);
 } usbus_handler_driver_t;
 
 /**

--- a/sys/include/usb/usbus/cdc/ecm.h
+++ b/sys/include/usb/usbus/cdc/ecm.h
@@ -28,6 +28,7 @@
 #include "net/ethernet/hdr.h"
 #include "usb/descriptor.h"
 #include "usb/usbus.h"
+#include "usb/usbus/control.h"
 #include "net/netdev.h"
 #include "mutex.h"
 

--- a/sys/include/usb/usbus/control.h
+++ b/sys/include/usb/usbus/control.h
@@ -43,13 +43,36 @@ typedef struct {
  * @brief Endpoint zero event handler
  */
 typedef struct {
-    usbus_handler_t handler;            /**< Inherited generic handler        */
-    usb_setup_t setup;                  /**< Last received setup packet       */
-    usbus_setuprq_state_t setup_state;  /**< Setup request state machine      */
-    usbus_control_slicer_t slicer;      /**< Slicer for multipart control
-                                            messages */
-    usbdev_ep_t *out;                   /**< EP0 out endpoint                 */
-    usbdev_ep_t *in;                    /**< EP0 in endpoint                  */
+
+    /**
+     * @brief inherited generic handler
+     */
+    usbus_handler_t handler;
+
+    /**
+     * @brief Last received setup packet
+     */
+    usb_setup_t setup;
+
+    /**
+     * @brief Control request state machine state
+     */
+    usbus_control_request_state_t control_request_state;
+
+    /**
+     * @brief Slicer state for multipart control request messages
+     */
+    usbus_control_slicer_t slicer;
+
+    /**
+     * @brief EP0 OUT endpoint
+     */
+    usbdev_ep_t *out;
+
+    /**
+     * @brief EP0 IN endpoint
+     */
+    usbdev_ep_t *in;
 } usbus_control_handler_t;
 
 /**

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm.c
@@ -34,8 +34,9 @@
 
 static void _event_handler(usbus_t *usbus, usbus_handler_t *handler,
                           usbus_event_usb_t event);
-static int _setup_handler(usbus_t *usbus, usbus_handler_t *handler,
-                          usbus_setuprq_state_t state, usb_setup_t *setup);
+static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
+                            usbus_control_request_state_t state,
+                            usb_setup_t *setup);
 static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
                               usbdev_ep_t *ep, usbus_event_transfer_t event);
 static void _init(usbus_t *usbus, usbus_handler_t *handler);
@@ -147,7 +148,7 @@ static const usbus_handler_driver_t cdcecm_driver = {
     .init = _init,
     .event_handler = _event_handler,
     .transfer_handler = _transfer_handler,
-    .setup_handler = _setup_handler,
+    .control_handler = _control_handler,
 };
 
 static void _fill_ethernet(usbus_cdcecm_device_t *cdcecm)
@@ -237,8 +238,9 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
     usbus_handler_set_flag(handler, USBUS_HANDLER_FLAG_RESET);
 }
 
-static int _setup_handler(usbus_t *usbus, usbus_handler_t *handler,
-                          usbus_setuprq_state_t state, usb_setup_t *setup)
+static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
+                          usbus_control_request_state_t state,
+                          usb_setup_t *setup)
 {
     (void)usbus;
     (void)state;


### PR DESCRIPTION
### Contribution description

This PR changes the name of the requests over the control endpoints
to control requests instead of setup requests. This is a terminology fix
to follow the USB specification more closely as technically only the
first stage of a control request is named setup which contains a setup
packet. The whole transfer is a control transfer.

### Testing procedure

The binary itself should not change as this PR should only rename functions and documentation.

Of course `tests/usbus_cdc_ecm` should still work.

### Issues/PRs references

None