### PR TITLE
Adding: boards/avr-rss2 and AtMega256RFR2 based board         See doc.txt for details.

### DIFF
--- a/boards/avr-rss2/Makefile
+++ b/boards/avr-rss2/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/avr-rss2/Makefile.dep
+++ b/boards/avr-rss2/Makefile.dep
@@ -1,0 +1,6 @@
+USEMODULE += boards_common_atmega
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += bme280
+  USEMODULE += saul_gpio
+endif

--- a/boards/avr-rss2/Makefile.features
+++ b/boards/avr-rss2/Makefile.features
@@ -1,0 +1,8 @@
+
+CPU = atmega256rfr2
+
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/avr-rss2/Makefile.include
+++ b/boards/avr-rss2/Makefile.include
@@ -1,0 +1,20 @@
+# configure the terminal program
+PORT_LINUX  ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+# refine serial port information for pyterm
+BAUD        ?= 115200
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# PROGRAMMER defaults to wiring which is the internal flasher via USB
+# using avrdude. Can be overridden for debugging (which requires changes
+# that require to use an ISP)
+PROGRAMMER ?= stk500v2
+#
+# see /usr/include/asm-generic/termbits.h for availabel baudrates on your linux system
+
+# From current fuse configuration
+BOOTLOADER_SIZE ?= 4K
+ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+
+include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/avr-rss2/doc.txt
+++ b/boards/avr-rss2/doc.txt
@@ -1,0 +1,103 @@
+/**
+@defgroup    boards_avr-rss2 Atmega256RFR2 rss2
+@ingroup     boards
+@brief       Support for the Radio Sensors Atmega256RFR2 rss2 board
+
+### General information
+Document version V1.4 2019-11-10<br>
+Board is based AtMega256RFR2 with additional HW, EUI64 chip, HW comparator, RTC XTAL, BME280
+
+- Directory `$(RIOTBASE)/boards/avr-rss2'
+
+### Board Features
+
+- PCB Antenna. Supercardiod
+- Robust radio performance. Up to 300 meter line-of-sight
+- Unique EUI64 address via 24MAC602 chip with 2k EEPROM
+- Rev 2.4 Onboard BME280 for Temp/RH/Pressure
+- Light Sensor
+- 32kHz RTC clock xtal
+- HW comparator chip and input
+- Programmable power FET, (relay) for power on/off of sensors
+- Up to 25V DC input via LDO (LP2950). TVS protected
+- Standard. 6-pin TTL-USB header compatible w. FTDI cable for USART
+- PCB formfactor for cheap project box G.40X IP54
+- Power/current use:
+*- RX ~10mA (Full RPC AtMegaXXRFR2)
+*- Sleep ~45uA @ 16MHz XTAL
+*- Sleep ~15uA @  8MHz using internal oscillator
+- Preprogammed Atmel standard stk500v2 bootloader
+- CE certified by test institute
+
+### USART
+The board has one USART via the 6-pin TTL-USB adapter, The default
+baudrate is 115200 bps. It's possible to use higher speeds as is 250k
+and 500k baud which gives 0% Error with 16MHz clock.
+(An additional USART is on the chip but as default used by interrupt
+pins. Needs HW mod to be used)
+
+### Toolchain
+The Atmel toolchain is available in most operating systems.
+For a full toolchain and easy installation on Ubuntu:
+```
+apt-get install gcc-avr avr-libc avrdude
+```
+Otherwise if OS toolchain packages do not support the AtMega256RfR2
+MCU, another option is to download the C compiler toolchain from Microchip.
+
+### For Linux and MacOS
+1. Download the proper 8-bit C compiler AVR toolchain, 32 or 64-bit, [from Microchip](https://www.microchip.com/mplab/avr-support/avr-and-arm-toolchains-c-compilers).
+2. Unpack under `/usr/local`
+3. Add to your search PATH. For example add to `.bashrc`:
+```
+export PATH=$PATH:/usr/local/avr8-gnu-toolchain-linux_x86_64/bin (64-bit)
+export PATH=$PATH:/usr/local/avr8-gnu-toolchain-linux_x86/bin (32-bit)
+```
+4. For flash programming, you need `avrdude`. On Ubuntu Linux, it can be installed with the command
+
+```
+apt-get install avrdude
+```
+For MacOS, there is a [HomeBrewpackage](https://formula.brew.sh/formula/avrdude#default)
+that can be installed with the command:
+```
+brew install avrdude
+```
+
+### RIOT build
+
+```
+make BOARD=avr-rss2
+```
+
+### Flashing/Programming hardware
+Programming using avrdude using serial bootloader using a TTL-USB cable.
+Press the RESET button. The bootloader with wait for boot commands for 3 seconds. Program with:
+```
+avrdude -p m256rfr2 -c stk500v2 -P /dev/ttyUSB0 -b 115200 -e -U flash:w:bin/rss2-mega256rfr2/hello-world.elf
+```
+
+### Board approvals
+
+Summary: CE approved Radio Equipment Directive (RED) 2014/53/EU
+Rev 2.4
+- Safety: IEC 60950-1:2005 2nd Edition +Am 1:2009 +Am 2:2013
+- RF: ETSI EN 300 328 V2.1.1 (2016-11)
+- EMC: Draft ETSI EN 301 489-1 V2.2.0 (2017-03),Draft ETSI EN 301 489-17 V3.2.0 (2017-03)
+- EMF: EN 62479:2010
+- Human exposure to electromagnetic fields: EN 62479:2010
+
+### Commercial availability
+Through vendor and though resellers. Note board is will only available
+were CE approval is covered. This may be further restricted by WEEE.
+Contact vendor. For research legislation is more relaxed in most countries.
+
+### References
+- AtMega64/128/256/RFR2 chip documentation available via Atmel.
+- Smart Reduced Power Consumption Techniques. AT02594 available via Atmel.
+- Board documentation, schematics, CE and vendor via http://radio-sensors.com/
+
+### Board (Rev2.4) anatomy with connectors
+- http://radio-sensors.com/pictures/s2-2.4-front-edited.jpg
+- http://radio-sensors.com/pictures/s2-2.4-back-port-edited.jpg
+*/

