### PR TITLE
drivers/bmp180: fix potential use of uninitialized variable

### DIFF
--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -106,7 +106,7 @@ int bmp180_init(bmp180_t *dev, const bmp180_params_t *params)
 
 int16_t bmp180_read_temperature(const bmp180_t *dev)
 {
-    int32_t ut, b5;
+    int32_t ut = 0, b5;
     /* Acquire exclusive access */
     i2c_acquire(DEV_I2C);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is small cleanup in the bmp180 driver implementation. It fixes the use of a potentially uninitialized value in the driver. It was raised by scan-build.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run
  ```
  TOOLCHAIN=llvm make -C tests/driver_bmp180/ scan-build
  ```
  on master, you get this warning: `warning: 2nd function call argument is an uninitialized value _compute_b5(dev, ut, &b5);`. With this PR, it is fixed.

- One could also verify that the driver still works

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
