### PR TITLE
dist/tools/codespell: add interactive mode

### DIFF
--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -41,6 +41,15 @@ CODESPELL_OPTS+=" --check-hidden"
 # "dout => doubt"
 CODESPELL_OPTS+=" --ignore-words-list=ND,nd,wan,od,dout"
 
+if [ "${CODESPELL_INTERACTIVE}" = "1" ]; then
+    # interactive mode
+    CODESPELL_OPTS+=" -w -i3"
+    exec ${CODESPELL_CMD} ${CODESPELL_OPTS} ${FILES}
+    # (exits shell)
+fi
+
+# non-interactive mode
+
 # Filter-out all false positive raising "disabled due to" messages.
 ERRORS=$(${CODESPELL_CMD} ${CODESPELL_OPTS} ${FILES} | grep -ve "disabled due to")
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR allows calling the codespell script with `CODESPELL_INTERACTIVE=1 dist/tools/codespell/check.sh`, which will then interactively go through the found typos and directly change fixed files.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
