### PR TITLE
tools: add add_insufficient_memory_board.sh

### DIFF
--- a/dist/tools/insufficient_memory/Makefile.for_sh
+++ b/dist/tools/insufficient_memory/Makefile.for_sh
@@ -1,0 +1,18 @@
+-include $(DIR)/Makefile.ci
+
+define create_Makefile.ci
+	@echo "BOARD_INSUFFICIENT_MEMORY := \\" > $(1)
+	@for b in $(sort $(BOARD_INSUFFICIENT_MEMORY)); do echo "    $$b \\" >> $(1); done
+	@echo "    #" >> $(1)
+endef
+
+BOARD_INSUFFICIENT_MEMORY += $(BOARD)
+
+.PHONY: Makefile.ci
+ifeq ($(BOARD_INSUFFICIENT_MEMORY),)
+Makefile.ci:
+	@echo "skipping empty Makefile.ci"
+else
+Makefile.ci:
+	$(call create_Makefile.ci, $(DIR)/Makefile.ci)
+endif

--- a/dist/tools/insufficient_memory/README.md
+++ b/dist/tools/insufficient_memory/README.md
@@ -1,0 +1,9 @@
+add_insufficient_memory_board.sh
+------------------
+
+Usage: `add_insufficient_memory_board.sh <board_name>`
+
+Updates `Makefile.ci` to include `<board_name>` if the memory of the board is not sufficient for the test/example.
+
+For this the script will build every test and example to see if the result would fit into the memory of the specified
+board. If not the corresponding `Makefile.ci` is updated automatically.

--- a/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
+++ b/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright (C) 2019 Benjamin Valentin <benjamin.valentin@ml-pa.com>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+if [ -z $1 ]; then
+    echo "usage: $0 <board>"
+    exit 1
+fi
+
+BOARD=$1
+RIOTBASE=$(dirname $0)/../../..
+PROJECTS+=$RIOTBASE/examples/*/Makefile
+PROJECTS+=" "
+PROJECTS+=$RIOTBASE/tests/*/Makefile
+
+for i in $PROJECTS; do
+    test=$(dirname $(realpath $i));
+    if make BOARD=$BOARD -j -C $test 2>&1 >/dev/null | grep -e overflowed -e "not within region" > /dev/null; then
+        echo $(basename $test) is too big for $BOARD
+        make -f Makefile.for_sh -C $(dirname $0) DIR=$test BOARD=$BOARD Makefile.ci > /dev/null
+    else
+        echo $(basename $test) is OK
+    fi
+done


### PR DESCRIPTION
### Contribution description

This adds a script to automatically add a new board to all `Makefile.ci` files.
To achieve this it builds all examples and tests and checks if a build failure due to insufficient memory occurred.

So to add a new board, you only have to do

    dist/tools/insufficient_memory/add_insufficient_memory_board.sh my_tiny_board

### Testing procedure
- Remove e.g. `arduino-nano` from `Makefile.ci`.
- run `add_insufficient_memory_board.sh arduino-nano`
 - observe that the script added back the board to the `Makefile.ci` files.

### Issues/PRs references
related to #12484 and #12406
