### PR TITLE
cpu/mips32r2_common: Added call to stdio_init()

### DIFF
--- a/cpu/mips32r2_common/cpu.c
+++ b/cpu/mips32r2_common/cpu.c
@@ -17,6 +17,7 @@
 #include "periph/timer.h"
 #include "periph/init.h"
 #include "panic.h"
+#include "stdio_base.h"
 #include "kernel_init.h"
 #include "cpu.h"
 #include "board.h"
@@ -76,6 +77,9 @@ void panic_arch(void)
 
 void cpu_init(void)
 {
+    /* initialize stdio*/
+    stdio_init();
+
     /* trigger static peripheral initialization */
     periph_init();
 }


### PR DESCRIPTION
### Contribution description

Added a call to `stdio_init()` right before calling `periph_init().

- This guarantees that DEBUG() is available early in boot process
- Forgotten in https://github.com/RIOT-OS/RIOT/pull/11367, this fixes broken stdio

### Testing procedure

Flash and run e.g. `examples/default` or `examples/hello-world` and see if stdio is working again

### Issues/PRs references

Fixes bug introduced in https://github.com/RIOT-OS/RIOT/pull/11367