### PR TITLE
core/bitarithm: introduce bitarithm_get/set_masked(), convert pca9685

### DIFF
--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -163,6 +163,47 @@ static inline unsigned bitarithm_lsb(unsigned v)
 }
 #endif
 
+/**
+ * @brief           Sets the masked bits in a word to the given value.
+ *
+ * @note            The mask should be compile-time constant so the compiler
+ *                  is able to optimize the entire loop away.
+ *
+ * @param       val The value to modify.
+ * @param[in]  mask The bitmask to apply.
+ * @param[in]  bits The new value of the masked bits.
+ *
+ */
+#define bitarithm_set_masked(val, mask, bits) do {                  \
+        const unsigned _mask = mask;                                \
+        const unsigned _bits = bits;                                \
+        unsigned _shift = 0;                                        \
+        while (!((_mask >> _shift) & 0x01)) {                       \
+            _shift++;                                               \
+        }                                                           \
+        *(val) = ((*(val) & ~_mask) | ((_bits << _shift) & _mask)); \
+        } while (0)
+
+/**
+ * @brief           Gets the masked bits in a word.
+ *
+ * @note            The mask should be compile-time constant so the compiler
+ *                  is able to optimize the entire loop away.
+ *
+ * @param[in]   val The input value.
+ * @param[in]  mask The bitmask to apply.
+ * @return          The set bits in val where mask was applied, shifted down.
+ *
+ */
+static inline unsigned bitarithm_get_masked(unsigned val, unsigned mask)
+{
+    unsigned shift = 0;
+    while (!((mask >> shift) & 0x01)) {
+        shift++;
+    }
+    return (val & mask) >> shift;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/unittests/tests-core/tests-core-bitarithm.c
+++ b/tests/unittests/tests-core/tests-core-bitarithm.c
@@ -218,6 +218,80 @@ static void test_bitarithm_bits_set_u32_random(void)
     TEST_ASSERT_EQUAL_INT(21, bitarithm_bits_set_u32(4072524027)); /* Source: https://www.random.org/bytes */
 }
 
+static void test_bitarithm_set_masked_8(void)
+{
+    uint8_t val = 0;
+
+    bitarithm_set_masked(&val, 0x18, 3);
+    TEST_ASSERT_EQUAL_INT(0x18, val);
+
+    bitarithm_set_masked(&val, 0x18, 3);
+    TEST_ASSERT_EQUAL_INT(0x18, val);
+
+    bitarithm_set_masked(&val, 0x18, 2);
+    TEST_ASSERT_EQUAL_INT(0x10, val);
+
+    bitarithm_set_masked(&val, 0x18, 1);
+    TEST_ASSERT_EQUAL_INT(0x8, val);
+
+    bitarithm_set_masked(&val, 0x18, 0);
+    TEST_ASSERT_EQUAL_INT(0x0, val);
+
+    val = 0x81;
+    bitarithm_set_masked(&val, 0x18, 11);
+    TEST_ASSERT_EQUAL_INT(0x99, val);
+
+    bitarithm_set_masked(&val, 0xff, 0);
+    TEST_ASSERT_EQUAL_INT(0x0, val);
+}
+
+static void test_bitarithm_set_masked_16(void)
+{
+    uint16_t val = 0x2300;
+
+    bitarithm_set_masked(&val, 0x18, 3);
+    TEST_ASSERT_EQUAL_INT(0x2318, val);
+
+    bitarithm_set_masked(&val, 0x18, 3);
+    TEST_ASSERT_EQUAL_INT(0x2318, val);
+
+    bitarithm_set_masked(&val, 0x18, 2);
+    TEST_ASSERT_EQUAL_INT(0x2310, val);
+
+    bitarithm_set_masked(&val, 0x18, 1);
+    TEST_ASSERT_EQUAL_INT(0x2308, val);
+
+    bitarithm_set_masked(&val, 0x18, 0);
+    TEST_ASSERT_EQUAL_INT(0x2300, val);
+}
+
+static void test_bitarithm_set_masked_32(void)
+{
+    uint32_t val = 0xfefe2300;
+
+    bitarithm_set_masked(&val, 0x18, 3);
+    TEST_ASSERT_EQUAL_INT(0xfefe2318, val);
+
+    bitarithm_set_masked(&val, 0x18, 3);
+    TEST_ASSERT_EQUAL_INT(0xfefe2318, val);
+
+    bitarithm_set_masked(&val, 0x18, 2);
+    TEST_ASSERT_EQUAL_INT(0xfefe2310, val);
+
+    bitarithm_set_masked(&val, 0x18, 1);
+    TEST_ASSERT_EQUAL_INT(0xfefe2308, val);
+
+    bitarithm_set_masked(&val, 0x18, 0);
+    TEST_ASSERT_EQUAL_INT(0xfefe2300, val);
+}
+
+static void test_bitarithm_get_masked(void)
+{
+    TEST_ASSERT_EQUAL_INT(0x4, bitarithm_get_masked(0xA5, 0x38));
+    TEST_ASSERT_EQUAL_INT(0x3, bitarithm_get_masked(0xA9AA, 0x180));
+    TEST_ASSERT_EQUAL_INT(0x42, bitarithm_get_masked(0x55542AAA, 0xFF000));
+}
+
 Test *tests_core_bitarithm_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -252,6 +326,11 @@ Test *tests_core_bitarithm_tests(void)
         new_TestFixture(test_bitarithm_bits_set_limit),
         new_TestFixture(test_bitarithm_bits_set_random),
         new_TestFixture(test_bitarithm_bits_set_u32_random),
+
+        new_TestFixture(test_bitarithm_set_masked_8),
+        new_TestFixture(test_bitarithm_set_masked_16),
+        new_TestFixture(test_bitarithm_set_masked_32),
+        new_TestFixture(test_bitarithm_get_masked),
     };
 
     EMB_UNIT_TESTCALLER(core_bitarithm_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description
@gschorcht posted a collection of sensor drivers that all follow a common pattern. One neat helper function is `_set_reg_bit(uint8_t *byte, uint8_t mask, uint8_t bit)` that sets the masked bits in `byte` to the given value.

At first glance the function looks a bit odd as uses a loop to determine the lowest set bit of a compile-time constant. However, if `mask` is a compile-time constant, the compiler will [resolve the loop](https://godbolt.org/z/N_8UZD) and leave just a few instructions.

Now this pattern is quite useful for other drivers and to keep people from trying to optimize that loop that will be optimized away (for some reason, when replacing the loop with `bitarithm_lsb()`, the compiler will *not* optimize it away (only verified by increased binary size)), it's best to put it into common code. 

`bitarithm_set_masked()` is a macro only because this way it works for all types.

### Testing procedure

See if `tests/driver_pca9685` still produces the same binary.

### Issues/PRs references
#10083, #10082, #10092, #10420, #10462 all come with their own copy of this function.