### PR TITLE
tests: use common APPLICATION definition + enforce the pattern with CI check

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -188,6 +188,19 @@ check_board_insufficient_memory_not_in_makefile() {
         | error_with_message 'Move BOARD_INSUFFICIENT_MEMORY to Makefile.ci'
 }
 
+# Test applications must not define the APPLICATION variable
+checks_tests_application_not_defined_in_makefile() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e '^[[:space:]]*APPLICATION[[:space:]:+]=')
+
+    pathspec+=('tests/**/Makefile')
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message "Don't define APPLICATION in test Makefile"
+}
+
 error_on_input() {
     ! grep ''
 }
@@ -200,6 +213,7 @@ all_checks() {
     check_cpu_cpu_model_defined_in_makefile_features
     check_not_setting_board_equal
     check_board_insufficient_memory_not_in_makefile
+    checks_tests_application_not_defined_in_makefile
 }
 
 main() {

--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,6 +1,6 @@
 APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
 ifneq (,$(filter tests_driver_%,$(APPLICATION)))
-    BOARD ?= samr21-xpro
+  BOARD ?= samr21-xpro
 endif
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/build_system_cflags_spaces/Makefile
+++ b/tests/build_system_cflags_spaces/Makefile
@@ -1,7 +1,4 @@
-APPLICATION = cflags_with_spaces
-BOARD ?= native
-RIOTBASE ?= $(CURDIR)/../..
-
+include ../Makefile.tests_common
 CFLAGS += -DSUPER_STRING='"I love sentences with spaces"'
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_sht2x/Makefile
+++ b/tests/driver_sht2x/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
+FEATURES_REQUIRED += periph_i2c
 
 USEMODULE += sht2x
 USEMODULE += xtimer

--- a/tests/driver_sht2x/Makefile
+++ b/tests/driver_sht2x/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_sht2x
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_tps6274x/Makefile
+++ b/tests/driver_tps6274x/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_tps6274x
 include ../Makefile.tests_common
 
 USEMODULE += tps6274x

--- a/tests/driver_vcnl40x0/Makefile
+++ b/tests/driver_vcnl40x0/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_vcnl40x0
 include ../Makefile.tests_common
 
 USEMODULE += vcnl4010

--- a/tests/external_module_dirs/Makefile
+++ b/tests/external_module_dirs/Makefile
@@ -1,7 +1,4 @@
-APPLICATION = external_module_dirs
-BOARD ?= native
-RIOTBASE ?= $(CURDIR)/../..
-
+include ../Makefile.tests_common
 USEMODULE += random
 
 USEMODULE += external_module

--- a/tests/gnrc_gomach/Makefile
+++ b/tests/gnrc_gomach/Makefile
@@ -1,11 +1,6 @@
-# name of your application
-APPLICATION = gomach
-
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
-# If no BOARD is found in the environment, use this default:
+# use samr21-xpro as default:
 BOARD ?= samr21-xpro
+include ../Makefile.tests_common
 
 # Currently, GoMacH has only been tested and evaluated through on samr21-xpro and iotlab-m3
 # nodes. Once GoMacH has also been tested through on other devices, the whitelist should

--- a/tests/gnrc_lwmac/Makefile
+++ b/tests/gnrc_lwmac/Makefile
@@ -1,11 +1,6 @@
-# name of your application
-APPLICATION = lwmac
-
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
-# If no BOARD is found in the environment, use this default:
+# use samr21-xpro as default:
 BOARD ?= samr21-xpro
+include ../Makefile.tests_common
 
 # Currently, LWMAC is only tested and evaluated through on samr21-xpro.
 # Once LWMAC has also been tested through on other boards, the whitelist should

--- a/tests/gnrc_mac_timeout/Makefile
+++ b/tests/gnrc_mac_timeout/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = gnrc_mac_timeout
 include ../Makefile.tests_common
 
 USEMODULE += gnrc_mac

--- a/tests/isr_yield_higher/Makefile
+++ b/tests/isr_yield_higher/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = isr_yield_higher
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_fatfs_vfs
 include ../Makefile.tests_common
 
 USEMODULE += fatfs_vfs

--- a/tests/socket_zep/Makefile
+++ b/tests/socket_zep/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = socket_zep
 include ../Makefile.tests_common
 
 BOARD_WHITELIST = native    # socket_zep is only available on native

--- a/tests/thread_float/Makefile
+++ b/tests/thread_float/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_float
 include ../Makefile.tests_common
 
 USEMODULE += printf_float

--- a/tests/trace/Makefile
+++ b/tests/trace/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = trace
 include ../Makefile.tests_common
 
 USEMODULE += trace


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is cleaning up all `APPLICATION = <application>` remaining in test applications and ensure the definition from `Makefile.tests_common` is used.

For example, this is fixing a build issue when building `tests/driver_sht2x`, `tests/driver_tps6274x` and `tests/driver_vcn4010` without specifying a BOARD: in this case, the application is built for native which doesn't provide the `periph_i2c` feature.

This PR also extend the build_system_sanity_check script to ensure this pattern is not used anymore.

There is also a couple of commits doing some minor cleanup.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock should be ok
- Build `tests/driver_sht2x`, `tests/driver_tps6274x` and `tests/driver_vcn4010` without specifying a board: on master native is selected by default which results in a failing build, with this PR, samr21-xpro is selected by default, like for all other `driver_*` test applications, and the build works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
