### PR TITLE
sys/pipe: always include stdlib.h instead of malloc.h

### DIFF
--- a/sys/pipe/pipe_dynamic.c
+++ b/sys/pipe/pipe_dynamic.c
@@ -25,11 +25,7 @@
  * @}
  */
 
-#if defined(MCU_ATMEGA2560) || defined(MCU_ATMEGA1281) || defined(MCU_ATMEGA328P)
 #include <stdlib.h>
-#else
-#include <malloc.h>
-#endif
 
 #include "pipe.h"
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The malloc.h file is deprecated on most systems and should not be
used, instead include stdlib.h which handles needed function in a
portable manner.

This fix is needed to run unittests with RIOT native on FreeBSD
(and some others platforms).

### Testing procedure

compile and run unit tests, they should still work.


### Issues/PRs references

#3392 
see also 
- https://stackoverflow.com/questions/12973311/difference-between-stdlib-h-and-malloc-h/12973349#12973349
- https://lists.freebsd.org/pipermail/freebsd-questions/2005-February/078534.html
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
