### PR TITLE
cpu/native: add periph_eeprom driver implementation

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -73,7 +73,15 @@ ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
   PORT ?= tap0
 endif
 
-TERMFLAGS := $(PORT) $(TERMFLAGS)
+# Configure default eeprom file
+EEPROM_FILE ?= $(BINDIR)/native.eeprom
+
+# set the eeprom file flags only when the periph_eeprom feature is used.
+# NOTE: This can be turned into normal conditional syntax once #9913 is fixed
+EEPROM_FILE_FLAGS = $(if $(filter periph_eeprom,$(FEATURES_USED)),--eeprom $(EEPROM_FILE),)
+TERMFLAGS += $(EEPROM_FILE_FLAGS)
+
+TERMFLAGS += $(PORT)
 
 ASFLAGS =
 ifeq ($(shell basename $(DEBUGGER)),lldb)

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -2,6 +2,7 @@ FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_native
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm
 FEATURES_PROVIDED += periph_pwm

--- a/cpu/native/include/eeprom_native.h
+++ b/cpu/native/include/eeprom_native.h
@@ -27,6 +27,10 @@
 extern "C" {
 #endif
 
+#ifndef EEPROM_FILEPATH_MAX_LEN
+#define EEPROM_FILEPATH_MAX_LEN     (128U) /**< Maximum path len to store the EEPROM filepath */
+#endif
+
 /**
  * @brief   Read the configured file containing the EEPROM content
  *

--- a/cpu/native/include/eeprom_native.h
+++ b/cpu/native/include/eeprom_native.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_eeprom_native Native extra API for EEPROM
+ * @ingroup     cpu_native
+ * @brief       Implementation of EEPROM buffer persistence in file.
+ *
+ * @{
+ *
+ * @file
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef EEPROM_NATIVE_H
+#define EEPROM_NATIVE_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Read the configured file containing the EEPROM content
+ *
+ * This function is called once during the native instance startup.
+ *
+ * The file can be configured in a macro `EPPROM_FILE` via CFLAGS.
+ */
+void eeprom_native_read(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EEPROM_NATIVE_H */
+/** @} */

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -99,9 +99,6 @@ typedef enum {
 #ifndef EEPROM_SIZE
 #define EEPROM_SIZE             (1024U)  /* 1kB */
 #endif
-#ifndef EEPROM_FILE
-#define EEPROM_FILE             "/tmp/riot_native.eeprom"
-#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -92,6 +92,18 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 #endif /* MODULE_PERIPH_SPI | DOXYGEN */
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#ifndef EEPROM_SIZE
+#define EEPROM_SIZE             (1024U)  /* 1kB */
+#endif
+#ifndef EEPROM_FILE
+#define EEPROM_FILE             "/tmp/riot_native.eeprom"
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/periph/eeprom.c
+++ b/cpu/native/periph/eeprom.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_native
+ * @ingroup     drivers_periph_eeprom
+ * @{
+ *
+ * @file
+ * @brief       Low-level EEPROM driver implementation for native
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "native_internal.h"
+
+#include "cpu.h"
+#include "mutex.h"
+#include "periph/eeprom.h"
+#include "eeprom_native.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+char eeprom_file[EEPROM_FILEPATH_MAX_LEN];
+
+static uint8_t _eeprom_buf[EEPROM_SIZE] = { EEPROM_CLEAR_BYTE };
+
+static mutex_t lock = MUTEX_INIT;
+
+static inline void eeprom_native_write(void)
+{
+    FILE *fp = real_fopen(eeprom_file, "w");
+    if (!fp) {
+        return;
+    }
+    DEBUG("Writing data to EEPROM file %s:\n", eeprom_file);
+    fwrite(_eeprom_buf, 1, ARRAY_SIZE(_eeprom_buf), fp);
+
+    if (ENABLE_DEBUG) {
+        for (size_t i = 0; i < ARRAY_SIZE(_eeprom_buf); i++) {
+            DEBUG("0x%02X ", _eeprom_buf[i]);
+            if ((i + 1) % 16 == 0) {
+                DEBUG("\n");
+            }
+        }
+        DEBUG("\n");
+    }
+    fclose(fp);
+}
+
+void eeprom_native_read(void)
+{
+    FILE *fp = real_fopen(eeprom_file, "r");
+    if (!fp) {
+        return;
+    }
+
+    DEBUG("Reading data from EEPROM file %s:\n", eeprom_file);
+    fread(_eeprom_buf, 1, ARRAY_SIZE(_eeprom_buf), fp);
+    if (ENABLE_DEBUG) {
+        for (size_t i = 0; i < ARRAY_SIZE(_eeprom_buf); i++) {
+            DEBUG("0x%02X ", _eeprom_buf[i]);
+            if ((i + 1) % 16 == 0) {
+                DEBUG("\n");
+            }
+        }
+        DEBUG("\n");
+    }
+    fclose(fp);
+}
+
+size_t eeprom_read(uint32_t pos, void *data, size_t len)
+{
+    assert(pos + len <= EEPROM_SIZE);
+
+    mutex_lock(&lock);
+    memcpy(data, &_eeprom_buf[pos], len);
+    mutex_unlock(&lock);
+
+    return len;
+}
+
+size_t eeprom_write(uint32_t pos, const void *data, size_t len)
+{
+    assert(pos + len <= EEPROM_SIZE);
+
+    mutex_lock(&lock);
+    memcpy(&_eeprom_buf[pos], data, len);
+    mutex_unlock(&lock);
+
+    /* Persist to the file */
+    eeprom_native_write();
+
+    return len;
+}

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -47,10 +47,6 @@
 #include "periph/init.h"
 #include "periph/pm.h"
 
-#ifdef MODULE_PERIPH_EEPROM
-#include "eeprom_native.h"
-#endif
-
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -90,6 +86,10 @@ netdev_tap_params_t netdev_tap_params[NETDEV_TAP_MAX];
 
 socket_zep_params_t socket_zep_params[SOCKET_ZEP_MAX];
 #endif
+#ifdef MODULE_PERIPH_EEPROM
+#include "eeprom_native.h"
+extern char eeprom_file[EEPROM_FILEPATH_MAX_LEN];
+#endif
 
 static const char short_opts[] = ":hi:s:deEoc:"
 #ifdef MODULE_MTD_NATIVE
@@ -126,6 +126,9 @@ static const struct option long_opts[] = {
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
     { "spi", required_argument, NULL, 'p' },
+#endif
+#ifdef MODULE_PERIPH_EEPROM
+    { "eeprom", required_argument, NULL, 'M' },
 #endif
     { NULL, 0, NULL, '\0' },
 };
@@ -319,6 +322,12 @@ void usage_exit(int status)
 "        Supports up to %d buses with %d CS lines each.\n", SPI_NUMOF, SPI_MAXCS
     );
 #endif
+#ifdef MODULE_PERIPH_EEPROM
+    real_printf(
+"    -M <eeprom> , --eeprom=<eeprom>\n"
+"        Specify the file path where the EEPROM content is stored\n"
+"        Example: --eeprom=/tmp/riot_native.eeprom\n");
+#endif
     real_exit(status);
 }
 
@@ -504,6 +513,12 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
                     }
                 }
                 break;
