### PR TITLE
usb/misc: Fix spelling mistakes pointed out by codespell

### DIFF
--- a/cpu/sam0_common/periph/usbdev.c
+++ b/cpu/sam0_common/periph/usbdev.c
@@ -348,7 +348,7 @@ static void _usbdev_init(usbdev_t *dev)
     usbdev->config->device->CTRLA.reg |= USB_CTRLA_ENABLE;
     while (_syncbusy_enable(usbdev)) {}
 
-    /* Callibration values */
+    /* Calibration values */
     usbdev->config->device->PADCAL.reg =
         USB_PADCAL_TRANSP((*(uint32_t *)USB_FUSES_TRANSP_ADDR >>
                            USB_FUSES_TRANSP_Pos)) |

--- a/drivers/include/periph/usbdev.h
+++ b/drivers/include/periph/usbdev.h
@@ -140,7 +140,7 @@ typedef enum {
     USBDEV_EVENT_HOST_DISCONNECT,
 
     /**
-     * @brief Line reset occured
+     * @brief Line reset occurred
      *
      * A line reset is a host initiated USB reset to the peripheral
      *
@@ -172,7 +172,7 @@ typedef enum {
      * @brief Transaction completed event.
      *
      * An endpoint must emit this event after a transaction with the host
-     * occured to indicate that the data in the buffer is used or new
+     * occurred to indicate that the data in the buffer is used or new
      * depending on the endpoint direction
      */
     USBDEV_EVENT_TR_COMPLETE,

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -12,10 +12,10 @@
  * @brief       initializes USBUS, usb devices and handlers
  *
  * This auto initialization for USBUS is designed to cover the common use case
- * of a single usb peripheral. An USBUS instance is started with USB function
+ * of a single USB peripheral. An USBUS instance is started with USB function
  * handlers based on which module is compiled in.
  *
- * If this doesn't suit your use case, a different intialization function can
+ * If this doesn't suit your use case, a different initialization function can
  * to be created based on this initialization sequence.
  *
  * @author  Koen Zandberg <koen@bergzand.net>

--- a/sys/include/usb/usbus/control.h
+++ b/sys/include/usb/usbus/control.h
@@ -35,7 +35,7 @@ typedef struct {
     size_t start;                   /**< Start offset of the current part */
     size_t cur;                     /**< Current position in the message  */
     size_t len;                     /**< Length of the full message       */
-    size_t transfered;              /**< Number of bytes transfered       */
+    size_t transferred;             /**< Number of bytes transferred       */
     size_t reqlen;                  /**< Maximum length of the request    */
 } usbus_control_slicer_t;
 
@@ -124,7 +124,7 @@ void usbus_control_slicer_ready(usbus_t *usbus);
  * @param[in] usbus     USBUS context
  *
  * @return              1 when there is a next slice
- * @return              0 when the data is fully transfered
+ * @return              0 when the data is fully transferred
  */
 int usbus_control_slicer_nextslice(usbus_t *usbus);
 

--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -180,7 +180,7 @@ void usbus_cdc_acm_init(usbus_t *usbus, usbus_cdcacm_device_t *cdcacm,
 
 static void _init(usbus_t *usbus, usbus_handler_t *handler)
 {
-    DEBUG("CDC_ACM: intialization\n");
+    DEBUG("CDC_ACM: initialization\n");
     usbus_cdcacm_device_t *cdcacm = (usbus_cdcacm_device_t*)handler;
 
     cdcacm->flush.handler = _handle_flush;

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm.c
@@ -176,7 +176,7 @@ void usbus_cdcecm_init(usbus_t *usbus, usbus_cdcecm_device_t *handler)
 
 static void _init(usbus_t *usbus, usbus_handler_t *handler)
 {
-    DEBUG("CDC ECM: intialization\n");
+    DEBUG("CDC ECM: initialization\n");
     usbus_cdcecm_device_t *cdcecm = (usbus_cdcecm_device_t *)handler;
 
     /* Add event handlers */

--- a/sys/usb/usbus/usbus_control_slicer.c
+++ b/sys/usb/usbus/usbus_control_slicer.c
@@ -31,7 +31,7 @@ int usbus_control_slicer_nextslice(usbus_t *usbus)
     size_t end = bldr->start + ep0->in->len;
 
     if (bldr->cur > end && bldr->start < bldr->reqlen &&
-        bldr->transfered < bldr->reqlen) {
+        bldr->transferred < bldr->reqlen) {
         bldr->start += ep0->in->len;
         bldr->cur = 0;
         bldr->len = 0;
@@ -96,6 +96,6 @@ void usbus_control_slicer_ready(usbus_t *usbus)
     size_t len = bldr->len;
 
     len = len < bldr->reqlen - bldr->start ? len : bldr->reqlen - bldr->start;
-    bldr->transfered += len;
+    bldr->transferred += len;
     usbdev_ep_ready(ep0->in, len);
 }

--- a/tests/usbus_cdc_ecm/README.md
+++ b/tests/usbus_cdc_ecm/README.md
@@ -6,7 +6,7 @@ board under test and the host computer. Ping to the link local address from and
 to the host computer must work.
 
 On the host computer, using tools such as `ethtool` must show the USB CDC ECM
-interface as link dectected:
+interface as link detected:
 
 ```
 # ethtool enp0s20u9u4


### PR DESCRIPTION
### Contribution description

This PR fixes a number of spelling mistakes as pointed out by codespell. One of the mistakes was in a (usb private) struct member, all others are in printed debug strings or in documentation.

### Testing procedure

A run from Murdock should suffice, the codespell run from the static checks should not have any remaining complaints.

### Issues/PRs references

None