### PR TITLE
Makefile.include:  TERMFLASHDEPS to TERMDEPS so it also applies to `test`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -646,7 +646,7 @@ term: $(filter flash flash-only, $(MAKECMDGOALS)) $(TERMDEPS)
 # Term without the pyterm added logging
 # TERMFLAGS must be exported for `jlink.sh term_rtt`.
 cleanterm: export PYTERMFLAGS += --noprefix --no-repeat-command-on-empty-line
-cleanterm: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
+cleanterm: $(filter flash flash-only, $(MAKECMDGOALS)) $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -637,16 +637,17 @@ flash-only: $(FLASHDEPS)
 preflash: $(BUILD_BEFORE_FLASH)
 	$(PREFLASHER) $(PREFFLAGS)
 
+TERMFLASHDEPS ?= $(filter flash flash-only,$(MAKECMDGOALS))
 termdeps: $(TERMDEPS)
 
-term: $(filter flash flash-only, $(MAKECMDGOALS)) $(TERMDEPS)
+term: $(TERMFLASHDEPS) $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
 
 # Term without the pyterm added logging
 # TERMFLAGS must be exported for `jlink.sh term_rtt`.
 cleanterm: export PYTERMFLAGS += --noprefix --no-repeat-command-on-empty-line
-cleanterm: $(filter flash flash-only, $(MAKECMDGOALS)) $(TERMDEPS)
+cleanterm: $(TERMFLASHDEPS) $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -638,16 +638,18 @@ preflash: $(BUILD_BEFORE_FLASH)
 	$(PREFLASHER) $(PREFFLAGS)
 
 TERMFLASHDEPS ?= $(filter flash flash-only,$(MAKECMDGOALS))
+# Add TERMFLASHDEPS to TERMDEPS so it also applies to `test`
+TERMDEPS += $(TERMFLASHDEPS)
 termdeps: $(TERMDEPS)
 
-term: $(TERMFLASHDEPS) $(TERMDEPS)
+term: $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
 
 # Term without the pyterm added logging
 # TERMFLAGS must be exported for `jlink.sh term_rtt`.
 cleanterm: export PYTERMFLAGS += --noprefix --no-repeat-command-on-empty-line
-cleanterm: $(TERMFLASHDEPS) $(TERMDEPS)
+cleanterm: $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	$(TERMPROG) $(TERMFLAGS)
 


### PR DESCRIPTION

### Contribution description

This PR adds `TERMFLASHDEPS` to `TERMDEPS` so it also applies to `test`. Otherwise when compiling with `-j` the test can be launched before compilation and flashing fails.
 
### Testing procedure

`BOARD=samr21-xpro make -C tests/bloom_bytes/ flash test -j4`

<details><summary><b>FAIL</b> in master</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/tests/bloom_bytes'
Building application "tests_bloom_bytes" for "samr21-xpro" with MCU "samd21".

"make" -C /home/francisco/workspace/RIOT/boards/samr21-xpro
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/samd21
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
make[1]: Entering directory '/home/francisco/workspace/RIOT/tests/bloom_bytes'
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/tty-samr21-xpro" -b "115200" --noprefix --no-repeat-command-on-empty-line
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/riot/tty-samr21-xpro
Welcome to pyterm!
Type '/exit' to exit.
now=17.022732 (0x0103bf0c ticks), drift=0 us, jitter=0 us
now=18.022777 (0x01130179 ticks), drift=45 us, jitter=45 us
now=19.022732 (0x0122438c ticks), drift=0 us, jitter=-45 us
main(): This is RIOT! (Version: 2020.01-devel-61-g63be7-HEAD)
[START]

now=1.022731 (0x000f9b0b ticks), drift=0 us, jitter=0 us
now=2.022731 (0x001edd4b ticks), drift=0 us, jitter=0 us
now=3.022731 (0x002e1f8b ticks), drift=0 us, jitter=0 us
now=4.022731 (0x003d61cb ticks), drift=0 us, jitter=0 us
now=5.022731 (0x004ca40b ticks), drift=0 us, jitter=0 us
now=6.022731 (0x005be64b ticks), drift=0 us, jitter=0 us
now=7.022731 (0x006b288b ticks), drift=0 us, jitter=0 us
now=8.022731 (0x007a6acb ticks), drift=0 us, jitter=0 us
now=9.022731 (0x0089ad0b ticks), drift=0 us, jitter=0 us
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph

```
</details>

<details><summary><b>SUCCEED</b> in this PR</summary>

```
BOARD=samr21-xpro make -C tests/bloom_bytes/ flash test -j4
make: Entering directory '/home/francisco/workspace/RIOT/tests/bloom_bytes'
Building application "tests_bloom_bytes" for "samr21-xpro" with MCU "samd21".

"make" -C /home/francisco/workspace/RIOT/boards/samr21-xpro
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/samd21
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/bloom
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/fmt
"make" -C /home/francisco/workspace/RIOT/cpu/sam0_common
"make" -C /home/francisco/workspace/RIOT/cpu/sam0_common/periph
"make" -C /home/francisco/workspace/RIOT/sys/hashes
"make" -C /home/francisco/workspace/RIOT/sys/luid
"make" -C /home/francisco/workspace/RIOT/cpu/samd21/periph
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT/sys/random
"make" -C /home/francisco/workspace/RIOT/sys/random/tinymt32
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
   text    data     bss     dec     hex filename
  15360     152    3352   18864    49b0 /home/francisco/workspace/RIOT/tests/bloom_bytes/bin/samr21-xpro/tests_bloom_bytes.elf
/home/francisco/workspace/RIOT/dist/tools/edbg/edbg --serial ATML2127031800004957  --target atmel_cm0p --verbose --file /home/francisco/workspace/RIOT/tests/bloom_bytes/bin/samr21-xpro/tests_bloom_bytes.bin --verify || /home/francisco/workspace/RIOT/dist/tools/edbg/edbg --serial ATML2127031800004957  --target atmel_cm0p --verbose --file /home/francisco/workspace/RIOT/tests/bloom_bytes/bin/samr21-xpro/tests_bloom_bytes.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004957 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification...
at address 0x64 expected 0x75, read 0x71
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004957 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming................................................................ done.
Verification................................................................ done.
make[1]: Entering directory '/home/francisco/workspace/RIOT/tests/bloom_bytes'
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/tty-samr21-xpro" -b "115200" --noprefix --no-repeat-command-on-empty-line
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/riot/tty-samr21-xpro
Welcome to pyterm!
Type '/exit' to exit.
adding 512 elements took 258ms
checking 10000 elements took 2351ms

267 elements probably in the filter.
9733 elements not in the filter.
0.026700 false positive rate.

All done!
main(): This is RIOT! (Version: 2019.10-devel-1378-g18ae3-pr/make/parallel_flash_test)
Testing Bloom filter.

m: 4096 k: 8

adding 512 elements took 258ms
checking 10000 elements took 2351ms

267 elements probably in the filter.
9733 elements not in the filter.
0.026700 false positive rate.

All done!

make: Leaving directory '/home/francisco/workspace/RIOT/tests/bloom_bytes'
```
</details>
