### PR TITLE
cpu/kinetis/rtc: add rtc_set_compensation()

### DIFF
--- a/cpu/kinetis/periph/rtc.c
+++ b/cpu/kinetis/periph/rtc.c
@@ -92,6 +92,11 @@ void rtc_clear_alarm(void)
     rtc_callback.cb = NULL;
 }
 
+void rtc_set_compensation(int8_t adjust, uint8_t interval)
+{
+    rtt_set_compensation(adjust, interval);
+}
+
 void rtc_poweron(void)
 {
     rtt_poweron();

--- a/cpu/kinetis/periph/rtt.c
+++ b/cpu/kinetis/periph/rtt.c
@@ -150,6 +150,11 @@ void rtt_clear_alarm(void)
     bit_clear32(&RTC->IER, RTC_IER_TAIE_SHIFT);
 }
 
+void rtt_set_compensation(int8_t adjust, uint8_t interval)
+{
+    RTC->TCR = RTC_TCR_TCR(adjust) | RTC_TCR_CIR(interval);
+}
+
 /* RTC module has independent power suply. We can not really turn it on/off. */
 
 void rtt_poweron(void)

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -27,6 +27,7 @@
 #define PERIPH_RTC_H
 
 #include <time.h>
+#include <stdint.h>
 #include "periph_conf.h"
 
 #ifdef __cplusplus
@@ -94,6 +95,11 @@ int rtc_get_alarm(struct tm *time);
  * @brief Clear any set alarm, do nothing if nothing set
  */
 void rtc_clear_alarm(void);
+
+/**
+ * @brief Set RTC fine tuning
+ */
+void rtc_set_compensation(int8_t adjust, uint8_t interval);
 
 /**
  * @brief Turns the RTC hardware module on

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -155,6 +155,8 @@ uint32_t rtt_get_alarm(void);
  */
 void rtt_clear_alarm(void);
 
+void rtt_set_compensation(int8_t adjust, uint8_t interval);
+
 /**
  * @brief Turn the RTT hardware module on
  */


### PR DESCRIPTION
### Contribution description
This allows configuring the kinetis RTC peripheral to set the fine tuning registers, which is required to bring the accuracy from the order of 10ppm to the order of 1ppm, which ultimately helps achieve the goal of getting the best efficiency out of duty-cycling radio MACs.

All MCUs with 802.15.4 or BLE transceivers will support this feature and at some point there needs to be a standard API for doing this on all platforms but I have no proposal for what that should look like yet. This is just a first step and it would be useful to go ahead and have it in master.

Normally something would periodically call `rtc_set_compensation()` to update the trim based on the current board temperature. However for now I'm just calling it once at boot from `board.c` and this is adequate to improve the accuracy of the RTC from (in my case on kw41z-mini and kw41z-slip) about 6ppm to about 1ppm. Getting much less than 1ppm (or at least guaranteed <=1ppm) requires active temperature compensation and that's why it's needed to have an API to adjust this periodically in runtime.

### Testing procedure
Testing that the compensation is working as intended in an automated way is not entirely trivial. Perhaps we can be satisfied if it compiles and runs without crashing and that I've tested and used it myself.

To test that the RTC compensation is working as intended, call `rtc_set_compensation()` with some chosen values and then let the board run for some days and then compare the RTC against a timebase with preferably 0.1ppm accuracy.



