### PR TITLE
pkg/tinycbor: fix of compiler warnings "uninitialized variable used"

### DIFF
--- a/pkg/tinycbor/patches/0001-fix-compilation-warning-error.patch
+++ b/pkg/tinycbor/patches/0001-fix-compilation-warning-error.patch
@@ -1,0 +1,25 @@
+From d53d44a42a8e9c4c72438dd48e2663ec7f717397 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Sat, 19 Oct 2019 14:02:02 +0200
+Subject: [PATCH 1/1] fix compilation warning/error
+
+---
+ src/cborvalidation.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cborvalidation.c b/src/cborvalidation.c
+index 08c3511..28b99c4 100644
+--- a/src/cborvalidation.c
++++ b/src/cborvalidation.c
+@@ -379,7 +379,7 @@ static inline CborError validate_floating_point(CborValue *it, CborType type, ui
+     CborError err;
+     int r;
+     double val;
+-    float valf;
++    float valf = 0;  /* fixes the "uninitialized variable" compiler warning */
+     uint16_t valf16;
+ 
+     if (type != CborDoubleType) {
+-- 
+2.17.1
+

--- a/tests/pkg_tinycbor/Makefile
+++ b/tests/pkg_tinycbor/Makefile
@@ -3,9 +3,7 @@ include ../Makefile.tests_common
 # No 8 bit and 16 bit support yet
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \
-                   arduino-uno atmega328p chronos esp32-mh-et-live-minikit \
-                   esp32-olimex-evb esp32-wemos-lolin-d32-pro \
-                   esp32-wroom-32 esp32-wrover-kit microduino-corerf \
+                   arduino-uno atmega328p chronos microduino-corerf \
                    mega-xplained msb-430 msb-430h telosb waspmote-pro \
                    wsn430-v1_3b wsn430-v1_4 z1 \
 


### PR DESCRIPTION
### Contribution description

This PR patches the `tinycbor` package. On ESP32 and new ESP8266 (PR #11108) platforms, the compilation of the package fails since a local variable is potentially used uninitialized:
```
error: 'valf' may be used uninitialized in this function [-Werror=maybe-uninitialized]
```
With the patch provided in this PR, the variable is initialized with a default value and the according boards are removed from the balcklist.

### Testing procedure

Just try to compile `tests/tinycbor` for a ESP32 board:
```
make BOARD=esp32-wroom-32 -C tests/pkg_tinycbor
```

### Issues/PRs references

Required for PR #11108 