### PR TITLE
sys/arduino: make ADC feature optional

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -633,7 +633,7 @@ endif
 
 ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_REQUIRED += arduino
-  FEATURES_REQUIRED += periph_adc
+  FEATURES_OPTIONAL += periph_adc
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer
 endif

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -77,6 +77,7 @@ unsigned long millis()
     return xtimer_now_usec64() / US_PER_MS;
 }
 
+#if MODULE_PERIPH_ADC
 int analogRead(int arduino_pin)
 {
     /*
@@ -104,3 +105,4 @@ int analogRead(int arduino_pin)
 
     return adc_value;
 }
+#endif

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -110,6 +110,7 @@ unsigned long micros();
  */
 unsigned long millis();
 
+#if MODULE_PERIPH_ADC || DOXYGEN
 /**
  * @brief   Read the current value of the given analog pin
  *
@@ -119,6 +120,7 @@ unsigned long millis();
  * to the voltage applied to the pin
  */
 int analogRead(int pin);
+#endif
 
 #endif /* ARDUINO_H */
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR makes the use of ADC with Arduino conditional so arduino can be effectively used with boards not providing ADC.

### Testing procedure

Build and flash `tests/periph_gpio_arduino` on nucleo-l432kc.

On master, it can't be built, with this PR, one can play with it.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
