### PR TITLE
pkg/geck_sdk: update to version 2.6

### DIFF
--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg990f1024.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg990f1024.h
@@ -2,10 +2,10 @@
  * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32GG990F1024
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -144,42 +144,42 @@ typedef enum IRQn{
 #define PART_NUMBER          "EFM32GG990F1024" /**< Part Number */
 
 /** Memory Base addresses and limits */
-#define FLASH_MEM_BASE       ((uint32_t) 0x0UL)        /**< FLASH base address  */
-#define FLASH_MEM_SIZE       ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
-#define FLASH_MEM_END        ((uint32_t) 0xFFFFFFFUL)  /**< FLASH end address  */
-#define FLASH_MEM_BITS       ((uint32_t) 0x28UL)       /**< FLASH used bits  */
-#define AES_MEM_BASE         ((uint32_t) 0x400E0000UL) /**< AES base address  */
-#define AES_MEM_SIZE         ((uint32_t) 0x400UL)      /**< AES available address space  */
-#define AES_MEM_END          ((uint32_t) 0x400E03FFUL) /**< AES end address  */
-#define AES_MEM_BITS         ((uint32_t) 0x10UL)       /**< AES used bits  */
-#define USBC_MEM_BASE        ((uint32_t) 0x40100000UL) /**< USBC base address  */
-#define USBC_MEM_SIZE        ((uint32_t) 0x40000UL)    /**< USBC available address space  */
-#define USBC_MEM_END         ((uint32_t) 0x4013FFFFUL) /**< USBC end address  */
-#define USBC_MEM_BITS        ((uint32_t) 0x18UL)       /**< USBC used bits  */
-#define EBI_CODE_MEM_BASE    ((uint32_t) 0x12000000UL) /**< EBI_CODE base address  */
-#define EBI_CODE_MEM_SIZE    ((uint32_t) 0xE000000UL)  /**< EBI_CODE available address space  */
-#define EBI_CODE_MEM_END     ((uint32_t) 0x1FFFFFFFUL) /**< EBI_CODE end address  */
-#define EBI_CODE_MEM_BITS    ((uint32_t) 0x28UL)       /**< EBI_CODE used bits  */
-#define PER_MEM_BASE         ((uint32_t) 0x40000000UL) /**< PER base address  */
-#define PER_MEM_SIZE         ((uint32_t) 0xE0000UL)    /**< PER available address space  */
-#define PER_MEM_END          ((uint32_t) 0x400DFFFFUL) /**< PER end address  */
-#define PER_MEM_BITS         ((uint32_t) 0x20UL)       /**< PER used bits  */
-#define RAM_MEM_BASE         ((uint32_t) 0x20000000UL) /**< RAM base address  */
-#define RAM_MEM_SIZE         ((uint32_t) 0x40000UL)    /**< RAM available address space  */
-#define RAM_MEM_END          ((uint32_t) 0x2003FFFFUL) /**< RAM end address  */
-#define RAM_MEM_BITS         ((uint32_t) 0x18UL)       /**< RAM used bits  */
-#define RAM_CODE_MEM_BASE    ((uint32_t) 0x10000000UL) /**< RAM_CODE base address  */
-#define RAM_CODE_MEM_SIZE    ((uint32_t) 0x20000UL)    /**< RAM_CODE available address space  */
-#define RAM_CODE_MEM_END     ((uint32_t) 0x1001FFFFUL) /**< RAM_CODE end address  */
-#define RAM_CODE_MEM_BITS    ((uint32_t) 0x17UL)       /**< RAM_CODE used bits  */
-#define EBI_MEM_BASE         ((uint32_t) 0x80000000UL) /**< EBI base address  */
-#define EBI_MEM_SIZE         ((uint32_t) 0x40000000UL) /**< EBI available address space  */
-#define EBI_MEM_END          ((uint32_t) 0xBFFFFFFFUL) /**< EBI end address  */
-#define EBI_MEM_BITS         ((uint32_t) 0x30UL)       /**< EBI used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+#define USBC_MEM_BASE        (0x40100000UL) /**< USBC base address  */
+#define USBC_MEM_SIZE        (0x40000UL)    /**< USBC available address space  */
+#define USBC_MEM_END         (0x4013FFFFUL) /**< USBC end address  */
+#define USBC_MEM_BITS        (0x18UL)       /**< USBC used bits  */
+#define EBI_CODE_MEM_BASE    (0x12000000UL) /**< EBI_CODE base address  */
+#define EBI_CODE_MEM_SIZE    (0xE000000UL)  /**< EBI_CODE available address space  */
+#define EBI_CODE_MEM_END     (0x1FFFFFFFUL) /**< EBI_CODE end address  */
+#define EBI_CODE_MEM_BITS    (0x28UL)       /**< EBI_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x20000UL)    /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x1001FFFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x17UL)       /**< RAM_CODE used bits  */
+#define EBI_MEM_BASE         (0x80000000UL) /**< EBI base address  */
+#define EBI_MEM_SIZE         (0x40000000UL) /**< EBI available address space  */
+#define EBI_MEM_END          (0xBFFFFFFFUL) /**< EBI end address  */
+#define EBI_MEM_BITS         (0x30UL)       /**< EBI used bits  */
 
 /** Bit banding area */
-#define BITBAND_PER_BASE     ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
-#define BITBAND_RAM_BASE     ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
 
 /** Flash and SRAM limits for EFM32GG990F1024 */
 #define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_acmp.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_acmp.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_ACMP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_adc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_adc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_ADC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_aes.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_aes.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_AES register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_pins.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_pins.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_AF_PINS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_ports.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_ports.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_AF_PORTS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_BURTC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc_ret.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc_ret.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_BURTC_RET register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_calibrate.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_calibrate.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_CALIBRATE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_cmu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_cmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_CMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dac.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dac.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_DAC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_devinfo.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_devinfo.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_DEVINFO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_DMA register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_DMA_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_descriptor.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_descriptor.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmactrl.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmactrl.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_DMACTRL register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmareq.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmareq.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_DMAREQ register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_ebi.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_ebi.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_EBI register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_emu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_emu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_EMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_etm.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_etm.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_ETM register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_GPIO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio_p.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio_p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_GPIO_P register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_i2c.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_i2c.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_I2C register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lcd.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lcd.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_LCD register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_LESENSE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_buf.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_buf.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_LESENSE_BUF register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_LESENSE_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_st.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_st.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_LESENSE_ST register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_letimer.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_letimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_LETIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_leuart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_leuart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_LEUART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_msc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_msc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_MSC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_pcnt.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_pcnt.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_PCNT register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_PRS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_PRS_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_signals.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_signals.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_PRS_SIGNALS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rmu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_RMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_romtable.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_romtable.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_ROMTABLE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rtc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rtc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_RTC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_TIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer_cc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_TIMER_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_uart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_uart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_UART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_USART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_USB register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_diep.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_diep.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_USB_DIEP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_doep.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_doep.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_USB_DOEP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_hc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_hc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_USB_HC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_vcmp.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_vcmp.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_VCMP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_wdog.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_wdog.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32GG_WDOG register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/em_device.h
@@ -11,10 +11,10 @@
  *          Add "#include "em_device.h" to your source files
  * @endverbatim
  *
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/include/vendor/system_efm32gg.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/system_efm32gg.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3 System Layer for EFM32GG devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32gg/system.c
+++ b/cpu/efm32/families/efm32gg/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3 System Layer for EFM32GG devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg990f256.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg990f256.h
@@ -2,10 +2,10 @@
  * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32LG990F256
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -145,42 +145,42 @@ typedef enum IRQn{
 #define PART_NUMBER          "EFM32LG990F256" /**< Part Number */
 
 /** Memory Base addresses and limits */
-#define FLASH_MEM_BASE       ((uint32_t) 0x0UL)        /**< FLASH base address  */
-#define FLASH_MEM_SIZE       ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
-#define FLASH_MEM_END        ((uint32_t) 0xFFFFFFFUL)  /**< FLASH end address  */
-#define FLASH_MEM_BITS       ((uint32_t) 0x28UL)       /**< FLASH used bits  */
-#define AES_MEM_BASE         ((uint32_t) 0x400E0000UL) /**< AES base address  */
-#define AES_MEM_SIZE         ((uint32_t) 0x400UL)      /**< AES available address space  */
-#define AES_MEM_END          ((uint32_t) 0x400E03FFUL) /**< AES end address  */
-#define AES_MEM_BITS         ((uint32_t) 0x10UL)       /**< AES used bits  */
-#define USBC_MEM_BASE        ((uint32_t) 0x40100000UL) /**< USBC base address  */
-#define USBC_MEM_SIZE        ((uint32_t) 0x40000UL)    /**< USBC available address space  */
-#define USBC_MEM_END         ((uint32_t) 0x4013FFFFUL) /**< USBC end address  */
-#define USBC_MEM_BITS        ((uint32_t) 0x18UL)       /**< USBC used bits  */
-#define EBI_CODE_MEM_BASE    ((uint32_t) 0x12000000UL) /**< EBI_CODE base address  */
-#define EBI_CODE_MEM_SIZE    ((uint32_t) 0xE000000UL)  /**< EBI_CODE available address space  */
-#define EBI_CODE_MEM_END     ((uint32_t) 0x1FFFFFFFUL) /**< EBI_CODE end address  */
-#define EBI_CODE_MEM_BITS    ((uint32_t) 0x28UL)       /**< EBI_CODE used bits  */
-#define PER_MEM_BASE         ((uint32_t) 0x40000000UL) /**< PER base address  */
-#define PER_MEM_SIZE         ((uint32_t) 0xE0000UL)    /**< PER available address space  */
-#define PER_MEM_END          ((uint32_t) 0x400DFFFFUL) /**< PER end address  */
-#define PER_MEM_BITS         ((uint32_t) 0x20UL)       /**< PER used bits  */
-#define RAM_MEM_BASE         ((uint32_t) 0x20000000UL) /**< RAM base address  */
-#define RAM_MEM_SIZE         ((uint32_t) 0x40000UL)    /**< RAM available address space  */
-#define RAM_MEM_END          ((uint32_t) 0x2003FFFFUL) /**< RAM end address  */
-#define RAM_MEM_BITS         ((uint32_t) 0x18UL)       /**< RAM used bits  */
-#define RAM_CODE_MEM_BASE    ((uint32_t) 0x10000000UL) /**< RAM_CODE base address  */
-#define RAM_CODE_MEM_SIZE    ((uint32_t) 0x20000UL)    /**< RAM_CODE available address space  */
-#define RAM_CODE_MEM_END     ((uint32_t) 0x1001FFFFUL) /**< RAM_CODE end address  */
-#define RAM_CODE_MEM_BITS    ((uint32_t) 0x17UL)       /**< RAM_CODE used bits  */
-#define EBI_MEM_BASE         ((uint32_t) 0x80000000UL) /**< EBI base address  */
-#define EBI_MEM_SIZE         ((uint32_t) 0x40000000UL) /**< EBI available address space  */
-#define EBI_MEM_END          ((uint32_t) 0xBFFFFFFFUL) /**< EBI end address  */
-#define EBI_MEM_BITS         ((uint32_t) 0x30UL)       /**< EBI used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+#define USBC_MEM_BASE        (0x40100000UL) /**< USBC base address  */
+#define USBC_MEM_SIZE        (0x40000UL)    /**< USBC available address space  */
+#define USBC_MEM_END         (0x4013FFFFUL) /**< USBC end address  */
+#define USBC_MEM_BITS        (0x18UL)       /**< USBC used bits  */
+#define EBI_CODE_MEM_BASE    (0x12000000UL) /**< EBI_CODE base address  */
+#define EBI_CODE_MEM_SIZE    (0xE000000UL)  /**< EBI_CODE available address space  */
+#define EBI_CODE_MEM_END     (0x1FFFFFFFUL) /**< EBI_CODE end address  */
+#define EBI_CODE_MEM_BITS    (0x28UL)       /**< EBI_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x20000UL)    /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x1001FFFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x17UL)       /**< RAM_CODE used bits  */
+#define EBI_MEM_BASE         (0x80000000UL) /**< EBI base address  */
+#define EBI_MEM_SIZE         (0x40000000UL) /**< EBI available address space  */
+#define EBI_MEM_END          (0xBFFFFFFFUL) /**< EBI end address  */
+#define EBI_MEM_BITS         (0x30UL)       /**< EBI used bits  */
 
 /** Bit banding area */
-#define BITBAND_PER_BASE     ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
-#define BITBAND_RAM_BASE     ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
 
 /** Flash and SRAM limits for EFM32LG990F256 */
 #define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_acmp.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_acmp.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_ACMP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_adc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_adc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_ADC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_aes.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_aes.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_AES register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_pins.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_pins.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_AF_PINS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_ports.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_ports.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_AF_PORTS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_BURTC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc_ret.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc_ret.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_BURTC_RET register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_calibrate.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_calibrate.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_CALIBRATE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_cmu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_cmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_CMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dac.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dac.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_DAC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_devinfo.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_devinfo.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_DEVINFO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_DMA register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_DMA_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_descriptor.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_descriptor.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmactrl.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmactrl.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_DMACTRL register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmareq.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmareq.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_DMAREQ register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_ebi.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_ebi.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_EBI register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_emu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_emu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_EMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_etm.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_etm.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_ETM register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_GPIO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio_p.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio_p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_GPIO_P register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_i2c.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_i2c.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_I2C register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lcd.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lcd.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_LCD register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_LESENSE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_buf.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_buf.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_LESENSE_BUF register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_LESENSE_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_st.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_st.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_LESENSE_ST register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_letimer.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_letimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_LETIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_leuart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_leuart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_LEUART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_msc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_msc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_MSC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_pcnt.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_pcnt.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_PCNT register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_PRS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_PRS_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_signals.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_signals.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_PRS_SIGNALS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rmu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_RMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_romtable.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_romtable.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_ROMTABLE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rtc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rtc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_RTC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_TIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer_cc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_TIMER_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_uart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_uart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_UART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_USART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_USB register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_diep.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_diep.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_USB_DIEP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_doep.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_doep.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_USB_DOEP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_hc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_hc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_USB_HC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_vcmp.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_vcmp.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_VCMP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_wdog.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_wdog.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32LG_WDOG register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/em_device.h
@@ -11,10 +11,10 @@
  *          Add "#include "em_device.h" to your source files
  * @endverbatim
  *
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/include/vendor/system_efm32lg.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/system_efm32lg.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3 System Layer for EFM32LG devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32lg/system.c
+++ b/cpu/efm32/families/efm32lg/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3 System Layer for EFM32LG devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b500f1024gl125.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b500f1024gl125.h
@@ -2,10 +2,10 @@
  * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32PG12B500F1024GL125
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -153,86 +153,86 @@ typedef enum IRQn{
 #define PART_NUMBER                "EFM32PG12B500F1024GL125" /**< Part Number */
 
 /** Memory Base addresses and limits */
-#define RAM0_CODE_MEM_BASE         ((uint32_t) 0x10000000UL) /**< RAM0_CODE base address  */
-#define RAM0_CODE_MEM_SIZE         ((uint32_t) 0x20000UL)    /**< RAM0_CODE available address space  */
-#define RAM0_CODE_MEM_END          ((uint32_t) 0x1001FFFFUL) /**< RAM0_CODE end address  */
-#define RAM0_CODE_MEM_BITS         ((uint32_t) 0x00000011UL) /**< RAM0_CODE used bits  */
-#define RAM2_MEM_BASE              ((uint32_t) 0x20040000UL) /**< RAM2 base address  */
-#define RAM2_MEM_SIZE              ((uint32_t) 0x800UL)      /**< RAM2 available address space  */
-#define RAM2_MEM_END               ((uint32_t) 0x200407FFUL) /**< RAM2 end address  */
-#define RAM2_MEM_BITS              ((uint32_t) 0x0000000BUL) /**< RAM2 used bits  */
-#define RAM1_MEM_BASE              ((uint32_t) 0x20020000UL) /**< RAM1 base address  */
-#define RAM1_MEM_SIZE              ((uint32_t) 0x20000UL)    /**< RAM1 available address space  */
-#define RAM1_MEM_END               ((uint32_t) 0x2003FFFFUL) /**< RAM1 end address  */
-#define RAM1_MEM_BITS              ((uint32_t) 0x00000011UL) /**< RAM1 used bits  */
-#define CRYPTO1_BITCLR_MEM_BASE    ((uint32_t) 0x440F0400UL) /**< CRYPTO1_BITCLR base address  */
-#define CRYPTO1_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO1_BITCLR available address space  */
-#define CRYPTO1_BITCLR_MEM_END     ((uint32_t) 0x440F07FFUL) /**< CRYPTO1_BITCLR end address  */
-#define CRYPTO1_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO1_BITCLR used bits  */
-#define PER_MEM_BASE               ((uint32_t) 0x40000000UL) /**< PER base address  */
-#define PER_MEM_SIZE               ((uint32_t) 0xF0000UL)    /**< PER available address space  */
-#define PER_MEM_END                ((uint32_t) 0x400EFFFFUL) /**< PER end address  */
-#define PER_MEM_BITS               ((uint32_t) 0x00000014UL) /**< PER used bits  */
-#define RAM1_CODE_MEM_BASE         ((uint32_t) 0x10020000UL) /**< RAM1_CODE base address  */
-#define RAM1_CODE_MEM_SIZE         ((uint32_t) 0x20000UL)    /**< RAM1_CODE available address space  */
-#define RAM1_CODE_MEM_END          ((uint32_t) 0x1003FFFFUL) /**< RAM1_CODE end address  */
-#define RAM1_CODE_MEM_BITS         ((uint32_t) 0x00000011UL) /**< RAM1_CODE used bits  */
-#define CRYPTO1_MEM_BASE           ((uint32_t) 0x400F0400UL) /**< CRYPTO1 base address  */
-#define CRYPTO1_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO1 available address space  */
-#define CRYPTO1_MEM_END            ((uint32_t) 0x400F07FFUL) /**< CRYPTO1 end address  */
-#define CRYPTO1_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO1 used bits  */
-#define FLASH_MEM_BASE             ((uint32_t) 0x00000000UL) /**< FLASH base address  */
-#define FLASH_MEM_SIZE             ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
-#define FLASH_MEM_END              ((uint32_t) 0x0FFFFFFFUL) /**< FLASH end address  */
-#define FLASH_MEM_BITS             ((uint32_t) 0x0000001CUL) /**< FLASH used bits  */
-#define CRYPTO0_MEM_BASE           ((uint32_t) 0x400F0000UL) /**< CRYPTO0 base address  */
-#define CRYPTO0_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO0 available address space  */
-#define CRYPTO0_MEM_END            ((uint32_t) 0x400F03FFUL) /**< CRYPTO0 end address  */
-#define CRYPTO0_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO0 used bits  */
-#define CRYPTO_MEM_BASE            CRYPTO0_MEM_BASE          /**< Alias for CRYPTO0_MEM_BASE */
-#define CRYPTO_MEM_SIZE            CRYPTO0_MEM_SIZE          /**< Alias for CRYPTO0_MEM_SIZE */
-#define CRYPTO_MEM_END             CRYPTO0_MEM_END           /**< Alias for CRYPTO0_MEM_END  */
-#define CRYPTO_MEM_BITS            CRYPTO0_MEM_BITS          /**< Alias for CRYPTO0_MEM_BITS */
-#define PER_BITCLR_MEM_BASE        ((uint32_t) 0x44000000UL) /**< PER_BITCLR base address  */
-#define PER_BITCLR_MEM_SIZE        ((uint32_t) 0xF0000UL)    /**< PER_BITCLR available address space  */
-#define PER_BITCLR_MEM_END         ((uint32_t) 0x440EFFFFUL) /**< PER_BITCLR end address  */
-#define PER_BITCLR_MEM_BITS        ((uint32_t) 0x00000014UL) /**< PER_BITCLR used bits  */
-#define CRYPTO0_BITSET_MEM_BASE    ((uint32_t) 0x460F0000UL) /**< CRYPTO0_BITSET base address  */
-#define CRYPTO0_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO0_BITSET available address space  */
-#define CRYPTO0_BITSET_MEM_END     ((uint32_t) 0x460F03FFUL) /**< CRYPTO0_BITSET end address  */
-#define CRYPTO0_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO0_BITSET used bits  */
-#define CRYPTO_BITSET_MEM_BASE     CRYPTO0_BITSET_MEM_BASE   /**< Alias for CRYPTO0_BITSET_MEM_BASE */
-#define CRYPTO_BITSET_MEM_SIZE     CRYPTO0_BITSET_MEM_SIZE   /**< Alias for CRYPTO0_BITSET_MEM_SIZE */
-#define CRYPTO_BITSET_MEM_END      CRYPTO0_BITSET_MEM_END    /**< Alias for CRYPTO0_BITSET_MEM_END  */
-#define CRYPTO_BITSET_MEM_BITS     CRYPTO0_BITSET_MEM_BITS   /**< Alias for CRYPTO0_BITSET_MEM_BITS */
-#define CRYPTO0_BITCLR_MEM_BASE    ((uint32_t) 0x440F0000UL) /**< CRYPTO0_BITCLR base address  */
-#define CRYPTO0_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO0_BITCLR available address space  */
-#define CRYPTO0_BITCLR_MEM_END     ((uint32_t) 0x440F03FFUL) /**< CRYPTO0_BITCLR end address  */
-#define CRYPTO0_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO0_BITCLR used bits  */
-#define CRYPTO_BITCLR_MEM_BASE     CRYPTO0_BITCLR_MEM_BASE   /**< Alias for CRYPTO0_BITCLR_MEM_BASE */
-#define CRYPTO_BITCLR_MEM_SIZE     CRYPTO0_BITCLR_MEM_SIZE   /**< Alias for CRYPTO0_BITCLR_MEM_SIZE */
-#define CRYPTO_BITCLR_MEM_END      CRYPTO0_BITCLR_MEM_END    /**< Alias for CRYPTO0_BITCLR_MEM_END  */
-#define CRYPTO_BITCLR_MEM_BITS     CRYPTO0_BITCLR_MEM_BITS   /**< Alias for CRYPTO0_BITCLR_MEM_BITS */
-#define PER_BITSET_MEM_BASE        ((uint32_t) 0x46000000UL) /**< PER_BITSET base address  */
-#define PER_BITSET_MEM_SIZE        ((uint32_t) 0xF0000UL)    /**< PER_BITSET available address space  */
-#define PER_BITSET_MEM_END         ((uint32_t) 0x460EFFFFUL) /**< PER_BITSET end address  */
-#define PER_BITSET_MEM_BITS        ((uint32_t) 0x00000014UL) /**< PER_BITSET used bits  */
-#define CRYPTO1_BITSET_MEM_BASE    ((uint32_t) 0x460F0400UL) /**< CRYPTO1_BITSET base address  */
-#define CRYPTO1_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO1_BITSET available address space  */
-#define CRYPTO1_BITSET_MEM_END     ((uint32_t) 0x460F07FFUL) /**< CRYPTO1_BITSET end address  */
-#define CRYPTO1_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO1_BITSET used bits  */
-#define RAM2_CODE_MEM_BASE         ((uint32_t) 0x10040000UL) /**< RAM2_CODE base address  */
-#define RAM2_CODE_MEM_SIZE         ((uint32_t) 0x800UL)      /**< RAM2_CODE available address space  */
-#define RAM2_CODE_MEM_END          ((uint32_t) 0x100407FFUL) /**< RAM2_CODE end address  */
-#define RAM2_CODE_MEM_BITS         ((uint32_t) 0x0000000BUL) /**< RAM2_CODE used bits  */
-#define RAM_MEM_BASE               ((uint32_t) 0x20000000UL) /**< RAM base address  */
-#define RAM_MEM_SIZE               ((uint32_t) 0x20000UL)    /**< RAM available address space  */
-#define RAM_MEM_END                ((uint32_t) 0x2001FFFFUL) /**< RAM end address  */
-#define RAM_MEM_BITS               ((uint32_t) 0x00000011UL) /**< RAM used bits  */
+#define RAM0_CODE_MEM_BASE         (0x10000000UL)          /**< RAM0_CODE base address  */
+#define RAM0_CODE_MEM_SIZE         (0x20000UL)             /**< RAM0_CODE available address space  */
+#define RAM0_CODE_MEM_END          (0x1001FFFFUL)          /**< RAM0_CODE end address  */
+#define RAM0_CODE_MEM_BITS         (0x00000011UL)          /**< RAM0_CODE used bits  */
+#define RAM2_MEM_BASE              (0x20040000UL)          /**< RAM2 base address  */
+#define RAM2_MEM_SIZE              (0x800UL)               /**< RAM2 available address space  */
+#define RAM2_MEM_END               (0x200407FFUL)          /**< RAM2 end address  */
+#define RAM2_MEM_BITS              (0x0000000BUL)          /**< RAM2 used bits  */
+#define RAM1_MEM_BASE              (0x20020000UL)          /**< RAM1 base address  */
+#define RAM1_MEM_SIZE              (0x20000UL)             /**< RAM1 available address space  */
+#define RAM1_MEM_END               (0x2003FFFFUL)          /**< RAM1 end address  */
+#define RAM1_MEM_BITS              (0x00000011UL)          /**< RAM1 used bits  */
+#define CRYPTO1_BITCLR_MEM_BASE    (0x440F0400UL)          /**< CRYPTO1_BITCLR base address  */
+#define CRYPTO1_BITCLR_MEM_SIZE    (0x400UL)               /**< CRYPTO1_BITCLR available address space  */
+#define CRYPTO1_BITCLR_MEM_END     (0x440F07FFUL)          /**< CRYPTO1_BITCLR end address  */
+#define CRYPTO1_BITCLR_MEM_BITS    (0x0000000AUL)          /**< CRYPTO1_BITCLR used bits  */
+#define PER_MEM_BASE               (0x40000000UL)          /**< PER base address  */
+#define PER_MEM_SIZE               (0xF0000UL)             /**< PER available address space  */
+#define PER_MEM_END                (0x400EFFFFUL)          /**< PER end address  */
+#define PER_MEM_BITS               (0x00000014UL)          /**< PER used bits  */
+#define RAM1_CODE_MEM_BASE         (0x10020000UL)          /**< RAM1_CODE base address  */
+#define RAM1_CODE_MEM_SIZE         (0x20000UL)             /**< RAM1_CODE available address space  */
+#define RAM1_CODE_MEM_END          (0x1003FFFFUL)          /**< RAM1_CODE end address  */
+#define RAM1_CODE_MEM_BITS         (0x00000011UL)          /**< RAM1_CODE used bits  */
+#define CRYPTO1_MEM_BASE           (0x400F0400UL)          /**< CRYPTO1 base address  */
+#define CRYPTO1_MEM_SIZE           (0x400UL)               /**< CRYPTO1 available address space  */
+#define CRYPTO1_MEM_END            (0x400F07FFUL)          /**< CRYPTO1 end address  */
+#define CRYPTO1_MEM_BITS           (0x0000000AUL)          /**< CRYPTO1 used bits  */
+#define FLASH_MEM_BASE             (0x00000000UL)          /**< FLASH base address  */
+#define FLASH_MEM_SIZE             (0x10000000UL)          /**< FLASH available address space  */
+#define FLASH_MEM_END              (0x0FFFFFFFUL)          /**< FLASH end address  */
+#define FLASH_MEM_BITS             (0x0000001CUL)          /**< FLASH used bits  */
+#define CRYPTO0_MEM_BASE           (0x400F0000UL)          /**< CRYPTO0 base address  */
+#define CRYPTO0_MEM_SIZE           (0x400UL)               /**< CRYPTO0 available address space  */
+#define CRYPTO0_MEM_END            (0x400F03FFUL)          /**< CRYPTO0 end address  */
+#define CRYPTO0_MEM_BITS           (0x0000000AUL)          /**< CRYPTO0 used bits  */
+#define CRYPTO_MEM_BASE            CRYPTO0_MEM_BASE        /**< Alias for CRYPTO0_MEM_BASE */
+#define CRYPTO_MEM_SIZE            CRYPTO0_MEM_SIZE        /**< Alias for CRYPTO0_MEM_SIZE */
+#define CRYPTO_MEM_END             CRYPTO0_MEM_END         /**< Alias for CRYPTO0_MEM_END  */
+#define CRYPTO_MEM_BITS            CRYPTO0_MEM_BITS        /**< Alias for CRYPTO0_MEM_BITS */
+#define PER_BITCLR_MEM_BASE        (0x44000000UL)          /**< PER_BITCLR base address  */
+#define PER_BITCLR_MEM_SIZE        (0xF0000UL)             /**< PER_BITCLR available address space  */
+#define PER_BITCLR_MEM_END         (0x440EFFFFUL)          /**< PER_BITCLR end address  */
+#define PER_BITCLR_MEM_BITS        (0x00000014UL)          /**< PER_BITCLR used bits  */
+#define CRYPTO0_BITSET_MEM_BASE    (0x460F0000UL)          /**< CRYPTO0_BITSET base address  */
+#define CRYPTO0_BITSET_MEM_SIZE    (0x400UL)               /**< CRYPTO0_BITSET available address space  */
+#define CRYPTO0_BITSET_MEM_END     (0x460F03FFUL)          /**< CRYPTO0_BITSET end address  */
+#define CRYPTO0_BITSET_MEM_BITS    (0x0000000AUL)          /**< CRYPTO0_BITSET used bits  */
+#define CRYPTO_BITSET_MEM_BASE     CRYPTO0_BITSET_MEM_BASE /**< Alias for CRYPTO0_BITSET_MEM_BASE */
+#define CRYPTO_BITSET_MEM_SIZE     CRYPTO0_BITSET_MEM_SIZE /**< Alias for CRYPTO0_BITSET_MEM_SIZE */
+#define CRYPTO_BITSET_MEM_END      CRYPTO0_BITSET_MEM_END  /**< Alias for CRYPTO0_BITSET_MEM_END  */
+#define CRYPTO_BITSET_MEM_BITS     CRYPTO0_BITSET_MEM_BITS /**< Alias for CRYPTO0_BITSET_MEM_BITS */
+#define CRYPTO0_BITCLR_MEM_BASE    (0x440F0000UL)          /**< CRYPTO0_BITCLR base address  */
+#define CRYPTO0_BITCLR_MEM_SIZE    (0x400UL)               /**< CRYPTO0_BITCLR available address space  */
+#define CRYPTO0_BITCLR_MEM_END     (0x440F03FFUL)          /**< CRYPTO0_BITCLR end address  */
+#define CRYPTO0_BITCLR_MEM_BITS    (0x0000000AUL)          /**< CRYPTO0_BITCLR used bits  */
+#define CRYPTO_BITCLR_MEM_BASE     CRYPTO0_BITCLR_MEM_BASE /**< Alias for CRYPTO0_BITCLR_MEM_BASE */
+#define CRYPTO_BITCLR_MEM_SIZE     CRYPTO0_BITCLR_MEM_SIZE /**< Alias for CRYPTO0_BITCLR_MEM_SIZE */
+#define CRYPTO_BITCLR_MEM_END      CRYPTO0_BITCLR_MEM_END  /**< Alias for CRYPTO0_BITCLR_MEM_END  */
+#define CRYPTO_BITCLR_MEM_BITS     CRYPTO0_BITCLR_MEM_BITS /**< Alias for CRYPTO0_BITCLR_MEM_BITS */
+#define PER_BITSET_MEM_BASE        (0x46000000UL)          /**< PER_BITSET base address  */
+#define PER_BITSET_MEM_SIZE        (0xF0000UL)             /**< PER_BITSET available address space  */
+#define PER_BITSET_MEM_END         (0x460EFFFFUL)          /**< PER_BITSET end address  */
+#define PER_BITSET_MEM_BITS        (0x00000014UL)          /**< PER_BITSET used bits  */
+#define CRYPTO1_BITSET_MEM_BASE    (0x460F0400UL)          /**< CRYPTO1_BITSET base address  */
+#define CRYPTO1_BITSET_MEM_SIZE    (0x400UL)               /**< CRYPTO1_BITSET available address space  */
+#define CRYPTO1_BITSET_MEM_END     (0x460F07FFUL)          /**< CRYPTO1_BITSET end address  */
+#define CRYPTO1_BITSET_MEM_BITS    (0x0000000AUL)          /**< CRYPTO1_BITSET used bits  */
+#define RAM2_CODE_MEM_BASE         (0x10040000UL)          /**< RAM2_CODE base address  */
+#define RAM2_CODE_MEM_SIZE         (0x800UL)               /**< RAM2_CODE available address space  */
+#define RAM2_CODE_MEM_END          (0x100407FFUL)          /**< RAM2_CODE end address  */
+#define RAM2_CODE_MEM_BITS         (0x0000000BUL)          /**< RAM2_CODE used bits  */
+#define RAM_MEM_BASE               (0x20000000UL)          /**< RAM base address  */
+#define RAM_MEM_SIZE               (0x20000UL)             /**< RAM available address space  */
+#define RAM_MEM_END                (0x2001FFFFUL)          /**< RAM end address  */
+#define RAM_MEM_BITS               (0x00000011UL)          /**< RAM used bits  */
 
 /** Bit banding area */
-#define BITBAND_PER_BASE           ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
-#define BITBAND_RAM_BASE           ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+#define BITBAND_PER_BASE           (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE           (0x22000000UL) /**< SRAM Address Space bit-band area */
 
 /** Flash and SRAM limits for EFM32PG12B500F1024GL125 */
 #define FLASH_BASE                 (0x00000000UL) /**< Flash Base Address */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_acmp.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_acmp.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_ACMP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_adc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_adc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_ADC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_af_pins.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_af_pins.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_AF_PINS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_af_ports.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_af_ports.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_AF_PORTS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_cmu.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_cmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_CMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -1578,7 +1578,7 @@ typedef struct {
 #define _CMU_HFPERCLKEN0_ACMP1_MASK                       0x800UL                                    /**< Bit mask for CMU_ACMP1 */
 #define _CMU_HFPERCLKEN0_ACMP1_DEFAULT                    0x00000000UL                               /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
 #define CMU_HFPERCLKEN0_ACMP1_DEFAULT                     (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 11)     /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
-#define CMU_HFPERCLKEN0_CRYOTIMER                         (0x1UL << 12)                              /**< CryoTimer Clock Enable */
+#define CMU_HFPERCLKEN0_CRYOTIMER                         (0x1UL << 12)                              /**< CRYOTIMER Clock Enable */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_SHIFT                  12                                         /**< Shift value for CMU_CRYOTIMER */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_MASK                   0x1000UL                                   /**< Bit mask for CMU_CRYOTIMER */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for CMU_HFPERCLKEN0 */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_cryotimer.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_cryotimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_CRYOTIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_crypto.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_crypto.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_CRYPTO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_csen.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_csen.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_CSEN register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_devinfo.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_devinfo.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_DEVINFO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_dma_descriptor.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_dma_descriptor.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_dmareq.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_dmareq.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_DMAREQ register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_emu.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_emu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_EMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_etm.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_etm.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_ETM register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_fpueh.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_fpueh.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_FPUEH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpcrc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpcrc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_GPCRC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpio.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpio.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_GPIO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpio_p.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_gpio_p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_GPIO_P register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_i2c.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_i2c.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_I2C register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_idac.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_idac.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_IDAC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_ldma.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_ldma.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_LDMA register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_ldma_ch.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_ldma_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_LDMA_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_LESENSE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_buf.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_buf.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_LESENSE_BUF register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_ch.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_LESENSE_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_st.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_lesense_st.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_LESENSE_ST register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_letimer.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_letimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_LETIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_leuart.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_leuart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_LEUART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_msc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_msc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_MSC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_pcnt.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_pcnt.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_PCNT register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_PRS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs_ch.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_PRS_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs_signals.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_prs_signals.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_PRS_SIGNALS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rmu.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_RMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_romtable.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_romtable.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_ROMTABLE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_RTCC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc_cc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_RTCC_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc_ret.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_rtcc_ret.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_RTCC_RET register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_smu.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_smu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_SMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -142,7 +142,7 @@ typedef struct {
 #define _SMU_PPUPATD0_CMU_MASK             0x20UL                                 /**< Bit mask for SMU_CMU */
 #define _SMU_PPUPATD0_CMU_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for SMU_PPUPATD0 */
 #define SMU_PPUPATD0_CMU_DEFAULT           (_SMU_PPUPATD0_CMU_DEFAULT << 5)       /**< Shifted mode DEFAULT for SMU_PPUPATD0 */
-#define SMU_PPUPATD0_CRYOTIMER             (0x1UL << 7)                           /**< CryoTimer access control bit */
+#define SMU_PPUPATD0_CRYOTIMER             (0x1UL << 7)                           /**< CRYOTIMER access control bit */
 #define _SMU_PPUPATD0_CRYOTIMER_SHIFT      7                                      /**< Shift value for SMU_CRYOTIMER */
 #define _SMU_PPUPATD0_CRYOTIMER_MASK       0x80UL                                 /**< Bit mask for SMU_CRYOTIMER */
 #define _SMU_PPUPATD0_CRYOTIMER_DEFAULT    0x00000000UL                           /**< Mode DEFAULT for SMU_PPUPATD0 */

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_timer.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_timer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_TIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_timer_cc.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_timer_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_TIMER_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_trng.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_trng.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_TRNG register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_usart.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_usart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_USART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_vdac.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_vdac.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_VDAC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_vdac_opa.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_vdac_opa.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_VDAC_OPA register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_wdog.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_wdog.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_WDOG register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_wdog_pch.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/efm32pg12b_wdog_pch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG12B_WDOG_PCH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/em_device.h
@@ -11,10 +11,10 @@
  *          Add "#include "em_device.h" to your source files
  * @endverbatim
  *
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/include/vendor/system_efm32pg12b.h
+++ b/cpu/efm32/families/efm32pg12b/include/vendor/system_efm32pg12b.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg12b/system.c
+++ b/cpu/efm32/families/efm32pg12b/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b200f256gm48.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b200f256gm48.h
@@ -2,10 +2,10 @@
  * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32PG1B200F256GM48
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -135,46 +135,46 @@ typedef enum IRQn{
 #define PART_NUMBER               "EFM32PG1B200F256GM48" /**< Part Number */
 
 /** Memory Base addresses and limits */
-#define FLASH_MEM_BASE            ((uint32_t) 0x00000000UL) /**< FLASH base address  */
-#define FLASH_MEM_SIZE            ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
-#define FLASH_MEM_END             ((uint32_t) 0x0FFFFFFFUL) /**< FLASH end address  */
-#define FLASH_MEM_BITS            ((uint32_t) 0x0000001CUL) /**< FLASH used bits  */
-#define RAM_CODE_MEM_BASE         ((uint32_t) 0x10000000UL) /**< RAM_CODE base address  */
-#define RAM_CODE_MEM_SIZE         ((uint32_t) 0x7C00UL)     /**< RAM_CODE available address space  */
-#define RAM_CODE_MEM_END          ((uint32_t) 0x10007BFFUL) /**< RAM_CODE end address  */
-#define RAM_CODE_MEM_BITS         ((uint32_t) 0x0000000FUL) /**< RAM_CODE used bits  */
-#define PER_BITCLR_MEM_BASE       ((uint32_t) 0x44000000UL) /**< PER_BITCLR base address  */
-#define PER_BITCLR_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITCLR available address space  */
-#define PER_BITCLR_MEM_END        ((uint32_t) 0x440E7FFFUL) /**< PER_BITCLR end address  */
-#define PER_BITCLR_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITCLR used bits  */
-#define CRYPTO_BITSET_MEM_BASE    ((uint32_t) 0x460F0000UL) /**< CRYPTO_BITSET base address  */
-#define CRYPTO_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITSET available address space  */
-#define CRYPTO_BITSET_MEM_END     ((uint32_t) 0x460F03FFUL) /**< CRYPTO_BITSET end address  */
-#define CRYPTO_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITSET used bits  */
-#define CRYPTO_MEM_BASE           ((uint32_t) 0x400F0000UL) /**< CRYPTO base address  */
-#define CRYPTO_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO available address space  */
-#define CRYPTO_MEM_END            ((uint32_t) 0x400F03FFUL) /**< CRYPTO end address  */
-#define CRYPTO_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO used bits  */
-#define CRYPTO_BITCLR_MEM_BASE    ((uint32_t) 0x440F0000UL) /**< CRYPTO_BITCLR base address  */
-#define CRYPTO_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITCLR available address space  */
-#define CRYPTO_BITCLR_MEM_END     ((uint32_t) 0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
-#define CRYPTO_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
-#define PER_BITSET_MEM_BASE       ((uint32_t) 0x46000000UL) /**< PER_BITSET base address  */
-#define PER_BITSET_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITSET available address space  */
-#define PER_BITSET_MEM_END        ((uint32_t) 0x460E7FFFUL) /**< PER_BITSET end address  */
-#define PER_BITSET_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITSET used bits  */
-#define PER_MEM_BASE              ((uint32_t) 0x40000000UL) /**< PER base address  */
-#define PER_MEM_SIZE              ((uint32_t) 0xE8000UL)    /**< PER available address space  */
-#define PER_MEM_END               ((uint32_t) 0x400E7FFFUL) /**< PER end address  */
-#define PER_MEM_BITS              ((uint32_t) 0x00000014UL) /**< PER used bits  */
-#define RAM_MEM_BASE              ((uint32_t) 0x20000000UL) /**< RAM base address  */
-#define RAM_MEM_SIZE              ((uint32_t) 0x7C00UL)     /**< RAM available address space  */
-#define RAM_MEM_END               ((uint32_t) 0x20007BFFUL) /**< RAM end address  */
-#define RAM_MEM_BITS              ((uint32_t) 0x0000000FUL) /**< RAM used bits  */
+#define FLASH_MEM_BASE            (0x00000000UL) /**< FLASH base address  */
+#define FLASH_MEM_SIZE            (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END             (0x0FFFFFFFUL) /**< FLASH end address  */
+#define FLASH_MEM_BITS            (0x0000001CUL) /**< FLASH used bits  */
+#define RAM_CODE_MEM_BASE         (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE         (0x7C00UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END          (0x10007BFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS         (0x0000000FUL) /**< RAM_CODE used bits  */
+#define PER_BITCLR_MEM_BASE       (0x44000000UL) /**< PER_BITCLR base address  */
+#define PER_BITCLR_MEM_SIZE       (0xE8000UL)    /**< PER_BITCLR available address space  */
+#define PER_BITCLR_MEM_END        (0x440E7FFFUL) /**< PER_BITCLR end address  */
+#define PER_BITCLR_MEM_BITS       (0x00000014UL) /**< PER_BITCLR used bits  */
+#define CRYPTO_BITSET_MEM_BASE    (0x460F0000UL) /**< CRYPTO_BITSET base address  */
+#define CRYPTO_BITSET_MEM_SIZE    (0x400UL)      /**< CRYPTO_BITSET available address space  */
+#define CRYPTO_BITSET_MEM_END     (0x460F03FFUL) /**< CRYPTO_BITSET end address  */
+#define CRYPTO_BITSET_MEM_BITS    (0x0000000AUL) /**< CRYPTO_BITSET used bits  */
+#define CRYPTO_MEM_BASE           (0x400F0000UL) /**< CRYPTO base address  */
+#define CRYPTO_MEM_SIZE           (0x400UL)      /**< CRYPTO available address space  */
+#define CRYPTO_MEM_END            (0x400F03FFUL) /**< CRYPTO end address  */
+#define CRYPTO_MEM_BITS           (0x0000000AUL) /**< CRYPTO used bits  */
+#define CRYPTO_BITCLR_MEM_BASE    (0x440F0000UL) /**< CRYPTO_BITCLR base address  */
+#define CRYPTO_BITCLR_MEM_SIZE    (0x400UL)      /**< CRYPTO_BITCLR available address space  */
+#define CRYPTO_BITCLR_MEM_END     (0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
+#define CRYPTO_BITCLR_MEM_BITS    (0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
+#define PER_BITSET_MEM_BASE       (0x46000000UL) /**< PER_BITSET base address  */
+#define PER_BITSET_MEM_SIZE       (0xE8000UL)    /**< PER_BITSET available address space  */
+#define PER_BITSET_MEM_END        (0x460E7FFFUL) /**< PER_BITSET end address  */
+#define PER_BITSET_MEM_BITS       (0x00000014UL) /**< PER_BITSET used bits  */
+#define PER_MEM_BASE              (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE              (0xE8000UL)    /**< PER available address space  */
+#define PER_MEM_END               (0x400E7FFFUL) /**< PER end address  */
+#define PER_MEM_BITS              (0x00000014UL) /**< PER used bits  */
+#define RAM_MEM_BASE              (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE              (0x7C00UL)     /**< RAM available address space  */
+#define RAM_MEM_END               (0x20007BFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS              (0x0000000FUL) /**< RAM used bits  */
 
 /** Bit banding area */
-#define BITBAND_PER_BASE          ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
-#define BITBAND_RAM_BASE          ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+#define BITBAND_PER_BASE          (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE          (0x22000000UL) /**< SRAM Address Space bit-band area */
 
 /** Flash and SRAM limits for EFM32PG1B200F256GM48 */
 #define FLASH_BASE                (0x00000000UL) /**< Flash Base Address */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_acmp.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_acmp.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_ACMP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_adc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_adc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_ADC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_pins.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_pins.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_AF_PINS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_ports.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_ports.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_AF_PORTS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cmu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_CMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -1438,7 +1438,7 @@ typedef struct {
 #define _CMU_HFPERCLKEN0_ACMP1_MASK                       0x20UL                                    /**< Bit mask for CMU_ACMP1 */
 #define _CMU_HFPERCLKEN0_ACMP1_DEFAULT                    0x00000000UL                              /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
 #define CMU_HFPERCLKEN0_ACMP1_DEFAULT                     (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 5)     /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
-#define CMU_HFPERCLKEN0_CRYOTIMER                         (0x1UL << 6)                              /**< CryoTimer Clock Enable */
+#define CMU_HFPERCLKEN0_CRYOTIMER                         (0x1UL << 6)                              /**< CRYOTIMER Clock Enable */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_SHIFT                  6                                         /**< Shift value for CMU_CRYOTIMER */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_MASK                   0x40UL                                    /**< Bit mask for CMU_CRYOTIMER */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for CMU_HFPERCLKEN0 */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cryotimer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cryotimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_CRYOTIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_crypto.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_crypto.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_CRYPTO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_devinfo.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_devinfo.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_DEVINFO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dma_descriptor.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dma_descriptor.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dmareq.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dmareq.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_DMAREQ register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_emu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_emu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_EMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_fpueh.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_fpueh.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_FPUEH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpcrc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpcrc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_GPCRC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_GPIO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio_p.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio_p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_GPIO_P register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_i2c.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_i2c.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_I2C register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_idac.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_idac.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_IDAC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_LDMA register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma_ch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_LDMA_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_letimer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_letimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_LETIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_leuart.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_leuart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_LEUART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_msc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_msc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_MSC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_pcnt.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_pcnt.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_PCNT register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_PRS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_ch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_PRS_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_signals.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_signals.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_PRS_SIGNALS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rmu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_RMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_romtable.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_romtable.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_ROMTABLE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_RTCC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_cc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_RTCC_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_ret.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_ret.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_RTCC_RET register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_TIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer_cc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_TIMER_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_usart.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_usart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_USART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_WDOG register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog_pch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog_pch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFM32PG1B_WDOG_PCH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/em_device.h
@@ -11,10 +11,10 @@
  *          Add "#include "em_device.h" to your source files
  * @endverbatim
  *
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/include/vendor/system_efm32pg1b.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/system_efm32pg1b.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efm32pg1b/system.c
+++ b/cpu/efm32/families/efm32pg1b/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p332f1024gl125.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p332f1024gl125.h
@@ -2,10 +2,10 @@
  * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG12P332F1024GL125
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -167,86 +167,86 @@ typedef enum IRQn{
 #define PART_NUMBER                "EFR32MG12P332F1024GL125" /**< Part Number */
 
 /** Memory Base addresses and limits */
-#define RAM0_CODE_MEM_BASE         ((uint32_t) 0x10000000UL) /**< RAM0_CODE base address  */
-#define RAM0_CODE_MEM_SIZE         ((uint32_t) 0x20000UL)    /**< RAM0_CODE available address space  */
-#define RAM0_CODE_MEM_END          ((uint32_t) 0x1001FFFFUL) /**< RAM0_CODE end address  */
-#define RAM0_CODE_MEM_BITS         ((uint32_t) 0x00000011UL) /**< RAM0_CODE used bits  */
-#define RAM2_MEM_BASE              ((uint32_t) 0x20040000UL) /**< RAM2 base address  */
-#define RAM2_MEM_SIZE              ((uint32_t) 0x800UL)      /**< RAM2 available address space  */
-#define RAM2_MEM_END               ((uint32_t) 0x200407FFUL) /**< RAM2 end address  */
-#define RAM2_MEM_BITS              ((uint32_t) 0x0000000BUL) /**< RAM2 used bits  */
-#define RAM1_MEM_BASE              ((uint32_t) 0x20020000UL) /**< RAM1 base address  */
-#define RAM1_MEM_SIZE              ((uint32_t) 0x20000UL)    /**< RAM1 available address space  */
-#define RAM1_MEM_END               ((uint32_t) 0x2003FFFFUL) /**< RAM1 end address  */
-#define RAM1_MEM_BITS              ((uint32_t) 0x00000011UL) /**< RAM1 used bits  */
-#define CRYPTO1_BITCLR_MEM_BASE    ((uint32_t) 0x440F0400UL) /**< CRYPTO1_BITCLR base address  */
-#define CRYPTO1_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO1_BITCLR available address space  */
-#define CRYPTO1_BITCLR_MEM_END     ((uint32_t) 0x440F07FFUL) /**< CRYPTO1_BITCLR end address  */
-#define CRYPTO1_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO1_BITCLR used bits  */
-#define PER_MEM_BASE               ((uint32_t) 0x40000000UL) /**< PER base address  */
-#define PER_MEM_SIZE               ((uint32_t) 0xF0000UL)    /**< PER available address space  */
-#define PER_MEM_END                ((uint32_t) 0x400EFFFFUL) /**< PER end address  */
-#define PER_MEM_BITS               ((uint32_t) 0x00000014UL) /**< PER used bits  */
-#define RAM1_CODE_MEM_BASE         ((uint32_t) 0x10020000UL) /**< RAM1_CODE base address  */
-#define RAM1_CODE_MEM_SIZE         ((uint32_t) 0x20000UL)    /**< RAM1_CODE available address space  */
-#define RAM1_CODE_MEM_END          ((uint32_t) 0x1003FFFFUL) /**< RAM1_CODE end address  */
-#define RAM1_CODE_MEM_BITS         ((uint32_t) 0x00000011UL) /**< RAM1_CODE used bits  */
-#define CRYPTO1_MEM_BASE           ((uint32_t) 0x400F0400UL) /**< CRYPTO1 base address  */
-#define CRYPTO1_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO1 available address space  */
-#define CRYPTO1_MEM_END            ((uint32_t) 0x400F07FFUL) /**< CRYPTO1 end address  */
-#define CRYPTO1_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO1 used bits  */
-#define FLASH_MEM_BASE             ((uint32_t) 0x00000000UL) /**< FLASH base address  */
-#define FLASH_MEM_SIZE             ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
-#define FLASH_MEM_END              ((uint32_t) 0x0FFFFFFFUL) /**< FLASH end address  */
-#define FLASH_MEM_BITS             ((uint32_t) 0x0000001CUL) /**< FLASH used bits  */
-#define CRYPTO0_MEM_BASE           ((uint32_t) 0x400F0000UL) /**< CRYPTO0 base address  */
-#define CRYPTO0_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO0 available address space  */
-#define CRYPTO0_MEM_END            ((uint32_t) 0x400F03FFUL) /**< CRYPTO0 end address  */
-#define CRYPTO0_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO0 used bits  */
-#define CRYPTO_MEM_BASE            CRYPTO0_MEM_BASE          /**< Alias for CRYPTO0_MEM_BASE */
-#define CRYPTO_MEM_SIZE            CRYPTO0_MEM_SIZE          /**< Alias for CRYPTO0_MEM_SIZE */
-#define CRYPTO_MEM_END             CRYPTO0_MEM_END           /**< Alias for CRYPTO0_MEM_END  */
-#define CRYPTO_MEM_BITS            CRYPTO0_MEM_BITS          /**< Alias for CRYPTO0_MEM_BITS */
-#define PER_BITCLR_MEM_BASE        ((uint32_t) 0x44000000UL) /**< PER_BITCLR base address  */
-#define PER_BITCLR_MEM_SIZE        ((uint32_t) 0xF0000UL)    /**< PER_BITCLR available address space  */
-#define PER_BITCLR_MEM_END         ((uint32_t) 0x440EFFFFUL) /**< PER_BITCLR end address  */
-#define PER_BITCLR_MEM_BITS        ((uint32_t) 0x00000014UL) /**< PER_BITCLR used bits  */
-#define CRYPTO0_BITSET_MEM_BASE    ((uint32_t) 0x460F0000UL) /**< CRYPTO0_BITSET base address  */
-#define CRYPTO0_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO0_BITSET available address space  */
-#define CRYPTO0_BITSET_MEM_END     ((uint32_t) 0x460F03FFUL) /**< CRYPTO0_BITSET end address  */
-#define CRYPTO0_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO0_BITSET used bits  */
-#define CRYPTO_BITSET_MEM_BASE     CRYPTO0_BITSET_MEM_BASE   /**< Alias for CRYPTO0_BITSET_MEM_BASE */
-#define CRYPTO_BITSET_MEM_SIZE     CRYPTO0_BITSET_MEM_SIZE   /**< Alias for CRYPTO0_BITSET_MEM_SIZE */
-#define CRYPTO_BITSET_MEM_END      CRYPTO0_BITSET_MEM_END    /**< Alias for CRYPTO0_BITSET_MEM_END  */
-#define CRYPTO_BITSET_MEM_BITS     CRYPTO0_BITSET_MEM_BITS   /**< Alias for CRYPTO0_BITSET_MEM_BITS */
-#define CRYPTO0_BITCLR_MEM_BASE    ((uint32_t) 0x440F0000UL) /**< CRYPTO0_BITCLR base address  */
-#define CRYPTO0_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO0_BITCLR available address space  */
-#define CRYPTO0_BITCLR_MEM_END     ((uint32_t) 0x440F03FFUL) /**< CRYPTO0_BITCLR end address  */
-#define CRYPTO0_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO0_BITCLR used bits  */
-#define CRYPTO_BITCLR_MEM_BASE     CRYPTO0_BITCLR_MEM_BASE   /**< Alias for CRYPTO0_BITCLR_MEM_BASE */
-#define CRYPTO_BITCLR_MEM_SIZE     CRYPTO0_BITCLR_MEM_SIZE   /**< Alias for CRYPTO0_BITCLR_MEM_SIZE */
-#define CRYPTO_BITCLR_MEM_END      CRYPTO0_BITCLR_MEM_END    /**< Alias for CRYPTO0_BITCLR_MEM_END  */
-#define CRYPTO_BITCLR_MEM_BITS     CRYPTO0_BITCLR_MEM_BITS   /**< Alias for CRYPTO0_BITCLR_MEM_BITS */
-#define PER_BITSET_MEM_BASE        ((uint32_t) 0x46000000UL) /**< PER_BITSET base address  */
-#define PER_BITSET_MEM_SIZE        ((uint32_t) 0xF0000UL)    /**< PER_BITSET available address space  */
-#define PER_BITSET_MEM_END         ((uint32_t) 0x460EFFFFUL) /**< PER_BITSET end address  */
-#define PER_BITSET_MEM_BITS        ((uint32_t) 0x00000014UL) /**< PER_BITSET used bits  */
-#define CRYPTO1_BITSET_MEM_BASE    ((uint32_t) 0x460F0400UL) /**< CRYPTO1_BITSET base address  */
-#define CRYPTO1_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO1_BITSET available address space  */
-#define CRYPTO1_BITSET_MEM_END     ((uint32_t) 0x460F07FFUL) /**< CRYPTO1_BITSET end address  */
-#define CRYPTO1_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO1_BITSET used bits  */
-#define RAM2_CODE_MEM_BASE         ((uint32_t) 0x10040000UL) /**< RAM2_CODE base address  */
-#define RAM2_CODE_MEM_SIZE         ((uint32_t) 0x800UL)      /**< RAM2_CODE available address space  */
-#define RAM2_CODE_MEM_END          ((uint32_t) 0x100407FFUL) /**< RAM2_CODE end address  */
-#define RAM2_CODE_MEM_BITS         ((uint32_t) 0x0000000BUL) /**< RAM2_CODE used bits  */
-#define RAM_MEM_BASE               ((uint32_t) 0x20000000UL) /**< RAM base address  */
-#define RAM_MEM_SIZE               ((uint32_t) 0x20000UL)    /**< RAM available address space  */
-#define RAM_MEM_END                ((uint32_t) 0x2001FFFFUL) /**< RAM end address  */
-#define RAM_MEM_BITS               ((uint32_t) 0x00000011UL) /**< RAM used bits  */
+#define RAM0_CODE_MEM_BASE         (0x10000000UL)          /**< RAM0_CODE base address  */
+#define RAM0_CODE_MEM_SIZE         (0x20000UL)             /**< RAM0_CODE available address space  */
+#define RAM0_CODE_MEM_END          (0x1001FFFFUL)          /**< RAM0_CODE end address  */
+#define RAM0_CODE_MEM_BITS         (0x00000011UL)          /**< RAM0_CODE used bits  */
+#define RAM2_MEM_BASE              (0x20040000UL)          /**< RAM2 base address  */
+#define RAM2_MEM_SIZE              (0x800UL)               /**< RAM2 available address space  */
+#define RAM2_MEM_END               (0x200407FFUL)          /**< RAM2 end address  */
+#define RAM2_MEM_BITS              (0x0000000BUL)          /**< RAM2 used bits  */
+#define RAM1_MEM_BASE              (0x20020000UL)          /**< RAM1 base address  */
+#define RAM1_MEM_SIZE              (0x20000UL)             /**< RAM1 available address space  */
+#define RAM1_MEM_END               (0x2003FFFFUL)          /**< RAM1 end address  */
+#define RAM1_MEM_BITS              (0x00000011UL)          /**< RAM1 used bits  */
+#define CRYPTO1_BITCLR_MEM_BASE    (0x440F0400UL)          /**< CRYPTO1_BITCLR base address  */
+#define CRYPTO1_BITCLR_MEM_SIZE    (0x400UL)               /**< CRYPTO1_BITCLR available address space  */
+#define CRYPTO1_BITCLR_MEM_END     (0x440F07FFUL)          /**< CRYPTO1_BITCLR end address  */
+#define CRYPTO1_BITCLR_MEM_BITS    (0x0000000AUL)          /**< CRYPTO1_BITCLR used bits  */
+#define PER_MEM_BASE               (0x40000000UL)          /**< PER base address  */
+#define PER_MEM_SIZE               (0xF0000UL)             /**< PER available address space  */
+#define PER_MEM_END                (0x400EFFFFUL)          /**< PER end address  */
+#define PER_MEM_BITS               (0x00000014UL)          /**< PER used bits  */
+#define RAM1_CODE_MEM_BASE         (0x10020000UL)          /**< RAM1_CODE base address  */
+#define RAM1_CODE_MEM_SIZE         (0x20000UL)             /**< RAM1_CODE available address space  */
+#define RAM1_CODE_MEM_END          (0x1003FFFFUL)          /**< RAM1_CODE end address  */
+#define RAM1_CODE_MEM_BITS         (0x00000011UL)          /**< RAM1_CODE used bits  */
+#define CRYPTO1_MEM_BASE           (0x400F0400UL)          /**< CRYPTO1 base address  */
+#define CRYPTO1_MEM_SIZE           (0x400UL)               /**< CRYPTO1 available address space  */
+#define CRYPTO1_MEM_END            (0x400F07FFUL)          /**< CRYPTO1 end address  */
+#define CRYPTO1_MEM_BITS           (0x0000000AUL)          /**< CRYPTO1 used bits  */
+#define FLASH_MEM_BASE             (0x00000000UL)          /**< FLASH base address  */
+#define FLASH_MEM_SIZE             (0x10000000UL)          /**< FLASH available address space  */
+#define FLASH_MEM_END              (0x0FFFFFFFUL)          /**< FLASH end address  */
+#define FLASH_MEM_BITS             (0x0000001CUL)          /**< FLASH used bits  */
+#define CRYPTO0_MEM_BASE           (0x400F0000UL)          /**< CRYPTO0 base address  */
+#define CRYPTO0_MEM_SIZE           (0x400UL)               /**< CRYPTO0 available address space  */
+#define CRYPTO0_MEM_END            (0x400F03FFUL)          /**< CRYPTO0 end address  */
+#define CRYPTO0_MEM_BITS           (0x0000000AUL)          /**< CRYPTO0 used bits  */
+#define CRYPTO_MEM_BASE            CRYPTO0_MEM_BASE        /**< Alias for CRYPTO0_MEM_BASE */
+#define CRYPTO_MEM_SIZE            CRYPTO0_MEM_SIZE        /**< Alias for CRYPTO0_MEM_SIZE */
+#define CRYPTO_MEM_END             CRYPTO0_MEM_END         /**< Alias for CRYPTO0_MEM_END  */
+#define CRYPTO_MEM_BITS            CRYPTO0_MEM_BITS        /**< Alias for CRYPTO0_MEM_BITS */
+#define PER_BITCLR_MEM_BASE        (0x44000000UL)          /**< PER_BITCLR base address  */
+#define PER_BITCLR_MEM_SIZE        (0xF0000UL)             /**< PER_BITCLR available address space  */
+#define PER_BITCLR_MEM_END         (0x440EFFFFUL)          /**< PER_BITCLR end address  */
+#define PER_BITCLR_MEM_BITS        (0x00000014UL)          /**< PER_BITCLR used bits  */
+#define CRYPTO0_BITSET_MEM_BASE    (0x460F0000UL)          /**< CRYPTO0_BITSET base address  */
+#define CRYPTO0_BITSET_MEM_SIZE    (0x400UL)               /**< CRYPTO0_BITSET available address space  */
+#define CRYPTO0_BITSET_MEM_END     (0x460F03FFUL)          /**< CRYPTO0_BITSET end address  */
+#define CRYPTO0_BITSET_MEM_BITS    (0x0000000AUL)          /**< CRYPTO0_BITSET used bits  */
+#define CRYPTO_BITSET_MEM_BASE     CRYPTO0_BITSET_MEM_BASE /**< Alias for CRYPTO0_BITSET_MEM_BASE */
+#define CRYPTO_BITSET_MEM_SIZE     CRYPTO0_BITSET_MEM_SIZE /**< Alias for CRYPTO0_BITSET_MEM_SIZE */
+#define CRYPTO_BITSET_MEM_END      CRYPTO0_BITSET_MEM_END  /**< Alias for CRYPTO0_BITSET_MEM_END  */
+#define CRYPTO_BITSET_MEM_BITS     CRYPTO0_BITSET_MEM_BITS /**< Alias for CRYPTO0_BITSET_MEM_BITS */
+#define CRYPTO0_BITCLR_MEM_BASE    (0x440F0000UL)          /**< CRYPTO0_BITCLR base address  */
+#define CRYPTO0_BITCLR_MEM_SIZE    (0x400UL)               /**< CRYPTO0_BITCLR available address space  */
+#define CRYPTO0_BITCLR_MEM_END     (0x440F03FFUL)          /**< CRYPTO0_BITCLR end address  */
+#define CRYPTO0_BITCLR_MEM_BITS    (0x0000000AUL)          /**< CRYPTO0_BITCLR used bits  */
+#define CRYPTO_BITCLR_MEM_BASE     CRYPTO0_BITCLR_MEM_BASE /**< Alias for CRYPTO0_BITCLR_MEM_BASE */
+#define CRYPTO_BITCLR_MEM_SIZE     CRYPTO0_BITCLR_MEM_SIZE /**< Alias for CRYPTO0_BITCLR_MEM_SIZE */
+#define CRYPTO_BITCLR_MEM_END      CRYPTO0_BITCLR_MEM_END  /**< Alias for CRYPTO0_BITCLR_MEM_END  */
+#define CRYPTO_BITCLR_MEM_BITS     CRYPTO0_BITCLR_MEM_BITS /**< Alias for CRYPTO0_BITCLR_MEM_BITS */
+#define PER_BITSET_MEM_BASE        (0x46000000UL)          /**< PER_BITSET base address  */
+#define PER_BITSET_MEM_SIZE        (0xF0000UL)             /**< PER_BITSET available address space  */
+#define PER_BITSET_MEM_END         (0x460EFFFFUL)          /**< PER_BITSET end address  */
+#define PER_BITSET_MEM_BITS        (0x00000014UL)          /**< PER_BITSET used bits  */
+#define CRYPTO1_BITSET_MEM_BASE    (0x460F0400UL)          /**< CRYPTO1_BITSET base address  */
+#define CRYPTO1_BITSET_MEM_SIZE    (0x400UL)               /**< CRYPTO1_BITSET available address space  */
+#define CRYPTO1_BITSET_MEM_END     (0x460F07FFUL)          /**< CRYPTO1_BITSET end address  */
+#define CRYPTO1_BITSET_MEM_BITS    (0x0000000AUL)          /**< CRYPTO1_BITSET used bits  */
+#define RAM2_CODE_MEM_BASE         (0x10040000UL)          /**< RAM2_CODE base address  */
+#define RAM2_CODE_MEM_SIZE         (0x800UL)               /**< RAM2_CODE available address space  */
+#define RAM2_CODE_MEM_END          (0x100407FFUL)          /**< RAM2_CODE end address  */
+#define RAM2_CODE_MEM_BITS         (0x0000000BUL)          /**< RAM2_CODE used bits  */
+#define RAM_MEM_BASE               (0x20000000UL)          /**< RAM base address  */
+#define RAM_MEM_SIZE               (0x20000UL)             /**< RAM available address space  */
+#define RAM_MEM_END                (0x2001FFFFUL)          /**< RAM end address  */
+#define RAM_MEM_BITS               (0x00000011UL)          /**< RAM used bits  */
 
 /** Bit banding area */
-#define BITBAND_PER_BASE           ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
-#define BITBAND_RAM_BASE           ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+#define BITBAND_PER_BASE           (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE           (0x22000000UL) /**< SRAM Address Space bit-band area */
 
 /** Flash and SRAM limits for EFR32MG12P332F1024GL125 */
 #define FLASH_BASE                 (0x00000000UL) /**< Flash Base Address */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_acmp.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_acmp.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_ACMP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_adc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_adc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_ADC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_af_pins.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_af_pins.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_AF_PINS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_af_ports.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_af_ports.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_AF_PORTS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_cmu.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_cmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_CMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -1578,7 +1578,7 @@ typedef struct {
 #define _CMU_HFPERCLKEN0_ACMP1_MASK                       0x800UL                                    /**< Bit mask for CMU_ACMP1 */
 #define _CMU_HFPERCLKEN0_ACMP1_DEFAULT                    0x00000000UL                               /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
 #define CMU_HFPERCLKEN0_ACMP1_DEFAULT                     (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 11)     /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
-#define CMU_HFPERCLKEN0_CRYOTIMER                         (0x1UL << 12)                              /**< CryoTimer Clock Enable */
+#define CMU_HFPERCLKEN0_CRYOTIMER                         (0x1UL << 12)                              /**< CRYOTIMER Clock Enable */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_SHIFT                  12                                         /**< Shift value for CMU_CRYOTIMER */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_MASK                   0x1000UL                                   /**< Bit mask for CMU_CRYOTIMER */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for CMU_HFPERCLKEN0 */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_cryotimer.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_cryotimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_CRYOTIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_crypto.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_crypto.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_CRYPTO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_csen.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_csen.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_CSEN register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_devinfo.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_devinfo.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_DEVINFO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_dma_descriptor.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_dma_descriptor.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_dmareq.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_dmareq.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_DMAREQ register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_emu.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_emu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_EMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_etm.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_etm.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_ETM register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_fpueh.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_fpueh.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_FPUEH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpcrc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpcrc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_GPCRC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpio.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpio.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_GPIO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpio_p.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_gpio_p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_GPIO_P register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_i2c.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_i2c.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_I2C register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_idac.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_idac.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_IDAC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_ldma.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_ldma.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_LDMA register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_ldma_ch.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_ldma_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_LDMA_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_LESENSE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_buf.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_buf.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_LESENSE_BUF register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_ch.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_LESENSE_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_st.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_lesense_st.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_LESENSE_ST register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_letimer.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_letimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_LETIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_leuart.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_leuart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_LEUART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_msc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_msc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_MSC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_pcnt.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_pcnt.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_PCNT register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_PRS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs_ch.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_PRS_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs_signals.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_prs_signals.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_PRS_SIGNALS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rmu.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_RMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_romtable.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_romtable.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_ROMTABLE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_RTCC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc_cc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_RTCC_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc_ret.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_rtcc_ret.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_RTCC_RET register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_smu.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_smu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_SMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -142,7 +142,7 @@ typedef struct {
 #define _SMU_PPUPATD0_CMU_MASK             0x20UL                                 /**< Bit mask for SMU_CMU */
 #define _SMU_PPUPATD0_CMU_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for SMU_PPUPATD0 */
 #define SMU_PPUPATD0_CMU_DEFAULT           (_SMU_PPUPATD0_CMU_DEFAULT << 5)       /**< Shifted mode DEFAULT for SMU_PPUPATD0 */
-#define SMU_PPUPATD0_CRYOTIMER             (0x1UL << 7)                           /**< CryoTimer access control bit */
+#define SMU_PPUPATD0_CRYOTIMER             (0x1UL << 7)                           /**< CRYOTIMER access control bit */
 #define _SMU_PPUPATD0_CRYOTIMER_SHIFT      7                                      /**< Shift value for SMU_CRYOTIMER */
 #define _SMU_PPUPATD0_CRYOTIMER_MASK       0x80UL                                 /**< Bit mask for SMU_CRYOTIMER */
 #define _SMU_PPUPATD0_CRYOTIMER_DEFAULT    0x00000000UL                           /**< Mode DEFAULT for SMU_PPUPATD0 */

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_timer.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_timer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_TIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_timer_cc.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_timer_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_TIMER_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_trng.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_trng.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_TRNG register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_usart.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_usart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_USART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_vdac.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_vdac.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_VDAC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_vdac_opa.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_vdac_opa.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_VDAC_OPA register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_wdog.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_wdog.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_WDOG register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_wdog_pch.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/efr32mg12p_wdog_pch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG12P_WDOG_PCH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/em_device.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/em_device.h
@@ -11,10 +11,10 @@
  *          Add "#include "em_device.h" to your source files
  * @endverbatim
  *
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/include/vendor/system_efr32mg12p.h
+++ b/cpu/efm32/families/efr32mg12p/include/vendor/system_efr32mg12p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg12p/system.c
+++ b/cpu/efm32/families/efr32mg12p/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm32.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm32.h
@@ -2,10 +2,10 @@
  * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG1P132F256GM32
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -149,46 +149,46 @@ typedef enum IRQn{
 #define PART_NUMBER               "EFR32MG1P132F256GM32" /**< Part Number */
 
 /** Memory Base addresses and limits */
-#define FLASH_MEM_BASE            ((uint32_t) 0x00000000UL) /**< FLASH base address  */
-#define FLASH_MEM_SIZE            ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
-#define FLASH_MEM_END             ((uint32_t) 0x0FFFFFFFUL) /**< FLASH end address  */
-#define FLASH_MEM_BITS            ((uint32_t) 0x0000001CUL) /**< FLASH used bits  */
-#define RAM_CODE_MEM_BASE         ((uint32_t) 0x10000000UL) /**< RAM_CODE base address  */
-#define RAM_CODE_MEM_SIZE         ((uint32_t) 0x7C00UL)     /**< RAM_CODE available address space  */
-#define RAM_CODE_MEM_END          ((uint32_t) 0x10007BFFUL) /**< RAM_CODE end address  */
-#define RAM_CODE_MEM_BITS         ((uint32_t) 0x0000000FUL) /**< RAM_CODE used bits  */
-#define PER_BITCLR_MEM_BASE       ((uint32_t) 0x44000000UL) /**< PER_BITCLR base address  */
-#define PER_BITCLR_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITCLR available address space  */
-#define PER_BITCLR_MEM_END        ((uint32_t) 0x440E7FFFUL) /**< PER_BITCLR end address  */
-#define PER_BITCLR_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITCLR used bits  */
-#define CRYPTO_BITSET_MEM_BASE    ((uint32_t) 0x460F0000UL) /**< CRYPTO_BITSET base address  */
-#define CRYPTO_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITSET available address space  */
-#define CRYPTO_BITSET_MEM_END     ((uint32_t) 0x460F03FFUL) /**< CRYPTO_BITSET end address  */
-#define CRYPTO_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITSET used bits  */
-#define CRYPTO_MEM_BASE           ((uint32_t) 0x400F0000UL) /**< CRYPTO base address  */
-#define CRYPTO_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO available address space  */
-#define CRYPTO_MEM_END            ((uint32_t) 0x400F03FFUL) /**< CRYPTO end address  */
-#define CRYPTO_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO used bits  */
-#define CRYPTO_BITCLR_MEM_BASE    ((uint32_t) 0x440F0000UL) /**< CRYPTO_BITCLR base address  */
-#define CRYPTO_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITCLR available address space  */
-#define CRYPTO_BITCLR_MEM_END     ((uint32_t) 0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
-#define CRYPTO_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
-#define PER_BITSET_MEM_BASE       ((uint32_t) 0x46000000UL) /**< PER_BITSET base address  */
-#define PER_BITSET_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITSET available address space  */
-#define PER_BITSET_MEM_END        ((uint32_t) 0x460E7FFFUL) /**< PER_BITSET end address  */
-#define PER_BITSET_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITSET used bits  */
-#define PER_MEM_BASE              ((uint32_t) 0x40000000UL) /**< PER base address  */
-#define PER_MEM_SIZE              ((uint32_t) 0xE8000UL)    /**< PER available address space  */
-#define PER_MEM_END               ((uint32_t) 0x400E7FFFUL) /**< PER end address  */
-#define PER_MEM_BITS              ((uint32_t) 0x00000014UL) /**< PER used bits  */
-#define RAM_MEM_BASE              ((uint32_t) 0x20000000UL) /**< RAM base address  */
-#define RAM_MEM_SIZE              ((uint32_t) 0x7C00UL)     /**< RAM available address space  */
-#define RAM_MEM_END               ((uint32_t) 0x20007BFFUL) /**< RAM end address  */
-#define RAM_MEM_BITS              ((uint32_t) 0x0000000FUL) /**< RAM used bits  */
+#define FLASH_MEM_BASE            (0x00000000UL) /**< FLASH base address  */
+#define FLASH_MEM_SIZE            (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END             (0x0FFFFFFFUL) /**< FLASH end address  */
+#define FLASH_MEM_BITS            (0x0000001CUL) /**< FLASH used bits  */
+#define RAM_CODE_MEM_BASE         (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE         (0x7C00UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END          (0x10007BFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS         (0x0000000FUL) /**< RAM_CODE used bits  */
+#define PER_BITCLR_MEM_BASE       (0x44000000UL) /**< PER_BITCLR base address  */
+#define PER_BITCLR_MEM_SIZE       (0xE8000UL)    /**< PER_BITCLR available address space  */
+#define PER_BITCLR_MEM_END        (0x440E7FFFUL) /**< PER_BITCLR end address  */
+#define PER_BITCLR_MEM_BITS       (0x00000014UL) /**< PER_BITCLR used bits  */
+#define CRYPTO_BITSET_MEM_BASE    (0x460F0000UL) /**< CRYPTO_BITSET base address  */
+#define CRYPTO_BITSET_MEM_SIZE    (0x400UL)      /**< CRYPTO_BITSET available address space  */
+#define CRYPTO_BITSET_MEM_END     (0x460F03FFUL) /**< CRYPTO_BITSET end address  */
+#define CRYPTO_BITSET_MEM_BITS    (0x0000000AUL) /**< CRYPTO_BITSET used bits  */
+#define CRYPTO_MEM_BASE           (0x400F0000UL) /**< CRYPTO base address  */
+#define CRYPTO_MEM_SIZE           (0x400UL)      /**< CRYPTO available address space  */
+#define CRYPTO_MEM_END            (0x400F03FFUL) /**< CRYPTO end address  */
+#define CRYPTO_MEM_BITS           (0x0000000AUL) /**< CRYPTO used bits  */
+#define CRYPTO_BITCLR_MEM_BASE    (0x440F0000UL) /**< CRYPTO_BITCLR base address  */
+#define CRYPTO_BITCLR_MEM_SIZE    (0x400UL)      /**< CRYPTO_BITCLR available address space  */
+#define CRYPTO_BITCLR_MEM_END     (0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
+#define CRYPTO_BITCLR_MEM_BITS    (0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
+#define PER_BITSET_MEM_BASE       (0x46000000UL) /**< PER_BITSET base address  */
+#define PER_BITSET_MEM_SIZE       (0xE8000UL)    /**< PER_BITSET available address space  */
+#define PER_BITSET_MEM_END        (0x460E7FFFUL) /**< PER_BITSET end address  */
+#define PER_BITSET_MEM_BITS       (0x00000014UL) /**< PER_BITSET used bits  */
+#define PER_MEM_BASE              (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE              (0xE8000UL)    /**< PER available address space  */
+#define PER_MEM_END               (0x400E7FFFUL) /**< PER end address  */
+#define PER_MEM_BITS              (0x00000014UL) /**< PER used bits  */
+#define RAM_MEM_BASE              (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE              (0x7C00UL)     /**< RAM available address space  */
+#define RAM_MEM_END               (0x20007BFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS              (0x0000000FUL) /**< RAM used bits  */
 
 /** Bit banding area */
-#define BITBAND_PER_BASE          ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
-#define BITBAND_RAM_BASE          ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+#define BITBAND_PER_BASE          (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE          (0x22000000UL) /**< SRAM Address Space bit-band area */
 
 /** Flash and SRAM limits for EFR32MG1P132F256GM32 */
 #define FLASH_BASE                (0x00000000UL) /**< Flash Base Address */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm48.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm48.h
@@ -2,10 +2,10 @@
  * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG1P132F256GM48
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -149,46 +149,46 @@ typedef enum IRQn{
 #define PART_NUMBER               "EFR32MG1P132F256GM48" /**< Part Number */
 
 /** Memory Base addresses and limits */
-#define FLASH_MEM_BASE            ((uint32_t) 0x00000000UL) /**< FLASH base address  */
-#define FLASH_MEM_SIZE            ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
-#define FLASH_MEM_END             ((uint32_t) 0x0FFFFFFFUL) /**< FLASH end address  */
-#define FLASH_MEM_BITS            ((uint32_t) 0x0000001CUL) /**< FLASH used bits  */
-#define RAM_CODE_MEM_BASE         ((uint32_t) 0x10000000UL) /**< RAM_CODE base address  */
-#define RAM_CODE_MEM_SIZE         ((uint32_t) 0x7C00UL)     /**< RAM_CODE available address space  */
-#define RAM_CODE_MEM_END          ((uint32_t) 0x10007BFFUL) /**< RAM_CODE end address  */
-#define RAM_CODE_MEM_BITS         ((uint32_t) 0x0000000FUL) /**< RAM_CODE used bits  */
-#define PER_BITCLR_MEM_BASE       ((uint32_t) 0x44000000UL) /**< PER_BITCLR base address  */
-#define PER_BITCLR_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITCLR available address space  */
-#define PER_BITCLR_MEM_END        ((uint32_t) 0x440E7FFFUL) /**< PER_BITCLR end address  */
-#define PER_BITCLR_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITCLR used bits  */
-#define CRYPTO_BITSET_MEM_BASE    ((uint32_t) 0x460F0000UL) /**< CRYPTO_BITSET base address  */
-#define CRYPTO_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITSET available address space  */
-#define CRYPTO_BITSET_MEM_END     ((uint32_t) 0x460F03FFUL) /**< CRYPTO_BITSET end address  */
-#define CRYPTO_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITSET used bits  */
-#define CRYPTO_MEM_BASE           ((uint32_t) 0x400F0000UL) /**< CRYPTO base address  */
-#define CRYPTO_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO available address space  */
-#define CRYPTO_MEM_END            ((uint32_t) 0x400F03FFUL) /**< CRYPTO end address  */
-#define CRYPTO_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO used bits  */
-#define CRYPTO_BITCLR_MEM_BASE    ((uint32_t) 0x440F0000UL) /**< CRYPTO_BITCLR base address  */
-#define CRYPTO_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITCLR available address space  */
-#define CRYPTO_BITCLR_MEM_END     ((uint32_t) 0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
-#define CRYPTO_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
-#define PER_BITSET_MEM_BASE       ((uint32_t) 0x46000000UL) /**< PER_BITSET base address  */
-#define PER_BITSET_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITSET available address space  */
-#define PER_BITSET_MEM_END        ((uint32_t) 0x460E7FFFUL) /**< PER_BITSET end address  */
-#define PER_BITSET_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITSET used bits  */
-#define PER_MEM_BASE              ((uint32_t) 0x40000000UL) /**< PER base address  */
-#define PER_MEM_SIZE              ((uint32_t) 0xE8000UL)    /**< PER available address space  */
-#define PER_MEM_END               ((uint32_t) 0x400E7FFFUL) /**< PER end address  */
-#define PER_MEM_BITS              ((uint32_t) 0x00000014UL) /**< PER used bits  */
-#define RAM_MEM_BASE              ((uint32_t) 0x20000000UL) /**< RAM base address  */
-#define RAM_MEM_SIZE              ((uint32_t) 0x7C00UL)     /**< RAM available address space  */
-#define RAM_MEM_END               ((uint32_t) 0x20007BFFUL) /**< RAM end address  */
-#define RAM_MEM_BITS              ((uint32_t) 0x0000000FUL) /**< RAM used bits  */
+#define FLASH_MEM_BASE            (0x00000000UL) /**< FLASH base address  */
+#define FLASH_MEM_SIZE            (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END             (0x0FFFFFFFUL) /**< FLASH end address  */
+#define FLASH_MEM_BITS            (0x0000001CUL) /**< FLASH used bits  */
+#define RAM_CODE_MEM_BASE         (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE         (0x7C00UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END          (0x10007BFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS         (0x0000000FUL) /**< RAM_CODE used bits  */
+#define PER_BITCLR_MEM_BASE       (0x44000000UL) /**< PER_BITCLR base address  */
+#define PER_BITCLR_MEM_SIZE       (0xE8000UL)    /**< PER_BITCLR available address space  */
+#define PER_BITCLR_MEM_END        (0x440E7FFFUL) /**< PER_BITCLR end address  */
+#define PER_BITCLR_MEM_BITS       (0x00000014UL) /**< PER_BITCLR used bits  */
+#define CRYPTO_BITSET_MEM_BASE    (0x460F0000UL) /**< CRYPTO_BITSET base address  */
+#define CRYPTO_BITSET_MEM_SIZE    (0x400UL)      /**< CRYPTO_BITSET available address space  */
+#define CRYPTO_BITSET_MEM_END     (0x460F03FFUL) /**< CRYPTO_BITSET end address  */
+#define CRYPTO_BITSET_MEM_BITS    (0x0000000AUL) /**< CRYPTO_BITSET used bits  */
+#define CRYPTO_MEM_BASE           (0x400F0000UL) /**< CRYPTO base address  */
+#define CRYPTO_MEM_SIZE           (0x400UL)      /**< CRYPTO available address space  */
+#define CRYPTO_MEM_END            (0x400F03FFUL) /**< CRYPTO end address  */
+#define CRYPTO_MEM_BITS           (0x0000000AUL) /**< CRYPTO used bits  */
+#define CRYPTO_BITCLR_MEM_BASE    (0x440F0000UL) /**< CRYPTO_BITCLR base address  */
+#define CRYPTO_BITCLR_MEM_SIZE    (0x400UL)      /**< CRYPTO_BITCLR available address space  */
+#define CRYPTO_BITCLR_MEM_END     (0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
+#define CRYPTO_BITCLR_MEM_BITS    (0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
+#define PER_BITSET_MEM_BASE       (0x46000000UL) /**< PER_BITSET base address  */
+#define PER_BITSET_MEM_SIZE       (0xE8000UL)    /**< PER_BITSET available address space  */
+#define PER_BITSET_MEM_END        (0x460E7FFFUL) /**< PER_BITSET end address  */
+#define PER_BITSET_MEM_BITS       (0x00000014UL) /**< PER_BITSET used bits  */
+#define PER_MEM_BASE              (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE              (0xE8000UL)    /**< PER available address space  */
+#define PER_MEM_END               (0x400E7FFFUL) /**< PER end address  */
+#define PER_MEM_BITS              (0x00000014UL) /**< PER used bits  */
+#define RAM_MEM_BASE              (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE              (0x7C00UL)     /**< RAM available address space  */
+#define RAM_MEM_END               (0x20007BFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS              (0x0000000FUL) /**< RAM used bits  */
 
 /** Bit banding area */
-#define BITBAND_PER_BASE          ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
-#define BITBAND_RAM_BASE          ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+#define BITBAND_PER_BASE          (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE          (0x22000000UL) /**< SRAM Address Space bit-band area */
 
 /** Flash and SRAM limits for EFR32MG1P132F256GM48 */
 #define FLASH_BASE                (0x00000000UL) /**< Flash Base Address */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p233f256gm48.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p233f256gm48.h
@@ -2,10 +2,10 @@
  * @file
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG1P233F256GM48
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -149,46 +149,46 @@ typedef enum IRQn{
 #define PART_NUMBER               "EFR32MG1P233F256GM48" /**< Part Number */
 
 /** Memory Base addresses and limits */
-#define FLASH_MEM_BASE            ((uint32_t) 0x00000000UL) /**< FLASH base address  */
-#define FLASH_MEM_SIZE            ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
-#define FLASH_MEM_END             ((uint32_t) 0x0FFFFFFFUL) /**< FLASH end address  */
-#define FLASH_MEM_BITS            ((uint32_t) 0x0000001CUL) /**< FLASH used bits  */
-#define RAM_CODE_MEM_BASE         ((uint32_t) 0x10000000UL) /**< RAM_CODE base address  */
-#define RAM_CODE_MEM_SIZE         ((uint32_t) 0x7C00UL)     /**< RAM_CODE available address space  */
-#define RAM_CODE_MEM_END          ((uint32_t) 0x10007BFFUL) /**< RAM_CODE end address  */
-#define RAM_CODE_MEM_BITS         ((uint32_t) 0x0000000FUL) /**< RAM_CODE used bits  */
-#define PER_BITCLR_MEM_BASE       ((uint32_t) 0x44000000UL) /**< PER_BITCLR base address  */
-#define PER_BITCLR_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITCLR available address space  */
-#define PER_BITCLR_MEM_END        ((uint32_t) 0x440E7FFFUL) /**< PER_BITCLR end address  */
-#define PER_BITCLR_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITCLR used bits  */
-#define CRYPTO_BITSET_MEM_BASE    ((uint32_t) 0x460F0000UL) /**< CRYPTO_BITSET base address  */
-#define CRYPTO_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITSET available address space  */
-#define CRYPTO_BITSET_MEM_END     ((uint32_t) 0x460F03FFUL) /**< CRYPTO_BITSET end address  */
-#define CRYPTO_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITSET used bits  */
-#define CRYPTO_MEM_BASE           ((uint32_t) 0x400F0000UL) /**< CRYPTO base address  */
-#define CRYPTO_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO available address space  */
-#define CRYPTO_MEM_END            ((uint32_t) 0x400F03FFUL) /**< CRYPTO end address  */
-#define CRYPTO_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO used bits  */
-#define CRYPTO_BITCLR_MEM_BASE    ((uint32_t) 0x440F0000UL) /**< CRYPTO_BITCLR base address  */
-#define CRYPTO_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITCLR available address space  */
-#define CRYPTO_BITCLR_MEM_END     ((uint32_t) 0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
-#define CRYPTO_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
-#define PER_BITSET_MEM_BASE       ((uint32_t) 0x46000000UL) /**< PER_BITSET base address  */
-#define PER_BITSET_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITSET available address space  */
-#define PER_BITSET_MEM_END        ((uint32_t) 0x460E7FFFUL) /**< PER_BITSET end address  */
-#define PER_BITSET_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITSET used bits  */
-#define PER_MEM_BASE              ((uint32_t) 0x40000000UL) /**< PER base address  */
-#define PER_MEM_SIZE              ((uint32_t) 0xE8000UL)    /**< PER available address space  */
-#define PER_MEM_END               ((uint32_t) 0x400E7FFFUL) /**< PER end address  */
-#define PER_MEM_BITS              ((uint32_t) 0x00000014UL) /**< PER used bits  */
-#define RAM_MEM_BASE              ((uint32_t) 0x20000000UL) /**< RAM base address  */
-#define RAM_MEM_SIZE              ((uint32_t) 0x7C00UL)     /**< RAM available address space  */
-#define RAM_MEM_END               ((uint32_t) 0x20007BFFUL) /**< RAM end address  */
-#define RAM_MEM_BITS              ((uint32_t) 0x0000000FUL) /**< RAM used bits  */
+#define FLASH_MEM_BASE            (0x00000000UL) /**< FLASH base address  */
+#define FLASH_MEM_SIZE            (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END             (0x0FFFFFFFUL) /**< FLASH end address  */
+#define FLASH_MEM_BITS            (0x0000001CUL) /**< FLASH used bits  */
+#define RAM_CODE_MEM_BASE         (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE         (0x7C00UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END          (0x10007BFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS         (0x0000000FUL) /**< RAM_CODE used bits  */
+#define PER_BITCLR_MEM_BASE       (0x44000000UL) /**< PER_BITCLR base address  */
+#define PER_BITCLR_MEM_SIZE       (0xE8000UL)    /**< PER_BITCLR available address space  */
+#define PER_BITCLR_MEM_END        (0x440E7FFFUL) /**< PER_BITCLR end address  */
+#define PER_BITCLR_MEM_BITS       (0x00000014UL) /**< PER_BITCLR used bits  */
+#define CRYPTO_BITSET_MEM_BASE    (0x460F0000UL) /**< CRYPTO_BITSET base address  */
+#define CRYPTO_BITSET_MEM_SIZE    (0x400UL)      /**< CRYPTO_BITSET available address space  */
+#define CRYPTO_BITSET_MEM_END     (0x460F03FFUL) /**< CRYPTO_BITSET end address  */
+#define CRYPTO_BITSET_MEM_BITS    (0x0000000AUL) /**< CRYPTO_BITSET used bits  */
+#define CRYPTO_MEM_BASE           (0x400F0000UL) /**< CRYPTO base address  */
+#define CRYPTO_MEM_SIZE           (0x400UL)      /**< CRYPTO available address space  */
+#define CRYPTO_MEM_END            (0x400F03FFUL) /**< CRYPTO end address  */
+#define CRYPTO_MEM_BITS           (0x0000000AUL) /**< CRYPTO used bits  */
+#define CRYPTO_BITCLR_MEM_BASE    (0x440F0000UL) /**< CRYPTO_BITCLR base address  */
+#define CRYPTO_BITCLR_MEM_SIZE    (0x400UL)      /**< CRYPTO_BITCLR available address space  */
+#define CRYPTO_BITCLR_MEM_END     (0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
+#define CRYPTO_BITCLR_MEM_BITS    (0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
+#define PER_BITSET_MEM_BASE       (0x46000000UL) /**< PER_BITSET base address  */
+#define PER_BITSET_MEM_SIZE       (0xE8000UL)    /**< PER_BITSET available address space  */
+#define PER_BITSET_MEM_END        (0x460E7FFFUL) /**< PER_BITSET end address  */
+#define PER_BITSET_MEM_BITS       (0x00000014UL) /**< PER_BITSET used bits  */
+#define PER_MEM_BASE              (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE              (0xE8000UL)    /**< PER available address space  */
+#define PER_MEM_END               (0x400E7FFFUL) /**< PER end address  */
+#define PER_MEM_BITS              (0x00000014UL) /**< PER used bits  */
+#define RAM_MEM_BASE              (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE              (0x7C00UL)     /**< RAM available address space  */
+#define RAM_MEM_END               (0x20007BFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS              (0x0000000FUL) /**< RAM used bits  */
 
 /** Bit banding area */
-#define BITBAND_PER_BASE          ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
-#define BITBAND_RAM_BASE          ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+#define BITBAND_PER_BASE          (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE          (0x22000000UL) /**< SRAM Address Space bit-band area */
 
 /** Flash and SRAM limits for EFR32MG1P233F256GM48 */
 #define FLASH_BASE                (0x00000000UL) /**< Flash Base Address */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_acmp.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_acmp.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_ACMP register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_adc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_adc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_ADC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_pins.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_pins.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_AF_PINS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_ports.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_ports.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_AF_PORTS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cmu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_CMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -1438,7 +1438,7 @@ typedef struct {
 #define _CMU_HFPERCLKEN0_ACMP1_MASK                       0x20UL                                    /**< Bit mask for CMU_ACMP1 */
 #define _CMU_HFPERCLKEN0_ACMP1_DEFAULT                    0x00000000UL                              /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
 #define CMU_HFPERCLKEN0_ACMP1_DEFAULT                     (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 5)     /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
-#define CMU_HFPERCLKEN0_CRYOTIMER                         (0x1UL << 6)                              /**< CryoTimer Clock Enable */
+#define CMU_HFPERCLKEN0_CRYOTIMER                         (0x1UL << 6)                              /**< CRYOTIMER Clock Enable */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_SHIFT                  6                                         /**< Shift value for CMU_CRYOTIMER */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_MASK                   0x40UL                                    /**< Bit mask for CMU_CRYOTIMER */
 #define _CMU_HFPERCLKEN0_CRYOTIMER_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for CMU_HFPERCLKEN0 */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cryotimer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cryotimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_CRYOTIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_crypto.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_crypto.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_CRYPTO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_devinfo.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_devinfo.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_DEVINFO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dma_descriptor.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dma_descriptor.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dmareq.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dmareq.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_DMAREQ register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_emu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_emu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_EMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_fpueh.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_fpueh.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_FPUEH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpcrc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpcrc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_GPCRC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_GPIO register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio_p.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio_p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_GPIO_P register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_i2c.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_i2c.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_I2C register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_idac.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_idac.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_IDAC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_LDMA register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma_ch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_LDMA_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_letimer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_letimer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_LETIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_leuart.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_leuart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_LEUART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_msc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_msc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_MSC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_pcnt.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_pcnt.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_PCNT register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_PRS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_ch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_ch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_PRS_CH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_signals.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_signals.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_PRS_SIGNALS register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rmu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rmu.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_RMU register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_romtable.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_romtable.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_ROMTABLE register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_RTCC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_cc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_RTCC_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_ret.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_ret.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_RTCC_RET register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_TIMER register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer_cc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer_cc.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_TIMER_CC register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_usart.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_usart.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_USART register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_WDOG register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog_pch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog_pch.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief EFR32MG1P_WDOG_PCH register and bit field definitions
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/em_device.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/em_device.h
@@ -11,10 +11,10 @@
  *          Add "#include "em_device.h" to your source files
  * @endverbatim
  *
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/include/vendor/system_efr32mg1p.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/system_efr32mg1p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/cpu/efm32/families/efr32mg1p/system.c
+++ b/cpu/efm32/families/efr32mg1p/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.7.0
+ * @version 5.8.3
  *******************************************************************************
  * # License
- * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
  *******************************************************************************
  *
  * SPDX-License-Identifier: Zlib

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=755f5430c05d95812603524f9aa7516964dd5758
+PKG_VERSION=5d699ba8b9a69cfb5ada555cac6db74bb68ae0d2
 PKG_LICENSE=Zlib
 
 ifneq ($(CPU),efm32)


### PR DESCRIPTION
### Contribution description
This updates the Gecko SDK package (for the EFM32 cpu) to version 2.6. It's a small update, but ensures we are forever current. The old version cannot be built anymore (version 2.5 cannot be downloaded anymore), so there is no way to 'patch' that version for me anymore.

Most of the code in this PR is vendor code. 

Unfortunately, Silicon Labs decided not to include any release notes anymore, so I don't know the exact changes. However, the resulting binaries are different, so there are some changes that affect supported CPUs.

### Testing procedure
All EFM32 boards should still compile. All examples still work.

I tested `examples/default` on the `slstk3401a`, `slstk3402a`, `sltb001a` and `stk3600` with no issues.

### Issues/PRs references
n/a