### PR TITLE
cpu/fe310: implement driver for watchdog

### DIFF
--- a/cpu/fe310/Makefile.features
+++ b/cpu/fe310/Makefile.features
@@ -4,4 +4,5 @@ FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_wdt
 FEATURES_PROVIDED += ssp

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -138,6 +138,28 @@ typedef struct {
     i2c_speed_t speed;          /**< I2C speed */
 } i2c_conf_t;
 
+/**
+ * @name    WDT upper and lower bound times in ms
+ * @{
+ */
+#define NWDT_TIME_LOWER_LIMIT           (1)
+/* Ensure the internal "count" variable stays within the uint32 bounds.
+  This variable corresponds to max_time * RTC_FREQ / MS_PER_SEC. On fe310,
+  RTC_FREQ is 32768Hz. The 15 right shift is equivalent to a division by RTC_FREQ.
+ */
+#define NWDT_TIME_UPPER_LIMIT           ((UINT32_MAX >> 15)  * MS_PER_SEC + 1)
+/** @} */
+
+/**
+ * @brief   WDT interrupt priority: use highest priority
+ */
+#define WDT_INTR_PRIORITY               (PLIC_NUM_PRIORITIES)
+
+/**
+ * @brief   WDT can be stopped
+ */
+#define WDT_HAS_STOP                    (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/fe310/periph/wdt.c
+++ b/cpu/fe310/periph/wdt.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_fe310
+ * @ingroup     drivers_periph_wdt
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the watchdog peripheral interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <inttypes.h>
+#include <assert.h>
+
+#include "cpu.h"
+#include "timex.h"
+
+#include "periph/wdt.h"
+
+#include "vendor/aon.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void wdt_start(void)
+{
+    DEBUG("[wdt] start watchdog\n");
+
+    AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;
+    AON_REG(AON_WDOGCFG) |= AON_WDOGCFG_ENCOREAWAKE;
+}
+
+void wdt_stop(void)
+{
+    DEBUG("[wdt] stop watchdog\n");
+
+    AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;
+    AON_REG(AON_WDOGCFG) &= ~(AON_WDOGCFG_ENCOREAWAKE);
+}
+
+void wdt_kick(void)
+{
+    DEBUG("[wdt] reload the watchdog\n");
+
+    AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;
+    AON_REG(AON_WDOGFEED) = AON_WDOGFEED_VALUE;
+}
+
+static inline uint8_t _scale(uint32_t count)
+{
+    uint8_t scale = 0;
+    while (count > (UINT16_MAX - 1)) {
+        count >>= 1;
+        scale++;
+    }
+
+    return scale;
+}
+
+static inline uint8_t _setup(uint32_t min_time, uint32_t max_time)
+{
+    (void)min_time;
+
+    /* Windowed wdt not supported */
+    assert(min_time == 0);
+
+    /* Check reset time limit */
+    assert((max_time > NWDT_TIME_LOWER_LIMIT) || \
+           (max_time < NWDT_TIME_UPPER_LIMIT));
+
+    uint32_t count = ((uint32_t)max_time * RTC_FREQ) / MS_PER_SEC;
+    uint8_t scale = _scale(count);
+
+    AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;
+    AON_REG(AON_WDOGCMP) = count;
+
+    return scale;
+}
+
+void wdt_setup_reboot(uint32_t min_time, uint32_t max_time)
+{
+    uint8_t scale = _setup(min_time, max_time);
+
+    AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;
+    AON_REG(AON_WDOGCFG) = AON_WDOGCFG_RSTEN | AON_WDOGCFG_ZEROCMP | scale;
+
+    DEBUG("[wdt] watchdog setup complete\n");
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR implements the watchdog peripheral driver for the fe310 cpu (the one on the hifive1 boards).

Both reset and interrupt modes are implemented.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Automatic testing doesn't work well on hifive1b because the reboot of the board is super slow (no idea why). The feature can be tested by manual testing:
- Run `tests/periph_wdt` and play with the shell
  ```
  > setup 0 3000
  > start
  > kick
  > kick
  > stop
  > start
  => reboot after 3 seconds (+ reboot delay of the board...)
  ```
- To test interrupt mode, the easiest is to write an application by following the [online documentation](http://doc.riot-os.org/group__drivers__periph__wdt.html) (see WDT callback section).

### Issues/PRs references

Easier to test on hifive1b with #12662 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
