### PR TITLE
boards: add mcb2388

### DIFF
--- a/boards/mcb2388/Makefile
+++ b/boards/mcb2388/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/mcb2388/Makefile.dep
+++ b/boards/mcb2388/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/mcb2388/Makefile.features
+++ b/boards/mcb2388/Makefile.features
@@ -1,0 +1,8 @@
+CPU = lpc2387
+CPU_MODEL = lpc2388
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/mcb2388/Makefile.include
+++ b/boards/mcb2388/Makefile.include
@@ -1,0 +1,8 @@
+# FLASHER will be lpc2k_pgm still
+DEBUG_ADAPTER ?= dap
+PROGRAMMER ?= openocd
+
+JLINK_DEVICE := LPC2388
+
+include $(RIOTBOARD)/common/msba2/Makefile.include
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/mcb2388/board_init.c
+++ b/boards/mcb2388/board_init.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_mcb2388
+ * @{
+ */
+
+/**
+ * @file
+ * @brief       MCB2388 board initialization
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "periph/init.h"
+#include "stdio_base.h"
+
+void board_init(void)
+{
+    /* LEDS */
+    FIO2DIR |= LED0_MASK | LED1_MASK | LED2_MASK | LED3_MASK \
+            |  LED4_MASK | LED5_MASK | LED6_MASK | LED7_MASK;
+}

--- a/boards/mcb2388/dist/openocd.cfg
+++ b/boards/mcb2388/dist/openocd.cfg
@@ -1,0 +1,20 @@
+transport select jtag
+
+source [find target/lpc2xxx.cfg]
+# parameters:
+# - core_freq_khz - frequency of core in kHz during flashing, usually equal to connected crystal or internal oscillator, e.g. 12000
+# - adapter_freq_khz - frequency of debug adapter in kHz, should be 8x slower than core_freq_khz, e.g. 1000
+
+proc setup_lpc2388 {core_freq_khz adapter_freq_khz} {
+	# 512kB flash and 64kB SRAM
+	# setup_lpc2xxx <chip_name> <cputapid> <flash_size> <flash_variant> <workarea_size> <core_freq_khz> <adapter_freq_khz>
+	setup_lpc2xxx lpc2388 0x4f1f0f0f 0x7E000 lpc2000_v2 0x10000 $core_freq_khz $adapter_freq_khz
+}
+
+proc init_targets {} {
+	# default to core clocked with 4MHz internal oscillator
+	echo "Warning - assuming default core clock 4MHz! Flashing may fail if actual core clock is different."
+
+	# setup_lpc2378 <core_freq_khz> <adapter_freq_khz>
+	setup_lpc2388 4000 500
+}

--- a/boards/mcb2388/doc.txt
+++ b/boards/mcb2388/doc.txt
@@ -1,0 +1,69 @@
+/**
+@defgroup    boards_mcb2388 MCB2388 Evaluation Board
+@ingroup     boards
+@brief       Support for the MCB2388 Evaluation Board
+
+## Overview
+
+![MCB2388 image](http://www.keil.com/support/man/docs/mcb2300/mcb2388_board.jpg)
+
+## Hardware
+
+| MCU:      | LPC2388 ARM7-TDMI |
+|-----------|-------------------|
+| RAM:      | 96kb              |
+| Flash:    | 512kb             |
+
+# More info
+
+## Board Schematics
+[Board schematics](http://www.keil.com/mcb2300/mcb2300-schematics.pdf)
+
+## Flashing
+
+The MCB2388 is programmed via an ISP bootloader over UART. For this you have to
+connect an USB-RS232 converter to the COM0 port.
+
+Make sure to have the ISP Jumper set.
+
+Connect the MCB2388 to your PC using the serial port and run from within the
+folder of your application to flash:
+
+    BOARD=mcb2388 make flash
+
+You'll notice that during the first invocation takes a bit longer, as the tool
+`lpc2k_pgm` used to flash the MCB2388 is also compiled.
+
+You can connect to the shell by running:
+
+    BOARD=mcb2388 make term
+
+## Serial Terminal
+
+By default the RST line is connected to the RTS/CTS line of COM0.
+This will pull the MCU into reset when connecting a terminal. Use `pyterm -tg` to
+toggle the pins and complete the reset.
+
+If you want to connect a terminal application that does not support this, remove
+the RST jumper from the board.
+You will not be able to flash the board using `lpc2k_pgm` if the RST jumper is
+disconnected.
+
+## Debugging
+
+The development kit comes with a ULINK-ME Debug Unit that supports the CMSIS-DAP
+protocol.
+Connect it with the JTAG port on the board, the debugging should work by typing
+
+    BOARD=mcb2388 make debug
+
+### Flashing via OpenOCD
+
+Theoretically you should be able to flash also via JTAG.
+Unfortunately OpenOCD support for this chip family seems to be pretty buggy.
+I was unable to flash the board using the ULINK-ME adapter and OpenOCD. (2019)
+
+The board might get stuck when using OpenOCD, you have to power-cycle it to
+being able to use ISP programming again.
+
+ */

