### PR TITLE
sys/luid: add luid_get_eui48() / luid_get_eui64()

### DIFF
--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -55,6 +55,9 @@
 
 #include <stddef.h>
 
+#include "net/eui48.h"
+#include "net/eui64.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -81,6 +84,43 @@ extern "C" {
  * @param[in]  len      length of the LUID in bytes
  */
 void luid_get(void *buf, size_t len);
+
+/**
+ * @brief   Get a unique short unicast address
+ *
+ * The resulting address is built from the base ID generated with luid_base(), which
+ * isXORed with an 8-bit incrementing counter value into the least significant
+ * byte.
+ *
+ * @note    The resulting address will repeat after 255 calls.
+ *
+ * @param[out] addr     memory location to copy the address into.
+ */
+void luid_get_short(network_uint16_t *addr);
+
+/**
+ * @brief   Get a unique EUI48 address
+ *
+ * The resulting address is built from the base ID generated with luid_base(), which
+ * isXORed with an 8-bit incrementing counter value into the least significant byte.
+ *
+ * @note    The resulting address will repeat after 255 calls.
+ *
+ * @param[out] addr     memory location to copy the address into.
+ */
+void luid_get_eui48(eui48_t *addr);
+
+/**
+ * @brief   Get a unique EUI64 address
+ *
+ * The resulting address is built from the base ID generated with luid_base(), which
+ * isXORed with an 8-bit incrementing counter value into the least significant byte.
+ *
+ * @note    The resulting address will repeat after 255 calls.
+ *
+ * @param[out] addr     memory location to copy the address into.
+ */
+void luid_get_eui64(eui64_t *addr);
 
 /**
  * @brief   Get a custom unique ID based on a user given generator value

--- a/sys/include/net/eui64.h
+++ b/sys/include/net/eui64.h
@@ -32,6 +32,24 @@ extern "C" {
 #endif
 
 /**
+ * @name EUI-64 bit flags contained in the first octet
+ *
+ * @see IEEE 802-2001 section 9.2
+ * @{
+ */
+
+/**
+ * @brief Locally administered address.
+ */
+#define EUI64_LOCAL_FLAG        0x02
+
+/**
+ * @brief Group type address.
+ */
+#define EUI64_GROUP_FLAG        0x01
+/** @} */
+
+/**
  * @brief Data type to represent an EUI-64.
  */
 typedef union {
@@ -39,6 +57,31 @@ typedef union {
     uint8_t uint8[8];            /**< split into 8 8-bit words. */
     network_uint16_t uint16[4];  /**< split into 4 16-bit words. */
 } eui64_t;
+
+/**
+ * @brief Set the locally administrated bit in the EUI-64 address.
+ *
+ * @see IEEE 802-2001 section 9.2
+ *
+ * @param   addr    eui64 address
+ */
+static inline void eui64_set_local(eui64_t *addr)
+{
+    addr->uint8[0] |= EUI64_LOCAL_FLAG;
+}
+
+/**
+ * @brief Clear the group address bit to signal the address as individual
+ * address
+ *
+ * @see IEEE 802-2001 section 9.2
+ *
+ * @param   addr    eui64 address
+ */
+static inline void eui64_clear_group(eui64_t *addr)
+{
+    addr->uint8[0] &= ~EUI64_GROUP_FLAG;
+}
 
 #ifdef __cplusplus
 }

--- a/sys/luid/luid.c
+++ b/sys/luid/luid.c
@@ -63,3 +63,30 @@ void luid_custom(void *buf, size_t len, int gen)
     }
 }
 
+void luid_get_short(network_uint16_t *addr)
+{
+    luid_base(addr, sizeof(*addr));
+    addr->u8[1] ^= lastused++;
+
+    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
+     * 0 for unicast addresses */
+    addr->u8[0] &= 0x7F;
+}
+
+void luid_get_eui48(eui48_t *addr)
+{
+    luid_base(addr, sizeof(*addr));
+    addr->uint8[5] ^= lastused++;
+
+    eui48_set_local(addr);
+    eui48_clear_group(addr);
+}
+
+void luid_get_eui64(eui64_t *addr)
+{
+    luid_base(addr, sizeof(*addr));
+    addr->uint8[7] ^= lastused++;
+
+    eui64_set_local(addr);
+    eui64_clear_group(addr);
+}

--- a/sys/luid/luid.c
+++ b/sys/luid/luid.c
@@ -26,7 +26,26 @@
 
 #include "luid.h"
 
-static uint8_t lastused = 1;
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+void __attribute__((weak)) luid_base(void *buf, size_t len)
+{
+    memset(buf, LUID_BACKUP_SEED, len);
+
+#if CPUID_LEN
+    uint8_t *out = (uint8_t *)buf;
+    uint8_t cid[CPUID_LEN];
+
+    cpuid_get(cid);
+    for (size_t i = 0; i < MAX(len, CPUID_LEN); i++) {
+        out[i % len] ^= cid[i % CPUID_LEN];
+    }
+#endif
+}
+
+static uint8_t lastused;
 
 void luid_get(void *buf, size_t len)
 {
@@ -44,19 +63,3 @@ void luid_custom(void *buf, size_t len, int gen)
     }
 }
 
