### PR TITLE
examples/suit_update/test: change local to link

### DIFF
--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -170,7 +170,7 @@ If the Border Router is already set up when opening the terminal you should get
             RTR_ADV  6LO  IPHC
             Source address length: 8
             Link type: wireless
-            inet6 addr: fe80::7b7e:3255:1313:8d96  scope: local  VAL
+            inet6 addr: fe80::7b7e:3255:1313:8d96  scope: link  VAL
             inet6 addr: 2001:db8::7b7e:3255:1313:8d96  scope: global  VAL
             inet6 group: ff02::2
             inet6 group: ff02::1

--- a/examples/suit_update/tests/01-run.py
+++ b/examples/suit_update/tests/01-run.py
@@ -84,7 +84,7 @@ def get_ipv6_addr(child):
         child.expect_exact("Link type: wired")
         child.expect(
             r"inet6 addr: (?P<lladdr>[0-9a-fA-F:]+:[A-Fa-f:0-9]+)"
-            "  scope: local  VAL"
+            "  scope: link  VAL"
         )
         addr = "{}%{}".format(child.match.group("lladdr").lower(), TAP)
     return addr


### PR DESCRIPTION
### Contribution description

#12528 changed the shell output without checking tests that do not run on murdock. This PR fixs it as well as missing doc changes.

### Testing procedure

Follow the README for `examples/suit_update` automatic test.

<details><summary><b>master</b>: fails</summary>

```
main(): This is RIOT! (Version: 2020.01-devel-234-g7ec98-pr-12408)
RIOT SUIT update example application
running from slot 0
slot start addr = 0x1000
Image magic_number: 0x544f4952
Image Version: 0x5daee0c2
Image start address: 0x00001100
Header chksum: 0x1b91ed12

Waiting for address autoconfiguration...
Configured network interfaces:
Iface  5  HWaddr: 00:31:8B:E0:2D:3F 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::231:8bff:fee0:2d3f  scope: link  VAL
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffe0:2d3f
          inet6 group: ff02::1:ff00:2
          
suit_coap: started.
Timeout in expect script at "r"inet6 addr: (?P<lladdr>[0-9a-fA-F:]+:[A-Fa-f:0-9]+)"" (examples/suit_update/tests/01-run.py:86)

/home/francisco/workspace/RIOT/examples/suit_update/../../Makefile.include:710: recipe for target 'test' failed
make: *** [test] Error 1
make: Leaving directory '/home/francisco/workspace/RIOT/examples/suit_update'
```
</details>

<details><summary><b>PR</b>: Succeeds</summary>

```
main(): This is RIOT! (Version: 2020.01-devel-234-g7ec98-pr-12408)
RIOT SUIT update example application
running from slot 0
slot start addr = 0x1000
Image magic_number: 0x544f4952
Image Version: 0x5daee0c2
Image start address: 0x00001100
Header chksum: 0x1b91ed12

Waiting for address autoconfiguration...
Configured network interfaces:
Iface  5  HWaddr: 00:31:8B:E0:2D:3F 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::231:8bff:fee0:2d3f  scope: link  VAL
pinging node...
PING fe80::231:8bff:fee0:2d3f%riot0(fe80::231:8bff:fee0:2d3f%riot0) 56 data bytes

--- fe80::231:8bff:fee0:2d3f%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 39.814/39.814/39.814/0.000 ms
pinging node succeeded.
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffe0:2d3f
          inet6 group: ff02::1:ff00:2
          
suit_coap: started.
```

</details>

### Issues/PRs references

#12528