### PR TITLE
Makefile.features: introduce FEATURES_COMPATIBLE_feature += feature_2

### DIFF
--- a/Makefile.features
+++ b/Makefile.features
@@ -18,6 +18,7 @@ else
   $(warning CPU must be defined by board / board_common Makefile.features)
 endif
 
+include $(RIOTBASE)/drivers/Makefile.features
 
 # Resolve FEATURES_ variables
 # Their value will only be complete after resolving dependencies

--- a/Makefile.features
+++ b/Makefile.features
@@ -22,19 +22,25 @@ endif
 # Resolve FEATURES_ variables
 # Their value will only be complete after resolving dependencies
 
+# All features PROVIDED + compatible features (coming soon)
+FEATURES_COMPATIBLES = $(FEATURES_PROVIDED)
+# Only features that are got from compatible features
+FEATURES_COMPATIBLES_ONLY = $(filter-out $(FEATURES_PROVIDED),$(FEATURES_COMPATIBLES))
+
 # Features that are required by the application but not provided by the BSP
 # Having features missing may case the build to fail.
-FEATURES_MISSING = $(sort $(filter-out $(FEATURES_PROVIDED),$(FEATURES_REQUIRED)))
+FEATURES_MISSING = $(sort $(filter-out $(FEATURES_COMPATIBLES),$(FEATURES_REQUIRED)))
 
 # Features that are only optional and not required at the same time.
 # The policy is to by default use by features if they are provided by the BSP.
 FEATURES_OPTIONAL_ONLY = $(sort $(filter-out $(FEATURES_REQUIRED),$(FEATURES_OPTIONAL)))
-FEATURES_OPTIONAL_USED = $(sort $(filter $(FEATURES_PROVIDED),$(FEATURES_OPTIONAL_ONLY)))
+FEATURES_OPTIONAL_USED = $(sort $(filter $(FEATURES_COMPATIBLES),$(FEATURES_OPTIONAL_ONLY)))
 # Optional features that will not be used because they are not provided
-FEATURES_OPTIONAL_MISSING = $(sort $(filter-out $(FEATURES_PROVIDED),$(FEATURES_OPTIONAL_ONLY)))
+FEATURES_OPTIONAL_MISSING = $(sort $(filter-out $(FEATURES_COMPATIBLES),$(FEATURES_OPTIONAL_ONLY)))
 
 # Features that are used for an application
-FEATURES_USED = $(sort $(FEATURES_REQUIRED) $(FEATURES_OPTIONAL_USED))
+FEATURES_USED_EXPLICIT = $(sort $(FEATURES_REQUIRED) $(FEATURES_OPTIONAL_USED))
+FEATURES_USED = $(sort $(FEATURES_USED_EXPLICIT))
 
 # Used features that conflict when used together
 FEATURES_CONFLICTING = $(sort $(foreach conflict,$(FEATURES_CONFLICT),$(call _features_conflicting,$(conflict))))

--- a/Makefile.features
+++ b/Makefile.features
@@ -21,9 +21,16 @@ endif
 
 # Resolve FEATURES_ variables
 # Their value will only be complete after resolving dependencies
+#
+# Features can now declare features that they provide to allow automatic
+# handling of "parents" and "child", like a radio giving a "netif" feature
+# FEATURES_COMPATIBLE_name_of_the_feature += features_also_provided
 
-# All features PROVIDED + compatible features (coming soon)
-FEATURES_COMPATIBLES = $(FEATURES_PROVIDED)
+features_compatible = $1 $(foreach feature,$(FEATURES_COMPATIBLE_$1),$(call features_compatible,$(feature)))
+features_providers_all = $(foreach feature,$(FEATURES_COMPATIBLES),$(if $(findstring $1,$(FEATURES_COMPATIBLE_$(feature))),$(feature) $(call features_providers_all,$(feature))))
+
+# All features PROVIDED + compatible features
+FEATURES_COMPATIBLES = $(sort $(foreach feature,$(FEATURES_PROVIDED),$(call features_compatible,$(feature))))
 # Only features that are got from compatible features
 FEATURES_COMPATIBLES_ONLY = $(filter-out $(FEATURES_PROVIDED),$(FEATURES_COMPATIBLES))
 
