### PR TITLE
periph/gpio: add gpio_init_low() / gpio_init_high() helper functions

### DIFF
--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -236,6 +236,9 @@ void gpio_irq_disable(gpio_t pin);
 /**
  * @brief   Get the current value of the given pin
  *
+ * @pre     The given pin has been configured as Input using
+ *          @see gpio_init, @see gpio_init_high or @see gpio_init_low
+ *
  * @param[in] pin       the pin to read
  *
  * @return              0 when pin is LOW
@@ -246,12 +249,18 @@ int gpio_read(gpio_t pin);
 /**
  * @brief   Set the given pin to HIGH
  *
+ * @pre     The given pin has been configured as Output using
+ *          @see gpio_init, @see gpio_init_high or @see gpio_init_low
+ *
  * @param[in] pin       the pin to set
  */
 void gpio_set(gpio_t pin);
 
 /**
  * @brief   Set the given pin to LOW
+ *
+ * @pre     The given pin has been configured as Output using
+ *          @see gpio_init, @see gpio_init_high or @see gpio_init_low
  *
  * @param[in] pin       the pin to clear
  */
@@ -260,12 +269,18 @@ void gpio_clear(gpio_t pin);
 /**
  * @brief   Toggle the value of the given pin
  *
+ * @pre     The given pin has been configured as Output using
+ *          @see gpio_init, @see gpio_init_high or @see gpio_init_low
+ *
  * @param[in] pin       the pin to toggle
  */
 void gpio_toggle(gpio_t pin);
 
 /**
  * @brief   Set the given pin to the given value
+ *
+ * @pre     The given pin has been configured as Output using
+ *          @see gpio_init, @see gpio_init_high or @see gpio_init_low
  *
  * @param[in] pin       the pin to set
  * @param[in] value     value to set the pin to, 0 for LOW, HIGH otherwise

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -165,6 +165,28 @@ typedef struct {
  */
 int gpio_init(gpio_t pin, gpio_mode_t mode);
 
+/**
+ * @brief   Initialize the given pin as general purpose output with a low level.
+ *
+ * @param[in] pin       pin to initialize
+ * @param[in] mode      mode of the pin, see @c gpio_mode_t
+ *
+ * @return              0 on success
+ * @return              -1 on error
+ */
+int gpio_init_low(gpio_t pin, gpio_mode_t mode);
+
+/**
+ * @brief   Initialize the given pin as general purpose output with a high level.
+ *
+ * @param[in] pin       pin to initialize
+ * @param[in] mode      mode of the pin, see @c gpio_mode_t
+ *
+ * @return              0 on success
+ * @return              -1 on error
+ */
+int gpio_init_high(gpio_t pin, gpio_mode_t mode);
+
 #if defined(MODULE_PERIPH_GPIO_IRQ) || defined(DOXYGEN)
 /**
  * @brief   Initialize a GPIO pin for external interrupt usage

--- a/drivers/periph_common/gpio.c
+++ b/drivers/periph_common/gpio.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_periph_gpio
+ * @{
+ *
+ * @file        gpio.c
+ * @brief       Fallback Implementations for platform specific GPIO routines.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <assert.h>
+#include "periph/gpio.h"
+
+__attribute__((weak))
+int gpio_init_low(gpio_t pin, gpio_mode_t mode)
+{
+    assert(mode != GPIO_IN);
+    assert(mode != GPIO_IN_PD);
+    assert(mode != GPIO_IN_PU);
+
+    if (gpio_init(pin, mode)) {
+        return -1;
+    }
+
+    gpio_clear(pin);
+    return 0;
+}
+
+__attribute__((weak))
+int gpio_init_high(gpio_t pin, gpio_mode_t mode)
+{
+    assert(mode != GPIO_IN);
+    assert(mode != GPIO_IN_PD);
+    assert(mode != GPIO_IN_PU);
+
+    if (gpio_init(pin, mode)) {
+        return -1;
+    }
+
+    gpio_set(pin);
+    return 0;
+}

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014,2017 Freie Universität Berlin
+ * Copyright (C) 2014,2017,2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -14,12 +14,14 @@
  * @brief       Test application for GPIO peripheral drivers
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
  *
  * @}
  */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include "irq.h"
 #include "shell.h"
@@ -37,18 +39,45 @@ static void cb(void *arg)
 
 static int init_pin(int argc, char **argv, gpio_mode_t mode)
 {
-    int po, pi;
+    int port, pin;
 
     if (argc < 3) {
         printf("usage: %s <port> <pin>\n", argv[0]);
         return 1;
     }
 
-    po = atoi(argv[1]);
-    pi = atoi(argv[2]);
+    port = atoi(argv[1]);
+    pin  = atoi(argv[2]);
 
-    if (gpio_init(GPIO_PIN(po, pi), mode) < 0) {
-        printf("Error to initialize GPIO_PIN(%i, %02i)\n", po, pi);
+    if (gpio_init(GPIO_PIN(port, pin), mode)) {
+        printf("Error to initialize GPIO_PIN(%i, %02i)\n", port, pin);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int init_pin_hl(int argc, char **argv, bool high)
+{
+    int port, pin, res;
+
+    if (argc < 3) {
+        printf("usage: %s <port> <pin>\n", argv[0]);
+        return 1;
+    }
+
+    port = atoi(argv[1]);
+    pin  = atoi(argv[2]);
+
+    if (high) {
+        res = gpio_init_high(GPIO_PIN(port, pin), GPIO_OUT);
+    }
+    else {
+        res = gpio_init_low(GPIO_PIN(port, pin), GPIO_OUT);
+    }
+
+    if (res) {
+        printf("Error to initialize GPIO_PIN(%i, %02i)\n", port, pin);
         return 1;
     }
 
@@ -58,6 +87,16 @@ static int init_pin(int argc, char **argv, gpio_mode_t mode)
 static int init_out(int argc, char **argv)
 {
     return init_pin(argc, argv, GPIO_OUT);
+}
+
+static int init_out_h(int argc, char **argv)
+{
+    return init_pin_hl(argc, argv, true);
+}
+
+static int init_out_l(int argc, char **argv)
+{
+    return init_pin_hl(argc, argv, false);
 }
 
 static int init_in(int argc, char **argv)
@@ -272,6 +311,8 @@ static int bench(int argc, char **argv)
 
 static const shell_command_t shell_commands[] = {
     { "init_out", "init as output (push-pull mode)", init_out },
+    { "init_out_h", "init as output (push-pull mode, high after init)", init_out_h },
+    { "init_out_l", "init as output (push-pull mode, low after init)", init_out_l },
     { "init_in", "init as input w/o pull resistor", init_in },
     { "init_in_pu", "init as input with pull-up", init_in_pu },
     { "init_in_pd", "init as input with pull-down", init_in_pd },


### PR DESCRIPTION
### Contribution description
Provide a way to init a GPIO as output with a set level.
Some platforms can to this on init already and will always just set
the GPIO to LOW which can be undesireable.

For all other platforms, provide a fall-back implementation.

The functions are also convenient when de-initializing a previously
otherwise configured Pin, e.g. when disconnecting the power on an external
sensor through a transistor and wanting to avoid current leaking through a
high idle UART TX line.

### Testing procedure

The code is trivial, but you can check check that a pin is really HIGH after calling `gpio_init_high(GPIO_PIN(0,1));` 

### Issues/PRs references
Provides a clean solution for #12380