### PR TITLE
Makefile.base: implement relative path linking without 'realpath'

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -67,12 +67,12 @@ $(BINDIR)/$(MODULE)/:
 
 $(BINDIR)/$(MODULE).a $(OBJ): | $(BINDIR)/$(MODULE)/
 
-relpath = $(shell realpath --relative-to=$(abspath .) $(1))
-
+# Build the archive from the output directory to create relative thin archives
+# This allows having them valid in and outside of docker
 $(BINDIR)/$(MODULE).a: $(OBJ) | $(DIRS:%=ALL--%)
 	@# Recreate archive to cleanup deleted/non selected source files objects
 	$(Q)$(RM) $@
-	$(Q)$(AR) $(ARFLAGS) $(foreach f,$@ $^,$(call relpath,$f))
+	$(Q)cd $(@D) && $(AR) $(ARFLAGS) $(@F) $(subst $(@D)/,,$^)
 
 CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 CCASFLAGS = $(filter-out $(CCASUWFLAGS), $(CFLAGS)) $(CCASEXFLAGS)

--- a/Makefile.include
+++ b/Makefile.include
@@ -500,7 +500,8 @@ endif # BUILD_IN_DOCKER
 
 # Rules to check the correctness of thin archives.
 
-relpath = $(shell realpath --relative-to=$(abspath .) $(1))
+# OS independant relpath as 'realpath --relative-to' is not supported on OSx
+relpath = $(shell python3 -c 'import pathlib; print(pathlib.Path("$1").relative_to("$(CURDIR)"))')
 
 # Each ARCHECK file contains all the absolute paths found inside the archive.
 BASELIB_ARCHECKS = $(patsubst %.a,%.a-check,$(filter %.a,$(BASELIBS)))

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -2,7 +2,7 @@
 
 # Define application sketches module, it will be generated into $(BINDIR)
 SKETCH_MODULE     ?= arduino_sketches
