### PR TITLE
list-ttys: Add punctuation between name and serial

### DIFF
--- a/dist/tools/usb-serial/list-ttys.sh
+++ b/dist/tools/usb-serial/list-ttys.sh
@@ -28,5 +28,5 @@ for basedev in $(find /sys/bus/usb/devices/ -regex "/sys/bus/usb/devices/[0-9]+[
     serial=$(cat "${parent}/serial" 2>/dev/null)
     manuf=$(cat "${parent}/manufacturer" 2>/dev/null)
     product=$(cat "${parent}/product" 2>/dev/null)
-    echo "${parent}: ${manuf} ${product} serial: '${serial}', tty(s): ${ttys}"
+    echo "${parent}: ${manuf} ${product}, serial: '${serial}', tty(s): ${ttys}"
 done


### PR DESCRIPTION
### Contribution description

This PR changes the output from `make list-ttys` from:
```
/sys/bus/usb/devices/3-9.2.2: Atmel Corp. EDBG CMSIS-DAP serial: 'ATML2127031800008360', tty(s): ttyACM1
```
to:
```
/sys/bus/usb/devices/3-9.2.2: Atmel Corp. EDBG CMSIS-DAP, serial: 'ATML2127031800008360', tty(s): ttyACM1
```

This very significant change should fix many issues where people incorrectly think of their device being named `EDBG CMSIS-DAP serial` while it is of course named `EDBG CMSIS-DAP`. The 'serial' here indicates that the string following it is the serial string of the USB device.

### Testing procedure

execute `make list-ttys` on your favorite example. It should print a comma between the device name and `serial:`

### Issues/PRs references

None