### PR TITLE
examples/dtls-echo: remove board blacklist

### DIFF
--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -7,6 +7,8 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+FEATURES_REQUIRED += arch_32bit
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default


### PR DESCRIPTION

### Contribution description

Replaces the BOARD_BLACKLIST with a feature requirement, i.e. CPUs with 32 bit arch only.


### Testing procedure

compare output of `make info-boards-supported` of this PR and master, they should match, i.e. not differ


### Issues/PRs references

~~requires #12449~~ 

followup on #9081 
