### PR TITLE
Sodaq boards arduino

### DIFF
--- a/boards/sodaq-autonomo/Makefile.features
+++ b/boards/sodaq-autonomo/Makefile.features
@@ -2,6 +2,7 @@ CPU = samd21
 CPU_MODEL = samd21j18a
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/sodaq-autonomo/Makefile.features
+++ b/boards/sodaq-autonomo/Makefile.features
@@ -11,3 +11,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += arduino

--- a/boards/sodaq-autonomo/include/arduino_board.h
+++ b/boards/sodaq-autonomo/include/arduino_board.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C)  2019 Kees Bakker
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-autonomo
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Kees Bakker <kees@ijzerbout.nl>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The builtin LED
+ */
+#define ARDUINO_LED         (13)
+
+/**
+ * @brief   On-board serial port mapping
+ */
+#define ARDUINO_UART_DEV         UART_DEV(0)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    /* 0..1 - SERCOM/UART (Serial) */
+    GPIO_PIN(PA, 9),
+    GPIO_PIN(PA, 10),
+
+    /* 2..15 Digital */
+    GPIO_PIN(PA, 11),
+    GPIO_PIN(PB, 10),
+    GPIO_PIN(PB, 11),
+    GPIO_PIN(PB, 12),
+    GPIO_PIN(PB, 13),
+    GPIO_PIN(PB, 14),
+    GPIO_PIN(PB, 15),
+    GPIO_PIN(PA, 14),
+    GPIO_PIN(PA, 15),
+    GPIO_PIN(PA, 16),
+    GPIO_PIN(PA, 17),
+    GPIO_PIN(PA, 18),
+    GPIO_PIN(PA, 19),
+    GPIO_PIN(PB, 16),
+
+    /* 16..18 Other Digital */
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 28),
+    GPIO_PIN(PB, 17),
+
+    /* 19..32 A0..A13 */
+    GPIO_PIN(PA,  2),
+    GPIO_PIN(PA,  6),
+    GPIO_PIN(PA,  5),
+    GPIO_PIN(PA,  4),
+    GPIO_PIN(PB,  9),
+    GPIO_PIN(PB,  8),
+    GPIO_PIN(PB,  7),
+    GPIO_PIN(PB,  6),
+    GPIO_PIN(PB,  5),
+    GPIO_PIN(PB,  4),
+    GPIO_PIN(PA,  7),
+    GPIO_PIN(PB,  3),
+    GPIO_PIN(PB,  2),
+    GPIO_PIN(PB,  1),
+
+    /* 33-35 Other Analog + DAC */
+    GPIO_PIN(PB,  0),
+    GPIO_PIN(PA,  3),
+    GPIO_PIN(PA,  2),
+
+    /* 36..39 - SERCOM/UART (Serial1) */
+    GPIO_PIN(PB, 30),
+    GPIO_PIN(PB, 31),
+    GPIO_PIN(PB, 22),
+    GPIO_PIN(PB, 23),
+
+    /* 40..41 - I2C pins (SDA/SCL) */
+    GPIO_PIN(PA, 12),
+    GPIO_PIN(PA, 13),
+
+    /* 42..45 - SPI pins (ICSP: MISO, SS, MOSI, SCK) */
+    GPIO_PIN(PA, 22),
+    GPIO_PIN(PA, 23),
+    GPIO_PIN(PA, 20),
+    GPIO_PIN(PA, 21),
+
+    /* 46 - SD CARD CS */
+    GPIO_PIN(PA, 27),
+
+    /* 47..48 - USB */
+    GPIO_PIN(PA, 24),
+    GPIO_PIN(PA, 25),
+
+    /* 49..50 - Serial2 (alternative use for D6/D7) */
+    GPIO_PIN(PB, 13),
+    GPIO_PIN(PB, 14),
+
+    /* 51..52 - Serial3 (alternative use for D12/D13) */
+    GPIO_PIN(PA, 17),
+    GPIO_PIN(PA, 18),
+
+    /* 53..56 - SPI1 (alternative use for D5..D8) */
+    GPIO_PIN(PB, 12),
+    GPIO_PIN(PB, 13),
+    GPIO_PIN(PB, 14),
+    GPIO_PIN(PB, 15),
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ADC_LINE(0),
+    ADC_LINE(1),
+    ADC_LINE(2),
+    ADC_LINE(3),
+    ADC_LINE(4),
+    ADC_LINE(5),
+    ADC_LINE(6),
+    ADC_LINE(7),
+    ADC_LINE(8),
+    ADC_LINE(9),
+    ADC_LINE(10),
+    ADC_LINE(11),
+    ADC_LINE(12),
+    ADC_LINE(13),
+    ADC_LINE(14),
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -177,6 +177,42 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name ADC configuration
+ * @{
+ */
+
+/* ADC Default values */
+#define ADC_PRESCALER                      ADC_CTRLB_PRESCALER_DIV512
+
+#define ADC_NEG_INPUT                      ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT            ADC_INPUTCTRL_GAIN_DIV2
+#define ADC_REF_DEFAULT                    ADC_REFCTRL_REFSEL_INTVCC1
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, muxpos/pin */
+    /* Use the Arduino pin number order */
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* ADC/AIN[0], A0 */
+    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},     /* ADC/AIN[6], A1 */
+    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* ADC/AIN[5], A2 */
+    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* ADC/AIN[4], A3 */
+    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3},     /* ADC/AIN[3], A4 */
+    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},     /* ADC/AIN[2], A5 */
+    {GPIO_PIN(PB, 7), ADC_INPUTCTRL_MUXPOS_PIN15},    /* ADC/AIN[15], A6 */
+    {GPIO_PIN(PB, 6), ADC_INPUTCTRL_MUXPOS_PIN14},    /* ADC/AIN[14], A7 */
+    {GPIO_PIN(PB, 5), ADC_INPUTCTRL_MUXPOS_PIN13},    /* ADC/AIN[13], A8 */
+    {GPIO_PIN(PB, 4), ADC_INPUTCTRL_MUXPOS_PIN12},    /* ADC/AIN[12], A9 */
+    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* ADC/AIN[7], A10 */
+    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* ADC/AIN[11], A11 */
+    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* ADC/AIN[10], A12 */
+    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},     /* ADC/AIN[9], A13 (pin also used for DTR) */
+
+    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},     /* ADC/AIN[8], BATVOLT */
+};
+
+#define ADC_NUMOF                          ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
  * @name    PWM configuration
  * @{
  */

--- a/boards/sodaq-explorer/Makefile.features
+++ b/boards/sodaq-explorer/Makefile.features
@@ -10,3 +10,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += arduino

--- a/boards/sodaq-explorer/include/arduino_board.h
+++ b/boards/sodaq-explorer/include/arduino_board.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C)  2019 Kees Bakker
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-explorer
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Kees Bakker <kees@ijzerbout.nl>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The builtin LED
+ */
+#define ARDUINO_LED         (13)
+
+/**
+ * @brief   On-board serial port mapping
+ */
+#define ARDUINO_UART_DEV         UART_DEV(0)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    /* 0..1 - SERCOM/UART (Serial) */
+    GPIO_PIN(PB, 31),
+    GPIO_PIN(PB, 30),
+
+    /* 2..15 Digital */
+    GPIO_PIN(PA, 2),
+    GPIO_PIN(PA, 3),
+    GPIO_PIN(PB, 4),
+    GPIO_PIN(PB, 6),
+    GPIO_PIN(PB, 7),
+    GPIO_PIN(PB, 8),
+    GPIO_PIN(PB, 10),
+    GPIO_PIN(PB, 11),
+    GPIO_PIN(PA, 23),
+    GPIO_PIN(PA, 20),
+    GPIO_PIN(PA, 22),
+    GPIO_PIN(PA, 21),
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+
+    /* 16..19 Other Digital */
+    GPIO_PIN(PA, 12),
+    GPIO_PIN(PB, 15),
+    GPIO_PIN(PA, 13),
+    GPIO_PIN(PA, 15),
+
+    /* 20..28 A0..A8 */
+    GPIO_PIN(PB,  0),
+    GPIO_PIN(PB,  1),
+    GPIO_PIN(PB,  2),
+    GPIO_PIN(PB,  3),
+    GPIO_PIN(PA,  8),
+    GPIO_PIN(PA,  9),
+    GPIO_PIN(PA,  4),
+    GPIO_PIN(PA,  10),
+    GPIO_PIN(PA,  11),
+
+    /* 29..30 - SERCOM/UART (Serial1) */
+    GPIO_PIN(PB, 14),
+    GPIO_PIN(PB, 13),
+
+    /* 31..32 - SERCOM/UART (Serial2) */
+    GPIO_PIN(PA, 6),
+    GPIO_PIN(PA, 5),
+
+    /* 33..34 - I2C pins (SDA/SCL) */
+    GPIO_PIN(PA, 16),
+    GPIO_PIN(PA, 17),
+
+    /* 35..36 - I2C1 pins (SDA/SCL) */
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 9),
+
+    /* 37..40 - SPI pins (ICSP: MISO, SS, MOSI, SCK) */
+    /* Notice that SCK is sharing the same PA21 with LED_BUILTIN */
+    GPIO_PIN(PA, 22),
+    GPIO_PIN(PA, 23),
+    GPIO_PIN(PA, 20),
+    GPIO_PIN(PA, 21),
+
+    /* 41..42 - USB */
+    GPIO_PIN(PA, 24),
+    GPIO_PIN(PA, 25),
+
+    /* 43 DAC */
+    GPIO_PIN(PA,  2),
+
+    /* 44 Flash CS */
+    GPIO_PIN(PB, 16),
+
+    /* 45..46 LoRa, BT Reset */
+    GPIO_PIN(PA,  7),
+    GPIO_PIN(PB,  17),
+
+    /* 47 Button */
+    GPIO_PIN(PA,  14),
+
+    /* 48 BAT_VOLT */
+    GPIO_PIN(PB,  5),
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ADC_LINE(0),
+    ADC_LINE(1),
+    ADC_LINE(2),
+    ADC_LINE(3),
+    ADC_LINE(4),
+    ADC_LINE(5),
+    ADC_LINE(6),
+    ADC_LINE(7),
+    ADC_LINE(8),
+    ADC_LINE(9),
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -170,8 +170,8 @@ static const uart_conf_t uart_config[] = {
 #define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
-#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_DIV2
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -182,6 +182,9 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},    /* A4 */
     {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A5 */
     {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* A6 (temperature) */
+    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS_PIN18},   /* A7 */
+    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS_PIN19},   /* A8 */
+    {GPIO_PIN(PB, 5), ADC_INPUTCTRL_MUXPOS_PIN13},    /* BATVOLT */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/sodaq-one/Makefile.features
+++ b/boards/sodaq-one/Makefile.features
@@ -10,3 +10,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += arduino

