### PR TITLE
boards: remove duplicate include 'RIOTCPU/cpu/Makefile.features'

### DIFF
--- a/boards/common/blxxxpill/Makefile.features
+++ b/boards/common/blxxxpill/Makefile.features
@@ -7,5 +7,3 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/p-l496g-cell02/Makefile.features
+++ b/boards/p-l496g-cell02/Makefile.features
@@ -10,5 +10,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/samr34-xpro/Makefile.features
+++ b/boards/samr34-xpro/Makefile.features
@@ -10,6 +10,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# samr34 is a specific flavor of saml21
-include $(RIOTCPU)/saml21/Makefile.features

--- a/boards/stm32f723e-disco/Makefile.features
+++ b/boards/stm32f723e-disco/Makefile.features
@@ -9,5 +9,3 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-include $(RIOTCPU)/stm32f7/Makefile.features


### PR DESCRIPTION
### Contribution description

When 'CPU' is defined, the CPU Makefile.features is included by the
build system in the main Makefile.features.
No need to do it manually anymore.


### Testing procedure

Compare the output of `info-build` for all affected boards. Some duplicate includes are now removed:

```
for board in bluepill blackpill bluepill-128kib blackpill-128kib p-l496g-cell02 samr34-xpro stm32f723e-disco; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-build | sed "s|${PWD}/||"g ; done
```

The 3 removed lines in included makefiles in MAKEFILE_LIST are the 3 lines that are already parsed before:

<details><summary>Difference in info-build between master and this PR</summary>

```diff
--- info-build-master   2019-09-30 12:40:59.110072205 +0200
+++ info-build-pr       2019-09-30 12:40:24.357554378 +0200
@@ -170,9 +170,6 @@
        cpu/stm32f1/Makefile.features  
        cpu/stm32_common/Makefile.features  
        cpu/cortexm_common/Makefile.features  
-       cpu/stm32f1/Makefile.features  
-       cpu/stm32_common/Makefile.features  
-       cpu/cortexm_common/Makefile.features  
        makefiles/pseudomodules.inc.mk  
        makefiles/defaultmodules.inc.mk  
        boards/bluepill/Makefile.include  
@@ -387,9 +384,6 @@
        cpu/stm32f1/Makefile.features  
        cpu/stm32_common/Makefile.features  
        cpu/cortexm_common/Makefile.features  
-       cpu/stm32f1/Makefile.features  
-       cpu/stm32_common/Makefile.features  
-       cpu/cortexm_common/Makefile.features  
        makefiles/pseudomodules.inc.mk  
        makefiles/defaultmodules.inc.mk  
        boards/blackpill/Makefile.include  
@@ -604,9 +598,6 @@
        cpu/stm32f1/Makefile.features  
        cpu/stm32_common/Makefile.features  
        cpu/cortexm_common/Makefile.features  
-       cpu/stm32f1/Makefile.features  
-       cpu/stm32_common/Makefile.features  
-       cpu/cortexm_common/Makefile.features  
        makefiles/pseudomodules.inc.mk  
        makefiles/defaultmodules.inc.mk  
        boards/bluepill-128kib/Makefile.include  
@@ -821,9 +812,6 @@
        cpu/stm32f1/Makefile.features  
        cpu/stm32_common/Makefile.features  
        cpu/cortexm_common/Makefile.features  
-       cpu/stm32f1/Makefile.features  
-       cpu/stm32_common/Makefile.features  
-       cpu/cortexm_common/Makefile.features  
        makefiles/pseudomodules.inc.mk  
        makefiles/defaultmodules.inc.mk  
        boards/blackpill-128kib/Makefile.include  
@@ -1039,9 +1027,6 @@
        cpu/stm32l4/Makefile.features  
        cpu/stm32_common/Makefile.features  
        cpu/cortexm_common/Makefile.features  
-       cpu/stm32l4/Makefile.features  
-       cpu/stm32_common/Makefile.features  
-       cpu/cortexm_common/Makefile.features  
        makefiles/pseudomodules.inc.mk  
        makefiles/defaultmodules.inc.mk  
        boards/p-l496g-cell02/Makefile.include  
@@ -1251,9 +1236,6 @@
        cpu/saml21/Makefile.features  
        cpu/sam0_common/Makefile.features  
        cpu/cortexm_common/Makefile.features  
-       cpu/saml21/Makefile.features  
-       cpu/sam0_common/Makefile.features  
-       cpu/cortexm_common/Makefile.features  
        makefiles/pseudomodules.inc.mk  
        makefiles/defaultmodules.inc.mk  
        boards/samr34-xpro/Makefile.include  
@@ -1466,9 +1448,6 @@
        cpu/stm32f7/Makefile.features  
        cpu/stm32_common/Makefile.features  
        cpu/cortexm_common/Makefile.features  
-       cpu/stm32f7/Makefile.features  
-       cpu/stm32_common/Makefile.features  
-       cpu/cortexm_common/Makefile.features  
        makefiles/pseudomodules.inc.mk  
        makefiles/defaultmodules.inc.mk  
        boards/stm32f723e-disco/Makefile.include  
```
</details>

### Issues/PRs references

Part of Tracking: move CPU/CPU_MODEL to Makefile.features #11477