### PR TITLE
boards/mulle: remove custom PORT handling

### DIFF
--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -5,33 +5,13 @@ endif
 
 # Default debug adapter choice is to use the Mulle programmer board
 DEBUG_ADAPTER ?= mulle
-# Host OS name
-OS := $(shell uname)
 
 # Fall back to PROGRAMMER_SERIAL for backwards compatibility
 DEBUG_ADAPTER_ID ?= $(PROGRAMMER_SERIAL)
 
-ifeq ($(PORT),)
-  # try to find tty name by serial number, only works on Linux currently.
-  ifeq ($(OS),Linux)
-    ifneq ($(DEBUG_ADAPTER_ID),)
-      PORT := $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh '^$(DEBUG_ADAPTER_ID)$$'))
-    else
-      # find-tty.sh will return the first USB tty if no serial is given.
-      PORT := $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh))
-  endif
-  else ifeq ($(OS),Darwin)
-    ifneq ($(DEBUG_ADAPTER_ID),)
-      PORT := /dev/tty.usbserial-$(DEBUG_ADAPTER_ID)B
-    else
-      PORT := $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-    endif
-  endif
-endif
-ifeq ($(PORT),)
-  # fall back to a sensible default
-  PORT := /dev/ttyUSB0
-endif
+# Define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # We need special handling of the watchdog if we want to speed up the flash
 # verification by using the MCU to compute the image checksum after flashing.


### PR DESCRIPTION
### Contribution description

This PR removes the custom `PORT` handling for `mulle`. This allows to uniform how the default ports are handled and be inline with missing `PORT` error handling in `serial.inc.mk`.

The custom `automagic` handling can be followed in #7695.

This board is mainly only used by @cladmi, so I think it is safe to remove this custom handling.

Removing this also removes simple variable expansion of `PORT`, this avoids evaluating `PORT` if it is unneeded. (only `need` it for `term`, and eventually `flash`).

### Testing procedure

- Default value is the same and can be changed:

```
BOARD=mulle make --no-print-directory -C examples/hello-world/ info-debug-variable-PORT
/dev/ttyUSB0
```

- Calls to `$(shell)` are reduced when not using `PORT`:

This PR:
```
BOARD=mulle strace -ff -e trace=execve make --no-print-directory -C examples/hello-world/ info-debug-variable-QUIET 2>&1 | grep 'execve' | wc -l
93
```

Master:
```
BOARD=mulle strace -ff -e trace=execve make --no-print-directory -C examples/hello-world/ info-debug-variable-QUIET 2>&1 | grep 'execve' | wc -l
134
```
### Issues/PRs references

Depends on #12479
