### PR TITLE
gnrc_sixlowpan_frag_rb: allow for deletion timer after completion

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -98,6 +98,21 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Deletion timer for reassembly buffer entries in microseconds
+ *
+ * @note    Only applicable with
+ *          [gnrc_sixlowpan_frag_rb](@ref net_gnrc_sixlowpan_frag_rb) module
+ *
+ * Time to pass between completion of a datagram and the deletion of its
+ * reassembly buffer entry. If this value is 0, the entry is dropped
+ * immediately. Use this value to prevent re-creation of a reassembly buffer
+ * entry on late arriving link-layer duplicates.
+ */
+#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER
+#define GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER              (0U)
+#endif
+
+/**
  * @brief   Registration lifetime in minutes for the address registration option
  *
  * This value should be adapted to the devices power-lifecycle so that it is

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -21,6 +21,7 @@
 #include "net/ipv6/hdr.h"
 #include "net/gnrc.h"
 #include "net/gnrc/sixlowpan.h"
+#include "net/gnrc/sixlowpan/config.h"
 #ifdef  MODULE_GNRC_SIXLOWPAN_FRAG_VRB
 #include "net/gnrc/sixlowpan/frag/vrb.h"
 #endif  /* MODULE_GNRC_SIXLOWPAN_FRAG_VRB */
@@ -360,6 +361,18 @@ static bool _rbuf_update_ints(gnrc_sixlowpan_frag_rb_base_t *entry,
     return true;
 }
 
+static void _gc_pkt(gnrc_sixlowpan_frag_rb_t *rbuf)
+{
+#if GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0
+    if (rbuf->super.current_size == 0) {
+        /* packet is scheduled for deletion, but was complete, i.e. pkt is
+         * already handed up to other layer, i.e. no need to release */
+        return;
+    }
+#endif
+    gnrc_pktbuf_release(rbuf->pkt);
+}
+
 void gnrc_sixlowpan_frag_rb_gc(void)
 {
     uint32_t now_usec = xtimer_now_usec();
@@ -380,7 +393,7 @@ void gnrc_sixlowpan_frag_rb_gc(void)
                                          l2addr_str),
                   (unsigned)rbuf[i].super.datagram_size, rbuf[i].super.tag);
 
-            gnrc_pktbuf_release(rbuf[i].pkt);
+            _gc_pkt(&rbuf[i]);
             gnrc_sixlowpan_frag_rb_remove(&(rbuf[i]));
         }
     }
@@ -419,6 +432,14 @@ static int _rbuf_get(const void *src, size_t src_len,
                                          rbuf[i].super.dst_len,
                                          l2addr_str),
                   (unsigned)rbuf[i].super.datagram_size, rbuf[i].super.tag);
+#if GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0
+            if (rbuf[i].super.current_size == 0) {
+                /* ensure that only empty reassembly buffer entries and entries
+                 * scheduled for deletion have `current_size == 0` */
+                DEBUG("6lo rfrag: scheduled for deletion, don't add fragment\n");
+                return -1;
+            }
+#endif
             rbuf[i].super.arrival = now_usec;
             _set_rbuf_timeout();
             return i;
@@ -514,7 +535,7 @@ void gnrc_sixlowpan_frag_rb_reset(void)
     for (unsigned int i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         if ((rbuf[i].pkt != NULL) &&
             (rbuf[i].pkt->users > 0)) {
-            gnrc_pktbuf_release(rbuf[i].pkt);
+            _gc_pkt(&rbuf[i]);
         }
     }
     memset(rbuf, 0, sizeof(rbuf));
@@ -539,6 +560,25 @@ void gnrc_sixlowpan_frag_rb_base_rm(gnrc_sixlowpan_frag_rb_base_t *entry)
     entry->datagram_size = 0;
 }
 
