### PR TITLE
cpu/atmega_common: Use RC calibr byte in CPU_ID

### DIFF
--- a/cpu/atmega128rfa1/include/periph_cpu.h
+++ b/cpu/atmega128rfa1/include/periph_cpu.h
@@ -31,7 +31,7 @@ extern "C" {
  * @name   Length of the CPU_ID in octets
  * @{
  */
-#define CPUID_LEN           (8U)
+#define CPUID_LEN           (9U)
 /** @} */
 
 /**

--- a/cpu/atmega256rfr2/include/periph_cpu.h
+++ b/cpu/atmega256rfr2/include/periph_cpu.h
@@ -31,7 +31,7 @@ extern "C" {
  * @name   Length of the CPU_ID in octets
  * @{
  */
-#define CPUID_LEN           (8U)
+#define CPUID_LEN           (9U)
 /** @} */
 
 /**

--- a/cpu/atmega_common/periph/cpuid.c
+++ b/cpu/atmega_common/periph/cpuid.c
@@ -50,6 +50,7 @@ void cpuid_get(void *id)
 
     uint8_t  usr_sign_0 = boot_signature_byte_get(0x0100);
     uint8_t  usr_sign_1 = boot_signature_byte_get(0x0102);
+    uint8_t  int_rc_cal = boot_signature_byte_get(0x01);
 
     uint8_t addr[CPUID_LEN] = {
             signature_0,        /* 0x1E Atmel manufacturer ID */
@@ -61,6 +62,7 @@ void cpuid_get(void *id)
 /* last two bytes can be set to flash page 1. for differentiation of different boards */
             usr_sign_0,         /* user signature 0 */
             usr_sign_1,         /* user signature 1 */
+            int_rc_cal,         /* internal RC calibration byte */
     };
 
     memcpy(id, addr, CPUID_LEN);


### PR DESCRIPTION
### Contribution description

Added the calibration byte for the internal RC oscillator to the CPU ID. That way typical hobbyists with no access to JTAG adapters or high voltage programmer capable of writing the user signature have a good chance that the CPU IDs of their device do not collide.

### Testing procedure

Build, flash and run `tests/periph_cpuid` on the Microduino CoreRF

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/12578