### PR TITLE
drivers/hd44780: fix potential hardfault during initialization

### DIFF
--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -118,6 +118,7 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
         }
     }
     /* set mode depending on configured pins */
+    dev->flag = 0;
     if (count_pins < HD44780_MAX_PINS) {
         dev->flag |= HD44780_4BITMODE;
     }

--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -110,20 +110,13 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
         LOG_ERROR("hd44780_init: invalid LCD size!\n");
         return -1;
     }
-    uint8_t count_pins = 0;
-    /* check which pins are used */
-    for (unsigned i = 0; i < HD44780_MAX_PINS; ++i) {
-        if (dev->p.data[i] != GPIO_UNDEF) {
-            ++count_pins;
-        }
-    }
-    /* set mode depending on configured pins */
     dev->flag = 0;
-    if (count_pins < HD44780_MAX_PINS) {
-        dev->flag |= HD44780_4BITMODE;
+    /* set mode depending on configured pins */
+    if (dev->p.data[4] != GPIO_UNDEF) {
+        dev->flag |= HD44780_8BITMODE;
     }
     else {
-        dev->flag |= HD44780_8BITMODE;
+        dev->flag |= HD44780_4BITMODE;
     }
     /* set flag for 1 or 2 row mode, 4 rows are 2 rows split half */
     if (dev->p.rows > 1) {

--- a/drivers/include/hd44780.h
+++ b/drivers/include/hd44780.h
@@ -63,7 +63,7 @@ typedef struct {
     gpio_t rs;                      /**< rs gpio pin */
     gpio_t rw;                      /**< rw gpio pin */
     gpio_t enable;                  /**< enable gpio pin */
-    gpio_t data[8];                 /**< data gpio pins */
+    gpio_t data[HD44780_MAX_PINS];  /**< data gpio pins */
 } hd44780_params_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a hardfault when running the `tests/driver_hd44780` application on samr21-xpro, when built with LLVM, as reported in https://github.com/RIOT-OS/RIOT/pull/12487#issuecomment-547850143.

In fact, the test application also crashes when run on arduino-zero/samr30-xpro if built GCC or LLVM.

Since the data pins array param is stored on flash memory and the driver is accessing it in loops for initializing/setting/clearing the pins. I thought that there was something with this that could cause a crash so this PR is just adding a extra array in RAM for and use it in the driver instead of the param array. It seems to work, at least it doesn't crash anymore.

Surprisingly, there's no RAM increase, just 24 extra bytes on ROM.

There might be something else, related to SAM0 platforms since it works well on the other platforms I tested (STM32, nRF), but I have no idea what it could be.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run
  ```
  $ make BOARD=samr21-xpro -C tests/driver_hd44780 flash test
  $ TOOLCHAIN=llvm make BOARD=samr21-xpro -C tests/driver_hd44780 flash test
  ```
  on master and with this PR the first one works but the second one only works with this PR.
  Changing BOARD for arduino-zero or samr30-xpro none of the 2 commands works on master but both are fixed by this PR.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes the issue reported in  https://github.com/RIOT-OS/RIOT/pull/12487#issuecomment-547850143

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
