### PR TITLE
sys/xtimer: fix generation of documentation

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -415,7 +415,7 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
  */
 void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 
-#ifdef MODULE_CORE_MSG
+#if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
 /**
  * @brief Set a timer that sends a message
  *


### PR DESCRIPTION
### Contribution description

cd1ce6b98d43c accidentally disabled generating documentation for `xtimer_msg_*()` functions.

Always define those functions when building the documentation.

### Testing procedure

`make doc` and check the functions are documented again.

### Issues/PRs references
none, but the [xtimer.h File Reference](https://riot-os.org/api/xtimer_8h.html) does not contain any documentation for `xtimer_msg_*()` functions anymore.
