### PR TITLE
boards/sam0: refactor ADC_0 into plain ADC

### DIFF
--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -151,19 +151,13 @@ static const pwm_conf_t pwm_config[] = {
  * @name ADC configuration
  * @{
  */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   14
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -176,8 +170,7 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* A6 */
 };
 
-#define ADC_0_CHANNELS                     (7U)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -141,19 +141,19 @@ static const i2c_conf_t i2c_config[] = {
  * @name ADC Configuration
  * @{
  */
-#define ADC_NUMOF                          (1U)
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV256
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV256
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC2
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
     {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN8)},
 };
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG(0x18u)
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INTVCC2
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -178,19 +178,13 @@ static const pwm_conf_t pwm_config[] = {
  * @name    ADC configuration
  * @{
  */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   14
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -203,8 +197,7 @@ static const adc_conf_chan_t adc_channels[] = {
     { GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7 },     /* A7 */
 };
 
-#define ADC_0_CHANNELS                     (7U)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -157,19 +157,13 @@ static const tc32_conf_t timer_config[] = {
  * @name ADC Configuration
  * @{
  */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   14
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -178,8 +172,7 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},
 };
 
-#define ADC_0_CHANNELS                     (3U)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -303,19 +303,13 @@ static const i2c_conf_t i2c_config[] = {
  * @name ADC Configuration
  * @{
  */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   14
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -329,8 +323,7 @@ static const adc_conf_chan_t adc_channels[] = {
                         Move PA03 SELECT jumper to EXT3 to connect. */
 };
 
-#define ADC_0_CHANNELS                     (6U)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -155,11 +155,12 @@ static const i2c_conf_t i2c_config[] = {
  * @name ADC Configuration
  * @{
  */
-#define ADC_NUMOF                          (3U)
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV256
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV256
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC2
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -168,8 +169,7 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN0)}
 };
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG(0x18u)
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INTVCC2
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -274,19 +274,13 @@ static const i2c_conf_t i2c_config[] = {
  * @name ADC Configuration
  * @{
  */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   14
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -294,8 +288,7 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},      /* EXT1, pin 4 */
 };
 
-#define ADC_0_CHANNELS                     (2U)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -138,11 +138,12 @@ static const i2c_conf_t i2c_config[] = {
  * @name ADC Configuration
  * @{
  */
-#define ADC_NUMOF                               (5U)
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                        0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                         ADC_CTRLB_PRESCALER_DIV256
+/* ADC Default values */
+#define ADC_PRESCALER                           ADC_CTRLB_PRESCALER_DIV256
+
+#define ADC_NEG_INPUT                           ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                         ADC_REFCTRL_REFSEL_INTVCC2
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -153,8 +154,7 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN0)}
 };
 
-#define ADC_0_NEG_INPUT                         ADC_INPUTCTRL_MUXNEG(0x18u)
-#define ADC_0_REF_DEFAULT                       ADC_REFCTRL_REFSEL_INTVCC2
+#define ADC_NUMOF                               ARRAY_SIZE(adc_channels)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -140,11 +140,12 @@ static const i2c_conf_t i2c_config[] = {
  * @name ADC Configuration
  * @{
  */
-#define ADC_NUMOF                               (2U)
 
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                        0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                         ADC_CTRLB_PRESCALER_DIV256
+#define ADC_PRESCALER                           ADC_CTRLB_PRESCALER_DIV256
+
+#define ADC_NEG_INPUT                           ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                         ADC_REFCTRL_REFSEL_INTVCC2
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -152,8 +153,8 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN7)}
 };
 
-#define ADC_0_NEG_INPUT                         ADC_INPUTCTRL_MUXNEG(0x18u)
-#define ADC_0_REF_DEFAULT                       ADC_REFCTRL_REFSEL_INTVCC2
+
+#define ADC_NUMOF                               ARRAY_SIZE(adc_channels)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -213,18 +213,13 @@ static const i2c_conf_t i2c_config[] = {
  * @name    ADC configuration
  * @{
  */
-#define ADC_0_EN                           1
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 /* Digital pins (1 to 6) on the board can be configured as analog inputs */
 static const adc_conf_chan_t adc_channels[] = {
@@ -237,8 +232,7 @@ static const adc_conf_chan_t adc_channels[] = {
     { GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0 },     /* Digital 6 */
 };
 
-#define ADC_0_CHANNELS                     (6U)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -165,19 +165,13 @@ static const uart_conf_t uart_config[] = {
  * @name ADC configuration
  * @{
  */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   17
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -190,8 +184,7 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* A6 (temperature) */
 };
 
-#define ADC_0_CHANNELS                     (7U)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -158,19 +158,13 @@ static const uart_conf_t uart_config[] = {
  * @name ADC configuration
  * @{
  */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   17
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -192,8 +186,7 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* BAT_VOLT */
 };
 
-#define ADC_0_CHANNELS                     (12)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -160,19 +160,13 @@ static const uart_conf_t uart_config[] = {
  * @name ADC configuration
  * @{
  */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   19
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
 
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -189,8 +183,7 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},     /* AREF */
 };
 
-#define ADC_0_CHANNELS                     (11)
-#define ADC_NUMOF                          ADC_0_CHANNELS
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

This change is for all boards with a sam0 cpu. This cpu has just one ADC.
It is unnecessary to have defines with ADC_0_ prefix as if multiple ADCs
are possible.

Some defines were not used, such as ADC_0_EN, ADC_0_CHANNELS,
ADC_MAX_CHANNELS, ADC_0_CLK_SOURCE, ADC_0_CHANNELS. These
are deleted.

Change all ADC_0_ prefixes to ADC_

### Testing procedure

This PR changes the ADC configuration of all boards with a "sam0" cpu.
 * arduino-mkr1000
 * arduino-mkrfox1200
 * arduino-mkrzero
 * feather-m0
 * hamilton
 * samd21-xpro
 * saml10-xpro
 * saml11-xpro
 * saml21-xpro
 * samr21-xpro
 * samr30-xpro
 * sensebox_samd21
 * sodaq-explorer
 * sodaq-one
 * sodaq-sara-aff

Since almost every configuration is copy/pasted from another it might be
sufficient to test on just one or two boards.

I've tested with sodaq-one, which can measure battery voltage. However, a change in the sodaq-one ADC configuration is necessary to actually measure that voltage. (These changes will come in a separate PR.)