### PR TITLE
tests/driver_hd44780: allow use on non-Arduino boards

### DIFF
--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -83,6 +83,8 @@ static void _send(const hd44780_t *dev, uint8_t value, hd44780_state_t state)
         _write_bits(dev, 4, value>>4);
         _write_bits(dev, 4, value);
     }
+
+    xtimer_usleep(HD44780_PULSE_WAIT_SHORT);
 }
 
 static void _write_bits(const hd44780_t *dev, uint8_t bits, uint8_t value)

--- a/drivers/hd44780/include/hd44780_params.h
+++ b/drivers/hd44780/include/hd44780_params.h
@@ -11,10 +11,11 @@
  *
  * @{
  * @file
- * @brief       Pinout config for the HD44780 display
+ * @brief       Default configuration for the HD44780 driver
  *
  * @author      Sebastian Meiling <s@mlng.net>
  */
+
 #ifndef HD44780_PARAMS_H
 #define HD44780_PARAMS_H
 
@@ -28,6 +29,7 @@ extern "C"
 {
 #endif
 
+#ifdef MODULE_ARDUINO
 #define HD44780_PARAMS_ARDUINO {    \
     .cols   = 16,                   \
     .rows   = 2,                    \
@@ -38,12 +40,31 @@ extern "C"
                HD44780_RW_OFF, HD44780_RW_OFF, HD44780_RW_OFF, HD44780_RW_OFF} \
 }
 
+#ifndef HD44780_PARAMS
+#define HD44780_PARAMS HD44780_PARAMS_ARDUINO
+#endif
+#endif
+
+#ifndef HD44780_PARAMS
+#define HD44780_PARAMS {            \
+    .cols   = 16,                   \
+    .rows   = 2,                    \
+    .rs     = GPIO_PIN(0,1),        \
+    .rw     = GPIO_PIN(0,2),        \
+    .enable = GPIO_PIN(0,3),        \
+    .data   = {                     \
+                GPIO_PIN(0,4), GPIO_PIN(0,5), GPIO_PIN(0,6), GPIO_PIN(0,7),      \
+                HD44780_RW_OFF, HD44780_RW_OFF, HD44780_RW_OFF, HD44780_RW_OFF,  \
+              }                     \
+    }
+#endif
+
 /**
  * @brief   LCM1602C configuration
  */
 static const hd44780_params_t hd44780_params[] =
 {
-    HD44780_PARAMS_ARDUINO,
+    HD44780_PARAMS,
 };
 
 #ifdef __cplusplus

--- a/drivers/hd44780/include/hd44780_params.h
+++ b/drivers/hd44780/include/hd44780_params.h
@@ -43,7 +43,7 @@ extern "C"
 #ifndef HD44780_PARAMS
 #define HD44780_PARAMS HD44780_PARAMS_ARDUINO
 #endif
-#endif
+#endif /* MODULE_ARDUINO */
 
 #ifndef HD44780_PARAMS
 #define HD44780_PARAMS {            \

--- a/tests/driver_hd44780/Makefile
+++ b/tests/driver_hd44780/Makefile
@@ -7,9 +7,6 @@ BOARD_BLACKLIST := stm32f4discovery slstk3401a slstk3402a \
                    stk3600 stk3700 \
                    sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff
 
-# currently the test provides config params for arduinos only
-FEATURES_REQUIRED += arduino
-
 USEMODULE += hd44780
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description
Currently, `tests/driver_hd44780` depends on the Arduino module and hard-codes an Arduino default configuration.

This PR moves the default configuration to the driver like it is done in other such drivers and allows it to be overwritten by the board configuration.

When hooking up the 16x2 display on the MCB2300 board, the display would not light up.
I had to add a short delay (1µs was enough) after each byte transferred, then the display would update.

Curiously, increasing `HD44780_PULSE_WAIT_LONG` did not help.

### Testing procedure

Run `tests/driver_hd44780` and check that the display still prints the test messages.

### Issues/PRs references
none
