### PR TITLE
pkg/nimble/netif_conn: improve debug messages

### DIFF
--- a/pkg/nimble/netif/nimble_netif_conn.c
+++ b/pkg/nimble/netif/nimble_netif_conn.c
@@ -81,7 +81,7 @@ int nimble_netif_conn_get_by_addr(const uint8_t *addr)
     assert(addr);
     int handle = NIMBLE_NETIF_CONN_INVALID;
 
-    DEBUG("nimble_netif_conn_get_by_addr %02x\n", (int)addr[5]);
+    DEBUG("nimble_netif_conn_get_by_addr %02x\n", (int)addr[0]);
     mutex_lock(&_lock);
     for (unsigned i = 0; i < CONN_CNT; i++) {
         if ((_conn[i].state & NIMBLE_NETIF_L2CAP_CONNECTED) &&
@@ -91,7 +91,7 @@ int nimble_netif_conn_get_by_addr(const uint8_t *addr)
         }
     }
     mutex_unlock(&_lock);
-    DEBUG("nimble_netif_conn_get_by_addr - found: %i\n", handle);
+    DEBUG("nimble_netif_conn_get_by_addr - found handle: %i\n", handle);
 
     return handle;
 }
@@ -118,7 +118,7 @@ int nimble_netif_conn_start_connection(const uint8_t *addr)
 {
     int handle;
 
-    DEBUG("nimble_netif_conn_start_connection, addr %02x\n", (int)addr[5]);
+    DEBUG("nimble_netif_conn_start_connection, addr %02x\n", (int)addr[0]);
     mutex_lock(&_lock);
     handle = _find_by_state(NIMBLE_NETIF_UNUSED);
     if (handle != NIMBLE_NETIF_CONN_INVALID) {


### PR DESCRIPTION
### Contribution description
This PR fixes/improves some Debug messages for `nimble_netif`. Two messages were not adapted yet to the byteorder fixes recently done, and one is simply a little clearer now.

### Testing procedure
Building `gnrc_networking` for `nrf52` with `DEBUG := 1` in `pkg/nimble/netif/nimble_netif_conn.c` should do the trick. If no build errors appear, everything should be in order (low impact change)...

### Issues/PRs references
none