### PR TITLE
sys/luid: Added postcondition to luid_get()

### DIFF
--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -75,6 +75,8 @@ extern "C" {
  * byte.
  *
  * @note    The resulting LUID will repeat after 255 calls.
+ * @post    The generated LUID must be used unchanged, as it could collide with
+ *          other LUIDs if altered.
  *
  * @param[out] buf      memory location to copy the LUID into. MUST be able to
  *                      hold at least @p len bytes


### PR DESCRIPTION
### Contribution description

Stated the obvious in the doc: Altering the LUID returned by `luid_get()` breaks the guarantee that it is locally unique, as it than could collide with other LUIDs returned by `luid_get()`.

### Testing procedure

Read the new documentation and verify its correctness.

### Issues/PRs references

Related to https://github.com/RIOT-OS/RIOT/pull/12600, https://github.com/RIOT-OS/RIOT/pull/12592. Incorrect users of this API have been identified by @benpicco in https://github.com/RIOT-OS/RIOT/pull/12592