### PR TITLE
boards/efm32: move provided gpio features at cpu level

### DIFF
--- a/boards/common/slwstk6000b/Makefile.features
+++ b/boards/common/slwstk6000b/Makefile.features
@@ -3,7 +3,6 @@ CPU = efm32
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -2,7 +2,6 @@ CPU = efm32
 CPU_MODEL = efr32mg1p132f256gm32
 
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/slstk3401a/Makefile.features
+++ b/boards/slstk3401a/Makefile.features
@@ -3,7 +3,6 @@ CPU_MODEL = efm32pg1b200f256gm48
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/slstk3402a/Makefile.features
+++ b/boards/slstk3402a/Makefile.features
@@ -3,7 +3,6 @@ CPU_MODEL = efm32pg12b500f1024gl125
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/sltb001a/Makefile.features
+++ b/boards/sltb001a/Makefile.features
@@ -3,7 +3,6 @@ CPU_MODEL = efr32mg1p132f256gm48
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/slwstk6220a/Makefile.features
+++ b/boards/slwstk6220a/Makefile.features
@@ -2,6 +2,5 @@ CPU = ezr32wg
 CPU_MODEL = ezr32wg330f256r60
 
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/stk3600/Makefile.features
+++ b/boards/stk3600/Makefile.features
@@ -4,7 +4,6 @@ CPU_MODEL = efm32lg990f256
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/stk3700/Makefile.features
+++ b/boards/stk3700/Makefile.features
@@ -4,7 +4,6 @@ CPU_MODEL = efm32gg990f1024
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -3,6 +3,7 @@ include $(RIOTCPU)/efm32/efm32-features.mk
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 
 FEATURES_CONFLICT += periph_rtc:periph_rtt
 FEATURES_CONFLICT_MSG += "On the EFM32, the RTC and RTT map to the same hardware peripheral."

--- a/cpu/ezr32wg/Makefile.features
+++ b/cpu/ezr32wg/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 
 -include $(RIOTCPU)/cortexm_common/Makefile.features


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

All efm32 based boards provide the gpio/gpio_irq features. This PR is moving them at CPU level.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure


A green Murdock is ok

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
