### PR TITLE
boards: remove RTT_NUMOF/RTC_NUMOF

### DIFF
--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -260,7 +260,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1U)
 #define RTC_DEV             RTC->MODE2
 /** @} */
 
@@ -268,7 +267,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             RTC->MODE0
 #define RTT_IRQ             RTC_IRQn
 #define RTT_IRQ_PRIO        10

--- a/boards/avsextrem/include/periph_conf.h
+++ b/boards/avsextrem/include/periph_conf.h
@@ -44,12 +44,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name    Real Time Clock configuration
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
-/**
  * @name    UART configuration
  * @{
  */

--- a/boards/chronos/include/periph_conf.h
+++ b/boards/chronos/include/periph_conf.h
@@ -67,12 +67,6 @@ extern "C" {
 #define UART_TX_ISR         (USART1TX_VECTOR)
 /** @} */
 
-/**
- * @name    Real Time Clock configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
 
 #ifdef __cplusplus
 }

--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -195,7 +195,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1U)
 #define RTC_DEV             RTC->MODE2
 /** @} */
 
@@ -203,7 +202,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             RTC->MODE0
 #define RTT_IRQ             RTC_IRQn
 #define RTT_IRQ_PRIO        10

--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -153,7 +153,6 @@ static const uart_conf_t uart_config[] = {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_IRQ_PRIO        1
 
 #define RTT_DEV             RTC

--- a/boards/common/nrf51/include/cfg_rtt_default.h
+++ b/boards/common/nrf51/include/cfg_rtt_default.h
@@ -29,7 +29,6 @@ extern "C" {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             (1)             /* NRF_RTC1 */
 #define RTT_MAX_VALUE       (0x00ffffff)
 #define RTT_FREQUENCY       (1024)

--- a/boards/common/nrf52/include/cfg_rtt_default.h
+++ b/boards/common/nrf52/include/cfg_rtt_default.h
@@ -28,7 +28,6 @@ extern "C" {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             (1)             /* NRF_RTC1 */
 #define RTT_MAX_VALUE       (0x00ffffff)
 #define RTT_FREQUENCY       (1024)

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -122,7 +122,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1)
 #define EXTERNAL_OSC32_SOURCE                    1
 #define INTERNAL_OSC32_SOURCE                    0
 #define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      0
@@ -134,7 +133,6 @@ static const i2c_conf_t i2c_config[] = {
  */
 #define RTT_FREQUENCY       (32768U)
 #define RTT_MAX_VALUE       (0xffffffffU)
-#define RTT_NUMOF           (1)
 /** @} */
 
 /**

--- a/boards/common/slwstk6000b/include/periph_conf.h
+++ b/boards/common/slwstk6000b/include/periph_conf.h
@@ -103,16 +103,9 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   RTC configuration
- */
-#define RTC_NUMOF           (1U)
-
-/**
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
-
 #define RTT_MAX_VALUE       (0xFFFFFFFF)
 #define RTT_FREQUENCY       (1U)
 /** @} */

--- a/boards/common/sodaq/include/cfg_rtc_default.h
+++ b/boards/common/sodaq/include/cfg_rtc_default.h
@@ -32,7 +32,6 @@ extern "C" {
  * @name RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1U)
 #define RTC_DEV             RTC->MODE2
 /** @} */
 

--- a/boards/common/sodaq/include/cfg_rtt_default.h
+++ b/boards/common/sodaq/include/cfg_rtt_default.h
@@ -32,7 +32,6 @@ extern "C" {
  * @name RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             RTC->MODE0
 #define RTT_IRQ             RTC_IRQn
 #define RTT_IRQ_PRIO        10

--- a/boards/common/stm32/include/cfg_rtt_default.h
+++ b/boards/common/stm32/include/cfg_rtt_default.h
@@ -31,7 +31,6 @@ extern "C" {
  * On the STM32Lx platforms, we always utilize the LPTIM1.
  * @{
  */
-#define RTT_NUMOF           (1)
 #define RTT_FREQUENCY       (1024U)             /* 32768 / 2^n */
 #define RTT_MAX_VALUE       (0x0000ffff)        /* 16-bit timer */
 /** @} */

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -243,7 +243,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1U)
 #define RTC_DEV             RTC->MODE2
 /** @} */
 
@@ -251,7 +250,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             RTC->MODE0
 #define RTT_IRQ             RTC_IRQn
 #define RTT_IRQ_PRIO        10

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -158,7 +158,6 @@ static const spi_conf_t spi_config[] = {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_IRQ_PRIO        1
 
 #define RTT_DEV             RTC

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -91,7 +91,6 @@ extern "C" {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1U)
 #define RTC_DEV             RTC->MODE2
 /** @} */
 
@@ -99,7 +98,6 @@ extern "C" {
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             RTC->MODE0
 #define RTT_IRQ             RTC_IRQn
 #define RTT_IRQ_PRIO        10

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -54,12 +54,10 @@ extern "C" {
  *
  * @{
  */
-#define RTT_NUMOF                   (1)
 #define RTT_FREQUENCY               (1)             /* in Hz */
 #define RTT_MAX_VALUE               (0xFFFFFFFF)
 #define RTT_INTR_PRIORITY           (2)
 
-#define RTC_NUMOF                   (1)
 /** @} */
 
 /**

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -54,12 +54,10 @@ extern "C" {
  *
  * @{
  */
-#define RTT_NUMOF                   (1)
 #define RTT_FREQUENCY               (1)             /* in Hz */
 #define RTT_MAX_VALUE               (0xFFFFFFFF)
 #define RTT_INTR_PRIORITY           (2)
 
-#define RTC_NUMOF                   (1)
 /** @} */
 
 /**

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -48,18 +48,11 @@ extern "C" {
 #endif
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
 
 /**
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 
 #define RTT_MAX_VALUE       (0xFFFFFFFF)
 #define RTT_FREQUENCY       (1U)

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -68,12 +68,6 @@ extern "C" {
 #define PWM_FUNC          (1)
 /** @} */
 
-/**
- * @name    Real Time Clock configuration
- * @{
- */
-#define RTC_NUMOF           (1)
-/** @} */
 
 /**
  * @name    UART configuration

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -123,7 +123,6 @@ static const uart_conf_t uart_config[] = {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_IRQ_PRIO        1
 
 #define RTT_DEV             RTC

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -216,7 +216,6 @@ static const spi_conf_t spi_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1)
 #define RTT_FREQUENCY       (4096)
 #define RTT_MAX_VALUE       (0xffff)
 /** @} */

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -281,7 +281,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1U)
 #define RTC_DEV             RTC->MODE2
 /** @} */
 
@@ -289,7 +288,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             RTC->MODE0
 #define RTT_IRQ             RTC_IRQn
 #define RTT_IRQ_PRIO        10

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -138,7 +138,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1)
 #define EXTERNAL_OSC32_SOURCE                    1
 #define INTERNAL_OSC32_SOURCE                    0
 #define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      0
@@ -150,7 +149,6 @@ static const i2c_conf_t i2c_config[] = {
  */
 #define RTT_FREQUENCY       (32768U)
 #define RTT_MAX_VALUE       (0xffffffffU)
-#define RTT_NUMOF           (1)
 /** @} */
 
 /**

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -136,7 +136,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1)
 #define EXTERNAL_OSC32_SOURCE                    1
 #define INTERNAL_OSC32_SOURCE                    0
 #define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      0
@@ -148,7 +147,6 @@ static const i2c_conf_t i2c_config[] = {
  */
 #define RTT_FREQUENCY       (32768U)
 #define RTT_MAX_VALUE       (0xffffffffU)
-#define RTT_NUMOF           (1)
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -252,7 +252,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1U)
 #define RTC_DEV             RTC->MODE2
 /** @} */
 
@@ -260,7 +259,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 #define RTT_DEV             RTC->MODE0
 #define RTT_IRQ             RTC_IRQn
 #define RTT_IRQ_PRIO        10

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -119,7 +119,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF                               (1)
 #define EXTERNAL_OSC32_SOURCE                   1
 #define INTERNAL_OSC32_SOURCE                   0
 #define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE     0
@@ -131,7 +130,6 @@ static const i2c_conf_t i2c_config[] = {
  */
 #define RTT_FREQUENCY                           (32768U)
 #define RTT_MAX_VALUE                           (0xffffffffU)
-#define RTT_NUMOF                               (1)
 /** @} */
 
 /**

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -121,7 +121,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF                               (1)
 #define EXTERNAL_OSC32_SOURCE                   1
 #define INTERNAL_OSC32_SOURCE                   0
 #define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE     0
@@ -133,7 +132,6 @@ static const i2c_conf_t i2c_config[] = {
  */
 #define RTT_FREQUENCY                           (32768U)
 #define RTT_MAX_VALUE                           (0xffffffffU)
-#define RTT_NUMOF                               (1)
 /** @} */
 
 /**

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -204,7 +204,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (1U)
 #define RTC_DEV             RTC->MODE2
 
 /** @} */

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -110,16 +110,9 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   RTC configuration
- */
-#define RTC_NUMOF           (1U)
-
-/**
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
-
 #define RTT_MAX_VALUE       (0xFFFFFFFF)
 #define RTT_FREQUENCY       (1U)
 /** @} */

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -101,16 +101,9 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   RTC configuration
- */
-#define RTC_NUMOF           (1U)
-
-/**
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
-
 #define RTT_MAX_VALUE       (0xFFFFFFFF)
 #define RTT_FREQUENCY       (1U)
 /** @} */

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -110,16 +110,9 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   RTC configuration
- */
-#define RTC_NUMOF           (1U)
-
-/**
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
-
 #define RTT_MAX_VALUE       (0xFFFFFFFF)
 #define RTT_FREQUENCY       (1U)
 /** @} */

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -155,18 +155,11 @@ static const pwm_conf_t pwm_config[] = {
 #define PWM_NUMOF           ARRAY_SIZE(pwm_channel_config)
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
 
 /**
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 
 #define RTT_MAX_VALUE       (0xFFFFFF)
 #define RTT_FREQUENCY       (1U)

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -155,18 +155,11 @@ static const pwm_conf_t pwm_config[] = {
 #define PWM_NUMOF           ARRAY_SIZE(pwm_channel_config)
 /** @} */
 
-/**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
 
 /**
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
 
 #define RTT_MAX_VALUE       (0xFFFFFF)
 #define RTT_FREQUENCY       (1U)

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -141,8 +141,6 @@ typedef uint16_t gpio_t;
  * @name RTT and RTC configuration
  * @{
  */
-#define RTT_NUMOF                    (1U)
-#define RTC_NUMOF                    (1U)
 #define RTT_FREQUENCY                (1)
 #define RTT_MAX_VALUE                (0xffffffff)
 /** @} */

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -35,13 +35,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name RealTime Clock configuration
- * @{
- */
-#define RTC_NUMOF (1)
-/** @} */
-
-/**
  * @name Timer peripheral configuration
  * @{
  */

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -2016,8 +2016,6 @@ PREDEFINED             = DOXYGEN \
                          I2C_NUMOF \
                          PWM_NUMOF \
                          RANDOM_NUMOF \
-                         RTC_NUMOF \
-                         RTT_NUMOF \
                          GPIO_NUMOF \
                          SPI_NUMOF \
                          UART_NUMOF \


### PR DESCRIPTION
### Contribution description

Having a number of RTT/RTC devices seemed strange, yet many boards would define `RTC_NUMOF` or `RTT_NUMOF`.

A quick `grep` shows that those are never used anywhere, so remove them.

### Testing procedure

Murdock will confirm that nobody will miss those macros.

### Issues/PRs references

came up in #12672