### PR TITLE
makefiles/arch/cortexm.inc.mk: removing setting CPU_MODEL

### DIFF
--- a/cpu/lpc1768/Makefile.features
+++ b/cpu/lpc1768/Makefile.features
@@ -1,3 +1,5 @@
+# This CPU only implements one CPU_MODEL with the same name
+CPU_MODEL = lpc1768
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_pm
 

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -1,3 +1,7 @@
+ifeq (,$(CPU_MODEL))
+  $(error CPU_MODEL must have been defined by the board/cpu Makefile.features)
+endif
+
 # Target triple for the build. Use arm-none-eabi if you are unsure.
 export TARGET_ARCH ?= arm-none-eabi
 
@@ -38,9 +42,6 @@ export USEMODULE += cortexm_common_periph
 
 # all cortex MCU's use newlib as libc
 export USEMODULE += newlib
-
-# set default for CPU_MODEL
-export CPU_MODEL ?= $(CPU)
 
 
 # extract version inside the first parentheses


### PR DESCRIPTION
### Contribution description

All cortexm boards should now define it on there own.

Only the `lpc1768` cpu needed to be updated to now define `CPU_MODEL`, all others were already defining it.

### Interaction with another PR

Depending if https://github.com/RIOT-OS/RIOT/pull/12337 or this one goes first, the blacklist line should be removed by this PR or over there.

### Testing procedure

The value of `CPU_MODEL` is the same for all boards as in master:

<details><summary><code>for board in $(make info-boards); do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-CPU_MODEL; done</code></summary>

