### PR TITLE
tests/periph_timer: add frdm-k64f/k22f to 32kHz timers

### DIFF
--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -16,6 +16,8 @@ BOARDS_TIMER_32kHz := \
     hifive1 \
     hifive1b \
     %-kw41z \
+    frdm-k64f \
+    frdm-k22f \
     #
 
 ifneq (,$(filter $(BOARDS_TIMER_25kHz),$(BOARD)))


### PR DESCRIPTION

### Contribution description

`tests/periph_timer` is failing on `frdm-k64f` when testing against the low power timer, test is fixed for the board to use the LPTMR speed.

### Testing procedure

**master**:

```
2019-11-14 09:24:34,501 # TIMER_0: stopped
2019-11-14 09:24:37,008 # TIMER_0: set channel 0 to 5main(): This is RIOT! (Version: 2020.01-devel-624-g0e736-HEAD)
2019-11-14 09:24:37,008 # 
2019-11-14 09:24:37,009 # Test for peripheral TIMERs
2019-11-14 09:24:37,010 # 
2019-11-14 09:24:37,012 # Available timers: 3
2019-11-14 09:24:37,012 # 
2019-11-14 09:24:37,013 # Testing TIMER_0:
2019-11-14 09:24:37,016 # TIMER_0: initialization successful
2019-11-14 09:24:37,018 # TIMER_0: stopped
2019-11-14 09:24:37,020 # TIMER_0: set channel 0 to 5000
2019-11-14 09:24:37,022 # TIMER_0: starting
2019-11-14 09:24:37,032 # TIMER_0: channel 0 fired at SW count    23081 - init:    23081
2019-11-14 09:24:37,032 # 
2019-11-14 09:24:37,033 # Testing TIMER_1:
2019-11-14 09:24:37,037 # TIMER_1: initialization successful
2019-11-14 09:24:37,037 # TIMER_1: stopped
2019-11-14 09:24:37,041 # TIMER_1: set channel 0 to 5000
2019-11-14 09:24:37,042 # TIMER_1: starting
2019-11-14 09:24:37,052 # TIMER_1: channel 0 fired at SW count    23081 - init:    23081
2019-11-14 09:24:37,053 # 
2019-11-14 09:24:37,053 # Testing TIMER_2:
2019-11-14 09:24:37,057 # TIMER_2: ERROR on initialization - skipping
2019-11-14 09:24:37,058 # 
2019-11-14 09:24:37,058 # 
2019-11-14 09:24:37,058 # TEST FAILED
```

**This PR**

```
2019-11-14 09:29:04,106 # 
2019-11-14 09:29:04,109 # Test for peripheral TIMERs
2019-11-14 09:29:04,109 # 
2019-11-14 09:29:04,110 # Available timers: 3
2019-11-14 09:29:04,110 # 
2019-11-14 09:29:04,111 # Testing TIMER_0:
2019-11-14 09:29:04,115 # TIMER_0: initialization successful
2019-11-14 09:29:04,116 # TIMER_0: stopped
2019-11-14 09:29:04,119 # TIMER_0: set channel 0 to 5000
2019-11-14 09:29:04,120 # TIMER_0: starting
2019-11-14 09:29:04,278 # TIMER_0: channel 0 fired at SW count   763069 - init:   763069
2019-11-14 09:29:04,278 # 
2019-11-14 09:29:04,280 # Testing TIMER_1:
2019-11-14 09:29:04,283 # TIMER_1: initialization successful
2019-11-14 09:29:04,284 # TIMER_1: stopped
2019-11-14 09:29:04,287 # TIMER_1: set channel 0 to 5000
2019-11-14 09:29:04,288 # TIMER_1: starting
2019-11-14 09:29:04,446 # TIMER_1: channel 0 fired at SW count   763069 - init:   763069
2019-11-14 09:29:04,446 # 
2019-11-14 09:29:04,447 # Testing TIMER_2:
2019-11-14 09:29:04,450 # TIMER_2: initialization successful
2019-11-14 09:29:04,452 # TIMER_2: stopped
2019-11-14 09:29:04,454 # TIMER_2: set channel 0 to 5000
2019-11-14 09:29:04,456 # TIMER_2: starting
2019-11-14 09:29:04,614 # TIMER_2: channel 0 fired at SW count   762901 - init:   762901
2019-11-14 09:29:04,614 # 
2019-11-14 09:29:04,615 # TEST SUCCEEDED

```
