### PR TITLE
boards/microduino-corerf: Minor doc tweaks

### DIFF
--- a/boards/microduino-corerf/doc.txt
+++ b/boards/microduino-corerf/doc.txt
@@ -8,31 +8,36 @@
 
 ![corerf-pinout](https://wiki.microduinoinc.com/images/d/df/RF%E5%BC%95%E8%84%9A.jpg)
 
-Warning: Unlike on other ATmega MCUs, the GPIOs are not 5V tolerant.
+@warning    Unlike on other ATmega MCUs, the GPIOs are not 5V tolerant.
+
+@note       The 5V pin cannot be used to power the board, as the board is not
+            equipped with an voltage regulator. The pin is therefore not
+            connected. But it can be used to pass 5V to shields, if connected
+            to a 5V supply voltage.
 
 ## Board
 The board is just a breakout for the ATmega128RFA1 MCU.
 
 ## MCU Details
-| MCU            | ATmega128RFA1             |
-|:------------- -|:--------------------------|
-| Family         | ATmega                    |
-| Vendor         | Atmel                     |
-| Package        | QFN/MLF                   |
-| SRAM           | 16K                       |
-| Flash          | 128K                      |
-| EEPROM         | 4K                        |
-| Core Frequency | 8MHz (16MHz no power save mode) |
-| Oscillators    | 32.768 kHz & 16 MHz       |
-| Timerr         | 6 ( 2x8bit & 4x16bit )    |
-|Analog Comparator| 1                        |
-| ADCs           | 1x 15 channel 6 to 12-bit |
-| USARTs         | 2                         |
-| SPIs           | 3 (1 SPI & 2 USART SPI)   |
-| I2Cs           | 1 (called TWI)            |
-| Vcc            | 1.8V - 3.6V               |
-| Datasheet / Reference Manual | [Datasheet and Reference Manual](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8266-MCU_Wireless-ATmega128RFA1_Datasheet.pdf) |
-| Board Manual   | [Wiki Page](https://wiki.microduinoinc.com/Microduino-Module_CoreRF) |
+| MCU                           | ATmega128RFA1                     |
+|:------------------------------|:----------------------------------|
+| Family                        | ATmega                            |
+| Vendor                        | Atmel                             |
+| Package                       | QFN/MLF                           |
+| SRAM                          | 16KiB                             |
+| Flash                         | 128KiB                            |
+| EEPROM                        | 4KiB                              |
+| Core Frequency                | 8MHz (16MHz no power save mode)   |
+| Oscillators                   | 32.768 kHz & 16 MHz               |
+| Timer                         | 6 ( 2x8bit & 4x16bit )            |
+| Analog Comparator             | 1                                 |
+| ADCs                          | 1x 15 channel 6 to 12-bit         |
+| USARTs                        | 2                                 |
+| SPIs                          | 3 (1 SPI & 2 USART SPI)           |
+| I2Cs                          | 1 (called TWI)                    |
+| Vcc                           | 1.8V - 3.6V                       |
+| Datasheet / Reference Manual  | [Datasheet and Reference Manual](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8266-MCU_Wireless-ATmega128RFA1_Datasheet.pdf) |
+| Board Manual                  | [Wiki Page](https://wiki.microduinoinc.com/Microduino-Module_CoreRF) |
 
 The MCU comes with a 2.4 GHz IEEE 802.15.4 radio that is compatible with the
 Atmel AT86RF23x line of transceivers with the only difference being that it is


### PR DESCRIPTION
### Contribution description

- Using @warning Doxygen command to make warning more visible
- Used IEC units for size specifications
- Aligned markdown source of the table
- Added note that the 5V pin is not connected to the board and cannot be used to power the board

### Testing procedure

Run `make doc` and check the generated page

### Issues/PRs references

None