### PR TITLE
examples/gnrc_minimal: minimalize gnrc_minimal example

### DIFF
--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -23,6 +23,7 @@ USEMODULE += gnrc_icmpv6_echo
 # Use minimal standard PRNG
 USEMODULE += prng_minstd
 
+CFLAGS += -DLOG_LEVEL=LOG_NONE  # disable log output
 CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DGNRC_NETIF_IPV6_ADDRS_NUMOF=2 \
           -DGNRC_NETIF_IPV6_GROUPS_NUMOF=2 -DGNRC_IPV6_NIB_NUMOF=1 \
           -DGNRC_IPV6_NIB_OFFL_NUMOF=1 # be able to configure at least one route

--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -7,10 +7,10 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-# Comment this out to disable code in RIOT that does safety checking
+# Set this to 1 to enable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-DEVELHELP ?= 1
+DEVELHELP ?= 0
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Inspired by 9103e5b98e0e0bcc66fc9d18dd093c17a9b5c47d I looked and checked if the `gnrc_minimal` example also has `LOG_LEVEL=LOG_NONE` set. And in fact it hasn't. So I activated it. While I was minimizing around, I noticed that `DEVELHELP` was activated for this *minimal* example. This change goes way back to a change by @kYc0o in abf6c3e53fd0b733c006fb3099c62fc483bd980d (https://github.com/RIOT-OS/RIOT/pull/6406)... Apparently, I didn't look into the details of this example for a while now... IMHO the logic for this should be the other way around, due to the minimalized nature of that example: `DEVELHELP=0`, but the comment should provide help what to do to gain its advantages.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile `examples/gnrc_minimal`. It should now be significantly smaller than without these changes.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
