### PR TITLE
boards/stm32: add 54MHz and 108MHz SPI divtable entries

### DIFF
--- a/boards/common/stm32/include/cfg_spi_divtable.h
+++ b/boards/common/stm32/include/cfg_spi_divtable.h
@@ -237,6 +237,8 @@ static const uint8_t spi_divtable[2][5] = {
     CFG_SPIDIV_96
 #elif (CLOCK_APB1 == 100000000)
     CFG_SPIDIV_100
+#elif (CLOCK_APB1 == 108000000)
+    CFG_SPIDIV_108
 #else
 #error "CFG_SPI_DIVTABLE: no prescalers for selected APB1 bus clock defined"
 #endif
@@ -259,6 +261,8 @@ static const uint8_t spi_divtable[2][5] = {
     CFG_SPIDIV_48
 #elif (CLOCK_APB2 == 50000000)
     CFG_SPIDIV_50
+#elif (CLOCK_APB2 == 54000000)
+    CFG_SPIDIV_54
 #elif (CLOCK_APB2 == 72000000)
     CFG_SPIDIV_72
 #elif (CLOCK_APB2 == 60000000)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

#10979 attached a fixed file. I just turned that into this PR. The changes look sensible to me

Fixes #10979.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#10979 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
