### PR TITLE
sys/arduino: add implementation for analogWrite

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -635,9 +635,14 @@ endif
 
 ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_REQUIRED += arduino
+  FEATURES_OPTIONAL += arduino_pwm
   FEATURES_OPTIONAL += periph_adc
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer
+endif
+
+ifneq (,$(filter arduino_pwm,$(FEATURES_USED)))
+  FEATURES_REQUIRED += periph_pwm
 endif
 
 ifneq (,$(filter xtimer,$(USEMODULE)))

--- a/boards/arduino-zero/Makefile.features
+++ b/boards/arduino-zero/Makefile.features
@@ -14,3 +14,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += arduino_pwm

--- a/boards/arduino-zero/include/arduino_board.h
+++ b/boards/arduino-zero/include/arduino_board.h
@@ -22,6 +22,7 @@
 #define ARDUINO_BOARD_H
 
 #include "arduino_pinmap.h"
+#include "periph/pwm.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,6 +69,21 @@ static const adc_t arduino_analog_map[] = {
     ARDUINO_A3,
     ARDUINO_A4,
     ARDUINO_A5,
+};
+
+/**
+ * @brief   PWM frequency
+ */
+#define ARDUINO_PWM_FREQU       (732U)
+
+/**
+ * @brief   List of PWM GPIO mappings
+ */
+static const arduino_pwm_t arduino_pwm_list[] = {
+    { .pin = 3, .dev = PWM_DEV(0), .chan = 1 },
+    { .pin = 4, .dev = PWM_DEV(0), .chan = 0 },
+    { .pin = 8, .dev = PWM_DEV(1), .chan = 0 },
+    { .pin = 9, .dev = PWM_DEV(1), .chan = 1 },
 };
 
 #ifdef __cplusplus

--- a/boards/common/arduino-atmega/Makefile.features
+++ b/boards/common/arduino-atmega/Makefile.features
@@ -1,10 +1,11 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
-FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += arduino_pwm

--- a/boards/common/arduino-atmega/include/arduino_board.h
+++ b/boards/common/arduino-atmega/include/arduino_board.h
@@ -23,6 +23,7 @@
 #define ARDUINO_BOARD_H
 
 #include "arduino_pinmap.h"
+#include "periph/pwm.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -138,6 +139,34 @@ static const adc_t arduino_analog_map[] = {
     ARDUINO_A13,
     ARDUINO_A14,
     ARDUINO_A15,
+#endif
+};
+
+/**
+ * @brief   PWM frequency
+ */
+#define ARDUINO_PWM_FREQU       (490U)
+
+/**
+ * @brief   List of PWM GPIO mappings
+ */
+static const arduino_pwm_t arduino_pwm_list[] = {
+#if defined(CPU_ATMEGA2560)
+    { .pin = 13, .dev = PWM_DEV(0), .chan = 0 },
+    { .pin = 4,  .dev = PWM_DEV(0), .chan = 1 },
+#elif defined(CPU_ATMEGA32U4)
+    { .pin = 11, .dev = PWM_DEV(0), .chan = 0 },
+    { .pin = 3,  .dev = PWM_DEV(0), .chan = 1 },
+#else /* CPU_ATMEGA328p */
+    { .pin = 6, .dev = PWM_DEV(0), .chan = 0 },
+    { .pin = 5, .dev = PWM_DEV(0), .chan = 1 },
+#endif
+#if defined(CPU_ATMEGA2560)
+    { .pin = 10, .dev = PWM_DEV(1), .chan = 0 },
+    { .pin = 9,  .dev = PWM_DEV(1), .chan = 1 },
+#else /* CPU_ATMEGA328p */
+    { .pin = 11, .dev = PWM_DEV(1), .chan = 0 },
+    { .pin = 3,  .dev = PWM_DEV(1), .chan = 1 },
 #endif
 };
 

--- a/boards/common/arduino-mkr/Makefile.features
+++ b/boards/common/arduino-mkr/Makefile.features
@@ -15,3 +15,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += arduino_pwm

--- a/boards/common/arduino-mkr/include/arduino_board.h
+++ b/boards/common/arduino-mkr/include/arduino_board.h
@@ -22,6 +22,7 @@
 #define ARDUINO_BOARD_H
 
 #include "arduino_pinmap.h"
+#include "periph/pwm.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +67,19 @@ static const adc_t arduino_analog_map[] = {
     ARDUINO_A4,
     ARDUINO_A5,
     ARDUINO_A6,
+};
+
+/**
+ * @brief   PWM frequency
+ */
+#define ARDUINO_PWM_FREQU       (732U)
+
+/**
+ * @brief   List of PWM GPIO mappings
+ */
+static const arduino_pwm_t arduino_pwm_list[] = {
+    { .pin = 2, .dev = PWM_DEV(0), .chan = 0 },
+    { .pin = 3, .dev = PWM_DEV(0), .chan = 1 },
 };
 
 #ifdef __cplusplus

--- a/boards/sodaq-autonomo/Makefile.features
+++ b/boards/sodaq-autonomo/Makefile.features
@@ -2,4 +2,7 @@ CPU_MODEL = samd21j18a
 
 FEATURES_PROVIDED += periph_pwm
 
