### PR TITLE
Makefile/include: use ony one call to `uname`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -103,8 +103,11 @@ CLEAN = $(filter clean, $(MAKECMDGOALS))
 include $(RIOTMAKE)/utils/variables.mk
 include $(RIOTMAKE)/utils/strings.mk
 
-# OS is always needed so use simple variable expansion so only evaluated once
-OS := $(shell uname)
+
+# UNAME is always needed so use simple variable expansion so only evaluated once
+UNAME := $(OS -m)
+OS = $(word 1, $(UNAME))
+OS_ARCH = $(word 2, $(UNAME))
 
 # set python path, e.g. for tests
 PYTHONPATH := $(RIOTBASE)/dist/pythonlibs/:$(PYTHONPATH)

--- a/Makefile.include
+++ b/Makefile.include
@@ -103,7 +103,7 @@ CLEAN = $(filter clean, $(MAKECMDGOALS))
 include $(RIOTMAKE)/utils/variables.mk
 include $(RIOTMAKE)/utils/strings.mk
 
-# get host operating system
+# OS is always needed so use simple variable expansion so only evaluated once
 OS := $(shell uname)
 
 # set python path, e.g. for tests

--- a/Makefile.include
+++ b/Makefile.include
@@ -105,7 +105,7 @@ include $(RIOTMAKE)/utils/strings.mk
 
 
 # UNAME is always needed so use simple variable expansion so only evaluated once
-UNAME := $(OS -m)
+UNAME := $(shell uname -m -s)
 OS = $(word 1, $(UNAME))
 OS_ARCH = $(word 2, $(UNAME))
 

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -2,7 +2,6 @@
 export PROGRAMMER ?= cc2538-bsl
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
-  OS := $(shell uname)
   ifeq ($(OS),Linux)
     PORT_BSL ?= $(PORT_LINUX)
   else ifeq ($(OS),Darwin)

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -6,8 +6,9 @@ ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_native
 endif
 
+OS := $(shell uname -s)
 ifneq (,$(filter can,$(USEMODULE)))
-  ifeq ($(shell uname -s),Linux)
+  ifeq ($(OS),Linux)
     USEMODULE += can_linux
     CFLAGS += -DCAN_DLL_NUMOF=2
   endif

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -6,7 +6,6 @@ ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_native
 endif
 
-OS := $(shell uname -s)
 ifneq (,$(filter can,$(USEMODULE)))
   ifeq ($(OS),Linux)
     USEMODULE += can_linux

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -5,7 +5,9 @@ export NATIVEINCLUDES += -I$(RIOTBASE)/drivers/include/
 
 USEMODULE += native-drivers
 
-ifeq ($(shell uname -s),Darwin)
+OS := $(shell uname -s)
+
+ifeq ($(OS),Darwin)
   DEBUGGER ?= lldb
 else
   DEBUGGER ?= gdb
@@ -27,18 +29,22 @@ ifeq (,$(filter -std=%, $(CFLAGS)))
   CFLAGS += -std=gnu99
 endif
 
-ifeq ($(shell uname -m),x86_64)
+OS_ARCH := $(shell uname -m)
+ifeq ($(OS_ARCH),x86_64)
   CFLAGS += -m32
 endif
 ifneq (,$(filter -DDEVELHELP,$(CFLAGS)))
   CFLAGS += -fstack-protector-all
 endif
-ifeq ($(shell uname -s),FreeBSD)
-  ifeq ($(shell uname -m),amd64)
+OS := $(shell uname -s)
+ifeq ($(OS),FreeBSD)
+  OS_ARCH := $(shell uname -m)
+  ifeq ($(OS_ARCH),amd64)
     CFLAGS += -m32 -DCOMPAT_32BIT -B/usr/lib32
   endif
 endif
-ifeq ($(shell uname -s),Darwin)
+OS := $(shell uname -s)
+ifeq ($(OS),Darwin)
   CFLAGS += -Wno-deprecated-declarations
 endif
 
@@ -46,11 +52,14 @@ endif
 CXXUWFLAGS +=
 CXXEXFLAGS +=
 
-ifeq ($(shell uname -m),x86_64)
+OS_ARCH := $(shell uname -m)
+ifeq ($(OS_ARCH),x86_64)
   export LINKFLAGS += -m32
 endif
-ifeq ($(shell uname -s),FreeBSD)
-  ifeq ($(shell uname -m),amd64)
+OS := $(shell uname -s)
+ifeq ($(OS),FreeBSD)
+  OS_ARCH := $(shell uname -m)
+  ifeq ($(OS_ARCH),amd64)
     export LINKFLAGS += -m32 -DCOMPAT_32BIT -L/usr/lib32 -B/usr/lib32
   endif
   export LINKFLAGS += -L $(BINDIR)
