### PR TITLE
drivers: Add support of TCA6507

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -537,6 +537,10 @@ ifneq (,$(filter sx127%,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter tca6507,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter tcs37727,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -270,6 +270,10 @@ ifneq (,$(filter sx127x,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sx127x/include
 endif
 
+ifneq (,$(filter tca6507,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/tca6507/include
+endif
+
 ifneq (,$(filter tcs37727,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/tcs37727/include
 endif

--- a/drivers/include/tca6507.h
+++ b/drivers/include/tca6507.h
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2019 Noel Le Moult <noel.lemoult@dfxlab.fr>
+ * Copyright (C) 2019 William MARTIN <william.martin@power-lan.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+ /**
+  * @ingroup     drivers_actuators
+  * @ingroup     drivers_saul
+  * @defgroup    drivers_tca6507 TCA6507 I2C Led controller
+  * @brief       Public API for TCA6507 I2C Led controller
+  * @author      Noel Le Moult <noel.lemoult@dfxlab.fr>
+  * @author      William MARTIN <william.martin@power-lan.com>
+  * @file
+  * @{
+  */
+
+#ifndef TCA6507_H
+#define TCA6507_H
+
+#include "periph/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Driver return codes
+ */
+enum {
+    TCA6507_OK,                 /**< All OK */
+    TCA6507_ERR_NODEV,          /**< No valid device found on I2C bus */
+    TCA6507_ERR_I2C             /**< An error occurred when reading/writing on I2C bus */
+};
+
+
+/**
+ * @brief Bank define
+ *
+ * Each bank can be configured to a specific brightness with the function
+ * tca6507_intensity and TCA6507_BRIGHTNESS_*_PCENT defines. Then, you can
+ * select the bank to use when you use function: tca6507_set_led,
+ * tca6507_toggle_led, and tca6507_blink_led.
+ */
+enum {
+    TCA6507_BANK0,
+    TCA6507_BANK1,
+    TCA6507_BANK_COUNT
+};
+
+/**
+ * @brief Fadding times
+ */
+enum {
+    TCA6507_TIME_0_MS,
+    TCA6507_TIME_64_MS,
+    TCA6507_TIME_128_MS,
+    TCA6507_TIME_192_MS,
+    TCA6507_TIME_256_MS,
+    TCA6507_TIME_384_MS,
+    TCA6507_TIME_512_MS,
+    TCA6507_TIME_768_MS,
+    TCA6507_TIME_1024_MS,
+    TCA6507_TIME_2536_MS,
+    TCA6507_TIME_2048_MS,
+    TCA6507_TIME_3072_MS,
+    TCA6507_TIME_4096_MS,
+    TCA6507_TIME_5760_MS,
+    TCA6507_TIME_8128_MS,
+    TCA6507_TIME_16320_MS,
+    TCA6507_TIME_COUNT
+};
+
+/**
+ * @brief Brightness
+ */
+enum {
+    TCA6507_BRIGHTNESS_0_PCENT,
+    TCA6507_BRIGHTNESS_6_PCENT,
+    TCA6507_BRIGHTNESS_13_PCENT,
+    TCA6507_BRIGHTNESS_20_PCENT,
+    TCA6507_BRIGHTNESS_26_PCENT,
+    TCA6507_BRIGHTNESS_33_PCENT,
+    TCA6507_BRIGHTNESS_40_PCENT,
+    TCA6507_BRIGHTNESS_46_PCENT,
+    TCA6507_BRIGHTNESS_53_PCENT,
+    TCA6507_BRIGHTNESS_60_PCENT,
+    TCA6507_BRIGHTNESS_66_PCENT,
+    TCA6507_BRIGHTNESS_73_PCENT,
+    TCA6507_BRIGHTNESS_80_PCENT,
+    TCA6507_BRIGHTNESS_86_PCENT,
+    TCA6507_BRIGHTNESS_93_PCENT,
+    TCA6507_BRIGHTNESS_100_PCENT,
+    TCA6507_BRIGHTNESS_COUNT
+
+};
+
+/**
+ * @brief Device initialization parameters.
+ */
+typedef struct {
+    i2c_t i2c_dev;              /**< I2C bus the sensor is connected to */
+    uint8_t address;            /**< sensor address */
+} tca6507_params_t;
+
+/**
+ * @brief TCA6507 device descriptor.
+ */
+typedef struct {
+    tca6507_params_t params;     /**< Device parameters */
+} tca6507_t;
+
+/**
+ * @brief   Initialize and reset the sensor.
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] params        initialization parameters
+ *
+ * @return                  TCA6507_OK on successful initialization
+ * @return                  TCA6507_ERR_NODEV on device test error
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_init(tca6507_t *dev, const tca6507_params_t *params);
+
+/**
+ * @brief   Turn on a led
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] led           The led index
+ * @param[in] bank          The bank to use (intensity)
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_set_led(const tca6507_t *dev, uint8_t led, uint8_t bank);
+
+/**
+ * @brief   Turn off a led
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] led           The led index
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_clear_led(const tca6507_t *dev, uint8_t led);
+
+/**
+ * @brief   Turn off all leds
+ *
+ * @param[in] dev           device descriptor
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_clear_all(const tca6507_t *dev);
+
+/**
+ * @brief   Toggle a led on
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] led           The led index
+ * @param[in] bank          The bank to use (intensity)
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_toggle_led(const tca6507_t *dev, uint8_t led, uint8_t bank);
+
+/**
+ * @brief   Enable the blink mode for a led
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] led           The led index
+ * @param[in] bank          The bank to use (intensity)
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_blink_led(const tca6507_t *dev, uint8_t led, uint8_t bank);
+
+/**
+ * @brief   Confiure the intensity of a bank
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] intensity     Intensity of the led in percent
+ * @param[in] bank          The bank to configure
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_intensity(const tca6507_t *dev, uint8_t intensity, uint8_t bank);
+
+/**
+ * @brief   Configure the fade on time of a bank
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] time          Duration define by TCA6507_TIME_*
+ * @param[in] bank          The bank to configure
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_fade_on_time(const tca6507_t *dev, uint8_t time, uint8_t bank);
+
+/**
+ * @brief   Configure the fade off time of a bank
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] time          Duration define by TCA6507_TIME_*
+ * @param[in] bank          The bank to configure
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_fade_off_time(const tca6507_t *dev, uint8_t time, uint8_t bank);
+
+/**
+ * @brief   Configure the fully on time of a bank
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] time          Duration define by TCA6507_TIME_*
+ * @param[in] bank          The bank to configure
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_fully_on_time(const tca6507_t *dev, uint8_t time, uint8_t bank);
+
+/**
+ * @brief   Configure the first fully off time of a bank
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] time          Duration define by TCA6507_TIME_*
+ * @param[in] bank          The bank to configure
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_first_fully_off_time(const tca6507_t *dev, uint8_t time, uint8_t bank);
+
+/**
+ * @brief   Configure the second fully off time of a bank
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] time          Duration define by TCA6507_TIME_*
+ * @param[in] bank          The bank to configure
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_second_fully_off_time(const tca6507_t *dev, uint8_t time, uint8_t bank);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TCA6507_H */
+/** @} */

--- a/drivers/include/tca6507.h
+++ b/drivers/include/tca6507.h
@@ -52,6 +52,20 @@ enum {
 };
 
 /**
+ * @brief PWM Operating mode
+ * Table 19. One-Shot / Master Intensity Register
+ * The one-shot mode may be bugged by crappy design of the hardware chip, do not use it
+ */
+#define TCA6507_BANK0_MODE_NORMAL              (0 << 6)
+#define TCA6507_BANK0_MODE_ONESHOT             (1 << 6)
+#define TCA6507_BANK0_BRIGHTNESS_MASTER        (1 << 4)
+#define TCA6507_BANK0_BRIGHTNESS_BANK          (0 << 4)
+#define TCA6507_BANK1_MODE_NORMAL              (0 << 7)
+#define TCA6507_BANK1_MODE_ONESHOT             (1 << 7)
+#define TCA6507_BANK1_BRIGHTNESS_MASTER        (1 << 5)
+#define TCA6507_BANK1_BRIGHTNESS_BANK          (0 << 5)
+
+/**
  * @brief Fadding times
  */
 enum {
@@ -64,7 +78,7 @@ enum {
     TCA6507_TIME_512_MS,
     TCA6507_TIME_768_MS,
     TCA6507_TIME_1024_MS,
-    TCA6507_TIME_2536_MS,
+    TCA6507_TIME_1536_MS,
     TCA6507_TIME_2048_MS,
     TCA6507_TIME_3072_MS,
     TCA6507_TIME_4096_MS,
@@ -183,7 +197,7 @@ int tca6507_toggle_led(const tca6507_t *dev, uint8_t led, uint8_t bank);
 int tca6507_blink_led(const tca6507_t *dev, uint8_t led, uint8_t bank);
 
 /**
- * @brief   Confiure the intensity of a bank
+ * @brief   Configure the intensity of a bank
  *
  * @param[in] dev           device descriptor
  * @param[in] intensity     Intensity of the led in percent
@@ -193,6 +207,19 @@ int tca6507_blink_led(const tca6507_t *dev, uint8_t led, uint8_t bank);
  * @return                  TCA6507_ERR_I2C on I2C bus error
  */
 int tca6507_intensity(const tca6507_t *dev, uint8_t intensity, uint8_t bank);
+
+/**
+ * @brief   Configure the master intensity
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] intensity     Intensity of the led in percent
+ * @param[in] bank          The master intensity, this brightness can be configured
+ *                          to overwrite the bank brightness
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_master_intensity(const tca6507_t *dev, uint8_t brightness);
 
 /**
  * @brief   Configure the fade on time of a bank
@@ -253,6 +280,29 @@ int tca6507_first_fully_off_time(const tca6507_t *dev, uint8_t time, uint8_t ban
  * @return                  TCA6507_ERR_I2C on I2C bus error
  */
 int tca6507_second_fully_off_time(const tca6507_t *dev, uint8_t time, uint8_t bank);
+
+/**
+ * @brief   Advance configuration for banks
+ *
+ * @param[in] dev           device descriptor
+ * @param[in] mask          Bits mask for register 0x09 (One-Shot / Master Intensity)
+ *                          See TCA6507_BANK0_* and TCA6507_BANK1_* definitions
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_bank_setup(const tca6507_t *dev, uint8_t mask);
+
+/**
+ * @brief   Show content of hardware registers (for debug)
+ *
+ * @param[in] dev           device descriptor
+ *
+ * @return                  TCA6507_OK on success
+ * @return                  TCA6507_ERR_I2C on I2C bus error
+ */
+int tca6507_dump_registers(const tca6507_t *dev);
+
 
 #ifdef __cplusplus
 }

--- a/drivers/include/tca6507.h
+++ b/drivers/include/tca6507.h
@@ -213,8 +213,6 @@ int tca6507_intensity(const tca6507_t *dev, uint8_t intensity, uint8_t bank);
  *
  * @param[in] dev           device descriptor
  * @param[in] intensity     Intensity of the led in percent
- * @param[in] bank          The master intensity, this brightness can be configured
- *                          to overwrite the bank brightness
  *
  * @return                  TCA6507_OK on success
  * @return                  TCA6507_ERR_I2C on I2C bus error

--- a/drivers/tca6507/Makefile
+++ b/drivers/tca6507/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/tca6507/include/tca6507_internals.h
+++ b/drivers/tca6507/include/tca6507_internals.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 Noel Le Moult <noel.lemoult@dfxlab.fr>
+ * Copyright (C) 2019 William MARTIN <william.martin@power-lan.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_tca6507
+ * @brief       Internal definitions for TCA6507 I2C Led controller
+ * @author      Noel Le Moult <noel.lemoult@dfxlab.fr>
+ * @author      William MARTIN <william.martin@power-lan.com>
+ * @file
+ * @{
+ */
+
+#ifndef TCA6507_INTERNALS_H
+#define TCA6507_INTERNALS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief TCA6507 chip addresses.
+ */
+#define TCA6507_I2C_ADDRESS         (0x45)
+
+/**
+ * @name TCA6507 device commands.
+ * @{
+ */
+#define TCA6507_COMMAND_AUTOINC            (0x10)
+#define TCA6507_SELECT0                    (0x00)
+#define TCA6507_SELECT1                    (0x01)
+#define TCA6507_SELECT2                    (0x02)
+#define TCA6507_FADEON_TIME                (0x03)
+#define TCA6507_FULLYON_TIME               (0x04)
+#define TCA6507_FADEOFF_TIME               (0x05)
+#define TCA6507_FIRST_FULLYOFF_TIME        (0x06)
+#define TCA6507_SEC_FULLYOFF_TIME          (0x07)
+#define TCA6507_MAX_INTENSITY              (0x08)
+#define TCA6507_ONESHOT_MASTER_INTENSITY   (0x09)
+#define TCA6507_INIT                       (0x0A)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TCA6507_INTERNALS_H */
+/** @} */

--- a/drivers/tca6507/include/tca6507_params.h
+++ b/drivers/tca6507/include/tca6507_params.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 Noel Le Moult <noel.lemoult@dfxlab.fr>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_tca6507
+ * @brief       Default configuration for the TCA6507 I2C Led controller
+ * @author      Noel Le Moult <noel.lemoult@dfxlab.fr>
+ * @author      William MARTIN <william.martin@power-lan.com>
+ * @file
+ * @{
+ */
+
+#ifndef TCA6507_PARAMS_H
+#define TCA6507_PARAMS_H
+
+#include "board.h"
+#include "tca6507.h"
+#include "tca6507_internals.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the TCA6507 sensor
+ * @{
+ */
+#ifndef TCA6507_PARAM_I2C_DEV
+#define TCA6507_PARAM_I2C_DEV         I2C_DEV(0)
+#endif
+
+#ifndef TCA6507_PARAM_ADDR
+#define TCA6507_PARAM_ADDR            TCA6507_I2C_ADDRESS
+#endif
+
+#ifndef TCA6507_PARAMS
+#define TCA6507_PARAMS                { .i2c_dev = TCA6507_PARAM_I2C_DEV, \
+                                        .address = TCA6507_PARAM_ADDR }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configure TCA6507
+ */
+static const tca6507_params_t tca6507_params[] =
+{
+    TCA6507_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TCA6507_PARAMS_H */
+/** @} */

--- a/drivers/tca6507/tca6507.c
+++ b/drivers/tca6507/tca6507.c
@@ -377,7 +377,7 @@ int tca6507_dump_registers(const tca6507_t *dev)
 
   puts("tca6507 registers :");
   for (size_t i=0; i<sizeof(regs); i++) {
-    printf("\t%02lx: %02x\n", i, regs[i]);
+    printf("\t%02x: %02x\n", (unsigned)i, regs[i]);
   }
 
 finish:

--- a/drivers/tca6507/tca6507.c
+++ b/drivers/tca6507/tca6507.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright (C) 2019 Noel Le Moult <noel.lemoult@dfxlab.fr>
+ * Copyright (C) 2019 William MARTIN <william.martin@power-lan.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_tca6507
+ * @brief       Driver for the TCA6507 I2C Led controller
+ * @author      Noel Le Moult <noel.lemoult@dfxlab.fr>
+ * @author      William MARTIN <william.martin@power-lan.com>
+ * @file
+ */
+
+/*
+ * Datasheet: http://www.ti.com/lit/ds/symlink/tca6507.pdf
+ *
+ * Table 8. Select2, Select1, and Select0 Register States
+ *
+ * | SELECT 2 | SELECT 1 | SELECT 0 |  STATE                                                                                                                                |
+ * |----------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
+ * | 0        | 0        | 0        | LED off (high impedance)                                                                                                              |
+ * | 0        | 0        | 1        | LED off (high impedance)                                                                                                              |
+ * | 0        | 1        | 0        | LED on with maximum intensity value of PWM0 (ALD value or BRIGHT_F0 value, depending on One Shot / Master Intensity Register setting) |
+ * | 0        | 1        | 1        | LED on with maximum intensity value of PWM1 (ALD value or BRIGHT_F1 value, depending on One Shot / Master Intensity Register setting) |
+ * | 1        | 0        | 0        | LED fully on (output low). Can be used as general-purpose output                                                                      |
+ * | 1        | 0        | 1        | LED on at brightness set by One Shot / Master Intensity registe                                                                       |
+ * | 1        | 1        | 0        | LED blinking with intensity characteristics of BANK0 (PWM0).                                                                          |
+ * | 1        | 1        | 1        | LED blinking with intensity characteristics of BANK1 (PWM1).                                                                          |
+*/
+
+#include <string.h>
+#include "xtimer.h"
+
+#include "tca6507_internals.h"
+#include "tca6507.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define TCA6507_I2C     (dev->params.i2c_dev)
+#define TCA6507_ADDR    (dev->params.address)
+
+int tca6507_init(tca6507_t *dev, const tca6507_params_t *params)
+{
+    /* initialize the device descriptor */
+    dev->params = *params;
+
+#ifdef TCA6507_FORCE_PROBE_ON_INIT
+    i2c_acquire(TCA6507_I2C);
+
+    /* Dummy read to check the I2C bus */
+    uint8_t regs[1];
+    if (i2c_read_regs(TCA6507_I2C, TCA6507_ADDR, TCA6507_SELECT0, &regs,
+                      sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot access TCA6507 device.\n");
+        return TCA6507_ERR_I2C;
+    }
+
+    i2c_release(TCA6507_I2C);
+#endif
+
+    DEBUG("[DEBUG] Device initialized with success.\n");
+    return TCA6507_OK;
+}
+
+int tca6507_set_led(const tca6507_t *dev, uint8_t led, uint8_t bank)
+{
+    int ret = TCA6507_ERR_I2C;
+    uint8_t regs[3];
+
+    /* setup the i2c bus */
+    i2c_acquire(TCA6507_I2C);
+
+    if (i2c_read_regs(TCA6507_I2C, TCA6507_ADDR,
+                      TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                      sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot read TCA6507 from I2C.\n");
+        goto finish;
+    }
+
+    if (bank == 0) {
+        regs[0] = regs[0] & ~(1UL << led);
+        regs[1] = regs[1] | 1UL << led;
+        regs[2] = regs[2] & ~(1UL << led);
+    }
+    else {
+        regs[0] = regs[0] | 1UL << led;
+        regs[1] = regs[1] | 1UL << led;
+        regs[2] = regs[2] & ~(1UL << led);
+    }
+
+    if (i2c_write_regs(TCA6507_I2C, TCA6507_ADDR,
+                       TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                       sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot write command 'TCA6507_COMMAND_AUTOINC' to I2C.\n");
+        goto finish;
+    }
+    ret = TCA6507_OK;
+
+finish:
+    i2c_release(TCA6507_I2C);
+    return ret;
+}
+
+int tca6507_clear_led(const tca6507_t *dev, uint8_t led)
+{
+    int ret = TCA6507_ERR_I2C;
+    uint8_t regs[3];
+
+    /* setup the i2c bus */
+    i2c_acquire(TCA6507_I2C);
+
+    if (i2c_read_regs(TCA6507_I2C, TCA6507_ADDR,
+                      TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                      sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot read TCA6507 from I2C.\n");
+        goto finish;
+    }
+
+    regs[0] = regs[0] & ~(1UL << led);
+    regs[1] = regs[1] & ~(1UL << led);
+    regs[2] = regs[2] & ~(1UL << led);
+
+    if (i2c_write_regs(TCA6507_I2C, TCA6507_ADDR,
+                       TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                       sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot write command 'TCA6507_COMMAND_AUTOINC' to I2C.\n");
+        goto finish;
+    }
+    ret = TCA6507_OK;
+
+finish:
+    i2c_release(TCA6507_I2C);
+    return ret;
+}
+
+int tca6507_clear_all(const tca6507_t *dev)
+{
+    int ret = TCA6507_ERR_I2C;
+    uint8_t regs[3];
+
+    /* setup the i2c bus */
+    i2c_acquire(TCA6507_I2C);
+
+    regs[0] = 0;
+    regs[1] = 0;
+    regs[2] = 0;
+
+    if (i2c_write_regs(TCA6507_I2C, TCA6507_ADDR,
+                       TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                       sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot write command 'TCA6507_COMMAND_AUTOINC' to I2C.\n");
+        goto finish;
+    }
+    ret = TCA6507_OK;
+
+finish:
+    i2c_release(TCA6507_I2C);
+    return ret;
+}
+
+
+int tca6507_toggle_led(const tca6507_t *dev, uint8_t led, uint8_t bank)
+{
+    int ret = TCA6507_ERR_I2C;
+    uint8_t regs[3];
+
+    /* setup the i2c bus */
+    i2c_acquire(TCA6507_I2C);
+
+    if (i2c_read_regs(TCA6507_I2C, TCA6507_ADDR,
+                      TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                      sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot read TCA6507 from I2C.\n");
+        goto finish;
+    }
+
+    /* only work if led was is state 000 or 010/110 before. */
+    if (bank == 0) {
+        regs[0] = regs[0] ^ 0UL << led;
+        regs[1] = regs[1] ^ 1UL << led;
+        regs[2] = regs[2] ^ 0UL << led;
+    }
+    else {
+        regs[0] = regs[0] ^ 1UL << led;
+        regs[1] = regs[1] ^ 1UL << led;
+        regs[2] = regs[2] ^ 0UL << led;
+    }
+
+    if (i2c_write_regs(TCA6507_I2C, TCA6507_ADDR,
+                       TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                       sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot write command 'TCA6507_COMMAND_AUTOINC' to I2C.\n");
+        goto finish;
+    }
+    ret = TCA6507_OK;
+
+finish:
+    i2c_release(TCA6507_I2C);
+    return ret;
+}
+
+int tca6507_blink_led(const tca6507_t *dev, uint8_t led, uint8_t bank)
+{
+    int ret = TCA6507_ERR_I2C;
+    uint8_t regs[3];
+    uint8_t mask = 1UL << led;
+
+    /* setup the i2c bus */
+    i2c_acquire(TCA6507_I2C);
+
+    if (i2c_read_regs(TCA6507_I2C, TCA6507_ADDR,
+                      TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                      sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot read TCA6507 from I2C.\n");
+        goto finish;
+    }
+
+    if (bank == 0) {
+        regs[0] = regs[0] & ~mask;
+        regs[1] = regs[1] | mask;
+        regs[2] = regs[2] | mask;
+    }
+    else {
+        regs[0] = regs[0] | mask;
+        regs[1] = regs[1] | mask;
+        regs[2] = regs[2] | mask;
+    }
+
+    if (i2c_write_regs(TCA6507_I2C, TCA6507_ADDR,
+                       TCA6507_SELECT0 | TCA6507_COMMAND_AUTOINC, &regs,
+                       sizeof(regs), 0) != 0) {
+        DEBUG("[ERROR] Cannot write command 'TCA6507_MAX_INTENSITY' to I2C.\n");
+        goto finish;
+    }
+    ret = TCA6507_OK;
+
+finish:
+    i2c_release(TCA6507_I2C);
+    return ret;
+}
+
+static int tca6507_update_4bits(const tca6507_t *dev, uint8_t function,
+                                uint8_t payload, uint8_t bank)
+{
+    int ret = TCA6507_ERR_I2C;
+    uint8_t value;
+
+    /* setup the i2c bus */
+    i2c_acquire(TCA6507_I2C);
+
+    if (i2c_write_regs(TCA6507_I2C, TCA6507_ADDR, function, &value, 1,
+                       0) != 0) {
+        DEBUG("[ERROR] Cannot read TCA6507 from I2C.\n");
+        goto finish;
+    }
+
+    if (bank == 0) {
+        value = (value & 0xF0) | (payload & 0x0F);
+    }
+    else {
+        value = (value & 0x0F) | ((payload & 0x0F) << 4);
+    }
+
+    if (i2c_write_regs(TCA6507_I2C, TCA6507_ADDR, function, &value, 1,
+                       0) != 0) {
+        DEBUG("[ERROR] Cannot write command 'TCA6507_MAX_INTENSITY' to I2C.\n");
+        goto finish;
+    }
+
+    ret = TCA6507_OK;
+
+finish:
+    i2c_release(TCA6507_I2C);
+    return ret;
+}
+
+int tca6507_intensity(const tca6507_t *dev, uint8_t brightness, uint8_t bank)
+{
+    if (brightness > TCA6507_BRIGHTNESS_COUNT) {
+        DEBUG(
+            "[WARN] Brightness used a unsupported value, falling back to 100%%\n");
+        brightness = TCA6507_BRIGHTNESS_100_PCENT;
+    }
+
+    return tca6507_update_4bits(dev, TCA6507_MAX_INTENSITY, brightness, bank);
+}
+
+
+int tca6507_fade_on_time(const tca6507_t *dev, uint8_t time, uint8_t bank)
+{
+    if (time > TCA6507_TIME_COUNT) {
+        DEBUG("[WARN] Time used a unsupported value, falling back to 256ms\n");
+        time = TCA6507_TIME_256_MS;
+    }
+
+    return tca6507_update_4bits(dev, TCA6507_FADEON_TIME, time, bank);
+}
+
+int tca6507_fade_off_time(const tca6507_t *dev, uint8_t time, uint8_t bank)
+{
+    if (time > TCA6507_TIME_COUNT) {
+        DEBUG("[WARN] Time used a unsupported value, falling back to 256ms\n");
+        time = TCA6507_TIME_256_MS;
+    }
+
+    return tca6507_update_4bits(dev, TCA6507_FADEOFF_TIME, time, bank);
+}
+
+int tca6507_fully_on_time(const tca6507_t *dev, uint8_t time, uint8_t bank)
+{
+    if (time > TCA6507_TIME_COUNT) {
+        DEBUG("[WARN] Time used a unsupported value, falling back to 256ms\n");
+        time = TCA6507_TIME_256_MS;
+    }
+
+    return tca6507_update_4bits(dev, TCA6507_FULLYON_TIME, time, bank);
+}
+
+int tca6507_first_fully_off_time(const tca6507_t *dev, uint8_t time,
+                                 uint8_t bank)
+{
+    if (time > TCA6507_TIME_COUNT) {
+        DEBUG("[WARN] Time used a unsupported value, falling back to 256ms\n");
+        time = TCA6507_TIME_256_MS;
+    }
+
+    return tca6507_update_4bits(dev, TCA6507_FIRST_FULLYOFF_TIME, time, bank);
+}
+
+int tca6507_second_fully_off_time(const tca6507_t *dev, uint8_t time,
+                                  uint8_t bank)
+{
+    if (time > TCA6507_TIME_COUNT) {
+        DEBUG("[WARN] Time used a unsupported value, falling back to 256ms\n");
+        time = TCA6507_TIME_256_MS;
+    }
+
+    return tca6507_update_4bits(dev, TCA6507_SEC_FULLYOFF_TIME, time, bank);
+}

--- a/drivers/tca6507/tca6507.c
+++ b/drivers/tca6507/tca6507.c
@@ -377,7 +377,7 @@ int tca6507_dump_registers(const tca6507_t *dev)
 
   puts("tca6507 registers :");
   for (size_t i=0; i<sizeof(regs); i++) {
-    printf("\t%02x: %02x\n", i, regs[i]);
+    printf("\t%02lx: %02x\n", i, regs[i]);
   }
 
 finish:

--- a/tests/driver_tca6507/Makefile
+++ b/tests/driver_tca6507/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += tca6507
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tca6507/README.md
+++ b/tests/driver_tca6507/README.md
@@ -1,0 +1,2 @@
+# About
+This is a test application for the TCA6507 driver which turn on/off two leds.

--- a/tests/driver_tca6507/main.c
+++ b/tests/driver_tca6507/main.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 Noel Le Moult <noel.lemoult@dfxlab.fr>
+ * Copyright (C) 2019 William MARTIN <william.martin@power-lan.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @brief       Test application for the TCA6507 LED driver.
+ * @author      Noel Le Moult <noel.lemoult@dfxlab.fr>
+ * @author      William MARTIN <william.martin@power-lan.com>
+ * @file
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "tca6507.h"
+#include "tca6507_params.h"
+
+#define CHECK(rc) \
+    if (rc == TCA6507_OK) { \
+        puts("[OK]"); \
+    } else { \
+        puts("[Failed]"); \
+        return -1; \
+    }
+
+int main(void)
+{
+    int rc;
+    tca6507_t dev;
+
+    /* Init TCA6507 context */
+    puts("TCA6507 LED Driver: test application");
+    rc = tca6507_init(&dev, &tca6507_params[0]);
+    CHECK(rc);
+
+    /* Shutdown all leds */
+    puts("TCA6507 LED Driver: Clear all leds");
+    rc = tca6507_clear_all(&dev);
+    CHECK(rc);
+
+    /* Configure Brightness */
+    puts("TCA6507 LED Driver: Configure Bank 0 at 20%%");
+    rc = tca6507_intensity(&dev, TCA6507_BRIGHTNESS_20_PCENT, TCA6507_BANK0);
+    CHECK(rc);
+
+    puts("TCA6507 LED Driver: Configure Bank 1 at 100%%");
+    rc = tca6507_intensity(&dev, TCA6507_BRIGHTNESS_100_PCENT, TCA6507_BANK1);
+    CHECK(rc);
+
+    /* Configure Heartbeat like fadding on bank 0 */
+    puts("TCA6507 LED Driver: Configure fade on time at 64ms");
+    rc = tca6507_fade_on_time(&dev, TCA6507_TIME_64_MS, TCA6507_BANK0);
+    CHECK(rc);
+
+    puts("TCA6507 LED Driver: Configure fade off time at 64ms");
+    rc = tca6507_fade_off_time(&dev, TCA6507_TIME_64_MS, TCA6507_BANK0);
+    CHECK(rc);
+
+    puts("TCA6507 LED Driver: Configure fully on time at 128ms");
+    rc = tca6507_fully_on_time(&dev, TCA6507_TIME_128_MS, TCA6507_BANK0);
+    CHECK(rc);
+
+    puts("TCA6507 LED Driver: Configure first fully off time at 256ms");
+    rc = tca6507_first_fully_off_time(&dev, TCA6507_TIME_256_MS, TCA6507_BANK0);
+    CHECK(rc);
+
+    puts("TCA6507 LED Driver: Configure second fully off time at 256ms");
+    rc =
+        tca6507_second_fully_off_time(&dev, TCA6507_TIME_1024_MS,
+                                      TCA6507_BANK0);
+    CHECK(rc);
+
+    /* Start the heartbeat */
+    puts("TCA6507 LED Driver: Blink on led 1 at 20%% (i.e. Bank 0)");
+    rc = tca6507_blink_led(&dev, 0, TCA6507_BANK0);
+    CHECK(rc);
+
+    /* Manual led tests */
+    xtimer_usleep(1 * US_PER_SEC);
+    for (int i = 0; i < 5; i++) {
+        puts("TCA6507 LED Driver: Toggle Bank 1 for led 1");
+        rc = tca6507_toggle_led(&dev, 1, TCA6507_BANK1);
+        CHECK(rc);
+
+        xtimer_usleep(250 * MS_PER_SEC);
+        puts("TCA6507 LED Driver: Toggle Bank 1 for led 2");
+        rc = tca6507_toggle_led(&dev, 2, TCA6507_BANK1);
+        CHECK(rc);
+
+        xtimer_usleep(1 * US_PER_SEC);
+        puts("TCA6507 LED Driver: Toggle Bank 1 for led 2");
+        rc = tca6507_toggle_led(&dev, 2, TCA6507_BANK1);
+        CHECK(rc);
+
+        xtimer_usleep(250 * MS_PER_SEC);
+        puts("TCA6507 LED Driver: Toggle Bank 1 for led 1");
+        rc = tca6507_toggle_led(&dev, 1, TCA6507_BANK1);
+        CHECK(rc);
+
+        xtimer_usleep(250 * MS_PER_SEC);
+    }
+
+    /* Shutdown all leds */
+    puts("TCA6507 LED Driver: Clear all leds");
+    rc = tca6507_clear_all(&dev);
+    CHECK(rc);
+
+    puts("TCA6507 LED Driver: End\n");
+    return 0;
+}

--- a/tests/driver_tca6507/main.c
+++ b/tests/driver_tca6507/main.c
@@ -34,6 +34,8 @@ int main(void)
     int rc;
     tca6507_t dev;
 
+    xtimer_usleep(1 * US_PER_SEC);
+
     /* Init TCA6507 context */
     puts("TCA6507 LED Driver: test application");
     rc = tca6507_init(&dev, &tca6507_params[0]);
@@ -44,7 +46,7 @@ int main(void)
     rc = tca6507_clear_all(&dev);
     CHECK(rc);
 
-    /* Configure Brightness */
+    /* Configure Bank Brightness */
     puts("TCA6507 LED Driver: Configure Bank 0 at 20%%");
     rc = tca6507_intensity(&dev, TCA6507_BRIGHTNESS_20_PCENT, TCA6507_BANK0);
     CHECK(rc);
@@ -62,24 +64,46 @@ int main(void)
     rc = tca6507_fade_off_time(&dev, TCA6507_TIME_64_MS, TCA6507_BANK0);
     CHECK(rc);
 
-    puts("TCA6507 LED Driver: Configure fully on time at 128ms");
-    rc = tca6507_fully_on_time(&dev, TCA6507_TIME_128_MS, TCA6507_BANK0);
+    puts("TCA6507 LED Driver: Configure fully on time at 1024ms");
+    rc = tca6507_fully_on_time(&dev, TCA6507_TIME_1024_MS, TCA6507_BANK0);
     CHECK(rc);
 
-    puts("TCA6507 LED Driver: Configure first fully off time at 256ms");
-    rc = tca6507_first_fully_off_time(&dev, TCA6507_TIME_256_MS, TCA6507_BANK0);
+    puts("TCA6507 LED Driver: Configure first fully off time at 512ms");
+    rc = tca6507_first_fully_off_time(&dev, TCA6507_TIME_512_MS, TCA6507_BANK0);
     CHECK(rc);
 
-    puts("TCA6507 LED Driver: Configure second fully off time at 256ms");
-    rc =
-        tca6507_second_fully_off_time(&dev, TCA6507_TIME_1024_MS,
-                                      TCA6507_BANK0);
+    puts("TCA6507 LED Driver: Configure second fully off time at 2048ms");
+    rc = tca6507_second_fully_off_time(&dev, TCA6507_TIME_2048_MS, TCA6507_BANK0);
     CHECK(rc);
 
-    /* Start the heartbeat */
-    puts("TCA6507 LED Driver: Blink on led 1 at 20%% (i.e. Bank 0)");
+    /* Start the heartbeat for 10 seconds (BANK 0) */
+    puts("TCA6507 LED Driver: Blink on led 1 on Bank 0");
     rc = tca6507_blink_led(&dev, 0, TCA6507_BANK0);
     CHECK(rc);
+
+    rc = tca6507_dump_registers(&dev);
+    CHECK(rc);
+
+    xtimer_usleep(10 * US_PER_SEC);
+
+    puts("TCA6507 LED Driver: Clear all leds");
+    rc = tca6507_clear_all(&dev);
+    CHECK(rc);
+
+
+    /* Start the heartbeat for 10 seconds (BANK 1) */
+    puts("TCA6507 LED Driver: Blink on led 1 on Bank 1");
+    rc = tca6507_blink_led(&dev, 0, TCA6507_BANK1);
+    CHECK(rc);
+
+    xtimer_usleep(10 * US_PER_SEC);
+
+    puts("TCA6507 LED Driver: Clear all leds");
+    rc = tca6507_clear_all(&dev);
+    CHECK(rc);
+
+    xtimer_usleep(1 * US_PER_SEC);
+
 
     /* Manual led tests */
     xtimer_usleep(1 * US_PER_SEC);


### PR DESCRIPTION
### Contribution description

Add support for the TCA6507 chip in RIOT.

The TCA6507 is a LED driver over I2C which allow to turn ON/OFF, Blinking, and Fading at Programmable Rates. More detailled description can be found in the following datasheet.
http://www.ti.com/lit/ds/symlink/tca6507.pdf

No evaluation kit for TCA6507 is available, you must a have a custom board if you want to test it.

### Testing procedure

This module can be tested with any board with I2C support.

This code have been tested on a custom board based on the ST B-L072Z-LRWAN1 board.