### PR TITLE
boards/slwstk6000b: move CPU definiton to Makefile.features

### DIFF
--- a/boards/slwstk6000b/Makefile.dep
+++ b/boards/slwstk6000b/Makefile.dep
@@ -5,5 +5,3 @@ endif
 
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep
-
-include $(RIOTCPU)/efm32/Makefile.dep

--- a/boards/slwstk6000b/Makefile.features
+++ b/boards/slwstk6000b/Makefile.features
@@ -1,3 +1,6 @@
+CPU = efm32
+# TODO move CPU_MODEL here
+
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -9,5 +12,3 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 include $(RIOTBOARD)/common/silabs/Makefile.features
-
-include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slwstk6000b/Makefile.include
+++ b/boards/slwstk6000b/Makefile.include
@@ -3,8 +3,6 @@ include $(RIOTBOARD)/slwstk6000b/module-info.mk
 # add module specific includes
 INCLUDES += -I$(RIOTBOARD)/slwstk6000b/modules/$(BOARD_MODULE)/include
 
-# define the cpu used by SLWSTK6000B
-export CPU = efm32
 export CPU_MODEL = $(MODULE_CPU)
 
 # set default port depending on operating system


### PR DESCRIPTION
### Contribution description

cpu/$(CPU)/Makefile.features and cpu/$(CPU)/Makefile.dep are
automatically included

Part of moving CPU/CPU_MODEL definition to Makefile.features to have it
available before Makefile.include.

I did not move CPU_MODEL in that one as it requires other refactoring
first.

### Limitations

I did not move CPU_MODEL in this PR as it needs bigger changes.
However, moving CPU already in this one, allows going forward with the automatic inclusion of the `CPU` Makefiles and adding static tests to ensure this pattern.

### Testing procedure

The files parsed during a build stayed the same.
Only Makefile.dep is now included once instead of twice:

<details><summary><code>BOARD=slwstk6000b make --no-print-directory -C examples/hello-world/ info-build | sed "s|${PWD}/||"g</code></summary>

