### PR TITLE
tests/periph_cpuid: add automatic test script

### DIFF
--- a/tests/periph_cpuid/Makefile
+++ b/tests/periph_cpuid/Makefile
@@ -3,3 +3,24 @@ include ../Makefile.tests_common
 FEATURES_REQUIRED = periph_cpuid
 
 include $(RIOTBASE)/Makefile.include
+
+# Determine the CPUID_LEN based on the current architecture or CPU used in the
+# build system.
+ifneq (,$(filter arch_esp32,$(FEATURES_USED)))
+  CPUID_LEN = 7
+endif
+ifneq (,$(filter cc2538 efm32 ezr32wg nrf5%,$(CPU)))
+  CPUID_LEN = 8
+endif
+ifneq (,$(filter cc26x0 lpc1768 sam%,$(CPU)))
+  CPUID_LEN = 16
+endif
+ifneq (,$(filter fe310 kinetis stm32%,$(CPU)))
+  CPUID_LEN = 12
+endif
+
+# Use 4 as default as it is the minimum for all supported CPUs.
+CPUID_LEN ?= 4
+
+# Export CPUID_LEN env variable to the Python script.
+export CPUID_LEN

--- a/tests/periph_cpuid/tests/01-run.py
+++ b/tests/periph_cpuid/tests/01-run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+from testrunner import run
+
+
+CPUID_LEN = int(os.getenv('CPUID_LEN') or 4)
+
+
+def testfunc(child):
+    child.expect_exact('Test for the CPUID driver')
+    child.expect_exact('This test is reading out the CPUID of the platforms CPU')
+    expected = 'CPUID:' + CPUID_LEN * r' 0x[0-9a-fA-F]{2}'
+    child.expect(expected)
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an automatic Python test script for the `periph_cpuid` test application. The approach is to determine the CPUID_LEN from the architecture or CPU variables used during the build. An other approach would be to define the CPUID_LEN variable for all architectures in their Makefile.include, and adapt the macros in cpu_conf.h. I found this one too much intrusive so I dropped it.

The CPUID_LEN variable is passed via the environment variables to the Python script which then knows the number of bytes contained in the CPUID.

The default value is 4 which is the smallest cpuid len in all architectures supported by RIOT. If a cpuid len is greater than the expected value, the test still works.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following should work on all architectures providing the `periph_cpuid` feature:
```
make BOARD=<any board> -C tests/periph_cpuid flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
