### PR TITLE
core/kernel_defines: Introduce 'IS_ACTIVE' macro

### DIFF
--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -138,6 +138,84 @@
  */
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))
 
+/**
+ * @def         IS_ACTIVE(macro)
+ * @brief       Allows to verify a macro definition outside the preprocessor.
+ *
+ * @details     This macro is based on Linux's clever 'IS_BUILTIN'
+ *              (https://github.com/torvalds/linux/blob/master/include/linux/kconfig.h).
+ *              It takes a @p macro value that may be defined to 1 or not even
+ *              defined (e.g. FEATURE_FOO) and then expands it to an expression
+ *              that can be used in C code, either 1 or 0.
+ *
+ *              The advantage of using this is that the compiler sees all the
+ *              code, so checks can be performed, sections that would not be
+ *              executed are removed during optimization. For example:
+ * ```
+ * if (IS_ACTIVE(FEATURE_FOO)) {
+ *      do_something();
+ * }
+ * ```
+ * @param[in]   macro   Macro to evaluate
+ * @returns     1 if the macro is defined to 1
+ * @returns     0 if the macro is not defined, of if it is defined to something
+ *              else than 1.
+ *
+ * @note        This should only be used when macros are defined as 1, it will
+ *              not work if the macro value is, for example, (1) or 1U.
+ *
+ * @note        Although this may seem to work similarly to the preprocessor's
+ *              'defined', it is not entirely equal. If the given macro has
+ *              been defined with no value, this will expand to 0. Also note
+ *              that this is intended to be used with 'boolean' macros that act
+ *              as switches, and usually will be defined as 1 or not defined.
+ */
+#define IS_ACTIVE(macro) __is_active(macro)
+
+/**
+ * @def         IS_USED(module)
+ * @brief       Checks whether a module is being used or not. Can be used in C
+ *              conditionals.
+ *
+ * @param[in]   module   Module to check
+ * @returns     1 if the module is being used
+ * @returns     0 if the module is not being used
+ */
+#define IS_USED(module) IS_ACTIVE(module)
+
+/**
+ * @cond INTERNAL
+ */
+/* Here a prefix "__PREFIX_WHEN_" is added to the macro. So if it was a 1 we
+ * have "__PREFIX_WHEN_1", and if it was not defined we have "__PREFIX_WHEN_".
+ */
+#define __is_active(val)              ___is_active(__PREFIX_WHEN_##val)
+
+/* With this placeholder we turn the original value into two arguments when the
+ * original value was defined as 1 (note the comma).
+ */
+#define __PREFIX_WHEN_1 0,
+
+/* Here we add two extra arguments, that way the next macro can accept varargs.
+ *
+ * If the original macro was defined as 1, this will have three arguments
+ * (__take_second_arg(0, 1, 0, 0)), otherwise it will have two
+ * (__take_second_arg(__PREFIX_WHEN_ 1, 0, 0)). The third zero is there just to
+ * be compliant with C99, which states that when a function-like macro ends
+ * with ellipsis (...) it should be called with at least one argument for the
+ * variable list.
+ */
+#define ___is_active(arg1_or_junk)    __take_second_arg(arg1_or_junk 1, 0, 0)
+
+/* Finally, we just always take the second argument, which will be either 1
+ * (when three arguments are passed, i.e. macro was defined as 1) or 0 (when
+ * only two arguments are passed).
+ */
+#define __take_second_arg(__ignored, val, ...) val
+/**
+ * @endcond
+ */
+
 #ifdef __cplusplus
 }
 #endif

--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -1,6 +1,9 @@
 _ALLMODULES = $(sort $(USEMODULE) $(USEPKG))
 
 # Define MODULE_MODULE_NAME preprocessor macros for all modules.
+# Note: Some modules may be using the 'IS_USED' macro, defined in
+# kernel_defines.h, please refer to its documentation if you change the way
+# module macros are defined.
 ED = $(addprefix MODULE_,$(_ALLMODULES))
 # EXTDEFINES will be put in CFLAGS_WITH_MACROS
 EXTDEFINES = $(addprefix -D,$(call uppercase_and_underscore,$(ED)))


### PR DESCRIPTION
### Contribution description
This introduces the `IS_ACTIVE` macro to `kernel_defines.h`. It is based on [`IS_BUILTIN`](https://github.com/torvalds/linux/blob/master/include/linux/kconfig.h#L50) defined in Linux. The main idea behind it is to allow to check macro definitions directly in C expressions (i.e. not with preprocessor directives), even when the macro is not defined (e.g. `MODULE_<module>` macros, which will be defined to 1 when the module is used, but won't be defined when it is not).

The main advantage is that we can get rid of lots of `#ifdef` s in the code and use `if` statements instead, so the compiler can see this code and check for errors. If not used, the compiler will remove those blocks.

**EDIT**
#### Problem statement
- `#ifdef` logic is really [hard to follow](https://github.com/RIOT-OS/RIOT/blob/master/sys/ps/ps.c) most of times and hides the code from the tooling (e.g. cppcheck, coccinelle, IDEs) which prevents from checking syntax, types, symbol references, etc.

- This is adopted by different communities ([GNU](https://www.gnu.org/prep/standards/html_node/Conditional-Compilation.html), [Linux](https://01.org/linuxgraphics/gfx-docs/drm/process/coding-style.html#conditional-compilation)).

- [There is a tendency](https://github.com/RIOT-OS/RIOT/pull/9838#discussion_r213402924) towards using C conditionals where possible.
---

#### Example
**With the current approach**:
```C
/* this will be compiled with no errors */
#ifdef MODULE_NOT_USED
a+++;
do_something();
#endif
```
**Using this macro**:
```C
/* this fails to compile */
if (IS_ACTIVE(MODULE_NOT_USED)) {
   a+++;
   do_something();
}
```

### Testing procedure
1) **Try something like this patch to see the behaviour of the macro**:
```diff
diff --git a/examples/default/main.c b/examples/default/main.c
index 9d6542d0f..ecdcbd1c0 100644
--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "kernel_defines.h"
 #include "thread.h"
 #include "shell.h"
 #include "shell_commands.h"
@@ -36,12 +37,27 @@
 
 int main(void)
 {
+    int a = 0;
 #ifdef MODULE_NETIF
     gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                           gnrc_pktdump_pid);
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 #endif
 
+/* this error is not caught */
+#ifdef MODULE_THAT_DOES_NOT_EXIST
+    a+++;
+#endif
+
+    if (IS_ACTIVE(MODULE_NETIF)) {
+        puts("Netif is active");
+    }
+
+    if (IS_ACTIVE(MODULE_THAT_DOES_NOT_EXIST)) {
+        puts("Should not get in here");
+        a+++;
+    }
+
     (void) puts("Welcome to RIOT!");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
```
2) **It's kind of a tricky macro, so please check that documentation is clear enough.**

### Issues/PRs references
None.