--- a/boards/mcb2388/include/board.h
+++ b/boards/mcb2388/include/board.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_mcb2388
+ * @{
+ *
+ * @file
+ * @brief       Basic definitions for the MCB2388 board
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "lpc2387.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer tuning values
+ * @{
+ */
+#define XTIMER_OVERHEAD     7
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(2, 0)
+#define LED1_PIN            GPIO_PIN(2, 1)
+#define LED2_PIN            GPIO_PIN(2, 2)
+#define LED3_PIN            GPIO_PIN(2, 3)
+#define LED4_PIN            GPIO_PIN(2, 4)
+#define LED5_PIN            GPIO_PIN(2, 5)
+#define LED6_PIN            GPIO_PIN(2, 6)
+#define LED7_PIN            GPIO_PIN(2, 7)
+
+#define LED0_MASK           (BIT0)
+#define LED1_MASK           (BIT1)
+#define LED2_MASK           (BIT2)
+#define LED3_MASK           (BIT3)
+#define LED4_MASK           (BIT4)
+#define LED5_MASK           (BIT5)
+#define LED6_MASK           (BIT6)
+#define LED7_MASK           (BIT7)
+
+#define LED0_ON             (FIO2SET  = LED0_MASK)
+#define LED0_OFF            (FIO2CLR  = LED0_MASK)
+#define LED0_TOGGLE         (FIO2PIN ^= LED0_MASK)
+
+#define LED1_ON             (FIO2SET  = LED1_MASK)
+#define LED1_OFF            (FIO2CLR  = LED1_MASK)
+#define LED1_TOGGLE         (FIO2PIN ^= LED1_MASK)
+
+#define LED2_ON             (FIO2SET  = LED2_MASK)
+#define LED2_OFF            (FIO2CLR  = LED2_MASK)
+#define LED2_TOGGLE         (FIO2PIN ^= LED2_MASK)
+
+#define LED3_ON             (FIO2SET  = LED3_MASK)
+#define LED3_OFF            (FIO2CLR  = LED3_MASK)
+#define LED3_TOGGLE         (FIO2PIN ^= LED3_MASK)
+
+#define LED4_ON             (FIO2SET  = LED4_MASK)
+#define LED4_OFF            (FIO2CLR  = LED4_MASK)
+#define LED4_TOGGLE         (FIO2PIN ^= LED4_MASK)
+
+#define LED5_ON             (FIO2SET  = LED5_MASK)
+#define LED5_OFF            (FIO2CLR  = LED5_MASK)
+#define LED5_TOGGLE         (FIO2PIN ^= LED5_MASK)
+
+#define LED6_ON             (FIO2SET  = LED6_MASK)
+#define LED6_OFF            (FIO2CLR  = LED6_MASK)
+#define LED6_TOGGLE         (FIO2PIN ^= LED6_MASK)
+
+#define LED7_ON             (FIO2SET  = LED7_MASK)
+#define LED7_OFF            (FIO2CLR  = LED7_MASK)
+#define LED7_TOGGLE         (FIO2PIN ^= LED7_MASK)
+/** @} */
+
+/**
+ * @name    INT0 (Button) pin definitions
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(2, 10)
+#define BTN0_MODE           GPIO_IN
+/** @} */
+
+/**
+ * @name    Configuration for the 16x2 character LCD display
+ * @{
+ */
+#define HD44780_PARAM_COLS              (16U)
+#define HD44780_PARAM_ROWS              (2U)
+#define HD44780_PARAM_PIN_RS            GPIO_PIN(1, 28)
+#define HD44780_PARAM_PIN_RW            GPIO_PIN(1, 29)
+#define HD44780_PARAM_PIN_ENABLE        GPIO_PIN(1, 31)
+#define HD44780_PARAM_PINS_DATA         {   GPIO_PIN(1,24), GPIO_PIN(1,25), \
+                                            GPIO_PIN(1,26), GPIO_PIN(1,27), \
+                                            GPIO_UNDEF,     GPIO_UNDEF,     \
+                                            GPIO_UNDEF,     GPIO_UNDEF      }
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/mcb2388/include/gpio_params.h
+++ b/boards/mcb2388/include/gpio_params.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_mcb2388
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ *
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED0",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED1",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED2",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED3",
+        .pin = LED3_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED4",
+        .pin = LED4_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED5",
+        .pin = LED5_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED6",
+        .pin = LED6_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED7",
+        .pin = LED7_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "Button(INT0)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/mcb2388/include/periph_conf.h
+++ b/boards/mcb2388/include/periph_conf.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_mcb2388
+ * @{
+ *
+ * @file
+ * @brief       MCB2388 peripheral configuration
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ * @{
+ */
+#define XTAL_HZ             (12000000U)         /* the board provides a 12 MHz XTAL */
+
+#define CLOCK_CORECLOCK     (72000000U)         /* the lpc2388 runs with 72MHz */
+
+#define CLOCK_PCLK          (CLOCK_CORECLOCK)
+/** @} */
+
+/**
+ * @name    Timer configuration, select a number from 1 to 4
+ * @{
+ */
+#define TIMER_NUMOF         (1U)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = UART0,
+        .irq_prio_rx = 6,
+        .pinsel_rx   = 0,
+        .pinsel_tx   = 0,
+        .pinsel_msk_rx = BIT4,
+        .pinsel_msk_tx = BIT6,
+    },
+    {
+        .dev = UART1,
+        .irq_prio_rx = 6,
+        .pinsel_rx   = 1,
+        .pinsel_tx   = 0,
+        .pinsel_msk_rx = BIT0,
+        .pinsel_msk_tx = BIT30,
+    }
+};
+
+#define UART_NUMOF          (2)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * The SPI implementation is very much fixed, so we don't need to configure
+ * anything besides the mandatory SPI_NUMOF.
+ * @{
+ */
+#define SPI_NUMOF           (1)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

The [MCB2388 Evaluation Board](http://www.keil.com/arm/mcb2300/mcb2388.asp) is a development board for the LPC2388 MCU.
    
LPC2388 and LPC2387 are very similar, the only difference is that LPC2388 can also operate in USB host mode.

Since this is not used yet, I chose to just pretend it's an lpc2387.
    
So far, only the two UARTs, LEDs and LCD display are configured.

### Testing procedure

I tried `examples/default` to blink the LEDs with SAUL.
`tests/driver_hd44780` also displays text on the LCD.

### Issues/PRs references
Was used for past and future `cpu/lpc2387` PRs.