### PR TITLE
Revert "drivers/hd44780: add short delay after each character"

### DIFF
--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -83,8 +83,6 @@ static void _send(const hd44780_t *dev, uint8_t value, hd44780_state_t state)
         _write_bits(dev, 4, value>>4);
         _write_bits(dev, 4, value);
     }
-
-    xtimer_usleep(HD44780_PULSE_WAIT_SHORT);
 }
 
 static void _write_bits(const hd44780_t *dev, uint8_t bits, uint8_t value)


### PR DESCRIPTION
### Contribution description

This reverts commit cf01c743a89e17d78037fcc77f32b8daa859845e.

Adding an unexplained delay seemed wrong in the first place, but it fixed the display on the MCB2388, so I didn't give it much thought.

Turns out the display was erroneously operating in 8-bit mode due to the uninitialized flag register.
Why the delay helped here I don't know.

But with #12634 fixing this, this hack is not needed anymore.

### Testing procedure

`tests/driver_hd44780` now also works without this crutch. 

### Issues/PRs references
introduced in #12487
properly fixed by #12634
