### PR TITLE
gnrc_sixlowpan_frag_rb: externalize dispatch_when_complete

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -187,9 +187,14 @@ static inline void gnrc_sixlowpan_frag_rb_remove(gnrc_sixlowpan_frag_rb_t *rbuf)
  * @param[in] netif Original @ref gnrc_netif_hdr_t of the last received frame.
  *                  Used to construct the @ref gnrc_netif_hdr_t of the completed
  *                  datagram. Must not be NULL.
+ *
+ * @return  >0, when the datagram in @p rbuf was complete and dispatched.
+ * @return  0, when the datagram in @p rbuf is not complete.
+ * @return  -1, if the the reassembled datagram was not dispatched. @p rbuf is
+ *          destroyed either way.
  */
-void gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,
-                                                   gnrc_netif_hdr_t *netif);
+int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,
+                                                  gnrc_netif_hdr_t *netif);
 #else
 /* NOPs to be used with gnrc_sixlowpan_iphc if gnrc_sixlowpan_frag_rb is not
  * compiled in */

--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -198,9 +198,19 @@ int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf
 #else
 /* NOPs to be used with gnrc_sixlowpan_iphc if gnrc_sixlowpan_frag_rb is not
  * compiled in */
-#define gnrc_sixlowpan_frag_rb_remove(rbuf)     (void)(rbuf)
-#define gnrc_sixlowpan_frag_rb_dispatch_when_complete(rbuf, netif) \
-    (void)(rbuf); (void)(netif)
+static inline void gnrc_sixlowpan_frag_rb_remove(gnrc_sixlowpan_frag_rb_t *rbuf)
+{
+    (void)rbuf;
+    return;
+}
+
+static inline int gnrc_sixlowpan_frag_rb_dispatch_when_complete(
+        gnrc_sixlowpan_frag_rb_t *rbuf, gnrc_netif_hdr_t *netif)
+{
+    (void)rbuf;
+    (void)netif;
+    return -1;
+}
 #endif
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -105,10 +105,13 @@ typedef struct {
  * @param[in] frag          The fragment to add.
  * @param[in] offset        The fragment's offset.
  * @param[in] page          Current 6Lo dispatch parsing page.
+ *
+ * @return  The reassembly buffer entry the fragment was added to on success.
+ * @return  NULL on error.
  */
-void gnrc_sixlowpan_frag_rb_add(gnrc_netif_hdr_t *netif_hdr,
-                                gnrc_pktsnip_t *frag, size_t offset,
-                                unsigned page);
+gnrc_sixlowpan_frag_rb_t *gnrc_sixlowpan_frag_rb_add(gnrc_netif_hdr_t *netif_hdr,
+                                                     gnrc_pktsnip_t *frag,
+                                                     size_t offset, unsigned page);
 
 /**
  * @brief   Checks if a reassembly buffer entry is unset

--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -102,7 +102,8 @@ typedef struct {
  * @param[in] netif_hdr     The interface header of the fragment, with
  *                          gnrc_netif_hdr_t::if_pid and its source and
  *                          destination address set.
- * @param[in] frag          The fragment to add.
+ * @param[in] frag          The fragment to add. Will be released by the
+ *                          function.
  * @param[in] offset        The fragment's offset.
  * @param[in] page          Current 6Lo dispatch parsing page.
  *
@@ -158,24 +159,6 @@ void gnrc_sixlowpan_frag_rb_base_rm(gnrc_sixlowpan_frag_rb_base_t *entry);
  */
 void gnrc_sixlowpan_frag_rb_gc(void);
 
-#if defined(MODULE_GNRC_SIXLOWPAN_FRAG_RB) || defined(DOXYGEN)
-/**
- * @brief   Unsets a reassembly buffer entry (but does not free
- *          rbuf_t::super::pkt)
- *
- * @pre `rbuf != NULL`
- *
- * This functions sets rbuf_t::super::pkt to NULL and removes all rbuf::ints.
- *
- * @param[in] rbuf  A reassembly buffer entry. Must not be NULL.
- */
-static inline void gnrc_sixlowpan_frag_rb_remove(gnrc_sixlowpan_frag_rb_t *rbuf)
-{
-    assert(rbuf != NULL);
-    gnrc_sixlowpan_frag_rb_base_rm(&rbuf->super);
-    rbuf->pkt = NULL;
-}
-
 /**
  * @brief   Checks if a reassembly buffer entry is complete and dispatches it
  *          to the next layer if that is the case
@@ -195,6 +178,24 @@ static inline void gnrc_sixlowpan_frag_rb_remove(gnrc_sixlowpan_frag_rb_t *rbuf)
  */
 int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,
                                                   gnrc_netif_hdr_t *netif);
