### PR TITLE
tests: unify pktbuf expect for emptiness check

### DIFF
--- a/tests/gnrc_ipv6_ext/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext/tests/01-run.py
@@ -36,7 +36,7 @@ def pktbuf_empty(child):
     first_byte = child.match.group("first_byte")
     size = child.match.group("size")
     child.expect(
-            r"~ unused: {} \(next: (\(nil\)|0), size: {}\) ~".format(
+            r"~ unused: {} \(next: (\(nil\)|0(x0+)?), size: {}\) ~".format(
                 first_byte, size))
 
 

--- a/tests/gnrc_ipv6_ext_frag/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext_frag/tests/01-run.py
@@ -34,7 +34,7 @@ def pktbuf_empty(child):
     first_byte = child.match.group("first_byte")
     size = child.match.group("size")
     child.expect(
-            r"~ unused: {} \(next: (\(nil\)|0), size: {}\) ~".format(
+            r"~ unused: {} \(next: (\(nil\)|0(x0+)?), size: {}\) ~".format(
                 first_byte, size))
 
 

--- a/tests/gnrc_rpl_srh/tests/01-run.py
+++ b/tests/gnrc_rpl_srh/tests/01-run.py
@@ -127,7 +127,7 @@ def pktbuf_empty(child):
     first_byte = child.match.group("first_byte")
     size = child.match.group("size")
     child.expect(
-            r"~ unused: {} \(next: (\(nil\)|0), size: {}\) ~".format(
+            r"~ unused: {} \(next: (\(nil\)|0(x0+)?), size: {}\) ~".format(
                 first_byte, size))
 
 

--- a/tests/gnrc_tcp/tests/shared_func.py
+++ b/tests/gnrc_tcp/tests/shared_func.py
@@ -104,7 +104,8 @@ def verify_pktbuf_empty(child):
     pktbuf_addr = child.match.group(1)
     pktbuf_size = child.match.group(2)
 
-    child.expect(r'~ unused: {} \(next: (\(nil\)|0), size: {}\) ~'.format(pktbuf_addr, pktbuf_size))
+    child.expect(r'~ unused: {} \(next: (\(nil\)|0(x0+)?), size: {}\) ~'
+                 .format(pktbuf_addr, pktbuf_size))
 
 
 def sudo_guard(uses_scapy=False):


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
How a NULL pointer is represented by `printf()` differs from platform to platform. Sometimes it's `(nil)`, sometimes `0x0` (with varying length of 0s attached), and sometimes just `0`. This unifies the expect for that in the testing scripts.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run the tests changed on a handful of platforms. They should still pass (some require `sudo` and or TAP interfaces!).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses https://github.com/RIOT-OS/RIOT/pull/11108#issuecomment-545408811
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
