### PR TITLE
tests/log_color: fix string literal error

### DIFF
--- a/tests/log_color/main.c
+++ b/tests/log_color/main.c
@@ -18,11 +18,12 @@
 
 #include "log.h"
 
+#define format "Logging value '%d' and string '%s'\n"
+
 int main(void)
 {
     const uint8_t value = 42;
     const char *string = "test";
-    const char *format = "Logging value '%d' and string '%s'\n";
 
     LOG_ERROR(format, value, string);
     LOG_WARNING(format, value, string);


### PR DESCRIPTION
### Contribution description

The compilation of `tests/log_color` fails with GCC version in the new toolchain for ESP8266 in PR https://github.com/RIOT-OS/riotdocker with:
```
tests/log_color/main.c:27:5: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
     LOG_ERROR(format, value, string);
     ^
...
```
The reason is that this GCC version does not accept a character pointer as sting literal for the format argument in `printf`. The GCC version is 5.2.0.

This PR defines the format as string constant to fix the problem. It works for all other GCC version and platforms.

The problem occurred while testing PR #11108.

### Testing procedure

The compilation for all platforms has to succeed.

### Issues/PRs references

Required by PR #11108.