### PR TITLE
tests: add a simple proof of concept test for gnrc_sock + gnrc_neterr

### DIFF
--- a/tests/gnrc_sock_neterr/Makefile
+++ b/tests/gnrc_sock_neterr/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.tests_common
+
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_ipv6_default
+USEMODULE += gnrc_neterr
+USEMODULE += gnrc_sock_udp
+USEMODULE += od
+USEMODULE += xtimer
+
+CFLAGS += -DGNRC_PKTBUF_SIZE=200
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_sock_neterr/Makefile.ci
+++ b/tests/gnrc_sock_neterr/Makefile.ci
@@ -1,0 +1,10 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    stm32f030f4-demo \
+    #

--- a/tests/gnrc_sock_neterr/README.md
+++ b/tests/gnrc_sock_neterr/README.md
@@ -1,0 +1,11 @@
+This is a simple proof of concept test, that `gnrc_sock` with `gnrc_neterr`
+works as expected to report errors within the network stack up to the `sock`
+object.
+
+It just tests if the sock reports `-EHOSTUNREACH` when sending to an unreachable
+address. To confirm that this is indeed coming from the stack and not the `sock`
+wrapper you can do
+
+```
+git grep EHOSTUNREACH -- sys/net/gnrc/sock
+```

--- a/tests/gnrc_sock_neterr/main.c
+++ b/tests/gnrc_sock_neterr/main.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include "msg.h"
+#include "net/sock/udp.h"
+
+#define TEST_PORT               (38664U)
+#define TEST_LINK_LOCAL_REMOTE  { 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02 }
+#define TEST_GLOBAL_REMOTE      { 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, \
+                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02 }
+#define TEST_PAYLOAD            { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef }
+
+static const uint8_t _test_link_local_remote[] = TEST_LINK_LOCAL_REMOTE;
+static const uint8_t _test_global_remote[] = TEST_GLOBAL_REMOTE;
+static const uint8_t _test_payload[] = TEST_PAYLOAD;
+
+static msg_t _msg_queue[8U];
+static sock_udp_t _udp_sock;
+
+int _test_udp_send(sock_udp_ep_t *remote, char *errno_str, int exp_res) {
+
+    int res = sock_udp_send(&_udp_sock, _test_payload, sizeof(_test_payload),
+                        remote);
+    /* remote is not reachable or route does not exist, so it should return an
+     * error */
+    if (-res == exp_res) {
+        printf("SUCCESS: error code %s (%li == %i)\n",
+               errno_str, (long)(-res), exp_res);
+        return 0;
+    }
+    else {
+        printf("FAILURE: gnrc_udp_send() had an unexpected error code: %li\n",
+               (long int)res);
+        return 1;
+    }
+}
+
+int main(void)
+{
+    sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
+
+    local.port = TEST_PORT;
+    remote.port = TEST_PORT - 1;
+
+    msg_init_queue(_msg_queue, ARRAY_SIZE(_msg_queue));
+    sock_udp_create(&_udp_sock, &local, NULL, 0);
+
+    memcpy(remote.addr.ipv6, _test_link_local_remote,
+           sizeof(_test_link_local_remote));
+    /* With a 6LN this send may succeed, as according to RFC 6775 link-local
+     * addresses are assumed to be generated from the EUI-64, reversing the
+     * procedure of generating the address from EUI-64 for address resolution */
+    _test_udp_send(&remote, "EHOSTUNREACH", EHOSTUNREACH);
+    memcpy(remote.addr.ipv6, _test_global_remote,
+           sizeof(_test_global_remote));
+    _test_udp_send(&remote, "ENETUNREACH", ENETUNREACH);
+}
+
+/** @} */

--- a/tests/gnrc_sock_neterr/tests/01-run.py
+++ b/tests/gnrc_sock_neterr/tests/01-run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r"SUCCESS: error code EHOSTUNREACH \((\d+) == (\d+)\)")
+    assert child.match.group(1) == child.match.group(2)
+    child.expect(r"SUCCESS: error code ENETUNREACH \((\d+) == (\d+)\)")
+    assert child.match.group(1) == child.match.group(2)
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This introduces a simple proof-of-concept test that GNRC's `sock` implementation still works with `gnrc_neterr` compiled in and that errors reported by the stack are handed to the `sock` object. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Confirm that `EHOSTUNREACH` is not reported by `gnrc_sock` itself:


```
git grep EHOSTUNREACH -- sys/net/gnrc/sock
```

Run the test on a board of your choice:

```
make -C tests/gnrc_sock_neterr flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Issue popped up in #12625, but overall unrelated.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
