### PR TITLE
make/develhelp: make usage consistent + add ci check

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -201,6 +201,19 @@ checks_tests_application_not_defined_in_makefile() {
         | error_with_message "Don't define APPLICATION in test Makefile"
 }
 
+# Develhelp should not be set via CFLAGS
+checks_develhelp_not_defined_via_cflags() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e '^[[:space:]]*CFLAGS[[:space:]:+]+=[[:space:]:+]-DDEVELHELP')
+
+    pathspec+=('**/Makefile')
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message "Use DEVELHELP ?= 1 instead of using CFLAGS directly"
+}
+
 error_on_input() {
     ! grep ''
 }
@@ -214,6 +227,7 @@ all_checks() {
     check_not_setting_board_equal
     check_board_insufficient_memory_not_in_makefile
     checks_tests_application_not_defined_in_makefile
+    checks_develhelp_not_defined_via_cflags
 }
 
 main() {

--- a/examples/cord_ep/Makefile
+++ b/examples/cord_ep/Makefile
@@ -22,7 +22,7 @@ USEMODULE += fmt
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-CFLAGS += -DDEVELHELP
+DEVELHELP ?= 1
 
 # For debugging and demonstration purposes, we limit the lifetime to 60s
 CFLAGS += -DCORD_LT=60

--- a/examples/cord_epsim/Makefile
+++ b/examples/cord_epsim/Makefile
@@ -21,7 +21,7 @@ USEMODULE += xtimer
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-CFLAGS += -DDEVELHELP
+DEVELHELP ?= 1
 
 # For debugging and demonstration purposes, we limit the lifetime to the minimal
 # allowed value of 60s (see draft-ietf-core-resource-directory-11, Table 2)

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -48,7 +48,7 @@ CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-CFLAGS += -DDEVELHELP
+DEVELHELP ?= 1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/examples/dtls-wolfssl/Makefile
+++ b/examples/dtls-wolfssl/Makefile
@@ -40,7 +40,7 @@ CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-CFLAGS += -DDEVELHELP
+DEVELHELP ?= 1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/examples/ndn-ping/Makefile
+++ b/examples/ndn-ping/Makefile
@@ -23,7 +23,7 @@ USEPKG += ndn-riot
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-CFLAGS += -DDEVELHELP
+DEVELHELP ?= 1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/tests/driver_lc709203f/Makefile
+++ b/tests/driver_lc709203f/Makefile
@@ -2,6 +2,5 @@ include ../Makefile.tests_common
 
 USEMODULE += lc709203f
 USEMODULE += xtimer
-CFLAGS += -DDEVELHELP
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_gomach/Makefile
+++ b/tests/gnrc_gomach/Makefile
@@ -7,11 +7,6 @@ include ../Makefile.tests_common
 # be then accordingly extended.
 BOARD_WHITELIST := samr21-xpro iotlab-m3
 
-# Comment this out to disable code in RIOT that does safety checking
-# which is not needed in a production environment but helps in the
-# development process:
-CFLAGS += -DDEVELHELP
-
 # Modules to include:
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/tests/socket_zep/Makefile
+++ b/tests/socket_zep/Makefile
@@ -11,8 +11,6 @@ DISABLE_MODULE += auto_init
 USEMODULE += od
 USEMODULE += socket_zep
 
-CFLAGS += -DDEVELHELP
-
 TERMFLAGS ?= -z [::1]:17754
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR makes the usage of DEVELHELP consistent across all applications: instead of setting it via CFLAGS, use the corresponding variable which is handled afterward in Makefile.include.

A CI check is also added.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be ok.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
