### PR TITLE
tools/codespell: improve ignored words list + enable colored output

### DIFF
--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -37,9 +37,7 @@ ${CODESPELL_CMD} --version &> /dev/null || {
 
 CODESPELL_OPTS="-q 2"  # Disable "WARNING: Binary file"
 CODESPELL_OPTS+=" --check-hidden"
-# Disable false positives "nd  => and, 2nd", "WAN => WANT", "od => of",
-# "dout => doubt"
-CODESPELL_OPTS+=" --ignore-words-list=ND,nd,wan,od,dout"
+CODESPELL_OPTS+=" --ignore-words ${RIOTTOOLS}/codespell/ignored_words.txt"
 
 if [ "${CODESPELL_INTERACTIVE}" = "1" ]; then
     # interactive mode

--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -38,6 +38,7 @@ ${CODESPELL_CMD} --version &> /dev/null || {
 CODESPELL_OPTS="-q 2"  # Disable "WARNING: Binary file"
 CODESPELL_OPTS+=" --check-hidden"
 CODESPELL_OPTS+=" --ignore-words ${RIOTTOOLS}/codespell/ignored_words.txt"
+CODESPELL_OPTS+=" -c"   # Enable colored output
 
 if [ "${CODESPELL_INTERACTIVE}" = "1" ]; then
     # interactive mode

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -1,0 +1,15 @@
+# This file contains ignored words that triggered false positive with codespell
+#
+# Extend it when needed, one word per line with documentation in a comment.
+
+# nd (Neighbor Discovery) => and, 2nd
+nd
+
+# wan (Wide Area Network) => want
+wan
+
+# od (Object Dump) => of
+od
+
+# dout (Digital out) => doubt
+dout


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR modifies the codespell static test script so that ignored words can be set in a separate file. This should simplify the maintenance of this file in the future, without having to touch the script.

The documentation of ignored words is also updated (@miri64 will like this).

In the meantime, this PR enable the colored output in codespell (use -c)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following command should return the same result on master and on this PR:
`./dist/tools/codespell/check.sh | wc -l`

The following command should display the list of typos using a colored output.
`./dist/tools/codespell/check.sh`


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
