### PR TITLE
makefiles/sam0: fix typo

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -28,7 +28,7 @@ ifeq ($(DEBUG_ADAPTER),dap)
   PROGRAMMER ?= edbg
 else ifeq ($(DEBUG_ADAPTER),jlink)
   # only use JLinkExe if it's installed
-  ifneq (,$(shell command -v JLinkExe)))
+  ifneq (,$(shell command -v JLinkExe))
     PROGRAMMER ?= jlink
   else
     PROGRAMMER ?= openocd


### PR DESCRIPTION
### Contribution description
Ok, this is a bit embarrassing - an additional parenthesis had sneaked in when editing the PR that added the option to flash with `JlinkExe` and I didn't notice it until it was merged.

### Testing procedure
Flashing a sam0 board with `DEBUG_ADAPTER=jlink` should work.
But really, the number of opening parenthesis should match the number of closing parenthesis.


### Issues/PRs references
introduced by #11725