### PR TITLE
cpu/stm32_common: fix RAM_SIZE for stm32f103xc, stm32f105xx and stm32f107xx

### DIFF
--- a/cpu/stm32_common/stm32_mem_lengths.mk
+++ b/cpu/stm32_common/stm32_mem_lengths.mk
@@ -88,9 +88,9 @@ ifeq ($(STM32_TYPE), F)
         else ifneq (, $(filter $(STM32_ROMSIZE), F G))
           RAM_LEN = 96K
         endif
-      endif
-    else ifneq (, $(filter $(STM32_MODEL), 105 107))
+      else ifneq (, $(filter $(STM32_MODEL), 105 107))
         RAM_LEN = 64K
+      endif
     endif
   else ifeq ($(STM32_FAMILY), 2)
     ifeq ($(STM32_MODEL3), 5)

--- a/cpu/stm32_common/stm32_mem_lengths.mk
+++ b/cpu/stm32_common/stm32_mem_lengths.mk
@@ -81,7 +81,9 @@ ifeq ($(STM32_TYPE), F)
           RAM_LEN = 10K
         else ifneq (, $(filter $(STM32_ROMSIZE), 8 B))
           RAM_LEN = 20K
-        else ifneq (, $(filter $(STM32_ROMSIZE), C D E))
+        else ifneq (, $(filter $(STM32_ROMSIZE), C))
+          RAM_LEN = 48K
+        else ifneq (, $(filter $(STM32_ROMSIZE), D E))
           RAM_LEN = 64K
         else ifneq (, $(filter $(STM32_ROMSIZE), F G))
           RAM_LEN = 96K


### PR DESCRIPTION
### Contribution description

I am working on a board based on the STM32F103RCT.

According to the MCU's datasheet the MCU features 48K of RAM but RIOT claims the RAM size to be 64K. Thus, the linker produces garbage.

I wrote a [really hacky script](https://gist.github.com/jue89/926d52fdb4dfe5664e909f787cf9e8a5) that reads the database that comes with STM32CubeMX and compares the listed MCUs with the output of `info-stm32`. It outputs this table:

|MCU            |CubeMX|RIOT  |
|---------------|------|------|
|stm32f103vctx  |48    |64    |
|stm32f103vchx  |48    |64    |
|stm32f103rctx  |48    |64    |
|stm32f103zctx  |48    |64    |
|stm32f103zchx  |48    |64    |

It becomes obvious that only *stm32f103_c* MCUs have different RAM sizes compared to the result of the `stm32_mem_lengths.mk` script.

To fix this, I inserted the already introduced `STM32_RAMMOD` flag for the STM32F1 family.


### Testing procedure

```sh
$ cd examples/hello-world
$ make BOARD=bluepill CPU_MODEL=stm32f103rc info-stm32
CPU: stm32f103rc
	Line: STM32F103xE
	Pin count:	64
	ROM size:	256K (262144 Bytes)
	RAM size:	64K
$ make BOARD=bluepill CPU_MODEL=stm32f103rc_a info-stm32
CPU: stm32f103rc_a
	Line: STM32F103xE
	Pin count:	64
	ROM size:	256K (262144 Bytes)
	RAM size:	48K
```
