### PR TITLE
tests/emb6: replace boards blacklist

### DIFF
--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -3,7 +3,7 @@ BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 # MSP-430 doesn't support C11's atomic functionality yet
-BOARD_BLACKLIST := msb-430 msb-430h pic32-clicker pic32-wifire \
+BOARD_BLACKLIST := msb-430 msb-430h \
                    telosb wsn430-v1_3b wsn430-v1_4 z1
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -3,8 +3,7 @@ BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 # MSP-430 doesn't support C11's atomic functionality yet
-BOARD_BLACKLIST := msb-430 msb-430h \
-                   telosb wsn430-v1_3b wsn430-v1_4 z1
+FEATURES_BLACKLIST += arch_msp430
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This replace the boards blacklist to feature blacklisting, and also remove pic32 from blacklist bc it misses SPI anyway.

I know emb6 is deprecated but still as long as it is we should keep the Makefile up to date.
### Testing procedure

compare `make info-boards-supported` for this PR and master, which should match.


### Issues/PRs references
#9081 
