### PR TITLE
sys/hashes/pbkdf2: Add PBKDF2-sha256 implementation.

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -721,6 +721,10 @@ ifneq (,$(filter random,$(USEMODULE)))
   USEMODULE += luid
 endif
 
+ifneq (,$(filter hashes,$(USEMODULE)))
+  USEMODULE += crypto
+endif
+
 ifneq (,$(filter asymcute,$(USEMODULE)))
   USEMODULE += sock_udp
   USEMODULE += sock_util

--- a/sys/hashes/pbkdf2.c
+++ b/sys/hashes/pbkdf2.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       PBKDF2 key derivation implementation- only sha256 is supported
+ *              at the moment, and the key size is fixed.
+ *
+ * @author      Juan I Carrano <j.carrano@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "hashes/sha256.h"
+#include "hashes/pbkdf2.h"
+
+static void inplace_xor_scalar(uint8_t *bytes, size_t len, uint8_t c)
+{
+    while (len--) {
+        *bytes ^= c;
+        bytes++;
+    }
+}
+
+static void inplace_xor_digests(uint8_t *d1, const uint8_t *d2)
+{
+    int len = SHA256_DIGEST_LENGTH;
+
+    while (len--) {
+        *d1 ^= *d2;
+        d1++;
+        d2++;
+    }
+}
+
+void pbkdf2_sha256(const uint8_t *password, size_t password_len,
+                   const uint8_t *salt, size_t salt_len,
+                   int iterations,
+                   uint8_t *output)
+{
+    sha256_context_t inner;
+    sha256_context_t outer;
+    uint8_t tmp_digest[SHA256_DIGEST_LENGTH];
+    int first_iter = 1;
+
+    {
+        uint8_t processed_pass[SHA256_INTERNAL_BLOCK_SIZE] = {0};
+
+        if (password_len > sizeof(processed_pass)) {
+            sha256_init(&inner);
+            sha256_update(&inner, password, password_len);
+            sha256_final(&inner, processed_pass);
+        } else {
+            memcpy(processed_pass, password, password_len);
+        }
+
+        sha256_init(&inner);
+        sha256_init(&outer);
+
+        /* Trick: doing inner.update(processed_pass XOR 0x36) followed by
+         * inner.update(processed_pass XOR 0x5C) requires remembering
+         * processed_pass. Instead undo the first XOR while doing the second.
+         */
+        inplace_xor_scalar(processed_pass, sizeof(processed_pass), 0x36);
+        sha256_update(&inner, processed_pass, sizeof(processed_pass));
+
+        inplace_xor_scalar(processed_pass, sizeof(processed_pass), 0x36 ^ 0x5C);
+        sha256_update(&outer, processed_pass, sizeof(processed_pass));
+    }
+
+    memset(output, 0, SHA256_DIGEST_LENGTH);
+
+    while (iterations--) {
+        sha256_context_t inner_copy = inner, outer_copy = outer;
+
+        if (first_iter) {
+            sha256_update(&inner_copy, salt, salt_len);
+            sha256_update(&inner_copy, "\x00\x00\x00\x01", 4);
+            first_iter = 0;
+        } else {
+            sha256_update(&inner_copy, tmp_digest, sizeof(tmp_digest));
+        }
+
+        sha256_final(&inner_copy, tmp_digest);
+
+        sha256_update(&outer_copy, tmp_digest, sizeof(tmp_digest));
+        sha256_final(&outer_copy, tmp_digest);
+
+        inplace_xor_digests(output, tmp_digest);
+    }
+}

