### PR TITLE
cpu/fe310: change default optimization to "-Os"

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -4,8 +4,8 @@ export TARGET_ARCH ?= riscv-none-embed
 # define build specific options
 CFLAGS_CPU   = -march=rv32imac -mabi=ilp32 -mcmodel=medlow -msmall-data-limit=8
 CFLAGS_LINK  = -nostartfiles -ffunction-sections -fdata-sections
-CFLAGS_DBG  ?= -g3 -Og
-#CFLAGS_OPT  ?= -Os
+CFLAGS_DBG  ?= -g3
+CFLAGS_OPT  ?= -Os
 
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
 export LINKER_SCRIPT ?= $(CPU_MODEL).ld

--- a/pkg/wolfssl/Makefile.wolfcrypt
+++ b/pkg/wolfssl/Makefile.wolfcrypt
@@ -29,10 +29,5 @@ SRC +=  ge_low_mem.c
 SRC +=  sp_int.c
 SRC +=  sp_c32.c
 
-# Disable maybe-uninitialized warning raised by the optimization level used
-# by risv toolchain (-Og)
-ifeq ($(TARGET_ARCH),riscv-none-embed)
-  CFLAGS += -Wno-maybe-uninitialized
-endif
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR changes RISC-V's default optimization level to `-Os`.
Also moves the option to CFLAGS_OPT.

IMO this was a development leftover.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The usual board tests for hifive1 and hifive1b.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

First reported in #12097. See also #12502.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
