### PR TITLE
boards: pic32-wifire: Add support for JLink programmer

### DIFF
--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -1,16 +1,28 @@
+export CPU = mips_pic32mz
+export CPU_MODEL=p32mz2048efg100
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
 
 PORT_LINUX ?= /dev/ttyUSB0
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# pic32prog
-#
-# For PICkit3:
-#
-# * Connect the chipKIT-Wi-Fire to USB
-# * Connect the PICkit3 to ICSP holes
-# * https://docs.creatordev.io/wifire/guides/wifire-programming/
-# * The triangle `▶` goes into the port number 1 (a hole with a square around it)
-#   opposite side of the JP1 ICSP text.
-include $(RIOTMAKE)/tools/pic32prog.inc.mk
+# use pic32prog by default to program this board
+PROGRAMMER ?= pic32prog
+
+ifeq ($(PROGRAMMER),pic32prog)
+  # pic32prog
+  #
+  # For PICkit3:
+  #
+  # * Connect the chipKIT-Wi-Fire to USB
+  # * Connect the PICkit3 to ICSP holes
+  # * https://docs.creatordev.io/wifire/guides/wifire-programming/
+  # * The triangle `▶` goes into the port number 1 (a hole with a square around it)
+  #   opposite side of the JP1 ICSP text.
+  include $(RIOTMAKE)/tools/pic32prog.inc.mk
+else ifeq ($(PROGRAMMER),jlink)
+  FLASHFILE ?= $(HEXFILE)
+  export JLINK_DEVICE := PIC32MZ2048EFG100
+  export JLINK_IF := JTAG
+  include $(RIOTMAKE)/tools/jlink.inc.mk
+endif


### PR DESCRIPTION
### Contribution description

The wifire board has JTAG exposed on connector JP3 ~~J17~~.
This PR adds support for flashing and debugging pic32 WiFire boards with JLink programmer.

### Testing procedure

Compile, flash and debug `examples/hello-world` by running this command:

```
$ PROGRAMMER=jlink BOARD=pic32-wifire make flash debug
```

### Issues/PRs references

None.
