### PR TITLE
.gitignore: Ignore archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,14 @@ compile_flags.txt
 
 # suit manifest keys
 keys/
+
+# archive files
+*.zip
+*.tar.xz
+*.7z
+*.tar.bz2
+*.tar.gz
+*.tar
+# whitelist existing archives in the test
+!/tests/pkg_fatfs/riot_fatfs_disk.tar.gz
+!/tests/pkg_fatfs_vfs/riot_fatfs_disk.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -72,13 +72,10 @@ compile_flags.txt
 # suit manifest keys
 keys/
 
-# archive files
-*.zip
-*.tar.xz
-*.7z
-*.tar.bz2
-*.tar.gz
-*.tar
-# whitelist existing archives in the test
-!/tests/pkg_fatfs/riot_fatfs_disk.tar.gz
-!/tests/pkg_fatfs_vfs/riot_fatfs_disk.tar.gz
+# archive files in examples
+examples/**/*.zip
+examples/**/*.tar.xz
+examples/**/*.7z
+examples/**/*.tar.bz2
+examples/**/*.tar.gz
+examples/**/*.tar


### PR DESCRIPTION
### Contribution description

Once merged, common archives types will be ignored to prevent them accidentally being commited. The two archives that where purposely added to the tests are explicitly white-listed.

### Testing procedure

1. Try adding [42.zip](http://www.fefe.de/antivirus/42.zip). It should not work without force
2. Try adding changes to `tests/pkg_fatfs/riot_fatfs_disk.tar.gz` or `tests/pkg_fatfs_vfs/riot_fatfs_disk.tar.gz`, it should work


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/12406, https://github.com/RIOT-OS/RIOT/pull/12720