### PR TITLE
[RFC] cpu/atmega_common: implement periph/flashpage

### DIFF
--- a/cpu/atmega_common/Makefile.features
+++ b/cpu/atmega_common/Makefile.features
@@ -4,3 +4,4 @@ FEATURES_PROVIDED += atmega_pcint0
 FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_flashpage

--- a/cpu/atmega_common/include/cpu_conf.h
+++ b/cpu/atmega_common/include/cpu_conf.h
@@ -27,6 +27,10 @@
 
 #include "atmega_regs_common.h"
 
+#ifndef FLASHSTART
+#define FLASHSTART                 (0x0000)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -60,6 +64,13 @@ extern "C" {
  * @brief   Declare the heap_stats function as available
  */
 #define HAVE_HEAP_STATS
+
+/**
+ * @brief   Flash page configuration
+ * @{
+ */
+#define FLASHPAGE_SIZE                  SPM_PAGESIZE
+#define FLASHPAGE_NUMOF                 ((FLASHEND - FLASHSTART) / SPM_PAGESIZE)
 
 #ifdef __cplusplus
 }

--- a/cpu/atmega_common/periph/flashpage.c
+++ b/cpu/atmega_common/periph/flashpage.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_atmega_common
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the peripheral flashpage interface
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @note        Based on AVR-libC example code at
+ *              https://www.nongnu.org/avr-libc/user-manual/group__avr__boot.html#details
+ *
+ * @}
+ */
+
+#include <avr/io.h>
+#include <avr/boot.h>
+
+#include "cpu.h"
+#include "irq.h"
+#include "periph/flashpage.h"
+
+void flashpage_write(int page, const void *data)
+{
+    assert(page < FLASHPAGE_NUMOF);
+
+    uint32_t dst = page * FLASHPAGE_SIZE;
+    const uint16_t *src = data;
+    unsigned istate;
+
+    /* disable interrupts */
+    istate = irq_disable();
+    eeprom_busy_wait();
+
+    /* erase page and wait for completion */
+    boot_page_erase(dst);
+    boot_spm_busy_wait();
+
+    if (data) {
+        for (const void *end = src + FLASHPAGE_SIZE; src != end; ++src) {
+            boot_page_fill(dst, *src);
+            dst += sizeof(*src);
+        }
+    }
+
+    boot_page_write (page);     /* Store buffer in flash page */
+    boot_spm_busy_wait();       /* Wait until the memory is written */
+
+    /* Reenable RWW-section again. We need this if we want to jump back
+       to the application after bootloading. */
+    boot_rww_enable();
+
+    /* re-enable interrupts (if they were ever enabled) */
+    irq_restore(istate);
+}

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -28,14 +28,14 @@
 
 #include "periph/flashpage.h"
 
-void flashpage_read(int page, void *data)
+void __attribute__((weak)) flashpage_read(int page, void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
 
     memcpy(data, flashpage_addr(page), FLASHPAGE_SIZE);
 }
 
-int flashpage_verify(int page, const void *data)
+int __attribute__((weak)) flashpage_verify(int page, const void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
 


### PR DESCRIPTION
### Contribution description

I thought adding `periph/flashpage` to ATmega would be straighforward enough, there is even an [example in AVR libc](https://www.nongnu.org/avr-libc/user-manual/group__avr__boot.html#details).

However you will find that all writes to flash will be ignored.
After some digging I found out that writing flash is only possible for code placed in the `BOOTLOADER_SECTION`, which is a problem.

It seems like placing just `flashpage_write()` there should work, but that would still require flashing the bootloader.

Maybe this might still be useful for riotboot?

### Testing procedure

**This does not work yet**
see contribution description.

### Issues/PRs references
none
