### PR TITLE
sys/arduino: use 64bit usec to compute millis()

### DIFF
--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -74,7 +74,7 @@ unsigned long micros()
 
 unsigned long millis()
 {
-    return xtimer_now_usec() / US_PER_MS;
+    return xtimer_now_usec64() / US_PER_MS;
 }
 
 int analogRead(int arduino_pin)


### PR DESCRIPTION
### Contribution description

This is quick solution to avoid wrapping around after 4294967 milliseconds.
It uses xtimer_now_usec64 instead of xtimer_now_usec.

Notice that this is more expansive than the previous solution, especially
on AVR systems.

### Testing procedure

Use the new upcoming #12180 which adds support for using Arduino libraries. The test program is a simple loop with `TalkingLED`, flashing leds. Without the fix in this PR the test program will hang roughly after 4295 seconds. I realize that this is way too long for a normal test program. An alternative is to create a special test program which would bump the "now" value to, say 4290 seconds, wait 10 seconds and look at the `millis()`. But I don't think it is worth the effort.

### Issues/PRs references

See also #12180 and #12116 