### PR TITLE
riotboot: add RIOTBOOT_BUILD make var

### DIFF
--- a/bootloaders/riotboot/Makefile
+++ b/bootloaders/riotboot/Makefile
@@ -7,6 +7,8 @@ BOARD ?= samr21-xpro
 # Select the boards with riotboot feature
 FEATURES_REQUIRED += riotboot
 
+# Set RIOTBOOT_BUILD to indicate a riotboot application build
+RIOTBOOT_BUILD = 1
 # Provide a define to detect if building the bootloader
 CFLAGS += -DRIOTBOOT
 

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -1,4 +1,5 @@
 ifneq (,$(filter riotboot,$(FEATURES_USED)))
+ifneq (1,$(RIOTBOOT_BUILD))
 
 .PHONY: riotboot/flash riotboot/flash-bootloader riotboot/flash-slot0 riotboot/flash-slot1 riotboot/bootloader/%
 
@@ -154,4 +155,5 @@ riotboot:
 	$(Q)echo "error: riotboot feature not selected! (try FEATURES_REQUIRED += riotboot)"
 	$(Q)false
 
+endif # (1,$(RIOTBOOT_BUILD))
 endif # (,$(filter riotboot,$(FEATURES_USED)))


### PR DESCRIPTION
### Contribution description

This PR attempts to fix the first part of #12003 

> * Introduced by bb71e979f
>   * the file use when flashing is not the bootloader firmware but an extended bootloader with a slot0 bootloader. So `riotboot/flash-bootloader` would overwrite `slot0` and `slot1` header.

With the pseudomodule we can specify that the bootloader application is using to `bootloader` itself, and normal applications aren't, they are just using `riotboot` modules or functionality.

This allows defining FLASHFILE as a regular `ELFFILE` for the bootloader and keeping the current behavior where we wan't it, i.e. flashing an application + boot-loader using `riotboot`.

All boards providing riotboot now provide `riotboot_bootloader`.

### Testing procedure

- Verify this fixes the issue:

```
BOARD=iotlab-m3 make --no-print-directory -C bootloaders/riotboot/ info-debug-variable-FLASHFILE
/home/francisco/workspace/RIOT/bootloaders/riotboot/bin/iotlab-m3/riotboot.elf
```

- Previous behavior is kept

```
BOARD=iotlab-m3 make --no-print-directory -C tests/riotboot/ info-debug-variable-FLASHFILE
/home/francisco/workspace/RIOT/tests/riotboot/bin/iotlab-m3/tests_riotboot-slot0-extended.bin
```

### Issues/PRs references

Addresses #12003 
Related to #12302