### PR TITLE
gnrc_sixlowpan: move remaining reassembly buffer components to gnrc_sixlowpan_frag_rb

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -65,7 +65,7 @@ extern "C" {
  * @brief   Size of the reassembly buffer
  *
  * @note    Only applicable with
- *          [gnrc_sixlowpan_frag](@ref net_gnrc_sixlowpan_frag) module
+ *          [gnrc_sixlowpan_frag_rb](@ref net_gnrc_sixlowpan_frag_rb) module
  */
 #ifndef GNRC_SIXLOWPAN_FRAG_RBUF_SIZE
 #define GNRC_SIXLOWPAN_FRAG_RBUF_SIZE       (4U)
@@ -75,7 +75,7 @@ extern "C" {
  * @brief   Timeout for reassembly buffer entries in microseconds
  *
  * @note    Only applicable with
- *          [gnrc_sixlowpan_frag](@ref net_gnrc_sixlowpan_frag) module
+ *          [gnrc_sixlowpan_frag_rb](@ref net_gnrc_sixlowpan_frag_rb) module
  */
 #ifndef GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US
 #define GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US (3U * US_PER_SEC)
@@ -85,7 +85,7 @@ extern "C" {
  * @brief   Aggressively override reassembly buffer when full
  *
  * @note    Only applicable with
- *          [gnrc_sixlowpan_frag](@ref net_gnrc_sixlowpan_frag) module
+ *          [gnrc_sixlowpan_frag_rb](@ref net_gnrc_sixlowpan_frag_rb) module
  *
  * When set to a non-zero value this will cause the reassembly buffer to
  * override the oldest entry no matter what. When set to zero only the oldest

--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -51,11 +51,6 @@ extern "C" {
  * @brief   Message type for passing one 6LoWPAN fragment down the network stack
  */
 #define GNRC_SIXLOWPAN_MSG_FRAG_SND         (0x0225)
-
-/**
- * @brief   Message type for triggering garbage collection reassembly buffer
- */
-#define GNRC_SIXLOWPAN_MSG_FRAG_GC_RBUF     (0x0226)
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -31,6 +31,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+/**
+ * @brief   Message type for triggering garbage collection reassembly buffer
+ */
+#define GNRC_SIXLOWPAN_FRAG_RB_GC_MSG       (0x0226)
 
 /**
  * @brief   Fragment intervals to identify limits of fragments and duplicates.

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -55,7 +55,7 @@ static gnrc_sixlowpan_frag_rb_t rbuf[GNRC_SIXLOWPAN_FRAG_RBUF_SIZE];
 static char l2addr_str[3 * IEEE802154_LONG_ADDRESS_LEN];
 
 static xtimer_t _gc_timer;
-static msg_t _gc_timer_msg = { .type = GNRC_SIXLOWPAN_MSG_FRAG_GC_RBUF };
+static msg_t _gc_timer_msg = { .type = GNRC_SIXLOWPAN_FRAG_RB_GC_MSG };
 
 /* ------------------------------------
  * internal function definitions

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -348,7 +348,9 @@ static void *_event_loop(void *args)
                 DEBUG("6lo: send fragmented event received\n");
                 gnrc_sixlowpan_frag_send(NULL, msg.content.ptr, 0);
                 break;
-            case GNRC_SIXLOWPAN_MSG_FRAG_GC_RBUF:
+#endif
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_RB
+            case GNRC_SIXLOWPAN_FRAG_RB_GC_MSG:
                 DEBUG("6lo: garbage collect reassembly buffer event received\n");
                 gnrc_sixlowpan_frag_rb_gc();
                 break;

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -594,7 +594,7 @@ static void test_rbuf_gc__timed(void)
             xtimer_msg_receive_timeout(&msg, TEST_GC_TIMEOUT) >= 0,
             "Waiting for GC timer timed out"
         );
-    TEST_ASSERT_EQUAL_INT(GNRC_SIXLOWPAN_MSG_FRAG_GC_RBUF, msg.type);
+    TEST_ASSERT_EQUAL_INT(GNRC_SIXLOWPAN_FRAG_RB_GC_MSG, msg.type);
     gnrc_sixlowpan_frag_rb_gc();
     /* reassembly buffer is now empty */
     TEST_ASSERT_NULL(_first_non_empty_rbuf());


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While working on #12559, I noticed that there were some left-overs from https://github.com/RIOT-OS/RIOT/pull/12318 that I now also moved to `gnrc_sixlowpan_frag_rb`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Just moves some code around and renames stuff, so a simple CI build test should suffice.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #12318.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
