### PR TITLE
boards/hifive1b: fix Linux default serial port

### DIFF
--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -2,7 +2,7 @@
 USEMODULE += stdio_uart
 
 # set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB1
+PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 # setup serial terminal


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is updating the default serial port that is configured on Linux for the hifive1b board. The board provides a JLink adapter which is exposed as /dev/ttyACMx on Linux and stdio over UART is available on this port.

I'm not sure what was the initial reason to use /dev/ttyUSB initially. Maybe it was just a copy-paste from hifive1 ? If this is the case, this was a mistake since hifive1 provides an FTDI interface which is usually exposed on /dev/ttyUSB.

I don't know if the default port for mac OS is the right one.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Plug the board via USB on a Linux computer
- Run the following:
  ```
  $ make BOARD=hifive1b -C example/hello-world flash term
  ```
  The terminal is opened automatically and the hello world message is displayed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
