### PR TITLE
USBUS: CDC ACM to UART functionality with example.

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -927,6 +927,8 @@ ifneq (,$(filter usbus_cdc_ecm,$(USEMODULE)))
 endif
 
 ifneq (,$(filter usbus_cdc_acm_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_uart
+  FEATURES_OPTIONAL += periph_uart_modecfg
   USEMODULE += usbus_cdc_acm
   USEMODULE += isrpipe
 endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -926,6 +926,11 @@ ifneq (,$(filter usbus_cdc_ecm,$(USEMODULE)))
   USEMODULE += luid
 endif
 
+ifneq (,$(filter usbus_cdc_acm_uart,$(USEMODULE)))
+  USEMODULE += usbus_cdc_acm
+  USEMODULE += isrpipe
+endif
+
 ifneq (,$(filter uuid,$(USEMODULE)))
   USEMODULE += hashes
   USEMODULE += random

--- a/examples/usbus_uart_adapter/Makefile
+++ b/examples/usbus_uart_adapter/Makefile
@@ -1,0 +1,44 @@
+# name of your application
+APPLICATION = usbus_uart_adapter
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= samr21-xpro
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+USEMODULE += usbus_cdc_acm_uart
+USEMODULE += fmt
+
+USEMODULE += stdio_cdc_acm
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+FEATURES_REQUIRED += periph_uart
+FEATURES_OPTIONAL += periph_uart_modecfg
+
+# USB device vendor and product ID
+USB_VID ?= 1209
+USB_PID ?= 0001
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+CFLAGS += -DUSB_CONFIG_VID=0x$(USB_VID) -DUSB_CONFIG_PID=0x$(USB_PID)
+
+include $(RIOTBASE)/Makefile.include
+
+.PHONY: usb_id_check
+usb_id_check:
+	@if [ $(USB_VID) = $(DEFAULT_VID) ] || [ $(USB_PID) = $(DEFAULT_PID) ] ; then \
+		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+	fi
+
+all: | usb_id_check

--- a/examples/usbus_uart_adapter/Makefile
+++ b/examples/usbus_uart_adapter/Makefile
@@ -15,28 +15,35 @@ DEVELHELP ?= 1
 USEMODULE += usbus_cdc_acm_uart
 USEMODULE += fmt
 
-USEMODULE += stdio_cdc_acm
-USEMODULE += shell
-USEMODULE += shell_commands
-USEMODULE += ps
-
-FEATURES_REQUIRED += periph_uart
-FEATURES_OPTIONAL += periph_uart_modecfg
+USEMODULE += stdio_null
 
 # USB device vendor and product ID
-USB_VID ?= 1209
-USB_PID ?= 0001
+export DEFAULT_VID = 1209
+export DEFAULT_PID = 7D00
+USB_VID ?= $(DEFAULT_VID)
+USB_PID ?= $(DEFAULT_PID)
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-CFLAGS += -DUSB_CONFIG_VID=0x$(USB_VID) -DUSB_CONFIG_PID=0x$(USB_PID)
-
 include $(RIOTBASE)/Makefile.include
+
+# Set USB VID/PID via CFLAGS if not being set via Kconfig
+ifndef CONFIG_USB_VID
+  CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID)
+else
+  USB_VID = $(patsubst 0x%,%,$(CONFIG_USB_VID))
+endif
+
+ifndef CONFIG_USB_PID
+  CFLAGS += -DCONFIG_USB_PID=0x$(USB_PID)
+else
+  USB_PID = $(patsubst 0x%,%,$(CONFIG_USB_PID))
+endif
 
 .PHONY: usb_id_check
 usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) ] || [ $(USB_PID) = $(DEFAULT_PID) ] ; then \
+	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
 		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
 		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi

--- a/examples/usbus_uart_adapter/Makefile
+++ b/examples/usbus_uart_adapter/Makefile
@@ -12,6 +12,8 @@ RIOTBASE ?= $(CURDIR)/../..
 # development process:
 DEVELHELP ?= 1
 
+# Disable the auto init, we handle USBUS initialization in the main.c
+DISABLE_MODULE += auto_init_usbus
 USEMODULE += usbus_cdc_acm_uart
 USEMODULE += fmt
 