@@ -40,7 +47,7 @@ FEATURES_OPTIONAL_MISSING = $(sort $(filter-out $(FEATURES_COMPATIBLES),$(FEATUR
 
 # Features that are used for an application
 FEATURES_USED_EXPLICIT = $(sort $(FEATURES_REQUIRED) $(FEATURES_OPTIONAL_USED))
-FEATURES_USED = $(sort $(FEATURES_USED_EXPLICIT))
+FEATURES_USED = $(sort $(FEATURES_USED_EXPLICIT) $(foreach feature,$(FEATURES_USED_EXPLICIT),$(call features_providers_all,$(feature))))
 
 # Used features that conflict when used together
 FEATURES_CONFLICTING = $(sort $(foreach conflict,$(FEATURES_CONFLICT),$(call _features_conflicting,$(conflict))))
@@ -53,3 +60,10 @@ _features_conflicting = $(if $(call _features_used_conflicting,$(subst :, ,$1)),
 #   $1: list of features that conflict together
 #   Return non empty on error
 _features_used_conflicting = $(filter $(words $1),$(words $(filter $(FEATURES_USED),$1)))
+
+
+# Define FEATURES_PROVIDERS_ and FEATURES_PROVIDERS_ALL_
+# Only define theme currently for debug, not sure if required or not
+features_providers = $(sort $(foreach feature,$(FEATURES_COMPATIBLES),$(if $(findstring $1,$(FEATURES_COMPATIBLE_$(feature))),$(feature))))
+define_providers = $(eval FEATURES_PROVIDERS_$1 = $$(call features_providers,$1))$(eval FEATURES_PROVIDERS_ALL_$1 = $$(call features_providers_all,$1))
+$(foreach feature,$(FEATURES_COMPATIBLES_ONLY),$(eval $(call define_providers,$(feature))))

--- a/boards/common/iotlab/Makefile.features
+++ b/boards/common/iotlab/Makefile.features
@@ -10,3 +10,5 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+
+FEATURES_PROVIDED += driver_at86rf231

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -7,3 +7,5 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+FEATURES_PROVIDED += driver_at86rf231

--- a/boards/mulle/Makefile.features
+++ b/boards/mulle/Makefile.features
@@ -18,3 +18,5 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+FEATURES_PROVIDED += driver_at86rf21b

--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -16,3 +16,5 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+
+FEATURES_PROVIDED += driver_kw2xrf

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -14,3 +14,5 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+
+FEATURES_PROVIDED += driver_at86rf233

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -600,3 +600,8 @@ ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE += xtimer
   USEMODULE += netif
 endif
+
+
+# The feature must trigger the driver module inclusion
+# Lets do it automatic here for now but may be better explicit?
+USEMODULE += $(patsubst driver_%,%,$(filter driver_%,$(FEATURES_USED)))

--- a/drivers/Makefile.features
+++ b/drivers/Makefile.features
@@ -1,0 +1,8 @@
+FEATURES_COMPATIBLE_driver_at86rf231 += driver_at86rf2xx
+FEATURES_COMPATIBLE_driver_at86rf233 += driver_at86rf2xx
+FEATURES_COMPATIBLE_driver_at86rf21b += driver_at86rf2xx
+
+FEATURES_COMPATIBLE_driver_at86rf2xx += radio_802154
+FEATURES_COMPATIBLE_driver_cc2420 += radio_802154
+FEATURES_COMPATIBLE_driver_kw2xrf += radio_802154
+FEATURES_COMPATIBLE_radio_802154 += netif

--- a/drivers/Makefile.features
+++ b/drivers/Makefile.features
@@ -1,8 +1,9 @@
-FEATURES_COMPATIBLE_driver_at86rf231 += driver_at86rf2xx
-FEATURES_COMPATIBLE_driver_at86rf233 += driver_at86rf2xx
-FEATURES_COMPATIBLE_driver_at86rf21b += driver_at86rf2xx
+# Only define FEATURES_COMPATIBLE_ with '=' !
+FEATURES_COMPATIBLE_driver_at86rf231 = driver_at86rf2xx
+FEATURES_COMPATIBLE_driver_at86rf233 = driver_at86rf2xx
+FEATURES_COMPATIBLE_driver_at86rf21b = driver_at86rf2xx
 
-FEATURES_COMPATIBLE_driver_at86rf2xx += radio_802154
-FEATURES_COMPATIBLE_driver_cc2420 += radio_802154
-FEATURES_COMPATIBLE_driver_kw2xrf += radio_802154
-FEATURES_COMPATIBLE_radio_802154 += netif
+FEATURES_COMPATIBLE_driver_at86rf2xx = radio_802154
+FEATURES_COMPATIBLE_driver_cc2420 = radio_802154
+FEATURES_COMPATIBLE_driver_kw2xrf = radio_802154
+FEATURES_COMPATIBLE_radio_802154 = netif

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -50,6 +50,8 @@ info-build:
 	@echo ''
 	@echo 'FEATURES_USED:'
 	@echo '         $(or $(FEATURES_USED), -none-)'
+	@echo 'FEATURES_USED_EXPLICIT:' (features that were directly requested, without parent features)
+	@echo '         $(or $(FEATURES_USED_EXPLICIT), -none-)'
 	@echo 'FEATURES_REQUIRED:'
 	@echo '         $(or $(sort $(FEATURES_REQUIRED)), -none-)'
 	@echo 'FEATURES_OPTIONAL_ONLY (optional that are not required, strictly "nice to have"):'
@@ -57,6 +59,10 @@ info-build:
 	@echo 'FEATURES_OPTIONAL_MISSING (missing optional features):'
 	@echo '         $(or $(FEATURES_OPTIONAL_MISSING), -none-)'
 	@echo 'FEATURES_PROVIDED (by the board or USEMODULE'"'"'d drivers):'
+	@echo '         $(or $(sort $(FEATURES_PROVIDED)), -none-)'
+	@echo 'FEATURES_COMPATIBLES (provided directly by the board or by a feature when declared 'COMPATIBLE')
+	@echo '         $(or $(sort $(FEATURES_PROVIDED)), -none-)'
+	@echo 'FEATURES_COMPATIBLES_ONLY (provided by a compatible provided feature)
 	@echo '         $(or $(sort $(FEATURES_PROVIDED)), -none-)'
 	@echo 'FEATURES_MISSING (only non optional features):'
 	@echo '         $(or $(FEATURES_MISSING), -none-)'

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -11,21 +11,10 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# define the driver to be used for selected boards
-ifneq (,$(filter samr21-xpro,$(BOARD)))
-  DRIVER := at86rf233
-endif
-ifneq (,$(filter iotlab-m3 fox,$(BOARD)))
-  DRIVER := at86rf231
-endif
-ifneq (,$(filter mulle,$(BOARD)))
-  DRIVER := at86rf212b
-endif
+FEATURES_REQUIRED += driver_at86rf2xx
 
-# use the at86rf231 as fallback device
-DRIVER ?= at86rf231
-
-# include the selected driver
-USEMODULE += $(DRIVER)
+# Use 'at86rf231' as fallback device
+# Just copied the previous behavior of the test
+FEATURES_OPTIONAL += driver_at86rf231
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

This introduces a new concept that a feature can declare other feature it provides. I used the name "compatible" here as we just heard about the 'compatible' string in device trees.

Naming can be changed of course.
I used here 'driver_DRIVERNAME' to allow automatic mapping to the module, but not sure I like it.

This currently means that we do

```
FEATURES_COMPATIBLE_driver_at86rf231 = driver_at86rf2xx
FEATURES_COMPATIBLE_driver_at86rf2xx = radio_802154
FEATURES_COMPATIBLE_radio_802154 = netif
```

The handling is correct and complete but could still get some refinement.
It is just a 2 hours version.

Drivers and examples are at example state but give the idea of what should be done.

~**This currently breaks info-boards-supported by making really really slow** do not build with CI !!!~ fixed by using 'FEATURES_COMPATIBLE_name = auie'


### Testing procedure


Requesting a "child" feature, correctly triggers the inclusion of the "parent" features.

In `examples/hello_world`:

```
FEATURES_OPTIONAL=netif BOARD=iotlab-m3 make info-debug-variable-USEMODULE
at86rf231 at86rf2xx auto_init board boards_common_iotlab core core_msg cortexm_common cortexm_common_periph cpu div ieee802154 luid netdev_ieee802154 netif newlib newlib_nano newlib_syscalls_default periph periph_common periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_spi periph_timer periph_uart pm_layered prng prng_tinymt32 random stdio_uart stm32_common stm32_common_periph sys tinymt32 xtimer
```

<details><summary>With a lot of debugging variables showing each intermediat variables, and the `FEATURES_PROVIDERS_*` debug variables too.</summary>

```
FEATURES_OPTIONAL=netif BOARD=iotlab-m3 make info-debug-variable-FEATURES_PROVIDED info-debug-variable-FEATURES_COMPATIBLES info-debug-variable-FEATURES_COMPATIBLES_ONLY info-debug-variable-emptyline info-debug-variable-FEATURES_PROVIDERS_netif info-debug-variable-FEATURES_PROVIDERS_radio_802154 info-debug-variable-emptyline2 info-debug-variable-FEATURES_PROVIDERS_ALL_netif info-debug-variable-FEATURES_PROVIDERS_ALL_radio_802154 info-debug-variable-FEATURES_USED_EXPLICIT  info-debug-variable-FEATURES_USED info-debug-variable-emptyline3 info-debug-variable-USEMODULE
periph_i2c periph_rtt periph_spi periph_timer periph_uart riotboot driver_at86rf231 periph_dma periph_flashpage periph_flashpage_raw periph_cpuid periph_gpio periph_gpio_irq puf_sram periph_uart_modecfg periph_wdt periph_pm cpp cpu_check_address
cpp cpu_check_address driver_at86rf231 driver_at86rf2xx netif periph_cpuid periph_dma periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_i2c periph_pm periph_rtt periph_spi periph_timer periph_uart periph_uart_modecfg periph_wdt puf_sram radio_802154 riotboot
driver_at86rf2xx netif radio_802154

radio_802154
driver_at86rf2xx

radio_802154 driver_at86rf2xx driver_at86rf231
driver_at86rf2xx driver_at86rf231
netif periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_spi periph_timer periph_uart
driver_at86rf231 driver_at86rf2xx netif periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_spi periph_timer periph_uart radio_802154

at86rf231 at86rf2xx auto_init board boards_common_iotlab core core_msg cortexm_common cortexm_common_periph cpu div ieee802154 luid netdev_ieee802154 netif newlib newlib_nano newlib_syscalls_default periph periph_common periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_spi periph_timer periph_uart pm_layered prng prng_tinymt32 random stdio_uart stm32_common stm32_common_periph sys tinymt32 xtimer
```
</details>

Try listing the modules for `samr21-xpro`, `iotlab-m3` and `mulle` for `tests/driver_at86rf2xx`. The driver is selected without explicit value in the application.

<details><summary><code>BOARD=samr21-xpro make --no-print-directory -C tests/driver_at86rf2xx/ info-debug-variable-USEMODULE</code></summary>

```
BOARD=samr21-xpro make --no-print-directory -C tests/driver_at86rf2xx/ info-debug-variable-USEMODULE
at86rf233 at86rf2xx board core core_msg cortexm_common cortexm_common_periph cpu div fmt ieee802154 isrpipe luid netdev_ieee802154 netif newlib newlib_nano newlib_syscalls_default od periph periph_common periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_spi periph_timer periph_uart pm_layered prng prng_tinymt32 ps random sam0_common_periph shell shell_commands stdin stdio_uart stdio_uart_rx sys tinymt32 tsrb xtimer

BOARD=iotlab-m3 make --no-print-directory -C tests/driver_at86rf2xx/ info-debug-variable-USEMODULE
at86rf231 at86rf2xx board boards_common_iotlab core core_msg cortexm_common cortexm_common_periph cpu div fmt ieee802154 isrpipe luid netdev_ieee802154 netif newlib newlib_nano newlib_syscalls_default od periph periph_common periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_spi periph_timer periph_uart pm_layered prng prng_tinymt32 ps random shell shell_commands stdin stdio_uart stdio_uart_rx stm32_common stm32_common_periph sys tinymt32 tsrb xtimer

BOARD=mulle make --no-print-directory -C tests/driver_at86rf2xx/ info-debug-variable-USEMODULE
at86rf21b at86rf2xx board core core_msg cortexm_common cortexm_common_periph cpu devfs div fmt ieee802154 isrpipe luid mtd mtd_spi_nor netdev_ieee802154 netif newlib newlib_nano newlib_syscalls_default nvram nvram_spi od periph periph_common periph_cpuid periph_gpio periph_gpio_irq periph_hwrng periph_mcg periph_pm periph_rtt periph_spi periph_timer periph_uart periph_wdog posix_headers prng prng_tinymt32 ps random shell shell_commands stdin stdio_uart stdio_uart_rx sys tinymt32 tsrb vfs xtimer
```

In master it was the same

```
BOARD=samr21-xpro make --no-print-directory -C tests/driver_at86rf2xx/ info-debug-variable-USEMODULE
at86rf233 at86rf2xx board core core_msg cortexm_common cortexm_common_periph cpu div fmt ieee802154 isrpipe luid netdev_ieee802154 netif newlib newlib_nano newlib_syscalls_default od periph periph_common periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_spi periph_timer periph_uart pm_layered prng prng_tinymt32 ps random sam0_common_periph shell shell_commands stdin stdio_uart stdio_uart_rx sys tinymt32 tsrb xtimer

BOARD=iotlab-m3 make --no-print-directory -C tests/driver_at86rf2xx/ info-debug-variable-USEMODULE
at86rf231 at86rf2xx board boards_common_iotlab core core_msg cortexm_common cortexm_common_periph cpu div fmt ieee802154 isrpipe luid netdev_ieee802154 netif newlib newlib_nano newlib_syscalls_default od periph periph_common periph_cpuid periph_gpio periph_gpio_irq periph_pm periph_spi periph_timer periph_uart pm_layered prng prng_tinymt32 ps random shell shell_commands stdin stdio_uart stdio_uart_rx stm32_common stm32_common_periph sys tinymt32 tsrb xtimer

BOARD=mulle make --no-print-directory -C tests/driver_at86rf2xx/ info-debug-variable-USEMODULE
at86rf212b at86rf2xx board core core_msg cortexm_common cortexm_common_periph cpu devfs div fmt ieee802154 isrpipe luid mtd mtd_spi_nor netdev_ieee802154 netif newlib newlib_nano newlib_syscalls_default nvram nvram_spi od periph periph_common periph_cpuid periph_gpio periph_gpio_irq periph_hwrng periph_mcg periph_pm periph_rtt periph_spi periph_timer periph_uart periph_wdog posix_headers prng prng_tinymt32 ps random shell shell_commands stdin stdio_uart stdio_uart_rx sys tinymt32 tsrb vfs xtimer
```
</details>

It finds unsatisfied features.

```
BOARD=native make --no-print-directory -C tests/driver_at86rf2xx/ 
There are unsatisfied feature requirements: driver_at86rf2xx periph_gpio_irq periph_spi


EXPECT ERRORS!


Building application "tests_driver_at86rf2xx" for "native" with MCU "native".
```

### Issues/PRs references

Implementation of https://github.com/RIOT-OS/RIOT/pull/11676#issuecomment-502716886
