### PR TITLE
drivers/mrf24j40: don't loop in mrf24j40_reset_state_machine()

### DIFF
--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -476,14 +476,9 @@ void mrf24j40_assert_awake(mrf24j40_t *dev)
 
 void mrf24j40_reset_state_machine(mrf24j40_t *dev)
 {
-    uint8_t rfstate;
-
     mrf24j40_reg_write_short(dev, MRF24J40_REG_RFCTL, MRF24J40_RFCTL_RFRST);
     mrf24j40_reg_write_short(dev, MRF24J40_REG_RFCTL, 0x00);
     xtimer_usleep(MRF24J40_STATE_RESET_DELAY);             /* Delay at least 192us */
-    do {
-        rfstate = mrf24j40_reg_read_long(dev, MRF24J40_REG_RFSTATE);
-    } while ((rfstate & MRF24J40_RFSTATE_MASK) != MRF24J40_RFSTATE_RX);
 }
 
 void mrf24j40_software_reset(mrf24j40_t *dev)


### PR DESCRIPTION
### Contribution description

When hooking up the mrf24j40 to a blackpill board, the driver would always get stuck on init.

Debugging revealed that it would get stuck in the `mrf24j40_reset_state_machine()` function because it expects the `RFSTATE` to have a special value after reset.

However when reading the data sheet in section [3.1 Reset](http://ww1.microchip.com/downloads/en/DeviceDoc/MRF24J40-Data-Sheet-30009776D.pdf#page=89), the value of `RFSTATE` is not specified.

The [Linux driver](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/net/ieee802154/mrf24j40.c?h=v5.4-rc2#n651) also does not wait for the `RFSTATE` register and most importantly, without the loop, the driver is functioning fine.

### Testing procedure

Boards with the mrf24j40 chip should still behave as they did before.

If you want to reproduce the behavior with the `blackpill-128kib` board, I've used this config:

```C
#define MRF24J40_PARAM_SPI        SPI_DEV(1)
#define MRF24J40_PARAM_SPI_CLK    SPI_CLK_1MHZ
#define MRF24J40_PARAM_CS         GPIO_PIN(1, 12) /* PB12 */
#define MRF24J40_PARAM_INT        GPIO_PIN(1,  7) /* PB7  */
#define MRF24J40_PARAM_RESET      GPIO_PIN(1,  6) /* PB6  */
```


### Issues/PRs references
none