### PR TITLE
sys/suit: use c25519 instead of hacl

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -939,7 +939,7 @@ endif
 ifneq (,$(filter suit_v4,$(USEMODULE)))
   USEPKG += tinycbor
   USEPKG += libcose
-  USEMODULE += libcose_crypt_hacl
+  USEMODULE += libcose_crypt_c25519
   USEMODULE += suit_conditions
 
   # SUIT depends on riotboot support and some extra riotboot modules


### PR DESCRIPTION

### Contribution description

This PR changes the crypto library use by `libcose`, the main benefit is reducing the fw size by ~12kb.

### Testing procedure

- Build fw in master and with this PR:

```
make -C examples/suit_update/ BOARD=samr21-xpro all
```

    - pr: -rw-rw-r--  1 francisco francisco   70660 Oct 16 09:55 suit_update-slot0-combined.bin

    - mr: -rw-rw-r--  1 francisco francisco   82864 Oct 16 10:12 suit_update-slot0-combined.bin

- Test the application

In one terminal:

```
sudo dist/tools/ethos/setup_network.sh riot0 2001:db8::/64
```

In another:

```
make -C examples/suit_update/ BOARD=samr21-xpro flash test
```

