### PR TITLE
make/targets: fix typo in message

### DIFF
--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -10,22 +10,22 @@
 $(RIOTTOOLS)/bossa/bossac:
 	@echo "[INFO] bossac binary not found - building it from source"
 	@make -C $(RIOTTOOLS)/bossa
-	@echo "[INFO] bossac binary successfully build!"
+	@echo "[INFO] bossac binary successfully built!"
 
 $(RIOTTOOLS)/pic32prog/pic32prog: $(RIOTTOOLS)/pic32prog/Makefile
 	@echo "[INFO] $(@F) binary not found - building it from source now"
 	make -C $(@D)
-	@echo "[INFO] $(@F) binary successfully build!"
+	@echo "[INFO] $(@F) binary successfully built!"
 
 $(RIOTTOOLS)/edbg/edbg: $(RIOTTOOLS)/edbg/Makefile
 	@echo "[INFO] edbg binary not found - building it from source now"
 	CC= CFLAGS= make -C $(RIOTTOOLS)/edbg
-	@echo "[INFO] edbg binary successfully build!"
+	@echo "[INFO] edbg binary successfully built!"
 
 $(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb:
 	@echo "[INFO] rsmb binary not found - building it from source now"
 	@make -C $(RIOTTOOLS)/mosquitto_rsmb
-	@echo "[INFO] rsmb binary successfully build!"
+	@echo "[INFO] rsmb binary successfully built!"
 
 mosquitto_rsmb: $(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb
 	@make -C $(RIOTTOOLS)/mosquitto_rsmb run
@@ -33,4 +33,4 @@ mosquitto_rsmb: $(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb
 $(RIOTTOOLS)/setsid/setsid: $(RIOTTOOLS)/setsid/Makefile
 	@echo "[INFO] setsid binary not found - building it from source now"
 	@make -C $(RIOTTOOLS)/setsid
-	@echo "[INFO] setsid binary successfully build!"
+	@echo "[INFO] setsid binary successfully built!"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

As promised in https://github.com/RIOT-OS/RIOT/pull/10204#discussion_r330552593, this PR fixes typo in the message displayed when optional tools are built automatically when required.

Maybe the message could be reworded ? Maybe some factorization could be done ?


### Testing procedure

Reading the code should be enough but the zealous reviewer could try to call the targets on related platforms to force a rebuild. Example with edbg:

1. Ensure edbg is not present on the system and in `dist/tools/edbg`
2. call make BOARD=samr21-xpro -C examples/hello-world flash
=> edbg should be built on the fly, the message "[INFO] edbg binary successfully built!" should be displayed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #10204

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
