### PR TITLE
cdcacm: Add the interface assoc descriptor to the length

### DIFF
--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -54,7 +54,8 @@ static const usbus_hdr_gen_funcs_t _cdcacm_descriptor = {
     .fmt_pre_descriptor = _gen_assoc_descriptor,
     .get_header = _gen_full_acm_descriptor,
     .len = {
-        .fixed_len = sizeof(usb_desc_cdc_t) +
+        .fixed_len = sizeof(usb_descriptor_interface_association_t) +
+                     sizeof(usb_desc_cdc_t) +
                      sizeof(usb_desc_acm_t) +
                      sizeof(usb_desc_union_t) +
                      sizeof(usb_desc_call_mngt_t),


### PR DESCRIPTION
### Contribution description

The interface association descriptor length must be included in the descriptor length claimed by the descriptor generator, otherwise the USB stack will report an incorrect total descriptor length.

### Testing procedure

Before this PR `tests/usbus_cdc_acm_stdio` should be either broken or the Linux kernel should report something along the lines of:
```
[415964.073466] usb 1-9.2.2: new full-speed USB device number 113 using xhci_hcd
[415964.151103] usb 1-9.2.2: config 1 has an invalid descriptor of length 7, skipping remainder of the config
[415964.151111] usb 1-9.2.2: config 1 interface 1 altsetting 0 has 0 endpoint descriptors, different from the interface descriptor's value: 2
[415964.151779] usb 1-9.2.2: New USB device found, idVendor=1209, idProduct=0001, bcdDevice= 0.00
[415964.151784] usb 1-9.2.2: New USB device strings: Mfr=3, Product=2, SerialNumber=0
[415964.151787] usb 1-9.2.2: Product: USB device
[415964.151790] usb 1-9.2.2: Manufacturer: RIOT-os.org
[415964.156518] cdc_acm: probe of 1-9.2.2:1.0 failed with error -22
```

This PR fixes that.

### Issues/PRs references

Broken by #12430 