### PR TITLE
cpu/atmega: cleanup dependencies handling

### DIFF
--- a/cpu/atmega1281/Makefile.dep
+++ b/cpu/atmega1281/Makefile.dep
@@ -1,0 +1,6 @@
+# expand atmega_pcint for additional PCINTs of atmega1281
+ifneq (,$(filter atmega_pcint,$(USEMODULE)))
+  USEMODULE += atmega_pcint1 atmega_pcint2
+endif
+
+include $(RIOTCPU)/atmega_common/Makefile.dep

--- a/cpu/atmega1281/Makefile.include
+++ b/cpu/atmega1281/Makefile.include
@@ -1,13 +1,5 @@
-# tell the build system that the CPU depends on the atmega common files
-USEMODULE += atmega_common
-
 RAM_LEN = 8K
 ROM_LEN = 128K
-
-# expand atmega_pcint for additional PCINTs of atmega1281
-ifneq (,$(filter atmega_pcint,$(USEMODULE)))
-  USEMODULE += atmega_pcint1 atmega_pcint2
-endif
 
 # CPU depends on the atmega common module, so include it
 include $(RIOTCPU)/atmega_common/Makefile.include

--- a/cpu/atmega1284p/Makefile.include
+++ b/cpu/atmega1284p/Makefile.include
@@ -1,13 +1,5 @@
-# tell the build system that the CPU depends on the atmega common files
-USEMODULE += atmega_common
-
 RAM_LEN = 16K
 ROM_LEN = 128K
-
-# expand atmega_pcint for atmega1284p
-ifneq (,$(filter atmega_pcint,$(USEMODULE)))
-  USEMODULE += atmega_pcint1 atmega_pcint2 atmega_pcint3
-endif
 
 # CPU depends on the atmega common module, so include it
 include $(RIOTCPU)/atmega_common/Makefile.include

--- a/cpu/atmega128rfa1/Makefile.include
+++ b/cpu/atmega128rfa1/Makefile.include
@@ -1,13 +1,5 @@
-# tell the build system that the CPU depends on the atmega common files
-USEMODULE += atmega_common
-
 RAM_LEN = 16K
 ROM_LEN = 128K
-
-# expand atmega_pcint for atmega128rfa1
-ifneq (,$(filter atmega_pcint,$(USEMODULE)))
-  USEMODULE += atmega_pcint1
-endif
 
 # CPU depends on the atmega common module, so include it
 include $(RIOTCPU)/atmega_common/Makefile.include

--- a/cpu/atmega2560/Makefile.include
+++ b/cpu/atmega2560/Makefile.include
@@ -1,13 +1,5 @@
-# tell the build system that the CPU depends on the atmega common files
-USEMODULE += atmega_common
-
 RAM_LEN = 8K
 ROM_LEN = 256K
-
-# expand atmega_pcint with additional PCINTs for atmega2560
-ifneq (,$(filter atmega_pcint,$(USEMODULE)))
-  USEMODULE += atmega_pcint1 atmega_pcint2
-endif
 
 # CPU depends on the atmega common module, so include it
 include $(RIOTCPU)/atmega_common/Makefile.include

--- a/cpu/atmega256rfr2/Makefile.include
+++ b/cpu/atmega256rfr2/Makefile.include
@@ -1,13 +1,5 @@
-# tell the build system that the CPU depends on the atmega common files
-USEMODULE += atmega_common
-
 RAM_LEN = 32K
 ROM_LEN = 256K
-
-# expand atmega_pcint for atmega256rfr2
-ifneq (,$(filter atmega_pcint,$(USEMODULE)))
-  USEMODULE += atmega_pcint1
-endif
 
 # CPU depends on the atmega common module, so include it
 include $(RIOTCPU)/atmega_common/Makefile.include

