### PR TITLE
tests/periph_pm: use button as a wake-up source

### DIFF
--- a/tests/periph_pm/Makefile
+++ b/tests/periph_pm/Makefile
@@ -5,6 +5,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := chronos msb-430h msb-430 telosb wsn430-v1_3b wsn430-v1_4 z1
 
 FEATURES_OPTIONAL += periph_rtc
+FEATURES_OPTIONAL += periph_gpio_irq
 
 USEMODULE += shell
 

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -23,6 +23,10 @@
 #include <stdlib.h>
 
 #include "periph/pm.h"
+#ifdef MODULE_PERIPH_GPIO
+#include "board.h"
+#include "periph/gpio.h"
+#endif
 #ifdef MODULE_PM_LAYERED
 #ifdef MODULE_PERIPH_RTC
 #include "periph/rtc.h"
@@ -204,6 +208,15 @@ static int cmd_unblock_rtc(int argc, char **argv)
 #endif /* MODULE_PERIPH_RTC */
 #endif /* MODULE_PM_LAYERED */
 
+#if defined(MODULE_PERIPH_GPIO_IRQ) && defined(BTN0_PIN)
+static void btn_cb(void *ctx)
+{
+    (void) ctx;
+    puts("BTN0 pressed.");
+}
+#endif /* MODULE_PERIPH_GPIO_IRQ */
+
+
 /**
  * @brief   List of shell commands for this example.
  */
@@ -239,6 +252,11 @@ int main(void)
     puts("This application allows you to test the CPU power management.\n"
          "Layered support is not unavailable for this CPU. Reset the CPU if\n"
          "needed.");
+#endif
+
+#if defined(MODULE_PERIPH_GPIO_IRQ) && defined(BTN0_PIN)
+    puts("using BTN0 as wake-up source");
+    gpio_init_int(BTN0_PIN, BTN0_MODE, GPIO_RISING, btn_cb, NULL);
 #endif
 
     /* run the shell and wait for the user to enter a mode */


### PR DESCRIPTION
### Contribution description

To test if GPIO interrupts can wake the CPU from sleep, configure BTN0 (if available) as a wake-up source.

Pressing the buttong should wake up the CPU.

### Testing procedure

On `samr21-xpro` enter `set 0` to enter the deepest sleep mode.
You will find that the CPU does not react to UART input anymore.
Press the button on the board.

A `Button pressed.` message should be printed and the CPU should return to the previous operation mode.

### Issues/PRs references
During #12615 it was discussed why GCLK0 wasn't used for the EIC controller. My speculation for the use of the 32kHz clock was that it might still work in deep sleep mode.
This tests confirms that assumption.

With
```patch
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -188,7 +188,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
        internal or external 32 kHz */
     GCLK->CLKCTRL.reg = (EIC_GCLK_ID |
                          GCLK_CLKCTRL_CLKEN |
-                         GCLK_CLKCTRL_GEN_GCLK2);
+                         GCLK_CLKCTRL_GEN_GCLK0);
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 #else /* CPU_FAM_SAML21 */
     /* enable clocks for the EIC module */
```
the CPU won't wake up from Deep Sleep when the button is pressed.

A drawback of the slow clock is that fast interrupts are lost. This is a real problem I observed with the `at86rf215` driver.
A solution would be to switch the EIC clock to GCLK2 when entering Deep Sleep.
