### PR TITLE
makefiles/docker.inc.mk: add a 'docker_volume' function

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -185,7 +185,7 @@ endef
 #
 #   docker_volumes_mapping <path_in_docker_args|...>
 #     Command line argument for mapping volumes, if it should be mounted
-#       -v directory:docker_directory
+#       -v 'directory:docker_directory'
 #
 #   docker_environ_mapping <path_in_docker_args|...>
 #     Command line argument for mapping environment variables
@@ -204,7 +204,7 @@ define _docker_volume_and_env
   $(call docker_environ_mapping,$1,$2,$3)
 endef
 docker_volumes_mapping = $(foreach d,$1,$(call _docker_volume_mapping,$d,$2,$3))
-_docker_volume_mapping = $(if $1,$(if $(call dir_is_outside_riotbase,$1), -v '$(abspath $1):$(call path_in_docker,$1,$2,$3)'))
+_docker_volume_mapping = $(if $1,$(if $(call dir_is_outside_riotbase,$1),-v '$(abspath $1):$(call path_in_docker,$1,$2,$3)'))
 docker_environ_mapping = $(addprefix -e ,$(call docker_cmdline_mapping,$1,$2,$3))
 docker_cmdline_mapping = $(if $($1),'$1=$(call path_in_docker,$($1),$2,$3)')
 
@@ -228,8 +228,8 @@ DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,RIOTBOARD,,riotboard)
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,RIOTMAKE,,riotmake)
 
 # Add GIT_CACHE_DIR if the directory exists
-DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)),-v $(GIT_CACHE_DIR):$(DOCKER_BUILD_ROOT)/gitcache)
-DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)),-e GIT_CACHE_DIR=$(DOCKER_BUILD_ROOT)/gitcache)
+DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)),-v '$(GIT_CACHE_DIR):$(DOCKER_BUILD_ROOT)/gitcache')
+DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)),-e 'GIT_CACHE_DIR=$(DOCKER_BUILD_ROOT)/gitcache')
 
 # Remap external module directories.
 #
@@ -261,7 +261,7 @@ endif
 # Handle worktree by mounting the git common dir in the same location
 _is_git_worktree = $(shell grep '^gitdir: ' $(RIOTBASE)/.git 2>/dev/null)
 GIT_WORKTREE_COMMONDIR = $(abspath $(shell git rev-parse --git-common-dir))
-DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):$(GIT_WORKTREE_COMMONDIR))
+DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v '$(GIT_WORKTREE_COMMONDIR):$(GIT_WORKTREE_COMMONDIR)')
 
 # This will execute `make $(DOCKER_MAKECMDGOALS)` inside a Docker container.
 # We do not push the regular $(MAKECMDGOALS) to the container's make command in

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -198,6 +198,11 @@ endef
 # Arguments are the same as 'path_in_docker'
 # If the 'directories' variable is empty, it will not be exported to docker
 
+# docker_volume command line arguments. Allows giving volume mount options.
+# By default 'DOCKER_VOLUME_OPTIONS'. Argument option ignore the default.
+DOCKER_VOLUME_OPTIONS ?=
+docker_volume = -v '$1:$2$(addprefix :,$(or $3,$(DOCKER_VOLUME_OPTIONS)))'
+
 docker_volume_and_env = $(strip $(call _docker_volume_and_env,$1,$2,$3))
 define _docker_volume_and_env
   $(call docker_volumes_mapping,$($1),$2,$3)


### PR DESCRIPTION
### Contribution description

Refactor the '--volume' mounting handling.
This prepares for using a global 'DOCKER_VOLUME_OPTIONS'.

The goal is to have only one point where to change '--volume' mount options for https://github.com/RIOT-OS/RIOT/pull/12218

### Testing procedure

I am running a test procedure with external board, cpu, and modules.

Prepare external board and cpu, and run a test in 'tests/external_module_dirs':


```
mkdir -p /tmp/out
cp -r boards/  /tmp/out/
cp -r cpu  /tmp/out/
```

