### PR TITLE
tests: re-enable utf-8 tests on native

### DIFF
--- a/tests/lua_loader/Makefile
+++ b/tests/lua_loader/Makefile
@@ -13,7 +13,4 @@ ifneq ($(BOARD),native)
   CFLAGS += -DTHREAD_STACKSIZE_MAIN='(THREAD_STACKSIZE_DEFAULT+2048)'
 endif
 
-# HACK Blacklist native as `murdock` fails on utf-8 characters for native tests
-TEST_ON_CI_BLACKLIST += native
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_u8g2/Makefile
+++ b/tests/pkg_u8g2/Makefile
@@ -59,7 +59,4 @@ CFLAGS += -DTEST_PIN_RESET=$(TEST_PIN_RESET)
 
 CFLAGS += -DTEST_DISPLAY=$(TEST_DISPLAY)
 
-# HACK Blacklist native as `murdock` fails on utf-8 characters for native tests
-TEST_ON_CI_BLACKLIST += native
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -24,7 +24,4 @@ BOARD_INSUFFICIENT_MEMORY = \
 	stm32l0538-disco \
 	#
 
-# HACK Blacklist native as `murdock` fails on utf-8 characters for native tests
-TEST_ON_CI_BLACKLIST += native
-
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

The docker image should now be configured with LC_ALL|LANG=C.UTF-8
and used in murdock.

Now that https://github.com/RIOT-OS/riotdocker/pull/75 is merged, the tests should run again in murdock

Closes https://github.com/RIOT-OS/RIOT/issues/11691

### Testing procedure

The 'native' tests work in murdock

### Issues/PRs references

murdock and tests using `utf-8` characters #11691
Fix in riotdocker https://github.com/RIOT-OS/riotdocker/pull/75