### PR TITLE
particle-*: Configure antenna switch

### DIFF
--- a/boards/common/particle-mesh/Makefile.include
+++ b/boards/common/particle-mesh/Makefile.include
@@ -1,3 +1,7 @@
+# See doc.txt on nRF antenna selection
+BOARD_NRFANTENNA_DEFAULT ?= BUILTIN
+CFLAGS += -DBOARD_NRFANTENNA_DEFAULT=BOARD_NRFANTENNA_$(BOARD_NRFANTENNA_DEFAULT)
+
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/common/particle-mesh/board.c
+++ b/boards/common/particle-mesh/board.c
@@ -33,6 +33,16 @@ void board_init(void)
     gpio_init(LED2_PIN, GPIO_OUT);
     gpio_set(LED2_PIN);
 
+    gpio_init(VCTL1_PIN, GPIO_OUT);
+    /* Suppress output to the UFL connector */
+    gpio_set(VCTL1_PIN);
+#ifdef VCTL2_PIN
+    /* On boards without VCLT2_PIN (Boron), the VCTL2 net is driven by NOT(VCTL1) */
+    gpio_init(VCTL2_PIN, GPIO_OUT);
+    /* Enable output to the built-in antenna */
+    gpio_clear(VCTL2_PIN);
+#endif
+
     /* initialize the CPU */
     cpu_init();
 }

--- a/boards/common/particle-mesh/board.c
+++ b/boards/common/particle-mesh/board.c
@@ -23,6 +23,26 @@
 
 #include "periph/gpio.h"
 
