### PR TITLE
pyterm: Add device timeout

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -76,6 +76,9 @@ defaultport = "/dev/ttyUSB0"
 # default baudrate for serial connection
 defaultbaud = 115200
 
+# default timeout for opening the serial connection
+defaultdevicetimeout = 0
+
 # directory to store configuration and log files
 defaultdir = os.environ['HOME'] + os.path.sep + '.pyterm'
 
@@ -109,7 +112,8 @@ class SerCmd(cmd.Cmd):
                  confdir=None, conffile=None, host=None, run_name=None,
                  log_dir_name=None, newline=None, formatter=None,
                  set_rts=None, set_dtr=None, serprompt=None,
-                 repeat_command_on_empty_line=defaultrepeat_cmd_empty_line):
+                 repeat_command_on_empty_line=defaultrepeat_cmd_empty_line,
+                 devicetimeout=None):
         """Constructor.
 
         Args:
@@ -120,6 +124,7 @@ class SerCmd(cmd.Cmd):
             conffile (str):     configuration file name
             host (str):         local host name
             run_name (str):     identifier for log files subdirectory
+            devicetimeout (int): seconds to wait for device file autocreation
 
         """
 
@@ -135,6 +140,7 @@ class SerCmd(cmd.Cmd):
         self.configfile = conffile
         self.host = host
         self.run_name = run_name
+        self.devicetimeout = devicetimeout
         self.log_dir_name = log_dir_name
         self.newline = newline
         self.serprompt = serprompt
@@ -626,7 +632,21 @@ class SerCmd(cmd.Cmd):
                 self.process_line(line)
 
     def serial_connect(self):
-        self.ser = serial.Serial(port=self.port, dsrdtr=0, rtscts=0)
+        attempts = self.devicetimeout + 1
+        while attempts:
+            try:
+                self.ser = serial.Serial(port=self.port, dsrdtr=0, rtscts=0)
+            except serial.SerialException as e:
+                attempts -= 1
+                if not attempts:
+                    raise
+                if attempts == self.devicetimeout:
+                    self.logger.warning("Serial port unavailable, waiting "
+                                        "up to %s seconds" % attempts)
+                time.sleep(1)
+            else:
+                break
+
         self.ser.baudrate = self.baudrate
 
         if self.toggle:
@@ -782,6 +802,13 @@ if __name__ == "__main__":
                         action="store",
                         default=None,
                         help="Specifies the value of DTR pin")
+    parser.add_argument("--device-timeout",
+                        dest="devicetimeout",
+                        type=int,
+                        action="store",
+                        default=defaultdevicetimeout,
+                        help="Seconds to wait for device to appear, default "
+                        "is %s" % defaultdevicetimeout)
     parser.add_argument('-d', '--directory',
                         help="Specify the Pyterm directory, default is %s"
                         % defaultdir,
@@ -839,7 +866,7 @@ if __name__ == "__main__":
                      args.directory, args.config, args.host, args.run_name,
                      args.log_dir_name, args.newline, args.format,
                      args.set_rts, args.set_dtr, args.prompt,
-                     args.repeat_command_on_empty_line)
+                     args.repeat_command_on_empty_line, args.devicetimeout)
     myshell.prompt = ''
 
     try:


### PR DESCRIPTION
### Contribution description

When pyterm is used on boards that use CDC-ACM stdio (ie. provide their own USB device), that device is not available immediately after flashing, and a `make flash term` is likely to fail.

This adds a --device-timeout option to pyterm that will repeat pyterm's device opening step until the timeout is exceeded (in which case it will fail as it had before), or the device can be opened.

Boards that use such a configuration will want to set PYTERMFLAGS += --device-timeout=5 or another suitable value depending on the board's expected time to go from bootloader to operational.

### Testing procedure

On a board that uses the the stdio_cdc_acm module, set PYTERMFLAGS=--device-timeout=5 and `make flash term` and see that the terminal opens after a few seconds rather than failing with a "device not found" message.

On other boards the test can be emulated by running `make term` with the serial connection unplugged, plugging it in a second after the command has started.

### Issues/PRs references

The issue will become more widespread when #11085 is available and boards like the nrf52840-dongle (#12189) become more easily usable with RIOT.

### Alternatives

This solves the problem only for pyterm. Worse yet, it may still be racy if the bootloader used is occupying the same file name as the serial target. (That is the case on my board, but the race always went well, presumably because the USB reset caused by the flashing tool is immediate).

An alternative solution would be to have a `term-ready` target that `term` would always depend on, and boards could set a `TERM_READY_TOOL` (defaulting to `true`?) that would be active in that stage. A simple tool that does not handle the racing case could be shipped as a shell script. The variable would also provide an entry point for a more sophisticated solution that can tell boot loaders apart from real terminal ttys.

I could implement that as well (come to think of it writing this last line I'm leaning more and more towards that rather than this PR), but would need some guidance in the complex Makefile ecosystem.