### PR TITLE
boards/pic32-wifire: remove export of CPU/CPU_MODEL

### DIFF
--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -1,5 +1,3 @@
-export CPU = mips_pic32mz
-export CPU_MODEL=p32mz2048efg100
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
 


### PR DESCRIPTION
These values are already defined in Makefile.features

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Apparently these 2 defines are not needed as they are already defined in `Makefile.features`.

Comparing with `pic32-clicker` and there those 2 export doesn't exist.
This was reintroduced by #12266 by mistake I guess.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be ok.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Problem introduced by #12266 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
