### PR TITLE
boards/atmega1284p: Add ATmega1284P as board

### DIFF
--- a/boards/atmega1284p/Makefile
+++ b/boards/atmega1284p/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/atmega1284p/Makefile.dep
+++ b/boards/atmega1284p/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += boards_common_atmega

--- a/boards/atmega1284p/Makefile.features
+++ b/boards/atmega1284p/Makefile.features
@@ -1,0 +1,9 @@
+CPU = atmega1284p
+
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/atmega1284p/Makefile.include
+++ b/boards/atmega1284p/Makefile.include
@@ -1,0 +1,18 @@
+# configure the terminal program
+PORT_LINUX          ?= /dev/ttyUSB0
+PORT_DARWIN         ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+BAUD                ?= 9600
+ATMEGA328P_CLOCK    ?=
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# Allow overwriting programmer via env variables without affecting other boards
+PROGRAMMER_BOARD_ATMEGA1284P ?= dragon_isp
+# ICSP programmer to use for avrdude
+PROGRAMMER ?= $(PROGRAMMER_BOARD_ATMEGA1284P)
+
+ifneq (,$(ATMEGA1284P_CLOCK))
+  CFLAGS += -DCLOCK_CORECLOCK=$(ATMEGA1284P_CLOCK)
+endif
+
+include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/atmega1284p/doc.txt
+++ b/boards/atmega1284p/doc.txt
@@ -1,0 +1,101 @@
+/**
+@defgroup    boards_atmega1284p Standalone ATmega1284P
+@ingroup     boards
+@brief       Support for using the ATmega1284P as standalone board
+
+## Overview
+
+As the ATmega1284P can run from the internal oscillator, placing it on a
+breadboard, connecting an USB-UART adapter and power is enough to run RIOT on
+it. (An ISP programmer will be needed to program it; or to program a bootloader
+to subsequently allow programming via UART.)
+
+### MCU
+| MCU           | ATmega328p                             |
+|:------------- |:-------------------------------------- |
+| Family        | AVR/ATmega                             |
+| Vendor        | Microchip (previously Atmel)           |
+| RAM           | 16KiB                                  |
+| Flash         | 128KiB                                 |
+| EEPROM        | 4KiB                                   |
+| Frequency     | 8MHz (up to 20MHz with external clock) |
+| Timers        | 3 (2x 8bit, 1x 16bit)                  |
+| ADCs          | 6 analog input pins                    |
+| UARTs         | 1                                      |
+| SPIs          | 1                                      |
+| I2Cs          | 1 (called TWI)                         |
+| Vcc           | 2.7V - 5.5V (when clocked at 8MHz)     |
+| Datasheet     | [Official datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42719-ATmega1284P_Datasheet.pdf) |
+
+### Pinout
+
+\htmlonly<style>div.image img[src="http://i.imgur.com/ayagBbM.png"]{width:50%;}</style>\endhtmlonly
+@image html "http://i.imgur.com/ayagBbM.png" "Pinout of the ATmega1284P"<br>
+
+The pinout image was posted in the
+[Arduino Forum](https://forum.arduino.cc/index.php?topic=322745.0).
+All credit goes to its poster, hansibull.
+
+### Clock Frequency
+
+The ATmega1284P has two internal oscillators clocked at 8MHz and at 128kHz that
+allow it to be operated without any external clock source or crystal. By default
+the fuses are configured to use the internal 8MHz oscillator, but the `CKDIV8`
+fuse is set, so that the clock is divided down to 1MHz. By disabling the
+`CKDIV8` fuse the clock will operate at 8MHz. This is highly encouraged, and
+can be done with:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+avrdude -c dragon_isp -p m1284p -B 32 -U lfuse:w:0xc2:m
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(Replace `dragon_isp` with the programmer you are using. The -B 32 might be
+needed for some programmers to successfully communicate with ATmegas clocked at
+less than 2MHz. It will no longer be needed after disabling `CKDIV8`.)
+
+By setting the environment variable `ATMEGA1284P_CLOCK` to a custom frequency in
+Hz (e.g. `1000000` for 1MHz), this core clock can be changed easily. Refer to
+the datasheet on how to configure the ATmega1284p to use an external crystal,
+an external clock source or the clock divider.
+
+### Relation Between Supply Voltage, Clock Frequency and Power Consumption
+
+A higher supply voltage results in a higher current drawn. Thus, lower power
+consumption can be achieved by using a lower supply voltage. However, higher
+clock frequencies require higher supply voltages for reliable operation.
+
+The lowest possible supply voltage at 8 MHz is 2.7V (with some safety margin).
+
+## Flashing the Device
+
+In order to flash the ATmega1284P without a bootloader, an ISP programmer is
+needed. Connect the programmer as follows:
+
+| ISCP pin | ATmega1284P    |
+|:-------- |:-------------- |
+| MISO     | 7/PB6/MISO     |
+| VCC      | 10/VCC         |
+| SCK      | 8/PB7/SCK      |
+| MOSI     | 6/PB5/MOSI     |
+| RESET    | 9/RESET        |
+| Ground   | 11/GND         |
+
+The tool `avrdude` needs to be installed. When using the AVR Dragon for
+programming, running
+
+    make BOARD=atmega1284p flash
+
+will take care of everything. To use the programmer `<FOOBAR>` instead, run
+
+    make BOARD=atmega1284p PROGRAMMER=<FOOBAR> flash
+
+## Serial Terminal
+
+Connect a TTL adapter with pins 14/RXD0 and 15/TXD0 an run
+
+    make BOARD=atmega1284p term
+
+Please note that the supply voltage should be compatible with the logic level of
+the TTL adapter. Usually everything between 3.3 V and 5 V should work.
+
+ */

