### PR TITLE
netbuf: add initial support

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -151,6 +151,9 @@ endif
 ifneq (,$(filter credman,$(USEMODULE)))
   DIRS += net/credman
 endif
+ifneq (,$(filter netbuf,$(USEMODULE)))
+  DIRS += net/netbuf
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, $(USEMODULE))))
 

--- a/sys/include/net/netbuf.h
+++ b/sys/include/net/netbuf.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_netbuf Network buffer abstraction
+ * @ingroup     net
+ * @brief       Provides an abstraction for network stack buffers
+ * @{
+ *
+ * @file
+ * @brief       Network buffer abstraction definition
+ *
+ * @author  Jose I. Alamos <jose.alamos@haw-hamburg.de>
+ */
+#ifndef NET_NETBUF_H
+#define NET_NETBUF_H
+
+#include <stdbool.h>
+#include "assert.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Netbuf descriptor
+ */
+typedef struct {
+    void *data;       /**< pointer to the data */
+    size_t size;      /**< size of the buffer */
+    void *ctx;        /**< context of the buffer */
+} netbuf_t;
+
+/**
+ * @brief Set to 1 if the stack doesn't provide an allocation mechanism
+ *        (see @ref netbuf_stack_alloc)
+ */
+#ifndef CONFIG_NETBUF_DISABLE_STACK_ALLOC
+#define CONFIG_NETBUF_DISABLE_STACK_ALLOC (0)
+#endif
+
+/**
+ * @brief Allocate a buffer from the network stack.
+ *
+ *        This function should populate at least `netbuf->data` and
+ *        `netbuf->size`. If needed, `netbuf->ctx` should contain the context
+ *        for freeing the buffer.
+ *
+ * @note  This function MUST be implemented by the network stack if
+ *        CONFIG_NETBUF_DISABLE_STACK_ALLOC == 0. If
+ *        CONFIG_NETBUF_DISABLE_STACK_ALLOC == 1, this function will be
+ *        defined as a function that always returns NULL.
+ *
+ * @param[out]  netbuf  pointer to netbuf
+ * @param[in]   size    size of the pkt to be allocated
+ *
+ * @return      pointer to the allocated buffer
+ * @return      NULL if packet couldn't be allocated
+ */
+void *netbuf_stack_alloc(netbuf_t *netbuf, size_t size);
+
+/**
+ * @brief Initialize a netbuf with a given buffer and size.
+ *
+ * @param[out]  netbuf  pointer to the netbuf
+ * @param[in]   data    pointer to the buffer. It can be NULL if
+ *                      @ref netbuf_alloc should get the buffer from the stack
+ * @param[in]   max_len Maximum length of the buffer. If `data` is NULL, this
+ *                      value is not used.
+ */
+void netbuf_init(netbuf_t *netbuf, void *data, size_t max_len);
+
+/**
+ * @brief Allocate a packet with a given size
+ *
+ *        Depending on the value of `netbuf->data`, this function will either
+ *        return a pointer to the currently existing buffer in `netbuf` or it
+ *        will try to allocate a packet from the network stack using
+ *        @ref netbuf_stack_alloc.
+ *
+ * @note  The netbuf MUST be initialized before calling this function
+ *        (see @ref netbuf_init).
+ * @note  The behavior of calling this function twice for the same `netbuf`
+ *        is undefined.
+ *
+ * @param[in, out]  netbuf  pointer to the netbuf
+ * @param[in]       size    size of the buffer to be allocated
+ *
+ * @return          `netbuf->data` if `netbuf->data` != NULL && `size` <= `netbuf->size`
+ * @return          the result of @ref netbuf_stack_alloc if `netbuf->data` == NULL
+ * @return          NULL otherwise.
+ */
+void *netbuf_alloc(netbuf_t *netbuf, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_NETBUF_H */
+/** @} */

--- a/sys/net/netbuf/Makefile
+++ b/sys/net/netbuf/Makefile
@@ -1,0 +1,2 @@
+MODULE = netbuf
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/netbuf/netbuf.c
+++ b/sys/net/netbuf/netbuf.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Jose I. Alamos <jose.alamos@haw-hamburg.de>
+ */
+
+#include <string.h>
+#include "net/netbuf.h"
+
+#if CONFIG_NETBUF_DISABLE_STACK_ALLOC
+void *netbuf_stack_alloc(netbuf_t *netbuf, size_t size)
+{
+    (void) netbuf;
+    (void) size;
+    return NULL;
+}
+#endif /* CONFIG_NETBUF_DISABLE_STACK_ALLOC */
+
+void *netbuf_alloc(netbuf_t *netbuf, size_t size)
+{
+    assert(netbuf);
+
+    if(netbuf->data) {
+        return size > netbuf->size ? NULL : netbuf->data;
+    }
+    else {
+        return netbuf_stack_alloc(netbuf, size);
+    }
+}
+
+void netbuf_init(netbuf_t *netbuf, void *data, size_t max_len)
+{
+    memset(netbuf, '\0', sizeof(netbuf_t));
+    netbuf->data = data;
+    netbuf->size = max_len;
+}
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds an abstraction for allocating packets from a network stack or static buffer.
The motivation behind this is:
- To keep zero copy, the network stack is the one who in practice allocates the buffer for the packet. 
At the same time if we want to have MAC and PHY layers that are independent to the network stack, we need an interface for allocation.
- We can "instruct" the lower layers to allocate packets so the PHY layer can allocate a packet just right after reading the pkt_len (e.g first byte of the IEEE802.15.4 PHY frame). So we could think of dropping the "get packet lengh" and "drop packet" behavior of `dev->driver->recv` (see https://github.com/RIOT-OS/RIOT/issues/11652)

If CONFIG_NETBUF_DISABLE_STACK_ALLOC==0, it's necessary to define a `netbuf_stack_alloc` function for every stack.

### How to use
Let's assume there's a radio API for reading data from the framebuffer:
```c
int radio_read_packet(radio_t radio, netbuf_t *netbuf)
{
    char pkt_len;
    radio_read_framebuffer(radio, &pkt_len, 1);

    /* Allocate pkt of "pkt_len" bytes long */
    void *pkt = netbuf_alloc(&netbuf, pkt_len);
    if(!pkt) {
        return -ENOBUFS;
    }
    radio_read_framebuffer(radio, pkt, pkt_len);
    return pkt_len;
}
```
Depending on how the netbuf is initialized, it's possible to either get a buffer from the stack allocator or from a static buffer.
Let's assume GNRC has the following `netbuf_stack_alloc` function:
```c
void *netbuf_stack_alloc(netbuf_t *netbuf, size_t size)
{
    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, size, GNRC_NETTYPE_UNDEF);
    if(!pkt) {
        return NULL;
    }
    netbuf->ctx = pkt;
    netbuf->data = pkt->data;
    netbuf->size = size;
    return pkt->data;
}
```
Some examples:
- Dynamically allocate packet when receiving:
```c
netbuf_t netbuf;
netbuf_init(&netbuf, NULL, 0); /* Pass NULL to ask the stack to allocate a packet when calling netbuf_alloc */
radio_read_packet(radio, &netbuf);
/* if everything is OK, netbuf.data contains the packet of length netbuf.size. */
/* If using GNRC, netbuf.ctx has a pointer to the pkt snip so it can be released afterwards */
```
- Pass a fixed buffer (useful when the size of the packet is known, e.g IEEE802.15.4 ACK packet)
```c
netbuf_t netbuf;
char ack[5]; /* Allocate space for the IEEE802.15.4 ACK */
netbuf_init(&netbuf, ack, 5); /* Pass the ACK buffer to the netbuf */
radio_read_packet(radio, &netbuf);
/*The ACK should be in the ack buffer*/
```

### Considerations about the RX procedure
I wrote [this patch](https://gist.github.com/jia200x/01fde55f1733ac5c6a8957b8e50c2d21) that overloads the "recv" function of netdev to receive a `netbuf` instead of a buffer, and removed the "drop" and "get packet length" logic. 

The "recv" function will read the pkt_len, try to get a buffer from the netbuf and write directly to that buffer. The frame buffer is read once and the logic is simpler now.

It also makes the binary smaller from:
```
   text    data     bss     dec     hex filename
  42864     508    6232   49604    c1c4 /home/jialamos/Development/RIOT/examples/default/bin/iotlab-m3/default.elf
```
to
```
   text    data     bss     dec     hex filename
  42716     508    6232   49456    c130 /home/jialamos/Development/RIOT/examples/default/bin/iotlab-m3/default.elf
```

And calling `netif->ops->recv()` is 6-8% faster with this method.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
- Check the documentation is OK with `make doc`
- Try the proposed patch.
- TBD: I will add some tests soon.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
It's related to the PHY/MAC rework proposed in #11483
#11652
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
