### PR TITLE
common/nrf52840/Makefile.dep: nrf802154 if no nimble_%

### DIFF
--- a/boards/common/nrf52/nrf52840/Makefile.dep
+++ b/boards/common/nrf52/nrf52840/Makefile.dep
@@ -1,5 +1,5 @@
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
-  ifeq (,$(filter nimble_netif nrfmin,$(USEMODULE)))
+  ifeq (,$(filter nimble_% nrfmin,$(USEMODULE)))
     USEMODULE += nrf802154
   endif
 endif


### PR DESCRIPTION
### Contribution description

This PR changes the resolution to default to `nrf802154` only if no `nimble_%` is used. #12361 will introduce a `nimble_autoconn_*` that includes `nimble_netif` itself but since board dependency resolution happens before `PKG` dependency resolution.

### Testing procedure

Includes `nimble` and not `nrf802154` when required:

- `USEMODULE+=nimble_netif BOARD=nrf52840-mdk make -C examples/gnrc_networking`

- Rebase on #12361, without this PR the following fails:

`USEMODULE+=nimble_autoconn_ipsp BOARD=nrf52840-mdk make -C examples/gnrc_networking`

### Issues/PRs references

Related to #12361