### PR TITLE
boards/stm32f030f4-demo: Allow using BMP

### DIFF
--- a/boards/stm32f030f4-demo/Makefile.include
+++ b/boards/stm32f030f4-demo/Makefile.include
@@ -1,8 +1,15 @@
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # configure the serial terminal
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+PROGRAMMER ?= openocd
+ifeq (bmp,$(PROGRAMMER))
+  PORT_LINUX ?= /dev/ttyACM1
+  # first item is gdb server, so we take the second
+  PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
+else
+  PORT_LINUX ?= /dev/ttyACM0
+  PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+endif
 
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
@@ -11,8 +18,11 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # use connect_assert_srst to always be able to flash or reset the boards.
 export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
 
-# all Nucleo boards have an on-board ST-link adapter
-DEBUG_ADAPTER ?= stlink
+ifeq (bmp,$(PROGRAMMER))
+  include $(RIOTMAKE)/tools/bmp.inc.mk
+else
+  DEBUG_ADAPTER ?= stlink
 
-# stlink use openocd
-include $(RIOTMAKE)/tools/openocd.inc.mk
+  # stlink use openocd
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+endif


### PR DESCRIPTION
### Contribution description

Allow using the black magic probe by running:

```
BOARD=stm32f030f4-demo PROGRAMMER=bmp make flash -C path/to/app
```

Also the default port for the serial is adapted when `PROGRAMMER=bmp` is set.

### Testing procedure

1. `make flash` should work with both `PROGRAMMER=bmp` (using a black magic probe) and without (using openocd)
2. `make term` should work with both `PROGRAMMER=bmp` and without

### Issues/PRs references

None