### PR TITLE
Makefile.dep: gnrc_udp and gnrc_tcp depend on gnrc_ipv6

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -33,6 +33,10 @@ ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter gnrc_udp gnrc_tcp,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6
+endif
+
 ifneq (,$(filter gnrc_mac,$(USEMODULE)))
   USEMODULE += gnrc_priority_pktqueue
   USEMODULE += csma_sender


### PR DESCRIPTION
### Contribution description

`gnrc_udp` and `gnrc_tcp` fail to build if `gnrc_ipv6` is not used, so make that dependency explicit.


### Testing procedure

Add `USEMODULE += gnrc_udp` to `examples/default/`, observe that the build fails if `gnrc_ipv6` is not used as well.


### Issues/PRs references
none