### PR TITLE
tools/docheck: fix for non-GNU OSes

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -10,6 +10,14 @@
 
 RIOTBASE="$(cd $(dirname $0)/../../..; pwd)"
 
+# change 'make' to 'gmake' for FreeBSD
+OS=$(uname -s)
+if [ ${OS} == "FreeBSD" ]; then
+    MAKE=gmake
+fi
+# set default if not provided by env
+MAKE=${MAKE:-make}
+
 if tput colors &> /dev/null && [ $(tput colors) -ge 8 ]; then
     CERROR="\e[1;31m"
     CWARN="\033[1;33m"
@@ -20,11 +28,11 @@ else
     CRESET=
 fi
 
-DOXY_OUTPUT=$(make -C "${RIOTBASE}" doc 2>&1)
+DOXY_OUTPUT=$(${MAKE} -C "${RIOTBASE}" doc 2>&1)
 DOXY_ERRCODE=$?
 
 if [ "${DOXY_ERRCODE}" -ne 0 ] ; then
-    echo "'make doc' exited with non-zero code (${DOXY_ERRCODE})"
+    echo "'${MAKE} doc' exited with non-zero code (${DOXY_ERRCODE})"
     echo "${DOXY_OUTPUT}"
     exit 2
 else

--- a/doc/doxygen/generate-changelog.py
+++ b/doc/doxygen/generate-changelog.py
@@ -12,9 +12,9 @@ import sys
 
 
 def generate_changelog(template_filename, changelog_filename, output_filename):
-    with open(template_filename) as template, \
-         open(changelog_filename) as changelog, \
-         open(output_filename, "w") as output:
+    with open(template_filename,    "r", encoding="utf-8") as template, \
+         open(changelog_filename,   "r", encoding="utf-8") as changelog, \
+         open(output_filename,      "w", encoding="utf-8") as output:
         changelog_lines = []
         release_title = re.compile(r"((RIOT-\d{4}\.\d{2} - Release Notes)|(Release 2013\.08))")
         notes_template = re.compile(r"\[Notes\]")


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides 2 fixes to run `./dist/tools/doccheck/check.sh` on non-GNU (Linux) OSes such as FreeBSD. First it allows to overwrite the `make` command through the environment, which is needed bc FreeBSD provides non-GNU make by default and thus RIOT must use `gmake` instead.
And second, there was also an encoding error in `generate-changelog.py` bc on FreeBSD if no encoding is set for `open` it defaults to `ascii` but RIOT uses `utf-8`.


### Testing procedure

Run `make static-test` or `./dist/tools/doccheck/check.sh` on your (favourite) OS and it should still work as usual.

### Issues/PRs references

#3392 