### PR TITLE
unittests: remove blacklisting for non-32 platforms

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,23 +1,6 @@
 DEVELHELP ?= 0
 include ../Makefile.tests_common
 
-# Issue with integer width
-# There are present for a long time but hidden by being not compiled
-BOARD_BLACKLIST += arduino-duemilanove
-BOARD_BLACKLIST += arduino-leonardo
-BOARD_BLACKLIST += arduino-mega2560
-BOARD_BLACKLIST += arduino-nano
-BOARD_BLACKLIST += arduino-uno
-BOARD_BLACKLIST += chronos
-BOARD_BLACKLIST += mega-xplained
-BOARD_BLACKLIST += msb-430
-BOARD_BLACKLIST += msb-430h
-BOARD_BLACKLIST += telosb
-BOARD_BLACKLIST += waspmote-pro
-BOARD_BLACKLIST += wsn430-v1_3b
-BOARD_BLACKLIST += wsn430-v1_4
-BOARD_BLACKLIST += z1
-
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-duemilanove \
                              arduino-leonardo \

--- a/tests/unittests/tests-pkt/tests-pkt.c
+++ b/tests/unittests/tests-pkt/tests-pkt.c
@@ -185,8 +185,8 @@ static void test_pkt_equals_iolist(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(&iol, &pkt, sizeof(iol)));
 
     /* check size position */
-    iol.iol_len = 0x12345678;
-    pkt.size = 0x12345678;
+    iol.iol_len = (size_t)0x12345678U;
+    pkt.size = (size_t)0x12345678U;
 
     TEST_ASSERT_EQUAL_INT(0, memcmp(&iol, &pkt, sizeof(iol)));
 

--- a/tests/unittests/tests-rtc/Makefile.include
+++ b/tests/unittests/tests-rtc/Makefile.include
@@ -1,3 +1,6 @@
 CFLAGS += -DRTC_NORMALIZE_COMPAT=1
 
 USEMODULE += periph_rtc_common
+
+# MSP-430's libc does not provide `mktime()` used by this test
+FEATURES_BLACKLIST += arch_msp430

--- a/tests/unittests/tests-rtc/tests-rtc.c
+++ b/tests/unittests/tests-rtc/tests-rtc.c
@@ -54,7 +54,7 @@ static void test_rtc_compat(void)
 static void test_rtc_sec_wrap(void)
 {
     struct tm t1 = {
-        .tm_sec  = 360,
+        .tm_sec  = 120,
         .tm_min  =  58,
         .tm_hour =  23,
         .tm_mday =  30,
@@ -75,7 +75,7 @@ static void test_rtc_sec_wrap(void)
 static void test_rtc_lyear(void)
 {
     struct tm t1 = {
-        .tm_sec  = 360,
+        .tm_sec  = 120,
         .tm_min  =  58,
         .tm_hour =  23,
         .tm_mday =  28,
@@ -96,7 +96,7 @@ static void test_rtc_lyear(void)
 static void test_rtc_nyear(void)
 {
     struct tm t1 = {
-        .tm_sec  = 360,
+        .tm_sec  = 120,
         .tm_min  =  58,
         .tm_hour =  23,
         .tm_mday =  28,
@@ -117,7 +117,7 @@ static void test_rtc_nyear(void)
 static void test_rtc_ywrap(void)
 {
     struct tm t1 = {
-        .tm_sec  = 360,
+        .tm_sec  = 120,
         .tm_min  =  58,
         .tm_hour =  23,
         .tm_mday =  32,
@@ -138,7 +138,7 @@ static void test_rtc_ywrap(void)
 static void test_rtc_year(void)
 {
     struct tm t1 = {
-        .tm_sec  = 360,
+        .tm_sec  = 120,
         .tm_min  =  58,
         .tm_hour =  23,
         .tm_mday =  32,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Inspired by #9081 I looked into the unittests what could be cleaned up there to remove `BOARD_BLACKLIST`. For this I had to:

- Adapt some test values to make the tests compilable for non-32-bit platforms again
  - for tests-pkt: it just compares the sizes, so the value is arbitrary
  and can be cast to `size_t` without worries
  - for `tests-rtc`: 360 and 120 are the same under `mod 60` (which seconds usually are), but 120 fits into `int8_t`'s value space used by `avr-libc`'s `struct tm`.
- blacklist `arch_msp430` for the `tests-rtc` test suite, as it uses `mktime()` which is not provided by `msp430-libc`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/unittests` should still work. Specifically, they should now also work (test-suite-wise) on AVR-based platforms and for the most part on MSP430-based (excluding the `tests-rtc` test suite).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #9081, reverting parts of #12040.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
