### PR TITLE
gnrc_sixlowpan_frag_vrb: fix for draft update

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -89,10 +89,6 @@ void gnrc_sixlowpan_frag_vrb_gc(void);
  *
  * @param[in] src           Link-layer source address of the original fragment.
  * @param[in] src_len       Length of @p src.
- * @param[in] dst           Link-layer destination address of the original
- *                          fragment.
- * @param[in] dst_len       Length of @p dst.
- * @param[in] datagram_size The original fragment's datagram size.
  * @param[in] src_tag       Tag of the original fragment.
  *
  * @return  The VRB entry identified by the given parameters.
@@ -100,9 +96,7 @@ void gnrc_sixlowpan_frag_vrb_gc(void);
  *          by the given parameters.
  */
 gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
-        const uint8_t *src, size_t src_len,
-        const uint8_t *dst, size_t dst_len,
-        size_t datagram_size, unsigned src_tag);
+        const uint8_t *src, size_t src_len, unsigned src_tag);
 
 /**
  * @brief   Removes an entry from the VRB
@@ -114,8 +108,8 @@ static inline void gnrc_sixlowpan_frag_vrb_rm(gnrc_sixlowpan_frag_vrb_t *vrb)
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG
     gnrc_sixlowpan_frag_rb_base_rm(&vrb->super);
 #elif   defined(TEST_SUITES)
-    /* for testing just zero datagram_size */
-    vrb->super.datagram_size = 0;
+    /* for testing just zero src_len */
+    vrb->super.src_len = 0;
 #endif  /* MODULE_GNRC_SIXLOWPAN_FRAG */
 }
 
@@ -129,7 +123,7 @@ static inline void gnrc_sixlowpan_frag_vrb_rm(gnrc_sixlowpan_frag_vrb_t *vrb)
  */
 static inline bool gnrc_sixlowpan_frag_vrb_entry_empty(gnrc_sixlowpan_frag_vrb_t *vrb)
 {
-    return (vrb->super.datagram_size == 0);
+    return (vrb->super.src_len == 0);
 }
 
 #if defined(TEST_SUITES) || defined(DOXYGEN)

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -82,24 +82,16 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
 }
 
 gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
-        const uint8_t *src, size_t src_len,
-        const uint8_t *dst, size_t dst_len,
-        size_t datagram_size, unsigned src_tag)
+        const uint8_t *src, size_t src_len, unsigned src_tag)
 {
-    DEBUG("6lo vrb: trying to get entry for (%s, ",
-          gnrc_netif_addr_to_str(src, src_len, l2addr_str));
-    DEBUG("%s, %u, %u)\n",
-          gnrc_netif_addr_to_str(dst, dst_len, l2addr_str),
-          (unsigned)datagram_size, src_tag);
+    DEBUG("6lo vrb: trying to get entry for (%s, %u)\n",
+          gnrc_netif_addr_to_str(src, src_len, l2addr_str), src_tag);
     for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         gnrc_sixlowpan_frag_vrb_t *vrbe = &_vrb[i];
 
-        if ((vrbe->super.datagram_size == datagram_size) &&
-            (vrbe->super.tag == src_tag) &&
+        if ((vrbe->super.tag == src_tag) &&
             (vrbe->super.src_len == src_len) &&
-            (vrbe->super.dst_len == dst_len) &&
-            (memcmp(vrbe->super.src, src, src_len) == 0) &&
-            (memcmp(vrbe->super.dst, dst, dst_len) == 0)) {
+            (memcmp(vrbe->super.src, src, src_len) == 0)) {
             DEBUG("6lo vrb: got VRB to (%s, %u)\n",
                   gnrc_netif_addr_to_str(vrbe->out_dst,
                                          vrbe->out_dst_len,

--- a/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
+++ b/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
@@ -155,8 +155,7 @@ static void test_vrb_add__full(void)
                                                  out_dst, sizeof(out_dst)));
     /* check if it really isn't in the VRB */
     TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(base.src, base.src_len,
-                                                 base.dst, base.dst_len,
-                                                 base.datagram_size, base.tag));
+                                                 base.tag));
 }
 
 static void test_vrb_get__empty(void)
