### PR TITLE
gnrc_ipv6_nib: don't auto-configure IPv6 w/o SLAAC on non-6LN interface [backport 2019.10]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -15,6 +15,7 @@
 
 #include <stdbool.h>
 
+#include "log.h"
 #include "luid.h"
 #include "net/gnrc/netif/internal.h"
 
@@ -34,6 +35,15 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
     int idx;
     uint8_t flags = GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE;
 
+#if !GNRC_IPV6_NIB_CONF_SLAAC
+    if (!gnrc_netif_is_6ln(netif)) {
+        LOG_WARNING("SLAAC not activated; will not auto-configure IPv6 address "
+                         "for interface %u.\n"
+                    "    Use GNRC_IPV6_NIB_CONF_SLAAC=1 to activate.\n",
+                    netif->pid);
+        return;
+    }
+#endif
     if (!(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR)) {
         DEBUG("nib: interface %i has no link-layer addresses\n", netif->pid);
         return;


### PR DESCRIPTION
# Backport of #12513

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When the NIB is compiled for 6LN mode (but not a 6LBR), the Stateless Address Autoconfiguration (SLAAC) functionality is disabled, as it is typically not required; see

https://github.com/RIOT-OS/RIOT/blob/d9c240a2ff2fad62587f1e6f967d83c16d2919db/sys/include/net/gnrc/ipv6/nib/conf.h#L41-L48

https://github.com/RIOT-OS/RIOT/blob/d9c240a2ff2fad62587f1e6f967d83c16d2919db/sys/include/net/gnrc/ipv6/nib/conf.h#L50-L59

However, if a non-6LN interface is also compiled in (still without making the node a border router) an auto-configured address will be assigned in accordance with [RFC 6775] to the interface, just assuming the interface is a 6LN interface. As it then only performs duplicate address detection RFC-6775-style then, the address then never becomes valid, as the duplicate address detection according to [RFC 4862] (part of the SLAAC functionality) is never performed.

As auto-configuring an address without SLAAC doesn't make sense, this fix makes the interface skip it completely, but provides a warning to the user, so they know what to do.

[RFC 6775]: https://tools.ietf.org/html/rfc6775#section-5.2
[RFC 4862]: https://tools.ietf.org/html/rfc4862#section-5.4
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile `examples/gnrc_networking` `native` with both a `netdev_tap` and `socket_zep`:

```sh
GNRC_NETIF_NUMOF=2 USEMODULE=socket_zep TERMFLAGS="-z [::]:17755 tap0" \
   make -C examples/gnrc_networking all term
```

With this fix, the link-local address of the Ethernet interface won't receive an auto-configured link-local address and a warning is printed

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

SLAAC not activated; won't auto-configure IPv6 for interface 7
    Use GNRC_IPV6_NIB_CONF_SLAAC=1 to activate
main(): This is RIOT! (Version: 2020.01-devel-197-gc93b3-gnrc_netif/enh/split-6lo-6ln)
RIOT network stack example application
All up, running the shell now
> ifconfig
ifconfig
Iface  7  HWaddr: 26:82:DC:3B:CA:E6 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 group: ff02::2
          inet6 group: ff02::1
          
          Statistics for Layer 2
            RX packets 4  bytes 440
            TX packets 3 (Multicast: 3)  bytes 186
            TX succeeded 3 errors 0
          Statistics for IPv6
            RX packets 4  bytes 384
            TX packets 3 (Multicast: 3)  bytes 144
            TX succeeded 3 errors 0

Iface  8  HWaddr: 45:5B  Channel: 26  NID: 0x23
          Long HWaddr: 00:5A:45:50:0A:00:45:5B 
          L2-PDU:102 MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::25a:4550:a00:455b  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff00:455b
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 3 (Multicast: 3)  bytes 86
            TX succeeded 6 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 3 (Multicast: 3)  bytes 192
            TX succeeded 3 errors 0
```

Compiling with `CFLAGS+=-DGNRC_IPV6_NIB_CONF_SLAAC=1` still auto-configures the address and validates it shortly after the node started (and the warning is not shown ;-)):

```
> ifconfig
ifconfig
Iface  7  HWaddr: 26:82:DC:3B:CA:E6 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::2482:dcff:fe3b:cae6  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff3b:cae6
          
          Statistics for Layer 2
            RX packets 5  bytes 526
            TX packets 2 (Multicast: 2)  bytes 140
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 5  bytes 456
            TX packets 2 (Multicast: 2)  bytes 112
            TX succeeded 2 errors 0

Iface  8  HWaddr: 45:5B  Channel: 26  NID: 0x23
          Long HWaddr: 00:5A:45:50:0A:00:45:5B 
          L2-PDU:102 MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::25a:4550:a00:455b  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff00:455b
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 43
            TX succeeded 3 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 128
            TX succeeded 2 errors 0
```

Without the fix and CFLAGS=-DGNRC_IPV6_NIB_CONF_SLAAC=1 not set the Ethernet interface gets a link-local address which will stay tentative forever:

```
> ifconfig
ifconfig
Iface  7  HWaddr: 26:82:DC:3B:CA:E6 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::2482:dcff:fe3b:cae6  scope: local  TNT[1]
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff3b:cae6
          
          Statistics for Layer 2
            RX packets 5  bytes 526
            TX packets 1 (Multicast: 1)  bytes 62
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 5  bytes 456
            TX packets 1 (Multicast: 1)  bytes 48
            TX succeeded 1 errors 0

Iface  8  HWaddr: 45:5B  Channel: 26  NID: 0x23
          Long HWaddr: 00:5A:45:50:0A:00:45:5B 
          L2-PDU:102 MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::25a:4550:a00:455b  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff00:455b
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 43
            TX succeeded 3 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 128
            TX succeeded 2 errors 0
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Several, but triggered by testing procedures in #12512 and #10499.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
