### PR TITLE
drivers/ata8520e: fix potentially unused variables

### DIFF
--- a/drivers/ata8520e/ata8520e.c
+++ b/drivers/ata8520e/ata8520e.c
@@ -210,6 +210,11 @@ static void _status(const ata8520e_t *dev)
         _print_sigfox_status(sigfox);
         _print_sigfox_status(sigfox2);
     }
+    else {
+        (void)atmel;
+        (void)sigfox;
+        (void)sigfox2;
+    }
 }
 
 static void _reset(const ata8520e_t *dev)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR does a little cleanup in the ATA8520E SigFox driver: it _void_ 3 unused variables when ENABLE_DEBUG is not set (the default in fact).

The fix is straight forward and harmless.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run
  ```
  TOOLCHAIN=llvm make -C tests/driver_ata8520e/ scan-build
  ```
  on master you get a warning about potentially unused variables, with this PR it is fixed
- Maybe also try the driver but I don't think that's really needed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick on item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
