### PR TITLE
cpu/esp32: fix CS handling in spi_transfer_bytes

### DIFF
--- a/cpu/esp32/periph/spi.c
+++ b/cpu/esp32/periph/spi.c
@@ -456,7 +456,9 @@ void IRAM_ATTR spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
     }
     #endif
 
-    gpio_clear (cs != SPI_CS_UNDEF ? cs : spi_config[bus].cs);
+    if (cs != SPI_CS_UNDEF) {
+        gpio_clear(cs);
+    }
 
     size_t blocks = len / SPI_BLOCK_SIZE;
     uint8_t tail = len % SPI_BLOCK_SIZE;
@@ -474,8 +476,9 @@ void IRAM_ATTR spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
                           out ? (const uint8_t *)out + blocks * SPI_BLOCK_SIZE : 0,
                           in  ? (uint8_t *)in + blocks * SPI_BLOCK_SIZE : NULL, tail);
     }
-    if (!cont) {
-        gpio_set (cs != SPI_CS_UNDEF ? cs : spi_config[bus].cs);
+
+    if (!cont && (cs != SPI_CS_UNDEF)) {
+        gpio_set (cs);
     }
 
     #if ENABLE_DEBUG


### PR DESCRIPTION
### Contribution description

This PR fixes the CS pin handling in `spi_transfer_bytes`. If `SPI_CS_UNDEF` is given as the `cs` parameter, CS pin MUST not be handled by the driver. 

### Testing procedure

It's a very small change. Compilation should be enough as test.
```
make BOARD=esp32-wroom-32 -C tests/periph_spi
```
The change was tested with a complex device driver that is using SPI:
```
USEMODULE=mrf24j40 make BOARD=esp32-mh-et-live-minikit -C examples/gnrc_networking flash term
```

### Issues/PRs references

Problem was figured out in #12118 when testing with #12518.