+# Various other features (if any)
+FEATURES_PROVIDED += arduino_pwm
+
 include $(RIOTBOARD)/common/sodaq/Makefile.features

--- a/boards/sodaq-autonomo/include/arduino_board.h
+++ b/boards/sodaq-autonomo/include/arduino_board.h
@@ -21,6 +21,7 @@
 
 #include "periph/gpio.h"
 #include "periph/adc.h"
+#include "periph/pwm.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -143,6 +144,22 @@ static const adc_t arduino_analog_map[] = {
     ADC_LINE(12),
     ADC_LINE(13),
     ADC_LINE(14),
+};
+
+/**
+ * @brief   PWM frequency
+ */
+#define ARDUINO_PWM_FREQU       (732U)
+
+/**
+ * @brief   List of PWM GPIO mappings
+ */
+static const arduino_pwm_t arduino_pwm_list[] = {
+    { .pin = 20, .dev = PWM_DEV(0), .chan = 0 },
+    { .pin = 29, .dev = PWM_DEV(0), .chan = 1 },
+    { .pin = 11, .dev = PWM_DEV(1), .chan = 0 },
+    { .pin = 13, .dev = PWM_DEV(1), .chan = 1 },
+    { .pin = 14, .dev = PWM_DEV(1), .chan = 2 },
 };
 
 #ifdef __cplusplus

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -103,6 +103,17 @@ typedef enum {
 } pwm_mode_t;
 #endif
 
+#ifdef MODULE_ARDUINO
+/**
+ * @brief   RIOT GPIO mapping between Arduino pin, PWM device and channel
+ */
+typedef struct {
+    int pin;        /**< Arduino pin number */
+    int dev;        /**< PWM device index of pin */
+    int chan;       /**< PWM channel index */
+} arduino_pwm_t;
+#endif
+
 /**
  * @brief   Initialize a PWM device
  *

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -122,5 +122,37 @@ unsigned long millis();
 int analogRead(int pin);
 #endif
 
+#if MODULE_PERIPH_PWM || DOXYGEN
+/**
+ * @brief   PWM default frequency
+ *
+ * Can be overridden at board level in arduino_board.h.
+ *
+ * See table from https://www.arduino.cc/reference/en/language/functions/analog-io/analogwrite/
+ * for reference values.
+ */
+#ifndef ARDUINO_PWM_FREQU
+#define ARDUINO_PWM_FREQU           (1000U)
+#endif
+
+/**
+ * @brief   PWM mode
+ */
+#define ARDUINO_PWM_MODE            PWM_LEFT
+
+/**
+ * @brief   PWM steps
+ */
+#define ARDUINO_PWM_STEPS           (256U)
+
+/**
+ * @brief   Write an analog value to a pin
+ *
+ * @param[in] pin       pin to write
+ * @param[in] value     duty cycle value, between 0 and 255
+ */
+void analogWrite(int pin, int value);
+#endif
+
 #endif /* ARDUINO_HPP */
 /** @} */

--- a/tests/sys_arduino_analog/Makefile
+++ b/tests/sys_arduino_analog/Makefile
@@ -1,0 +1,15 @@
+BOARD ?= arduino-zero
+
+include ../Makefile.tests_common
+
+LED_PIN ?= 3
+
+USEMODULE += arduino
+
+# Features used by Arduino analogRead/analogWrite functions are required
+FEATURES_REQUIRED += arduino_pwm
+FEATURES_REQUIRED += periph_adc
+
+CFLAGS += -DLED_PIN=$(LED_PIN)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys_arduino_analog/arduino-test.sketch
+++ b/tests/sys_arduino_analog/arduino-test.sketch
@@ -1,0 +1,15 @@
+// Example sketch given in analogWrite documentation
+// https://www.arduino.cc/reference/en/language/functions/analog-io/analogwrite/
+
+int ledPin = LED_PIN;         // LED connected to digital pin 3 by default
+int analogPin = 1;            // potentiometer connected to analog pin 1
+int val = 0;                  // variable to store the read value
+
+void setup() {
+  pinMode(ledPin, OUTPUT);    // sets the pin as output
+}
+
+void loop() {
+  val = analogRead(analogPin);  // read the input pin
+  analogWrite(ledPin, val / 4); // analogRead values go from 0 to 1023, analogWrite values from 0 to 255
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an implementation for the analogWrite function of the Arduino API. It's based on the PWM peripheral interface of RIOT.

The `arduino_pwm` feature is introduced to only have to provide this implementation on a  subset of boards (arduino-zero, sodaq-automono and arduino-mkrs) which already provides arduino and periph_pwm features. Other boards can then be adapted later: Arduino atmega, STM32 nucleos, etc.

Since there's no one to one mapping possible between Arduino PWM pins and RIOT, there's a not so nice logic to look for an index in a list of pin/PWM dev/channel mapping. I tried to use designated initializers but doesn't build with c++ unless empty elements are also initialized with dummy values. And it makes the array static initialization quite ugly.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Plug a LED on D9 and flash the following Arduino sketch on arduino-zero:
```cpp
int value = 0;
int ledPwm = 9;

void setup(void)
{}

void loop(void)
{
    analogWrite(ledPwm, value);
    value = (value + 10) % 256;
    // wait a bit
    delay(50);
}
```

And watch it oscillate.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Now based on #12541 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
