### PR TITLE
examples/timer_periodic_wakeup: no feature required

### DIFF
--- a/examples/timer_periodic_wakeup/Makefile
+++ b/examples/timer_periodic_wakeup/Makefile
@@ -9,6 +9,4 @@ QUIET ?= 1
 # development process:
 DEVELHELP ?= 1
 
-FEATURES_REQUIRED += periph_timer
-
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Removing the periph_timer feature requirement, which is not
directly required by this examples but rather by xtimer.
The latter set this requirement already in Makefile.dep
hence, it is duplicated and not necessary here.

see https://github.com/RIOT-OS/RIOT/blob/master/Makefile.dep#L642

### Testing procedure

build the example, which should still work.


### Issues/PRs references

found while working on #12423  and #12406 