### PR TITLE
Makefile.include: set default PROGRAMMER value when flahsing on IoT-LAB

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -106,6 +106,11 @@ OS := $(shell uname)
 # set python path, e.g. for tests
 PYTHONPATH := $(RIOTBASE)/dist/pythonlibs/:$(PYTHONPATH)
 
+# set default PROGRAMMER value if flashing a board on IoT-LAB
+ifneq(,$(IOTLAB_NODE))
+  PROGRAMMER = iotlab
+endif
+
 # Include Docker settings near the top because we need to build the environment
 # command line before some of the variable origins are overwritten below when
 # using abspath, strip etc.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This will avoid to load all edbg programmer management logic from a board Makefile.include and especially will avoid to add edbg to the list of FLASHDEPS: it won't be unnecessarily built when flashing a samr21-xpro/arduino-zero board on IoT-LAB.

The idea is to set a default value to the PROGRAMMER variable when IOTLAB_NODE is set (the arbitrary `iotlab` value is used) before the Makefile.include from the board is included. This way all edbg logic is skipped (including the addition to FLASHDEPS).

Also note that in master, issuing a flash command for samr21-xpro or arduino-zero from an IoT-LAB SSH Frontend is broken because edbg cannot be built on the fly (due to missing libudev libraries).

@cladmi, what's opinion on this fix ?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. Start an experiment on IoT-LAB with a samr21-xpro or arduino-zero board:
```
$ iotlab-experiment submit -n "" -d 20 -l saclay,samr21,1
$ iotlab-experiment wait
```
2. 2 cases:
  - Locally, ensure that you don't have edbg already built/available (in dist/tools) and flash the board from your machine:
    ```
    $ make BOARD=samr21-xpro IOTLAB_NODE=auto-ssh -C examples/hello-world
    ```
    => on master, edbg is rebuilt before flashing on IoT-LAB. With this PR, only `iotlab-node --update` is called

  - On the SSH frontend:
    ```
    $ ssh <login>@saclay.iot-lab.info
    $ cd RIOT
    $ make BOARD=samr21-xpro IOTLAB_NODE=auto-ssh -C examples/hello-world
    ``` 
    => on master, the last command fails. With this PR, the board is flashed correctly.
  

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Related to #9694

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
