### PR TITLE
sock_async: fix compile-time errors

### DIFF
--- a/sys/include/net/sock/async.h
+++ b/sys/include/net/sock/async.h
@@ -23,27 +23,31 @@
 #ifndef NET_SOCK_ASYNC_H
 #define NET_SOCK_ASYNC_H
 
-#ifdef SOCK_DTLS
-#include "sock/dtls.h"
+#ifdef MODULE_SOCK_DTLS
+#include "net/sock/dtls.h"
 #endif
 
-#ifdef SOCK_IP
-#include "sock/ip.h"
+#ifdef MODULE_SOCK_IP
+#include "net/sock/ip.h"
 #endif
 
-#ifdef SOCK_TCP
-#include "sock/tcp.h"
+#ifdef MODULE_SOCK_TCP
+#include "net/sock/tcp.h"
 #endif
 
-#ifdef SOCK_UDP
-#include "sock/udp"
+#ifdef MODULE_SOCK_UDP
+#include "net/sock/udp.h"
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if SOCK_HAS_ASYNC || defined(DOXYGEN)
+#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+#ifdef SOCK_HAS_ASYNC_CTX
+#include "sock_async_ctx.h"     /* defines sock_async_ctx_t */
+#endif
+
 /**
  * @brief   Flag types to signify asynchronous sock events
  * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
@@ -57,11 +61,7 @@ typedef enum {
     SOCK_ASYNC_PATH_PROP = 0x0040,  /**< Path property changed event */
 } sock_async_flags_t;
 
-#if defined(SOCK_HAS_ASYNC) && defined(SOCK_HAS_ASYNC_CTX)
-#include "sock_async_ctx.h"     /* defines sock_async_ctx_t */
-#endif
-
-#if defined(SOCK_DTLS) || defined(DOXYGEN)
+#if defined(MODULE_SOCK_DTLS) || defined(DOXYGEN)
 /**
  * @brief   Event callback for @ref sock_dtls_t
  *
@@ -95,9 +95,9 @@ typedef void (*sock_dtls_cb_t)(sock_dtls_t *sock, sock_async_flags_t flags);
  * @param[in] cb    An event callback. May be NULL to unset event callback.
  */
 void sock_dtls_set_cb(sock_dtls_t *sock, sock_dtls_cb_t cb);
-#endif  /* defined(SOCK_DTLS) || defined(DOXYGEN) */
+#endif  /* defined(MODULE_SOCK_DTLS) || defined(DOXYGEN) */
 
-#if defined(SOCK_IP) || defined(DOXYGEN)
+#if defined(MODULE_SOCK_IP) || defined(DOXYGEN)
 /**
  * @brief   Event callback for @ref sock_ip_t
  *
@@ -128,9 +128,9 @@ typedef void (*sock_ip_cb_t)(sock_ip_t *sock, sock_async_flags_t flags);
  * @param[in] cb    An event callback. May be NULL to unset event callback.
  */
 void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb);
-#endif  /* defined(SOCK_IP) || defined(DOXYGEN) */
+#endif  /* defined(MODULE_SOCK_IP) || defined(DOXYGEN) */
 
-#if defined(SOCK_TCP) || defined(DOXYGEN)
+#if defined(MODULE_SOCK_TCP) || defined(DOXYGEN)
 /**
  * @brief   Event callback for @ref sock_tcp_t
  *
@@ -192,9 +192,9 @@ void sock_tcp_set_cb(sock_tcp_t *sock, sock_tcp_cb_t cb);
  * @param[in] cb    An event callback. May be NULL to unset event callback.
  */
 void sock_tcp_queue_set_cb(sock_tcp_queue_t *queue, sock_tcp_queue_cb_t cb);
-#endif  /* defined(SOCK_TCP) || defined(DOXYGEN) */
+#endif  /* defined(MODULE_SOCK_TCP) || defined(DOXYGEN) */
 
-#if defined(SOCK_UDP) || defined(DOXYGEN)
+#if defined(MODULE_SOCK_UDP) || defined(DOXYGEN)
 /**
  * @brief   Event callback for @ref sock_udp_t
  *
@@ -225,10 +225,10 @@ typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t type);
  * @param[in] cb    An event callback. May be NULL to unset event callback.
  */
 void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb);
-#endif  /* defined(SOCK_UDP) || defined(DOXYGEN) */
+#endif  /* defined(MODULE_SOCK_UDP) || defined(DOXYGEN) */
 
-#if SOCK_HAS_ASYNC_CTX || defined(DOXYGEN)
-#if defined(SOCK_DTLS) || defined(DOXYGEN)
+#if defined(SOCK_HAS_ASYNC_CTX) || defined(DOXYGEN)
+#if defined(MODULE_SOCK_DTLS) || defined(DOXYGEN)
 /**
  * @brief   Gets the asynchronous event context from sock object
  *
@@ -244,9 +244,9 @@ void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb);
  * @return  The asynchronous event context
  */
 sock_async_ctx_t *sock_dtls_get_async_ctx(sock_dtls_t *sock);
-#endif  /* defined(SOCK_DTLS) || defined(DOXYGEN) */
+#endif  /* defined(MODULE_SOCK_DTLS) || defined(DOXYGEN) */
 
