### PR TITLE
drivers/at86rf2xx: Updated address API

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -106,8 +106,8 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     addr_long.uint8[0] &= ~(0x01);
     addr_long.uint8[0] |=  (0x02);
     /* set short and long address */
-    at86rf2xx_set_addr_long(dev, ntohll(addr_long.uint64.u64));
-    at86rf2xx_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
+    at86rf2xx_set_addr_long(dev, &addr_long);
+    at86rf2xx_set_addr_short(dev, &addr_long.uint16[ARRAY_SIZE(addr_long.uint16) - 1]);
 
     /* set default channel */
     at86rf2xx_set_chan(dev, AT86RF2XX_DEFAULT_CHANNEL);

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -469,13 +469,13 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
     switch (opt) {
         case NETOPT_ADDRESS:
-            assert(len <= sizeof(uint16_t));
-            at86rf2xx_set_addr_short(dev, *((const uint16_t *)val));
+            assert(len >= sizeof(network_uint16_t));
+            at86rf2xx_set_addr_short(dev, val);
             /* don't set res to set netdev_ieee802154_t::short_addr */
             break;
         case NETOPT_ADDRESS_LONG:
-            assert(len <= sizeof(uint64_t));
-            at86rf2xx_set_addr_long(dev, *((const uint64_t *)val));
+            assert(len >= sizeof(eui64_t));
+            at86rf2xx_set_addr_long(dev, val);
             /* don't set res to set netdev_ieee802154_t::long_addr */
             break;
         case NETOPT_NID:

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -282,11 +282,12 @@ void at86rf2xx_reset(at86rf2xx_t *dev);
 /**
  * @brief   Get the short address of the given device
  *
- * @param[in] dev           device to read from
+ * @param[in]   dev         device to read from
+ * @param[out]  addr        the short address will be stored here
  *
  * @return                  the currently set (2-byte) short address
  */
-uint16_t at86rf2xx_get_addr_short(const at86rf2xx_t *dev);
+void at86rf2xx_get_addr_short(const at86rf2xx_t *dev, network_uint16_t *addr);
 
 /**
  * @brief   Set the short address of the given device
@@ -294,16 +295,17 @@ uint16_t at86rf2xx_get_addr_short(const at86rf2xx_t *dev);
  * @param[in,out] dev       device to write to
  * @param[in] addr          (2-byte) short address to set
  */
-void at86rf2xx_set_addr_short(at86rf2xx_t *dev, uint16_t addr);
+void at86rf2xx_set_addr_short(at86rf2xx_t *dev, const network_uint16_t *addr);
 
 /**
  * @brief   Get the configured long address of the given device
  *
- * @param[in] dev           device to read from
+ * @param[in]   dev         device to read from
+ * @param[out]  addr        the long address will be stored here
  *
  * @return                  the currently set (8-byte) long address
  */
-uint64_t at86rf2xx_get_addr_long(const at86rf2xx_t *dev);
+void at86rf2xx_get_addr_long(const at86rf2xx_t *dev, eui64_t *addr);
 
 /**
  * @brief   Set the long address of the given device
@@ -311,7 +313,7 @@ uint64_t at86rf2xx_get_addr_long(const at86rf2xx_t *dev);
  * @param[in,out] dev       device to write to
  * @param[in] addr          (8-byte) long address to set
  */
-void at86rf2xx_set_addr_long(at86rf2xx_t *dev, uint64_t addr);
+void at86rf2xx_set_addr_long(at86rf2xx_t *dev, const eui64_t *addr);
 
 /**
  * @brief   Get the configured channel number of the given device


### PR DESCRIPTION
### Contribution description

Changed the address getter and setter functions to avoid byte order confusion. In addition, passing the value via pointer reduces the ROM size a bit on ARM and quite significantly on AVR.

```
BOARD=microduino-corerf make -C examples/gnrc_minimal
   text    data     bss     dec     hex filename
  45590     426    3354   49370    c0da Current master
  45400     426    3354   49180    c01c This PR
```

```
USEMODULE=at86rf233 BOARD=nucleo-f446re make -C examples/gnrc_networking
   text    data     bss     dec     hex filename
  89328     196   18756  108280   1a6f8
  89264     196   18756  108216   1a6b8 This PR
```

### Testing procedure

E.g. `ping6` on a board equipped with an at86rf2xx transceiver should still work.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/12600, as this turned out surprisingly complex. (Or I turned out surprisingly incapable of getting this right...)