### PR TITLE
boards/jiminy-mega256rfr2: remove mentions in applications and board/common

### DIFF
--- a/boards/common/arduino-atmega/Makefile.features
+++ b/boards/common/arduino-atmega/Makefile.features
@@ -7,7 +7,5 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-ifeq (,$(filter jiminy-mega256rfr2,$(BOARD)))
-  FEATURES_PROVIDED += arduino
-  FEATURES_PROVIDED += periph_pwm
-endif
+FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += periph_pwm

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../..
 # TinyDTLS only has support for 32-bit architectures ATM
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   arduino-uno chronos mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/examples/dtls-wolfssl/Makefile
+++ b/examples/dtls-wolfssl/Makefile
@@ -9,7 +9,7 @@ RIOTBASE ?= $(CURDIR)/../..
 
 # wolfSSL supports 32-bit architectures only
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-nano arduino-uno \
-                   chronos jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb \
+                   chronos mega-xplained msb-430 msb-430h telosb \
                    waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill \

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -23,7 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill \
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
                    arduino-nano arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
-                   wsn430-v1_4 z1 pic32-wifire pic32-clicker jiminy-mega256rfr2 \
+                   wsn430-v1_4 z1 pic32-wifire pic32-clicker \
                    mega-xplained
 
 # Comment this out to disable code in RIOT that does safety checking

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -33,7 +33,7 @@ BOARD_INSUFFICIENT_MEMORY := blackpill blackpill-128kib bluepill \
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano arduino-uno \
-                   chronos hifive1 hifive1b jiminy-mega256rfr2 mega-xplained \
+                   chronos hifive1 hifive1b mega-xplained \
                    msb-430 msb-430h pic32-clicker pic32-wifire telosb \
                    waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -19,7 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := blackpill blackpill-128kib bluepill \
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos hifive1 hifive1b jiminy-mega256rfr2 \
+                   arduino-uno chronos hifive1 hifive1b \
                    mega-xplained msb-430 msb-430h pic32-clicker \
                    pic32-wifire telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/driver_hd44780/Makefile
+++ b/tests/driver_hd44780/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 # the stm32f4discovery does not have the arduino pinout
-BOARD_BLACKLIST := stm32f4discovery jiminy-mega256rfr2 slstk3401a slstk3402a \
+BOARD_BLACKLIST := stm32f4discovery slstk3401a slstk3402a \
                    sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a \
                    stk3600 stk3700
 

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
+                   arduino-uno mega-xplained waspmote-pro
 # arduino-mega2560: builds locally but breaks travis (possibly because of
 # differences in the toolchain)
 # The MSP boards don't feature round(), exp(), and log(), which are used in the unittests

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -5,7 +5,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
                    arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
-                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   esp8266-sparkfun-thing mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon hifive1 hifive1b i-nucleo-lrwan1 nrf6310 \

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -5,7 +5,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
                    arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
-                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   esp8266-sparkfun-thing mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY = i-nucleo-lrwan1 nucleo-f031k6 nucleo-f042k6 \

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -5,7 +5,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
                    arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
-                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   esp8266-sparkfun-thing mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY = blackpill bluepill i-nucleo-lrwan1 \

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -5,7 +5,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
                    arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
-                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   esp8266-sparkfun-thing mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY = i-nucleo-lrwan1 nucleo-f031k6 nucleo-f042k6 \

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   arduino-uno chronos mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f031k6 nucleo-f042k6 \

--- a/tests/pipe/Makefile
+++ b/tests/pipe/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 #malloc.h not found
-BOARD_BLACKLIST := arduino-leonardo jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-leonardo mega-xplained
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              nucleo-f031k6
 

--- a/tests/pkg_cifra/Makefile
+++ b/tests/pkg_cifra/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 # No 8 bit and 16 bit support
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   arduino-uno chronos mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/tests/pkg_cn-cbor/Makefile
+++ b/tests/pkg_cn-cbor/Makefile
@@ -6,7 +6,6 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     arduino-nano \
                     arduino-uno \
                     chronos \
-                    jiminy-mega256rfr2 \
                     mega-xplained \
                     msb-430 \
                     msb-430h \

--- a/tests/pkg_hacl/Makefile
+++ b/tests/pkg_hacl/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   arduino-uno chronos mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 # msp430 and avr have problems with int width and libcoaps usage of :x notation in structs
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained msb-430 \
+                   arduino-uno chronos mega-xplained msb-430 \
                    msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY := chronos i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 \

