### PR TITLE
boards/p-l496zg-cell02: move cpu define to Makefile.features

### DIFF
--- a/boards/p-l496g-cell02/Makefile.features
+++ b/boards/p-l496g-cell02/Makefile.features
@@ -1,3 +1,7 @@
+# the cpu to build for
+export CPU = stm32l4
+export CPU_MODEL = stm32l496ag
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart

--- a/boards/p-l496g-cell02/Makefile.include
+++ b/boards/p-l496g-cell02/Makefile.include
@@ -1,7 +1,3 @@
-# the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l496ag
-
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing a small inconsistency introduced by #11984: it moves the CPU/MODEL definitions from `Makefile.include` to `Makefile.features`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be ok

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #11984 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
