### PR TITLE
makefiles/sam0: fix debugging with edbg

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -44,12 +44,10 @@ ifeq ($(PROGRAMMER),edbg)
   endif
 endif
 
-# this board uses J-Link for debug and possibly flashing
 ifeq ($(PROGRAMMER),jlink)
+  # this board uses J-Link for debug and possibly flashing
   include $(RIOTMAKE)/tools/jlink.inc.mk
-endif
-
-# this board uses openocd for debug and possibly flashing
-ifeq ($(PROGRAMMER),openocd)
+else
+  # this board uses openocd for debug and possibly flashing
   include $(RIOTMAKE)/tools/openocd.inc.mk
 endif


### PR DESCRIPTION
### Contribution description

OpenOCD should *always* be included for debugging if `JLinkExe` is not used.


### Testing procedure

run `make BOARD=samr21-xpro debug` 

### Issues/PRs references
fixes #12652
