### PR TITLE
gnrc_ipv6_ext_frag: fix release on rbuf creation for n-th fragment [backport 2019.10]

### DIFF
--- a/tests/gnrc_ipv6_ext_frag/Makefile
+++ b/tests/gnrc_ipv6_ext_frag/Makefile
@@ -3,11 +3,10 @@ DEVELHELP := 1
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
-                             arduino-mega2560 arduino-nano arduino-uno \
-                             blackpill bluepill hifive1 hifive1b \
-                             i-nucleo-lrwan1 mega-xplained msb-430 msb-430h \
-                             nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-f070rb nucleo-f072rb nucleo-f302r8 \
+                             arduino-mega2560 arduino-nano arduino-uno hifive1 \
+                             hifive1b i-nucleo-lrwan1 mega-xplained msb-430 \
+                             msb-430h nucleo-f030r8 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \
                              nucleo-l053r8 saml10-xpro saml11-xpro \
                              stm32f0discovery stm32l0538-disco telosb \

--- a/tests/gnrc_ipv6_ext_frag/main.c
+++ b/tests/gnrc_ipv6_ext_frag/main.c
@@ -90,6 +90,13 @@ static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
 };
 
+static const ipv6_addr_t _src = { .u8 = TEST_SRC };
+static const ipv6_addr_t _dst = { .u8 = TEST_DST };
+static const uint8_t _exp_payload[] = TEST_PAYLOAD;
+static const uint8_t _test_frag1[] = TEST_FRAG1;
+static const uint8_t _test_frag2[] = TEST_FRAG2;
+static const uint8_t _test_frag3[] = TEST_FRAG3;
+
 static void tear_down_tests(void)
 {
     gnrc_ipv6_ext_frag_init();
@@ -178,15 +185,9 @@ static void test_ipv6_ext_frag_rbuf_gc(void)
 
 static void test_ipv6_ext_frag_reass_in_order(void)
 {
-    static const ipv6_addr_t src = { .u8 = TEST_SRC };
-    static const ipv6_addr_t dst = { .u8 = TEST_DST };
-    static const uint8_t exp_payload[] = TEST_PAYLOAD;
-    static const uint8_t test_frag1[] = TEST_FRAG1;
-    static const uint8_t test_frag2[] = TEST_FRAG2;
-    static const uint8_t test_frag3[] = TEST_FRAG3;
-    gnrc_pktsnip_t *ipv6_snip = gnrc_ipv6_hdr_build(NULL, &src, &dst);
-    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(ipv6_snip, test_frag1,
-                                          sizeof(test_frag1),
+    gnrc_pktsnip_t *ipv6_snip = gnrc_ipv6_hdr_build(NULL, &_src, &_dst);
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(ipv6_snip, _test_frag1,
+                                          sizeof(_test_frag1),
                                           GNRC_NETTYPE_UNDEF);
     ipv6_hdr_t *ipv6 = ipv6_snip->data;
     ipv6_ext_frag_t *frag = pkt->data;
@@ -206,7 +207,7 @@ static void test_ipv6_ext_frag_reass_in_order(void)
     TEST_ASSERT_NULL(gnrc_ipv6_ext_frag_reass(pkt));
     TEST_ASSERT_NOT_NULL((rbuf = gnrc_ipv6_ext_frag_rbuf_get(ipv6, TEST_ID)));
     TEST_ASSERT_NOT_NULL(rbuf->pkt);
-    TEST_ASSERT_EQUAL_INT(sizeof(test_frag1) - sizeof(ipv6_ext_frag_t),
+    TEST_ASSERT_EQUAL_INT(sizeof(_test_frag1) - sizeof(ipv6_ext_frag_t),
                           rbuf->pkt->size);
     TEST_ASSERT_MESSAGE(ipv6 == rbuf->ipv6, "IPv6 header is not the same");
     TEST_ASSERT_EQUAL_INT(TEST_ID, rbuf->id);
@@ -218,12 +219,12 @@ static void test_ipv6_ext_frag_reass_in_order(void)
     TEST_ASSERT_EQUAL_INT(0, ptr->start);
     TEST_ASSERT_EQUAL_INT(TEST_FRAG2_OFFSET / 8, ptr->end);
     TEST_ASSERT(((clist_node_t *)ptr) == rbuf->limits.next);
-    TEST_ASSERT(memcmp(exp_payload, rbuf->pkt->data, rbuf->pkt->size) == 0);
+    TEST_ASSERT(memcmp(_exp_payload, rbuf->pkt->data, rbuf->pkt->size) == 0);
 
     /* prepare 2nd fragment */
-    ipv6_snip = gnrc_ipv6_hdr_build(NULL, &src, &dst);
-    pkt = gnrc_pktbuf_add(ipv6_snip, test_frag2,
-                          sizeof(test_frag2),
+    ipv6_snip = gnrc_ipv6_hdr_build(NULL, &_src, &_dst);
+    pkt = gnrc_pktbuf_add(ipv6_snip, _test_frag2,
+                          sizeof(_test_frag2),
                           GNRC_NETTYPE_UNDEF);
     ipv6 = ipv6_snip->data;
     frag = pkt->data;
@@ -240,7 +241,7 @@ static void test_ipv6_ext_frag_reass_in_order(void)
     /* receive 2nd fragment */
     TEST_ASSERT_NULL(gnrc_ipv6_ext_frag_reass(pkt));
     TEST_ASSERT_NOT_NULL(rbuf->pkt);
-    TEST_ASSERT_EQUAL_INT(sizeof(test_frag1) + sizeof(test_frag2) -
+    TEST_ASSERT_EQUAL_INT(sizeof(_test_frag1) + sizeof(_test_frag2) -
                           (2 * sizeof(ipv6_ext_frag_t)),
                           rbuf->pkt->size);
     TEST_ASSERT_EQUAL_INT(TEST_ID, rbuf->id);
@@ -257,12 +258,12 @@ static void test_ipv6_ext_frag_reass_in_order(void)
     TEST_ASSERT_EQUAL_INT(TEST_FRAG2_OFFSET / 8, ptr->start);
     TEST_ASSERT_EQUAL_INT(TEST_FRAG3_OFFSET / 8, ptr->end);
     TEST_ASSERT(((clist_node_t *)ptr) == rbuf->limits.next);
-    TEST_ASSERT(memcmp(exp_payload, rbuf->pkt->data, rbuf->pkt->size) == 0);
+    TEST_ASSERT(memcmp(_exp_payload, rbuf->pkt->data, rbuf->pkt->size) == 0);
 
     /* prepare 3rd fragment */
-    ipv6_snip = gnrc_ipv6_hdr_build(NULL, &src, &dst);
-    pkt = gnrc_pktbuf_add(ipv6_snip, test_frag3,
-                          sizeof(test_frag3),
+    ipv6_snip = gnrc_ipv6_hdr_build(NULL, &_src, &_dst);
+    pkt = gnrc_pktbuf_add(ipv6_snip, _test_frag3,
+                          sizeof(_test_frag3),
                           GNRC_NETTYPE_UNDEF);
     ipv6 = ipv6_snip->data;
     frag = pkt->data;
@@ -279,8 +280,8 @@ static void test_ipv6_ext_frag_reass_in_order(void)
     TEST_ASSERT_NOT_NULL((pkt = gnrc_ipv6_ext_frag_reass(pkt)));
     /* reassembly buffer should be deleted */
     TEST_ASSERT_NULL(rbuf->ipv6);
-    TEST_ASSERT_EQUAL_INT(sizeof(exp_payload), pkt->size);
-    TEST_ASSERT(memcmp(exp_payload, pkt->data, pkt->size) == 0);
+    TEST_ASSERT_EQUAL_INT(sizeof(_exp_payload), pkt->size);
+    TEST_ASSERT(memcmp(_exp_payload, pkt->data, pkt->size) == 0);
     TEST_ASSERT_NOT_NULL(pkt->next);
     TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_IPV6, pkt->next->type);
     ipv6 = pkt->next->data;
@@ -294,15 +295,9 @@ static void test_ipv6_ext_frag_reass_in_order(void)
 
 static void test_ipv6_ext_frag_reass_out_of_order(void)
 {
-    static const ipv6_addr_t src = { .u8 = TEST_SRC };
-    static const ipv6_addr_t dst = { .u8 = TEST_DST };
-    static const uint8_t exp_payload[] = TEST_PAYLOAD;
-    static const uint8_t test_frag1[] = TEST_FRAG1;
-    static const uint8_t test_frag2[] = TEST_FRAG2;
-    static const uint8_t test_frag3[] = TEST_FRAG3;
-    gnrc_pktsnip_t *ipv6_snip = gnrc_ipv6_hdr_build(NULL, &src, &dst);
-    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(ipv6_snip, test_frag3,
-                                          sizeof(test_frag3),
+    gnrc_pktsnip_t *ipv6_snip = gnrc_ipv6_hdr_build(NULL, &_src, &_dst);
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(ipv6_snip, _test_frag3,
+                                          sizeof(_test_frag3),
                                           GNRC_NETTYPE_UNDEF);
     ipv6_hdr_t *ipv6 = ipv6_snip->data;
     ipv6_ext_frag_t *frag = pkt->data;
@@ -322,7 +317,7 @@ static void test_ipv6_ext_frag_reass_out_of_order(void)
     TEST_ASSERT_NULL(gnrc_ipv6_ext_frag_reass(pkt));
     TEST_ASSERT_NOT_NULL((rbuf = gnrc_ipv6_ext_frag_rbuf_get(ipv6, TEST_ID)));
     TEST_ASSERT_NOT_NULL(rbuf->pkt);
-    TEST_ASSERT_EQUAL_INT(sizeof(exp_payload), rbuf->pkt->size);
+    TEST_ASSERT_EQUAL_INT(sizeof(_exp_payload), rbuf->pkt->size);
     TEST_ASSERT_EQUAL_INT(TEST_ID, rbuf->id);
     TEST_ASSERT(rbuf->last);
     ptr = (gnrc_ipv6_ext_frag_limits_t *)rbuf->limits.next;
@@ -330,16 +325,16 @@ static void test_ipv6_ext_frag_reass_out_of_order(void)
     ptr = ptr->next;
     TEST_ASSERT_NOT_NULL(ptr);
     TEST_ASSERT_EQUAL_INT(TEST_FRAG3_OFFSET / 8, ptr->start);
-    TEST_ASSERT_EQUAL_INT(sizeof(exp_payload) / 8, ptr->end);
+    TEST_ASSERT_EQUAL_INT(sizeof(_exp_payload) / 8, ptr->end);
     TEST_ASSERT(((clist_node_t *)ptr) == rbuf->limits.next);
-    TEST_ASSERT(memcmp(&exp_payload[TEST_FRAG3_OFFSET],
+    TEST_ASSERT(memcmp(&_exp_payload[TEST_FRAG3_OFFSET],
                        (uint8_t *)rbuf->pkt->data + TEST_FRAG3_OFFSET,
                        rbuf->pkt->size - TEST_FRAG3_OFFSET) == 0);
 
     /* prepare 2nd fragment */
-    ipv6_snip = gnrc_ipv6_hdr_build(NULL, &src, &dst);
-    pkt = gnrc_pktbuf_add(ipv6_snip, test_frag2,
-                          sizeof(test_frag2),
+    ipv6_snip = gnrc_ipv6_hdr_build(NULL, &_src, &_dst);
+    pkt = gnrc_pktbuf_add(ipv6_snip, _test_frag2,
+                          sizeof(_test_frag2),
                           GNRC_NETTYPE_UNDEF);
     ipv6 = ipv6_snip->data;
     frag = pkt->data;
@@ -356,7 +351,7 @@ static void test_ipv6_ext_frag_reass_out_of_order(void)
     /* receive 2nd fragment */
     TEST_ASSERT_NULL(gnrc_ipv6_ext_frag_reass(pkt));
     TEST_ASSERT_NOT_NULL(rbuf->pkt);
-    TEST_ASSERT_EQUAL_INT(sizeof(exp_payload), rbuf->pkt->size);
+    TEST_ASSERT_EQUAL_INT(sizeof(_exp_payload), rbuf->pkt->size);
     TEST_ASSERT(rbuf->last);
     ptr = (gnrc_ipv6_ext_frag_limits_t *)rbuf->limits.next;
     TEST_ASSERT_NOT_NULL(ptr);
@@ -367,17 +362,17 @@ static void test_ipv6_ext_frag_reass_out_of_order(void)
     ptr = ptr->next;
     TEST_ASSERT_NOT_NULL(ptr);
     TEST_ASSERT_EQUAL_INT(TEST_FRAG3_OFFSET / 8, ptr->start);
-    TEST_ASSERT_EQUAL_INT(sizeof(exp_payload) / 8, ptr->end);
+    TEST_ASSERT_EQUAL_INT(sizeof(_exp_payload) / 8, ptr->end);
     TEST_ASSERT_NOT_NULL(ptr->next);
     TEST_ASSERT(((clist_node_t *)ptr) == rbuf->limits.next);
-    TEST_ASSERT(memcmp(&exp_payload[TEST_FRAG2_OFFSET],
+    TEST_ASSERT(memcmp(&_exp_payload[TEST_FRAG2_OFFSET],
                        (uint8_t *)rbuf->pkt->data + TEST_FRAG2_OFFSET,
                        rbuf->pkt->size - TEST_FRAG2_OFFSET) == 0);
 
     /* prepare 1st fragment */
-    ipv6_snip = gnrc_ipv6_hdr_build(NULL, &src, &dst);
-    pkt = gnrc_pktbuf_add(ipv6_snip, test_frag1,
-                          sizeof(test_frag2),
+    ipv6_snip = gnrc_ipv6_hdr_build(NULL, &_src, &_dst);
+    pkt = gnrc_pktbuf_add(ipv6_snip, _test_frag1,
+                          sizeof(_test_frag2),
                           GNRC_NETTYPE_UNDEF);
     ipv6 = ipv6_snip->data;
     frag = pkt->data;
@@ -394,8 +389,8 @@ static void test_ipv6_ext_frag_reass_out_of_order(void)
     TEST_ASSERT_NOT_NULL((pkt = gnrc_ipv6_ext_frag_reass(pkt)));
     /* reassembly buffer should be deleted */
     TEST_ASSERT_NULL(rbuf->ipv6);
-    TEST_ASSERT_EQUAL_INT(sizeof(exp_payload), pkt->size);
-    TEST_ASSERT(memcmp(exp_payload, pkt->data, pkt->size) == 0);
+    TEST_ASSERT_EQUAL_INT(sizeof(_exp_payload), pkt->size);
+    TEST_ASSERT(memcmp(_exp_payload, pkt->data, pkt->size) == 0);
     TEST_ASSERT_NOT_NULL(pkt->next);
     TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_IPV6, pkt->next->type);
     ipv6 = pkt->next->data;
@@ -409,13 +404,9 @@ static void test_ipv6_ext_frag_reass_out_of_order(void)
 
 static void test_ipv6_ext_frag_reass_one_frag(void)
 {
-    static const ipv6_addr_t src = { .u8 = TEST_SRC };
-    static const ipv6_addr_t dst = { .u8 = TEST_DST };
-    static const uint8_t exp_payload[] = TEST_PAYLOAD;
-    static const uint8_t test_frag1[] = TEST_FRAG1;
-    gnrc_pktsnip_t *ipv6_snip = gnrc_ipv6_hdr_build(NULL, &src, &dst);
-    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(ipv6_snip, test_frag1,
-                                          sizeof(test_frag1),
+    gnrc_pktsnip_t *ipv6_snip = gnrc_ipv6_hdr_build(NULL, &_src, &_dst);
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(ipv6_snip, _test_frag1,
+                                          sizeof(_test_frag1),
                                           GNRC_NETTYPE_UNDEF);
     ipv6_hdr_t *ipv6 = ipv6_snip->data;
     ipv6_ext_frag_t *frag = pkt->data;
@@ -431,9 +422,9 @@ static void test_ipv6_ext_frag_reass_one_frag(void)
     /* receive 1st fragment */
     TEST_ASSERT_NOT_NULL((pkt = gnrc_ipv6_ext_frag_reass(pkt)));
     /* reassembly buffer already consumed */
-    TEST_ASSERT_EQUAL_INT(sizeof(test_frag1) - sizeof(ipv6_ext_frag_t),
+    TEST_ASSERT_EQUAL_INT(sizeof(_test_frag1) - sizeof(ipv6_ext_frag_t),
                           pkt->size);
-    TEST_ASSERT(memcmp(exp_payload, pkt->data, pkt->size) == 0);
+    TEST_ASSERT(memcmp(_exp_payload, pkt->data, pkt->size) == 0);
     TEST_ASSERT_NOT_NULL(pkt->next);
     TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_IPV6, pkt->next->type);
     ipv6 = pkt->next->data;


### PR DESCRIPTION
# Backport of #12414

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While testing #12375, @kb2ma noticed that in some rare cases, one of the nodes crashes. He informed me offline and I was able to reproduce that. After some more runs, I was able to pinpoint it to the following corner case:
1. a subsequent fragment is received before the first and
2. the reassembly buffer is currently filled up when another fragment of a different datagram arrives and thus needs to be cached out to make room for the new reassembly.

Due to that I added a test case to the unittests of IPv6 reassembly (feee568).

In the end it turned out that when a subsequent fragment is received packet parts that are stored in the reassembly buffer are freed from the packet buffer on reassembly buffer creation. This in turn leads that freed (but still referenced by the reassembly buffer) region to be reused for another packet coming in, e.g. another fragment, that then caches the other reassembly buffer entry out, since the reassembly buffer is full, leading to parts of its data to be released by the reassembly buffer, causing a crash, as the data is now not valid anymore.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
With a board of your choice (preferably `native`, as this test due to an `ethos` bug [#12264] skips some tests for non-native boards):
```
make -C tests/gnrc_ipv6_ext_frag flash
sudo make -C tests/gnrc_ipv6_ext test
```

if feee568 is reverted, the test fails.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #12375.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
