### PR TITLE
unittests: remove board blacklist, fix doc for MCU architectures

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,23 +1,6 @@
 DEVELHELP ?= 0
 include ../Makefile.tests_common
 
-# Issue with integer width
-# There are present for a long time but hidden by being not compiled
-BOARD_BLACKLIST += arduino-duemilanove
-BOARD_BLACKLIST += arduino-leonardo
-BOARD_BLACKLIST += arduino-mega2560
-BOARD_BLACKLIST += arduino-nano
-BOARD_BLACKLIST += arduino-uno
-BOARD_BLACKLIST += chronos
-BOARD_BLACKLIST += mega-xplained
-BOARD_BLACKLIST += msb-430
-BOARD_BLACKLIST += msb-430h
-BOARD_BLACKLIST += telosb
-BOARD_BLACKLIST += waspmote-pro
-BOARD_BLACKLIST += wsn430-v1_3b
-BOARD_BLACKLIST += wsn430-v1_4
-BOARD_BLACKLIST += z1
-
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-duemilanove \
                              arduino-leonardo \

--- a/tests/unittests/tests-pkt/Makefile.include
+++ b/tests/unittests/tests-pkt/Makefile.include
@@ -1,1 +1,5 @@
 USEMODULE += gnrc_ipv6
+
+# Test assumes 32-bit width for `size_t` which is only the case on our 32-bit
+# platforms
+FEATURES_REQUIRED += arch_32bit

--- a/tests/unittests/tests-rtc/Makefile.include
+++ b/tests/unittests/tests-rtc/Makefile.include
@@ -1,3 +1,10 @@
 CFLAGS += -DRTC_NORMALIZE_COMPAT=1
 
 USEMODULE += periph_rtc_common
+
+# MSP-430's libc does not provide `mktime()` used by this test
+FEATURES_BLACKLIST += arch_msp430
+
+# AVR/ATmega uses `int8_t` for `struct tm` which leads to integer overflows
+# in these tests
+FEATURES_BLACKLIST += arch_avr8


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Moves unittests from `BOARD_BLACKLIST` to architecture `FEATURES_*`. Additionally, the doc is fixed from just "integer width" problem to document the specific problems with integer width (and other problems).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/unittests` should still pass the compile tests on CI.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to #12447 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
