### PR TITLE
shell_commands: gnrc_netif: print correct scope for IPv6 address 

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -352,11 +352,17 @@ static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
     printf("inet6 addr: ");
     ipv6_addr_to_str(addr_str, addr, sizeof(addr_str));
     printf("%s  scope: ", addr_str);
-    if ((ipv6_addr_is_link_local(addr))) {
-        printf("local");
+    if (ipv6_addr_is_link_local(addr)) {
+        printf("link");
+    }
+    else if (ipv6_addr_is_site_local(addr)) {
+        printf("site");
+    }
+    else if (ipv6_addr_is_global(addr)) {
+        printf("global");
     }
     else {
-        printf("global");
+        printf("unknown");
     }
     if (flags & GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST) {
         printf(" [anycast]");

--- a/tests/gnrc_ipv6_ext_frag/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext_frag/tests/01-run.py
@@ -371,7 +371,7 @@ def testfunc(child):
         child.expect("HWaddr: (?P<hwaddr>[A-Fa-f:0-9]+)")
         hwaddr_dst = child.match.group("hwaddr").lower()
         res = child.expect([
-            r"(?P<lladdr>fe80::[A-Fa-f:0-9]+)\s+scope:\s+local\s+VAL",
+            r"(?P<lladdr>fe80::[A-Fa-f:0-9]+)\s+scope:\s+link\s+VAL",
             pexpect.TIMEOUT
         ])
         count += 1

--- a/tests/nanocoap_cli/main.c
+++ b/tests/nanocoap_cli/main.c
@@ -50,7 +50,7 @@ static void _print_addr(ipv6_addr_t *addr, uint8_t flags)
     ipv6_addr_to_str(addr_str, addr, sizeof(addr_str));
     printf("%s  scope: ", addr_str);
     if ((ipv6_addr_is_link_local(addr))) {
-        printf("local");
+        printf("link");
     }
     else {
         printf("global");


### PR DESCRIPTION
### Contribution description

Previously `ifconfig` would only know link-local addresses (printed as 'local') and everything else would be 'global'.

This is wrong for site-local and unique local addresses which were also denoted as global.

So use the already existing helper functions to determine the correct type of IPv6 address when printing.

**before**:
```
2019-10-21 13:42:43,897 # Iface  8  HWaddr: D2:AF  Channel: 26  NID: 0xe  PHY: O-QPSK 
2019-10-21 13:42:43,899 #            chip rate: 2000  rate mode: 0 (legacy)   BW: 5000kHz 
2019-10-21 13:42:43,902 #           Long HWaddr: D2:AF:0C:1B:20:54:05:8F 
2019-10-21 13:42:43,905 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2019-10-21 13:42:43,913 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
2019-10-21 13:42:43,914 #           RTR_ADV  6LO  IPHC  
2019-10-21 13:42:43,917 #           Source address length: 8
2019-10-21 13:42:43,920 #           Link type: wireless
2019-10-21 13:42:43,926 #           inet6 addr: fe80::d0af:c1b:2054:58f  scope: local  VAL
2019-10-21 13:42:43,931 #           inet6 addr: fd00:1:2:3:d0af:c1b:2054:58f  scope: global  VAL
2019-10-21 13:42:43,934 #           inet6 group: ff02::2
2019-10-21 13:42:43,937 #           inet6 group: ff02::1
2019-10-21 13:42:43,941 #           inet6 group: ff02::1:ff54:58f
2019-10-21 13:42:43,942 #           
2019-10-21 13:42:43,945 #           Statistics for Layer 2
2019-10-21 13:42:43,949 #             RX packets 44  bytes 3422
2019-10-21 13:42:43,952 #             TX packets 34 (Multicast: 1)  bytes 2964
2019-10-21 13:42:43,956 #             TX succeeded 31 errors 0
2019-10-21 13:42:43,959 #           Statistics for IPv6
2019-10-21 13:42:43,962 #             RX packets 43  bytes 3463
2019-10-21 13:42:43,966 #             TX packets 34 (Multicast: 1)  bytes 2944
2019-10-21 13:42:43,969 #             TX succeeded 34 errors 0
```

**after:**
```
2019-10-21 13:54:18,653 # Iface  8  HWaddr: D2:AF  Channel: 26  NID: 0xe  PHY: O-QPSK 
2019-10-21 13:54:18,659 #            chip rate: 2000  rate mode: 0 (legacy)   BW: 5000kHz 
2019-10-21 13:54:18,663 #           Long HWaddr: D2:AF:0C:1B:20:54:05:8F 
2019-10-21 13:54:18,670 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2019-10-21 13:54:18,676 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
2019-10-21 13:54:18,678 #           RTR_ADV  6LO  IPHC  
2019-10-21 13:54:18,682 #           Source address length: 8
2019-10-21 13:54:18,684 #           Link type: wireless
2019-10-21 13:54:18,690 #           inet6 addr: fe80::d0af:c1b:2054:58f  scope: link  VAL
2019-10-21 13:54:18,696 #           inet6 addr: fd00:1:2:3:d0af:c1b:2054:58f  scope: local  VAL
2019-10-21 13:54:18,699 #           inet6 group: ff02::2
2019-10-21 13:54:18,701 #           inet6 group: ff02::1
2019-10-21 13:54:18,708 #           inet6 group: ff02::1:ff54:58f
2019-10-21 13:54:18,709 #           
2019-10-21 13:54:18,711 #           Statistics for Layer 2
2019-10-21 13:54:18,712 #             RX packets 3  bytes 320
2019-10-21 13:54:18,716 #             TX packets 5 (Multicast: 4)  bytes 268
2019-10-21 13:54:18,719 #             TX succeeded 5 errors 0
2019-10-21 13:54:18,721 #           Statistics for IPv6
2019-10-21 13:54:18,724 #             RX packets 3  bytes 336
2019-10-21 13:54:18,728 #             TX packets 5 (Multicast: 4)  bytes 352
2019-10-21 13:54:18,732 #             TX succeeded 5 errors 0
```

### Testing procedure

Only user visible output has changed.
I did not yet check if any test scripts rely on this output.

### Issues/PRs references
none
