### PR TITLE
boards/stm32: initialize board gpios after cpu

### DIFF
--- a/boards/f4vi1/board.c
+++ b/boards/f4vi1/board.c
@@ -24,11 +24,11 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
     gpio_init(LED2_PIN, GPIO_OUT);
-
-    /* initialize the CPU */
-    cpu_init();
 }

--- a/boards/limifrog-v1/board.c
+++ b/boards/limifrog-v1/board.c
@@ -24,8 +24,9 @@
 
 void board_init(void)
 {
-    /* initialize the boards LEDs */
-    gpio_init(LED0_PIN, GPIO_OUT);
     /* initialize the CPU */
     cpu_init();
+
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
 }

--- a/boards/p-l496g-cell02/board.c
+++ b/boards/p-l496g-cell02/board.c
@@ -23,10 +23,10 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
-
-    /* initialize the CPU */
-    cpu_init();
 }

--- a/boards/spark-core/board.c
+++ b/boards/spark-core/board.c
@@ -24,6 +24,9 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
@@ -34,8 +37,6 @@ void board_init(void)
     gpio_set(LED2_PIN);
     gpio_set(LED3_PIN);
 
-    /* initialize the CPU */
-    cpu_init();
     /* disable systick interrupt, set by the spark bootloader */
     SysTick->CTRL = 0;
     /* signal to spark bootloader: do not enable IWDG! set Stop Mode Flag! */

--- a/boards/stm32f0discovery/board.c
+++ b/boards/stm32f0discovery/board.c
@@ -23,10 +23,10 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
-
-    /* initialize the CPU */
-    cpu_init();
 }

--- a/boards/stm32f3discovery/board.c
+++ b/boards/stm32f3discovery/board.c
@@ -23,6 +23,9 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
@@ -32,7 +35,4 @@ void board_init(void)
     gpio_init(LED5_PIN, GPIO_OUT);
     gpio_init(LED6_PIN, GPIO_OUT);
     gpio_init(LED7_PIN, GPIO_OUT);
-
-    /* initialize the CPU */
-    cpu_init();
 }

--- a/boards/stm32f429i-disc1/board.c
+++ b/boards/stm32f429i-disc1/board.c
@@ -23,10 +23,10 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
-
-    /* initialize the CPU */
-    cpu_init();
 }

--- a/boards/stm32f4discovery/board.c
+++ b/boards/stm32f4discovery/board.c
@@ -23,12 +23,12 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
     gpio_init(LED2_PIN, GPIO_OUT);
     gpio_init(LED3_PIN, GPIO_OUT);
-
-    /* initialize the CPU */
-    cpu_init();
 }

--- a/boards/stm32l0538-disco/board.c
+++ b/boards/stm32l0538-disco/board.c
@@ -23,10 +23,10 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
-
-    /* initialize the CPU */
-    cpu_init();
 }

--- a/boards/stm32l476g-disco/board.c
+++ b/boards/stm32l476g-disco/board.c
@@ -23,10 +23,10 @@
 
 void board_init(void)
 {
+    /* initialize the CPU */
+    cpu_init();
+
     /* initialize LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
-
-    /* initialize the CPU */
-    cpu_init();
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This update all STM32 based boards where gpio are initialized after cpu in `board_init`. Since #11758, `tests/leds` is broken for these boards as reported in #12373

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `tests/leds` on modified boards, see https://github.com/RIOT-OS/RIOT/issues/12373#issuecomment-538433121, and verify the leds are blinking.
On master they are not blinking at all.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #12373 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
