### PR TITLE
pkg/littlefs: bump littlefs version to 1.7.2

### DIFF
--- a/pkg/littlefs/Makefile
+++ b/pkg/littlefs/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=littlefs
-PKG_URL=https://github.com/geky/littlefs.git
-# v1.6.2
-PKG_VERSION=0bb1f7af17755bd792f0c4966877fb1886dfc802
+PKG_URL=https://github.com/ARMmbed/littlefs.git
+# v1.7.2
+PKG_VERSION=7e110b44c0e796dc56e2fe86587762d685653029
 PKG_LICENSE=Apache-2.0
 
 .PHONY: all


### PR DESCRIPTION
### Contribution description

Let's stay on the v1 branch with this pkg to avoid incompatibilities. 

### Testing procedure

Make sure `tests/pkg_littlefs`.
Since this is just a point release, and for now the last one in the v1 series, no major breakage is (hopefully) expected.

### Issues/PRs references
less radical than #12657 