### PR TITLE
examples/default: update BOARD_PROVIDES_NETIF

### DIFF
--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -38,10 +38,10 @@ USEMODULE += ps
 USEMODULE += saul_default
 
 BOARD_PROVIDES_NETIF := acd52832 airfy-beacon b-l072z-lrwan1 cc2538dk fox \
-        iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \
+        hamilton iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \
         native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf6310 \
-        nucleo-f767zi openmote-cc2538 pba-d-01-kw2x remote-pa remote-reva \
-        samr21-xpro spark-core telosb yunjia-nrf51822 z1
+        nucleo-f767zi openmote-b openmote-cc2538 pba-d-01-kw2x remote-pa remote-reva \
+        ruuvitag samr21-xpro samr30-xpro spark-core telosb thingy52 yunjia-nrf51822 z1
 
 ifneq (,$(filter $(BOARD),$(BOARD_PROVIDES_NETIF)))
   # Use modules for networking


### PR DESCRIPTION
### Contribution description

Add hamilton, openmote-b, ruuvitag, samr30-xpro and thingy52 to the `BOARD_PROVIDES_NETIF`.

I grepped for `gnrc_netdev` in `boards/` and these came up as missing. I ignored the `common/` boards for now.

This is of course terrible.

But since this is the first Makefile being used, we can't rely on `FEATURES_PROVIDED` (which also does not provide a `gnrc_netdev` option yet).

Until we come up with something better, at least improve the default user experience for users of those boards a bit.

### Testing procedure

Flash `examples/default` with one of those boards and observe that the example now provides a L2 network interface as it should.

### Issues/PRs references
came up in #12356