### PR TITLE
makefiles/vars.inc.mk: introduce and use `PROG_DEV`

### DIFF
--- a/boards/arduino-leonardo/Makefile.include
+++ b/boards/arduino-leonardo/Makefile.include
@@ -1,5 +1,11 @@
+# For backward compatibility
+ifneq (,$(AVRDUDE_PORT))
+  $(warning Warning! AVRDUDE_PORT is deprecated use PROG_DEV)
+  PROG_DEV ?= $(AVRDUDE_PORT)
+endif
+
 PORT_LINUX      ?= /dev/ttyUSB0
-AVRDUDE_PORT    ?= /dev/ttyACM0
+PROG_DEV        ?= /dev/ttyACM0
 PORT_DARWIN     ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD            ?= 9600
 

--- a/boards/arduino-leonardo/doc.txt
+++ b/boards/arduino-leonardo/doc.txt
@@ -55,8 +55,8 @@ the user program, flashing will fail. See below to work arround
 
 ## Mac Users
 
-Mac Users have export the environment variable both `PORT` and `AVRDUDE_PORT`
+Mac Users have export the environment variable both `PORT` and `PROG_DEV`
 to point to the device file of the TTL adapter (`PORT`) and the device file of
-the Arduino Leonardo (`AVRDUDE_PORT`).
+the Arduino Leonardo (`PROG_DEV`).
 
  */

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -20,7 +20,7 @@ export PROGRAMMER ?= cc2538-bsl
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
   FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  FFLAGS  = -p "$(PORT)" -e -w -v $(FLASHFILE)
+  FFLAGS  = -p "$(PROG_DEV)" -e -w -v $(FLASHFILE)
 else ifeq ($(PROGRAMMER),jlink)
   FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
   FFLAGS  = $(BINDIR) $(FLASHFILE)

--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -5,4 +5,4 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
 RESET ?= esptool.py
-RESET_FLAGS ?= --port $(PORT) --before default_reset run
+RESET_FLAGS ?= --port $(PROG_DEV) --before default_reset run

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -5,4 +5,4 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
 RESET ?= esptool.py
-RESET_FLAGS ?= --port $(PORT) --before default_reset run
+RESET_FLAGS ?= --port $(PROG_DEV) --before default_reset run

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -8,7 +8,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 export PROGRAMMER ?= olimex
 MSPDEBUGFLAGS += -j $(PROGRAMMER)
 ifeq ($(strip $(PROGRAMMER)),uif)
-  MSPDEBUGFLAGS += -d $(PORT)
+  MSPDEBUGFLAGS += -d $(PROG_DEV)
 endif
 FLASHER ?= mspdebug
 FLASHFILE ?= $(HEXFILE)

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -20,6 +20,6 @@ PYTERMFLAGS += -tg
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 FLASHFILE ?= $(HEXFILE)
-FFLAGS = $(PORT) $(FLASHFILE)
+FFLAGS = $(PROG_DEV) $(FLASHFILE)
 
 INCLUDES += -I$(RIOTBOARD)/common/msba2/include

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -30,4 +30,3 @@ OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 
 # include common remote includes
 INCLUDES += -I$(RIOTBOARD)/common/remote/include
-

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -1,15 +1,19 @@
 # define the default flash-tool
 export PROGRAMMER ?= cc2538-bsl
 
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# For backward compatibility
+ifneq (,$(PORT_BSL))
+  $(warning Warning! PORT_BSL is deprecated use PROG_DEV)
+  PROG_DEV ?= $(PORT_BSL)
+endif
+
 ifeq ($(PROGRAMMER),cc2538-bsl)
-  ifeq ($(OS),Linux)
-    PORT_BSL ?= $(PORT_LINUX)
-  else ifeq ($(OS),Darwin)
-    PORT_BSL ?= $(PORT_DARWIN)
-  endif
-  RESET ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py -p "$(PORT_BSL)"
+  RESET ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py -p "$(PROG_DEV)"
   FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  FFLAGS  = -p "$(PORT_BSL)" -e -w -v -b 115200 $(FLASHFILE)
+  FFLAGS  = -p "$(PROG_DEV)" -e -w -v -b 115200 $(FLASHFILE)
 else ifeq ($(PROGRAMMER),jlink)
   FLASHER = $(RIOTBOARD)/common/remote/dist/flash.sh
   FFLAGS  = $(BINDIR) $(FLASHFILE)
@@ -27,5 +31,3 @@ OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 # include common remote includes
 INCLUDES += -I$(RIOTBOARD)/common/remote/include
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -11,4 +11,4 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # configure the flash tool
 FLASHER = mspdebug
 FLASHFILE ?= $(HEXFILE)
