### PR TITLE
sam0: include openocd.inc.mk always when DEBUG_ADAPTER != jlink

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -45,11 +45,9 @@ ifeq ($(PROGRAMMER),edbg)
 endif
 
 # this board uses J-Link for debug and possibly flashing
-ifeq ($(PROGRAMMER),jlink)
+ifeq ($(DEBUG_ADAPTER),jlink)
   include $(RIOTMAKE)/tools/jlink.inc.mk
-endif
-
-# this board uses openocd for debug and possibly flashing
-ifeq ($(PROGRAMMER),openocd)
+else
+  # this board uses openocd for debug and possibly flashing
   include $(RIOTMAKE)/tools/openocd.inc.mk
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This reverts the behavior of `make debug` to the behavior prior to
b617e409501a373795065260e2d60ce1ee4b585e while still allowing for debug
support
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Plug-in a `samr21-xpro`, and type
```sh
BOARD=samr21 make -C examples/hello-world
```

and GDB should start. Without this change GDB does not start.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #12652.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
