### PR TITLE
gnrc_sixlowpan_frag_rb: add new functions for SFR

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -115,6 +115,45 @@ gnrc_sixlowpan_frag_rb_t *gnrc_sixlowpan_frag_rb_add(gnrc_netif_hdr_t *netif_hdr
                                                      size_t offset, unsigned page);
 
 /**
+ * @brief   Checks if a reassembly buffer entry with a given link-layer address
+ *          pair and tag exists
+ *
+ * @pre     `netif_hdr != NULL`
+ *
+ * @param[in] netif_hdr An interface header to provide the (source, destination)
+ *                      link-layer address pair. Must not be NULL.
+ * @param[in] tag       Tag to search for.
+ *
+ * @note    datagram_size is not a search parameter as the primary use case
+ *          for this function is [Selective Fragment Recovery]
+ *          (https://tools.ietf.org/html/draft-ietf-6lo-fragment-recovery-05)
+ *          where this information only exists in the first fragment.
+ *
+ * @return  true, if an entry with the given tuple exist.
+ * @return  false, if no entry with the given tuple exist.
+ */
+bool gnrc_sixlowpan_frag_rb_exists(const gnrc_netif_hdr_t *netif_hdr,
+                                   uint16_t tag);
+
+/**
+ * @brief   Removes a reassembly buffer entry with a given link-layer address
+ *          pair and tag
+ *
+ * @pre     `netif_hdr != NULL`
+ *
+ * @param[in] netif_hdr An interface header to provide the (source, destination)
+ *                      link-layer address pair. Must not be NULL.
+ * @param[in] tag       Tag to search for.
+ *
+ * @note    datagram_size is not a search parameter as the primary use case
+ *          for this function is [Selective Fragment Recovery]
+ *          (https://tools.ietf.org/html/draft-ietf-6lo-fragment-recovery-05)
+ *          where this information only exists in the first fragment.
+ */
+void gnrc_sixlowpan_frag_rb_rm_by_datagram(const gnrc_netif_hdr_t *netif_hdr,
+                                           uint16_t tag);
+
+/**
  * @brief   Checks if a reassembly buffer entry is unset
  *
  * @param[in] rbuf  A reassembly buffer entry

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -73,6 +73,9 @@ static int _rbuf_get(const void *src, size_t src_len,
                      const void *dst, size_t dst_len,
                      size_t size, uint16_t tag,
                      unsigned page);
+/* gets an entry only by link-layer information and tag */
+static gnrc_sixlowpan_frag_rb_t *_rbuf_get_by_tag(const gnrc_netif_hdr_t *netif_hdr,
+                                                  uint16_t tag);
 /* internal add to repeat add when fragments overlapped */
 static int _rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
                      size_t offset, unsigned page);
@@ -136,6 +139,47 @@ gnrc_sixlowpan_frag_rb_t *gnrc_sixlowpan_frag_rb_add(gnrc_netif_hdr_t *netif_hdr
         res = _rbuf_add(netif_hdr, pkt, offset, page);
     }
     return (res < 0) ? NULL : &rbuf[res];
