### PR TITLE
driver/bme680: add I2C/SPI driver for BME680 device

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -97,6 +97,9 @@ endif
 ifneq (,$(filter bme680_%,$(USEMODULE)))
   USEPKG += driver_bme680
   USEMODULE += bme680
+  ifneq (,$(filter saul%,$(USEMODULE)))
+    USEMODULE += xtimer
+  endif
 endif
 
 ifneq (,$(filter bme680_i2c,$(USEMODULE)))

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -94,6 +94,20 @@ ifneq (,$(filter bh1900nux,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter bme680_%,$(USEMODULE)))
+  USEPKG += driver_bme680
+  USEMODULE += bme680
+endif
+
+ifneq (,$(filter bme680_i2c,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter bme680_spi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
+endif
+
 ifneq (,$(filter bmp180,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += xtimer

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -48,6 +48,10 @@ ifneq (,$(filter bh1900nux,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bh1900nux/include
 endif
 
+ifneq (,$(filter bme680_%,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bme680/include
+endif
+
 ifneq (,$(filter bmp180,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bmp180/include
 endif

--- a/drivers/bme680/Makefile
+++ b/drivers/bme680/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/bme680/bme680.c
+++ b/drivers/bme680/bme680.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019 Mesotic SAS
+ *               2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_bme680
+ * @{
+ * @file
+ * @brief       Bosch BME680 sensor driver implementation
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include "bme680.h"
+#include "bme680_hal.h"
+#include "bme680_params.h"
+
+#include "log.h"
+
+#ifdef MODULE_BME680_I2C
+#include "periph/i2c.h"
+#endif
+
+#ifdef MODULE_BME680_SPI
+#include "periph/spi.h"
+#endif
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+unsigned int bme680_devs_numof = 0;
+
+bme680_t *bme680_devs[BME680_NUMOF] = { };
+
+int bme680_init(bme680_t *dev, const bme680_params_t *params)
+{
+    int8_t ret;
+
+    assert(bme680_devs_numof < BME680_NUMOF);
+    assert(dev);
+
+    bme680_devs[bme680_devs_numof] = dev;
+    BME680_SENSOR(dev).dev_id = bme680_devs_numof++;
+
+    /* store interface parameters in the device for the HAL functions */
+    dev->intf = params->intf;
+
+    /* Select device interface and apply needed params */
+    if (params->ifsel == BME680_I2C_INTF) {
+#ifdef MODULE_BME680_I2C
+        BME680_SENSOR(dev).intf = BME680_I2C_INTF;
+        BME680_SENSOR(dev).read = bme680_i2c_read_hal;
+        BME680_SENSOR(dev).write = bme680_i2c_write_hal;
+#else
+        LOG_ERROR("[bme680]: module bme680_i2c not enabled\n");
+        return BME680_NO_DEV;
+#endif
+    }
+    else {
+#ifdef MODULE_BME680_SPI
+        BME680_SENSOR(dev).intf = BME680_SPI_INTF;
+        BME680_SENSOR(dev).read = bme680_spi_read_hal;
+        BME680_SENSOR(dev).write = bme680_spi_write_hal;
+        spi_init_cs(SPI_DEV(0), params->intf.spi.nss_pin);
+#else
+        LOG_ERROR("[bme680]: module bme680_spi not enabled\n");
+        return BME680_NO_DEV;
+#endif
+    }
+
+    BME680_SENSOR(dev).delay_ms = bme680_ms_sleep;
+
+    /* call internal bme680_init from Bosch Sensortech driver */
+    ret = bme680_init_internal(&BME680_SENSOR(dev));
+    if (ret != 0) {
+        DEBUG("[bme680]: Failed to get ID\n");
+        return ret;
+    }
+
+    /*  retrieve params and set them in bme680_t */
+    BME680_SENSOR(dev).tph_sett.os_temp = params->temp_os;
+    BME680_SENSOR(dev).tph_sett.os_hum = params->hum_os;
+    BME680_SENSOR(dev).tph_sett.os_pres = params->pres_os;
+
+    BME680_SENSOR(dev).tph_sett.filter = params->filter;
+
+    /* Enable gas measurement if needed */
+    BME680_SENSOR(dev).gas_sett.run_gas = params->gas_measure;
+    /* Create a ramp heat waveform in 3 steps */
+    BME680_SENSOR(dev).gas_sett.heatr_temp = params->heater_temp;
+    BME680_SENSOR(dev).gas_sett.heatr_dur = params->heater_dur;
+
+    /* Select the intended power mode */
+    /* Must be set before writing the sensor configuration */
+    BME680_SENSOR(dev).power_mode = BME680_FORCED_MODE;
+
+    /* Set the desired sensor configuration */
+    ret = bme680_set_sensor_settings(params->settings, &BME680_SENSOR(dev));
+    if (ret != 0) {
+        DEBUG("[bme680]: failed to set settings\n");
+    }
+
+    return ret;
+}
+
+int bme680_force_measurement(bme680_t *dev)
+{
+    assert(dev);
+    BME680_SENSOR(dev).power_mode = BME680_FORCED_MODE;
+    return bme680_set_sensor_mode(&BME680_SENSOR(dev));
+}
+
+int bme680_get_duration(bme680_t* dev)
+{
+    assert(dev);
+
+    uint16_t duration;
+    bme680_get_profile_dur(&duration, &BME680_SENSOR(dev));
+    return duration;
+}
+
+int bme680_get_data(bme680_t* dev, bme680_field_data_t *data)
+{
+    assert(dev);
+
+    int8_t res;
+    if ((res = bme680_get_sensor_data(data, &BME680_SENSOR(dev))) == 0) {
+        return BME680_OK;
+    }
+
+    DEBUG("[bme680]: reading data failed with reason %d\n", res);
+
+    if (res == BME680_W_NO_NEW_DATA) {
+        return BME680_NO_NEW_DATA;
+    }
+    return res;
+}
+
+int bme680_set_ambient_temp(bme680_t* dev, int8_t temp)
+{
+    assert(dev);
+
+    BME680_SENSOR(dev).amb_temp = temp;
+    return bme680_set_sensor_settings(BME680_GAS_MEAS_SEL, &BME680_SENSOR(dev));
+}

--- a/drivers/bme680/bme680_saul.c
+++ b/drivers/bme680/bme680_saul.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_bme680
+ * @brief       SAUL adaption for BME680 devices
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "phydat.h"
+#include "saul.h"
+#include "bme680.h"
+#include "bme680_params.h"
+#include "xtimer.h"
+
+extern bme680_t bme680_devs_saul[BME680_NUMOF];
+
+/**
+ * Temperature, pressure, humidity and gas sensor values are fetched by separate
+ * saul functions. To avoid multiple waiting for the sensor, we read all sensor
+ * values once, if necessary, and store them in local variables to provide them
+ * in the separate saul read functions.
+ */
+static bool _temp_valid[BME680_NUMOF] = { false };
+static bool _press_valid[BME680_NUMOF] = { false };
+static bool _hum_valid[BME680_NUMOF] = { false };
+static bool _gas_valid[BME680_NUMOF] = { false };
+static int16_t _temp[BME680_NUMOF];
+static int16_t _press[BME680_NUMOF];
+static int16_t _hum[BME680_NUMOF];
+static uint32_t _gas[BME680_NUMOF];
+
+static unsigned _dev2index (const bme680_t *dev)
+{
+    /*
+     * returns the index of the device in bme680_devs_saul[] or BME680_NUMOF
+     * if not found
+     */
+    for (unsigned i = 0; i < BME680_NUMOF; i++) {
+        if (dev == &bme680_devs_saul[i]) {
+            return i;
+        }
+    }
+    return BME680_NUMOF;
+}
+
+static int read(int dev)
+{
+    /* measure and read sensor values */
+    int res;
+    if ((res = bme680_force_measurement(&bme680_devs_saul[dev])) != BME680_OK) {
+        return res;
+    }
+    int drt;
+    if ((drt = bme680_get_duration(&bme680_devs_saul[dev])) < 0) {
+        return BME680_INVALID;
+    }
+    xtimer_usleep(drt * US_PER_MS);
+
+    bme680_field_data_t data;
+    if ((res = bme680_get_data(&bme680_devs_saul[dev], &data)) != BME680_OK) {
+        return res;
+    }
+
+#if MODULE_BME680_FP
+    _temp[dev] = data.temperature * 100;
+    _press[dev] = data.pressure / 100;
+    _hum[dev] = data.humidity * 100;
+#else
+    _temp[dev] = data.temperature;
+    _press[dev] = data.pressure / 100;
+    _hum[dev] = data.humidity / 10;
+#endif
+    _gas[dev] = (data.status & BME680_GASM_VALID_MSK) ? data.gas_resistance : 0;
+
+    /* mark sensor values as valid */
+    _temp_valid[dev] = true;
+    _press_valid[dev] = true;
+    _hum_valid[dev] = true;
+    _gas_valid[dev] = true;
+    return BME680_OK;
+}
+
+static int read_temp(const void *dev, phydat_t *data)
+{
+    /* find the device index */
+    unsigned dev_index = _dev2index((const bme680_t *)dev);
+    if (dev_index == BME680_NUMOF) {
+        /* return with error if device index could not be found */
+        return -ECANCELED;
+    }
+
+    /* either local variable is valid or fetching it was successful */
+    if (_temp_valid[dev_index] || read(dev_index) == BME680_OK) {
+        /* mark local variable as invalid */
+        _temp_valid[dev_index] = false;
+
+        data->val[0] = _temp[dev_index];
+        data->unit = UNIT_TEMP_C;
+        data->scale = -2;
+        return 1;
+    }
+    return -ECANCELED;
+}
+
+static int read_press(const void *dev, phydat_t *data)
+{
+    /* find the device index */
+    unsigned dev_index = _dev2index((const bme680_t *)dev);
+    if (dev_index == BME680_NUMOF) {
+        /* return with error if device index could not be found */
+        return -ECANCELED;
+    }
+
+    /* either local variable is valid or fetching it was successful */
+    if (_press_valid[dev_index] || read(dev_index) == BME680_OK) {
+        /* mark local variable as invalid */
+        _press_valid[dev_index] = false;
+
+        data->val[0] = _press[dev_index];
+        data->unit = UNIT_PA;
+        data->scale = 2;
+        return 1;
+    }
+    return -ECANCELED;
+}
+
+static int read_hum(const void *dev, phydat_t *data)
+{
+    /* find the device index */
+    unsigned dev_index = _dev2index((const bme680_t *)dev);
+    if (dev_index == BME680_NUMOF) {
+        /* return with error if device index could not be found */
+        return -ECANCELED;
+    }
+
+    /* either local variable is valid or fetching it was successful */
+    if (_hum_valid[dev_index] || read(dev_index) == BME680_OK) {
+        /* mark local variable as invalid */
+        _hum_valid[dev_index] = false;
+
+        data->val[0] = _hum[dev_index];
+        data->unit = UNIT_PERCENT;
+        data->scale = -2;
+        return 1;
+    }
+    return -ECANCELED;
+}
+
+static int read_gas(const void *dev, phydat_t *data)
+{
+    /* find the device index */
+    unsigned dev_index = _dev2index((const bme680_t *)dev);
+    if (dev_index == BME680_NUMOF) {
+        /* return with error if device index could not be found */
+        return -ECANCELED;
+    }
+
+    /* either local variable is valid or fetching it was successful */
+    if (_gas_valid[dev_index] || read(dev_index) == BME680_OK) {
+        /* mark local variable as invalid */
+        _gas_valid[dev_index] = false;
+
+        if (_gas[dev_index] > INT16_MAX) {
+            data->val[0] = _gas[dev_index] / 1000;
+            data->scale = 3;
+        }
+        else {
+            data->val[0] = _gas[dev_index];
+            data->scale = 0;
+        }
+        data->unit = UNIT_OHM;
+        return 1;
+    }
+    return -ECANCELED;
+}
+
+const saul_driver_t bme680_saul_driver_temperature = {
+    .read = read_temp,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP
+};
+
+const saul_driver_t bme680_saul_driver_pressure = {
+    .read = read_press,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_PRESS
+};
+
+const saul_driver_t bme680_saul_driver_humidity = {
+    .read = read_hum,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_HUM
+};
+
+const saul_driver_t bme680_saul_driver_gas = {
+    .read = read_gas,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_GAS
+};

--- a/drivers/bme680/include/bme680_params.h
+++ b/drivers/bme680/include/bme680_params.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2019 Mesotic SAS
+ *               2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_bme680
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for BME680 device driver
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BME680_PARAMS_H
+#define BME680_PARAMS_H
+
+#include "board.h"
+#include "bme680.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the BME680
+ * @{
+ */
+
+#if MODULE_PERIPH_I2C || DOXYGEN
+#ifndef BME680_PARAM_I2C_DEV
+#define BME680_PARAM_I2C_DEV        (I2C_DEV(0))
+#endif
+
+#ifndef BME680_PARAM_I2C_ADDR
+#define BME680_PARAM_I2C_ADDR       (BME680_I2C_ADDR_2)
+#endif
+#endif /* MODULE_PERIPH_I2C */
+
+#if MODULE_PERIPH_SPI || DOXYGEN
+#ifndef BME680_PARAM_SPI_DEV
+#define BME680_PARAM_SPI_DEV        (SPI_DEV(0))
+#endif
+
+#ifndef BME680_PARAM_SPI_NSS_PIN
+#define BME680_PARAM_SPI_NSS_PIN    GPIO_PIN(0, 5)
+#endif
+#endif /* MODULE_PERIPH_SPI */
+
+/**
+ * @brief   Defaults I2C parameters if none provided
+ */
+#define BME680_PARAMS_I2C                               \
+{                                                       \
+        .ifsel              = BME680_I2C_INTF,          \
+        .temp_os            = BME680_OS_8X,             \
+        .hum_os             = BME680_OS_2X,             \
+        .pres_os            = BME680_OS_4X,             \
+        .filter             = BME680_FILTER_SIZE_3,     \
+        .gas_measure        = BME680_ENABLE_GAS_MEAS,   \
+        .heater_dur         = 320,                      \
+        .heater_temp        = 150,                      \
+        .settings           = BME680_OST_SEL |          \
+                              BME680_OSP_SEL |          \
+                              BME680_OSH_SEL |          \
+                              BME680_FILTER_SEL |       \
+                              BME680_GAS_SENSOR_SEL,    \
+        .intf.i2c.dev   = BME680_PARAM_I2C_DEV,         \
+        .intf.i2c.addr  = BME680_PARAM_I2C_ADDR,        \
+}
+
+/**
+ * @brief   Defaults SPI parameters if none provided
+ */
+#define BME680_PARAMS_SPI                               \
+{                                                       \
+        .ifsel              = BME680_SPI_INTF,          \
+        .temp_os            = BME680_OS_8X,             \
+        .hum_os             = BME680_OS_2X,             \
+        .pres_os            = BME680_OS_4X,             \
+        .filter             = BME680_FILTER_SIZE_3,     \
+        .gas_measure        = BME680_ENABLE_GAS_MEAS,   \
+        .heater_dur         = 320,                      \
+        .heater_temp        = 150,                      \
+        .settings           = BME680_OST_SEL |          \
+                              BME680_OSP_SEL |          \
+                              BME680_OSH_SEL |          \
+                              BME680_FILTER_SEL |       \
+                              BME680_GAS_SENSOR_SEL,    \
+        .intf.spi.dev       = BME680_PARAM_SPI_DEV,     \
+        .intf.spi.nss_pin   = BME680_PARAM_SPI_NSS_PIN, \
+}
+/**@}*/
+
+/**
+ * @brief   Configure params for BME680
+ */
+static const bme680_params_t bme680_params[] =
+{
+#if MODULE_BME680_I2C || DOXYGEN
+    BME680_PARAMS_I2C,
+#endif
+#if MODULE_BME680_SPI || DOXYGEN
+    BME680_PARAMS_SPI,
+#endif
+};
+
+/**
+ * @brief   The number of configured sensors
+ */
+#define BME680_NUMOF    ARRAY_SIZE(bme680_params)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BME680_PARAMS_H */
+/** @} */

--- a/drivers/bme680/include/bme680_params.h
+++ b/drivers/bme680/include/bme680_params.h
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "bme680.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -96,6 +97,18 @@ extern "C" {
         .intf.spi.dev       = BME680_PARAM_SPI_DEV,     \
         .intf.spi.nss_pin   = BME680_PARAM_SPI_NSS_PIN, \
 }
+
+/**
+ * @brief   Default SAUL meta information
+ */
+#ifndef BME680_SAUL_INFO
+#if MODULE_BME680_I2C && MODULE_BME680_SPI
+#define BME680_SAUL_INFO    { .name = "bme680:0" }, \
+                            { .name = "bme680:1" },
+#else /* MODULE_BME680_I2C && MODULE_BME680_SPI */
+#define BME680_SAUL_INFO    { .name = "bme680" }
+#endif /* MODULE_BME680_I2C && MODULE_BME680_SPI */
+#endif /* BME680_SAUL_INFO */
 /**@}*/
 
 /**
@@ -109,6 +122,14 @@ static const bme680_params_t bme680_params[] =
 #if MODULE_BME680_SPI || DOXYGEN
     BME680_PARAMS_SPI,
 #endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t bme680_saul_info[] =
+{
+    BME680_SAUL_INFO
 };
 
 /**

--- a/drivers/include/bme680.h
+++ b/drivers/include/bme680.h
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2019 Mesotic SAS
+ *               2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_bme680 BME680 Temperature/Humidity/Pressure/Gas sensor
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the Bosch BME680  sensor
+ *
+ * ### Introduction
+ *
+ * The driver allows the use of BME680 sensors connected either via I2C or SPI.
+ * Instead of implementing a complete driver, it simply uses the
+ * [BME680 vendor driver](https://github.com/BoschSensortec/BME680_driver)
+ * written and maintained by Bosch Sensortec as a package.
+ *
+ * Even though this driver interface provides an easy-to-use API, the vendor's
+ * driver API can still be used directly. This becomes necessary, for example,
+ * if the settings of the ambient temperature have to be updated from
+ * measurements with other sensors for gas measurement.
+ *
+ * All functions of the vendor's driver API require a reference to a
+ * sensor device structure of type `struct bme680_dev`. Use macro
+ * @ref BME680_SENSOR(dev) for a given device descriptor of type
+ * @ref bme680_t to the according sensor device structure of type
+ * `struct bme680_dev`, for example:
+ *
+ * ```c
+ * bme680_t dev;
+ * ...
+ * BME680_SENSOR(dev).amb_temp = value_from_other_sensor;
+ * bme680_set_sensor_settings(BME680_GAS_MEAS_SEL, &BME680_SENSOR(dev));
+ * ```
+ *
+ * Refer to the code documentation at
+ * [GitHub](https://github.com/BoschSensortec/BME680_driver)
+ * for detailed information on the API of the vendor driver.
+ *
+ * ### Sensor Operation Modes
+ *
+ * The BME680 sensor supports only two modes, sleep mode and forced mode, in
+ * which measurements are taken. After the power-on sequence, the sensor
+ * automatically starts in sleep mode. To start a measurement, the sensor
+ * must switch to forced mode. In this mode it performs exactly one
+ * measurement of temperature, pressure, humidity and gas in this order, the
+ * so-called TPHG measurement cycle. After executing this TPHG measurement
+ * cycle, the raw data from the sensor is available and the sensor
+ * automatically returns to sleep mode
+ *
+ * ### Ambient Temperature
+ *
+ * The sensor is initialized with a fixed ambient temperature defined by the
+ * parameter settings in @ref bme680_params. However, precise gas measurements
+ * require the calculation of the heating resistance based on the ambient
+ * temperature.
+ *
+ * The temperature of the internal temperature sensor is typically higher
+ * than the actual ambient temperature due to the self-heating of the sensor.
+ * element. It should therefore not be used to set the ambient temperature
+ * unless gas measurements are very infrequent and self-heating is negligible.
+ * Rather another temperature sensor should be used for that purpose.
+ *
+ * Function @ref bme680_set_ambient_temp can be used to change the ambient
+ * temperature.
+ *
+ * ### Using the Sensor
+ *
+ * Using the BME680 consists of the following steps
+ *
+ * 1. Trigger the sensor with @ref bme680_force_measurement to change to the
+ *    forced mode and perform a THPG cycle.
+ * 2. Wait at least the time returned by @ref bme680_get_duration until the
+ *    THPG cycle is finished.
+ * 3. Use @ref bme680_get_data to fetch raw sensor data and convert them to the
+ *    resulting sensor values
+ *
+ * ### Driver Configuration
+ *
+ * BME680 sensors are connected either via I2C or SPI. Which interface is used
+ * by which BME680 sensor is defined by the parameters in @ref bme680_params.
+ * The respective driver implementation is enabled by the modules `bme680_i2c`
+ * and `bme680_spi`. Several BME680 sensors and a mixed configuration of I2C
+ * and SPI can be used in one application.
+ * ```
+ * USEMODULE='bme680_spi bme680_i2c' make BOARD=... -C tests/driver_bme680
+ * ```
+ *
+ * The vendor driver allows the use of floating point conversions. In order
+ * to use these floating point conversions, module `bme680_fp` has to
+ * be enabled:
+ * ```
+ * USEMODULE='bme680_fp bme680_i2c' make BOARD=... -C tests/driver_bme680
+ * ```
+ *
+ * @{
+ * @file
+ * @brief       Interface definition for the Bosch BME680 sensor
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BME680_H
+#define BME680_H
+
+#include "periph/i2c.h"
+#include "periph/spi.h"
+
+#ifdef MODULE_BME680_FP
+#define BME680_FLOAT_POINT_COMPENSATION
+#endif
+
+#include "bme680_hal.h"
+#include "bme680_internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    I2C address when SDO pin is LOW
+ */
+#define BME680_I2C_ADDR_1   (0x76)
+
+/**
+ * @brief    I2C address when SDO pin is HIGH
+ */
+#define BME680_I2C_ADDR_2   (0x77)
+
+/**
+ * @brief   Converts a BME680 device descriptor to the BME680 sensor device
+ *          structure for the vendor BME680 device driver.
+ */
+#define BME680_SENSOR(d)    (*((struct bme680_dev *)d))
+
+/**
+ * @brief   Named return values
+ */
+enum {
+    BME680_NULL_PTR     = -1,   /**< NULL pointer check failed. */
+    BME680_COM_FAILED   = -2,   /**< Communication with the device failed. */
+    BME680_NO_DEV       = -3,   /**< Device doesn't exist. */
+    BME680_INVALID      = -4,   /**< Invalid value or length. */
+    BME680_NO_NEW_DATA  = -5,   /**< No new data. */
+};
+
+#ifdef DOXYGEN
+/**
+ * @brief   BME680 sensor field data
+ */
+typedef struct bme680_field_data {
+    uint8_t status;     /**< Status for new data, gas measurement valid and
+                             heater stable. Use `BME680_NEW_DATA_MSK`,
+                             `BME680_GASM_VALID_MSK` and BME680_HEAT_STAB_MSK
+                             to check for the status. */
+    uint8_t gas_index;  /**< Index of used heater profile */
+    uint8_t meas_index; /**< Measurement index */
+#ifndef MODULE_BME680_FP
+    int16_t temperature;        /**< Temperature in degree Celsius x 100 */
+    uint32_t pressure;          /**< Pressure in Pascal */
+    uint32_t humidity;          /**< Relative humidity in percent x 1000 */
+    uint32_t gas_resistance;    /**< Gas resistance in ohms */
+#else /* MODULE_BME680_FP */
+    float temperature;          /**< Temperature in degree Celsius */
+    float pressure;             /**< Pressure in Pascal */
+    float humidity;             /**< Relative humidity in percent */
+    float gas_resistance;       /**< Gas resistance in ohms */
+#endif /* MODULE_BME680_FP */
+};
+
+#endif /* DOXYGEN */
+
+/**
+ * @brief   Shortcut type definition for BME680 sensor field data
+ */
+typedef struct bme680_field_data bme680_field_data_t;
+
+/**
+ * @brief   Shortcut type definition for BME680 sensor device structure
+ * @see [struct bme680_dev](https://github.com/BoschSensortec/BME680_driver/blob/9014031fa00a5cc1eea1498c4cd1f94ec4b8ab11/bme680_defs.h#L496-L530)
+ */
+typedef struct bme680_dev bme680_dev_t;
+
+/**
+ * @brief   BME680 I2C parameters
+ */
+typedef struct {
+    i2c_t dev;                    /**< I2C device which is used */
+    uint8_t addr;                 /**< I2C address */
+} bme680_intf_i2c_t;
+
+/**
+ * @brief   BME680 SPI parameters
+ */
+typedef struct {
+    spi_t dev;                  /**< SPI device which is used */
+    gpio_t nss_pin;             /**< Chip Select pin */
+} bme680_intf_spi_t;
+
+/**
+ * @brief   BME680 Hardware interface parameters union
+ */
+typedef union {
+    bme680_intf_i2c_t i2c;        /**< I2C specific interface parameters */
+    bme680_intf_spi_t spi;        /**< SPI specific interface parameters */
+} bme680_intf_t;
+
+/**
+ * @brief   BME680 device initialization parameters
+ */
+typedef struct {
+    uint8_t ifsel;              /**< Interface selection */
+    uint8_t temp_os;            /**< Temperature oversampling */
+    uint8_t hum_os;             /**< Humidity oversampling */
+    uint8_t pres_os;            /**< Pressure oversampling */
+    uint8_t filter;             /**< IIR filter coefficient */
+    uint8_t gas_measure;        /**< Enable gas measurement */
+    uint16_t heater_dur;        /**< Heater duration in ms */
+    uint16_t heater_temp;       /**< Heater temperature in °C */
+    uint8_t power_mode;         /**< Power mode (sleep or forced) */
+    uint8_t settings;           /**< Settings used */
+    bme680_intf_t intf;         /**< Hardware interface parameters */
+} bme680_params_t;
+
+/**
+ * @brief   BME680 device descriptor
+ */
+typedef struct {
+    struct bme680_dev sensor; /**< Inherited device structure from vendor API */
+    bme680_intf_t intf;       /**< Device interface */
+} bme680_t;
+
+/**
+ * @brief   References to BME680 sensor devices used by the HAL functions
+ */
+extern bme680_t *bme680_devs[];
+
+/**
+ * @brief   Number of initialized BME680 sensor devices in bme680_devs
+ */
+extern unsigned int bme680_devs_numof;
+
+/**
+ * @brief   Initialize the BME680 sensor.
+ *
+ * @param[in,out]   dev     device descriptor of the sensor to initialize
+ * @param[in]       params  configuration parameters
+ *
+ * @return 0 on success
+ * @return < 0 on error
+  */
+int bme680_init(bme680_t *dev, const bme680_params_t *params);
+
+/**
+ * @brief    Force a single TPHG measurement cycle
+ *
+ * The function triggers the sensor to start one THPG measurement cycle. The
+ * duration of the TPHG measurement cycle depends on the selected parameters.
+ * It can vary from 1.25 ms to 4.5 seconds. The duration of the measurement
+ * cycle can be determined with the #bme680_get_duration function.
+ *
+ * @param[in,out]   dev     device descriptor of the sensor
+ *
+ * @return 0 on success
+ * @return < 0 on error
+ */
+int bme680_force_measurement(bme680_t *dev);
+
+/**
+ * @brief    Duration one THPG measurement cycle
+ *
+ * This function determines the duration of one THPG measurement cycle
+ * according to the selected parameter settings. The duration can be used
+ * to wait for the measurement results once a THPG measurement has been
+ * started with #bme680_force_measurement.
+ *
+ * @param[in,out]   dev     device descriptor of the sensor
+ *
+ * @return  duration of one THPG measurement cylce in milliseconds.
+ * @return  < 0 on error
+ */
+int bme680_get_duration(bme680_t* dev);
+
+/**
+ * @brief   Get results of a TPHG measurement
+ *
+ * The function returns the results of a TPHG measurement that has been
+ * started before with #bme680_force_measurement. For that purpose, the
+ * function fetches the raw sensor data and converts them into sensor values.
+ * If the measurement is still running, the function fails and returns
+ * invalid values.
+ *
+ * @param[in,out]   dev     device descriptor of the sensor
+ * @param[out]      data    pointer to a data structure with the field data
+ *
+ * @return 0 on success
+ * @return < 0 on error
+ */
+int bme680_get_data(bme680_t* dev, bme680_field_data_t *data);
+
+/**
+ * @brief   Set the ambient temperature
+ *
+ * The function sets the ambient temperature for the calculation of the heater
+ * resistance.
+ *
+ * @param[in,out]   dev     device descriptor of the sensor
+ * @param[in]       temp    ambient temperature in degC.
+ *
+ * @return 0 on success
+ * @return < 0 on error
+ */
+int bme680_set_ambient_temp(bme680_t* dev, int8_t temp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BME680_H */
+/** @} */

--- a/drivers/include/bme680.h
+++ b/drivers/include/bme680.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    drivers_bme680 BME680 Temperature/Humidity/Pressure/Gas sensor
  * @ingroup     drivers_sensors
- * @brief       Driver for the Bosch BME680  sensor
+ * @brief       Driver for the Bosch BME680 sensor
  *
  * ### Introduction
  *

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -124,6 +124,7 @@ enum {
     SAUL_SENSE_ID_DISTANCE,         /**< sensor: distance */
     SAUL_SENSE_ID_CO2,              /**< sensor: CO2 Gas */
     SAUL_SENSE_ID_TVOC,             /**< sensor: TVOC Gas */
+    SAUL_SENSE_ID_GAS,              /**< sensor: Gas common */
     SAUL_SENSE_ID_OCCUP,            /**< sensor: occupancy */
     SAUL_SENSE_ID_PROXIMITY,        /**< sensor: proximity */
     SAUL_SENSE_ID_RSSI,             /**< sensor: RSSI */
@@ -194,6 +195,8 @@ enum {
     SAUL_SENSE_CO2          = SAUL_CAT_SENSE | SAUL_SENSE_ID_CO2,
     /** sensor: TVOC Gas */
     SAUL_SENSE_TVOC         = SAUL_CAT_SENSE | SAUL_SENSE_ID_TVOC,
+    /** sensor: Gas common */
+    SAUL_SENSE_GAS          = SAUL_CAT_SENSE | SAUL_SENSE_ID_GAS,
     /** sensor: occupancy */
     SAUL_SENSE_OCCUP        = SAUL_CAT_SENSE | SAUL_SENSE_ID_OCCUP,
     /** sensor: proximity */

--- a/drivers/saul/init_devs/auto_init_bme680.c
+++ b/drivers/saul/init_devs/auto_init_bme680.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @brief       Auto initialization of Bosch BME680 device driver
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#ifdef MODULE_BME680
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "bme680.h"
+#include "bme680_params.h"
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+bme680_t bme680_devs_saul[BME680_NUMOF];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[BME680_NUMOF * 4];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define BME680_INFO_NUMOF   ARRAY_SIZE(bme680_saul_info)
+
+/**
+ * @name    Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t bme680_saul_driver_temperature;
+extern const saul_driver_t bme680_saul_driver_pressure;
+extern const saul_driver_t bme680_saul_driver_humidity;
+extern const saul_driver_t bme680_saul_driver_gas;
+/** @} */
+
+void auto_init_bme680(void)
+{
+    assert(BME680_INFO_NUMOF == BME680_NUMOF);
+
+    for (unsigned i = 0; i < BME680_NUMOF; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing BME680 #%u\n", i);
+
+        if (bme680_init(&bme680_devs_saul[i],
+                        &bme680_params[i]) != BME680_OK) {
+            LOG_ERROR("[auto_init_saul] error initializing BME680 #%u\n", i);
+            continue;
+        }
+
+        /* temperature */
+        saul_entries[(i * 4)].dev = &(bme680_devs_saul[i]);
+        saul_entries[(i * 4)].name = bme680_saul_info[i].name;
+        saul_entries[(i * 4)].driver = &bme680_saul_driver_temperature;
+
+        /* pressure */
+        saul_entries[(i * 4) + 1].dev = &(bme680_devs_saul[i]);
+        saul_entries[(i * 4) + 1].name = bme680_saul_info[i].name;
+        saul_entries[(i * 4) + 1].driver = &bme680_saul_driver_pressure;
+
+        /* relative humidity */
+        saul_entries[(i * 4) + 2].dev = &(bme680_devs_saul[i]);
+        saul_entries[(i * 4) + 2].name = bme680_saul_info[i].name;
+        saul_entries[(i * 4) + 2].driver = &bme680_saul_driver_humidity;
+
+        /* relative humidity */
+        saul_entries[(i * 4) + 3].dev = &(bme680_devs_saul[i]);
+        saul_entries[(i * 4) + 3].name = bme680_saul_info[i].name;
+        saul_entries[(i * 4) + 3].driver = &bme680_saul_driver_gas;
+
+        /* register to saul */
+        saul_reg_add(&(saul_entries[(i * 4)]));
+        saul_reg_add(&(saul_entries[(i * 4) + 1]));
+        saul_reg_add(&(saul_entries[(i * 4) + 2]));
+        saul_reg_add(&(saul_entries[(i * 4) + 3]));
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_BME680 */

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -59,6 +59,10 @@ void saul_init_devs(void)
         extern void auto_init_apds99xx(void);
         auto_init_apds99xx();
     }
+    if (IS_USED(MODULE_BME680)) {
+        extern void auto_init_bme680(void);
+        auto_init_bme680();
+    }
     if (IS_USED(MODULE_BMP180)) {
         extern void auto_init_bmp180(void);
         auto_init_bmp180();

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -52,6 +52,7 @@ static const char *sensors[] = {
     [SAUL_SENSE_ID_DISTANCE]    = "SENSE_DISTANCE",
     [SAUL_SENSE_ID_CO2]         = "SENSE_CO2",
     [SAUL_SENSE_ID_TVOC]        = "SENSE_TVOC",
+    [SAUL_SENSE_ID_GAS]         = "SENSE_GAS",
     [SAUL_SENSE_ID_PROXIMITY]   = "SENSE_PROXIMITY",
     [SAUL_SENSE_ID_RSSI]        = "SENSE_RSSI",
     [SAUL_SENSE_ID_CHARGE]      = "SENSE_CHARGE",

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -117,6 +117,11 @@ PSEUDOMODULES += at86rf21%
 PSEUDOMODULES += at86rfa1
 PSEUDOMODULES += at86rfr2
 
+# include variants of the BME680 drivers as pseudo modules
+PSEUDOMODULES += bme680_i2c
+PSEUDOMODULES += bme680_spi
+PSEUDOMODULES += bme680_fp
+
 # include variants of the BMX280 drivers as pseudo modules
 PSEUDOMODULES += bmp280_i2c
 PSEUDOMODULES += bmp280_spi

--- a/pkg/driver_bme680/Makefile
+++ b/pkg/driver_bme680/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME=driver_bme680
+PKG_URL=https://github.com/BoschSensortec/BME680_driver
+PKG_VERSION=63bb5336db4659519860832be2738c685133aa33
+PKG_LICENSE=BSD-3-Clause
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+.PHONY: all
+
+all:
+	@cp Makefile.$(PKG_NAME) $(PKG_BUILDDIR)/Makefile
+	"$(MAKE)" -C $(PKG_BUILDDIR)

--- a/pkg/driver_bme680/Makefile.dep
+++ b/pkg/driver_bme680/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += driver_bme680_contrib

--- a/pkg/driver_bme680/Makefile.driver_bme680
+++ b/pkg/driver_bme680/Makefile.driver_bme680
@@ -1,0 +1,7 @@
+MODULE = driver_bme680
+
+ifneq (,$(filter bme680_fp,$(USEMODULE)))
+  CFLAGS += -DBME680_FLOAT_POINT_COMPENSATION
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/driver_bme680/Makefile.include
+++ b/pkg/driver_bme680/Makefile.include
@@ -1,0 +1,4 @@
+INCLUDES += -I$(PKGDIRBASE)/driver_bme680
+INCLUDES += -I$(RIOTPKG)/driver_bme680/include
+
+DIRS += $(RIOTPKG)/driver_bme680/contrib

--- a/pkg/driver_bme680/README.md
+++ b/pkg/driver_bme680/README.md
@@ -1,0 +1,41 @@
+# BME680 vendor driver
+
+## Introduction
+
+The [BME680_driver](https://github.com/BoschSensortec/BME680_driver) is an
+I2C/SPI API for BME680 sensor.
+
+The library is written and maintained by Bosch Sensortec. It is platform
+independent, as long as the right drivers are available for the given MCU.
+
+In addition, this driver can use floating point if available on your MCU.
+By default, this package does not use it.
+
+## Usage
+
+Refer to the code documentation at
+[GitHub](https://github.com/BoschSensortec/BME680_driver) for more information
+on the API.
+
+## RIOT-OS interface
+
+BME680 sensors are connected either via I2C or SPI. Which interface is used by
+which BME680 sensor is defined in the `bme680_params` parameters. The
+respective implementation is enabled by the modules `bme680_i2c` and
+`bme680_spi`. Both I2C and SPI can be used in one application.
+```
+USEMODULE='bme680_spi bme680_i2c' make BOARD=... -C tests/driver_bme680
+```
+
+In order to use floating point, you can enable module `bme680_fp` variable:
+```
+USEMODULE='bme680_fp bme680_i2c' make BOARD=... -C tests/driver_bme680
+```
+
+The following callbacks add support for the included drivers via I2C and SPI
+peripherals:
+
+* `bme680_i2c_read_hal`
+* `bme680_i2c_write_hal`
+* `bme680_spi_read_hal`
+* `bme680_spi_write_hal`

--- a/pkg/driver_bme680/contrib/Makefile
+++ b/pkg/driver_bme680/contrib/Makefile
@@ -1,0 +1,3 @@
+MODULE = driver_bme680_contrib
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/driver_bme680/contrib/bme680_hal.c
+++ b/pkg/driver_bme680/contrib/bme680_hal.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 Mesotic SAS
+ *               2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_driver_bme680
+ * @ingroup     drivers_bme680
+ * @{
+ *
+ * @file
+ * @brief       Abstraction layer for RIOT adaption
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "bme680.h"
+#include "bme680_hal.h"
+
+#ifdef MODULE_PERIPH_I2C
+#include "periph/i2c.h"
+#endif
+#ifdef MODULE_PERIPH_SPI
+#include "periph/spi.h"
+#endif
+
+#include "xtimer.h"
+
+#ifndef BME680_SPI_SPEED
+#define BME680_SPI_SPEED    (SPI_CLK_1MHZ)
+#endif /* BME680_SPI_SPEED */
+
+#ifndef BME680_SPI_MODE
+#define BME680_SPI_MODE     (SPI_MODE_0)
+#endif /* BME680_SPI_MODE */
+
+void bme680_ms_sleep(uint32_t msleep)
+{
+    xtimer_usleep(msleep * US_PER_MS);
+}
+
+#ifdef MODULE_PERIPH_I2C
+int8_t bme680_i2c_read_hal(uint8_t dev_id, uint8_t reg_addr,
+                           uint8_t *data, uint16_t len)
+{
+    assert(dev_id < bme680_devs_numof);
+
+    bme680_intf_i2c_t* intf = &(bme680_devs[dev_id]->intf.i2c);
+    uint8_t ret;
+
+    i2c_acquire(intf->dev);
+    ret = i2c_read_regs(intf->dev, intf->addr, reg_addr, data, len, 0);
+    i2c_release(intf->dev);
+    return ret;
+}
+
+int8_t bme680_i2c_write_hal(uint8_t dev_id, uint8_t reg_addr,
+                            uint8_t *data, uint16_t len)
+{
+    assert(dev_id < bme680_devs_numof);
+
+    bme680_intf_i2c_t* intf = &(bme680_devs[dev_id]->intf.i2c);
+    uint8_t ret;
+
+    i2c_acquire(intf->dev);
+    ret = i2c_write_regs(intf->dev, intf->addr, reg_addr, data, len, 0);
+    i2c_release(intf->dev);
+    return ret;
+}
+#endif /* MODULE_PERIPH_I2C */
+
+#ifdef MODULE_PERIPH_SPI
+int8_t bme680_spi_read_hal(uint8_t dev_id, uint8_t reg_addr,
+                           uint8_t *data, uint16_t len)
+{
+    assert(dev_id < bme680_devs_numof);
+
+    bme680_intf_spi_t* intf = &(bme680_devs[dev_id]->intf.spi);
+    unsigned int cpsr = irq_disable();
+
+    gpio_clear(intf->nss_pin);
+    spi_acquire(intf->dev, SPI_CS_UNDEF, BME680_SPI_MODE, BME680_SPI_SPEED);
+    spi_transfer_regs(intf->dev, SPI_CS_UNDEF, reg_addr, NULL, data, len);
+    gpio_set(intf->nss_pin);
+
+    irq_restore(cpsr);
+    spi_release(intf->dev);
+    return 0;
+}
+
+int8_t bme680_spi_write_hal(uint8_t dev_id, uint8_t reg_addr,
+                            uint8_t *data, uint16_t len)
+{
+    assert(dev_id < bme680_devs_numof);
+
+    bme680_intf_spi_t* intf = &(bme680_devs[dev_id]->intf.spi);
+    unsigned int cpsr = irq_disable();
+
+    gpio_clear(intf->nss_pin);
+    spi_acquire(intf->dev, SPI_CS_UNDEF, BME680_SPI_MODE, BME680_SPI_SPEED);
+    spi_transfer_regs(intf->dev, SPI_CS_UNDEF, reg_addr, data, NULL, len);
+    gpio_set(intf->nss_pin);
+
+    irq_restore(cpsr);
+    spi_release(intf->dev);
+    return 0;
+}
+#endif /* MODULE_PERIPH_SPI */

--- a/pkg/driver_bme680/doc.txt
+++ b/pkg/driver_bme680/doc.txt
@@ -1,0 +1,6 @@
+/**
+ * @defgroup pkg_driver_bme680  Driver package for I2C/SPI BME680 sensor
+ * @ingroup  pkg
+ * @brief    Provides the Bosch Sensortec's BME680 gas sensor API
+ * @see      https://github.com/BoschSensortec/BME680_driver
+ */

--- a/pkg/driver_bme680/include/bme680_hal.h
+++ b/pkg/driver_bme680/include/bme680_hal.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2018 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_driver_bme680
+ * @{
+ *
+ * @file
+ * @brief       Abstraction layer for RIOT adaption
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef BME680_HAL_H
+#define BME680_HAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void bme680_ms_sleep(uint32_t msleep);
+
+#ifdef MODULE_PERIPH_I2C
+
+int8_t bme680_i2c_read_hal(uint8_t dev_id, uint8_t reg_addr,
+                           uint8_t *data, uint16_t len);
+int8_t bme680_i2c_write_hal(uint8_t dev_id, uint8_t reg_addr,
+                            uint8_t *data, uint16_t len);
+#endif
+
+#ifdef MODULE_PERIPH_SPI
+
+int8_t bme680_spi_read_hal(uint8_t dev_id, uint8_t reg_addr,
+                           uint8_t *data, uint16_t len);
+int8_t bme680_spi_write_hal(uint8_t dev_id, uint8_t reg_addr,
+                            uint8_t *data, uint16_t len);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BME680_HAL_H */
+/** @} */

--- a/pkg/driver_bme680/patches/0001-reword-files-and-functions.patch
+++ b/pkg/driver_bme680/patches/0001-reword-files-and-functions.patch
@@ -1,0 +1,56 @@
+From 60f0355beaeea25bf3cee187b8ce8244cc1bbf6a Mon Sep 17 00:00:00 2001
+From: dylad <dylan.laduranty@mesotic.com>
+Date: Fri, 8 Nov 2019 20:05:46 +0100
+Subject: [PATCH] reword files and functions
+
+---
+ bme680.c => bme680_internal.c | 4 ++--
+ bme680.h => bme680_internal.h | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+ rename bme680.c => bme680_internal.c (96%)
+ rename bme680.h => bme680_internal.h (96%)
+
+diff --git a/bme680.c b/bme680_internal.c
+similarity index 96%
+rename from bme680.c
+rename to bme680_internal.c
+index ccd1bf8..33ffb90 100644
+--- a/bme680.c
++++ b/bme680_internal.c
+@@ -47,7 +47,7 @@
+ 
+ /*! @file bme680.c
+  @brief Sensor driver for BME680 sensor */
+-#include "bme680.h"
++#include "bme680_internal.h"
+ 
+ /*!
+  * @brief This internal API is used to read the calibrated data from the sensor.
+@@ -284,7 +284,7 @@ static int8_t boundary_check(uint8_t *value, uint8_t min, uint8_t max, struct bm
+  *@brief This API is the entry point.
+  *It reads the chip-id and calibration data from the sensor.
+  */
+-int8_t bme680_init(struct bme680_dev *dev)
++int8_t bme680_init_internal(struct bme680_dev *dev)
+ {
+ 	int8_t rslt;
+ 
+diff --git a/bme680.h b/bme680_internal.h
+similarity index 96%
+rename from bme680.h
+rename to bme680_internal.h
+index 8274a8e..6578b3c 100644
+--- a/bme680.h
++++ b/bme680_internal.h
+@@ -72,7 +72,7 @@ extern "C"
+  *  @return Result of API execution status
+  *  @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+  */
+-int8_t bme680_init(struct bme680_dev *dev);
++int8_t bme680_init_internal(struct bme680_dev *dev);
+ 
+ /*!
+  * @brief This API writes the given data to the register address
+-- 
+2.17.1
+

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -99,6 +99,7 @@ enum {
     UNIT_DBM,       /**< decibel-milliwatts */
     UNIT_COULOMB,   /**< coulomb */
     UNIT_F,         /**< Farad */
+    UNIT_OHM,       /**< Ohm */
     /* electrochemical */
     UNIT_PH,        /**< pH  */
     /* pressure */

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -127,6 +127,7 @@ const char *phydat_unit_to_str(uint8_t unit)
         case UNIT_F:        return "F";
         case UNIT_PH:       return "pH";
         case UNIT_CPM3:     return "#/m^3";
+        case UNIT_OHM:      return "ohm";
 
         default:            return "";
     }

--- a/tests/driver_bme680/Makefile
+++ b/tests/driver_bme680/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.tests_common
+
+DRIVER ?= bme680_i2c
+
+USEMODULE += $(DRIVER)
+USEMODULE += xtimer
+
+ifeq ($(ENABLE_FP),1)
+  USEMODULE += bme680_fp
+endif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bme680/Makefile.ci
+++ b/tests/driver_bme680/Makefile.ci
@@ -1,0 +1,11 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-uno \
+    chronos \
+    msb-430 \
+    msb-430h \
+    nucleo-f031k6 \
+    telosb \
+    wsn430-v1_3b \
+    wsn430-v1_4 z1 \
+    #

--- a/tests/driver_bme680/README.md
+++ b/tests/driver_bme680/README.md
@@ -1,0 +1,45 @@
+# BME680 driver test
+
+## About
+
+This is a test application for the BME680 driver.
+This driver depends on the Bosch Sensortech
+[BME680 driver](https://github.com/BoschSensortec/BME680_driver).
+
+## Usage
+
+This test application will initialize one or more BME680 devices to output
+the following every 5 seconds:
+
+* Temperature
+* Humidity
+* Pressure
+* Resistance value (depending on VOC gas)
+
+The driver can use either fixed-point or floating-point arithmetic for all
+conversions. By default fixed-point arithmetic is used. To use floating-point
+arithmetic, the `bme680_fp` module has to be enabled. This can be done in the
+test application by setting the environment variable `ENABLE_FP`:
+```
+ENABLE_FP=1 make BOARD=... -C tests/driver_bme680
+```
+
+## Interface
+
+BME680 sensors can be used with I2C and/or SPI. Which interface is used by
+which BME680 sensor is defined in the `bme680_params` parameters. The
+respective implementation is enabled by the modules `bme680_i2c` and
+`bme680_spi`.
+
+Which implementation is used for the test application is defined by the
+`DRIVER` environment variable. By default `bme680_i2c` is used. To use
+`bme680_spi`, the `DRIVER` variable could be set at the make command line:
+```
+DRIVER=bme680_spi make BOARD=... -C tests/driver_bme680
+```
+
+It is also possible to use I2C as well SPI simultaneously in the test
+application:
+```
+DRIVER=bme680_spi bme680_i2c' make BOARD=... -C tests/driver_bme680
+```

--- a/tests/driver_bme680/main.c
+++ b/tests/driver_bme680/main.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2018 Mesotic SAS
+ *               2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the bme680_driver package.
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "board.h"
+#include "bme680.h"
+#include "bme680_params.h"
+#include "mutex.h"
+#include "xtimer.h"
+
+#define BME680_TEST_PERIOD_US   (5 * US_PER_SEC)
+
+xtimer_t timer;
+
+static void _timer_cb(void *arg)
+{
+    xtimer_set(&timer, BME680_TEST_PERIOD_US);
+    mutex_unlock(arg);
+}
+
+int main(void)
+{
+    mutex_t timer_mtx = MUTEX_INIT_LOCKED;
+
+    bme680_t dev[BME680_NUMOF];
+
+    for (unsigned i = 0; i < BME680_NUMOF; i++) {
+        /*
+         * We use a fix temperature here. The ambient temperature could be
+         * determined by performing a few temperature readings without
+         * operating the gas sensor or by another temperature sensor. Function
+         * bme680_set_ambient_temp can be used at any time to change it.
+         */
+        BME680_SENSOR(&dev[i]).amb_temp = 25;
+
+        printf("Initialize BME680 sensor %u ... ", i);
+        if (bme680_init(&dev[i], &bme680_params[i]) != BME680_OK) {
+            puts("failed");
+        }
+        else {
+            puts("OK");
+        }
+    }
+
+    timer.callback = _timer_cb;
+    timer.arg = &timer_mtx;
+    xtimer_set(&timer, BME680_TEST_PERIOD_US);
+
+    while (1)
+    {
+        struct bme680_field_data data;
+
+        for (unsigned i = 0; i < BME680_NUMOF; i++) {
+            /* trigger one measuerment */
+            bme680_force_measurement(&dev[i]);
+            /* get the duration for the measurement */
+            int duration = bme680_get_duration(&dev[i]);
+            /* wait for the duration */
+            xtimer_usleep(duration * US_PER_MS);
+            /* read the data */
+            int res = bme680_get_data(&dev[i], &data);
+
+            if (res == 0 && dev[i].sensor.new_fields) {
+#ifndef MODULE_BME680_FP
+                printf("[bme680]: dev=%u, "
+                       "T = %02d.%02d degC, "
+                       "P = %" PRIu32 " Pa, H = %02" PRIu32 ".%03" PRIu32 " %%",
+                       i, data.temperature / 100, data.temperature % 100,
+                       data.pressure,
+                       data.humidity / 1000, data.humidity % 1000);
+                /* Avoid using measurements from an unstable heating setup */
+                if (data.status & BME680_GASM_VALID_MSK) {
+                    printf(", G = %" PRIu32 " ohms", data.gas_resistance);
+                }
+#else
+                printf("[bme680]: dev=%u T = %.2f degC, P = %.2f Pa, H %.3f %%",
+                       i, data.temperature, data.pressure, data.humidity);
+                /* Avoid using measurements from an unstable heating setup */
+                if (data.status & BME680_GASM_VALID_MSK) {
+                    printf(", G = %.0f ohms", data.gas_resistance);
+                }
+#endif
+                printf("\n");
+            }
+            else if (res == 0) {
+                printf("[bme680]: no new data\n");
+            }
+            else {
+                printf("[bme680]: read data failed with reason %d\n", res);
+            }
+        }
+        printf("+-----------------------------------------+\n");
+        mutex_lock(&timer_mtx);
+    }
+    /* Should never reach here */
+    return 0;
+}

--- a/tests/driver_bme680/tests/01-run.py
+++ b/tests/driver_bme680/tests/01-run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Gunar Schorcht <gunar@schorcht.net>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect('Initialize BME680 sensor 0 ... ')
+    i = child.expect(['[OK]', '[failed]'])
+    if i == 1:
+        print('FAILED')
+        return
+    child.expect('\[bme680\]: dev=0, ')
+    child.expect(r'T = \d+.\d+ degC, ')
+    child.expect(r'P = \d+ Pa, ')
+    child.expect(r'H = \d+.\d+ \%, ')
+    child.expect(r'G = \d+ ohms')
+    print('SUCCESS')
+    return
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This PR provides support for BME680 sensor using the vendor driver from [Bosch Sensortech](https://github.com/BoschSensortec/BME680_driver) as package.

The  sensor provides measurement for temperature, humidity, pressure and VOC gas concentration. It  can be connected either via I2C or via SPI. The driver supports multiple BME680 sensor and mixed I2C/SPI configurations.

The driver supports SAUL.

### Testing procedure

Apply the parameters you want in the `bme680_params.h` file run `tests/driver_bme680`

- with one I2C device
   ```
   DRIVER='bme680_i2c'  BOARD=... make -C tests/driver_bme680 flash test
   ```

- with one SPI device
   ```
   DRIVER='bme680_spi'  BOARD=... make -C tests/driver_bme680 flash test
   ```
- or with one I2C and one SPI device
   ```
   DRIVER='bme680_spi bme680_i2c'  BOARD=... make -C tests/driver_bme680 flash term
   ```
SAUL can be tested with `tests/saul`. The used interface(s) has/have to be defined with `USEMODULE`, for example
```
USEMODULE='bme680_spi bme680_i2c' BOARD=... make -C tests/saul flash term
```

### Issues/PRs references

Replaces #10502 