### PR TITLE
net/ipv6: Don't assume interface specifier is an int for splitting

### DIFF
--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -328,8 +328,8 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
     remote->port = (unsigned short) DTLS_DEFAULT_PORT;
 
     /* Parsing <address>[:<iface>]:Port */
-    int iface = ipv6_addr_split_iface(addr_str);
-    if (iface == -1) {
+    char *iface = ipv6_addr_split_iface(addr_str);
+    if (!iface) {
         if (gnrc_netif_numof() == 1) {
             /* assign the single interface found in gnrc_netif_numof() */
             dst->ifindex = (uint16_t)gnrc_netif_iter(NULL)->pid;
@@ -341,7 +341,7 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
         }
     }
     else {
-        gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+        gnrc_netif_t *netif = gnrc_netif_get_by_pid(atoi(iface));
         if (netif == NULL) {
             puts("ERROR: interface not valid");
             return new_context;

--- a/examples/dtls-wolfssl/dtls-client.c
+++ b/examples/dtls-wolfssl/dtls-client.c
@@ -86,7 +86,7 @@ int dtls_client(int argc, char **argv)
 {
     int ret = 0;
     char buf[APP_DTLS_BUF_SIZE] = "Hello from DTLS client!";
-    int iface;
+    char *iface;
     char *addr_str;
     int connect_timeout = 0;
     const int max_connect_timeouts = 5;
@@ -102,14 +102,14 @@ int dtls_client(int argc, char **argv)
 
     /* Parsing <address> */
     iface = ipv6_addr_split_iface(addr_str);
-    if (iface == -1) {
+    if (!iface) {
         if (gnrc_netif_numof() == 1) {
             /* assign the single interface found in gnrc_netif_numof() */
             remote.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
         }
     }
     else {
-        gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+        gnrc_netif_t *netif = gnrc_netif_get_by_pid(atoi(iface));
         if (netif == NULL) {
             LOG(LOG_ERROR, "ERROR: interface not valid");
             usage(argv[0]);

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -221,8 +221,8 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
     remote.family = AF_INET6;
 
     /* parse for interface */
-    int iface = ipv6_addr_split_iface(addr_str);
-    if (iface == -1) {
+    char *iface = ipv6_addr_split_iface(addr_str);
+    if (!iface) {
         if (gnrc_netif_numof() == 1) {
             /* assign the single interface found in gnrc_netif_numof() */
             remote.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
@@ -232,13 +232,13 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
         }
     }
     else {
-        if (gnrc_netif_get_by_pid(iface) == NULL) {
+        int pid = atoi(iface);
+        if (gnrc_netif_get_by_pid(pid) == NULL) {
             puts("gcoap_cli: interface not valid");
             return 0;
         }
-        remote.netif = iface;
+        remote.netif = pid;
     }
-
     /* parse destination address */
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
         puts("gcoap_cli: unable to parse destination address");

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -39,19 +39,19 @@ static gnrc_netreg_entry_t server = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX
 static void send(char *addr_str, char *port_str, char *data, unsigned int num,
                  unsigned int delay)
 {
-    gnrc_netif_t *netif;
-    int iface;
+    gnrc_netif_t *netif = NULL;
+    char *iface;
     uint16_t port;
     ipv6_addr_t addr;
 
-    /* get interface, if available */
     iface = ipv6_addr_split_iface(addr_str);
-    if ((iface < 0) && (gnrc_netif_numof() == 1)) {
+    if ((!iface) && (gnrc_netif_numof() == 1)) {
         netif = gnrc_netif_iter(NULL);
     }
-    else {
-        netif = gnrc_netif_get_by_pid(iface);
+    else if (iface) {
+        netif = gnrc_netif_get_by_pid(atoi(iface));
     }
+
     /* parse destination address */
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
         puts("Error: unable to parse destination address");

--- a/examples/gnrc_networking_mac/udp.c
+++ b/examples/gnrc_networking_mac/udp.c
@@ -39,18 +39,18 @@ static gnrc_netreg_entry_t server = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX
 static void send(char *addr_str, char *port_str, char *data, unsigned int num,
                  unsigned int delay)
 {
-    gnrc_netif_t *netif;
-    int iface;
+    gnrc_netif_t *netif = NULL;
+    char *iface;
     uint16_t port;
     ipv6_addr_t addr;
 
     /* get interface, if available */
     iface = ipv6_addr_split_iface(addr_str);
-    if ((iface < 0) && (gnrc_netif_numof() == 1)) {
+    if ((!iface) && (gnrc_netif_numof() == 1)) {
         netif = gnrc_netif_iter(NULL);
     }
-    else {
-        netif = gnrc_netif_get_by_pid(iface);
+    else if (iface){
+        netif = gnrc_netif_get_by_pid(atoi(iface));
     }
     /* parse destination address */
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -730,6 +730,20 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
 ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr);
 
 /**
+ * @brief split IPv6 address string representation and return remaining string
+ *
+ * Will change @p separator position in @p addr_str to '\0'
+ *
+ * @param[in,out]   addr_str    Address to split
+ * @param[in]       separator   Separator char to use
+ *
+ * @return      string following the first occurrence of @p separator in
+ *              @p addr_str.
+ * @return      NULL if @p separator was not found.
+ */
+char *ipv6_addr_split_str(char *addr_str, char separator);
+
+/**
  * @brief split IPv6 address string representation
  *
  * @note Will change @p seperator position in @p addr_str to '\0'
@@ -741,7 +755,7 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr);
  * @return      atoi(string after split)
  * @return      @p _default if no string after @p seperator
  */
-int ipv6_addr_split(char *addr_str, char seperator, int _default);
+int ipv6_addr_split_int(char *addr_str, char seperator, int _default);
 
 /**
  * @brief split IPv6 prefix string representation
@@ -753,7 +767,7 @@ int ipv6_addr_split(char *addr_str, char seperator, int _default);
  */
 static inline int ipv6_addr_split_prefix(char *addr_str)
 {
-    return ipv6_addr_split(addr_str, '/', 128);
+    return ipv6_addr_split_int(addr_str, '/', 128);
 }
 
 /**
@@ -762,11 +776,12 @@ static inline int ipv6_addr_split_prefix(char *addr_str)
  * E.g., "fe80::1%5" returns "5", changes @p addr_str to "fe80::1"
  *
  * @param[in,out]   addr_str Address to split
- * @return          interface number or -1 if none specified
+ * @return          string containing the interface specifier.
+ * @return          NULL if no interface was specified.
  */
-static inline int ipv6_addr_split_iface(char *addr_str)
+static inline char *ipv6_addr_split_iface(char *addr_str)
 {
-    return ipv6_addr_split(addr_str, '%', -1);
+    return ipv6_addr_split_str(addr_str, '%');
 }
 
 /**

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -168,15 +168,15 @@ static int _gnrc_tcp_open(gnrc_tcp_tcb_t *tcb, char *target_addr, uint16_t targe
         if ((target_addr != NULL) && (tcb->address_family == AF_INET6)) {
 
             /* Extract interface (optional) specifier from target address */
-            int ll_iface = ipv6_addr_split_iface(target_addr);
+            char *ll_iface = ipv6_addr_split_iface(target_addr);
             if (ipv6_addr_from_str((ipv6_addr_t *) tcb->peer_addr, target_addr) == NULL) {
                 DEBUG("gnrc_tcp.c : _gnrc_tcp_open() : Invalid peer addr\n");
                 return -EINVAL;
             }
 
             /* In case the given address is link-local: Memorize the interface Id if existing. */
-            if ((ll_iface > 0) && ipv6_addr_is_link_local((ipv6_addr_t *) tcb->peer_addr)) {
-                tcb->ll_iface = ll_iface;
+            if ((ll_iface) && ipv6_addr_is_link_local((ipv6_addr_t *) tcb->peer_addr)) {
+                tcb->ll_iface = atoi(ll_iface);
             }
         }
  #endif

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -123,20 +123,23 @@ void ipv6_addr_init_iid(ipv6_addr_t *out, const uint8_t *iid, uint8_t bits)
     memcpy(&(out->u8[pos]), iid, bytes);
 }
 
-int ipv6_addr_split(char *addr_str, char seperator, int _default)
+char *ipv6_addr_split_str(char *addr_str, char seperator)
 {
     char *sep = addr_str;
-    while(*++sep) {
+    while (*(++sep)) {
         if (*sep == seperator) {
             *sep++ = '\0';
-            if (*sep) {
-                _default = atoi(sep);
-            }
             break;
         }
     }
 
-    return _default;
+    return *sep ? sep : NULL;
+}
+
+int ipv6_addr_split_int(char *addr_str, char separator, int _default)
+{
+    char *val = ipv6_addr_split_str(addr_str, separator);
+    return val ? atoi(val) : _default;
 }
 
 void ipv6_addr_print(const ipv6_addr_t *addr)

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -171,7 +171,6 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
     for (int i = 1; i < argc; i++) {
         char *arg = argv[i];
         if (arg[0] != '-') {
-            int iface;
 
             data->hostname = arg;
 #ifdef MODULE_SOCK_DNS
@@ -179,9 +178,9 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
                 continue;
             }
 #endif
-            iface = ipv6_addr_split_iface(data->hostname);
-            if (iface != -1) {
-                data->netif = gnrc_netif_get_by_pid(iface);
+            char *iface = ipv6_addr_split_iface(data->hostname);
+            if (iface) {
+                data->netif = gnrc_netif_get_by_pid(atoi(iface));
             }
 #if GNRC_NETIF_NUMOF == 1
             else {

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -1103,7 +1103,7 @@ static int _netif_flag(char *cmd, kernel_pid_t iface, char *flag)
 #ifdef MODULE_GNRC_IPV6
 static uint8_t _get_prefix_len(char *addr)
 {
-    int prefix_len = ipv6_addr_split(addr, '/', _IPV6_DEFAULT_PREFIX_LEN);
+    int prefix_len = ipv6_addr_split_int(addr, '/', _IPV6_DEFAULT_PREFIX_LEN);
 
     if (prefix_len < 1) {
         prefix_len = _IPV6_DEFAULT_PREFIX_LEN;

--- a/sys/shell/commands/sc_sntp.c
+++ b/sys/shell/commands/sc_sntp.c
@@ -46,10 +46,8 @@ int _ntpdate(int argc, char **argv)
     sock_udp_ep_t server = { .port = NTP_PORT, .family = AF_INET6 };
     ipv6_addr_t *addr = (ipv6_addr_t *)&server.addr;
 
-    kernel_pid_t src_iface = ipv6_addr_split_iface(argv[1]);
-    if (src_iface == -1) {
-        src_iface = KERNEL_PID_UNDEF;
-    }
+    char *iface = ipv6_addr_split_iface(argv[1]);
+    kernel_pid_t src_iface = iface ? atoi(iface) : KERNEL_PID_UNDEF;
 
     if (ipv6_addr_from_str(addr, argv[1]) == NULL) {
         puts("error: malformed address");

--- a/tests/gnrc_ipv6_ext_frag/udp.c
+++ b/tests/gnrc_ipv6_ext_frag/udp.c
@@ -37,13 +37,16 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
                  unsigned int delay)
 {
     int iface;
+    char *iface_spec;
     char *conversion_end;
     uint16_t port;
     ipv6_addr_t addr;
     size_t data_len;
 
     /* get interface, if available */
-    iface = ipv6_addr_split_iface(addr_str);
+    iface_spec = ipv6_addr_split_iface(addr_str);
+    iface = iface_spec ? atoi(iface_spec) : -1;
+
     if ((iface < 0) && (gnrc_netif_numof() == 1)) {
         iface = gnrc_netif_iter(NULL)->pid;
     }

--- a/tests/gnrc_udp/udp.c
+++ b/tests/gnrc_udp/udp.c
@@ -82,8 +82,8 @@ static void *_eventloop(void *arg)
 static void send(char *addr_str, char *port_str, char *data_len_str, unsigned int num,
                  unsigned int delay)
 {
-    gnrc_netif_t *netif;
-    int iface;
+    gnrc_netif_t *netif = NULL;
+    char *iface;
     char *conversion_end;
     uint16_t port;
     ipv6_addr_t addr;
@@ -91,11 +91,11 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
 
     /* get interface, if available */
     iface = ipv6_addr_split_iface(addr_str);
-    if ((iface < 0) && (gnrc_netif_numof() == 1)) {
+    if ((!iface) && (gnrc_netif_numof() == 1)) {
         netif = gnrc_netif_iter(NULL);
     }
-    else {
-        netif = gnrc_netif_get_by_pid(iface);
+    else if (iface) {
+        netif = gnrc_netif_get_by_pid(atoi(iface));
     }
     /* parse destination address */
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -37,8 +37,8 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str
     remote.family = AF_INET6;
 
     /* parse for interface */
-    int iface = ipv6_addr_split_iface(addr_str);
-    if (iface == -1) {
+    char *iface = ipv6_addr_split_iface(addr_str);
+    if (!iface) {
         if (gnrc_netif_numof() == 1) {
             /* assign the single interface found in gnrc_netif_numof() */
             remote.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
@@ -48,11 +48,12 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str
         }
     }
     else {
-        if (gnrc_netif_get_by_pid(iface) == NULL) {
+        int pid = atoi(iface);
+        if (gnrc_netif_get_by_pid(pid) == NULL) {
             puts("nanocli: interface not valid");
             return 0;
         }
-        remote.netif = iface;
+        remote.netif = pid;
     }
 
     /* parse destination address */

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -1042,6 +1042,20 @@ static void test_ipv6_addr_split_iface__with_iface(void)
     TEST_ASSERT_EQUAL_INT(*(iface - 1), '\0');
 }
 
+static void test_ipv6_addr_split_prefix__no_prefix(void)
+{
+    char a[] = "fd00:dead:beef::1";
+    TEST_ASSERT_EQUAL_INT(ipv6_addr_split_prefix(a), 128);
+}
+
+static void test_ipv6_addr_split_prefix__with_prefix(void)
+{
+    char a[] = "fd00:dead:beef::1/64";
+    TEST_ASSERT_EQUAL_INT(ipv6_addr_split_prefix(a), 64);
+    /* check that the separator has been replaced with '\0' */
+    TEST_ASSERT_EQUAL_INT(strcmp("fd00:dead:beef::1", a), 0);
+}
+
 Test *tests_ipv6_addr_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -1132,6 +1146,8 @@ Test *tests_ipv6_addr_tests(void)
         new_TestFixture(test_ipv6_addr_from_str__success6),
         new_TestFixture(test_ipv6_addr_split_iface__no_iface),
         new_TestFixture(test_ipv6_addr_split_iface__with_iface),
+        new_TestFixture(test_ipv6_addr_split_prefix__no_prefix),
+        new_TestFixture(test_ipv6_addr_split_prefix__with_prefix),
     };
 
     EMB_UNIT_TESTCALLER(ipv6_addr_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -1026,6 +1026,22 @@ static void test_ipv6_addr_from_str__success6(void)
     TEST_ASSERT(ipv6_addr_equal(&a, &result));
 }
 
+static void test_ipv6_addr_split_iface__no_iface(void)
+{
+    char a[] = "fe80::f8f9:fafb:fcfd:feff";
+    TEST_ASSERT_NULL(ipv6_addr_split_iface(a));
+}
+
+static void test_ipv6_addr_split_iface__with_iface(void)
+{
+    char a[] = "fe80::f8f9:fafb:fcfd:feff%eth0";
+    char *iface = ipv6_addr_split_iface(a);
+    TEST_ASSERT_NOT_NULL(iface);
+    TEST_ASSERT_EQUAL_INT(strcmp("eth0", iface), 0);
+    /* check that the separator has been replaced with '\0' */
+    TEST_ASSERT_EQUAL_INT(*(iface - 1), '\0');
+}
+
 Test *tests_ipv6_addr_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -1114,6 +1130,8 @@ Test *tests_ipv6_addr_tests(void)
         new_TestFixture(test_ipv6_addr_from_str__success4),
         new_TestFixture(test_ipv6_addr_from_str__success5),
         new_TestFixture(test_ipv6_addr_from_str__success6),
+        new_TestFixture(test_ipv6_addr_split_iface__no_iface),
+        new_TestFixture(test_ipv6_addr_split_iface__with_iface),
     };
 
     EMB_UNIT_TESTCALLER(ipv6_addr_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description
Currently `ipv6_addr_split_iface` assumes that the 'interface specifier' of a string representation of IPv6 will always be a number, which [is not always the case](https://tools.ietf.org/html/rfc6874#section-2).

In order to be able to use the Network Interface API, interfaces should be referred by their name, which is a string (e.g. current implementation of `netif_get_name` for GNRC returns `if<n>` for interface with PID `<n>`).

This changes `ipv6_addr_split_iface` so it returns a pointer to the string that specifies the interface. In every usage of it so far, the interface specifier is transformed to an int as before though, as the application is already accessing the interfaces via GNRC's API.

### Testing procedure
Check that the modified applications still work as expected.

### Issues/PRs references
Found while rebasing #11036