### PR TITLE
net/coap: Document requirement to add CoAP options in order

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -71,7 +71,9 @@
  *
  * -# Call gcoap_resp_init() to initialize the response.
  * -# Use the coap_opt_add_xxx() functions to include any Options, for example
- *    coap_opt_add_format() for Content-Format of the payload.
+ *    coap_opt_add_format() for Content-Format of the payload. Options *must*
+ *    be written in order by option number (see "CoAP option numbers" in
+ *    [CoAP defines](group__net__coap.html)).
  * -# Call coap_opt_finish() to complete the PDU metadata. Retain the returned
  *    metadata length.
  * -# Write the response payload, starting at the updated _payload_ pointer
@@ -112,7 +114,9 @@
  * -# Optionally, mark the request confirmable by calling coap_hdr_set_type()
  *    with COAP_TYPE_CON.
  * -# Use the coap_opt_add_xxx() functions to include any Options beyond
- *    Uri-Path, which was added in the first step.
+ *    Uri-Path, which was added in the first step. Options *must* be written
+ *    in order by option number (see "CoAP option numbers" in
+ *    [CoAP defines](group__net__coap.html)).
  * -# Call coap_opt_finish() to complete the PDU metadata. Retain the returned
  *    metadata length.
  * -# Write the request payload, starting at the updated _payload_ pointer
@@ -162,7 +166,9 @@
  *    Test the return value, which may indicate there is not an observer for
  *    the resource. If so, you are done.
  * -# Use the coap_opt_add_xxx() functions to include any Options, for example
- *    coap_opt_add_format() for Content-Format of the payload.
+ *    coap_opt_add_format() for Content-Format of the payload. Options *must*
+ *    be written in order by option number (see "CoAP option numbers" in
+ *    [CoAP defines](group__net__coap.html)).
  * -# Call coap_opt_finish() to complete the PDU metadata. Retain the returned
  *    metadata length.
  * -# Write the notification payload, starting at the updated _payload_ pointer

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -46,6 +46,9 @@
  * space remaining in the buffer; however, the API *will not* write past the
  * end of the buffer, and returns -ENOSPC when it is full.
  *
+ * For either API, the caller *must* write options in order by option number
+ * (see "CoAP option numbers" in [CoAP defines](group__net__coap.html)).
+ *
  * ## Server path matching
  *
  * By default the URI-path of an incoming request should match exactly one of

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -83,7 +83,8 @@
  * Next, use the functions in the _Options Write Buffer API_ section of
  * [nanocoap](group__net__nanocoap.html) to write each option. These functions
  * require the position in the buffer to start writing, and return the number
- * of bytes written.
+ * of bytes written. Options *must* be written in order by option number (see
+ * "CoAP option numbers" in [CoAP defines](group__net__coap.html)).
  *
  * @note You must ensure the buffer has enough space remaining to write each
  * option. The API does not verify the safety of writing an option.


### PR DESCRIPTION
### Contribution description

#10876 reorganized the nanocoap documentation to move text specific to nanocoap_sock to that module. Unfortunately, the instruction to add CoAP options in order by option number was lost. This PR reinserts that instruction in the top level documentation for nanocoap, as well as in the module specific documentation in nanocoap sock and gcoap.

### Testing procedure

Build and compare the updated source documentation. There are changes to the nanocoap, nanocoap sock, and gcoap pages.

### Issues/PRs references

Fixes the loss of this documentation in #10876.