### PR TITLE
boards/stm32f429i-disc1: fix flashing with openocd

### DIFF
--- a/boards/stm32f429i-disc1/Makefile.include
+++ b/boards/stm32f429i-disc1/Makefile.include
@@ -10,6 +10,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # this board has an on-board ST-link adapter
 DEBUG_ADAPTER ?= stlink
+STLINK_VERSION ?= 2
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk


### PR DESCRIPTION
### Contribution description

At least with openocd 0.10.0, `STLINK_VERSION` needs to explicitly set to 2 for flashing of this board to work.

### Testing procedure

Run `make BOARD=stm32f429i-disc1 flash` with any application

### Issues/PRs references
none
