### PR TITLE
gnrc_ipv6_nib: use recursive mutex instead of mutex for locking

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -42,7 +42,7 @@ static _nib_dr_entry_t _def_routers[GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF];
 #if GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
 static _nib_abr_entry_t _abrs[GNRC_IPV6_NIB_ABR_NUMOF];
 #endif  /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C */
-static mutex_t _nib_mutex = MUTEX_INIT;
+static rmutex_t _nib_mutex = RMUTEX_INIT;
 
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
@@ -70,12 +70,12 @@ void _nib_init(void)
 
 void _nib_acquire(void)
 {
-    mutex_lock(&_nib_mutex);
+    rmutex_lock(&_nib_mutex);
 }
 
 void _nib_release(void)
 {
-    mutex_unlock(&_nib_mutex);
+    rmutex_unlock(&_nib_mutex);
 }
 
 static inline bool _addr_equals(const ipv6_addr_t *addr,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -42,10 +42,10 @@ static _nib_dr_entry_t _def_routers[GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF];
 #if GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
 static _nib_abr_entry_t _abrs[GNRC_IPV6_NIB_ABR_NUMOF];
 #endif  /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C */
+static mutex_t _nib_mutex = MUTEX_INIT;
 
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
-mutex_t _nib_mutex = MUTEX_INIT;
 evtimer_msg_t _nib_evtimer;
 
 static void _override_node(const ipv6_addr_t *addr, unsigned iface,
@@ -66,6 +66,16 @@ void _nib_init(void)
 #endif  /* TEST_SUITES */
     evtimer_init_msg(&_nib_evtimer);
     /* TODO: load ABR information from persistent memory */
+}
+
+void _nib_acquire(void)
+{
+    mutex_lock(&_nib_mutex);
+}
+
+void _nib_release(void)
+{
+    mutex_unlock(&_nib_mutex);
 }
 
 static inline bool _addr_equals(const ipv6_addr_t *addr,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -242,11 +242,6 @@ typedef struct {
 } _nib_abr_entry_t;
 
 /**
- * @brief   Mutex for locking the NIB
- */
-extern mutex_t _nib_mutex;
-
-/**
  * @brief   Event timer for the NIB.
  */
 extern evtimer_msg_t _nib_evtimer;
@@ -269,18 +264,12 @@ void _nib_init(void);
 /**
  * @brief   Acquire exclusive access to the NIB
  */
-static inline void _nib_acquire(void)
-{
-    mutex_lock(&_nib_mutex);
-}
+void _nib_acquire(void);
 
 /**
  * @brief   Release exclusive access to the NIB
  */
-static inline void _nib_release(void)
-{
-    mutex_unlock(&_nib_mutex);
-}
+void _nib_release(void);
 
 /**
  * @brief   Gets interface identifier from a NIB entry

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -267,6 +267,22 @@ extern _nib_dr_entry_t *_prime_def_router;
 void _nib_init(void);
 
 /**
+ * @brief   Acquire exclusive access to the NIB
+ */
+static inline void _nib_acquire(void)
+{
+    mutex_lock(&_nib_mutex);
+}
+
+/**
+ * @brief   Release exclusive access to the NIB
+ */
+static inline void _nib_release(void)
+{
+    mutex_unlock(&_nib_mutex);
+}
+
+/**
  * @brief   Gets interface identifier from a NIB entry
  *
  * @param[in] node  A NIB entry.

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
@@ -27,9 +27,9 @@ int gnrc_ipv6_nib_abr_add(const ipv6_addr_t *addr)
     _nib_abr_entry_t *abr;
     _nib_offl_entry_t *offl = NULL;
 
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     if ((abr = _nib_abr_add(addr)) == NULL) {
-        mutex_unlock(&_nib_mutex);
+        _nib_release();
         return -ENOMEM;
     }
     abr->valid_until = 0U;
@@ -45,15 +45,15 @@ int gnrc_ipv6_nib_abr_add(const ipv6_addr_t *addr)
         }
     }
 #endif  /* MODULE_GNRC_SIXLOWPAN_CTX */
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
     return 0;
 }
 
 void gnrc_ipv6_nib_abr_del(const ipv6_addr_t *addr)
 {
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     _nib_abr_remove(addr);
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
 }
 #endif  /* GNRC_IPV6_NIB_CONF_6LBR */
 
@@ -61,7 +61,7 @@ bool gnrc_ipv6_nib_abr_iter(void **state, gnrc_ipv6_nib_abr_t *entry)
 {
     _nib_abr_entry_t *abr = *state;
 
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     while ((abr = _nib_abr_iter(abr)) != NULL) {
         if (!ipv6_addr_is_unspecified(&abr->addr)) {
             memcpy(&entry->addr, &abr->addr, sizeof(entry->addr));
@@ -70,7 +70,7 @@ bool gnrc_ipv6_nib_abr_iter(void **state, gnrc_ipv6_nib_abr_t *entry)
             break;
         }
     }
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
     *state = abr;
     return (*state != NULL);
 }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
@@ -26,9 +26,9 @@ int gnrc_ipv6_nib_ft_get(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,
     int res;
 
     assert((dst != NULL) && (fte != NULL));
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     res = _nib_get_route(dst, pkt, fte);
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
     return res;
 }
 
@@ -43,7 +43,7 @@ int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
     if ((iface == 0) || ((is_default_route) && (next_hop == NULL))) {
         return -EINVAL;
     }
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     if (is_default_route) {
         _nib_dr_entry_t *ptr;
 
@@ -78,13 +78,13 @@ int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
         res = -ENOTSUP;
     }
 #endif
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
     return res;
 }
 
 void gnrc_ipv6_nib_ft_del(const ipv6_addr_t *dst, unsigned dst_len)
 {
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     if ((dst == NULL) || (dst_len == 0) || ipv6_addr_is_unspecified(dst)) {
         _nib_dr_entry_t *entry = _nib_drl_get_dr();
 
@@ -105,7 +105,7 @@ void gnrc_ipv6_nib_ft_del(const ipv6_addr_t *dst, unsigned dst_len)
         }
     }
 #endif
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
 }
 
 bool gnrc_ipv6_nib_ft_iter(const ipv6_addr_t *next_hop, unsigned iface,

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -42,11 +42,11 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
         ipv6_addr_is_multicast(pfx) || (pref_ltime > valid_ltime)) {
         return -EINVAL;
     }
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     dst = _nib_pl_add(iface, pfx, pfx_len, valid_ltime,
                       pref_ltime);
     if (dst == NULL) {
-        mutex_unlock(&_nib_mutex);
+        _nib_release();
         return -ENOMEM;
     }
 #ifdef MODULE_GNRC_NETIF
