### PR TITLE
cpu/lpc2387: enable RTC on rtc_init()

### DIFF
--- a/cpu/lpc2387/periph/rtc.c
+++ b/cpu/lpc2387/periph/rtc.c
@@ -62,6 +62,8 @@ void rtc_init(void)
         _rtc_set(0);
     }
 
+    rtc_poweron();
+
     DEBUG("%2lu.%2lu.%4lu  %2lu:%2lu:%2lu\n",
             RTC_DOM, RTC_MONTH, RTC_YEAR, RTC_HOUR, RTC_MIN, RTC_SEC);
 }


### PR DESCRIPTION
### Contribution description

On all other CPU implementeations it is expected for the RTC to run after `rtc_init()` was called.
This was not the case on lpc2387, but it can be remedied trivially.

### Testing procedure
run `tests/periph_rtc`:

```
2019-10-27 01:17:50,524 # RIOT RTC low-level driver test
2019-10-27 01:17:50,526 # This test will display 'Alarm!' every 2 seconds for 4 times
2019-10-27 01:17:50,527 #   Setting clock to   2011-12-13 14:15:57
2019-10-27 01:17:50,527 # Clock value is now   2011-12-13 14:15:57
2019-10-27 01:17:50,528 #   Setting alarm to   2011-12-13 14:15:59
2019-10-27 01:17:50,529 #    Alarm is set to   2011-12-13 14:15:59
2019-10-27 01:17:50,529 # 
2019-10-27 01:17:52,319 # Alarm!
2019-10-27 01:17:54,324 # Alarm!
2019-10-27 01:17:56,330 # Alarm!
2019-10-27 01:17:58,320 # Alarm!
```

### Issues/PRs references
discovered in #11413