### PR TITLE
boards/blxxxpill: move CPU/CPU_MODEL to Makefile.features

### DIFF
--- a/boards/blackpill-128kib/Makefile.features
+++ b/boards/blackpill-128kib/Makefile.features
@@ -1,1 +1,3 @@
+CPU_MODEL = stm32f103cb
+
 include $(RIOTBOARD)/common/blxxxpill/Makefile.features

--- a/boards/blackpill-128kib/Makefile.include
+++ b/boards/blackpill-128kib/Makefile.include
@@ -1,6 +1,3 @@
-## the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103cb
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/blxxxpill/dist/openocd-128kib.cfg
 
 USEMODULE += boards_common_blxxxpill

--- a/boards/blackpill/Makefile.features
+++ b/boards/blackpill/Makefile.features
@@ -1,1 +1,3 @@
+CPU_MODEL = stm32f103c8
+
 include $(RIOTBOARD)/common/blxxxpill/Makefile.features

--- a/boards/blackpill/Makefile.include
+++ b/boards/blackpill/Makefile.include
@@ -1,6 +1,3 @@
-## the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103c8
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/blxxxpill/dist/openocd.cfg
 
 USEMODULE += boards_common_blxxxpill

--- a/boards/bluepill-128kib/Makefile.features
+++ b/boards/bluepill-128kib/Makefile.features
@@ -1,1 +1,3 @@
+CPU_MODEL = stm32f103cb
+
 include $(RIOTBOARD)/common/blxxxpill/Makefile.features

--- a/boards/bluepill-128kib/Makefile.include
+++ b/boards/bluepill-128kib/Makefile.include
@@ -1,6 +1,3 @@
-## the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103cb
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/blxxxpill/dist/openocd-128kib.cfg
 
 USEMODULE += boards_common_blxxxpill

--- a/boards/bluepill/Makefile.features
+++ b/boards/bluepill/Makefile.features
@@ -1,1 +1,3 @@
+CPU_MODEL = stm32f103c8
+
 include $(RIOTBOARD)/common/blxxxpill/Makefile.features

--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -1,6 +1,3 @@
-## the cpu to build for
-export CPU = stm32f1
-export CPU_MODEL = stm32f103c8
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/blxxxpill/dist/openocd.cfg
 
 USEMODULE += boards_common_blxxxpill

--- a/boards/common/blxxxpill/Makefile.features
+++ b/boards/common/blxxxpill/Makefile.features
@@ -1,3 +1,5 @@
+CPU = stm32f1
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR moves the definition of CPU/CPU_MODEL from Makefile.include to Makefile.features file for bluepill/blackpill (and derivatives) boards.

CPU definition is even moved to `common/blxxxpill/Makefile.features` because it's the same for all variants.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #11477

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
