### PR TITLE
Changed doubles to floats in sx127x module

### DIFF
--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -167,14 +167,14 @@ int16_t bmp180_altitude(const bmp180_t *dev, uint32_t pressure_0)
 {
     uint32_t p = bmp180_read_pressure(dev);
 
-    return (int16_t)(44330.0 * (1.0 - pow((double)p / pressure_0, 0.1903)));;
+    return (int16_t)(44330.0 * (1.0 - pow((float)p / pressure_0, 0.1903)));;
 }
 
 uint32_t bmp180_sealevel_pressure(const bmp180_t *dev, int16_t altitude)
 {
     uint32_t p = bmp180_read_pressure(dev);
 
-    return (uint32_t)((double)p / pow(1.0 - (altitude / 44330.0), 5.255));;
+    return (uint32_t)((float)p / pow(1.0 - (altitude / 44330.0), 5.255));;
 }
 
 /*------------------------------------------------------------------------------------*/

--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -167,14 +167,14 @@ int16_t bmp180_altitude(const bmp180_t *dev, uint32_t pressure_0)
 {
     uint32_t p = bmp180_read_pressure(dev);
 
-    return (int16_t)(44330.0 * (1.0 - pow((float)p / pressure_0, 0.1903)));;
+    return (int16_t)(44330.0 * (1.0 - pow((double)p / pressure_0, 0.1903)));;
 }
 
 uint32_t bmp180_sealevel_pressure(const bmp180_t *dev, int16_t altitude)
 {
     uint32_t p = bmp180_read_pressure(dev);
 
-    return (uint32_t)((float)p / pow(1.0 - (altitude / 44330.0), 5.255));;
+    return (uint32_t)((double)p / pow(1.0 - (altitude / 44330.0), 5.255));;
 }
 
 /*------------------------------------------------------------------------------------*/

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -128,7 +128,7 @@ void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
     dev->settings.channel = channel;
 
     /* shift to avoid float division */
-    channel = (uint32_t)( channel << 8 / LORA_FREQUENCY_RESOLUTION_DEFAULT << 8 );
+    channel = (uint32_t)( (float) channel / (float) LORA_FREQUENCY_RESOLUTION_DEFAULT );
 
     /* Write frequency settings into chip */
     sx127x_reg_write(dev, SX127X_REG_FRFMSB, (uint8_t)((channel >> 16) & 0xFF));

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -816,7 +816,7 @@ void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
 #else /* MODULE_SX1276 */
     sx127x_reg_write(dev, SX1276_REG_PADAC, pa_dac);
 #endif
-}
+
 
 uint16_t sx127x_get_preamble_length(const sx127x_t *dev)
 {

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -816,7 +816,7 @@ void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
 #else /* MODULE_SX1276 */
     sx127x_reg_write(dev, SX1276_REG_PADAC, pa_dac);
 #endif
-
+}
 
 uint16_t sx127x_get_preamble_length(const sx127x_t *dev)
 {

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -127,7 +127,7 @@ void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
     /* Save current operating mode */
     dev->settings.channel = channel;
 
-    channel = (uint32_t)((double) channel / (double)LORA_FREQUENCY_RESOLUTION_DEFAULT);
+    channel = (uint32_t)((float) channel / (float)LORA_FREQUENCY_RESOLUTION_DEFAULT);
 
     /* Write frequency settings into chip */
     sx127x_reg_write(dev, SX127X_REG_FRFMSB, (uint8_t)((channel >> 16) & 0xFF));
@@ -145,7 +145,7 @@ uint32_t sx127x_get_time_on_air(const sx127x_t *dev, uint8_t pkt_len)
             break;
         case SX127X_MODEM_LORA:
         {
-            double bw = 0.0;
+            float bw = 0.0;
 
             /* Note: When using LoRa modem only bandwidths 125, 250 and 500 kHz are supported. */
             switch (dev->settings.lora.bandwidth) {
@@ -164,27 +164,27 @@ uint32_t sx127x_get_time_on_air(const sx127x_t *dev, uint8_t pkt_len)
             }
 
             /* Symbol rate : time for one symbol [secs] */
-            double rs = bw / (1 << dev->settings.lora.datarate);
-            double ts = 1 / rs;
+            float rs = bw / (1 << dev->settings.lora.datarate);
+            float ts = 1 / rs;
 
             /* time of preamble */
-            double t_preamble = (dev->settings.lora.preamble_len + 4.25) * ts;
+            float t_preamble = (dev->settings.lora.preamble_len + 4.25) * ts;
 
             /* Symbol length of payload and time */
-            double tmp =
+            float tmp =
                 ceil(
                     (8 * pkt_len - 4 * dev->settings.lora.datarate + 28
                      + 16 * (dev->settings.lora.flags & SX127X_ENABLE_CRC_FLAG)
                      - (!(dev->settings.lora.flags & SX127X_ENABLE_FIXED_HEADER_LENGTH_FLAG) ? 20 : 0))
-                    / (double) (4 * dev->settings.lora.datarate
+                    / (float) (4 * dev->settings.lora.datarate
                                 - (((dev->settings.lora.flags & SX127X_LOW_DATARATE_OPTIMIZE_FLAG)
                                     > 0) ? 2 : 0)))
                 * (dev->settings.lora.coderate + 4);
-            double n_payload = 8 + ((tmp > 0) ? tmp : 0);
-            double t_payload = n_payload * ts;
+            float n_payload = 8 + ((tmp > 0) ? tmp : 0);
+            float t_payload = n_payload * ts;
 
             /* Time on air */
-            double t_on_air = t_preamble + t_payload;
+            float t_on_air = t_preamble + t_payload;
 
             /* return milli seconds */
             air_time = floor(t_on_air * 1e3 + 0.999);

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -127,7 +127,8 @@ void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
     /* Save current operating mode */
     dev->settings.channel = channel;
 
-    channel = (uint32_t)((float) channel / (float)LORA_FREQUENCY_RESOLUTION_DEFAULT);
+    /* shift to avoid float division */
+    channel = (uint32_t)( channel << 8 / LORA_FREQUENCY_RESOLUTION_DEFAULT << 8 );
 
     /* Write frequency settings into chip */
     sx127x_reg_write(dev, SX127X_REG_FRFMSB, (uint8_t)((channel >> 16) & 0xFF));

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -120,9 +120,9 @@ void sx1276_rx_chain_calibration(sx127x_t *dev)
 
     /* Save context */
     reg_pa_config_init_val = sx127x_reg_read(dev, SX127X_REG_PACONFIG);
-    initial_freq = (double) (((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
+    initial_freq = (float) (((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
                              | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8)
-                             | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * (double)LORA_FREQUENCY_RESOLUTION_DEFAULT;
+                             | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * (float)LORA_FREQUENCY_RESOLUTION_DEFAULT;
 
     /* Cut the PA just in case, RFO output, power = -1 dBm */
     sx127x_reg_write(dev, SX127X_REG_PACONFIG, 0x00);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Changed some double casts to floats instead, saving a bit of memory.

### Testing procedure

Compiled using the test from `tests/driver_sx127x`.
Tested remotely via IoTLab testbed, where deployment was successful.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes partially #12045 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
