### PR TITLE
tests/driver_adt7310: Add explicit cast required for llvm

### DIFF
--- a/tests/driver_adt7310/main.c
+++ b/tests/driver_adt7310/main.c
@@ -79,8 +79,8 @@ int test_adt7310_sample_print(adt7310_t *dev)
     float fractional;
     fractional = modff(celsius_float, &integral);
 
-    printf("0x%04" PRIx16 " %7" PRId32 " mC %4d.%07u C)\n", raw, millicelsius,
-        (int)integral, abs(fractional * 10000000.f));
+    printf("0x%04" PRIx16 " %7" PRId32 " mC %4d.%07lu C)\n", raw, millicelsius,
+        (int)integral, labs((long)(fractional * 10000000.f)));
     return 0;
 }
 


### PR DESCRIPTION
### Contribution description

This PR is related to PR #11352, where I suggest to add support for Linux' `/dev/spidev` devices to the native cpu. Enabling SPI causes the `tests/driver_adt7310` test to be run with the llvm toolchain for the first time.

llvm doesn't allow [the implicit cast to `int`](https://github.com/RIOT-OS/RIOT/blob/master/tests/driver_adt7310/main.c#L83) in tests/driver_adt7310 (see [Murdock's output](https://ci.riot-os.org/RIOT-OS/RIOT/11352/a9b48f793548f05c811fae3961e9756215c015d9/output.html#error0)).

This PR fixes this by using an explicit cast. Furthermore, `abs()` is replaced with `labs()`, as the parameter may take values which exceed a 16 bit `int` and could cause undefined behavior.

### Testing procedure

Run `BOARD=native TOOLCHAIN=llvm make -C tests/driver_adt7310 all` without and with this PR and verify that the warning disappears. The build will still fail though, as native misses the required SPI support introduced in #11352.

### Issues/PRs references

Required for PR #11352 
