### PR TITLE
tests/malloc: cleanup

### DIFF
--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -23,36 +23,40 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef CHUNK_SIZE
 #define CHUNK_SIZE 1024
+#endif
 
 struct node {
     struct node *next;
     void *ptr;
 };
 
-int total = 0;
+static int total = 0;
 
-void fill_memory(struct node *head)
+static void fill_memory(struct node *head)
 {
     while (head && (head->ptr = malloc(CHUNK_SIZE))) {
-        printf("Allocated %d Bytes at 0x%p, total %d\n", CHUNK_SIZE, head->ptr, total += CHUNK_SIZE);
+        printf("Allocated %d Bytes at 0x%p, total %d\n",
+               CHUNK_SIZE, head->ptr, total += CHUNK_SIZE);
         memset(head->ptr, '@', CHUNK_SIZE);
         head = head->next = malloc(sizeof(struct node));
         if (head) {
-            head->ptr =  0;
+            total += sizeof(struct node);
+            head->ptr  = 0;
             head->next = 0;
         }
-        total += sizeof(struct node);
     }
 }
 
-void free_memory(struct node *head)
+static void free_memory(struct node *head)
 {
     struct node *old_head;
 
     while (head) {
         if (head->ptr) {
-            printf("Free %d Bytes at 0x%p, total %d\n", CHUNK_SIZE, head->ptr, total -= CHUNK_SIZE);
+            printf("Free %d Bytes at 0x%p, total %d\n",
+                   CHUNK_SIZE, head->ptr, total -= CHUNK_SIZE);
             free(head->ptr);
         }
 


### PR DESCRIPTION
### Contribution description

When looking at the old malloc test, some cosmetic improvements come to mind:

- make local functions / variables static
- adhere to the 80 column limit
- don't increment total if head could not be allocated
- allow to overwrite CHUNK_SIZE

The functionality remains the same.

### Testing procedure

Run `tests/malloc`


### Issues/PRs references
none
