### PR TITLE
cpu/stm32_common/periph/gpio: Pull-down on gpio_init_af

### DIFF
--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -88,7 +88,7 @@ static inline void uart_init_pins(uart_t uart, uart_rx_cb_t rx_cb)
 #endif
     /* configure RX pin */
     if (rx_cb) {
-        gpio_init(uart_config[uart].rx_pin, GPIO_IN);
+        gpio_init(uart_config[uart].rx_pin, GPIO_IN_PU);
 #ifndef CPU_FAM_STM32F1
         gpio_init_af(uart_config[uart].rx_pin, uart_config[uart].rx_af);
 #endif


### PR DESCRIPTION
### Contribution description

This code makes the gpio_init_af method globally pull-down the pins.

### Testing procedure

Flashed on exiting project that uses UART, I2C and SPI and checked whether everything is still working as expected and UART not functions without 47k resistor on RX.

### Issues/PRs references

The reason for this is mainly with the use of UART. After UART is being initialised, it requires the UART peer to be connected an online. If it's shut down or disconnected, the UART interrupt callback will fire continuously. There is a hardware fix for this, which consists of pulling-down the RX pin by connecting it to GND using a 47k resistor, but that should not be needed since the board itself already can do that.

However, it would probably be better to only pull down when using the RX pin and not globally. I couldn't find a way to limit this, though, as these areas of the GPIO code don't really know about individual pin functions. Suggestions are welcome.