### PR TITLE
boards: pic32-wifire: Fix uart initialization

### DIFF
--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -2,7 +2,6 @@ export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
 
 PORT_LINUX ?= /dev/ttyUSB0
-BAUD ?= 9600
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # pic32prog

--- a/boards/pic32-wifire/include/board.h
+++ b/boards/pic32-wifire/include/board.h
@@ -81,6 +81,13 @@ extern "C" {
  */
 void board_init(void);
 
+/**
+ * @brief   Use the 4th UART for STDIO on this board
+ *
+ * This is the UART connected to the FTDI USB <-> UART device.
+ */
+#define STDIO_UART_DEV      UART_DEV(4)
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/pic32-wifire/include/periph_conf.h
+++ b/boards/pic32-wifire/include/periph_conf.h
@@ -43,15 +43,11 @@ extern "C" {
 /**
   * @name    UART Definitions
   *          There are 6 UARTS available on this CPU.
-  *          We route debug via UART4 on this board,
-  *          this is the UART connected to the FTDI USB <-> UART device.
   *
-  *          Note Microchip number the UARTS 1->4.
+  *          Note Microchip number the UARTS 1->6.
   * @{
   */
 #define UART_NUMOF          (6)
-#define DEBUG_VIA_UART      (4)
-#define DEBUG_UART_BAUD     (9600)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/pic32-wifire/wifire.c
+++ b/boards/pic32-wifire/wifire.c
@@ -8,11 +8,9 @@
  *
  */
 
-#include <stdio.h>
 #include <stdint.h>
 #include "periph/gpio.h"
 #include "periph/hwrng.h"
-#include "periph/uart.h"
 #include "bitarithm.h"
 #include "board.h"
 #include "cpu.h"
@@ -27,11 +25,6 @@ void board_init(void)
      */
     U4RXR =   0xb;            /* connect pin RPF2 to UART 4 RX */
     RPF8R =   0x2;            /* connect pin RPF8 to UART 4 TX */
-
-    /* intialise UART used for debug (printf) */
-#ifdef DEBUG_VIA_UART
-    uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
-#endif
 
     /* Turn off all LED's */
     gpio_init(LED1_PIN, GPIO_OUT);

--- a/cpu/mips32r2_common/thread_arch.c
+++ b/cpu/mips32r2_common/thread_arch.c
@@ -17,9 +17,8 @@
 #include "cpu.h"
 #include "irq.h"
 #include "cpu_conf.h"
-#include "periph_conf.h" /* for debug uart number */
-#include "periph/uart.h"
 #include "malloc.h"
+#include "stdio_uart.h"
 
 #define STACK_END_PAINT    (0xdeadc0de)
 #define C0_STATUS_EXL      (2)
@@ -216,7 +215,7 @@ _mips_handle_exception(struct gpctx *ctx, int exception)
             syscall_num = (mem_rw((const void *)ctx->epc) >> 6) & 0xFFFF;
 #endif
 
-#ifdef DEBUG_VIA_UART
+#ifdef MODULE_STDIO_UART
 #include <mips/uhi_syscalls.h>
             /*
              * intercept UHI write syscalls (printf) which would normally
@@ -228,7 +227,7 @@ _mips_handle_exception(struct gpctx *ctx, int exception)
                 if (ctx->t2[1] == __MIPS_UHI_WRITE &&
                     (ctx->a[0] == STDOUT_FILENO || ctx->a[0] == STDERR_FILENO)) {
                     uint32_t status = irq_disable();
-                    uart_write(DEBUG_VIA_UART, (uint8_t *)ctx->a[1], ctx->a[2]);
+                    stdio_write((void *)ctx->a[1], ctx->a[2]);
                     ctx->v[0] = ctx->a[2];
                     ctx->epc += 4; /* move PC past the syscall */
                     irq_restore(status);


### PR DESCRIPTION
### Contribution description

stdio_uart was not working on PIC32 WiFire because `STDIO_UART_DEV` was not defined. This PR also includes some cleanup (remove call to uart_init in board_init, remove useless macros).

### Testing procedure

Compile hello-world and check the output.

### Issues/PRs references

Depends on ~~#11986~~ and ~~#12227~~
