### PR TITLE
Makefile.features: assert CPU is defined by BOARD/Makefile.features

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -5,12 +5,8 @@ OLD_USEPKG := $(sort $(USEPKG))
 # include board dependencies
 -include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 
-# Transitional conditional include until all boards define 'CPU' in
-# Makefile.features
-ifneq (,$(CPU))
-  # include cpu dependencies
-  -include $(RIOTCPU)/$(CPU)/Makefile.dep
-endif
+# include cpu dependencies
+-include $(RIOTCPU)/$(CPU)/Makefile.dep
 
 # include external modules dependencies
 # processed before RIOT ones to be evaluated before the 'default' rules.

--- a/Makefile.features
+++ b/Makefile.features
@@ -5,18 +5,14 @@
 # This makes them available when setting features based on CPU_MODEL in the cpu
 # Makefile.features and also during dependency resolution.
 
-# Transition:
-#   Moving 'CPU/CPU_MODEL' to Makefile.features is an ongoing work and may not
-#   reflect the state of all boards for the moment.
-
 include $(RIOTBOARD)/$(BOARD)/Makefile.features
 
-# Transitional conditional include until all boards define 'CPU'
-ifneq (,$(CPU))
-  include $(RIOTCPU)/$(CPU)/Makefile.features
-else
-  $(warning CPU must be defined by board / board_common Makefile.features)
+# Sanity check
+ifeq (,$(CPU))
+  $(error CPU must be defined by board / board_common Makefile.features)
 endif
+
+include $(RIOTCPU)/$(CPU)/Makefile.features
 
 
 # Resolve FEATURES_ variables

--- a/Makefile.include
+++ b/Makefile.include
@@ -298,13 +298,6 @@ include $(RIOTBOARD)/$(BOARD)/Makefile.include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
-# Sanity check
-# The check is only done after 'include $(RIOTBOARD)/$(BOARD)/Makefile.include'
-# because we need to have the 'CPU' variable defined
-ifeq (,$(filter $(RIOTCPU)/$(CPU)/Makefile.features,$(MAKEFILE_LIST)))
-  $(error $$(RIOTCPU)/$$(CPU)/Makefile.features must have been included by the board / board common Makefile.features or Makefile.features)
-endif
-
 # Assume GCC/GNU as supported toolchain if CPU's Makefile.include doesn't
 # provide this macro
 TOOLCHAINS_SUPPORTED ?= gnu


### PR DESCRIPTION
### Contribution description

CPU must now be defined by `$(RIOTBOARD)/$(BOARD)/Makefile.features` or
one of its common included Makefile.features file.
The cpu `Makefile.dep` file can now automatically be included when it exists.

This now forbids the previous scheme, but with an error message explaining what to do, and updating would still be compatible with a previous version too.

It was just not the good time to do it before the release.

### Testing procedure

All boards in RIOT already define `CPU` as checked by `dist/tools/build_system_sanity_check/check.sh` and the error are not raised when parsing the makefiles.

```
for board in $(make info-boards); do BOARD=${board} make --no-print-directory -C examples/hello-world/ clean; done
```

If I comment the `CPU` line in `boards/samr21-xpro/Makefile.features` then it raises an error.

```
BOARD=samr21-xpro make --no-print-directory -C examples/hello-world/ clean
/home/harter/work/git/RIOT/Makefile.features:12: *** CPU must be defined by board / board_common Makefile.features.  Stop.
```

### Issues/PRs references

Finalization of the migration done by https://github.com/RIOT-OS/RIOT/pull/11477
https://github.com/RIOT-OS/RIOT/pull/11477#issuecomment-540466065

Depends on release 2019.10
