### PR TITLE
drivers/hd44780: PCF857x I2C interface added

### DIFF
--- a/drivers/hd44780/include/hd44780_params.h
+++ b/drivers/hd44780/include/hd44780_params.h
@@ -19,7 +19,11 @@
 #define HD44780_PARAMS_H
 
 #include "board.h"
+#ifdef MODULE_PCF857X
+#include "pcf857x.h"
+#else
 #include "periph/gpio.h"
+#endif
 
 #ifdef __cplusplus
 extern "C"
@@ -34,6 +38,9 @@ extern "C"
 #ifndef HD44780_PARAM_ROWS
 #define HD44780_PARAM_ROWS              (2U)
 #endif
+
+#ifndef MODULE_PCF857X
+
 #ifndef HD44780_PARAM_PIN_RS
 #define HD44780_PARAM_PIN_RS            GPIO_PIN(0, 14)         /* Arduino D2 */
 #endif
@@ -53,6 +60,30 @@ extern "C"
                                             GPIO_UNDEF,                           \
                                             GPIO_UNDEF }
 #endif
+
+#else /* !MODULE_PCF857X */
+
+#ifndef HD44780_PARAM_PIN_RS
+#define HD44780_PARAM_PIN_RS            PCF857X_GPIO_PIN(0, 0)      /* Bit 0 */
+#endif
+#ifndef HD44780_PARAM_PIN_RW
+#define HD44780_PARAM_PIN_RW            PCF857X_GPIO_PIN(0, 1)      /* Bit 1 */
+#endif
+#ifndef HD44780_PARAM_PIN_ENABLE
+#define HD44780_PARAM_PIN_ENABLE        PCF857X_GPIO_PIN(0, 2)      /* Bit 2 */
+#endif
+#ifndef HD44780_PARAM_PINS_DATA
+#define HD44780_PARAM_PINS_DATA         {   PCF857X_GPIO_PIN(0, 4), /* Bit 4 */  \
+                                            PCF857X_GPIO_PIN(0, 5), /* Bit 5 */  \
+                                            PCF857X_GPIO_PIN(0, 6), /* Bit 6 */  \
+                                            PCF857X_GPIO_PIN(0, 7), /* Bit 7 */  \
+                                            GPIO_UNDEF,                          \
+                                            GPIO_UNDEF,                          \
+                                            GPIO_UNDEF,                          \
+                                            GPIO_UNDEF }
+#endif
+
+#endif /* !MODULE_PCF857X */
 
 #ifndef HD44780_PARAMS
 #define HD44780_PARAMS               {  .cols   = HD44780_PARAM_COLS,       \


### PR DESCRIPTION
### Contribution description

There are tons of cheap alphanumeric displays with a dimension of 2 x 16 characters that are controlled by a HD44780 over an I2C interface.

The I2C interface of these displays is simply realized by an I2C 8bit I/O expander which provides the I2C interface and is connected to the pins of the HD44780. All these I2C displays use either PCF8574 or PCF8574A for this purpose. That is, using the HD44780 driver togehter with PCF8574 driver work as driver for these displays.

This PR provides small changes of the HD44780 driver which demonstrates how it is possible to use it together with the PCF857X driver as provided in PR #10430. The PR requires some more work, e.g., an approach on how to define and initialize the PCF8574.

### Testing procedure

Fetch PR #10430 and this PR. Checkout this PR and rebase it onto PR #10430. Connect the display to `I2C_DEV(0)` and use
```
USEMODULE=pcf8574 make BOARD=esp8266-esp-12x -C tests/driver_hd44780 flash
```
or 
```
USEMODULE=pcf8574a make -C tests/driver_hd44780 BOARD=...  flash
```
dependent on whether your display uses the PCF8574 or the PCF8574A.

Furthermore, there are versions that use `0` and versions that use `7` as address offset to the base I2C address of the PCF8574 (Information about the versions can be found [here](https://github.com/va3wam/OpenSmart_1602_LCD_Display/blob/master/%5BOPEN-SMART%5D%20I2C%20LCD%201602/About%20I2C%20address%20of%20the%20LCD.jpg)). 

Dependent on which version you have, it might be necessary to define the offset as follows:
```
CFLAGS='-DPCF857X_PARAM_ADDR=7' \
USEMODULE=pcf8574a make -C tests/driver_hd44780 BOARD=... flash
```

### Issues/PRs references

Related to PR #12487 and PR #12590.
~Depends on PR #10430~