### PR TITLE
Makefile.include: fail by default when errors are expected

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -786,7 +786,12 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
     $(shell $(COLOR_ECHO) "\n$(COLOR_YELLOW)EXPECT undesired behaviour!$(COLOR_RESET)" 1>&2)
   endif
 
+  # Fail by default when errors are expected
+  CONTINUE_ON_EXPECTED_ERRORS ?= 0
   ifneq (, $(EXPECT_ERRORS))
+    ifneq (1,$(CONTINUE_ON_EXPECTED_ERRORS))
+      $(error You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line)
+    endif
     $(shell $(COLOR_ECHO) "\n\n$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)\n\n" 1>&2)
   endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates Makefile.include so that it fails when errors are expected because of features missing, blacklisted boards, etc

It's still possible to force the build using WERROR=0 on the command line. The make error message prints this info, just in case.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try for example:
- `make BOARD=arduino-uno -C tests/ssp/`
- `make BOARD=arduino-uno -C tests/periph_flashpage`

For both, the build is stopped immediately.

Try:
- `WERROR=0 make BOARD=arduino-uno -C tests/ssp/`

The build continues (but fails later). This is the same behavior as we have now.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
