### PR TITLE
Fix code style of crypto code

### DIFF
--- a/sys/crypto/chacha.c
+++ b/sys/crypto/chacha.c
@@ -34,7 +34,8 @@
 #include "byteorder.h"
 
 #if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
-#   error "This code is implementented in a way that it will only work for little-endian systems!"
+#   error \
+    "This code is implementented in a way that it will only work for little-endian systems!"
 #endif
 
 #include <string.h>
@@ -46,9 +47,11 @@ static void _r(uint32_t *d, uint32_t *a, const uint32_t *b, unsigned c)
     *d = (tmp << c) | (tmp >> (32 - c));
 }
 
-static void _doubleround(void *output_, const uint32_t input[16], uint8_t rounds)
+static void _doubleround(void *output_, const uint32_t input[16],
+                         uint8_t rounds)
 {
-    uint32_t *output = (uint32_t *) output_;
+    uint32_t *output = (uint32_t *)output_;
+
     memcpy(output, input, 64);
 
     rounds *= 4;
@@ -115,8 +118,9 @@ void chacha_keystream_bytes(chacha_ctx *ctx, void *x)
 void chacha_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c)
 {
     uint8_t x[64];
+
     chacha_keystream_bytes(ctx, x);
-    for (unsigned i = 0 ; i < 64; ++i) {
+    for (unsigned i = 0; i < 64; ++i) {
         c[i] = m[i] ^ x[i];
     }
 }

--- a/sys/crypto/ciphers.c
+++ b/sys/crypto/ciphers.c
@@ -19,7 +19,7 @@
 #include "crypto/ciphers.h"
 
 
-int cipher_init(cipher_t* cipher, cipher_id_t cipher_id, const uint8_t* key,
+int cipher_init(cipher_t *cipher, cipher_id_t cipher_id, const uint8_t *key,
                 uint8_t key_size)
 {
     if (key_size > cipher_id->max_key_size) {
@@ -32,19 +32,21 @@ int cipher_init(cipher_t* cipher, cipher_id_t cipher_id, const uint8_t* key,
 }
 
 
-int cipher_encrypt(const cipher_t* cipher, const uint8_t* input, uint8_t* output)
+int cipher_encrypt(const cipher_t *cipher, const uint8_t *input,
+                   uint8_t *output)
 {
     return cipher->interface->encrypt(&cipher->context, input, output);
 }
 
 
-int cipher_decrypt(const cipher_t* cipher, const uint8_t* input, uint8_t* output)
+int cipher_decrypt(const cipher_t *cipher, const uint8_t *input,
+                   uint8_t *output)
 {
     return cipher->interface->decrypt(&cipher->context, input, output);
 }
 
 
-int cipher_get_block_size(const cipher_t* cipher)
+int cipher_get_block_size(const cipher_t *cipher)
 {
     return cipher->interface->block_size;
 }

--- a/sys/crypto/helper.c
+++ b/sys/crypto/helper.c
@@ -12,6 +12,7 @@
 void crypto_block_inc_ctr(uint8_t block[16], int L)
 {
     uint8_t *b = &block[15];
+
     for (int i = 0; i < L; ++i, --b) {
         if (++*b != 0) {
             break;
@@ -22,6 +23,7 @@ void crypto_block_inc_ctr(uint8_t block[16], int L)
 int crypto_equals(const uint8_t *a, const uint8_t *b, size_t len)
 {
     uint8_t diff = 0;
+
     for (size_t i = 0; i < len; ++i, ++a, ++b) {
         diff |= (*a ^ *b);
     }
@@ -37,7 +39,8 @@ int crypto_equals(const uint8_t *a, const uint8_t *b, size_t len)
 /* Compiler should not be allowed to optimize this */
 void crypto_secure_wipe(void *buf, size_t len)
 {
-    volatile uint8_t *vbuf = (uint8_t*)buf;
+    volatile uint8_t *vbuf = (uint8_t *)buf;
+
     for (size_t i = 0; i < len; i++) {
         vbuf[i] = 0;
     }

--- a/sys/crypto/modes/cbc.c
+++ b/sys/crypto/modes/cbc.c
@@ -22,11 +22,11 @@
 #include <string.h>
 #include "crypto/modes/cbc.h"
 
-int cipher_encrypt_cbc(cipher_t* cipher, uint8_t iv[16],
-                       const uint8_t* input, size_t length, uint8_t* output)
+int cipher_encrypt_cbc(cipher_t *cipher, uint8_t iv[16],
+                       const uint8_t *input, size_t length, uint8_t *output)
 {
     size_t offset = 0;
-    uint8_t block_size, input_block[CIPHER_MAX_BLOCK_SIZE] = {0},
+    uint8_t block_size, input_block[CIPHER_MAX_BLOCK_SIZE] = { 0 },
             *output_block_last;
 
     block_size = cipher_get_block_size(cipher);
@@ -54,8 +54,8 @@ int cipher_encrypt_cbc(cipher_t* cipher, uint8_t iv[16],
 }
 
 
-int cipher_decrypt_cbc(cipher_t* cipher, uint8_t iv[16],
-                       const uint8_t* input, size_t length, uint8_t* output)
+int cipher_decrypt_cbc(cipher_t *cipher, uint8_t iv[16],
+                       const uint8_t *input, size_t length, uint8_t *output)
 {
     size_t offset = 0;
     const uint8_t *input_block, *input_block_last;

--- a/sys/crypto/modes/ctr.c
+++ b/sys/crypto/modes/ctr.c
@@ -7,26 +7,26 @@
  */
 
 /**
-* @ingroup     sys_crypto
-* @{
-*
-* @file
-* @brief       Crypto mode - Counter
-*
-* @author      Nico von Geyso <nico.geyso@fu-berlin.de>
-*
-* @}
-*/
+ * @ingroup     sys_crypto
+ * @{
+ *
+ * @file
+ * @brief       Crypto mode - Counter
+ *
+ * @author      Nico von Geyso <nico.geyso@fu-berlin.de>
+ *
+ * @}
+ */
 
 #include "crypto/helper.h"
 #include "crypto/modes/ctr.h"
 
-int cipher_encrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
-                       uint8_t nonce_len, const uint8_t* input, size_t length,
-                       uint8_t* output)
+int cipher_encrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
+                       uint8_t nonce_len, const uint8_t *input, size_t length,
+                       uint8_t *output)
 {
     size_t offset = 0;
-    uint8_t stream_block[16] = {0}, block_size;
+    uint8_t stream_block[16] = { 0 }, block_size;
 
     block_size = cipher_get_block_size(cipher);
     do {
@@ -49,9 +49,9 @@ int cipher_encrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
     return offset;
 }
 
-int cipher_decrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
-                       uint8_t nonce_len, const uint8_t* input, size_t length,
-                       uint8_t* output)
+int cipher_decrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
+                       uint8_t nonce_len, const uint8_t *input, size_t length,
+                       uint8_t *output)
 {
     return cipher_encrypt_ctr(cipher, nonce_counter, nonce_len, input,
                               length, output);

--- a/sys/crypto/modes/ecb.c
+++ b/sys/crypto/modes/ecb.c
@@ -7,24 +7,24 @@
  */
 
 /**
-* @ingroup     sys_crypto
-* @{
-*
-* @file
-* @brief       Crypto mode - electronic code book
-*
-* @author      Nico von Geyso <nico.geyso@fu-berlin.de>
-*
-* @}
-*/
+ * @ingroup     sys_crypto
+ * @{
+ *
+ * @file
+ * @brief       Crypto mode - electronic code book
+ *
+ * @author      Nico von Geyso <nico.geyso@fu-berlin.de>
+ *
+ * @}
+ */
 
 #include <stddef.h>
 #include <stdint.h>
 
 #include "crypto/modes/ecb.h"
 
-int cipher_encrypt_ecb(cipher_t* cipher, uint8_t* input,
-                       size_t length, uint8_t* output)
+int cipher_encrypt_ecb(cipher_t *cipher, uint8_t *input,
+                       size_t length, uint8_t *output)
 {
     size_t offset;
     uint8_t block_size;
@@ -46,8 +46,8 @@ int cipher_encrypt_ecb(cipher_t* cipher, uint8_t* input,
     return offset;
 }
 
-int cipher_decrypt_ecb(cipher_t* cipher, uint8_t* input,
-                       size_t length, uint8_t* output)
+int cipher_decrypt_ecb(cipher_t *cipher, uint8_t *input,
+                       size_t length, uint8_t *output)
 {
     size_t offset = 0;
     uint8_t block_size;

--- a/sys/crypto/poly1305.c
+++ b/sys/crypto/poly1305.c
@@ -27,9 +27,9 @@ static uint32_t u8to32(const uint8_t *p)
 {
     return
         ((uint32_t)p[0] |
-        ((uint32_t)p[1] <<  8) |
-        ((uint32_t)p[2] << 16) |
-        ((uint32_t)p[3] << 24));
+         ((uint32_t)p[1] <<  8) |
+         ((uint32_t)p[2] << 16) |
+         ((uint32_t)p[3] << 24));
 }
 
 static void u32to8(uint8_t *p, uint32_t v)
@@ -42,10 +42,10 @@ static void u32to8(uint8_t *p, uint32_t v)
 
 static void _clear_c(poly1305_ctx_t *ctx)
 {
-    ctx->c[0]  = 0;
-    ctx->c[1]  = 0;
-    ctx->c[2]  = 0;
-    ctx->c[3]  = 0;
+    ctx->c[0] = 0;
+    ctx->c[1] = 0;
+    ctx->c[2] = 0;
+    ctx->c[3] = 0;
     ctx->c_idx = 0;
 }
 
@@ -70,10 +70,10 @@ static void poly1305_block(poly1305_ctx_t *ctx, uint8_t c4)
     const uint32_t s4 = ctx->h[4] + c4;
 
     /* (h + c) * r, without carry propagation */
-    const uint64_t x0 = s0*r0 + s1*rr3 + s2*rr2 + s3*rr1 +s4*rr0;
-    const uint64_t x1 = s0*r1 + s1*r0  + s2*rr3 + s3*rr2 +s4*rr1;
-    const uint64_t x2 = s0*r2 + s1*r1  + s2*r0  + s3*rr3 +s4*rr2;
-    const uint64_t x3 = s0*r3 + s1*r2  + s2*r1  + s3*r0  +s4*rr3;
+    const uint64_t x0 = s0 * r0 + s1 * rr3 + s2 * rr2 + s3 * rr1 + s4 * rr0;
+    const uint64_t x1 = s0 * r1 + s1 * r0  + s2 * rr3 + s3 * rr2 + s4 * rr1;
+    const uint64_t x2 = s0 * r2 + s1 * r1  + s2 * r0  + s3 * rr3 + s4 * rr2;
+    const uint64_t x3 = s0 * r3 + s1 * r2  + s2 * r1  + s3 * r0  + s4 * rr3;
     const uint32_t x4 = s4 * (r0 & 3);
 
     /* partial reduction modulo 2^130 - 5 */
@@ -96,6 +96,7 @@ static void _take_input(poly1305_ctx_t *ctx, uint8_t input)
 {
     size_t word = ctx->c_idx >> 2;
     size_t byte = ctx->c_idx & 3;
+
     ctx->c[word] |= (uint32_t)input << (byte * 8);
     ctx->c_idx++;
 }
@@ -116,10 +117,10 @@ void poly1305_init(poly1305_ctx_t *ctx, const uint8_t *key)
     /* load and clamp key */
     ctx->r[0] = u8to32(key) & 0x0fffffff;
     for (size_t i = 1; i < 4; i++) {
-        ctx->r[i] = u8to32(&key[4*i]) & 0x0ffffffc;
+        ctx->r[i] = u8to32(&key[4 * i]) & 0x0ffffffc;
     }
     for (size_t i = 0; i < 4; i++) {
-        ctx->pad[i] = u8to32(&key[16 + i*4]);
+        ctx->pad[i] = u8to32(&key[16 + i * 4]);
     }
 
     /* Zero the hash */
@@ -140,11 +141,11 @@ void poly1305_finish(poly1305_ctx_t *ctx, uint8_t *mac)
 
     /* check if we should subtract 2^130-5 by performing the
      * corresponding carry propagation. */
-    const uint64_t u0 = (uint64_t)5 + ctx->h[0]; // <= 1_00000004
-    const uint64_t u1 = (u0 >> 32)  + ctx->h[1]; // <= 1_00000000
-    const uint64_t u2 = (u1 >> 32)  + ctx->h[2]; // <= 1_00000000
-    const uint64_t u3 = (u2 >> 32)  + ctx->h[3]; // <= 1_00000000
-    const uint64_t u4 = (u3 >> 32)  + ctx->h[4]; // <=          5
+    const uint64_t u0 = (uint64_t)5 + ctx->h[0];    // <= 1_00000004
+    const uint64_t u1 = (u0 >> 32)  + ctx->h[1];    // <= 1_00000000
+    const uint64_t u2 = (u1 >> 32)  + ctx->h[2];    // <= 1_00000000
+    const uint64_t u3 = (u2 >> 32)  + ctx->h[3];    // <= 1_00000000
+    const uint64_t u4 = (u3 >> 32)  + ctx->h[4];    // <=          5
     /* u4 indicates how many times we should subtract 2^130-5 (0 or 1) */
 
     /* h + pad, minus 2^130-5 if u4 exceeds 3 */
@@ -152,17 +153,18 @@ void poly1305_finish(poly1305_ctx_t *ctx, uint8_t *mac)
     u32to8(mac, uu0);
 
     const uint64_t uu1 = (uu0 >> 32)   + ctx->h[1] + ctx->pad[1];
-    u32to8(mac+4, uu1);
+    u32to8(mac + 4, uu1);
 
     const uint64_t uu2 = (uu1 >> 32)   + ctx->h[2] + ctx->pad[2];
-    u32to8(mac+8, uu2);
+    u32to8(mac + 8, uu2);
 
     const uint64_t uu3 = (uu2 >> 32)   + ctx->h[3] + ctx->pad[3];
-    u32to8(mac+12, uu3);
+    u32to8(mac + 12, uu3);
 
 }
 
-void poly1305_auth(uint8_t *mac, const uint8_t *data, size_t len, const uint8_t *key)
+void poly1305_auth(uint8_t *mac, const uint8_t *data, size_t len,
+                   const uint8_t *key)
 {
     poly1305_ctx_t ctx;
 

--- a/sys/include/crypto/chacha.h
+++ b/sys/include/crypto/chacha.h
@@ -99,7 +99,8 @@ void chacha_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c);
 /**
  * @copydoc chacha_encrypt_bytes()
  */
-static inline void chacha_decrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c)
+static inline void chacha_decrypt_bytes(chacha_ctx *ctx, const uint8_t *m,
+                                        uint8_t *c)
 {
     chacha_encrypt_bytes(ctx, m, c);
 }

--- a/sys/include/crypto/chacha20poly1305.h
+++ b/sys/include/crypto/chacha20poly1305.h
@@ -34,21 +34,20 @@
 extern "C" {
 #endif
 
-#define CHACHA20POLY1305_KEY_BYTES      (32U) /**< Key length in bytes */
-#define CHACHA20POLY1305_NONCE_BYTES    (12U) /**< Nonce length in bytes */
-#define CHACHA20POLY1305_TAG_BYTES      (16U) /**< Tag length in bytes */
+#define CHACHA20POLY1305_KEY_BYTES      (32U)   /**< Key length in bytes */
+#define CHACHA20POLY1305_NONCE_BYTES    (12U)   /**< Nonce length in bytes */
+#define CHACHA20POLY1305_TAG_BYTES      (16U)   /**< Tag length in bytes */
 
 /**
  * @brief Chacha20poly1305 state struct
  */
-typedef union
-{
+typedef union {
     /* We need both the state matrix and the poly1305 state, but nearly not at
      * the same time. This works as long as the first 8 members of state
      * overlap fully or completely not with the first and second key parts
      * from the @ref poly1305_ctx_t struct */
-    uint32_t state[16];  /**< The current state of the key stream. */
-    poly1305_ctx_t poly; /**< Poly1305 state for the MAC */
+    uint32_t state[16];     /**< The current state of the key stream. */
+    poly1305_ctx_t poly;    /**< Poly1305 state for the MAC */
 } chacha20poly1305_ctx_t;
 
 /**

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -148,7 +148,8 @@ int cipher_init(cipher_t *cipher, cipher_id_t cipher_id, const uint8_t *key,
  *                   cipher, which is always 1 in case of success
  * @return           A negative value for an error
  */
-int cipher_encrypt(const cipher_t *cipher, const uint8_t *input, uint8_t *output);
+int cipher_encrypt(const cipher_t *cipher, const uint8_t *input,
+                   uint8_t *output);
 
 
 /**
@@ -164,7 +165,8 @@ int cipher_encrypt(const cipher_t *cipher, const uint8_t *input, uint8_t *output
  *                   cipher, which is always 1 in case of success
  * @return           A negative value for an error
  */
-int cipher_decrypt(const cipher_t *cipher, const uint8_t *input, uint8_t *output);
+int cipher_decrypt(const cipher_t *cipher, const uint8_t *input,
+                   uint8_t *output);
 
 
 /**

--- a/sys/include/crypto/modes/ccm.h
+++ b/sys/include/crypto/modes/ccm.h
@@ -57,12 +57,12 @@ extern "C" {
  * @return                 Length of encrypted data on a successful encryption
  * @return                 A negative error code if something went wrong
  */
-int cipher_encrypt_ccm(cipher_t* cipher,
-                       const uint8_t* auth_data, uint32_t auth_data_len,
+int cipher_encrypt_ccm(cipher_t *cipher,
+                       const uint8_t *auth_data, uint32_t auth_data_len,
                        uint8_t mac_length, uint8_t length_encoding,
-                       const uint8_t* nonce, size_t nonce_len,
-                       const uint8_t* input, size_t input_len,
-                       uint8_t* output);
+                       const uint8_t *nonce, size_t nonce_len,
+                       const uint8_t *input, size_t input_len,
+                       uint8_t *output);
 
 
 /**
@@ -86,12 +86,12 @@ int cipher_encrypt_ccm(cipher_t* cipher,
  * @return                 Length of the decrypted data on a successful decryption
  * @return                 A negative error code if something went wrong
  */
-int cipher_decrypt_ccm(cipher_t* cipher,
-                       const uint8_t* auth_data, uint32_t auth_data_len,
+int cipher_decrypt_ccm(cipher_t *cipher,
+                       const uint8_t *auth_data, uint32_t auth_data_len,
                        uint8_t mac_length, uint8_t length_encoding,
-                       const uint8_t* nonce, size_t nonce_len,
-                       const uint8_t* input, size_t input_len,
-                       uint8_t* output);
+                       const uint8_t *nonce, size_t nonce_len,
+                       const uint8_t *input, size_t input_len,
+                       uint8_t *output);
 
 #ifdef __cplusplus
 }

--- a/sys/include/crypto/modes/ctr.h
+++ b/sys/include/crypto/modes/ctr.h
@@ -44,9 +44,9 @@ extern "C" {
  * @return              Length of encrypted data on a successful encryption
  * @return              A negative error code if something went wrong
  */
-int cipher_encrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
-                       uint8_t nonce_len, const uint8_t* input, size_t length,
-                       uint8_t* output);
+int cipher_encrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
+                       uint8_t nonce_len, const uint8_t *input, size_t length,
+                       uint8_t *output);
 
 
 /**
@@ -68,9 +68,9 @@ int cipher_encrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
  * @return              Length of decrypted data on a successful decryption
  * @return              A negative error code if something went wrong
  */
-int cipher_decrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
-                       uint8_t nonce_len, const uint8_t* input, size_t length,
-                       uint8_t* output);
+int cipher_decrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
+                       uint8_t nonce_len, const uint8_t *input, size_t length,
+                       uint8_t *output);
 
 #ifdef __cplusplus
 }

--- a/sys/include/crypto/modes/ecb.h
+++ b/sys/include/crypto/modes/ecb.h
@@ -42,8 +42,8 @@ extern "C" {
  * @return           A negative error code if something went wrong
  *
  */
-int cipher_encrypt_ecb(cipher_t* cipher, uint8_t* input, size_t length,
-                       uint8_t* output);
+int cipher_encrypt_ecb(cipher_t *cipher, uint8_t *input, size_t length,
+                       uint8_t *output);
 
 
 /**
@@ -59,8 +59,8 @@ int cipher_encrypt_ecb(cipher_t* cipher, uint8_t* input, size_t length,
  * @return           Length of decrypted data on a successful decryption
  * @return           A negative error code if something went wrong
  */
-int cipher_decrypt_ecb(cipher_t* cipher, uint8_t* input, size_t length,
-                       uint8_t* output);
+int cipher_decrypt_ecb(cipher_t *cipher, uint8_t *input, size_t length,
+                       uint8_t *output);
 
 #ifdef __cplusplus
 }

--- a/sys/include/crypto/modes/ocb.h
+++ b/sys/include/crypto/modes/ocb.h
@@ -77,7 +77,8 @@ extern "C" {
  *                         It has to be of size data_len + tag_len.
  * @return                 Length of the encrypted data (including the tag) or a (negative) error code
  */
-int32_t cipher_encrypt_ocb(cipher_t *cipher, uint8_t *auth_data, size_t auth_data_len,
+int32_t cipher_encrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
+                           size_t auth_data_len,
                            uint8_t tag_len, uint8_t *nonce, size_t nonce_len,
                            uint8_t *input, size_t input_len, uint8_t *output);
 
@@ -99,7 +100,8 @@ int32_t cipher_encrypt_ocb(cipher_t *cipher, uint8_t *auth_data, size_t auth_dat
  *                         Will contain only zeroes, if the authentication fails.
  * @return                 Length of the plaintext data or a (negative) error code
  */
-int32_t cipher_decrypt_ocb(cipher_t *cipher, uint8_t *auth_data, size_t auth_data_len,
+int32_t cipher_decrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
+                           size_t auth_data_len,
                            uint8_t tag_len, uint8_t *nonce, size_t nonce_len,
                            uint8_t *input, size_t input_len, uint8_t *output);
 #ifdef __cplusplus

--- a/tests/sys_crypto/tests-crypto-aes.c
+++ b/tests/sys_crypto/tests-crypto-aes.c
@@ -51,14 +51,16 @@ static void test_crypto_aes_encrypt(void)
 
     err = aes_encrypt(&ctx, TEST_0_INP, data);
     TEST_ASSERT_EQUAL_INT(1, err);
-    TEST_ASSERT_MESSAGE(1 == compare(TEST_0_ENC, data, AES_BLOCK_SIZE), "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == compare(TEST_0_ENC, data,
+                                     AES_BLOCK_SIZE), "wrong ciphertext");
 
     err = aes_init(&ctx, TEST_1_KEY, sizeof(TEST_1_KEY));
     TEST_ASSERT_EQUAL_INT(1, err);
 
     err = aes_encrypt(&ctx, TEST_1_INP, data);
     TEST_ASSERT_EQUAL_INT(1, err);
-    TEST_ASSERT_MESSAGE(1 == compare(TEST_1_ENC, data, AES_BLOCK_SIZE), "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == compare(TEST_1_ENC, data,
+                                     AES_BLOCK_SIZE), "wrong ciphertext");
 }
 
 static void test_crypto_aes_decrypt(void)
@@ -72,14 +74,16 @@ static void test_crypto_aes_decrypt(void)
 
     err = aes_decrypt(&ctx, TEST_0_ENC, data);
     TEST_ASSERT_EQUAL_INT(1, err);
-    TEST_ASSERT_MESSAGE(1 == compare(TEST_0_INP, data, AES_BLOCK_SIZE), "wrong plaintext");
+    TEST_ASSERT_MESSAGE(1 == compare(TEST_0_INP, data,
+                                     AES_BLOCK_SIZE), "wrong plaintext");
 
     err = aes_init(&ctx, TEST_1_KEY, sizeof(TEST_1_KEY));
     TEST_ASSERT_EQUAL_INT(1, err);
 
     err = aes_decrypt(&ctx, TEST_1_ENC, data);
     TEST_ASSERT_EQUAL_INT(1, err);
-    TEST_ASSERT_MESSAGE(1 == compare(TEST_1_INP, data, AES_BLOCK_SIZE), "wrong plaintext");
+    TEST_ASSERT_MESSAGE(1 == compare(TEST_1_INP, data,
+                                     AES_BLOCK_SIZE), "wrong plaintext");
 }
 
 static void test_crypto_aes_init_key_length(void)

--- a/tests/sys_crypto/tests-crypto-chacha.c
+++ b/tests/sys_crypto/tests-crypto-chacha.c
@@ -97,7 +97,8 @@ static const uint8_t TC8_CHACHA20_BLOCK1[64] = {
 static void _test_crypto_chacha(unsigned rounds, unsigned keylen,
                                 const uint8_t key[32], const uint8_t iv[8],
                                 const uint32_t after_init[16],
-                                const uint8_t block0[64], const uint8_t block1[64])
+                                const uint8_t block0[64],
+                                const uint8_t block1[64])
 {
     chacha_ctx ctx;
     uint8_t block[64];
@@ -138,5 +139,5 @@ Test *tests_crypto_chacha_tests(void)
         new_TestFixture(test_crypto_chacha20_tc8),
     };
     EMB_UNIT_TESTCALLER(crypto_chacha_tests, NULL, NULL, fixtures);
-    return (Test *) &crypto_chacha_tests;
+    return (Test *)&crypto_chacha_tests;
 }

--- a/tests/sys_crypto/tests-crypto-cipher.c
+++ b/tests/sys_crypto/tests-crypto-cipher.c
@@ -78,13 +78,19 @@ static void test_crypto_cipher_init_aes_key_length(void)
     uint8_t unsupported_key_3[8];
     memset(unsupported_key_3, 0, sizeof(unsupported_key_3));
 
-    err = cipher_init(&cipher, CIPHER_AES_128, unsupported_key_1, sizeof(unsupported_key_1));
+    err =
+        cipher_init(&cipher, CIPHER_AES_128, unsupported_key_1,
+                    sizeof(unsupported_key_1));
     TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
 
-    err = cipher_init(&cipher, CIPHER_AES_128, unsupported_key_2, sizeof(unsupported_key_2));
+    err =
+        cipher_init(&cipher, CIPHER_AES_128, unsupported_key_2,
+                    sizeof(unsupported_key_2));
     TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
 
-    err = cipher_init(&cipher, CIPHER_AES_128, unsupported_key_3, sizeof(unsupported_key_3));
+    err =
+        cipher_init(&cipher, CIPHER_AES_128, unsupported_key_3,
+                    sizeof(unsupported_key_3));
     TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
 }
 

--- a/tests/sys_crypto/tests-crypto-helper.c
+++ b/tests/sys_crypto/tests-crypto-helper.c
@@ -34,5 +34,5 @@ Test *tests_crypto_helper_tests(void)
         new_TestFixture(test_crypto_wipe),
     };
     EMB_UNIT_TESTCALLER(crypto_helper_tests, NULL, NULL, fixtures);
