### PR TITLE
tests/pkg_spiffs: exclude msp430 boards because of missing memory

### DIFF
--- a/tests/pkg_spiffs/Makefile
+++ b/tests/pkg_spiffs/Makefile
@@ -1,13 +1,5 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := chronos \
-                   msb-430 \
-                   msb-430h \
-                   telosb \
-                   wsn430-v1_3b \
-                   wsn430-v1_4 \
-                   z1 \
-
 USEMODULE += spiffs
 USEMODULE += embunit
 

--- a/tests/pkg_spiffs/Makefile.ci
+++ b/tests/pkg_spiffs/Makefile.ci
@@ -4,7 +4,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    chronos \
     i-nucleo-lrwan1 \
+    msb-430 \
+    msb-430h \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
@@ -13,4 +16,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \
+    telosb \
+    wsn430-v1_3b \
+    wsn430-v1_4 \
+    z1 \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes the use of BOARD_BLACKLIST in `tests/pkg_spiffs`: all boards there are msp430 and the build only fails at link time which just means that those boards doesn't have enough memory.

So the boards are just moved to the BOARD_INSUFFICIENT_MEMORY_VARIABLE and there's no need anymore to put them in BOARD_BLACKLIST. So the BOARD_BLACKLIST variable is simply removed.

<details><summary>Output of the build where we clearly see the failure at link time:</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=z1 -C tests/pkg_spiffs
make: Entering directory '/work/riot/RIOT/tests/pkg_spiffs'
Launching build container using image "riot/riotbuild:latest".
docker run --rm -t -u "$(id -u)" \
    -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'     \
    -e 'BOARD=z1' \
    -w '/data/riotbuild/riotbase/tests/pkg_spiffs/' \
    'riot/riotbuild:latest' make  'BOARD=z1' 
Building application "tests_pkg_spiffs" for "z1" with MCU "msp430fxyz".

if [ 5e2d4d9628f641863101c17ac8c8041187d6e768 != 287148c46587089c4543a21eef2d6e9e14b88364 ] ; then \
	git -C /data/riotbuild/riotbase/tests/pkg_spiffs/bin/pkg/z1/spiffs clean -xdff ; \
	git -C /data/riotbuild/riotbase/tests/pkg_spiffs/bin/pkg/z1/spiffs fetch "https://github.com/pellepl/spiffs.git" "287148c46587089c4543a21eef2d6e9e14b88364" ; \
	git -C /data/riotbuild/riotbase/tests/pkg_spiffs/bin/pkg/z1/spiffs checkout -f 287148c46587089c4543a21eef2d6e9e14b88364 ; \
	touch /data/riotbuild/riotbase/tests/pkg_spiffs/bin/pkg/z1/spiffs/.git-downloaded ; \
fi
Removing .git-downloaded
Removing .git-patched
From https://github.com/pellepl/spiffs
 * branch            287148c46587089c4543a21eef2d6e9e14b88364 -> FETCH_HEAD
Warning: you are leaving 1 commit behind, not connected to
any of your branches:

  5e2d4d9 Constify pointer for write operations

If you want to keep it by creating a new branch, this may be a good time
to do so with:

 git branch <new-branch-name> 5e2d4d9

HEAD is now at 287148c 0.3.7 documenting
git -C /data/riotbuild/riotbase/tests/pkg_spiffs/bin/pkg/z1/spiffs checkout -f 287148c46587089c4543a21eef2d6e9e14b88364
HEAD is now at 287148c 0.3.7 documenting
git -c user.email=buildsystem@riot -c user.name="RIOT buildsystem" -C /data/riotbuild/riotbase/tests/pkg_spiffs/bin/pkg/z1/spiffs am --no-gpg-sign --ignore-whitespace "/data/riotbuild/riotbase/pkg/spiffs"/patches/*.patch
Applying: Constify pointer for write operations
touch /data/riotbuild/riotbase/tests/pkg_spiffs/bin/pkg/z1/spiffs/.git-patched
"make" -C /data/riotbuild/riotbase/pkg/spiffs
"make" -C /data/riotbuild/riotbase/tests/pkg_spiffs/bin/pkg/z1/spiffs/src -f /data/riotbuild/riotbase/pkg/spiffs/Makefile.spiffs
"make" -C /data/riotbuild/riotbase/boards/z1
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/msp430fxyz
"make" -C /data/riotbuild/riotbase/cpu/msp430_common
"make" -C /data/riotbuild/riotbase/cpu/msp430_common/periph
"make" -C /data/riotbuild/riotbase/cpu/msp430fxyz/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/mtd
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/pkg/spiffs/fs
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/embunit
"make" -C /data/riotbuild/riotbase/sys/oneway-malloc
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/vfs
/data/riotbuild/riotbase/tests/pkg_spiffs/bin/z1/spiffs/spiffs_check.o:(.debug_loc+0x7c2): relocation truncated to fit: R_MSP430_16_BYTE against `no symbol'
/data/riotbuild/riotbase/tests/pkg_spiffs/bin/z1/spiffs/spiffs_check.o:(.debug_loc+0x7cc): relocation truncated to fit: R_MSP430_16_BYTE against `no symbol'
collect2: ld returned 1 exit status
/data/riotbuild/riotbase/Makefile.include:512: recipe for target '/data/riotbuild/riotbase/tests/pkg_spiffs/bin/z1/tests_pkg_spiffs.elf' failed
make: *** [/data/riotbuild/riotbase/tests/pkg_spiffs/bin/z1/tests_pkg_spiffs.elf] Error 1
make: *** [/work/riot/RIOT/makefiles/docker.inc.mk:282: ..in-docker-container] Error 2
```

</details>

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock is ok.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
