### PR TITLE
tools/compile_and_test_for_board: allow setting the flash targets

### DIFF
--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -38,6 +38,7 @@ usage: compile_and_test_for_board.py [-h] [--applications APPLICATIONS]
                                      [--loglevel {debug,info,warning,error,fatal,critical}]
                                      [--incremental] [--clean-after]
                                      [--compile-targets COMPILE_TARGETS]
+                                     [--flash-targets FLASH_TARGETS]
                                      [--test-targets TEST_TARGETS]
                                      [--test-available-targets TEST_AVAILABLE_TARGETS]
                                      [--jobs JOBS]
@@ -68,6 +69,8 @@ optional arguments:
   --clean-after         Clean after running each test (default: False)
   --compile-targets COMPILE_TARGETS
                         List of make targets to compile (default: clean all)
+  --flash-targets FLASH_TARGETS
+                        List of make targets to flash (default: flash-only)
   --test-targets TEST_TARGETS
                         List of make targets to run test (default: test)
   --test-available-targets TEST_AVAILABLE_TARGETS
@@ -192,6 +195,7 @@ class RIOTApplication():
     MAKEFLAGS = ('RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory')
 
     COMPILE_TARGETS = ('clean', 'all',)
+    FLASH_TARGETS = ('flash-only',)
     TEST_TARGETS = ('test',)
     TEST_AVAILABLE_TARGETS = ('test/available',)
 
@@ -332,7 +336,7 @@ class RIOTApplication():
         if runtest:
             if has_test:
                 setuptasks = collections.OrderedDict(
-                    [('flash', ['flash-only'])])
+                    [('flash', self.FLASH_TARGETS)])
                 self.make_with_outfile('test', self.TEST_TARGETS,
                                        save_output=True, setuptasks=setuptasks)
                 if clean_after:
@@ -581,6 +585,9 @@ PARSER.add_argument('--clean-after', action='store_true', default=False,
 PARSER.add_argument('--compile-targets', type=list_from_string,
                     default=' '.join(RIOTApplication.COMPILE_TARGETS),
                     help='List of make targets to compile')
+PARSER.add_argument('--flash-targets', type=list_from_string,
+                    default=' '.join(RIOTApplication.FLASH_TARGETS),
+                    help='List of make targets to flash')
 PARSER.add_argument('--test-targets', type=list_from_string,
                     default=' '.join(RIOTApplication.TEST_TARGETS),
                     help='List of make targets to run test')
@@ -620,6 +627,7 @@ def main():
 
     # Overwrite the compile/test targets from command line arguments
     RIOTApplication.COMPILE_TARGETS = args.compile_targets
+    RIOTApplication.FLASH_TARGETS = args.flash_targets
     RIOTApplication.TEST_TARGETS = args.test_targets
     RIOTApplication.TEST_AVAILABLE_TARGETS = args.test_available_targets
 


### PR DESCRIPTION
### Contribution description

This allow configuring the flash targets in the same way as the
compilation and test targets.

This is part of trying to flash with docker using a different flash target.


### Testing procedure

The flash targets can be overwritten from command line:
See `'flash', 'reset'` in the output.

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --loglevel debug . native --applications=tests/bloom_bytes --flash-targets="flash reset"
INFO:native:Saving toolchain
DEBUG:native:board: native
DEBUG:native:app_dirs: ['tests/bloom_bytes']
DEBUG:native:resultdir: results
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'info-boards-supported'] ENV {'BOARDS': 'native', 'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Board supported: True
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'info-debug-variable-BOARD_INSUFFICIENT_MEMORY'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Board has enough memory: True
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'test/available'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Application has test: True
INFO:native.tests/bloom_bytes:Run compilation
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'clean', 'all'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Run test
INFO:native.tests/bloom_bytes:Run test.flash
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'flash', 'reset'] ENV {'BOARD': 'native'}
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'test'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Success
INFO:native:Tests successful
```

The previous behavior is kept to use 'flash-only' by default:

See `'flash-only'` in the output.

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py --loglevel debug . native --applications=tests/bloom_bytes 
INFO:native:Saving toolchain
DEBUG:native:board: native
DEBUG:native:app_dirs: ['tests/bloom_bytes']
DEBUG:native:resultdir: results
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'info-boards-supported'] ENV {'BOARDS': 'native', 'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Board supported: True
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'info-debug-variable-BOARD_INSUFFICIENT_MEMORY'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Board has enough memory: True
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'test/available'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Application has test: True
INFO:native.tests/bloom_bytes:Run compilation
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'clean', 'all'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Run test
INFO:native.tests/bloom_bytes:Run test.flash
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'flash-only'] ENV {'BOARD': 'native'}
DEBUG:native.tests/bloom_bytes:['make', 'RIOT_CI_BUILD=1', 'CC_NOCOLOR=1', '--no-print-directory', '-C', './tests/bloom_bytes', 'test'] ENV {'BOARD': 'native'}
INFO:native.tests/bloom_bytes:Success
INFO:native:Tests successful
```

Running `tox` in `dist/tools/compile_and_test_for_board/` works without error

```
cd dist/tools/compile_and_test_for_board/; tox
...
  test: commands succeeded
  lint: commands succeeded
  flake8: commands succeeded
  congratulations :)
```

### Issues/PRs references

Part of trying to do:
* Flashing and testing in docker #11220  
* [WIP] Fixes to compile using DOCKER and flash boards without local toolchain #10870