### PR TITLE
boards/native: Default to C11 instead of C99

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -24,7 +24,7 @@ export GPROF ?= gprof
 CFLAGS += -Wall -Wextra -pedantic
 # default std set to gnu99 of not overwritten by user
 ifeq (,$(filter -std=%, $(CFLAGS)))
-  CFLAGS += -std=gnu99
+  CFLAGS += -std=gnu11
 endif
 
 ifeq ($(OS_ARCH),x86_64)


### PR DESCRIPTION
### Contribution description

Changes the compiler flag `-std=gnu99` to `-std=gnu11`. This eases the use of C11 atomics, `_Static_assert()`, etc. It is pretty safe to update to C11 now, as most embedded toolchains provide support for it for quite a while.

### Testing procedure

Murdock will check if still everything compiles as previously. In addition, running a randomly selected example application on `native` should be sufficient.

### Issues/PRs references

Needed for https://github.com/RIOT-OS/RIOT/pull/12548