### PR TITLE
drivers/nrf24l01p: fix potentially undefined return value

### DIFF
--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -618,30 +618,13 @@ int nrf24l01p_set_power(const nrf24l01p_t *dev, int pwr)
     return nrf24l01p_write_reg(dev, REG_RF_SETUP, rf_setup);
 }
 
+static const int8_t _nrf24l01p_power_map[4] = { -18, -12, -6, 0 };
+
 int nrf24l01p_get_power(const nrf24l01p_t *dev)
 {
     char rf_setup;
-    int pwr;
-
     nrf24l01p_read_reg(dev, REG_RF_SETUP, &rf_setup);
-
-    if ((rf_setup & 0x6) == 0) {
-        pwr = -18;
-    }
-
-    if ((rf_setup & 0x6) == 2) {
-        pwr = -12;
-    }
-
-    if ((rf_setup & 0x6) == 4) {
-        pwr = -6;
-    }
-
-    if ((rf_setup & 0x6) == 6) {
-        pwr = 0;
-    }
-
-    return pwr;
+    return _nrf24l01p_power_map[(rf_setup & 0x6) >> 1];
 }
 
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a potentially uninitialized returned value in the nrf24l01p driver.
The problem is raised when running scan-build with the LLVM toolchain.

After checking the datasheet, it seems that the returned value is quite deterministic (4 possible values, coded on 2 bits). So using using a map containing the expected power values should work.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Verify scan-build is fixed:
  ```
  $ TOOLCHAIN=llvm make -C tests/driver_nrf24l01p_lowlevel scan-build
  ```
- Verify the driver works (I couldn't test because of no hardware available)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
