### PR TITLE
tests/riotboot: fix test running test in docker.

### DIFF
--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -21,6 +21,11 @@ QUIET ?= 1
 # Thus default to that (instead of epoch set by makefiles/boot/riotboot.inc.mk).
 APP_VER?=0
 
+# Ensure both slot bin files are always generated and linked to avoid compiling
+# during the test. This ensures that "BUILD_IN_DOCKER=1 make test"
+# can rely on them being present without having to trigger re-compilation.
+BUILD_FILES += $(SLOT_RIOT_ELFS:%.elf=%.bin)
+
 # The test needs the linked slot binaries without header in order to be able to
 # create final binaries with specific APP_VER values. The CI RasPi test workers
 # don't compile themselves, thus add the required files here so they will be


### PR DESCRIPTION
### Contribution description

This PR fixes `riotboot` test when building in docker.

I'm not sure this is necessarily the best fix, since the issue actually comes from:

https://github.com/RIOT-OS/RIOT/blob/8a1e78bf4ddeb714fb779e2ddf3ca974c6ff3557/Makefile.include#L491-L521

So it comes from the fact that the following target is not defined when calling `make test` and `BUILD_IN_DOCKER` is set.

```
%.bin: %.elf
	$(Q)$(OBJCOPY) $(OFLAGS) -Obinary $< $@
```

Although this is not actually a build instruction it does require the tool-chain.

I think the proposed solution might be better since it is not very intrusive and can be easily introduced and backported without changing the default handling of for `BUILD_IN_DOCKER`. I think the handling itself is flaud

I also think this should be back-ported.

### Testing procedure

As reported in #12003, the following command fails in master:

```
BUILD_IN_DOCKER=1 RIOTBOOT_SKIP_COMPILE=1 BOARD=iotlab-m3 make --no-print-directory -C tests/riotboot clean flash test
```

<details><summary><b>master</b></summary>

```
�main(): This is RIOT! (Version: 2020.01-devel-32-g9bc60-HEAD)
Hello riotboot!
You are running RIOT on a(n) iotlab-m3 board.
This board features a(n) stm32f1 MCU.
riotboot_test: running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x00000000
Image start address: 0x08001400
Header chksum: 0x8d7ab9a1

>  curslotnr
Current slot=0
> curslothdr
 curslothdr
Image magic_number: 0x544f4952
Image Version: 0x00000000
Image start address: 0x08001400
Header chksum: 0x8d7ab9a1

> getslotaddr 0
 getslotaddr 0
Slot 0 address=0x08001400
> dumpaddrs
 dumpaddrs
slot 0: metadata: 0x8001000 image: 0x08001400
slot 1: metadata: 0x8040800 image: 0x00000000
> 
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
make[1]: *** No rule to make target '/home/francisco/workspace/RIOT/tests/riotboot/bin/iotlab-m3/tests_riotboot-slot1.bin', needed by '/home/francisco/workspace/RIOT/tests/riotboot/bin/iotlab-m3/tests_riotboot-slot1.hdr'.  Stop.
/home/francisco/workspace/RIOT/tests/riotboot/../../Makefile.include:689: recipe for target 'test' failed
make: *** [test] Error 1
```
</details>

<details><summary><b>This PR</b></summary>

```
�main(): This is RIOT! (Version: 2020.01-devel-33-gdbc94-pr_fix_tests_riotboot)
Hello riotboot!
You are running RIOT on a(n) iotlab-m3 board.
This board features a(n) stm32f1 MCU.
riotboot_test: running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x00000002
Image start address: 0x08001400
Header chksum: 0x8d82b9a3

>  curslotnr
Current slot=0
> curslothdr
 curslothdr
Image magic_number: 0x544f4952
Image Version: 0x00000002
Image start address: 0x08001400
Header chksum: 0x8d82b9a3

> getslotaddr 0
 getslotaddr 0
Slot 0 address=0x08001400
> dumpaddrs
 dumpaddrs
slot 0: metadata: 0x8001000 image: 0x08001400
slot 1: metadata: 0x8040800 image: 0x08040c00
> 
[TEST PASSED]
```
</details>

### Issues/PRs references

Related to #12003 