### PR TITLE
RIOT: fix PEP8 errors

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -224,12 +224,12 @@ class SerCmd(cmd.Cmd):
                     af, socktype, proto, canonname, sa = res
                     try:
                         s = fdsocket(af, socktype, proto)
-                    except socket.error as msg:
+                    except socket.error:
                         s = None
                         continue
                     try:
                         s.connect(sa)
-                    except socket.error as msg:
+                    except socket.error:
                         s.close()
                         s = None
                         continue

--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -274,7 +274,7 @@ class SerCmd(cmd.Cmd):
         """
         self.logger.debug("processing line #%s#" % line)
         if (line.startswith("/")):
-                return "PYTERM_" + line[1:]
+            return "PYTERM_" + line[1:]
         return line
 
     def emptyline(self):

--- a/examples/suit_update/tests/01-run.py
+++ b/examples/suit_update/tests/01-run.py
@@ -65,10 +65,10 @@ def publish(server_dir, server_url, app_ver, latest_name=None):
 
 
 def wait_for_update(child):
-        return child.expect([r"riotboot_flashwrite: processing bytes (\d+)-(\d+)",
-                             "riotboot_flashwrite: riotboot flashing "
-                             "completed successfully"],
-                            timeout=UPDATING_TIMEOUT)
+    return child.expect([r"riotboot_flashwrite: processing bytes (\d+)-(\d+)",
+                         "riotboot_flashwrite: riotboot flashing "
+                         "completed successfully"],
+                        timeout=UPDATING_TIMEOUT)
 
 
 def get_ipv6_addr(child):

--- a/tests/bitarithm_timings/tests/01-run.py
+++ b/tests/bitarithm_timings/tests/01-run.py
@@ -12,9 +12,9 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact("Start.")
-    child.expect('\+ bitarithm_msb: \d+ iterations per second')
-    child.expect('\+ bitarithm_lsb: \d+ iterations per second')
-    child.expect('\+ bitarithm_bits_set: \d+ iterations per second')
+    child.expect(r'\+ bitarithm_msb: \d+ iterations per second')
+    child.expect(r'\+ bitarithm_lsb: \d+ iterations per second')
+    child.expect(r'\+ bitarithm_bits_set: \d+ iterations per second')
     child.expect_exact("Done.")
 
 

--- a/tests/cb_mux_bench/tests/01-run.py
+++ b/tests/cb_mux_bench/tests/01-run.py
@@ -12,10 +12,10 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact("cb_mux benchmark application")
-    child.expect(u"Populating cb_mux list with \d+ items")
+    child.expect(r"Populating cb_mux list with \d+ items")
     child.expect_exact("Finding the last list entry")
-    child.expect(u"List walk time: \d+ us")
-    child.expect(u"Walk time less than threshold of \d+ us")
+    child.expect(r"List walk time: \d+ us")
+    child.expect(r"Walk time less than threshold of \d+ us")
     child.expect_exact("[SUCCESS]")
 
 

--- a/tests/cond_order/tests/01-run.py
+++ b/tests/cond_order/tests/01-run.py
@@ -26,20 +26,20 @@ def testfunc(child):
     test_utils_interactive_sync(child)
 
     for k in thread_prio.keys():
-        child.expect(u"T%i \(prio %i\): waiting on condition variable now" % (k, thread_prio[k]))
-
+        child.expect_exact("T{} (prio {}): waiting on condition variable now"
+                           .format(k, thread_prio[k]))
     count = 0
     last = -1
-    child.expect(u"First batch was signaled")
+    child.expect_exact("First batch was signaled")
     for _ in range(len(thread_prio)):
-        child.expect(u"T\d+ \(prio (\d+)\): condition variable was signaled now")
+        child.expect(r"T\d+ \(prio (\d+)\): condition variable was signaled now")
         assert(int(child.match.group(1)) > last)
         last = int(child.match.group(1))
         count += 1
         if count == 3:
-            child.expect(u"First batch has woken up")
-            child.expect(u"Second batch was signaled")
-    child.expect(u"Second batch has woken up")
+            child.expect_exact("First batch has woken up")
+            child.expect_exact("Second batch was signaled")
+    child.expect_exact("Second batch has woken up")
 
 
 if __name__ == "__main__":

--- a/tests/gnrc_ipv6_ext_frag/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext_frag/tests/01-run.py
@@ -61,7 +61,7 @@ def stop_udp_server(child):
 def udp_send(child, addr, port, length, num=1, delay=1000000):
     child.sendline("udp send {addr}%6 {port} {length} {num} {delay}"
                    .format(**vars()))
-    child.expect("Success: send {length} byte to \[[0-9a-f:]+\]:{port}"
+    child.expect(r"Success: send {length} byte to \[[0-9a-f:]+\]:{port}"
                  .format(**vars()))
 
 
@@ -125,13 +125,13 @@ def test_reass_successful_udp(child, iface, hw_dst, ll_dst, ll_src):
         s.sendto(bytes(i for i in range(byte_max)) * (payload_len // byte_max),
                  (ll_dst, port))
         child.expect(
-                "~~ SNIP  0 - size: {} byte, type: NETTYPE_UNDEF \(\d+\)"
+                r"~~ SNIP  0 - size: {} byte, type: NETTYPE_UNDEF \(\d+\)"
                 .format(payload_len)
             )
         # 4 snips: payload, UDP header, IPv6 header, netif header
         # (fragmentation header was removed)
         child.expect(
-                "~~ PKT    -  4 snips, total size: (\d+) byte"
+                r"~~ PKT    -  4 snips, total size: (\d+) byte"
             )
         size = int(child.match.group(1))
         # 40 = IPv6 header length; 8 = UDP header length

--- a/tests/gnrc_netif/tests/01-run.py
+++ b/tests/gnrc_netif/tests/01-run.py
@@ -86,7 +86,7 @@ def testfunc(child):
     child.expect("flags: 0x0")
     child.expect("src_l2addr: 3E:E6:B5:22:FD:0B")
     child.expect("dst_l2addr: 3E:E6:B5:22:FD:0A")
-    child.expect("~~ PKT    -  2 snips, total size:  \d+ byte")
+    child.expect(r"~~ PKT    -  2 snips, total size:  \d+ byte")
     # test_netapi_recv__empty_ieee802154_payload
     child.expect(r"pktdump dumping IEEE 802\.15\.4 packet with empty payload")
     child.expect("PKTDUMP: data received:")
@@ -97,7 +97,7 @@ def testfunc(child):
     child.expect("flags: 0x0")
     child.expect("src_l2addr: 3E:E6:B5:0F:19:22:FD:0B")
     child.expect("dst_l2addr: 3E:E6:B5:0F:19:22:FD:0A")
-    child.expect("~~ PKT    -  2 snips, total size:  \d+ byte")
+    child.expect(r"~~ PKT    -  2 snips, total size:  \d+ byte")
     # test_netapi_recv__raw_ethernet_payload
     child.expect("pktdump dumping Ethernet packet with payload 12 34 45 56")
     child.expect("PKTDUMP: data received:")
@@ -109,7 +109,7 @@ def testfunc(child):
     child.expect("flags: 0x0")
     child.expect("src_l2addr: 3E:E6:B5:22:FD:0B")
     child.expect("dst_l2addr: 3E:E6:B5:22:FD:0A")
-    child.expect("~~ PKT    -  2 snips, total size:  \d+ byte")
+    child.expect(r"~~ PKT    -  2 snips, total size:  \d+ byte")
     # test_netapi_recv__raw_ieee802154_payload
     child.expect(r"pktdump dumping IEEE 802\.15\.4 packet with payload 12 34 45 56")
     child.expect("PKTDUMP: data received:")
@@ -121,7 +121,7 @@ def testfunc(child):
     child.expect("flags: 0x0")
     child.expect("src_l2addr: 3E:E6:B5:0F:19:22:FD:0B")
     child.expect("dst_l2addr: 3E:E6:B5:0F:19:22:FD:0A")
-    child.expect("~~ PKT    -  2 snips, total size:  \d+ byte")
+    child.expect(r"~~ PKT    -  2 snips, total size:  \d+ byte")
     # test_netapi_recv__ipv6_ethernet_payload
     child.expect("pktdump dumping IPv6 over Ethernet packet with payload 01")
     child.expect("PKTDUMP: data received:")
@@ -139,7 +139,7 @@ def testfunc(child):
     child.expect("flags: 0x0")
     child.expect("src_l2addr: 3E:E6:B5:22:FD:0B")
     child.expect("dst_l2addr: 3E:E6:B5:22:FD:0A")
-    child.expect("~~ PKT    -  2 snips, total size:  \d+ byte")
+    child.expect(r"~~ PKT    -  2 snips, total size:  \d+ byte")
 
 
 if __name__ == "__main__":

--- a/tests/heap_cmd/tests/01-run.py
+++ b/tests/heap_cmd/tests/01-run.py
@@ -14,7 +14,7 @@ def testfunc(child):
     # check startup message
     child.expect('Shell-based test application for heap functions.')
     child.sendline('heap')
-    ret = child.expect(['heap: \d+ \(used \d+, free \d+\) \[bytes\]', 'heap statistics are not supported'])
+    ret = child.expect([r'heap: \d+ \(used \d+, free \d+\) \[bytes\]', 'heap statistics are not supported'])
     if ret == 1:
         return
     child.sendline('malloc 100')
@@ -23,12 +23,12 @@ def testfunc(child):
     addr = addr[:-2]
     child.expect_exact('> ')
     child.sendline('heap')
-    child.expect('heap: \d+ \(used \d+, free \d+\) \[bytes\]')
+    child.expect(r'heap: \d+ \(used \d+, free \d+\) \[bytes\]')
     child.sendline('free 0x' + addr)
     child.expect('freed 0x' + addr)
     child.expect_exact('>')
     child.sendline('heap')
-    child.expect('heap: \d+ \(used \d+, free \d+\) \[bytes\]')
+    child.expect(r'heap: \d+ \(used \d+, free \d+\) \[bytes\]')
 
 
 if __name__ == "__main__":

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -232,13 +232,13 @@ def test_udpv6_send(board_group, application, env=None):
         receiver.sendline(u"udp server start %d" % port)
         # wait for neighbor discovery to be done
         time.sleep(5)
-        sender.sendline(u"udp send %s %d ab:cd:ef" % (rerun
-        sender.expect_exact(u"Success: send 3 byte over run
-                            (receiver_ip, port))
+        sender.sendline(u"udp send %s %d ab:cd:ef" % (receiver_ip, port))
+        sender.expect_exact("Success: send 3 byte over UDP to [{}]:{}"
+                            .format(receiver_ip, port))
         receiver.expect(u"00000000  AB  CD  EF")
 
 
-def test_tcpv6_send(board_group, application, env=None):run
+def test_tcpv6_send(board_group, application, env=None):
     env_client = os.environ.copy()
     if env is not None:
         env_client.update(env)

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -82,7 +82,7 @@ class Board(object):
             pass
 
         if (name == "native") and (reset is None):
-                reset = _reset_native_execute
+            reset = _reset_native_execute
 
         self.name = name
         self.port = port
@@ -232,13 +232,13 @@ def test_udpv6_send(board_group, application, env=None):
         receiver.sendline(u"udp server start %d" % port)
         # wait for neighbor discovery to be done
         time.sleep(5)
-        sender.sendline(u"udp send %s %d ab:cd:ef" % (receiver_ip, port))
-        sender.expect_exact(u"Success: send 3 byte over UDP to [%s]:%d" %
+        sender.sendline(u"udp send %s %d ab:cd:ef" % (rerun
+        sender.expect_exact(u"Success: send 3 byte over run
                             (receiver_ip, port))
         receiver.expect(u"00000000  AB  CD  EF")
 
 
-def test_tcpv6_send(board_group, application, env=None):
+def test_tcpv6_send(board_group, application, env=None):run
     env_client = os.environ.copy()
     if env is not None:
         env_client.update(env)

--- a/tests/msg_try_receive/tests/01-run.py
+++ b/tests/msg_try_receive/tests/01-run.py
@@ -5,8 +5,8 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect('main starting')
-    child.expect('msg available: 1 \(should be 1\!\)')
+    child.expect_exact('main starting')
+    child.expect_exact('msg available: 1 (should be 1!)')
 
 
 if __name__ == "__main__":

--- a/tests/mutex_order/tests/01-run.py
+++ b/tests/mutex_order/tests/01-run.py
@@ -22,11 +22,12 @@ thread_prio = {
 
 def testfunc(child):
     for k in thread_prio.keys():
-        child.expect(u"T%i \(prio %i\): trying to lock mutex now" % (k, thread_prio[k]))
+        child.expect_exact("T{} (prio {}): trying to lock mutex now"
+                           .format(k, thread_prio[k]))
 
     last = -1
     for i in range(len(thread_prio)):
-        child.expect(u"T\d+ \(prio (\d+)\): locked mutex now")
+        child.expect(r"T\d+ \(prio (\d+)\): locked mutex now")
         assert(int(child.match.group(1)) > last)
         last = int(child.match.group(1))
 

--- a/tests/periph_timer/tests/01-run.py
+++ b/tests/periph_timer/tests/01-run.py
@@ -11,7 +11,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect('Available timers: (\d+)')
+    child.expect(r'Available timers: (\d+)')
     timers_num = int(child.match.group(1))
     for timer in range(timers_num):
         child.expect_exact('Testing TIMER_{}'.format(timer))

--- a/tests/periph_wdt/tests/01-run.py
+++ b/tests/periph_wdt/tests/01-run.py
@@ -27,7 +27,7 @@ def get_reset_time(child):
         start = time.time()
         timeout = 10  # seconds
         while time.time() < start + timeout:
-            child.expect(u"reset time: (\d+) us", timeout=1)
+            child.expect(r"reset time: (\d+) us", timeout=1)
             reset_time = int(child.match.group(1))
         else:
             # timeout
@@ -38,7 +38,7 @@ def get_reset_time(child):
 
 def testfunc(child):
     child.sendline("range")
-    child.expect(u"lower_bound: (\d+) upper_bound: (\d+) ",
+    child.expect(r"lower_bound: (\d+) upper_bound: (\d+)",
                  timeout=1)
     wdt_lower_bound = int(child.match.group(1))
     wdt_upper_bound = int(child.match.group(2))
@@ -49,7 +49,7 @@ def testfunc(child):
             child.expect_exact("invalid time, see \"range\"", timeout=1)
         else:
             child.sendline("startloop")
-            child.expect(u"start time: (\d+) us", timeout=1)
+            child.expect(r"start time: (\d+) us", timeout=1)
             start_time_us = int(child.match.group(1))
             reset_time_us = get_reset_time(child)
             wdt_reset_time = (reset_time_us - start_time_us) / 1e3

--- a/tests/pkg_c25519/tests/01-run.py
+++ b/tests/pkg_c25519/tests/01-run.py
@@ -15,7 +15,7 @@ def testfunc(child):
     board = os.environ['BOARD']
     # Increase timeout on "real" hardware
     # 170 seconds on `arduino-mega2560`
-    timeout = 200 if board is not 'native' else -1
+    timeout = 200 if board != 'native' else -1
     child.expect(r"OK \(2 tests\)", timeout=timeout)
 
 

--- a/tests/pkg_fatfs_vfs/tests/01-run.py
+++ b/tests/pkg_fatfs_vfs/tests/01-run.py
@@ -16,14 +16,14 @@ class TestFailed(Exception):
 
 def testfunc(child):
 
-    child.expect(u"Tests for FatFs over VFS - test results will be printed in "
-                 "the format test_name:result\r\n")
+    child.expect_exact("Tests for FatFs over VFS - test results will be printed"
+                       " in the format test_name:result\r\n")
 
     while True:
-        res = child.expect([u"[^\n]*:\[OK\]\r\n",
-                            u"Test end.\r\n",
-                            u".[^\n]*:\[FAILED\]\r\n",
-                            u".*\r\n"])
+        res = child.expect([r"[^\n]*:\[OK\]\r\n",
+                            r"Test end.\r\n",
+                            r".[^\n]*:\[FAILED\]\r\n",
+                            r".*\r\n"])
         if res > 1:
             raise TestFailed(child.after.split(':', 1)[0] + " test failed!")
         elif res == 1:

--- a/tests/pkg_hacl/tests/01-run.py
+++ b/tests/pkg_hacl/tests/01-run.py
@@ -16,7 +16,7 @@ TIMEOUT = 30
 
 
 def testfunc(child):
-    child.expect('OK \(\d+ tests\)', timeout=TIMEOUT)
+    child.expect(r'OK \(\d+ tests\)', timeout=TIMEOUT)
 
 
 if __name__ == "__main__":

--- a/tests/pkg_heatshrink/tests/01-run.py
+++ b/tests/pkg_heatshrink/tests/01-run.py
@@ -11,7 +11,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect('OK \(\d+ tests\)')
+    child.expect(r'OK \(\d+ tests\)')
 
 
 if __name__ == "__main__":

--- a/tests/pkg_libcose/tests/01-run.py
+++ b/tests/pkg_libcose/tests/01-run.py
@@ -20,7 +20,7 @@ def testfunc(child):
     board = os.environ['BOARD']
     # Increase timeout on "real" hardware
     timeout = HW_TIMEOUT if board is not 'native' else -1
-    child.expect('OK \(\d+ tests\)', timeout=timeout)
+    child.expect(r'OK \(\d+ tests\)', timeout=timeout)
 
 
 if __name__ == "__main__":

--- a/tests/pkg_libcose/tests/01-run.py
+++ b/tests/pkg_libcose/tests/01-run.py
@@ -19,7 +19,7 @@ HW_TIMEOUT = 300
 def testfunc(child):
     board = os.environ['BOARD']
     # Increase timeout on "real" hardware
-    timeout = HW_TIMEOUT if board is not 'native' else -1
+    timeout = HW_TIMEOUT if board != 'native' else -1
     child.expect(r'OK \(\d+ tests\)', timeout=timeout)
 
 

--- a/tests/pkg_qdsa/tests/01-run.py
+++ b/tests/pkg_qdsa/tests/01-run.py
@@ -14,7 +14,7 @@ TIMEOUT = 15
 
 
 def testfunc(child):
-    child.expect('OK \(\d+ tests\)', timeout=TIMEOUT)
+    child.expect(r'OK \(\d+ tests\)', timeout=TIMEOUT)
 
 
 if __name__ == "__main__":

--- a/tests/pkg_tweetnacl/tests/01-run.py
+++ b/tests/pkg_tweetnacl/tests/01-run.py
@@ -14,7 +14,7 @@ from testrunner import run
 def testfunc(child):
     board = os.environ['BOARD']
     # Increase timeout on "real" hardware
-    timeout = 120 if board is not 'native' else -1
+    timeout = 120 if board != 'native' else -1
     child.expect(r'OK \(\d+ tests\)', timeout=timeout)
 
 

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -10,25 +10,25 @@ import sys
 from testrunner import run
 
 PS_EXPECTED = (
-    ('\tpid | name                 | state    Q | pri | stack  ( used) | '
-     'base addr  | current     | runtime  | switches'),
-    ('\t  - | isr_stack            | -        - |   - | \d+  ( -?\d+) | '
-     '0x\d+ | 0x\d+'),
-    ('\t  1 | idle                 | pending  Q |  15 | \d+  ( -?\d+) | '
-     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    ('\t  2 | main                 | running  Q |   7 | \d+  ( -?\d+) | '
-     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    ('\t  3 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
-     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    ('\t  4 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
-     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    ('\t  5 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
-     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    ('\t  6 | thread               | bl mutex _ |   6 | \d+  ( -?\d+) | '
-     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    ('\t  7 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
-     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    ('\t    | SUM                  |            |     | \d+  (\d+)')
+    (r'\tpid | name                 | state    Q | pri | stack  ( used) | '
+     r'base addr  | current     | runtime  | switches'),
+    (r'\t  - | isr_stack            | -        - |   - | \d+  ( -?\d+) | '
+     r'0x\d+ | 0x\d+'),
+    (r'\t  1 | idle                 | pending  Q |  15 | \d+  ( -?\d+) | '
+     r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    (r'\t  2 | main                 | running  Q |   7 | \d+  ( -?\d+) | '
+     r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    (r'\t  3 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+     r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    (r'\t  4 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+     r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    (r'\t  5 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+     r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    (r'\t  6 | thread               | bl mutex _ |   6 | \d+  ( -?\d+) | '
+     r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    (r'\t  7 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+     r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    (r'\t    | SUM                  |            |     | \d+  (\d+)')
 )
 
 

--- a/tests/pthread_tls/tests/01-run.py
+++ b/tests/pthread_tls/tests/01-run.py
@@ -8,7 +8,7 @@ def _check_test_output(child):
     child.expect('show tls values:')
     for i in range(20):
         if i != 5:
-            child.expect('key\[%d\]: -?\d+, val: %d'
+            child.expect(r'key\[%d\]: -?\d+, val: %d'
                          % (i, i + 1 if i != 3 else 42))
 
 
@@ -17,7 +17,7 @@ def testfunc(child):
     child.expect('-= TEST 1 - create 20 tls with sequencial values 0...19 =-')
     _check_test_output(child)
     child.expect('-= TEST 2 - '
-                 'delete deliberate key \(key\[5\]:-?\d+\) =-')
+                 r'delete deliberate key \(key\[5\]:-?\d+\) =-')
     _check_test_output(child)
     child.expect('-= TEST 3 - create new tls =-')
     _check_test_output(child)
@@ -26,11 +26,11 @@ def testfunc(child):
     child.expect('-= TEST 5 - try delete non-existing key =-')
     child.expect('try to delete returns: 0')
     child.expect('-= TEST 6 - add key and delete without a tls =-')
-    child.expect('created key: -?\d+')
+    child.expect(r'created key: -?\d+')
     child.expect('try to delete returns: 0')
     child.expect('-= TEST 7 - add key without tls =-')
-    child.expect('created key: -?\d+')
-    child.expect('test_7_val: (0|\(nil\))')
+    child.expect(r'created key: -?\d+')
+    child.expect(r'test_7_val: (0|\(nil\))')
     child.expect('tls tests finished.')
     child.expect('SUCCESS')
 

--- a/tests/rmutex/tests/01-run.py
+++ b/tests/rmutex/tests/01-run.py
@@ -35,14 +35,14 @@ def thread_prio_sort(x):
 
 def testfunc(child):
     for k in thread_prio.keys():
-        child.expect(u"T%i \(prio %i, depth 0\): trying to lock rmutex now" %
-                     (k, thread_prio[k]))
+        child.expect_exact("T{} (prio {}, depth 0): trying to lock rmutex now"
+                           .format(k, thread_prio[k]))
 
     pri_sorted = sorted(thread_prio, key=thread_prio_sort)
     for T in pri_sorted:
         for depth in range(lock_depth[T]):
-            child.expect(u"T%i \(prio %i, depth %i\): locked rmutex now" %
-                         (T, thread_prio[T], depth))
+            child.expect_exact("T{} (prio {}, depth {}): locked rmutex now"
+                               .format(T, thread_prio[T], depth))
 
 
 if __name__ == "__main__":

--- a/tests/rmutex_cpp/tests/01-run.py
+++ b/tests/rmutex_cpp/tests/01-run.py
@@ -35,14 +35,14 @@ def thread_prio_sort(x):
 
 def testfunc(child):
     for k in thread_prio.keys():
-        child.expect(u"T%i \(prio %i, depth 0\): trying to lock rmutex now" %
-                     (k, thread_prio[k]))
+        child.expect_exact("T{} (prio {}, depth 0): trying to lock rmutex now"
+                           .format(k, thread_prio[k]))
 
     pri_sorted = sorted(thread_prio, key=thread_prio_sort)
     for T in pri_sorted:
         for depth in range(lock_depth[T]):
-            child.expect(u"T%i \(prio %i, depth %i\): locked rmutex now" %
-                         (T, thread_prio[T], depth))
+            child.expect_exact("T{} (prio {}, depth {}): locked rmutex now"
+                               .format(T, thread_prio[T], depth))
 
 
 if __name__ == "__main__":

--- a/tests/thread_msg_seq/tests/01-run.py
+++ b/tests/thread_msg_seq/tests/01-run.py
@@ -5,18 +5,18 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect("START")
-    child.expect("THREADS CREATED")
-    child.expect("THREAD nr1 \(pid:3\) start")
-    child.expect("THREAD nr1 \(pid:3\) end.")
-    child.expect("THREAD nr2 \(pid:4\) start")
-    child.expect("THREAD nr3 \(pid:5\) start")
-    child.expect("Got msg from pid 3: \"nr1\"")
-    child.expect("THREAD nr2 \(pid:4\) end.")
-    child.expect("Got msg from pid 4: \"nr2\"")
-    child.expect("THREAD nr3 \(pid:5\) end.")
-    child.expect("Got msg from pid 5: \"nr3\"")
-    child.expect("SUCCESS")
+    child.expect_exact("START")
+    child.expect_exact("THREADS CREATED")
+    child.expect_exact("THREAD nr1 (pid:3) start")
+    child.expect_exact("THREAD nr1 (pid:3) end.")
+    child.expect_exact("THREAD nr2 (pid:4) start")
+    child.expect_exact("THREAD nr3 (pid:5) start")
+    child.expect_exact("Got msg from pid 3: \"nr1\"")
+    child.expect_exact("THREAD nr2 (pid:4) end.")
+    child.expect_exact("Got msg from pid 4: \"nr2\"")
+    child.expect_exact("THREAD nr3 (pid:5) end.")
+    child.expect_exact("Got msg from pid 5: \"nr3\"")
+    child.expect_exact("SUCCESS")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_hang/tests/01-run.py
+++ b/tests/xtimer_hang/tests/01-run.py
@@ -16,7 +16,7 @@ def testfunc(child):
     # due to timer inaccuracies, boards might not display exactly 100 steps, so
     # we accept 10% deviation
     for i in range(90):
-        child.expect(u"Testing \( +\d+%\)")
+        child.expect(r"Testing \( +\d+%\)")
 
     child.expect_exact("[SUCCESS]")
 

--- a/tests/xtimer_now64_continuity/tests/01-run.py
+++ b/tests/xtimer_now64_continuity/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact("[START]")
-    child.expect(u"\[RESULTS\] min=\d+, avg=\d+, max=\d+")
+    child.expect(r"\[RESULTS\] min=\d+, avg=\d+, max=\d+")
     child.expect_exact("[SUCCESS]")
 
 

--- a/tests/xtimer_periodic_wakeup/tests/01-run.py
+++ b/tests/xtimer_periodic_wakeup/tests/01-run.py
@@ -14,11 +14,11 @@ def testfunc(child):
     child.expect_exact("xtimer_periodic_wakeup test application.")
 
     for i in range(256):
-        child.expect(u"Testing interval \d+... \(now=\d+\)")
+        child.expect(r"Testing interval \d+... \(now=\d+\)")
     for i in range(256):
-        child.expect(u" +\d+ diff=\d+")
+        child.expect(r" +\d+ diff=\d+")
 
-    child.expect(u"Min/max error: \d+/\d+")
+    child.expect(r"Min/max error: \d+/\d+")
     child.expect_exact("Test complete.")
 
 

--- a/tests/xtimer_reset/tests/01-run.py
+++ b/tests/xtimer_reset/tests/01-run.py
@@ -14,9 +14,9 @@ def testfunc(child):
     child.expect_exact("This test tests re-setting of an already active timer.")
     child.expect_exact("It should print three times \"now=<value>\", with "
                        "values approximately 100ms (100000us) apart.")
-    child.expect(u"now=\d+")
-    child.expect(u"now=\d+")
-    child.expect(u"now=\d+")
+    child.expect(r"now=\d+")
+    child.expect(r"now=\d+")
+    child.expect(r"now=\d+")
     child.expect_exact("Test completed!")
 
 


### PR DESCRIPTION
### Contribution description

There are some PEP8 still present in the code base, this PR removes them.

### Testing procedure

In master running `./dist/tools/flake8/check.sh` will list multiple issues, non with this PR.

### Issues/PRs references

Depends on #12687 that fixes libfixmath pep8 errors.