### PR TITLE
pkg/oonf_api: add avr8 and msp430 arch to features blacklist

### DIFF
--- a/pkg/oonf_api/Makefile.dep
+++ b/pkg/oonf_api/Makefile.dep
@@ -1,0 +1,5 @@
+# avr-libc does not provide `strings.h`
+FEATURES_BLACKLIST += arch_avr8
+
+# msp430-libc does not provide `strftime`
+FEATURES_BLACKLIST += arch_msp430

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -1,11 +1,5 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano arduino-uno \
-                   atmega328p chronos mega-xplained microduino-corerf \
-                   msb-430 msb-430h telosb waspmote-pro \
-                   wsn430-v1_3b wsn430-v1_4 z1
-
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sock_udp
 USEMODULE += nhdp


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This allows to drop the BOARD_BLACKLIST in the tests/nhdp application because nhdp module depends on the oonf_api package.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- a green Murdock
- `make -C tests/nhdp info-boards-supported` should return the same list of boards


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #12608 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
