### PR TITLE
sys/arduino: fix build issue with analogRead

### DIFF
--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -110,7 +110,6 @@ unsigned long micros();
  */
 unsigned long millis();
 
-#if MODULE_PERIPH_ADC || DOXYGEN
 /**
  * @brief   Read the current value of the given analog pin
  *
@@ -120,7 +119,6 @@ unsigned long millis();
  * to the voltage applied to the pin
  */
 int analogRead(int pin);
-#endif
 
 #endif /* ARDUINO_H */
 /** @} */


### PR DESCRIPTION
When using analogRead in an Arduino sketch with a board providing ADC feature, the build fails because the function is not defined. This commit fixes that

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When using analogRead in an Arduino sketch, the build fails because the function is not defined, even if the board provide the ADC feature.

This PR fixes that by unconditionally define the function. The build should fail at link with board not providing the ADC feature.

I think the main reason is that somehow defined macro related to features (and maybe other things) are not defined in cpp header files but I have no idea how this could/should be fixed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try to build a sketch that uses analogRead on a board providing ADC (arduino-zero, etc). On master it fails, with this PR it works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

That was missed in #12388 (my bad).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
