### PR TITLE
dist/pythonlibs/testrunner: add reset option, reset before `cleanterm`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -706,7 +706,7 @@ TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*[^~]),\
 # See #11762.
 TEST_DEPS += $(TERMDEPS)
 
-$(call target-export-variables,test,MAKE_RESET_WITH_TERM)
+$(call target-export-variables,test,TESTRUNNER_RESET_SYNC)
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
 		$$t || exit 1; \

--- a/Makefile.include
+++ b/Makefile.include
@@ -706,6 +706,7 @@ TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*[^~]),\
 # See #11762.
 TEST_DEPS += $(TERMDEPS)
 
+$(call target-export-variables,test,MAKE_RESET_WITH_TERM)
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
 		$$t || exit 1; \

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -24,6 +24,12 @@ FLASHFILE ?= $(BINFILE)
 DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 
+# remote use cc2538-bsl attaching to the serial PORT to reset the board. If
+# `make reset` is called when the terminal is open it will set the device in
+# bootloader but fail in the next commands, leaving the device in bootloader
+# mode
+MAKE_RESET_WITH_TERM ?= 0
+
 # include common remote includes
 INCLUDES += -I$(RIOTBOARD)/common/remote/include
 

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -27,8 +27,8 @@ OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 # remote use cc2538-bsl attaching to the serial PORT to reset the board. If
 # `make reset` is called when the terminal is open it will set the device in
 # bootloader but fail in the next commands, leaving the device in bootloader
-# mode
-MAKE_RESET_WITH_TERM ?= 0
+# mode. Disable using reset as a sync method in `test` because of this.
+TESTRUNNER_RESET_SYNC ?= 0
 
 # include common remote includes
 INCLUDES += -I$(RIOTBOARD)/common/remote/include

--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -21,10 +21,15 @@ from .utils import test_utils_interactive_sync # noqa, F401 expose to users
 # default value (10)
 TIMEOUT = int(os.environ.get('RIOT_TEST_TIMEOUT') or 10)
 
+# Some boards can't be resetted during test since this resets the serial
+# connection. Default to 1 for those boards.
+MAKE_RESET_WITH_TERM = int(os.environ.get('MAKE_RESET_WITH_TERM', 1))
 
-def run(testfunc, timeout=TIMEOUT, echo=True, traceback=False):
+def run(testfunc, timeout=TIMEOUT, echo=True, traceback=False,
+        reset=MAKE_RESET_WITH_TERM):
     child = setup_child(timeout, env=os.environ,
-                        logfile=sys.stdout if echo else None)
+                        logfile=sys.stdout if echo else None,
+                        reset=reset)
     try:
         testfunc(child)
     except pexpect.TIMEOUT:

--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -21,15 +21,9 @@ from .utils import test_utils_interactive_sync # noqa, F401 expose to users
 # default value (10)
 TIMEOUT = int(os.environ.get('RIOT_TEST_TIMEOUT') or 10)
 
-# Some boards can't be resetted during test since this resets the serial
-# connection. Default to 1 for those boards.
-MAKE_RESET_WITH_TERM = int(os.environ.get('MAKE_RESET_WITH_TERM', 1))
-
-def run(testfunc, timeout=TIMEOUT, echo=True, traceback=False,
-        reset=MAKE_RESET_WITH_TERM):
+def run(testfunc, timeout=TIMEOUT, echo=True, traceback=False):
     child = setup_child(timeout, env=os.environ,
-                        logfile=sys.stdout if echo else None,
-                        reset=reset)
+                        logfile=sys.stdout if echo else None)
     try:
         testfunc(child)
     except pexpect.TIMEOUT:

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -23,7 +23,6 @@ RIOTBASE = (os.environ.get('RIOTBASE') or
 # default value (3)
 MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
 
-
 def list_until(l, cond):
     return l[:([i for i, e in enumerate(l) if cond(e)][0])]
 
@@ -35,7 +34,8 @@ def find_exc_origin(exc_info):
     return (pos[3], os.path.relpath(os.path.abspath(pos[0]), RIOTBASE), pos[1])
 
 
-def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
+def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None,
+                reset=True):
     child = spawnclass("make cleanterm", env=env, timeout=timeout,
                        codec_errors='replace', echo=False)
 
@@ -44,12 +44,13 @@ def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
 
     child.logfile = logfile
 
