### PR TITLE
tests/malloc: improve application and add an automatic test script

### DIFF
--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -22,9 +22,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #ifndef CHUNK_SIZE
-#define CHUNK_SIZE 1024
+#ifdef BOARD_NATIVE
+#define CHUNK_SIZE          (1024 * 1024U)
+#else
+#define CHUNK_SIZE          (1024U)
+#endif
+#endif
+
+#ifndef NUMBER_OF_TESTS
+#define NUMBER_OF_TESTS     3
+#endif
+
+#ifndef MAX_MEM
+#define MAX_MEM             (256 * 1024UL * 1024UL)
 #endif
 
 struct node {
@@ -32,13 +45,20 @@ struct node {
     void *ptr;
 };
 
-static int total = 0;
+static uint32_t total = 0;
 
 static void fill_memory(struct node *head)
 {
-    while (head && (head->ptr = malloc(CHUNK_SIZE))) {
-        printf("Allocated %d Bytes at 0x%p, total %d\n",
-               CHUNK_SIZE, head->ptr, total += CHUNK_SIZE);
+    uint32_t allocations = 0;
+
+    if (head) {
+        head->next = NULL;
+    }
+
+    total = 0;
+    while (head && (head->ptr = malloc(CHUNK_SIZE)) && total < MAX_MEM) {
+        printf("Allocated %"PRIu32" Bytes at 0x%p, total %"PRIu32"\n",
+               (uint32_t)CHUNK_SIZE, head->ptr, total += CHUNK_SIZE);
         memset(head->ptr, '@', CHUNK_SIZE);
         head = head->next = malloc(sizeof(struct node));
         if (head) {
@@ -46,7 +66,10 @@ static void fill_memory(struct node *head)
             head->ptr  = 0;
             head->next = 0;
         }
+        allocations++;
     }
+
+    printf("Allocations count: %"PRIu32"\n", allocations);
 }
 
 static void free_memory(struct node *head)
@@ -55,8 +78,11 @@ static void free_memory(struct node *head)
 
     while (head) {
         if (head->ptr) {
-            printf("Free %d Bytes at 0x%p, total %d\n",
-                   CHUNK_SIZE, head->ptr, total -= CHUNK_SIZE);
+            if (total > CHUNK_SIZE) {
+                total -= CHUNK_SIZE;
+            }
+            printf("Free %"PRIu32" Bytes at 0x%p, total %"PRIu32"\n",
+                   (uint32_t)CHUNK_SIZE, head->ptr, total);
             free(head->ptr);
         }
 
@@ -76,13 +102,19 @@ static void free_memory(struct node *head)
 
 int main(void)
 {
-    while (1) {
+    printf("CHUNK_SIZE: %"PRIu32"\n", (uint32_t)CHUNK_SIZE);
+    printf("NUMBER_OF_TESTS: %d\n", NUMBER_OF_TESTS);
+
+    uint8_t test = NUMBER_OF_TESTS;
+    while (test--) {
         struct node *head = malloc(sizeof(struct node));
         total += sizeof(struct node);
 
         fill_memory(head);
         free_memory(head);
     }
+
+    puts("[SUCCESS]");
 
     return 0;
 }

--- a/tests/malloc/tests/01-run.py
+++ b/tests/malloc/tests/01-run.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'CHUNK_SIZE: (\d+)')
+    chunk_size = int(child.match.group(1))
+    child.expect(r'NUMBER_OF_TESTS: (\d+)')
+    number_of_tests = int(child.match.group(1))
+    initial_allocations = 0
+    for _ in range(number_of_tests):
+        child.expect(r"Allocated {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+"
+                     .format(chunk_size))
+        child.expect(r'Allocations count: (\d+)')
+        allocations = int(child.match.group(1))
+        assert allocations > 0
+        if initial_allocations == 0:
+            initial_allocations = allocations
+        assert initial_allocations == allocations
+        for _ in range(allocations):
+            child.expect(r"Free {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+"
+                         .format(chunk_size))
+    child.expect_exact("[SUCCESS]")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Similar to #12632, this PR adds a Python automatic test script to the `tests/malloc` application.

To achieve this, the test application is updated to a similar approach as the `tests/memarray` one. Note that in master, this application fills the RAM using malloc. On native, this can be a little problematic: if one lets the application running, the computer becomes unusable.
This PR then change that logic to use malloc to allocate a small memory space.

This PR is also fixing one of the scan-build issue reported in #11852.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test using the following commands:
```
$ make BOARD=native -C tests/malloc all test
$ make BOARD=atmega256rfr2-xpro -C tests/malloc flash test
$ make BOARD=samr21-xpro -C tests/malloc flash test
```
on master, the native version just fills the RAM until the computer becomes unusable.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Similar to #12632 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
