### PR TITLE
cpu/atmega_common: cpuid: add a word of warning

### DIFF
--- a/cpu/atmega_common/periph/cpuid.c
+++ b/cpu/atmega_common/periph/cpuid.c
@@ -21,6 +21,10 @@
 #include <stdint.h>
 #include "avr/boot.h"
 
+/*
+ * This uses the RC calibration byte as CPU ID, so it may not be very unique.
+ * The first three bytes are constant across different MCUs of the same series.
+ */
 void cpuid_get(void *id)
 {
     uint8_t *out = id;


### PR DESCRIPTION
### Contribution description

The CPU ID only differs in byte 4 (RC calibration) between devices.

Add a word of warning to the documentation that this may not be very unique.

### Testing procedure

Only adds a comment.

### Issues/PRs references
#12578