@@ -60,7 +69,8 @@ endif
 
 # clean up unused functions
 CFLAGS += -ffunction-sections -fdata-sections
-ifeq ($(shell uname -s),Darwin)
+OS := $(shell uname -m)
+ifeq ($(OS),Darwin)
   export LINKFLAGS += -Wl,-dead_strip
 else
   export LINKFLAGS += -Wl,--gc-sections
@@ -113,7 +123,8 @@ endif
 
 # backward compatability with glibc <= 2.17 for native
 ifeq ($(CPU),native)
-  ifeq ($(shell uname -s),Linux)
+  OS := $(shell uname -s)
+  ifeq ($(OS),Linux)
     ifeq ($(shell ldd --version |  awk '/^ldd/{if ($$NF < 2.17) {print "yes"} else {print "no"} }'),yes)
 	  LINKFLAGS += -lrt
     endif
@@ -123,7 +134,8 @@ endif
 # clumsy way to enable building native on osx:
 BUILDOSXNATIVE = 0
 ifeq ($(CPU),native)
-  ifeq ($(shell uname -s),Darwin)
+ OS := $(shell uname -s)
+  ifeq ($(OS),Darwin)
     BUILDOSXNATIVE = 1
   endif
 endif

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -5,8 +5,6 @@ export NATIVEINCLUDES += -I$(RIOTBASE)/drivers/include/
 
 USEMODULE += native-drivers
 
-OS := $(shell uname -s)
-
 ifeq ($(OS),Darwin)
   DEBUGGER ?= lldb
 else
@@ -29,21 +27,17 @@ ifeq (,$(filter -std=%, $(CFLAGS)))
   CFLAGS += -std=gnu99
 endif
 
-OS_ARCH := $(shell uname -m)
 ifeq ($(OS_ARCH),x86_64)
   CFLAGS += -m32
 endif
 ifneq (,$(filter -DDEVELHELP,$(CFLAGS)))
   CFLAGS += -fstack-protector-all
 endif
-OS := $(shell uname -s)
 ifeq ($(OS),FreeBSD)
-  OS_ARCH := $(shell uname -m)
   ifeq ($(OS_ARCH),amd64)
     CFLAGS += -m32 -DCOMPAT_32BIT -B/usr/lib32
   endif
 endif
-OS := $(shell uname -s)
 ifeq ($(OS),Darwin)
   CFLAGS += -Wno-deprecated-declarations
 endif
@@ -52,13 +46,10 @@ endif
 CXXUWFLAGS +=
 CXXEXFLAGS +=
 
-OS_ARCH := $(shell uname -m)
 ifeq ($(OS_ARCH),x86_64)
   export LINKFLAGS += -m32
 endif
-OS := $(shell uname -s)
 ifeq ($(OS),FreeBSD)
-  OS_ARCH := $(shell uname -m)
   ifeq ($(OS_ARCH),amd64)
     export LINKFLAGS += -m32 -DCOMPAT_32BIT -L/usr/lib32 -B/usr/lib32
   endif
@@ -69,7 +60,6 @@ endif
 
 # clean up unused functions
 CFLAGS += -ffunction-sections -fdata-sections
-OS := $(shell uname -m)
 ifeq ($(OS),Darwin)
   export LINKFLAGS += -Wl,-dead_strip
 else
@@ -123,7 +113,6 @@ endif
 
 # backward compatability with glibc <= 2.17 for native
 ifeq ($(CPU),native)
-  OS := $(shell uname -s)
   ifeq ($(OS),Linux)
     ifeq ($(shell ldd --version |  awk '/^ldd/{if ($$NF < 2.17) {print "yes"} else {print "no"} }'),yes)
 	  LINKFLAGS += -lrt
@@ -134,7 +123,6 @@ endif
 # clumsy way to enable building native on osx:
 BUILDOSXNATIVE = 0
 ifeq ($(CPU),native)
- OS := $(shell uname -s)
   ifeq ($(OS),Darwin)
     BUILDOSXNATIVE = 1
   endif

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -6,7 +6,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 export PROGRAMMER ?= cc2538-bsl
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
-  OS := $(shell uname)
   ifeq ($(OS),Linux)
     PORT_BSL ?= $(PORT_LINUX)
   else ifeq ($(OS),Darwin)

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -3,7 +3,8 @@ MODULE = cpu
 DIRS += periph
 DIRS += vfs
 
