### PR TITLE
gnrc_sixlowpan_frag_vrb: add gnrc_sixlowpan_frag_vrb_from_route() 

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -27,6 +27,9 @@
 
 #include "net/gnrc/netif.h"
 #include "net/gnrc/sixlowpan/config.h"
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG
+#include "net/gnrc/sixlowpan/frag.h"
+#endif /* MODULE_GNRC_SIXLOWPAN_FRAG */
 #include "net/gnrc/sixlowpan/frag/rb.h"
 #include "timex.h"
 

--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -76,6 +76,28 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
         gnrc_netif_t *out_netif, const uint8_t *out_dst, size_t out_dst_len);
 
 /**
+ * @brief   Generate reassembly buffer from a header's forwarding information.
+ *
+ * @param[in] base  Base data of the datagram. Must not be `NULL`.
+ * @param[in] netif Restict route to this interface. May be `NULL` for any
+ *                  interface.
+ * @param[in] hdr   Header from which to take the forwarding information from
+ *                  (e.g. IPv6 header implies `hdr->type == GNRC_NETTYPE_IPV6`).
+ *
+ * @pre `base != NULL`
+ * @pre `(hdr != NULL) && (hdr->data != NULL) && (hdr->size > 0)`
+ *
+ * @return  The VRB entry pointing to the next hop based on the forwarding
+ *          information provided in @p hdr and present in the respective
+ *          forwarding information base for `hdr->type`.
+ * @return  NULL, if VRB is full or if there is no route to destination in
+ *          @p hdr.
+ */
+gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_from_route(
+            const gnrc_sixlowpan_frag_rb_base_t *base,
+            gnrc_netif_t *netif, const gnrc_pktsnip_t *hdr);
+
+/**
  * @brief   Checks timeouts and removes entries if necessary
  */
 void gnrc_sixlowpan_frag_vrb_gc(void);

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -22,7 +22,7 @@
 #include "debug.h"
 
 static gnrc_sixlowpan_frag_vrb_t _vrb[GNRC_SIXLOWPAN_FRAG_VRB_SIZE];
-static char l2addr_str[3 * IEEE802154_LONG_ADDRESS_LEN];
+static char addr_str[3 * IEEE802154_LONG_ADDRESS_LEN];
 
 #if !defined(MODULE_GNRC_SIXLOWPAN_FRAG) && defined(TEST_SUITES)
 /* mock for e.g. testing */
@@ -69,16 +69,16 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
                 DEBUG("6lo vrb: creating entry (%s, ",
                       gnrc_netif_addr_to_str(vrbe->super.src,
                                              vrbe->super.src_len,
-                                             l2addr_str));
+                                             addr_str));
                 DEBUG("%s, %u, %u) => ",
                       gnrc_netif_addr_to_str(vrbe->super.dst,
                                              vrbe->super.dst_len,
-                                             l2addr_str),
+                                             addr_str),
                       (unsigned)vrbe->super.datagram_size, vrbe->super.tag);
                 DEBUG("(%s, %u)\n",
                       gnrc_netif_addr_to_str(vrbe->super.dst,
                                              vrbe->super.dst_len,
-                                             l2addr_str), vrbe->out_tag);
+                                             addr_str), vrbe->out_tag);
             }
             break;
         }
@@ -95,7 +95,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
         const uint8_t *src, size_t src_len, unsigned src_tag)
 {
     DEBUG("6lo vrb: trying to get entry for (%s, %u)\n",
-          gnrc_netif_addr_to_str(src, src_len, l2addr_str), src_tag);
+          gnrc_netif_addr_to_str(src, src_len, addr_str), src_tag);
     for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         gnrc_sixlowpan_frag_vrb_t *vrbe = &_vrb[i];
 
@@ -103,7 +103,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
             DEBUG("6lo vrb: got VRB to (%s, %u)\n",
                   gnrc_netif_addr_to_str(vrbe->super.dst,
                                          vrbe->super.dst_len,
-                                         l2addr_str), vrbe->out_tag);
+                                         addr_str), vrbe->out_tag);
             return vrbe;
         }
     }
@@ -121,11 +121,11 @@ void gnrc_sixlowpan_frag_vrb_gc(void)
             DEBUG("6lo vrb: entry (%s, ",
                   gnrc_netif_addr_to_str(_vrb[i].super.src,
                                          _vrb[i].super.src_len,
-                                         l2addr_str));
+                                         addr_str));
             DEBUG("%s, %u, %u) timed out\n",
                   gnrc_netif_addr_to_str(_vrb[i].super.dst,
                                          _vrb[i].super.dst_len,
-                                         l2addr_str),
+                                         addr_str),
                   (unsigned)_vrb[i].super.datagram_size, _vrb[i].super.tag);
             gnrc_sixlowpan_frag_vrb_rm(&_vrb[i]);
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds a new VRB function that receives a header with forwarding information and creates a VRB entry from it. Currently, only IPv6 is supported.

This function was originally part of `gnrc_sixlowpan_frag_minfwd` (see https://github.com/RIOT-OS/RIOT/pull/11068): https://github.com/RIOT-OS/RIOT/blob/62980a96558a2c8fd9e1729c68cdaec0ad99d191/sys/net/gnrc/network_layer/sixlowpan/frag/minfwd/gnrc_sixlowpan_frag_minfwd.c#L36-L75 However, as this is a core functionality of the VRB rather than minimal fragment forwarding (Selective Fragment Recovery also needs it e.g.) I decided to put it into the VRB instead.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
None, but that it works can be seen by the results of [our paper](https://arxiv.org/abs/1905.08089). The changes to the parameters due to the new scope can be checked by careful reading and compile testing with (note: a board that pulls in `gnrc_sixlowpan` as a dependency in normal compilation is required for a successful build):

```sh
BOARD=iotlab-m3 USEMODULE=gnrc_sixlowpan_frag_vrb make -C examples/gnrc_networking
```

As the IPv6 dependency would be required for a proper unittest and which would pull in the whole GNRC stack into the unittests, I don't plan to amend them for this new function (it will however be covered by my SFR tests and my adaptation of the tests for `gnrc_sixlowpan_frag_minfwd` in #11068).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Original code from #11068.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
