### PR TITLE
native: allow for native to be resetable via SIGUSR1

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -11,6 +11,7 @@ else
   DEBUGGER ?= gdb
 endif
 
+RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 FLASHER = true
 FLASHFILE ?= $(ELFFILE)
 

--- a/boards/native/dist/reset.sh
+++ b/boards/native/dist/reset.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Copyright (C) 2019 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+case ${DEBUG_ADAPTER_ID} in
+    # check if ${DEBUG_ADAPTER_ID} is empty or contains a number
+    ''|*[!0-9]*)
+        echo "Please provide native instance's PID using DEBUG_ADAPTER_ID" >&2
+        exit 1
+        ;;
+    *)  ;;
+esac
+
+kill -USR1 "${DEBUG_ADAPTER_ID}"

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -44,6 +44,7 @@
 #include "tty_uart.h"
 
 #include "periph/init.h"
+#include "periph/pm.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -390,6 +391,11 @@ extern init_func_t __init_array_start;
 extern init_func_t __init_array_end;
 #endif
 
+static void _reset_handler(void)
+{
+    pm_reboot();
+}
+
 __attribute__((constructor)) static void startup(int argc, char **argv, char **envp)
 {
     _native_init_syscalls();
@@ -576,6 +582,8 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
 
     periph_init();
     board_init();
+
+    register_interrupt(SIGUSR1, _reset_handler);
 
     puts("RIOT native hardware initialization complete.\n");
     irq_enable();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Based on the discussion sparked by this comment https://github.com/RIOT-OS/RIOT/issues/12448#issuecomment-541732537 I decided to provide a simple PoC of how to make `native` resetable.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Start a `native` instance in one terminal (application is arbitrary), find out its PID in another terminal, and then use the PID to reset e.g.:

```
$ pgrep -f native/hello-world
96937
$ DEBUG_ADAPTER_ID=96937 make -C examples/hello-world reset
```
The `native` instance should then reboot (noticeable by a big fat `!! REBOOT !!` printed)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/issues/12448#issuecomment-541732537
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