+
+#if defined(MODULE_GNRC_SIXLOWPAN_FRAG_RB) || defined(DOXYGEN)
+/**
+ * @brief   Unsets a reassembly buffer entry (but does not free
+ *          rbuf_t::super::pkt)
+ *
+ * @pre `rbuf != NULL`
+ *
+ * This functions sets rbuf_t::super::pkt to NULL and removes all rbuf::ints.
+ *
+ * @param[in] rbuf  A reassembly buffer entry. Must not be NULL.
+ */
+static inline void gnrc_sixlowpan_frag_rb_remove(gnrc_sixlowpan_frag_rb_t *rbuf)
+{
+    assert(rbuf != NULL);
+    gnrc_sixlowpan_frag_rb_base_rm(&rbuf->super);
+    rbuf->pkt = NULL;
+}
 #else
 /* NOPs to be used with gnrc_sixlowpan_iphc if gnrc_sixlowpan_frag_rb is not
  * compiled in */
@@ -202,14 +203,6 @@ static inline void gnrc_sixlowpan_frag_rb_remove(gnrc_sixlowpan_frag_rb_t *rbuf)
 {
     (void)rbuf;
     return;
-}
-
-static inline int gnrc_sixlowpan_frag_rb_dispatch_when_complete(
-        gnrc_sixlowpan_frag_rb_t *rbuf, gnrc_netif_hdr_t *netif)
-{
-    (void)rbuf;
-    (void)netif;
-    return -1;
 }
 #endif
 

--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -188,6 +188,8 @@ int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf
  *
  * This functions sets rbuf_t::super::pkt to NULL and removes all rbuf::ints.
  *
+ * @note    Does nothing if module `gnrc_sixlowpan_frag_rb` is not included.
+ *
  * @param[in] rbuf  A reassembly buffer entry. Must not be NULL.
  */
 static inline void gnrc_sixlowpan_frag_rb_remove(gnrc_sixlowpan_frag_rb_t *rbuf)

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -223,27 +223,39 @@ static int _rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
         if (offset == 0) {
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
             if (sixlowpan_iphc_is(data)) {
+                DEBUG("6lo rbuf: detected IPHC header.\n");
                 gnrc_pktsnip_t *frag_hdr = gnrc_pktbuf_mark(pkt,
                         sizeof(sixlowpan_frag_t), GNRC_NETTYPE_SIXLOWPAN);
                 if (frag_hdr == NULL) {
+                    DEBUG("6lo rbuf: unable to mark fragment header. "
+                          "aborting reassembly.\n");
                     gnrc_pktbuf_release(entry->pkt);
                     gnrc_pktbuf_release(pkt);
                     gnrc_sixlowpan_frag_rb_remove(entry);
                     return RBUF_ADD_ERROR;
                 }
-                gnrc_sixlowpan_iphc_recv(pkt, entry, 0);
-                return res;
+                else {
+                    DEBUG("6lo rbuf: handing over to IPHC reception.\n");
+                    /* `pkt` released in IPHC */
+                    gnrc_sixlowpan_iphc_recv(pkt, entry, 0);
+                    /* check if entry was deleted in IPHC (error case) */
+                    if (gnrc_sixlowpan_frag_rb_entry_empty(entry)) {
+                        res = RBUF_ADD_ERROR;
+                    }
+                    return res;
+                }
             }
             else
 #endif
             if (data[0] == SIXLOWPAN_UNCOMP) {
+                DEBUG("6lo rbuf: detected uncompressed datagram\n");
                 data++;
             }
         }
         memcpy(((uint8_t *)entry->pkt->data) + offset, data,
                frag_size);
     }
