### PR TITLE
asymcute: Fix null pointer dereference

### DIFF
--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -281,6 +281,9 @@ static unsigned _on_suback_timeout(asymcute_con_t *con, asymcute_req_t *req)
 
     /* reset the subscription context */
     asymcute_sub_t *sub = (asymcute_sub_t *)req->arg;
+    if (sub == NULL) {
+        return ASYMCUTE_REJECTED;
+    }
     sub->topic = NULL;
     return ASYMCUTE_TIMEOUT;
 }
@@ -389,6 +392,10 @@ static void _on_regack(asymcute_con_t *con, const uint8_t *data, size_t len)
     if (data[6] == MQTTSN_ACCEPTED) {
         /* finish the registration by applying the topic id */
         asymcute_topic_t *topic = (asymcute_topic_t *)req->arg;
+        if (topic == NULL) {
+            return;
+        }
+
         topic->id = byteorder_bebuftohs(&data[2]);
         topic->con = con;
         ret = ASYMCUTE_REGISTERED;
@@ -468,6 +475,10 @@ static void _on_suback(asymcute_con_t *con, const uint8_t *data, size_t len)
     if (data[7] == MQTTSN_ACCEPTED) {
         /* parse and apply assigned topic id */
         asymcute_sub_t *sub = (asymcute_sub_t *)req->arg;
+        if (sub == NULL) {
+            return;
+        }
+
         sub->topic->id = byteorder_bebuftohs(&data[3]);
         sub->topic->con = con;
         /* insert subscription to connection context */
@@ -494,7 +505,9 @@ static void _on_unsuback(asymcute_con_t *con, const uint8_t *data, size_t len)
 
     /* remove subscription from list */
     asymcute_sub_t *sub = (asymcute_sub_t *)req->arg;
-    if (con->subscriptions == sub) {
+    if (sub == NULL) {
+        return;
+    } else if (con->subscriptions == sub) {
         con->subscriptions = sub->next;
     }
     else {


### PR DESCRIPTION
### Contribution description

This PR fixes various null pointer dereferences in `asymcute`. All of
these are due to the assumption that `req->arg` is always non-NULL.
Since an attacker can spoof mqtt replies this is not neccessarly the
case.

This assumption is made at various places in the code. I only tested
this with `MQTTSN_SUBACK` messages (`_on_suback` function) but the same
issue should apply to any function accessing `req->arg` without checking
for `NULL`.

### Testing procedure

My tap setup is as follows:

```
4: tap0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 72:f3:e4:fd:13:9c brd ff:ff:ff:ff:ff:ff
    inet6 fe80::70f3:e4ff:fefd:139c/64 scope link
       valid_lft forever preferred_lft forever
```

On `native`:

```
$ make -C `examples/asymcute_mqttsn` all-valgrind
$ make -C `examples/asymcute_mqttsn` term-valgrind
main(): This is RIOT! (Version: UNKNOWN (builddir: /root/RIOT))
Asymcute MQTT-SN example application

Type 'help' to get started and have a look at the README.md for more information.
> connect myclient [fe80::70f3:e4ff:fefd:139c]:2342
```

Before the connect request timesout spoof a reply using:

```
printf CBMAAAIAAAA= | base64 -d | \
	busybox nc -p 2342 -u 'fe80::70f3:e4ff:fefd:139d%tap0' 49152
```

`49152` should be the default ephemeral port. The packet must have the
server address as source address and the server port as source port.

**Expected result:** The packet should be rejected.
**Actual result:** Segmentation fault + invalid read of size 4.

### Impact

The null pointer dereference should result in a crash on most
platforms. Thereby allowing a denial of service. The attacker must be
able to spoof a MQTT response which is easy as the ephemeral port is not
picked at random. Additionally, the attacker needs to know a pending
MQTT MsgId, however, those aren't picked at random either and there are
only `2^8` possible values.