--- a/boards/avr-rss2/include/board.h
+++ b/boards/avr-rss2/include/board.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 Robert Olsson <roolss@kth.se>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_avr-rss2
+ * @{
+ *
+ * @file
+ * @brief       Board definitions for the rss2 256rfr2 board.
+ *
+ * @author      Robert Olsson <roolss@kth.se>
+ *
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+#define LED_PORT            PORTE
+#define LED_PORT_DDR        DDRE
+
+#define LED0_PIN            GPIO_PIN(PORT_E, 4) /* RED */
+#define LED1_PIN            GPIO_PIN(PORT_E, 3) /* YELLOW */
+
+#define LED0_MASK           (1 << 4)
+#define LED1_MASK           (1 << 3)
+
+#define LED0_MODE           GPIO_OUT
+#define LED0_OFF            (LED_PORT |=  LED0_MASK)
+#define LED0_ON             (LED_PORT &= ~LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT ^=  LED0_MASK)
+
+#define LED1_MODE           GPIO_OUT
+#define LED1_OFF            (LED_PORT |=  LED1_MASK)
+#define LED1_ON             (LED_PORT &= ~LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT ^=  LED1_MASK)
+
+
+/**
+ * @name    Usage of LED to turn on when a kernel panic occurs.
+ * @{
+ */
+#define LED_PANIC           LED0_ON
+/** @} */
+
+
+/**
+ * @name DS18 pins  OW_BUS_0
+ * @{
+ */
+#define DS18_PARAM_PIN      GPIO_PIN(PORT_D, 7)
+#define DS18_PARAM_PULL     (GPIO_IN_PU)
+
+/**
+ * @name xtimer configuration values
+ * @{
+ */
+#define XTIMER_DEV          TIMER_DEV(0)
+#define XTIMER_CHAN         (0)
+#define XTIMER_WIDTH        (16)
+#define XTIMER_HZ           (62500UL)
+
+/**
+ * @name Indicate Watchdog cleared in bootloader an
+ *
+ * AVR CPUs need to reset the Watchdog as fast as possible.
+ * This flag indicates that the watchdog is reset in the bootloader
+ * and that the MCUSR value is stored in register 0 (r0)
+ * @{
+ */
+#define BOOTLOADER_CLEARS_WATCHDOG_AND_PASSES_MCUSR 0
+/** @} */
+
+/**
+ * @name CPU clock scale for avr-rss2
+ *
+ */
+#define CPU_ATMEGA_CLK_SCALE_INIT    CPU_ATMEGA_CLK_SCALE_DIV1
+/** @} */
+
+/**
+ * @name    User button configuration
+ * @{
+ */
+#define MODULE_ATMEGA_PCINT0
+#define BTN0_PIN            GPIO_PIN(PORT_B, 0)
+#define BTN0_MODE           GPIO_IN
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/avr-rss2/include/gpio_params.h
+++ b/boards/avr-rss2/include/gpio_params.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 Robert Olsson <roolss@kth.se>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_avr-rss2
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Robert Olsson <roolss@kth.se>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GPIO configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BTN0 (S2 BUTTON)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED0 (Red)",
+        .pin = LED0_PIN,
+        .mode = LED0_MODE,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name = "LED1 (Yellow)",
+        .pin = LED1_PIN,
+        .mode = LED1_MODE,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/avr-rss2/include/periph_conf.h
+++ b/boards/avr-rss2/include/periph_conf.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 Robert Olsson <roolss@kth.se>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_avr-rss2
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the rss2 AtMega256rfr2 board
+ * @author      Robert Olsson <roolss@kth.se>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Clock configuration
+ * @{
+ */
+#define CLOCK_CORECLOCK     (16000000UL)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "periph_conf_atmega_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/avr-rss2/led_init.c
+++ b/boards/avr-rss2/led_init.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 Robert Olsson <roolss@kth.se>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_avr-rss2
+ * @{
+ *
+ * @file
+ * @brief       Board specific LED initialization
+ * @author      Robert Olsson <roolss@kth.se>
+ *
+ *
+ * @}
+ */
+
+#include "board.h"
+
+void led_init(void)
+{
+    /* Ports Pins as Output */
+    LED_PORT_DDR |= LED1_MASK | LED0_MASK;
+    /* All LEDs OFF */
+    LED_PORT |= (LED1_MASK | LED0_MASK);
+}

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -34,7 +34,7 @@ USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 
-BOARD_PROVIDES_NETIF := acd52832 airfy-beacon atmega256rfr2-xpro b-l072z-lrwan1 cc2538dk fox \
+BOARD_PROVIDES_NETIF := acd52832 airfy-beacon atmega256rfr2-xpro avr-rss2 b-l072z-lrwan1 cc2538dk fox \
         hamilton iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \
         microduino-corerf native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf6310 \
         nucleo-f767zi openmote-b openmote-cc2538 pba-d-01-kw2x remote-pa remote-reva \

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
-                   arduino-mega2560 arduino-nano arduino-uno \
+                   arduino-mega2560 arduino-nano arduino-uno avr-rss2 \
                    atmega328p atmega256rfr2-xpro atmega1284p mega-xplained \
                    microduino-corerf waspmote-pro
 # arduino-mega2560: builds locally but breaks travis (possibly because of

--- a/tests/sys_crypto/Makefile
+++ b/tests/sys_crypto/Makefile
@@ -7,6 +7,7 @@ BOARD_BLACKLIST += arduino-mega2560
 BOARD_BLACKLIST += arduino-nano
 BOARD_BLACKLIST += arduino-uno
 BOARD_BLACKLIST += atmega256rfr2-xpro
+BOARD_BLACKLIST += avr-rss2
 BOARD_BLACKLIST += atmega328p
 BOARD_BLACKLIST += atmega1284p
 BOARD_BLACKLIST += chronos


### PR DESCRIPTION
### Contribution description

Support for a new boards/avr-rss2 an AtMega256RFR2 based. See `doc.txt` for detail. PR does not touch any core files. The PR also demonstrates ease and small footprint in RIOT. PR uses in total 426 bytes.  

### Testing procedure

Tested with examples/gnrc_networking using the at86rf2xx radio with the recent PR #12537 using ping6 RPL over 6LowPAN.

### Issues/PRs references
Follow-up work is planned to enable eui64 chip support see PR #12592