### PR TITLE
boards/atmega256rfr2-xpro: update clock configuration/stdio baudrate + a test timeout

### DIFF
--- a/boards/atmega256rfr2-xpro/Makefile.include
+++ b/boards/atmega256rfr2-xpro/Makefile.include
@@ -1,7 +1,7 @@
 # configure the terminal program
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-BAUD ?= 9600
+BAUD ?= 115200
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # Use EDBG (xplainedpro) programmer with avrdude

--- a/boards/atmega256rfr2-xpro/doc.txt
+++ b/boards/atmega256rfr2-xpro/doc.txt
@@ -11,7 +11,20 @@ is an evaluation kit by Microchip for their ATmega256RFR2 microcontroller.
 ### Flash the board
 
 You can flash the board using the on-board EDBG programmer via JTAG. Avrdude has
-support for programming an AVR via EDBG with its xplainedpro programmer:
+support for programming an AVR via EDBG with its xplainedpro programmer.
+
+First, make sure the default fuse settings are correct. In particular, the low
+byte fuse are enabling the use of the on-board 16MHz external oscillator.<br/>
+
+WARNING: setting the fuses incorrectly can brick your board!
+```
+avrdude -p m256rfr2 -c xplainedpro -U efuse:w:0xFF:m
+avrdude -p m256rfr2 -c xplainedpro -U hfuse:w:0x1F:m
+avrdude -p m256rfr2 -c xplainedpro -U lfuse:w:0xFF:m
+```
+
+To flash the board, just call `make` from an application directory with the
+`flash` target:
 
 ```
 make BOARD=atmega256rfr2-xpro -C examples/hello-world flash

--- a/boards/atmega256rfr2-xpro/include/board.h
+++ b/boards/atmega256rfr2-xpro/include/board.h
@@ -27,16 +27,6 @@ extern "C" {
 #endif
 
 /**
- * @name    STDIO configuration
- *
- * As the CPU is too slow to handle 115200 baud, we set the default
- * baudrate to 9600 for this board
- * @{
- */
-#define STDIO_UART_BAUDRATE (9600U)
-/** @} */
-
-/**
  * @brief   Use the UART 1 for STDIO on this board
  */
 #define STDIO_UART_DEV       (UART_DEV(1))

--- a/boards/atmega256rfr2-xpro/include/board.h
+++ b/boards/atmega256rfr2-xpro/include/board.h
@@ -44,13 +44,11 @@ extern "C" {
 /**
  * @name    xtimer configuration values
  *
- * Xtimer runs at 8MHz / 64 = 125kHz
+ * Xtimer runs at 16MHz / 64 = 250kHz
  * @{
  */
-#define XTIMER_DEV                  (0)
-#define XTIMER_CHAN                 (0)
 #define XTIMER_WIDTH                (16)
-#define XTIMER_HZ                   (125000UL)
+#define XTIMER_HZ                   (250000UL)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/atmega256rfr2-xpro/include/periph_conf.h
+++ b/boards/atmega256rfr2-xpro/include/periph_conf.h
@@ -19,24 +19,14 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+#include "periph_conf_atmega_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/**
- * @name    Clock configuration
- * @{
- */
-#ifndef CLOCK_CORECLOCK
-/* Using 8MHz internal oscillator as default clock source */
-#define CLOCK_CORECLOCK     (8000000UL)
-#endif
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
-
-#include "periph_conf_atmega_common.h"
 
 #endif /* PERIPH_CONF_H */

--- a/tests/periph_gpio/tests/02-bench.py
+++ b/tests/periph_gpio/tests/02-bench.py
@@ -10,6 +10,10 @@ import sys
 from testrunner import run
 
 
+# On slow platforms, like AVR, this test can take some time to complete.
+TIMEOUT = 30
+
+
 def testfunc(child):
     child.expect_exact("GPIO peripheral driver test")
     child.expect_exact(">")
@@ -33,4 +37,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc, timeout=10))
+    sys.exit(run(testfunc, timeout=TIMEOUT))

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -7,6 +7,7 @@ BOARDS_TIMER_25kHz := \
     arduino-leonardo \
     arduino-mega2560 \
     arduino-uno \
+    atmega256rfr2-xpro \
     atmega328p \
     waspmote-pro \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is improving the atmega256rfr2-xpro clock configuration by using the available external 16MHz oscillator. This allows to use a 115200 baudrate for stdio, which is fixing some timeout with the automatic tests. There is a commit that adds some doc about how to correctly setup the fuse bytes.

This PR also provides a timeout increase for `tests/periph_gpio`.

There are still failing automatic tests but they are not directly related to this board. My guess is that AVR support is not working in some cases, or some tests don't support this platform at all. I will report later in detail the problems I found.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock at least
- Run the automatic tests on the boards (will report my results here later)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #12639 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
