### PR TITLE
examples/suit_update: use shell module

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -28,6 +28,7 @@ USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_icmpv6_echo
 
 # include this for printing IP addresses
+USEMODULE += shell
 USEMODULE += shell_commands
 
 # Set this to 1 to enable code in RIOT that does safety checking


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the shell module to the `suit_update` example. The nanocoap server is moved to its own thread. The Python test is adapted to add a call to ifconfig in order to retrieve the IPv6 address of the device.

Opening this PR was requested by @fjmolinas in #12471, which now depends on this one.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Following the automatic testing procedure in the README should work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#12471 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
