### PR TITLE
gnrc_netif: use irq_handler instead of IPC

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -156,6 +156,7 @@ ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += l2util
   USEMODULE += fmt
+  USEMODULE += irq_handler
   ifneq (,$(filter netdev_ieee802154,$(USEMODULE)))
     USEMODULE += gnrc_netif_ieee802154
   endif

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "irq_handler.h"
 #include "kernel_types.h"
 #include "msg.h"
 #include "net/ipv6/addr.h"
@@ -71,6 +72,7 @@ typedef struct {
     const gnrc_netif_ops_t *ops;            /**< Operations of the network interface */
     netdev_t *dev;                          /**< Network device of the network interface */
     rmutex_t mutex;                         /**< Mutex of the interface */
+    irq_event_t irq_ev;                     /**< IRQ event for the network device */
 #ifdef MODULE_NETSTATS_L2
     netstats_t stats;                       /**< transceiver's statistics */
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR uses the `irq_handler` module to process network device events (NETDEV_EVENT_TYPE_ISR), instead of waiting for NETDEV_MSG_TYPE_EVENT IPC messages in the gnrc_netif thread.

The implications of this are:
- The receive procedure is preemptive, which is not possible with the current approach in master: if a packet arrives when the gnrc_netif thread is already processing a GNRC_NETAPI_MSG_TYPE_SND, a NETDEV_MSG_TYPE_SND event will be queued to be processed right after the send procedure finishes.  If the network device shares the same framebuffer for RX and TX, then the flow goes like 
```
dev->driver->isr(dev) => dev->event_callback(NETDEV_EVENT_RX_COMPLETE) => dev->driver-read(dev, ...) /* FRAME BUFFER WAS OVERRIDEN BY THE SEND PROCEDURE!! */
```

This is the root cause of #11256. Using the `irq_handler` module, the packet gets processed first.

- Same as #9326, the request to handle the ISR will never get lost.
- The drivers can directly offload the ISR, so it's possible to avoid the usage of the `isr` field of the `netdev_driver_t` structure (that's the goal, but I'm trying to go there in small steps)
- If this happens, the OS process the driver events. Meaning that different network stacks (OpenThread, lwip, etc) don't need to handle network device events. Thus, one step closer of having stack independent network interfaces.

I'm aware this increase the ram consumption because of the extra irq_handler thread, but the effect is mitigated if other modules (drivers, etc) also use the irq_handler mechanism. Also if the gnrc_netif events are processed from irq_handlers (or directly in the thread who calls gnrc's send, get and set stuff), then it's possible to remove the gnrc_netif thread.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
I would recommend to run some of the Release Specs tests for this one (e.g [ICMP stress test](https://github.com/RIOT-OS/Release-Specs/blob/master/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md#task-09---icmpv6-stress-test-on-iotlab-m3))
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#11483
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
