### PR TITLE
boards/frdm: fix flashing from invalid state

### DIFF
--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -34,5 +34,9 @@ export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield.sh
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# The board can become un-flashable after some execution,
+# use connect_assert_srst to always be able to flash or reset the board.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
+
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk


### PR DESCRIPTION
### Contribution description

When flashing some applications the flasher sometimes gets stuck which
prevents flashing after.
It may be from a specific firmware or operation but do not have one yet.
Connect with reset asserted fix flashing from this state.

### Testing procedure

I do not have an application that cannot flash anymore to really show the fix.
But I have been using a fix like this for several month and had no flashing issue in my test machine.

Flashing boards that use `common/frdm` so `frdm-kw41z` and other similar boards, `frdm-k22f` and `frdm-k64f` keep flashing correctly. (the

They now use `connect_assert_srst` when flashing instead of `connect_deassert_srst` as it was in `master

PR:
`srst_only separate srst_nogate srst_open_drain connect_assert_srst`

master

`srst_only separate srst_nogate srst_open_drain connect_deassert_srst`

Both appear with this PR as the `deassert` is the value in the configuration which is then changed by command line option.

<details><summary><code>frdm-k64f</code></summary>

```
BOARD=frdm-k64f RIOT_CI_BUILD=1 make -C examples/hello-world/ flash 
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Building application "hello-world" for "frdm-k64f" with MCU "kinetis".

   text    data     bss     dec     hex filename
   9160     116    2544   11820    2e2c /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-k64f/hello-world.elf
/home/harter/work/git/RIOT/dist/tools/openocd/openocd.sh flash /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-k64f/hello-world.elf
### Flashing Target ###
/home/harter/work/git/RIOT/examples/hello-world/bin/frdm-k64f/hello-world.elf is not locked.
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:37)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
Info : add flash_bank kinetis kx.pflash
adapter speed: 1000 kHz
none separate
cortex_m reset_config sysresetreq
srst_only separate srst_nogate srst_open_drain connect_deassert_srst
srst_only separate srst_nogate srst_open_drain connect_assert_srst
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 1.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : Connecting under reset
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : MDM: Chip is unsecured. Continuing.
Info : kx.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 44403 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* kx.cpu             cortex_m   little kx.cpu             reset
Info : MDM: Chip is unsecured. Continuing.
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x0000073c msp: 0x1fff0200
auto erase enabled
Info : Kinetis MK64FN1M0xxx12 detected: 2 flash blocks
Info : 2 PFlash banks: 1024k total
wrote 12288 bytes from file /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-k64f/hello-world.elf in 0.895014s (13.408 KiB/s)
Error: timed out while waiting for target halted
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000bd2 psp: 0x1fff0408
Error: error executing cortex_m crc algorithm
verified 9276 bytes in 20.942808s (0.433 KiB/s)
Info : MDM: Chip is unsecured. Continuing.
shutdown command invoked
Done flashing
make: Leaving directory '/home/harter/work/git/RIOT/examples/hello-world'
```
</details>

<details><summary><code>frdm-kw41z</code></summary>

```
BOARD=frdm-kw41z RIOT_CI_BUILD=1 make -C examples/hello-world/ flash
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Building application "hello-world" for "frdm-kw41z" with MCU "kinetis".

   text    data     bss     dec     hex filename
   9080     116    2544   11740    2ddc /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-kw41z/hello-world.elf
/home/harter/work/git/RIOT/dist/tools/openocd/openocd.sh flash /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-kw41z/hello-world.elf
### Flashing Target ###
/home/harter/work/git/RIOT/examples/hello-world/bin/frdm-kw41z/hello-world.elf is not locked.
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:37)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : add flash_bank kinetis klx.pflash
adapter speed: 1000 kHz
none separate
cortex_m reset_config sysresetreq
srst_only separate srst_nogate srst_open_drain connect_deassert_srst
srst_only separate srst_nogate srst_open_drain connect_assert_srst
Info : J-Link OpenSDA 2 compiled May  6 2016 11:04:17
Info : Hardware version: 1.00
Info : VTarget = 3.300 V
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x0bc11477
Info : MDM: Chip is unsecured. Continuing.
Info : klx.cpu: hardware has 2 breakpoints, 2 watchpoints
Info : Listening on port 35329 for gdb connections
    TargetName         Type       Endian TapName            State
--  ------------------ ---------- ------ ------------------ ------------
 0* klx.cpu            cortex_m   little klx.cpu            reset
Info : MDM: Chip is unsecured. Continuing.
target halted due to debug-request, current mode: Thread
xPSR: 0x01000000 pc: 0x00000758 msp: 0x1fff8200
auto erase enabled
Info : Kinetis MKW41Z512xxx4 detected: 2 flash blocks
Info : 2 PFlash banks: 512k total
Info : This device supports Program Longword execution only.
Info : Disabling Kinetis watchdog (initial SIM_COPC 0x0c)
Warn : not enough working area available(requested 2048)
Info : This device supports Program Longword execution only.
Warn : not enough working area available(requested 2048)
wrote 10240 bytes from file /home/harter/work/git/RIOT/examples/hello-world/bin/frdm-kw41z/hello-world.elf in 0.374071s (26.733 KiB/s)
verified 9196 bytes in 0.119052s (75.433 KiB/s)
Info : MDM: Chip is unsecured. Continuing.
shutdown command invoked
Done flashing
make: Leaving directory '/home/harter/work/git/RIOT/examples/hello-world'
```
</details>

### Issues/PRs references

* Similar to https://github.com/RIOT-OS/RIOT/pull/11549
* Using the mechanism introduced in: dist/tools/openocd: add OPENOCD_EXTRA_INIT_RESET use for nucleo-f091rc #11976 
* Found while running the test suite on the board in #10870