### PR TITLE
gnrc_netif: warn when not joining solicited-nodes from non-6LN netif

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -613,6 +613,13 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
               netif->pid);
         return res;
     }
+#else  /* GNRC_IPV6_NIB_CONF_ARSM */
+    if (!gnrc_netif_is_6ln(netif)) {
+        LOG_WARNING("Address-resolution state-machine not activated. Neighbors "
+                    "from interface %u\nwill not be able to resolve address %s\n"
+                    "    Use GNRC_IPV6_NIB_CONF_ARSM=1 to activate.\n",
+                    netif->pid, ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));
+    }
 #endif /* GNRC_IPV6_NIB_CONF_ARSM */
     netif->ipv6.addrs_flags[idx] = flags;
     memcpy(&netif->ipv6.addrs[idx], addr, sizeof(netif->ipv6.addrs[idx]));

--- a/tests/gnrc_ipv6_nib_6ln/Makefile
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile
@@ -9,6 +9,8 @@ USEMODULE += embunit
 USEMODULE += netdev_ieee802154
 USEMODULE += netdev_test
 
+# lower log-level to save memory of LOG_WARNING() in gnrc_netif
+CFLAGS += -DLOG_LEVEL=LOG_ERROR
 CFLAGS += -DGNRC_NETTYPE_NDP=GNRC_NETTYPE_TEST
 CFLAGS += -DGNRC_PKTBUF_SIZE=512
 CFLAGS += -DTEST_SUITES


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Similar as with #12513, when the NIB is compiled in 6LN mode (but not 6LR mode), the address-resolution state-machine (ARSM) functionality is disabled in favor of the more simpler address resolution proposed in RFC 6775.

However, if a non-6LN interface is also compiled in (without making it a router or border router) it will never join the solicited-nodes multicast address of addresses added to it, resulting in address
resolution to that interface to fail.

If the interface is not a 6LN (which in case 6LN mode is disabled is always false), a warning is now printed, encouraging the user to activate the ARSM functionality if needed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Follow testing procedures in #12545. A warning should now be shown, e.g.

```
Address-resolution state-machine not activated. Neighbors from interface 7
will not be able to resolve address fe80::2482:dcff:fe3b:cae6
    Use GNRC_IPV6_NIB_CONF_ARSM=1 to activate.
```

Adding `-DGNRC_IPV6_NIB_CONF_ARSM=1` to the CFLAGS should prevent the warning from appearing and the address of the interface should be pingable.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #12545.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
