### PR TITLE
CONTRIBUTING/MAINTAINING: Clarify guidelines

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -117,6 +117,11 @@ complete that no input from the original developer or maintainer is required.
 -   Be friendly. Respect the original author, bearing in mind that their coding
     style or their design may be just as valid as the way you would have done
     it. And of course, always follow the [Code of Conduct].
+-   If a contributor has opened a PR, the reviewer should attempt to
+    help the author of the contribution to get it to its best shape and
+    according to the RIOT Standard™. If there is disagreement, it’s important
+    to understand the reasons behind and always give technical arguments,
+    pros and cons or snippets.
 
 
 ### Organisation of reviewing between maintainers


### PR DESCRIPTION
### Contribution description

Due to some community issues, clarification on rules could be used.
This is meant to improve interactions with the community.
It addresses the problem of competing contributions within the community.
Guidelines are added both for contributors and for maintainers.

The problem lies with the following events:
1. **Contributor A** creates a **PR1**
2. **Reviewer B** reviews **PR1**
3. **Reviewer C** blocks **PR1** with good reason
4. Without informing **Contributor A**, **Reviewer C** opens **PR2** solving the problem of **PR1**
5. **PR2** gets merged before **PR1** making the work for **PR1** unrecognized and obsolete

These scenarios happen, many times without intention or since it is the fastest way to solve the problem but sometimes it can be frustrating for **Contributor A** and **Reviewer B**.

Many things can be done to avoid these frustrations.

- **Contributor A** can ask if a solution exists beforehand
- **Reviewer C** can discuss with **Contributor A** beforehand
- maintainers can block **PR2** until it is clear to **Contributor A** what and why **PR2** was opened
- **Reviewer C** can give appropriate reference in **PR2** to **PR1** so the idea is still credited to **Contributor A**

### Testing procedure

N/A

### Issues/PRs references
