### PR TITLE
suit/examples: add gpio callback trigger

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -49,6 +49,12 @@ USEMODULE += suit suit_coap
 # SUIT draft v4 support:
 USEMODULE += suit_v4
 
+# Optional feature to trigger suit update through gpio callback
+FEATURES_OPTIONAL += periph_gpio_irq
+
+# Default COAP manifest resource location when fetched through gpio trigger
+CFLAGS += -DSUIT_MANIFEST_RESOURCE=\"$(SUIT_COAP_ROOT)/$(SUIT_NOTIFY_MANIFEST)\"
+
 # Change this to 0 to not use ethos
 USE_ETHOS ?= 1
 

--- a/makefiles/suit.v4.inc.mk
+++ b/makefiles/suit.v4.inc.mk
@@ -11,7 +11,7 @@ SUIT_MANIFEST_SIGNED ?= $(BINDIR_APP)-riot.suitv4_signed.$(APP_VER).bin
 SUIT_MANIFEST_SIGNED_LATEST ?= $(BINDIR_APP)-riot.suitv4_signed.latest.bin
 
 SUIT_NOTIFY_VERSION ?= latest
-SUIT_NOTIFY_MANIFEST ?= $(BINDIR_APP)-riot.suitv4_signed.$(SUIT_NOTIFY_VERSION).bin
+SUIT_NOTIFY_MANIFEST ?= $(APPLICATION)-riot.suitv4_signed.$(SUIT_NOTIFY_VERSION).bin
 
 # Long manifest names require more buffer space when parsing
 export CFLAGS += -DSOCK_URLPATH_MAXLEN=128
@@ -99,5 +99,5 @@ suit/publish: $(SUIT_MANIFESTS) $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 suit/notify: | $(filter suit/publish, $(MAKECMDGOALS))
 	@test -n "$(SUIT_CLIENT)" || { echo "error: SUIT_CLIENT unset!"; false; }
 	aiocoap-client -m POST "coap://$(SUIT_CLIENT)/suit/trigger" \
-		--payload "$(SUIT_COAP_ROOT)/$$(basename $(SUIT_NOTIFY_MANIFEST))" && \
+		--payload "$(SUIT_COAP_ROOT)/$(SUIT_NOTIFY_MANIFEST)" && \
 		echo "Triggered $(SUIT_CLIENT) to update."


### PR DESCRIPTION
### Contribution description

This PR adds a cb that triggers an update when a button is executed. This resembles a little more how a real deployment would work, devices would not be waiting for notify messages but periodically check the fw update server. Going from a `gpio` callback to an `xtimer_set()` based callback would be direct. 

### Testing procedure

On a board supporting `periph_gpio_irq `

- start `aiocoap-fileserver`, if README is followed you should be able to do:

```
exec aiocoap-fileserver coaproot/
```

- setup network

```
sudo dist/tools/ethos/setup_network.sh riot0 ${LOCAL_IP6_PREFIX}::/64
```

- bootstrap device:
```
SUIT_COAP_SERVER=[fd00:dead:beef::1] make -C examples/suit_update/ BOARD=samr21-xpro flash -j term
```

- Publish new firmware
```
SUIT_COAP_SERVER=[fd00:dead:beef::1] make -C examples/suit_update suit/publish -j4
```

- Press button, it will start updating:

```
main(): This is RIOT! (Version: 2020.01-devel-134-g0bcb6-pr_suit_update_trigger)
RIOT SUIT update example application
running from slot 0
slot start addr = 0x1000
Image magic_number: 0x544f4952
Image Version: 0x5da9714e
Image start address: 0x00001100
Header chksum: 0x5db07d99

suit_coap: started.
Starting the shell
> Button preseed! Triggering suit Update! 
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suitv4_signed.latest.bin"
suit_coap: got manifest with size 545
suit: verifying manifest signature...
```
### Issues/PRs references

Depends on #12471
