### PR TITLE
cpu/nrf5x: decelare radio_nrfble feat for all nrfs

### DIFF
--- a/boards/common/nrf52/Makefile.features
+++ b/boards/common/nrf52/Makefile.features
@@ -9,4 +9,3 @@ endif
 
 # Various other features (if any)
 FEATURES_PROVIDED += ble_nimble
-FEATURES_PROVIDED += radio_nrfble

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -9,6 +9,7 @@ FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += periph_wdt periph_wdt_cb
 
 # Various other features (if any)
+FEATURES_PROVIDED += radio_nrfble
 FEATURES_PROVIDED += radio_nrfmin
 FEATURES_PROVIDED += puf_sram
 


### PR DESCRIPTION
# Contribution description
The `nrfble` driver is working for all nrf-based CPUs (nrf51 and nrf52x), but the `radio_nrfble` feature is right now only and weirdly declared in `boards/common/nrf52/Makefile.features`. So the clean way would obviously be to declare that feature in `cpu/nrf5x_common/Makefile.features`, same as already done for `radio_nrfmin`.

Besides the structural cleanup, this change does furthermore enable `skald` to be build on `nrf51`-based platforms. This is intended and works as expected.

### Testing procedure
`make buildtest` for `examples/skald_x` should build all boards that were build before, and also for all `nrf51`-based ones.

Further, at least one `nrf51`-based board should be flashed with a `skald` example and its behavior should should be verified with any BLE scanner (e.g. use your phone or `examples/nimble_scanner` on any `nrf52`-based board).

### Issues/PRs references
none