### PR TITLE
makefiles/arch/cortexm.inc.mk: remove clang 3.6.2 workaround

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -68,20 +68,6 @@ ifneq (1,$(BUILD_IN_DOCKER))
   endif # ARM_GCC_UNSUPPORTED
 endif # BUILD_IN_DOCKER
 
-
-# Temporary LLVM/Clang Workaround:
-# report cortex-m0 instead of cortex-m0plus if llvm/clang (<= 3.6.2) is used
-# llvm/clang version 3.6.2 still does not support the cortex-m0plus mcpu type
-ifeq (llvm,$(TOOLCHAIN))
-ifeq (cortex-m0plus,$(CPU_ARCH))
-LLVM_UNSUP = $(shell clang -target arm-none-eabi -mcpu=$(CPU_ARCH) -c -x c /dev/null -o /dev/null \
-                     > /dev/null 2>&1 || echo 1 )
-ifeq (1,$(LLVM_UNSUP))
-CPU_ARCH = cortex-m0
-endif
-endif
-endif
-
 CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))
 CFLAGS += -DCPU_ARCH_$(call uppercase_and_underscore,$(CPU_ARCH))
 


### PR DESCRIPTION
### Contribution description

Remove the workaround for clang 3.6.2 that did not support
'cortex-m0plus'.

clang 3.8 was already supporting it according to the PR introducing the check. (see https://github.com/RIOT-OS/RIOT/pull/3870)
clang >=3.8 is avaible since ubuntu-xenial and debian-stretch.
The current ubuntu-bionic has clang 6 and debian-buster clang 7.

This removes overwriting 'CPU_ARCH'.

### Testing procedure

Compiling `gnrc_networking` for `samr21-xpro` with `llvm` should work on `ubuntu-bionic`.

This will be done by `murdock`.

```
TOOLCHAIN=llvm BOARD=samr21-xpro make --no-print-directory -C examples/hello-world/ clean all
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /home/harter/work/git/RIOT/boards/samr21-xpro
"make" -C /home/harter/work/git/RIOT/core
"make" -C /home/harter/work/git/RIOT/cpu/samd21
"make" -C /home/harter/work/git/RIOT/cpu/cortexm_common
"make" -C /home/harter/work/git/RIOT/cpu/cortexm_common/periph
"make" -C /home/harter/work/git/RIOT/cpu/sam0_common
"make" -C /home/harter/work/git/RIOT/cpu/sam0_common/periph
"make" -C /home/harter/work/git/RIOT/cpu/samd21/periph
"make" -C /home/harter/work/git/RIOT/drivers
"make" -C /home/harter/work/git/RIOT/drivers/periph_common
"make" -C /home/harter/work/git/RIOT/sys
"make" -C /home/harter/work/git/RIOT/sys/auto_init
"make" -C /home/harter/work/git/RIOT/sys/newlib_syscalls_default
"make" -C /home/harter/work/git/RIOT/sys/pm_layered
"make" -C /home/harter/work/git/RIOT/sys/stdio_uart
   text    data     bss     dec     hex filename
   8272       0    2548   10820    2a44 /home/harter/work/git/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
```

### Issues/PRs references

Was a cleanup required for moving the definition of `CPU_ARCH` to `Makefile.features`.
Part of "Build dependencies - processing order issues" #9913

Was introduced 4 years ago by https://github.com/RIOT-OS/RIOT/pull/3870