### PR TITLE
pkg/nimble/netif: set max conn explicitly

### DIFF
--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -77,6 +77,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief   The maximum number of BLE connections that can be open concurrently
+ *
+ * @note    This value *must* be <= MYNEWT_VAL_BLE_MAX_CONNECTIONS
+ */
+#ifndef NIMBLE_NETIF_MAX_CONN
+#define NIMBLE_NETIF_MAX_CONN       (MYNEWT_VAL_BLE_MAX_CONNECTIONS)
+#endif
+
+/**
  * @brief   Default L2CAP channel ID to use
  */
 #ifndef NIMBLE_NETIF_CID

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -56,7 +56,7 @@
 #define MBUF_OVHD               (sizeof(struct os_mbuf) + \
                                  sizeof(struct os_mbuf_pkthdr))
 #define MBUF_SIZE               (MBUF_OVHD + MYNEWT_VAL_BLE_L2CAP_COC_MPS)
-#define MBUF_CNT                (MYNEWT_VAL_BLE_MAX_CONNECTIONS * 2 * \
+#define MBUF_CNT                (NIMBLE_NETIF_MAX_CONN * 2 * \
                                  ((MTU_SIZE + (MBUF_SIZE - 1)) / MBUF_SIZE))
 
 /* thread flag used for signaling transmit readiness */

--- a/pkg/nimble/netif/nimble_netif_conn.c
+++ b/pkg/nimble/netif/nimble_netif_conn.c
@@ -23,7 +23,7 @@
 #define ENABLE_DEBUG            (0)
 #include "debug.h"
 
-#define CONN_CNT                (MYNEWT_VAL_BLE_MAX_CONNECTIONS)
+#define CONN_CNT                (NIMBLE_NETIF_MAX_CONN)
 
 static mutex_t _lock = MUTEX_INIT;
 static nimble_netif_conn_t _conn[CONN_CNT];

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -130,7 +130,7 @@ static void _cmd_info(void)
 #endif
     puts("");
 
-    printf(" Free slots: %u/%u\n", free, MYNEWT_VAL_BLE_MAX_CONNECTIONS);
+    printf(" Free slots: %u/%u\n", free, NIMBLE_NETIF_MAX_CONN);
     printf("Advertising: ");
     if (nimble_netif_conn_get_adv() != NIMBLE_NETIF_CONN_INVALID) {
         puts("yes");


### PR DESCRIPTION
### Contribution description
So far, the maximum number of connections that `nimble_netif` can handle was hard-coded to `MYNEWT_VAL_BLE_MAX_CONNECTIONS`. But there are use cases, where ist useful to allocate only a sub-set of available connection slots to `nimble_netif`, while others could be reserved to GATT connection(s) or similar.

In any case, having this a separate define does not hurt...

### Testing procedure
Build and run `examples/gnrc_networking` on a `nrf52dk` or similar, just make sure it actually builds with `nimble_netif` (some nrf52 boards use `nrfmin` as default radio at the moment...). Everything should still work as expected, and the `ble info` shell command should show 3 possible connections (3 is the default value).

### Issues/PRs references
none