### PR TITLE
pkg/semtech-loramac: fix failed assertion in randr function

### DIFF
--- a/pkg/semtech-loramac/patches/0002-adapt-utilities-to-riot.patch
+++ b/pkg/semtech-loramac/patches/0002-adapt-utilities-to-riot.patch
@@ -1,4 +1,4 @@
-From 68f3239926462e04931b7bc71dc199ee776d37cb Mon Sep 17 00:00:00 2001
+From 6a902f4c2406aa9bf3286bb73a8116953b21257a Mon Sep 17 00:00:00 2001
 From: Alexandre Abadie <alexandre.abadie@inria.fr>
 Date: Mon, 6 Aug 2018 15:46:40 +0200
 Subject: [PATCH] Applying: patch utilities functions
@@ -9,7 +9,7 @@ Subject: [PATCH] Applying: patch utilities functions
  2 files changed, 6 insertions(+), 21 deletions(-)
 
 diff --git a/src/boards/mcu/utilities.c b/src/boards/mcu/utilities.c
-index d32d573..2d29f9d 100644
+index d32d5735..be141100 100644
 --- a/src/boards/mcu/utilities.c
 +++ b/src/boards/mcu/utilities.c
 @@ -22,7 +22,9 @@
@@ -34,7 +34,7 @@ index d32d573..2d29f9d 100644
  int32_t randr( int32_t min, int32_t max )
  {
 -    return ( int32_t )rand1( ) % ( max - min + 1 ) + min;
-+    return (int32_t) (random_uint32_range(0, max - min) + min);
++    return (min == max) ? min : (int32_t) (random_uint32_range(0, max - min) + min);
  }
  
  void memcpy1( uint8_t *dst, const uint8_t *src, uint16_t size )
@@ -60,7 +60,7 @@ index d32d573..2d29f9d 100644
  
  int8_t Nibble2HexChar( uint8_t a )
 diff --git a/src/boards/utilities.h b/src/boards/utilities.h
-index 8e0b028..9e226d4 100644
+index 8e0b0284..9e226d4a 100644
 --- a/src/boards/utilities.h
 +++ b/src/boards/utilities.h
 @@ -25,17 +25,6 @@
@@ -82,5 +82,5 @@ index 8e0b028..9e226d4 100644
   * \brief Returns the minimum value between a and b
   *
 -- 
-2.17.1
+2.20.1
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an alternative to #11983 to fix #11978, as a first step, before the package is migrated to the latest release.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Connecting to a LoRaWAN network in EU868 or US915 regions should work. In master US915 region doesn't work, as described in #11978.

Note: for EU868, this cannot be tested on iotlab right now, where there seem to have an issue on the TTN gateway...

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #11978
closes #11983

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
