### PR TITLE
make: improve handling of the stdio_rtt module, improve dependency management at application level

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -468,6 +468,9 @@ endif
 
 ifneq (,$(filter stdio_uart,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
+
+  # stdio_rtt cannot be used when stdio_uart is loaded
+  DISABLE_MODULE += stdio_rtt
 endif
 
 ifneq (,$(filter isrpipe,$(USEMODULE)))

--- a/boards/hamilton/Makefile.dep
+++ b/boards/hamilton/Makefile.dep
@@ -12,3 +12,6 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   # ToDo: peripherals to be added in the future
   #USEMODULE += apds9007
 endif
+
+# Use Segger's RTT by default for stdio on this board
+DEFAULT_MODULE += stdio_rtt

--- a/boards/hamilton/Makefile.include
+++ b/boards/hamilton/Makefile.include
@@ -3,10 +3,8 @@ export JLINK_DEVICE := atsamr21e18a
 OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 OFLAGS := --gap-fill 0xff
 
-# Configure terminal, hamilton doesn't provide any UART, thus use RTT
-TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term-rtt
-
-USEMODULE += stdio_rtt
+# use JLink Segger RTT by default
+RIOT_TERMINAL ?= jlink
+include $(RIOTMAKE)/tools/serial.inc.mk
 
 include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/ruuvitag/Makefile.dep
+++ b/boards/ruuvitag/Makefile.dep
@@ -4,4 +4,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lis2dh12_spi
 endif
 
+# Use Segger's RTT by default for stdio on this board
+DEFAULT_MODULE += stdio_rtt
+
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/ruuvitag/Makefile.include
+++ b/boards/ruuvitag/Makefile.include
@@ -1,7 +1,11 @@
-# for this board, we are using Segger's RTT as default terminal interface
-USEMODULE += stdio_rtt
-TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term-rtt
+# HACK: replicate dependency resolution in Makefile.dep, only works
+# if `USEMODULE` or `DEFAULT_MODULE` is set by the command line or in the
+# application Makefile.
+ifeq (,$(filter stdio_%,$(DISABLE_MODULE) $(USEMODULE)))
+  RIOT_TERMINAL ?= jlink
+endif
+
+include $(RIOTMAKE)/tools/serial.inc.mk
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/thingy52/Makefile.dep
+++ b/boards/thingy52/Makefile.dep
@@ -4,4 +4,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lps22hb
 endif
 
+# Use Segger's RTT by default for stdio on this board
+DEFAULT_MODULE += stdio_rtt
+
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -1,7 +1,11 @@
-# for this board, we are using Segger's RTT as default terminal interface
-USEMODULE += stdio_rtt
-TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term-rtt
+# HACK: replicate dependency resolution in Makefile.dep, only works
+# if `USEMODULE` or `DEFAULT_MODULE` is set by the command line or in the
+# application Makefile.
+ifeq (,$(filter stdio_%,$(DISABLE_MODULE) $(USEMODULE)))
+  RIOT_TERMINAL ?= jlink
+endif
+
+include $(RIOTMAKE)/tools/serial.inc.mk
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -7,9 +7,6 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-# The following boards do not have an available UART
-BOARD_BLACKLIST += pic32-wifire pic32-clicker ruuvitag thingy52
-
 # use ethos (ethernet over serial) for network communication and stdio over
 # UART, but not on native, as native has a tap interface towards the host.
 ifeq (,$(filter native,$(BOARD)))

--- a/examples/suit_update/Makefile.ci
+++ b/examples/suit_update/Makefile.ci
@@ -18,12 +18,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \
-    ruuvitag \
     saml10-xpro \
     saml11-xpro \
     stm32f0discovery \
     telosb \
-    thingy52 \
     waspmote-pro \
     wsn430-v1_3b \
     wsn430-v1_4 \

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -26,4 +26,7 @@ else ifeq ($(RIOT_TERMINAL),miniterm)
   # The RIOT shell will still transmit back a CRLF, but at least with --eol LF
   # we avoid sending two lines on every "enter".
   TERMFLAGS ?= --eol LF "$(PORT)" "$(BAUD)"
+else ifeq ($(RIOT_TERMINAL),jlink)
+  TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
+  TERMFLAGS = term-rtt
 endif

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -2,9 +2,6 @@ DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common
 
-# chronos, hamilton and ruuvitag boards don't support ethos
-BOARD_BLACKLIST := chronos hamilton ruuvitag
-
 export TAP ?= tap0
 
 # use Ethernet as link-layer protocol

--- a/tests/gnrc_ipv6_ext_frag/Makefile
+++ b/tests/gnrc_ipv6_ext_frag/Makefile
@@ -2,9 +2,6 @@ DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common
 
-# chronos, hamilton, ruuvitag, and thingy52 boards don't support ethos
-BOARD_BLACKLIST := chronos hamilton ruuvitag thingy52
-
 export TAP ?= tap0
 
 CFLAGS += -DOUTPUT=TEXT

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -2,9 +2,6 @@ DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common
 
-# chronos, hamilton and ruuvitag boards don't support ethos
-BOARD_BLACKLIST := chronos hamilton ruuvitag
-
 export TAP ?= tap0
 
 CFLAGS += -DOUTPUT=TEXT

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -2,9 +2,6 @@ include ../Makefile.tests_common
 
 RIOTBASE ?= $(CURDIR)/../..
 
-# chronos, hamilton and ruuvitag boards don't support ethos
-BOARD_BLACKLIST := chronos hamilton ruuvitag
-
 export TAP ?= tap0
 
 USEMODULE += sock_dns

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -8,9 +8,6 @@ TAP ?= tap0
 MSL_US ?= 1000000
 TIMEOUT_US ?= 3000000
 
-# unsupported by ethos: chronos, hamilton, ruuvitag
-BOARD_BLACKLIST := chronos hamilton ruuvitag thingy52
-
 # This test depends on tap device setup (only allowed by root)
 # Suppress test execution to avoid CI errors
 TEST_ON_CI_BLACKLIST += all


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduces the stdio_rtt feature for boards for which stdio is accessed via RTT (there is a strong dependency on this for these boards): hamilton, thingy52 and ruuvitag.

The (new) `stdio_rtt` feature is required when the (already existing) `stdio_rtt` module is used.
This then allows to blacklist this feature when stdio_ethos is used in the build: indeed stdio_ethos has a strong dependency to stdio_uart, which is not compatible.

Thanks to this, the PR also removes all `BOARD_BLACKLIST` variables that were added because of this incompatibility.

There is a small trick for `gnrc_*` tests application that was taken from #12304 (commit 6f43ab7 is cherry-picked from this PR in fact).

Some details (pic32 chronos boards removed) are explained in related commit details comments.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Check the list of board supported by updated applications

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