-SKETCH_MODULE_DIR ?= $(BINDIR)/$(SKETCH_MODULE)_src
+SKETCH_MODULE_DIR ?= $(BINDIR)/$(SKETCH_MODULE)
 SKETCHES           = $(wildcard $(APPDIR)/*.sketch)
 include $(RIOTBASE)/sys/arduino/sketches.inc.mk
 

--- a/sys/arduino/sketches.inc.mk
+++ b/sys/arduino/sketches.inc.mk
@@ -19,8 +19,7 @@ SKETCH_GENERATED_FILES = $(SKETCH_MODULE_DIR)/Makefile $(SKETCH_MODULE_DIR)/$(SK
 # Building the module files
 #   Do not use $^ in receipes as Makefile is also a prerequisite
 $(SKETCH_MODULE_DIR)/Makefile: $(SKETCH_MODULE_DIR)/$(SKETCH_CPP)
-	$(Q)echo 'MODULE = $(SKETCH_MODULE)'           > $@
-	$(Q)echo 'SRCXX = $(SKETCH_CPP)'              >> $@
+	$(Q)echo 'SRCXX = $(SKETCH_CPP)'               > $@
 	$(Q)echo 'include $$(RIOTBASE)/Makefile.base' >> $@
 $(SKETCH_MODULE_DIR)/$(SKETCH_CPP): $(SKETCHES_ALL)
 	@mkdir -p $(@D)


### PR DESCRIPTION
### Contribution description

This fixes the following issues:
    
* Use of 'realpath' not supported on mac
* Call of 'realpath' once for each file instead of one per archive
* Do not trigger 'llvm-ar' bug when invoked in the object directory.
  ```
  llvm-ar rcTs ../m.a obj.o  # Bugged
  llvm-ar rcTs m.a m/obj.o   # working
  ```
    
Using relative path linking is required to have a valid thin archive
path in the host when build in docker.

This is a group of changes discussed offline that were not put into the original PR.


### Testing procedure

Compiling in `OSX` works.

~The testing still uses "realpath" and was not changed by this.~ Fixed to use a `python3/pathlib` version. `os.path` does not support `relpath`.

The testing procedure from https://github.com/RIOT-OS/RIOT/pull/10195 works, even in 'examples/arduino_hello-world' without the special handling.


```
TOOLCHAIN=llvm BUILD_IN_DOCKER=1 DOCKER="sudo docker" BOARD=stm32f4discovery make -C examples/arduino_hello-world/ clean all archive-check
make: Entering directory '/home/harter/work/git/RIOT/examples/arduino_hello-world'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache   \
    -e 'BOARD=stm32f4discovery' -e 'TOOLCHAIN=llvm' \
    -w '/data/riotbuild/riotbase/examples/arduino_hello-world/' \
    'riot/riotbuild:latest' make all archive-check
Building application "arduino_hello-world" for "stm32f4discovery" with MCU "stm32f4".

"make" -C /data/riotbuild/riotbase/boards/stm32f4discovery
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32f4
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32_common
"make" -C /data/riotbuild/riotbase/cpu/stm32_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32f4/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/arduino_sketches
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/arduino
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text    data     bss     dec     hex filename
  15872       0    3020   18892    49cc /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/arduino_hello-world.elf
Archives correctly formed
rm /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/arduino.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/stm32_common.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/cpu.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/periph.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/stm32_common_periph.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/pm_layered.a-check
/data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/auto_init.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/arduino_sketches.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/cortexm_common_periph.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/div.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/stdio_uart.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/core.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/xtimer.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/newlib_syscalls_default.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/board.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/cortexm_common.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/application_arduino_hello-world.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/sys.a-check /data/riotbuild/riotbase/examples/arduino_hello-world/bin/stm32f4discovery/periph_common.a-check
make: Nothing to be done for 'archive-check'.
make: Leaving directory '/home/harter/work/git/RIOT/examples/arduino_hello-world'
```

<details><summary>Thin archives are used, the file size is tiny</summary>

```
ls -l examples/arduino_hello-world/bin/stm32f4discovery/*.a
-rw-r--r-- 1 harter root    8 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/application_arduino_hello-world.a
-rw-r--r-- 1 harter root 1552 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/arduino.a
-rw-r--r-- 1 harter root  296 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/arduino_sketches.a
-rw-r--r-- 1 harter root  230 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/auto_init.a
-rw-r--r-- 1 harter root  224 Sep 16 13:23 examples/arduino_hello-world/bin/stm32f4discovery/board.a
-rw-r--r-- 1 harter root 4314 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/core.a
-rw-r--r-- 1 harter root 1366 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/cortexm_common.a
-rw-r--r-- 1 harter root  234 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/cortexm_common_periph.a
-rw-r--r-- 1 harter root 2062 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/cpu.a
-rw-r--r-- 1 harter root  222 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/div.a
-rw-r--r-- 1 harter root    8 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/drivers.a
-rw-r--r-- 1 harter root  492 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/newlib_syscalls_default.a
-rw-r--r-- 1 harter root  234 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/periph.a
-rw-r--r-- 1 harter root 1224 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/periph_common.a
-rw-r--r-- 1 harter root  272 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/pm_layered.a
-rw-r--r-- 1 harter root  264 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/stdio_uart.a
-rw-r--r-- 1 harter root  816 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/stm32_common.a
-rw-r--r-- 1 harter root  892 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/stm32_common_periph.a
-rw-r--r-- 1 harter root    8 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/sys.a
-rw-r--r-- 1 harter root  658 Sep 16 13:24 examples/arduino_hello-world/bin/stm32f4discovery/xtimer.a
```
</details>

And the path is valid outside of docker:

```
ar t examples/arduino_hello-world/bin/stm32f4discovery/arduino_sketches.a 
examples/arduino_hello-world/bin/stm32f4discovery/arduino_sketches/arduino_sketches.o
```

BTW the 'archive-check' testing should be done outside of docker as it is why there is work done to use relative path for consistency with the host.


#### Building in OSX

<details><summary>Working with this PR</summary>

```
make -C examples/hello-world/
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
/Users/harter/RIOT/makefiles/toolchain/llvm.inc.mk:25: objcopy not found. Hex file will not be created.
Building application "hello-world" for "native" with MCU "native".

"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/boards/native
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/boards/native/drivers
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: native-drivers.a(native-qdec.o) has no symbols
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/core
ar: warning: priority_queue.o truncated to priority_queue.
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: core.a(atomic_sync.o) has no symbols
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/cpu/native
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/cpu/native/periph
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/cpu/native/vfs
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/drivers
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/drivers/periph_common
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: periph_common.a(cpuid.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: periph_common.a(eeprom.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: periph_common.a(flashpage.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: periph_common.a(i2c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: periph_common.a(pm.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: periph_common.a(spi.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: periph_common.a(timer.o) has no symbols
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/sys
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/sys/auto_init
ld: warning: The i386 architecture is deprecated for macOS (remove from the Xcode build setting: ARCHS)
__TEXT  __DATA  __OBJC  others  dec     hex
24576   806912  0       20480   851968  d0000
```
</details>

However it looks like mac is ignoring the 'T' option and not creating a thin archive anyway:

<details><summary>ar t examples/hello-world/bin/native/periph_common.a</summary>

```
ar t examples/hello-world/bin/native/periph_common.a
__.SYMDEF SORTED
cpuid.o
eeprom.o
flashpage.o
gpio_util.o
i2c.o
init.o
pm.o
rtc.o
spi.o
timer.o
```
</details>

<details><summary>ls -l examples/hello-world/bin/native/*.a</summary>

Files have a big size so are not thin

```
ls -l examples/hello-world/bin/native/*.a
-rw-r--r--  1 harter  staff   1328 Sep 16 13:26 examples/hello-world/bin/native/application_hello-world.a
-rw-r--r--  1 harter  staff    952 Sep 16 13:26 examples/hello-world/bin/native/auto_init.a
-rw-r--r--  1 harter  staff   1208 Sep 16 13:26 examples/hello-world/bin/native/board.a
-rw-r--r--  1 harter  staff  67784 Sep 16 13:26 examples/hello-world/bin/native/core.a
-rw-r--r--  1 harter  staff  52176 Sep 16 13:26 examples/hello-world/bin/native/cpu.a
-rw-r--r--  1 harter  staff      8 Sep 16 13:26 examples/hello-world/bin/native/drivers.a
-rw-r--r--  1 harter  staff   2768 Sep 16 13:26 examples/hello-world/bin/native/native-drivers.a
-rw-r--r--  1 harter  staff   4016 Sep 16 13:26 examples/hello-world/bin/native/native_vfs.a
-rw-r--r--  1 harter  staff   8288 Sep 16 13:26 examples/hello-world/bin/native/periph.a
-rw-r--r--  1 harter  staff   5600 Sep 16 13:26 examples/hello-world/bin/native/periph_common.a
-rw-r--r--  1 harter  staff      8 Sep 16 13:26 examples/hello-world/bin/native/sys.a
```
</details>

<details><summary>Failing in master</summary>

```
make -C examples/hello-world/
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
/Users/harter/RIOT/makefiles/toolchain/llvm.inc.mk:25: objcopy not found. Hex file will not be created.
Building application "hello-world" for "native" with MCU "native".

"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/boards/native
"/Library/Developer/CommandLineTools/usr/bin/make" -C /Users/harter/RIOT/boards/native/drivers
make[3]: realpath: Command not found
make[3]: realpath: Command not found
make[3]: realpath: Command not found
usage:  ar -d [-TLsv] archive file ...
        ar -m [-TLsv] archive file ...
        ar -m [-abiTLsv] position archive file ...
        ar -p [-TLsv] archive [file ...]
        ar -q [-cTLsv] archive file ...
        ar -r [-cuTLsv] archive file ...
        ar -r [-abciuTLsv] position archive file ...
        ar -t [-TLsv] archive [file ...]
        ar -x [-ouTLsv] archive [file ...]
make[3]: *** [/Users/harter/RIOT/examples/hello-world/bin/native/native-drivers.a] Error 1
make[2]: *** [ALL--/Users/harter/RIOT/boards/native/drivers] Error 2
make[1]: *** [ALL--/Users/harter/RIOT/boards/native] Error 2
make: *** [/Users/harter/RIOT/examples/hello-world/bin/native/application_hello-world.a] Error 2
```
</details>


### Issues/PRs references

Introduced by https://github.com/RIOT-OS/RIOT/pull/10195

Fixes compiling in OSX