### PR TITLE
gnrc_sixlowpan_iphc: remove duplicate gnrc_netif_hdr_get_netif()

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -673,6 +673,7 @@ void gnrc_sixlowpan_iphc_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     uint16_t inline_pos = SIXLOWPAN_IPHC_HDR_LEN;
 
     (void)ctx;
+    assert(iface != NULL);
     dispatch = NULL;    /* use dispatch as temporary pointer for prev */
     /* determine maximum dispatch size and write protect all headers until
      * then because they will be removed */
@@ -1035,9 +1036,7 @@ void gnrc_sixlowpan_iphc_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     dispatch->next = pkt->next;
     pkt->next = dispatch;
 
-    gnrc_netif_t *netif = gnrc_netif_hdr_get_netif(netif_hdr);
-    assert(netif != NULL);
-    gnrc_sixlowpan_multiplex_by_size(pkt, orig_datagram_size, netif, page);
+    gnrc_sixlowpan_multiplex_by_size(pkt, orig_datagram_size, iface, page);
 }
 
 /** @} */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The interface is already fetched [in the beginning of the function](https://github.com/RIOT-OS/RIOT/blob/865059fc6665156d3b779fa426e231abdcaa284d/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c#L665) and doesn't change during its run, so getting the interface again at this point is just redundant.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Pinging a node from another should still work:

```
$ BOARD=samr21-xpro SERIAL=ATML2127031800008319 RIOT_CI_BUILD=1 make -C examples/gnrc_networking flash term
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
Building application "gnrc_networking" for "samr21-xpro" with MCU "samd21".

   text	   data	    bss	    dec	    hex	filename
  87664	    196	  18748	 106608	  1a070	/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg/edbg --serial ATML2127031800008319 --serial ATML2127031800008319  --target atmel_cm0p --verbose --file /home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.bin --verify || /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg/edbg --serial ATML2127031800008319 --serial ATML2127031800008319  --target atmel_cm0p --verbose --file /home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800008319 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev D)
Verification...
at address 0xf4 expected 0x04, read 0x2c
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800008319 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev D)
Programming........................................................................................................................................................................................................................................................................................................................................................... done.
Verification........................................................................................................................................................................................................................................................................................................................................................... done.
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-11-01 18:31:29,258 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
> ping6 fe80::7b65:822:8693:9d5a
2019-11-01 18:31:51,120 #  ping6 fe80::7b65:822:8693:9d5a
2019-11-01 18:31:51,139 # 12 bytes from fe80::7b65:822:8693:9d5a: icmp_seq=0 ttl=64 rssi=-35 dBm time=10.540 ms
2019-11-01 18:31:52,137 # 12 bytes from fe80::7b65:822:8693:9d5a: icmp_seq=1 ttl=64 rssi=-37 dBm time=9.262 ms
2019-11-01 18:31:53,136 # 12 bytes from fe80::7b65:822:8693:9d5a: icmp_seq=2 ttl=64 rssi=-37 dBm time=9.891 ms
2019-11-01 18:31:53,136 # 
2019-11-01 18:31:53,141 # --- fe80::7b65:822:8693:9d5a PING statistics ---
2019-11-01 18:31:53,146 # 3 packets transmitted, 3 packets received, 0% packet loss
2019-11-01 18:31:53,150 # round-trip min/avg/max = 9.262/9.897/10.540 ms
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