@@ -54,7 +54,7 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
     int idx;
 
     if (netif == NULL) {
-        mutex_unlock(&_nib_mutex);
+        _nib_release();
         return 0;
     }
     gnrc_netif_acquire(netif);
@@ -78,7 +78,7 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
 #endif
     gnrc_netif_release(netif);
 #endif  /* MODULE_GNRC_NETIF */
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
 #if defined(MODULE_GNRC_NETIF) && GNRC_IPV6_NIB_CONF_ROUTER
     /* update prefixes down-stream */
     _handle_snd_mc_ra(netif);
@@ -92,14 +92,14 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
     _nib_offl_entry_t *dst = NULL;
 
     assert(pfx != NULL);
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     while ((dst = _nib_offl_iter(dst)) != NULL) {
         assert(dst->next_hop != NULL);
         if ((pfx_len == dst->pfx_len) &&
             ((iface == 0) || (iface == _nib_onl_get_if(dst->next_hop))) &&
             (ipv6_addr_match_prefix(pfx, &dst->pfx) >= pfx_len)) {
             _nib_pl_remove(dst);
-            mutex_unlock(&_nib_mutex);
+            _nib_release();
 #if GNRC_IPV6_NIB_CONF_ROUTER
             gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
 
@@ -111,7 +111,7 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
             return;
         }
     }
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
 }
 
 bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
@@ -119,7 +119,7 @@ bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
 {
     _nib_offl_entry_t *dst = *state;
 
-    mutex_lock(&_nib_mutex);
+    _nib_acquire();
     while ((dst = _nib_offl_iter(dst)) != NULL) {
         const _nib_onl_entry_t *node = dst->next_hop;
         if ((node != NULL) && (dst->mode & _PL) &&
@@ -133,7 +133,7 @@ bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
             break;
         }
     }
-    mutex_unlock(&_nib_mutex);
+    _nib_release();
     *state = dst;
     return (*state != NULL);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This should make the problem that popped up in https://github.com/RIOT-OS/RIOT/pull/12408 easier to solve. There, since the source address detection accesses the NIB's prefix list interface now to determine the prefix lengths of given addresses. This deadlocks its internal process, however, since this function is also called by the neighbor solicitation send function from within the NIB. With a recursive mutex this can't happen.

I also made the mutex itself private and implemented two functions two lock/unlock it from the outside, which scraped of some 100 bytes of ROM on Cortex M0+.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
make -C tests/gnrc_ipv6_nib flash test
```
and
```
make -C tests/gnrc_ipv6_nib_6ln flash test
```

still pass, pinging between two `gnrc_networking` instances works.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Preparation for a rework of #12408.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
