### PR TITLE
sys/riotboot/flashwrite: display progress bar during copy/download

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -49,6 +49,9 @@ USEMODULE += suit suit_coap
 # SUIT draft v4 support:
 USEMODULE += suit_v4
 
+# Display a progress bar during firmware download
+USEMODULE += progress_bar
+
 # Optional feature to trigger suit update through gpio callback
 FEATURES_OPTIONAL += periph_gpio_irq
 

--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -275,14 +275,12 @@ in regards to the running slot to see witch firmware image to fetch.
 
 Once the manifest validation is complete, the application fetches the image
 and starts flashing.
-This step takes some time to fetch and write to flash, a series of messages like
-the following are printed to the terminal:
+This step takes some time to fetch and write to flash. A progress bar is
+displayed during this step:
 
     ....
-    riotboot_flashwrite: processing bytes 1344-1407
-    riotboot_flashwrite: processing bytes 1408-1471
-    riotboot_flashwrite: processing bytes 1472-1535
-    ...
+    Fetching firmware |█████████████            |  50%
+    ....
 
 Once the new image is written, a final validation is performed and, in case of
 success, the application reboots on the new slot:

--- a/examples/suit_update/tests/01-run.py
+++ b/examples/suit_update/tests/01-run.py
@@ -67,7 +67,7 @@ def publish(server_dir, server_url, app_ver, keys='default', latest_name=None):
 
 
 def wait_for_update(child):
-    return child.expect([r"riotboot_flashwrite: processing bytes (\d+)-(\d+)",
+    return child.expect([r"Fetching firmware \|[█ ]+\|\s+\d+\%",
                          "riotboot_flashwrite: riotboot flashing "
                          "completed successfully"],
                         timeout=UPDATING_TIMEOUT)

--- a/sys/include/suit/v4/suit.h
+++ b/sys/include/suit/v4/suit.h
@@ -262,7 +262,7 @@ int suit_cbor_subparse(nanocbor_value_t *bseq, nanocbor_value_t *it);
 /**
  * @brief Helper function for writing bytes on flash a specified offset
  *
- * @param[in]   arg     ptr to flash writer
+ * @param[in]   arg     ptr to the SUIT manifest
  * @param[in]   offset  offset to write to on flash
  * @param[in]   buf     bytes to write
  * @param[in]   len     length of bytes to write

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -65,7 +65,7 @@ int riotboot_flashwrite_init_raw(riotboot_flashwrite_t *state, int target_slot,
 int riotboot_flashwrite_putbytes(riotboot_flashwrite_t *state,
                                  const uint8_t *bytes, size_t len, bool more)
 {
-    LOG_INFO(LOG_PREFIX "processing bytes %u-%u\n", state->offset, state->offset + len - 1);
+    LOG_DEBUG(LOG_PREFIX "processing bytes %u-%u\n", state->offset, state->offset + len - 1);
 
     while (len) {
         size_t flashpage_pos = state->offset % FLASHPAGE_SIZE;

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -263,7 +263,7 @@ static int _dtv_fetch(suit_v4_manifest_t *manifest, int key, nanocbor_value_t *_
     int target_slot = riotboot_slot_other();
     riotboot_flashwrite_init(manifest->writer, target_slot);
     int res = suit_coap_get_blockwise_url(manifest->urlbuf, COAP_BLOCKSIZE_64, suit_flashwrite_helper,
-            manifest->writer);
+            manifest);
 
     if (res) {
         LOG_INFO("image download failed\n)");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR makes use of the progress bar introduced in #12550 to nicely follow the copy/download of a firmware on flash.
The logic for updating the progress bar is added in riotboot/flashwrite submodule. The API had to be updated to add a `firmware_size` argument. There might be a better way, so suggestions are welcome.

The suit module is adapted to retrieve the firmware size from the manifest and pass it to the flashwrite module.

In the `riotboot_flashwrite`, the max uint32_t value is used for the firmware_size. It is used as a fallback when the firmware_size is not known in advance.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run the `examples/suit_update` testing procedure. The progress bar is displayed during the update, the automatic test works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on #12550 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
