### PR TITLE
shell_commands: gnrc_netif: only include LoRA options when LoRA PHY is present

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -521,6 +521,11 @@ ifneq (,$(filter sx127%,$(USEMODULE)))
   USEMODULE += sx127x
   USEMODULE += netif
   USEMODULE += lora
+
+  ifneq (,$(filter gnrc,$(USEMODULE)))
+    # Pull in `ifconfig` support for LoRA
+    USEMODULE += gnrc_netif_cmd_lora
+  endif
 endif
 
 ifneq (,$(filter tcs37727,$(USEMODULE)))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -27,6 +27,7 @@ PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_pktbuf_cmd
+PSEUDOMODULES += gnrc_netif_cmd_%
 PSEUDOMODULES += gnrc_netif_dedup
 PSEUDOMODULES += gnrc_sixloenc
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -160,9 +160,11 @@ static void _set_usage(char *cmd_name)
          "       * \"pan\" - alias for \"nid\"\n"
          "       * \"pan_id\" - alias for \"nid\"\n"
          "       * \"phy_busy\" - set busy mode on-off\n"
+#ifdef MODULE_GNRC_NETIF_CMD_LORA
          "       * \"bw\" - alias for channel bandwidth\n"
          "       * \"sf\" - alias for spreading factor\n"
          "       * \"cr\" - alias for coding rate\n"
+#endif
          "       * \"power\" - TX power in dBm\n"
          "       * \"retrans\" - max. number of retransmissions\n"
          "       * \"src_len\" - sets the source address length in byte\n"
@@ -264,6 +266,7 @@ static void _print_netopt(netopt_t opt)
             printf("encryption key");
             break;
 
+#ifdef MODULE_GNRC_NETIF_CMD_LORA
         case NETOPT_BANDWIDTH:
             printf("bandwidth");
             break;
@@ -275,7 +278,7 @@ static void _print_netopt(netopt_t opt)
         case NETOPT_CODING_RATE:
             printf("coding rate");
             break;
-
+#endif
         case NETOPT_CHECKSUM:
             printf("checksum");
             break;
@@ -300,6 +303,7 @@ static const char *_netopt_state_str[] = {
     [NETOPT_STATE_STANDBY] = "STANDBY"
 };
 
+#ifdef MODULE_GNRC_NETIF_CMD_LORA
 static const char *_netopt_bandwidth_str[] = {
     [LORA_BW_125_KHZ] = "125",
     [LORA_BW_250_KHZ] = "250",
@@ -312,6 +316,7 @@ static const char *_netopt_coding_rate_str[] = {
     [LORA_CR_4_7] = "4/7",
     [LORA_CR_4_8] = "4/8"
 };
+#endif
 
 /* for some lines threshold might just be 0, so we can't use _LINE_THRESHOLD
  * here */
@@ -425,6 +430,7 @@ static void _netif_list(kernel_pid_t iface)
     if (res >= 0) {
         printf(" NID: 0x%" PRIx16, u16);
     }
+#ifdef MODULE_GNRC_NETIF_CMD_LORA
     res = gnrc_netapi_get(iface, NETOPT_BANDWIDTH, 0, &u8, sizeof(u8));
     if (res >= 0) {
         printf(" BW: %skHz ", _netopt_bandwidth_str[u8]);
@@ -437,6 +443,7 @@ static void _netif_list(kernel_pid_t iface)
     if (res >= 0) {
         printf(" CR: %s ", _netopt_coding_rate_str[u8]);
     }
+#endif
     res = gnrc_netapi_get(iface, NETOPT_LINK_CONNECTED, 0, &u8, sizeof(u8));
     if (res >= 0) {
         printf(" Link: %s ", (netopt_enable_t)u8 ? "up" : "down" );
@@ -644,6 +651,7 @@ static int _netif_set_u32(kernel_pid_t iface, netopt_t opt, uint32_t context,
     return 0;
 }
 
+#ifdef MODULE_GNRC_NETIF_CMD_LORA
 static int _netif_set_bandwidth(kernel_pid_t iface, char *value)
 {
     uint8_t bw;
@@ -702,6 +710,7 @@ static int _netif_set_coding_rate(kernel_pid_t iface, char *value)
 
     return 0;
 }
+#endif /* MODULE_GNRC_NETIF_CMD_LORA */
 
 static int _netif_set_u16(kernel_pid_t iface, netopt_t opt, uint16_t context,
                           char *u16_str)
@@ -1009,6 +1018,7 @@ static int _netif_set(char *cmd_name, kernel_pid_t iface, char *key, char *value
     else if ((strcmp("frequency", key) == 0) || (strcmp("freq", key) == 0)) {
         return _netif_set_u32(iface, NETOPT_CHANNEL_FREQUENCY, 0, value);
     }
+#ifdef MODULE_GNRC_NETIF_CMD_LORA
     else if ((strcmp("bandwidth", key) == 0) || (strcmp("bw", key) == 0)) {
         return _netif_set_bandwidth(iface, value);
     }
@@ -1018,6 +1028,7 @@ static int _netif_set(char *cmd_name, kernel_pid_t iface, char *key, char *value
     else if ((strcmp("coding_rate", key) == 0) || (strcmp("cr", key) == 0)) {
         return _netif_set_coding_rate(iface, value);
     }
+#endif
     else if ((strcmp("channel", key) == 0) || (strcmp("chan", key) == 0)) {
         return _netif_set_u16(iface, NETOPT_CHANNEL, 0, value);
     }


### PR DESCRIPTION
### Contribution description

If no LoRA module is used, there is no use in compiling in all the config options for LoRA PHYs.

This saves about 1k of `.text`.

It also slims down the switch case in `_print_netopt`.
Right now, adding only one more entry there will cause an error on AVR:

```
RIOT/sys/shell/commands/sc_gnrc_netif.c:279:(.text._print_netopt+0x32): relocation truncated to fit: R_AVR_7_PCREL against `no symbol'
```

This is because there are too many cases and local jumps on that platform can only be so far.

### Testing procedure

Compile e.g. `examples/gnrc_networking` for `samr21-xpro`

#### Before:
```
before:
   text    data     bss     dec     hex filename
  91512     196   18724  110432   1af60 /home/benpicco/dev/RIOT/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
```

#### After:
```
after:
   text    data     bss     dec     hex filename
  90440     196   18724  109360   1ab30 /home/benpicco/dev/RIOT/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
```

Examples using the sx127x module should continue to work.

### Issues/PRs references
this adapts the idea from #12171 to existing code.

In that PR, drivers will select a pseudomodule to indicate which PHY options they support
