### PR TITLE
emb6: deprecate package

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -828,7 +828,6 @@ EXCLUDE_PATTERNS       = */board/*/tools/* \
                          */cpu/native/osx-libc-extra \
                          */cpu/x86/include/* \
                          */drivers/kw2xrf/include/overwrites.h \
-                         */pkg/emb6/* \
                          */pkg/lwip/* \
                          */pkg/tlsf/patch.txt \
                          */sys/include/embUnit/* \

--- a/pkg/emb6/doc.txt
+++ b/pkg/emb6/doc.txt
@@ -5,6 +5,10 @@
  * @brief    emb6 network stack
  * @see      https://github.com/hso-esk/emb6/blob/14e4a3cfff01644e078870e14e16a1fe60dcc895/doc/pdf/emb6.pdf
  *
+ * @deprecated  Based on very old version of `emb6` and the package is
+ *              basically unmaintained; will be removed after the 2020.07
+ *              release.
+ *
  * emb6 is a fork of Contiki's uIP network stack without its usage of
  * proto-threads. It uses periodic event polling instead.
  */

--- a/pkg/emb6/include/board_conf.h
+++ b/pkg/emb6/include/board_conf.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    emb6    emb6 network stack
- * @ingroup pkg
+ * @addtogroup  pkg_emb6
  * @brief
  * @{
  *

--- a/pkg/emb6/include/sock_types.h
+++ b/pkg/emb6/include/sock_types.h
@@ -33,6 +33,9 @@
 extern "C" {
 #endif
 
+/**
+ * @brief   Size for struct sock_udp::mbox_queue
+ */
 #ifndef SOCK_MBOX_SIZE
 #define SOCK_MBOX_SIZE  (2)
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I basically didn't work on `emb6` since 2016 and adapting to the newest version would mean some major overhaul. However, the development at their end seems to be stalled [since March 2018][emb6-develop] as well. All this speaks for deprecating this package.

[emb6-develop]: https://github.com/hso-esk/emb6/tree/develop
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read, compile `make doc`, it should show up in the deprecated list (`doc/doxygen/html/deprecated.html`)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
