### PR TITLE
boards/atmega328p: Fixed xtimer frequency

### DIFF
--- a/boards/atmega328p/include/board.h
+++ b/boards/atmega328p/include/board.h
@@ -24,6 +24,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,7 +45,11 @@ extern "C" {
  * @{
  */
 #define XTIMER_WIDTH                (16)
-#define XTIMER_HZ                   (250000UL)
+#if CLOCK_CORECLOCK > 4000000UL
+#define XTIMER_HZ                   (CLOCK_CORECLOCK / 64)
+#else
+#define XTIMER_HZ                   (CLOCK_CORECLOCK / 8)
+#endif
 #define XTIMER_BACKOFF              (40)
 /** @} */
 


### PR DESCRIPTION
### Contribution description

As the ATmega328p on a breadboard can have various frequencies depending on the fuse settings and whether and which crystal is connected, a fixed xtimer frequency that can be configured (with the available prescalers) is not possible. Therefore, the fixed frequency is replaced by a frequency depending on the CPU clock speed. On 16 MHz, XTIMER_HZ will yield 250000UL, the same value
used on the Arduino UNO.

### Testing procedure

E.g. by flashing and running `tests/xtimer_usleep` on an ATmega328p with a core clock different from 16MHz

### Issues/PRs references

none