### PR TITLE
[WIP] automatically set GNRC_NETIF_NUMOF

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -311,13 +311,6 @@ include $(RIOTMAKE)/toolchain/$(TOOLCHAIN).inc.mk
 # For more information, see http://petereisentraut.blogspot.com/2011/09/ccache-and-clang-part-2.html
 export CCACHE_CPP2=yes
 
-# get number of interfaces straight before resolving dependencies
-GNRC_NETIF_NUMOF ?= 1
-
-ifneq ($(GNRC_NETIF_NUMOF),1)
-  CFLAGS += -DGNRC_NETIF_NUMOF=$(GNRC_NETIF_NUMOF)
-endif
-
 # handle removal of default modules
 USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
 

--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -42,8 +42,6 @@
 #define AT86RF2XX_MAC_PRIO          (GNRC_NETIF_PRIO)
 #endif
 
-#define AT86RF2XX_NUM ARRAY_SIZE(at86rf2xx_params)
-
 static at86rf2xx_t at86rf2xx_devs[AT86RF2XX_NUM];
 static char _at86rf2xx_stacks[AT86RF2XX_NUM][AT86RF2XX_MAC_STACKSIZE];
 

--- a/sys/auto_init/netif/auto_init_cc110x.c
+++ b/sys/auto_init/netif/auto_init_cc110x.c
@@ -55,11 +55,6 @@
 #endif
 
 /**
- * @brief   Calculate the number of configured CC1100/CC1101 transceivers
- */
-#define CC110X_NUM                      ARRAY_SIZE(cc110x_params)
-
-/**
  * @brief   Statically allocate memory for device descriptors
  */
 cc110x_t _cc110x_devs[CC110X_NUM];

--- a/sys/auto_init/netif/auto_init_cc2420.c
+++ b/sys/auto_init/netif/auto_init_cc2420.c
@@ -40,21 +40,16 @@
 /** @} */
 
 /**
- * @brief   Get the number of configured CC2420 devices
- */
-#define CC2420_NUMOF        ARRAY_SIZE(cc2420_params)
-
-/**
  * @brief   Allocate memory for dev descriptors, stacks, and 802.15.4 adaption
  * @{
  */
