### PR TITLE
makefiles/arch/mips.inc.mk: use makefiles/utils lowercase function

### DIFF
--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -3,9 +3,6 @@ export TARGET_ARCH ?= mips-mti-elf
 
 export ABI=32
 
-# Portable 'lowercase' func.
-lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
-
 # Default values for the linker script symbols listed below are
 # defined in the linker script.
 
@@ -21,7 +18,7 @@ comma := ,
 # A bit of makefile magic:
 # foreach symbol in overridable ld-symbols :
 #   If symbol has a value, produce a linker argument for that symbol.
-MIPS_HAL_LDFLAGS = $(foreach a,$(priv_symbols),$(if $($a),-Wl$(comma)--defsym$(comma)__$(call lc,$(a))=$($a)))
+MIPS_HAL_LDFLAGS = $(foreach a,$(priv_symbols),$(if $($a),-Wl$(comma)--defsym$(comma)__$(call lowercase,$(a))=$($a)))
 
 ifeq ($(ROMABLE),1)
 MIPS_HAL_LDFLAGS += -T bootcode.ld


### PR DESCRIPTION
### Contribution description

Use the new common 'lowercase' function from makefiles/utils.

The `lowercase` function was added based on the `lc` implementation in #12119 
So now use the common version.

### Testing procedure

When one of the `priv_symbol` is defined, (I will set `MEMORY_BASE`), the output is the same as in master.
No idea what it does, it just kept the behavior.

<details><summary><code>for board in pic32-clicker pic32-wifire; do MEMORY_BASE=set_a_random_value BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-LINKFLAGS; done | sed "s|${PWD}/||g"</code></summary>

```
for board in pic32-clicker pic32-wifire; do MEMORY_BASE=set_a_random_value BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-LINKFLAGS; done | sed "s|${PWD}/||g" 
-luhi -msoft-float -Wl,--defsym,__memory_base=set_a_random_value -T bootcode.ld -Lcpu/mips_pic32mx/ldscripts -EL -mabi=32 -g3 -Os -Wl,--gc-sections -Wl,--defsym,__use_excpt_boot=0 -DDEVELHELP -Werror -std=gnu99 -EL -mabi=32 -ffunction-sections -fno-builtin -fshort-enums -fdata-sections -Os -g3 -msoft-float -march=m4k -DSKIP_COPY_TO_RAM -DRIOT_APPLICATION="hello-world" -DBOARD_PIC32_CLICKER="pic32-clicker" -DRIOT_BOARD=BOARD_PIC32_CLICKER -DCPU_MIPS_PIC32MX="mips_pic32mx" -DRIOT_CPU=CPU_MIPS_PIC32MX -DMCU_MIPS_PIC32MX="mips_pic32mx" -DRIOT_MCU=MCU_MIPS_PIC32MX -fno-common -Wall -Wextra -Wmissing-include-dirs -fno-delete-null-pointer-checks -Wstrict-prototypes -Wold-style-definition -Wformat=2 -include examples/hello-world/bin/pic32-clicker/riotbuild/riotbuild.h -Tpic32mx512_12_128_uhi.ld -lc
-luhi -msoft-float -Wl,--defsym,__memory_base=set_a_random_value -T bootcode.ld -Lcpu/mips_pic32mz/ldscripts -EL -mabi=32 -g3 -Os -Wl,--gc-sections -Wl,--defsym,__use_excpt_boot=0 -DDEVELHELP -Werror -std=gnu99 -EL -mabi=32 -ffunction-sections -fno-builtin -fshort-enums -fdata-sections -Os -g3 -msoft-float -march=m5101 -mmicromips -DSKIP_COPY_TO_RAM -DMIPS_MICROMIPS -DRIOT_APPLICATION="hello-world" -DBOARD_PIC32_WIFIRE="pic32-wifire" -DRIOT_BOARD=BOARD_PIC32_WIFIRE -DCPU_MIPS_PIC32MZ="mips_pic32mz" -DRIOT_CPU=CPU_MIPS_PIC32MZ -DMCU_MIPS_PIC32MZ="mips_pic32mz" -DRIOT_MCU=MCU_MIPS_PIC32MZ -fno-common -Wall -Wextra -Wmissing-include-dirs -fno-delete-null-pointer-checks -Wstrict-prototypes -Wold-style-definition -Wformat=2 -include examples/hello-world/bin/pic32-wifire/riotbuild/riotbuild.h -Tpic32mz2048_uhi.ld -lc
```
</details>

### Issues/PRs references

Using functions defined in #12119