-    return (Test *) &crypto_helper_tests;
+    return (Test *)&crypto_helper_tests;
 }

--- a/tests/sys_crypto/tests-crypto-modes-cbc.c
+++ b/tests/sys_crypto/tests-crypto-modes-cbc.c
@@ -61,8 +61,8 @@ static uint8_t TEST_1_CIPHER[] = {
 };
 static uint8_t TEST_1_CIPHER_LEN = 64;
 
-static void test_encrypt_op(uint8_t* key, uint8_t key_len, uint8_t iv[16],
-                            uint8_t* input, uint8_t input_len, uint8_t* output,
+static void test_encrypt_op(uint8_t *key, uint8_t key_len, uint8_t iv[16],
+                            uint8_t *input, uint8_t input_len, uint8_t *output,
                             uint8_t output_len)
 {
     cipher_t cipher;
@@ -77,12 +77,12 @@ static void test_encrypt_op(uint8_t* key, uint8_t key_len, uint8_t iv[16],
 
     TEST_ASSERT_EQUAL_INT(output_len, len);
     cmp = compare(output, data, len);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 
 }
 
-static void test_decrypt_op(uint8_t* key, uint8_t key_len, uint8_t iv[16],
-                            uint8_t* input, uint8_t input_len, uint8_t* output,
+static void test_decrypt_op(uint8_t *key, uint8_t key_len, uint8_t iv[16],
+                            uint8_t *input, uint8_t input_len, uint8_t *output,
                             uint8_t output_len)
 {
     cipher_t cipher;
@@ -97,7 +97,7 @@ static void test_decrypt_op(uint8_t* key, uint8_t key_len, uint8_t iv[16],
 
     TEST_ASSERT_EQUAL_INT(output_len, len);
     cmp = compare(output, data, len);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 
 }
 
@@ -114,14 +114,14 @@ static void test_crypto_modes_cbc_decrypt(void)
 }
 
 
-Test* tests_crypto_modes_cbc_tests(void)
+Test *tests_crypto_modes_cbc_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_crypto_modes_cbc_encrypt),
-                        new_TestFixture(test_crypto_modes_cbc_decrypt)
+        new_TestFixture(test_crypto_modes_cbc_decrypt)
     };
 
     EMB_UNIT_TESTCALLER(crypto_modes_cbc_tests, NULL, NULL, fixtures);
 
-    return (Test*)&crypto_modes_cbc_tests;
+    return (Test *)&crypto_modes_cbc_tests;
 }

