### PR TITLE
periph_common/rtc: add rtc_tm_compare()

### DIFF
--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -131,6 +131,22 @@ void rtc_poweroff(void);
  */
 void rtc_tm_normalize(struct tm *time);
 
+/**
+ * @brief Compare two time structs.
+ *
+ * @pre   The time structs @p a and @p b are assumed to be normalized.
+ *        Use @ref rtc_tm_normalize to normalize a struct tm that has been
+ *        manually edited.
+ *
+ * @param[in] a       The first time struct.
+ * @param[in] b       The second time struct.
+ *
+ * @return an integer < 0 if a is earlier than b
+ * @return an integer > 0 if a is later than b
+ * @return              0 if a and b are equal
+ */
+int rtc_tm_compare(const struct tm *a, const struct tm *b);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/periph_common/rtc.c
+++ b/drivers/periph_common/rtc.c
@@ -147,3 +147,20 @@ void rtc_tm_normalize(struct tm *t)
     t->tm_wday = _wday(t->tm_mday, t->tm_mon, t->tm_year + 1900);
 #endif
 }
+
+#define RETURN_IF_DIFFERENT(a, b, member)   \
+    if (a->member != b->member) {           \
+        return a->member-b->member;         \
+    }
+
+int rtc_tm_compare(const struct tm *a, const struct tm *b)
+{
+    RETURN_IF_DIFFERENT(a, b, tm_year);
+    RETURN_IF_DIFFERENT(a, b, tm_mon);
+    RETURN_IF_DIFFERENT(a, b, tm_mday);
+    RETURN_IF_DIFFERENT(a, b, tm_hour);
+    RETURN_IF_DIFFERENT(a, b, tm_min);
+    RETURN_IF_DIFFERENT(a, b, tm_sec);
+
+    return 0;
+}

--- a/tests/unittests/tests-rtc/tests-rtc.c
+++ b/tests/unittests/tests-rtc/tests-rtc.c
@@ -28,6 +28,7 @@ static void _test_equal_tm(const struct tm *a, const struct tm *b)
     TEST_ASSERT_EQUAL_INT((a)->tm_year, (b)->tm_year);
     TEST_ASSERT_EQUAL_INT((a)->tm_wday, (b)->tm_wday);
     TEST_ASSERT_EQUAL_INT((a)->tm_yday, (b)->tm_yday);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(a, b));
 }
 
 static void test_rtc_compat(void)
@@ -170,6 +171,34 @@ static void test_rtc_year(void)
     }
 }
 
+static void test_rtc_compare(void)
+{
+    struct tm t1 = {
+        .tm_sec  =  10,
+        .tm_min  =  58,
+        .tm_hour =  23,
+        .tm_mday =  32,
+        .tm_mon  =  11,
+        .tm_year = 100,
+        .tm_wday =   0,
+        .tm_yday =   0,
+    };
+
+    mktime(&t1);
+
+    struct tm t2 = t1;
+
+    TEST_ASSERT(rtc_tm_compare(&t1, &t2) == 0);
+
+    t1.tm_hour += 1;
+    mktime(&t1);
+    TEST_ASSERT(rtc_tm_compare(&t1, &t2) > 0);
+
+    t1.tm_mday -= 1;
+    mktime(&t1);
+    TEST_ASSERT(rtc_tm_compare(&t1, &t2) < 0);
+}
+
 Test *tests_rtc_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -179,6 +208,7 @@ Test *tests_rtc_tests(void)
         new_TestFixture(test_rtc_nyear),
         new_TestFixture(test_rtc_ywrap),
         new_TestFixture(test_rtc_year),
+        new_TestFixture(test_rtc_compare),
     };
 
     EMB_UNIT_TESTCALLER(rtc_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description
When reviewing #12259 I noticed it would be useful to have a function to compare two time values, so I added one.

It's pretty straightforward, it returns an integer like `memcpy()`/`strcmp()` to indicate which of the two dates is earlier, or `0` if they are equal.

### Testing procedure

The function has been added to `unittests/tests-rtc`

### Issues/PRs references
useful, but not necessary for #12259