### PR TITLE
pkg/semtech-loramac: blacklist arch_msp430 and remove use of BOARD_BLACKLIST

### DIFF
--- a/pkg/semtech-loramac/Makefile.dep
+++ b/pkg/semtech-loramac/Makefile.dep
@@ -5,3 +5,7 @@ USEMODULE += semtech_loramac_mac
 USEMODULE += semtech_loramac_mac_region
 USEMODULE += semtech_loramac_crypto
 USEMODULE += semtech_loramac_arch
+
+# The build fails on MSP430 because the toolchain doesn't provide
+# EXIT_SUCCESS/EXIT_FAILURE macros
+FEATURES_BLACKLIST += arch_msp430

--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -2,9 +2,6 @@ BOARD ?= b-l072z-lrwan1
 
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := msb-430 msb-430h pic32-clicker pic32-wifire \
-                   telosb wsn430-v1_3b wsn430-v1_4 z1
-
 # waspmote-pro and arduino-meag2560 don't have enough RAM to support another
 # thread dedicated to RX messages
 BOARD_WITHOUT_LORAMAC_RX := arduino-mega2560 waspmote-pro


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR blacklist the MSP430 architecture in the semtech-loramac package dependencies and as a result, removes the need of BOARD_BLACKLIST in the corresponding test application.
Note that pic32-clicker/wifire boards were also in this list but are not concerned by the change in the package: this is because they are not providing 2 required feartures (spi/gpio_irq) and thus don't need to be explicitly blacklisted.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Compare the list of supported boards between this PR and master: there should be no unexpected difference:

Using
```
$ make --no-print-directory -C tests/pkg_semtech-loramac info-boards-supported
```

<details><summary><b>this PR</b></summary>

```
acd52832 airfy-beacon arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano arduino-uno arduino-zero atmega256rfr2-xpro atmega328p avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib cc2538dk ek-lm4f120xl esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing feather-m0 firefly fox frdm-k22f frdm-k64f frdm-kw41z hamilton i-nucleo-lrwan1 ikea-tradfri iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lsn50 maple-mini mega-xplained microduino-corerf msba2 msbiot mulle nrf51dk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f031k6 nucleo-f042k6 nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 openmote-b openmote-cc2538 p-l496g-cell02 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pyboard reel remote-pa remote-reva remote-revb ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff spark-core stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f723e-disco stm32l0538-disco ublox-c030-u201 udoo usb-kw41z waspmote-pro yunjia-nrf51822
```

</details>

<details><summary><b>master</b></summary>

```
acd52832 airfy-beacon arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano arduino-uno arduino-zero atmega256rfr2-xpro atmega328p avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib cc2538dk ek-lm4f120xl esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing feather-m0 firefly fox frdm-k22f frdm-k64f frdm-kw41z hamilton i-nucleo-lrwan1 ikea-tradfri iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lsn50 maple-mini mega-xplained microduino-corerf msba2 msbiot mulle nrf51dk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f031k6 nucleo-f042k6 nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 openmote-b openmote-cc2538 p-l496g-cell02 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pyboard reel remote-pa remote-reva remote-revb ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff spark-core stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f723e-disco stm32l0538-disco ublox-c030-u201 udoo usb-kw41z waspmote-pro yunjia-nrf51822
```

</details>

<details><summary><b>diff</b></summary>

```
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #12608 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