-FFLAGS = -d $(PORT) -j uif "prog $(FLASHFILE)"
+FFLAGS = -d $(PROG_DEV) -j uif "prog $(FLASHFILE)"

--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -15,6 +15,6 @@ FLASHFILE ?= $(BINFILE)
 # -u: use sector by sector erase
 # -S: swap RTS and DTR
 # -l 0x1ff: amount of sectors to erase
-FFLAGS += -p $(PORT) -e -u -S -l 0x1ff -w $(FLASHFILE)
+FFLAGS += -p $(PROG_DEV) -e -u -S -l 0x1ff -w $(FLASHFILE)
 
 PYTERMFLAGS +=  --set-rts 0

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -3,22 +3,28 @@
 BOOTLOADER_SIZE ?= 4K
 ROM_RESERVED ?= $(BOOTLOADER_SIZE)
 
-# configure the terminal program
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-BAUD        ?= 9600
-include $(RIOTMAKE)/tools/serial.inc.mk
+# For backward compatibility
+ifneq (,$(AVRDUDE_PORT))
+  $(warning Warning! AVRDUDE_PORT is deprecated use PROG_DEV)
+  PROG_DEV ?= $(AVRDUDE_PORT)
+endif
 
 # PROGRAMMER defaults to the external flasher Bus Pirate ISP using avrdude.
 PROGRAMMER  ?= buspirate
 # set serial port for avrdude with buspirate
 ifeq ($(OS),Linux)
-  AVRDUDE_PORT ?= /dev/ttyUSB0
+  PROG_DEV ?= /dev/ttyUSB0
 else ifeq ($(OS),Darwin)
-  AVRDUDE_PORT ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+  PROG_DEV ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 endif
 # avoid error if mcu signature doesn't match
 FFLAGS_EXTRA += -F
+
+# configure the terminal program
+PORT_LINUX  ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+BAUD        ?= 9600
+include $(RIOTMAKE)/tools/serial.inc.mk
 
 include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -1,18 +1,17 @@
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
 # custom flasher to use with the bootloader
 FLASHER = $(RIOTBOARD)/$(BOARD)/dist/robotis-loader.py
 DEBUGGER =
 DEBUGSERVER =
 
 FLASHFILE ?= $(BINFILE)
-FFLAGS = $(PORT) $(FLASHFILE)
+FFLAGS = $(PROG_DEV) $(FLASHFILE)
 DEBUGGER_FLAGS =
-
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 # Skip the space needed by the embedded bootloader
 export ROM_OFFSET ?= 0x3000
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -2,20 +2,24 @@
 PORT_LINUX ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
 # Set default flash tool
 export PROGRAMMER ?= cc2538-bsl
 
+# For backward compatibility
+ifneq (,$(PORT_BSL))
+  $(warning Warning! PORT_BSL is deprecated use PROG_DEV)
+  PROG_DEV ?= $(PORT_BSL)
+endif
+
 ifeq ($(PROGRAMMER),cc2538-bsl)
-  ifeq ($(OS),Linux)
-    PORT_BSL ?= $(PORT_LINUX)
-  else ifeq ($(OS),Darwin)
-    PORT_BSL ?= $(PORT_DARWIN)
-  endif
   FLASHFILE ?= $(HEXFILE)
   FLASHER = $(RIOTBASE)/dist/tools/cc2538-bsl/cc2538-bsl.py
-  FFLAGS  = -p "$(PORT_BSL)" --bootloader-invert-lines -e -w -v -b 460800 $(FLASHFILE)
+  FFLAGS  = -p "$(PROG_DEV)" --bootloader-invert-lines -e -w -v -b 460800 $(FLASHFILE)
   RESET ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  RESET_FLAGS ?= -p "$(PORT_BSL)" --bootloader-invert-lines
+  RESET_FLAGS ?= -p "$(PROG_DEV)" --bootloader-invert-lines
 else ifeq ($(PROGRAMMER),jlink)
   # Special flashing and reset scripts are required due to board hardware
   export FLASH_ADDR = 0x200000
@@ -26,6 +30,3 @@ else ifeq ($(PROGRAMMER),jlink)
 endif
 
 OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/openmote-b/doc.txt
+++ b/boards/openmote-b/doc.txt
@@ -38,7 +38,7 @@ RIOT support flashing with USB by default.
 `make flash`
 
 You may have to specify the flashing port with