-    gnrc_sixlowpan_frag_rb_dispatch_when_complete(entry, netif_hdr);
+    /* no errors and not consumed => release packet */
     gnrc_pktbuf_release(pkt);
     return res;
 }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -476,12 +476,14 @@ void gnrc_sixlowpan_frag_rb_base_rm(gnrc_sixlowpan_frag_rb_base_t *entry)
     entry->datagram_size = 0;
 }
 
-void gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,
+int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,
                                                    gnrc_netif_hdr_t *netif_hdr)
 {
     assert(rbuf);
     assert(netif_hdr);
-    if (rbuf->super.current_size == rbuf->super.datagram_size) {
+    int res = (rbuf->super.current_size == rbuf->super.datagram_size);
+
+    if (res) {
         gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(rbuf->super.src,
                                                      rbuf->super.src_len,
                                                      rbuf->super.dst,
@@ -491,7 +493,7 @@ void gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbu
             DEBUG("6lo rbuf: error allocating netif header\n");
             gnrc_pktbuf_release(rbuf->pkt);
             gnrc_sixlowpan_frag_rb_remove(rbuf);
-            return;
+            return -1;
         }
 
         /* copy the transmit information of the latest fragment into the newly
@@ -507,6 +509,7 @@ void gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbu
         gnrc_sixlowpan_dispatch_recv(rbuf->pkt, NULL, 0);
         gnrc_sixlowpan_frag_rb_remove(rbuf);
     }
+    return res;
 }
 
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -126,6 +126,13 @@ gnrc_sixlowpan_frag_rb_t *gnrc_sixlowpan_frag_rb_add(gnrc_netif_hdr_t *netif_hdr
 {
     int res;
     if ((res = _rbuf_add(netif_hdr, pkt, offset, page)) == RBUF_ADD_REPEAT) {
+        /* there was an overlap with existing fragments detected when trying to
+         * add the new fragment.
+         * https://tools.ietf.org/html/rfc4944#section-5.3 states "A fresh
+         * reassembly may be commenced with the most recently received link
+         * fragment.", so let's do that. Since the reassembly buffer entry was
+         * deleted another overlap should not be detected (so _rbuf_add() won't
+         * return RBUF_ADD_REPEAT again) */
         res = _rbuf_add(netif_hdr, pkt, offset, page);
     }
     return (res < 0) ? NULL : &rbuf[res];

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -582,7 +582,6 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
            sixlo->size - payload_offset);
     if (rbuf != NULL) {
         rbuf->super.current_size += (uncomp_hdr_len - payload_offset);
-        gnrc_sixlowpan_frag_rb_dispatch_when_complete(rbuf, netif_hdr);
     }
     else {
         LL_DELETE(sixlo, netif);

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -317,6 +317,7 @@ static void test_rbuf_add__success_complete(void)
     gnrc_pktsnip_t *pkt4 = gnrc_pktbuf_add(NULL, _fragment4, sizeof(_fragment4),
                                            GNRC_NETTYPE_SIXLOWPAN);
     gnrc_pktsnip_t *datagram;
+    gnrc_sixlowpan_frag_rb_t *entry1, *entry2;
     msg_t msg = { .type = 0U };
     gnrc_netreg_entry_t reg = GNRC_NETREG_ENTRY_INIT_PID(
             GNRC_NETREG_DEMUX_CTX_ALL,
@@ -326,20 +327,35 @@ static void test_rbuf_add__success_complete(void)
     gnrc_netreg_register(TEST_DATAGRAM_NETTYPE, &reg);
     /* Mixing up things. Order decided by fair dice-rolls ;-) */
     TEST_ASSERT_NOT_NULL(pkt2);
-    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+    TEST_ASSERT_NOT_NULL((entry1 = gnrc_sixlowpan_frag_rb_add(
             &_test_netif_hdr.hdr, pkt2, TEST_FRAGMENT2_OFFSET, TEST_PAGE
+        )));
+    TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_rb_dispatch_when_complete(
+            entry1, &_test_netif_hdr.hdr
         ));
     TEST_ASSERT_NOT_NULL(pkt4);
-    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+    TEST_ASSERT_NOT_NULL((entry2 = gnrc_sixlowpan_frag_rb_add(
             &_test_netif_hdr.hdr, pkt4, TEST_FRAGMENT4_OFFSET, TEST_PAGE
+        )));
+    TEST_ASSERT(entry1 == entry2);
+    TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_rb_dispatch_when_complete(
+            entry1, &_test_netif_hdr.hdr
         ));
     TEST_ASSERT_NOT_NULL(pkt1);
-    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+    TEST_ASSERT_NOT_NULL((entry2 = gnrc_sixlowpan_frag_rb_add(
             &_test_netif_hdr.hdr, pkt1, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        )));
+    TEST_ASSERT(entry1 == entry2);
+    TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_rb_dispatch_when_complete(
+            entry1, &_test_netif_hdr.hdr
         ));
     TEST_ASSERT_NOT_NULL(pkt3);
