### PR TITLE
gnrc_pktbuf_static: unify NULL pointer output for stats

### DIFF
--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -275,10 +275,23 @@ static inline void _print_chunk(void *chunk, size_t size, int num)
     od_hex_dump(chunk, size, OD_WIDTH_DEFAULT);
 }
 
+static inline void _print_ptr(_unused_t *ptr)
+{
+    if (ptr == NULL) {
+        printf("(nil)");
+    }
+    else {
+        printf("%p", (void *)ptr);
+    }
+}
+
 static inline void _print_unused(_unused_t *ptr)
 {
-    printf("~ unused: %p (next: %p, size: %4u) ~\n", (void *)ptr,
-           (void *)ptr->next, ptr->size);
+    printf("~ unused: ");
+    _print_ptr(ptr);
+    printf(" (next: ");
+    _print_ptr(ptr->next);
+    printf(", size: %4u) ~\n", ptr->size);
 }
 #endif
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Different platforms evaluate `printf()` for NULL pointers differently, resulting tests checking for a certain output to fail. This unifies that (debug) output for the static packet buffer statistics.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The following tests should still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to https://github.com/RIOT-OS/RIOT/pull/12553
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
