### PR TITLE
board/samr34: fix typo in TCXO

### DIFF
--- a/boards/samr34-xpro/board.c
+++ b/boards/samr34-xpro/board.c
@@ -41,8 +41,8 @@ void board_init(void)
 
     /* initialize board specific pins for LoRa */
 #ifdef MODULE_SX127X
-    gpio_init(TXCO_PWR_PIN, GPIO_OUT);
-    gpio_set(TXCO_PWR_PIN);
+    gpio_init(TCXO_PWR_PIN, GPIO_OUT);
+    gpio_set(TCXO_PWR_PIN);
     gpio_init(TX_OUTPUT_SEL_PIN, GPIO_OUT);
     gpio_write(TX_OUTPUT_SEL_PIN, !SX127X_PARAM_PASELECT);
 #endif /* USEMODULE_SX127X */

--- a/boards/samr34-xpro/include/board.h
+++ b/boards/samr34-xpro/include/board.h
@@ -46,7 +46,7 @@ extern "C" {
  * @name Board specific configuration
  *  @{
  */
-#define TXCO_PWR_PIN                        GPIO_PIN(PA, 9)
+#define TCXO_PWR_PIN                        GPIO_PIN(PA, 9)
 #define TX_OUTPUT_SEL_PIN                   GPIO_PIN(PA, 13)
 /** @}*/
 


### PR DESCRIPTION

### Contribution description
This PR fixes a typo in a define, TXCO should be TCXO.
Credits to @ant9000 for spotting this.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile-wise, this is just a define renaming
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Reported-by @ant9000 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