-ifeq ($(shell uname -s),Darwin)
+OS := $(shell uname -s)
+ifeq ($(OS),Darwin)
   CFLAGS += -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE
 endif
 

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -3,7 +3,6 @@ MODULE = cpu
 DIRS += periph
 DIRS += vfs
 
-OS := $(shell uname -s)
 ifeq ($(OS),Darwin)
   CFLAGS += -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE
 endif

--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -5,7 +5,6 @@ FFLAGS  ?= -p $(PORT) -e -i -w -v -b -R $(FLASHFILE)
 # some arduino boards need to toggle the serial interface a little bit to get
 # them ready for flashing...
 ifneq (,$(BOSSA_ARDUINO_PREFLASH))
-  OS := $(shell uname)
   ifeq ($(OS),Linux)
     STTY_FLAG = -F
   else ifeq ($(OS),Darwin)

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,5 +1,4 @@
 # set default port depending on operating system
-OS := $(shell uname)
 ifeq ($(OS),Linux)
   PORT ?= $(call ensure_value,$(PORT_LINUX),No port set)
 else ifeq ($(OS),Darwin)

--- a/pkg/fatfs/Makefile.include
+++ b/pkg/fatfs/Makefile.include
@@ -16,6 +16,7 @@ else
   CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=1
 endif
 
-ifeq ($(shell uname -s),Darwin)
+OS := $(shell uname -s)
+ifeq ($(OS),Darwin)
   CFLAGS += -Wno-empty-body
 endif

--- a/pkg/fatfs/Makefile.include
+++ b/pkg/fatfs/Makefile.include
@@ -16,7 +16,6 @@ else
   CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=1
 endif
 
-OS := $(shell uname -s)
 ifeq ($(OS),Darwin)
   CFLAGS += -Wno-empty-body
 endif


### PR DESCRIPTION
### Contribution description

This PR removes all calls to `shell uname` except the one in `Makefiel.include`. This avoids useless shell calls of an already defined variables.

### Testing procedure

I've added a REMOVEME commit just before removing all the `shell uname` calls that were not assigned to a variable to be able to check variables difference before and after. 

- No change in `pkg_fatfs` and `bossa.mk`:

```
for OS in Darwin Linux; do BOARD=arduino-due make -C tests/pkg_fatfs info-debug-variable-CFLAGS OS=${OS} info-debug-variable-STTY_FLAG; done > pr.txt
git checkout HEAD~1
for OS in Darwin Linux; do BOARD=arduino-due make -C tests/pkg_fatfs info-debug-variable-CFLAGS OS=${OS} info-debug-variable-STTY_FLAG; done > master.txt
diff pr.txt master.txt
#no diff
```
- No change in native:

```
for OS in Darwin Linux; do for OS_ARCH in amd64 x86_64; do make -C examples/hello-world info-debug-variable-CFLAGS info-debug-variable-LINKFLAGS info-debug-variable-DEBUGGER info-debug-variable-BUILDOSXNATIVE OS=${OS} OS_ARCH=${OS_ARCH}; done; done > pr.txt
git checkout HEAD~1
for OS in Darwin Linux; do for OS_ARCH in amd64 x86_64; do make -C examples/hello-world info-debug-variable-CFLAGS info-debug-variable-LINKFLAGS info-debug-variable-DEBUGGER info-debug-variable-BUILDOSXNATIVE OS=${OS} OS_ARCH=${OS_ARCH}; done; done > master.txt
diff master.txt pr.txt 
#no diff
```

- No change in `serial.inc.mk`, `openmote-b`, `remote-revb`, handling of `PORT`, `PORT_BSL`

```
for OS in Darwin Linux; do for BOARD in mulle remote-revb openmote-b; do make -C examples/hello-world info-debug-variable-PORT_BSL info-debug-variable-PORT OS=${OS}; done; done > pr.txt
git checkout HEAD~1
for OS in Darwin Linux; do for BOARD in mulle remote-revb openmote-b; do make -C examples/hello-world info-debug-variable-PORT_BSL info-debug-variable-PORT OS=${OS}; done; done > master.txt
diff master.txt pr.txt
#no diff
```

- reduced calls yo shell:

```
BOARD=mulle strace -ff -e trace=execve make --no-print-directory -C examples/hello-world/ info-debug-variable-QUIET 2>&1 | grep 'execve' | wc -l
86
git checkout upstream/master 
BOARD=mulle strace -ff -e trace=execve make --no-print-directory -C examples/hello-world/ info-debug-variable-QUIET 2>&1 | grep 'execve' | wc -l
99
```

- Besides that we Know `Makefile.include` is the first Makefile  included after `Makefile.test.common` and the application `Makefile` so `OS` and `OS_ARCH` will allways be defined

### Issues/PRs referenc