-    try:
-        subprocess.check_output(('make', 'reset'), env=env,
-                                stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError:
-        # make reset yields error on some boards even if successful
-        pass
+    if reset:
+        try:
+            subprocess.check_output(('make', 'reset'), env=env,
+                                    stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError:
+            # make reset yields error on some boards even if successful
+            pass
     return child
 
 

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -23,6 +23,12 @@ RIOTBASE = (os.environ.get('RIOTBASE') or
 # default value (3)
 MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
 
+# Resetting the board after the terminal is opened is used by the testrunner
+# to sync the device (application under test), and the test script. This can't
+# be done for some boards so provide a way of disabling the behavior.
+TESTRUNNER_RESET_SYNC = int(os.environ.get('TESTRUNNER_RESET_SYNC', 1))
+
+
 def list_until(l, cond):
     return l[:([i for i, e in enumerate(l) if cond(e)][0])]
 
@@ -34,8 +40,7 @@ def find_exc_origin(exc_info):
     return (pos[3], os.path.relpath(os.path.abspath(pos[0]), RIOTBASE), pos[1])
 
 
-def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None,
-                reset=True):
+def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
     # Some boards can't be reset after a terminal is open. We currently still
     # need to reset after opening the terminal because most tests use this as a
     # way to sync the device and the test. As long as this is still the behavior
@@ -55,7 +60,7 @@ def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None,
 
     child.logfile = logfile
 
-    if reset:
+    if TESTRUNNER_RESET_SYNC:
         try:
             subprocess.check_output(('make', 'reset'), env=env,
                                     stderr=subprocess.PIPE)

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -26,8 +26,7 @@ MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
 # Resetting the board after the terminal is opened is used by the testrunner
 # to sync the device (application under test), and the test script. This can't
 # be done for some boards so provide a way of disabling the behavior.
-TESTRUNNER_RESET_SYNC = int(os.environ.get('TESTRUNNER_RESET_SYNC', 1))
-
+TESTRUNNER_RESET_SYNC = int(os.getenv('TESTRUNNER_RESET_SYNC') or '1')
 
 def list_until(l, cond):
     return l[:([i for i, e in enumerate(l) if cond(e)][0])]

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -36,6 +36,17 @@ def find_exc_origin(exc_info):
 
 def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None,
                 reset=True):
+    # Some boards can't be reset after a terminal is open. We currently still
+    # need to reset after opening the terminal because most tests use this as a
+    # way to sync the device and the test. As long as this is still the behavior
+    # we keep both resets.
+    try:
+        subprocess.check_output(('make', 'reset'), env=env,
+                                stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        # make reset yields error on some boards even if successful
+        pass
+
     child = spawnclass("make cleanterm", env=env, timeout=timeout,
                        codec_errors='replace', echo=False)
 


### PR DESCRIPTION
### Contribution description

For some board `make reset` is only possible if a serial connection is not already open or its execution might disrupt it. This causes some tests to fail since before running a test the board
is reset.

This PR introduces two changes to address this:

- reset before `make cleanterm` to ensure the application is always reset so one could eventually call `make test` multiple times.
- make resetting after `make cleanterm` (which used as a sync feature) optional with  `TESTRUNNER_RESET_SYNC`

I include both changes in the same PR because I think it is important to always rest the board before flashing.

This is not enough to run all tests with boards like `remote-revb` since in absence of a reset there is no way to sync the test and the device. If also using #12461, tests failing go down to 14 (from 100%).

### Testing procedure

Since the default behavior is the same testing can be performed on boards that do need this feature, e.g.: remote-revb:

- In master or setting `TESTRUNNER_RESET_SYNC=1`

<details><summary>TESTRUNNER_RESET_SYNC=1 make -C tests/xtimer_usleep BOARD=remote-revb flash test
</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/tests/xtimer_usleep'
Building application "tests_xtimer_usleep" for "remote-revb" with MCU "cc2538".

"make" -C /home/francisco/workspace/RIOT/boards/remote-revb
"make" -C /home/francisco/workspace/RIOT/boards/common/remote
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/cc2538
"make" -C /home/francisco/workspace/RIOT/cpu/cc2538/periph
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/tsrb
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12176	    136	   2680	  14992	   3a90	/home/francisco/workspace/RIOT/tests/xtimer_usleep/bin/remote-revb/tests_xtimer_usleep.elf
/home/francisco/workspace/RIOT/dist/tools/cc2538-bsl/cc2538-bsl.py -p "/dev/ttyUSB0" -e -w -v -b 115200 /home/francisco/workspace/RIOT/tests/xtimer_usleep/bin/remote-revb/tests_xtimer_usleep.bin
Opening port /dev/ttyUSB0, baud 115200
Reading data from /home/francisco/workspace/RIOT/tests/xtimer_usleep/bin/remote-revb/tests_xtimer_usleep.bin
Cannot auto-detect firmware filetype: Assuming .bin
Connecting to target...
CC2538 PG2.0: 512KB Flash, 32KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:14:D5:2D:91
Erasing 524288 bytes starting at address 0x00200000
    Erase done
Writing 524288 bytes starting at address 0x00200000
Write 16 bytes at 0x0027FFF0F8
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0xf2c214f2)
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/tty-remote-revb" -b "115200" --noprefix --no-repeat-command-on-empty-line
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/riot/tty-remote-revb
Welcome to pyterm!
Type '/exit' to exit.
main(): This is RIOT! (Version: 2020.01-devel-177-g3802d-pr_dont_reset)
Running test 5 times with 7 distinct sleep times
Help: Press s to start test, r to print it is ready
r
r
r
```
</details>

- This PR:


<details><summary>make -C tests/xtimer_usleep BOARD=remote-revb flash test
</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/tests/xtimer_usleep'
Building application "tests_xtimer_usleep" for "remote-revb" with MCU "cc2538".

"make" -C /home/francisco/workspace/RIOT/boards/remote-revb
"make" -C /home/francisco/workspace/RIOT/boards/common/remote
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/cc2538
"make" -C /home/francisco/workspace/RIOT/cpu/cc2538/periph
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/tsrb
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12176	    136	   2680	  14992	   3a90	/home/francisco/workspace/RIOT/tests/xtimer_usleep/bin/remote-revb/tests_xtimer_usleep.elf
/home/francisco/workspace/RIOT/dist/tools/cc2538-bsl/cc2538-bsl.py -p "/dev/ttyUSB0" -e -w -v -b 115200 /home/francisco/workspace/RIOT/tests/xtimer_usleep/bin/remote-revb/tests_xtimer_usleep.bin
Opening port /dev/ttyUSB0, baud 115200
Reading data from /home/francisco/workspace/RIOT/tests/xtimer_usleep/bin/remote-revb/tests_xtimer_usleep.bin
Cannot auto-detect firmware filetype: Assuming .bin
Connecting to target...
CC2538 PG2.0: 512KB Flash, 32KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:14:D5:2D:91
Erasing 524288 bytes starting at address 0x00200000
    Erase done
Writing 524288 bytes starting at address 0x00200000
Write 16 bytes at 0x0027FFF0F8
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0xeafee2be)
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/tty-remote-revb" -b "115200" --noprefix --no-repeat-command-on-empty-line
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/riot/tty-remote-revb
Welcome to pyterm!
Type '/exit' to exit.
main(): This is RIOT! (Version: 2020.01-devel-178-g98935-pr_dont_reset)
Running test 5 times with 7 distinct sleep times
Help: Press s to start test, r to print it is ready
r
READY
s
START
Slept for 10064 us (expected: 10000 us) Offset: 64 us
Slept for 50064 us (expected: 50000 us) Offset: 64 us
Slept for 10298 us (expected: 10234 us) Offset: 64 us
Slept for 56844 us (expected: 56780 us) Offset: 64 us
Slept for 12186 us (expected: 12122 us) Offset: 64 us
Slept for 98829 us (expected: 98765 us) Offset: 64 us
Slept for 75063 us (expected: 75000 us) Offset: 63 us
Slept for 10063 us (expected: 10000 us) Offset: 63 us
Slept for 50064 us (expected: 50000 us) Offset: 64 us
Slept for 10298 us (expected: 10234 us) Offset: 64 us
Slept for 56844 us (expected: 56780 us) Offset: 64 us
Slept for 12185 us (expected: 12122 us) Offset: 63 us
Slept for 98828 us (expected: 98765 us) Offset: 63 us
Slept for 75064 us (expected: 75000 us) Offset: 64 us
Slept for 10063 us (expected: 10000 us) Offset: 63 us
Slept for 50064 us (expected: 50000 us) Offset: 64 us
Slept for 10298 us (expected: 10234 us) Offset: 64 us
Slept for 56843 us (expected: 56780 us) Offset: 63 us
Slept for 12185 us (expected: 12122 us) Offset: 63 us
Slept for 98828 us (expected: 98765 us) Offset: 63 us
Slept for 75063 us (expected: 75000 us) Offset: 63 us
Slept for 10063 us (expected: 10000 us) Offset: 63 us
Slept for 50064 us (expected: 50000 us) Offset: 64 us
Slept for 10298 us (expected: 10234 us) Offset: 64 us
Slept for 56844 us (expected: 56780 us) Offset: 64 us
Slept for 12185 us (expected: 12122 us) Offset: 63 us
Slept for 98828 us (expected: 98765 us) Offset: 63 us
Slept for 75064 us (expected: 75000 us) Offset: 64 us
Slept for 10063 us (expected: 10000 us) Offset: 63 us
Slept for 50064 us (expected: 50000 us) Offset: 64 us
Slept for 10298 us (expected: 10234 us) Offset: 64 us
Slept for 56843 us (expected: 56780 us) Offset: 63 us
Slept for 12185 us (expected: 12122 us) Offset: 63 us
Slept for 98829 us (expected: 98765 us) Offset: 64 us
Slept for 75063 us (expected: 75000 us) Offset: 63 us
Test ran for 1691591 us

make: Leaving directory '/home/francisco/workspace/RIOT/tests/xtimer_usleep'

```
</details>

### Issues/PRs references

Part of #12448