+void board_nrfantenna_select(enum board_nrfantenna_selection choice)
+{
+    switch (choice) {
+        case BOARD_NRFANTENNA_BUILTIN:
+            /* Suppress output to the UFL connector */
+            gpio_set(VCTL1_PIN);
+#ifdef VCTL2_PIN
+            /* Enable output to the built-in antenna */
+            gpio_clear(VCTL2_PIN);
+#endif
+            break;
+        case BOARD_NRFANTENNA_EXTERNAL:
+            gpio_clear(VCTL1_PIN);
+#ifdef VCTL2_PIN
+            gpio_set(VCTL2_PIN);
+#endif
+            break;
+    }
+}
+
 void board_init(void)
 {
     /* initialize the boards LEDs */
@@ -34,14 +54,12 @@ void board_init(void)
     gpio_set(LED2_PIN);
 
     gpio_init(VCTL1_PIN, GPIO_OUT);
-    /* Suppress output to the UFL connector */
-    gpio_set(VCTL1_PIN);
 #ifdef VCTL2_PIN
     /* On boards without VCLT2_PIN (Boron), the VCTL2 net is driven by NOT(VCTL1) */
     gpio_init(VCTL2_PIN, GPIO_OUT);
-    /* Enable output to the built-in antenna */
-    gpio_clear(VCTL2_PIN);
 #endif
+
+    board_nrfantenna_select(BOARD_NRFANTENNA_DEFAULT);
 
     /* initialize the CPU */
     cpu_init();

--- a/boards/common/particle-mesh/doc.txt
+++ b/boards/common/particle-mesh/doc.txt
@@ -50,4 +50,18 @@ The STDIO is not accessible via the USB port.
 To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
 the RX/TX pins on the board.
 
+### nRF antenna selection
+
+The Particle Mesh boards all have two antenna choices for their nRF (Bluetooth
+/ 802.15.4) radios, a on-board antenna and a U.FL connector for an external
+antenna.
+
+By default, the on-board antenna is selected at startup. That choice can be
+overridden by setting ``BOARD_NRFANTENNA_DEFAULT = EXTERNAL`` (as opposed to
+the default ``BUILTIN``) in a project's `Makefile`, or at runtime using @ref
+board_nrfantenna_select function.
+
+The external antenna connection should only be enabled if a suitable antenna is
+connected.
+
  */

--- a/boards/common/particle-mesh/include/board.h
+++ b/boards/common/particle-mesh/include/board.h
@@ -66,8 +66,42 @@ extern "C" {
  * @{
  */
 
-#ifdef BOARD_PARTICLE_XENON
+/** Choices in antenna outputs for the board's nRF radio
+ *
+ * @see board_nrfantenna_select */
+enum board_nrfantenna_selection {
+    /** The board's built-in antenna */
+    BOARD_NRFANTENNA_BUILTIN,
+    /** The board's uFL connector */
+    BOARD_NRFANTENNA_EXTERNAL,
+};
+
+/** @brief Antenna output selection
+ *
+ * Drive the on-board antenna switch to connect the nRF radio to a given @p
+ * choice of antenna output.
+ *
+ * This can be called to change the antenna selection at runtime; for the
+ * default configuration that gets set during board initialization, see @ref
+ * boards_common_particle-mesh.
+ * */
+void board_nrfantenna_select(enum board_nrfantenna_selection choice);
+
+#if defined(BOARD_PARTICLE_XENON) || defined(DOXYGEN)
+/** The GPIO pin used to drive the VCTL1 pin of antenna switch
+ *
+ * Rather than actuating this directly, consider using the @ref
+ * board_nrfantenna_select function.
+ */
 #define VCTL1_PIN           GPIO_PIN(0, 24)
+/** The GPIO pin used to drive the VCTL2 pin of antenna switch
+ *
+ * This definition is left out for boards whose VCTL2 is driven by an inverter
+ * from VCTL1.
+ *
+ * Rather than actuating this directly, consider using the @ref
+ * board_nrfantenna_select function.
+ */
 #define VCTL2_PIN           GPIO_PIN(0, 25)
 #endif
 

--- a/boards/common/particle-mesh/include/board.h
+++ b/boards/common/particle-mesh/include/board.h
@@ -61,6 +61,27 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */
 
+/**
+ * @name    Antenna selection configuration
+ * @{
+ */
+
+#ifdef BOARD_PARTICLE_XENON
+#define VCTL1_PIN           GPIO_PIN(0, 24)
+#define VCTL2_PIN           GPIO_PIN(0, 25)
+#endif
+
+#ifdef BOARD_PARTICLE_ARGON
+#define VCTL1_PIN           GPIO_PIN(0, 25)
+#define VCTL2_PIN           GPIO_PIN(0, 2)
+#endif
+
+#ifdef BOARD_PARTICLE_BORON
+#define VCTL1_PIN           GPIO_PIN(0, 7)
+#endif
+
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

The particle-{argon,boron,xenon} boards all have a uFL connector and a PCB antenna for 2.4GHz radio, connected by a SKY13351-378LF switch configured by a VCTL[12] pin pair.

This sets the default configuration to use the PCB antenna, as driving an unconnected antenna will deteriorate radio perforance. I don't think that the nRF52 will damage itself driving an unconnected antenna, but doing that it's generally very bad practice. With bad conscience I did a brief test with pins configured the other way, and got a 20dB signal increase compared to that test.

### Testing procedure

I only tested this on a Xenon board, as that's the only of those I have; there, I got about 20dB increases in ping RSSIs compared to switching on the other antenna. (Testing the original state is rather pointless as there's floating pin on capacitors then, and the switch's behavior when not exactly one pin is on is undefined). My test output (top: correct; bottom: wrong antenna enabled):

```
> ping6 fe80::cc30:8ef6:582b:14c6%9
ping6 fe80::cc30:8ef6:582b:14c6%9
12 bytes from fe80::cc30:8ef6:582b:14c6: icmp_seq=0 ttl=64 rssi=-49 dBm time=3.765 ms
12 bytes from fe80::cc30:8ef6:582b:14c6: icmp_seq=1 ttl=64 rssi=-52 dBm time=3.765 ms
12 bytes from fe80::cc30:8ef6:582b:14c6: icmp_seq=2 ttl=64 rssi=-52 dBm time=3.765 ms
```
```
> ping6 fe80::cc30:8ef6:582b:14c6%9
ping6 fe80::cc30:8ef6:582b:14c6%9
12 bytes from fe80::cc30:8ef6:582b:14c6: icmp_seq=0 ttl=64 rssi=-69 dBm time=3.766 ms
12 bytes from fe80::cc30:8ef6:582b:14c6: icmp_seq=1 ttl=64 rssi=-70 dBm time=3.765 ms
12 bytes from fe80::cc30:8ef6:582b:14c6: icmp_seq=2 ttl=64 rssi=-69 dBm time=3.765 ms
```

That was produced from a nrf52840-dongle talking to a particle-xenon with the different antenna configurations, both running the gcoap example with additional modules enabled to give me USB Ethernet and serial.

I did not do the tests on the master branch but on [my branch for DFU uploads on the Xenon](https://github.com/RIOT-OS/RIOT/issues/12320); I built it as I'm PR'ing it here for all three boards, but would ask the maintainers of the boards who have programming equipment to test as well.