### PR TITLE
core: add zombie thread state

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -101,19 +101,20 @@ typedef struct _thread thread_t;
  * @{
  */
 typedef enum {
-    STATUS_STOPPED,                 /**< has terminated                       */
-    STATUS_SLEEPING,                /**< sleeping                             */
-    STATUS_MUTEX_BLOCKED,           /**< waiting for a locked mutex           */
-    STATUS_RECEIVE_BLOCKED,         /**< waiting for a message                */
-    STATUS_SEND_BLOCKED,            /**< waiting for message to be delivered  */
-    STATUS_REPLY_BLOCKED,           /**< waiting for a message response       */
-    STATUS_FLAG_BLOCKED_ANY,        /**< waiting for any flag from flag_mask  */
-    STATUS_FLAG_BLOCKED_ALL,        /**< waiting for all flags in flag_mask   */
-    STATUS_MBOX_BLOCKED,            /**< waiting for get/put on mbox          */
-    STATUS_COND_BLOCKED,            /**< waiting for a condition variable     */
-    STATUS_RUNNING,                 /**< currently running                    */
-    STATUS_PENDING,                 /**< waiting to be scheduled to run       */
-    STATUS_NUMOF                    /**< number of supported thread states    */
+    STATUS_STOPPED,                 /**< has terminated                           */
+    STATUS_ZOMBIE,                  /**< has terminated & keeps thread's thread_t */
+    STATUS_SLEEPING,                /**< sleeping                                 */
+    STATUS_MUTEX_BLOCKED,           /**< waiting for a locked mutex               */
+    STATUS_RECEIVE_BLOCKED,         /**< waiting for a message                    */
+    STATUS_SEND_BLOCKED,            /**< waiting for message to be delivered      */
+    STATUS_REPLY_BLOCKED,           /**< waiting for a message response           */
+    STATUS_FLAG_BLOCKED_ANY,        /**< waiting for any flag from flag_mask      */
+    STATUS_FLAG_BLOCKED_ALL,        /**< waiting for all flags in flag_mask       */
+    STATUS_MBOX_BLOCKED,            /**< waiting for get/put on mbox              */
+    STATUS_COND_BLOCKED,            /**< waiting for a condition variable         */
+    STATUS_RUNNING,                 /**< currently running                        */
+    STATUS_PENDING,                 /**< waiting to be scheduled to run           */
+    STATUS_NUMOF                    /**< number of supported thread states        */
 } thread_status_t;
 /** @} */
 

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -399,6 +399,27 @@ void thread_yield(void);
 void thread_yield_higher(void);
 
 /**
+ * @brief   Puts the current thread into zombie state.
+ *
+ * @details Does nothing when in ISR.
+ *          A thread in zombie state will never be scheduled again,
+ *          but its scheduler entry and stack will be kept.
+ *          A zombie state thread is supposed to be cleaned up
+ *          by @ref thread_kill_zombie().
+ */
+void thread_zombify(void);
+
+/**
+ * @brief Terminates zombie thread.
+ *
+ * @param[in] pid   the PID of the thread to terminate
+ *
+ * @return          `1` on success
+ * @return          `STATUS_NOT_FOUND` if pid is unknown or not a zombie
+ */
+int thread_kill_zombie(kernel_pid_t pid);
+
+/**
  * @brief Wakes up a sleeping thread.
  *
  * @param[in] pid   the PID of the thread to be woken up

--- a/core/thread.c
+++ b/core/thread.c
@@ -55,6 +55,49 @@ const char *thread_getname(kernel_pid_t pid)
 #endif
 }
 
+void thread_zombify(void)
+{
+    if (irq_is_in()) {
+        return;
+    }
+
+    unsigned state = irq_disable();
+    sched_set_status((thread_t *)sched_active_thread, STATUS_ZOMBIE);
+    irq_restore(state);
+    thread_yield_higher();
+
+    /* this line should never be reached */
+    UNREACHABLE();
+}
+
+int thread_kill_zombie(kernel_pid_t pid)
+{
+    DEBUG("thread_kill: Trying to kill PID %" PRIkernel_pid "...\n", pid);
+    unsigned state = irq_disable();
+
+    int result = (int)STATUS_NOT_FOUND;
+
+    thread_t *thread = (thread_t *) thread_get(pid);
+
+    if (!thread) {
+        DEBUG("thread_kill: Thread does not exist!\n");
+    }
+    else if (thread->status == STATUS_ZOMBIE) {
+        DEBUG("thread_kill: Thread is a zombie.\n");
+
+        sched_threads[pid] = NULL;
+        sched_num_threads--;
+        sched_set_status(thread, STATUS_STOPPED);
+
+        result =  1;
+    }
+    else {
+        DEBUG("thread_kill: Thread is not a zombie!\n");
+    }
+    irq_restore(state);
+    return result;
+}
+
 void thread_sleep(void)
 {
     if (irq_is_in()) {

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -37,6 +37,7 @@ static const char *state_names[] = {
     [STATUS_PENDING] = "pending",
     [STATUS_STOPPED] = "stopped",
     [STATUS_SLEEPING] = "sleeping",
+    [STATUS_ZOMBIE] = "zombie",
     [STATUS_MUTEX_BLOCKED] = "bl mutex",
     [STATUS_RECEIVE_BLOCKED] = "bl rx",
     [STATUS_SEND_BLOCKED] = "bl send",

--- a/tests/thread_zombie/Makefile
+++ b/tests/thread_zombie/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.tests_common
+
+DISABLE_MODULE += auto_init
+# For better testing use ps
+#USEMODULE += ps
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_zombie/Makefile.ci
+++ b/tests/thread_zombie/Makefile.ci
@@ -1,0 +1,9 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    nucleo-f031k6 \
+    stm32f030f4-demo
+    #

--- a/tests/thread_zombie/main.c
+++ b/tests/thread_zombie/main.c
@@ -1,0 +1,275 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin,
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Thread test application
+ *
+ *
+ * @author      Julian Holzwarth <julian.holzwarth@fu-berlin.de>
+ *
+ */
+
+#include <stdio.h>
+#include "thread.h"
+#include "test_utils/interactive_sync.h"
+#ifdef MODULE_PS
+#include "ps.h"
+#endif /* MODULE_PS */
+
+#define TEST_THREAD_STACKSIZE ((2 * THREAD_STACKSIZE_IDLE) + \
+                               THREAD_EXTRA_STACKSIZE_PRINTF)
+
+/* stacks for testing threads */
+static char t2_stack[TEST_THREAD_STACKSIZE];
+static char t3_stack[TEST_THREAD_STACKSIZE];
+static char t4_stack[TEST_THREAD_STACKSIZE];
+
+/* function for testing threads */
+void *second_thread(void *arg)
+{
+    printf("Thread: %d is starting\n", (int)arg);
+    printf("Thread: %d calls zombify\n", (int)arg);
+    thread_zombify();
+    puts("ERROR zombie runs again!");
+    return NULL;
+}
+
+int main(void)
+{
+    test_utils_interactive_sync();
+
+    /* save thread count on test start */
+    int current_thread_count;
+    int start_thread_count = sched_num_threads;
+
+    printf("Number of threads before the test = %d\n", start_thread_count);
+
+    /* creating threads for testing */
+    puts("Creating first thread (sleeping)");
+    kernel_pid_t first_pid =  thread_create(
+        t2_stack, sizeof(t2_stack),
+        THREAD_PRIORITY_MAIN - 1,
+        THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+        second_thread, (void *)1, "nr1");
+
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    puts("Creating second thread (sleeping)");
+    kernel_pid_t second_pid =  thread_create(
+        t3_stack, sizeof(t3_stack),
+        THREAD_PRIORITY_MAIN - 1,
+        THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+        second_thread, (void *)2, "nr2");
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    puts("Creating third thread (sleeping)");
+    kernel_pid_t third_pid =  thread_create(
+        t4_stack, sizeof(t4_stack),
+        THREAD_PRIORITY_MAIN - 1,
+        THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+        second_thread, (void *)3, "nr3");
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    current_thread_count = sched_num_threads;
+    printf("Current number of threads = %d\n", current_thread_count);
+
+    /* check if all threads got created */
+    if (start_thread_count + 3 != current_thread_count) {
+        puts("Error wrong thread count");
+    }
+    else {
+        puts("OK");
+    }
+
+    /* wakeup first thread and check if the thread zombified itself */
+    puts("Waking up first thread");
+    thread_wakeup(first_pid);
+
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    current_thread_count = sched_num_threads;
+    printf("Current number of threads = %d\n", current_thread_count);
+    if (thread_getstatus(first_pid) != STATUS_ZOMBIE) {
+        puts("Error Wrong Status: first thread is not a zombie!");
+    }
+    else {
+        if (start_thread_count + 3 != current_thread_count) {
+            puts("Error wrong thread count");
+        }
+        else {
+            puts("OK");
+        }
+    }
+
+    /* wakeup second thread and check if the thread zombified itself */
+    puts("Waking up second thread");
+    thread_wakeup(second_pid);
+
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    current_thread_count = sched_num_threads;
+    printf("Current number of threads = %d\n", current_thread_count);
+
+    if (thread_getstatus(first_pid) != STATUS_ZOMBIE) {
+        puts("Error Wrong Status: first thread is not a zombie!");
+    }
+    else {
+        if (thread_getstatus(second_pid) != STATUS_ZOMBIE) {
+            puts("Error Wrong Status: second thread is not a zombie!");
+        }
+        else {
+            if (start_thread_count + 3 != current_thread_count) {
+                puts("Error wrong thread count");
+            }
+            else {
+                puts("OK");
+            }
+
+        }
+    }
+
+    /* kill first zombie thread and check if the thread still exist (it should not) */
+    puts("Kill first thread");
+
+    if (thread_kill_zombie(first_pid) != 1) {
+        puts("Error thread_kill_zombie returned an error");
+    }
+
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    current_thread_count = sched_num_threads;
+    printf("Current number of threads = %d\n", current_thread_count);
+
+    if (thread_getstatus(first_pid) != STATUS_NOT_FOUND) {
+        puts("Error first Thread does still exist");
+    }
+    else {
+        if (thread_getstatus(second_pid) != STATUS_ZOMBIE) {
+            puts("Error Wrong Status: second thread is not a zombie!");
+        }
+        else {
+            if (start_thread_count + 2 != current_thread_count) {
+                puts("Error wrong thread count");
+            }
+            else {
+                puts("OK");
+            }
+        }
+    }
+
+    /* wakeup third thread and check if the thread zombified itself */
+    puts("Waking up third thread");
+    thread_wakeup(third_pid);
+
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    if (thread_getstatus(first_pid) != STATUS_NOT_FOUND) {
+        puts("Error first Thread does still exist");
+    }
+    else {
+        if (thread_getstatus(second_pid) != STATUS_ZOMBIE) {
+            puts("Error Wrong Status: third thread is not a zombie!");
+        }
+        else {
+            if (thread_getstatus(third_pid) != STATUS_ZOMBIE) {
+                puts("Error Wrong Status: second thread is not a zombie!");
+            }
+            else {
+                if (start_thread_count + 2 != current_thread_count) {
+                    puts("Error wrong thread count");
+                }
+                else {
+                    puts("OK");
+                }
+            }
+        }
+    }
+
+    /* check if threads are created normally after killing a zombie */
+    puts("Creating fourth thread (sleeping)");
+    kernel_pid_t last_pid =  thread_create(
+        t2_stack, sizeof(t2_stack),
+        THREAD_PRIORITY_MAIN - 1,
+        THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+        second_thread, (void *)4, "nr4");
+
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    if (thread_getstatus(last_pid) != STATUS_SLEEPING) {
+        puts("Error last Thread is not sleeping");
+    }
+    else {
+        if (last_pid != first_pid) {
+            puts("Error thread did not reuse first thread pid");
+        }
+        else {
+            if (thread_getstatus(second_pid) != STATUS_ZOMBIE) {
+                puts("Error Wrong Status: third thread is not a zombie!");
+            }
+            else {
+                if (thread_getstatus(third_pid) != STATUS_ZOMBIE) {
+                    puts("Error Wrong Status: second thread is not a zombie!");
+                }
+                else {
+                    if (start_thread_count + 2 != current_thread_count) {
+                        puts("Error wrong thread count");
+                    }
+                    else {
+                        puts("OK");
+                    }
+                }
+            }
+        }
+    }
+
+    #ifdef MODULE_PS
+    ps();
+    puts("");
+    #endif /* MODULE_PS */
+
+    current_thread_count = sched_num_threads;
+    printf("Current number of threads = %d\n", current_thread_count);
+
+    /* check if all threads got created */
+    if (start_thread_count + 3 != current_thread_count) {
+        puts("Error wrong thread count");
+    }
+    else {
+        puts("OK");
+    }
+
+    return 0;
+}

--- a/tests/thread_zombie/tests/01-run.py
+++ b/tests/thread_zombie/tests/01-run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Freie Universität Berlin,
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("OK")
+    child.expect("OK")
+    child.expect("OK")
+    child.expect("OK")
+    child.expect("OK")
+    child.expect("OK")
+    child.expect("OK")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This pull request adds a new feature.
Zombie thread state is added (`STATUS_ZOMBIE`).
This is a thread state to keep the `thread_t` (holds thread's context data) and to keep the pid (make sure no other thread can have the pid) of a thread that wants/needs to keep it for another thread. Zombie threads cannot be started again, will never run and will only be removed when the function `thread_kill_zombie` is called. A thread has to call `thread_zombify` to make itself a zombie. The thread will then stop to run and change it thread state to `STATUS_ZOMBIE`. This is useful for posix pthreads.

This pr makes ps able to correctly display zombie threads.
This pr adds a test.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Run the test. 
The test shows ps output to make sure it is correctly displayed.

run: `BOARD=native make -C tests/thread_zombie/  flash test`
expected output:

```
...
main(): This is RIOT! (Version: 2020.01-devel-174-g6dd10-pr/thread_status_t/zombie)
start threads = 2
	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x56638420 | 0x56638420
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x56636240 | 0x566380b0 
	  2 | main                 | running  Q |   7 |  12288 ( 2572) | 0x56633240 | 0x566360b0 
	  3 | nr2                  | sleeping _ |   6 |  20480 (  420) | 0x56624120 | 0x56628f90 
	    | SUM                  |            |     |  49152 ( 3412)

	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x56638420 | 0x56638420
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x56636240 | 0x566380b0 
	  2 | main                 | running  Q |   7 |  12288 ( 2572) | 0x56633240 | 0x566360b0 
	  3 | nr2                  | sleeping _ |   6 |  20480 (  420) | 0x56624120 | 0x56628f90 
	  4 | nr3                  | sleeping _ |   6 |  20480 (  420) | 0x56629120 | 0x5662df90 
	    | SUM                  |            |     |  69632 ( 3832)

	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x56638420 | 0x56638420
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x56636240 | 0x566380b0 
	  2 | main                 | running  Q |   7 |  12288 ( 2572) | 0x56633240 | 0x566360b0 
	  3 | nr2                  | sleeping _ |   6 |  20480 (  420) | 0x56624120 | 0x56628f90 
	  4 | nr3                  | sleeping _ |   6 |  20480 (  420) | 0x56629120 | 0x5662df90 
	  5 | nr4                  | sleeping _ |   6 |  20480 (  420) | 0x5662e120 | 0x56632f90 
	    | SUM                  |            |     |  90112 ( 4252)

threads = 5
OK
other thread

	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x56638420 | 0x56638420
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x56636240 | 0x566380b0 
	  2 | main                 | running  Q |   7 |  12288 ( 2572) | 0x56633240 | 0x566360b0 
	  3 | nr2                  | zombie   _ |   6 |  20480 (  768) | 0x56624120 | 0x56628f90 
	  4 | nr3                  | sleeping _ |   6 |  20480 (  420) | 0x56629120 | 0x5662df90 
	  5 | nr4                  | sleeping _ |   6 |  20480 (  420) | 0x5662e120 | 0x56632f90 
	    | SUM                  |            |     |  90112 ( 4600)

threads = 5
OK
other thread

	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x56638420 | 0x56638420
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x56636240 | 0x566380b0 
	  2 | main                 | running  Q |   7 |  12288 ( 2572) | 0x56633240 | 0x566360b0 
	  3 | nr2                  | zombie   _ |   6 |  20480 (  768) | 0x56624120 | 0x56628f90 
	  4 | nr3                  | zombie   _ |   6 |  20480 (  768) | 0x56629120 | 0x5662df90 
	  5 | nr4                  | sleeping _ |   6 |  20480 (  420) | 0x5662e120 | 0x56632f90 
	    | SUM                  |            |     |  90112 ( 4948)

threads = 5
OK
	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x56638420 | 0x56638420
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x56636240 | 0x566380b0 
	  2 | main                 | running  Q |   7 |  12288 ( 2572) | 0x56633240 | 0x566360b0 
	  4 | nr3                  | zombie   _ |   6 |  20480 (  768) | 0x56629120 | 0x5662df90 
	  5 | nr4                  | sleeping _ |   6 |  20480 (  420) | 0x5662e120 | 0x56632f90 
	    | SUM                  |            |     |  69632 ( 4180)

threads = 4
OK
other thread

	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x56638420 | 0x56638420
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x56636240 | 0x566380b0 
	  2 | main                 | running  Q |   7 |  12288 ( 2572) | 0x56633240 | 0x566360b0 
	  4 | nr3                  | zombie   _ |   6 |  20480 (  768) | 0x56629120 | 0x5662df90 
	  5 | nr4                  | zombie   _ |   6 |  20480 (  768) | 0x5662e120 | 0x56632f90 
	    | SUM                  |            |     |  69632 ( 4528)

OK
	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) | 0x56638420 | 0x56638420
	  1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x56636240 | 0x566380b0 
	  2 | main                 | running  Q |   7 |  12288 ( 2572) | 0x56633240 | 0x566360b0 
	  3 | nr2                  | sleeping _ |   6 |  20480 (  420) | 0x56624120 | 0x56628f90 
	  4 | nr3                  | zombie   _ |   6 |  20480 (  768) | 0x56629120 | 0x5662df90 
	  5 | nr4                  | zombie   _ |   6 |  20480 (  768) | 0x5662e120 | 0x56632f90 
	    | SUM                  |            |     |  90112 ( 4948)

OK

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
