### PR TITLE
cpu/esp32: Moved stdio_init() before periph_init()

### DIFF
--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -33,6 +33,7 @@
 #include "kernel_defines.h"
 #include "kernel_init.h"
 #include "log.h"
+#include "stdio_base.h"
 #include "syscalls.h"
 #include "thread_arch.h"
 
@@ -318,6 +319,9 @@ static NORETURN void IRAM system_init (void)
 
     /* initialize the board */
     board_init();
+
+    /* initialize stdio */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();


### PR DESCRIPTION
### Contribution description

Added a call to `stdio_init()` right before calling `periph_init().

- This guarantees that DEBUG() is available early in boot process
- Forgotten in https://github.com/RIOT-OS/RIOT/pull/11367, this fixes broken stdio

### Testing procedure

Flash and run e.g. `examples/default` or `examples/hello-world` and see if stdio is working again

### Issues/PRs references

Bug introduced in https://github.com/RIOT-OS/RIOT/pull/11367