### PR TITLE
[Tracking] makefiles/docker: add docker/% targets

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -302,3 +302,5 @@ docker_run_make = \
 ..in-docker-container:
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Launching build container using image "$(DOCKER_IMAGE)".$(COLOR_RESET)'
 	$(call docker_run_make,$(DOCKER_MAKECMDGOALS),$(DOCKER_IMAGE),,$(DOCKER_MAKE_ARGS))
+
+include $(RIOTMAKE)/docker/dockertargets.inc.mk

--- a/makefiles/docker/dockertargets.inc.mk
+++ b/makefiles/docker/dockertargets.inc.mk
@@ -1,0 +1,80 @@
+# TODO
+#        - All code in this section move to common
+#        - docker common, refactoring
+#        - first document only in advanced-build-system-tricks until mature
+#        - We do not care for handling `clean` and other targets in parallel
+
+DOCKER_USER ?= $$(id -u)
+
+DOCKER_RUN_FLAGS ?= --rm --tty --user $(DOCKER_USER)
+
+docker_run_make = \
+	$(DOCKER) run $(DOCKER_RUN_FLAGS) \
+	$(DOCKER_VOLUMES_AND_ENV) \
+	$(DOCKER_ENVIRONMENT_CMDLINE) \
+	$3 \
+	-w '$(DOCKER_APPDIR)' '$2' \
+	make $(DOCKER_OVERRIDE_CMDLINE) $4 $1
+
+# currently the BOARD is not always passed to docker, we always want to
+DOCKER_ENVIRONMENT_CMDLINE += --env BOARD=$(BOARD)
+
+################################################################################
+
+# TODO: is it a good separator?
+DOCKER_TARGET_SEPARATOR ?= __
+
+# TODO:
+#       - DOCKER_IMAGE should execute 32bit for native
+#       - DOCKER_IMAGE needs native toolchain for flashing
+#       - DOCKER_IMAGE general cleanup
+#       - Should it be an extension of riot/riotbuild
+#       - IPV6?
+# HACK:
+#       - currently riot/riotbuild is enough to test native samr21-xpro
+# DOCKER_TARGET_IMAGE ?= riot/riotflash:latest
+DOCKER_TARGET_IMAGE ?= $(DOCKER_IMAGE)
+
+# TODO:
+#       - fedora doesn't have this
+#       - how to handle in winows & mac
+DOCKER_TARGET_GROUPS ?= dialout plugdev
+
+# Unless using --privileged every device we want the container to have acces
+# must me mapped. PORT maps the serial device and PROG_DEV maps the serial
+# device, these are usually not the same.
+DOCKER_TARGET_PORT_VARS ?= PROG_DEV PORT
+DOCKER_TARGET_ENVIRONMENT += $(foreach var,$(DOCKER_TARGET_PORT_VARS),--env $(var)=$(realpath $($(var))))
+
+# TODO:
+#       - Add SERIAL_TERM, SERIAL_PROG
+#       - Migrate all SERIAL_* to SERIAL_TERM, SERIAL_PROG
+DOCKER_TARGET_SERIAL_VARS ?= SERIAL DEBUG_ADAPTER_ID JLINK_SERIAL
+DOCKER_TARGET_ENVIRONMENT += $(foreach var,$(DOCKER_TARGET_SERIAL_VARS),--env $(var)=$($(var)))
+
+# Export device variables for the target BOARD to docker
+DOCKER_TARGET_FLAGS += $(DOCKER_TARGET_ENVIRONMENT)
+
+# Need interactive for term
+DOCKER_TARGET_FLAGS += --interactive
+
+# This will map all /dev to the container, should not be needed
+# DOCKER_TARGET_VOLUMES ?= $(call docker_volume,/dev,/dev)
+# DOCKER_TARGET_FLAGS += $(DOCKER_TARGET_VOLUMES)
+
+# --privileged can be added to succeed in any case without groups, /dev, device configuration
+# DOCKER_TARGET_FLAGS += --privileged
+DOCKER_TARGET_FLAGS += $(addprefix --group-add ,$(DOCKER_TARGET_GROUPS))
+DOCKER_TARGET_FLAGS += $(foreach var,$(DOCKER_TARGET_PORT_VARS),$(call map_existing_device,$($(var))))
+map_existing_device = $(addprefix --device=,$(wildcard $1))
+
+# Allow setting make args from command line like '-j'
+DOCKER_TARGET_MAKE_ARGS ?=
+
+.PHONY: docker/%
+
+# Use a separator to execute multiple targets on the same container.
+DOCKER_TARGET_TARGETS = $(subst $(DOCKER_TARGET_SEPARATOR), ,$*)
+
+docker/%:
+	$(call docker_run_make,$(DOCKER_TARGET_TARGETS),$(DOCKER_TARGET_IMAGE),$(DOCKER_TARGET_FLAGS),$(DOCKER_TARGET_MAKE_ARGS))

