### PR TITLE
boards/common/nucleo: Marked board_init as weak

### DIFF
--- a/boards/common/nucleo/board_common_nucleo_init.c
+++ b/boards/common/nucleo/board_common_nucleo_init.c
@@ -29,9 +29,10 @@
  */
 
 #include "board.h"
+#include "board_nucleo.h"
 #include "periph/gpio.h"
 
-void board_init(void)
+void board_common_nucleo_init(void)
 {
     /* initialize the CPU */
     cpu_init();
@@ -47,4 +48,14 @@ void board_init(void)
 #ifdef LED2_PIN
     gpio_init(LED2_PIN, GPIO_OUT);
 #endif
+}
+
+/*
+ * Allow overwriting board_init if common implementation doesn't work.
+ * If at link time another implementation of board_init() not marked as weak
+ * ((a.k.a. a strong symbol) is present, it will be linked in instead.
+ */
+void __attribute__((weak)) board_init(void)
+{
+    board_common_nucleo_init();
 }

--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -58,6 +58,11 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Common board initialization routine for Nucleo boards
+ */
+void board_common_nucleo_init(void);
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);


### PR DESCRIPTION
### Contribution description

Made `void board_init(void)` in the common implementation a weak symbol to allow providing a custom board init, if the common nucleo board init misses features.

The testbed nodes developed here at the University in Magdeburg ([presented at the RIOT summit](https://www.youtube.com/watch?v=kcJnExd2NHQ)) are based on a Nucleo, but require a custom init routine for the initialization of the attached hardware.

### Testing procedure

Initialization on the nucleos should work. In fact, the generated binaries should not change.

### Issues/PRs references

None