-    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+    TEST_ASSERT_NOT_NULL((entry2 = gnrc_sixlowpan_frag_rb_add(
             &_test_netif_hdr.hdr, pkt3, TEST_FRAGMENT3_OFFSET, TEST_PAGE
+        )));
+    TEST_ASSERT(entry1 == entry2);
+    TEST_ASSERT(0 < gnrc_sixlowpan_frag_rb_dispatch_when_complete(
+            entry1, &_test_netif_hdr.hdr
         ));
     TEST_ASSERT_MESSAGE(
             xtimer_msg_receive_timeout(&msg, TEST_RECEIVE_TIMEOUT) >= 0,

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -256,9 +256,9 @@ static void test_rbuf_add__success_first_fragment(void)
     const gnrc_sixlowpan_frag_rb_t *entry;
 
     TEST_ASSERT_NOT_NULL(pkt);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt,
-                               TEST_FRAGMENT1_OFFSET, TEST_PAGE);
-    entry = _first_non_empty_rbuf();
+    TEST_ASSERT_NOT_NULL((entry = gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        )));
     /* current_size must be the offset of fragment 2, not the size of
      * fragment 1 (fragment dispatch was removed, IPHC was applied etc.). */
     _test_entry(entry, TEST_FRAGMENT2_OFFSET,
@@ -273,9 +273,9 @@ static void test_rbuf_add__success_subsequent_fragment(void)
     const gnrc_sixlowpan_frag_rb_t *entry;
 
     TEST_ASSERT_NOT_NULL(pkt);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt,
-                               TEST_FRAGMENT2_OFFSET, TEST_PAGE);
-    entry = _first_non_empty_rbuf();
+    TEST_ASSERT_NOT_NULL((entry = gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT2_OFFSET, TEST_PAGE
+        )));
     /* current_size must be the offset of fragment 3, not the size of
      * fragment 2 (fragment dispatch was removed, IPHC was applied etc.). */
     _test_entry(entry, TEST_FRAGMENT3_OFFSET - TEST_FRAGMENT2_OFFSET,
@@ -292,12 +292,13 @@ static void test_rbuf_add__success_duplicate_fragments(void)
     const gnrc_sixlowpan_frag_rb_t *entry;
 
     TEST_ASSERT_NOT_NULL(pkt1);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt1,
-                               TEST_FRAGMENT3_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt1, TEST_FRAGMENT3_OFFSET, TEST_PAGE
+        ));
     TEST_ASSERT_NOT_NULL(pkt2);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt2,
