### PR TITLE
demonstrator: take on shared event handler threads

### DIFF
--- a/sys/include/tasklet.h
+++ b/sys/include/tasklet.h
@@ -1,0 +1,25 @@
+
+
+
+
+#include <stddef.h>
+
+#include "event.h"
+
+
+typedef struct {
+    uint8_t prio;
+    char *stack;
+    size_t stack_size;
+} tasklet_params_t;
+
+
+void auto_init_tasklet(void);
+event_queue_t *tasklet_get(unsigned n);
+
+/* for syntactic sugar, we could discuss to add some (none overhead) wrappers */
+static inline tasklet_schedule(unsgined n, event_t *evt)
+{
+    even_post(tasklet_get(n), evt);
+}
+// and so on...

--- a/sys/include/tasklet_param.h
+++ b/sys/include/tasklet_param.h
@@ -1,0 +1,35 @@
+
+#include "tasklet.h"
+
+#ifdef MODULE_TASKLET_HIGHPRIO
+static char _stack_t1[SOME_STACK_SIZE];
+#endif
+
+#ifdef MODULE_TASKLET_LOWPRIO
+static char _stack_t2[SOME_OTHER_STACK_SIZE];
+
+/* syntactic sugar: we could give some names - however, we need to find a better
+ * way to do this non statically depending on the actual selected modules... */
+#define TASKLET_LOWPRIO         (1u) /* position in params array */
+#endif
+
+
+
+static tasklet_params_t tasklet_params[] = {
+#ifdef MODULE_TASKLET_HIGHPRIO
+    {
+        .prio = (THREAD_PRIORITY_HIGHEST + 1),
+        .stack = _stack_t1,
+        .stack_size = sizeof(stack_t1),
+
+    },
+#endif
+#ifdef MODULE_TASKLET_LOWPRIO
+    {
+        .prio = (THREAD_PRIORITY_IDLE - 1),
+        .stack = _stack_t2,
+        .stack_size = sizeof(stack_t2),
+
+    },
+#endif
+}

--- a/sys/tasklet/tasklet.c
+++ b/sys/tasklet/tasklet.c
@@ -1,0 +1,28 @@
+
+#include "thread.h"
+#include "event.h"
+#include "tasklet.h"
+#include "tasklet_params.h"
+
+
+static event_queue_t _eqs[ARRAY_SIZE(tasklet_params)];
+
+static void *_runner(void *arg)
+{
+    event_queue_init((event_queue_t *)arg);
+    event_loop((event_queue_t *)arg);
+    return NULL;
+}
+
+void auto_init_tasklet(void)
+{
+    for (unsigned i = 0; i < ARRAY_SIZE(tasklet_params); i++) {
+        thread_create(tasklet_params.stack, ... , _runner, &_eqs[i]);
+    }
+}
+
+void tasklet_get(unsigned n)
+{
+    assert(n <= ARRAY_SIZE(tasklet_params));
+    return &_eqs[n];
+}


### PR DESCRIPTION
### Contribution description
Quickly drafted out my own ideas about the topic discussed in #12459. This is not meant to be ever merged, its rather to demonstrate some thoughts and contribute to the discussion pointed out above!

I wanted to try out, how the use of the term `tasklet` would feel like when just just to provided the shared event handler threads (as proposed in #12474). If the discussion in the end just boils down to the name of the submodule, I couldn't care less. But the main things to take are IMHO:
- negligible overhead compared to using `event_x()` API call directly (in this case one array lookup)
- being able to use all functionality that `event` provides -> timer handling ('event/timeout'), canceling events, ...

### Testing procedure
never to be tested :-)

### Issues/PRs references
#12459 and #12474