--- a/tests/pkg_libcose/Makefile
+++ b/tests/pkg_libcose/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 # HACL* only compiles on 32bit platforms
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   arduino-uno chronos mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/tests/pkg_libhydrogen/Makefile
+++ b/tests/pkg_libhydrogen/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 # MSP430 boards: invalid alignment of 'hydro_random_context'
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-uno \
-                   jiminy-mega256rfr2 mega-xplained waspmote-pro \
+                   mega-xplained waspmote-pro \
                    chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
 USEPKG += libhydrogen

--- a/tests/pkg_monocypher/Makefile
+++ b/tests/pkg_monocypher/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 # No 8 bit and 16 bit support
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   arduino-uno chronos mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
 

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -10,7 +10,6 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     f4vi1 \
                     hifive1 \
                     hifive1b \
-                    jiminy-mega256rfr2 \
                     mega-xplained \
                     msb-430 \
                     msb-430h \

--- a/tests/pkg_tinycbor/Makefile
+++ b/tests/pkg_tinycbor/Makefile
@@ -5,7 +5,7 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
                    arduino-uno chronos esp32-mh-et-live-minikit \
                    esp32-olimex-evb esp32-wemos-lolin-d32-pro \
-                   esp32-wroom-32 esp32-wrover-kit jiminy-mega256rfr2 \
+                   esp32-wroom-32 esp32-wrover-kit \
                    mega-xplained msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1 \
 

--- a/tests/pkg_ubasic/Makefile
+++ b/tests/pkg_ubasic/Makefile
@@ -16,7 +16,6 @@ BOARD_BLACKLIST := \
                    esp8266-olimex-mod \
                    hifive1 \
                    hifive1b \
-                   jiminy-mega256rfr2 \
                    mega-xplained \
                    msb-430 \
                    msb-430h \

--- a/tests/pkg_wolfcrypt-ed25519-verify/Makefile
+++ b/tests/pkg_wolfcrypt-ed25519-verify/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
                    arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
-                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   esp8266-sparkfun-thing mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/pkg_wolfssl/Makefile
+++ b/tests/pkg_wolfssl/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
                    arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
-                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   esp8266-sparkfun-thing mega-xplained \
                    msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -16,7 +16,6 @@ BOARD_INSUFFICIENT_MEMORY := \
 BOARD_INSUFFICIENT_MEMORY += \
 	arduino-leonardo \
 	arduino-mega2560 \
-	jiminy-mega256rfr2 \
 	mega-xplained \
 	waspmote-pro \
 	#

--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
                    arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
-                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   esp8266-sparkfun-thing mega-xplained \
                    msb-430 msb-430h pic32-clicker pic32-wifire telosb \
                    waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/sys_crypto/Makefile
+++ b/tests/sys_crypto/Makefile
@@ -7,7 +7,6 @@ BOARD_BLACKLIST += arduino-mega2560
 BOARD_BLACKLIST += arduino-nano
 BOARD_BLACKLIST += arduino-uno
 BOARD_BLACKLIST += chronos
-BOARD_BLACKLIST += jiminy-mega256rfr2
 BOARD_BLACKLIST += mega-xplained
 BOARD_BLACKLIST += msb-430
 BOARD_BLACKLIST += msb-430h

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -9,7 +9,6 @@ BOARD_BLACKLIST += arduino-mega2560
 BOARD_BLACKLIST += arduino-nano
 BOARD_BLACKLIST += arduino-uno
 BOARD_BLACKLIST += chronos
-BOARD_BLACKLIST += jiminy-mega256rfr2
 BOARD_BLACKLIST += mega-xplained
 BOARD_BLACKLIST += msb-430
 BOARD_BLACKLIST += msb-430h


### PR DESCRIPTION
### Contribution description

The board was removed in #12182 but specific handling or definitions were still referenced in the repository.

Remove the deprecated board from BOARD_BLACKLIST and BOARD_INSUFFICIENT_MEMORY in applications.

Remove special case for jiminy-mega256rfr2 in boards/common/arduino-atmega

Having the `arduino` and `periph_pwm` features is now required for all
boards using 'arduino-atmega' (as it was except for that board).

If this should change in the future, it should be defined either in each
arduino board, in another board common, or per CPU_MODEL.

### Testing procedure

The board is now not referenced anymore except in release-notes and lost and found.

```
git grep jiminy-mega256rfr2
LOSTANDFOUND.md:### boards/jiminy-mega256rfr2 [232aed3e18118624b862d36bfec7cd1c21ca2d26]
release-notes.txt:    + jiminy-mega256rfr2
```

### Issues/PRs references

Found while rebasing the cleanup to not do per board blacklisting of features.

Board was removed in "boards: Remove support for the Jiminy-Mega256RFR2" #12182