### PR TITLE
tests/periph_cpuid: read CPUID_LEN from app instead of environment

### DIFF
--- a/tests/periph_cpuid/Makefile
+++ b/tests/periph_cpuid/Makefile
@@ -3,24 +3,3 @@ include ../Makefile.tests_common
 FEATURES_REQUIRED = periph_cpuid
 
 include $(RIOTBASE)/Makefile.include
-
-# Determine the CPUID_LEN based on the current architecture or CPU used in the
-# build system.
-ifneq (,$(filter arch_esp32,$(FEATURES_USED)))
-  CPUID_LEN = 7
-endif
-ifneq (,$(filter cc2538 efm32 ezr32wg nrf5%,$(CPU)))
-  CPUID_LEN = 8
-endif
-ifneq (,$(filter cc26x0 lpc1768 sam%,$(CPU)))
-  CPUID_LEN = 16
-endif
-ifneq (,$(filter fe310 kinetis stm32%,$(CPU)))
-  CPUID_LEN = 12
-endif
-
-# Use 4 as default as it is the minimum for all supported CPUs.
-CPUID_LEN ?= 4
-
-# Export CPUID_LEN env variable to the Python script.
-export CPUID_LEN

--- a/tests/periph_cpuid/main.c
+++ b/tests/periph_cpuid/main.c
@@ -32,6 +32,8 @@ int main(void)
     puts("Test for the CPUID driver");
     puts("This test is reading out the CPUID of the platforms CPU\n");
 
+    printf("CPUID_LEN: %u\n", CPUID_LEN);
+
     /* read the CPUID */
     cpuid_get(id);
 

--- a/tests/periph_cpuid/tests/01-run.py
+++ b/tests/periph_cpuid/tests/01-run.py
@@ -15,8 +15,8 @@ def testfunc(child):
     child.expect_exact('This test is reading out the CPUID of the platforms CPU')
     child.expect(r'CPUID_LEN: (\d+)')
     cpuid_len = int(child.match.group(1))
-    expected = 'CPUID:' + cpuid_len * r' 0x[0-9a-fA-F]{2}'
-    child.expect(expected)
+    child.expect(r'CPUID:( 0x[0-9a-fA-F]{2})+\s*$')
+    assert child.match.group(0).count(' 0x') == cpuid_len
 
 
 if __name__ == "__main__":

--- a/tests/periph_cpuid/tests/01-run.py
+++ b/tests/periph_cpuid/tests/01-run.py
@@ -6,18 +6,16 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-import os
 import sys
 from testrunner import run
-
-
-CPUID_LEN = int(os.getenv('CPUID_LEN') or 4)
 
 
 def testfunc(child):
     child.expect_exact('Test for the CPUID driver')
     child.expect_exact('This test is reading out the CPUID of the platforms CPU')
-    expected = 'CPUID:' + CPUID_LEN * r' 0x[0-9a-fA-F]{2}'
+    child.expect(r'CPUID_LEN: (\d+)')
+    cpuid_len = int(child.match.group(1))
+    expected = 'CPUID:' + cpuid_len * r' 0x[0-9a-fA-F]{2}'
     child.expect(expected)
 
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This is an extension of #12692 aiming to not require `CPUID_LEN` to be defined in the environment by just printing it in the application. It also checks if the provided `CPUID_LEN` aligns with the number of printed bytes of the CPU-ID
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash and run the test on a board of your choice. It should succeed.

```
make -C tests/periph_cpuid/ flash test
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #12692.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
