### PR TITLE
USBUS CDC ECM: host and MCU mac addresses should differ

### DIFF
--- a/sys/usb/usbus/cdc/ecm/cdc_ecm.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm.c
@@ -155,9 +155,7 @@ static void _fill_ethernet(usbus_cdcecm_device_t *cdcecm)
 {
     uint8_t ethernet[ETHERNET_ADDR_LEN];
 
-    luid_get(ethernet, ETHERNET_ADDR_LEN);
-    eui48_set_local((eui48_t*)ethernet);
-    eui48_clear_group((eui48_t*)ethernet);
+    luid_get_eui48((eui48_t*)ethernet);
     fmt_bytes_hex(cdcecm->mac_host, ethernet, sizeof(ethernet));
 
 }

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -145,9 +145,7 @@ static int _init(netdev_t *netdev)
 {
     usbus_cdcecm_device_t *cdcecm = _netdev_to_cdcecm(netdev);
 
-    luid_get(cdcecm->mac_netdev, ETHERNET_ADDR_LEN);
-    eui48_set_local((eui48_t*)cdcecm->mac_netdev);
-    eui48_clear_group((eui48_t*)cdcecm->mac_netdev);
+    luid_get_eui48((eui48_t*)cdcecm->mac_netdev);
     return 0;
 }
 


### PR DESCRIPTION
I noticed that host and MCU mac addresses on a USBUS CDC ECM link were equal - which caused autoconfiguration of the interface to fail, and made radvd unable to work.

I make use of the newly introduced (#12592) luid_get_eui48 function to overcome the problem.



