### PR TITLE
drivers/at86rf2xx: don't copy params to RAM

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -54,7 +54,7 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK, 0x00);
 #else
     /* initialize device descriptor */
-    dev->params = *params;
+    dev->params = params;
 #endif
 }
 

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -528,7 +528,7 @@ uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
             /* Setting SLPTR bit brings radio transceiver to sleep in in TRX_OFF*/
             *AT86RF2XX_REG__TRXPR |= (AT86RF2XX_TRXPR_SLPTR);
 #else
-            gpio_set(dev->params.sleep_pin);
+            gpio_set(dev->params->sleep_pin);
 #endif
             dev->state = state;
         }

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -29,12 +29,12 @@
 #include "periph/spi.h"
 #include "periph/gpio.h"
 
-#define SPIDEV          (dev->params.spi)
-#define CSPIN           (dev->params.cs_pin)
+#define SPIDEV          (dev->params->spi)
+#define CSPIN           (dev->params->cs_pin)
 
 static inline void getbus(const at86rf2xx_t *dev)
 {
-    spi_acquire(SPIDEV, CSPIN, SPI_MODE_0, dev->params.spi_clk);
+    spi_acquire(SPIDEV, CSPIN, SPI_MODE_0, dev->params->spi_clk);
 }
 
 void at86rf2xx_reg_write(const at86rf2xx_t *dev, uint8_t addr, uint8_t value)
@@ -125,7 +125,7 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev)
          * to the TRX_OFF state */
         *AT86RF2XX_REG__TRXPR &= ~(AT86RF2XX_TRXPR_SLPTR);
 #else
-        gpio_clear(dev->params.sleep_pin);
+        gpio_clear(dev->params->sleep_pin);
 #endif
         xtimer_usleep(AT86RF2XX_WAKEUP_DELAY);
 
@@ -148,9 +148,9 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
     /* set reset Bit */
     *(AT86RF2XX_REG__TRXPR) |= AT86RF2XX_TRXPR_TRXRST;
 #else
-    gpio_clear(dev->params.reset_pin);
+    gpio_clear(dev->params->reset_pin);
     xtimer_usleep(AT86RF2XX_RESET_PULSE_WIDTH);
-    gpio_set(dev->params.reset_pin);
+    gpio_set(dev->params->reset_pin);
 #endif
     xtimer_usleep(AT86RF2XX_RESET_DELAY);
 

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -81,21 +81,21 @@ static int _init(netdev_t *netdev)
     at86rfmega_dev = netdev;
 #else
     /* initialize GPIOs */
-    spi_init_cs(dev->params.spi, dev->params.cs_pin);
-    gpio_init(dev->params.sleep_pin, GPIO_OUT);
-    gpio_clear(dev->params.sleep_pin);
-    gpio_init(dev->params.reset_pin, GPIO_OUT);
-    gpio_set(dev->params.reset_pin);
-    gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
+    spi_init_cs(dev->params->spi, dev->params->cs_pin);
+    gpio_init(dev->params->sleep_pin, GPIO_OUT);
+    gpio_clear(dev->params->sleep_pin);
+    gpio_init(dev->params->reset_pin, GPIO_OUT);
+    gpio_set(dev->params->reset_pin);
+    gpio_init_int(dev->params->int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
 
     /* Intentionally check if bus can be acquired,
        since getbus() drops the return value */
-    if (spi_acquire(dev->params.spi, dev->params.cs_pin, SPI_MODE_0,
-                                                dev->params.spi_clk) < 0) {
+    if (spi_acquire(dev->params->spi, dev->params->cs_pin, SPI_MODE_0,
+                                                dev->params->spi_clk) < 0) {
         DEBUG("[at86rf2xx] error: unable to acquire SPI bus\n");
         return -EIO;
     }
-    spi_release(dev->params.spi);
+    spi_release(dev->params->spi);
 #endif
 
     /* test if the device is responding */

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -244,7 +244,7 @@ typedef struct {
     uint8_t irq_status;                     /**< save irq status */
 #else
     /* device specific fields */
-    at86rf2xx_params_t params;              /**< parameters for initialization */
+    const at86rf2xx_params_t *params;       /**< parameters for initialization */
 #endif
     uint16_t flags;                         /**< Device specific flags */
     uint8_t state;                          /**< current state of the radio */


### PR DESCRIPTION
### Contribution description

The `params` struct is not changed at run-time, so there is no point in copying it to RAM.

With the `gnrc_networking` on `samr21-xpro` the difference is rather negligible though:

This uses 44 bytes *more* ROM and 16 bytes *less* RAM.

#### before

```
before:
   text    data     bss     dec     hex
  91596     192   19060  110848   1b100
````

#### after
```
   text    data     bss     dec     hex
  91640     192   19044  110876   1b11c
```

### Testing procedure

I ran `gnrc_networking` and did not notice a difference in behavior.

### Issues/PRs references
Came up in #12641 when discussing if it's possible to find out the index of a netdev in the `at86rf215_params[]` array. 