### PR TITLE
Makefile.include: add flash-only as dependency of term

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -616,7 +616,7 @@ preflash: $(BUILD_BEFORE_FLASH)
 
 termdeps: $(TERMDEPS)
 
-term: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
+term: $(filter flash flash-only, $(MAKECMDGOALS)) $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
 


### PR DESCRIPTION

### Contribution description

Currently it is only enforced that `flash` is called before `term` but not flash-only. This PR fixes that.

### Testing procedure

In master:

```
make -C examples/hello-world/ BOARD=samr21-xpro term flash-only
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-09-26 10:01:45,787 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
```

This PR:

```
make -C examples/hello-world/ BOARD=samr21-xpro term flash-only
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/francisco/workspace/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800011523 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming.................................... done.
Verification.................................... done.
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-09-26 10:01:58,194 - INFO # Connect to serial port /dev/ttyACM0
```

### Issues/PRs references

