### PR TITLE
net/netbuf: introduce network buffer abstraction (v2.0)

### DIFF
--- a/sys/include/net/netbuf.h
+++ b/sys/include/net/netbuf.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_netbuf Network buffer abstraction
+ * @ingroup     net
+ * @brief       Provides an abstraction for network stack buffers
+ * @{
+ *
+ * @file
+ * @brief       Network buffer abstraction definition
+ *
+ * @author  Jose I. Alamos <jose.alamos@haw-hamburg.de>
+ */
+#ifndef NET_NETBUF_H
+#define NET_NETBUF_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Netbuf descriptor
+ */
+typedef void netbuf_t;
+
+/**
+ * @brief   Allocate a network buffer with a given size.
+ *
+ * @note    Supposed to be implemented by the networking module.
+ *
+ * @param[in]       size    size of the buffer to be allocated.
+ *
+ * @return          pointer to the netbuf with the allocated buffer.
+ * @return          NULL if there's not enough memory for allocation.
+ */
+netbuf_t *netbuf_alloc(size_t size);
+
+/**
+ * @brief   Get the @ref iolist_t representation of the network buffer.
+ *
+ * @pre     @p netbuf not NULL.
+ * @pre     @p iol not NULL.
+ *
+ * @note    Supposed to be implemented by the networking module.
+ *
+ * @param[in]       netbuf  pointer to the netbuf.
+ * @param[out]      iol     iolist representation of the netbuf.
+ *
+ * @return          @ref iolist_t representation on @p iol.
+ */
+void netbuf_get_iolist(netbuf_t *netbuf, iolist_t *iol);
+
+/**
+ * @brief Free the resources of a network buffer
+ *
+ * @note    Supposed to be implemented by the networking module.
+ *
+ * @param[in]       netbuf  pointer to the netbuf descriptor.
+ */
+void netbuf_free(netbuf_t *netbuf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_NETBUF_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Towards an network stack independent `netif` (https://github.com/RIOT-OS/RIOT/issues/12688), this proposes an API for stack independent packet allocation, release and access to content. 
This approach replaces #12315 since it's cleaner and a smaller step.

Each network stack needs to define these 3 functions:
- `netbuf_alloc`: allocate a network buffer
- `netbuf_free`: free the resources associated to the network buffer
- `netbuf_get_iolist`: get `iolist_t` representation of the network buffer.

With these functions, it's possible e.g to remove all GNRC pktbuf specific functions in `gnrc_netif_ieee802154`, so this layer can be reused by other network stacks (it still requires some `netif` abstract functions but that would come soon :).

I'm also naming it "netbuf" and not "netif_pkt_t" because this is intended to represent the data of the pkt and not the metadata. As discussed with @miri64 offline, there might be something like:

```c
typedef struct {
    netbuf_t *buf;
    int rssi;
    int lqi;
    uint8_t *l2_address;
    /* ... */
} netif_pkt_t;
```

So the `netif` receive function could look like:
```c
void netif_recv(netif_t *netif, netif_pkt_t *pkt)
{
    /* Pass packet to the stack */
}
```
## RFC
- Does this approach make sense?
- Are we ok with the name?
- Does the API make sense?
- Does it work for all network stacks?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Check the documentation build ok: `make doc`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Replaces #12315
#12688
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