-                               TEST_FRAGMENT3_OFFSET, TEST_PAGE);
-    entry = _first_non_empty_rbuf();
+    TEST_ASSERT_NOT_NULL((entry = gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt2, TEST_FRAGMENT3_OFFSET, TEST_PAGE
+        )));
     /* current_size must be the offset of fragment 4, not the size of
      * fragment 3 (fragment dispatch was removed, IPHC was applied etc.). */
     _test_entry(entry, TEST_FRAGMENT4_OFFSET - TEST_FRAGMENT3_OFFSET,
@@ -325,17 +326,21 @@ static void test_rbuf_add__success_complete(void)
     gnrc_netreg_register(TEST_DATAGRAM_NETTYPE, &reg);
     /* Mixing up things. Order decided by fair dice-rolls ;-) */
     TEST_ASSERT_NOT_NULL(pkt2);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt2,
-                               TEST_FRAGMENT2_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt2, TEST_FRAGMENT2_OFFSET, TEST_PAGE
+        ));
     TEST_ASSERT_NOT_NULL(pkt4);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt4,
-                               TEST_FRAGMENT4_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt4, TEST_FRAGMENT4_OFFSET, TEST_PAGE
+        ));
     TEST_ASSERT_NOT_NULL(pkt1);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt1,
-                               TEST_FRAGMENT1_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt1, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        ));
     TEST_ASSERT_NOT_NULL(pkt3);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt3,
-                               TEST_FRAGMENT3_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt3, TEST_FRAGMENT3_OFFSET, TEST_PAGE
+        ));
     TEST_ASSERT_MESSAGE(
             xtimer_msg_receive_timeout(&msg, TEST_RECEIVE_TIMEOUT) >= 0,
             "Receiving reassembled datagram timed out"
@@ -362,16 +367,18 @@ static void test_rbuf_add__full_rbuf(void)
         pkt = gnrc_pktbuf_add(NULL, _fragment1, sizeof(_fragment1),
                               GNRC_NETTYPE_SIXLOWPAN);
         TEST_ASSERT_NOT_NULL(pkt);
-        gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt,
-                                   TEST_FRAGMENT1_OFFSET, TEST_PAGE);
+        TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        ));
         _set_fragment_tag(_fragment1, TEST_TAG + i + 1);
         /* pkt is released in gnrc_sixlowpan_frag_rb_add() */
     }
     pkt = gnrc_pktbuf_add(NULL, _fragment1, sizeof(_fragment1),
                           GNRC_NETTYPE_SIXLOWPAN);
     TEST_ASSERT_NOT_NULL(pkt);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt,
-                               TEST_FRAGMENT1_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        ));
     rbuf = gnrc_sixlowpan_frag_rb_array();
     for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         const gnrc_sixlowpan_frag_rb_t *entry = &rbuf[i];
@@ -404,8 +411,9 @@ static void test_rbuf_add__too_big_fragment(void)
                                           GNRC_NETTYPE_SIXLOWPAN);
 
     TEST_ASSERT_NOT_NULL(pkt);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt,
-                               TEST_FRAGMENT1_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        ));
     /* packet buffer is empty*/
     TEST_ASSERT_NULL(_first_non_empty_rbuf());
     _check_pktbuf(NULL);
@@ -424,11 +432,13 @@ static void test_rbuf_add__overlap_lhs(void)
     pkt2 = gnrc_pktbuf_add(NULL, _fragment2, sizeof(_fragment2),
                            GNRC_NETTYPE_SIXLOWPAN);
     TEST_ASSERT_NOT_NULL(pkt1);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt1,
-                               TEST_FRAGMENT1_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt1, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        ));
     TEST_ASSERT_NOT_NULL(pkt2);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt2, pkt2_offset,
-                               TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt2, pkt2_offset, TEST_PAGE
+        ));
     rbuf = gnrc_sixlowpan_frag_rb_array();
     for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         const gnrc_sixlowpan_frag_rb_t *entry = &rbuf[i];
