### PR TITLE
nucleo-l031/l432: fix wrong i2c configuration

### DIFF
--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -23,7 +23,7 @@
 
 #include "periph_cpu.h"
 #include "l0/cfg_clock_32_16_1.h"
-#include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_i2c1_pb6_pb7.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
 

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -22,7 +22,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
-#include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_i2c1_pb6_pb7.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing the wrong I2C configuration for nucleo-l031k6/nucleo-l432kc introduced by #12141 by mistake.

On those 2 boards, the I2C is connected to PB6/PB7 and not to PB8/PB9.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test an I2C sensor on both boards, it should work. In master, it's broken.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes misconfiguration introduced by #12141.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
