### PR TITLE
drivers/mrf24j40: allow for basic self-test on init

### DIFF
--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -116,6 +116,13 @@ extern "C" {
 #define MRF24J40_MAX_FRAME_RETRIES      (3U)        /**< Number of frame retries (fixed) */
 
 /**
+ * @defgroup drivers_mrf24j40_config     mrf24j40 driver compile configuration
+ * @ingroup drivers_mrf24j40
+ * @ingroup config
+ * @{
+ */
+
+/**
  * @brief Enable external PA/LNA control
  *
  * Increase RSSI for MRF24J40MC/MD/ME devices. No effect on MRF24J40MA.
@@ -124,6 +131,19 @@ extern "C" {
 #ifndef MRF24J40_USE_EXT_PA_LNA
 #define MRF24J40_USE_EXT_PA_LNA         (0U)
 #endif
+
+/**
+ * @brief Enable basic self-test on init
+ *
+ * Perform a write / read to a known register on startup to detect
+ * if the device is connected.
+ * Enable this if you want the boot not to hang if the device is
+ * not connected / there are SPI errors.
+ */
+#ifndef MRF24J40_TEST_SPI_CONNECTION
+#define MRF24J40_TEST_SPI_CONNECTION    (0U)
+#endif
+/** @} */
 
 /**
  * @brief   struct holding all params needed for device initialization
@@ -165,8 +185,10 @@ void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params);
  * @brief   Trigger a hardware reset and configure radio with default values
  *
  * @param[in] dev           device to reset
+ *
+ * @return                  0 on success, error otherwise
  */
-void mrf24j40_reset(mrf24j40_t *dev);
+int mrf24j40_reset(mrf24j40_t *dev);
 
 /**
  * @brief   Trigger a clear channel assessment & retrieve RSSI

--- a/drivers/mrf24j40/include/mrf24j40_internal.h
+++ b/drivers/mrf24j40/include/mrf24j40_internal.h
@@ -32,8 +32,12 @@ extern "C" {
 
 /**
  * @brief initialization as decribed in datasheet
+ *
+ * @param[in] dev device to initialize
+ *
+ * @return 0 on success, error otherwise
  */
-void mrf24j40_init(mrf24j40_t *dev);
+int mrf24j40_init(mrf24j40_t *dev);
 
 /**
  * @brief Read from a register with a  at address `addr` from device `dev`. Register with 8bit address

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -40,11 +40,15 @@ void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params)
     dev->params = *params;
 }
 
-void mrf24j40_reset(mrf24j40_t *dev)
+int mrf24j40_reset(mrf24j40_t *dev)
 {
     eui64_t addr_long;
 
-    mrf24j40_init(dev);
+    int res = mrf24j40_init(dev);
+
+    if (res < 0) {
+        return res;
+    }
 
     netdev_ieee802154_reset(&dev->netdev);
 
@@ -72,6 +76,8 @@ void mrf24j40_reset(mrf24j40_t *dev)
     dev->state = 0;
     mrf24j40_set_state(dev, MRF24J40_PSEUDO_STATE_IDLE);
     DEBUG("mrf24j40_reset(): reset complete.\n");
+
+    return 0;
 }
 
 bool mrf24j40_cca(mrf24j40_t *dev, int8_t *rssi)

--- a/drivers/mrf24j40/mrf24j40_internal.c
+++ b/drivers/mrf24j40/mrf24j40_internal.c
@@ -98,12 +98,9 @@ void mrf24j40_enable_lna(mrf24j40_t *dev)
 }
 #endif /* MRF24J40_USE_EXT_PA_LNA */
 
-void mrf24j40_init(mrf24j40_t *dev)
+int mrf24j40_init(mrf24j40_t *dev)
 {
-
-    mrf24j40_hardware_reset(dev);
-
-#if ENABLE_DEBUG
+#if MRF24J40_TEST_SPI_CONNECTION
     /* Check if MRF24J40 is available */
     uint8_t txmcr = mrf24j40_reg_read_short(dev, MRF24J40_REG_TXMCR);
     if ((txmcr == 0xFF) || (txmcr == 0x00)) {
@@ -117,10 +114,12 @@ void mrf24j40_init(mrf24j40_t *dev)
                       MRF24J40_TXMCR_CSMABF2)) {
             DEBUG("[mrf24j40] Initialization failure, SPI interface communication failed\n");
             /* Return to prevents hangup later in the initialization */
-            return;
+            return -ENODEV;
         }
     }
 #endif
+
+    mrf24j40_hardware_reset(dev);
 
     /* do a soft reset */
     mrf24j40_reg_write_short(dev, MRF24J40_REG_SOFTRST, MRF24J40_SOFTRST_RSTPWR |
@@ -165,6 +164,8 @@ void mrf24j40_init(mrf24j40_t *dev)
 
     /* mrf24j40_set_interrupts */
     mrf24j40_reg_write_short(dev, MRF24J40_REG_INTCON, ~(MRF24J40_INTCON_RXIE | MRF24J40_INTCON_TXNIE));
+
+    return 0;
 }
 
 uint8_t mrf24j40_reg_read_short(mrf24j40_t *dev, const uint8_t addr)

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -58,7 +58,10 @@ static int _init(netdev_t *netdev)
     gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
 
     /* reset device to default values and put it into RX state */
-    mrf24j40_reset(dev);
+    if (mrf24j40_reset(dev)) {
+        return -ENODEV;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
### Contribution description

During production it is often desirable for devices to perform some kind of basic self test to isolate defects.

For this it is necessary for the initialization not to hang if a component is faulty / not connected.

This moves an already existing self-check that was previously enabled as a debug option to an independent compile-time configurable.

It is necessary to call this in `_init()` before `mrf24j40_hardware_reset()` as the reset function uses `xtimer_usleep()` which will cause another thread to get scheduled.
If this thread (e.g. rpl or ipv6) then tries to access the netdev, RIOT will crash.
### Testing procedure
- On a board with no mrf24j40 connected, add `USEMODULE += mrf24j40` to the Makefile of `examples/gnrc_networking`.
- observe that RIOT hangs on init.
- now add `CFLAGS += -DMRF24J40_TEST_SPI_CONNECTION=1` to the Makefile.
- observe that an error gets reported and RIOT boots normally without a radio interface.

- on a board with properly connected mrf24j40 no change in behavior should be visible.

### Issues/PRs references
#12142 implemented this for at86rf2xx