### PR TITLE
cpu/lpc2387: update the UART driver

### DIFF
--- a/boards/avsextrem/board_init.c
+++ b/boards/avsextrem/board_init.c
@@ -26,10 +26,6 @@
 /*---------------------------------------------------------------------------*/
 void board_init(void)
 {
-    /* UART0 */
-    PINSEL0 |= BIT4 + BIT6;   // RxD0 and TxD0
-    PINSEL0 &= ~(BIT5 + BIT7);
-
     //PTTU:
 
     /*Turn Board on*/

--- a/boards/avsextrem/include/periph_conf.h
+++ b/boards/avsextrem/include/periph_conf.h
@@ -19,7 +19,7 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
-#include "lpc2387.h"
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,8 +53,18 @@ extern "C" {
  * @name    UART configuration
  * @{
  */
-#define UART_NUMOF          (1U)
-#define UART_0_EN           (1)
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = UART0,
+        .irq_prio_rx = 6,
+        .pinsel_rx   = 0,
+        .pinsel_tx   = 0,
+        .pinsel_msk_rx = BIT4,
+        .pinsel_msk_tx = BIT6,
+    }
+};
+
+#define UART_NUMOF          (1)
 /** @} */
 
 /**

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -31,10 +31,6 @@
 
 void board_init(void)
 {
-    /* UART0 */
-    PINSEL0 |= BIT4 + BIT6;     /* RxD0 and TxD0 */
-    PINSEL0 &= ~(BIT5 + BIT7);
-
     /* LEDS */
     FIO3DIR |= LED0_MASK;
     FIO3DIR |= LED1_MASK;

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -19,7 +19,7 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
-#include "lpc2387.h"
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -79,8 +79,18 @@ extern "C" {
  * @name    UART configuration
  * @{
  */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = UART0,
+        .irq_prio_rx = 6,
+        .pinsel_rx   = 0,
+        .pinsel_tx   = 0,
+        .pinsel_msk_rx = BIT4,
+        .pinsel_msk_tx = BIT6,
+    }
+};
+
 #define UART_NUMOF          (1)
-#define UART_0_EN           (1)
 /** @} */
 
 /**

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -87,10 +87,34 @@ static const uart_conf_t uart_config[] = {
         .pinsel_tx   = 0,
         .pinsel_msk_rx = BIT4,
         .pinsel_msk_tx = BIT6,
-    }
+    },
+    {
+        .dev = UART1,
+        .irq_prio_rx = 6,
+        .pinsel_rx   = 4,
+        .pinsel_tx   = 4,
+        .pinsel_msk_rx = BIT3,
+        .pinsel_msk_tx = BIT1,
+    },
+    {
+        .dev = UART2,
+        .irq_prio_rx = 6,
+        .pinsel_rx   = 0,
+        .pinsel_tx   = 0,
+        .pinsel_msk_rx = BIT22,
+        .pinsel_msk_tx = BIT20,
+    },
+    {
+        .dev = UART3,
+        .irq_prio_rx = 6,
+        .pinsel_rx   = 9,
+        .pinsel_tx   = 9,
+        .pinsel_msk_rx = BIT26 | BIT27,
+        .pinsel_msk_tx = BIT24 | BIT25,
+    },
 };
 
-#define UART_NUMOF          (1)
+#define UART_NUMOF          (4)
 /** @} */
 
 /**

--- a/cpu/lpc2387/include/lpc2387.h
+++ b/cpu/lpc2387/include/lpc2387.h
@@ -96,7 +96,7 @@ extern "C" {
  * @name UART Constants
  * @{
  */
-#define ULSR_RDR        BIT0
+#define ULSR_RDR    BIT0
 #define ULSR_OE     BIT1
 #define ULSR_PE     BIT2
 #define ULSR_FE     BIT3

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -19,9 +19,6 @@
 #ifndef PERIPH_CPU_H
 #define PERIPH_CPU_H
 
-#include "cpu.h"
-#include "periph/dev_enums.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -74,6 +71,18 @@ typedef enum {
     GPIO_BOTH = 3           /**< emit interrupt on both flanks */
 } gpio_flank_t;
 #endif /* ndef DOXYGEN */
