### PR TITLE
cpu/cc2538: fix spi_transfer_bytes()

### DIFF
--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -145,14 +145,13 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
             dev(bus)->DR;
         }
     }
-    else if (!out_buf) { /*TODO this case is currently untested */
+    else if (!out_buf) {
         size_t in_cnt = 0;
         for (size_t i = 0; i < len; i++) {
             while (!(dev(bus)->SR & SSI_SR_TNF)) {}
             dev(bus)->DR = 0;
-            if (dev(bus)->SR & SSI_SR_RNE) {
-                in_buf[in_cnt++] = dev(bus)->DR;
-            }
+            while (!(dev(bus)->SR & SSI_SR_RNE)) {}
+            in_buf[in_cnt++] = dev(bus)->DR;
         }
         /* get remaining bytes */
         while (dev(bus)->SR & SSI_SR_RNE) {
@@ -163,7 +162,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         for (size_t i = 0; i < len; i++) {
             while (!(dev(bus)->SR & SSI_SR_TNF)) {}
             dev(bus)->DR = out_buf[i];
-            while (!(dev(bus)->SR & SSI_SR_RNE)){}
+            while (!(dev(bus)->SR & SSI_SR_RNE)) {}
             in_buf[i] = dev(bus)->DR;
         }
         /* wait until no more busy */


### PR DESCRIPTION
### Contribution description

For some reason the `spi_transfer_bytes()` function did not wait for data bytes to be received in the `!out_buf` case which was reassuringly marked as `/* TODO this case is currently untested */`.

When @tinstructor [tested](https://github.com/RIOT-OS/RIOT/pull/12128#issuecomment-536515649) the at86rf215 driver on the Openmote-b, he discovered that functions that read multiple bytes would not work because of that.

### Testing procedure

Read data from a spi slave without sending data: `spi_transfer_bytes(SPIDEV, CSPIN, true, NULL, data, sizeof(data));`

But really, there shouldn't be a difference between writing payload bytes or writing 0 / don't care bytes to the SPI slave - we have to wait for `SSI_SR_RNE` in both cases.

Looking at the code, both cases now use the same logic - as they should.

### Issues/PRs references
discovered while testing #12128
