### PR TITLE
boards/slwstk6000b-*: move CPU_MODEL definition to Makefile.features

### DIFF
--- a/boards/common/slwstk6000b/Makefile.features
+++ b/boards/common/slwstk6000b/Makefile.features
@@ -1,5 +1,5 @@
 CPU = efm32
-# TODO move CPU_MODEL here
+# TODO move CPU_MODEL here based on the daughter board
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc

--- a/boards/common/slwstk6000b/Makefile.include
+++ b/boards/common/slwstk6000b/Makefile.include
@@ -4,8 +4,6 @@ INCLUDES += -I$(RIOTBOARD)/common/slwstk6000b/include
 # add module specific includes
 INCLUDES += -I$(RIOTBOARD)/common/slwstk6000b/modules/$(BOARD_MODULE)/include
 
-export CPU_MODEL = $(MODULE_CPU)
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/slwstk6000b-slwrb4150a/Makefile.features
+++ b/boards/slwstk6000b-slwrb4150a/Makefile.features
@@ -1,1 +1,3 @@
+# HACK this should be deduced from the daughter board in 'common/slwstk6000b'
+CPU_MODEL = efr32mg1p233f256gm48
 include $(RIOTBOARD)/common/slwstk6000b/Makefile.features

--- a/boards/slwstk6000b-slwrb4162a/Makefile.features
+++ b/boards/slwstk6000b-slwrb4162a/Makefile.features
@@ -1,1 +1,3 @@
+# HACK this should be deduced from the daughter board in 'common/slwstk6000b'
+CPU_MODEL = efr32mg12p332f1024gl125
 include $(RIOTBOARD)/common/slwstk6000b/Makefile.features

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -155,9 +155,6 @@ check_cpu_cpu_model_defined_in_makefile_features() {
     pathspec+=(':!boards/**/Makefile.features')
     pathspec+=(':!cpu/**/Makefile.features')
 
-    # Currently blacklist this non migrated file for CPU_MODEL
-    pathspec+=(':!boards/common/slwstk6000b/Makefile.include')
-
     git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
             | error_with_message 'CPU and CPU_MODEL definition must be done by board/BOARD/Makefile.features, board/common/**/Makefile.features or cpu/CPU/Makefile.features'
 }


### PR DESCRIPTION
### Contribution description

This is still currently a hack to hardcode it as the value can be deduced
from the `BOARD_MODULE` daughter board name.

But it requires more cleanup and could come in a separate step.

Part of moving CPU/CPU_MODEL definition to Makefile.features to have it
available before Makefile.include.


There is now no more boards defining `CPU_MODEL` in `Makefile.include`.

### Testing procedure


The value of `CPU_MODEL` and the output of `info-build` stayed the same:

```
for board in slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-CPU_MODEL info-build; done
```

The `dist/tools/buildsystem_sanity_check/check.sh` executes without error (done by CI).

### Issues/PRs references

* Part of Tracking: move CPU/CPU_MODEL to Makefile.features #11477