### PR TITLE
Revert "cpu/esp8266: update deprecated flash_size argument"

### DIFF
--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -141,7 +141,7 @@ LINKFLAGS += -nostdlib -lgcc -u ets_run -Wl,-gc-sections # -Wl,--print-gc-sectio
 FLASHFILE ?= $(ELFFILE)
 
 # configure preflasher to convert .elf to .bin before flashing
-FLASH_SIZE = -fs 1MB
+FLASH_SIZE = -fs 8m
 PREFLASHER ?= esptool.py
 PREFFLAGS  ?= elf2image $(FLASH_SIZE) $(FLASHFILE)
 FLASHDEPS  += preflash


### PR DESCRIPTION
### Contribution description

This reverts commit 422644bd3a1d4247ae74253ca2fa50d7d59fbd1b.

The option is only supported after 2.6 which is currently not the
version given with 'esp' toolchain.
It was a bit too early to switch to the new version.
Version 2.7 also supports the old option with only a warning.


The version installed in the 'esp8266' toolchain is version 2.5 that do not support the option. So use the old name as it is still compatible.

This could be re-added when the installed `esptool.py` is at least 2.6 everywhere.

Fixes https://github.com/RIOT-OS/RIOT/issues/12247

### Testing procedure

Please test the procedure from https://github.com/RIOT-OS/RIOT/issues/12247

I used this adapted test procedure for my machine:

```
git clone https://github.com/gschorcht/RIOT-Xtensa-ESP8266-toolchain.git /tmp/opt/esp
export PATH=/tmp/opt/esp/esp-open-sdk/xtensa-lx106-elf/bin:$PATH
```

It works again with this PR:

```
RIOT_CI_BUILD=1 ESP8266_NEWLIB_DIR=/tmp/opt/esp/newlib-xtensa ESP8266_SDK_DIR=/tmp/opt/esp/esp-open-sdk/sdk make -C examples/hello-world BOARD=esp8266-esp-12x flash
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Building application "hello-world" for "esp8266-esp-12x" with MCU "esp8266".

   text    data     bss     dec     hex filename
  63851    4304    7008   75163   1259b /home/harter/work/git/RIOT/examples/hello-world/bin/esp8266-esp-12x/hello-world.elf
esptool.py elf2image -fs 8m /home/harter/work/git/RIOT/examples/hello-world/bin/esp8266-esp-12x/hello-world.elf
esptool.py v1.2
Warning: ELF binary has undefined symbol LoadStoreErrorHandler
esptool.py -p /dev/ttyUSB0 -b 460800 write_flash -fm dout 0 /home/harter/work/git/RIOT/examples/hello-world/bin/esp8266-esp-12x/hello-world.elf-0x00000.bin 0x10000 /home/harter/work/git/RIOT/examples/hello-world/bin/esp8266-esp-12x/hello-world.elf-0x10000.bin; esptool.py -p /dev/ttyUSB0 run
esptool.py v1.2
# fails as no board connected
```

With master:

```
RIOT_CI_BUILD=1 ESP8266_NEWLIB_DIR=/tmp/opt/esp/newlib-xtensa ESP8266_SDK_DIR=/tmp/opt/esp/esp-open-sdk/sdk make -C examples/hello-world BOARD=esp8266-esp-12x flash
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Building application "hello-world" for "esp8266-esp-12x" with MCU "esp8266".

   text    data     bss     dec     hex filename
  63851    4304    7008   75163   1259b /home/harter/work/git/RIOT/examples/hello-world/bin/esp8266-esp-12x/hello-world.elf
esptool.py elf2image -fs 1MB /home/harter/work/git/RIOT/examples/hello-world/bin/esp8266-esp-12x/hello-world.elf
usage: esptool elf2image [-h] [--output OUTPUT] [--version {1,2}]
                         [--flash_freq {40m,26m,20m,80m}]
                         [--flash_mode {qio,qout,dio,dout}]
                         [--flash_size {4m,2m,8m,16m,32m,16m-c1,32m-c1,32m-c2}]
                         input
esptool elf2image: error: argument --flash_size/-fs: invalid choice: '1mb' (choose from '4m', '2m', '8m', '16m', '32m', '16m-c1', '32m-c1', '32m-c2')
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:605: recipe for target 'preflash' failed
make: *** [preflash] Error 2
make: Leaving directory '/home/harter/work/git/RIOT/examples/hello-world'
```

### Issues/PRs references

Reported in:
* https://github.com/RIOT-OS/RIOT/pull/11646#issuecomment-531739891
* https://github.com/RIOT-OS/RIOT/issues/12247
