### PR TITLE
tests: remove remaining use of "TEST_ON_CI_WHITELIST += all"

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -116,6 +116,7 @@ check_deprecated_vars_patterns() {
     local pathspec=()
 
     patterns+=(-e 'FEATURES_MCU_GROUP')
+    patterns+=(-e 'TEST_ON_CI_WHITELIST += all')
 
     # Pathspec with exclude should start by an inclusive pathspec in git 2.7.4
     pathspec+=('*')

--- a/tests/sys_crypto/Makefile
+++ b/tests/sys_crypto/Makefile
@@ -27,6 +27,4 @@ USEMODULE += crypto
 USEMODULE += cipher_modes
 CFLAGS += -DCRYPTO_THREEDES
 
-TEST_ON_CI_WHITELIST += all
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/test_tools/Makefile
+++ b/tests/test_tools/Makefile
@@ -3,8 +3,6 @@ include ../Makefile.tests_common
 
 USEMODULE += shell
 
-TEST_ON_CI_WHITELIST += all
-
 # Disable shell echo and prompt to not have them in the way for testing
 CFLAGS += -DSHELL_NO_ECHO=1 -DSHELL_NO_PROMPT=1
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Apparently there are 2 remaining use of `TEST_ON_CI_WHITELIST += all` in the test applications although this is not needed since `all` is the default on Murdock (e.g. all boards are whitelisted), see [here](https://github.com/RIOT-OS/RIOT/blob/master/makefiles/murdock.inc.mk#L40).

This PR does 2 things:
- fixing the 2 application Makefiles where the pattern is still used: `tests/test_tools` and `tests/sys_crypto`
- exclude this pattern in the buildsystem sanity check script

Also cc'ing @cladmi to have his opinion on that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Enable `CI: run tests` and verify the 2 tests are run on all available boards
- Add the pattern in one test application Makefile and verify that the buildsystem sanity check reports an error (e.g. by running `./dist/tools/buildsystem_sanity_check/check.sh`)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Not sure which one this is related to.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
