### PR TITLE
luid: change last byte instead of first on `luid_get()` re-calls

### DIFF
--- a/sys/luid/luid.c
+++ b/sys/luid/luid.c
@@ -32,7 +32,7 @@ void luid_get(void *buf, size_t len)
 {
     luid_base(buf, len);
 
-    ((uint8_t *)buf)[0] ^= lastused++;
+    ((uint8_t *)buf)[len - 1] ^= lastused++;
 }
 
 void luid_custom(void *buf, size_t len, int gen)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
For the first byte bit 2 and 3 are changed when e.g. used as EUI-64 to make it a valid unicast EUI-64. So changing only the first byte on re-calls of `luid_get()` reduces the potential pool of non-duplicates for nodes with multiple interfaces.

The general doc btw already states as much:

https://github.com/RIOT-OS/RIOT/blob/85a392e5032436deba03959c4dceef0ffcc32a1a/sys/include/luid.h#L36-L37

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
A node with two network devices using the same address length and using `luid_get()` to generate the MAC address should differ in their last byte now, not the first.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to https://github.com/RIOT-OS/RIOT/pull/12592
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
