### PR TITLE
cdcacm: Activate data out endpoint on DTE present signal

### DIFF
--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -428,6 +428,24 @@ uint16_t usbus_add_string_descriptor(usbus_t *usbus, usbus_string_t *desc,
 uint16_t usbus_add_interface(usbus_t *usbus, usbus_interface_t *iface);
 
 /**
+ * @brief Find an endpoint from an interface based on the endpoint properties
+ *
+ * This iterates over the endpoints in an interface and will return the first
+ * endpoint from the interface matching the @p type and @p dir. It will return
+ * NULL when no matching endpoint is found.
+ *
+ * @param[in] interface interface to look in
+ * @param[in] type      endpoint type to match
+ * @param[in] dir       endpoint direction to match
+ *
+ * @return              ptr to the first matching endpoint
+ * @return              NULL when no endpoint is found
+ */
+usbus_endpoint_t *usbus_interface_find_endpoint(usbus_interface_t *interface,
+                                                usb_ep_type_t type,
+                                                usb_ep_dir_t dir);
+
+/**
  * @brief Add an endpoint to the specified interface
  *
  * An @ref usbdev_ep_t is requested from the low level peripheral matching the

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -127,6 +127,18 @@ void usbus_register_event_handler(usbus_t *usbus, usbus_handler_t *handler)
     *last = handler;
 }
 
+usbus_endpoint_t *usbus_interface_find_endpoint(usbus_interface_t *interface,
+                                                usb_ep_type_t type,
+                                                usb_ep_dir_t dir)
+{
+    for (usbus_endpoint_t *uep = interface->ep; uep; uep = uep->next) {
+        if (uep->ep->type == type && uep->ep->dir == dir) {
+            return uep;
+        }
+    }
+    return NULL;
+}
+
 usbus_endpoint_t *usbus_add_endpoint(usbus_t *usbus, usbus_interface_t *iface,
                                      usb_ep_type_t type, usb_ep_dir_t dir,
                                      size_t len)


### PR DESCRIPTION
### Contribution description

This PR modifies the CDC ACM code to signal the data out endpoint to be ready when the host has indicated that an application opened the serial console, DTE present in CDC ACM terminology.

This mainly prevents the code from calling the ready function when no USB host is present and at least after the low level endpoint is initialized by usbus. The downside is that the cdcacm struct requires a reference to the endpoint.

### Testing procedure

Verify that `tests/usbus_cdc_acm` is still working and that RIOT shell commands still work over the CDC ACM function.

### Issues/PRs references

Testing should be a bit easier with #12535 included