```
RIOTCPU=/tmp/out/cpu RIOTBOARD=/tmp/out/boards BUILD_IN_DOCKER=1 DOCKER="sudo docker" RIOT_VERSION=buildtest make --no-print-directory -C tests/external_module_dirs/
```

Difference by default between this PR and master is quotes being added:

``` diff
--- master      2019-09-16 11:11:24.388013256 +0200
+++ pr  2019-09-16 11:16:41.889835701 +0200
@@ -1,7 +1,7 @@
 RIOTCPU=/tmp/out/cpu RIOTBOARD=/tmp/out/boards BUILD_IN_DOCKER=1 DOCKER="sudo docker" RIOT_VERSION=buildtest make --no-print-directory -C tests/external_module_dirs/
 Launching build container using image "riot/riotbuild:latest".
 sudo docker run --rm -t -u "$(id -u)" \
-    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -v '/tmp/out/cpu:/data/riotbuild/riotcpu' -e 'RIOTCPU=/data/riotbuild/riotcpu' -v '/tmp/out/boards:/data/riotbuild/riotboard' -e 'RIOTBOARD=/data/riotbuild/riotboard' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
+    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -v '/tmp/out/cpu:/data/riotbuild/riotcpu' -e 'RIOTCPU=/data/riotbuild/riotcpu' -v '/tmp/out/boards:/data/riotbuild/riotboard' -e 'RIOTBOARD=/data/riotbuild/riotboard' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/harter/.gitcache:/data/riotbuild/gitcache' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'   \
     -e 'RIOT_VERSION=buildtest' \
     -w '/data/riotbuild/riotbase/tests/external_module_dirs/' \
     'riot/riotbuild:latest' make   'EXTERNAL_MODULE_DIRS=/data/riotbuild/riotbase/tests/external_module_dirs/external_module'
```

<details><summary>With PR</summary>

```
RIOTCPU=/tmp/out/cpu RIOTBOARD=/tmp/out/boards BUILD_IN_DOCKER=1 DOCKER="sudo docker" RIOT_VERSION=buildtest make --no-print-directory -C tests/external_module_dirs/
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -v '/tmp/out/cpu:/data/riotbuild/riotcpu' -e 'RIOTCPU=/data/riotbuild/riotcpu' -v '/tmp/out/boards:/data/riotbuild/riotboard' -e 'RIOTBOARD=/data/riotbuild/riotboard' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/harter/.gitcache:/data/riotbuild/gitcache' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'   \
    -e 'RIOT_VERSION=buildtest' \
    -w '/data/riotbuild/riotbase/tests/external_module_dirs/' \
    'riot/riotbuild:latest' make   'EXTERNAL_MODULE_DIRS=/data/riotbuild/riotbase/tests/external_module_dirs/external_module'
Building application "external_module_dirs" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/tests/external_module_dirs/external_module
"make" -C /data/riotbuild/riotboard/native
"make" -C /data/riotbuild/riotboard/native/drivers
"make" -C /data/riotbuild/riotcpu/native
"make" -C /data/riotbuild/riotcpu/native/periph
"make" -C /data/riotbuild/riotcpu/native/vfs
   text    data     bss     dec     hex filename
  21654     576   47660   69890   11102 /data/riotbuild/riotbase/tests/external_module_dirs/bin/native/external_module_dirs.elf
```
</details>

<details><summary>With master</summary>

```
RIOTCPU=/tmp/out/cpu RIOTBOARD=/tmp/out/boards BUILD_IN_DOCKER=1 DOCKER="sudo docker" make --no-print-directory -C tests/external_module_dirs/
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -v '/tmp/out/cpu:/data/riotbuild/riotcpu' -e 'RIOTCPU=/data/riotbuild/riotcpu' -v '/tmp/out/boards:/data/riotbuild/riotboard' -e 'RIOTBOARD=/data/riotbuild/riotboard' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
     \
    -w '/data/riotbuild/riotbase/tests/external_module_dirs/' \
    'riot/riotbuild:latest' make   'EXTERNAL_MODULE_DIRS=/data/riotbuild/riotbase/tests/external_module_dirs/external_module'
Building application "external_module_dirs" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/tests/external_module_dirs/external_module
"make" -C /data/riotbuild/riotboard/native
"make" -C /data/riotbuild/riotboard/native/drivers
"make" -C /data/riotbuild/riotcpu/native
"make" -C /data/riotbuild/riotcpu/native/periph
"make" -C /data/riotbuild/riotcpu/native/vfs
   text    data     bss     dec     hex filename
  21666     576   47660   69902   1110e /data/riotbuild/riotbase/tests/external_module_dirs/bin/native/external_module_dirs.elf
```
</details>


