### PR TITLE
cpu/efm32: provide periph_uart_mode

### DIFF
--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_uart_modecfg

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -121,9 +121,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PB, 14),
         .loc = USART_ROUTELOC0_RXLOC_LOC9 |
                USART_ROUTELOC0_TXLOC_LOC9,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     }

--- a/boards/slstk3401a/Makefile.features
+++ b/boards/slstk3401a/Makefile.features
@@ -9,6 +9,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 include $(RIOTBOARD)/common/silabs/Makefile.features

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -180,9 +180,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA, 0),
         .loc = USART_ROUTELOC0_RXLOC_LOC0 |
                USART_ROUTELOC0_TXLOC_LOC0,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     },
@@ -192,9 +189,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PC, 6),
         .loc = USART_ROUTELOC0_RXLOC_LOC11 |
                USART_ROUTELOC0_TXLOC_LOC11,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     },
@@ -204,9 +198,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PD, 10),
         .loc = LEUART_ROUTELOC0_RXLOC_LOC18 |
                LEUART_ROUTELOC0_TXLOC_LOC18,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/boards/slstk3402a/Makefile.features
+++ b/boards/slstk3402a/Makefile.features
@@ -9,6 +9,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 include $(RIOTBOARD)/common/silabs/Makefile.features

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -171,9 +171,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA, 0),
         .loc = USART_ROUTELOC0_RXLOC_LOC0 |
                USART_ROUTELOC0_TXLOC_LOC0,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     },
@@ -183,9 +180,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PD, 10),
         .loc = LEUART_ROUTELOC0_RXLOC_LOC18 |
                LEUART_ROUTELOC0_TXLOC_LOC18,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/boards/sltb001a/Makefile.features
+++ b/boards/sltb001a/Makefile.features
@@ -9,6 +9,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 include $(RIOTBOARD)/common/silabs/Makefile.features

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -180,9 +180,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA, 0),
         .loc = USART_ROUTELOC0_RXLOC_LOC0 |
                USART_ROUTELOC0_TXLOC_LOC0,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     },
@@ -192,9 +189,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PC, 7),
         .loc = USART_ROUTELOC0_RXLOC_LOC11 |
                USART_ROUTELOC0_TXLOC_LOC11,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     },
@@ -204,9 +198,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PD, 10),
         .loc = LEUART_ROUTELOC0_RXLOC_LOC18 |
                LEUART_ROUTELOC0_TXLOC_LOC18,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/boards/slwstk6000b/Makefile.features
+++ b/boards/slwstk6000b/Makefile.features
@@ -6,7 +6,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 include $(RIOTBOARD)/common/silabs/Makefile.features
 

--- a/boards/slwstk6000b/include/periph_conf.h
+++ b/boards/slwstk6000b/include/periph_conf.h
@@ -173,9 +173,6 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = MODULE_PIN_F6,
         .loc = USART_ROUTELOC0_RXLOC_LOC0 |
                USART_ROUTELOC0_TXLOC_LOC0,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     }

--- a/boards/stk3600/Makefile.features
+++ b/boards/stk3600/Makefile.features
@@ -11,6 +11,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 include $(RIOTBOARD)/common/silabs/Makefile.features

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -234,9 +234,6 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PE, 1),
         .tx_pin = GPIO_PIN(PE, 0),
         .loc = UART_ROUTE_LOCATION_LOC1,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_UART0,
         .irq = UART0_RX_IRQn
     },
@@ -245,9 +242,6 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PD, 1),
         .tx_pin = GPIO_PIN(PD, 0),
         .loc = USART_ROUTE_LOCATION_LOC1,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     },
@@ -256,9 +250,6 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PD, 5),
         .tx_pin = GPIO_PIN(PD, 4),
         .loc = LEUART_ROUTE_LOCATION_LOC0,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/boards/stk3700/Makefile.features
+++ b/boards/stk3700/Makefile.features
@@ -11,6 +11,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 include $(RIOTBOARD)/common/silabs/Makefile.features

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -234,9 +234,6 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PE, 1),
         .tx_pin = GPIO_PIN(PE, 0),
         .loc = UART_ROUTE_LOCATION_LOC1,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_UART0,
         .irq = UART0_RX_IRQn
     },
@@ -245,9 +242,6 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PD, 1),
         .tx_pin = GPIO_PIN(PD, 0),
         .loc = USART_ROUTE_LOCATION_LOC1,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     },
@@ -256,9 +250,6 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PD, 5),
         .tx_pin = GPIO_PIN(PD, 4),
         .loc = LEUART_ROUTE_LOCATION_LOC0,
