### PR TITLE
cpu/sam0_common: fix potential undefined result with sercom_id

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -340,42 +340,53 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
  *
  * @return              numeric id of the given SERCOM device
  */
-static inline int sercom_id(const void *sercom)
+static inline uint8_t sercom_id(const void *sercom)
 {
 #ifdef SERCOM0
-    if (sercom == SERCOM0)
+    if (sercom == SERCOM0) {
         return 0;
+    }
 #endif
 #ifdef SERCOM1
-    if (sercom == SERCOM1)
+    if (sercom == SERCOM1) {
         return 1;
+    }
 #endif
 #ifdef SERCOM2
-    if (sercom == SERCOM2)
+    if (sercom == SERCOM2) {
         return 2;
+    }
 #endif
 #ifdef SERCOM3
-    if (sercom == SERCOM3)
+    if (sercom == SERCOM3) {
         return 3;
+    }
 #endif
 #ifdef SERCOM4
-    if (sercom == SERCOM4)
+    if (sercom == SERCOM4) {
         return 4;
+    }
 #endif
 #ifdef SERCOM5
-    if (sercom == SERCOM5)
+    if (sercom == SERCOM5) {
         return 5;
+    }
 #endif
 #ifdef SERCOM6
-    if (sercom == SERCOM6)
+    if (sercom == SERCOM6) {
         return 6;
+    }
 #endif
 #ifdef SERCOM7
-    if (sercom == SERCOM7)
+    if (sercom == SERCOM7) {
         return 7;
+    }
 #endif
 
-    return -1;
+    /* should not be reached, so fail with assert */
+    assert(false);
+
+    return SERCOM_INST_NUM;
 }
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As reported in #11852 there are tons of scan-build warning when building an application for a sam0 based boards.
Scan-build is detecting that sercom_id could return -1 and the value of this function is affected to uint8_t variables. Since these variables are used for shitfing bit in registers, this could lead to undefined results.

This PR is fixing that by using the SERCOM_INST_NUM macro defined in the CMSIS instead of -1. There's an assert added to check that the value returned is not SERCOM_INST_NUM.

This change also adds 16 extra bytes in ROM.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run `BOARD=samr21-xpro TOOLCHAIN=llvm make -C examples/hello-world/ scan-build`
  on master it raises tons of warning, with this PR the warning are gone

- Trigger CI: run tests on Murdock and verify they work (on samr21-xpro which is sam0 based).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
