### PR TITLE
cpu: mips_pic32_common: Refactor GPIO peripheral

### DIFF
--- a/boards/pic32-clicker/include/board.h
+++ b/boards/pic32-clicker/include/board.h
@@ -32,8 +32,6 @@
 extern "C" {
 #endif
 
-#include "vendor/p32mx470f512h.h"
-
 /**
  * @brief   Set how many increments of the count register per uS
  *          needed by the timer code.

--- a/boards/pic32-wifire/include/board.h
+++ b/boards/pic32-wifire/include/board.h
@@ -32,8 +32,6 @@
 extern "C" {
 #endif
 
-#include "vendor/p32mz2048efg100.h"
-
 /**
  * @brief   Set how many increments of the count register per uS
  *          needed by the timer code.

--- a/cpu/mips_pic32_common/include/periph_cpu_common.h
+++ b/cpu/mips_pic32_common/include/periph_cpu_common.h
@@ -22,6 +22,8 @@
 #ifndef PERIPH_CPU_COMMON_H
 #define PERIPH_CPU_COMMON_H
 
+#include "cpu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -43,10 +45,20 @@ extern "C" {
  */
 #define CPUID_LEN           (4U)
 
+#ifndef DOXYGEN
+/**
+ * @brief   Overwrite the default gpio_t type definition
+ * @{
+ */
+#define HAVE_GPIO_T
+typedef uint32_t gpio_t;
+/** @} */
+#endif
+
 /**
  * @brief   Override GPIO pin selection macro
  */
-#define GPIO_PIN(x,y)       ((x << 4) | (y & 0xf))
+#define GPIO_PIN(x, y)      (((_PORTB_BASE_ADDRESS & 0xFFFFF000) + (x << 8)) | y)
 
 /**
  * @brief   Available ports on the PIC32 family


### PR DESCRIPTION
### Contribution description

This PR simplifies the code of the GPIO peripheral.

```
 # (master, commit: 0146c7b497df)
 111496	   3017	   5056	 119569	  1d311	/home/francois/projects/RIOT/examples/hello-world/bin/pic32-wifire/hello-world.elf

 # This PR
 111308	   3017	   5056	 119381	  1d255	/home/francois/projects/RIOT/examples/hello-world/bin/pic32-wifire/hello-world.elf
```

### Testing procedure

I modified hello-world example to toggle, switch on/off LEDs. UART should keep working.

### Issues/PRs references

None