### PR TITLE
gnrc_netif: only use prefix matching as tie-breaker in source selection

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -474,7 +474,6 @@ void gnrc_netif_release(gnrc_netif_t *netif)
 }
 
 #ifdef MODULE_GNRC_IPV6
-static inline bool _addr_anycast(const gnrc_netif_t *netif, unsigned idx);
 static int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
@@ -501,9 +500,6 @@ static unsigned _match_to_len(const gnrc_netif_t *netif,
  *
  * @param[in] netif     the network interface
  * @param[in] addr      the address to match
- * @param[in] filter    a bitfield with the bits at the position equal to the
- *                      indexes of the addresses you want to include in the
- *                      search set to one. NULL for all addresses
  *
  * @return  index of the best match for @p addr
  * @return  -1 if no match was found
@@ -511,8 +507,7 @@ static unsigned _match_to_len(const gnrc_netif_t *netif,
  * @pre `netif != NULL` and `addr != NULL`
  */
 static int _match_to_idx(const gnrc_netif_t *netif,
-                        const ipv6_addr_t *addr,
-                        const uint8_t *filter);
+                        const ipv6_addr_t *addr);
 /**
  * @brief Determines the scope of the given address.
  *
@@ -700,7 +695,7 @@ int gnrc_netif_ipv6_addr_match(gnrc_netif_t *netif,
 {
     assert((netif != NULL) && (addr != NULL));
     gnrc_netif_acquire(netif);
-    int idx = _match_to_idx(netif, addr, NULL);
+    int idx = _match_to_idx(netif, addr);
     gnrc_netif_release(netif);
     return idx;
 }
@@ -818,11 +813,6 @@ int gnrc_netif_ipv6_group_idx(gnrc_netif_t *netif, const ipv6_addr_t *addr)
     return idx;
 }
 
-static inline bool _addr_anycast(const gnrc_netif_t *netif, unsigned idx)
-{
-    return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST);
-}
-
 static int _idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr, bool mcast)
 {
     if (!ipv6_addr_is_unspecified(addr)) {
@@ -852,13 +842,12 @@ static unsigned _match_to_len(const gnrc_netif_t *netif,
 {
     assert((netif != NULL) && (addr != NULL));
 
-    int n = _match_to_idx(netif, addr, NULL);
+    int n = _match_to_idx(netif, addr);
     return (n >= 0) ? ipv6_addr_match_prefix(&(netif->ipv6.addrs[n]), addr) : 0;
 }
 
 static int _match_to_idx(const gnrc_netif_t *netif,
-                         const ipv6_addr_t *addr,
-                         const uint8_t *filter)
+                         const ipv6_addr_t *addr)
 {
     assert((netif != NULL) && (addr != NULL));
 
@@ -867,10 +856,7 @@ static int _match_to_idx(const gnrc_netif_t *netif,
     for (int i = 0; i < GNRC_NETIF_IPV6_ADDRS_NUMOF; i++) {
         unsigned match;
 
-        if ((netif->ipv6.addrs_flags[i] == 0) ||
-            ((filter != NULL) && _addr_anycast(netif, i)) ||
-            /* discard const intentionally */
-            ((filter != NULL) && !(bf_isset((uint8_t *)filter, i)))) {
+        if (netif->ipv6.addrs_flags[i] == 0) {
             continue;
         }
         match = ipv6_addr_match_prefix(&(netif->ipv6.addrs[i]), addr);
@@ -884,17 +870,15 @@ static int _match_to_idx(const gnrc_netif_t *netif,
               ipv6_addr_to_str(addr_str, &netif->ipv6.addrs[idx],
                                sizeof(addr_str)),
               netif->pid);
-        DEBUG("%s by %u bits (used as source address = %s)\n",
+        DEBUG("%s by %u bits\n",
               ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
-              best_match,
-              (filter != NULL) ? "true" : "false");
+              best_match);
     }
     else {
         DEBUG("gnrc_netif: Did not found any address on interface %" PRIkernel_pid
-              " matching %s (used as source address = %s)\n",
+              " matching %s\n",
               netif->pid,
-              ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
-              (filter != NULL) ? "true" : "false");
+              ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));
     }
     return idx;
 }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -954,8 +954,19 @@ static int _create_candidate_set(const gnrc_netif_t *netif,
               ipv6_addr_to_str(addr_str, tmp, sizeof(addr_str)));
         /* "In any case, multicast addresses and the unspecified address MUST NOT
          *  be included in a candidate set."
+         *
+         * flags are set if not unspecfied and multicast addresses are in
+         * `netif->ipv6.groups` so not considered here.
          */
         if ((netif->ipv6.addrs_flags[i] == 0) ||
+            /* https://tools.ietf.org/html/rfc4862#section-2:
+             *  A tentative address is not considered assigned to an interface
+             *  in the usual sense.  An interface discards received packets
+             *  addressed to a tentative address, but accepts Neighbor Discovery
+             *  packets related to Duplicate Address Detection for the tentative
+             *  address.
+             *  (so don't consider tentative addresses for source address
+             *  selection) */
             gnrc_netif_ipv6_addr_dad_trans(netif, i)) {
             continue;
         }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1041,24 +1041,16 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
         if (candidate_scope == dst_scope) {
             DEBUG("winner for rule 2 (same scope) found\n");
             winner_set[i] += RULE_2A_PTS;
-            if (winner_set[i] > max_pts) {
-                max_pts = RULE_2A_PTS;
-            }
         }
         else if (candidate_scope < dst_scope) {
             DEBUG("winner for rule 2 (smaller scope) found\n");
             winner_set[i] += RULE_2B_PTS;
-            if (winner_set[i] > max_pts) {
-                max_pts = winner_set[i];
-            }
         }
