### PR TITLE
tests/gnrc_rpl_srh: fix test assumption

### DIFF
--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -99,12 +99,10 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh, void **err_ptr)
 
     if (ipv6_addr_is_multicast(&ipv6->dst)) {
         DEBUG("RPL SRH: found a multicast destination address - discard\n");
-        *err_ptr = &ipv6->dst;
         return GNRC_IPV6_EXT_RH_ERROR;
     }
     if (ipv6_addr_is_multicast(&addr)) {
         DEBUG("RPL SRH: found a multicast addres in next address - discard\n");
-        *err_ptr = current_address;
         return GNRC_IPV6_EXT_RH_ERROR;
     }
 

--- a/tests/gnrc_rpl_srh/main.c
+++ b/tests/gnrc_rpl_srh/main.c
@@ -85,7 +85,7 @@ static void test_rpl_srh_dst_multicast(void)
     static const ipv6_addr_t mcast = IPV6_MCAST_ADDR;
     gnrc_rpl_srh_t *srh;
     uint8_t *vec;
-    void *err_ptr;
+    void *err_ptr = NULL;
     int res;
 
     _init_hdrs(&srh, &vec, &mcast);
@@ -96,7 +96,7 @@ static void test_rpl_srh_dst_multicast(void)
 
     res = gnrc_rpl_srh_process(&hdr, srh, &err_ptr);
     TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_ERROR);
-    TEST_ASSERT((&hdr.dst) == err_ptr);
+    TEST_ASSERT_NULL(err_ptr);
 }
 
 static void test_rpl_srh_route_multicast(void)
@@ -106,7 +106,7 @@ static void test_rpl_srh_route_multicast(void)
     static const ipv6_addr_t dst = IPV6_DST;
     gnrc_rpl_srh_t *srh;
     uint8_t *vec;
-    void *err_ptr;
+    void *err_ptr = NULL;
     int res;
 
     _init_hdrs(&srh, &vec, &dst);
@@ -117,7 +117,7 @@ static void test_rpl_srh_route_multicast(void)
 
     res = gnrc_rpl_srh_process(&hdr, srh, &err_ptr);
     TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_ERROR);
-    TEST_ASSERT(vec == err_ptr);
+    TEST_ASSERT_NULL(err_ptr);
 }
 
 static void test_rpl_srh_too_many_seg_left(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
If the destination address or an address within the source route is multicast within a RPL source routing header, a receiving node is supposed to just discard the packets, but not to send an ICMPv6 error message, as the test assumes at the moment.

Source: https://tools.ietf.org/html/rfc6554#section-4.2

There is also a fix that prevents the implementation from sending such an error message: If we leave the `err_ptr` unset in these cases, the [node will not send an error message][err_ptr set].

[err_ptr set]: https://github.com/RIOT-OS/RIOT/blob/9bc600a/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c#L100-L105
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read the algorithm provided above, especially the section regarding multicast:

         if Address[i] or the IPv6 Destination Address is multicast {
            discard the packet
         }

The test cases that check multicast addresses in `tests/gnrc_rpl_srh` should now pass (the test in general does not pass completely (but will, when #12442 is merged).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes one of the issues in https://github.com/RIOT-OS/RIOT/issues/12436
Accompanies #12442
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
