### PR TITLE
tools: fix shebang in scripts

### DIFF
--- a/dist/tools/has_minimal_version/has_minimal_version.sh
+++ b/dist/tools/has_minimal_version/has_minimal_version.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 #
 # usage: has_minimal_version.sh <version> <minimal_version> [toolname]
 #   Checks that version >= minimal_version

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Unified OpenOCD script for RIOT
 #

--- a/dist/tools/packer/setup.sh
+++ b/dist/tools/packer/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash -eux
 
 # inspired by https://github.com/boxcutter/ubuntu
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Changes shebang in all remaining tools scripts from `/bin/bash` to `/usr/bin/env bash`.
This fixes problems when `bash` is not available in its standard location, e.g. on non-Linux
OSes such as FreeBSD.

### Testing procedure

Run scripts on your OS, they should still work as before.

### Issues/PRs references

follow up on #12239 
#3392 