### PR TITLE
sys/net/nanocoap: fix dead assignment in nanocoap server

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -144,7 +144,7 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
                 continue;
             }
             if ((res = coap_handle_req(&pkt, buf, bufsize)) > 0) {
-                res = sock_udp_send(&sock, buf, res, &remote);
+                sock_udp_send(&sock, buf, res, &remote);
             }
             else {
                 DEBUG("error handling request %d\n", (int)res);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing a warning raised by LLVM scan-build when building the nanocoap_server example. The fix simply consists in removing an assignment to a variable (res) that is unused after.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run TOOLCHAIN=llvm make -C examples/nanocoap_server/ scan-build

On master it reports a dead assignment on this nanocoap_server.c. With this pr it's fixed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
