### PR TITLE
gnrc_ipv6: fix scan-build errors

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -256,6 +256,7 @@ static void _send_to_iface(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     const ipv6_hdr_t *hdr = pkt->next->data;
 
+    (void)hdr;  /* only used for DEBUG messages */
     assert(netif != NULL);
     gnrc_netif_hdr_set_netif(pkt->data, netif);
     if (gnrc_pkt_len(pkt->next) > netif->ipv6.mtu) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -439,7 +439,6 @@ static void _handle_rtr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     size_t tmp_len = icmpv6_len - sizeof(ndp_rtr_sol_t);
     _nib_onl_entry_t *nce = NULL;
     ndp_opt_t *opt;
-    uint32_t next_ra_delay = random_uint32_range(0, NDP_MAX_RA_DELAY);
 
     assert(netif != NULL);
     /* check validity, see: https://tools.ietf.org/html/rfc4861#section-6.1.1 */
@@ -498,6 +497,7 @@ static void _handle_rtr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         nce = _nib_onl_get(&ipv6->src, netif->pid);
     }
     if (!gnrc_netif_is_6ln(netif)) {
+        uint32_t next_ra_delay = random_uint32_range(0, NDP_MAX_RA_DELAY);
         uint32_t next_ra_scheduled = _evtimer_lookup(netif,
                                                      GNRC_IPV6_NIB_SND_MC_RA);
         if (next_ra_scheduled < next_ra_delay) {
@@ -529,6 +529,9 @@ static void _handle_rtr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         _snd_rtr_advs(netif, &ipv6->src, false);
     }
 #endif  /* GNRC_IPV6_NIB_CONF_6LR */
+#if GNRC_IPV6_NIB_CONF_6LN
+    (void)nce;  /* NCE is not used */
+#endif
 }
 #endif  /* GNRC_IPV6_NIB_CONF_ROUTER */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixes #11852 for `gnrc_ipv6`
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run

```C
TOOLCHAIN=llvm make -C examples/gnrc_networking scan-build-analyze
```

for `native`. All `gnrc_ipv6` related files should now not trigger an error anymore (`sys/include/net/ipv6/addr.h` is not part of `gnrc_ipv6` ;-)).

CI should still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses parts of #11852.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
