### PR TITLE
gnrc_tcp: check if option has valid length set

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
@@ -69,7 +69,8 @@ int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
                 }
         }
 
-        if (opt_left < TCP_OPTION_LENGTH_MIN || option->length > opt_left) {
+        if ((opt_left < TCP_OPTION_LENGTH_MIN) || (option->length > opt_left) ||
+            (option->length < TCP_OPTION_LENGTH_MIN)) {
             DEBUG("gnrc_tcp_option.c : _option_parse() : Invalid option. Drop Packet.\n");
             return -1;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While adding some regression tests for the issues @nmeum found to the new test application added in #11930, I sadly found that https://github.com/RIOT-OS/RIOT/pull/12298 reintroduced parts of https://github.com/RIOT-OS/RIOT/pull/12086. If the test provided with that issue is used, the infinite loop pointed out there is triggered in current master, since the test provides an option with its length field set to zero.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Redo the test in #12086. On current master they show the exact same behavior, but not with this fix.
`tests/gnrc_tcp` should still pass on both master and a different board (please test, I only have access to master right now!).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes a regression introduced in #12298
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
