### PR TITLE
examples/dtls-*: Use passed interface if present

### DIFF
--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -341,12 +341,13 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
         }
     }
     else {
-        if (gnrc_netif_get_by_pid(iface) == NULL) {
+        gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+        if (netif == NULL) {
             puts("ERROR: interface not valid");
             return new_context;
         }
-        dst->ifindex = (uint16_t)gnrc_netif_iter(NULL)->pid;
-        remote->netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+        dst->ifindex = (uint16_t)netif->pid;
+        remote->netif = (uint16_t)netif->pid;
     }
 
     if (ipv6_addr_from_str((ipv6_addr_t *)remote->addr.ipv6, addr_str) == NULL) {

--- a/examples/dtls-wolfssl/dtls-client.c
+++ b/examples/dtls-wolfssl/dtls-client.c
@@ -109,12 +109,13 @@ int dtls_client(int argc, char **argv)
         }
     }
     else {
-        if (gnrc_netif_get_by_pid(iface) == NULL) {
+        gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+        if (netif == NULL) {
             LOG(LOG_ERROR, "ERROR: interface not valid");
             usage(argv[0]);
             return -1;
         }
-        remote.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+        remote.netif = (uint16_t)netif->pid;
     }
     if (ipv6_addr_from_str((ipv6_addr_t *)remote.addr.ipv6, addr_str) == NULL) {
         LOG(LOG_ERROR, "ERROR: unable to parse destination address");


### PR DESCRIPTION
### Contribution description
Right now, in the DTLS example applications 'send' functions, if an interface is passed in the destination IPv6 address it is ignored and the first available interface is used instead. This fixes this issue by actually using the passed interface.

### Testing procedure
- [ ] `examples/dtls-echo` should send through the indicated interface
- [ ] `examples/dtls-wolfssl` should send through the indicated interface

### Issues/PRs references
None