--- a/tests/sys_crypto/tests-crypto-modes-ccm.c
+++ b/tests/sys_crypto/tests-crypto-modes-ccm.c
@@ -826,11 +826,11 @@ static const size_t TEST_NIST_3_EXPECTED_LEN = 52;
 /* Share test buffer output */
 static uint8_t data[60];
 
-static void test_encrypt_op(const uint8_t* key, uint8_t key_len,
-                            const uint8_t* adata, size_t adata_len,
-                            const uint8_t* nonce, uint8_t nonce_len,
-                            const uint8_t* plain, size_t plain_len,
-                            const uint8_t* output_expected,
+static void test_encrypt_op(const uint8_t *key, uint8_t key_len,
+                            const uint8_t *adata, size_t adata_len,
+                            const uint8_t *nonce, uint8_t nonce_len,
+                            const uint8_t *plain, size_t plain_len,
+                            const uint8_t *output_expected,
                             size_t output_expected_len,
                             uint8_t mac_length)
 {
@@ -851,15 +851,15 @@ static void test_encrypt_op(const uint8_t* key, uint8_t key_len,
 
     TEST_ASSERT_EQUAL_INT(output_expected_len, len);
     cmp = compare(output_expected, data, len);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 
 }
 
-static void test_decrypt_op(const uint8_t* key, uint8_t key_len,
-                            const uint8_t* adata, size_t adata_len,
-                            const uint8_t* nonce, uint8_t nonce_len,
-                            const uint8_t* encrypted, size_t encrypted_len,
-                            const uint8_t* output_expected,
+static void test_decrypt_op(const uint8_t *key, uint8_t key_len,
+                            const uint8_t *adata, size_t adata_len,
+                            const uint8_t *nonce, uint8_t nonce_len,
+                            const uint8_t *encrypted, size_t encrypted_len,
+                            const uint8_t *output_expected,
                             size_t output_expected_len,
                             uint8_t mac_length)
 {
@@ -880,23 +880,23 @@ static void test_decrypt_op(const uint8_t* key, uint8_t key_len,
 
     TEST_ASSERT_EQUAL_INT(output_expected_len, len);
     cmp = compare(output_expected, data, len);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 
 }
 
 #define do_test_encrypt_op(name) do { \
-    test_encrypt_op(TEST_##name##_KEY, TEST_##name##_KEY_LEN, \
-                    TEST_##name##_INPUT, TEST_##name##_ADATA_LEN, \
-                    TEST_##name##_NONCE, TEST_##name##_NONCE_LEN, \
+        test_encrypt_op(TEST_ ## name ## _KEY, TEST_ ## name ## _KEY_LEN, \
+                        TEST_ ## name ## _INPUT, TEST_ ## name ## _ADATA_LEN, \
+                        TEST_ ## name ## _NONCE, TEST_ ## name ## _NONCE_LEN, \
                     \
-                    TEST_##name##_INPUT + TEST_##name##_ADATA_LEN, \
-                    TEST_##name##_INPUT_LEN, \
+                        TEST_ ## name ## _INPUT + TEST_ ## name ## _ADATA_LEN, \
+                        TEST_ ## name ## _INPUT_LEN, \
                     \
-                    TEST_##name##_EXPECTED + TEST_##name##_ADATA_LEN, \
-                    TEST_##name##_EXPECTED_LEN - TEST_##name##_ADATA_LEN, \
+                        TEST_ ## name ## _EXPECTED + TEST_ ## name ## _ADATA_LEN, \
+                        TEST_ ## name ## _EXPECTED_LEN - TEST_ ## name ## _ADATA_LEN, \
                     \
-                    TEST_##name##_MAC_LEN \
-                    ); \
+                        TEST_ ## name ## _MAC_LEN \
+                        ); \
 } while (0)
 
 
@@ -933,18 +933,18 @@ static void test_crypto_modes_ccm_encrypt(void)
 }
 
 #define do_test_decrypt_op(name) do { \
-    test_decrypt_op(TEST_##name##_KEY, TEST_##name##_KEY_LEN, \
-                    TEST_##name##_INPUT, TEST_##name##_ADATA_LEN, \
-                    TEST_##name##_NONCE, TEST_##name##_NONCE_LEN, \
+        test_decrypt_op(TEST_ ## name ## _KEY, TEST_ ## name ## _KEY_LEN, \
+                        TEST_ ## name ## _INPUT, TEST_ ## name ## _ADATA_LEN, \
+                        TEST_ ## name ## _NONCE, TEST_ ## name ## _NONCE_LEN, \
                     \
-                    TEST_##name##_EXPECTED + TEST_##name##_ADATA_LEN, \
-                    TEST_##name##_EXPECTED_LEN - TEST_##name##_ADATA_LEN, \
+                        TEST_ ## name ## _EXPECTED + TEST_ ## name ## _ADATA_LEN, \
+                        TEST_ ## name ## _EXPECTED_LEN - TEST_ ## name ## _ADATA_LEN, \
                     \
-                    TEST_##name##_INPUT + TEST_##name##_ADATA_LEN, \
-                    TEST_##name##_INPUT_LEN, \
+                        TEST_ ## name ## _INPUT + TEST_ ## name ## _ADATA_LEN, \
+                        TEST_ ## name ## _INPUT_LEN, \
                     \
-                    TEST_##name##_MAC_LEN \
-                    ); \
+                        TEST_ ## name ## _MAC_LEN \
+                        ); \
 } while (0)
 
 static void test_crypto_modes_ccm_decrypt(void)
@@ -980,20 +980,22 @@ static void test_crypto_modes_ccm_decrypt(void)
 }
 
 