-static cc2420_t cc2420_devs[CC2420_NUMOF];
-static char _cc2420_stacks[CC2420_NUMOF][CC2420_MAC_STACKSIZE];
+static cc2420_t cc2420_devs[CC2420_NUM];
+static char _cc2420_stacks[CC2420_NUM][CC2420_MAC_STACKSIZE];
 /** @} */
 
 void auto_init_cc2420(void)
 {
-    for (unsigned i = 0; i < CC2420_NUMOF; i++) {
+    for (unsigned i = 0; i < CC2420_NUM; i++) {
         LOG_DEBUG("[auto_init_netif] initializing cc2420 #%u\n", i);
 
         cc2420_setup(&cc2420_devs[i], &cc2420_params[i]);

--- a/sys/auto_init/netif/auto_init_enc28j60.c
+++ b/sys/auto_init/netif/auto_init_enc28j60.c
@@ -37,11 +37,6 @@
 /*** @} */
 
 /**
- * @brief   Find out how many of these devices we need to care for
- */
-#define ENC28J60_NUM    ARRAY_SIZE(enc28j60_params)
-
-/**
  * @brief   Allocate memory for the device descriptors
  * @{
  */

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -39,8 +39,6 @@
 #define KW2XRF_MAC_PRIO          (GNRC_NETIF_PRIO)
 #endif
 
-#define KW2XRF_NUM ARRAY_SIZE(kw2xrf_params)
-
 static kw2xrf_t kw2xrf_devs[KW2XRF_NUM];
 static char _kw2xrf_stacks[KW2XRF_NUM][KW2XRF_MAC_STACKSIZE];
 

--- a/sys/auto_init/netif/auto_init_mrf24j40.c
+++ b/sys/auto_init/netif/auto_init_mrf24j40.c
@@ -36,8 +36,6 @@
 #define MRF24J40_MAC_PRIO          (GNRC_NETIF_PRIO)
 #endif
 
-#define MRF24J40_NUM ARRAY_SIZE(mrf24j40_params)
-
 static mrf24j40_t mrf24j40_devs[MRF24J40_NUM];
 static char _mrf24j40_stacks[MRF24J40_NUM][MRF24J40_MAC_STACKSIZE];
 

--- a/sys/auto_init/netif/auto_init_slipdev.c
+++ b/sys/auto_init/netif/auto_init_slipdev.c
@@ -27,8 +27,6 @@
 #include "slipdev.h"
 #include "slipdev_params.h"
 
-#define SLIPDEV_NUM ARRAY_SIZE(slipdev_params)
-
 /**
  * @brief   Define stack parameters for the MAC layer thread
  * @{

--- a/sys/auto_init/netif/auto_init_sx127x.c
+++ b/sys/auto_init/netif/auto_init_sx127x.c
@@ -28,11 +28,6 @@
 #include "sx127x_params.h"
 
 /**
- * @brief   Calculate the number of configured SX127x devices
- */
-#define SX127X_NUMOF        ARRAY_SIZE(sx127x_params)
-
-/**
  * @brief   Define stack parameters for the MAC layer thread
  */
 #define SX127X_STACKSIZE           (THREAD_STACKSIZE_DEFAULT)
@@ -43,12 +38,12 @@
 /**
  * @brief   Allocate memory for device descriptors, stacks, and GNRC adaption
  */
-static sx127x_t sx127x_devs[SX127X_NUMOF];
-static char sx127x_stacks[SX127X_NUMOF][SX127X_STACKSIZE];
+static sx127x_t sx127x_devs[SX127X_NUM];
+static char sx127x_stacks[SX127X_NUM][SX127X_STACKSIZE];
 
 void auto_init_sx127x(void)
 {
-    for (unsigned i = 0; i < SX127X_NUMOF; ++i) {
+    for (unsigned i = 0; i < SX127X_NUM; ++i) {
 #if defined(MODULE_SX1272)
         LOG_DEBUG("[auto_init_netif] initializing sx1272 #%u\n", i);
 #else /* MODULE_SX1276 */

--- a/sys/auto_init/netif/auto_init_w5100.c
+++ b/sys/auto_init/netif/auto_init_w5100.c
@@ -33,11 +33,6 @@
 /*** @} */
 
 /**
- * @brief   Find out how many of these devices we need to care for
- */
-#define W5100_NUM    ARRAY_SIZE(w5100_params)
-
-/**
  * @brief   Allocate memory for the device descriptors
  * @{
  */

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -28,11 +28,6 @@
 #include "xbee_params.h"
 
 /**
- * @brief   Calculate the number of configured XBee devices
- */
-#define XBEE_NUM        ARRAY_SIZE(xbee_params)
-
-/**
  * @brief   Define stack parameters for the MAC layer thread
  */
 #define XBEE_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT)

--- a/sys/include/auto_init_netif.h
+++ b/sys/include/auto_init_netif.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2019 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_auto_init_gnrc_netif
+ * @brief       Auto initialize network interfaces
+ *
+ * @{
+ *
+ * @file
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef AUTO_INIT_NETIF_H
+#define AUTO_INIT_NETIF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef MODULE_AT86RF2XX
+#include "at86rf2xx.h"
+#include "at86rf2xx_params.h"
+#define AT86RF2XX_NUM ARRAY_SIZE(at86rf2xx_params)
+#else
+#define AT86RF2XX_NUM (0)
+#endif
+
+#ifdef MODULE_CC2420
+#include "cc2420_params.h"
+#define CC2420_NUM ARRAY_SIZE(cc2420_params)
+#else
+#define CC2420_NUM (0)
+#endif
+
+#ifdef MODULE_KW2XRF
+#include "kw2xrf_params.h"
+#define KW2XRF_NUM ARRAY_SIZE(kw2xrf_params)
+#else
+#define KW2XRF_NUM (0)
+#endif
+
+#ifdef MODULE_MRF24J40
+#include "mrf24j40_params.h"
+#define MRF24J40_NUM ARRAY_SIZE(mrf24j40_params)
+#else
+#define MRF24J40_NUM (0)
+#endif
+
+#ifdef MODULE_SLIPDEV
+#include "slipdev_params.h"
+#define SLIPDEV_NUM ARRAY_SIZE(slipdev_params)
+#else
+#define SLIPDEV_NUM (0)
+#endif
+
+#ifdef MODULE_SX127X
+#include "sx127x_params.h"
+#define SX127X_NUM ARRAY_SIZE(sx127x_params)
+#else
+#define SX127X_NUM (0)
+#endif
+
+#ifdef MODULE_W5100
+#include "w5100_params.h"
+#define W5100_NUM ARRAY_SIZE(w5100_params)
+#else
+#define W5100_NUM (0)
+#endif
+
+#ifdef MODULE_XBEE
+#include "xbee_params.h"
+#define XBEE_NUM ARRAY_SIZE(xbee_params)
+#else
+#define XBEE_NUM (0)
+#endif
+
+#ifdef MODULE_NETDEV_TAP
+#include "netdev_tap_params.h"
+#define NETDEV_TAP_NUM (NETDEV_TAP_MAX)
+#else
+#define NETDEV_TAP_NUM (0)
+#endif
+
+#ifdef MODULE_SOCKET_ZEP
+#include "socket_zep_params.h"
+#define NETDEV_SOCKET_ZEP_NUM (SOCKET_ZEP_MAX)
+#else
+#define NETDEV_SOCKET_ZEP_NUM (0)
+#endif
+
+#ifdef MODULE_CC2538_RF
+#define CC2538_RF_NUM (1)
+#else
+#define CC2538_RF_NUM (0)
+#endif
+
+#ifdef MODULE_CDCECM
+#define CDCECM_NUM (1)
+#else
+#define CDCECM_NUM (0)
+#endif
+
+#ifdef MODULE_ETHOS
+#define ETHOS_NUM (1)
+#else
+#define ETHOS_NUM (0)
+#endif
+
+#ifdef MODULE_NRF802154
+#define NRF802154_NUM (1)
+#else
+#define NRF802154_NUM (0)
+#endif
+
+#ifdef MODULE_STM32_ETH
+#define STM32_ETH_NUM (1)
+#else
+#define STM32_ETH_NUM (0)
+#endif
+
+#define GNRC_NETIF_NUMOF (AT86RF2XX_NUM + CC2420_NUM + KW2XRF_NUM + MRF24J40_NUM    \
+                         + SLIPDEV_NUM + SX127X_NUM + W5100_NUM + XBEE_NUM          \
+                         + CC2538_RF_NUM + CDCECM_NUM + ETHOS_NUM + NRF802154_NUM   \
+                         + STM32_ETH_NUM + NETDEV_TAP_NUM + NETDEV_SOCKET_ZEP_NUM)
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* AUTO_INIT_NETIF_H */

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -30,6 +30,9 @@
 
 #include "kernel_types.h"
 #include "msg.h"
+
+#include "auto_init_netif.h"
+
 #include "net/ipv6/addr.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/pkt.h"

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -36,11 +36,9 @@
 #include <inttypes.h>
 #endif
 
-#if (GNRC_NETIF_NUMOF > 1)
 /* TODO: change API to make link-local address communitcation with
  * multiple network interfaces */
-#warning "gnrc_tftp does not work reliably with link-local addresses and >1 network interfaces."
-#endif
+_Static_assert(GNRC_NETIF_NUMOF == 1, "gnrc_tftp does not work reliably with link-local addresses and >1 network interfaces.");
 
 static kernel_pid_t _tftp_kernel_pid;
 

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -53,7 +53,7 @@ gnrc_netif_t *gnrc_netif_create(char *stack, int stacksize, char priority,
     gnrc_netif_t *netif = NULL;
     int res;
 
-    for (int i = 0; i < GNRC_NETIF_NUMOF; i++) {
+    for (unsigned i = 0; i < GNRC_NETIF_NUMOF; i++) {
         if (_netifs[i].dev == netdev) {
             return &_netifs[i];
         }
@@ -1091,25 +1091,6 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
     return (idx < 0) ? NULL : &netif->ipv6.addrs[idx];
 }
 #endif  /* MODULE_GNRC_IPV6 */
-
-#if (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN)
-bool gnrc_netif_is_6ln(const gnrc_netif_t *netif)
-{
-    switch (netif->device_type) {
-#ifdef MODULE_GNRC_SIXLOENC
-        case NETDEV_TYPE_ETHERNET:
-#endif
-        case NETDEV_TYPE_IEEE802154:
-        case NETDEV_TYPE_CC110X:
-        case NETDEV_TYPE_BLE:
-        case NETDEV_TYPE_NRFMIN:
-        case NETDEV_TYPE_ESP_NOW:
-            return true;
-        default:
-            return false;
-    }
-}
-#endif  /* (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN) */
 
 static void _update_l2addr_from_dev(gnrc_netif_t *netif)
 {

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
@@ -26,37 +26,41 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#ifndef GNRC_RPL_DEFAULT_NETIF
+#define GNRC_RPL_DEFAULT_NETIF (0)
+#endif
+
 void auto_init_gnrc_rpl(void)
 {
-#if (GNRC_NETIF_NUMOF == 1)
-    gnrc_netif_t *netif = gnrc_netif_iter(NULL);
-    if (netif == NULL) {
-        /* XXX this is just a work-around ideally this would happen with
-         * an `up` event of the interface */
-        LOG_INFO("Unable to auto-initialize RPL. No interfaces found.\n");
-        return;
-    }
-    DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n",
-          netif->pid);
-    gnrc_rpl_init(netif->pid);
-    return;
-#elif defined(GNRC_RPL_DEFAULT_NETIF)
-    if (gnrc_netif_get_by_pid(GNRC_RPL_DEFAULT_NETIF) != NULL) {
+    if (GNRC_NETIF_NUMOF == 1) {
+        gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+        if (netif == NULL) {
+            /* XXX this is just a work-around ideally this would happen with
+             * an `up` event of the interface */
+            LOG_INFO("Unable to auto-initialize RPL. No interfaces found.\n");
+            return;
+        }
         DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n",
-              GNRC_RPL_DEFAULT_NETIF);
-        gnrc_rpl_init(GNRC_RPL_DEFAULT_NETIF);
+              netif->pid);
+        gnrc_rpl_init(netif->pid);
         return;
+    } else if (GNRC_RPL_DEFAULT_NETIF) {
+        if (gnrc_netif_get_by_pid(GNRC_RPL_DEFAULT_NETIF) != NULL) {
+            DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n",
+                  GNRC_RPL_DEFAULT_NETIF);
+            gnrc_rpl_init(GNRC_RPL_DEFAULT_NETIF);
+            return;
+        }
+        /* XXX this is just a work-around ideally this would happen with
+         * an `up` event of the GNRC_RPL_DEFAULT_NETIF */
+        DEBUG("auto_init_gnrc_rpl: could not initialize RPL on interface %" PRIkernel_pid" - "
+              "interface does not exist\n", GNRC_RPL_DEFAULT_NETIF);
+        return;
+    } else {
+        /* XXX this is just a work-around ideally this should be defined in some
+         * run-time interface configuration */
+        DEBUG("auto_init_gnrc_rpl: please specify an interface by setting GNRC_RPL_DEFAULT_NETIF\n");
     }
-    /* XXX this is just a work-around ideally this would happen with
-     * an `up` event of the GNRC_RPL_DEFAULT_NETIF */
-    DEBUG("auto_init_gnrc_rpl: could not initialize RPL on interface %" PRIkernel_pid" - "
-          "interface does not exist\n", GNRC_RPL_DEFAULT_NETIF);
-    return;
-#else
-    /* XXX this is just a work-around ideally this should be defined in some
-     * run-time interface configuration */
-    DEBUG("auto_init_gnrc_rpl: please specify an interface by setting GNRC_RPL_DEFAULT_NETIF\n");
-#endif
 }
 #else
 typedef int dont_be_pedantic;

--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -103,14 +103,17 @@ static inline void gnrc_ep_set(sock_ip_ep_t *out, const sock_ip_ep_t *in,
                                size_t in_size)
 {
     memcpy(out, in, in_size);
-#if GNRC_NETIF_NUMOF == 1
+
+    if (GNRC_NETIF_NUMOF > 1) {
+        return;
+    }
+
     /* set interface implicitly */
     gnrc_netif_t *netif = gnrc_netif_iter(NULL);
 
     if (netif != NULL) {
         out->netif = netif->pid;
     }
-#endif
 }
 
 /**

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -183,11 +183,9 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
             if (iface != -1) {
                 data->netif = gnrc_netif_get_by_pid(iface);
             }
-#if GNRC_NETIF_NUMOF == 1
-            else {
+            else if (GNRC_NETIF_NUMOF == 1) {
                 data->netif = gnrc_netif_iter(NULL);
             }
-#endif
             if (ipv6_addr_from_str(&data->host, data->hostname) == NULL) {
                 break;
             }


### PR DESCRIPTION
### Contribution description
Currently, `GNRC_NETIF_NUMOF` has to be set manually.
This PR changes that so that each network interface will increment `GNRC_NETIF_NUMOF` at compile-time.

Since `GNRC_NETIF_NUMOF` now consists of `0 + 0 + sizeof(…) + 0 + sizeof(…) + …` the processor can not evaluate it anymore. This is not a problem since the compiler will see the same job if it sees an `if (0)`.
But as a prerequisite, many `#if (GNRC_NETIF_NUMOF > 0)` had to be changed into `if (GNRC_NETIF_NUMOF > 0)`.

As expected, code size did not increase.

### Testing procedure

Check if everything still works, especially examples/tests that define `GNRC_NETIF_NUMOF := 2`

### Issues/PRs references
#11979
#9903