### PR TITLE
boards/nucleo32: fix arduino pinmap for nucleo-l432kc

### DIFF
--- a/boards/common/nucleo32/include/arduino_pinmap.h
+++ b/boards/common/nucleo32/include/arduino_pinmap.h
@@ -39,7 +39,7 @@ extern "C" {
 #define ARDUINO_PIN_4           GPIO_PIN(PORT_B, 7)
 #define ARDUINO_PIN_5           GPIO_PIN(PORT_B, 6)
 #define ARDUINO_PIN_6           GPIO_PIN(PORT_B, 1)
-#if defined(CPU_MODEL_STM32L031K6)
+#if defined(CPU_MODEL_STM32L031K6) || defined(CPU_MODEL_STM32L432KC)
 #define ARDUINO_PIN_7           GPIO_PIN(PORT_C, 14)
 #define ARDUINO_PIN_8           GPIO_PIN(PORT_C, 15)
 #else


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing the Arduino pinmap of D7/D8 for nucleo-l432kc, as reported in #12138.

I checked the user manual of nucleo32 boards and only nucleo-l432kc needs this change. The other nucleo32 impacted board is nucleo-l412kb but is not supported yet (but is provided by #12144)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

Write an application that uses ARDUINO_PIN_7 and ARDUINO_PIN_8, build it on nucleo-l432kc and verify it is working compared to master (I'll write something and give a link here if needed).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #12138

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