-#if defined(SOCK_IP) || defined(DOXYGEN)
+#if defined(MODULE_SOCK_IP) || defined(DOXYGEN)
 /**
  * @brief   Gets the asynchronous event context from sock object
  *
@@ -262,9 +262,9 @@ sock_async_ctx_t *sock_dtls_get_async_ctx(sock_dtls_t *sock);
  * @return  The asynchronous event context
  */
 sock_async_ctx_t *sock_ip_get_async_ctx(sock_ip_t *sock);
-#endif  /* defined(SOCK_IP) || defined(DOXYGEN) */
+#endif  /* defined(MODULE_SOCK_IP) || defined(DOXYGEN) */
 
-#if defined(SOCK_TCP) || defined(DOXYGEN)
+#if defined(MODULE_SOCK_TCP) || defined(DOXYGEN)
 /**
  * @brief   Gets the asynchronous event context from sock object
  *
@@ -296,9 +296,9 @@ sock_async_ctx_t *sock_tcp_get_async_ctx(sock_tcp_t *sock);
  * @return  The asynchronous event context
  */
 sock_async_ctx_t *sock_tcp_queue_get_async_ctx(sock_tcp_queue_t *queue);
-#endif  /* defined(SOCK_TCP) || defined(DOXYGEN) */
+#endif  /* defined(MODULE_SOCK_TCP) || defined(DOXYGEN) */
 
-#if defined(SOCK_UDP) || defined(DOXYGEN)
+#if defined(MODULE_SOCK_UDP) || defined(DOXYGEN)
 /**
  * @brief   Gets the asynchronous event context from sock object
  *
@@ -314,8 +314,9 @@ sock_async_ctx_t *sock_tcp_queue_get_async_ctx(sock_tcp_queue_t *queue);
  * @return  The asynchronous event context
  */
 sock_async_ctx_t *sock_udp_get_async_ctx(sock_udp_t *sock);
-#endif  /* defined(SOCK_UDP) || defined(DOXYGEN) */
-#endif /* SOCK_HAS_ASYNC_CTX */
+#endif  /* defined(MODULE_SOCK_UDP) || defined(DOXYGEN) */
+#endif  /* defined(SOCK_HAS_ASYNC_CTX) || defined(DOXYGEN) */
+#endif  /* defined(SOCK_HAS_ASYNC) || defined(DOXYGEN) */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When trying to implement the backend for `sock_async` in GNRC, I found a bunch of compile-time issues in the header. I guess that's what happens if you just provide a header ^^"
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Still nothing to compile it with. I tried various versions using `-include`, but as you can see 

<details><summary>there are some problems when trying to do that</summary>

```
[mlenders@sarajevo RIOT]<3 CFLAGS="-include ${PWD}/sys/include/net/sock/async.h" RIOT_CI_BUILD=1 make -C examples/hello-world/
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".

   text	   data	    bss	    dec	    hex	filename
  23027	    568	  47716	  71311	  1168f	/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/bin/native/hello-world.elf
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world'
[mlenders@sarajevo RIOT]<3 CFLAGS="-include ${PWD}/sys/include/net/sock/async.h -DSOCK_HAS_ASYNC" RIOT_CI_BUILD=1 make -C examples/hello-world/
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".

/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h: Assembler messages:
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:55: Error: no such instruction: `typedef enum {'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:56: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:57: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:58: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:59: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:60: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:61: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:62: Error: junk at end of line, first unrecognized character is `}'
make[2]: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/Makefile.base:110: /home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/bin/native/cpu/tramp.o] Error 1
make[1]: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/Makefile.base:20: ALL--/home/mlenders/Repositories/RIOT-OS/RIOT/cpu/native] Error 2
make: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/../../Makefile.include:522: /home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/bin/native/application_hello-world.a] Error 2
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world'
[mlenders@sarajevo RIOT]<3 CFLAGS="-include ${PWD}/sys/include/net/sock/async.h -DSOCK_HAS_ASYNC" RIOT_CI_BUILD=1 USEMODULE=gnrc_udp make -C examples/hello-world/
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".

/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h: Assembler messages:
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:55: Error: no such instruction: `typedef enum {'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:56: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:57: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:58: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:59: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:60: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:61: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:62: Error: junk at end of line, first unrecognized character is `}'
make[2]: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/Makefile.base:110: /home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/bin/native/cpu/tramp.o] Error 1
make[1]: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/Makefile.base:20: ALL--/home/mlenders/Repositories/RIOT-OS/RIOT/cpu/native] Error 2
make: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/../../Makefile.include:522: /home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/bin/native/application_hello-world.a] Error 2
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world'
[mlenders@sarajevo RIOT]<3 CFLAGS="-include ${PWD}/sys/include/net/sock/async.h -DSOCK_HAS_ASYNC" RIOT_CI_BUILD=1 USEMODULE=gnrc_ip make -C examples/hello-world/
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".

/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h: Assembler messages:
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:55: Error: no such instruction: `typedef enum {'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:56: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:57: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:58: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:59: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:60: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:61: Error: junk at end of line, first unrecognized character is `,'
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/async.h:62: Error: junk at end of line, first unrecognized character is `}'
make[2]: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/Makefile.base:110: /home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/bin/native/cpu/tramp.o] Error 1
make[1]: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/Makefile.base:20: ALL--/home/mlenders/Repositories/RIOT-OS/RIOT/cpu/native] Error 2
make: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/../../Makefile.include:522: /home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world/bin/native/application_hello-world.a] Error 2
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/hello-world'
```

</details>

Edit after opening #12625: alternatively you can just try to compile #12625 with and without this change.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #11723.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
