### PR TITLE
ci: add codespell check script for tracking typos

### DIFF
--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -39,7 +39,7 @@ function run {
     print_result $NEW_RESULT
     set_result $NEW_RESULT
 
-    # Indent command output so that its easily discernable from the rest
+    # Indent command output so that its easily discernible from the rest
     if [ -n "$OUT" ]; then
         echo "Command output:"
         echo ""

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -94,6 +94,7 @@ then
         run ./dist/tools/flake8/check.sh
         run ./dist/tools/headerguards/check.sh
         run ./dist/tools/buildsystem_sanity_check/check.sh
+        run ./dist/tools/codespell/check.sh
         exit $RESULT
     fi
 

--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Alexandre Abadie <alexandre.abadie@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+CODESPELL_CMD="codespell"
+
+if tput colors &> /dev/null && [ "$(tput colors)" -ge 8 ]; then
+    CERROR=$'\033[1;31m'
+    CRESET=$'\033[0m'
+else
+    CERROR=
+    CRESET=
+fi
+
+: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+cd $RIOTBASE
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
+. "${RIOTTOOLS}"/ci/changed_files.sh
+
+FILEREGEX='\.([CcHh]|[ch]pp|sh|py|md|txt)$'
+EXCLUDE='^(.+/vendor/)'
+FILES=$(FILEREGEX=${FILEREGEX} EXCLUDE=${EXCLUDE} changed_files)
+
+if [ -z "${FILES}" ]; then
+    exit 0
+fi
+
+${CODESPELL_CMD} --version &> /dev/null || {
+    printf "%s%s: cannot execute \"%s\"!%s\n" "${CERROR}" "$0" "${CODESPELL_CMD}" "${CRESET}"
+    exit 1
+}
+
+CODESPELL_OPTS="-q 2"  # Disable "WARNING: Binary file"
+CODESPELL_OPTS+=" --check-hidden"
+# Disable false positives "nd  => and, 2nd", "WAN => WANT", "od => of"
+CODESPELL_OPTS+=" --ignore-words-list=ND,nd,WAN,od"
+
+# Filter-out all false positive raising "disabled due to" messages.
+ERRORS=$(${CODESPELL_CMD} ${CODESPELL_OPTS} ${FILES} | grep -ve "disabled due to")
+
+if [ -n "${ERRORS}" ]
+then
+    printf "%sThere are typos in the following files:%s\n\n" "${CERROR}" "${CRESET}"
+    printf "%s\n" "${ERRORS}"
+    # TODO: return 1 when all typos are fixed
+    exit 0
+else
+    exit 0
+fi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduce a new static check script for tracking typos in PRs.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Wait for riotdocker to contain codespell (requires https://github.com/RIOT-OS/riotdocker/pull/86)
- Check the CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Should help with #12230 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
