### PR TITLE
drivers/at86rf2xx: enable Smart Reduced Power Consumption for AT86RFR2

### DIFF
--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -84,6 +84,7 @@ extern "C" {
 #define AT86RF2XX_REG__RX_CTRL                                  (&RX_CTRL)
 #define AT86RF2XX_REG__SFD_VALUE                                (&SFD_VALUE)
 #define AT86RF2XX_REG__TRX_CTRL_2                               (&TRX_CTRL_2)
+#define AT86RF2XX_REG__TRX_RPC                                  (&TRX_RPC)
 #define AT86RF2XX_REG__ANT_DIV                                  (&ANT_DIV)
 #define AT86RF2XX_REG__IRQ_MASK                                 (&IRQ_MASK)
 #define AT86RF2XX_REG__IRQ_STATUS                               (&IRQ_STATUS)
@@ -522,14 +523,12 @@ extern "C" {
  * @name    Bitfield definitions for the TRX_RPC register
  * @{
  */
-#ifdef MODULE_AT86RF233
 #define AT86RF2XX_TRX_RPC_MASK__RX_RPC_CTRL_MAXPWR              (0xC0)
 #define AT86RF2XX_TRX_RPC_MASK__RX_RPC_EN                       (0x20)
 #define AT86RF2XX_TRX_RPC_MASK__PDT_RPC_EN                      (0x10)
 #define AT86RF2XX_TRX_RPC_MASK__PLL_RPC_EN                      (0x08)
 #define AT86RF2XX_TRX_RPC_MASK__XAH_TX_RPC_EN                   (0x04)
 #define AT86RF2XX_TRX_RPC_MASK__IPAN_RPC_EN                     (0x02)
-#endif
 
 #ifdef __cplusplus
 }

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -158,7 +158,7 @@ extern "C" {
  * manual recommends to disable this feature for RSSI measurements or random number
  * generation (Section 8.4 and Section 11.2).
  */
-#ifdef MODULE_AT86RF233
+#if defined(MODULE_AT86RF233) || defined(MODULE_AT86RFR2)
 #ifndef AT86RF2XX_SMART_IDLE_LISTENING
 #define AT86RF2XX_SMART_IDLE_LISTENING     (1)
 #endif


### PR DESCRIPTION
### Contribution description

[*Smart Reduced Power Consumption Techniques*](http://ww1.microchip.com/downloads/en/Appnotes/Atmel-42356-Smart-Reduced-Power-Consumption-Techniques_ApplicationNote_AT02594.pdf) are supported by AT86RF233, ATmega2564/1284/644RFR2 and ATmega256/128/64RFR2 devices.

Functionality is the same as on AT86RF233, so we can just enable it.

### Testing procedure

Flash a board with an ATmega256RFR2 MCU and the e.g. `gnrc_networking` example. You should still be able to communicate with other nodes.

Tested with `avr-rss2` and a `same54-xpro` with an `at86rf233` radio connected to EXT3.

### Issues/PRs references
none
