### PR TITLE
gcoap: add lazy init mode

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -84,6 +84,7 @@ PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += suit_%
+PSEUDOMODULES += gcoap_lazy_init
 
 # handle suit_v4 being a distinct module
 NO_PSEUDOMODULES += suit_v4

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -14,6 +14,7 @@ PSEUDOMODULES += ecc_%
 PSEUDOMODULES += emb6_router
 PSEUDOMODULES += event_%
 PSEUDOMODULES += fmt_%
+PSEUDOMODULES += gcoap_lazy_init
 PSEUDOMODULES += gnrc_ipv6_default
 PSEUDOMODULES += gnrc_ipv6_router
 PSEUDOMODULES += gnrc_ipv6_router_default
@@ -84,7 +85,6 @@ PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += suit_%
-PSEUDOMODULES += gcoap_lazy_init
 
 # handle suit_v4 being a distinct module
 NO_PSEUDOMODULES += suit_v4

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -87,9 +87,14 @@ typedef struct {
                                            the entry is available */
 } gcoap_state_t;
 
+#ifdef MODULE_GCOAP_LAZY_INIT
+static gcoap_state_t _coap_state;
+#else
 static gcoap_state_t _coap_state = {
+    /* No default listeners registered in lazy init mode */
     .listeners   = &_default_listener,
 };
+#endif
 
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 static char _msg_stack[GCOAP_STACK_SIZE];
@@ -608,16 +613,29 @@ static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
 }
 
 /*
- * gcoap interface functions
+ * Starts the CoAP server thread
  */
-
-kernel_pid_t gcoap_init(void)
+static kernel_pid_t _start_server(void)
 {
     if (_pid != KERNEL_PID_UNDEF) {
         return -EEXIST;
     }
     _pid = thread_create(_msg_stack, sizeof(_msg_stack), THREAD_PRIORITY_MAIN - 1,
                             THREAD_CREATE_STACKTEST, _event_loop, NULL, "coap");
+    return _pid;
+}
+
+/*
+ * gcoap interface functions.
+ *
+ * Returns `KERNEL_PID_UNDEF` in `gcoap_lazy_init` mode.
+ */
+
+kernel_pid_t gcoap_init(void)
+{
+#ifndef MODULE_GCOAP_LAZY_INIT
+    _pid = _start_server();
+#endif
 
     mutex_init(&_coap_state.lock);
     /* Blank lists so we know if an entry is available. */
@@ -633,6 +651,15 @@ kernel_pid_t gcoap_init(void)
 
 void gcoap_register_listener(gcoap_listener_t *listener)
 {
+#ifdef MODULE_GCOAP_LAZY_INIT
+    /* A CoAP server must be started here and the default listener added
+     * because we are now expecting requests */
+    if (_pid == KERNEL_PID_UNDEF) {
+        _coap_state.listeners = &_default_listener;
+        _pid = _start_server();
+    }
+#endif
+
     /* Add the listener to the end of the linked list. */
     gcoap_listener_t *_last = _coap_state.listeners;
     while (_last->next) {
@@ -650,6 +677,12 @@ int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                    unsigned code, const char *path)
 {
     assert((path == NULL) || (path[0] == '/'));
+
+#ifdef MODULE_GCOAP_LAZY_INIT
+    if (_pid == KERNEL_PID_UNDEF) {
+        DEBUG("gcoap: sending request in lazy init mode, responses will be ignored\n");
+    }
+#endif
 
     pdu->hdr = (coap_hdr_t *)buf;
 
@@ -722,8 +755,14 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
                       gcoap_resp_handler_t resp_handler)
 {
     gcoap_request_memo_t *memo = NULL;
-    unsigned msg_type  = (*buf & 0x30) >> 4;
     uint32_t timeout   = 0;
+    unsigned msg_type  = (*buf & 0x30) >> 4;
+#ifdef MODULE_GCOAP_LAZY_INIT
+    if (msg_type == COAP_TYPE_CON && _pid == KERNEL_PID_UNDEF) {
+        DEBUG("gcoap: cannot send CON request in lazy init mode\n");
+        return 0;
+    }
+#endif
 
     assert(remote != NULL);
 


### PR DESCRIPTION
### Contribution description

This PR introduces lazy init mode for gcoap. lazy init mode is for applications that want to first do something before gcoap starts its server thread (e.g. loading credential into credman for (D)TLS). It can be enabled by adding  `USEMODULE += gcoap_lazy_init` to the application Makefile

An alternative to this approach would be to just take `gcoap_init()` out of autoinit and calls it manually from the application but this may break existing applications, so I prefer not to do that if there is an alternative.

#### How it works

In lazy init mode, the call to `gcoap_init()` only initializes the `_coap_state` but does not start the coap server thread. It will be started at the first `gcoap_register_listener()` call if there is no server that is started already.

As long as there is no server running, NON requests can be sent as usual but the responses will be ignored. Sending a CON request, on the other hand, will fail because a CON request expects to receive a response. After the server is started (`gcoap_register_listener()` is called), the application should behave like a normal gcoap application.

### Testing procedure

For now, I only tested sending NON and CON requests from a lazy init client to a gcoap normal server.

Set `BUILD_IN_DOCKER=0` if you are using Docker to build because the env values are not carried into the container for building.

0. From RIOT base directory: `cd examples/gcoap`
1. Start a normal gcoap instance: `PORT=tap0 make all term`
2. Start a gcoap in lazy init mode: `PORT=tap1 USEMODULE=gcoap_lazy_init make all term`
3. Send a NON from lazy init instance to the normal: `coap put <server ip> 5683 /cli/stats 100`
4. Check the output of `coap info` on the server, cli stats must be 100 now
5. Send a CON from lazy init instance to the normal: `coap put -c <server ip> 5683 /cli/stats 200`
6. Step 5. should fail and the value of /cli/stats at the server should stay 100.

### Issues/PRs references

This is part of the work needed to add DTLS support to gcoap. See https://github.com/RIOT-OS/RIOT/pull/12104#issuecomment-543638459.
