### PR TITLE
cdcecm: early exit on inactive usb interface

### DIFF
--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -59,6 +59,11 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     uint8_t *buf = cdcecm->ep_in->ep->buf;
     const iolist_t *iolist_start = iolist;
     size_t len = iolist_size(iolist);
+    /* interface with alternative function ID 1 is the interface containing the
+     * data endpoints, no sense trying to transmit data if it is not active */
+    if (cdcecm->active_iface != 1) {
+        return -ENOTCONN;
+    }
     DEBUG("CDC_ECM_netdev: sending %u bytes\n", len);
     /* load packet data into FIFO */
     size_t iol_offset = 0;


### PR DESCRIPTION
### Contribution description

This adds an early exit when the usb interface with the data endpoints
is not activated. This prevents the `cdc_ecm_netdev` code from attempting
to send the PDU when the USB device is not yet initialized or activated
by a host.

Also prevents an null pointer access when the netdev code happens to initialize before the usbus code.

### Testing procedure

1. Enable `DEBUG` in `sys/usb/usbus/cdc/ecm/cdc_ecm.c`.
2. flash `examples/usbus_cdc_ecm` on a supported board.
3. From the RIOT shell: `ping6 ff02::1%5`
4. Verify that [this](https://github.com/RIOT-OS/RIOT/blob/c32e749ca9ad52fe59512508f7193e18fbcfca1b/sys/usb/usbus/cdc/ecm/cdc_ecm.c#L287) and [this](https://github.com/RIOT-OS/RIOT/blob/c32e749ca9ad52fe59512508f7193e18fbcfca1b/sys/usb/usbus/cdc/ecm/cdc_ecm.c#L289) debug logging from `sys/usb/usbus/cdc/ecm/cdc_ecm.c` is *not* triggered.
5. Attach to a host with support for CDC ECM
6. repeat the ping and verify that it triggers debug logging.

### Issues/PRs references

None, but maybe test this together with #12533 