-typedef int (*func_ccm_t)(cipher_t*, const uint8_t*, uint32_t,
-                          uint8_t, uint8_t, const uint8_t*, size_t,
-                          const uint8_t*, size_t, uint8_t*);
+typedef int (*func_ccm_t)(cipher_t *, const uint8_t *, uint32_t,
+                          uint8_t, uint8_t, const uint8_t *, size_t,
+                          const uint8_t *, size_t, uint8_t *);
 
 static int _test_ccm_len(func_ccm_t func, uint8_t len_encoding,
-                         const uint8_t *input, size_t input_len, size_t adata_len)
+                         const uint8_t *input, size_t input_len,
+                         size_t adata_len)
 {
     int ret;
     cipher_t cipher;
     uint8_t mac_length = 8;
-    uint8_t nonce[15] = {0};
-    uint8_t key[16] = {0};
+    uint8_t nonce[15] = { 0 };
+    uint8_t key[16] = { 0 };
 
     uint8_t nonce_len = nonce_and_len_encoding_size - len_encoding;
+
     cipher_init(&cipher, CIPHER_AES_128, key, 16);
 
     ret = func(&cipher, NULL, adata_len, mac_length, len_encoding,
@@ -1006,6 +1008,7 @@ static int _test_ccm_len(func_ccm_t func, uint8_t len_encoding,
 static void test_crypto_modes_ccm_check_len(void)
 {
     int ret;
+
     /* Just 1 to big to fit */
     ret = _test_ccm_len(cipher_encrypt_ccm, 2, NULL, 1 << 16, 0);
     TEST_ASSERT_EQUAL_INT(CCM_ERR_INVALID_LENGTH_ENCODING, ret);
@@ -1044,7 +1047,7 @@ static void test_crypto_modes_ccm_check_len(void)
 }
 
 
-Test* tests_crypto_modes_ccm_tests(void)
+Test *tests_crypto_modes_ccm_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_crypto_modes_ccm_encrypt),
@@ -1054,5 +1057,5 @@ Test* tests_crypto_modes_ccm_tests(void)
 
     EMB_UNIT_TESTCALLER(crypto_modes_ccm_tests, NULL, NULL, fixtures);
 
-    return (Test*)&crypto_modes_ccm_tests;
+    return (Test *)&crypto_modes_ccm_tests;
 }

--- a/tests/sys_crypto/tests-crypto-modes-ctr.c
+++ b/tests/sys_crypto/tests-crypto-modes-ctr.c
@@ -61,8 +61,8 @@ static uint8_t TEST_1_CIPHER[] = {
 };
 static uint8_t TEST_1_CIPHER_LEN = 64;
 
-static void test_encrypt_op(uint8_t* key, uint8_t key_len, uint8_t ctr[16],
-                            uint8_t* input, uint8_t input_len, uint8_t* output,
+static void test_encrypt_op(uint8_t *key, uint8_t key_len, uint8_t ctr[16],
+                            uint8_t *input, uint8_t input_len, uint8_t *output,
                             uint8_t output_len)
 {
     cipher_t cipher;
@@ -77,12 +77,12 @@ static void test_encrypt_op(uint8_t* key, uint8_t key_len, uint8_t ctr[16],
 
     TEST_ASSERT_EQUAL_INT(output_len, len);
     cmp = compare(output, data, len);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 
 }
 
-static void test_decrypt_op(uint8_t* key, uint8_t key_len, uint8_t ctr[16],
-                            uint8_t* input, uint8_t input_len, uint8_t* output,
+static void test_decrypt_op(uint8_t *key, uint8_t key_len, uint8_t ctr[16],
+                            uint8_t *input, uint8_t input_len, uint8_t *output,
                             uint8_t output_len)
 {
     cipher_t cipher;
@@ -97,7 +97,7 @@ static void test_decrypt_op(uint8_t* key, uint8_t key_len, uint8_t ctr[16],
 
     TEST_ASSERT_EQUAL_INT(output_len, len);
     cmp = compare(output, data, len);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 
 }
 
@@ -120,14 +120,14 @@ static void test_crypto_modes_ctr_decrypt(void)
 }
 
 
-Test* tests_crypto_modes_ctr_tests(void)
+Test *tests_crypto_modes_ctr_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_crypto_modes_ctr_encrypt),
-                        new_TestFixture(test_crypto_modes_ctr_decrypt)
+        new_TestFixture(test_crypto_modes_ctr_decrypt)
     };
 
     EMB_UNIT_TESTCALLER(crypto_modes_ctr_tests, NULL, NULL, fixtures);
 
-    return (Test*)&crypto_modes_ctr_tests;
+    return (Test *)&crypto_modes_ctr_tests;
 }

--- a/tests/sys_crypto/tests-crypto-modes-ecb.c
+++ b/tests/sys_crypto/tests-crypto-modes-ecb.c
@@ -56,8 +56,8 @@ static uint8_t TEST_1_CIPHER[] = {
 };
 static uint8_t TEST_1_CIPHER_LEN = 64;
 
-static void test_encrypt_op(uint8_t* key, uint8_t key_len, uint8_t* input,
-                            uint8_t input_len, uint8_t* output,
+static void test_encrypt_op(uint8_t *key, uint8_t key_len, uint8_t *input,
+                            uint8_t input_len, uint8_t *output,
                             uint8_t output_len)
 {
     cipher_t cipher;
@@ -72,12 +72,12 @@ static void test_encrypt_op(uint8_t* key, uint8_t key_len, uint8_t* input,
 
     TEST_ASSERT_EQUAL_INT(output_len, len);
     cmp = compare(output, data, len);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 
 }
 
-static void test_decrypt_op(uint8_t* key, uint8_t key_len, uint8_t* input,
-                            uint8_t input_len, uint8_t* output,
+static void test_decrypt_op(uint8_t *key, uint8_t key_len, uint8_t *input,
+                            uint8_t input_len, uint8_t *output,
                             uint8_t output_len)
 {
     cipher_t cipher;
@@ -92,7 +92,7 @@ static void test_decrypt_op(uint8_t* key, uint8_t key_len, uint8_t* input,
 
     TEST_ASSERT_EQUAL_INT(output_len, len);
     cmp = compare(output, data, len);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 
 }
 
@@ -104,19 +104,20 @@ static void test_crypto_modes_ecb_encrypt(void)
 
 static void test_crypto_modes_ecb_decrypt(void)
 {
-    test_decrypt_op(TEST_1_KEY, TEST_1_KEY_LEN, TEST_1_CIPHER, TEST_1_CIPHER_LEN,
+    test_decrypt_op(TEST_1_KEY, TEST_1_KEY_LEN, TEST_1_CIPHER,
+                    TEST_1_CIPHER_LEN,
                     TEST_1_PLAIN, TEST_1_PLAIN_LEN);
 }
 
 
-Test* tests_crypto_modes_ecb_tests(void)
+Test *tests_crypto_modes_ecb_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_crypto_modes_ecb_encrypt),
-                        new_TestFixture(test_crypto_modes_ecb_decrypt)
+        new_TestFixture(test_crypto_modes_ecb_decrypt)
     };
 
     EMB_UNIT_TESTCALLER(crypto_modes_ecb_tests, NULL, NULL, fixtures);
 
-    return (Test*)&crypto_modes_ecb_tests;
+    return (Test *)&crypto_modes_ecb_tests;
 }

--- a/tests/sys_crypto/tests-crypto-modes-ocb.c
+++ b/tests/sys_crypto/tests-crypto-modes-ocb.c
@@ -414,16 +414,20 @@ static void test_crypto_modes_ocb_bad_parameter_values(void)
 
     cipher_init(&cipher, CIPHER_AES_128, key, 16);
     /* tag length must be positive */
-    int rv = cipher_encrypt_ocb(&cipher, auth_data, sizeof(auth_data), 0, nonce, 15, input, sizeof(input), output);
+    int rv = cipher_encrypt_ocb(&cipher, auth_data, sizeof(auth_data), 0, nonce,
+                                15, input, sizeof(input), output);
     TEST_ASSERT_EQUAL_INT(OCB_ERR_INVALID_TAG_LENGTH, rv);
     /* tag length must be <= 16 */
-    rv = cipher_encrypt_ocb(&cipher, auth_data, sizeof(auth_data), 17, nonce, 15, input, sizeof(input), output);
+    rv = cipher_encrypt_ocb(&cipher, auth_data, sizeof(auth_data), 17, nonce,
+                            15, input, sizeof(input), output);
     TEST_ASSERT_EQUAL_INT(OCB_ERR_INVALID_TAG_LENGTH, rv);
     /* nonce must not be empty */
-    rv = cipher_encrypt_ocb(&cipher, auth_data, sizeof(auth_data), 16, nonce, 0, input, sizeof(input), output);
+    rv = cipher_encrypt_ocb(&cipher, auth_data, sizeof(auth_data), 16, nonce, 0,
+                            input, sizeof(input), output);
     TEST_ASSERT_EQUAL_INT(OCB_ERR_INVALID_NONCE_LENGTH, rv);
     /* nonce must be <=15 */
-    rv = cipher_encrypt_ocb(&cipher, auth_data, sizeof(auth_data), 16, nonce, 16, input, sizeof(input), output);
+    rv = cipher_encrypt_ocb(&cipher, auth_data, sizeof(auth_data), 16, nonce,
+                            16, input, sizeof(input), output);
     TEST_ASSERT_EQUAL_INT(OCB_ERR_INVALID_NONCE_LENGTH, rv);
 }
 


### PR DESCRIPTION
### Contribution description

I fixed the code style of all crypto code files.

Uncrustify was run on all relevant source, header and test files.

No functional changes were made.


### Testing procedure

The tests in *sys_crypto* still work.

### Issues/PRs references

This was requested by @aabadie in PR #12362.