### PR TITLE
cpu/samd5x: allow more flexible selection of CLOCK_CORECLOCK

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -89,9 +89,9 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     }
 
     /* calculate and set baudrate */
-    uint32_t baud = ((((uint32_t)CLOCK_CORECLOCK * 10) / baudrate) / 16);
-    dev(uart)->BAUD.FRAC.FP = (baud % 10);
-    dev(uart)->BAUD.FRAC.BAUD = (baud / 10);
+    uint32_t baud = ((((uint32_t)CLOCK_CORECLOCK * 8) / baudrate) / 16);
+    dev(uart)->BAUD.FRAC.FP = (baud % 8);
+    dev(uart)->BAUD.FRAC.BAUD = (baud / 8);
 
     /* enable transmitter, and configure 8N1 mode */
     dev(uart)->CTRLB.reg = SERCOM_USART_CTRLB_TXEN;

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -29,6 +29,21 @@ extern "C" {
 #endif
 
 /**
+ * @brief   DFLL runs at at fixed frequency of 48 MHz
+ */
+#define SAM0_DFLL_FREQ_HZ       (48000000U)
+
+/**
+ * @brief   DPLL must run with at least 96 MHz
+ */
+#define SAM0_DPLL_FREQ_MIN_HZ   (96000000U)
+
+/**
+ * @brief   DPLL frequency must not exceed 200 MHz
+ */
+#define SAM0_DPLL_FREQ_MAX_HZ   (200000000U)
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 static const int8_t exti_config[4][32] = {


### PR DESCRIPTION
### Contribution description

Right now the main clock on samd5x always uses DPLL directly.
According to the data sheet, DPLL must run at at least 96 MHz, so running the CPU at a lower frequency is currently not possible.

There are some constraints to the oscillators on the samd5x.

 - DFLL is fixed to run at 48 MHz
 - DPLL can run at 96 to 200 MHz

This makes the core clock always use DFLL for frequencies <= 48 MHz.
For frequencies >= 96 MHz, it uses DPLL directly as before.
For frequencies < 96 MHz, DPLL is clocked at twice the desired frequency, then a divider is used to reach the target frequency.


### Testing procedure
Configure a different `CLOCK_CORECLOCK` in `boards/same54-xpro/include/periph_conf.h`.

Try, e.g. 8 MHz, 16 MHz or 64 MHz.

### Issues/PRs references
#12037 if you want to use i2c, it is currently necessary to use a lower clock speed.
But a lower clock is also desirable for battery powered devices that don't need the full 120 MHz.
