### PR TITLE
atmega_common: provide CPU ID for every device

### DIFF
--- a/cpu/atmega128rfa1/Makefile.features
+++ b/cpu/atmega128rfa1/Makefile.features
@@ -4,6 +4,3 @@ include $(RIOTCPU)/atmega_common/Makefile.features
 
 # additional PCINT for atmega128rfa1
 FEATURES_PROVIDED += atmega_pcint1
-
-# Various other features (if any)
-FEATURES_PROVIDED += periph_cpuid

--- a/cpu/atmega128rfa1/include/periph_cpu.h
+++ b/cpu/atmega128rfa1/include/periph_cpu.h
@@ -28,13 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @name   Length of the CPU_ID in octets
- * @{
- */
-#define CPUID_LEN           (8U)
-/** @} */
-
-/**
  * @name   Available ports on the ATmega128rfa1 MCU
  * @{
  */

--- a/cpu/atmega256rfr2/Makefile.features
+++ b/cpu/atmega256rfr2/Makefile.features
@@ -4,6 +4,3 @@ include $(RIOTCPU)/atmega_common/Makefile.features
 
 # additional PCINT for atmega256rfr2
 FEATURES_PROVIDED += atmega_pcint1
-
-# Various other features (if any)
-FEATURES_PROVIDED += periph_cpuid

--- a/cpu/atmega256rfr2/include/periph_cpu.h
+++ b/cpu/atmega256rfr2/include/periph_cpu.h
@@ -28,13 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @name   Length of the CPU_ID in octets
- * @{
- */
-#define CPUID_LEN           (8U)
-/** @} */
-
-/**
  * @name   Available ports on the ATmega256rfr family
  * @{
  */

--- a/cpu/atmega_common/Makefile.features
+++ b/cpu/atmega_common/Makefile.features
@@ -4,4 +4,5 @@ FEATURES_PROVIDED += atmega_pcint0
 FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_wdt

--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -29,6 +29,13 @@
 extern "C" {
 #endif
 
+/**
+ * @name   Length of the CPU_ID in octets
+ * @{
+ */
+#define CPUID_LEN           (4U)
+/** @} */
+
 #ifndef DOXYGEN
 /**
  * @brief   Overwrite the default gpio_t type definition

--- a/cpu/atmega_common/periph/cpuid.c
+++ b/cpu/atmega_common/periph/cpuid.c
@@ -18,50 +18,14 @@
  *
  * @}
  */
-#include <stdio.h>
 #include <stdint.h>
-#include <string.h>
-
-#include "periph/cpuid.h"
-
-#include "atmega_regs_common.h"
 #include "avr/boot.h"
 
-#define ENABLE_DEBUG (0)
-#include "debug.h"
-
-/**
- * @brief CPU_ID build from MCU register
- *
- *  CPIUD is taken from MCU Control Register and Signature bytes.
- *  CPUID:  1e a8 02 1f 94 03 ff ff
- *  CPUID:  1e a8 02 1f 94 92 XX XX
- *  MEGA62/128/256_RFR2 [MANUAL] p.505
- *  MEGA62/128/256_RFR2 [MANUAL] p.138
- *  MEGA62/128/256_RFR2 [MANUAL] p.492
- *
- *  usr_sign_0/1 are configurable values on flash page 1.
- */
 void cpuid_get(void *id)
 {
-    uint8_t  signature_0 = boot_signature_byte_get(0x00);
-    uint8_t  signature_1 = boot_signature_byte_get(0x02);
-    uint8_t  signature_2 = boot_signature_byte_get(0x04);
-
-    uint8_t  usr_sign_0 = boot_signature_byte_get(0x0100);
-    uint8_t  usr_sign_1 = boot_signature_byte_get(0x0102);
-
-    uint8_t addr[CPUID_LEN] = {
-            signature_0,        /* 0x1E Atmel manufacturer ID */
-            signature_1,        /* 0xA8 Part Number high byte */
-            signature_2,        /* 0x02 Part Number low byte */
-            MAN_ID_0,           /* 0x1F Atmel JEDEC manufacturer ID */
-            PART_NUM,           /* 0x94 PART_NUM  Identification */
-            VERSION_NUM,        /* 0x02 VERSION_NUM  Identification */
-/* last two bytes can be set to flash page 1. for differentiation of different boards */
-            usr_sign_0,         /* user signature 0 */
-            usr_sign_1,         /* user signature 1 */
-    };
-
-    memcpy(id, addr, CPUID_LEN);
+    uint8_t *out = id;
+    out[0] = boot_signature_byte_get(0x00);     /* Atmel manufacturer ID (0x1E) */
+    out[1] = boot_signature_byte_get(0x02);     /* Part Number high byte */
+    out[2] = boot_signature_byte_get(0x04);     /* Part Number low byte */
+    out[3] = boot_signature_byte_get(0x01);     /* internal RC calibration byte */
 }


### PR DESCRIPTION
### Contribution description

ATmega128RFA1/ATmega256RFR2 do not have a unique CPU ID, so relying on ID Macros specific to that family brings no benefit.

Use the RC oscillator callibration byte as an impromptu CPU ID and rely on bootlader constants present on all ATmega families for the remaining bytes.

This way we can provide a faux CPU ID on all ATmega MCUs and typical hobbyists
with no access to JTAG adapters or high voltage programmer capable of writing
the user signature have a good chance that the CPU IDs of their device do not collide.

### Testing procedure

Build, flash and run `tests/periph_cpuid` on any ATmega MCU.

#### arduino-mega2560
```CPUID: 0x1e 0x98 0x01 0xa3 0x1e 0x98```

#### microduino-corerf
```CPUID: 0x1e 0xa7 0x01 0xa8 0x1e 0xa7```

### Issues/PRs references
extension/alternative of #12609