-`PORT_BSL=<my_openmote_port> make flash`
+`PORT_DEV=<my_openmote_port> make flash`
 
 ### Flashing via JTAG
 

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -2,6 +2,8 @@
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
 # Set default flash tool
 export PROGRAMMER ?= cc2538-bsl
 
@@ -15,8 +17,5 @@ ifeq ($(PROGRAMMER),jlink)
 else
   FLASHFILE ?= $(BINFILE)
   FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  FFLAGS  = -p "$(PORT)" -e -w -v -b 460800 $(FLASHFILE)
+  FFLAGS  = -p "$(PROG_DEV)" -e -w -v -b 460800 $(FLASHFILE)
 endif
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -1,8 +1,8 @@
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-include $(RIOTMAKE)/tools/serial.inc.mk
 
+include $(RIOTMAKE)/tools/serial.inc.mk
 FLASHER = dfu-util
 DEBUGGER = # spark core has no debugger
 RESET ?= # dfu-util has no support for resetting the device

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -8,4 +8,4 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # flash tool configuration
 FLASHER = $(RIOTTOOLS)/goodfet/goodfet.bsl
 FLASHFILE ?= $(HEXFILE)
-FFLAGS = --telosb -c $(PORT) -r -e -I -p $(FLASHFILE)
+FFLAGS = --telosb -c $(PROG_DEV) -r -e -I -p $(FLASHFILE)

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -7,4 +7,4 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # setup flash tool
 FLASHER = $(RIOTTOOLS)/goodfet/goodfet.bsl
 FLASHFILE ?= $(HEXFILE)
-FFLAGS = --z1 -I -c $(PORT) -r -e -p $(FLASHFILE)
+FFLAGS = --z1 -I -c $(PROG_DEV) -r -e -p $(FLASHFILE)

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -196,7 +196,7 @@ ifeq ($(QEMU), 1)
 else
     export PROGRAMMER_SPEED ?= 460800
     FLASHER = $(ESPTOOL)
-    FFLAGS += --chip esp32 -p $(PORT) -b $(PROGRAMMER_SPEED)
+    FFLAGS += --chip esp32 -p $(PROG_DEV) -b $(PROGRAMMER_SPEED)
     FFLAGS += --before default_reset --after hard_reset write_flash
     FFLAGS += -z -fm $(FLASH_MODE) -fs detect -ff $(FLASH_FREQ)
     FFLAGS += 0x1000 $(RIOTCPU)/$(CPU)/bin/bootloader.bin

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -156,10 +156,10 @@ else
     FLASH_MODE ?= dout
     export PROGRAMMER_SPEED ?= 460800
     FLASHER = esptool.py
-    FFLAGS += -p $(PORT) -b $(PROGRAMMER_SPEED) write_flash
+    FFLAGS += -p $(PROG_DEV) -b $(PROGRAMMER_SPEED) write_flash
     FFLAGS += -fm $(FLASH_MODE)
     FFLAGS += 0 $(FLASHFILE)-0x00000.bin
-    FFLAGS += 0x10000 $(FLASHFILE)-0x10000.bin; esptool.py -p $(PORT) run
+    FFLAGS += 0x10000 $(FLASHFILE)-0x10000.bin; esptool.py -p $(PROG_DEV) run
 endif
 
 OPTIONAL_CFLAGS_BLACKLIST += -fdiagnostics-color

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -91,6 +91,7 @@ info-build:
 	@echo 'TERMPROG:  $(TERMPROG)'
 	@echo 'TERMFLAGS: $(TERMFLAGS)'
 	@echo 'PORT:      $(PORT)'
+	@echo 'PROG_DEV:  $(PROG_DEV)'
 	@echo ''
 	@echo 'DEBUGGER:       $(DEBUGGER)'
 	@echo 'DEBUGGER_FLAGS: $(DEBUGGER_FLAGS)'

--- a/makefiles/tools/avrdude.inc.mk
+++ b/makefiles/tools/avrdude.inc.mk
@@ -12,8 +12,7 @@ PROGRAMMER_FLAGS = -p $(subst atmega,m,$(CPU))
 ifneq (,$(filter $(PROGRAMMER),arduino avr109 buspirate stk500v1 stk500v2 wiring))
   # make the flasher port configurable (e.g. with atmelice the port is usb)
   # defaults to terminal's serial port if not configured
-  AVRDUDE_PORT     ?= $(PORT)
-  PROGRAMMER_FLAGS += -P $(AVRDUDE_PORT)
+  PROGRAMMER_FLAGS += -P $(PROG_DEV)
 endif
 PROGRAMMER_FLAGS += $(FFLAGS_EXTRA)
 

