### PR TITLE
lwip: sys_arch: replace sched_switch() with thread_yield_higher()

### DIFF
--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -218,7 +218,7 @@ sys_thread_t sys_thread_new(const char *name, lwip_thread_fn thread, void *arg,
         abort();
     }
     mutex_lock(&params.sync);
-    sched_switch((char)prio);
+    thread_yield_higher();
     return res;
 }
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`sched_switch()` is supposed to be used in core only.

This fixes #6756.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Running one of the `lwip` tests on `native` should suffice, as they use the function changed. I used `tests/lwip_sock_udp` and `tests/lwip`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #6756
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
