### PR TITLE
net/ieee802154: Use `eui64_t` and `network_uint16_t` in `ieee802154_t` for addresses

### DIFF
--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -164,10 +164,10 @@ static inline bool _dst_not_me(socket_zep_t *dev, const void *buf)
                                  &dst_pan);
     switch (dst_len) {
         case IEEE802154_LONG_ADDRESS_LEN:
-            return memcmp(dst_addr, dev->netdev.long_addr, dst_len) != 0;
+            return memcmp(dst_addr, dev->netdev.long_addr.uint8, dst_len) != 0;
         case IEEE802154_SHORT_ADDRESS_LEN:
             return (memcmp(dst_addr, ieee802154_addr_bcast, dst_len) != 0) &&
-                   (memcmp(dst_addr, dev->netdev.short_addr, dst_len) != 0);
+                   (memcmp(dst_addr, dev->netdev.short_addr.u8, dst_len) != 0);
         default:
             return false;    /* better safe than sorry ;-) */
     }
@@ -383,16 +383,15 @@ void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params)
     assert(ss_len >= IEEE802154_LONG_ADDRESS_LEN);
 
     /* generate hardware address from socket address and port info */
-    dev->netdev.long_addr[1] = 'Z';     /* The "OUI" */
-    dev->netdev.long_addr[2] = 'E';
-    dev->netdev.long_addr[3] = 'P';
+    dev->netdev.long_addr.uint8[1] = 'Z';     /* The "OUI" */
+    dev->netdev.long_addr.uint8[2] = 'E';
+    dev->netdev.long_addr.uint8[3] = 'P';
     for (unsigned i = 0; i < ss_len; i++) { /* generate NIC from local source */
         unsigned addr_idx = (i % (IEEE802154_LONG_ADDRESS_LEN / 2)) +
                             (IEEE802154_LONG_ADDRESS_LEN / 2);
-        dev->netdev.long_addr[addr_idx] ^= ss_array[i];
+        dev->netdev.long_addr.uint8[addr_idx] ^= ss_array[i];
     }
-    dev->netdev.short_addr[0] = dev->netdev.long_addr[6];
-    dev->netdev.short_addr[1] = dev->netdev.long_addr[7];
+    dev->netdev.short_addr.u16 = dev->netdev.long_addr.uint16[3].u16;
     native_async_read_setup();
     native_async_read_add_handler(dev->sock_fd, dev, _socket_isr);
 }

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -51,8 +51,8 @@ netdev_ieee802154_t nrf802154_dev = {
 #endif
 #endif
     .pan = IEEE802154_DEFAULT_PANID,
-    .short_addr = { 0, 0 },
-    .long_addr = { 0, 0, 0, 0, 0, 0, 0, 0 },
+    .short_addr = { .u8 = { 0, 0 } },
+    .long_addr = { .uint8 = { 0, 0, 0, 0, 0, 0, 0, 0 } },
     .chan = IEEE802154_DEFAULT_CHANNEL,
     .flags = 0
 };
@@ -236,8 +236,8 @@ static int _init(netdev_t *dev)
     NRF_RADIO->MODECNF0 |= RADIO_MODECNF0_RU_Msk;
 
     /* assign default addresses */
-    luid_get(nrf802154_dev.long_addr, IEEE802154_LONG_ADDRESS_LEN);
-    memcpy(nrf802154_dev.short_addr, &nrf802154_dev.long_addr[6],
+    luid_get_eui64(&nrf802154_dev.long_addr);
+    memcpy(nrf802154_dev.short_addr.u8, &nrf802154_dev.long_addr.uint8[6],
            IEEE802154_SHORT_ADDRESS_LEN);
 
     /* set default channel */

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -143,13 +143,13 @@ void at86rf2xx_set_addr_short(at86rf2xx_t *dev, const network_uint16_t *addr)
 #ifdef MODULE_SIXLOWPAN
     /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
      * 0 for unicast addresses */
-    dev->netdev.short_addr[0] &= 0x7F;
+    dev->netdev.short_addr.u8[0] &= 0x7F;
 #endif
     /* device use lsb first, not network byte order */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_0,
-                        dev->netdev.short_addr[1]);
+                        dev->netdev.short_addr.u8[1]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_1,
-                        dev->netdev.short_addr[0]);
+                        dev->netdev.short_addr.u8[0]);
 }
 
 void at86rf2xx_get_addr_long(const at86rf2xx_t *dev, eui64_t *addr)