--- a/cpu/atmega328p/Makefile.dep
+++ b/cpu/atmega328p/Makefile.dep
@@ -1,0 +1,6 @@
+# additional PCINTs for atmega328p
+ifneq (,$(filter atmega_pcint,$(USEMODULE)))
+  USEMODULE += atmega_pcint1 atmega_pcint2
+endif
+
+include $(RIOTCPU)/atmega_common/Makefile.dep

--- a/cpu/atmega328p/Makefile.include
+++ b/cpu/atmega328p/Makefile.include
@@ -1,13 +1,5 @@
-# tell the build system that the CPU depends on the atmega common files
-USEMODULE += atmega_common
-
 RAM_LEN = 2K
 ROM_LEN = 32K
-
-# additional PCINTs for atmega328p
-ifneq (,$(filter atmega_pcint,$(USEMODULE)))
-  USEMODULE += atmega_pcint1 atmega_pcint2
-endif
 
 # CPU depends on the atmega common module, so include it
 include $(RIOTCPU)/atmega_common/Makefile.include

--- a/cpu/atmega32u4/Makefile.include
+++ b/cpu/atmega32u4/Makefile.include
@@ -1,9 +1,6 @@
 # this CPU implementation is using the new core/CPU interface
 CFLAGS += -DCOREIF_NG=1
 
-# tell the build system that the CPU depends on the atmega common files
-USEMODULE += atmega_common
-
 # define path to atmega common module, which is needed for this CPU
 export ATMEGA_COMMON = $(RIOTCPU)/atmega_common/
 

--- a/cpu/atmega_common/Makefile.dep
+++ b/cpu/atmega_common/Makefile.dep
@@ -1,3 +1,6 @@
+# tell the build system to build the atmega common files
+USEMODULE += atmega_common
+
 # expand atmega_pcint module
 ifneq (,$(filter atmega_pcint,$(USEMODULE)))
   USEMODULE += atmega_pcint0

--- a/cpu/atmega_common/Makefile.include
+++ b/cpu/atmega_common/Makefile.include
@@ -9,31 +9,4 @@ USEMODULE += avr_libc_extra
 PSEUDOMODULES += atmega_pcint
 PSEUDOMODULES += atmega_pcint%
 
-# expand atmega_pcint module
-# atmega16u4 only features atmega_pcint0, therefore additional pseudomodules
-# are activated in each CPU's Makefile.include
-ifneq (,$(filter atmega_pcint,$(USEMODULE)))
-  USEMODULE += atmega_pcint0
-endif
-
-# feature for atmega_pcint0 module
-ifneq (,$(filter atmega_pcint0,$(USEMODULE)))
-  FEATURES_REQUIRED += atmega_pcint0
-endif
-
-# feature for atmega_pcint1 module
-ifneq (,$(filter atmega_pcint1,$(USEMODULE)))
-  FEATURES_REQUIRED += atmega_pcint1
-endif
-
-# feature for atmega_pcint2 module
-ifneq (,$(filter atmega_pcint2,$(USEMODULE)))
-  FEATURES_REQUIRED += atmega_pcint2
-endif
-
-# feature for atmega_pcint3 module
-ifneq (,$(filter atmega_pcint3,$(USEMODULE)))
-  FEATURES_REQUIRED += atmega_pcint3
-endif
-
 include $(RIOTMAKE)/arch/atmega.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While looking at the changes in #12411, I noticed duplicated inclusions of modules in different files.
Example:
```mk
# expand atmega_pcint for atmega128rfa1
ifneq (,$(filter atmega_pcint,$(USEMODULE)))
  USEMODULE += atmega_pcint1
endif
```
was used in `Makefile.include` and `Makefile.dep`. Comparing with other atmega cpu, the problem was there all over the place.

This PR is trying to clean this up a little:
- Create a Makefile.dep with the handling of additional pcint modules
- Remove duplicates addition of pcint modules from `Makefile.include`
- Move `USEMODULE += atmega_common` to the common atmega `Makefile.dep`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be ok but maybe more functional tests could also be done.
Maybe also compare the modules included in a build with master (not sure how to do that).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
