### PR TITLE
net/coap: remove deprecated COAP_CT_... defines

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -128,19 +128,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name    Content types
- * @deprecated  Deprecated in favour of [COAP_FORMAT_](@ref net_coap_format)
- *              style defines
- * @{
- */
-#define COAP_CT_LINK_FORMAT     (40)
-#define COAP_CT_XML             (41)
-#define COAP_CT_OCTET_STREAM    (42)
-#define COAP_CT_EXI             (47)
-#define COAP_CT_JSON            (50)
-/** @} */
-
-/**
  * @name    Content-Format option codes
  * @anchor  net_coap_format
  * @{


### PR DESCRIPTION
### Contribution description
#10108 deprecated the COAP_CT_... defines in favor of COAP_FORMAT_..., which more clearly describes their meaning. The deprecated defines did not see much use, the PR was merged in 2018-10, and there are no remaining uses of them in master. So, this PR removes the definitions.

### Testing procedure
Since there are no uses, there really isn't anything to test. As long as the CI is OK, we should be good.

### Issues/PRs references
Deprecated in #10108.