+
         /* Rule 3: Avoid deprecated addresses. */
         if (_get_state(netif, i) != GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_DEPRECATED) {
             DEBUG("winner for rule 3 found\n");
             winner_set[i] += RULE_3_PTS;
-            if (winner_set[i] > max_pts) {
-                max_pts = winner_set[i];
-            }
         }
 
         /* Rule 4: Prefer home addresses.
@@ -1087,6 +1079,10 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
          * Temporary addresses are currently not supported by gnrc.
          * TODO: update as soon as gnrc supports temporary addresses
          */
+
+        if (winner_set[i] > max_pts) {
+            max_pts = winner_set[i];
+        }
     }
     /* reset candidate set to mark winners */
     memset(candidate_set, 0, (GNRC_NETIF_IPV6_ADDRS_NUMOF + 7) / 8);

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -874,8 +874,7 @@ static int _match_to_idx(const gnrc_netif_t *netif,
             continue;
         }
         match = ipv6_addr_match_prefix(&(netif->ipv6.addrs[i]), addr);
-        if (((match > 64U) || !ipv6_addr_is_link_local(&(netif->ipv6.addrs[i]))) &&
-            (match >= best_match)) {
+        if (match > best_match) {
             idx = i;
             best_match = match;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When source address selection is done, both [RFC](https://tools.ietf.org/html/rfc6724#section-5) and comments in the code state, that a longest prefix match should *only* be used as a tie-breaker between more than one viable candidate. If there is only one address, there is

a) no need for a tie-breaker
b) in the case of either the destination address or the single remaining address being ULAs ([which are considered to be of global scope][RFC4193]) possibly not matching, as `fd00::/7` and e.g. `2001::/8` do not have a common prefix.

(b) in fact causes the match function to return -1, causing the source address selection to return -1, causing the outer function to return the first address it found (which most often is the link-local address), causing e.g. a ping to an ULA to fail, even is there is a global address.

I also piggy-backed a reduction of code duplication (so I can set `idx` just at one point) and added some doc on candidate creation, because some things were unclear to me when I tried to wrap my head around the problem.

[RFC4193]: https://tools.ietf.org/html/rfc4193
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Pinging the link-local address between two native instances should still select the link-local address of the sender (I tested with `examples/gnrc_networking` on `native` and sniffed `tapbr0` while pinging):
  ```
  ifconfig 6 add 2001:db8::1
  ping6 fe80::d826:95ff:fe26:f1d5
  ```
- When merging #12404, pinging `fd00:dead:beef::1` from a `examples/gnrc_networking` node via an `examples/gnrc_border_router` node should still work (after the global addresses are set up on all nodes).
- `make -C tests/gnrc_netif flash test` should still work for a board of your choice and should not work if you revert the fix to the prefix matching:
  - `git revert HEAD~2; git revert HEAD~4; make -C tests/gnrc_netif`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
~~Fixes an issue in source address selection with ULAs becoming obvious in https://github.com/RIOT-OS/RIOT/pull/12404. Required to make https://github.com/RIOT-OS/RIOT/pull/12404 mergable.~~ (#12404 now is included here)

Requires #12425 for address resolution to still work fully (and `tests/gnrc_ipv6_nib` to pass)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