@@ -173,8 +172,7 @@ static void test_vrb_get__empty(void)
         .arrival = 1742197326U,
     };
     TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(base.src, base.src_len,
-                                                 base.dst, base.dst_len,
-                                                 base.datagram_size, base.tag));
+                                                 base.tag));
 }
 
 static void test_vrb_get__after_add(void)
@@ -199,9 +197,6 @@ static void test_vrb_get__after_add(void)
                                                              sizeof(out_dst))));
     TEST_ASSERT_NOT_NULL((res2 = gnrc_sixlowpan_frag_vrb_get(base.src,
                                                              base.src_len,
-                                                             base.dst,
-                                                             base.dst_len,
-                                                             base.datagram_size,
                                                              base.tag)));
     TEST_ASSERT(res1 == res2);
 }
@@ -228,8 +223,7 @@ static void test_vrb_rm(void)
                                                             sizeof(out_dst))));
     gnrc_sixlowpan_frag_vrb_rm(res);
     TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(base.src, base.src_len,
-                                                 base.dst, base.dst_len,
-                                                 base.datagram_size, base.tag));
+                                                 base.tag));
 }
 
 static void test_vrb_gc(void)
@@ -254,8 +248,7 @@ static void test_vrb_gc(void)
                                                             sizeof(out_dst))));
     gnrc_sixlowpan_frag_vrb_gc();
     TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(base.src, base.src_len,
-                                                 base.dst, base.dst_len,
-                                                 base.datagram_size, base.tag));
+                                                 base.tag));
 }
 
 static Test *tests_gnrc_sixlowpan_frag_vrb_tests(void)

--- a/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
+++ b/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
@@ -37,6 +37,24 @@ extern uint16_t tag;
  * reference for forwarding) so an uninitialized one is enough */
 static gnrc_netif_t _dummy_netif;
 
