### PR TITLE
boards/frdm: remove exporting unset OPENOCD_EXTRA_INIT

### DIFF
--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -21,7 +21,6 @@ ifeq (1,$(USE_OLD_OPENOCD))
 export OPENOCD_PRE_VERIFY_CMDS += \
   -c 'load_image $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin 0x20000000 bin' \
   -c 'resume 0x20000000'
-export OPENOCD_EXTRA_INIT
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/frdm/dist/old-openocd-$(CPU_FAMILY).cfg
 endif
 


### PR DESCRIPTION
### Contribution description

Remove exporting the unset OPENOCD_EXTRA_INIT
The default value in `openocd.sh` is being empty, so no use for exporting it.

### Testing procedure

The first match shows the default value is empty.
And there is no definition of `OPENOCD_EXTRA_INIT` in the `frdm` boards (and not in `RIOT` in general).

<details><summary><code>git grep -C 1 OPENOCD_EXTRA_INIT</code></summary>

```
git grep -C 1 OPENOCD_EXTRA_INIT
dist/tools/openocd/openocd.sh-# Extra board initialization commands to pass to OpenOCD
dist/tools/openocd/openocd.sh:: ${OPENOCD_EXTRA_INIT:=}
dist/tools/openocd/openocd.sh-# Debugger interface initialization commands to pass to OpenOCD
--
dist/tools/openocd/openocd.sh-            -f '${OPENOCD_CONFIG}' \
dist/tools/openocd/openocd.sh:            ${OPENOCD_EXTRA_INIT} \
dist/tools/openocd/openocd.sh-            ${OPENOCD_EXTRA_RESET_INIT} \
--
dist/tools/openocd/openocd.sh-            -f '${OPENOCD_CONFIG}' \
dist/tools/openocd/openocd.sh:            ${OPENOCD_EXTRA_INIT} \
dist/tools/openocd/openocd.sh-            -c 'tcl_port ${TCL_PORT}' \
--
dist/tools/openocd/openocd.sh-            -f '${OPENOCD_CONFIG}' \
dist/tools/openocd/openocd.sh:            ${OPENOCD_EXTRA_INIT} \
dist/tools/openocd/openocd.sh-            -c 'tcl_port ${TCL_PORT}' \
--
dist/tools/openocd/openocd.sh-            -f '${OPENOCD_CONFIG}' \
dist/tools/openocd/openocd.sh:            ${OPENOCD_EXTRA_INIT} \
dist/tools/openocd/openocd.sh-            ${OPENOCD_EXTRA_RESET_INIT} \
```
</details>

### Issues/PRs references

Found after cleaning https://github.com/RIOT-OS/RIOT/pull/12151