### PR TITLE
sys/base64: fix handling of empty buffers

### DIFF
--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -66,8 +66,9 @@ int base64_encode(const void *data_in, size_t data_in_size,
         return BASE64_ERROR_DATA_IN;
     }
 
-    if (data_in_size < 1) {
-        return BASE64_ERROR_DATA_IN_SIZE;
+    if (data_in_size == 0) {
+        *base64_out_size = 0;
+        return BASE64_SUCCESS;
     }
 
     if (*base64_out_size < required_size) {
@@ -168,6 +169,11 @@ int base64_decode(const unsigned char *base64_in, size_t base64_in_size,
 
     if (base64_in == NULL) {
         return BASE64_ERROR_DATA_IN;
+    }
+
+    if (base64_in_size == 0) {
+        *data_out_size = 0;
+        return BASE64_SUCCESS;
     }
 
     if (base64_in_size < 4) {

--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -383,6 +383,33 @@ static void test_base64_09_encode_size_determination(void)
     TEST_ASSERT_EQUAL_INT(required_out_size, expected_out_size);
 }
 
+static void test_base64_10_encode_empty(void)
+{
+    unsigned char data_in[] = "";
+
+    size_t base64_out_size = 8;
+    unsigned char base64_out[8];
+
+    int ret = base64_encode(data_in, 0, base64_out, &base64_out_size);
+
+    TEST_ASSERT_EQUAL_INT(BASE64_SUCCESS, ret);
+    TEST_ASSERT_EQUAL_INT(0, base64_out_size);
+}
+
+static void test_base64_10_decode_empty(void)
+{
+    unsigned char data_in[] = "";
+
+    size_t base64_out_size = 8;
+    unsigned char base64_out[8];
+
+    int ret = base64_decode(data_in, 0, base64_out, &base64_out_size);
+
+    TEST_ASSERT_EQUAL_INT(BASE64_SUCCESS, ret);
+    TEST_ASSERT_EQUAL_INT(0, base64_out_size);
+}
+
+
 Test *tests_base64_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -395,6 +422,8 @@ Test *tests_base64_tests(void)
         new_TestFixture(test_base64_07_stream_decode),
         new_TestFixture(test_base64_08_encode_16_bytes),
         new_TestFixture(test_base64_09_encode_size_determination),
+        new_TestFixture(test_base64_10_encode_empty),
+        new_TestFixture(test_base64_10_decode_empty),
     };
 
     EMB_UNIT_TESTCALLER(base64_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix #12213.

The unittests change proposed in #12213 is also added.

I'm not sure if it's the best fix but the values returned (output size) are now correct at least.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run
```
make -C tests/unittests/ tests-base64 test
```

and get the following output:

<details>

```
make: Entering directory '/work/riot/RIOT/tests/unittests'
Building application "tests_unittests" for "native" with MCU "native".

"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/vfs
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/base64
"make" -C /work/riot/RIOT/sys/embunit
"make" -C /work/riot/RIOT/tests/unittests/tests-base64
   text	   data	    bss	    dec	    hex	filename
  37074	    720	  47740	  85534	  14e1e	/work/riot/RIOT/tests/unittests/bin/native/tests_unittests.elf
/work/riot/RIOT/tests/unittests/bin/native/tests_unittests.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2019.10-devel-1335-gd749e2)
...........
OK (11 tests)

make: Leaving directory '/work/riot/RIOT/tests/unittests'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #12213 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
