### PR TITLE
ccn-lite: introduce feature and use in examples

### DIFF
--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -7,3 +7,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += ccn-lite

--- a/boards/iotlab-m3/Makefile.features
+++ b/boards/iotlab-m3/Makefile.features
@@ -1,3 +1,4 @@
 include $(RIOTBOARD)/common/iotlab/Makefile.features
 
 FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += ccn-lite

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -5,5 +5,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += ccn-lite
 
 include $(RIOTBOARD)/common/msba2/Makefile.features

--- a/boards/mulle/Makefile.features
+++ b/boards/mulle/Makefile.features
@@ -18,3 +18,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += ccn-lite

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -7,6 +7,7 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_qdec
+FEATURES_PROVIDED += ccn-lite
 
 # Various other features (if any)
 FEATURES_PROVIDED += ethernet

--- a/boards/nrf52840dk/Makefile.features
+++ b/boards/nrf52840dk/Makefile.features
@@ -6,3 +6,4 @@ include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features
 FEATURES_PROVIDED += radio_nrf802154
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += ccn-lite

--- a/boards/nrf52dk/Makefile.features
+++ b/boards/nrf52dk/Makefile.features
@@ -1,3 +1,5 @@
 CPU_MODEL = nrf52832xxaa
 
+FEATURES_PROVIDED += ccn-lite
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features

--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -13,6 +13,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += ccn-lite
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -11,6 +11,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += ccn-lite
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -3,10 +3,6 @@ APPLICATION = ccn-lite-relay
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
 
-BOARD_WHITELIST := fox iotlab-m3 msba2 mulle native nrf52dk nrf52840dk \
-                   pba-d-01-kw2x samr21-xpro
-
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
@@ -37,5 +33,7 @@ USEMODULE += gnrc_pktdump
 USEMODULE += prng_xorshift
 
 USEPKG += ccn-lite
+
+FEATURES_REQUIRED += ccn-lite
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This introduces a new feature `ccn-lite` which is added to board that are currently whitelisted in `examples/ccn-lite-relay`. Also this removes the whitelist from the said examples and uses `FEATURES_REQUIRED += ccn-lite` instead. 

This PR should only serve as an example on how to get rid of the boards whitelists and blacklists we currently use, and use features mechanism instead. Applied throughout the build system this should remove the hassle of updating board lists - at least white and black lists. 


### Testing procedure

Build `examples/ccn-lite-relay` for e.g. `samr21-xpro` and `nucleo-f411re` with this PR and on master it should work without warning for the former and should give a warning for the latter board.
Though the warnings will differ, the outcome is the same.

Also verify that `make -C examples/ccn-lite-relay info-boards-supported` has the same output on
this PR and master.


### Issues/PRs references

partly replaces #12406