### PR TITLE
drivers/rn2xx3: fix sleep function

### DIFF
--- a/drivers/include/rn2xx3.h
+++ b/drivers/include/rn2xx3.h
@@ -260,22 +260,14 @@ int rn2xx3_mac_init(rn2xx3_t *dev);
 int rn2xx3_write_cmd(rn2xx3_t *dev);
 
 /**
- * @brief   Writes a command to the RN2XX3 device but don't wait for timeout
+ * @brief   Writes a command to the RN2XX3 device but don't wait for timeout or response
  *
- * The module will immediately reply with a meaningful message if the command
- * is valid or not.
+ * The response can be checked in the `dev->resp_buf` buffer after a small delay
+ * (for example 1ms).
  *
  * @param[in] dev           RN2XX3 device descriptor
  *
  * @return                  RN2XX3_OK on success
- * @return                  RN2XX3_ERR_INVALID_PARAM if command is invalid
- * @return                  RN2XX3_ERR_NOT_JOINED if network is not joined
- * @return                  RN2XX3_ERR_NO_FREE_CH if no free channel
- * @return                  RN2XX3_ERR_SILENT if device is in Silent state
- * @return                  RN2XX3_ERR_FR_CNT_REJOIN_NEEDED if frame counter rolled over
- * @return                  RN2XX3_ERR_BUSY if MAC is not in Idle state
- * @return                  RN2XX3_ERR_INVALID_DATA_LENGTH if payload is too large
- * @return                  RN2XX3_ERR_KEYS_NOT_INIT if keys are not configured
  */
 int rn2xx3_write_cmd_no_wait(rn2xx3_t *dev);
 

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -222,9 +222,23 @@ int rn2xx3_sys_factory_reset(rn2xx3_t *dev)
 int rn2xx3_sys_sleep(rn2xx3_t *dev)
 {
     size_t p = snprintf(dev->cmd_buf, sizeof(dev->cmd_buf) - 1,
-                        "sys sleep %lu", (unsigned long)dev->sleep);
+                        "sys sleep %" PRIu32 "", dev->sleep);
     dev->cmd_buf[p] = 0;
-    if (rn2xx3_write_cmd_no_wait(dev) == RN2XX3_ERR_INVALID_PARAM) {
+
+    if (dev->int_state == RN2XX3_INT_STATE_SLEEP) {
+        DEBUG("[rn2xx3] sleep: device already in sleep mode\n");
+        return RN2XX3_ERR_SLEEP_MODE;
+    }
+
+    /* always succeeds */
+    rn2xx3_write_cmd_no_wait(dev);
+
+    /* Wait a little to check if the device could go to sleep. No answer means
+       it worked. */
+    xtimer_usleep(US_PER_MS);
+
+    DEBUG("[rn2xx3] RESP: %s\n", dev->resp_buf);
+    if (rn2xx3_process_response(dev) == RN2XX3_ERR_INVALID_PARAM) {
         DEBUG("[rn2xx3] sleep: cannot put module in sleep mode\n");
         return RN2XX3_ERR_INVALID_PARAM;
     }

--- a/drivers/rn2xx3/rn2xx3_internal.c
+++ b/drivers/rn2xx3/rn2xx3_internal.c
@@ -178,22 +178,14 @@ int rn2xx3_write_cmd(rn2xx3_t *dev)
 
 int rn2xx3_write_cmd_no_wait(rn2xx3_t *dev)
 {
-    DEBUG("[rn2xx3] CMD: %s\n", dev->cmd_buf);
-
-    if (dev->int_state == RN2XX3_INT_STATE_SLEEP) {
-        DEBUG("[rn2xx3] ABORT: device is in sleep mode\n");
-        return RN2XX3_ERR_SLEEP_MODE;
-    }
+    DEBUG("[rn2xx3] CMD (NO WAIT): %s\n", dev->cmd_buf);
 
     mutex_lock(&(dev->cmd_lock));
     _uart_write_str(dev, dev->cmd_buf);
     _uart_write_str(dev, closing_seq);
-
-    DEBUG("[rn2xx3] RET: %s\n", dev->resp_buf);
-
     mutex_unlock(&(dev->cmd_lock));
 
-    return rn2xx3_process_response(dev);
+    return RN2XX3_OK;
 }
 
 int rn2xx3_wait_response(rn2xx3_t *dev)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is cleaning up the sleep function in the rn2xx3 driver (LoRaWAN). The issue was reported by @keestux in #10620.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

**Required hardware:**
Either `sodaq-explorer` board or Arduino-Zero + wireless shield + RN2XX3 Bee-like module

- Build/flash/term `tests/driver_rn2xx3` on the board (I take Arduino Zero as example here):
```
$ make BOARD=arduino-zero -C tests/driver_rn2xx3 flash term
```
- Set the module to sleep and verify that it works (call reset within the 5s sleep):
```
> sys sleep
Success: device is in sleep mode during 5s
> sys reset
System reset failed    Note: because the module is sleeping
```
- Set the module to sleep and verify the command failed after if already in sleep mode (call sleep within the 5s sleep):
```
> sys sleep
Success: device is in sleep mode during 5s
> sys sleep
Cannot put device in sleep mode
```

On master this last step doesn't work as expected: the command always returns "Success: device is in sleep mode during 5s" which is not correct.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #10620 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
