### PR TITLE
Makefile.include: only keep macros in riotbuild.h

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -786,9 +786,22 @@ endif
 include $(RIOTTOOLS)/desvirt/Makefile.desvirt
 
 # Build a header file with all common macro definitions and undefinitions
-# make it depend on FORCE to re-run of the script every time even if the file exists
-# The script will only touch the file if anything has changed since last time.
-$(RIOTBUILD_CONFIG_HEADER_C): FORCE
+# Everytime the header is updated, it will trigger a new compilation.
+#
+# The file is created first through a `.in` file that will be modified if
+# any CFLAGS changed. It depends on FORCE to re-run of the script every time
+# even if the file exists but the file will only be updated on modifications.
+#
+# The header is then created by keeping only the macros. Keeping the
+# comments added absolute path in the file that screwed caching.
+#
+# The rebuild behavior could even only be done with an empty file, but currently
+# some macros definitions are passed through this file.
+$(RIOTBUILD_CONFIG_HEADER_C): $(RIOTBUILD_CONFIG_HEADER_C).in
+	$(Q)sed -n -e '1i /* Generated file do not edit */' -e '/^#.*/ p' $< > $@
+
+.SECONDARY: $(RIOTBUILD_CONFIG_HEADER_C).in
+$(RIOTBUILD_CONFIG_HEADER_C).in: FORCE | $(CLEAN)
 	@mkdir -p '$(dir $@)'
 	$(Q)'$(RIOTTOOLS)/genconfigheader/genconfigheader.sh' $(CFLAGS_WITH_MACROS) \
 		| '$(LAZYSPONGE)' $(LAZYSPONGE_FLAGS) '$@'


### PR DESCRIPTION
### Contribution description

Rely on creating an intermediate riotbuild.h.in file that is updated on
CFLAGS changes, but then generate 'riotbuild.h' without the comments.
The updated timestamp will still trigger a rebuild but not cause ccache
miss due to the content of the CFLAGS that contains absolute path.

This removes the caching issue due to the absolute path that was
added to `CFLAGS` and so the comment in that file.


### Testing procedure

#### Low level testing procedure

The file `riotbuild.h` does not contain any absolute path anymore in a comment.

File is not updated on rebuilding the same thing but is on `CFLAGS` change:

```
RIOT_CI_BUILD=1 make -C examples/hello-world/ >/dev/null
stat --format='%y' examples/hello-world/bin/native/riotbuild/riotbuild.h
stat --format='%y' examples/hello-world/bin/native/application_hello-world/main.o
sleep 1s
RIOT_CI_BUILD=1 make -C examples/hello-world/ >/dev/null
echo It should be the same timestamps
stat --format='%y' examples/hello-world/bin/native/riotbuild/riotbuild.h
stat --format='%y' examples/hello-world/bin/native/application_hello-world/main.o
md5sum examples/hello-world/bin/native/riotbuild/riotbuild.h
# Then modify CFLAGS without modifying macros
sleep 1s
CFLAGS=-Werror RIOT_CI_BUILD=1 make -C examples/hello-world/ >/dev/null
echo Timestamp changed but md5sum stay the same
stat --format='%y' examples/hello-world/bin/native/riotbuild/riotbuild.h
stat --format='%y' examples/hello-world/bin/native/application_hello-world/main.o
md5sum examples/hello-world/bin/native/riotbuild/riotbuild.h
```

The output shows that on the first rebuild, both the header and the object were not changed, but on the rebuild with a different CFLAGS, it was rebuild despite still having the same content in `riotbuild.h`.

```
2019-10-01 11:11:21.715478333 +0200
2019-10-01 11:11:21.735478454 +0200
It should be the same timestamps
2019-10-01 11:11:21.715478333 +0200
2019-10-01 11:11:21.735478454 +0200
9b0ced6bc25fde0ca2c25922cad8069b  examples/hello-world/bin/native/riotbuild/riotbuild.h
Timestamp changed but md5sum stay the same
2019-10-01 11:11:25.411500357 +0200
2019-10-01 11:11:25.431500476 +0200
9b0ced6bc25fde0ca2c25922cad8069b  examples/hello-world/bin/native/riotbuild/riotbuild.h

```

<details><summary>The file content is the same as before without the `CFLAGS` comment:</summary>

```
cat examples/hello-world/bin/native/riotbuild/riotbuild.h
/* Generated file do not edit */
#define DEVELHELP 1
#define DEBUG_ASSERT_VERBOSE 1
#define RIOT_APPLICATION "hello-world"
#define BOARD_NATIVE "native"
#define RIOT_BOARD BOARD_NATIVE
#define CPU_NATIVE "native"
#define RIOT_CPU CPU_NATIVE
#define MCU_NATIVE "native"
#define RIOT_MCU MCU_NATIVE
#define RIOT_VERSION "buildtest"
#define MODULE_AUTO_INIT 1
#define MODULE_BOARD 1
#define MODULE_CORE 1
#define MODULE_CORE_MSG 1
#define MODULE_CPU 1
#define MODULE_NATIVE_DRIVERS 1
#define MODULE_PERIPH 1
#define MODULE_PERIPH_COMMON 1
#define MODULE_PERIPH_GPIO 1
#define MODULE_PERIPH_PM 1
#define MODULE_PERIPH_UART 1
#define MODULE_SYS 1
```
</details>

#### High level testing procedure

Changing a macro like the `RIOT_VERSION` without cleaning still re-builds:

<details><summary>Hello-world with different RIOT_VERSION</summary>

```
RIOT_CI_BUILD=1 make -C examples/hello-world/ flash term 
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".

   text    data     bss     dec     hex filename
  22918     568   47652   71138   115e2 /home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.elf
true 
/home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
```
And then just after

```
RIOT_VERSION=lalala RIOT_CI_BUILD=1 make -C examples/hello-world/ flash term 
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".

   text    data     bss     dec     hex filename
  22914     568   47652   71134   115de /home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.elf
true 
/home/harter/work/git/RIOT/examples/hello-world/bin/native/hello-world.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: lalala)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
```
</details>

#### Caching impact

@kaspar030 testing procedure for the caching


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/12262#issuecomment-536696188