--- a/makefiles/docker/dockertargets.inc.mk
+++ b/makefiles/docker/dockertargets.inc.mk
@@ -1,20 +1,6 @@
-# TODO
-#        - All code in this section move to common
-#        - docker common, refactoring
-#        - first document only in advanced-build-system-tricks until mature
+# TODO:
+#        - First document only in advanced-build-system-tricks until mature
 #        - We do not care for handling `clean` and other targets in parallel
-
-DOCKER_USER ?= $$(id -u)
-
-DOCKER_RUN_FLAGS ?= --rm --tty --user $(DOCKER_USER)
-
-docker_run_make = \
-	$(DOCKER) run $(DOCKER_RUN_FLAGS) \
-	$(DOCKER_VOLUMES_AND_ENV) \
-	$(DOCKER_ENVIRONMENT_CMDLINE) \
-	$3 \
-	-w '$(DOCKER_APPDIR)' '$2' \
-	make $(DOCKER_OVERRIDE_CMDLINE) $4 $1
 
 # currently the BOARD is not always passed to docker, we always want to
 DOCKER_ENVIRONMENT_CMDLINE += --env BOARD=$(BOARD)
@@ -37,7 +23,7 @@ DOCKER_TARGET_IMAGE ?= $(DOCKER_IMAGE)
 
 # TODO:
 #       - fedora doesn't have this
-#       - how to handle in winows & mac
+#       - how to handle in windows & mac
 DOCKER_TARGET_GROUPS ?= dialout plugdev
 
 # Unless using --privileged every device we want the container to have acces


### PR DESCRIPTION
### Contribution description

This PR adds `docker/%` targets to be able to `flash` and `tests` in docker. It is still WIP but wanted to PR early so it can be tested (firstly in @cladmi and my one "paper-ci"). There is also the first section of common code that can be merged early (after release).

**TODO**:

- [x] add `PROG_DEV`, `/dev` used for programming
- [ ] add `SERIAL_ID` for serial device (could be different from programmer)
- [ ] add docker image with flash tools
- [ ] documentation on how to map devices

### Testing procedure

Try flashing, testing on a target. The easy way of testing is just passing `DOCKER_TARGET_FLAGS=--privileged`.

To be done properly for most boards a `PROG_PORT` must be passed to docker to map the `device` used for flashing. I don't yet understand in detail which one, but in the case of  `samr21-xpro` it is `/dev/hidraw*` but for `mulle` is `/dev/bus/usb/001/065`

I was able to find the device by doing:

```
udevadm monitor -ukp | grep DEVNAME

DEVNAME=/dev/bus/usb/001/065
DEVNAME=/dev/usb/hiddev4
DEVNAME=/dev/hidraw6
DEVNAME=/dev/ttyACM0
DEVNAME=/dev/bus/usb/001/065
DEVNAME=/dev/bus/usb/001/065
```

For `native` and `samr21-xpro` (or other boards using `edbg`) this can be done without the need of aditional flash-tools since `riot/riotbuild` is capable of building `edbg` and has `pyserial`.

If wanting to test on other toolchains I have a very WIP and dirty `Dockerfile` to build https://github.com/fjmolinas/riotdocker/blob/riot/Dockerfile.build.flash an Image with all flashing toolchains (or most of them).

```
docker build -t riot/riotflash -f Dockerfile.build.flash .
```

```
PROG_PORT=/dev/bus/usb/001/062 DOCKER_TARGET_IMAGE=riot/riotbuildflash BOARD=mulle make -C examples/default/ docker/flash-only docker/term
```

### Issues/PRs references

Alternative to #11220.
