### PR TITLE
core/assert: allow multiple static_asserts within a function

### DIFF
--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -119,7 +119,7 @@ NORETURN void _assert_failure(const char *file, unsigned line);
  * Generates a division by zero compile error when cond is false
  */
 #define static_assert(cond, ...) \
-    enum { static_assert_failed_on_div_by_0 = 1 / (!!(cond)) }
+    { enum { static_assert_failed_on_div_by_0 = 1 / (!!(cond)) }; }
 #endif
 #endif
 

--- a/sys/can/pkt.c
+++ b/sys/can/pkt.c
@@ -39,10 +39,10 @@ static mutex_t _mutex = MUTEX_INIT;
 
 static can_pkt_t _pkt_buf[CAN_PKT_BUF_SIZE];
 static memarray_t _pkt_array;
-static_assert(sizeof(can_pkt_t) >= sizeof(can_rx_data_t), "sizeof(can_rx_data_t) must be at most sizeof(can_pkt_t)");
 
 void can_pkt_init(void)
 {
+    static_assert(sizeof(can_pkt_t) >= sizeof(can_rx_data_t), "sizeof(can_rx_data_t) must be at most sizeof(can_pkt_t)");
     mutex_lock(&_mutex);
     handle = 1;
     memarray_init(&_pkt_array, _pkt_buf, sizeof(can_pkt_t), CAN_PKT_BUF_SIZE);


### PR DESCRIPTION
### Contribution description

Uses an own scope for the definition of the enum const declaration to allow multiple `static_assert` statements within the same function in non-C11 environments.

The advantage is that dfifferent conditions can be tested in different `static_asserts` instead of ANDing all conditions in only one `static_assert`. This allows finer granular static testing when several conditions must be met.

The disadvantage is that the `static_assert` has be used in any function.

### Testing procedure

1. Use `tests/thread_basic` and add two `static_assert(1);` statements in the main function. Compile it for a Arduino board.

    ```
    make BOARD=arduino-uno -C tests/thread_basic
    ```
    
     Without this PR the compilation fails with something like the following:
    ```
    core/include/assert.h:122:12: error: redeclaration of enumerator ‘static_assert_failed_on_div_by_0’
         enum { static_assert_failed_on_div_by_0 = 1 / (!!(cond)) }
                ^
    tests/thread_basic/main.c:36:1: note: in expansion of macro ‘static_assert’
     static_assert(1);
     ^
    ```
    With the PR the compilation succeed.

2. Change the second `static_assert` statement to `static_assert(0);`. The compilation should now stop at this `static_assert` statement with
    ```
    core/include/assert.h:122:51: error: division by zero [-Werror=div-by-zero]
         { enum { static_assert_failed_on_div_by_0 = 1 / (!!(cond)) }; }
                                                       ^
    tests/thread_basic/main.c:36:1: note: in expansion of macro ‘static_assert’
     static_assert(0);
     ^
    ```

### Issues/PRs references
