### PR TITLE
make: handle blacklisted features separatly from missing requirements

### DIFF
--- a/Makefile.features
+++ b/Makefile.features
@@ -25,8 +25,7 @@ endif
 # Features that are required by the application but not provided by the BSP and
 # features that are used but blacklisted (prepended with "!").
 # Having features missing may case the build to fail.
-FEATURES_MISSING = $(sort $(filter-out $(FEATURES_PROVIDED),$(FEATURES_REQUIRED)) \
-                     $(call _features_used_blacklisted))
+FEATURES_MISSING = $(sort $(filter-out $(FEATURES_PROVIDED),$(FEATURES_REQUIRED)))
 
 # Features that are only optional and not required at the same time.
 # The policy is to by default use by features if they are provided by the BSP.
@@ -50,6 +49,6 @@ _features_conflicting = $(if $(call _features_used_conflicting,$(subst :, ,$1)),
 #   Return non empty on error
 _features_used_conflicting = $(filter $(words $1),$(words $(filter $(FEATURES_USED),$1)))
 
-# Return features that are used but blacklisted as
-# "!<feature>" ("not feature")
-_features_used_blacklisted = $(addprefix !,$(sort $(filter $(FEATURES_USED), $(FEATURES_BLACKLIST))))
+# Features that are used by the application but blacklisted by the BSP.
+# Having blacklisted features may case the build to fail.
+FEATURES_BLACKLISTED = $(sort $(filter $(FEATURES_USED), $(FEATURES_BLACKLIST)))

--- a/Makefile.include
+++ b/Makefile.include
@@ -732,13 +732,17 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
     EXPECT_ERRORS := 1
   endif
 
-  # turn provided but blacklisted features into required "!<feature>"
-  FEATURES_REQUIRED += $(addprefix !,$(sort $(filter $(FEATURES_PROVIDED), $(FEATURES_BLACKLIST))))
-
   # Test if all feature requirements were met by the selected board.
   ifneq (,$(FEATURES_MISSING))
     $(shell $(COLOR_ECHO) "$(COLOR_RED)There are unsatisfied feature requirements:$(COLOR_RESET)"\
                           "$(FEATURES_MISSING)" 1>&2)
+    EXPECT_ERRORS := 1
+  endif
+
+  # Test if no feature in the requirements is blacklisted for the selected board.
+  ifneq (,$(FEATURES_BLACKLISTED))
+    $(shell $(COLOR_ECHO) "$(COLOR_RED)Some feature requirements are blacklisted:$(COLOR_RESET)"\
+                          "$(FEATURES_BLACKLISTED)" 1>&2)
     EXPECT_ERRORS := 1
   endif
 

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -11,7 +11,7 @@ DISABLE_MODULE_GLOBAL := $(DISABLE_MODULE)
 DEFAULT_MODULE_GLOBAL := $(DEFAULT_MODULE)
 FEATURES_BLACKLIST_GLOBAL := $(FEATURES_BLACKLIST)
 
-define board_missing_features
+define board_unsatisfied_features
   BOARD             := $(1)
   USEMODULE         := $(USEMODULE_GLOBAL)
   USEPKG            := $(USEPKG_GLOBAL)
@@ -43,6 +43,11 @@ define board_missing_features
     BOARDS_WITH_MISSING_FEATURES += $(1)
   endif
 
+  ifneq (,$$(FEATURES_BLACKLISTED))
+    BOARDS_FEATURES_BLACKLISTED += "$(1) $$(FEATURES_BLACKLISTED)"
+    BOARDS_WITH_BLACKLISTED_FEATURES += $(1)
+  endif
+
   ifneq (,$$(DEPENDENCY_DEBUG))
     $$(call file_save_dependencies_variables,dependencies_info-boards-supported)
   endif
@@ -53,8 +58,11 @@ BOARDS := $(filter-out $(BOARD_BLACKLIST), $(BOARDS))
 
 BOARDS_WITH_MISSING_FEATURES :=
 BOARDS_FEATURES_MISSING :=
-$(foreach BOARD, $(BOARDS), $(eval $(call board_missing_features,$(BOARD))))
-BOARDS := $(filter-out $(BOARDS_WITH_MISSING_FEATURES), $(BOARDS))
+BOARDS_WITH_BLACKLISTED_FEATURES :=
+BOARDS_FEATURES_BLACKLISTED :=
+
+$(foreach BOARD, $(BOARDS), $(eval $(call board_unsatisfied_features,$(BOARD))))
+BOARDS := $(filter-out $(BOARDS_WITH_MISSING_FEATURES) $(BOARDS_WITH_BLACKLISTED_FEATURES), $(BOARDS))
 
 info-buildsizes: SHELL=bash
 info-buildsizes:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR addresses the several comments (https://github.com/RIOT-OS/RIOT/pull/9081#discussion_r186130635, https://github.com/RIOT-OS/RIOT/pull/9081#discussion_r334361682) made in #9081 but kept unadressed about moving the management of blacklisted features in a dedicated variable.

The current behavior is to say a blacklisted features used is a missing non blacklisted requirements. This is far from obvious.

We can discuss on the name of the new variable introduced by this PR. But at least the error message displayed when one wants to use a blacklisted feature in an application is much more easy to understand.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `make info-board-supported` should not differ from master
- A green CI is also a good indicator

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Cleanup of #9081 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
