### PR TITLE
cpu: add missing arch features to fe310

### DIFF
--- a/cpu/fe310/Makefile.features
+++ b/cpu/fe310/Makefile.features
@@ -1,2 +1,4 @@
+FEATURES_PROVIDED += arch_32bit
+FEATURES_PROVIDED += arch_riscv
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_pm


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adds arch_32bit and arch_riscv to cpu/fe310 to allow for feature
requirements and blacklisting.

### Testing procedure

just an addition, CI green should be enough.


### Issues/PRs references

follow up on #9081 