```
BOARD=slwstk6000b make --no-print-directory -C examples/hello-world/ info-build | sed "s|${PWD}/||"g
APPLICATION: hello-world
APPDIR:      examples/hello-world

supported boards:
acd52832 airfy-beacon arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-mkr1000 arduino-mkrfox1200 arduino-mkrzero arduino-nano arduino-uno arduino-zero avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib calliope-mini cc2538dk cc2650-launchpad cc2650stk ek-lm4f120xl esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing f4vi1 feather-m0 firefly fox frdm-k22f frdm-k64f frdm-kw41z hifive1 hifive1b i-nucleo-lrwan1 ikea-tradfri iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lsn50 maple-mini mbed_lpc1768 mega-xplained microbit msb-430 msb-430h msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 opencm904 openmote-b openmote-cc2538 p-l496g-cell02 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pic32-clicker pic32-wifire pyboard reel remote-pa remote-reva remote-revb ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeeduino_arch-pro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff spark-core stk3600 stk3700 stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f723e-disco stm32f769i-disco stm32l0538-disco stm32l476g-disco teensy31 telosb thingy52 ublox-c030-u201 udoo usb-kw41z waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1

BOARD:   slwstk6000b
CPU:     efm32
MCU:     efm32

RIOTBASE:  /home/harter/work/git/RIOT
RIOTBOARD: boards
RIOTCPU:   cpu
RIOTPKG:   pkg

DEFAULT_MODULE: auto_init board core core_msg cpu sys
DISABLE_MODULE: 
USEMODULE:      boards_common_silabs cortexm_common cortexm_common_periph cortexm_fpu cpu_efr32mg12p gecko_sdk_emlib gecko_sdk_emlib_extra newlib newlib_nano newlib_syscalls_default periph periph_common periph_gpio periph_pm periph_uart pm_layered silabs_aem silabs_bc stdio_uart

ELFFILE: examples/hello-world/bin/slwstk6000b/hello-world.elf
HEXFILE: examples/hello-world/bin/slwstk6000b/hello-world.hex
BINFILE: examples/hello-world/bin/slwstk6000b/hello-world.bin
FLASHFILE: examples/hello-world/bin/slwstk6000b/hello-world.bin

FEATURES_USED:
         periph_gpio periph_pm periph_uart
FEATURES_REQUIRED:
         periph_uart
FEATURES_OPTIONAL_ONLY (optional that are not required, strictly "nice to have"):
         periph_gpio periph_pm
FEATURES_OPTIONAL_MISSING (missing optional features):
         -none-
FEATURES_PROVIDED (by the board or USEMODULE'd drivers):
         arduino cpp cpu_check_address periph_adc periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_i2c periph_pm periph_rtc periph_rtt periph_spi periph_timer periph_uart
FEATURES_MISSING (only non optional features):
         -none-

FEATURES_CONFLICT:     periph_rtc:periph_rtt
FEATURES_CONFLICT_MSG: "On the EFM32, the RTC and RTT map to the same hardware peripheral."
FEATURES_CONFLICTING:
         -none-

INCLUDES: 
	-isystem  
	/opt/gcc-arm-none-eabi-7-2018-q2-update/arm-none-eabi/include/newlib-nano  
	-Icore/include  
	-Idrivers/include  
	-Isys/include  
	-Iboards/slwstk6000b/include  
	-Iboards/slwstk6000b/modules/slwrb4162a/include  
	-Iboards/common/silabs/include  
	-Iboards/common/silabs/drivers/include  
	-Icpu/efm32/include  
	-Icpu/efm32/families/efr32mg12p/include/vendor  
	-Icpu/cortexm_common/include  
	-Icpu/cortexm_common/include/vendor  
	-Isys/libc/include  
	-Iexamples/hello-world/bin/pkg/slwstk6000b/gecko_sdk/dist/emlib/inc  
	-Iexamples/hello-world/bin/pkg/slwstk6000b/gecko_sdk/dist/emlib-extra/inc

CC:      arm-none-eabi-gcc
CFLAGS: 
	-DDEVELHELP  
	-Werror  
	-DEFR32MG12P332F1024GL125  
	-mno-thumb-interwork  
	-mcpu=cortex-m4  
	-mlittle-endian  
	-mthumb  
	-mfloat-abi=hard  
	-mfpu=fpv4-sp-d16  
	-ffunction-sections  
	-fdata-sections  
	-fno-builtin  
	-fshort-enums  
	-ggdb  
	-g3  
	-Os  
	-DCPU_MODEL_EFR32MG12P332F1024GL125  
	-DCPU_ARCH_CORTEX_M4F  
	-DRIOT_APPLICATION=\"hello-world\"  
	-DBOARD_SLWSTK6000B=\"slwstk6000b\"  
	-DRIOT_BOARD=BOARD_SLWSTK6000B  
	-DCPU_EFM32=\"efm32\"  
	-DRIOT_CPU=CPU_EFM32  
	-DMCU_EFM32=\"efm32\"  
	-DRIOT_MCU=MCU_EFM32  
	-std=c99  
	-fno-common  
	-Wall  
	-Wextra  
	-Wmissing-include-dirs  
	-fno-delete-null-pointer-checks  
	-Wstrict-prototypes  
	-Wold-style-definition  
	-gz  
	-Wformat=2  
	-Wformat-overflow  
	-Wformat-truncation  
	-include  
	examples/hello-world/bin/slwstk6000b/riotbuild/riotbuild.h

CXX:     arm-none-eabi-g++
CXXUWFLAGS: 
	-std=%  
	-Wstrict-prototypes  
	-Wold-style-definition
CXXEXFLAGS:

LINK:    arm-none-eabi-gcc
LINKFLAGS: 
	-Lcpu/efm32/ldscripts  
	-Lcpu/cortexm_common/ldscripts  
	-Tcortexm.ld  
	-Wl,--fatal-warnings  
	-mcpu=cortex-m4  
	-mlittle-endian  
	-mthumb  
	-mfloat-abi=hard  
	-mfpu=fpv4-sp-d16  
	-ggdb  
	-g3  
	-Os  
	-static  
	-lgcc  
	-nostartfiles  
	-Wl,--gc-sections  
	-Wl,--defsym=_rom_start_addr=0x00000000  
	-Wl,--defsym=_ram_start_addr=0x20000000  
	-Wl,--defsym=_rom_length=0x00100000  
	-Wl,--defsym=_ram_length=0x00040000  
	-specs=nano.specs  
	-lc

OBJCOPY: /opt/gcc-arm-none-eabi-7-2018-q2-update/bin/arm-none-eabi-objcopy
OFLAGS:  

FLASHER: dist/tools/jlink/jlink.sh
FFLAGS:  flash examples/hello-world/bin/slwstk6000b/hello-world.bin

TERMPROG:  dist/tools/pyterm/pyterm
TERMFLAGS: -p "/dev/ttyACM0" -b "115200" 
PORT:      /dev/ttyACM0

DEBUGGER:       dist/tools/jlink/jlink.sh
DEBUGGER_FLAGS: debug examples/hello-world/bin/slwstk6000b/hello-world.elf

DOWNLOAD_TO_FILE:   /usr/bin/wget -nv -c -O
DOWNLOAD_TO_STDOUT: /usr/bin/curl -s
UNZIP_HERE:         /usr/bin/unzip -q

DEBUGSERVER:       dist/tools/jlink/jlink.sh
DEBUGSERVER_FLAGS: debug-server

RESET:       dist/tools/jlink/jlink.sh
RESET_FLAGS: reset

MAKEFILE_LIST: 
	examples/hello-world/Makefile  
	Makefile.include  
	makefiles/utils/variables.mk  
	makefiles/utils/strings.mk  
	makefiles/docker.inc.mk  
	makefiles/color.inc.mk  
	makefiles/info-nproc.inc.mk  
	makefiles/boards.inc.mk  
	makefiles/info.inc.mk  
	makefiles/scan-build.inc.mk  
	Makefile.features  
	boards/slwstk6000b/Makefile.features  
	boards/common/silabs/Makefile.features  
	cpu/efm32/Makefile.features  
	cpu/efm32/efm32-features.mk  
	cpu/cortexm_common/Makefile.features  
	makefiles/pseudomodules.inc.mk  
	makefiles/defaultmodules.inc.mk  
	boards/slwstk6000b/Makefile.include  
	boards/slwstk6000b/module-info.mk  
	makefiles/tools/serial.inc.mk  
	makefiles/tools/jlink.inc.mk  
	boards/common/silabs/Makefile.include  
	cpu/efm32/Makefile.include  
	cpu/efm32/efm32-info.mk  
	makefiles/arch/cortexm.inc.mk  
	cpu/cortexm_common/Makefile.include  
	makefiles/toolchain/gnu.inc.mk  
	makefiles/tools/gdb.inc.mk  
	Makefile.dep  
	boards/slwstk6000b/Makefile.dep  
	boards/common/silabs/Makefile.dep  
	cpu/efm32/Makefile.dep  
	sys/Makefile.dep  
	sys/test_utils/Makefile.dep  
	drivers/Makefile.dep  
	Makefile.dep  
	boards/slwstk6000b/Makefile.dep  
	boards/common/silabs/Makefile.dep  
	cpu/efm32/Makefile.dep  
	sys/Makefile.dep  
	sys/test_utils/Makefile.dep  
	drivers/Makefile.dep  
	makefiles/cflags.inc.mk  
	makefiles/git_version.inc.mk  
	sys/Makefile.include  
	makefiles/libc/newlib.mk  
	sys/newlib_syscalls_default/Makefile.include  
	drivers/Makefile.include  
	pkg/gecko_sdk/Makefile.include  
	makefiles/bindist.inc.mk  
	makefiles/modules.inc.mk  
	makefiles/boot/riotboot.mk  
	makefiles/eclipse.inc.mk  
	makefiles/vars.inc.mk  
	makefiles/tools/targets.inc.mk  
	dist/tools/desvirt/Makefile.desvirt  
	makefiles/mcuboot.mk  
	makefiles/murdock.inc.mk
```
</details>

And compared to `master` the output difference is 

```diff
--- info-build-master   2019-09-30 12:29:06.286171845 +0200
+++ info-build-pr       2019-09-30 12:30:23.734611304 +0200
@@ -189,7 +189,6 @@
        boards/slwstk6000b/Makefile.dep  
        boards/common/silabs/Makefile.dep  
        cpu/efm32/Makefile.dep  
-       cpu/efm32/Makefile.dep  
        sys/Makefile.dep  
        sys/test_utils/Makefile.dep  
        drivers/Makefile.dep  
@@ -197,7 +196,6 @@
        boards/slwstk6000b/Makefile.dep  
        boards/common/silabs/Makefile.dep  
        cpu/efm32/Makefile.dep  
-       cpu/efm32/Makefile.dep  
        sys/Makefile.dep  
        sys/test_utils/Makefile.dep  
        drivers/Makefile.dep  
```

### Issues/PRs references

Tracking: move CPU/CPU_MODEL to Makefile.features #11477