+#endif
+#ifdef MODULE_PERIPH_EEPROM
+            case 'M': {
+                strncpy(eeprom_file, optarg, EEPROM_FILEPATH_MAX_LEN);
+                break;
+            }
 #endif
             default:
                 usage_exit(EXIT_FAILURE);

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -47,6 +47,10 @@
 #include "periph/init.h"
 #include "periph/pm.h"
 
+#ifdef MODULE_PERIPH_EEPROM
+#include "eeprom_native.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -581,6 +585,10 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
     for (int i = 0; i < NETDEV_TAP_MAX; i++) {
         netdev_tap_params[i].tap_name = &argv[optind + i];
     }
+#endif
+
+#ifdef MODULE_PERIPH_EEPROM
+    eeprom_native_read();
 #endif
 
     periph_init();

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -76,6 +76,7 @@ export SIZEFLAGS             # The optional size flags.
 export UNDEF                 # Object files that the linker must include in the ELFFILE even if no call to the functions or symbols (ex: interrupt vectors).
 export WERROR                # Treat all compiler warnings as errors if set to 1 (see -Werror flag in GCC manual)
 export WPEDANTIC             # Issue all (extensive) compiler warnings demanded by strict C/C++
+# EEPROM_FILE                # (Native only!) file path where the content of the EEPROM is stored
 
 export GITCACHE              # path to git-cache executable
 export GIT_CACHE_DIR         # path to git-cache cache directory

--- a/tests/periph_eeprom/Makefile
+++ b/tests/periph_eeprom/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= b-l072z-lrwan1
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_eeprom

--- a/tests/periph_eeprom/tests/01-run.py
+++ b/tests/periph_eeprom/tests/01-run.py
@@ -14,6 +14,16 @@ def testfunc(child):
     child.sendline('test')
     child.expect('SUCCESS')
 
+    # reboot the device to ensure data are still available on EEPROM
+    child.sendline('reboot')
+    child.expect(r'EEPROM size:		(\d+)')
+    eeprom_size = int(child.match.group(1))
+    child.expect_exact('>')
+    child.sendline('read 0 4')
+    child.expect_exact('Data read from EEPROM (4 bytes): AAAA')
+    child.sendline('read {} 4'.format(eeprom_size - 4))
+    child.expect_exact('Data read from EEPROM (4 bytes): AAAA')
+
 
 if __name__ == "__main__":
     sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This implementation is an emulation of an EEPROM for native using an in memory buffer modified during runtime. This buffer is filled from a file on disk at instance startup and dumped to this file at exit/reboot.
This provides the same persistence mechanism as a hardware eeprom.

The eeprom file is provided via termflags. I'm not 100% sure the integration is correct here, so comments are welcome.
The EEPROM size for native is 1024kB.

The periph_eeprom test application is modified:
- native board is now the default
- the test script triggers a reboot of the application and checks that previous data are still available on EEPROM

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following commands are working (now the first one is building for native):
```
$ make -C tests/periph_eeprom flash test
$ make BOARD=nucleo-l073rz -C tests/periph_eeprom flash test
$ make BOARD=nucleo-l152re -C tests/periph_eeprom flash test
```

Another thing that could be tested on native is the `EEPROM_FILE` variable:
```
$ ls /tmp/riot_test.eeprom 
ls: cannot access '/tmp/riot_test.eeprom': No such file or directory
$ EEPROM_FILE=/tmp/riot_test.eeprom make -C tests/periph_eeprom all test
$ hexdump /tmp/riot_test.eeprom 
0000000 4141 4141 0000 0000 0000 0000 0000 0000
0000010 0000 0000 0000 0000 0000 0000 0000 0000
*
0000200 0041 0000 0000 0000 0000 0000 0000 0000
0000210 0000 0000 0000 0000 0000 0000 0000 0000
*
00003f0 0000 0000 0000 0000 0000 0000 4141 4141
0000400
```
=> the file is automatically created and content is correct: the last tests are writing AAAA at the beginning and at the end of the EEPROM.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