@@ -467,14 +477,17 @@ static void test_rbuf_add__overlap_rhs(void)
     pkt2 = gnrc_pktbuf_add(NULL, _fragment2, sizeof(_fragment2),
                            GNRC_NETTYPE_SIXLOWPAN);
     TEST_ASSERT_NOT_NULL(pkt1);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt1,
-                               TEST_FRAGMENT1_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt1, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        ));
     TEST_ASSERT_NOT_NULL(pkt3);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt3,
-                               TEST_FRAGMENT3_OFFSET, TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt3, TEST_FRAGMENT3_OFFSET, TEST_PAGE
+        ));
     TEST_ASSERT_NOT_NULL(pkt2);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt2, pkt2_offset,
-                               TEST_PAGE);
+    TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt2, pkt2_offset, TEST_PAGE
+        ));
     rbuf = gnrc_sixlowpan_frag_rb_array();
     for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         const gnrc_sixlowpan_frag_rb_t *entry = &rbuf[i];
@@ -521,10 +534,9 @@ static void test_rbuf_gc__manually(void)
     gnrc_sixlowpan_frag_rb_t *entry;
 
     TEST_ASSERT_NOT_NULL(pkt);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt,
-                               TEST_FRAGMENT1_OFFSET, TEST_PAGE);
-    /* discarding const qualifier intentionally to override `arrival` */
-    entry = (gnrc_sixlowpan_frag_rb_t *)_first_non_empty_rbuf();
+    TEST_ASSERT_NOT_NULL((entry = gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        )));
     TEST_ASSERT_NOT_NULL(entry);
     /* set arrival GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US into the past */
     entry->super.arrival -= GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US;
@@ -542,10 +554,9 @@ static void test_rbuf_gc__timed(void)
     gnrc_sixlowpan_frag_rb_t *entry;
 
     TEST_ASSERT_NOT_NULL(pkt);
