### PR TITLE
gnrc_sixlowpan_frag_vrb: add xtimer dependency

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -215,6 +215,10 @@ ifneq (,$(filter gnrc_sixlowpan_frag,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter gnrc_sixlowpan_frag_vrb,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
   USEMODULE += gnrc_ipv6
   USEMODULE += gnrc_sixlowpan


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The VRB uses xtimer for its garbage collection but doesn't list it as a dependency.

https://github.com/RIOT-OS/RIOT/blob/aa84406ac14aba9e0540e9106b2f8663e377031f/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c#L114-L117

The only reason it worked so far is because it was always compiled with `gnrc_sixlowpan_frag` and other modules that pull in `xtimer` as a dependency on their own.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Unittests should still compile and run

```sh
make -C tests/unittests/ tests-gnrc_sixlowpan_frag_vrb flash-only test
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