+static const gnrc_sixlowpan_frag_rb_int_t _interval = {
+    .next = NULL,
+    .start = 0,
+    .end = 116U,
+};
+static const gnrc_sixlowpan_frag_rb_base_t _base = {
+    .ints = (gnrc_sixlowpan_frag_rb_int_t *)&_interval,
+    .src = TEST_SRC,
+    .dst = TEST_DST,
+    .src_len = TEST_SRC_LEN,
+    .dst_len = TEST_DST_LEN,
+    .tag = TEST_TAG,
+    .datagram_size = 1156U,
+    .current_size = 116U,
+    .arrival = 1742197326U,
+};
+static uint8_t _out_dst[] = TEST_OUT_DST;
+
 static void set_up(void)
 {
     gnrc_sixlowpan_frag_vrb_reset();
@@ -45,50 +63,33 @@ static void set_up(void)
 
 static void test_vrb_add__success(void)
 {
-    static const gnrc_sixlowpan_frag_rb_int_t interval = {
-        .next = NULL,
-        .start = 0,
-        .end = 116U,
-    };
-    static const gnrc_sixlowpan_frag_rb_base_t base = {
-        .ints = (gnrc_sixlowpan_frag_rb_int_t *)&interval,
-        .src = TEST_SRC,
-        .dst = TEST_DST,
-        .src_len = TEST_SRC_LEN,
-        .dst_len = TEST_DST_LEN,
-        .tag = TEST_TAG,
-        .datagram_size = 1156U,
-        .current_size = 116U,
-        .arrival = 1742197326U,
-    };
-    static uint8_t out_dst[] = TEST_OUT_DST;
     gnrc_sixlowpan_frag_vrb_t *res;
 
     tag = TEST_TAG_INITIAL;
-    TEST_ASSERT_NOT_NULL((res = gnrc_sixlowpan_frag_vrb_add(&base,
+    TEST_ASSERT_NOT_NULL((res = gnrc_sixlowpan_frag_vrb_add(&_base,
                                                             &_dummy_netif,
-                                                            out_dst,
-                                                            sizeof(out_dst))));
+                                                            _out_dst,
+                                                            sizeof(_out_dst))));
     TEST_ASSERT_NOT_NULL(res->super.ints);
     TEST_ASSERT_NULL(res->super.ints->next);
-    /* make sure base and res->super are distinct*/
-    TEST_ASSERT((&base) != (&res->super));
+    /* make sure _base and res->super are distinct*/
+    TEST_ASSERT((&_base) != (&res->super));
     /* but that the values are the same */
-    TEST_ASSERT_EQUAL_INT(interval.start, res->super.ints->start);
-    TEST_ASSERT_EQUAL_INT(interval.end, res->super.ints->end);
-    TEST_ASSERT_EQUAL_INT(base.src_len, res->super.src_len);
-    TEST_ASSERT_MESSAGE(memcmp(base.src, res->super.src, TEST_SRC_LEN) == 0,
+    TEST_ASSERT_EQUAL_INT(_interval.start, res->super.ints->start);
+    TEST_ASSERT_EQUAL_INT(_interval.end, res->super.ints->end);
+    TEST_ASSERT_EQUAL_INT(_base.src_len, res->super.src_len);
+    TEST_ASSERT_MESSAGE(memcmp(_base.src, res->super.src, TEST_SRC_LEN) == 0,
                         "TEST_SRC != res->super.src");
-    TEST_ASSERT_EQUAL_INT(base.dst_len, res->super.src_len);
-    TEST_ASSERT_MESSAGE(memcmp(base.dst, res->super.dst, TEST_DST_LEN) == 0,
+    TEST_ASSERT_EQUAL_INT(_base.dst_len, res->super.src_len);
+    TEST_ASSERT_MESSAGE(memcmp(_base.dst, res->super.dst, TEST_DST_LEN) == 0,
                         "TEST_DST != res->super.dst");
-    TEST_ASSERT_EQUAL_INT(base.tag, res->super.tag);
-    TEST_ASSERT_EQUAL_INT(base.datagram_size, res->super.datagram_size);
-    TEST_ASSERT_EQUAL_INT(base.current_size, res->super.current_size);
-    TEST_ASSERT_EQUAL_INT(base.arrival, res->super.arrival);
+    TEST_ASSERT_EQUAL_INT(_base.tag, res->super.tag);
+    TEST_ASSERT_EQUAL_INT(_base.datagram_size, res->super.datagram_size);
+    TEST_ASSERT_EQUAL_INT(_base.current_size, res->super.current_size);
+    TEST_ASSERT_EQUAL_INT(_base.arrival, res->super.arrival);
     TEST_ASSERT((&_dummy_netif) == res->out_netif);
-    TEST_ASSERT_EQUAL_INT(sizeof(out_dst), res->out_dst_len);
-    TEST_ASSERT_MESSAGE(memcmp(out_dst, res->out_dst, sizeof(out_dst)) == 0,
+    TEST_ASSERT_EQUAL_INT(sizeof(_out_dst), res->out_dst_len);
+    TEST_ASSERT_MESSAGE(memcmp(_out_dst, res->out_dst, sizeof(_out_dst)) == 0,
                         "TEST_DST != res->super.dst");
     TEST_ASSERT_EQUAL_INT(TEST_TAG_INITIAL, res->out_tag);
     TEST_ASSERT(TEST_TAG_INITIAL != tag);
@@ -96,63 +97,35 @@ static void test_vrb_add__success(void)
 
 static void test_vrb_add__duplicate(void)
 {
-    static const gnrc_sixlowpan_frag_rb_int_t interval = {
-        .next = NULL,
-        .start = 0,
-        .end = 116U,
-    };
-    static const gnrc_sixlowpan_frag_rb_base_t base = {
-        .ints = (gnrc_sixlowpan_frag_rb_int_t *)&interval,
-        .src = TEST_SRC,
-        .dst = TEST_DST,
-        .src_len = TEST_SRC_LEN,
-        .dst_len = TEST_DST_LEN,
-        .tag = TEST_TAG,
-        .datagram_size = 1156U,
-        .current_size = 116U,
-        .arrival = 1742197326U,
-    };
-    static uint8_t out_dst[] = TEST_OUT_DST;
     gnrc_sixlowpan_frag_vrb_t *res1, *res2;
 
     tag = TEST_TAG_INITIAL;
-    TEST_ASSERT_NOT_NULL((res1 = gnrc_sixlowpan_frag_vrb_add(&base,
+    TEST_ASSERT_NOT_NULL((res1 = gnrc_sixlowpan_frag_vrb_add(&_base,
                                                              &_dummy_netif,
-                                                             out_dst,
-                                                             sizeof(out_dst))));
-    TEST_ASSERT_NOT_NULL((res2 = gnrc_sixlowpan_frag_vrb_add(&base,
+                                                             _out_dst,
+                                                             sizeof(_out_dst))));
+    TEST_ASSERT_NOT_NULL((res2 = gnrc_sixlowpan_frag_vrb_add(&_base,
                                                              &_dummy_netif,
-                                                             out_dst,
-                                                             sizeof(out_dst))));
+                                                             _out_dst,
+                                                             sizeof(_out_dst))));
     TEST_ASSERT(res1 == res2);
 }
 
 static void test_vrb_add__full(void)
 {
-    gnrc_sixlowpan_frag_rb_base_t base = {
-        .ints = NULL,
-        .src = TEST_SRC,
-        .dst = TEST_DST,
-        .src_len = TEST_SRC_LEN,
-        .dst_len = TEST_DST_LEN,
-        .tag = TEST_TAG,
-        .datagram_size = 1156U,
-        .current_size = 116U,
-        .arrival = 1742197326U,
-    };
-    static uint8_t out_dst[] = TEST_OUT_DST;
+    gnrc_sixlowpan_frag_rb_base_t base = _base;
 
     /* fill up VRB */
     for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_vrb_add(&base,
                                                          &_dummy_netif,
-                                                         out_dst,
-                                                         sizeof(out_dst)));
+                                                         _out_dst,
+                                                         sizeof(_out_dst)));
         base.tag++;
     }
     /* another entry will not fit */
     TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_add(&base, &_dummy_netif,
-                                                 out_dst, sizeof(out_dst)));
+                                                 _out_dst, sizeof(_out_dst)));
     /* check if it really isn't in the VRB */
     TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(base.src, base.src_len,
                                                  base.tag));
