### PR TITLE
boards/sodaq: restore accidentally removed arduino feature

### DIFF
--- a/boards/common/sodaq/Makefile.features
+++ b/boards/common/sodaq/Makefile.features
@@ -9,3 +9,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += arduino


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When #12438 was merged, the arduino feature was accidentally removed. This PR is restoring it.

It should have been added in the common module here https://github.com/RIOT-OS/RIOT/pull/12438/commits/f9631953cb67a92928d8e021b43f3a413bfd0217#diff-f8175dddf1dfe52f59df14763e9b0e66R11
and was removed in all sodaq boards (example: https://github.com/RIOT-OS/RIOT/pull/12438/commits/536809cdcaca9a67d638b1dd1bf4dbd6beb40011#diff-83f9efaf9b119999e101a34bc26f7bb8L16)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The `examples/arduino_hello-world` and `tests/sys_arduino` applications should build fine on sodaq boards.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This issue went through in #12438. I noticed that while rebasing #12304.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
