### PR TITLE
gnrc_tcp: check if option length field is present before accessing it

### DIFF
--- a/sys/include/net/tcp.h
+++ b/sys/include/net/tcp.h
@@ -49,6 +49,7 @@ extern "C" {
  * @brief TCP option "length"-field values.
  * @{
  */
+#define TCP_OPTION_LENGTH_MIN (2U)    /**< Mimimum amount of bytes needed for an option with a length field */
 #define TCP_OPTION_LENGTH_MSS (0x04)  /**< MSS Option Size always 4 */
 /** @} */
 

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
@@ -51,7 +51,7 @@ int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
                 continue;
 
             case TCP_OPTION_KIND_MSS:
-                if (option->length > opt_left || option->length != TCP_OPTION_LENGTH_MSS) {
+                if (opt_left < TCP_OPTION_LENGTH_MIN || option->length > opt_left || option->length != TCP_OPTION_LENGTH_MSS) {
                     DEBUG("gnrc_tcp_option.c : _option_parse() : invalid MSS Option length.\n");
                     return -1;
                 }
@@ -66,7 +66,7 @@ int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
                 return -1;
         }
 
-        if (option->length > opt_left) {
+        if (opt_left < TCP_OPTION_LENGTH_MIN || option->length > opt_left) {
             DEBUG("gnrc_tcp_option.c : _option_parse() : invalid option length\n");
             return 0;
         }


### PR DESCRIPTION
TCP options have a maximum size of 3 byte (kind, length, value). The
current code only checks for the presence of the first field. Before
accessing the second field (length) the code must ensure that a length
field is even present.

**Discussion:** Change is somewhat ugly as it introduces a magic constant.
The proper way of solving this would probably be not using a packed struct
to parse these variable-length options.