### PR TITLE
cpu/lpc2387: Add MCU features to Makefile.features

### DIFF
--- a/boards/avsextrem/Makefile.features
+++ b/boards/avsextrem/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -1,9 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
 
 include $(RIOTBOARD)/common/msba2/Makefile.features

--- a/cpu/lpc2387/Makefile.features
+++ b/cpu/lpc2387/Makefile.features
@@ -1,1 +1,4 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+
 -include $(RIOTCPU)/arm7_common/Makefile.features


### PR DESCRIPTION
### Contribution description

As little as the title suggests:

- Added MCU provided features to `cpu/lpc2387/Makefile.features`
- Updated the `Makefile.features` in `avsextrem` and `msba2` to include the new file

### Testing procedure

Run:
1. `make info-features-provided BOARD=msba2`
2. `make info-features-provided BOARD=avsextrem`

The output should not change with this PR

### Issues/PRs references

Suggested by @aabadie  in https://github.com/RIOT-OS/RIOT/pull/12669