### PR TITLE
shell/gnrc_netif: Use netif API for ifconfig

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -368,7 +368,7 @@ typedef enum {
     NETOPT_DEVICE_TYPE,
 
     /**
-     * @brief   (uint8_t) channel page as defined by IEEE 802.15.4
+     * @brief   (uint16_t) channel page as defined by IEEE 802.15.4
      */
     NETOPT_CHANNEL_PAGE,
 

--- a/sys/net/gnrc/netif/_netif.c
+++ b/sys/net/gnrc/netif/_netif.c
@@ -28,7 +28,6 @@ int netif_get_name(netif_t *iface, char *name)
     gnrc_netif_t *netif = (gnrc_netif_t*) iface;
 
     int res = 0;
-    res += fmt_str(name, "if");
     res += fmt_u16_dec(&name[res], netif->pid);
     name[res] = '\0';
     return res;

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1131,7 +1131,7 @@ static void test_netif_get_name(void)
     TEST_ASSERT_NOT_NULL(netif);
 
     res = netif_get_name(netif, name);
-    sprintf(exp_name, "if%d", (int) ((gnrc_netif_t *)netif)->pid);
+    sprintf(exp_name, "%d", (int) ((gnrc_netif_t *)netif)->pid);
     TEST_ASSERT_EQUAL_INT(strlen(exp_name), res);
     TEST_ASSERT_EQUAL_STRING(&exp_name[0], &name[0]);
 }


### PR DESCRIPTION
### Contribution description
This PR modifies the `ifconfig` and `txtsnd` command implementations to use the new netif API introduced in #11879. ~~Some changes had to be made in tests as now the name for GNRC interfaces returns `if<n>` (that's the value returned by GNRC's implementation of `netif_get_name`).~~

This may be a first step towards having a generic implementation of this command, that does not depend on the stack that is currently being used.

~~For now the PR includes commits of #11879, I will rebase when it gets merged, but the changes on the commands can be reviewed anyway.~~

### Testing procedure

- Check that the commands work as expected
- ~~Run the modified tests, they should still work.~~

### Issues/PRs references
~~Depends on #11879~~