### PR TITLE
cpu/esp32: unconditionally disable thin archives

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -42,9 +42,6 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     # crypto and hashes produce symbol conflicts with esp_idf_wpa_supplicant_crypto
     DISABLE_MODULE += crypto
     DISABLE_MODULE += hashes
-
-    # thin archives trigger a reboot loop - see #12258
-    ARFLAGS = rcs
 endif
 
 ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -112,6 +112,9 @@ OPTIONAL_CFLAGS_BLACKLIST += -gz
 
 ASFLAGS += --longcalls --text-section-literals
 
+# thin archives trigger a reboot loop - see #12258, #12035, #12346
+ARFLAGS = rcs
+
 ifneq ($(CONFIGS),)
     CFLAGS += $(CONFIGS)
 endif


### PR DESCRIPTION

### Contribution description

Thin archives also cause a boot loop when using the flash module.
To prevent further surprises, disable thin archives unconditionally until the cause for this behaviour is known. 

### Testing procedure

Run `tests/pkg_spiffs` or any application that uses the `esp_wifi` module.


### Issues/PRs references
follow-up to #12292
discovered in #12258, #12035
bug introduced by #10195
