### PR TITLE
usbus_fmt: assert descriptor length matches claimed length

### DIFF
--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -260,6 +260,7 @@ size_t usbus_fmt_descriptor_conf(usbus_t *usbus)
     usbus_control_slicer_put_bytes(usbus, (uint8_t *)&conf, sizeof(conf));
     len += _fmt_descriptors_post(usbus, usbus->descr_gen);
     len += _fmt_descriptors_ifaces(usbus);
+    assert(len == conf.total_length);
     return len;
 }
 


### PR DESCRIPTION
### Contribution description

More low hanging USBUS fruit

This commit adds runtime assertions to validate that the total length of
the configuration descriptor as communicated to the host device matches the
generated length of the configuration descriptor.

### Testing procedure

The usual, test the set of usbus_cdc_acm, ecm and such to verify that the assert is not triggered by the current code. If it is triggered it is a bug in the current code, not in this PR :)

### Issues/PRs references

Should make it a bit more difficult to slip in bugs such as #12535 