--- a/examples/usbus_uart_adapter/README.md
+++ b/examples/usbus_uart_adapter/README.md
@@ -1,0 +1,23 @@
+# USBUS UART example
+
+This example shows how to manually instantiate an USBUS thread without relying
+on the auto_init module for USBUS. In this example the USBUS thread is started
+with the USBUS STDIO over CDC ACM module and then as many USBUS CDC ACM to UART
+interfaces allowed by both the usbus peripheral and the number of UART
+peripherals available on the board.
+
+## Requirements
+
+A board with `periph_usbdev` is required for this. Furthermore, an available
+number of UART devices is useful but not strictly required for the example.
+
+## Usage
+
+When started and attached to a host computer, the host computer should recognize
+the device as multiple USB ACM devices. On Linux these show up as
+`/dev/ttyACMn` devices, with increasing numbers. The first ttyACM device
+provided by the board is attached to the local RIOT shell of the board.
+
+The other ttyACMn devices are connected to the UART peripherals of the board.
+Both the baud rate and the parity can be controlled from the host computer as
+long as the MCU supports the configured setting.

--- a/examples/usbus_uart_adapter/README.md
+++ b/examples/usbus_uart_adapter/README.md
@@ -2,22 +2,21 @@
 
 This example shows how to manually instantiate an USBUS thread without relying
 on the auto_init module for USBUS. In this example the USBUS thread is started
-with the USBUS STDIO over CDC ACM module and then as many USBUS CDC ACM to UART
-interfaces allowed by both the usbus peripheral and the number of UART
-peripherals available on the board.
+with  as many USBUS CDC ACM to UART interfaces allowed by both the usbus
+peripheral and the number of UART peripherals available on the board.
 
 ## Requirements
 
-A board with `periph_usbdev` is required for this. Furthermore, an available
-number of UART devices is useful but not strictly required for the example.
+A board with `periph_usbdev` is required for this. Furthermore, at least one
+UART peripheral is required for the example. UART mode config is optional and is
+exposed over USB when present.
 
 ## Usage
 
 When started and attached to a host computer, the host computer should recognize
 the device as multiple USB ACM devices. On Linux these show up as
-`/dev/ttyACMn` devices, with increasing numbers. The first ttyACM device
-provided by the board is attached to the local RIOT shell of the board.
+`/dev/ttyACMn` devices, with increasing numbers.
 
-The other ttyACMn devices are connected to the UART peripherals of the board.
-Both the baud rate and the parity can be controlled from the host computer as
+The ttyACMn devices are connected to the UART peripherals of the board. Both
+the baud rate and the parity can be controlled from the host computer as
 long as the MCU supports the configured setting.

--- a/examples/usbus_uart_adapter/main.c
+++ b/examples/usbus_uart_adapter/main.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Example application for demonstrating the RIOT USB stack
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "board.h"
+#include "fmt.h"
+#include "shell.h"
+#include "shell_commands.h"
+#include "usb/usbus.h"
+#include "usb/usbus/cdc/acm.h"
+#include "usb/usbus/cdc/acm_uart.h"
+
+static char _stack[USBUS_STACKSIZE];
+
+static usbus_t usbus;
+
+#define MIN(a,b)        (((a) < (b)) ? a : b)
+/* Max number of USB to UART functions.                                    *
+ * Reduced by 3 for the control endpoint and the two endpoints used by the *
+ * STDIO CDC ACM module. Divided by two as each CDC ACM function requires  *
+ * two endpoints in each direction                                         */
+#define USB_ACM_MAX     ((USBDEV_NUM_ENDPOINTS - 3U)/2U)
+/* Determine the number of USB to UART functions possible */
+#define NUMOF_ACM       MIN(USB_ACM_MAX, UART_NUMOF)
+
+static usbus_cdc_acm_uart_device_t acmuart[NUMOF_ACM];
+static char _cdc_acm_uart_stack[NUMOF_ACM][THREAD_STACKSIZE_SMALL];
+static char _cdc_acm_uart_name[NUMOF_ACM][16];
+
+static void _init_usb(void)
+{
+    /* Get driver context */
+    usbdev_t *usbdev = usbdev_get_ctx(0);
+    assert(usbdev);
+
+    /* Initialize basic usbus struct, don't start the thread yet */
+    usbus_init(&usbus, usbdev);
+
+    /* Start the cdc acm functionality */
+    void usb_cdc_acm_stdio_init(usbus_t *usbus);
+    usb_cdc_acm_stdio_init(&usbus);
+
+    /* Instantiate the threads */
+    for(unsigned i = 0; i < NUMOF_ACM; i++) {
+        static const char basename[] = "uart: ";
+        memcpy(_cdc_acm_uart_name[i], basename, sizeof(basename));
+        fmt_u32_dec(&_cdc_acm_uart_name[i][strlen(basename)], i);
+        usbus_cdc_acm_uart_init(&usbus, &acmuart[i], UART_DEV(i),
+                                _cdc_acm_uart_stack[i],
+                                sizeof(_cdc_acm_uart_stack[i]),
+                                _cdc_acm_uart_name[i]);
+    }
+
+    /* And create and start the usbus stack */
+    usbus_create(_stack, USBUS_STACKSIZE, USBUS_PRIO, USBUS_TNAME, &usbus);
+}
+
+int main(void)
+{
+    _init_usb();
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}

