### PR TITLE
tools: fix shebang for static-test.sh

### DIFF
--- a/dist/tools/static-tests.sh
+++ b/dist/tools/static-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2015 Lucas Jenß <lucas@x3ro.de>
 #


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Change shebang in static-test.sh from `/bin/bash` to `/usr/bin/env bash`
This fixes problems when `bash` is not available in standard location,
but e.g. in `/usr/local/bin/` as on FreeBSD.


### Testing procedure

run `make static-test` on your favourite OS which should still work.


### Issues/PRs references

#3392
