### PR TITLE
riotboot: define if building the bootloader

### DIFF
--- a/bootloaders/riotboot/Makefile
+++ b/bootloaders/riotboot/Makefile
@@ -7,6 +7,9 @@ BOARD ?= samr21-xpro
 # Select the boards with riotboot feature
 FEATURES_REQUIRED += riotboot
 
+# Provide a define to detect if building the bootloader
+CFLAGS += -DRIOTBOOT
+
 # Disable unused modules
 CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 DISABLE_MODULE += auto_init

--- a/bootloaders/riotboot/README.md
+++ b/bootloaders/riotboot/README.md
@@ -60,6 +60,12 @@ A board capable to use riotboot must meet the following requirements:
 The above requirements are usually met if the board succeeds to execute
 the riotboot test in tests/.
 
+When building the bootloader, the global define `RIOTBOOT` is available. You
+can use this define to skip certain parts in `board_init()` (or `cpu_init()`)
+that should not be executed during boot. Note that this define is different
+from `MODULE_RIOTBOOT`, which is also defined when building an application that
+utilizes riotboot.
+
 # Single Slot
 Just compile your application with `FEATURES_REQUIRED += riotboot`. The header
 is generated automatically according to your `APP_VER`, which can be optionally


### PR DESCRIPTION
### Contribution description
This PR exposes a global define that can be used to skip certain parts of the bootloader, when building the bootloader.

I need that for several reasons:

* reducing the size of the bootloader (for instance, the EFM32 `cpu_init()` does a lot more that should not happen in the bootloader)
* skipping parts in `cpu_init()` that are not relevant during boot
  * configuring clock sources
    * example: I could have an updated firmware that uses another source/configuration
  * e.g. chip applying errata
    * example: there can be new (conflicting) [EFM32 errata](https://github.com/RIOT-OS/RIOT/blob/master/cpu/efm32/cpu.c#L159)
  * configuring DC-DC parameters
    * example: I decide to update [DC-DC parameters](https://github.com/RIOT-OS/RIOT/blob/master/cpu/efm32/cpu.c#L59) to make my board more efficient or stable  
  * peripheral initialization

My goal is to boot as quick as possible to the actual firmware on the defaults, and then do proper initialization.

### Testing procedure
Any test that uses the `riotboot` bootloader should still work.

### Issues/PRs references
#11940, https://github.com/RIOT-OS/RIOT/pull/8902#issuecomment-410159021