### PR TITLE
tools/ci: fix remaining errors reported by coccinelle static check

### DIFF
--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -183,9 +183,7 @@ static bool _send_wa(gnrc_netif_t *netif)
     /* Send WA */
     if (_gnrc_lwmac_transmit(netif, pkt) < 0) {
         LOG_ERROR("ERROR: [LWMAC-rx] Send WA failed.");
-        if (pkt != NULL) {
-            gnrc_pktbuf_release(pkt);
-        }
+        gnrc_pktbuf_release(pkt);
         gnrc_lwmac_set_quit_rx(netif, true);
         return false;
     }

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -217,9 +217,7 @@ static uint8_t _send_wr(gnrc_netif_t *netif)
     int res = _gnrc_lwmac_transmit(netif, pkt);
     if (res < 0) {
         LOG_ERROR("ERROR: [LWMAC-tx] Send WR failed.");
-        if (pkt != NULL) {
-            gnrc_pktbuf_release(pkt);
-        }
+        gnrc_pktbuf_release(pkt);
         tx_info |= GNRC_LWMAC_TX_FAIL;
         return tx_info;
     }

--- a/tests/nimble_l2cap/main.c
+++ b/tests/nimble_l2cap/main.c
@@ -224,10 +224,10 @@ static int _cmd_inctest(int argc, char **argv)
 
     /* parse params */
     if (argc >= 2) {
-        step = (size_t)atoi(argv[1]);
+        step = atoi(argv[1]);
     }
     if (argc >= 3) {
-        limit = (size_t)atoi(argv[2]);
+        limit = atoi(argv[2]);
         if ((limit < 8) || (limit > APP_MTU)) {
             puts("err: invalid limit payload length given");
             return 1;
@@ -268,14 +268,14 @@ static int _cmd_floodtest(int argc, char **argv)
     }
 
     if (argc >= 2) {
-        pktsize = (size_t)atoi(argv[1]);
+        pktsize = atoi(argv[1]);
         if ((pktsize < 8) || (pktsize > APP_MTU)) {
             puts("err: invalid packet size given");
             return 1;
         }
     }
     if (argc >= 3) {
-        limit = (unsigned)atoi(argv[2]);
+        limit = atoi(argv[2]);
     }
 
     /* now lets flood */

--- a/tests/nimble_l2cap/main.c
+++ b/tests/nimble_l2cap/main.c
@@ -35,9 +35,6 @@
 
 #include "nimble_l2cap_test_conf.h"
 
-#define ENABLE_DEBUG        (1)
-#include "debug.h"
-
 #define FLAG_UP             (1u << 0)
 #define FLAG_SYNC           (1u << 1)
 #define FLAG_TX_UNSTALLED   (1u << 2)

--- a/tests/periph_pwm/main.c
+++ b/tests/periph_pwm/main.c
@@ -46,7 +46,7 @@ static uint32_t initiated;
 
 static unsigned _get_dev(const char *dev_str)
 {
-    unsigned dev = (unsigned)atoi(dev_str);
+    unsigned dev = atoi(dev_str);
     if (dev >= PWM_NUMOF) {
         printf("Error: device PWM_DEV(%u) is unknown\n", dev);
         return UINT_MAX;
@@ -123,7 +123,7 @@ static int _set(int argc, char**argv)
         return 1;
     }
 
-    uint8_t chan = (uint8_t)atoi(argv[2]);
+    uint8_t chan = atoi(argv[2]);
     if (chan >= pwm_channels(PWM_DEV(dev))) {
         printf("Error: channel %d is unknown.\n", chan);
         return 1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing (small) issues reported by Coccinelle when its check script is called directly (e.g. without using `make static-test`. Apparently in this case, the files changed returns all files in the RIOT repo so they are all analyzed.

Here is the list of reported issues on current master when running the following command:
```
$ ./dist/tools/coccinelle/check.sh 
```
<details>

```
--- tests/nimble_l2cap/main.c
+++ /tmp/cocci-output-17675-c3e326-main.c
@@ -35,7 +35,7 @@
 
 #include "nimble_l2cap_test_conf.h"
 
-#define ENABLE_DEBUG        (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 #define FLAG_UP             (1u << 0)
--- sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ /tmp/cocci-output-17688-d37c8c-rx_state_machine.c
@@ -183,7 +183,7 @@ static bool _send_wa(gnrc_netif_t *netif
     /* Send WA */
     if (_gnrc_lwmac_transmit(netif, pkt) < 0) {
         LOG_ERROR("ERROR: [LWMAC-rx] Send WA failed.");
-        if (pkt != NULL) {
+        {
             gnrc_pktbuf_release(pkt);
         }
         gnrc_lwmac_set_quit_rx(netif, true);
--- sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ /tmp/cocci-output-17688-c4bbbc-tx_state_machine.c
@@ -217,7 +217,7 @@ static uint8_t _send_wr(gnrc_netif_t *ne
     int res = _gnrc_lwmac_transmit(netif, pkt);
     if (res < 0) {
         LOG_ERROR("ERROR: [LWMAC-tx] Send WR failed.");
-        if (pkt != NULL) {
+        {
             gnrc_pktbuf_release(pkt);
         }
         tx_info |= GNRC_LWMAC_TX_FAIL;
--- tests/nimble_l2cap/main.c
+++ /tmp/cocci-output-17709-f89ba0-main.c
@@ -224,10 +224,10 @@ static int _cmd_inctest(int argc, char *
 
     /* parse params */
     if (argc >= 2) {
-        step = (size_t)atoi(argv[1]);
+        step = atoi(argv[1]);
     }
     if (argc >= 3) {
-        limit = (size_t)atoi(argv[2]);
+        limit = atoi(argv[2]);
         if ((limit < 8) || (limit > APP_MTU)) {
             puts("err: invalid limit payload length given");
             return 1;
@@ -268,14 +268,14 @@ static int _cmd_floodtest(int argc, char
     }
 
     if (argc >= 2) {
-        pktsize = (size_t)atoi(argv[1]);
+        pktsize = atoi(argv[1]);
         if ((pktsize < 8) || (pktsize > APP_MTU)) {
             puts("err: invalid packet size given");
             return 1;
         }
     }
     if (argc >= 3) {
-        limit = (unsigned)atoi(argv[2]);
+        limit = atoi(argv[2]);
     }
 
     /* now lets flood */
--- tests/periph_pwm/main.c
+++ /tmp/cocci-output-17709-f39a99-main.c
@@ -46,7 +46,7 @@ static uint32_t initiated;
 
 static unsigned _get_dev(const char *dev_str)
 {
-    unsigned dev = (unsigned)atoi(dev_str);
+    unsigned dev = atoi(dev_str);
     if (dev >= PWM_NUMOF) {
         printf("Error: device PWM_DEV(%u) is unknown
", dev);
         return UINT_MAX;
@@ -123,7 +123,7 @@ static int _set(int argc, char**argv)
         return 1;
     }
 
-    uint8_t chan = (uint8_t)atoi(argv[2]);
+    uint8_t chan = atoi(argv[2]);
     if (chan >= pwm_channels(PWM_DEV(dev))) {
         printf("Error: channel %d is unknown.
", chan);
         return 1;
```

</details>

I'm not 100% sure of the change in lwmac, so this one needs careful review. Could it be a false positive ?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Verify the modified test applications, `tests/periph_pwm` and `tests/nimble_l2cap` still work the same
- Verify no regression is introduced in lwmac MAC layer.
- Verify no errors are still reported by coccinelle

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
