### PR TITLE
cpu/esp32: use 'printf' instead of 'echo'

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -167,10 +167,10 @@ PREFLASHER = $(ESPTOOL)
 PREFFLAGS  = --chip esp32 elf2image
 PREFFLAGS += -fm $(FLASH_MODE) -fs $(FLASH_SIZE) -ff $(FLASH_FREQ)
 PREFFLAGS += -o $(FLASHFILE).bin $(FLASHFILE);
-PREFFLAGS += echo "" > $(BINDIR)/partitions.csv;
-PREFFLAGS += echo "nvs, data, nvs, 0x9000, 0x6000" >> $(BINDIR)/partitions.csv;
-PREFFLAGS += echo "phy_init, data, phy, 0xf000, 0x1000" >> $(BINDIR)/partitions.csv;
-PREFFLAGS += echo -n "factory, app, factory, 0x10000, " >> $(BINDIR)/partitions.csv;
+PREFFLAGS += printf "\n" > $(BINDIR)/partitions.csv;
+PREFFLAGS += printf "nvs, data, nvs, 0x9000, 0x6000\n" >> $(BINDIR)/partitions.csv;
+PREFFLAGS += printf "phy_init, data, phy, 0xf000, 0x1000\n" >> $(BINDIR)/partitions.csv;
+PREFFLAGS += printf "factory, app, factory, 0x10000, " >> $(BINDIR)/partitions.csv;
 PREFFLAGS += ls -l $(FLASHFILE).bin | awk '{ print $$5 }' >> $(BINDIR)/partitions.csv;
 
 PREFFLAGS += python $(RIOTCPU)/$(CPU)/gen_esp32part.py --disable-sha256sum


### PR DESCRIPTION
### Contribution description 

Use 'printf' instead of 'echo' as the behavior is different between Linux
and OSx.
OSx default 'echo' does not support `-n`, so it appears in the generated
file.

Also 'printf' is recommended over 'echo' in general.

> Nowadays, echo(1) is only portable if you omit flags and escape sequences.
> Use printf(1) instead, if you need more than plain text.

https://www.in-ulm.de/~mascheck/various/echo+printf/

Fixes #12244 


### Testing procedure

The generated `partition.csv` is the same with this PR:

```
ESPTOOL=esptool.py BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 BOARD=esp32-wroom-32 make -C examples/hello-world/ flash
```

This file is the same with this PR and `master`:

```
cat examples/hello-world/bin/esp32-wroom-32/partitions.csv 

nvs, data, nvs, 0x9000, 0x6000
phy_init, data, phy, 0xf000, 0x1000
factory, app, factory, 0x10000, 112864
```

#### Testing #12244 

Try flashing on OSX when setting `CC_NOCOLOR=1` to be sure `/bin/bash` EDIT *is not used* as shell as https://github.com/RIOT-OS/RIOT/blob/bd5ceb58e7628b51882eeff0db2c1b103e88a4fb/makefiles/color.inc.mk#L25-L27 is not triggered.

I cannot really do this one.

### Issues/PRs references

Fixes #12244 