### PR TITLE
sys/net/sock_util: fix dead initialization warning

### DIFF
--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -151,7 +151,7 @@ int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str)
 {
     unsigned brackets_flag;
     char *hoststart = (char*)str;
-    char *hostend = hoststart;
+    char *hostend;
 
     char hostbuf[SOCK_HOSTPORT_MAXLEN];
 


### PR DESCRIPTION
This was reported by LLVM scan build. The value assigned at initialization is never used, so could be removed

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a variable dead initialization, reported when using LLVM scan-build. The value assigned during initialization is never used after, because the variable gets another value reassigned before it's actually used.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run `TOOLCHAIN=llvm make -C examples/suit_update scan-build`
  on master, there's a warning (among others) about a dead initialization in sock_util.c. With this PR, the warning is gone. 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #11852

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
