### PR TITLE
sys/flashwrite: remove useless line

### DIFF
--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -77,7 +77,6 @@ int riotboot_flashwrite_putbytes(riotboot_flashwrite_t *state,
         flashpage_avail -= to_copy;
 
         state->offset += to_copy;
-        flashpage_pos += to_copy;
         bytes += to_copy;
         len -= to_copy;
         if ((!flashpage_avail) || (!more)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes a useless line in the riotboot/flashwrite module.

It was reported by scan-build with the message "Value stored to 'flashpage_pos' is never read"

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run 
  ```
  TOOLCHAIN=llvm make -C tests/riotboot_flashwrite/ scan-build
  ```
  On master, scan-build reports the "value never read" message. With this PR the message is gone.

- Verify that `tests/riotboot_flashwrite` is still working.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
