### PR TITLE
examples/filesystem: blacklist feature instead of boards

### DIFF
--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -6,14 +6,7 @@ BOARD ?= native
 
 
 # Blacklisting msp430-based boards, as file syscalls are not supported
-BOARD_BLACKLIST :=  chronos \
-                    msb-430 \
-                    msb-430h \
-                    telosb \
-                    wsn430-v1_3b \
-                    wsn430-v1_4 \
-                    z1 \
-                    #
+FEATURES_BLACKLIST += arch_msp430
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              arduino-uno nucleo-f031k6


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Remove BOARD_BLACKLIST and use FEATURES_BLACKLIST instead.


### Testing procedure

compare `make info-boards-supported` from this PR and master, should be equal.


### Issues/PRs references

~~requires #9081~~ 

see #12406 and #12423 