-void luid_base(void *buf, size_t len)
-{
-    assert(buf && (len > 0));
-
-    memset(buf, LUID_BACKUP_SEED, len);
-
-#if CPUID_LEN
-    uint8_t *out = (uint8_t *)buf;
-    uint8_t cid[CPUID_LEN];
-
-    cpuid_get(cid);
-    for (size_t i = 0; i < CPUID_LEN; i++) {
-        out[i % len] ^= cid[i];
-    }
-#endif
-}

--- a/tests/unittests/tests-luid/Makefile
+++ b/tests/unittests/tests-luid/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-luid/Makefile.include
+++ b/tests/unittests/tests-luid/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += luid

--- a/tests/unittests/tests-luid/tests-luid.c
+++ b/tests/unittests/tests-luid/tests-luid.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <luid.h>
+
+#include "tests-luid.h"
+
+static void test_luid_uniqe_eui64(void)
+{
+    eui64_t mac[3];
+
+    luid_get_eui64(&mac[0]);
+    luid_get_eui64(&mac[1]);
+    luid_get_eui64(&mac[2]);
+    TEST_ASSERT_EQUAL_INT(0, !memcmp(&mac[0], &mac[1], sizeof(mac[0])));
+    TEST_ASSERT_EQUAL_INT(0, !memcmp(&mac[1], &mac[2], sizeof(mac[1])));
+}
+
+static void test_luid_uniqe_eui48(void)
+{
+    eui48_t mac[3];
+
+    luid_get_eui48(&mac[0]);
+    luid_get_eui48(&mac[1]);
+    luid_get_eui48(&mac[2]);
+    TEST_ASSERT_EQUAL_INT(0, !memcmp(&mac[0], &mac[1], sizeof(mac[0])));
+    TEST_ASSERT_EQUAL_INT(0, !memcmp(&mac[1], &mac[2], sizeof(mac[1])));
+}
+
+static void test_luid_custom(void)
+{
+    uint8_t a[2][8];
+    uint8_t b[2][8];
+
+    luid_custom(a[0], sizeof(a[0]), 0xfefe);
+    luid_custom(a[1], sizeof(a[1]), 0xfefe);
+    luid_custom(b[0], sizeof(b[0]), 0xbeef);
+    luid_custom(b[1], sizeof(b[1]), 0xbeef);
+
+    TEST_ASSERT_EQUAL_INT(0, !memcmp(a[0], b[0], sizeof(a[0])));
+    TEST_ASSERT_EQUAL_INT(0, !memcmp(a[1], b[1], sizeof(a[1])));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(a[0], a[0], sizeof(a[0])));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(b[1], b[1], sizeof(b[0])));
+}
+
+Test *tests_luid_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_luid_uniqe_eui48),
+        new_TestFixture(test_luid_uniqe_eui64),
+        new_TestFixture(test_luid_custom),
+    };
+
+    EMB_UNIT_TESTCALLER(luid_tests, NULL, NULL, fixtures);
+
+    return (Test *)&luid_tests;
+}
+
+void tests_luid(void)
+{
+    TESTS_RUN(tests_luid_tests());
+}

--- a/tests/unittests/tests-luid/tests-luid.h
+++ b/tests/unittests/tests-luid/tests-luid.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``luid`` module
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#ifndef TESTS_LUID_H
+#define TESTS_LUID_H
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_luid(void);
+
+/**
+ * @brief   Generates tests for luid
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_luid_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_LUID_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

The `luid_get()` function is used to generate a hardware address for networking interfaces.
For this, the lowest to bits of the first byte are always set to a defined value.
This is problematic as the current `luid_get()` implementation will only increment the first byte, resulting in a different address on every third invocation only:

```
0: d2 ae 0c 1b 20 54 05 8f 
1: d2 ae 0c 1b 20 54 05 8f 
2: d2 ae 0c 1b 20 54 05 8f 
3: d6 ae 0c 1b 20 54 05 8f 
4: d6 ae 0c 1b 20 54 05 8f 
5: d6 ae 0c 1b 20 54 05 8f 
6: d6 ae 0c 1b 20 54 05 8f 
7: da ae 0c 1b 20 54 05 8f 
8: da ae 0c 1b 20 54 05 8f 
9: da ae 0c 1b 20 54 05 8f 
```

To fix this and not duplicate the EUI48/64 generation logic in every driver, add dedicated functions for that use-case.

```
0: 06 13 23 23 06 13 23 22 
1: 06 13 23 23 06 13 23 21 
2: 06 13 23 23 06 13 23 20 
3: 06 13 23 23 06 13 23 27 
4: 06 13 23 23 06 13 23 26 
5: 06 13 23 23 06 13 23 25 
6: 06 13 23 23 06 13 23 24 
7: 06 13 23 23 06 13 23 2b 
8: 06 13 23 23 06 13 23 2a 
9: 06 13 23 23 06 13 23 29 
```

@herjulf wanted to source the MAC address from an EUI64MAC chip if no CPU id is present.
With this PR this is possible by implementing a custom `size_t luid_get_eui64_custom(eui64_t *addr, uint8_t idx)` function.

This also adds a unit test to ensure that two calls to `luid_get_eui64_custom()` have different results and two calls to `luid_custom()` have the same result if the same generator is used.

### Testing procedure
Run `make -C tests/unittests tests-luid`.

~~Also make sure that unique hardware addresses for network interfaces are still generated.~~
Drivers are not yet converted to the new API.

### Issues/PRs references
came up in #12537