### PR TITLE
tests/sys_crypto: remove use of BOARD_BLACKLIST variable

### DIFF
--- a/sys/crypto/modes/ocb.c
+++ b/sys/crypto/modes/ocb.c
@@ -319,8 +319,7 @@ int32_t cipher_decrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
                            uint8_t tag_len, uint8_t *nonce, size_t nonce_len,
                            uint8_t *input, size_t input_len, uint8_t *output)
 {
-
-    if (input_len - tag_len > INT32_MAX) {
+    if (input_len > (uint32_t)(INT32_MAX + tag_len)) {
         // We would not be able to return the proper output length for data this long
         return OCB_ERR_INVALID_DATA_LENGTH;
     }

--- a/tests/sys_crypto/Makefile
+++ b/tests/sys_crypto/Makefile
@@ -1,26 +1,5 @@
 include ../Makefile.tests_common
 
-# Issue with integer width
-BOARD_BLACKLIST += arduino-duemilanove
-BOARD_BLACKLIST += arduino-leonardo
-BOARD_BLACKLIST += arduino-mega2560
-BOARD_BLACKLIST += arduino-nano
-BOARD_BLACKLIST += arduino-uno
-BOARD_BLACKLIST += atmega256rfr2-xpro
-BOARD_BLACKLIST += avr-rss2
-BOARD_BLACKLIST += atmega328p
-BOARD_BLACKLIST += atmega1284p
-BOARD_BLACKLIST += chronos
-BOARD_BLACKLIST += mega-xplained
-BOARD_BLACKLIST += microduino-corerf
-BOARD_BLACKLIST += msb-430
-BOARD_BLACKLIST += msb-430h
-BOARD_BLACKLIST += telosb
-BOARD_BLACKLIST += waspmote-pro
-BOARD_BLACKLIST += wsn430-v1_3b
-BOARD_BLACKLIST += wsn430-v1_4
-BOARD_BLACKLIST += z1
-
 USEMODULE += embunit
 
 USEMODULE += crypto

--- a/tests/sys_crypto/Makefile.ci
+++ b/tests/sys_crypto/Makefile.ci
@@ -1,6 +1,14 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    chronos \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l031k6 \
     stm32f030f4-demo \
+    waspmote-pro \
     #

--- a/tests/sys_crypto/tests-crypto-modes-ccm.c
+++ b/tests/sys_crypto/tests-crypto-modes-ccm.c
@@ -1009,6 +1009,9 @@ static void test_crypto_modes_ccm_check_len(void)
 {
     int ret;
 
+/* Using length_encoding above UINT16_MAX doesn't work on 8/16 bit
+   architectures, SIZE_MAX is equal to UINT16_MAX there */
+#if SIZE_MAX > UINT16_MAX
     /* Just 1 to big to fit */
     ret = _test_ccm_len(cipher_encrypt_ccm, 2, NULL, 1 << 16, 0);
     TEST_ASSERT_EQUAL_INT(CCM_ERR_INVALID_LENGTH_ENCODING, ret);
@@ -1019,6 +1022,11 @@ static void test_crypto_modes_ccm_check_len(void)
     ret = _test_ccm_len(cipher_encrypt_ccm, 2, NULL, 1 << 16, 65535);
     TEST_ASSERT_EQUAL_INT(CCM_ERR_INVALID_LENGTH_ENCODING, ret);
     ret = _test_ccm_len(cipher_decrypt_ccm, 2, NULL, 1 << 16, 65535);
+    TEST_ASSERT_EQUAL_INT(CCM_ERR_INVALID_LENGTH_ENCODING, ret);
+#endif
+
+    /* Invalid length when length_encoding < 2 */
+    ret = _test_ccm_len(cipher_encrypt_ccm, 1, NULL, 8, 0);
     TEST_ASSERT_EQUAL_INT(CCM_ERR_INVALID_LENGTH_ENCODING, ret);
 
     /* Valid length that were wrongly checked */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR tries to get rid of the BOARD_BLACKLIST variable in `tests/sys_crypto` application. The approach is to try to fix the integer length issues raised when building on 8/16 bit architectures instead of just blacklisting the corresponding features.

While doing, I think I found a potential bug in one of the decrypt function, see 4d214cc. On 8/16 bit architectures, the compiler was failing with "error: comparison is always false due to limited range of data type". Which makes sense when looking at the code.

After all these integer length issues were fixed, it was just a matter of moving some boards to the insufficient memory variable.

The test application now builds fine on some msp430 and AVR based boards.

I haven't tested the test script on MSP430/AVR8 boards because I don't have the hardware with me.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following commands should build and work fine (if test is supported):
```
$ make BOARD=z1 -C test/sys_crypto flash test
$ make BOARD=mega-xplained -C test/sys_crypto flash test
$ make BOARD=microduino-corerf -C test/sys_crypto flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
