### PR TITLE
pkg/ubasic: use features blacklist and remove use of BOARD_BLACKLIST in test

### DIFF
--- a/pkg/ubasic/Makefile.dep
+++ b/pkg/ubasic/Makefile.dep
@@ -1,0 +1,11 @@
+# avr-libc does not provide `clock `required by ubasic_tests
+FEATURES_BLACKLIST += arch_avr8
+
+# msp430-libc does not provide `stdout` variable required by ubasic_tests
+FEATURES_BLACKLIST += arch_msp430
+
+# newlib for MIPS does not provide _times_r
+FEATURES_BLACKLIST += arch_mips32r2
+
+# newlib for RISCV does not provide _times
+FEATURES_BLACKLIST += arch_riscv

--- a/tests/pkg_ubasic/Makefile
+++ b/tests/pkg_ubasic/Makefile
@@ -1,33 +1,5 @@
 include ../Makefile.tests_common
 
-# msp430-libc does not provide `stdout` variable required by ubasic_tests
-# avr-libc does not provide `clock `required by ubasic_tests
-# newlib for esp8266 and MIPS does not provide _times_r
-BOARD_BLACKLIST := \
-                   arduino-duemilanove \
-                   arduino-leonardo \
-                   arduino-mega2560 \
-                   arduino-nano \
-                   arduino-uno \
-                   atmega328p \
-                   chronos \
-                   esp8266-esp-12x \
-                   esp8266-olimex-mod \
-                   hifive1 \
-                   hifive1b \
-                   mega-xplained \
-                   microduino-corerf \
-                   msb-430 \
-                   msb-430h \
-                   pic32-clicker \
-                   pic32-wifire \
-                   telosb \
-                   waspmote-pro \
-                   wsn430-v1_3b \
-                   wsn430-v1_4 \
-                   z1 \
-                   #
-
 USEPKG += ubasic
 USEMODULE += ubasic_tests
 USEMODULE += printf_float


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR blacklist unsupported architectures for the ubasic package at the package level. This way there's no need to define the BOARD_BLACKLIST variable in the corresponding test.

This PR is follow-up of #12608.

The list of boards supported is the nearly the same compared to master. Apparently the reason for blacklisting the esp8266 architecture is no longer true. It builds just fine now.

<details><summary>This PR</summary>

```
acd52832 airfy-beacon arduino-due arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-zero avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib calliope-mini cc1352-launchpad cc2538dk cc2650-launchpad cc2650stk ek-lm4f120xl esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit f4vi1 feather-m0 firefly fox frdm-k22f frdm-k64f frdm-kw41z hamilton i-nucleo-lrwan1 ikea-tradfri iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lsn50 maple-mini mbed_lpc1768 microbit msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 opencm904 openmote-b openmote-cc2538 p-l496g-cell02 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pyboard reel remote-pa remote-reva remote-revb ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeeduino_arch-pro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff spark-core stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f723e-disco stm32f769i-disco stm32l0538-disco stm32l476g-disco teensy31 thingy52 ublox-c030-u201 udoo usb-kw41z yunjia-nrf51822
```

</details>

<details><summary>master</summary>

```
acd52832 airfy-beacon arduino-due arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-zero avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib calliope-mini cc1352-launchpad cc2538dk cc2650-launchpad cc2650stk ek-lm4f120xl esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-sparkfun-thing f4vi1 feather-m0 firefly fox frdm-k22f frdm-k64f frdm-kw41z hamilton i-nucleo-lrwan1 ikea-tradfri iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lsn50 maple-mini mbed_lpc1768 microbit msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 opencm904 openmote-b openmote-cc2538 p-l496g-cell02 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pyboard reel remote-pa remote-reva remote-revb ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeeduino_arch-pro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff spark-core stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f723e-disco stm32f769i-disco stm32l0538-disco stm32l476g-disco teensy31 thingy52 ublox-c030-u201 udoo usb-kw41z yunjia-nrf51822
```

</details>



<details><summary>diff</summary>

```
26a27
< esp8266-esp-12x
< esp8266-olimex-mod
```

</details>

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Check `make -C tests/pkg_ubasic info-boards-supported` is changed, but with good reasons.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #12608

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
