### PR TITLE
tools/pr_check: add REMOVEME in filtered keyword

### DIFF
--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -29,8 +29,15 @@ else
     RIOT_MASTER="master"
 fi
 
+keyword_filter() {
+    grep -i \
+        -e "^    [0-9a-f]\+ .\{0,2\}SQUASH" \
+        -e "^    [0-9a-f]\+ .\{0,2\}FIX" \
+        -e "^    [0-9a-f]\+ .\{0,2\}REMOVE *ME"
+}
+
 SQUASH_COMMITS="$(git log $(git merge-base HEAD "${RIOT_MASTER}")...HEAD --pretty=format:"    %h %s" | \
-                  grep -i -e "^    [0-9a-f]\+ .\{0,2\}SQUASH" -e "^    [0-9a-f]\+ .\{0,2\}FIX")"
+                  keyword_filter)"
 
 if [ -n "${SQUASH_COMMITS}" ]; then
     echo -e "${CERROR}Pull request needs squashing:${CRESET}" 1>&2


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR extends the pr check script to also add "Needs squashing" when a PR contains commits starting with the REMOVEME keyword.

I personally made the mistake last week (yes, throw me tomatoes) in #12494 where the global change was ok, but the history was containing a REMOVEME commit...

Note that this PR contains 4 commits containing excluded keyword that should fail on the CI.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `make static-test` fails with the 4 forbidden commits
- `make static-test` passes without the 4 forbidden commits

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Once merged, this PR will avoid the (harmless) mistake done in #12494

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
