### PR TITLE
boards/arduino-mkr: feather-m0: sodaq-*: provide stdio over USB and setup automatic flash with bossa

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -492,6 +492,17 @@ ifneq (,$(filter stdio_cdc_acm stdio_null stdio_uart slipdev_stdio,$(USEMODULE))
   DISABLE_MODULE += stdio_rtt
 endif
 
+ifneq (,$(filter stdio_rtt stdio_null stdio_uart slipdev_stdio,$(USEMODULE)))
+  # stdio_cdc_acm cannot be used when another STDIO is loaded
+  DISABLE_MODULE += stdio_cdc_acm
+endif
+
+ifeq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+  # The arduino bootloader feature cannot be used if the stdio_cdc_acm module
+  # is not used
+  FEATURES_BLACKLIST += bootloader_arduino
+endif
+
 ifneq (,$(filter isrpipe,$(USEMODULE)))
   USEMODULE += tsrb
 endif

--- a/boards/arduino-mkrfox1200/doc.txt
+++ b/boards/arduino-mkrfox1200/doc.txt
@@ -16,19 +16,22 @@ powered by an Atmel SAMD21 microcontroller.
 
 ### Flash the board
 
-1. Put the board in bootloader mode by double tapping the reset button.<br/>
-   When the board is in bootloader mode, the user led (green) oscillates
-   smoothly.
-
-
-2. Use `BOARD=arduino-mkrfox1200` with the `make` command.<br/>
-   Example with `hello-world` application:
+Use `BOARD=arduino-mkrfox1200` with the `make` command.<br/>
+Example with `hello-world` application:
 ```
      make BOARD=arduino-mkrfox1200 -C examples/hello-world flash
 ```
 
+@note     If the application crashes, automatic reflashing via USB, as explained
+          above won't be possible. In this case, the board must be set in
+          bootloader mode by double tapping the reset button before running the
+          flash command.
+
 ### Accessing STDIO via UART
 
-To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
-the RX/TX pins on the board.
+STDIO of RIOT is directly available over the USB port.
+
+The `TERM_DELAY` environment variable can be used to add a delay (in second)
+before opening the serial terminal. The default value is 2s which should be
+enough in most of the situation.
  */

--- a/boards/arduino-mkrwan1300/doc.txt
+++ b/boards/arduino-mkrwan1300/doc.txt
@@ -1,37 +1,37 @@
 /**
- * @defgroup    boards_arduino-mkrwan1300 Arduino MKR WAN 1300
- * @ingroup     boards
- * @brief       Support for the Arduino MKR WAN 1300 board.
- *
- * ### General information
- *
- * The [Arduino MKR WAN 1300](https://store.arduino.cc/mkr-wan-1300) board is
- * a learning and development board that provides LoRa connectivity and is
- * powered by an Atmel SAMD21 microcontroller.
- *
- * ### Pinout
- *
- * <img src="https://www.arduino.cc/en/uploads/Main/MKR1000_pinout.png"
- *      alt="Arduino MKR WAN 1300 pinout" style="height:800px;"/>
- *
- * ### Flash the board
- *
- * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
- *    When the board is in bootloader mode, the user led (amber) oscillates
- *    smoothly.
- *
- *
- * 2. Use `BOARD=arduino-mkrwan1300` with the `make` command.<br/>
- *    Example with `hello-world` application:
- * ```
- *      make BOARD=arduino-mkrwan1300 -C examples/hello-world flash
- * ```
- *
- * @warning Unplug the board from the anti-static protective foam before
- *          starting to use it otherwise it may not work as expected.
- *
- * ### Accessing STDIO via UART
- *
- * To access the STDIO of RIOT, a FTDI to USB converted needs to be plugged to
- * the RX/TX pins on the board.
+@defgroup    boards_arduino-mkrwan1300 Arduino MKR WAN 1300
+@ingroup     boards
+@brief       Support for the Arduino MKR WAN 1300 board.
+
+### General information
+
+The [Arduino MKR WAN 1300](https://store.arduino.cc/mkr-wan-1300) board is
+a learning and development board that provides LoRa connectivity and is
+powered by an Atmel SAMD21 microcontroller.
+
+### Pinout
+
+<img src="https://www.arduino.cc/en/uploads/Main/MKR1000_pinout.png"
+     alt="Arduino MKR WAN 1300 pinout" style="height:800px;"/>
+
+### Flash the board
+
+Use `BOARD=arduino-mkrgsm1400` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+     make BOARD=arduino-mkrgsm1400 -C examples/hello-world flash
+```
+
+@note     If the application crashes, automatic reflashing via USB, as explained
+          above won't be possible. In this case, the board must be set in
+          bootloader mode by double tapping the reset button before running the
+          flash command.
+
+### Accessing STDIO via UART
+
+STDIO of RIOT is directly available over the USB port.
+
+The `TERM_DELAY` environment variable can be used to add a delay (in second)
+before opening the serial terminal. The default value is 2s which should be
+enough in most of the situation.
  */

--- a/boards/common/arduino-mkr/Makefile.dep
+++ b/boards/common/arduino-mkr/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep

--- a/boards/common/arduino-mkr/Makefile.features
+++ b/boards/common/arduino-mkr/Makefile.features
@@ -16,3 +16,4 @@ FEATURES_PROVIDED += periph_usbdev
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
 FEATURES_PROVIDED += arduino_pwm
+FEATURES_PROVIDED += bootloader_arduino

--- a/boards/common/arduino-mkr/Makefile.include
+++ b/boards/common/arduino-mkr/Makefile.include
@@ -9,12 +9,9 @@ ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model
   JLINK_DEVICE = $(MKR_JLINK_DEVICE)
   include $(RIOTMAKE)/tools/jlink.inc.mk
-else
-  # by default, we use BOSSA to flash this board and take into account the
-  # preinstalled Arduino bootloader. ROM_OFFSET skips the space taken by
-  # such bootloader.
-  ROM_OFFSET ?= 0x2000
-  include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
+
+# Include all definitions for flashing with bossa over USB
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.include
 
 INCLUDES += -I$(RIOTBOARD)/common/arduino-mkr/include

--- a/boards/common/samd21-arduino-bootloader/Makefile
+++ b/boards/common/samd21-arduino-bootloader/Makefile
@@ -1,0 +1,3 @@
+MODULE = boards_common_samd21-arduino-bootloader
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/common/samd21-arduino-bootloader/Makefile.dep
+++ b/boards/common/samd21-arduino-bootloader/Makefile.dep
@@ -1,0 +1,13 @@
+# Provide stdio over USB by default
+# This is a temporary solution until management of stdio is correctly
+# handled by the build system
+DEFAULT_MODULE += stdio_cdc_acm
+
+# Default auto-initialization of usbus for stdio other USB
+USEMODULE += auto_init_usbus
+
+# This boards requires support for Arduino bootloader.
+USEMODULE += usb_board_reset
+USEMODULE += boards_common_samd21-arduino-bootloader
+
+FEATURES_REQUIRED += bootloader_arduino

--- a/boards/common/samd21-arduino-bootloader/Makefile.include
+++ b/boards/common/samd21-arduino-bootloader/Makefile.include
@@ -1,0 +1,31 @@
+# setup the flash tool used
+# Bossa is the default programmer
+PROGRAMMER ?= bossa
+
+ifeq ($(PROGRAMMER),bossa)
+  # by default, we use BOSSA to flash this board and take into account the
+  # preinstalled Arduino bootloader. ROM_OFFSET skips the space taken by
+  # such bootloader.
+  ROM_OFFSET ?= 0x2000
+  BOSSA_ARDUINO_PREFLASH = yes
+  PREFLASH_DELAY = 1
+
+  ifneq (,$(filter reset flash flash-only, $(MAKECMDGOALS)))
+    # By default, add 2 seconds delay before opening terminal: this is required
+    # when opening the terminal right after flashing. In this case, the stdio
+    # over USB needs some time after reset before being ready.
+    TERM_DELAY ?= 2
+    TERMDEPS += term-delay
+  endif
+
+  include $(RIOTMAKE)/tools/bossa.inc.mk
+endif
+
+term-delay:
+	sleep $(TERM_DELAY)
+
+TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
+$(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
+
+# Add the samd21-arduino-bootloader directory to the build
+DIRS += $(RIOTBOARD)/common/samd21-arduino-bootloader

--- a/boards/common/samd21-arduino-bootloader/reset.c
+++ b/boards/common/samd21-arduino-bootloader/reset.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C)  2019 Inria
+ *                2019 Kees Bakker, SODAQ
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common
+ * @{
+ * @file
+ * @brief       Board common implementations for managing an Arduino bootloader
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Kees Bakker <kees@sodaq.com>
+ *
+ * @}
+ */
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
+#include "usb_board_reset.h"
+
+
+#define SAMD21_DOUBLE_TAP_ADDR              (0x20007FFCUL)
+#define SAMD21_DOUBLE_TAP_MAGIC_NUMBER      (0x07738135UL)
+
+void usb_board_reset_in_bootloader(void)
+{
+    /* The Arduino bootloader checks for a magic number in SRAM to remain in
+       bootloader mode.
+       See
+       https://github.com/arduino/ArduinoCore-samd/blob/master/bootloaders/zero/board_definitions_arduino_mkr1000.h#L38
+       and
+       https://github.com/arduino/ArduinoCore-samd/blob/master/bootloaders/zero/main.c#L94
+       for implementation details. */
+    uint32_t *reset_addr = (uint32_t *)SAMD21_DOUBLE_TAP_ADDR;
+    *reset_addr = (uint32_t)SAMD21_DOUBLE_TAP_MAGIC_NUMBER;
+
+    usb_board_reset_in_application();
+}

--- a/boards/common/sodaq/Makefile.dep
+++ b/boards/common/sodaq/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep

--- a/boards/common/sodaq/Makefile.features
+++ b/boards/common/sodaq/Makefile.features
@@ -12,3 +12,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += bootloader_arduino

--- a/boards/common/sodaq/Makefile.include
+++ b/boards/common/sodaq/Makefile.include
@@ -7,8 +7,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # Add board common includes
 INCLUDES += -I$(RIOTBOARD)/common/sodaq/include
 
-# setup the flash tool used
-# we use BOSSA to flash this board since there's an Arduino bootloader
-# preflashed on it. ROM_OFFSET skips the space taken by such bootloader.
-ROM_OFFSET ?= 0x2000
-include $(RIOTMAKE)/tools/bossa.inc.mk
+# Include all definitions for flashing with bossa over USB
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.include

--- a/boards/feather-m0/Makefile.dep
+++ b/boards/feather-m0/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -11,3 +11,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += bootloader_arduino

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -9,13 +9,7 @@ ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model
   JLINK_DEVICE = atsamd21
   include $(RIOTMAKE)/tools/jlink.inc.mk
-else
-  # by default, we use BOSSA to flash this board to take into account the
-  # pre-flashed Arduino bootloader. ROM_OFFSET skips the space taken by
-  # such bootloader.
-  ROM_OFFSET ?= 0x2000
-  include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
 
-# setup the boards dependencies
-include $(RIOTBOARD)/feather-m0/Makefile.dep
+# Include all definitions for flashing with bossa over USB
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.include

--- a/boards/feather-m0/doc.txt
+++ b/boards/feather-m0/doc.txt
@@ -41,18 +41,22 @@ printf("Bat: %dV\n", vbat);
 
 ### Flash the board
 
-1. Put the board in bootloader mode by double tapping the reset button.<br/>
-   When the board is in bootloader mode, the user led (red) oscillates smoothly.
-
-
-2. Use `BOARD=feather-m0` with the `make` command.<br/>
-   Example with `hello-world` application:
+Use `BOARD=feather-m0` with the `make` command.<br/>
+Example with `hello-world` application:
 ```
      make BOARD=feather-m0 -C examples/hello-world flash
 ```
 
+@note     If the application crashes, automatic reflashing via USB, as explained
+          above won't be possible. In this case, the board must be set in
+          bootloader mode by double tapping the reset button before running the
+          flash command.
+
 ### Accessing STDIO via UART
 
-To access the STDIO of RIOT, a FTDI to USB converted needs to be plugged to
-the RX/TX pins on the board.
+STDIO of RIOT is directly available over the USB port.
+
+The `TERM_DELAY` environment variable can be used to add a delay (in second)
+before opening the serial terminal. The default value is 2s which should be
+enough in most of the situation.
  */

--- a/boards/sodaq-autonomo/doc.txt
+++ b/boards/sodaq-autonomo/doc.txt
@@ -93,15 +93,24 @@ Besides the SAMD21 the board has the following features:
 
 ## Flashing the device
 
-1. Put the board in bootloader mode by double tapping the reset button.<br/>
-   When the board is in bootloader mode, the user led (green) oscillates
-   smoothly.
-
-2. Use `BOARD=sodaq-autonomo` with the `make` command.<br/>
-   Example with `hello-world` application:
+Use `BOARD=sodaq-autonomo` with the `make` command.<br/>
+Example with `hello-world` application:
 ```
      make BOARD=sodaq-autonomo -C examples/hello-world flash
 ```
+
+@note     If the application crashes, automatic reflashing via USB, as explained
+          above won't be possible. In this case, the board must be set in
+          bootloader mode by double tapping the reset button before running the
+          flash command.
+
+## Accessing STDIO via UART
+
+STDIO of RIOT is directly available over the USB port.
+
+The `TERM_DELAY` environment variable can be used to add a delay (in second)
+before opening the serial terminal. The default value is 2s which should be
+enough in most of the situation.
 
 ## Supported Toolchains
 

--- a/boards/sodaq-explorer/doc.txt
+++ b/boards/sodaq-explorer/doc.txt
@@ -10,20 +10,22 @@ General information about this board can be found on the
 
 ### Flash the board
 
-1. Put the board in bootloader mode by double tapping the reset button.<br/>
-   When the board is in bootloader mode, the user led (blue) oscillates
-   smoothly.
-
-
-2. Use `BOARD=sodaq-explorer` with the `make` command.<br/>
-   Example with `hello-world` application:
+Use `BOARD=sodaq-explorer` with the `make` command.<br/>
+Example with `hello-world` application:
 ```
      make BOARD=sodaq-explorer -C examples/hello-world flash
 ```
 
+@note     If the application crashes, automatic reflashing via USB, as explained
+          above won't be possible. In this case, the board must be set in
+          bootloader mode by double tapping the reset button before running the
+          flash command.
+
 ### Accessing STDIO via UART
 
-To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
-the RX/TX pins on the board.
+STDIO of RIOT is directly available over the USB port.
 
+The `TERM_DELAY` environment variable can be used to add a delay (in second)
+before opening the serial terminal. The default value is 2s which should be
+enough in most of the situation.
  */

--- a/boards/sodaq-one/doc.txt
+++ b/boards/sodaq-one/doc.txt
@@ -10,20 +10,22 @@
  *
  * ### Flash the board
  *
- * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
- *    When the board is in bootloader mode, the user led (blue) oscillates
- *    smoothly.
- *
- *
- * 2. Use `BOARD=sodaq-one` with the `make` command.<br/>
- *    Example with `hello-world` application:
+ * Use `BOARD=sodaq-one` with the `make` command.<br/>
+ * Example with `hello-world` application:
  * ```
  *      make BOARD=sodaq-one -C examples/hello-world flash
  * ```
  *
+ * @note     If the application crashes, automatic reflashing via USB, as explained
+ *           above won't be possible. In this case, the board must be set in
+ *           bootloader mode by double tapping the reset button before running the
+ *           flash command.
+ *
  * ### Accessing STDIO via UART
  *
- * To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
- * the RX/TX pins on the board.
+ * STDIO of RIOT is directly available over the USB port.
  *
+ * The `TERM_DELAY` environment variable can be used to add a delay (in second)
+ * before opening the serial terminal. The default value is 2s which should be
+ * enough in most of the situation.
  */

--- a/boards/sodaq-sara-aff/doc.txt
+++ b/boards/sodaq-sara-aff/doc.txt
@@ -12,20 +12,22 @@
  *
  * ### Flash the board
  *
- * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
- *    When the board is in bootloader mode, the user led (blue) oscillates
- *    smoothly.
- *
- *
- * 2. Use `BOARD=sodaq-sara-aff` with the `make` command.<br/>
- *    Example with `hello-world` application:
+ * Use `BOARD=sodaq-sara-aff` with the `make` command.<br/>
+ * Example with `hello-world` application:
  * ```
  *      make BOARD=sodaq-sara-aff -C examples/hello-world flash
  * ```
  *
+ * @note     If the application crashes, automatic reflashing via USB, as explained
+ *           above won't be possible. In this case, the board must be set in
+ *           bootloader mode by double tapping the reset button before running the
+ *           flash command.
+ *
  * ### Accessing STDIO via UART
  *
- * To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
- * the RX/TX pins on the board.
+ * STDIO of RIOT is directly available over the USB port.
  *
+ * The `TERM_DELAY` environment variable can be used to add a delay (in second)
+ * before opening the serial terminal. The default value is 2s which should be
+ * enough in most of the situation.
  */

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -28,6 +28,10 @@ MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
 # default value (0, no delay)
 MAKE_RESET_DELAY = int(os.environ.get('TESTRUNNER_RESET_DELAY') or 0)
 
+# Setting an empty 'TESTRUNNER_CONNECT_DELAY' environment variable use the
+# default value (0)
+MAKE_TERM_CONNECT_DELAY = int(os.environ.get('TESTRUNNER_CONNECT_DELAY') or 0)
+
 # Allow customizing test interactive settings with environment variables
 TEST_INTERACTIVE_RETRIES = int(os.environ.get('TEST_INTERACTIVE_RETRIES') or 5)
 TEST_INTERACTIVE_DELAY = int(os.environ.get('TEST_INTERACTIVE_DELAY') or 1)
@@ -65,6 +69,10 @@ def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
     # Some boards can't be reset after a terminal is open. Therefore reset
     # before `cleanterm`.
     _reset_board(env)
+
+    # on platforms exposing UART over USB, wait a little before connecting to
+    # the serial terminal. This gives time for stdio to be ready.
+    time.sleep(MAKE_TERM_CONNECT_DELAY)
 
     child = spawnclass("make cleanterm", env=env, timeout=timeout,
                        codec_errors='replace', echo=False)

--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -14,9 +14,18 @@ ifneq (,$(BOSSA_ARDUINO_PREFLASH))
 
   PREFLASHER ?= stty
   PREFFLAGS  ?= $(STTY_FLAG) $(PROG_DEV) raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
-  FLASHDEPS += preflash
+  ifneq (,$(PREFLASH_DELAY))
+    FLASHDEPS += preflash-delay
+  else
+    FLASHDEPS += preflash
+  endif
 
+  RESETFFLASG ?= $(STTY_FLAG) $(PORT) raw ispeed 600 ospeed 600 cs8 -cstopb ignpar eol 255 eof 255
+  RESET ?= $(PREFLASHER) $(RESETFFLASG)
 endif
+
+preflash-delay: preflash
+	sleep $(PREFLASH_DELAY)
 
 # if we go with the default (BOSSA shipped with RIOT), we download and build
 # the tool if not already done

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1,6 +1,7 @@
 ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_OPTIONAL += periph_i2c
   FEATURES_OPTIONAL += periph_spi
+  FEATURES_REQUIRED += periph_uart
 endif
 
 ifneq (,$(filter eepreg,$(USEMODULE)))

--- a/sys/include/usb_board_reset.h
+++ b/sys/include/usb_board_reset.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_usb_board_reset Board reset via USB CDC ACM
+ * @ingroup     sys
+ * @brief       Trigger a board reset via USB CDC ACM
+ *
+ * @{
+ *
+ * @file
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef USB_BOARD_RESET_H
+#define USB_BOARD_RESET_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+
+#include "usb/usbus/cdc/acm.h"
+
+/**
+ * @brief   USB coding callback used to trigger the board reset
+ *
+ * @param[in] cdcacm    Pointer to the cdcacm device
+ * @param[in] baud      Baudrate used by the client. Only 1200 baud is taken into account
+ * @param[in] bits      Number of bit mode used by the client
+ * @param[in] parity    Parity mode used by the client
+ * @param[in] stop      Stop bit mode used by the client
+ *
+ * @return  Always return 0
+ */
+int usb_board_reset_coding_cb(usbus_cdcacm_device_t *cdcacm,
+                              uint32_t baud, uint8_t bits,
+                              uint8_t parity, uint8_t stop);
+
+/**
+ * @brief   Trigger a simple reset, back to the application
+ */
+void usb_board_reset_in_application(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_BOARD_RESET_H */
+/** @} */

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 
+#include "log.h"
 #include "isrpipe.h"
 
 #include "usb/usbus.h"
@@ -30,6 +31,10 @@
 
 #if MODULE_VFS
 #include "vfs.h"
+#endif
+
+#ifdef MODULE_USB_BOARD_RESET
+#include "usb_board_reset.h"
 #endif
 
 static usbus_cdcacm_device_t cdcacm;
@@ -78,4 +83,7 @@ void usb_cdc_acm_stdio_init(usbus_t *usbus)
 {
     usbus_cdc_acm_init(usbus, &cdcacm, _cdc_acm_rx_pipe, NULL,
                        _cdc_tx_buf_mem, sizeof(_cdc_tx_buf_mem));
+#ifdef MODULE_USB_BOARD_RESET
+    usbus_cdc_acm_set_coding_cb(&cdcacm, usb_board_reset_coding_cb);
+#endif
 }

--- a/sys/usb_board_reset/Makefile
+++ b/sys/usb_board_reset/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/usb_board_reset/usb_board_reset.c
+++ b/sys/usb_board_reset/usb_board_reset.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys
+ * @{
+ * @file
+ *
+ * @author  Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @}
+ */
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
+#include "log.h"
+
+#include "usb/usbus/cdc/acm.h"
+#include "usb_board_reset.h"
+
+#include "periph/pm.h"
+
+#ifndef RESET_IN_BOOTLOADER_TRIGGER_BAUDRATE
+#define RESET_IN_BOOTLOADER_TRIGGER_BAUDRATE    (1200U)
+#endif
+
+#ifndef RESET_IN_APPLICATION_TRIGGER_BAUDRATE
+#define RESET_IN_APPLICATION_TRIGGER_BAUDRATE   (600U)
+#endif
+
+void usb_board_reset_in_bootloader(void);
+
+int usb_board_reset_coding_cb(usbus_cdcacm_device_t *cdcacm,
+                              uint32_t baud, uint8_t bits,
+                              uint8_t parity, uint8_t stop)
+{
+    (void)cdcacm;
+    (void)bits;
+    (void)parity;
+    (void)stop;
+    switch (baud) {
+        case RESET_IN_BOOTLOADER_TRIGGER_BAUDRATE:
+            LOG_DEBUG("[cdc-acm-stdio] reset in bootloader");
+            usb_board_reset_in_bootloader();
+            break;
+        case RESET_IN_APPLICATION_TRIGGER_BAUDRATE:
+            LOG_DEBUG("[cdc-acm-stdio] reset in application");
+            usb_board_reset_in_application();
+            break;
+        default:
+            (void)baud;
+            break;
+    }
+
+    return 0;
+}
+
+void usb_board_reset_in_application(void)
+{
+    pm_reboot();
+    while (1) {}
+}

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -7,6 +7,10 @@ USEMODULE += xtimer
 LOW_MEMORY_BOARDS += \
   airfy-beacon \
   arduino-mega2560 \
+  arduino-mkr1000 \
+  arduino-mkrfox1200 \
+  arduino-mkrwan1300 \
+  arduino-mkrzero \
   atmega1284p \
   b-l072z-lrwan1 \
   blackpill \
@@ -20,6 +24,7 @@ LOW_MEMORY_BOARDS += \
   cc2650stk \
   chronos \
   derfmega128 \
+  feather-m0 \
   hifive1 \
   hifive1b \
   i-nucleo-lrwan1 \
@@ -45,6 +50,10 @@ LOW_MEMORY_BOARDS += \
   opencm904 \
   saml10-xpro \
   saml11-xpro \
+  sodaq-autonomo \
+  sodaq-explorer \
+  sodaq-one \
+  sodaq-sara-aff \
   spark-core \
   stm32f0discovery \
   stm32l0538-disco \

--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -2,6 +2,10 @@ include ../Makefile.tests_common
 
 USEMODULE += ssp
 
+# This test intentionally crashes the firmware and when using a board with a
+# preflashed bootloader, it cannot be reflashed automatically afterwards.
+FEATURES_BLACKLIST += bootloader_arduino
+
 include $(RIOTBASE)/Makefile.include
 
 ifneq (,$(shell $(CC) --help=warnings | grep '\-Wstringop-overflow='))

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -13,6 +13,12 @@ endif
 
 DISABLE_MODULE += auto_init
 
+# boards using arduino bootloader require auto_init to
+# automatically initialize stdio over USB. Without this, the bootloader
+# management feature cannot be used (auto reset and auto reboot in bootloader
+# mode)
+FEATURES_BLACKLIST += bootloader_arduino
+
 # Pull in `Makefile.include`s from the test suites:
 -include $(UNIT_TESTS:%=$(RIOTBASE)/tests/unittests/%/Makefile.include)
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides stdio over USB to all Arduino MKR boards and setup the reset in bootloader mode like it's done with Arduino IDE.

In Arduino, the application resets in bootloader mode when the stdio is opened at 1200 baud.
In this PR, the hook function is implemented in `board.c` but the actual connection with `cdc_acm_stdio` is done in the `cdc_acm_stdio` module only when the RESET_IN_BOOTLOADER module is loaded. This might not be the cleanest solution but it works. Any better suggestion is welcome of course.

To be able to reset in bootloader, there are other tricks:
- open the serial at 1200 baud with stty
- force the bootloader mode after reset: this code was taken from @ynezz who commented about it in #7510. His code is  [here](https://github.com/ynezz/RIOT/commit/9ca8afc4dffdf583824a0d01b19da3dda3529714#diff-970cb2802ea5c7c9ca519a80fe0b1327). I just readapted it for this PR.
- Adapted the build system in order to add a delay after preflash command (to let some time for the board to reset in bootloader mode)

I'm testing this PR with arduino-mkrfox1200 but it should work the same with other mkr boards. It's also easily adaptable to SODAQ and Feather-M0 boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just build/flash/term any application with an Arduino MKR board plugged via USB : the board is automatically flashed and stdio is printed (shell works as well).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on (the awesome) #11085 to get the stdio over USB feature.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
