### PR TITLE
edbg: verify before flash

### DIFF
--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -14,10 +14,11 @@ endif
 # Set offset according to IMAGE_OFFSET if it's defined
 EDBG_ARGS += $(if $(IMAGE_OFFSET),--offset $(IMAGE_OFFSET))
 
-FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -v -p -f $(FLASHFILE)
+FFLAGS ?= $(EDBG_ARGS) --target $(EDBG_DEVICE_TYPE) --verbose \
+                       --verify --program --file $(FLASHFILE)
 
 ifeq ($(RIOT_EDBG),$(FLASHER))
   FLASHDEPS += $(RIOT_EDBG)
 endif
 RESET ?= $(EDBG)
-RESET_FLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE)
+RESET_FLAGS ?= $(EDBG_ARGS) --target $(EDBG_DEVICE_TYPE)

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -15,10 +15,17 @@ endif
 EDBG_ARGS += $(if $(IMAGE_OFFSET),--offset $(IMAGE_OFFSET))
 
 FFLAGS ?= $(EDBG_ARGS) --target $(EDBG_DEVICE_TYPE) --verbose \
-                       --verify --program --file $(FLASHFILE)
+                       --file $(FLASHFILE)
 
 ifeq ($(RIOT_EDBG),$(FLASHER))
   FLASHDEPS += $(RIOT_EDBG)
 endif
 RESET ?= $(EDBG)
 RESET_FLAGS ?= $(EDBG_ARGS) --target $(EDBG_DEVICE_TYPE)
+
+define edbg-flash-recipe
+  $(call check_cmd,$(FLASHER),Flash program)
+  $(FLASHER) $(FFLAGS) --verify || $(FLASHER) $(FFLAGS) --verify --program
+endef
+
+flash-recipe = $(edbg-flash-recipe)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR overrides the flash recipe *edit* as suggested [here](https://github.com/RIOT-OS/RIOT/pull/11093#issuecomment-469999895) *edit* when using edbg in order to make it verify before flash. This saves a flash cycle when the contents already match.

The first commit changes all edbg short options to use the long options. If the whole diff looks scary, take a look at the individual commits. :)

### Testing procedure

With an edbg supported board, try ```make all; make flash-only; make flash-only``` and observe that the first flashing actually programs the device, the second skips programming.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Supercedes #11093.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
