### PR TITLE
cpu/esp32: note on using ADC2 and WiFi in documentation

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -512,7 +512,11 @@ ESP32 integrates two 12-bit ADCs (ADC1 and ADC2) capable of measuring up to 18 a
 
 These GPIOs are realized by the RTC unit and are therefore also called RTC GPIOs or RTCIO GPIOs.
 
-@note GPIO37 and GPIO38 are usually not broken out on ESP32 boards and are therefore not usable.
+@note
+- GPIO37 and GPIO38 are usually not broken out on ESP32 boards and can not be
+  used therefore.
+- ADC2 is used by the WiFi module. The GPIOs connected to ADC2 are therefore not
+  available as ADC channels if the modules `esp_wifi` or `esp_now` are used.
 
 The GPIOs that can be used as ADC channels for a given board are defined by the <b>```ADC_GPIOS```</b> macro in the board-specific peripheral configuration. This configuration can be changed by [application-specific configurations](#esp32_application_specific_configurations).
 


### PR DESCRIPTION
### Contribution description

As figured out in #12482 and described in the documentation of the  [ESP32 SDK](https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/adc.html), the ADC2 controller of the ESP32 is used by the WiFi module. Therefore, the GPIOs connected to the ADC2 controller cannot be used as ADC channels if the WiFi module is enabled.

This PR adds an according note to the documentation.

### Testing procedure

Compilation of the documentation with
```
make doc
```
should succeed.

### Issues/PRs references

Problem clarified by the note was figured out in #12482 
Closes #12482 