-#if EFM32_UART_MODES
-        .mode = UART_MODE_8N1,
-#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -376,6 +376,46 @@ typedef struct {
 /**
  * @brief   UART device configuration.
  */
+#ifndef DOXYGEN
+/**
+ * @brief   Override parity values
+ * @{
+ */
+#define HAVE_UART_PARITY_T
+typedef enum {
+   UART_PARITY_NONE = 0,
+   UART_PARITY_ODD = 1,
+   UART_PARITY_EVEN = 2,
+   UART_PARITY_MARK = 3,
+   UART_PARITY_SPACE = 4,
+} uart_parity_t;
+/** @} */
+
+/**
+ * @brief   Override data bits length values
+ * @{
+ */
+#define HAVE_UART_DATA_BITS_T
+typedef enum {
+    UART_DATA_BITS_5 = 5,
+    UART_DATA_BITS_6 = 6,
+    UART_DATA_BITS_7 = 7,
+    UART_DATA_BITS_8 = 8,
+} uart_data_bits_t;
+/** @} */
+
+/**
+ * @brief   Override stop bits length values
+ * @{
+ */
+#define HAVE_UART_STOP_BITS_T
+typedef enum {
+   UART_STOP_BITS_1 = 2,
+   UART_STOP_BITS_2 = 4,
+} uart_stop_bits_t;
+/** @} */
+#endif /* ndef DOXYGEN */
+
 typedef struct {
     void *dev;              /**< UART, USART or LEUART device used */
     gpio_t rx_pin;          /**< pin used for RX */

--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -154,6 +154,42 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     return 0;
 }
 
+#ifdef MODULE_PERIPH_UART_MODECFG
+int uart_mode(uart_t dev, uart_data_bits_t data_bits, uart_parity_t parity,
+              uart_stop_bits_t stop_bits)
+{
+    if (parity == UART_PARITY_MARK || parity == UART_PARITY_SPACE) {
+        return UART_NOMODE;
+    }
+
+#ifdef USE_LEUART
+    if (_is_usart(dev)) {
+#endif
+        USART_TypeDef *uart = (USART_TypeDef *) uart_config[dev].dev;
+
+        USART_FrameSet(uart,
+                       USART_DataBits2Def(data_bits),
+                       USART_StopBits2Def(stop_bits),
+                       USART_Parity2Def(parity));
+#ifdef USE_LEUART
+    } else {
+        if (data_bits != UART_DATA_BITS_8) {
+            return UART_NOMODE;
+        }
+
+        LEUART_TypeDef *leuart = (LEUART_TypeDef *) uart_config[dev].dev;
+
+        LEUART_FrameSet(leuart,
+                        LEUART_DataBits2Def(data_bits),
+                        LEUART_StopBits2Def(stop_bits),
+                        LEUART_Parity2Def(parity));
+    }
+#endif
+
+    return UART_OK;
+}
+#endif
+
 void uart_write(uart_t dev, const uint8_t *data, size_t len)
 {
 #ifdef USE_LEUART

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=50996be7377cec885954312b7d4caf61788aaa40
+PKG_VERSION=755f5430c05d95812603524f9aa7516964dd5758
 PKG_LICENSE=Zlib
 
 ifneq ($(CPU),efm32)


### PR DESCRIPTION
### Contribution description
This PR removes the non-standard UART mode feature, and replaces it with the `uart_mode` implementation for both UART and LEUART (only supports 8 or 9 bit frames).

### Testing procedure
Run `tests/periph_uart_mode` and follow the test instructions. All other tests that output to the shell should still work.

Here are some oscilloscope screenshots that show that the API is working (it's time-consuming to test this). I've used a custom application that just sends out 0x55.

UART 5N1:
![uart-5n1](https://user-images.githubusercontent.com/815976/65815071-a5b1ca80-e1ea-11e9-874c-b24c5db6f3f4.png)

UART 7E2:
![uart-7e2](https://user-images.githubusercontent.com/815976/65815073-a64a6100-e1ea-11e9-82a0-6be38c25e997.png)

LEUART 8N1 (default)
![leuart-8n1](https://user-images.githubusercontent.com/815976/65815095-dd207700-e1ea-11e9-9d83-235db1f74d1b.png)

LEUART 8O2:
![leuart-8o2](https://user-images.githubusercontent.com/815976/65815096-dd207700-e1ea-11e9-8ea3-be1c793b7dd1.png)



My scope show question marks whenever it cannot match the decoding settings to the actual data:

![uart-7e2-questionmark](https://user-images.githubusercontent.com/815976/65815072-a64a6100-e1ea-11e9-8437-4741c42305ed.png)

### Issues/PRs references
~~Depends on #12322.~~