### PR TITLE
pkg/nimble: bump NimBLE version

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = 997dad8c9fc549e64b6c54eafcec109d92789418
+PKG_VERSION = fb7651b773734a075c47ff10210b92e6d55ef55b
 PKG_LICENSE = Apache-2.0
 
 TDIR = $(RIOTPKG)/$(PKG_NAME)

--- a/tests/nimble_l2cap_server/main.c
+++ b/tests/nimble_l2cap_server/main.c
@@ -60,7 +60,6 @@ static void _on_data(struct ble_l2cap_event *event)
 
     res = os_mbuf_copydata(rxd, 0, rx_len, _rxbuf);
     assert(res == 0);
-    printf("# Received: len %5i, seq %5u\n", rx_len, (unsigned)_rxbuf[POS_SEQ]);
 
     res = ble_l2cap_send(_coc, rxd);
     assert((res == 0) || (res == BLE_HS_ESTALLED));
@@ -70,6 +69,8 @@ static void _on_data(struct ble_l2cap_event *event)
     assert(rxd != NULL);
     res = ble_l2cap_recv_ready(_coc, rxd);
     assert(res == 0);
+
+    printf("# Received: len %5i, seq %5u\n", rx_len, (unsigned)_rxbuf[POS_SEQ]);
 }
 
 static int _on_gap_evt(struct ble_gap_event *event, void *arg)


### PR DESCRIPTION
### Contribution description
NimBLE has again advanced over the last months, many bug fixes to controller and host... This new commit is now also based on the NimBLE 1.2.0 Version.

### Testing procedure
Verify that `examples/nimble_gatt` and the `tests/nimble_l2cap[_server]` applicatoins still work as expected.

### Issues/PRs references
none