### PR TITLE
gnrc_tcp: Always ensure that option->length doesn't exceed opt_left

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
@@ -51,7 +51,7 @@ int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
                 continue;
 
             case TCP_OPTION_KIND_MSS:
-                if (option->length != TCP_OPTION_LENGTH_MSS) {
+                if (option->length > opt_left || option->length != TCP_OPTION_LENGTH_MSS) {
                     DEBUG("gnrc_tcp_option.c : _option_parse() : invalid MSS Option length.\n");
                     return -1;
                 }


### PR DESCRIPTION
Noticed this while working on #12249 the MSS option length of a malicious packet might exceed `opt_left`.  