### PR TITLE
gnrc_nettest: add deprecation note

### DIFF
--- a/sys/include/net/gnrc/nettest.h
+++ b/sys/include/net/gnrc/nettest.h
@@ -11,6 +11,10 @@
  * @ingroup     net_gnrc_netapi
  * @brief       This provides a framework to test the @ref net_gnrc_netapi IPC
  *              calls.
+ *
+ * @deprecated  This module was intended to be a test framework for GNRC but
+ *              it never got used. It has not been maintained for 3 years.
+ *              It will be removed after the 2020.07 release at the latest.
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
As discussed offline with @miri64 ,this module was intended to be a test framework for GNRC but it never
really got used. It was not maintained for 3 years. 
I'm adding a deprecation note to remove it after 2020.07 release.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make doc`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
