### PR TITLE
emcute: never return from receive loop

### DIFF
--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -515,7 +515,7 @@ void emcute_run(uint16_t port, const char *id)
 
         if ((len < 0) && (len != -ETIMEDOUT)) {
             LOG_ERROR("[emcute] error while receiving UDP packet\n");
-            return;
+            continue;
         }
 
         if (len >= 2) {


### PR DESCRIPTION
### Contribution description

The receive thread of the MQTT-SN implementation emcute returns from the packet receive loop if `sock_udp_recv` returns an error. This is, for instance, the case when a given packet doesn't fit into the supplied buffer. This condition can be triggered by anyone able to send large packets (> 512 byte) to the UDP socket. If so, this will stop the MQTT client from working until the device is restarted, i.e. `emcute_run` is invoked again.

https://github.com/RIOT-OS/RIOT/blob/89afc378a92bf198246335fd2fa64a76dfe6e00e/sys/net/application_layer/emcute/emcute.c#L515-L521

### Testing procedure

My tap configuration is as follows:

```
4: tap0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 32:e2:ba:2b:07:d1 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::30e2:baff:fe2b:7d1/64 scope link 
       valid_lft forever preferred_lft forever
```

1. Enable debug in `sys/net/application_layer/emcute/emcute.c`.
2. Compile and run `examples/emcute_mqttsn`.
3. Connect to a bugos MQTT server address.
4. Spoof a server reply with a packet exceeding the default buffer size (512 byte). This causes `sock_udp_recv` to return `-ENOBUFS`.
5. Attempt to connect to a real working MQTT server (will fail).

```
MQTT-SN example application

Type 'help' to get started. Have a look at the README.md for more information.
> con fe80::30e2:baff:fe2b:7d1 2342
```

Spoof the reply, e.g. using:

```
head -c 525 < /dev/urandom  | busybox nc -p 2342 -u 'fe80::30e2:baff:fe2b:7d2%tap0' 1883
```

This should cause `emcute_run` to return and output the message `[emcute] error while receiving UDP packet`. Afterwards, it should no longer be possible to connect to a working MQTT-SN server since emcute will nerver receive the CONNACK reply from it since it doesn't read from the socket anymore.

### Impact

Denial of service, a spoofed server message will cause the emcute client to stop working until `emcute_run` is invoked again which is usually the case when the device is restarted.