### PR TITLE
Makefile.include: add BUILD_FILES variable that holds all files to be built

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -442,6 +442,9 @@ ifeq (,$(FLASHFILE))
   $(error FLASHFILE is not defined for this board: $(FLASHFILE))
 endif
 
+# By default always build ELFFILE and FLASHFILE
+BUILD_FILES += $(ELFFILE) $(FLASHFILE)
+
 # variables used to compile and link c++
 CPPMIX ?= $(if $(wildcard *.cpp),1,)
 
@@ -470,7 +473,7 @@ ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container
 else
 ifeq (,$(RIOTNOLINK))
-link: ..compiler-check ..build-message $(ELFFILE) $(FLASHFILE) print-size
+link: ..compiler-check ..build-message $(BUILD_FILES) print-size
 else
 link: ..compiler-check ..build-message $(BASELIBS)
 endif # RIOTNOLINK

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -49,9 +49,7 @@ SLOT_RIOT_ELFS = $(BINDIR_APP)-slot0.elf $(BINDIR_APP)-slot1.elf
 # ensure both slot elf files are always linked
 # this ensures that both "make test" and "make test-murdock" can rely on them
 # being present without having to trigger re-compilation.
-ifneq (1, $(RIOTNOLINK))
-link: $(SLOT_RIOT_ELFS)
-endif
+BUILD_FILES += $(SLOT_RIOT_ELFS)
 
 # Create binary target with RIOT header
 $(SLOT_RIOT_BINS): %.$(APP_VER).riot.bin: %.hdr %.bin

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -80,6 +80,7 @@ export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The 'intel hex' stripped result of the compilation.
 # BINFILE                    # The 'binary' stripped result of the compilation.
 # FLASHFILE                  # The output file used for flashing
+# BUILD_FILES                # The list of files to be built
 # DEBUGGER                   # The command to call on "make debug", usually a script starting the GDB front-end.
 # DEBUGGER_FLAGS             # The parameters to supply to DEBUGGER.
 # DEBUGSERVER                # The command to call on "make debug-server", usually a script starting the GDB server.


### PR DESCRIPTION
### Contribution Description

This PR adds a `BUILD_FILES` variable to hold all files that need to be linked. This is an attempt to fix #12003. 

By default `BUILD_FILES` will hold `$(ELFFILE)`, `$(FLASHFILE)` but more dependencies can be added as for example `SLOT_RIOT_ELFS`. This ensures the added targets are also built in docker when required.

There are other possible solutions, e.g:

```
ifneq (1, $(RIOTNOLINK))
  ifneq (1, $(BUILD_IN_DOCKER))
  link: $(SLOT_RIOT_ELFS)
  endif
endif
```

The first approach is better IMO as it doesn't mix in docker logic into `riotboot.mk` and the built files are correctly defined.

**PS: I'm unsure about the name of the variable.**

### Testing procedure

Building in docker now succeeds and doesn't use the local toolchain.

<details><summary>BUILD_IN_DOCKER=1 DOCKER="sudo docker" BOARD=frdm-k64f make --no-print-directory -C bootloaders/riotboot/</summary>

```
Unknown device, --name=, --path=, or absolute path in /dev/ or /sys expected.
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/home/francisco/workspace/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'     \
    -e 'BOARD=frdm-k64f' \
    -w '/data/riotbuild/riotbase/bootloaders/riotboot/' \
    'riot/riotbuild:latest' make   
[sudo] password for francisco: 
Building application "riotboot" for "frdm-k64f" with MCU "kinetis".

"make" -C /data/riotbuild/riotbase/boards/frdm-k64f
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/kinetis
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/kinetis/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/checksum
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/riotboot
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
compiling /data/riotbuild/riotbase/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /data/riotbuild/riotbase/bootloaders/riotboot/bin/frdm-k64f/riotboot-slot0.1569401349.riot.bin...
   text	   data	    bss	    dec	    hex	filename
   3444	      0	    604	   4048	    fd0	/data/riotbuild/riotbase/bootloaders/riotboot/bin/frdm-k64f/riotboot.elf
```
</details>

Also tested on machine without local toolchain that uses docker by default.

<details><summary>make -C bootloaders/riotboot/</summary>

```
Launching build container using image "riot/riotbuild:latest".
docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/builds/tmp/RIOT:/data/riotbuild/riotbase' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/ci/.gitcache:/data/riotbuild/gitcache' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'   \
     \
    -w '/data/riotbuild/riotbase/bootloaders/riotboot/' \
    'riot/riotbuild:latest' make    
Building application "riotboot" for "samr21-xpro" with MCU "samd21".

"make" -C /data/riotbuild/riotbase/boards/samr21-xpro
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/samd21
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/sam0_common
"make" -C /data/riotbuild/riotbase/cpu/sam0_common/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/checksum
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/riotboot
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
compiling /data/riotbuild/riotbase/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /data/riotbuild/riotbase/bootloaders/riotboot/bin/samr21-xpro/riotboot-slot0.1569401425.riot.bin...
   text	   data	    bss	    dec	    hex	filename
   2564	      0	    608	   3172	    c64	/data/riotbuild/riotbase/bootloaders/riotboot/bin/samr21-xpro/riotboot.elf

```
</details>

There should be no consequences as the base behavior is kept.

### Issues/PRs references

Fixes partially #12003 