### PR TITLE
makefiles/tools/serial: ensure PORT is set and fail early.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -106,6 +106,9 @@ OS := $(shell uname)
 # set python path, e.g. for tests
 PYTHONPATH := $(RIOTBASE)/dist/pythonlibs/:$(PYTHONPATH)
 
+# Basic utilities included before anything else
+include $(RIOTMAKE)/utils/checks.mk
+
 # Include Docker settings near the top because we need to build the environment
 # command line before some of the variable origins are overwritten below when
 # using abspath, strip etc.

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,12 +1,9 @@
 # set default port depending on operating system
 OS := $(shell uname)
 ifeq ($(OS),Linux)
-  PORT ?= $(PORT_LINUX)
+  PORT ?= $(call ensure_value,$(PORT_LINUX),No port set)
 else ifeq ($(OS),Darwin)
-  PORT ?= $(PORT_DARWIN)
-endif
-ifeq ($(PORT),)
-  $(info Warning: no PORT set!)
+  PORT ?= $(call ensure_value,$(PORT_DARWIN),No port set)
 endif
 
 export BAUD ?= 115200


### PR DESCRIPTION
### Contribution description

This commit has been cherry-picked from #10342 

> By ensuring the PORT auto-detection worked, we can give meaningful
> error messages and fail earlier.
> 
> This uses ensure_value from makefiles/utils/checks.mk. An include was
> added to Makefile.include to make this fuction available to all other
> makefiles.

This also avoids evaluating `$(PORT)`.

### Testing procedure

Set `PORT_LINUX` empty:

```
PORT_LINUX='' BOARD=cc2538dk make -C examples/hello-world/ term

make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/examples/hello-world/../../Makefile.include:646: *** No port set.  Stop.
make: Leaving directory '/home/francisco/workspace/RIOT/examples/hello-world'
```

### Issues/PRs references

From #10342, closes #10342 