### PR TITLE
Stm32f103 use pa13 pa14 as gpio

### DIFF
--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -98,6 +98,16 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     }
 #endif
 
+#ifdef BOARD_BLUEPILL
+    /* disable SWJ to allow using the pin as IO
+       this may also work on other f103 based boards but it was only tested on
+       bluepill */
+    if ((pin_num == 13 || pin_num == 14) && _port_num(pin) == 0) {
+        RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
+        AFIO->MAPR |= AFIO_MAPR_SWJ_CFG_DISABLE;
+    }
+#endif
+
     /* set pin mode */
     port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
     port->CR[pin_num >> 3] |=  ((mode & MODE_MASK) << ((pin_num & 0x7) * 4));

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -113,10 +113,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     port->CR[pin_num >> 3] |=  ((mode & MODE_MASK) << ((pin_num & 0x7) * 4));
 
     /* set ODR */
-    if (mode == GPIO_IN_PU)
+    if (mode == GPIO_IN_PU) {
         port->ODR |= 1 << pin_num;
-    else
+    }
+    else {
         port->ODR &= ~(1 << pin_num);
+    }
 
     return 0; /* all OK */
 }
@@ -242,6 +244,7 @@ void isr_exti(void)
 {
     /* only generate interrupts against lines which have their IMR set */
     uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
+
     for (unsigned i = 0; i < GPIO_ISR_CHAN_NUMOF; i++) {
         if (pending_isr & (1 << i)) {
             EXTI->PR = (1 << i);        /* clear by writing a 1 */


### PR DESCRIPTION
### Contribution description
Add the ability to use pin PA13 and PA14 as GPIO
Disable SWJ to allow using the pin as IO

### Testing procedure

Steps to test your contribution:
- use test tests/periph_gpio with board bluepill 
- use command "init_out 0 13" and "init_out 0 14" to init pin as GPIO
- use command "toggle 0 13" and "toggle 0 14" to toggle pin level.

How to know that it was not working/available in master:
the pin level don't change (stuck in SWIO and  SWCLK mode) when using the test tests/periph_gpio

The expected success test output:
the pin level of pin PA13 is toggle each time the test command "toggle 0 13" is entered
the pin level of pin PA14 is toggle each time the test command "toggle 0 14" is entered
connect a led to the pin is an easy way to display the result.
