### PR TITLE
sys/hashes/sha256: fix typo in docu

### DIFF
--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -176,7 +176,7 @@ const void *hmac_sha256(const void *key, size_t key_length,
                         const void *data, size_t len, void *digest);
 
 /**
- * @brief function to produce a hash chain statring with a given seed element.
+ * @brief function to produce a hash chain starting with a given seed element.
  *        The chain is computed by taking the sha256 from the seed,
  *        hash the resulting sha256 and continuing taking sha256
  *        from each result consecutively.
@@ -193,7 +193,7 @@ void *sha256_chain(const void *seed, size_t seed_length,
                    size_t elements, void *tail_element);
 
 /**
- * @brief function to produce a hash chain statring with a given seed element.
+ * @brief function to produce a hash chain starting with a given seed element.
  *        The chain is computed the same way as done with sha256_chain().
  *        Additionally intermediate elements are saved while computing the chain.
  *        This slows down computation, but provides the caller with indexed


### PR DESCRIPTION

### Contribution description
fixed a tiny typo in documentation i noticed
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
read
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
no
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
