### PR TITLE
make: enable SECONDEXPANSION for module/application builds

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -2,6 +2,15 @@ ifeq (, $(__RIOTBUILD_FLAG))
   $(error You cannot build a module on its own. Use "make" in your application's directory instead.)
 endif
 
+#
+# enable second expansion of prerequisites.
+#
+# Doing that here enables it globally for all modules and the application.
+#
+# See https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html
+# for what it can be used for.
+.SECONDEXPANSION:
+
 unexport DIRS
 DIRS := $(sort $(abspath $(DIRS)))
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR enables GNU make SECONDEXPANSION for all module/application builds.

See the GNU [make ](https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html) for more information.

This will make support for module source files in subfolders easy to implement.
See e.g., #11870.

This has been split out of #11870 in order to isolate any possible side effects.

### Testing procedure

All build outputs should be binary identical.

### Issues/PRs references

Split out of #11870.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
