### PR TITLE
cpu/esp32: disable thin archives if esp_wifi is used

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -42,6 +42,9 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     # crypto and hashes produce symbol conflicts with esp_idf_wpa_supplicant_crypto
     DISABLE_MODULE += crypto
     DISABLE_MODULE += hashes
+
+    # thin archives trigger a reboot loop - see #12258
+    ARFLAGS = rcs
 endif
 
 ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description
For a yet unknown reason esp32 gets stuck in a reboot loop when thin archives are used.

As a workaround, disable thin archives for now if esp_wifi is used.

### Testing procedure
Compile `examples/gnrc_networking` with `USEMODULE += esp_wifi`

On master, the device will be stuck in a boot loop.

With this applied RIOT starts up normally and connects to the WiFi.

### Issues/PRs references

fixes #12258
bug introduced by #10195