### PR TITLE
tests/nordic_softdevice: cleanup test script and fix test

### DIFF
--- a/tests/nordic_softdevice/tests/01-run.py
+++ b/tests/nordic_softdevice/tests/01-run.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 
 import sys
+import time
 from testrunner import run
 
 
 def testfunc(child):
-    child.expect("All up, running the shell now")
+    child.expect_exact("All up, running the shell now")
+    child.expect_exact(">")
+    time.sleep(1)  # Wait 1s to let some time for the interface to be fully ready
     child.sendline("ifconfig")
     child.expect(r"Iface\s+(\d+)\s+HWaddr:")
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc, timeout=1, echo=False))
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is an attempt to fix #12214 and it does 2 things:
- cleanup of the test script
- add a 1s delay after the shell is effectively ready (`>` displayed) before requesting the interface with the `ifconfig` command.

After this fix, the test is working reliably locally.

For me this is a bit minor, so I don't really think it needs a backport but maybe other will disagree.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Use the following script (from the RIOT base directory):
```
#! /bin/bash -xe

make --no-print-directory -C tests/nordic_softdevice/

for i in {0..10}; do
    make --no-print-directory -C tests/nordic_softdevice/ flash-only test
done
```

On master, it fails most of the time. With this PR it works all the time.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #12214 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
