### PR TITLE
drivers/mrf24j40: add pseudomodules for MRF24J40MA/B/C/D/E

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -331,6 +331,15 @@ ifneq (,$(filter mq3,$(USEMODULE)))
   FEATURES_REQUIRED += periph_adc
 endif
 
+ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
+  USEMODULE += mrf24j40
+
+  # all modules but mrf24j40ma have an external PA
+  ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
+    CFLAGS += -DMRF24J40_USE_EXT_PA_LNA
+  endif
+endif
+
 ifneq (,$(filter mrf24j40,$(USEMODULE)))
   USEMODULE += xtimer
   USEMODULE += luid

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -107,6 +107,9 @@ PSEUDOMODULES += cc1100
 PSEUDOMODULES += cc1100e
 PSEUDOMODULES += cc1101
 
+# include variants of mrf24j40 drivers as pseudo modules
+PSEUDOMODULES += mrf24j40m%
+
 # include variants of SX127X drivers as pseudo modules
 PSEUDOMODULES += sx1272
 PSEUDOMODULES += sx1276


### PR DESCRIPTION
### Contribution description
Microchip offers ready-to-use modules with the mrf24j40 chip.
All but the MRF24J40MA integrate an external PA/LNA, they also come with an RF shield.

If the PA/LNA is not enabled, the signal off these modules is really poor.

This adds pseudomodules so that the PA/LNA is automatically enabled when the appropriate module is used.

Linux does [something simmilar](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/net/ieee802154/mrf24j40.c#n1134).

### Testing procedure
*Tested using a MRF24J40MD*

##### with`USEMODULE += mrf24j40`

```
2019-09-28 19:27:11,931 # 12 bytes from fe80::2123:2323:2323:2322: icmp_seq=0 ttl=64 rssi=-78 dBm time=9.878 ms
2019-09-28 19:27:12,930 # 12 bytes from fe80::2123:2323:2323:2322: icmp_seq=1 ttl=64 rssi=-78 dBm time=7.644 ms
2019-09-28 19:27:13,932 # 12 bytes from fe80::2123:2323:2323:2322: icmp_seq=2 ttl=64 rssi=-78 dBm time=8.301 ms
```

##### with`USEMODULE += mrf24j40md`

```
2019-09-28 19:27:41,852 # 12 bytes from fe80::2123:2323:2323:2322: icmp_seq=0 ttl=64 rssi=-20 dBm time=10.416 ms
2019-09-28 19:27:42,852 # 12 bytes from fe80::2123:2323:2323:2322: icmp_seq=1 ttl=64 rssi=-19 dBm time=9.888 ms
2019-09-28 19:27:43,855 # 12 bytes from fe80::2123:2323:2323:2322: icmp_seq=2 ttl=64 rssi=-20 dBm time=10.845 ms
```

### Issues/PRs references
follow-up to #11410