### PR TITLE
boards/arduino-zero: configure ADC channels

### DIFF
--- a/boards/arduino-zero/Makefile.features
+++ b/boards/arduino-zero/Makefile.features
@@ -2,6 +2,7 @@ CPU = samd21
 CPU_MODEL = samd21g18a
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -194,7 +194,25 @@ static const pwm_conf_t pwm_config[] = {
  * @name ADC configuration
  * @{
  */
-#define ADC_NUMOF           (0)
+
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},   /* A0 */
+    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},   /* A1 */
+    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3},   /* A2 */
+    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},   /* A3 */
+    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},   /* A4 */
+    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},  /* A5 */
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the periph_adc features to the arduino-zero board and configure the 6 ADC channels exposed on the board.

Tested with success using the `tests/periph_adc` application and a potentiometer plugged on each Ax pins.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Use the `tests/periph_adc` application and plug a potentiometer on each Ax pins.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Required by #12523 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
