### PR TITLE
boards: Common STM32 programmer/debugger/serial config

### DIFF
--- a/boards/common/blxxxpill/Makefile.include
+++ b/boards/common/blxxxpill/Makefile.include
@@ -1,36 +1,11 @@
 INCLUDES += -I$(RIOTBOARD)/common/blxxxpill/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+# For older versions of the DFU bootloader, set DFU_USB_ID to 1d50:6017 and
+# uncomment the DFU_FLAGS line
+DFU_USB_ID ?= 1eaf:0003
+#DFU_FLAGS ?= -s 0x08002000:leave
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+STLINK_VERSION ?= 2
 
-# optionally, use dfu-util to flash via usb
-# note: needs a bootloader flashed before, config below is compatible
-# with blackmagic_dfu, see https://github.com/blacksphere/blackmagic/
-# To stop bootloader from loading an existing firmware, pull down
-# (ground) GPIO B1.
-ifeq ($(PROGRAMMER),dfu-util)
-  export ROM_OFFSET ?= 0x2000 # Skip the space needed by the embedded bootloader
-  FLASHER = dfu-util
-  DEBUGGER = # no debugger
-  RESET ?= # dfu-util has no support for resetting the device
-
-  FLASHFILE ?= $(BINFILE)
-  FFLAGS = -d 1eaf:0003 -a 2 -D $(FLASHFILE)
-  # for older bootloader versions use this:
-  # FFLAGS = -d 1d50:6017 -s 0x08002000:leave -D $(FLASHFILE)
-else
-
-  # this board uses openocd by default
-  DEBUG_ADAPTER ?= stlink
-  STLINK_VERSION ?= 2
-
-  # call a 'reset halt' command before starting the debugger
-  # it is required as `connect_assert_srst` is set
-  export OPENOCD_DBG_START_CMD = -c 'reset halt'
-
-  include $(RIOTMAKE)/tools/openocd.inc.mk
-endif
+# Setup of programmer and serial is shared between STM32 based boards
+include $(RIOTMAKE)/boards/stm32.inc.mk

--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -5,19 +5,5 @@ INCLUDES  += -I$(RIOTBOARD)/common/nucleo/include
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# configure the serial terminal
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
-# nucleo boards can become un-flashable after a hardfault,
-# use connect_assert_srst to always be able to flash or reset the boards.
-export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
-
-# all Nucleo boards have an on-board ST-link adapter
-DEBUG_ADAPTER ?= stlink
-
-# nucleo boards use openocd
-include $(RIOTMAKE)/tools/openocd.inc.mk
+# Setup of programmer and serial is shared between STM32 based boards
+include $(RIOTMAKE)/boards/stm32.inc.mk

--- a/boards/stm32f030f4-demo/Makefile.include
+++ b/boards/stm32f030f4-demo/Makefile.include
@@ -1,18 +1,4 @@
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# configure the serial terminal
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
-# stm32 boards can become un-flashable after a hardfault,
-# use connect_assert_srst to always be able to flash or reset the boards.
-export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
-
-# all Nucleo boards have an on-board ST-link adapter
-DEBUG_ADAPTER ?= stlink
-
-# stlink use openocd
-include $(RIOTMAKE)/tools/openocd.inc.mk
+# Setup of programmer and serial is shared between STM32 based boards
+include $(RIOTMAKE)/boards/stm32.inc.mk

--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -1,0 +1,58 @@
+PROGRAMMER ?= openocd
+
+PROGRAMMERS_SUPPORTED := bmp dfu-util openocd
+
+ifeq (,$(filter $(PROGRAMMER), $(PROGRAMMERS_SUPPORTED)))
+  $(error Programmer $(PROGRAMMER) not supported)
+endif
+
+ifeq (bmp,$(PROGRAMMER))
+  # On Blackmagic Probe, the first ACM is used to connect to the gdb server,
+  # the second is the BMP's UART interface
+  PORT_LINUX ?= /dev/ttyACM1
+  PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
+else
+  # configure the serial terminal
+  PORT_LINUX ?= /dev/ttyACM0
+  PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+endif
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+ifeq (openocd,$(PROGRAMMER))
+  # STM32 boards can become un-flashable after a hardfault,
+  # use connect_assert_srst to always be able to flash or reset the boards.
+  export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
+
+  # For STM32 boards the ST-link adapter is the default adapter, e.g. all
+  # Nucleo boards have an on-board ST-link adapter
+  DEBUG_ADAPTER ?= stlink
+
+  # RIOT uses openocd by default
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+endif
+
+ifeq (bmp,$(PROGRAMMER))
+  include $(RIOTMAKE)/tools/bmp.inc.mk
+endif
+
+ifeq (dfu-util,$(PROGRAMMER))
+  # optionally, use dfu-util to flash via usb
+  # note: needs a bootloader flashed before, config below is compatible
+  # with blackmagic_dfu, see https://github.com/blacksphere/blackmagic/
+  # To stop bootloader from loading an existing firmware, pull down
+  # (ground) GPIO B1.
+  ifeq (,$(DFU_USB_ID))
+    $(error DFU_USB_ID is not set)
+  endif
+  # Skip the space needed by the embedded bootloader
+  export ROM_OFFSET ?= 0x2000
+  FLASHER = dfu-util
+  DEBUGGER = # no debugger
+  RESET ?= # dfu-util has no support for resetting the device
+
+  FLASHFILE ?= $(BINFILE)
+  DFU_FLAGS ?= -a 2
+  FFLAGS = -d $(DFU_USB_ID) $(DFU_FLAGS) -D $(FLASHFILE)
+endif


### PR DESCRIPTION
### Contribution description

De-duplicated code by adding a common configuration for setting the programmer/debugger/serial. This also brings some new programmer support to other boards.

### Testing procedure

Programmering, debugging and `make term` should still work as previously

### Issues/PRs references

None. (But some follow up PRs are needed to also apply the config for other boards. But to keep testing to a reasonable amount, I purposely left a bunch of boards out for now.)