### PR TITLE
boards/feather-m0: fix typo in doc

### DIFF
--- a/boards/feather-m0/doc.txt
+++ b/boards/feather-m0/doc.txt
@@ -17,7 +17,7 @@ Several types of Feather M0 boards exist:
 * [Feather M0 Adalogger](https://learn.adafruit.com/adafruit-feather-m0-adalogger/)
 * [Feather M0 LoRa](https://learn.adafruit.com/adafruit-feather-m0-radio-with-lora-radio-module)
 
-The different modules used to differenciate the boards (ATWINC1500 WiFi,
+The different modules used to differentiate the boards (ATWINC1500 WiFi,
 Bluefruit LE, SD card, LoRa) are connected via SPI (SPI_DEV(0)) to the
 SAMD21 mcu.
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a typo in feather-m0 documentation. It was reported by codespell in #12304 ([here](https://ci.riot-os.org/RIOT-OS/RIOT/12304/46deca1727fc64d4601f2018fe57c1cb535a3c41/output/static_tests.txt))

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read the doc.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Reported by codespell in #12304 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
