### PR TITLE
cpu/esp32: fix of a linking problem with _esp_wifi_dev and lwIP

### DIFF
--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -73,7 +73,7 @@
  * not provide an argument that could be used as pointer to the ESP WiFi
  * device which triggers the interrupt.
  */
-static esp_wifi_netdev_t _esp_wifi_dev;
+esp_wifi_netdev_t _esp_wifi_dev;
 static const netdev_driver_t _esp_wifi_driver;
 
 /*


### PR DESCRIPTION
### Contribution description

This PR fixes a linking problem that has been introduced with PR #11994. Commit 73552b2c115c2fab1c1dfd92656fa14250e387a6 of PR #11946 which exposed `_esp_wifi_netdev` for `lwip` has been overwritten by an automatic rebase of PR #11997. This PR exposes the `esp_wifi_netdev` for `lwIP` again.

### Testing procedure

Compile `tests/lwip` with following command
```
USEMODULE=esp_wifi make BOARD=esp32-wroom-32 -C tests/lwip
```
Without the PR, this leads to link error:
```
lwip_contrib.a(lwip.o):(.text.lwip_bootstrap+0x0): undefined reference to `_esp_wifi_dev'
```
With the PR, there is no link error. Functionality of this change was already tested with PR #11946.

### Issues/PRs references

Fixes a problem caused by PR #11994.