### PR TITLE
sys/riotboot: Fixed flashwrite_slotsize to return size of slot 1

### DIFF
--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -38,7 +38,7 @@ size_t riotboot_flashwrite_slotsize(const riotboot_flashwrite_t *state)
 {
     switch (state->target_slot) {
         case 0: return SLOT0_LEN;
-#if NUMOF_SLOTS==2
+#if NUM_SLOTS==2
         case 1: return SLOT1_LEN;
 #endif
         default: return 0;


### PR DESCRIPTION
# Contribution description

This PR fixes `riotboot_flashwrite_slotsize()`. The used pre-processor variable `NUMOF_SLOTS` is never defined. But `Makefile.inlcude` sets `NUM_SLOTS`.


### Testing procedure

Grab a board with `FEATURES_PROVIDED += riotboot` and flash this modified hello-world:

```diff
diff --git a/examples/hello-world/Makefile b/examples/hello-world/Makefile
index 258d8e9..c9862b2 100644
--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -7,6 +7,9 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+FEATURES_REQUIRED += riotboot
+USEMODULE += riotboot_flashwrite
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c..fca8e80 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdio.h>
+#include "riotboot/flashwrite.h"
 
 int main(void)
 {
@@ -28,5 +29,11 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    riotboot_flashwrite_t s0 = {.target_slot = 0};
+    riotboot_flashwrite_t s1 = {.target_slot = 1};
+    printf("Slot 0: %d     Slot 1: %d\n",
+           riotboot_flashwrite_slotsize(&s0),
+           riotboot_flashwrite_slotsize(&s1));
+
     return 0;
 }
```