### PR TITLE
boards: add initial support for the PINE64 PineTime smartwatch

### DIFF
--- a/boards/pinetime/Makefile
+++ b/boards/pinetime/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/pinetime/Makefile.dep
+++ b/boards/pinetime/Makefile.dep
@@ -1,0 +1,3 @@
+# include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/nrf52832/Makefile.dep
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/pinetime/Makefile.features
+++ b/boards/pinetime/Makefile.features
@@ -1,0 +1,8 @@
+CPU_MODEL = nrf52832xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+#FEATURES_PROVIDED += periph_uart
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/pinetime/Makefile.include
+++ b/boards/pinetime/Makefile.include
@@ -1,0 +1,7 @@
+# for this board, we are using Segger's RTT as default terminal interface
+USEMODULE += stdio_rtt
+TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
+TERMFLAGS = term-rtt
+
+# use shared Makefile.include
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *               2020 Inria
+ *               2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_pinetime
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the PineTime
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize pins */
+    gpio_init(VCC33, GPIO_OUT);
+    gpio_init(BUTTON0_ENABLE, GPIO_OUT);
+    gpio_init(BUTTON0, GPIO_IN);
+    gpio_init(VIBRATOR, GPIO_OUT);
+    gpio_init(LCD_BACKLIGHT_LOW, GPIO_OUT);
+    gpio_init(LCD_BACKLIGHT_MID, GPIO_OUT);
+    gpio_init(LCD_BACKLIGHT_HIGH, GPIO_OUT);
+
+    gpio_set(VCC33);
+    gpio_set(BUTTON0_ENABLE);
+    gpio_set(VIBRATOR);
+    gpio_set(LCD_BACKLIGHT_LOW);
+    gpio_set(LCD_BACKLIGHT_MID);
+    gpio_set(LCD_BACKLIGHT_HIGH);
+}

--- a/boards/pinetime/doc.txt
+++ b/boards/pinetime/doc.txt
@@ -1,0 +1,14 @@
+/**
+@defgroup    boards_pinetime PineTime
+@ingroup     boards
+@brief       Support for the Pinetime
+
+### General information
+
+"The PINE64 SmartWatch, dubbed "PineTime", is a product of a community effort
+for an open source smartwatch in collaboration with wearable RTOS and Linux app
+developers & communities."
+
+See https://wiki.pine64.org/index.php/PineTime for more information.
+
+ */

--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2019 Inria
+ *               2019 Freie Universität Berlin
+ *               2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_pinetime
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the PineTime
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name GPIO pin defines
+ * @{
+ */
+#define LCD_RS                      GPIO_PIN(0, 18)
+#define LCD_DET                     GPIO_PIN(0, 9)
+#define LCD_CS                      GPIO_PIN(0, 25)
+#define LCD_RESET                   GPIO_PIN(0, 26)
+
+#define LCD_BACKLIGHT_LOW           GPIO_PIN(0, 14)
+#define LCD_BACKLIGHT_MID           GPIO_PIN(0, 22)
+#define LCD_BACKLIGHT_HIGH          GPIO_PIN(0, 23)
+
+#define BUTTON0_ENABLE              GPIO_PIN(0, 13)
+#define BUTTON0                     GPIO_PIN(0, 15)
+#define VIBRATOR                    GPIO_PIN(0, 16)
+
+#define VCC33                       GPIO_PIN(0, 24)
+#define POWER_PRESENCE              GPIO_PIN(0, 19)
+#define CHARGING_ACTIVE             GPIO_PIN(0, 12)
+#define BATTERY_ADC                 NRF52
+/** @} */
+
+/**
+ * @name LCD configuration
+ * @{
+ */
+#define ILI9341_PARAM_SPI          SPI_DEV(0)
+#define ILI9341_PARAM_SPI_CLK      SPI_CLK_10MHZ
+#define ILI9341_PARAM_SPI_MODE     SPI_MODE_3
+#define ILI9341_PARAM_CS           LCD_CS
+#define ILI9341_PARAM_DCX          LCD_RS
+#define ILI9341_PARAM_RST          LCD_RESET
+#define ILI9341_PARAM_RGB          1
+#define ILI9341_PARAM_INVERTED     1
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/pinetime/include/periph_conf.h
+++ b/boards/pinetime/include/periph_conf.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2019 Inria
+ *               2019 Freie Universität Berlin
+ *               2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_pinetime
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the PineTime
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = GPIO_PIN(0, 2),
+        .mosi = GPIO_PIN(0, 3),
+        .miso = GPIO_PIN(0, 4),
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = GPIO_PIN(0, 7),
+        .sda = GPIO_PIN(0, 6),
+        .speed = I2C_SPEED_FAST
+    }
+};
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/tests/driver_ili9341/main.c
+++ b/tests/driver_ili9341/main.c
@@ -34,6 +34,11 @@ int main(void)
     /* initialize the sensor */
     printf("Initializing display...");
 
+#ifdef BOARD_PINETIME
+    /* on PineTime, enable the backlight */
+    gpio_clear(LCD_BACKLIGHT_LOW);
+#endif
+
     if (ili9341_init(&dev, &ili9341_params[0]) == 0) {
         puts("[OK]");
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I just got the PineTime devkit. It was a breeze to port, from opening the device to hello world took <15minutes. Thanks @aabadie @haukepetersen et al for the nice abstractions there!

For more information about the board, please look here:
https://wiki.pine64.org/index.php/PineTime

*edit*
This currently only adds the basic board configuration and flashing etc. No drivers are used, yet.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

AFAIK they just started shipping the devkits, so I'm probably the only maintainer who has one.
I'll provide output and test results.

For now, maybe concentrate on the integration.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