#### Support for mount options:

When setting 'DOCKER_VOLUME_OPTIONS=delegated', the value is used everywhere, except for 'localtime' where it stays 'ro'. (this is the current implementation)

<details><summary>PR with adding <code>DOCKER_VOLUME_OPTIONS</code></summary>

```
RIOTCPU=/tmp/out/cpu RIOTBOARD=/tmp/out/boards  DOCKER_VOLUME_OPTIONS=delegated BUILD_IN_DOCKER=1 DOCKER="sudo docker" RIOT_VERSION=buildtest make --no-print-directory -C tests/external_module_dirs/
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -v '/tmp/out/cpu:/data/riotbuild/riotcpu:delegated' -e 'RIOTCPU=/data/riotbuild/riotcpu' -v '/tmp/out/boards:/data/riotbuild/riotboard:delegated' -e 'RIOTBOARD=/data/riotbuild/riotboard' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/harter/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'   \
    -e 'RIOT_VERSION=buildtest' \
    -w '/data/riotbuild/riotbase/tests/external_module_dirs/' \
    'riot/riotbuild:latest' make   'EXTERNAL_MODULE_DIRS=/data/riotbuild/riotbase/tests/external_module_dirs/external_module'
Building application "external_module_dirs" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/tests/external_module_dirs/external_module
"make" -C /data/riotbuild/riotboard/native
"make" -C /data/riotbuild/riotboard/native/drivers
"make" -C /data/riotbuild/riotcpu/native
"make" -C /data/riotbuild/riotcpu/native/periph
"make" -C /data/riotbuild/riotcpu/native/vfs
   text    data     bss     dec     hex filename
  21654     576   47660   69890   11102 /data/riotbuild/riotbase/tests/external_module_dirs/bin/native/external_module_dirs.elf
```
</details>

<details><summary>For completeness, test with RIOT as worktree</summary>

I also tested with RIOT being in a worktree but did not make it the default test as it is harder to setup.

```
RIOTCPU=/tmp/out/cpu RIOTBOARD=/tmp/out/boards  DOCKER_VOLUME_OPTIONS=delegated BUILD_IN_DOCKER=1 DOCKER="sudo docker" make --no-print-directory -C tests/external_module_dirs/
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/worktree/riot_test:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -v '/tmp/out/cpu:/data/riotbuild/riotcpu:delegated' -e 'RIOTCPU=/data/riotbuild/riotcpu' -v '/tmp/out/boards:/data/riotbuild/riotboard:delegated' -e 'RIOTBOARD=/data/riotbuild/riotboard' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/harter/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'  -v '/home/harter/work/git/RIOT/.git:/home/harter/work/git/RIOT/.git:delegated' \
     \
    -w '/data/riotbuild/riotbase/tests/external_module_dirs/' \
    'riot/riotbuild:latest' make   'EXTERNAL_MODULE_DIRS=/data/riotbuild/riotbase/tests/external_module_dirs/external_module'
Building application "external_module_dirs" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/tests/external_module_dirs/external_module
"make" -C /data/riotbuild/riotboard/native
"make" -C /data/riotbuild/riotboard/native/drivers
"make" -C /data/riotbuild/riotcpu/native
"make" -C /data/riotbuild/riotcpu/native/periph
"make" -C /data/riotbuild/riotcpu/native/vfs
   text    data     bss     dec     hex filename
  21694     576   47660   69930   1112a /data/riotbuild/riotbase/tests/external_module_dirs/bin/native/external_module_dirs.elf
```
</details>

### Issues/PRs references

Refactoring prior to https://github.com/RIOT-OS/RIOT/pull/12218