### PR TITLE
gnrc_sixlowpan_frag_vrb: re-use now unused super::dst for out_dst

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -36,27 +36,20 @@ extern "C" {
 
 /**
  * @brief   Representation of the virtual reassembly buffer entry
+ *
+ * gnrc_sixlowpan_frag_rb_base_t::dst of gnrc_sixlowpan_frag_vrb_t::super
+ * becomes the next hop destination address.
  */
 typedef struct {
     gnrc_sixlowpan_frag_rb_base_t super;    /**< base type */
-
     /**
-     * @brief   Link-layer destination address to which the fragments are
-     *          supposed to be forwarded to
-     */
-    uint8_t out_dst[IEEE802154_LONG_ADDRESS_LEN];
-    /**
-     * @brief   Outgoing interface to gnrc_sixlowpan_frag_vrb_t::out_dst
+     * @brief   Outgoing interface to gnrc_sixlowpan_frag_rb_base_t::dst
      */
     gnrc_netif_t *out_netif;
     /**
-     * @brief   Outgoing tag to gnrc_sixlowpan_frag_vrb_t::out_dst
+     * @brief   Outgoing tag to gnrc_sixlowpan_frag_rb_base_t::dst
      */
     uint16_t out_tag;
-    /**
-     * @brief   Length of gnrc_sixlowpan_frag_vrb_t::out_dst
-     */
-    uint8_t out_dst_len;
 } gnrc_sixlowpan_frag_vrb_t;
 
 /**

--- a/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
+++ b/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
@@ -80,16 +80,13 @@ static void test_vrb_add__success(void)
     TEST_ASSERT_EQUAL_INT(_base.src_len, res->super.src_len);
     TEST_ASSERT_MESSAGE(memcmp(_base.src, res->super.src, TEST_SRC_LEN) == 0,
                         "TEST_SRC != res->super.src");
-    TEST_ASSERT_EQUAL_INT(_base.dst_len, res->super.src_len);
-    TEST_ASSERT_MESSAGE(memcmp(_base.dst, res->super.dst, TEST_DST_LEN) == 0,
-                        "TEST_DST != res->super.dst");
     TEST_ASSERT_EQUAL_INT(_base.tag, res->super.tag);
     TEST_ASSERT_EQUAL_INT(_base.datagram_size, res->super.datagram_size);
     TEST_ASSERT_EQUAL_INT(_base.current_size, res->super.current_size);
     TEST_ASSERT_EQUAL_INT(_base.arrival, res->super.arrival);
     TEST_ASSERT((&_dummy_netif) == res->out_netif);
-    TEST_ASSERT_EQUAL_INT(sizeof(_out_dst), res->out_dst_len);
-    TEST_ASSERT_MESSAGE(memcmp(_out_dst, res->out_dst, sizeof(_out_dst)) == 0,
+    TEST_ASSERT_EQUAL_INT(sizeof(_out_dst), res->super.dst_len);
+    TEST_ASSERT_MESSAGE(memcmp(_out_dst, res->super.dst, sizeof(_out_dst)) == 0,
                         "TEST_DST != res->super.dst");
     TEST_ASSERT_EQUAL_INT(TEST_TAG_INITIAL, res->out_tag);
     TEST_ASSERT(TEST_TAG_INITIAL != tag);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Due to #12300 `dst` and `dst_len` become unused in the VRB. This PR re-uses these members instead of the members `out_dst` and `out_dst_len` of the VRB (and deletes those members). 

While technically an API change, the member is only used internally (and checked by the tests) when disregarding #11068.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/unittests` should still run, spefically `tests-gnrc_sixlowpan_frag_vrb`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on ~~#12300~~ (merged) and ~~#12324~~ (merged).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
