### PR TITLE
 unittests: fix `tests-pkt` for non-32bit platforms 

### DIFF
--- a/tests/unittests/tests-pkt/Makefile.include
+++ b/tests/unittests/tests-pkt/Makefile.include
@@ -1,5 +1,1 @@
 USEMODULE += gnrc_ipv6
-
-# Test assumes 32-bit width for `size_t` which is only the case on our 32-bit
-# platforms
-FEATURES_REQUIRED += arch_32bit

--- a/tests/unittests/tests-pkt/tests-pkt.c
+++ b/tests/unittests/tests-pkt/tests-pkt.c
@@ -185,8 +185,8 @@ static void test_pkt_equals_iolist(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(&iol, &pkt, sizeof(iol)));
 
     /* check size position */
-    iol.iol_len = 0x12345678;
-    pkt.size = 0x12345678;
+    iol.iol_len = (size_t)0x12345678;
+    pkt.size = (size_t)0x12345678;
 
     TEST_ASSERT_EQUAL_INT(0, memcmp(&iol, &pkt, sizeof(iol)));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
See notes on `tests-pkt` in https://github.com/RIOT-OS/RIOT/pull/12447.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
make -C tests/unittests tests-pkt test
```

should work for non-32bit platforms.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to https://github.com/RIOT-OS/RIOT/pull/12447, depends on #12455 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
