### PR TITLE
tests/isr_yield_higher: adapt TEST_TIME to start-up time

### DIFF
--- a/tests/isr_yield_higher/main.c
+++ b/tests/isr_yield_higher/main.c
@@ -27,11 +27,12 @@
 #define TEST_TIME (200000U)
 
 static char t2_stack[THREAD_STACKSIZE_MAIN];
+static uint32_t start_time;
 
 static void *second_thread(void *arg)
 {
-    (void) arg;
-    if (xtimer_now_usec() < TEST_TIME) {
+    (void)arg;
+    if (xtimer_now_usec() < (TEST_TIME + start_time)) {
         puts("TEST FAILED");
     }
     else {
@@ -49,19 +50,21 @@ static void _cb(void *arg)
 
 int main(void)
 {
-    (void) thread_create(
-            t2_stack, sizeof(t2_stack),
-            THREAD_PRIORITY_MAIN,
-            THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
-            second_thread, NULL, "nr2");
-
     puts("first thread started");
+
+    start_time = xtimer_now_usec();
 
     xtimer_t timer;
     timer.callback = _cb;
-    xtimer_set(&timer, TEST_TIME/2);
+    xtimer_set(&timer, TEST_TIME / 2);
 
-    while(xtimer_now_usec() < TEST_TIME) {}
+    (void)thread_create(
+        t2_stack, sizeof(t2_stack),
+        THREAD_PRIORITY_MAIN,
+        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+        second_thread, NULL, "nr2");
+
+    while (xtimer_now_usec() < (TEST_TIME + start_time)) {}
 
     puts("first thread done");
 


### PR DESCRIPTION

### Contribution description

This commit is cherry-picked from #12461. The current test depends on start-ups time since `TEST_TIME` is absolute, this can cause issue if there is a delayed start, eg. a sync mechanism is used in the test (see #12461). This makes `TEST_TIME` related checks depend on `start_time`.

### Testing procedure

Test still passes.

`make -C tests/isr_yield_higher/ BOARD=samr21-xpro flash test -j3`

### Issues/PRs references

#12461 depends on this.
