### PR TITLE
netdev_tap: don't allocate DEBUG_EXTRA_STACKSIZE twice

### DIFF
--- a/sys/auto_init/netif/auto_init_netdev_tap.c
+++ b/sys/auto_init/netif/auto_init_netdev_tap.c
@@ -28,7 +28,7 @@
 #define TAP_MAC_PRIO                (GNRC_NETIF_PRIO)
 
 static netdev_tap_t netdev_tap[NETDEV_TAP_MAX];
-static char _netdev_eth_stack[NETDEV_TAP_MAX][TAP_MAC_STACKSIZE + DEBUG_EXTRA_STACKSIZE];
+static char _netdev_eth_stack[NETDEV_TAP_MAX][TAP_MAC_STACKSIZE];
 
 void auto_init_netdev_tap(void)
 {


### PR DESCRIPTION
### Contribution description
While browsing some code, I noticed that `DEBUG_EXTRA_STACKSIZE` is used at two places in the auto initialization of `netdev_tap`. I presume that the second time it was used incorrectly, because when creating the thread, it specified the stack size `TAP_MAC_STACKSIZE`.

### Testing procedure
I don't have het tap device set up on macOS, but I don't think this change impacts anything, except reducing the actual allocated stack size.

### Issues/PRs references
None