### PR TITLE
cpu/efm32: remove EFM32_UART_MODES

### DIFF
--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -11,10 +11,6 @@ ifeq (1,$(EFM32_TNRG))
   FEATURES_PROVIDED += periph_hwrng
 endif
 
-ifeq (1,$(EFM32_UART_MODES))
-  CFLAGS += -DEFM32_UART_MODES=1
-endif
-
 ifeq (1,$(EFM32_LEUART_ENABLED))
   CFLAGS += -DEFM32_LEUART_ENABLED=1
 endif

--- a/cpu/efm32/efm32-features.mk
+++ b/cpu/efm32/efm32-features.mk
@@ -1,5 +1,4 @@
 # This file provides defaults for additional EFM32-specific features. You
 # should override them from the command line, or in your Makefile. Note that
 # some features may not be applicable to all EFM32 boards or CPUs.
-export EFM32_UART_MODES ?= 0
 export EFM32_LEUART_ENABLED ?= 1

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -360,20 +360,6 @@ typedef struct {
 /** @} */
 
 /**
- * @brief   Internal macro for combining UART modes data bits (x), stop bits
- *          (y, in half bits) and parity (z).
- */
-#define UART_MODE(x, y, z)      ((z << 8) | ((y * 2) << 4) | x)
-
-/**
- * @brief   Internal, pre-defined UART modes.
- * @{
- */
-#define UART_MODE_8N1           UART_MODE(8, 1, 0)
-#define UART_MODE_8E1           UART_MODE(8, 1, 2)
-/** @} */
-
-/**
  * @brief   UART device configuration.
  */
 #ifndef DOXYGEN
@@ -421,9 +407,6 @@ typedef struct {
     gpio_t rx_pin;          /**< pin used for RX */
     gpio_t tx_pin;          /**< pin used for TX */
     uint32_t loc;           /**< location of UART pins */
-#if EFM32_UART_MODES
-    uint32_t mode;          /**< UART mode of operation */
-#endif
     CMU_Clock_TypeDef cmu;  /**< the device CMU channel */
     IRQn_Type irq;          /**< the devices base IRQ channel */
 } uart_conf_t;

--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -85,11 +85,6 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
         init.enable = usartDisable;
         init.baudrate = baudrate;
-#if EFM32_UART_MODES
-        init.databits = USART_DataBits2Def((uart_config[dev].mode >> 0) & 0xf);
-        init.stopbits = USART_StopBits2Def((uart_config[dev].mode >> 4) & 0xf);
-        init.parity = USART_Parity2Def((uart_config[dev].mode >> 8) & 0xf);
-#endif
 
         USART_InitAsync(uart, &init);
 
@@ -121,11 +116,6 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
         init.enable = leuartDisable;
         init.baudrate = baudrate;
-#if EFM32_UART_MODES
-        init.databits = LEUART_DataBits2Def((uart_config[dev].mode >> 0) & 0xf);
-        init.stopbits = LEUART_StopBits2Def((uart_config[dev].mode >> 4) & 0xf);
-        init.parity = LEUART_Parity2Def((uart_config[dev].mode >> 8) & 0xf);
-#endif
 
         LEUART_Init(leuart, &init);
 

--- a/tests/cpu_efm32_features/Makefile
+++ b/tests/cpu_efm32_features/Makefile
@@ -11,7 +11,6 @@ BOARD_WHITELIST := ikea-tradfri \
                    stk3700
 
 # see cpu/efm32/efm32-features.mk for the supported flags
-EFM32_UART_MODES = 1
 EFM32_LEUART_ENABLED = 0
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_efm32_features/main.c
+++ b/tests/cpu_efm32_features/main.c
@@ -26,21 +26,7 @@
 
 int main(void)
 {
-    /* test if uart_config[i].mode is set to a know value */
-    for (unsigned i = 0; i < UART_NUMOF; i++) {
-        printf("UART %u mode: ", i);
-
-        switch (uart_config[i].mode) {
-            case UART_MODE_8N1:
-                puts("8N1");
-                break;
-            case UART_MODE_8E1:
-                puts("8E1");
-                break;
-            default:
-                puts("unknown");
-        }
-    }
+    puts("Board booted, with some EFM32 features enabled or disabled.");
 
     return 0;
 }

--- a/tests/cpu_efm32_features/tests/01-run.py
+++ b/tests/cpu_efm32_features/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Bas Stottelaar <basstottelaar@gmail.com>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(
+        r'Board booted, with some EFM32 features enabled or disabled.')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
When I created #12323 I probably removed a commit while rebasing, which cleaned up some of the left-overs of the non-standard API. This PR resolves this by cleaning up the left-overs (basically removing dead code).

While at it, I also add a test script.

### Testing procedure
 Run `BOARD=sltb001a make -C tests/cpu_efm32_features flash test`.

It should be OK.

### Issues/PRs references
#12323