### PR TITLE
drivers/pca9685: blacklist efm32 architecture

### DIFF
--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -1,5 +1,6 @@
 include $(RIOTCPU)/efm32/efm32-features.mk
 
+FEATURES_PROVIDED += arch_efm32
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -421,6 +421,9 @@ ifneq (,$(filter pca9685,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += xtimer
+
+  # efm32 CPU doesn't support PWM_RIGHT
+  FEATURES_BLACKLIST += arch_efm32
 endif
 
 ifneq (,$(filter pcd8544,$(USEMODULE)))

--- a/tests/driver_pca9685/Makefile
+++ b/tests/driver_pca9685/Makefile
@@ -1,10 +1,5 @@
 include ../Makefile.tests_common
 
-# These boards are blacklisted since efm32 CPU dosn't support PWM_RIGHT
-BOARD_BLACKLIST := slstk3401a slstk3402a sltb001a \
-                   slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a \
-                   stk3600 stk3700
-
 USEMODULE += pca9685
 USEMODULE += shell
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the `arch_efm32` to the EFM32 cpus and make use of it to blacklist this platform in the pca9685 driver.

This allows to get rid of the BOARD_BLACKLIST in the pca9685 driver test application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
