### PR TITLE
gnrc_tcp: allow unknown options

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
@@ -51,7 +51,9 @@ int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
                 continue;
 
             case TCP_OPTION_KIND_MSS:
-                if (opt_left < TCP_OPTION_LENGTH_MIN || option->length > opt_left || option->length != TCP_OPTION_LENGTH_MSS) {
+                if (opt_left < TCP_OPTION_LENGTH_MIN || option->length > opt_left ||
+                    option->length != TCP_OPTION_LENGTH_MSS) {
+
                     DEBUG("gnrc_tcp_option.c : _option_parse() : invalid MSS Option length.\n");
                     return -1;
                 }
@@ -61,14 +63,15 @@ int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
                 break;
 
             default:
-                DEBUG("gnrc_tcp_option.c : _option_parse() : Unknown option found.\
-                      KIND=%"PRIu8", LENGTH=%"PRIu8"\n", option->kind, option->length);
-                return -1;
+                if (opt_left >= TCP_OPTION_LENGTH_MIN) {
+                    DEBUG("gnrc_tcp_option.c : _option_parse() : Unsupported option found.\
+                          KIND=%"PRIu8", LENGTH=%"PRIu8"\n", option->kind, option->length);
+                }
         }
 
         if (opt_left < TCP_OPTION_LENGTH_MIN || option->length > opt_left) {
-            DEBUG("gnrc_tcp_option.c : _option_parse() : invalid option length\n");
-            return 0;
+            DEBUG("gnrc_tcp_option.c : _option_parse() : Invalid option. Drop Packet.\n");
+            return -1;
         }
 
         opt_ptr += option->length;


### PR DESCRIPTION
The latest hardening of the gnrc_tcp option parser was a bit too restrictive.

Packets with unknown options were dropped by gnrc_tcp. This leads to problems then communicating with feature complete tcp implementations, since valid options like SACK are often announced in first SYN Packet. Without this PR such a SYN would be dropped by gnrc_tcp.

This PR allows packets with unknown options to be valid as long as they respect the boundaries of the option field and the option minimal length.
