### PR TITLE
dist/tools/pyterm: drop loglevel from output

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -86,7 +86,7 @@ defaultfile = "pyterm-" + defaulthostname + ".conf"
 defaultrunname = "default-run"
 
 # default logging prefix format string
-default_fmt_str = '%(asctime)s - %(levelname)s # %(message)s'
+default_fmt_str = '%(asctime)s # %(message)s'
 
 # default newline setting
 defaultnewline = "LF"


### PR DESCRIPTION
### Contribution description

The loglevel on pyterm is always `INFO`.
It needlessly takes up space, so remove it to declutter the output.

**before:**
```
2019-09-27 14:17:51,602 - INFO # Iface  7  HWaddr: D2:AE  Channel: 2  NID: 0x23 PHY: O-QPSK 
2019-09-27 14:17:51,610 - INFO #            chip rate: 1000 rate mode: 0 (legacy) 
2019-09-27 14:17:51,612 - INFO #           Long HWaddr: D2:AE:0C:1B:20:54:05:8F 
2019-09-27 14:17:51,623 - INFO #            TX-Power: 3dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2019-09-27 14:17:51,624 - INFO #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
2019-09-27 14:17:51,626 - INFO #           6LO  IPHC  
2019-09-27 14:17:51,629 - INFO #           Source address length: 8
2019-09-27 14:17:51,631 - INFO #           Link type: wireless
2019-09-27 14:17:51,637 - INFO #           inet6 addr: fe80::d0ae:c1b:2054:58f  scope: local  VAL
2019-09-27 14:17:51,640 - INFO #           inet6 group: ff02::2
2019-09-27 14:17:51,645 - INFO #           inet6 group: ff02::1
2019-09-27 14:17:51,646 - INFO #           inet6 group: ff02::1:ff54:58f
2019-09-27 14:17:51,648 - INFO #           
2019-09-27 14:17:51,655 - INFO #           Statistics for Layer 2
2019-09-27 14:17:51,659 - INFO #             RX packets 0  bytes 0
2019-09-27 14:17:51,666 - INFO #             TX packets 43 (Multicast: 37)  bytes 1807
2019-09-27 14:17:51,670 - INFO #             TX succeeded 36 errors 0
2019-09-27 14:17:51,671 - INFO #           Statistics for IPv6
2019-09-27 14:17:51,672 - INFO #             RX packets 0  bytes 0
2019-09-27 14:17:51,676 - INFO #             TX packets 43 (Multicast: 37)  bytes 2680
2019-09-27 14:17:51,680 - INFO #             TX succeeded 43 errors 0

```

**after:**

```
2019-09-27 15:17:43,684 # Iface  7  HWaddr: 3B:66  Channel: 26  Page: 0  NID: 0xabcd
2019-09-27 15:17:43,686 #           Long HWaddr: 8F:1B:32:02:AE:20:BB:66 
2019-09-27 15:17:43,692 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2019-09-27 15:17:43,697 #           ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
2019-09-27 15:17:43,700 #           6LO  IPHC  
2019-09-27 15:17:43,702 #           Source address length: 8
2019-09-27 15:17:43,709 #           Link type: wireless
2019-09-27 15:17:43,711 #           inet6 addr: fe80::8d1b:3202:ae20:bb66  scope: local  VAL
2019-09-27 15:17:43,715 #           inet6 addr: de71:c105::8d1b:3202:ae20:bb66  scope: global  VAL
2019-09-27 15:17:43,719 #           inet6 group: ff02::2
2019-09-27 15:17:43,721 #           inet6 group: ff02::1
2019-09-27 15:17:43,726 #           inet6 group: ff02::1:ff20:bb66
2019-09-27 15:17:43,729 #           inet6 group: ff02::1a
2019-09-27 15:17:43,730 #           
2019-09-27 15:17:43,733 #           Statistics for Layer 2
2019-09-27 15:17:43,734 #             RX packets 0  bytes 0
2019-09-27 15:17:43,739 #             TX packets 14 (Multicast: 14)  bytes 588
2019-09-27 15:17:43,742 #             TX succeeded 14 errors 0
2019-09-27 15:17:43,745 #           Statistics for IPv6
2019-09-27 15:17:43,748 #             RX packets 0  bytes 0
2019-09-27 15:17:43,752 #             TX packets 14 (Multicast: 14)  bytes 882
2019-09-27 15:17:43,755 #             TX succeeded 14 errors 0
```



### Testing procedure
run `make term` and see if you like the output better.

### Issues/PRs references
none