### PR TITLE
boards: don't export CPU/CPU_MODEL for stm32f723i-disco and p-l496g-cell02

### DIFF
--- a/boards/p-l496g-cell02/Makefile.features
+++ b/boards/p-l496g-cell02/Makefile.features
@@ -1,6 +1,6 @@
 # the cpu to build for
-export CPU = stm32l4
-export CPU_MODEL = stm32l496ag
+CPU = stm32l4
+CPU_MODEL = stm32l496ag
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c

--- a/boards/stm32f723e-disco/Makefile.features
+++ b/boards/stm32f723e-disco/Makefile.features
@@ -1,6 +1,6 @@
 # define the cpu used by the stm32f723e-disco board
-export CPU = stm32f7
-export CPU_MODEL = stm32f723ie
+CPU = stm32f7
+CPU_MODEL = stm32f723ie
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Follow-up of #11984 and #11800 where CPU/CPU_MODEL variables are exported in `Makefile.features` although this is not needed.

Reported offfline by @fjmolinas.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Cleanup of #11984 and #11800 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
