### PR TITLE
pkg/ndn-riot: blacklist ble_nimble feature

### DIFF
--- a/examples/ndn-ping/Makefile
+++ b/examples/ndn-ping/Makefile
@@ -7,10 +7,6 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../
 
-# Do not build for any board that supports nimble_netif, as NimBLE and ndn-riot
-# use different crypto libraries that have name clashes (tinycrypt vs uECC)
-BOARD_BLACKLIST := acd52832 nrf52832-mdk nrf52dk ruuvitag thingy52
-
 # Include packages that pull up and auto-init the link layer.
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/pkg/ndn-riot/Makefile.dep
+++ b/pkg/ndn-riot/Makefile.dep
@@ -1,1 +1,6 @@
 USEMODULE += ndn-encoding
+
+# Blacklist platforms using nimble_netif with gnrc netif, e.g providing
+# ble_nimble: NimBLE and ndn-riot use different crypto libraries that have
+# name clashes (tinycrypt vs uECC)
+FEATURES_BLACKLIST += ble_nimble


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR manages the dependencies incompatibilities between the `ndn-riot` package and the `ble_nimble` feature (in fact `nimble_netif`) in the `ndn_riot` package itself using the `FEATURES_BLACKLIST` variable.

This allows to remove the need for BOARD_BLACKLIST in the `examples/ndn-ping` application

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- `make -C examples/ndn-ping info-boards-supported` returns an unchanged list of boards between this PR and master

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
