### PR TITLE
cpu/samd21: use dedicated 1kHz GCLK4 for RTC and WDT

### DIFF
--- a/cpu/sam0_common/periph/rtc.c
+++ b/cpu/sam0_common/periph/rtc.c
@@ -65,10 +65,8 @@ static inline void _rtc_set_enabled(bool on)
 #ifdef CPU_SAMD21
 static void _rtc_clock_setup(void)
 {
-    /* Setup clock GCLK2 with OSC32K divided by 32 */
-    GCLK->GENDIV.reg = GCLK_GENDIV_ID(2) | GCLK_GENDIV_DIV(4);
-    GCLK->GENCTRL.bit.DIVSEL = 1;
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(2) | GCLK_CLKCTRL_ID_RTC;
+    /* Use 1024 Hz GCLK4 */
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(4) | GCLK_CLKCTRL_ID_RTC;
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 }
 #else

--- a/cpu/sam0_common/periph/wdt.c
+++ b/cpu/sam0_common/periph/wdt.c
@@ -83,18 +83,9 @@ static uint32_t ms_to_per(uint32_t ms)
 #ifdef CPU_SAMD21
 static void _wdt_clock_setup(void)
 {
-/* RTC / RTT will alredy set up GCLK2 as needed */
-#if !defined(MODULE_PERIPH_RTC) && !defined(MODULE_PERIPH_RTT)
-    /* Setup clock GCLK2 with OSCULP32K divided by 32 */
-    GCLK->GENDIV.reg  = GCLK_GENDIV_ID(2) | GCLK_GENDIV_DIV(4);
-    GCLK->GENCTRL.reg = GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K | GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_DIVSEL;
-
-    while (GCLK->STATUS.bit.SYNCBUSY) {}
-#endif
-
-    /* Connect to GCLK2 (~1.024 kHz) */
+    /* Connect to GCLK4 (~1.024 kHz) */
     GCLK->CLKCTRL.reg = GCLK_CLKCTRL_ID_WDT
-                      | GCLK_CLKCTRL_GEN_GCLK2
+                      | GCLK_CLKCTRL_GEN_GCLK4
                       | GCLK_CLKCTRL_CLKEN;
 }
 #else

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -188,7 +188,7 @@ static void clk_init(void)
     /* make sure we synchronize clock generator 0 before we go on */
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
-    /* Setup Clock generator 2 with divider 1 (32.768kHz) */
+    /* Setup GCLK2 with divider 1 (32.768kHz) */
     GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(2)  | GCLK_GENDIV_DIV(0));
     GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_GENEN
                       | GCLK_GENCTRL_RUNSTDBY
@@ -202,6 +202,16 @@ static void clk_init(void)
                          | SYSCTRL_XOSC32K_XTALEN
                          | SYSCTRL_XOSC32K_STARTUP(6)
                          | SYSCTRL_XOSC32K_ENABLE;
+#endif
+
+    /* Setup GCLK4 with divider 32 (1024 Hz) */
+    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(4)  | GCLK_GENDIV_DIV(4));
+    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(4) | GCLK_GENCTRL_GENEN
+                      | GCLK_GENCTRL_RUNSTDBY | GCLK_GENCTRL_DIVSEL
+#if GEN2_ULP32K
+                      | GCLK_GENCTRL_SRC_OSCULP32K);
+#else
+                      | GCLK_GENCTRL_SRC_XOSC32K);
 #endif
 
     /* redirect all peripherals to a disabled clock generator (7) by default */


### PR DESCRIPTION
### Contribution description
Having spend the last couple of days debugging a suspected race condition in my at86rf215 driver I have now found the unlikely culprit.
The issue was that interrupts were 'lost', but only when using our custom application, not with `examples/gnrc_networking` and only on samr21.

So what was happening?

It turns out using the `periph_rtc` will re-configure the 32 kHz GCLK2 to run at 1024 Hz to accommodate it's frequency requirements.

However, GCLK2 is also used to clock the EIC, which now operates much slower and will lose fast events.

To fix this, just dedicate a separate 1kHz clock to RTC and WTD - something @keestux had already suggested.

### Testing procedure

I checked that `tests/periph_wdt` and `tests/periph_rtc` still work on `samr21-xpro`.

### Issues/PRs references
required for #12128 to work on samd21 together with `periph_rtc`, but other breakage is expected.