```
for board in $(make info-boards); do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-CPU_MODEL; done
acd52832
nrf52832xxaa
airfy-beacon
nrf51x22xxaa
arduino-due
sam3x8e
arduino-duemilanove

arduino-leonardo

arduino-mega2560

arduino-mkr1000
samd21g18a
arduino-mkrfox1200
samd21g18a
arduino-mkrzero
samd21g18a
arduino-nano

arduino-uno

arduino-zero
samd21g18a
avsextrem

b-l072z-lrwan1
stm32l072cz
b-l475e-iot01a
stm32l475vg
blackpill
stm32f103c8
blackpill-128kib
stm32f103cb
bluepill
stm32f103c8
bluepill-128kib
stm32f103cb
calliope-mini
nrf51x22xxab
Warning: no PORT set!
cc2538dk
cc2538nf53
cc2650-launchpad
cc26x0f128
cc2650stk
cc26x0f128
chronos
cc430f6137
ek-lm4f120xl
LM4F120H5QR
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
esp32-mh-et-live-minikit
esp32
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
esp32-olimex-evb
esp32
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
esp32-wemos-lolin-d32-pro
esp32
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
esp32-wroom-32
esp32
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
esp32-wrover-kit
esp32
ESP8266_NEWLIB_DIR should be defined as /path/to/newlib directory
ESP8266_NEWLIB_DIR is set by default to /opt/esp/newlib-xtensa
ESP8266_SDK_DIR should be defined as /path/to/sdk directory
ESP8266_SDK_DIR is set by default to /opt/esp/esp-open-sdk/sdk
esp8266-esp-12x
esp8266
ESP8266_NEWLIB_DIR should be defined as /path/to/newlib directory
ESP8266_NEWLIB_DIR is set by default to /opt/esp/newlib-xtensa
ESP8266_SDK_DIR should be defined as /path/to/sdk directory
ESP8266_SDK_DIR is set by default to /opt/esp/esp-open-sdk/sdk
esp8266-olimex-mod
esp8266
ESP8266_NEWLIB_DIR should be defined as /path/to/newlib directory
ESP8266_NEWLIB_DIR is set by default to /opt/esp/newlib-xtensa
ESP8266_SDK_DIR should be defined as /path/to/sdk directory
ESP8266_SDK_DIR is set by default to /opt/esp/esp-open-sdk/sdk
esp8266-sparkfun-thing
esp8266
f4vi1
stm32f415rg
feather-m0
samd21g18a
firefly
cc2538sf53
fox
stm32f103re
frdm-k22f
mk22fn512vlh12
frdm-k64f
mk64fn1m0vll12
frdm-kw41z
mkw41z512vht4
hamilton
samr21e18a
hifive1
fe310_g000
hifive1b
fe310_g002
i-nucleo-lrwan1
stm32l052t8
ikea-tradfri
efr32mg1p132f256gm32
iotlab-a8-m3
stm32f103re
iotlab-m3
stm32f103re
limifrog-v1
stm32l151rc
lobaro-lorabox
stm32l151cb_a
lsn50
stm32l072cz
maple-mini
stm32f103cb
mbed_lpc1768
lpc1768
mega-xplained

microbit
nrf51x22xxab
msb-430
msp430f1612
msb-430h
msp430f1612
msba2

msbiot
stm32f415rg
mulle
mk60dn512vll10
native

nrf51dk
nrf51x22xxac
nrf51dongle
nrf51x22xxab
nrf52832-mdk
nrf52832xxaa
nrf52840-mdk
nrf52840xxaa
nrf52840dk
nrf52840xxaa
nrf52dk
nrf52832xxaa
nrf6310
nrf51x22xxaa
nucleo-f030r8
stm32f030r8
nucleo-f031k6
stm32f031k6
nucleo-f042k6
stm32f042k6
nucleo-f070rb
stm32f070rb
nucleo-f072rb
stm32f072rb
nucleo-f091rc
stm32f091rc
nucleo-f103rb
stm32f103rb
nucleo-f207zg
stm32f207zg
nucleo-f302r8
stm32f302r8
nucleo-f303k8
stm32f303k8
nucleo-f303re
stm32f303re
nucleo-f303ze
stm32f303ze
nucleo-f334r8
stm32f334r8
nucleo-f401re
stm32f401re
nucleo-f410rb
stm32f410rb
nucleo-f411re
stm32f411re
nucleo-f412zg
stm32f412zg
nucleo-f413zh
stm32f413zh
nucleo-f429zi
stm32f429zi
nucleo-f446re
stm32f446re
nucleo-f446ze
stm32f446ze
nucleo-f722ze
stm32f722ze
nucleo-f746zg
stm32f746zg
nucleo-f767zi
stm32f767zi
nucleo-l031k6
stm32l031k6
nucleo-l053r8
stm32l053r8
nucleo-l073rz
stm32l073rz
nucleo-l152re
stm32l152re
nucleo-l432kc
stm32l432kc
nucleo-l433rc
stm32l433rc
nucleo-l452re
stm32l452re
nucleo-l476rg
stm32l476rg
nucleo-l496zg
stm32l496zg
nucleo-l4r5zi
stm32l4r5zi
nz32-sc151
stm32l151rc
opencm904
stm32f103cb
openmote-b
cc2538sf53
openmote-cc2538
cc2538sf53
p-l496g-cell02
stm32l496ag
particle-argon
nrf52840xxaa
particle-boron
nrf52840xxaa
particle-xenon
nrf52840xxaa
pba-d-01-kw2x
mkw21d256vha5
phynode-kw41z
mkw41z512vht4
pic32-clicker
p32mx470f512h
pic32-wifire
p32mz2048efg100
pyboard
stm32f405rg
reel
nrf52840xxaa
remote-pa
cc2538sf53
remote-reva
cc2538sf53
remote-revb
cc2538sf53
ruuvitag
nrf52832xxaa
samd21-xpro
samd21j18a
same54-xpro
same54p20a
saml10-xpro
saml10e16a
saml11-xpro
saml11e16a
saml21-xpro
saml21j18a
samr21-xpro
samr21g18a
samr30-xpro
samr30g18a
samr34-xpro
samr34j18b
seeeduino_arch-pro
lpc1768
sensebox_samd21
samd21g18a
slstk3401a
efm32pg1b200f256gm48
slstk3402a
efm32pg12b500f1024gl125
sltb001a
efr32mg1p132f256gm48
slwstk6000b
efr32mg12p332f1024gl125
slwstk6220a
ezr32wg330f256r60
sodaq-autonomo
samd21j18a
sodaq-explorer
samd21j18a
sodaq-one
samd21g18a
sodaq-sara-aff
samd21j18a
spark-core
stm32f103cb
stk3600
efm32lg990f256
stk3700
efm32gg990f1024
stm32f0discovery
stm32f051r8
stm32f3discovery
stm32f303vc
stm32f429i-disc1
stm32f429zi
stm32f4discovery
stm32f407vg
stm32f723e-disco
stm32f723ie
stm32f769i-disco
stm32f769ni
stm32l0538-disco
stm32l053c8
stm32l476g-disco
stm32l476vg
teensy31
mk20dx256vlh7
telosb
msp430f1611
thingy52
nrf52832xxaa
ublox-c030-u201
stm32f437vg
udoo
sam3x8e
usb-kw41z
mkw41z512vht4
waspmote-pro

wsn430-v1_3b
msp430f1611
wsn430-v1_4
msp430f1611
yunjia-nrf51822
nrf51x22xxaa
z1
msp430f2617
```
</details>


### Issues/PRs references

Part of Tracking: move CPU/CPU_MODEL to Makefile.features #11477
Has interactions with https://github.com/RIOT-OS/RIOT/pull/12337 as it removes the need for the blacklist of `cortexm.inc.mk` in the static check.
