### PR TITLE
cpu/efm32: move LOW_POWER_ENABLED to efm32-features.mk

### DIFF
--- a/boards/slstk3401a/doc.txt
+++ b/boards/slstk3401a/doc.txt
@@ -151,8 +151,6 @@ You can override the branch's clock source by adding `CLOCK_LFA=source` to your 
 ### Low-power peripherals
 The low-power UART is capable of providing an UART peripheral using a low-speed clock. When the LFB clock source is the LFRCO or LFXO, it can still be used in EM2. However, this limits the baud rate to 9600 baud. If a higher baud rate is desired, set the clock source to CORELEDIV2.
 
-If you don't need low-power peripheral support, passing `LOW_POWER_ENABLED=0` to the compiler will disable support in the drivers (currently LEUART). This feature costs approximately 600 bytes (default compilation settings, LEUART only).
-
 **Note:** peripheral mappings in your board definitions will not be affected by this setting. Ensure you do not refer to any low-power peripherals.
 
 ### RTC or RTT

--- a/boards/slstk3402a/doc.txt
+++ b/boards/slstk3402a/doc.txt
@@ -153,8 +153,6 @@ You can override the branch's clock source by adding `CLOCK_LFA=source` to your 
 ### Low-power peripherals
 The low-power UART is capable of providing an UART peripheral using a low-speed clock. When the LFB clock source is the LFRCO or LFXO, it can still be used in EM2. However, this limits the baud rate to 9600 baud. If a higher baud rate is desired, set the clock source to CORELEDIV2.
 
-If you don't need low-power peripheral support, passing `LOW_POWER_ENABLED=0` to the compiler will disable support in the drivers (currently LEUART). This feature costs approximately 600 bytes (default compilation settings, LEUART only).
-
 **Note:** peripheral mappings in your board definitions will not be affected by this setting. Ensure you do not refer to any low-power peripherals.
 
 ### RTC or RTT

--- a/boards/sltb001a/doc.txt
+++ b/boards/sltb001a/doc.txt
@@ -139,8 +139,6 @@ You can override the branch's clock source by adding `CLOCK_LFA=source` to your 
 ### Low-power peripherals
 The low-power UART is capable of providing an UART peripheral using a low-speed clock. When the LFB clock source is the LFRCO or LFXO, it can still be used in EM2. However, this limits the baud rate to 9600 baud. If a higher baud rate is desired, set the clock source to CORELEDIV2.
 
-If you don't need low-power peripheral support, passing `LOW_POWER_ENABLED=0` to the compiler will disable support in the drivers (currently LEUART). This feature costs approximately 600 bytes (default compilation settings, LEUART only).
-
 **Note:** peripheral mappings in your board definitions will not be affected by this setting. Ensure you do not refer to any low-power peripherals.
 
 ### RTC or RTT

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -15,4 +15,8 @@ ifeq (1,$(EFM32_UART_MODES))
   CFLAGS += -DEFM32_UART_MODES=1
 endif
 
+ifeq (1,$(EFM32_LEUART_ENABLED))
+  CFLAGS += -DEFM32_LEUART_ENABLED=1
+endif
+
 include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/efm32/doc.txt
+++ b/cpu/efm32/doc.txt
@@ -62,7 +62,12 @@
  * =======================
  *
  * The EFM32/EFR32/EZR32 MCUs have support for low-power peripherals. Support
- * is enabled by default, but can be disabled by setting LOW_POWER_ENABLED=0.
+ * is enabled by default, but can be disabled if not used.
+ *
+ * - Setting `EFM32_LEUART_ENABLED=0` will disable support for the LEUART
+ *   in the UART driver peripheral and save approximately 400 bytes.
+ *
+ * Refer to `cpu/efm32/efm32-features.mk` for more options.
  */
 
 /**

--- a/cpu/efm32/efm32-features.mk
+++ b/cpu/efm32/efm32-features.mk
@@ -2,3 +2,4 @@
 # should override them from the command line, or in your Makefile. Note that
 # some features may not be applicable to all EFM32 boards or CPUs.
 export EFM32_UART_MODES ?= 0
+export EFM32_LEUART_ENABLED ?= 1

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -39,15 +39,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Enable support for Low-power peripherals (if supported by CPU).
- * @{
- */
-#ifndef LOW_POWER_ENABLED
-#define LOW_POWER_ENABLED   (1)
-#endif
-/** @} */
-
-/**
  * @brief   Internal macro for combining ADC resolution (x) with number of
  *          shifts (y).
  */

--- a/tests/cpu_efm32_features/Makefile
+++ b/tests/cpu_efm32_features/Makefile
@@ -11,5 +11,6 @@ BOARD_WHITELIST := ikea-tradfri \
 
 # see cpu/efm32/efm32-features.mk for the supported flags
 EFM32_UART_MODES = 1
+EFM32_LEUART_ENABLED = 0
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_efm32_features/README.md
+++ b/tests/cpu_efm32_features/README.md
@@ -3,7 +3,8 @@
 ## Introduction
 The EFM32 support several features that can be toggled compile-time.
 
-This test will ensure that RIOT-OS will compile whenever these features are toggled.
+This test will ensure that RIOT-OS will compile whenever these features are
+toggled.
 
 ## Expected result
 The test application compiles for EFM32-based boards.

--- a/tests/cpu_efm32_features/main.c
+++ b/tests/cpu_efm32_features/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2018-2019 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -19,6 +19,10 @@
  */
 
 #include "periph/uart.h"
+
+#if EFM32_LEUART_ENABLED
+#error "Expected EFM32_LEUART_ENABLED feature to be disabled."
+#endif
 
 int main(void)
 {


### PR DESCRIPTION
### Contribution description
This PR moves `LOW_POWER_ENABLED` to a feature in `efm32-features.mk`. This 'centralizes' all (low-level) tunables at one place, and now allows one to simply add it to a Makefile.

I renamed this to `EFM32_LEUART_ENABLED` so it is clear that it's about the EFM32 CPU.

### Testing procedure
The test in `tests/cpu_efm32_features` will ensure that it compiles. 

### Issues/PRs references
n/a