### PR TITLE
cpu/nrf52: allow accessing multiple i2c peripherals

### DIFF
--- a/cpu/nrf52/periph/i2c.c
+++ b/cpu/nrf52/periph/i2c.c
@@ -47,8 +47,7 @@ static mutex_t locks[I2C_NUMOF];
 
 static inline NRF_TWIM_Type *bus(i2c_t dev)
 {
-    (void) dev;
-    return i2c_config[0].dev;
+    return i2c_config[dev].dev;
 }
 
 static int finish(i2c_t dev)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

While trying to find out what was wrong with #10793, I found that the i2c driver was always returning the pointer on the first device. This PR is fixing this problem, since the driver should be able to handle multiple configured devices.

### Testing procedure

Try this PR with #10793, the new configured devices should work with the saul application.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while debugging #10793.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
