### PR TITLE
makefiles: Disable `-Watomic-alignment` on LLVM

### DIFF
--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -72,6 +72,18 @@ ifneq (,$(TARGET_ARCH))
   CXXINCLUDES += $(GCC_CXX_INCLUDES)
 endif
 
+# For bare metal targets the performance penalty of atomic operations being
+# implemented with library calls is totally insignificant. In case LTO is
+# is enabled, the overhead compared to manually disabling interrupts is fully
+# optimized out (unless atomic operations could be grouped together to a single
+# critical section). So there is - in our use case - no value in having the
+# warning
+CFLAGS += -Wno-atomic-alignment
+
+# For compatibility with older clang versions we also disable warnings on
+# unsupported warning flags:
+CFLAGS += -Wno-unknown-warning-option
+
 OPTIONAL_CFLAGS_BLACKLIST += -fno-delete-null-pointer-checks
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation


### PR DESCRIPTION
### Contribution description

This PR disables `-Watomic-alignment` when build with LLVM.

#### Reasoning

`-Watomic-alignment` warns when C11 atomics have to be implemented via a to one of the functions in `core/atomic_c11.c`. Unlike to the context of Desktop or Server class machines, the performance penalty of this calls is insignificant (and not existing with LTO). So this is not an issue in our context.

On the other hand: Keeping `-Watomic-alignment` prevents building applications using C11 atomics on all platforms the atomic operations are not implemented without calls to `core/atomic_c11.c` (due to `-Werror`), reducing portability.

So not only does the warning is not useful in our context, it actually prevents portable use of C11 atomics. It is the most sensible thing to just disable it.

### Testing procedure

Run `make TOOLCHAIN=llvm BOARD=samd21-xpro -C tests/rmutex/`. It should not work be with current master, but it should with this PR applied.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/12048, supersedes https://github.com/RIOT-OS/RIOT/pull/12122