### PR TITLE
sys/net/uhcp: remove unused returned value in uhcp_client

### DIFF
--- a/sys/net/application_layer/uhcp/uhcpc.c
+++ b/sys/net/application_layer/uhcp/uhcpc.c
@@ -38,6 +38,10 @@ void uhcp_client(uhcp_iface_t iface)
 
     /* create listening socket */
     int res = sock_udp_create(&sock, &local, NULL, 0);
+    if (res < 0) {
+        puts("uhcp_client(): cannot create listening socket");
+        return;
+    }
 
     uint8_t buf[sizeof(uhcp_push_t) + 16];
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an obvious fix removing a return value set in a variable that is never used afterward.

The ideal fix would be to take into account the return code in case of an error but that would need an API change in uhcp.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `TOOLCHAIN=llvm make -C examples/gnrc_border_router/ scan-build`

With this PR the warning related to uhcp is gone.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick another item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