@@ -403,7 +403,7 @@ void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state)
                 DEBUG("[at86rf2xx] opt: enabling CSMA mode" \
                       "(4 retries, min BE: 3 max BE: 5)\n");
                 /* Initialize CSMA seed with hardware address */
-                at86rf2xx_set_csma_seed(dev, dev->netdev.long_addr);
+                at86rf2xx_set_csma_seed(dev, dev->netdev.long_addr.uint8);
                 at86rf2xx_set_csma_max_retries(dev, 4);
                 at86rf2xx_set_csma_backoff_exp(dev, 3, 5);
             }

--- a/drivers/cc2420/cc2420_getset.c
+++ b/drivers/cc2420/cc2420_getset.c
@@ -70,12 +70,12 @@ void cc2420_set_addr_short(cc2420_t *dev, const uint8_t *addr)
     tmp[0] = addr[1];
     tmp[1] = addr[0];
 
-    memcpy(dev->netdev.short_addr, addr, 2);
+    memcpy(dev->netdev.short_addr.u8, addr, 2);
 
 #ifdef MODULE_SIXLOWPAN
     /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
      * 0 for unicast addresses */
-    dev->netdev.short_addr[0] &= 0x7F;
+    dev->netdev.short_addr.u8[0] &= 0x7F;
 #endif
 
     cc2420_ram_write(dev, CC2420_RAM_SHORTADR, tmp, 2);
@@ -83,11 +83,8 @@ void cc2420_set_addr_short(cc2420_t *dev, const uint8_t *addr)
 
 void cc2420_get_addr_long(cc2420_t *dev, uint8_t *addr)
 {
-    cc2420_ram_read(dev, CC2420_RAM_IEEEADR, addr, 8);
-
-    uint8_t *ap = (uint8_t *)(&addr);
-    for (int i = 0; i < 8; i++) {
-        ap[i] = dev->netdev.long_addr[i];
+    for (unsigned i = 0; i < sizeof(dev->netdev.long_addr); i++) {
+        addr[i] = dev->netdev.long_addr.uint8[i];
     }
 }
 
@@ -97,7 +94,7 @@ void cc2420_set_addr_long(cc2420_t *dev, const uint8_t *addr)
     uint8_t tmp[8];
 
     for (i = 0, j = 7; i < 8; i++, j--) {
-        dev->netdev.long_addr[i] = addr[i];
+        dev->netdev.long_addr.uint8[i] = addr[i];
         tmp[j] = addr[i];
     }
 

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -101,15 +101,8 @@ typedef struct {
      */
     uint16_t pan;
 
-    /**
-     * @brief   Short address in network byte order
-     */
-    uint8_t short_addr[IEEE802154_SHORT_ADDRESS_LEN];
-
-    /**
-     * @brief   Long address in network byte order
-     */
-    uint8_t long_addr[IEEE802154_LONG_ADDRESS_LEN];
+    network_uint16_t short_addr;            /**< short address */
+    eui64_t long_addr;                      /**< long address */
     uint8_t seq;                            /**< sequence number */
     uint8_t chan;                           /**< channel */
     uint8_t page;                           /**< channel page */

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -72,19 +72,19 @@ void netdev_ieee802154_reset(netdev_ieee802154_t *dev)
 }
 
 int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
-                           size_t max_len)
+                          size_t max_len)
 {
     int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(max_len >= sizeof(dev->short_addr));
-            memcpy(value, dev->short_addr, sizeof(dev->short_addr));
+            memcpy(value, dev->short_addr.u8, sizeof(dev->short_addr));
             res = sizeof(dev->short_addr);
             break;
         case NETOPT_ADDRESS_LONG:
             assert(max_len >= sizeof(dev->long_addr));
-            memcpy(value, dev->long_addr, sizeof(dev->long_addr));
+            memcpy(value, dev->long_addr.uint8, sizeof(dev->long_addr));
             res = sizeof(dev->long_addr);
             break;
         case NETOPT_ADDR_LEN:
@@ -183,14 +183,14 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *va
         }
         case NETOPT_ADDRESS:
             assert(len <= sizeof(dev->short_addr));
