### PR TITLE
cpu/cortexm: don't disable IRQs in cpu_jump_to_image()

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -199,8 +199,19 @@ static inline void cortexm_isr_end(void)
  */
 static inline void cpu_jump_to_image(uint32_t image_address)
 {
-    /* Disable IRQ */
-    __disable_irq();
+    /* On Cortex-M platforms, the flash begins with:
+     *
+     * 1. 4 byte pointer to stack to be used at startup
+     * 2. 4 byte pointer to the reset vector function
+     *
+     * On powerup, the CPU sets the stack pointer and starts executing the
+     * reset vector.
+     *
+     * We're doing the same here, but we'd like to start at image_address.
+     *
+     * This function must be called while executing from MSP (Master Stack
+     * Pointer).
+     */
 
     /* set MSP */
     __set_MSP(*(uint32_t*)image_address);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

```cpu_jump_to_image()``` disables IRQs. As the function is supposed to be called from bootloaders, this shouldn't be necessary.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Primarily all users of riotboot must still work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes #12311. *edit* fixed reference