### PR TITLE
dist/tools: Add Kconfiglib

### DIFF
--- a/dist/tools/kconfiglib/.gitignore
+++ b/dist/tools/kconfiglib/.gitignore
@@ -1,0 +1,5 @@
+genconfig.py
+kconfiglib.py
+menuconfig.py
+merge_config.py
+__pycache__

--- a/dist/tools/kconfiglib/Makefile
+++ b/dist/tools/kconfiglib/Makefile
@@ -1,0 +1,13 @@
+PKG_NAME=kconfiglib
+PKG_URL=https://github.com/ulfalizer/Kconfiglib
+PKG_VERSION=82f59179b1b35fcd8b6d188453b283599ea70518
+PKG_LICENSE=ISC
+PKG_BUILDDIR=$(CURDIR)/bin
+
+.PHONY: all
+
+all: git-download
+	cp -t . $(PKG_BUILDDIR)/kconfiglib.py $(PKG_BUILDDIR)/menuconfig.py \
+		$(PKG_BUILDDIR)/genconfig.py $(PKG_BUILDDIR)/examples/merge_config.py
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/makefiles/tools/kconfiglib.inc.mk
+++ b/makefiles/tools/kconfiglib.inc.mk
@@ -1,0 +1,13 @@
+# Define tools to use
+MENUCONFIG ?= $(RIOTTOOLS)/kconfiglib/menuconfig.py
+GENCONFIG ?= $(RIOTTOOLS)/kconfiglib/genconfig.py
+MERGECONFIG ?= $(RIOTTOOLS)/kconfiglib/merge_config.py
+
+$(MENUCONFIG):
+	@echo "[INFO] Kconfiglib not found - getting it"
+	@make -C $(RIOTTOOLS)/kconfiglib
+	@echo "[INFO] Kconfiglib downloaded"
+
+$(GENCONFIG): $(MENUCONFIG)
+
+$(MERGECONFIG): $(MENUCONFIG)


### PR DESCRIPTION
### Contribution description
This PR adds [Kconfiglib](https://github.com/ulfalizer/Kconfiglib) to our tools, as a package. Kconfiglib is a Kconfig implementation in Python 2/3.

It can run standalone, but also includes some tools already implemented (e.g. menuconfig or genconfig, which are copied from the package in this PR). This has the advantage that we can handle Kconfig files using Python scripts (such as generating Doxygen documentation for all compile-time options).

### Testing procedure
You can apply [this patch](https://gist.github.com/leandrolanzieri/2273634db68794cf8d1e70236089dcb5) and run `make test-tool -C examples/default`. It should download the package and check that the files were copied, printing `PASS` if everything went as expected.

### Issues/PRs references
None so far
