### PR TITLE
gnrc_sixlowpan_frag_vrb: set src_len to 0 on remove

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -125,10 +125,8 @@ static inline void gnrc_sixlowpan_frag_vrb_rm(gnrc_sixlowpan_frag_vrb_t *vrb)
 {
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG
     gnrc_sixlowpan_frag_rb_base_rm(&vrb->super);
-#elif   defined(TEST_SUITES)
-    /* for testing just zero src_len */
-    vrb->super.src_len = 0;
 #endif  /* MODULE_GNRC_SIXLOWPAN_FRAG */
+    vrb->super.src_len = 0;
 }
 
 /**


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
45f7966 made the `src_len` field the "emptiness signifier" for the VRB. However, when `gnrc_sixlowpan_frag` is compiled in, the remove function `gnrc_sixlowpan_frag_vrb_rm()` does not set the `src_len` to zero, resulting in already deleted entry to be recognized as non-empty.
    
Additionally, is the `#ifdef` guard outdated, as the base function called is part of `gnrc_sixlowpan_frag_rb` since 1f7770d (and later was renamed).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Unittests in `tests/unittests` still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