-            memset(dev->short_addr, 0, sizeof(dev->short_addr));
-            memcpy(dev->short_addr, value, len);
+            memset(dev->short_addr.u8, 0, sizeof(dev->short_addr));
+            memcpy(dev->short_addr.u8, value, len);
             res = sizeof(dev->short_addr);
             break;
         case NETOPT_ADDRESS_LONG:
             assert(len <= sizeof(dev->long_addr));
-            memset(dev->long_addr, 0, sizeof(dev->long_addr));
-            memcpy(dev->long_addr, value, len);
+            memset(dev->long_addr.uint8, 0, sizeof(dev->long_addr));
+            memcpy(dev->long_addr.uint8, value, len);
             res = sizeof(dev->long_addr);
             break;
         case NETOPT_ADDR_LEN:
@@ -269,10 +269,10 @@ int netdev_ieee802154_dst_filter(netdev_ieee802154_t *dev, const uint8_t *mhr)
 
     /* check destination address */
     if (((addr_len == IEEE802154_SHORT_ADDRESS_LEN) &&
-          (memcmp(dev->short_addr, dst_addr, addr_len) == 0 ||
+          (memcmp(dev->short_addr.u8, dst_addr, addr_len) == 0 ||
            memcmp(ieee802154_addr_bcast, dst_addr, addr_len) == 0)) ||
         ((addr_len == IEEE802154_LONG_ADDRESS_LEN) &&
-          (memcmp(dev->long_addr, dst_addr, addr_len) == 0))) {
+          (memcmp(dev->long_addr.uint8, dst_addr, addr_len) == 0))) {
         return 0;
     }
 

--- a/tests/driver_at86rf2xx/cmd.c
+++ b/tests/driver_at86rf2xx/cmd.c
@@ -42,9 +42,9 @@ int ifconfig_list(int idx)
     uint16_t u16_val;
 
     printf("Iface %3d  HWaddr: ", idx);
-    print_addr(dev->short_addr, IEEE802154_SHORT_ADDRESS_LEN);
+    print_addr(dev->short_addr.u8, IEEE802154_SHORT_ADDRESS_LEN);
     printf(", Long HWaddr: ");
-    print_addr(dev->long_addr, IEEE802154_LONG_ADDRESS_LEN);
+    print_addr(dev->long_addr.uint8, IEEE802154_LONG_ADDRESS_LEN);
     printf(", PAN: 0x%04x", dev->pan);
 
     res = get((netdev_t *)dev, NETOPT_ADDR_LEN, &u16_val, sizeof(u16_val));
@@ -267,11 +267,11 @@ static int send(int iface, le_uint16_t dst_pan, uint8_t *dst, size_t dst_len,
     }
     if (dev->flags & NETDEV_IEEE802154_SRC_MODE_LONG) {
         src_len = 8;
-        src = dev->long_addr;
+        src = dev->long_addr.uint8;
     }
     else {
         src_len = 2;
-        src = dev->short_addr;
+        src = dev->short_addr.u8;
     }
     /* fill MAC header, seq should be set by device */
     if ((res = ieee802154_set_frame_hdr(mhr, src, src_len,


### PR DESCRIPTION
### Contribution description

- Updated `ieee802154_t` to use
    - `eui64_t` for storing the long address
    - `network_uint16_t` for storing the short address
- Updated the shared IEEE 802.15.4 code to that API
- Updated `at86rf2xx` to that API
- Updated `cc2420` to that API
- Fixed a super strange bug in `cc2420`
- Updated `kw2xrf` to that API
- Updated `mrf24j40` to that API
- Updated `native` to that API
- Updated `nrf52/nrf802154` to that API
- Updated `xbee` to that API
- Updated test for `at86rf2xx` to that API

### Testing procedure

`ping6` should still work on:

- [ ] `at86rf2xx`
- [ ] `cc2420`
- [ ] `kw2xrf`
- [ ] `mrf24j40`
- [ ] `native`
- [ ] `nrf52/nrf802154`
- [ ] `xbee`

### Issues/PRs references

Found this as useful in https://github.com/RIOT-OS/RIOT/pull/12600