### PR TITLE
dist/tools/codespell: update ignore list

### DIFF
--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -37,8 +37,9 @@ ${CODESPELL_CMD} --version &> /dev/null || {
 
 CODESPELL_OPTS="-q 2"  # Disable "WARNING: Binary file"
 CODESPELL_OPTS+=" --check-hidden"
-# Disable false positives "nd  => and, 2nd", "WAN => WANT", "od => of"
-CODESPELL_OPTS+=" --ignore-words-list=ND,nd,WAN,od"
+# Disable false positives "nd  => and, 2nd", "WAN => WANT", "od => of",
+# "dout => doubt"
+CODESPELL_OPTS+=" --ignore-words-list=ND,nd,wan,od,dout"
 
 # Filter-out all false positive raising "disabled due to" messages.
 ERRORS=$(${CODESPELL_CMD} ${CODESPELL_OPTS} ${FILES} | grep -ve "disabled due to")


### PR DESCRIPTION
### Contribution description

changed wan -> WAN, codespell help says:
"Words are case sensitive based on how they are written in the dictionary file"
Thus WAN doesn't match but "wan" does.

Also added "dout" (used a lot as short form of digital out), which codespell wants to correct to "doubt".

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
