### PR TITLE
tests: replace SLEEP define

### DIFF
--- a/tests/driver_ad7746/main.c
+++ b/tests/driver_ad7746/main.c
@@ -25,7 +25,7 @@
 #include "ad7746.h"
 #include "ad7746_params.h"
 
-#define SLEEP       (1000 * US_PER_MS)
+#define SLEEP_USEC  (1000 * US_PER_MS)
 
 static ad7746_t dev;
 
@@ -84,7 +84,7 @@ int main(void)
             printf("Error reading internal temperature\n");
         }
         puts("");
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_adcxx1c/main.c
+++ b/tests/driver_adcxx1c/main.c
@@ -24,7 +24,7 @@
 #include "adcxx1c.h"
 #include "adcxx1c_params.h"
 
-#define SLEEP       (100 * US_PER_MS)
+#define SLEEP_USEC  (100 * US_PER_MS)
 
 static adcxx1c_t dev;
 
@@ -62,7 +62,7 @@ int main(void)
     while (1) {
         adcxx1c_read_raw(&dev, &data);
         printf("Raw analog value: %d\n", data);
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_ads101x/main.c
+++ b/tests/driver_ads101x/main.c
@@ -27,7 +27,7 @@
 #include "ads101x_params.h"
 #include "ads101x_regs.h"
 
-#define SLEEP       (100 * US_PER_MS)
+#define SLEEP_USEC  (100 * US_PER_MS)
 
 static ads101x_t dev;
 static ads101x_alert_t alert_dev;
@@ -117,7 +117,7 @@ int main(void)
 
         puts("");
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_hdc1000/main.c
+++ b/tests/driver_hdc1000/main.c
@@ -27,7 +27,7 @@
 #include "hdc1000.h"
 #include "hdc1000_params.h"
 
-#define SLEEP       (1000 * 1000U)
+#define SLEEP_USEC  (1000 * 1000U)
 
 int main(void)
 {
@@ -57,7 +57,7 @@ int main(void)
         hstr[len] = '\0';
         printf("Reading: T: %s °C  RH: %s %%\n", tstr, hstr);
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_ina220/main.c
+++ b/tests/driver_ina220/main.c
@@ -40,7 +40,7 @@
 #define CONFIG   (INA220_MODE_CONTINUOUS_SHUNT_BUS | INA220_RANGE_320MV | \
                   INA220_BRNG_32V_FSR | INA220_SADC_12BIT | INA220_BADC_12BIT)
 #define CALIBRATION (4096)
-#define SLEEP    (100 * 1000U)
+#define SLEEP_USEC    (100 * 1000U)
 
 int main(void)
 {
@@ -95,7 +95,7 @@ int main(void)
         ina220_read_power(&dev, &val);
         printf("\tpower: %6d\n", val);
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_isl29020/main.c
+++ b/tests/driver_isl29020/main.c
@@ -24,7 +24,7 @@
 #include "isl29020.h"
 #include "isl29020_params.h"
 
-#define SLEEP       (250 * 1000U)
+#define SLEEP_USEC  (250 * 1000U)
 
 int main(void)
 {
@@ -42,7 +42,7 @@ int main(void)
 
     while (1) {
         printf("Light value: %5i LUX\n", isl29020_read(&dev));
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_isl29125/main.c
+++ b/tests/driver_isl29125/main.c
@@ -28,7 +28,7 @@
 #include "isl29125.h"
 #include "isl29125_params.h"
 
-#define SLEEP       (250 * 1000U)
+#define SLEEP_USEC  (250 * 1000U)
 
 void cb(void *arg)
 {
@@ -79,7 +79,7 @@ int main(void)
     for (size_t i = 0; i < ARRAY_SIZE(modes); i++) {
         printf("Setting mode %s\n", mode_names[i]);
         isl29125_set_mode(&dev, modes[i]);
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
         isl29125_read_rgb_color(&dev, &data8bit);
         printf("RGB value: (%3i / %3i / %3i) 8 bit\n",
                 data8bit.r, data8bit.g, data8bit.b);
@@ -87,12 +87,12 @@ int main(void)
 
     puts("Resetting mode to RGB and reading continuously");
     isl29125_set_mode(&dev, ISL29125_MODE_RGB);
-    xtimer_usleep(SLEEP);
+    xtimer_usleep(SLEEP_USEC);
     while (1) {
         isl29125_read_rgb_lux(&dev, &data);
         printf("RGB value: (%5i / %5i / %5i) lux\n",
                 (int)data.red, (int)data.green, (int)data.blue);
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
         printf("IRQ-Status: %i \n", isl29125_read_irq_status(&dev));
     }
 

--- a/tests/driver_l3g4200d/main.c
+++ b/tests/driver_l3g4200d/main.c
@@ -24,7 +24,7 @@
 #include "l3g4200d.h"
 #include "l3g4200d_params.h"
 
-#define SLEEP       (100 * 1000U)
+#define SLEEP_USEC  (100 * 1000U)
 
 int main(void)
 {
@@ -47,7 +47,7 @@ int main(void)
         printf("Gyro data [dps] - X: %6i   Y: %6i   Z: %6i\n",
                acc_data.acc_x, acc_data.acc_y, acc_data.acc_z);
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_lis3dh/main.c
+++ b/tests/driver_lis3dh/main.c
@@ -27,7 +27,7 @@
 #include "lis3dh_params.h"
 
 
-#define SLEEP       (100 * 1000U)
+#define SLEEP_USEC  (100 * 1000U)
 
 #define WATERMARK_LEVEL 16
 
@@ -145,7 +145,7 @@ int main(void)
             --fifo_level;
         }
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_lis3mdl/main.c
+++ b/tests/driver_lis3mdl/main.c
@@ -25,7 +25,7 @@
 #include "lis3mdl.h"
 #include "lis3mdl_params.h"
 
-#define SLEEP       (800 * 800U)
+#define SLEEP_USEC  (800 * 800U)
 
 int main(void)
 {
@@ -54,7 +54,7 @@ int main(void)
         lis3mdl_read_temp(&dev, &temp_value);
         printf("Temperature:\t\t%i°C\n", temp_value);
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_lsm303dlhc/main.c
+++ b/tests/driver_lsm303dlhc/main.c
@@ -24,7 +24,7 @@
 #include "lsm303dlhc.h"
 #include "lsm303dlhc_params.h"
 
-#define SLEEP       (100 * 1000U)
+#define SLEEP_USEC  (100 * 1000U)
 
 int main(void)
 {
@@ -70,7 +70,7 @@ int main(void)
             puts("\nFailed reading magnetometer values\n");
         }
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_lsm6dsl/main.c
+++ b/tests/driver_lsm6dsl/main.c
@@ -26,7 +26,7 @@
 #include "lsm6dsl.h"
 #include "lsm6dsl_params.h"
 
-#define SLEEP       (500UL * US_PER_MS)
+#define SLEEP_USEC  (500UL * US_PER_MS)
 
 int main(void)
 {
@@ -95,7 +95,7 @@ int main(void)
         }
 
         puts("");
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_mag3110/main.c
+++ b/tests/driver_mag3110/main.c
@@ -30,7 +30,7 @@
 #include "mag3110.h"
 #include "mag3110_params.h"
 
-#define SLEEP       (1U * US_PER_SEC)
+#define SLEEP_USEC  (1U * US_PER_SEC)
 
 static mag3110_t dev;
 
@@ -49,7 +49,7 @@ int main(void)
     puts("[SUCCESS]");
 
     while (1) {
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
         mag3110_read(&dev, &data);
         printf("Field strength: X: %d Y: %d Z: %d\n", data.x, data.y, data.z);
         mag3110_read_dtemp(&dev, &temp);

--- a/tests/driver_mma7660/main.c
+++ b/tests/driver_mma7660/main.c
@@ -24,7 +24,7 @@
 #include "mma7660.h"
 #include "mma7660_params.h"
 
-#define SLEEP       (100 * US_PER_MS)
+#define SLEEP_USEC  (100 * US_PER_MS)
 
 static mma7660_t dev;
 
@@ -47,7 +47,7 @@ int main(void)
         mma7660_read(&dev, &data);
         printf("Acceleration [in mg]: X: %d Y: %d Z: %d\n",
                data.x, data.y, data.z);
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_mma8x5x/main.c
+++ b/tests/driver_mma8x5x/main.c
@@ -26,7 +26,7 @@
 #include "mma8x5x.h"
 #include "mma8x5x_params.h"
 
-#define SLEEP       (100 * 1000U)
+#define SLEEP_USEC  (100 * 1000U)
 
 static mma8x5x_t dev;
 
@@ -50,7 +50,7 @@ int main(void)
         mma8x5x_read(&dev, &data);
         printf("Acceleration [in mg]: X: %d Y: %d Z: %d\n",
                 data.x, data.y, data.z);
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_mpl3115a2/main.c
+++ b/tests/driver_mpl3115a2/main.c
@@ -27,7 +27,7 @@
 #include "mpl3115a2.h"
 #include "mpl3115a2_params.h"
 
-#define SLEEP       (1UL * US_PER_SEC)
+#define SLEEP_USEC  (1UL * US_PER_SEC)
 static mpl3115a2_t dev;
 
 int main(void)
@@ -50,7 +50,7 @@ int main(void)
         uint32_t pressure;
         int16_t temp;
         uint8_t status;
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
         if ((mpl3115a2_read_pressure(&dev, &pressure, &status) |
              mpl3115a2_read_temp(&dev, &temp)) != MPL3115A2_OK) {
             puts("[FAILED] read values!");

--- a/tests/driver_mpu9150/main.c
+++ b/tests/driver_mpu9150/main.c
@@ -27,7 +27,7 @@
 #include "mpu9150.h"
 #include "mpu9150_params.h"
 
-#define SLEEP   (1000 * 1000u)
+#define SLEEP_USEC   (1000 * 1000u)
 
 int main(void)
 {
@@ -90,7 +90,7 @@ int main(void)
         printf("Temperature [milli deg] : %"PRId32"\n", temperature);
         printf("\n+-------------------------------------+\n");
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_pulse_counter/main.c
+++ b/tests/driver_pulse_counter/main.c
@@ -23,7 +23,7 @@
 #include "xtimer.h"
 #include "pulse_counter_params.h"
 
-#define SLEEP       US_PER_SEC
+#define SLEEP_USEC  US_PER_SEC
 
 int main(void)
 {
@@ -45,7 +45,7 @@ int main(void)
         int16_t count = pulse_counter_read_with_reset(&dev);
         printf("pulse counter: %d\n", count);
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;

--- a/tests/driver_srf08/main.c
+++ b/tests/driver_srf08/main.c
@@ -38,7 +38,7 @@
 #include "srf08.h"
 #include "periph/i2c.h"
 
- #define SLEEP       (1000 * 1000U)
+ #define SLEEP_USEC  (1000 * 1000U)
 
  static srf08_t srf08_0;
 
@@ -76,7 +76,7 @@ int main(void)
             else {
                 puts("An error occured");
             }
-            xtimer_usleep(SLEEP);
+            xtimer_usleep(SLEEP_USEC);
         }
     }
 }

--- a/tests/driver_tcs37727/main.c
+++ b/tests/driver_tcs37727/main.c
@@ -26,7 +26,7 @@
 #include "tcs37727.h"
 #include "tcs37727_params.h"
 
-#define SLEEP       (1 * US_PER_SEC)
+#define SLEEP_USEC  (1 * US_PER_SEC)
 
 int main(void)
 {
@@ -51,7 +51,7 @@ int main(void)
         printf("CT : %5"PRIu32" Lux: %6"PRIu32" AGAIN: %2d ATIME %"PRIu32"\n",
                data.ct, data.lux, dev.again, dev.p.atime);
 
-        xtimer_usleep(SLEEP);
+        xtimer_usleep(SLEEP_USEC);
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description

The `SLEEP` define collides with an Atmega header file, so all those tests will fail to build for #12411
This renames the defines to resolve the conflict.

### Testing procedure

No semantic changes, so compile test should be enough.

### Issues/PRs references
fixes build failures for #12411
