### PR TITLE
examples/suit_update:enable murdock

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -79,11 +79,6 @@ endif
 # files here so they will be submitted along with the test jobs.
 TEST_EXTRA_FILES += $(SLOT_RIOT_ELFS) $(SUIT_SEC) $(SUIT_PUB)
 
-# Due to issues with source address selection, this test currently might not
-# run reliably on CI.
-# See #12404, #12408.
-TEST_ON_CI_BLACKLIST += all
-
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: host-tools


### PR DESCRIPTION
### Contribution description

Now that #12408 is in, the test should work reliably in murdock and it should always answer to aiocoap with the EUI64 link local address, which is the first one, there should be no issue anymore where it answers with the EUI64 to a request to `fe80::2` (this can happen the other way arround).

_For details see https://github.com/RIOT-OS/RIOT/pull/11818#issuecomment-540019463_

### Testing procedure

- run the test multiple times since the issue did not appear all the time.

```
sudo dist/tools/ethos/setup_network.sh riot0 2001:db8:/64
```
```
make -C examples/suit_update/ flash-only -j3 test 
suit_v4_parse() success
SUIT policy check OK.
suit_coap: finalizing image flash
riotboot_flashwrite: riotboot flashing completed successfully
Image magic_number: 0x544f4952
Image Version: 0x5db1c077
Image start address: 0x00001100
Header chksum: 0x9a6dccca

----> ethos: hello received
Failed to send flush request: Operation not permitted
gnrc_uhcpc: Using 5 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2020.01-devel-307-gce366-pr_enable_suit)
RIOT SUIT update example application
running from slot 0
TEST PASSED
```

- murdock should be happy

### Issues/PRs references

#11818