### PR TITLE
make: docker: delegate bind mounts to the containers

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -200,7 +200,7 @@ endef
 
 # docker_volume command line arguments. Allows giving volume mount options.
 # By default 'DOCKER_VOLUME_OPTIONS'. Argument option ignore the default.
-DOCKER_VOLUME_OPTIONS ?=
+DOCKER_VOLUME_OPTIONS ?= delegated
 docker_volume = -v '$1:$2$(addprefix :,$(or $3,$(DOCKER_VOLUME_OPTIONS)))'
 
 docker_volume_and_env = $(strip $(call _docker_volume_and_env,$1,$2,$3))


### PR DESCRIPTION
# Contribution description
At least on Docker for Mac, loosening consistency for bind mounts  brings a huge boost in build performance, see https://docs.docker.com/docker-for-mac/osxfs-caching/:

Before: `real	6m23.003s`
After:  `real	1m57.923s`

Someone running Docker on other platforms needs to check whether the
":delegated" option is ignored there.
