### PR TITLE
cpu/efm32/uart: uart_init(): begin with TX pin at idle level

### DIFF
--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -68,7 +68,7 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
     /* initialize the pins */
     gpio_init(uart_config[dev].rx_pin, GPIO_IN_PU);
-    gpio_init(uart_config[dev].tx_pin, GPIO_OUT);
+    gpio_init(uart_config[dev].tx_pin, GPIO_OUT | 1); /* 1 for high */
 
     /* initialize the UART/USART/LEUART device */
 #ifdef USE_LEUART


### PR DESCRIPTION
### Contribution description
This corrects an unintentional momentary assertion of the UART TX pin during `uart_init()` which fixes some edge cases that are sensitive to that.

Currently when `uart_init()` calls `gpio_init()` the TX pin is set to output low. It remains low until some (configuration-dependent) time later when the UART hardware initializes it to the idle (high) level. In a lot of cases this hasn't caused a problem but of course it's wrong behavior.

### Testing procedure
Reproducing the bug may be deceptively nontrivial without simply checking for it on a scope.

The specific case that triggered an issue for me was using LPUART at 9600 baud connected to a peer that has a pullup on its RX with an application that calls `uart_write()` very soon after `uart_init()` (`hello-world` does this).

The LPUART takes a while to initialize, so TX is asserted for about 200 usec which is significant and would normally be interpreted as a single garbage character. However since `uart_write()` is called so soon after this, the legitimate characters are also misinterpreted until the bus goes idle long enough for the receiver to resynchronize on the start bit of a clean character. For `hello-world` this means that ALL characters are received as garbage since there is no such idle period until the end of the output.

![scope_15](https://user-images.githubusercontent.com/64743/66281200-d4c9db00-e87f-11e9-8411-8b22ca943eee.png)

The green trace (2) is with this PR and looks normal. The orange trace (R1) is without this PR and is a perfect match to the green trace except for the extra pulse just before the legitimate characters begin. Despite the otherwise perfect match, all characters appeared in my terminal as garbage because of the extra pulse.

This took quite some effort to find since it's very easy to accidentally mask the buggy behavior and that's why I've ended up with such a detailed explanation for a small and obvious change. 