+static void _tmp_rm(gnrc_sixlowpan_frag_rb_t *rbuf)
+{
+#if GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0U
+        /* use garbage-collection to leave the entry for at least
+         * GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER in the reassembly buffer by
+         * setting the arrival time to
+         * (GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US - GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER)
+         * microseconds in the past */
+        rbuf->super.arrival = xtimer_now_usec() -
+                              (GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US -
+                               GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER);
+        /* reset current size to prevent late duplicates to trigger another
+         * dispatch */
+        rbuf->super.current_size = 0;
+#else   /* GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER == 0U */
+        gnrc_sixlowpan_frag_rb_remove(rbuf);
+#endif  /* GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER */
+}
+
 int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,
                                                    gnrc_netif_hdr_t *netif_hdr)
 {
@@ -555,7 +595,7 @@ int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf
         if (netif == NULL) {
             DEBUG("6lo rbuf: error allocating netif header\n");
             gnrc_pktbuf_release(rbuf->pkt);
-            gnrc_sixlowpan_frag_rb_remove(rbuf);
+            _tmp_rm(rbuf);
             return -1;
         }
 
@@ -570,7 +610,7 @@ int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf
         new_netif_hdr->rssi = netif_hdr->rssi;
         LL_APPEND(rbuf->pkt, netif);
         gnrc_sixlowpan_dispatch_recv(rbuf->pkt, NULL, 0);
-        gnrc_sixlowpan_frag_rb_remove(rbuf);
+        _tmp_rm(rbuf);
     }
     return res;
 }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -116,7 +116,7 @@ static int _check_fragments(gnrc_sixlowpan_frag_rb_base_t *entry,
         }
         /* End was already checked in overlap check */
         if (ptr->start == offset) {
-            DEBUG("6lo rbuf: fragment already in reassembly buffer");
+            DEBUG("6lo rbuf: fragment already in reassembly buffer\n");
             return RBUF_ADD_DUPLICATE;
         }
         ptr = ptr->next;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This allows to set a timer between the completion of a datagram in the reassembly buffer and the deletion of the corresponding reassembly buffer entry. This allows to ignore potentially late incoming link-layer duplicates of fragments of the datagram that then will have the reassembly buffer entry be blocked.

This was noted in this [discussion] for classic 6LoWPAN reassembly (and minimal fragment forwarding) and is recommended in the current [selective fragment recovery draft][SFR draft].

[discussion]: https://mailarchive.ietf.org/arch/msg/6lo/Ez0tzZDqawVn6AFhYzAFWUOtJns
[SFR draft]: https://tools.ietf.org/html/draft-ietf-6lo-fragment-recovery-07#section-6

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
There is no significant performance decrease with (`USEMODULE=gnrc_pktbuf_cmd BOARD=samr21-xpro CFLAGS="-DGNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER=10000" SERIAL=ATML2127031800004989 make -C examples/gnrc_networking flash -j16`) or without (`USEMODULE=gnrc_pktbuf_cmd BOARD=samr21-xpro make -C examples/gnrc_networking flash -j16`) this feature. The packet buffer is empty after a short while with this feature.

With:
```
2019-10-28 15:16:41,541 #  ping6 -s 145 -c 100 -i 100 fe80::7b64:154:15dc:ab2a
[…]
2019-10-28 15:16:51,494 # 
2019-10-28 15:16:51,498 # --- fe80::7b64:154:15dc:ab2a PING statistics ---
2019-10-28 15:16:51,504 # 100 packets transmitted, 100 packets received, 0% packet loss
2019-10-28 15:16:51,508 # round-trip min/avg/max = 21.972/25.837/31.137 ms
> pktbuf
2019-10-28 15:17:11,018 #  pktbuf
2019-10-28 15:17:11,025 # packet buffer: first byte: 0x20001998, last byte: 0x20003198 (size: 6144)
2019-10-28 15:17:11,028 #   position of last byte used: 696
2019-10-28 15:17:11,032 # ~ unused: 0x20001998 (next: (nil), size: 6144)
```

Without:

```
2019-10-28 15:12:44,432 #  ping6 -s 145 -i 100 -c 100 fe80::7b64:154:15dc:ab2a
[…]
2019-10-28 15:12:54,383 # 
2019-10-28 15:12:54,387 # --- fe80::7b64:154:15dc:ab2a PING statistics ---
2019-10-28 15:12:54,392 # 100 packets transmitted, 100 packets received, 0% packet loss
2019-10-28 15:12:54,397 # round-trip min/avg/max = 21.890/25.743/33.191 ms
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
