### PR TITLE
Fix stdio on platforms left out by "cpu: Moved stdio_init() prior to periph_init() for ARM targets"

### DIFF
--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -26,6 +26,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @name    Clock configuration
  * @{
  */

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -53,6 +53,11 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @name    Power management configuration
  * @{
  */

--- a/cpu/cc26x0/include/periph_cpu.h
+++ b/cpu/cc26x0/include/periph_cpu.h
@@ -35,6 +35,11 @@ extern "C" {
 #define CPUID_LEN           (16U)
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @name    Power management configuration
  * @{
  */

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -398,6 +398,11 @@ typedef struct {
 } uart_conf_t;
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   CPU provides own pm_off() function
  */
 #define PROVIDES_PM_LAYERED_OFF

--- a/cpu/ezr32wg/include/periph_cpu.h
+++ b/cpu/ezr32wg/include/periph_cpu.h
@@ -39,6 +39,11 @@ typedef uint32_t tim_t;
 /** @} */
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Starting offset of CPU_ID
  */
 #define CPUID_ADDR          (&DEVINFO->UNIQUEL)

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -125,6 +125,11 @@ typedef uint16_t gpio_t;
 /** @} */
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Prevent shared timer functions from being used
  */
 #define PERIPH_TIMER_PROVIDES_SET

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -29,6 +29,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Overwrite the default gpio_t type definition
  * @{
  */

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -69,6 +69,11 @@ typedef enum {
 #define PROVIDES_PM_LAYERED_OFF
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Power management configuration
  */
 #define PM_NUM_MODES    (2U)

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -31,6 +31,11 @@ extern "C" {
 #define CLOCK_CORECLOCK     (16000000U)
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Redefine some peripheral names to unify them between nRF51 and 52
  * @{
  */

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -36,6 +36,11 @@ extern "C" {
 #define PERIPH_CLOCK        (16000000U)
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Redefine some peripheral names to unify them between nRF51 and 52
  * @{
  */

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -46,6 +46,11 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x, y)      (((uint32_t)PIOA + (x << 9)) | y)
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief Declare needed generic SPI functions
  * @{
  */

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -35,6 +35,11 @@ extern "C" {
 #define PM_BLOCKER_INITIAL  { .val_u32 = 0x00000001 }
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @name   SAMD21 sleep modes for PM
  * @{
  */

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -29,6 +29,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 static const int8_t exti_config[4][32] = {

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -27,6 +27,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Override the default initial PM blocker
  * @todo   Idle modes are enabled by default, deep sleep mode blocked
  */

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -27,6 +27,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 #if defined(CPU_MODEL_SAML21E18A) || defined(CPU_MODEL_SAML21E18B) || \

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -55,6 +55,11 @@ extern "C" {
 #define PROVIDES_PM_LAYERED_OFF
 
 /**
+ * @brief   We provide early initialisation of stdio
+ */
+#define PROVIDES_EARLY_STDIO_INIT
+
+/**
  * @brief   All STM timers have 4 capture-compare channels
  */
 #define TIMER_CHAN          (4U)

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -69,7 +69,9 @@ char *heap_top = &_sheap + 4;
  */
 void _init(void)
 {
-    /* nothing to do here */
+#ifndef PROVIDES_EARLY_STDIO_INIT
+    stdio_init();
+#endif
 }
 
 /**


### PR DESCRIPTION
### Contribution description
When #11367 moved `stdio_init()` out of common code into CPU specific code, several platforms were forgotten. This broke stdio on esp8266 and esp32, possibly others too.

This PR introduces a `PROVIDES_EARLY_STDIO_INIT` define with which CPUs that got converted to CPU specific `stdio_init()`can advertise this.
If this is not defined, `stdio_init()` is called in syscalls.c `_init()` again as it was before.

### Testing procedure
Check if stdio works again.

### Issues/PRs references
#11367
