### PR TITLE
drivers/tmp00x: cleanup return codes and fix potential use of uninitialized parameter

### DIFF
--- a/drivers/include/tmp00x.h
+++ b/drivers/include/tmp00x.h
@@ -257,6 +257,10 @@ void tmp00x_convert(int16_t rawv, int16_t rawt,  float *tamb, float *tobj);
  * @param[in]  dev          device descriptor of sensor
  * @param[out] ta           converted ambient temperature
  * @param[out] to           converted object temperature
+ *
+ * @return                  TMP00X_OK on success
+ * @return                  -TMP00X_ERROR if data read not ready
+ * @return                  -TMP00X_ERROR_BUS on I2C error
  */
 int tmp00x_read_temperature(const tmp00x_t *dev, int16_t *ta, int16_t *to);
 

--- a/drivers/tmp00x/tmp00x.c
+++ b/drivers/tmp00x/tmp00x.c
@@ -214,18 +214,30 @@ int tmp00x_read_temperature(const tmp00x_t *dev, int16_t *ta, int16_t *to)
     xtimer_usleep(TMP00X_CONVERSION_TIME);
 #endif
 
+int ret;
 #if TMP00X_USE_RAW_VALUES
-    tmp00x_read(dev, to, ta, &drdy);
+    if ((ret = tmp00x_read(dev, to, ta, &drdy)) < 0) {
+        return ret;
+    }
 
     if (!drdy) {
-        return TMP00X_ERROR;
+#if TMP00X_USE_LOW_POWER
+        tmp00x_set_standby(dev);
+#endif
+        return -TMP00X_ERROR;
     }
 #else
-    tmp00x_read(dev, &rawvolt, &rawtemp, &drdy);
+    if ((ret = tmp00x_read(dev, &rawvolt, &rawtemp, &drdy)) < 0) {
+        return ret;
+    }
 
     if (!drdy) {
-        return TMP00X_ERROR;
+#if TMP00X_USE_LOW_POWER
+        tmp00x_set_standby(dev);
+#endif
+        return -TMP00X_ERROR;
     }
+
     tmp00x_convert(rawvolt, rawtemp,  &tamb, &tobj);
     *ta = (int16_t)(tamb*100);
     *to = (int16_t)(tobj*100);
@@ -233,7 +245,7 @@ int tmp00x_read_temperature(const tmp00x_t *dev, int16_t *ta, int16_t *to)
 
 #if TMP00X_USE_LOW_POWER
     if (tmp00x_set_standby(dev)) {
-        return TMP00X_ERROR;
+        return -TMP00X_ERROR;
     }
 #endif
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is small cleanup of the tmp00x sensor driver. Things changed:
- correctly handle error codes of call to tmp00x_read function. This fixes a potential use of an uninitialized parameter to the tmp00x_convert function
- make error code consistent: use `-TMP00X_ERROR` instead of `TMP00X_ERROR`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Check that scan-build is fixed:
  ```
  $ TOOLCHAIN=llvm make -C tests/driver_tmp00x scan-build
  ```
- Maybe also check the sensor is still working, even if this PR shouldn't have any functional impact

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
