### PR TITLE
stmclk: Fix M-factor shift for SAI PLL

### DIFF
--- a/cpu/stm32_common/stmclk.c
+++ b/cpu/stm32_common/stmclk.c
@@ -87,7 +87,7 @@
 
 #if (CLOCK_ENABLE_PLL_SAI)
 #ifdef RCC_PLLSAICFGR_PLLSAIN_Pos
-#define PLLSAI_M                 (CLOCK_PLL_SAI_M << RCC_PLLSAICFGR_PLLSAIN_Pos)
+#define PLLSAI_M                 (CLOCK_PLL_SAI_M << RCC_PLLSAICFGR_PLLSAIM_Pos)
 #else
 #define PLLSAI_M                 (0)
 #endif


### PR DESCRIPTION
### Contribution description

This PR fixes, what I guess is, a copy-paste mistake in the SAI PLL config for the stm32.

The SAI M-factor is incorrectly shifted with the N-factor register position, causing a M-factor of 1 and an N-factor of the bitwise OR between the M-factor and the N-factor. This PR fixes the shift

### Testing procedure

I don't know if anything is actually using this PLL somewhere, I found it while debugging USB issues on an stm32f446re. I think a close look at the code diff should be enough to verify the change.

Please let me know if a backport is needed.

### Issues/PRs references

None