### PR TITLE
tests/pkg_ubasic: increase timeout value, per test

### DIFF
--- a/tests/pkg_ubasic/tests/01-run.py
+++ b/tests/pkg_ubasic/tests/01-run.py
@@ -10,10 +10,16 @@ import sys
 from testrunner import run
 
 
+# Use custom timeout, per test.
+# test #3 requires ~150s to complete on samr30-xpro.
+TIMEOUT = 180
+
+
 def testfunc(child):
     for i in range(1, 6):
-        child.expect(r"Running test #{}... done. Run time: [0-9.]* s".format(i))
+        child.expect(r"Running test #{}... done. Run time: [0-9.]* s".format(i),
+                     timeout=TIMEOUT)
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc, timeout=120))
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing `tests/pkg_ubasic` on samr30-xpro, as reported in https://github.com/RIOT-OS/RIOT/pull/10941#issuecomment-537439460.

The idea is just to use the timeout value per test and with a high enough value.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run
```
make BOARD=samr30-xpro -C tests/pkg_ubasic flash test
```
With this PR, it works, on master, it fails because of a timeout.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while reviewing #10941

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
