### PR TITLE
core/thread.c: change thread_getstatus return type

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -364,7 +364,7 @@ volatile thread_t *thread_get(kernel_pid_t pid);
  * @return          status of the thread
  * @return          `STATUS_NOT_FOUND` if pid is unknown
  */
-int thread_getstatus(kernel_pid_t pid);
+thread_status_t thread_getstatus(kernel_pid_t pid);
 
 /**
  * @brief Puts the current thread into sleep mode. Has to be woken up externally.

--- a/core/thread.c
+++ b/core/thread.c
@@ -38,10 +38,10 @@ volatile thread_t *thread_get(kernel_pid_t pid)
     return NULL;
 }
 
-int thread_getstatus(kernel_pid_t pid)
+thread_status_t thread_getstatus(kernel_pid_t pid)
 {
     volatile thread_t *thread = thread_get(pid);
-    return thread ? (int)thread->status : (int)STATUS_NOT_FOUND;
+    return thread ? thread->status : STATUS_NOT_FOUND;
 }
 
 const char *thread_getname(kernel_pid_t pid)

--- a/sys/cpp11-compat/thread.cpp
+++ b/sys/cpp11-compat/thread.cpp
@@ -42,7 +42,7 @@ void thread::join() {
   }
   if (joinable()) {
     auto status = thread_getstatus(m_handle);
-    if (status != (int)STATUS_NOT_FOUND && status != STATUS_STOPPED) {
+    if (status != STATUS_NOT_FOUND && status != STATUS_STOPPED) {
       m_data->joining_thread = sched_active_pid;
       thread_sleep();
     }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`thread_getstatus()` return type is after the change `thread_status_t` instead of an `int`. To compare it to a status easier. 


