### PR TITLE
dist/testbed-support: add nrf5840mdk in IOTLAB_NODE targets

### DIFF
--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -76,6 +76,7 @@ IOTLAB_ARCHI_microbit       = microbit:ble
 IOTLAB_ARCHI_nrf51dk        = nrf51dk:ble
 IOTLAB_ARCHI_nrf52dk        = nrf52dk:ble
 IOTLAB_ARCHI_nrf52840dk     = nrf52840dk:multi
+IOTLAB_ARCHI_nrf52840-mdk   = nrf52840mdk:multi
 IOTLAB_ARCHI_pba-d-01-kw2x  = phynode:kw2xrf
 IOTLAB_ARCHI_samr21-xpro    = samr21:at86rf233
 IOTLAB_ARCHI_samr30-xpro    = samr30:at86rf212b


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While debugging #12394, I was surprised when I realized that nrf52840-mdk was not in the list of iotlab supported boards.

This PR fixes that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Start an experiment on (the only) nrf52840-mdk board in iotlab:
```
$ iotlab-experiment submit -n "" -d 60 -l saclay,nrf52840mdk,1
```
- Verify that you can flash it and get a terminal:
```
$ make BOARD=nrf52840-mdk IOTLAB_NODE=auto-ssh -C examples/hello-world flash term
```

Note: this doesn't work without #12394 


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
