### PR TITLE
examples/dtls-echo: handle handshake_failure alert

### DIFF
--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -79,8 +79,10 @@ static int _events_handler(struct dtls_context_t *ctx,
  * DTLS records. Also, it determines if said DTLS record is coming from a new
  * peer or a currently established peer.
  *
+ * Return value < 0 if dtls_handle_message() returns error and 0 on other
+ * errors.
  */
-static void dtls_handle_read(dtls_context_t *ctx)
+static int dtls_handle_read(dtls_context_t *ctx)
 {
     static session_t session;
     static sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
@@ -88,12 +90,12 @@ static void dtls_handle_read(dtls_context_t *ctx)
 
     if (!ctx) {
         DEBUG("%s: No DTLS context\n", __func__);
-        return;
+        return 0;
     }
 
     if (!dtls_get_app_data(ctx)) {
         DEBUG("%s: No app_data stored!\n", __func__);
-        return;
+        return 0;
     }
 
     sock_udp_t *sock;
@@ -102,18 +104,17 @@ static void dtls_handle_read(dtls_context_t *ctx)
 
     if (sock_udp_get_remote(sock, &remote) == -ENOTCONN) {
         DEBUG("%s: Unable to retrieve remote!\n", __func__);
-        return;
+        return 0;
     }
 
-    ssize_t res = sock_udp_recv(sock, packet_rcvd, DTLS_MAX_BUF,
-                                1 * US_PER_SEC + DEFAULT_US_DELAY,
-                                &remote);
+    ssize_t res = sock_udp_recv(sock, packet_rcvd, sizeof(packet_rcvd),
+                                1 * US_PER_SEC + DEFAULT_US_DELAY, &remote);
 
     if (res <= 0) {
         if ((ENABLE_DEBUG) && (res != -EAGAIN) && (res != -ETIMEDOUT)) {
-            DEBUG("sock_udp_recv unexepcted code error: %i\n", (int)res);
+            DEBUG("sock_udp_recv unexpected code error: %i\n", (int)res);
         }
-        return;
+        return 0;
     }
 
     /* session requires the remote socket (IPv6:UDP) address and netif  */
@@ -126,10 +127,7 @@ static void dtls_handle_read(dtls_context_t *ctx)
         session.ifindex = remote.netif;
     }
 
-    if (memcpy(&session.addr, &remote.addr.ipv6, 16) == NULL) {
-        puts("ERROR: memcpy failed!");
-        return;
-    }
+    memcpy(&session.addr, &remote.addr.ipv6, sizeof(session.addr));
 
     if (ENABLE_DEBUG) {
         DEBUG("DBG-Client: Msg received from \n\t Addr Src: [");
@@ -137,9 +135,7 @@ static void dtls_handle_read(dtls_context_t *ctx)
         DEBUG("]:%u\n", remote.port);
     }
 
-    dtls_handle_message(ctx, &session, packet_rcvd, (int)DTLS_MAX_BUF);
-
-    return;
+    return dtls_handle_message(ctx, &session, packet_rcvd, res);
 }
 
 #ifdef DTLS_PSK
@@ -267,7 +263,7 @@ ssize_t try_send(struct dtls_context_t *ctx, session_t *dst, uint8 *buf, size_t 
         len -= res;
         return len;
     }
