### PR TITLE
boards/ek-lm4f120xl: provide SAUL configuration

### DIFF
--- a/boards/ek-lm4f120xl/Makefile.dep
+++ b/boards/ek-lm4f120xl/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/ek-lm4f120xl/include/board.h
+++ b/boards/ek-lm4f120xl/include/board.h
@@ -28,12 +28,23 @@ extern "C" {
 #endif
 
 /**
+ * @name    Button pin definitions
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(5, 4)
+#define BTN1_PIN            GPIO_PIN(5, 0)
+
+#define BTN0_MODE           GPIO_IN_PU
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(5, 7)
+#define LED0_PIN            GPIO_PIN(5, 1)
 #define LED1_PIN            GPIO_PIN(5, 2)
-#define LED2_PIN            GPIO_PIN(5, 1)
+#define LED2_PIN            GPIO_PIN(5, 3)
 
 #define LED_PORT            (GPIO_PORTF_DATA_R)
 #define LED0_MASK           (1 << 7)

--- a/boards/ek-lm4f120xl/include/gpio_params.h
+++ b/boards/ek-lm4f120xl/include/gpio_params.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_ek-lm4f120xl
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED (red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED (blue)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED (green)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "Button (SW0)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "Button (SW1)",
+        .pin  = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
### Contribution description
I found this old dev board in my drawer to hook up a mrf24j40.

I noticed the LED was wrong  and not all colors are configured.
So I added the config for the LEDs and Buttons and provided a config for SAUL, as this was missing.

### Testing procedure

See if you can toggle the LEDs and read the state of the buttons.
Alternatively, look at the [datasheet](http://www.ti.com/lit/ug/spmu289c/spmu289c.pdf). (Page 9)

### Issues/PRs references
none