+
+/**
+ * @brief   UART device configuration
+ */
+typedef struct {
+    lpc23xx_uart_t *dev;    /**< pointer to the UART device */
+    uint8_t irq_prio_rx;    /**< priority of the RX IRQ */
+    uint8_t pinsel_rx;      /**< PINSEL# of the RX pin  */
+    uint8_t pinsel_tx;      /**< PINSEL# of the TX pin  */
+    uint32_t pinsel_msk_rx; /**< RX PINSEL Mask         */
+    uint32_t pinsel_msk_tx; /**< TX PINSEL Mask         */
+} uart_conf_t;
 
 /**
  * @brief   Number of available timer channels

--- a/cpu/lpc2387/include/vendor/lpc23xx.h
+++ b/cpu/lpc2387/include/vendor/lpc23xx.h
@@ -26,6 +26,16 @@ extern "C" {
  */
 #define REG32       volatile uint32_t
 
+/**
+ * @brief   Type for 16-bit registers
+ */
+#define REG16       volatile uint16_t
+
+/**
+ * @brief   Type for 8-bit registers
+ */
+#define REG8        volatile uint8_t
+
 /* Vectored Interrupt Controller (VIC) */
 #define VIC_BASE_ADDR   0xFFFFF000
 #define VICIRQStatus   (*(volatile unsigned long *)(VIC_BASE_ADDR + 0x000))
