### PR TITLE
sys/net/gnrc: Flag cc110x as 6LN

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -102,6 +102,9 @@ void gnrc_netif_init_6ln(gnrc_netif_t *netif)
         }
         /* intentionally falls through */
         case NETDEV_TYPE_BLE:
+#ifdef MODULE_CC110X
+        case NETDEV_TYPE_CC110X:
+#endif
         case NETDEV_TYPE_NRFMIN:
 #if GNRC_IPV6_NIB_CONF_6LN
             netif->flags |= GNRC_NETIF_FLAGS_6LN;


### PR DESCRIPTION
### Contribution description

In gnrc_netif_init_6ln() the flag GNRC_NETIF_FLAGS_6LN is accidentally not set for cc110x devices. This PR fixes this.

### Testing procedure

Running `ifconfig` in `examples/gnrc_networking` e.g. on the MSB-A2 shows no IPv6 address with master. With this PR, the address should show up again and `ping6`ing should work.

### Issues/PRs references

Needed since commit https://github.com/RIOT-OS/RIOT/commit/363afa62ee168305e8a684915e8d974ae2b378d8 merged with PR https://github.com/RIOT-OS/RIOT/pull/10499