--- a/boards/atmega1284p/include/board.h
+++ b/boards/atmega1284p/include/board.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2016 Laurent Navet <laurent.navet@gmail.com>
+ *               2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atmega1284p
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the standalone ATmega1284P "board"
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+ * @author      Laurent Navet <laurent.navet@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    STDIO configuration
+ *
+ * As the CPU is too slow to handle 115200 baud, we set the default
+ * baudrate to 9600 for this board
+ * @{
+ */
+#define STDIO_UART_BAUDRATE (9600U)
+/** @} */
+
+/**
+ * @name    xtimer configuration values
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+#if CLOCK_CORECLOCK > 4000000UL
+#define XTIMER_HZ                   (CLOCK_CORECLOCK / 64)
+#else
+#define XTIMER_HZ                   (CLOCK_CORECLOCK / 8)
+#endif
+#define XTIMER_BACKOFF              (40)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/atmega1284p/include/periph_conf.h
+++ b/boards/atmega1284p/include/periph_conf.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup boards_atmega1284p
+ * @{
+ *
+ * @file
+ * @brief   Peripheral MCU configuration for the ATmega1284p standalone "board"
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+/* Using 8MHz internal oscillator as default clock source */
+#define CLOCK_CORECLOCK     (8000000UL)
+#endif
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "periph_conf_atmega_common.h"
+
+#endif /* PERIPH_CONF_H */

--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -311,7 +311,8 @@ extern "C" {
  * @name   PWM configuration
  *
  * The current implementation supports only 8-bit timers for PWM generation.
- * These timers are typically timer 0 and timer 2 in Atmega2560/1281/328p.
+ * These timers are typically timer 0 and timer 2 for
+ * ATmega 328P/1281/1284P/2560.
  *
  * Setting the first channel to GPIO_UNDEF allows multiple resolutions for the
  * PWM channel. Otherwise the resolution is fixed to 256, allowing duty cycle
@@ -326,6 +327,9 @@ extern "C" {
 #elif defined(CPU_ATMEGA1281)
     #define PWM_PINS_CH0 { GPIO_PIN(PORT_B, 7), GPIO_PIN(PORT_G, 5) }
     #define PWM_PINS_CH1 { GPIO_PIN(PORT_B, 4), GPIO_UNDEF }
+#elif defined(CPU_ATMEGA1284P)
+    #define PWM_PINS_CH0 { GPIO_PIN(PORT_B, 3), GPIO_PIN(PORT_B, 4) }
+    #define PWM_PINS_CH1 { GPIO_PIN(PORT_D, 7), GPIO_PIN(PORT_D, 6) }
 #elif defined(CPU_ATMEGA2560)
     #define PWM_PINS_CH0 { GPIO_PIN(PORT_B, 7), GPIO_PIN(PORT_G, 5) }
     #define PWM_PINS_CH1 { GPIO_PIN(PORT_B, 4), GPIO_PIN(PORT_H, 6) }
@@ -335,7 +339,9 @@ extern "C" {
     #define PWM_NUMOF           (0U)
 #endif
 
-#if defined(CPU_ATMEGA328P) || defined(CPU_ATMEGA1281) || defined(CPU_ATMEGA2560) || defined(CPU_ATMEGA32U4)
+#if defined(CPU_ATMEGA32U4) || defined(CPU_ATMEGA328P) || \
+    defined(CPU_ATMEGA1281) || defined(CPU_ATMEGA1284P) || \
+    defined(CPU_ATMEGA2560)
     static const pwm_conf_t pwm_conf[] = {
         {
             .dev = MINI_TIMER0,

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     chronos \
     hifive1 \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     chronos \
     hifive1 \

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     chronos \
     hifive1 \

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     chronos \
     i-nucleo-lrwan1 \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     b-l072z-lrwan1 \
     blackpill \

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     blackpill \
     bluepill \

--- a/examples/gnrc_tftp/Makefile.ci
+++ b/examples/gnrc_tftp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     b-l072z-lrwan1 \
     blackpill \

--- a/examples/ndn-ping/Makefile.ci
+++ b/examples/ndn-ping/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     chronos \
     i-nucleo-lrwan1 \

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     chronos \
     i-nucleo-lrwan1 \

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     blackpill \
     bluepill \

--- a/tests/driver_enc28j60/Makefile.ci
+++ b/tests/driver_enc28j60/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     blackpill \
     bluepill \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     b-l072z-lrwan1 \
     blackpill \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     chronos \
     hifive1 \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     calliope-mini \
     chronos \

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano arduino-uno \
-                   atmega328p atmega256rfr2-xpro mega-xplained \
+                   atmega328p atmega256rfr2-xpro atmega1284p mega-xplained \
                    microduino-corerf waspmote-pro
 # arduino-mega2560: builds locally but breaks travis (possibly because of
 # differences in the toolchain)

--- a/tests/pkg_libb2/Makefile.ci
+++ b/tests/pkg_libb2/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega256rfr2-xpro \
     atmega328p \
     chronos \

--- a/tests/sys_crypto/Makefile
+++ b/tests/sys_crypto/Makefile
@@ -8,6 +8,7 @@ BOARD_BLACKLIST += arduino-nano
 BOARD_BLACKLIST += arduino-uno
 BOARD_BLACKLIST += atmega256rfr2-xpro
 BOARD_BLACKLIST += atmega328p
+BOARD_BLACKLIST += atmega1284p
 BOARD_BLACKLIST += chronos
 BOARD_BLACKLIST += mega-xplained
 BOARD_BLACKLIST += microduino-corerf


### PR DESCRIPTION
### Contribution description

This PR add support for the ATmega1284P MCU used as standalone "board". In addition, the PWM configuration for the ATmega1284P MCU has been added to `board/common/atmega`, so that all boards using this MCU should gain PWM capabilities.

#### Details About the Board

The ATmega1284P can be run on a breadboard with no external components, except for a power supply and (if access to the serial is required) an USB-TTL adapter. This commit adds it as a "board".

#### Motivation

The ATmega1284P is one of the few 8bit MCUs with enough RAM for some serious network tests. And just using the PDIP package is the cheapest, easily sourceable, commercially available option.

This board might also make the life of users of custom ATmega1284P based boards (e.g. the INGA board) easier.

### Testing procedure

Run test applications that verify correct boards settings. On the ATmega platform, SPI and I2C need no board support (so no need to test that). However, the timer settings and the xtimer integration, as well as the UART settings require correct configuration in the board. I suggest the following as minimal testing procedure:

- [ ] Run `examples/default` to verify UART. Interact with the shell a bit
- [ ] Run `tests/periph_timer`
- [ ] Run some xtimer test(s)
- [ ] Run `tests/periph_pwm`

### Issues/PRs references

None