### PR TITLE
nrf5x: move nimble_ble feat. to cpu

### DIFF
--- a/boards/common/nrf51/Makefile.features
+++ b/boards/common/nrf51/Makefile.features
@@ -3,6 +3,3 @@ CPU = nrf51
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
-
-# Various other features (if any)
-FEATURES_PROVIDED += ble_nimble

--- a/boards/common/nrf52/Makefile.features
+++ b/boards/common/nrf52/Makefile.features
@@ -7,9 +7,6 @@ ifeq (,$(filter nordic_softdevice_ble,$(USEPKG)))
   FEATURES_PROVIDED += riotboot
 endif
 
-# Various other features (if any)
-FEATURES_PROVIDED += ble_nimble
-
 ifneq (,$(findstring nrf52832, $(CPU_MODEL)))
   # Nordic SoftDevice support in RIOT is verified for all nrf52832-based boards
   FEATURES_PROVIDED += ble_nordic_softdevice

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -9,6 +9,7 @@ FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += periph_wdt periph_wdt_cb
 
 # Various other features (if any)
+FEATURES_PROVIDED += ble_nimble
 FEATURES_PROVIDED += radio_nrfble
 FEATURES_PROVIDED += radio_nrfmin
 FEATURES_PROVIDED += puf_sram


### PR DESCRIPTION
### Contribution description
since a while, `nimble` works on all nrf5x-based CPUs/platforms. But for historic reasons, the `ble_nimble` feature was still defined separately in both `boards/common/nrf51` and `boards/common/nrf52`. This PR moves the feature declaration in a single location to `cpu/nrf5x_common`.

### Testing procedure
Do `make buildtest` on `examples/nimble_gatt` with and without this PR. The list of boards that the example is build for should be identical.

### Issues/PRs references
none