### PR TITLE
examples/dtls-wolfssl: remove boards blacklist

### DIFF
--- a/examples/dtls-wolfssl/Makefile
+++ b/examples/dtls-wolfssl/Makefile
@@ -8,9 +8,7 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 # wolfSSL supports 32-bit architectures only
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-nano arduino-uno \
-                   chronos mega-xplained msb-430 msb-430h telosb \
-                   waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+FEATURES_REQUIRED += arch_32bit
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill \
                              calliope-mini cc2650-launchpad cc2650stk hifive1 i-nucleo-lrwan1 \


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Replaces the boards blacklist with a new arch_32bit feature requirement.


### Testing procedure

Compare `info-boards-supported` for this PR and master, should match with no diff.
Also compiling and running the example should work as on master.


### Issues/PRs references

#9081, #12450 