--- a/examples/usbus_uart_adapter/main.c
+++ b/examples/usbus_uart_adapter/main.c
@@ -33,12 +33,12 @@ static char _stack[USBUS_STACKSIZE];
 
 static usbus_t usbus;
 
-#define MIN(a,b)        (((a) < (b)) ? a : b)
+#define MIN(a, b)        (((a) < (b)) ? a : b)
 /* Max number of USB to UART functions.                                    *
- * Reduced by 3 for the control endpoint and the two endpoints used by the *
- * STDIO CDC ACM module. Divided by two as each CDC ACM function requires  *
- * two endpoints in each direction                                         */
-#define USB_ACM_MAX     ((USBDEV_NUM_ENDPOINTS - 1U)/2U)
+* Reduced by 3 for the control endpoint and the two endpoints used by the *
+* STDIO CDC ACM module. Divided by two as each CDC ACM function requires  *
+* two endpoints in each direction                                         */
+#define USB_ACM_MAX     ((USBDEV_NUM_ENDPOINTS - 1U) / 2U)
 /* Determine the number of USB to UART functions possible */
 #define NUMOF_ACM       MIN(USB_ACM_MAX, UART_NUMOF)
 
@@ -50,13 +50,14 @@ static void _init_usb(void)
 {
     /* Get driver context */
     usbdev_t *usbdev = usbdev_get_ctx(0);
+
     assert(usbdev);
 
     /* Initialize basic usbus struct, don't start the thread yet */
     usbus_init(&usbus, usbdev);
 
     /* Instantiate the threads */
-    for(unsigned i = 0; i < NUMOF_ACM; i++) {
+    for (unsigned i = 0; i < NUMOF_ACM; i++) {
         static const char basename[] = "uart: ";
         memcpy(_cdc_acm_uart_name[i], basename, sizeof(basename));
         fmt_u32_dec(&_cdc_acm_uart_name[i][strlen(basename)], i);

--- a/examples/usbus_uart_adapter/main.c
+++ b/examples/usbus_uart_adapter/main.c
@@ -38,7 +38,7 @@ static usbus_t usbus;
  * Reduced by 3 for the control endpoint and the two endpoints used by the *
  * STDIO CDC ACM module. Divided by two as each CDC ACM function requires  *
  * two endpoints in each direction                                         */
-#define USB_ACM_MAX     ((USBDEV_NUM_ENDPOINTS - 3U)/2U)
+#define USB_ACM_MAX     ((USBDEV_NUM_ENDPOINTS - 1U)/2U)
 /* Determine the number of USB to UART functions possible */
 #define NUMOF_ACM       MIN(USB_ACM_MAX, UART_NUMOF)
 
@@ -54,10 +54,6 @@ static void _init_usb(void)
 
     /* Initialize basic usbus struct, don't start the thread yet */
     usbus_init(&usbus, usbdev);
-
-    /* Start the cdc acm functionality */
-    void usb_cdc_acm_stdio_init(usbus_t *usbus);
-    usb_cdc_acm_stdio_init(&usbus);
 
     /* Instantiate the threads */
     for(unsigned i = 0; i < NUMOF_ACM; i++) {
@@ -77,8 +73,4 @@ static void _init_usb(void)
 int main(void)
 {
     _init_usb();
-
-    char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
-    return 0;
 }

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -98,6 +98,7 @@ PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += suit_transport_%
+PSEUDOMODULES += usbus_cdc_acm_uart
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += zptr
 PSEUDOMODULES += ztimer%

--- a/sys/include/usb/usbus/cdc/acm_uart.h
+++ b/sys/include/usb/usbus/cdc/acm_uart.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2019 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    usb_cdc_acm   CDC - USB communications device class
+ * @ingroup     usb_cdc
+ * @brief       Generic USB CDC defines and helpers
+ *
+ * @{
+ *
+ * @file
+ * @brief       Definition for USB CDC interfaces
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef USBUS_CDC_ACM_UART
+#define USBUS_CDC_ACM_UART
+
+#include "periph/uart.h"
+#include "isrpipe.h"
+#include "usb/usbus/cdc/acm.h"
+
+#ifdef __cplusplus
+extern "c" {
+#endif
+
+/**
+ * @brief Local buffer for UART data
+ */
+#ifndef USBUS_CDC_ACM_UART_BUF_SIZE
+#define USBUS_CDC_ACM_UART_BUF_SIZE 128
+#endif
+
+/**
+ * @brief Default baud rate at which the uart interface is initialized
+ */
+#define USBUS_CDC_ACM_UART_DEFAULT_BAUD 115200
+
+/**
+ * @brief usbus CDC ACM to UART handler struct
+ */
+typedef struct {
+    usbus_cdcacm_device_t cdcacm;                /**< CDC ACM USB function */
+    uint8_t buf[USBUS_CDC_ACM_UART_BUF_SIZE];    /**< uart receive buffer  */
+    uint8_t acmbuf[USBUS_CDC_ACM_UART_BUF_SIZE]; /**< USB receive buffer   */
+    isrpipe_t usb2uart;                          /**< isrpipe to uart      */
+    uint32_t baud;                               /**< Current baud rate    */
+    uart_t uart;                                 /**< UART device handler  */
+} usbus_cdc_acm_uart_device_t;
+
+/**
+ * @brief Initialize a USB UART handler device
+ *
+ * This function inializes a thread to handle and buffer data from the USB
+ * thread to the UART device and the data received from UART to the USB
+ * function. Can be called multiple times for instantiating multiple USB to
+ * UART functions
+ *
+ * @param usbus     USBUS thread context
+ * @param acmuart   CDC ACM to UART handler struct
+ * @param uart      UART device to use
+ * @param stack     Stack space for the thread
+ * @param stacksize Size of the stack in bytes
+ * @param name      Name of the thread
+ */
+void usbus_cdc_acm_uart_init(usbus_t *usbus,
+                             usbus_cdc_acm_uart_device_t *acmuart, uart_t uart,
+                             char *stack, size_t stacksize, char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USBUS_CDC_ACM_UART */

--- a/sys/include/usb/usbus/cdc/acm_uart.h
+++ b/sys/include/usb/usbus/cdc/acm_uart.h
@@ -28,7 +28,7 @@
 #include "usb/usbus/cdc/acm.h"
 
 #ifdef __cplusplus
-extern "c" {
+extern "C" {
 #endif
 
 /**
@@ -47,12 +47,12 @@ extern "c" {
  * @brief usbus CDC ACM to UART handler struct
  */
 typedef struct {
-    usbus_cdcacm_device_t cdcacm;                /**< CDC ACM USB function */
-    uint8_t buf[USBUS_CDC_ACM_UART_BUF_SIZE];    /**< uart receive buffer  */
-    uint8_t acmbuf[USBUS_CDC_ACM_UART_BUF_SIZE]; /**< USB receive buffer   */
-    isrpipe_t usb2uart;                          /**< isrpipe to uart      */
-    uint32_t baud;                               /**< Current baud rate    */
-    uart_t uart;                                 /**< UART device handler  */
+    usbus_cdcacm_device_t cdcacm;                   /**< CDC ACM USB function */
+    uint8_t buf[USBUS_CDC_ACM_UART_BUF_SIZE];       /**< uart receive buffer  */
+    uint8_t acmbuf[USBUS_CDC_ACM_UART_BUF_SIZE];    /**< USB receive buffer   */
+    isrpipe_t usb2uart;                             /**< isrpipe to uart      */
+    uint32_t baud;                                  /**< Current baud rate    */
+    uart_t uart;                                    /**< UART device handler  */
 } usbus_cdc_acm_uart_device_t;
 
 /**
@@ -79,3 +79,4 @@ void usbus_cdc_acm_uart_init(usbus_t *usbus,
 #endif
 
 #endif /* USBUS_CDC_ACM_UART */
+/** @} */

--- a/sys/include/usb/usbus/cdc/acm_uart.h
+++ b/sys/include/usb/usbus/cdc/acm_uart.h
@@ -20,8 +20,8 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef USBUS_CDC_ACM_UART
-#define USBUS_CDC_ACM_UART
+#ifndef USB_USBUS_CDC_ACM_UART
+#define USB_USBUS_CDC_ACM_UART
 
 #include "periph/uart.h"
 #include "isrpipe.h"
@@ -78,5 +78,5 @@ void usbus_cdc_acm_uart_init(usbus_t *usbus,
 }
 #endif
 
-#endif /* USBUS_CDC_ACM_UART */
+#endif /* USB_USBUS_CDC_ACM_UART */
 /** @} */

--- a/sys/include/usb/usbus/cdc/acm_uart.h
+++ b/sys/include/usb/usbus/cdc/acm_uart.h
@@ -7,21 +7,20 @@
  */
 
 /**
- * @defgroup    usb_cdc_acm   CDC - USB communications device class
- * @ingroup     usb_cdc
- * @brief       Generic USB CDC defines and helpers
+ * @defgroup    usbus_cdc_acm_uart USBUS CDC ACM - USBUS CDC ACM - UART
+ * @ingroup     usbus_cdc_acm
+ * @brief       USB CDC ACM to UART functionality
  *
  * @{
  *
  * @file
- * @brief       Definition for USB CDC interfaces
+ * @brief       Definition for USB CDC ACM to UART functionality
  *
- * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef USB_USBUS_CDC_ACM_UART
-#define USB_USBUS_CDC_ACM_UART
+#ifndef USB_USBUS_CDC_ACM_UART_H
+#define USB_USBUS_CDC_ACM_UART_H
 
 #include "periph/uart.h"
 #include "isrpipe.h"
@@ -32,7 +31,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Local buffer for UART data
+ * @brief Size of the local buffer for UART data
  */
 #ifndef USBUS_CDC_ACM_UART_BUF_SIZE
 #define USBUS_CDC_ACM_UART_BUF_SIZE 128
@@ -78,5 +77,5 @@ void usbus_cdc_acm_uart_init(usbus_t *usbus,
 }
 #endif
 
-#endif /* USB_USBUS_CDC_ACM_UART */
+#endif /* USB_USBUS_CDC_ACM_UART_H */
 /** @} */

--- a/sys/usb/usbus/cdc/acm/Makefile
+++ b/sys/usb/usbus/cdc/acm/Makefile
@@ -4,4 +4,7 @@ SRC = cdc_acm.c
 ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
   SRC += cdc_acm_stdio.c
 endif
+ifneq (,$(filter usbus_cdc_acm_uart,$(USEMODULE)))
+  SRC += cdc_acm_uart.c
+endif
 include $(RIOTBASE)/Makefile.base

--- a/sys/usb/usbus/cdc/acm/cdc_acm_uart.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_uart.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2019 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup usb_acm Virtual Serial Port UART implementation
+ * @{
+ *
+ * @file
+ * @brief CDC ACM UART implementation
+ *
+ * This file implements a USB CDC ACM callback and read functions from an UART
+ * peripheral.
+ * @}
+ */
+
+#include "periph/uart.h"
+#include "usb/cdc.h"
+#include "usb/usbus/cdc/acm_uart.h"
+
+#ifdef PERIPH_UART_MODECFG
+static int _acm2uart_bits(uint8_t bits, uart_data_bits_t *conv)
+{
+    switch(bits) {
+        case 5:
+            *conv = UART_DATA_BITS_5;
+            break;
+        case 6:
+            *conv = UART_DATA_BITS_6;
+            break;
+        case 7:
+            *conv = UART_DATA_BITS_7;
+            break;
+        case 8:
+            *conv = UART_DATA_BITS_8;
+            break;
+        default:
+            return -1;
+    }
+    return 0;
+}
+
+static int _acm2uart_parity(uint8_t parity, uart_parity_t *conv)
+{
+    switch(parity) {
+        case USB_CDC_ACM_CODING_PARITY_NONE:
+            *conv = UART_PARITY_NONE;
+            break;
+        case USB_CDC_ACM_CODING_PARITY_EVEN:
+            *conv = UART_PARITY_EVEN;
+            break;
+        case USB_CDC_ACM_CODING_PARITY_ODD:
+            *conv = UART_PARITY_ODD;
+            break;
+        case USB_CDC_ACM_CODING_PARITY_MARK:
+            *conv = UART_PARITY_MARK;
+            break;
+        case USB_CDC_ACM_CODING_PARITY_SPACE:
+            *conv = UART_PARITY_SPACE;
+            break;
+        default:
+            return -1;
+    }
+    return 0;
+}
+
+static int _acm2uart_stop(uint8_t stop, uart_stop_bits_t *conv)
+{
+    switch(stop) {
+        case USB_CDC_ACM_CODING_STOP_BITS_1:
+            *conv = UART_STOP_BITS_1;
+            break;
+        case USB_CDC_ACM_CODING_STOP_BITS_2:
+            *conv = UART_STOP_BITS_2;
+            break;
+        default:
+            return -1;
+    }
+    return 0;
+}
+#endif
+
+static void _rx_cb(void *arg, uint8_t data)
+{
+    usbus_cdc_acm_uart_device_t *acmuart = (usbus_cdc_acm_uart_device_t*)arg;
+    usbus_cdc_acm_submit(&acmuart->cdcacm, &data, 1);
+    if (data == '\n') {
+        usbus_cdc_acm_flush(&acmuart->cdcacm);
+    }
+}
+
+static int _coding_cb(usbus_cdcacm_device_t *cdcacm, uint32_t baud, uint8_t bits,
+                      uint8_t parity, uint8_t stop)
+{
+    usbus_cdc_acm_uart_device_t *acmuart =
+        container_of(cdcacm, usbus_cdc_acm_uart_device_t, cdcacm);
+
+#ifdef PERIPH_UART_MODECFG
+    uart_data_bits_t ubits = UART_DATA_BITS_8;
+    uart_parity_t uparity = UART_PARITY_NONE;
+    uart_stop_bits_t ustop = UART_STOP_BITS_1;
+    if (_acm2uart_bits(bits, &ubits) < 0 ||
+            _acm2uart_parity(parity, &uparity) < 0 ||
+            _acm2uart_stop(stop, &ustop) < 0) {
+        return -1;
+    }
+#else
+    if (bits != 8 || parity != USB_CDC_ACM_CODING_PARITY_NONE || stop != USB_CDC_ACM_CODING_STOP_BITS_1) {
+        return -1;
+    }
+#endif
+
+    if (baud != acmuart->baud) {
+        uart_init(acmuart->uart, baud, _rx_cb, acmuart);
+        acmuart->baud = baud;
+    }
+#ifdef PERIPH_UART_MODECFG
+    if (uart_mode(acmuart->uart, ubits, uparity, ustop) == UART_OK) {
+        return 0;
+    }
+    return -1;
+#endif
+    return 0;
+}
+
+void _submit_pipe(usbus_cdcacm_device_t *cdcacm,
+                           uint8_t *data, size_t len)
+{
+    usbus_cdc_acm_uart_device_t *acmuart =
+        container_of(cdcacm, usbus_cdc_acm_uart_device_t, cdcacm);
+
+    for (size_t i = 0; i < len; i++) {
+        isrpipe_write_one(&acmuart->usb2uart, data[i]);
+    }
+}
+
+void *_thread(void *arg)
+{
+    usbus_cdc_acm_uart_device_t *acmuart = (usbus_cdc_acm_uart_device_t*)arg;
+    while(1) {
+        uint8_t uartbuf[16];
+        size_t bytes = isrpipe_read(&acmuart->usb2uart,
+                                    uartbuf, sizeof(uartbuf));
+        uart_write(acmuart->uart, uartbuf, bytes);
+    }
+    return NULL;
+}
+
+void usbus_cdc_acm_uart_init(usbus_t *usbus,
+                             usbus_cdc_acm_uart_device_t *acmuart, uart_t uart,
+                             char *stack, size_t stacksize, char* name)
+{
+    acmuart->uart = uart;
+    isrpipe_init(&acmuart->usb2uart, acmuart->buf,
+                 USBUS_CDC_ACM_UART_BUF_SIZE);
+    uart_init(acmuart->uart, USBUS_CDC_ACM_UART_DEFAULT_BAUD, _rx_cb, acmuart);
+    usbus_cdc_acm_init(usbus, &acmuart->cdcacm, _submit_pipe, _coding_cb,
+                       acmuart->acmbuf, USBUS_CDC_ACM_UART_BUF_SIZE);
+
+    thread_create(stack, stacksize, USBUS_PRIO+1, THREAD_CREATE_STACKTEST,
+                            _thread, (void *)acmuart, name);
+}

--- a/sys/usb/usbus/cdc/acm/cdc_acm_uart.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_uart.c
@@ -25,7 +25,7 @@
 #ifdef PERIPH_UART_MODECFG
 static int _acm2uart_bits(uint8_t bits, uart_data_bits_t *conv)
 {
-    switch(bits) {
+    switch (bits) {
         case 5:
             *conv = UART_DATA_BITS_5;
             break;
@@ -46,7 +46,7 @@ static int _acm2uart_bits(uint8_t bits, uart_data_bits_t *conv)
 
 static int _acm2uart_parity(uint8_t parity, uart_parity_t *conv)
 {
-    switch(parity) {
+    switch (parity) {
         case USB_CDC_ACM_CODING_PARITY_NONE:
             *conv = UART_PARITY_NONE;
             break;
@@ -70,7 +70,7 @@ static int _acm2uart_parity(uint8_t parity, uart_parity_t *conv)
 
 static int _acm2uart_stop(uint8_t stop, uart_stop_bits_t *conv)
 {
-    switch(stop) {
+    switch (stop) {
         case USB_CDC_ACM_CODING_STOP_BITS_1:
             *conv = UART_STOP_BITS_1;
             break;
@@ -86,15 +86,16 @@ static int _acm2uart_stop(uint8_t stop, uart_stop_bits_t *conv)
 
 static void _rx_cb(void *arg, uint8_t data)
 {
-    usbus_cdc_acm_uart_device_t *acmuart = (usbus_cdc_acm_uart_device_t*)arg;
+    usbus_cdc_acm_uart_device_t *acmuart = (usbus_cdc_acm_uart_device_t *)arg;
+
     usbus_cdc_acm_submit(&acmuart->cdcacm, &data, 1);
     if (data == '\n') {
         usbus_cdc_acm_flush(&acmuart->cdcacm);
     }
 }
 
-static int _coding_cb(usbus_cdcacm_device_t *cdcacm, uint32_t baud, uint8_t bits,
-                      uint8_t parity, uint8_t stop)
+static int _coding_cb(usbus_cdcacm_device_t *cdcacm, uint32_t baud,
+                      uint8_t bits, uint8_t parity, uint8_t stop)
 {
     usbus_cdc_acm_uart_device_t *acmuart =
         container_of(cdcacm, usbus_cdc_acm_uart_device_t, cdcacm);
@@ -104,12 +105,14 @@ static int _coding_cb(usbus_cdcacm_device_t *cdcacm, uint32_t baud, uint8_t bits
     uart_parity_t uparity = UART_PARITY_NONE;
     uart_stop_bits_t ustop = UART_STOP_BITS_1;
     if (_acm2uart_bits(bits, &ubits) < 0 ||
-            _acm2uart_parity(parity, &uparity) < 0 ||
-            _acm2uart_stop(stop, &ustop) < 0) {
+        _acm2uart_parity(parity, &uparity) < 0 ||
+        _acm2uart_stop(stop, &ustop) < 0) {
         return -1;
     }
 #else
-    if (bits != 8 || parity != USB_CDC_ACM_CODING_PARITY_NONE || stop != USB_CDC_ACM_CODING_STOP_BITS_1) {
+    if (bits != 8 ||
+        parity != USB_CDC_ACM_CODING_PARITY_NONE ||
+        stop != USB_CDC_ACM_CODING_STOP_BITS_1) {
         return -1;
     }
 #endif
@@ -128,7 +131,7 @@ static int _coding_cb(usbus_cdcacm_device_t *cdcacm, uint32_t baud, uint8_t bits
 }
 
 void _submit_pipe(usbus_cdcacm_device_t *cdcacm,
-                           uint8_t *data, size_t len)
+                  uint8_t *data, size_t len)
 {
     usbus_cdc_acm_uart_device_t *acmuart =
         container_of(cdcacm, usbus_cdc_acm_uart_device_t, cdcacm);
@@ -140,8 +143,9 @@ void _submit_pipe(usbus_cdcacm_device_t *cdcacm,
 
 void *_thread(void *arg)
 {
-    usbus_cdc_acm_uart_device_t *acmuart = (usbus_cdc_acm_uart_device_t*)arg;
-    while(1) {
+    usbus_cdc_acm_uart_device_t *acmuart = (usbus_cdc_acm_uart_device_t *)arg;
+
+    while (1) {
         uint8_t uartbuf[16];
         size_t bytes = isrpipe_read(&acmuart->usb2uart,
                                     uartbuf, sizeof(uartbuf));
@@ -152,7 +156,7 @@ void *_thread(void *arg)
 
 void usbus_cdc_acm_uart_init(usbus_t *usbus,
                              usbus_cdc_acm_uart_device_t *acmuart, uart_t uart,
-                             char *stack, size_t stacksize, char* name)
+                             char *stack, size_t stacksize, char *name)
 {
     acmuart->uart = uart;
     isrpipe_init(&acmuart->usb2uart, acmuart->buf,
@@ -161,6 +165,6 @@ void usbus_cdc_acm_uart_init(usbus_t *usbus,
     usbus_cdc_acm_init(usbus, &acmuart->cdcacm, _submit_pipe, _coding_cb,
                        acmuart->acmbuf, USBUS_CDC_ACM_UART_BUF_SIZE);
 
-    thread_create(stack, stacksize, USBUS_PRIO+1, THREAD_CREATE_STACKTEST,
-                            _thread, (void *)acmuart, name);
+    thread_create(stack, stacksize, USBUS_PRIO + 1, THREAD_CREATE_STACKTEST,
+                  _thread, (void *)acmuart, name);
 }


### PR DESCRIPTION
### Contribution description

This PR adds integration for UART peripherals for the USBUS CDC ACM (serial over usb) functionality. It allows for transfering data over serial, configuring baud rate and parity bits of the UART peripheral from the host computer.

### Testing procedure

Run `examples/usbus_uart_adapter`. When attached to a host computer, it should provide multiple (depending on the board) ttyACM devices of which the first one is connected to the RIOT shell and the others are proxied to the UART peripherals on the board.

On a samr21-xpro, using `make list-ttys` this shows up as:
```
/sys/bus/usb/devices/3-9.2.3: RIOT-os.org USB device serial: '', tty(s): ttyACM3, ttyACM2, ttyACM4
```

In this case, `ttyACM3` is the *first* serial function and is connected to the RIOT shell.

### Issues/PRs references

Depends on #11085 