### PR TITLE
cpu/stm32_common: fix i2c_1 build with llvm toolchain

### DIFF
--- a/cpu/stm32_common/periph/i2c_1.c
+++ b/cpu/stm32_common/periph/i2c_1.c
@@ -312,7 +312,7 @@ static int _start(I2C_TypeDef *i2c, uint32_t cr2, uint8_t flags)
         cr2 |= I2C_CR2_AUTOEND;
         cr2 &= ~(I2C_CR2_RELOAD);
     }
-    DEBUG("[i2c] start: Setting CR2=0x%08lX\n", cr2);
+    DEBUG("[i2c] start: Setting CR2=0x%08x\n", (unsigned int)cr2);
     i2c->CR2 = cr2;
     if (!(flags & I2C_NOSTART)) {
         uint16_t tick = TICK_TIMEOUT;
@@ -377,7 +377,7 @@ static int _wait_isr_set(I2C_TypeDef *i2c, uint32_t mask, uint8_t flags)
             return -EAGAIN;
         }
         if (isr & mask) {
-            DEBUG("[i2c] wait_isr_set: ISR 0x%08lX set\n", mask);
+            DEBUG("[i2c] wait_isr_set: ISR 0x%08x set\n", (unsigned int)mask);
             return 0;
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing a build issue when using LLVM to build a firmware for STM32 and which contains I2C support from i2c_1 driver.

The build issue a just a problem with unsigned int types in a DEBUG call. The proposed fix in this PR has no incidence on the debug message (tested on hardware).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Verify both GCC and LLVM builds works:
  ```
  $ make BOARD=nucleo-l073rz -C tests/periph_i2C
  $ TOOLCHAIN=llvm make BOARD=nucleo-l073rz -C tests/periph_i2C
  ```

- Verify that the debug message are unchanged:
  - set `ENABLE_DEBUG` to 1 in `cpu/stm32_common/periph/i2c_1.c`
  - Build and flash a firmware with i2c and verify the debug messages:
    ```
    $ USEMODULE=hts221 TOOLCHAIN=llvm make BOARD=nucleo-l073rz -C examples/saul flash term
    > reboot
    ```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
