### PR TITLE
boards/samr34-xpro: move cpu definitions to Makefile.features

### DIFF
--- a/boards/samr34-xpro/Makefile.features
+++ b/boards/samr34-xpro/Makefile.features
@@ -1,3 +1,7 @@
+# cpu used by the samr34-xpro board is based on saml21
+CPU = saml21
+CPU_MODEL = samr34j18b
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c

--- a/boards/samr34-xpro/Makefile.include
+++ b/boards/samr34-xpro/Makefile.include
@@ -1,7 +1,3 @@
-# define the cpu used by the samr34-xpro board (based on saml21)
-export CPU = saml21
-export CPU_MODEL = samr34j18b
-
 # set edbg device type
 EDBG_DEVICE_TYPE = atmel_cm0p
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Follow-up of #11250 where I missed the fact that CPU and CPU_MODEL were defined in Makefile.include instead of Makefile.features.

Reported offline by @fjmolinas.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I guess a green Murdock should be ok.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #11250 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