--- a/boards/sodaq-one/include/arduino_board.h
+++ b/boards/sodaq-one/include/arduino_board.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C)  2019 Kees Bakker
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-one
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Kees Bakker <kees@ijzerbout.nl>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The green of the RGB led is used as "the builtin led"
+ */
+#define ARDUINO_LED         (15)
+
+/**
+ * @brief   On-board serial port mapping
+ */
+#define ARDUINO_UART_DEV         UART_DEV(0)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    /* 0..3 Main IO Pins (D0-D3) Digital Properties */
+    GPIO_PIN(PA, 2),
+    GPIO_PIN(PA, 3),
+    GPIO_PIN(PB, 8),
+    GPIO_PIN(PB, 9),
+
+    /* 4..5 Other Digital Pins */
+    GPIO_PIN(PA, 21),
+    GPIO_PIN(PA, 20),
+
+    /* 6..13 Main IO Pins (D6-D13) Digital Properties */
+    GPIO_PIN(PA, 6),
+    GPIO_PIN(PA, 7),
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 9),
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+    GPIO_PIN(PB, 2),
+    GPIO_PIN(PB, 3),
+
+    /* 14..21 Other Digital Pins */
+    GPIO_PIN(PA, 15),
+    GPIO_PIN(PB, 10),
+    GPIO_PIN(PB, 11),
+    GPIO_PIN(PA, 14),
+    GPIO_PIN(PA, 18),
+    GPIO_PIN(PA, 16),
+    GPIO_PIN(PB, 22),
+    GPIO_PIN(PA, 17),
+
+    /* 22..33 Main IO Pins Analog Properties */
+    GPIO_PIN(PA, 2),
+    GPIO_PIN(PA, 3),
+    GPIO_PIN(PB, 8),
+    GPIO_PIN(PB, 9),
+    GPIO_PIN(PA, 6),
+    GPIO_PIN(PA, 7),
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 9),
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+    GPIO_PIN(PB, 2),
+    GPIO_PIN(PB, 3),
+
+    /* 34..36 Other Analog Pins */
+    GPIO_PIN(PA, 2),
+    GPIO_PIN(PA, 3),
+    GPIO_PIN(PA, 5),
+
+    /* 37..38 USB Pins */
+    GPIO_PIN(PA, 24),
+    GPIO_PIN(PA, 25),
+
+    /* 39..40 Serial */
+    GPIO_PIN(PB, 3),
+    GPIO_PIN(PB, 2),
+
+    /* 41..42 Serial1 */
+    GPIO_PIN(PA, 13),
+    GPIO_PIN(PA, 12),
+
+    /* 43..46 SPI  */
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 9),
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+
+    /* 47..48 I2C */
+    GPIO_PIN(PA, 22),
+    GPIO_PIN(PA, 23),
+
+    /* 49 LoRa RESET */
+    GPIO_PIN(PA,  4),
+
+    /* 50 MAG_INT */
+    GPIO_PIN(PA, 19),
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ADC_LINE(0),
+    ADC_LINE(1),
+    ADC_LINE(2),
+    ADC_LINE(3),
+    ADC_LINE(4),
+    ADC_LINE(5),
+    ADC_LINE(6),
+    ADC_LINE(7),
+    ADC_LINE(8),
+    ADC_LINE(9),
+    ADC_LINE(10),
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -178,11 +178,12 @@ static const adc_conf_chan_t adc_channels[] = {
     {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A7 */
     {GPIO_PIN(PA,10), ADC_INPUTCTRL_MUXPOS_PIN18},    /* A8 */
     {GPIO_PIN(PA,11), ADC_INPUTCTRL_MUXPOS_PIN19},    /* A9 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A10 */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A11 */
+#if 0
+    /* These pins are also used for RX/TX uart0 */
+    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A10, TX */
+    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A11, RX */
+#endif
 
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* DAC/VOUT */
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},     /* AREF */
     {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* BAT_VOLT */
 };
 

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -163,8 +163,8 @@ static const uart_conf_t uart_config[] = {
 #define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
-#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_DIV2
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/boards/sodaq-sara-aff/Makefile.features
+++ b/boards/sodaq-sara-aff/Makefile.features
@@ -10,3 +10,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += arduino

--- a/boards/sodaq-sara-aff/include/arduino_board.h
+++ b/boards/sodaq-sara-aff/include/arduino_board.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C)  2019 Kees Bakker
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-aff
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Kees Bakker <kees@ijzerbout.nl>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The green of the RGB led is used as "the builtin led"
+ */
+#define ARDUINO_LED         (17)
+
+/**
+ * @brief   On-board serial port mapping
+ */
+#define ARDUINO_UART_DEV         UART_DEV(0)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    /* 0..1 - SERCOM/UART (Serial) */
+    GPIO_PIN(PB, 31),
+    GPIO_PIN(PB, 30),
+
+    /* 2..15 Digital */
+    GPIO_PIN(PA, 2),
+    GPIO_PIN(PA, 19),
+    GPIO_PIN(PB, 4),
+    GPIO_PIN(PB, 6),
+    GPIO_PIN(PB, 7),
+    GPIO_PIN(PB, 8),
+    GPIO_PIN(PB, 10),
+    GPIO_PIN(PB, 11),
+    GPIO_PIN(PA, 23),
+    GPIO_PIN(PA, 20),
+    GPIO_PIN(PA, 22),
+    GPIO_PIN(PA, 21),
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+
+    /* 16..18 RGB LED */
+    GPIO_PIN(PA, 12),
+    GPIO_PIN(PB, 15),
+    GPIO_PIN(PA, 13),
+
+    /* 19..25 On-board Peripheral Inputs */
+    GPIO_PIN(PA, 14),
+    GPIO_PIN(PA, 15),
+    GPIO_PIN(PA, 18),
+    GPIO_PIN(PB, 16),
+    GPIO_PIN(PB, 22),
+    GPIO_PIN(PA, 4),
+    GPIO_PIN(PA, 7),
+
+    /* 26..30 On-board Peripheral Outputs */
+    GPIO_PIN(PA, 28),
+    GPIO_PIN(PA, 27),
+    GPIO_PIN(PB, 14),
+    GPIO_PIN(PB, 13),
+    GPIO_PIN(PB, 12),
+
+    /* 31..36 A0..A5 */
+    GPIO_PIN(PB,  0),
+    GPIO_PIN(PB,  1),
+    GPIO_PIN(PB,  2),
+    GPIO_PIN(PB,  3),
+    GPIO_PIN(PA,  8),
+    GPIO_PIN(PA,  9),
+
+    /* 37..40 Other Analog Inputs */
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+    GPIO_PIN(PB,  5),
+    GPIO_PIN(PB,  9),
+
+    /* 41..42 - SERCOM/UART (Serial1) */
+    GPIO_PIN(PA, 6),
+    GPIO_PIN(PA, 5),
+
+    /* 43..44 - I2C pins (SDA/SCL) */
+    GPIO_PIN(PA, 16),
+    GPIO_PIN(PA, 17),
+
+    /* 45..48 - SPI pins (ICSP: MISO, SS, MOSI, SCK)
+     * Notice that SCK is sharing the same PA21 with LED_BUILTIN
+     */
+    GPIO_PIN(PA, 22),
+    GPIO_PIN(PA, 23),
+    GPIO_PIN(PA, 20),
+    GPIO_PIN(PA, 21),
+
+    /* 49..50 - USB */
+    GPIO_PIN(PA, 24),
+    GPIO_PIN(PA, 25),
+
+    /* 51..52 - DAC, SARA_R4XX_TOGGLE */
+    GPIO_PIN(PA,  2),
+    GPIO_PIN(PB, 17),
+
+    /* 53..54 - I2C1 pins (SDA/SCL) */
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 9),
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ADC_LINE(0),
+    ADC_LINE(1),
+    ADC_LINE(2),
+    ADC_LINE(3),
+    ADC_LINE(4),
+    ADC_LINE(5),
+    ADC_LINE(6),
+    ADC_LINE(7),
+    ADC_LINE(8),
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -165,8 +165,8 @@ static const uart_conf_t uart_config[] = {
 #define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
-#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_DIV2
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/tests/driver_hd44780/Makefile
+++ b/tests/driver_hd44780/Makefile
@@ -1,9 +1,11 @@
 include ../Makefile.tests_common
 
 # the stm32f4discovery does not have the arduino pinout
+# Sodaq boards don't have ARDUINO_PIN_*
 BOARD_BLACKLIST := stm32f4discovery slstk3401a slstk3402a \
                    sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a \
-                   stk3600 stk3700
+                   stk3600 stk3700 \
+                   sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff
 
 # currently the test provides config params for arduinos only
 FEATURES_REQUIRED += arduino


### PR DESCRIPTION
### Contribution description

This PR adds the Arduino include files for 4 Sodaq boards (Autonomo, Explorer, One, Sara AFF).

As an extra this PR also adds the ADC configuration for Sodaq Autonomo. Furthermore it adjusts the ADC configurations for the other Sodaq boards so that each of them can properly reads it BATVOLT.

### Testing procedure

Build and run `tests/periph_gpio_arduino` and `tests/sys_arduino`.