--- a/sys/include/hashes/pbkdf2.h
+++ b/sys/include/hashes/pbkdf2.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @defgroup    sys_hashes_pbkdf2 PBKDF2
+ * @ingroup     sys_hashes
+ * @brief       PBKDF2 key derivation implementation.
+ * @{
+ *
+ * @file
+ * @brief       PBKDF2 key derivation implementation.
+ *
+ * @author      Juan I Carrano <j.carrano@fu-berlin.de>
+ *
+ * @}
+ */
+
+#ifndef HASHES_PBKDF2_H
+#define HASHES_PBKDF2_H
+
+#include "hashes/sha256.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PBKDF2_KEY_SIZE SHA256_DIGEST_LENGTH
+
+/**
+ * Create a key from a password and hash using PBKDF2.
+ *
+ * @param   iterations  Number of rounds. Must be >1.
+ * @param[out]   output  Array of size PBKDF2_KEY_SIZE
+ */
+void pbkdf2_sha256(const uint8_t *password, size_t password_len,
+                   const uint8_t *salt, size_t salt_len,
+                   int iterations,
+                   uint8_t *output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HASHES_PBKDF2_H */

--- a/tests/pbkdf2/Makefile
+++ b/tests/pbkdf2/Makefile
@@ -1,0 +1,17 @@
+include ../Makefile.tests_common
+
+# This application uses getchar and thus expects input from stdio
+USEMODULE += stdin
+USEMODULE += hashes
+USEMODULE += base64
+
+ifeq (,$(filter native,$(BOARD)))
+  RIOT_TERMINAL = other
+  TERMPROG = miniterm.py
+  TERMFLAGS = --eol LF /dev/ttyACM0 115200
+endif
+
+# boards fail due to UART weirdness and line buffering done by the terminal
+BOARD_WHITELIST += native
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pbkdf2/README
+++ b/tests/pbkdf2/README
@@ -1,0 +1,11 @@
+Test PBKDF2 implementation
+==========================
+
+This test evaluates the RIOT implementation against a reference. The objective
+is flexibility and clarity, and for this reason there are no hard coded vectors,
+but instead the test is interactive, with the DUT processing vectors given
+through the serial interface.
+
+This means that the test is slower, but more complete and trustworthy.
+
+The test is completely automated.

--- a/tests/pbkdf2/main.c
+++ b/tests/pbkdf2/main.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief       Test PBKDF2-sha256 implementation.
+ *
+ * @author      Juan Carrano <j.carrano@fu-berlin.de>
+ *
+ * This application reads (password, salt, iterations) tuples from the
+ * standard input and outputs the derived key.
+ *
+ * The salt must be base64 encoded. The key is printed as base64.
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "base64.h"
+#include "hashes/pbkdf2.h"
+
+const char error_message[] = "{error}";
+const char input_message[] = "{ready}";
+
+#define LINEBUF_SZ (128)
+
+enum TEST_STATE {
+    TEST_READ_PASS,
+    TEST_READ_SALT,
+    TEST_READ_ITERS,
+    TEST_COMPUTE,
+    TEST_ERROR
+};
+
+int main(void)
+{
+    static char linebuf[LINEBUF_SZ];
+
+    /* There will be a few bytes wasted here */
+    static char password[LINEBUF_SZ];
+    static uint8_t salt[LINEBUF_SZ];
+    static uint8_t key[PBKDF2_KEY_SIZE];
+
+    size_t passwd_len = 0, salt_len = 0;
+    int iterations = 0;
+
+    enum TEST_STATE state = TEST_READ_PASS;
+
+    while ((puts(input_message), fgets(linebuf, LINEBUF_SZ, stdin) != NULL)) {
+        char *s_end;
+        int conversion_status, line_len = strlen(linebuf)-1;
+        size_t b64_buff_size;
+
+        linebuf[line_len] = '\0';
+
+        switch (state) {
+            case TEST_READ_PASS:
+                strcpy(password, linebuf);
+                passwd_len = line_len;
+
+                state++;
+
+                break;
+            case TEST_READ_SALT:
+                /* work around bug in base64_decode */
+                if (line_len == 0) {
+                    salt_len = 0;
+                    conversion_status = BASE64_SUCCESS;
+                } else {
+                    salt_len = sizeof(salt);
+                    conversion_status = base64_decode((uint8_t*)linebuf,
+                                                      line_len+1,
+                                                      salt, &salt_len);
+                }
+
+                if(conversion_status == BASE64_SUCCESS) {
+                    state++;
+                } else {
+                    state = TEST_ERROR;
+                }
+
+                break;
+            case TEST_READ_ITERS:
+                iterations = strtol(linebuf, &s_end, 10);
+
+                if (*s_end != '\0') {
+                    state = TEST_ERROR;
+                } else {
+                    state++;
+                }
+
+                break;
+            default:
+                assert(1);
+                break;
+        }
+
+        switch (state) {
+            case TEST_COMPUTE:
+                pbkdf2_sha256((uint8_t*)password, passwd_len, salt, salt_len,
+                              iterations, key);
+
+                b64_buff_size = sizeof(linebuf);
+                conversion_status = base64_encode(key, sizeof(key),
+                                                  (uint8_t*)linebuf,
+                                                  &b64_buff_size);
+
+                if(conversion_status == BASE64_SUCCESS) {
+                    linebuf[b64_buff_size] = 0;
+                    puts(linebuf);
+                } else {
+                    puts(error_message);
+                }
+
+                state = TEST_READ_PASS;
+                break;
+            case TEST_ERROR:
+                puts(error_message);
+                state = TEST_READ_PASS;
+                break;
+            default:
+                break;
+        }
+    }
+
+    return 0;
+}

--- a/tests/pbkdf2/tests/01-random.py
+++ b/tests/pbkdf2/tests/01-random.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (C) 2019 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+# Author: Juan Carrano <j.carrano@fu-berlin.de>
+"""Random test vectors"""
+
+import hashlib
+import random
+
+import test_base
+
+randgen = random.Random(42)
+
+_pass_chars = [c for c in (chr(x) for x in range(128))
+               if c.isprintable()]
+
+
+def randompass(length):
+    return "".join(randgen.choices(_pass_chars, k=length))
+
+
+def randomsalt(bytes_):
+    return (randgen.getrandbits(bytes_*8).to_bytes(bytes_, 'big')
+            if bytes_ else b'')
+
+
+def randomvector(pass_len, salt_len, iters):
+    pass_ = randompass(pass_len)
+    salt = randomsalt(salt_len)
+    key = hashlib.pbkdf2_hmac('sha256', pass_.encode('ascii'), salt, iters)
+
+    return pass_, salt, iters, key
+
+
+VECTORS = [
+    randomvector(0, 16, 10),
+    randomvector(8, 0, 10),
+    randomvector(9, 64, 1),
+    randomvector(65, 38, 20),
+    randomvector(32, 15, 12),
+    randomvector(48, 32, 15),
+    ]
+
+
+if __name__ == "__main__":
+    test_base.main(VECTORS)

--- a/tests/pbkdf2/tests/01-rfc.py
+++ b/tests/pbkdf2/tests/01-rfc.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (C) 2019 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+# Author: Juan Carrano <j.carrano@fu-berlin.de>
+"""Vector from RFC 7914 section 11"""
+
+import os
+
+import hashlib
+import test_base
+
+KEY_SIZE = hashlib.sha256().digest_size
+
+v_easy = """55 ac 04 6e 56 e3 08 9f ec 16 91 c2 25 44 b6 05
+   f9 41 85 21 6d de 04 65 e6 8b 9d 57 c2 0d ac bc
+   49 ca 9c cc f1 79 b6 45 99 16 64 b3 9d 77 ef 31
+   7c 71 b8 45 b1 e3 0b d5 09 11 20 41 d3 a1 97 83"""
+
+v_hard = """
+   4d dc d8 f6 0b 98 be 21 83 0c ee 5e f2 27 01 f9
+   64 1a 44 18 d0 4c 04 14 ae ff 08 87 6b 34 ab 56
+   a1 d4 25 a1 22 58 33 54 9a db 84 1b 51 c9 b3 17
+   6a 27 2b de bb a1 d0 78 47 8f 62 b3 97 f3 3c 8d"""
+
+
+def process_octets(s):
+    return bytes(int(x, 16) for x in s.split())[:KEY_SIZE]
+
+
+VECTORS = [
+    ('passwd', b"salt", 1, process_octets(v_easy))
+    ]
+
+if os.environ.get('BOARD') == 'native':
+    VECTORS.append(("Password", b"NaCl", 80000, process_octets(v_hard)))
+
+if __name__ == "__main__":
+    test_base.main(VECTORS)

--- a/tests/pbkdf2/tests/test_base.py
+++ b/tests/pbkdf2/tests/test_base.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2019 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+# Author: Juan Carrano <j.carrano@fu-berlin.de>
+
+import os
+import sys
+import base64
+from functools import partial
+
+MAX_LINE = 128
+
+
+def safe_encode(data):
+    """Empty lines will confue the target, replace them with padding."""
+    return base64.b64encode(data).decode('ascii') if data else ""
+
+
+def test(vectors, child):
+    def _safe_expect_exact(s):
+        idx = child.expect_exact([s+'\r\n', '{error}\r\n'])
+        assert idx == 0
+        return idx
+
+    def _safe_sendline(l):
+        assert len(l) < MAX_LINE
+        _safe_expect_exact('{ready}')
+        child.sendline(l)
+
+    for passwd, salt, iters, key in vectors:
+        _safe_sendline(passwd)
+        _safe_sendline(safe_encode(salt))
+        _safe_sendline(str(iters))
+
+        expected_key = base64.b64encode(key).decode('ascii')
+        _safe_expect_exact(expected_key)
+
+
+def main(vectors):
+    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
+    from testrunner import run
+    sys.exit(run(partial(test, vectors)))


### PR DESCRIPTION
### Contribution description

This add an implementation of PBKDF2 using sha256 hmac. Only one derived key length is supported (32) though it should not be hard to extend it.

### Testing procedure

The testing is done with both random (with fixed seed) vectors and vectors from rfc7914. As usual, I ran into weirdness with interactive tests so I enabled it only for native. Using miniterm.py everything is fine (at least on samr21-xpro)

### Issues/PRs references

Taken from #12191 .