@@ -160,92 +133,47 @@ static void test_vrb_add__full(void)
 
 static void test_vrb_get__empty(void)
 {
-    static const gnrc_sixlowpan_frag_rb_base_t base = {
-        .ints = NULL,
-        .src = TEST_SRC,
-        .dst = TEST_DST,
-        .src_len = TEST_SRC_LEN,
-        .dst_len = TEST_DST_LEN,
-        .tag = TEST_TAG,
-        .datagram_size = 1156U,
-        .current_size = 116U,
-        .arrival = 1742197326U,
-    };
-    TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(base.src, base.src_len,
-                                                 base.tag));
+    TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(_base.src, _base.src_len,
+                                                 _base.tag));
 }
 
 static void test_vrb_get__after_add(void)
 {
-    static const gnrc_sixlowpan_frag_rb_base_t base = {
-        .ints = NULL,
-        .src = TEST_SRC,
-        .dst = TEST_DST,
-        .src_len = TEST_SRC_LEN,
-        .dst_len = TEST_DST_LEN,
-        .tag = TEST_TAG,
-        .datagram_size = 1156U,
-        .current_size = 116U,
-        .arrival = 1742197326U,
-    };
-    static uint8_t out_dst[] = TEST_OUT_DST;
     gnrc_sixlowpan_frag_vrb_t *res1, *res2;
 
-    TEST_ASSERT_NOT_NULL((res1 = gnrc_sixlowpan_frag_vrb_add(&base,
+    TEST_ASSERT_NOT_NULL((res1 = gnrc_sixlowpan_frag_vrb_add(&_base,
                                                              &_dummy_netif,
-                                                             out_dst,
-                                                             sizeof(out_dst))));
-    TEST_ASSERT_NOT_NULL((res2 = gnrc_sixlowpan_frag_vrb_get(base.src,
-                                                             base.src_len,
-                                                             base.tag)));
+                                                             _out_dst,
+                                                             sizeof(_out_dst))));
+    TEST_ASSERT_NOT_NULL((res2 = gnrc_sixlowpan_frag_vrb_get(_base.src,
+                                                             _base.src_len,
+                                                             _base.tag)));
     TEST_ASSERT(res1 == res2);
 }
 
 static void test_vrb_rm(void)
 {
-    static const gnrc_sixlowpan_frag_rb_base_t base = {
-        .ints = NULL,
-        .src = TEST_SRC,
-        .dst = TEST_DST,
-        .src_len = TEST_SRC_LEN,
-        .dst_len = TEST_DST_LEN,
-        .tag = TEST_TAG,
-        .datagram_size = 1156U,
-        .current_size = 116U,
-        .arrival = 1742197326U,
-    };
-    static uint8_t out_dst[] = TEST_OUT_DST;
     gnrc_sixlowpan_frag_vrb_t *res;
 
-    TEST_ASSERT_NOT_NULL((res = gnrc_sixlowpan_frag_vrb_add(&base,
+    TEST_ASSERT_NOT_NULL((res = gnrc_sixlowpan_frag_vrb_add(&_base,
                                                             &_dummy_netif,
-                                                            out_dst,
-                                                            sizeof(out_dst))));
+                                                            _out_dst,
+                                                            sizeof(_out_dst))));
     gnrc_sixlowpan_frag_vrb_rm(res);
-    TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(base.src, base.src_len,
-                                                 base.tag));
+    TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(_base.src, _base.src_len,
+                                                 _base.tag));
 }
 
 static void test_vrb_gc(void)
 {
-    gnrc_sixlowpan_frag_rb_base_t base = {
-        .ints = NULL,
-        .src = TEST_SRC,
-        .dst = TEST_DST,
-        .src_len = TEST_SRC_LEN,
-        .dst_len = TEST_DST_LEN,
-        .tag = TEST_TAG,
-        .datagram_size = 1156U,
-        .current_size = 116U,
-        .arrival = xtimer_now_usec() - GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US - 1000,
-    };
-    static uint8_t out_dst[] = TEST_OUT_DST;
+    gnrc_sixlowpan_frag_rb_base_t base = _base;
     gnrc_sixlowpan_frag_vrb_t *res;
 
+    base.arrival = xtimer_now_usec() - GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US - 1000;
     TEST_ASSERT_NOT_NULL((res = gnrc_sixlowpan_frag_vrb_add(&base,
                                                             &_dummy_netif,
-                                                            out_dst,
-                                                            sizeof(out_dst))));
+                                                            _out_dst,
+                                                            sizeof(_out_dst))));
     gnrc_sixlowpan_frag_vrb_gc();
     TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(base.src, base.src_len,
                                                  base.tag));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Due to some changes to the minimal forwarding draft and in preparation for Selective Fragment Recovery some changes to the VRB API were needed. Now the index of a VRB entry is only (L2 src, tag) not as before (L2 src, L2 dst, length, tag).

I know that the current `rbuf_base` causes waste, as all the fields not used by the new index are effectively not used by the VRB. I'd like to fix that however in a later change, since that also requires some modifications of the classic reassembly buffer, and thus would complicate the review and testing of the change.

Sources for the index change:
- https://tools.ietf.org/html/draft-ietf-6lo-minimal-fragment-04#section-1
- https://mailarchive.ietf.org/arch/browse/6lo/?gbt=1&index=DLCTxC2X4bRNtYPHhtEkavMWlz4

(I also piggy-backed some improvements to the unittests)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I've updated the unittests for the VRB, so

```sh
make -C tests/unittests tests-gnrc_sixlowpan_frag_vrb flash-only test
```

should still work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
