### PR TITLE
tests: add distinct test app for nrfmin driver

### DIFF
--- a/tests/driver_nrfmin/Makefile
+++ b/tests/driver_nrfmin/Makefile
@@ -1,0 +1,15 @@
+BOARD ?= nrf52dk
+include ../Makefile.tests_common
+
+# include nrfmin, the main purpose of this test
+USEMODULE += nrfmin
+# use a minimal GNRC configuration
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_ipv6
+USEMODULE += gnrc_icmpv6_echo
+# also add the shell with some basic shell commands
+USEMODULE += shell
+USEMODULE += shell_commands
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_nrfmin/README.md
+++ b/tests/driver_nrfmin/README.md
@@ -1,0 +1,10 @@
+# Test for the `nrfmin` radio driver
+The `nrfmin` driver is a RIOT specific driver that runs the on-chip radios on
+Nordic nRF5x-based CPUs in a proprietary mode. But per default, we run the nRF's
+radios either in BLE mode (using NImBLE), or in IEEE802.15.4 mode (using the
+`nrf802154` driver).
+
+To make sure the `nrfmin` driver is still covered by RIOT's test system, this
+test application is added. The test simply contains a basic GNRC configuration
+and of course the `nrfmin` driver, which should be enough to verify the drivers
+functionality.

--- a/tests/driver_nrfmin/main.c
+++ b/tests/driver_nrfmin/main.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test for the Nordic specific nrfmin radio driver
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("Test for the RIOT integration of the nrfmin radio driver");
+
+    /* start shell */
+    puts("All up, running the shell now");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}

--- a/tests/driver_nrfmin/tests/01-run.py
+++ b/tests/driver_nrfmin/tests/01-run.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("All up, running the shell now")
+    child.sendline("ifconfig")
+    child.expect(r"Iface\s+(\d+)\s+HWaddr:")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=1, echo=False))


### PR DESCRIPTION
# Contribution description
At the moment, we make `nrfmin` as default netif interface for some randomly selected nrf52-based platforms (e.g. `ruuvitag`). I think it would be much better to be consistent and have the same default interfaces for all platforms using the same CPU:
- `nrf51`, `nrf52832` -> `nimble_netif`
- `nrf52840` -> ´nrf802154`

But if we would apply that mapping right now (see also discussion in #11792), `nrfmin` would be dropped from our testing. So this PR adds a dedicated test application for this driver to make sure this doesn't happen.

### Testing procedure
Run `make test` for any nrf-based board, it should always work :-)

### Issues/PRs references
#11792 does some dependency cleanup for `nrf52`-based boards. With this the generic structure can even be more simplified.