### PR TITLE
tests/pkg_ubasic: improve test output regex

### DIFF
--- a/tests/pkg_ubasic/tests/01-run.py
+++ b/tests/pkg_ubasic/tests/01-run.py
@@ -17,7 +17,7 @@ TIMEOUT = 180
 
 def testfunc(child):
     for i in range(1, 6):
-        child.expect(r"Running test #{}... done. Run time: [0-9.]* s".format(i),
+        child.expect(r"Running test #%d... done. Run time: \d+.\d{3} s" % i,
                      timeout=TIMEOUT)
 
 


### PR DESCRIPTION
The test application now correctly prints float value, with a 3 digits precision. The python test script now verifies the run time value printed for each test is following the x.xxx pattern.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is improving the python test script of `tests/pkg_ubasic`. Now that #12358 is merged the test application displays the run time with the following pattern: `x.xxx`. The change proposed here simply uses a regex to verify that the output matches that pattern.

Output result on native:

<details>

```
$ make BOARD=native -C tests/pkg_ubasic/ all test
make: Entering directory '/work/riot/RIOT/tests/pkg_ubasic'
Building application "tests_pkg_ubasic" for "native" with MCU "native".

rm -Rf /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic
mkdir -p /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic
/work/riot/RIOT/dist/tools/git/git-cache clone "https://github.com/adamdunkels/ubasic" "cc07193c231e21ecb418335aba5b199a08d4685c" "/work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic"
Cloning into '/work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic'...
remote: Enumerating objects: 60, done.
remote: Total 60 (delta 0), reused 0 (delta 0), pack-reused 60
Unpacking objects: 100% (60/60), done.
HEAD is now at cc07193 Merge pull request #1 from dbohdan/master
touch /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic/.git-downloaded
if [ cc07193c231e21ecb418335aba5b199a08d4685c != cc07193c231e21ecb418335aba5b199a08d4685c ] ; then \
	git -C /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic clean -xdff ; \
	git -C /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic fetch "https://github.com/adamdunkels/ubasic" "cc07193c231e21ecb418335aba5b199a08d4685c" ; \
	git -C /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic checkout -f cc07193c231e21ecb418335aba5b199a08d4685c ; \
	touch /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic/.git-downloaded ; \
fi
"make" -C /work/riot/RIOT/pkg/ubasic
"make" -f /work/riot/RIOT/pkg/ubasic/ubasic_tests.mk -C /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic
"make" -f /work/riot/RIOT/pkg/ubasic/ubasic.mk -C /work/riot/RIOT/tests/pkg_ubasic/bin/pkg/native/ubasic
"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/vfs
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
   text	   data	    bss	    dec	    hex	filename
  32922	    752	  47984	  81658	  13efa	/work/riot/RIOT/tests/pkg_ubasic/bin/native/tests_pkg_ubasic.elf
/work/riot/RIOT/tests/pkg_ubasic/bin/native/tests_pkg_ubasic.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2019.10-devel-1252-g630e7-pr/tests/pkg_ubasic_python)
Running test #1... done. Run time: 0.000 s
Running test #2... done. Run time: 0.000 s
Running test #3... done. Run time: 0.251 s
Running test #4... done. Run time: 0.000 s
Running test #5... done. Run time: 0.000 s

make: Leaving directory '/work/riot/RIOT/tests/pkg_ubasic'
```

</details>

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make -C tests/pkg_ubasic all test` should work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #12358 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
