### PR TITLE
sys/suit: sys/shell: examples/suit_update: add shell command for triggering suit updates

### DIFF
--- a/sys/include/suit/coap.h
+++ b/sys/include/suit/coap.h
@@ -19,6 +19,8 @@
  *
  * @brief       SUIT CoAP helper API
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  *
  */
 
@@ -140,6 +142,19 @@ typedef enum {
 int suit_coap_get_blockwise_url(const char *url,
                                coap_blksize_t blksize,
                                coap_blockwise_cb_t callback, void *arg);
+
+/**
+ * @brief   Set the url used to fetch the SUIT manifest
+ *
+ * @param[in] url       url pointer containing the full coap url to the manifest
+ * @param[in] len       length of the url
+ */
+void suit_coap_set_url(const uint8_t *url, size_t len);
+
+/**
+ * @brief   Trigger a SUIT udate
+ */
+void suit_coap_trigger(void);
 
 #endif /* DOXYGEN */
 

--- a/sys/include/suit/coap.h
+++ b/sys/include/suit/coap.h
@@ -144,17 +144,12 @@ int suit_coap_get_blockwise_url(const char *url,
                                coap_blockwise_cb_t callback, void *arg);
 
 /**
- * @brief   Set the url used to fetch the SUIT manifest
+ * @brief   Trigger a SUIT udate
  *
  * @param[in] url       url pointer containing the full coap url to the manifest
  * @param[in] len       length of the url
  */
-void suit_coap_set_url(const uint8_t *url, size_t len);
-
-/**
- * @brief   Trigger a SUIT udate
- */
-void suit_coap_trigger(void);
+void suit_coap_trigger(const uint8_t *url, size_t len);
 
 #endif /* DOXYGEN */
 

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -99,4 +99,8 @@ ifneq (,$(filter test_utils_interactive_sync,$(USEMODULE)))
   SRC += sc_interactive_sync.c
 endif
 
+ifneq (,$(filter suit_coap,$(USEMODULE)))
+  SRC += sc_suit.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/sc_suit.c
+++ b/sys/shell/commands/sc_suit.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Trigger a firmware update from the shell
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "suit/coap.h"
+
+
+int _suit_handler(int argc, char **argv)
+{
+    if (argc != 2) {
+        printf("Usage: %s <manifest url>\n", argv[0]);
+        return 1;
+    }
+
+    suit_coap_trigger((uint8_t *)argv[1], strlen(argv[1]));
+
+    return 0;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -168,6 +168,10 @@ extern int _test_start(int argc, char **argv);
 extern int _test_ready(int argc, char **argv);
 #endif
 
+#ifdef MODULE_SUIT_COAP
+extern int _suit_handler(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
 #ifdef MODULE_CONFIG
@@ -276,6 +280,9 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
     { "r", "Test sync, Ready query", _test_ready },
     { "s", "Test sync, Start test trigger", _test_start },
+#endif
+#ifdef MODULE_SUIT_COAP
+    { "suit", "Trigger a SUIT firmware update", _suit_handler },
 #endif
     {NULL, NULL, NULL}
 };

--- a/sys/suit/coap.c
+++ b/sys/suit/coap.c
@@ -17,6 +17,8 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  * @}
  */
 
@@ -480,13 +482,9 @@ static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
             code = COAP_CODE_REQUEST_ENTITY_TOO_LARGE;
         }
         else {
-            memcpy(_url, pkt->payload, payload_len);
-            _url[payload_len] = '\0';
-
             code = COAP_CODE_CREATED;
-            LOG_INFO("suit: received URL: \"%s\"\n", _url);
-            msg_t m = { .content.value = SUIT_MSG_TRIGGER };
-            msg_send(&m, _suit_coap_pid);
+            LOG_INFO("suit: received URL: \"%s\"\n", (char*)pkt->payload);
+            suit_coap_trigger(pkt->payload, payload_len);
         }
     }
     else {
@@ -495,6 +493,14 @@ static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
 
     return coap_reply_simple(pkt, code, buf, len,
                              COAP_FORMAT_NONE, NULL, 0);
+}
+
+void suit_coap_trigger(const uint8_t *url, size_t len)
+{
+    memcpy(_url, url, len);
+    _url[len] = '\0';
+    msg_t m = { .content.value = SUIT_MSG_TRIGGER };
+    msg_send(&m, _suit_coap_pid);
 }
 
 static const coap_resource_t _subtree[] = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a basic `suit` shell command for triggering suit updates from the shell.

The idea is to have a way to trigger the update manually from the device itsel. I think the workflow is also simpler since one only has to copy the url of the manifest displayed in the output of the publish command and paste it to the `suit` command directly.

Something like `suit coap://[2001:db8::1]/fw/samr21-xpro/suit_update-riot.suitv4_signed.latest.bin`.

The `suit_update` is also adapted:
- shell commands are added
- the nanocoap server is running in a separate thread

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Follow the README in `examples/suit_update` but instead of notify the device via coap, use the url of the manifest returned by the publish command and pass it to the `suit` command in the shell of the device.

The suit update should start as usual.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on #12496 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
