### PR TITLE
ble/skald: remove broken assert in init()

### DIFF
--- a/sys/net/ble/skald/skald.c
+++ b/sys/net/ble/skald/skald.c
@@ -104,8 +104,6 @@ static void _on_radio_evt(netdev_t *netdev, netdev_event_t event)
 
 void skald_init(void)
 {
-    assert(dev);
-
     /* setup and a fitting radio driver - potentially move to auto-init at some
      * point */
 #if defined(MODULE_NRFBLE)


### PR DESCRIPTION
### Contribution description
Right now, skald does not build when buidling with develhelp, simple reason a leftover `assert()` on a non-existing variable. This PR removes that statement.

The fix should be quite obvious :-)

### Testing procedure
Build any of the `skald` examples (`examples/skald_ibeacon/eddystone`) with on master enabling develhelp -> it won't build. Do the same with this PR -> i will build.

### Issues/PRs references
none