### PR TITLE
make/testbed-support: fix error with FLASHFILE not defined [backport 2019.10]

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -280,6 +280,10 @@ export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
 # be done in makefile.iotlab.single.inc.mk which is included after.
 ifneq (,$(IOTLAB_NODE))
   PROGRAMMER ?= iotlab
+  # iotlab uses ELFFILE by default for flashing boards, except for WSN430.
+  ifeq (,$(filter wsn430-%,$(BOARD)))
+    FLASHFILE ?= $(ELFFILE)
+  endif
 endif
 
 # Add standard include directories
@@ -438,6 +442,11 @@ include $(RIOTMAKE)/modules.inc.mk
 # https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
 # https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
 .PHONY: FORCE
+
+ifneq (,$(IOTLAB_NODE))
+  # iot-lab serial and flasher
+  include $(RIOTBASE)/dist/testbed-support/makefile.iotlab.single.inc.mk
+endif
 
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
@@ -796,10 +805,6 @@ ifneq (,$(filter iotlab-m3 wsn430-v1_3b wsn430-v1_4,$(BOARD)))
   ifneq (,$(filter iotlab-%,$(MAKECMDGOALS)))
     include $(RIOTBASE)/dist/testbed-support/Makefile.iotlab
   endif
-endif
-ifneq (,$(IOTLAB_NODE))
-  # iot-lab serial and flasher
-  include $(RIOTBASE)/dist/testbed-support/makefile.iotlab.single.inc.mk
 endif
 
 # Include desvirt Makefile

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -12,6 +12,3 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 FLASHER = mspdebug
 FLASHFILE ?= $(HEXFILE)
 FFLAGS = -d $(PORT) -j uif "prog $(FLASHFILE)"
-
-# Use the HEXFILE when using iot-lab.single.inc.mk
-IOTLAB_FLASHFILE = $(FLASHFILE)

--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -54,9 +54,6 @@ IOTLAB_USER ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
 # Optional Experiment id. Required when having multiple experiments
 IOTLAB_EXP_ID ?=
 
-# File to use for flashing
-IOTLAB_FLASHFILE ?= $(ELFFILE)
-
 # Specify experiment-id option if provided
 _IOTLAB_EXP_ID := $(if $(IOTLAB_EXP_ID),--id $(IOTLAB_EXP_ID))
 
@@ -161,7 +158,7 @@ ifneq (iotlab-a8-m3,$(BOARD))
   FLASHER     = iotlab-node
   RESET       = iotlab-node
   _NODE_FMT   = --jmespath='keys(@)[0]' --format='int'
-  FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) --update $(IOTLAB_FLASHFILE) | $(_STDIN_EQ_0)
+  FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) --update $(FLASHFILE) | $(_STDIN_EQ_0)
   RESET_FLAGS = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) --reset | $(_STDIN_EQ_0)
 
   ifeq (,$(_IOTLAB_ON_FRONTEND))
@@ -178,7 +175,7 @@ else
   FLASHER     = iotlab-ssh
   RESET       = iotlab-ssh
   _NODE_FMT   = --jmespath='keys(values(@)[0])[0]' --fmt='int'
-  FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) flash-m3 $(_IOTLAB_NODELIST) $(IOTLAB_FLASHFILE) | $(_STDIN_EQ_0)
+  FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) flash-m3 $(_IOTLAB_NODELIST) $(FLASHFILE) | $(_STDIN_EQ_0)
   RESET_FLAGS = $(_NODE_FMT) $(_IOTLAB_EXP_ID) reset-m3 $(_IOTLAB_NODELIST) | $(_STDIN_EQ_0)
 
   TERMPROG  = ssh


### PR DESCRIPTION
# Backport of #12394

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing a bug introduced by #12317 when using  IOTLAB_NODE. For all nrf boards (and maybe others), FLASHFILE was set based on the programmer used (jlink, openocd, pyocd). Since iotlab is set as default programmer, FLASHFILE is no longer set and this results in an error raised here:
https://github.com/RIOT-OS/RIOT/blob/d749e2de5d427e3c69f56890670698ab0e2cad17/Makefile.include#L458

This PR is now setting the default FLASHFILE when IOTLAB_NODE is used to the value corresponding to the board (HEXFILE for wsn430, ELFFILE for others).

Note that this PR is also removing the IOTLAB_FLASHFILE variable, since it becomes useless after the proposed fix.

CC'ing @cladmi to also get his opinion on the fix and his possible ideas for improvement.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Start an experiment on nrf** boards provided by iotlab
```
$ iotlab-experiment submit -n "" -d 60 -l saclay,nrf51dk,2 -l saclay,nrf52dk,2 -l saclay,nrf52840dk,2
```
- Try to build and flash an example on the boards:
```
$ make BOARD=nrfxxdk IOTLAB_NODE=auto-ssh -C examples/hello-world
```

=> on master, you get the following error message:
```
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/examples/hello-world/../../Makefile.include:458: *** FLASHFILE is not defined for this board: .  Stop.
make: Leaving directory '/work/riot/RIOT/examples/hello-world
```

With this PR, it works like a charm for all boards.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Bug introduced by #12317

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
