### PR TITLE
gnrc_sock: consider all pktsnip for gnrc_neterr reporting

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -490,7 +490,7 @@ static void _send_unicast(gnrc_pktsnip_t *pkt, bool prep_hdr,
     if (gnrc_ipv6_nib_get_next_hop_l2addr(&ipv6_hdr->dst, netif, pkt,
                                           &nce) < 0) {
         /* packet is released by NIB */
-        DEBUG("ipv6: no link-layer address or interface for next hop to %s",
+        DEBUG("ipv6: no link-layer address or interface for next hop to %s\n",
               ipv6_addr_to_str(addr_str, &ipv6_hdr->dst, sizeof(addr_str)));
         return;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
As analyzed in https://github.com/RIOT-OS/RIOT/pull/12678#issuecomment-552184195 there are cases where different reports can be generated for the different snips of the packet send via the `sock`.

To catch all errors generated by the stack, the sock has to subscribe for all snips of the packet sent. If any of the snips reports an error distinct from `GNRC_NETERR_SUCCESS` or the previous one, we report that status instead of just the first we receive. This way we are ensured to have the first error reported by the stack for the given packet.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Merge #12678 into this PR, set `ENABLE_DEBUG=1` in `sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c` (fix for debug messages piggy-backed) and run the test for several scenarios: It should succeed or fail, but with good reason. E.g.

<details><summary>Vanilla (no interfaces)</summary>

```
ipv6: waiting for incoming message.
main(): This is RIOT! (Version: 2020.01-devel-584-g0d08d-gnrc_sock/fix/consider-all-snips-for-error)
ipv6: GNRC_NETAPI_MSG_TYPE_SND received
ipv6: send unicast
ipv6: no link-layer address or interface for next hop to fe80::2
ipv6: waiting for incoming message.
SUCCESS: error code EHOSTUNREACH (113 == 113)
ipv6: GNRC_NETAPI_MSG_TYPE_SND received
ipv6: send unicast
ipv6: no link-layer address or interface for next hop to 2001:db8::2
ipv6: waiting for incoming message.
SUCCESS: error code ENETUNREACH (101 == 101)
```
</details>

<details><summary>With an IEEE 802.15.4 interface (i.e. using 6Lo-ND)</summary>

```
[…]
ipv6: waiting for incoming message.
main(): This is RIOT! (Version: 2020.01-devel-584-g0d08d-gnrc_sock/fix/consider-all-snips-for-error)
ipv6: GNRC_NETAPI_MSG_TYPE_SND received
ipv6: send unicast
ipv6: set payload length to 16 (network byteorder 1000)
ipv6: set next header to 17
ipv6: set packet source to fe80::25a:4550:a00:455b
ipv6: write protect up to payload to calculate checksum
ipv6: calculate checksum for upper header.
ipv6: add interface header to packet
ipv6: send unicast over interface 6
ipv6: Sending (src = fe80::25a:4550:a00:455b, dst = fe80::2, next header = 17, length = 16)
ipv6: send to 6LoWPAN instead
ipv6: waiting for incoming message.
FAILURE: gnrc_udp_send() had an unexpected error code: 8
ipv6: GNRC_NETAPI_MSG_TYPE_SND received
ipv6: send unicast
ipv6: no link-layer address or interface for next hop to 2001:db8::2
ipv6: waiting for incoming message.
SUCCESS: error code ENETUNREACH (101 == 101)
[…]
```

(first send succeeds as the link-local packet is actually send due to address resolution by reverse translation, second fails with `-ENETUNREACH`, as  the non-existing route is looked up as with vanilla)

</details>


<details><summary>With an Ethernet interface</summary>

```
[…]
ipv6: waiting for incoming message.
main(): This is RIOT! (Version: 2020.01-devel-584-g0d08d-gnrc_sock/fix/consider-all-snips-for-error)
[…]
ipv6: GNRC_NETAPI_MSG_TYPE_SND received
ipv6: set payload length to 32 (network byteorder 2000)
ipv6: set next header to 58
ipv6: write protect up to payload to calculate checksum
ipv6: calculate checksum for upper header.
ipv6: send multicast over interface 5
ipv6: Sending (src = fe80::2482:dcff:fe3b:cae6, dst = ff02::1:ff00:2, next header = 58, length = 32)
ipv6: waiting for incoming message.
ipv6: NIB timer event received
ipv6: waiting for incoming message.
ipv6: GNRC_NETAPI_MSG_TYPE_SND received
ipv6: set payload length to 32 (network byteorder 2000)
ipv6: set next header to 58
ipv6: write protect up to payload to calculate checksum
ipv6: calculate checksum for upper header.
ipv6: send multicast over interface 5
ipv6: Sending (src = fe80::2482:dcff:fe3b:cae6, dst = ff02::1:ff00:2, next header = 58, length = 32)
ipv6: waiting for incoming message.
ipv6: NIB timer event received
ipv6: waiting for incoming message.
SUCCESS: error code EHOSTUNREACH (113 == 113)
ipv6: GNRC_NETAPI_MSG_TYPE_SND received
ipv6: send unicast
ipv6: no link-layer address or interface for next hop to 2001:db8::2
ipv6: waiting for incoming message.
SUCCESS: error code ENETUNREACH (101 == 101)
[…]
```

(node tries to probe for neighbor several times before finally reporting `EHOSTUNREACH` for the first, for the second `ENETUNREACH` is again reported, as  the non-existing route is looked up as with vanilla 

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered in #12678.
Fixes #11551.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
