### PR TITLE
gnrc/netif: don't treat link local differently in prefix matching

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -873,8 +873,7 @@ static int _match_to_idx(const gnrc_netif_t *netif,
             continue;
         }
         match = ipv6_addr_match_prefix(&(netif->ipv6.addrs[i]), addr);
-        if (((match > 64U) || !ipv6_addr_is_link_local(&(netif->ipv6.addrs[i]))) &&
-            (match >= best_match)) {
+        if (match > best_match) {
             idx = i;
             best_match = match;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

[RFC6725](https://tools.ietf.org/html/rfc6724) describes the algorithm for source address selection.
Rule 9 does not state that link-local address should be treated differently.

Previously, GNRC's ```_match_to_idx()``` would always chose the first link-local address, instead of doing a prefix match, in case it was comparing a link-local address.

This PR removes any special handling of link-local addresses from `_match_to_idx()`.

### Testing procedure

Test the shit out of GNRC IP.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

We thing this happened at some point in #11818.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
