### PR TITLE
cpu/esp8266: Moved stdio_init before periph_init

### DIFF
--- a/cpu/esp8266/startup.c
+++ b/cpu/esp8266/startup.c
@@ -33,6 +33,7 @@
 #include "board.h"
 #include "common.h"
 #include "exceptions.h"
+#include "stdio_base.h"
 #include "syscalls.h"
 #include "tools.h"
 #include "thread_arch.h"
@@ -158,6 +159,9 @@ void system_init(void)
     /* init flash drive */
     extern void flash_drive_init (void);
     flash_drive_init();
+
+    /* initialize stdio*/
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();
@@ -692,6 +696,9 @@ void __attribute__((noreturn)) IRAM cpu_user_start (void)
     /* init flash drive */
     extern void flash_drive_init (void);
     flash_drive_init();
+
+    /* initialize stdio*/
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();


### PR DESCRIPTION
### Contribution description

Added a call to `stdio_init()` right before calling `periph_init().

- This guarantees that DEBUG() is available early in boot process
- Forgotten in https://github.com/RIOT-OS/RIOT/pull/11367, this fixes broken stdio

### Testing procedure

Flash and run e.g. `examples/default` or `examples/hello-world` and see if stdio is working again

### Issues/PRs references

Fixes bug introduced in https://github.com/RIOT-OS/RIOT/pull/11367