### PR TITLE
tests: use test_interactive_test_util when possible

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -96,6 +96,12 @@
 #include "schedstatistics.h"
 #endif
 
+#ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
+#ifndef MODULE_SHELL_COMMANDS
+#include "test_utils/interactive_sync.h"
+#endif
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -597,4 +603,10 @@ void auto_init(void)
     extern void suit_init_conditions(void);
     suit_init_conditions();
 #endif /* MODULE_SUIT */
+
+#ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
+#ifndef MODULE_SHELL_COMMANDS
+    test_utils_interactive_sync();
+#endif
+#endif /* MODULE_TEST_UTILS_INTERACTIVE_SYNC */
 }

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -95,4 +95,8 @@ ifneq (,$(filter nimble_netif,$(USEMODULE)))
   SRC += sc_nimble_netif.c
 endif
 
+ifneq (,$(filter test_utils_interactive_sync,$(USEMODULE)))
+  SRC += sc_interactive_sync.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/sc_interactive_sync.c
+++ b/sys/shell/commands/sc_interactive_sync.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell commands interactive sync util
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include <stdio.h>
+#include "test_utils/interactive_sync.h"
+
+int _test_start(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    puts("START");
+
+    return 0;
+}
+
+
+int _test_ready(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    puts("READY");
+    return 0;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -163,6 +163,11 @@ extern int _loramac_handler(int argc, char **argv);
 extern int _nimble_netif_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
+extern int _test_start(int argc, char **argv);
+extern int _test_ready(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
 #ifdef MODULE_CONFIG
@@ -267,6 +272,10 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_NIMBLE_NETIF
     { "ble", "Manage BLE connections for NimBLE", _nimble_netif_handler },
+#endif
+#ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
+    { "r", "Test sync, Ready query", _test_ready },
+    { "s", "Test sync, Start test trigger", _test_start },
 #endif
     {NULL, NULL, NULL}
 };

--- a/sys/test_utils/interactive_sync/interactive_sync.c
+++ b/sys/test_utils/interactive_sync/interactive_sync.c
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       Interactive Sync implementation
+ *
+ *
+ * @author      Gaëtan Harter <gaetan.harter@fu-berlin.de>
+ */
+
 #include <stdio.h>
 #include "test_utils/interactive_sync.h"
 

--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,4 +1,7 @@
 APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
+
+DEFAULT_MODULE += test_utils_interactive_sync
+
 ifneq (,$(filter tests_driver_%,$(APPLICATION)))
   BOARD ?= samr21-xpro
 endif

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,6 +7,26 @@ allow basic functionality to be verified as well as provide an example of
 usage.
 
 
+Implementing automated tests
+----------------------------
+
+The goal is to be able to run all tests in a sequential way for as many targets
+as possible.
+
+As some board can't be reset without a manual trigger tests should be implemented
+with some kind of `synchronization`. This can be done in two ways:
+
+- use `test_utils_interactive_sync` when uart input/output does not need to be
+  disabled for the test. This is enabled by default.
+- set up the test in a loop so the test script will be able so sync with some kind
+  of start condition in the test.
+
+The module for the first option is `test_utils_interactive_sync` and is set as a
+default module in `Makefile.tests_common`. It can be disabled by setting in the
+application makefile `DISABLE_MODULE += test_utils_interactive_sync`. The python
+test script will adapt to it automatically.
+
+
 Running automated tests
 -----------------------
 

--- a/tests/bench_msg_pingpong/Makefile.ci
+++ b/tests/bench_msg_pingpong/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_mutex_pingpong/Makefile.ci
+++ b/tests/bench_mutex_pingpong/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_thread_flags_pingpong/Makefile.ci
+++ b/tests/bench_thread_flags_pingpong/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_thread_yield_pingpong/Makefile.ci
+++ b/tests/bench_thread_yield_pingpong/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bloom_bytes/main.c
+++ b/tests/bloom_bytes/main.c
@@ -22,6 +22,8 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "test_utils/interactive_sync.h"
+
 #include "xtimer.h"
 #include "fmt.h"
 
@@ -62,6 +64,8 @@ int main(void)
     xtimer_init();
 
     bloom_init(&bloom, BLOOM_BITS, bf, hashes, BLOOM_HASHF);
+
+    test_utils_interactive_sync();
 
     printf("Testing Bloom filter.\n\n");
     printf("m: %" PRIu32 " k: %" PRIu32 "\n\n", (uint32_t) bloom.m,

--- a/tests/cond_order/main.c
+++ b/tests/cond_order/main.c
@@ -24,7 +24,6 @@
 #include "cond.h"
 #include "mutex.h"
 #include "thread.h"
-#include "test_utils/interactive_sync.h"
 
 #define THREAD_NUMOF            (5U)
 #define THREAD_FIRSTGROUP_NUMOF (3U)
@@ -62,8 +61,6 @@ int main(void)
 {
     puts("Condition variable order test");
     puts("Please refer to the README.md for more information\n");
-
-    test_utils_interactive_sync();
 
     mutex_init(&testlock);
     cond_init(&testcond);

--- a/tests/cond_order/tests/01-run.py
+++ b/tests/cond_order/tests/01-run.py
@@ -10,8 +10,6 @@
 import os
 import sys
 
-from testrunner import test_utils_interactive_sync
-
 thread_prio = {
         3:  6,
         4:  4,
@@ -23,7 +21,6 @@ first_group_size = 3
 
 
 def testfunc(child):
-    test_utils_interactive_sync(child)
 
     for k in thread_prio.keys():
         child.expect_exact("T{} (prio {}): waiting on condition variable now"

--- a/tests/cpp_ctors/main.c
+++ b/tests/cpp_ctors/main.c
@@ -9,6 +9,7 @@
 #include "embUnit.h"
 #include "tests-cpp_ctors.h"
 #include "thread.h" /* For thread_getpid() */
+#include "test_utils/interactive_sync.h"
 
 long tests_cpp_ctors_global_value(void);
 long tests_cpp_ctors_static_value(void);
@@ -58,6 +59,8 @@ Test *tests_cpp_ctors_tests(void)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     TESTS_START();
     TESTS_RUN(tests_cpp_ctors_tests());
     TESTS_END();

--- a/tests/driver_ds1307/Makefile.ci
+++ b/tests/driver_ds1307/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \

--- a/tests/driver_nrfmin/tests/01-run.py
+++ b/tests/driver_nrfmin/tests/01-run.py
@@ -5,7 +5,6 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect("All up, running the shell now")
     child.sendline("ifconfig")
     child.expect(r"Iface\s+(\d+)\s+HWaddr:")
 

--- a/tests/float/main.c
+++ b/tests/float/main.c
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <math.h>
 
+#include "test_utils/interactive_sync.h"
+
 #include "board.h"
 
 /* as default we run the test 100k times */
@@ -34,6 +36,8 @@
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     double x = 1234567.0 / 1024.0;
 
     puts("Testing floating point arithmetic...\n");

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -35,6 +35,8 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
+DISABLE_MODULE += test_utils_interactive_sync
+
 # The test requires some setup and to be run as root
 # So it cannot currently be run
 TEST_ON_CI_BLACKLIST += all

--- a/tests/gnrc_ipv6_ext_frag/Makefile
+++ b/tests/gnrc_ipv6_ext_frag/Makefile
@@ -44,6 +44,8 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
+DISABLE_MODULE += test_utils_interactive_sync
+
 # The test requires some setup and to be run as root
 # So it cannot currently be run
 TEST_ON_CI_BLACKLIST += all

--- a/tests/gnrc_ndp/Makefile.ci
+++ b/tests/gnrc_ndp/Makefile.ci
@@ -21,4 +21,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     wsn430-v1_3b \
     wsn430-v1_4 \
+    z1 \
     #

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -39,6 +39,8 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
+DISABLE_MODULE += test_utils_interactive_sync
+
 # The test requires some setup and to be run as root
 # So it cannot currently be run
 TEST_ON_CI_BLACKLIST += all

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -25,6 +25,8 @@
 #include "net/gnrc/sixlowpan/frag/rb.h"
 #include "xtimer.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define TEST_NETIF_HDR_SRC      { 0xb3, 0x47, 0x60, 0x49, \
                                   0x78, 0xfe, 0x95, 0x48 }
 #define TEST_NETIF_HDR_DST      { 0xa4, 0xf2, 0xd2, 0xc9, \
@@ -627,6 +629,8 @@ static void run_unittests(void)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     /* no auto-init, so xtimer needs to be initialized manually*/
     xtimer_init();
     /* netreg requires queue, but queue size one should be enough for us */

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -32,6 +32,8 @@ USEMODULE += shell_commands
 
 USEMODULE += posix_inet
 
+DISABLE_MODULE += test_utils_interactive_sync
+
 LOW_MEMORY_BOARDS := nucleo-f334r8 msb-430 msb-430h
 
 ifeq ($(BOARD),$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -39,6 +39,8 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += od
 
+DISABLE_MODULE += test_utils_interactive_sync
+
 # Export used tap device to environment
 export TAPDEV = $(TAP)
 

--- a/tests/heap_cmd/tests/01-run.py
+++ b/tests/heap_cmd/tests/01-run.py
@@ -12,7 +12,6 @@ from testrunner import run
 
 def testfunc(child):
     # check startup message
-    child.expect('Shell-based test application for heap functions.')
     child.sendline('heap')
     ret = child.expect([r'heap: \d+ \(used \d+, free \d+\) \[bytes\]', 'heap statistics are not supported'])
     if ret == 1:

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -20,6 +20,8 @@ ifneq ($(BOARD),native)
   TESTS=
 endif
 
+DISABLE_MODULE += test_utils_interactive_sync
+
 # test fails on murdock and on my machine due to the process exiting directly
 TEST_ON_CI_BLACKLIST += all
 

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "test_utils/interactive_sync.h"
+
 #include "net/sock/ip.h"
 #include "xtimer.h"
 
@@ -1080,6 +1082,8 @@ static void test_sock_ip_send6__no_sock(void)
 int main(void)
 {
     uint8_t code = 0;
+
+    test_utils_interactive_sync();
 
 #ifdef SO_REUSE
     code |= 1;

--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -33,6 +33,8 @@
 #include "constants.h"
 #include "stack.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define _TEST_BUFFER_SIZE   (128)
 #define _QUEUE_SIZE         (1)
 
@@ -958,6 +960,8 @@ static void test_tcp_write6__success(void)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     uint8_t code = 0;
 
 #ifdef SO_REUSE

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -28,6 +28,8 @@
 #include "constants.h"
 #include "stack.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define _TEST_BUFFER_SIZE   (128)
 
 static uint8_t _test_buffer[_TEST_BUFFER_SIZE];
@@ -1317,6 +1319,8 @@ static void test_sock_udp_send6__no_sock(void)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     uint8_t code = 0;
 
 #ifdef SO_REUSE

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -4,5 +4,6 @@ include ../Makefile.tests_common
 CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 
 DISABLE_MODULE += auto_init
+DISABLE_MODULE += test_utils_interactive_sync
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/msg_avail/main.c
+++ b/tests/msg_avail/main.c
@@ -25,6 +25,7 @@
 
 #include "log.h"
 #include "msg.h"
+#include "test_utils/interactive_sync.h"
 
 #define MSG_QUEUE_LENGTH                (8)
 
@@ -32,11 +33,14 @@ msg_t msg_queue[MSG_QUEUE_LENGTH];
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     msg_t msges[MSG_QUEUE_LENGTH];
 
     msg_init_queue(msg_queue, MSG_QUEUE_LENGTH);
 
     puts("[START]");
+
     /* add message to own queue */
     for (int idx = 0; idx < MSG_QUEUE_LENGTH; ++idx) {
         msges[idx].type = idx;

--- a/tests/msg_try_receive/Makefile.ci
+++ b/tests/msg_try_receive/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/mutex_unlock_and_sleep/main.c
+++ b/tests/mutex_unlock_and_sleep/main.c
@@ -22,6 +22,8 @@
 #include "thread.h"
 #include "mutex.h"
 
+#include "test_utils/interactive_sync.h"
+
 static mutex_t mutex = MUTEX_INIT;
 static volatile int indicator;
 static kernel_pid_t main_pid;
@@ -47,6 +49,8 @@ static void *second_thread(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     uint32_t count = 0;
     uint32_t kcount = 0;
 

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -28,6 +28,8 @@
 #include "thread.h"
 #include "utlist.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define _EXP_LENGTH     (64)
 
 #define _MAC_STACKSIZE  (THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)
@@ -249,6 +251,8 @@ static int test_set_addr(void)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     /* initialization */
     gnrc_pktbuf_init();
     msg_init_queue(_main_msg_queue, _MAIN_MSG_QUEUE_SIZE);

--- a/tests/nordic_softdevice/tests/01-run.py
+++ b/tests/nordic_softdevice/tests/01-run.py
@@ -6,7 +6,6 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect_exact("All up, running the shell now")
     child.expect_exact(">")
     time.sleep(1)  # Wait 1s to let some time for the interface to be fully ready
     child.sendline("ifconfig")

--- a/tests/periph_rtt/main.c
+++ b/tests/periph_rtt/main.c
@@ -29,6 +29,8 @@
 #include "periph_conf.h"
 #include "periph/rtt.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define TICKS_TO_WAIT       (5 * RTT_FREQUENCY)
 
 static volatile uint32_t last;
@@ -46,6 +48,8 @@ void cb(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     puts("\nRIOT RTT low-level driver test");
     puts("This test will display 'Hello' every 5 seconds\n");
 

--- a/tests/periph_wdt/Makefile
+++ b/tests/periph_wdt/Makefile
@@ -5,5 +5,6 @@ FEATURES_REQUIRED += periph_wdt
 
 USEMODULE += xtimer
 USEMODULE += shell
+USEMODULE += shell_commands
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_libfixmath/Makefile
+++ b/tests/pkg_libfixmath/Makefile
@@ -2,6 +2,5 @@ include ../Makefile.tests_common
 
 USEPKG += libfixmath
 USEMODULE += libfixmath
-USEMODULE += test_utils_interactive_sync
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_libfixmath/main.c
+++ b/tests/pkg_libfixmath/main.c
@@ -33,7 +33,6 @@
 
 #include "kernel_defines.h"
 #include "fix16.h"
-#include "test_utils/interactive_sync.h"
 
 #ifndef M_PI
 #   define M_PI 3.14159265359
@@ -238,9 +237,6 @@ static void unary_ops(void)
 
 int main(void)
 {
-    /* Sync to prevent flooding of buffer */
-    test_utils_interactive_sync();
-
     puts("Unary.");
     unary_ops();
 

--- a/tests/pkg_libfixmath/tests/01-run.py
+++ b/tests/pkg_libfixmath/tests/01-run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
-from testrunner import run, test_utils_interactive_sync
+from testrunner import run
 
 
 def expect_unary(child):
@@ -46,7 +46,6 @@ def expect_binary(child):
 
 
 def testfunc(child):
-    test_utils_interactive_sync(child)
     child.expect_exact('Unary.')
     expect_unary(child)
     child.expect_exact('Binary.')

--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -32,6 +32,8 @@
 #include "thread.h"
 #include "xtimer.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define SEMAPHORE_MSG_QUEUE_SIZE        (8)
 #define SEMAPHORE_TEST_THREADS          (5)
 static char test1_thread_stack[THREAD_STACKSIZE_MAIN];
@@ -292,6 +294,8 @@ void test4(void)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     msg_init_queue(main_msg_queue, SEMAPHORE_MSG_QUEUE_SIZE);
     xtimer_init();
     puts("######################### TEST1:");

--- a/tests/posix_time/Makefile
+++ b/tests/posix_time/Makefile
@@ -2,6 +2,4 @@ include ../Makefile.tests_common
 
 USEMODULE += posix_time
 
-USEMODULE += test_utils_interactive_sync
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/posix_time/main.c
+++ b/tests/posix_time/main.c
@@ -26,11 +26,9 @@
 
 #include <stdio.h>
 #include <unistd.h>
-#include "test_utils/interactive_sync.h"
 
 int main(void)
 {
-    test_utils_interactive_sync();
     puts("5 x usleep(i++ * 500000)");
     for (unsigned i = 0; i < 5; i++) {
         useconds_t us = i * 500000u;

--- a/tests/posix_time/tests/01-run.py
+++ b/tests/posix_time/tests/01-run.py
@@ -10,7 +10,7 @@
 
 import sys
 import time
-from testrunner import run, test_utils_interactive_sync
+from testrunner import run
 
 US_PER_SEC = 1000000
 EXTERNAL_JITTER = 0.15
@@ -22,7 +22,6 @@ class InvalidTimeout(Exception):
 
 def testfunc(child):
     try:
-        test_utils_interactive_sync(child)
         start_test = time.time()
         child.expect_exact("5 x usleep(i++ * 500000)")
         for i in range(5):

--- a/tests/ps_schedstatistics/main.c
+++ b/tests/ps_schedstatistics/main.c
@@ -27,6 +27,8 @@
 #include <thread.h>
 #include <xtimer.h>
 
+#include "test_utils/interactive_sync.h"
+
 #define NB_THREADS  (5U)
 
 static char stacks[NB_THREADS][THREAD_STACKSIZE_DEFAULT];
@@ -54,6 +56,8 @@ static void *_thread_fn(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     for (unsigned i = 0; i < NB_THREADS; ++i) {
         pids[i] = thread_create(stacks[i], sizeof(stacks[i]),
                                 THREAD_PRIORITY_MAIN - 1,

--- a/tests/pthread_condition_variable/Makefile.ci
+++ b/tests/pthread_condition_variable/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -10,6 +10,7 @@ USEMODULE += ps
 RIOT_TERMINAL ?= socat
 
 DISABLE_MODULE += auto_init
+DISABLE_MODULE += test_utils_interactive_sync
 
 # chronos is missing a getchar implementation
 BOARD_BLACKLIST += chronos

--- a/tests/socket_zep/main.c
+++ b/tests/socket_zep/main.c
@@ -31,6 +31,8 @@
 #include "msg.h"
 #include "od.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define MSG_QUEUE_SIZE  (8)
 #define MSG_TYPE_ISR    (0x3456)
 #define RECVBUF_SIZE    (IEEE802154_FRAME_LEN_MAX)
@@ -104,6 +106,8 @@ static void test_recv(void)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     puts("Socket ZEP device driver test");
     msg_init_queue(_msg_queue, MSG_QUEUE_SIZE);
     _main_pid = sched_active_pid;

--- a/tests/stdin/Makefile
+++ b/tests/stdin/Makefile
@@ -2,4 +2,6 @@ include ../Makefile.tests_common
 
 USEMODULE += stdin
 
+DISABLE_MODULE += test_utils_interactive_sync
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 DISABLE_MODULE += auto_init
 
 USEMODULE += shell
+USEMODULE += shell_commands
 USEMODULE += timex
 
 # The MSP-430 toolchain lacks sscanf:

--- a/tests/thread_basic/main.c
+++ b/tests/thread_basic/main.c
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include "thread.h"
 
+#include "test_utils/interactive_sync.h"
+
 char t2_stack[THREAD_STACKSIZE_MAIN];
 
 void *second_thread(void *arg)
@@ -32,6 +34,8 @@ void *second_thread(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     (void) thread_create(
             t2_stack, sizeof(t2_stack),
             THREAD_PRIORITY_MAIN - 1,

--- a/tests/thread_cooperation/main.c
+++ b/tests/thread_cooperation/main.c
@@ -25,6 +25,8 @@
 #include "thread.h"
 #include "mutex.h"
 
+#include "test_utils/interactive_sync.h"
+
 #ifndef PROBLEM
 #define PROBLEM 12
 #endif
@@ -63,6 +65,8 @@ int main(void)
     msg_t args[PROBLEM];
     kernel_pid_t ths;
     uint32_t factorial = 1;
+
+    test_utils_interactive_sync();
 
     printf("[START] compute %d! (factorial).\n", PROBLEM);
 

--- a/tests/thread_exit/main.c
+++ b/tests/thread_exit/main.c
@@ -22,6 +22,8 @@
 
 #include "thread.h"
 
+#include "test_utils/interactive_sync.h"
+
 char second_thread_stack[THREAD_STACKSIZE_MAIN];
 char third_thread_stack[THREAD_STACKSIZE_MAIN];
 
@@ -78,6 +80,7 @@ void *second_thread(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
     puts("main: starting");
 
     if ((thread_create(

--- a/tests/thread_flood/main.c
+++ b/tests/thread_flood/main.c
@@ -27,6 +27,8 @@
 #include "thread.h"
 #include "kernel_types.h"
 
+#include "test_utils/interactive_sync.h"
+
 /* One stack for all threads. DON'T TRY THIS AT HOME!! */
 static char dummy_stack[THREAD_STACKSIZE_IDLE];
 
@@ -37,6 +39,8 @@ static void *thread_func(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     kernel_pid_t thr_id = KERNEL_PID_UNDEF;
     unsigned thr_cnt = 0;
 

--- a/tests/thread_msg/main.c
+++ b/tests/thread_msg/main.c
@@ -24,6 +24,8 @@
 #include "thread.h"
 #include "msg.h"
 
+#include "test_utils/interactive_sync.h"
+
 char t1_stack[THREAD_STACKSIZE_MAIN];
 char t2_stack[THREAD_STACKSIZE_MAIN];
 char t3_stack[THREAD_STACKSIZE_MAIN];
@@ -85,6 +87,8 @@ void *thread3(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     p_main = sched_active_pid;
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,

--- a/tests/thread_msg_block_race/main.c
+++ b/tests/thread_msg_block_race/main.c
@@ -27,6 +27,8 @@
 #include "thread.h"
 #include "msg.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define CANARY_TYPE         (0x21fd)
 
 #define TIMER_FREQ          (1000000LU)
@@ -79,6 +81,8 @@ static void *_thread(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     kernel_pid_t pid;
 
     timer_init(TIMER_DEV(0), TIMER_FREQ, _timer, NULL);

--- a/tests/thread_msg_block_w_queue/Makefile.ci
+++ b/tests/thread_msg_block_w_queue/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/thread_msg_block_w_queue/main.c
+++ b/tests/thread_msg_block_w_queue/main.c
@@ -25,6 +25,8 @@
 #include "thread.h"
 #include "msg.h"
 
+#include "test_utils/interactive_sync.h"
+
 char t1_stack[THREAD_STACKSIZE_MAIN];
 
 kernel_pid_t p_send = KERNEL_PID_UNDEF, p_recv = KERNEL_PID_UNDEF;
@@ -54,6 +56,8 @@ void *sender_thread(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     msg_t msg;
     p_recv = sched_active_pid;
 

--- a/tests/thread_msg_block_wo_queue/Makefile.ci
+++ b/tests/thread_msg_block_wo_queue/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/thread_msg_block_wo_queue/main.c
+++ b/tests/thread_msg_block_wo_queue/main.c
@@ -25,6 +25,8 @@
 #include "thread.h"
 #include "msg.h"
 
+#include "test_utils/interactive_sync.h"
+
 char t1_stack[THREAD_STACKSIZE_MAIN];
 
 kernel_pid_t p_send = KERNEL_PID_UNDEF, p_recv = KERNEL_PID_UNDEF;
@@ -54,6 +56,8 @@ void *thread1(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     msg_t msg;
     p_recv = sched_active_pid;
 

--- a/tests/thread_msg_seq/main.c
+++ b/tests/thread_msg_seq/main.c
@@ -25,6 +25,8 @@
 #include "thread.h"
 #include "msg.h"
 
+#include "test_utils/interactive_sync.h"
+
 char t1_stack[THREAD_STACKSIZE_MAIN];
 char t2_stack[THREAD_STACKSIZE_MAIN];
 char t3_stack[THREAD_STACKSIZE_MAIN];
@@ -51,6 +53,8 @@ void *sub_thread(void *arg)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     puts("START");
     msg_t msg;
 

--- a/tests/thread_race/main.c
+++ b/tests/thread_race/main.c
@@ -26,6 +26,8 @@
 #include "sched.h"
 #include "thread.h"
 
+#include "test_utils/interactive_sync.h"
+
 char iqr_check_stack[THREAD_STACKSIZE_DEFAULT];
 
 static volatile uint8_t irq_occurred;
@@ -65,6 +67,8 @@ static void _spin(void)
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
     puts("Context swap race condition test application");
 
     kernel_pid_t pid;

--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -11,6 +11,8 @@
 #include "embUnit.h"
 #include "xtimer.h"
 
+#include "test_utils/interactive_sync.h"
+
 #define UNCURRY(FUN, ARGS) FUN(ARGS)
 #define RUN_TEST_SUITES(...) MAP(RUN_TEST_SUITE, __VA_ARGS__)
 #define RUN_TEST_SUITE(TEST_SUITE) \
@@ -21,6 +23,8 @@
 
 int main(void)
 {
+    test_utils_interactive_sync();
+
 #ifdef MODULE_XTIMER
     /* auto_init is disabled, but some modules depends on this module being initialized */
     xtimer_init();

--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -5,8 +5,6 @@ USEMODULE += xtimer
 # This test randomly fails on `native` so disable it from CI
 TEST_ON_CI_BLACKLIST += native
 
-USEMODULE += test_utils_interactive_sync
-
 # Port and pin configuration for probing with oscilloscope
 # Port number should be found in port enum e.g in cpu/include/periph_cpu.h
 #FEATURES_REQUIRED += periph_gpio

--- a/tests/xtimer_usleep/main.c
+++ b/tests/xtimer_usleep/main.c
@@ -27,7 +27,6 @@
 
 #include "xtimer.h"
 #include "timex.h"
-#include "test_utils/interactive_sync.h"
 
 #define RUNS                (5U)
 #define SLEEP_TIMES_NUMOF   ARRAY_SIZE(sleep_times)
@@ -62,7 +61,6 @@ int main(void)
 
     printf("Running test %u times with %u distinct sleep times\n", RUNS,
            (unsigned)SLEEP_TIMES_NUMOF);
-    test_utils_interactive_sync();
     start_test = xtimer_now_usec();
     for (unsigned m = 0; m < RUNS; m++) {
         for (unsigned n = 0;

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -11,7 +11,7 @@
 
 import sys
 import time
-from testrunner import run, test_utils_interactive_sync
+from testrunner import run
 
 
 US_PER_SEC = 1000000
@@ -28,7 +28,6 @@ def testfunc(child):
     RUNS = int(child.match.group(1))
     SLEEP_TIMES_NUMOF = int(child.match.group(2))
     try:
-        test_utils_interactive_sync(child)
         start_test = time.time()
         for m in range(RUNS):
             for n in range(SLEEP_TIMES_NUMOF):


### PR DESCRIPTION
### Contribution description

In order to be able to run tests on as many boards as possible use `test_interactive_test_util` in all possible cases.

Many tests depend on resetting the board after the terminal has been opened to make sure the captured output is the start of the tests.

When `BOARD`'s can't provide this feature using `test_interactive_test_util` allows the application to wait for a `sync` from the test script to actually start.

Changes introduced:

- 0e1c79e: modify test runner to accept a `sync` option
- 28948d6: add shell commands for interactive sync
- faf8fa1: used interactive sync when possible. The module is added in `auto-init`. I did't split the commit since introducing it before the test changes would make most tests failed.

Can be splited from the PR:

- e5b1cd7: improve `tests/isr_yield_higher`

TODO in follow-up:

- reset before term
- not reset if `sync=True`:

```
    if sync is True:
        try:
            subprocess.check_output(('make', 'reset'), env=env,
                                    stderr=subprocess.PIPE)
        except subprocess.CalledProcessError:
            # make reset yields error on some boards even if successful
            pass
```


### Testing procedure

- Run all tests on multiple boards that support resetting, nothing should have changed:

<details><summary><b>native</b></summary>

```
python3 dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native  --with-test-only
ERROR:native:Tests failed: 7
Failures during test:
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)
- [tests/lwip](tests/lwip/test.failed)
- [tests/netstats_l2](tests/netstats_l2/test.failed)
```
</details>

<details><summary><b>samr21-xpro</b></summary>

```
python3 dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . samr21-xpro  --with-test-only
Failures during test:
- [examples/suit_update](examples/suit_update/test.failed)
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)
- [tests/pkg_fatfs_vfs](tests/pkg_fatfs_vfs/test.failed)

```
</details>

<details><summary><b>iotlab-m3</b></summary>

```
ERROR:iotlab-m3:Tests failed: 7
Failures during test:
- [examples/suit_update](examples/suit_update/test.failed)
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)
- [tests/pkg_fatfs_vfs](tests/pkg_fatfs_vfs/test.failed)


```
</details>

- Green murdock to see I haven't missed any dependency

### Issues/PRs references

Part of #12448