### PR TITLE
cpu/sam0_common: rtt: enable COUNTSYNC in CTRLA

### DIFF
--- a/cpu/sam0_common/periph/rtt.c
+++ b/cpu/sam0_common/periph/rtt.c
@@ -27,6 +27,14 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+/*
+ * Bit introduced by SAML21xxxB, setting it on SAML21xxxxA too has no ill
+ * effects, but simplifies the code. (This bit is always set on SAML21xxxxA)
+ */
+#ifndef RTC_MODE0_CTRLA_COUNTSYNC
+#define RTC_MODE0_CTRLA_COUNTSYNC   BIT15
+#endif
+
 static rtt_cb_t _overflow_cb;
 static void* _overflow_arg;
 
@@ -91,7 +99,7 @@ void rtt_init(void)
 
     /* set 32bit counting mode & enable the RTC */
 #ifdef REG_RTC_MODE0_CTRLA
-    RTC->MODE0.CTRLA.reg = RTC_MODE0_CTRLA_MODE(0) | RTC_MODE0_CTRLA_ENABLE;
+    RTC->MODE0.CTRLA.reg = RTC_MODE0_CTRLA_MODE(0) | RTC_MODE0_CTRLA_ENABLE | RTC_MODE0_CTRLA_COUNTSYNC;
 #else
     RTC->MODE0.CTRL.reg = RTC_MODE0_CTRL_MODE(0) | RTC_MODE0_CTRL_ENABLE;
 #endif


### PR DESCRIPTION
### Contribution description

From the data sheet:

> The COUNT register requires synchronization when reading.
> Disabling the synchronization will prevent reading valid
> values from the COUNT register.

Without this bit enabled, `rtt_get_counter()` will always return 0.

### Testing procedure

Run `tests/periph_rtt` on any sam0 MCU that has the CTRLA register (that is, all non-samd21 sam0s) and this patch:

```patch
diff --git a/tests/periph_rtt/main.c b/tests/periph_rtt/main.c
index a0647ff45..46a722bb7 100644
--- a/tests/periph_rtt/main.c
+++ b/tests/periph_rtt/main.c
@@ -41,7 +41,7 @@ void cb(void *arg)
     last &= RTT_MAX_VALUE;
     rtt_set_alarm(last, cb, 0);
 
-    puts("Hello");
+    printf("Hello (%ld)\n", rtt_get_counter());
 }
 
 int main(void)
```

#### before
```
2019-11-08 15:12:28,113 # Initializing the RTT driver
2019-11-08 15:12:28,114 # RTT now: 0
2019-11-08 15:12:28,118 # Setting initial alarm to now + 5 s (163840)
2019-11-08 15:12:28,122 # Done setting up the RTT, wait for many Hellos
2019-11-08 15:12:33,115 # Hello (0)
2019-11-08 15:12:38,115 # Hello (0)
2019-11-08 15:12:43,115 # Hello (0)
2019-11-08 15:12:48,115 # Hello (0)
2019-11-08 15:12:53,116 # Hello (0)
```

#### after
```
2019-11-08 15:18:13,775 # Initializing the RTT driver
2019-11-08 15:18:13,776 # RTT now: 0
2019-11-08 15:18:13,787 # Setting initial alarm to now + 5 s (163840)
2019-11-08 15:18:13,788 # Done setting up the RTT, wait for many Hellos
2019-11-08 15:18:18,777 # Hello (163841)
2019-11-08 15:18:23,776 # Hello (327681)
2019-11-08 15:18:28,777 # Hello (491521)
2019-11-08 15:18:33,777 # Hello (655361)
```


### Issues/PRs references
none
