### PR TITLE
cpu/atmega_common: add implementation for watchdog

### DIFF
--- a/cpu/atmega_common/Makefile.features
+++ b/cpu/atmega_common/Makefile.features
@@ -4,3 +4,4 @@ FEATURES_PROVIDED += atmega_pcint0
 FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_wdt

--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -151,6 +151,19 @@ typedef struct {
  */
 #define EEPROM_CLEAR_BYTE              (0xff)
 
+/**
+ * @name    WDT upper and lower bound times in ms
+ * @{
+ */
+#define NWDT_TIME_LOWER_LIMIT           (1)
+#define NWDT_TIME_UPPER_LIMIT           (8192U)
+/** @} */
+
+/**
+ * @brief   WDT can be stopped on AVR
+ */
+#define WDT_HAS_STOP                    (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega_common/periph/wdt.c
+++ b/cpu/atmega_common/periph/wdt.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_atmega_common
+ * @ingroup     drivers_periph_wdt
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the watchdog peripheral interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/pm.h"
+#include "periph/wdt.h"
+
+#include <avr/interrupt.h>
+#include "avr/wdt.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+uint8_t wdt_prescaler = WDTO_15MS;
+
+void wdt_start(void)
+{
+    DEBUG("[wdt] start the watchdog\n");
+    wdt_enable(wdt_prescaler);
+}
+
+void wdt_stop(void)
+{
+    DEBUG("[wdt] stop the watchdog\n");
+    wdt_disable();
+}
+
+void wdt_kick(void)
+{
+    DEBUG("[wdt] reload the watchdog\n");
+    wdt_reset();
+    wdt_enable(wdt_prescaler);
+}
+
+void wdt_setup_reboot(uint32_t min_time, uint32_t max_time)
+{
+    (void)min_time;
+
+    /* Windowed wdt not supported */
+    assert(min_time == 0);
+
+    /* Check reset time limit */
+    assert((max_time > NWDT_TIME_LOWER_LIMIT) || \
+           (max_time < NWDT_TIME_UPPER_LIMIT));
+
+    /* disable watchdog */
+    wdt_disable();
+
+    if (max_time >= 8000) {
+        wdt_prescaler = WDTO_8S;
+    }
+    else if (max_time >= 4000) {
+        wdt_prescaler = WDTO_4S;
+    }
+    else if (max_time >= 2000) {
+        wdt_prescaler = WDTO_2S;
+    }
+    else if (max_time >= 1000) {
+        wdt_prescaler = WDTO_1S;
+    }
+    else if (max_time >= 500) {
+        wdt_prescaler = WDTO_500MS;
+    }
+    else if (max_time >= 250) {
+        wdt_prescaler = WDTO_250MS;
+    }
+    else if (max_time >= 125) {
+        wdt_prescaler = WDTO_120MS;
+    }
+    else if (max_time >= 64) {
+        wdt_prescaler = WDTO_60MS;
+    }
+    else if (max_time >= 32) {
+        wdt_prescaler = WDTO_30MS;
+    }
+    else {
+        wdt_prescaler = WDTO_15MS;
+    }
+
+    DEBUG("[wdt] watchdog setup complete\n");
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the watchdog peripheral features to atmega cpus. The callback mode is not implemented as I couldn't make it work like it should: I have problems setting the prescaler value along with setting the interrupt mode. This could be added in a follow-up PR.

Otherwise the implementation is very basic and is directly using functions from avr libc.

It was only tested on atmega256rfr2-xpro.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- The following should work:

  ```
  $ make BOARD=atmega256rfr2-xpro -C tests/periph_wdt flash test
  ```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
