### PR TITLE
ble/skald: cleanup dependency to nrfble

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -825,6 +825,7 @@ endif
 
 ifneq (,$(filter skald,$(USEMODULE)))
   FEATURES_REQUIRED += radio_nrfble
+  USEMODULE += nrfble
   USEMODULE += xtimer
   USEMODULE += random
 endif

--- a/boards/common/nrf52/Makefile.dep
+++ b/boards/common/nrf52/Makefile.dep
@@ -1,7 +1,3 @@
-ifneq (,$(filter skald,$(USEMODULE)))
-  USEMODULE += nrfble
-endif
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_nrf_temperature
 endif


### PR DESCRIPTION
### Contribution description
Currently, Skald depends on the `nrfble` driver to work. Although this might change in the future (e.g. by having other BLE device drivers for other types of BLE radios), this will not happen in the near future. So for now, it is much cleaner to have this dependency expressed directly in `Makefile.dep` instead of the some (common) board Makefile...

### Testing procedure
`make buildtest` in on of the skald examples should (successfully) build for the same set of boards then in master.

### Issues/PRs references
none