### PR TITLE
stm32_common/i2c_2: Fix repeated read condition

### DIFF
--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -218,8 +218,13 @@ int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,
     I2C_TypeDef *i2c = i2c_config[dev].dev;
     DEBUG("[i2c] read_bytes: Starting\n");
 
-    /* Do not support repeated start reading */
-    if ((i2c->SR2 & I2C_SR2_BUSY) && !(flags & I2C_NOSTART)) {
+    /* Do not support repeated start reading
+     * The repeated start read requires the bus to be busy (I2C_SR2_BUSY == 1)
+     * the previous R/W state to be a read (I2C_SR2_TRA == 0)
+     * and for the command not to be split frame (I2C_NOSTART == 0)
+    */
+    if (((i2c->SR2 & (I2C_SR2_BUSY | I2C_SR2_TRA)) == I2C_SR2_BUSY) &&
+        !(flags & I2C_NOSTART)) {
         return -EOPNOTSUPP;
     }
     int ret = _start(i2c, (address << 1) | I2C_FLAG_READ, flags, length);


### PR DESCRIPTION
## Contribution description

Fix the condition to return -ENOPNOTSUPP when i2c repeated read attempted.
Currently the error occures even if a read after write is attempted.
This is the standard way to i2c_read_reg which should be supported.
The -EOPNOTSUPP requires the previous R/W state to be reading.
This means a `I2C_SR2_TRA` must be checked to be 0.

This bug was caught by @aabadie with and using saul in iotlabs testbed.

### Testing procedure

To test you can use the iotlab-m3 and test the lps331ap driver:

`BOARD=iotlab-m3 IOTLAB_NODE=<my_iotlab_node> make flash term -C tests/driver_lpsxxx/`

To ensure the no support error is correctly working:
`BOARD=iotlab-m3 IOTLAB_NODE=<my_iotlab_node> make flash term -C tests/periph_i2c/`

```
> i2c_write_bytes 0 0x5C 4 0x0F
Success: i2c_0 wrote 1 bytes
> i2c_read_bytes 0 0X5C 1 0
Success: i2c_0 read 1 byte(s) : [0xbb]
# This means i2c_read_reg is now fixed

> i2c_read_bytes 0 0x5C 1 4
Success: i2c_0 read 1 byte(s) : [0xbb]
> i2c_read_bytes 0 0x5C 1 0
Error: EOPNOTSUPP [95]
# This means the desired error code is still returned
```


Also testing procedure is documented in #12564

### Issues/PRs references
Fixes #12564 
Request to add test for CI https://github.com/RIOT-OS/RobotFW-tests/issues/39
