### PR TITLE
stm32/cpu: Add functions for low power mode clock config

### DIFF
--- a/cpu/stm32_common/cpu_common.c
+++ b/cpu/stm32_common/cpu_common.c
@@ -169,3 +169,115 @@ void periph_clk_dis(bus_t bus, uint32_t mask)
             break;
     }
 }
+
+#if defined(CPU_FAM_STM32L4)
+void periph_lpclk_en(bus_t bus, uint32_t mask)
+{
+    switch (bus) {
+        case APB1:
+            RCC->APB1SMENR1 |= mask;
+            break;
+        case APB2:
+            RCC->APB2SMENR |= mask;
+            break;
+        case APB12:
+            RCC->APB1SMENR2 |= mask;
+            break;
+        case AHB1:
+            RCC->AHB1SMENR |= mask;
+            break;
+        case AHB2:
+            RCC->AHB2SMENR |= mask;
+            break;
+        case AHB3:
+            RCC->AHB3SMENR |= mask;
+            break;
+        default:
+            DEBUG("unsupported bus %d\n", (int)bus);
+            break;
+    }
+}
+
+void periph_lpclk_dis(bus_t bus, uint32_t mask)
+{
+    switch (bus) {
+        case APB1:
+            RCC->APB1SMENR1 &= ~(mask);
+            break;
+        case APB2:
+            RCC->APB2SMENR &= ~(mask);
+            break;
+        case APB12:
+            RCC->APB1SMENR2 &= ~(mask);
+            break;
+        case AHB1:
+            RCC->AHB1SMENR &= ~(mask);
+            break;
+        case AHB2:
+            RCC->AHB2SMENR &= ~(mask);
+            break;
+        case AHB3:
+            RCC->AHB3SMENR &= ~(mask);
+            break;
+        default:
+            DEBUG("unsupported bus %d\n", (int)bus);
+            break;
+    }
+}
+#elif defined(CPU_FAM_STM32F2) || \
+      defined(CPU_FAM_STM32F4) || \
+      defined(CPU_FAM_STM32F7)
+void periph_lpclk_en(bus_t bus, uint32_t mask)
+{
+    switch (bus) {
+        case APB1:
+            RCC->APB1LPENR |= mask;
+            break;
+        case APB2:
+            RCC->APB2LPENR |= mask;
+            break;
+        case AHB1:
+            RCC->AHB1LPENR |= mask;
+            break;
+/* STM32F410 RCC doesn't provide AHB2 and AHB3 */
+#if !defined(CPU_LINE_STM32F410Rx)
+        case AHB2:
+            RCC->AHB2LPENR |= mask;
+            break;
+        case AHB3:
+            RCC->AHB3LPENR |= mask;
+            break;
+#endif
+        default:
+            DEBUG("unsupported bus %d\n", (int)bus);
+            break;
+    }
+}
+
+void periph_lpclk_dis(bus_t bus, uint32_t mask)
+{
+    switch (bus) {
+        case APB1:
+            RCC->APB1LPENR &= ~(mask);
+            break;
+        case APB2:
+            RCC->APB2LPENR &= ~(mask);
+            break;
+        case AHB1:
+            RCC->AHB1LPENR &= ~(mask);
+            break;
+/* STM32F410 RCC doesn't provide AHB2 and AHB3 */
+#if !defined(CPU_LINE_STM32F410Rx)
+        case AHB2:
+            RCC->AHB2LPENR &= ~(mask);
+            break;
+        case AHB3:
+            RCC->AHB3LPENR &= ~(mask);
+            break;
+#endif
+        default:
+            DEBUG("unsupported bus %d\n", (int)bus);
+            break;
+    }
+}
+#endif

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -603,6 +603,22 @@ void periph_clk_en(bus_t bus, uint32_t mask);
  * @param[in] bus       bus the peripheral is connected to
  * @param[in] mask      bit in the RCC enable register
  */
+void periph_lpclk_dis(bus_t bus, uint32_t mask);
+
+/**
+ * @brief   Enable the given peripheral clock in low power mode
+ *
+ * @param[in] bus       bus the peripheral is connected to
+ * @param[in] mask      bit in the RCC enable register
+ */
+void periph_lpclk_en(bus_t bus, uint32_t mask);
+
+/**
+ * @brief   Disable the given peripheral clock in low power mode
+ *
+ * @param[in] bus       bus the peripheral is connected to
+ * @param[in] mask      bit in the RCC enable register
+ */
 void periph_clk_dis(bus_t bus, uint32_t mask);
 
 /**


### PR DESCRIPTION
### Contribution description

This PR adds functions for managing the clock config in low power mode for the STM32 devices.

### Testing procedure

I'm not really sure, it should at least compile for all stm32 based devices

### Issues/PRs references

Required for #12556 
