### PR TITLE
dist/buildsystem_sanity_check: add check for CPU/CPU_MODEL migration

### DIFF
--- a/Makefile.features
+++ b/Makefile.features
@@ -14,6 +14,8 @@ include $(RIOTBOARD)/$(BOARD)/Makefile.features
 # Transitional conditional include until all boards define 'CPU'
 ifneq (,$(CPU))
   include $(RIOTCPU)/$(CPU)/Makefile.features
+else
+  $(warning CPU must be defined by board / board_common Makefile.features)
 endif
 
 

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -128,6 +128,22 @@ check_deprecated_vars_patterns() {
         | error_with_message 'Deprecated variables or patterns:'
 }
 
+# Makefile files cpu must not be included by the board anymore
+# They are included by the main Makefile.include/Makefile.features/Makefile.dep
+check_board_do_not_include_cpu_features_dep() {
+    local patterns=()
+    local pathspec=()
+
+    # shellcheck disable=SC2016
+    # Single quotes are used to not expand expressions
+    patterns+=(-e 'include $(RIOTCPU)/.*/Makefile\..*')
+
+    pathspec+=('boards/')
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+            | error_with_message 'Makefiles files from cpu must not be included by the board anymore'
+}
+
 # Applications Makefile must not set 'BOARD =' unconditionally
 check_not_setting_board_equal() {
     local patterns=()
@@ -149,6 +165,7 @@ all_checks() {
     check_not_parsing_features
     check_not_exporting_variables
     check_deprecated_vars_patterns
+    check_board_do_not_include_cpu_features_dep
     check_not_setting_board_equal
 }
 

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -144,6 +144,24 @@ check_board_do_not_include_cpu_features_dep() {
             | error_with_message 'Makefiles files from cpu must not be included by the board anymore'
 }
 
+# CPU and CPU_MODEL definition have been moved to 'BOARD|CPU/Makefile.features'
+check_cpu_cpu_model_defined_in_makefile_features() {
+    local patterns=()
+    local pathspec=()
+
+    # With our without space and with or without ?=
+    patterns+=(-e '^ *\(export\)\? *CPU \??\?=')
+    patterns+=(-e '^ *\(export\)\? *CPU_MODEL \??\?=')
+    pathspec+=(':!boards/**/Makefile.features')
+    pathspec+=(':!cpu/**/Makefile.features')
+
+    # Currently blacklist this non migrated file for CPU_MODEL
+    pathspec+=(':!boards/slwstk6000b/Makefile.include')
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+            | error_with_message 'CPU and CPU_MODEL definition must be done by board/BOARD/Makefile.features, board/common/**/Makefile.features or cpu/CPU/Makefile.features'
+}
+
 # Applications Makefile must not set 'BOARD =' unconditionally
 check_not_setting_board_equal() {
     local patterns=()
@@ -166,6 +184,7 @@ all_checks() {
     check_not_exporting_variables
     check_deprecated_vars_patterns
     check_board_do_not_include_cpu_features_dep
+    check_cpu_cpu_model_defined_in_makefile_features
     check_not_setting_board_equal
 }
 


### PR DESCRIPTION
### Contribution description

Static tests to ensure.

* CPU Makefile.include/Makefile.features/Makefile.dep must not be
included by the board directly anymore.

* CPU and CPU_MODEL variables must now be defined by
`boards/**/Makefile.features` files instead of `**/Makefile.include.

* CPU is defined by board Makefile.features with a warning

This currently blacklist the slwstk6000b and cortexm.inc.mk that still define
'CPU_MODEL' in a file that is not a 'Makefile.features.
This allows getting this sanity check script in master

Depends on

* ~boards/slwstk6000b: move CPU definiton to Makefile.features #12334~
* ~boards: remove duplicate include 'RIOTCPU/cpu/Makefile.features' #12335~


This is currently only warning during build that `CPU` is not defined. I have commits in https://github.com/RIOT-OS/RIOT/pull/11477 to enforce it, not sure if we want it already or not.

### Testing procedure

The static tests do not fail, and no warning for any board regarding defining `CPU`.

When reverting both depending commits and removing the blacklist lines, the forbidden outputs are matched:

```
./dist/tools/buildsystem_sanity_check/check.sh
Invalid build system patterns found by ./dist/tools/buildsystem_sanity_check/check.sh:
Makefiles files from cpu must not be included by the board anymore
        boards/common/blxxxpill/Makefile.features:include $(RIOTCPU)/stm32f1/Makefile.features
        boards/p-l496g-cell02/Makefile.features:include $(RIOTCPU)/stm32l4/Makefile.features
        boards/samr34-xpro/Makefile.features:include $(RIOTCPU)/saml21/Makefile.features
        boards/slwstk6000b/Makefile.dep:include $(RIOTCPU)/efm32/Makefile.dep
        boards/slwstk6000b/Makefile.features:include $(RIOTCPU)/efm32/Makefile.features
        boards/stm32f723e-disco/Makefile.features:include $(RIOTCPU)/stm32f7/Makefile.features
CPU and CPU_MODEL definition must be done by board/BOARD/Makefile.features or board/common/**/Makefile.features
        boards/slwstk6000b/Makefile.include:export CPU = efm32
        boards/slwstk6000b/Makefile.include:export CPU_MODEL = $(MODULE_CPU)
        makefiles/arch/cortexm.inc.mk:export CPU_MODEL ?= $(CPU)
```

And the warning is triggered:

```
for board in $(make info-boards); do ESP32_SDK_DIR=/tmp ESP8266_SDK_DIR=/tmp ESP8266_NEWLIB_DIR=/tmp PORT=/dev/null BOARD=${board} make --n
o-print-directory -C examples/hello-world/ clean; done
/home/harter/work/git/RIOT/Makefile.features:18: CPU must be defined by board / board_common Makefile.features
```

### Issues/PRs references

Depends on

* ~boards/slwstk6000b: move CPU definiton to Makefile.features #12334~
* ~boards: remove duplicate include 'RIOTCPU/cpu/Makefile.features' #12335~

Part of Tracking: move CPU/CPU_MODEL to Makefile.features #11477 