@@ -655,9 +665,38 @@ typedef struct {
 #define PWM1LER         (*(volatile unsigned long *)(PWM1_BASE_ADDR + 0x50))
 #define PWM1CTCR        (*(volatile unsigned long *)(PWM1_BASE_ADDR + 0x70))
 
+/**
+ * @brief   Generic UART register map
+ */
+typedef struct {
+    union {
+        REG32   RBR;            /**< Receiver Buffer Register  */
+        REG32   THR;            /**< Transmit Holding Register */
+        REG8    DLL;            /**< Divisor Latch LSB         */
+    };
+    union {
+        REG32   IER;            /**< Interrupt Enable Register */
+        REG8    DLM;            /**< Divisor Latch MSB         */
+    };
+    union {
+        REG32   IIR;            /**< Interrupt ID Register     */
+        REG32   FCR;            /**< FIFO Control Register     */
+    };
+    REG32   LCR;                /**< Line Control Register     */
+    REG32   MCR;                /**< Modem Control Register    */
+    REG32   LSR;                /**< Line Status Register      */
+    REG32   MSR;                /**< Modem Status Register     */
+    REG32   SCR;                /**< Scratch Pad Register      */
+    REG32   ACR;                /**< Auto-baud Control Register*/
+    REG32   ICR;                /**< IrDA Control Register     */
+    REG32   FDR;                /**< Fractional Divider        */
+    REG32   reserved;           /**< unused                    */
+    REG8    TER;                /**< Transmit Enable Register  */
+} lpc23xx_uart_t;
 
 /* Universal Asynchronous Receiver Transmitter 0 (UART0) */
 #define UART0_BASE_ADDR     0xE000C000
+#define UART0          ((lpc23xx_uart_t *)UART0_BASE_ADDR)
 #define U0RBR          (*(volatile unsigned long *)(UART0_BASE_ADDR + 0x00))
 #define U0THR          (*(volatile unsigned long *)(UART0_BASE_ADDR + 0x00))
 #define U0DLL          (*(volatile unsigned long *)(UART0_BASE_ADDR + 0x00))
@@ -675,6 +714,7 @@ typedef struct {
 
 /* Universal Asynchronous Receiver Transmitter 1 (UART1) */
 #define UART1_BASE_ADDR     0xE0010000
+#define UART1          ((lpc23xx_uart_t *)UART1_BASE_ADDR)
 #define U1RBR          (*(volatile unsigned long *)(UART1_BASE_ADDR + 0x00))
 #define U1THR          (*(volatile unsigned long *)(UART1_BASE_ADDR + 0x00))
 #define U1DLL          (*(volatile unsigned long *)(UART1_BASE_ADDR + 0x00))
@@ -693,6 +733,7 @@ typedef struct {
 
 /* Universal Asynchronous Receiver Transmitter 2 (UART2) */
 #define UART2_BASE_ADDR     0xE0078000
+#define UART2          ((lpc23xx_uart_t *)UART2_BASE_ADDR)
 #define U2RBR          (*(volatile unsigned long *)(UART2_BASE_ADDR + 0x00))
 #define U2THR          (*(volatile unsigned long *)(UART2_BASE_ADDR + 0x00))
 #define U2DLL          (*(volatile unsigned long *)(UART2_BASE_ADDR + 0x00))
@@ -710,6 +751,7 @@ typedef struct {
 
 /* Universal Asynchronous Receiver Transmitter 3 (UART3) */
 #define UART3_BASE_ADDR     0xE007C000
+#define UART3          ((lpc23xx_uart_t *)UART3_BASE_ADDR)
 #define U3RBR          (*(volatile unsigned long *)(UART3_BASE_ADDR + 0x00))
 #define U3THR          (*(volatile unsigned long *)(UART3_BASE_ADDR + 0x00))
 #define U3DLL          (*(volatile unsigned long *)(UART3_BASE_ADDR + 0x00))

--- a/cpu/lpc2387/periph/uart.c
+++ b/cpu/lpc2387/periph/uart.c
@@ -17,6 +17,7 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
  *
  * @}
  */
@@ -29,84 +30,251 @@
 #include "VIC.h"
 #include "periph/uart.h"
 
-/* for now, we only support one UART device... */
-static uart_rx_cb_t _rx_cb;
-static void * _cb_arg;
+static uart_rx_cb_t _rx_cb[UART_NUMOF];
+static void * _cb_arg[UART_NUMOF];
 
-void UART0_IRQHandler(void) __attribute__((interrupt("IRQ")));
+typedef void (*irq_fun_t)(void);
+
+#if UART_NUMOF > 0
+static void UART0_IRQHandler(void) __attribute__((interrupt("IRQ")));
+#endif
+#if UART_NUMOF > 1
+static void UART1_IRQHandler(void) __attribute__((interrupt("IRQ")));
+#endif
+#if UART_NUMOF > 2
+static void UART2_IRQHandler(void) __attribute__((interrupt("IRQ")));
+#endif
+#if UART_NUMOF > 3
+static void UART3_IRQHandler(void) __attribute__((interrupt("IRQ")));
+#endif
+
+/**
+ * @brief   Get the pointer to the base register of the given UART device
+ *
+ * @param[in] dev       UART device identifier
+ *
+ * @return              base register address
+ */
+static inline lpc23xx_uart_t *get_dev(uart_t dev)
+{
+    return uart_config[dev].dev;
+}
+
+/* get the UART number from the address */
+static inline uint8_t _uart_num(lpc23xx_uart_t* uart)
+{
+    switch ((uint32_t) uart) {
+    case UART0_BASE_ADDR:
+        return 0;
+    case UART1_BASE_ADDR:
+        return 1;
+    case UART2_BASE_ADDR:
+        return 2;
+    case UART3_BASE_ADDR:
+        return 3;
+    }
+
+    return 0;
+}
+
+static const uint8_t _uart_int[] = {
+    UART0_INT, UART1_INT, UART2_INT, UART3_INT
+};
+
+static irq_fun_t _uart_isr[UART_NUMOF] = {
+#if UART_NUMOF > 0
+    UART0_IRQHandler,
+#endif
+#if UART_NUMOF > 1
+    UART1_IRQHandler,
+#endif
+#if UART_NUMOF > 2
+    UART2_IRQHandler,
+#endif
+#if UART_NUMOF > 3
+    UART3_IRQHandler,
+#endif
+};
+
+/* Table for FDR register contents
+ * bits 0…3: DIVADDVAL
+ * bits 4…7: MULVAL
+ */
+#define DIV_MUL(m, d) ((d << 4) | m)
+static const uint8_t div_table[] = {
+    DIV_MUL(0,  1),  /* 1       */
+    DIV_MUL(0,  1),  /* 1.03125 */
+    DIV_MUL(1, 15),  /* 1.0625  */
+    DIV_MUL(1, 11),  /* 1.09375 */
+    DIV_MUL(1,  8),  /* 1.125   */
+    DIV_MUL(2, 13),  /* 1.15625 */
+    DIV_MUL(2, 11),  /* 1.1875  */
+    DIV_MUL(2,  9),  /* 1.21875 */
+    DIV_MUL(1,  4),  /* 1.25    */
+    DIV_MUL(2,  7),  /* 1.21875 */
+    DIV_MUL(4, 13),  /* 1.3125  */
+    DIV_MUL(1,  3),  /* 1.34375 */
+    DIV_MUL(3,  8),  /* 1.375   */
+    DIV_MUL(2,  5),  /* 1.40625 */
+    DIV_MUL(3,  7),  /* 1.4375  */
+    DIV_MUL(7, 15),  /* 1.46875 */
+    DIV_MUL(1,  2),  /* 1.5     */
+    DIV_MUL(8, 15),  /* 1.53125 */
+    DIV_MUL(5,  9),  /* 1.5625  */
+    DIV_MUL(3,  5),  /* 1.59375 */
+    DIV_MUL(5,  8),  /* 1.625   */
+    DIV_MUL(9, 14),  /* 1.65625 */
+    DIV_MUL(2,  3),  /* 1.6875  */
+    DIV_MUL(5,  7),  /* 1.71875 */
+    DIV_MUL(3,  4),  /* 1.75    */
+    DIV_MUL(7,  9),  /* 1.78125 */
+    DIV_MUL(9, 11),  /* 1.8125  */
+    DIV_MUL(11,13),  /* 1.84375 */
+    DIV_MUL(7,  8),  /* 1.875   */
+    DIV_MUL(9, 13),  /* 1.90625 */
+    DIV_MUL(14,15),  /* 1.9375  */
+    DIV_MUL(14,15),  /* 1.96875 */
+};
 
 int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 {
-    (void) baudrate;
-    /* for now, we only support one UART device and only the RX interrupt */
-    if (dev != 0) {
+    if (dev >= UART_NUMOF) {
         return UART_NODEV;
     }
 
+    const uart_conf_t *cfg = &uart_config[dev];
+    lpc23xx_uart_t *uart = cfg->dev;
+    const uint8_t idx = _uart_num(uart);
+
+    /* configure RX & TX pins */
+    *(&PINSEL0 + cfg->pinsel_rx) |= cfg->pinsel_msk_rx;
+    *(&PINSEL0 + cfg->pinsel_tx) |= cfg->pinsel_msk_tx;
+
+    uart_poweron(dev);
+
     /* save interrupt context */
-    _rx_cb = rx_cb;
-    _cb_arg = arg;
+    _rx_cb[dev]  = rx_cb;
+    _cb_arg[dev] = arg;
 
-    /* power on the UART device */
-    PCONP |= PCUART0;
-    /* UART0 clock divider is CCLK/8 */
-    PCLKSEL0 |= BIT6 + BIT7;
-    /* configure to 8N1 */
-    U0LCR = 0x83;
+    uart->LCR = 0x80;       /* DLAB = 1 */
 
-    /* Baudrate calculation:
-     * BR = PCLK (9 MHz) / (16 x 256 x DLM + DLL) x (1/(DIVADDVAL/MULVAL)) */
-    /* TODO: UART Baudrate calculation using the baudrate parameter */
-    U0FDR = 0x92;       /* DIVADDVAL = 0010 = 2, MULVAL = 1001 = 9 */
-    U0DLM = 0x00;
-    U0DLL = 0x04;
+    /* set UART PCLK to CCLK/8 */
+    switch (idx) {
+    case 0:
+        PCLKSEL0 |= BIT6 + BIT7;
+        break;
+    case 1:
+        PCLKSEL0 |= BIT8 + BIT9;
+        break;
+    case 2:
+        PCLKSEL1 |= BIT16 + BIT17;
+        break;
+    case 3:
+        PCLKSEL1 |= BIT18 + BIT19;
+        break;
+    }
 
-    U0LCR = 0x03;       /* DLAB = 0 */
-    U0FCR = 0x07;       /* Enable and reset TX and RX FIFO */
+    /* PCLK = CCLK/8; DL = PCLK / (16 * F_Baud) */
+    uint16_t dl = CLOCK_CORECLOCK / (8 * 16 * baudrate);
+    /* 16 * DIVADDVAL / MULVAL = PCLK / (DL * F_Baud) - 16 */
+    /* frac = 16 * DIVADDVAL / MULVAL                      */
+    /* multiply everything by 2 for increased accuracy     */
+    uint8_t frac = 2 * CLOCK_CORECLOCK / (8 * dl) / baudrate - 32;
+
+    uart->FDR = div_table[frac];
+    uart->DLM = dl >> 8;
+    uart->DLL = dl & 0xFF;
+
+    uart->LCR = 0x03;       /* configure to 8N1 */
+    uart->FCR = 0x07;       /* Enable and reset TX and RX FIFO */
 
     /* install and enable the IRQ handler */
-    install_irq(UART0_INT, UART0_IRQHandler, 6);
-    U0IER |= BIT0;       /* enable only RX irq */
+    install_irq(_uart_int[idx], _uart_isr[dev], cfg->irq_prio_rx);
+    uart->IER |= BIT0;      /* enable only RX irq */
+
     return UART_OK;
 }
 
-void uart_write(uart_t uart, const uint8_t *data, size_t len)
+void uart_write(uart_t dev, const uint8_t *data, size_t len)
 {
-    (void) uart;
-    for (size_t i = 0; i < len; i++) {
-        while (!(U0LSR & BIT5)) {}
-        U0THR = data[i];
+    lpc23xx_uart_t *uart = get_dev(dev);
+
+    for (const uint8_t *end = data + len; data != end; ++data) {
+        while (!(uart->LSR & ULSR_THRE)) {}
+        uart->THR = *data;
     }
 }
 
-void UART0_IRQHandler(void)
+static void irq_handler(uart_t dev)
 {
-    switch (U0IIR & UIIR_ID_MASK) {
+    lpc23xx_uart_t *uart = get_dev(dev);
+
+    switch (uart->IIR & UIIR_ID_MASK) {
         case UIIR_CTI_INT:              /* Character Timeout Indicator */
         case UIIR_RDA_INT:              /* Receive Data Available */
                 do {
-                    uint8_t c = (uint8_t)U0RBR;
-                    _rx_cb(_cb_arg, c);
-                } while (U0LSR & ULSR_RDR);
+                    _rx_cb[dev](_cb_arg[dev], uart->RBR);
+                } while (uart->LSR & ULSR_RDR);
             break;
 
         default:
-            U0LSR;
-            U0RBR;
+            uart->LSR;
+            uart->RBR;
             break;
     }
+}
 
+#if UART_NUMOF > 0
+static void UART0_IRQHandler(void)
+{
+    irq_handler(0);
     VICVectAddr = 0;                    /* Acknowledge Interrupt */
 }
+#endif
+
+#if UART_NUMOF > 1
+static void UART1_IRQHandler(void)
+{
+    irq_handler(1);
+    VICVectAddr = 0;                    /* Acknowledge Interrupt */
+}
+#endif
+
+#if UART_NUMOF > 2
+static void UART2_IRQHandler(void)
+{
+    irq_handler(2);
+    VICVectAddr = 0;                    /* Acknowledge Interrupt */
+}
+#endif
+
+#if UART_NUMOF > 3
+static void UART3_IRQHandler(void)
+{
+    irq_handler(3);
+    VICVectAddr = 0;                    /* Acknowledge Interrupt */
+}
+#endif
+
+/* Bit in the Power Control for Peripherals Register */
+static const uint8_t _uart_pconp[] = {
+    3, 4, 24, 25
+};
 
 void uart_poweron(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    const uart_conf_t *cfg = &uart_config[uart];
+    const uint8_t idx = _uart_num(cfg->dev);
+
+    /* power on the UART device */
+    PCONP |= 1 << _uart_pconp[idx];
 }
 
 void uart_poweroff(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    const uart_conf_t *cfg = &uart_config[uart];
+    const uint8_t idx = _uart_num(cfg->dev);
+
+    /* power off the UART device */
+    PCONP &= ~(1 << _uart_pconp[idx]);
 }

--- a/cpu/lpc2387/periph/uart.c
+++ b/cpu/lpc2387/periph/uart.c
@@ -100,7 +100,7 @@ static irq_fun_t _uart_isr[UART_NUMOF] = {
  * bits 0…3: DIVADDVAL
  * bits 4…7: MULVAL
  */
-#define DIV_MUL(m, d) ((d << 4) | m)
+#define DIV_MUL(d, m) ((m << 4) | d)
 static const uint8_t div_table[] = {
     DIV_MUL(0,  1),  /* 1       */
     DIV_MUL(0,  1),  /* 1.03125 */


### PR DESCRIPTION
### Contribution description

The UART driver on lpc2387 was hard-coding one UART with a set baud rate.

This updates the driver to 

 - allow the board to configure the RX & TX pins using a config struct like other UART drivers
 - allow for more than one UART
 - allow setting the baudrate
 - implement poweron()/poweroff() functions

### Testing procedure

I tested the two UARTs on the MCB2388 board using 9600/57600/115200 Baud.

Please verify that the UART on the `msba2` still works.

I also added a config for the remaining UARTs on the msba2 which are exposed through JP2, JP3 & JP4 according to the schematics.
I don't have one of those boards to test the configuration, but it should be pretty straight forward.

### Issues/PRs references
Partially addresses #4693
