### PR TITLE
credman: change credman_buffer_t::s type to 'const void *'

### DIFF
--- a/sys/include/net/credman.h
+++ b/sys/include/net/credman.h
@@ -45,7 +45,7 @@ extern "C" {
  * @brief Buffer of the credential
  */
 typedef struct {
-    void *s;                /**< Pointer to the buffer */
+    const void *s;          /**< Pointer to the buffer */
     size_t len;             /**< Length of credman_buffer_t::s */
 } credman_buffer_t;
 


### PR DESCRIPTION
### Contribution description

This is a fix to the problem described in [comment](https://github.com/RIOT-OS/RIOT/pull/11943#discussion_r319457043).

### Testing procedure

Building #11943 without this change will produce error:

```
error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
```

With this change, the error is gone.
