### PR TITLE
makefiles: CFLAGS convert to the uppercase function instead of using the shell

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -340,9 +340,9 @@ ifeq ($(RIOT_CI_BUILD),1)
 endif
 
 # if you want to publish the board into the sources as an uppercase #define
-BOARDDEF := $(shell echo $(BOARD) | tr 'a-z' 'A-Z' | tr '-' '_')
-CPUDEF := $(shell echo $(CPU) | tr 'a-z' 'A-Z' | tr '-' '_')
-MCUDEF := $(shell echo $(MCU) | tr 'a-z' 'A-Z' | tr '-' '_')
+BOARDDEF = $(call uppercase_and_underscore,$(BOARD))
+CPUDEF = $(call uppercase_and_underscore,$(CPU))
+MCUDEF = $(call uppercase_and_underscore,$(MCU))
 CFLAGS += -DRIOT_APPLICATION=\"$(APPLICATION)\"
 CFLAGS += -DBOARD_$(BOARDDEF)=\"$(BOARD)\" -DRIOT_BOARD=BOARD_$(BOARDDEF)
 CFLAGS += -DCPU_$(CPUDEF)=\"$(CPU)\" -DRIOT_CPU=CPU_$(CPUDEF)

--- a/cpu/efm32/Makefile.include
+++ b/cpu/efm32/Makefile.include
@@ -4,7 +4,7 @@ export CPU_ARCH = $(EFM32_ARCHITECTURE)
 export CPU_FAM = $(EFM32_FAMILY)
 
 # the em_device.h header requires a global define with the cpu model
-CFLAGS += -D$(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
+CFLAGS += -D$(call uppercase_and_underscore,$(CPU_MODEL))
 
 # include Gecko SDK package
 USEPKG += gecko_sdk

--- a/cpu/msp430_common/Makefile.include
+++ b/cpu/msp430_common/Makefile.include
@@ -2,8 +2,7 @@ PSEUDOMODULES += msp430_malloc
 
 INCLUDES += -I$(RIOTCPU)/msp430_common/include/
 
-MODEL = $(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
-CFLAGS += -DCPU_MODEL_$(MODEL)
+CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))
 
 export UNDEF += $(BINDIR)/msp430_common/startup.o
 export USEMODULE += msp430_common msp430_common_periph msp430_malloc

--- a/cpu/nrf5x_common/Makefile.include
+++ b/cpu/nrf5x_common/Makefile.include
@@ -1,5 +1,4 @@
-FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
-CFLAGS += -DCPU_FAM_$(FAM)
+CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 
 # include nrf5x common periph drivers
 USEMODULE += nrf5x_common_periph

--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -1,5 +1,5 @@
 # Define the CPU family so we can differentiate between them in the code
-CFLAGS += -DCPU_FAM_$(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
+CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 
 # Set ROM and RAM lengths according to CPU model
 ifneq (,$(filter samd21g18a samd21j18a saml21j18b saml21j18a samr21e18a \

--- a/cpu/sam_common/Makefile.include
+++ b/cpu/sam_common/Makefile.include
@@ -1,5 +1,5 @@
 # Define the CPU family so we can differentiate between them in the code
-CFLAGS += -DCPU_FAM_$(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
+CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 
 # this CPU implementation doesn't use CMSIS initialization
 CFLAGS += -DDONT_USE_CMSIS_INIT

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -1,5 +1,4 @@
-FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
-CFLAGS += -DCPU_FAM_$(FAM)
+CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 
 # All stm32 families provide pm support
 USEMODULE += pm_layered

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -81,10 +81,8 @@ endif
 endif
 endif
 
-MODEL = $(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
-CFLAGS += -DCPU_MODEL_$(MODEL)
-ARCH = $(shell echo $(CPU_ARCH) | tr 'a-z-' 'A-Z_')
-CFLAGS += -DCPU_ARCH_$(ARCH)
+CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))
+CFLAGS += -DCPU_ARCH_$(call uppercase_and_underscore,$(CPU_ARCH))
 
 # set the compiler specific CPU and FPU options
 ifneq (,$(filter $(CPU_ARCH),cortex-m4f cortex-m7))

--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -3,7 +3,7 @@ _ALLMODULES = $(sort $(USEMODULE) $(USEPKG))
 # Define MODULE_MODULE_NAME preprocessor macros for all modules.
 ED = $(addprefix MODULE_,$(_ALLMODULES))
 # EXTDEFINES will be put in CFLAGS_WITH_MACROS
-EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))
+EXTDEFINES = $(addprefix -D,$(call uppercase_and_underscore,$(ED)))
 
 # filter "pseudomodules" from "real modules", but not "no_pseudomodules"
 REALMODULES += $(filter-out $(PSEUDOMODULES), $(_ALLMODULES))


### PR DESCRIPTION
### Contribution description

Convert the shell `tr 'a-z-' 'A-Z_'` to use the uppercase functions introduced by https://github.com/RIOT-OS/RIOT/pull/12119


### Testing procedure

The `CFLAGS_WITH_MACROS` (to include the `EXTDEFINES` are still the same as in master

```
for board in $(make info-boards); do RIOT_CI_BUILD=1 BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-CFLAGS_WITH_MACROS; done
```

### Issues/PRs references

Follow up PR from https://github.com/RIOT-OS/RIOT/pull/12119
It is part of removing `shell` calls that are not required.
