### PR TITLE
drivers: Replaced NETOPT_MAX_PACKET_SIZE by NETOPT_MAX_PDU_SIZE

### DIFF
--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -528,7 +528,7 @@ static int cc110x_get(netdev_t *netdev, netopt_t opt,
             assert(max_len == sizeof(gnrc_nettype_t));
             *((gnrc_nettype_t *)val) = CC110X_DEFAULT_PROTOCOL;
             return sizeof(gnrc_nettype_t);
-        case NETOPT_MAX_PACKET_SIZE:
+        case NETOPT_MAX_PDU_SIZE:
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)val) = CC110X_MAX_FRAME_SIZE - sizeof(cc1xxx_l2hdr_t);
             return sizeof(uint16_t);

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -224,7 +224,7 @@ static inline int _netdev_get(netdev_t *dev, netopt_t opt,
             *((uint16_t *)value) = BLE_ADDR_LEN;
             res = sizeof(uint16_t);
             break;
-        case NETOPT_MAX_PACKET_SIZE:
+        case NETOPT_MAX_PDU_SIZE:
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t *)value) = MTU_SIZE;
             res = sizeof(uint16_t);


### PR DESCRIPTION
### Contribution description

Replaced use of deprecated `NETOPT_MAX_PACKET_SIZE` by `NETOPT_MAX_PDU_SIZE` in `cc110x` and `nimble`.

### Testing procedure

Murdock and code review should do here.

### Issues/PRs references

`NETOPT_MAX_PACKET_SIZE` was deprecated in https://github.com/RIOT-OS/RIOT/pull/10905