--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -1,6 +1,6 @@
 FLASHFILE ?= $(BINFILE)
 FLASHER ?= $(RIOTTOOLS)/bossa/bossac
-FFLAGS  ?= -p $(PORT) -e -i -w -v -b -R $(FLASHFILE)
+FFLAGS  ?= -p $(PROG_DEV) -e -i -w -v -b -R $(FLASHFILE)
 
 # some arduino boards need to toggle the serial interface a little bit to get
 # them ready for flashing...
@@ -12,8 +12,9 @@ ifneq (,$(BOSSA_ARDUINO_PREFLASH))
   endif
 
   PREFLASHER ?= stty
-  PREFFLAGS  ?= $(STTY_FLAG) $(PORT) raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
+  PREFFLAGS  ?= $(STTY_FLAG) $(PROG_DEV) raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
   FLASHDEPS += preflash
+
 endif
 
 # if we go with the default (BOSSA shipped with RIOT), we download and build

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -5,6 +5,9 @@ else ifeq ($(OS),Darwin)
   PORT ?= $(call ensure_value,$(PORT_DARWIN),No port set)
 endif
 
+# Default PROG_DEV is the same as PORT
+PROG_DEV ?= $(PORT)
+
 export BAUD ?= 115200
 
 RIOT_TERMINAL ?= pyterm

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -74,6 +74,7 @@ export WERROR                # Treat all compiler warnings as errors if set to 1
 export GITCACHE              # path to git-cache executable
 export GIT_CACHE_DIR         # path to git-cache cache directory
 # FLASHER                    # The command to call on "make flash".
+# PROG_DEV                   # The device to connect the FLASHER and DEBUGGER
 # FFLAGS                     # The parameters to supply to FLASHER.
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.
 # TERMPROG                   # The command to call on "make term".


### PR DESCRIPTION
### Contribution description

In some cases the `PORT` used to program a `BOARD` is not the same used to open a serial `terminal`. This is already the case for boards using `PORT_BSL` and `AVRDUDE_PORT`. 

There are also use cases when boards that use a `BSL` botloader might want to use another `PORT` (threw a ftdi converter for examples). An examples of this are boards using `BOSA` (#12304) since the serial connection is lost if the the code halts or hardfaults, as well as during a reset command.

#12419 also needs this definition since it was shown that the `PORT` (device) used for programming is rarely the same device used for serial output, so both need to be passed to the container.

This PR introduces a new ~~`PROG_PORT`~~`PROG_DEV` and merges the definitions of `PORT_BSL` and `AVRDUDE_PORT` to also use ~~`PROG_PORT`~~`PROG_DEV` .

By default it is it set so that ~~`PROG_PORT`~~`PROG_DEV ?= PORT`. A warning is added for boards using old `PROGRAMMER PORT` definitions

### Testing procedure

- Nothing has changed for `BOARDS` using `AVRDUDE_PORT`:

```
for board in arduino-leonardo mega-xplained waspmote-pro; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-PORT info-debug-variable-PROG_DEV; done > PORT_AVRDUDE-pr.txt 
```
```
for board in arduino-leonardo mega-xplained waspmote-pro; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-PORT info-debug-variable-AVRDUDE_PORT; done > PORT_AVRDUDE-master.txt
```
```
diff PORT_AVRDUDE-pr.txt PORT_AVRDUDE-master.txt
#no diff
```

- Nothing has changed for `BOARDS` using `PORT_BSL`:

```
for board in openmote-b firefly remote-pa remote-revb remote-reva; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-PORT info-debug-variable-PROG_DEV done > PROG_DEV-pr.txt
```
```
for board in openmote-b firefly remote-pa remote-revb remote-reva; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-PORT info-debug-variable-PORT_BSL; done > PORT_BSL-master.txt
```
```
diff PORT_BSL-pr.txt PORT_BSL-master.txt
#no diff
```
- PORT is still the same:

```
for board in $(make info-boards); do PORT=/dev/test-port BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-PORT; done > PORT-[master/pr].txt
```
```
diff PORT-master.txt PORT-pr.txt
#no diff
```
- FFLAGS and related are the same:

```
for board in $(make info-boards); do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-FFLAGS info-debug-variable-PREFFLAGS info-debug-variable-PROGRAMMER_FLAGS info-debug-variable-RESET_FLAGS; done > FFLAGS-[pr/master].txt
```
```
git diff FFLAGS-pr.txt FFLAGS-master.txt
#no diff
```

- Do you agree with ~~`PROG_PORT`~~`PROG_DEV`  as a name? 

### Issues/PRs references

#12419