-    gnrc_sixlowpan_frag_rb_add(&_test_netif_hdr.hdr, pkt,
-                               TEST_FRAGMENT1_OFFSET, TEST_PAGE);
-    /* discarding const qualifier intentionally to override `arrival` */
-    entry = (gnrc_sixlowpan_frag_rb_t *)_first_non_empty_rbuf();
+    TEST_ASSERT_NOT_NULL((entry = gnrc_sixlowpan_frag_rb_add(
+            &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT1_OFFSET, TEST_PAGE
+        )));
     TEST_ASSERT_NOT_NULL(entry);
     TEST_ASSERT_MESSAGE(
             xtimer_msg_receive_timeout(&msg, TEST_GC_TIMEOUT) >= 0,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Another step in refactoring the reassembly buffer in preparation for SFR. SFR needs to know, if a fragment was complete to send a "Full-ACK". Likewise it needs to keep track of what was already received, if not complete. Both is not possible with the current reassembly buffer API, as it is hidden within the implementation of `gnrc_sixlowpan_frag_rb_add()` which doesn't give any feedback. This PR:

- adds the reassembly buffer entry created or updated as return value for `gnrc_sixlowpan_frag_rb_add()`
- Adds feedback on the completeness (or erroring behavior when complete) of a fragmented datagram for `gnrc_sixlowpan_frag_rb_dispatch_when_complete()`
- Moves `gnrc_sixlowpan_frag_rb_dispatch_when_complete()` out of `gnrc_sixlowpan_frag_rb_add()`. The caller of the latter function is now responsible to call it. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
make -C tests/gnrc_sixlowpan_frag flash test
```

should still work.

```
> ping6 -s 200 fe80::7b62:3323:ec77:c86
2019-10-01 09:15:51,370 #  ping6 -s 200 fe80::7b62:3323:ec77:c86
2019-10-01 09:15:51,414 # 208 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=0 ttl=64 rssi=-43 dBm time=35.464 ms
2019-10-01 09:15:52,415 # 208 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=1 ttl=64 rssi=-44 dBm time=34.502 ms
2019-10-01 09:15:53,418 # 208 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=2 ttl=64 rssi=-44 dBm time=35.445 ms
2019-10-01 09:15:53,418 # 
2019-10-01 09:15:53,422 # --- fe80::7b62:3323:ec77:c86 PING statistics ---
2019-10-01 09:15:53,427 # 3 packets transmitted, 3 packets received, 0% packet loss
2019-10-01 09:15:53,432 # round-trip min/avg/max = 34.502/35.137/35.464 ms
> ping6 -s 500 fe80::7b62:3323:ec77:c86
2019-10-01 09:15:56,541 #  ping6 -s 500 fe80::7b62:3323:ec77:c86
2019-10-01 09:15:56,629 # 508 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=0 ttl=64 rssi=-43 dBm time=80.199 ms
2019-10-01 09:15:57,628 # 508 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=1 ttl=64 rssi=-44 dBm time=77.011 ms
2019-10-01 09:15:58,632 # 508 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=2 ttl=64 rssi=-44 dBm time=78.262 ms
2019-10-01 09:15:58,632 # 
2019-10-01 09:15:58,636 # --- fe80::7b62:3323:ec77:c86 PING statistics ---
2019-10-01 09:15:58,641 # 3 packets transmitted, 3 packets received, 0% packet loss
2019-10-01 09:15:58,646 # round-trip min/avg/max = 77.011/78.490/80.199 ms
> ping6 -s 1000 fe80::7b62:3323:ec77:c86
2019-10-01 09:16:02,179 #  ping6 -s 1000 fe80::7b62:3323:ec77:c86
2019-10-01 09:16:02,334 # 1008 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=0 ttl=64 rssi=-44 dBm time=146.218 ms
2019-10-01 09:16:03,327 # 1008 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=1 ttl=64 rssi=-44 dBm time=137.262 ms
2019-10-01 09:16:04,330 # 1008 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=2 ttl=64 rssi=-44 dBm time=137.906 ms
2019-10-01 09:16:04,330 # 
2019-10-01 09:16:04,334 # --- fe80::7b62:3323:ec77:c86 PING statistics ---
2019-10-01 09:16:04,339 # 3 packets transmitted, 3 packets received, 0% packet loss
2019-10-01 09:16:04,344 # round-trip min/avg/max = 137.262/140.462/146.218 ms
ping6 -s 1232 fe80::7b62:3323:ec77:c86
2019-10-01 09:16:12,652 #  ping6 -s 1232 fe80::7b62:3323:ec77:c86
2019-10-01 09:16:12,832 # 1240 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=0 ttl=64 rssi=-43 dBm time=171.865 ms
2019-10-01 09:16:14,830 # 1240 bytes from fe80::7b62:3323:ec77:c86: icmp_seq=2 ttl=64 rssi=-44 dBm time=165.478 ms
2019-10-01 09:16:15,659 # 
2019-10-01 09:16:15,663 # --- fe80::7b62:3323:ec77:c86 PING statistics ---
2019-10-01 09:16:15,668 # 3 packets transmitted, 2 packets received, 33% packet loss
2019-10-01 09:16:15,673 # round-trip min/avg/max = 165.478/168.671/171.865 ms
```

Use `gnrc_pktbuf_cmd` to check if the packet buffer on both nodes is alright after that.

```
2019-10-01 09:21:16,258 #  pktbuf
2019-10-01 09:21:16,264 # packet buffer: first byte: 0x20001990, last byte: 0x20003190 (size: 6144)
2019-10-01 09:21:16,268 #   position of last byte used: 1672
2019-10-01 09:21:16,272 # ~ unused: 0x20001990 (next: 0, size: 6144) ~
```

```
2019-10-01 09:21:19,577 # pktbuf
2019-10-01 09:21:19,584 # packet buffer: first byte: 0x20001990, last byte: 0x20003190 (size: 6144)
2019-10-01 09:21:19,587 #   position of last byte used: 2808
2019-10-01 09:21:19,591 # ~ unused: 0x20001990 (next: 0, size: 6144) ~
```

Pinging larger packets between two `gnrc_networking` instances should still work
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #12318 and #12324.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
