### PR TITLE
Makefile.include: Fix call to sed for FreeBSD and OS X [backport 2019.10]

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -823,7 +823,8 @@ include $(RIOTTOOLS)/desvirt/Makefile.desvirt
 # The rebuild behavior could even only be done with an empty file, but currently
 # some macros definitions are passed through this file.
 $(RIOTBUILD_CONFIG_HEADER_C): $(RIOTBUILD_CONFIG_HEADER_C).in
-	$(Q)sed -n -e '1i /* Generated file do not edit */' -e '/^#.*/ p' $< > $@
+	$(Q)sed -n -e '1i\
+/* Generated file do not edit */' -e '/^#.*/ p' $< > $@
 
 .SECONDARY: $(RIOTBUILD_CONFIG_HEADER_C).in
 $(RIOTBUILD_CONFIG_HEADER_C).in: FORCE | $(CLEAN)


### PR DESCRIPTION
# Backport of #12435 

### Contribution description
Disclaimer: I'm not an expert on FreeBSD, but only stumbled upon this while using it to test another PR on a non-Linux platform and wanted to let you know.

If I didn't miss something, it looks like merging PR #12348 has broken the build on FreeBSD, as it uses `sed`'s insert functionality with a syntax that is tolerated by GNU's `sed` but not by the one on FreeBSD. This PR changes the call to `sed` in a way that works on both platforms.

The [call in question](https://github.com/RIOT-OS/RIOT/blob/master/Makefile.include#L821) is:
```
$(Q)sed -n -e '1i /* Generated file do not edit */' -e '/^#.*/ p' $< > $@
```

From [sed's manpage](https://linux.die.net/man/1/sed), we see that a backslash followed by a new line is required for the `i` command:
```
Zero- or One- address commands
[...]
  i \
  text   Insert text, which has each embedded newline preceded by a backslash.
```

While GNU's `sed` under Linux accepts the syntax used in PR #12348, the build with FreeBSD fails (master was on cce1438 for my tests, I also tried 3bfe30a in isolation):

```
$ export CC=gcc47
$ export LINK=gcc47
$ git checkout master
$ BOARD=native gmake -C examples/hello-world clean all
gmake: Entering directory '/usr/home/frank/riot/RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".
sed: 1: "1i /* Generated file do ...": command i expects \ followed by text
gmake: *** [/usr/home/frank/riot/RIOT/examples/hello-world/../../Makefile.include:821: /usr/home/frank/riot/RIOT/examples/hello-world/bin/native/riotbuild/riotbuild.h] Error 1
gmake: Leaving directory '/usr/home/frank/riot/RIOT/examples/hello-world'
```

Using commit 3f0dfc1 (immediately before the PR was merged) was still successful on FreeBSD:

```
$ export CC=gcc47
$ export LINK=gcc47
$ git checkout 3f0dfc14ac2f1dc7cc1546abc5307fb93f866b26 # Commit just before the PR was merged
$ BOARD=native gmake -C examples/hello-world clean all
gmake: Entering directory '/usr/home/frank/riot/RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".
"gmake" -C /usr/home/frank/riot/RIOT/boards/native
"gmake" -C /usr/home/frank/riot/RIOT/boards/native/drivers
"gmake" -C /usr/home/frank/riot/RIOT/core
"gmake" -C /usr/home/frank/riot/RIOT/cpu/native
"gmake" -C /usr/home/frank/riot/RIOT/cpu/native/periph
"gmake" -C /usr/home/frank/riot/RIOT/cpu/native/vfs
"gmake" -C /usr/home/frank/riot/RIOT/drivers
"gmake" -C /usr/home/frank/riot/RIOT/drivers/periph_common
"gmake" -C /usr/home/frank/riot/RIOT/sys
"gmake" -C /usr/home/frank/riot/RIOT/sys/auto_init
   text   data      bss      dec       hex   filename
  21205    368   128136   149709   0x248cd   /usr/home/frank/riot/RIOT/examples/hello-world/bin/native/hello-world.elf
gmake: Leaving directory '/usr/home/frank/riot/RIOT/examples/hello-world'
```

The formatting of the fix is not very nice, but using an actual line break was the only solution that allowed staying with `sed` only and worked for me independently of the host platform and shell. Something like `echo '/* ... */' | cat - $< | sed ... > $@` could be an alternative.

### Testing procedure

To verify that this issue exists, checkout the current master on FreeBSD, try to build an application (e.g. examples/hello_world), and see that the aforementioned error occurs:

```
export CC=gcc47
export LINK=gcc47
git checkout master
BOARD=native gmake -C examples/hello-world clean all
```

After applying this change, the error should be gone. Also verify that the content of `<appdir>/bin/native/riotbuild/riotbuild.h` has not changed with and without the PR.

### Issues/PRs references

See #12348