-    else if (res < 0) {
+    else {
         dtls_crit("Client: dtls_write returned error!\n");
         return -1;
     }
@@ -291,12 +287,7 @@ static int _send_to_peer_handler(struct dtls_context_t *ctx,
     sock_udp_t *sock;
     sock = (sock_udp_t *)dtls_get_app_data(ctx);
 
-    ssize_t res = sock_udp_send(sock, buf, len, NULL);
-    if (res <= 0) {
-        puts("ERROR: Unable to send DTLS record");
-    }
-
-    return res;
+    return sock_udp_send(sock, buf, len, NULL);
 }
 
 /* DTLS variables are initialized. */
@@ -384,7 +375,6 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
 static void client_send(char *addr_str, char *data)
 {
     static session_t dst;
-    dtls_context_t *dtls_context = NULL;
 
     sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
     sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
@@ -395,7 +385,8 @@ static void client_send(char *addr_str, char *data)
 
     /* NOTE: dtls_init() must be called previous to this (see main.c) */
 
-    dtls_context = _init_dtls(&sock, &local, &remote, &dst, addr_str);
+    dtls_context_t *dtls_context = _init_dtls(&sock, &local, &remote, &dst,
+                                              addr_str);
     if (!dtls_context) {
         puts("ERROR: Client unable to load context!");
         return;
@@ -455,8 +446,11 @@ static void client_send(char *addr_str, char *data)
         }
 
         /* Check if a DTLS record was received */
-        /* NOTE: We expect an answer after try_send() */
-        dtls_handle_read(dtls_context);
+        /* NOTE: We expect an answer or alert after try_send() */
+        if (dtls_handle_read(dtls_context) < 0) {
+            printf("Received error during message handling\n");
+            break;
+        }
         watch--;
     } /* END while */
 

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -77,7 +77,7 @@ char _dtls_server_stack[THREAD_STACKSIZE_MAIN +
  * DTLS records. Also, it determines if said DTLS record is coming from a new
  * peer or a currently established peer.
  */
-static void dtls_handle_read(dtls_context_t *ctx)
+static int dtls_handle_read(dtls_context_t *ctx)
 {
     static session_t session;
     static uint8_t packet_rcvd[DTLS_MAX_BUF];
@@ -87,25 +87,26 @@ static void dtls_handle_read(dtls_context_t *ctx)
 
     if (!ctx) {
         DEBUG("No DTLS context!\n");
-        return;
+        return 0;
     }
 
     if (!dtls_get_app_data(ctx)) {
         DEBUG("No app_data stored!\n");
-        return;
+        return 0;
     }
 
     dtls_remote_peer_t *remote_peer;
     remote_peer = (dtls_remote_peer_t *)dtls_get_app_data(ctx);
 
-    ssize_t res = sock_udp_recv(remote_peer->sock, packet_rcvd, DTLS_MAX_BUF,
-                                1 * US_PER_SEC, remote_peer->remote);
+    ssize_t res = sock_udp_recv(remote_peer->sock, packet_rcvd,
+                                sizeof(packet_rcvd), 1 * US_PER_SEC,
+                                remote_peer->remote);
 
     if (res <= 0) {
         if ((ENABLE_DEBUG) && (res != -EAGAIN) && (res != -ETIMEDOUT)) {
-            DEBUG("sock_udp_recv unexepcted code error: %i\n", (int)res);
+            DEBUG("sock_udp_recv unexpected code error: %i\n", (int)res);
         }
-        return;
+        return 0;
     }
 
     DEBUG("DBG-Server: Record Rcvd\n");
@@ -120,14 +121,8 @@ static void dtls_handle_read(dtls_context_t *ctx)
         session.ifindex = remote_peer->remote->netif;
     }
 
-    if (memcpy(&session.addr, &remote_peer->remote->addr.ipv6, 16) == NULL) {
-        puts("ERROR: memcpy failed!");
-        return;
-    }
-
-    dtls_handle_message(ctx, &session, packet_rcvd, (int)DTLS_MAX_BUF);
-
-    return;
+    memcpy(&session.addr, &remote_peer->remote->addr.ipv6, sizeof(session.addr));
+    return dtls_handle_message(ctx, &session, packet_rcvd, res);
 }
 
 /* Reception of a DTLS Application data record. */
@@ -357,7 +352,9 @@ void *_dtls_server_wrapper(void *arg)
         }
         else {
             /* Listening for any DTLS recodrd */
-            dtls_handle_read(dtls_context);
+            if (dtls_handle_read(dtls_context) < 0) {
+                printf("Received alert from client\n");
+            }
         }
     }
 

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinydtls
 PKG_URL=https://github.com/eclipse/tinydtls.git
-PKG_VERSION=dcac93f1b38e74f0a57b5df47647943f3df005c2
+PKG_VERSION=865ca387cd9d05e52943e5641ad0eefafef218a3
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 CFLAGS += -Wno-implicit-fallthrough


### PR DESCRIPTION
### Contribution description

This PR adds handling of handshake_failure alert in the dtls-echo example application and bumps tinydtls pkg to include fixes from the tinydtls repo. With this PR, the client should be able to react to handshake_failure alert sent from the server when e.g. no matching cipher suites are supported.

### Testing procedure

I wrote a test script using pexpect that starts two native instances and sends a packet from the client to the server. [Link to the script.](https://gist.github.com/pokgak/618a0904f95eacd1647decef9c534634) If anybody is using the script, set `BUILD_IN_DOCKER=0` because there is problem passing environment variable set to docker.

##### Steps to use this script

1. Create tap interfaces with `RIOT/dist/tools/tapsetup/tapsetup -c`
2. Change directory to `dtls-echo` example: `cd RIOT/dtls-echo`
3. Run a native instance with `PORT=tap0` and get the IP with `ifconfig`:
```
$ PORT=tap0 make all term
> ifconfig
```
4. Change `<SERVER_IP>` in the script to the one found in step 3.
5. Run script from the dtls-echo example application: `./test-send.py`

### Issues/PRs references

Fixes #12351 
