### PR TITLE
cpu/fe310: Moved stdio_init() before periph_init()

### DIFF
--- a/cpu/fe310/cpu.c
+++ b/cpu/fe310/cpu.c
@@ -17,19 +17,18 @@
  * @}
  */
 
-#include <stdio.h>
 #include <errno.h>
+#include <stdio.h>
 
-#include "thread.h"
+#include "context_frame.h"
+#include "cpu.h"
 #include "irq.h"
+#include "irq.h"
+#include "panic.h"
+#include "periph/init.h"
+#include "periph_cpu.h"
 #include "sched.h"
 #include "thread.h"
-#include "irq.h"
-#include "cpu.h"
-#include "context_frame.h"
-#include "periph_cpu.h"
-#include "periph/init.h"
-#include "panic.h"
 #include "vendor/encoding.h"
 #include "vendor/platform.h"
 #include "vendor/plic_driver.h"

--- a/cpu/fe310/cpu.c
+++ b/cpu/fe310/cpu.c
@@ -28,6 +28,7 @@
 #include "periph/init.h"
 #include "periph_cpu.h"
 #include "sched.h"
+#include "stdio_base.h"
 #include "thread.h"
 #include "vendor/encoding.h"
 #include "vendor/platform.h"
@@ -88,6 +89,9 @@ void cpu_init(void)
 
     /*  Set default state of mstatus */
     set_csr(mstatus, MSTATUS_DEFAULT);
+
+    /* initialize stdio */
+    stdio_init();
 
     /* trigger static peripheral initialization */
     periph_init();


### PR DESCRIPTION
### Contribution description

- Added a call to `stdio_init()` right before calling `periph_init().
    - This guarantees that DEBUG() is available early in boot process
    - Forgotten in https://github.com/RIOT-OS/RIOT/pull/11367, this fixes broken stdio
- Sorted and deduplicated `#include`s in `cpu.c`

### Testing procedure

Flash and run e.g. `examples/default` or `examples/hello-world` and see if stdio is working again

### Issues/PRs references

Fixes bug introduced in https://github.com/RIOT-OS/RIOT/pull/11367