+}
+
+
+
+bool gnrc_sixlowpan_frag_rb_exists(const gnrc_netif_hdr_t *netif_hdr,
+                                   uint16_t tag)
+{
+    return (_rbuf_get_by_tag(netif_hdr, tag) != NULL);
+}
+
+void gnrc_sixlowpan_frag_rb_rm_by_datagram(const gnrc_netif_hdr_t *netif_hdr,
+                                           uint16_t tag)
+{
+    gnrc_sixlowpan_frag_rb_t *e = _rbuf_get_by_tag(netif_hdr, tag);
+
+    if (e != NULL) {
+        gnrc_sixlowpan_frag_rb_remove(e);
+    }
+}
+
+static gnrc_sixlowpan_frag_rb_t *_rbuf_get_by_tag(const gnrc_netif_hdr_t *netif_hdr,
+                                                  uint16_t tag)
+{
+    assert(netif_hdr != NULL);
+    const uint8_t *src = gnrc_netif_hdr_get_src_addr(netif_hdr);
+    const uint8_t *dst = gnrc_netif_hdr_get_dst_addr(netif_hdr);
+    const uint8_t src_len = netif_hdr->src_l2addr_len;
+    const uint8_t dst_len = netif_hdr->dst_l2addr_len;
+
+    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+        gnrc_sixlowpan_frag_rb_t *e = &rbuf[i];
+
+        if ((e->pkt != NULL) && (e->super.tag == tag) &&
+            (e->super.src_len == src_len) &&
+            (e->super.dst_len == dst_len) &&
+            (memcmp(e->super.src, src, src_len) == 0) &&
+            (memcmp(e->super.dst, dst, dst_len) == 0)) {
+            return e;
+        }
+    }
+    return NULL;
 }
 
 #ifndef NDEBUG

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -68,7 +68,7 @@ static gnrc_sixlowpan_frag_rb_int_t *_rbuf_int_get_free(void);
 /* update interval buffer of entry */
 static bool _rbuf_update_ints(gnrc_sixlowpan_frag_rb_base_t *entry,
                               uint16_t offset, size_t frag_size);
-/* gets an entry identified by its tupel */
+/* gets an entry identified by its tuple */
 static int _rbuf_get(const void *src, size_t src_len,
                      const void *dst, size_t dst_len,
                      size_t size, uint16_t tag,

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -527,6 +527,22 @@ static void test_rbuf_add__overlap_rhs(void)
     _check_pktbuf(NULL);
 }
 
+static void test_rbuf_exists(void)
+{
+    TEST_ASSERT(!gnrc_sixlowpan_frag_rb_exists(&_test_netif_hdr.hdr, TEST_TAG));
+    /* add a fragment */
+    test_rbuf_add__success_first_fragment();
+    TEST_ASSERT(gnrc_sixlowpan_frag_rb_exists(&_test_netif_hdr.hdr, TEST_TAG));
+}
+
+static void test_rbuf_rm_by_dg(void)
+{
+    /* add a fragment */
+    test_rbuf_add__success_first_fragment();
+    gnrc_sixlowpan_frag_rb_rm_by_datagram(&_test_netif_hdr.hdr, TEST_TAG);
+    TEST_ASSERT(!gnrc_sixlowpan_frag_rb_exists(&_test_netif_hdr.hdr, TEST_TAG));
+}
+
 static void test_rbuf_rm(void)
 {
     const gnrc_sixlowpan_frag_rb_t *entry;
@@ -596,6 +612,8 @@ static void run_unittests(void)
         new_TestFixture(test_rbuf_add__too_big_fragment),
         new_TestFixture(test_rbuf_add__overlap_lhs),
         new_TestFixture(test_rbuf_add__overlap_rhs),
+        new_TestFixture(test_rbuf_exists),
+        new_TestFixture(test_rbuf_rm_by_dg),
         new_TestFixture(test_rbuf_rm),
         new_TestFixture(test_rbuf_gc__manually),
         new_TestFixture(test_rbuf_gc__timed),

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -417,7 +417,7 @@ static void test_rbuf_add__full_rbuf(void)
 static void test_rbuf_add__too_big_fragment(void)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, _fragment1,
-                                          /* something definetely bigger than
+                                          /* something definitely bigger than
                                            * the datagram size noted in
                                            * _fragment1, can't just be + 1,
                                            * since fragment dispatch and other


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This extends the 6LoWPAN reassembly buffer by two functions specifically for Selective Fragment Recovery:

- `gnrc_sixlowpan_frag_rb_exists()` checks if an entry with given parameters exist.
- `gnrc_sixlowpan_frag_rb_rm_by_datagram()` removes an entry by given parameters.o

In both cases datagram_size is not a search parameter as this information only exists in the first fragment and thus can't be determined for subsequent fragments without having the reassembly buffer entry first.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
~~Did not add tests yet. Will do (this is why this PR is WIP).~~ Tests were added to `tests/gnrc_sixlowpan_frag` so it should pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
