### PR TITLE
cpu/lpc2387: allow for more flexible clock selection

### DIFF
--- a/boards/avsextrem/include/periph_conf.h
+++ b/boards/avsextrem/include/periph_conf.h
@@ -29,6 +29,8 @@ extern "C" {
  * @name    Clock configuration
  * @{
  */
+#define XTAL_HZ             (16000000U)         /* the board provides a 16 MHz XTAL */
+
 #define CLOCK_CORECLOCK     (72000000U)         /* this board runs with 72MHz */
 
 #define CLOCK_PCLK          (CLOCK_CORECLOCK)

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -29,6 +29,8 @@ extern "C" {
  * @name    Clock configuration
  * @{
  */
+#define XTAL_HZ             (16000000U)         /* the board provides a 16 MHz XTAL */
+
 #define CLOCK_CORECLOCK     (72000000U)         /* the msba2 runs with 72MHz */
 
 #define CLOCK_PCLK          (CLOCK_CORECLOCK)

--- a/cpu/lpc2387/clocks.c
+++ b/cpu/lpc2387/clocks.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include "board.h"
 #include "cpu.h"
+#include "periph_conf.h"
 #include "lpc2387.h"
 
 #define CL_CPU_DIV      4
@@ -68,11 +69,17 @@ static void init_clks1(void)
 
     while (!(SCS & 0x40));              /* Wait until main OSC is usable */
 
-    /* select main OSC, 16MHz, as the PLL clock source */
+#ifdef XTAL_HZ
+    /* select main OSC (XTAL_HZ) as the PLL clock source */
     CLKSRCSEL = 0x0001;
+#else
+    /* use the internal RC OSC as the PLL clock source */
+#define XTAL_HZ F_RC_OSCILLATOR
+#endif
 
     /* Setting Multiplier and Divider values */
-    PLLCFG = 0x0008;                    /* M=9 N=1 Fcco = 288 MHz */
+    /* Fcco = (2 * Fin *  M)/ N = 288 MHz */
+    PLLCFG = PLLCFG_M(F_CCO/(XTAL_HZ)) | PLLCFG_N(2);
     pllfeed();
 
     /* Enabling the PLL */

--- a/cpu/lpc2387/include/lpc2387.h
+++ b/cpu/lpc2387/include/lpc2387.h
@@ -26,6 +26,9 @@ extern "C" {
 
 #define VIC_SIZE                32
 
+#define PLLCFG_N(n)             ((n - 1) << 16)
+#define PLLCFG_M(m)             (m - 1)
+
 #define GPIO_INT 17
 #define IRQP_GPIO 4
 


### PR DESCRIPTION
### Contribution description
Currently the `cpu/lpc2387` init code hard-codes a 16 MHz external oscillator.
Instead, calculate the PLL multiplier based on a board define for `XTAL_HZ` and fall back to the internal oscillator if this has not been defined.

### Testing procedure
On `msba2` everything should behave as before.
The PLL still runs at 288 MHz no matter what XTAL is used.

### Issues/PRs references
none, but needed for `mcb2300`  which uses a 12 MHz XTAL.
