### PR TITLE
cpu/efm32/uart: fix handling of RX when no RX callback is configured

### DIFF
--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -194,14 +194,25 @@ void uart_write(uart_t dev, const uint8_t *data, size_t len)
 #ifdef USE_LEUART
     if (_is_usart(dev)) {
 #endif
+        USART_TypeDef *usart = uart_config[dev].dev;
+
         while (len--) {
-            USART_Tx(uart_config[dev].dev, *(data++));
+            USART_Tx(usart, *(data++));
         }
+
+        /* spin until transmission is complete */
+        while (!(usart->STATUS & USART_STATUS_TXC)) {}
+
 #ifdef USE_LEUART
     } else {
+        LEUART_TypeDef *leuart = uart_config[dev].dev;
+
         while (len--) {
-            LEUART_Tx(uart_config[dev].dev, *(data++));
+            LEUART_Tx(leuart, *(data++));
         }
+
+        /* spin until transmission is complete */
+        while (!(leuart->STATUS & LEUART_STATUS_TXC)) {}
     }
 #endif
 }

--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -223,12 +223,18 @@ static void rx_irq(uart_t dev)
     if (_is_usart(dev)) {
 #endif
         if (USART_IntGet(uart_config[dev].dev) & USART_IF_RXDATAV) {
-            isr_ctx[dev].rx_cb(isr_ctx[dev].arg, USART_RxDataGet(uart_config[dev].dev));
+            uint8_t c = USART_RxDataGet(uart_config[dev].dev);
+            if (isr_ctx[dev].rx_cb) {
+                isr_ctx[dev].rx_cb(isr_ctx[dev].arg, c);
+            }
         }
 #ifdef USE_LEUART
     } else {
         if (LEUART_IntGet(uart_config[dev].dev) & LEUART_IF_RXDATAV) {
-            isr_ctx[dev].rx_cb(isr_ctx[dev].arg, LEUART_RxDataGet(uart_config[dev].dev));
+            uint8_t c = LEUART_RxDataGet(uart_config[dev].dev);
+            if (isr_ctx[dev].rx_cb) {
+                isr_ctx[dev].rx_cb(isr_ctx[dev].arg, c);
+            }
         }
     }
 #endif


### PR DESCRIPTION
### Contribution description
This fixes a crash that happens on efm32 when the UART receives a character while no UART RX callback is configured.

The first commit is adequate to avoid the crash but the next commits do some refactoring to make the rest of the driver consistent with the use case where no RX callback is configured.

### Testing procedure
1) Flash any example with a shell and confirm that UART still works as intended.
1) Flash the `hello-world` example (it has no shell) and confirm that typing UART characters causes no crash
1) Without this PR, the previous step causes a crash due to calling `rx_cb()` while `rx_cb == NULL`
