### PR TITLE
cpu/efm32/uart: enable pullup on RX pin

### DIFF
--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -57,7 +57,7 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     isr_ctx[dev].arg = arg;
 
     /* initialize the pins */
-    gpio_init(uart_config[dev].rx_pin, GPIO_IN);
+    gpio_init(uart_config[dev].rx_pin, GPIO_IN_PU);
     gpio_init(uart_config[dev].tx_pin, GPIO_OUT);
 
     /* initialize the UART/USART/LEUART device */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Similar to #12236, this enables the pullup resistor on the UART RX pin. This is to fix the undefined behavior that results when the RX pin is floating.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Confirm that a UART shell still works as intended.

To test that this PR effects a beneficial change, use the test in https://github.com/RIOT-OS/RIOT/pull/12236#issuecomment-531613204. In fact the results I posted there were from an efm32 board.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
This does for efm32 what #12236 did for stm32.