### PR TITLE
boards/sodaq-sff: add support for SODAQ SFF

### DIFF
--- a/boards/sodaq-autonomo/include/board.h
+++ b/boards/sodaq-autonomo/include/board.h
@@ -27,14 +27,6 @@ extern "C" {
 #endif
 
 /**
- * @name    xtimer configuration
- * @{
- */
-#define XTIMER              TIMER_1
-#define XTIMER_CHAN         (0)
-/** @} */
-
-/**
  * @name    LED pin definitions and handlers
  * @{
  */

--- a/boards/sodaq-one/include/board.h
+++ b/boards/sodaq-one/include/board.h
@@ -27,13 +27,6 @@ extern "C" {
 #endif
 
 /**
- * @name    xtimer configuration
- * @{
- */
-#define XTIMER_WIDTH        (16)
-/** @} */
-
-/**
  * @name    LED pin definitions and handlers
  * @{
  */

--- a/boards/sodaq-sara-aff/include/board.h
+++ b/boards/sodaq-sara-aff/include/board.h
@@ -27,13 +27,6 @@ extern "C" {
 #endif
 
 /**
- * @name    xtimer configuration
- * @{
- */
-#define XTIMER_WIDTH        (16)
-/** @} */
-
-/**
  * @name    LED pin definitions and handlers
  * @{
  */

--- a/boards/sodaq-sara-sff/Makefile
+++ b/boards/sodaq-sara-sff/Makefile
@@ -1,0 +1,8 @@
+MODULE = board
+
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # Add the samd21-arduino-bootloader directory to the build
+  DIRS += $(RIOTBOARD)/common/samd21-arduino-bootloader
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/sodaq-sara-sff/Makefile.dep
+++ b/boards/sodaq-sara-sff/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/sodaq/Makefile.dep

--- a/boards/sodaq-sara-sff/Makefile.features
+++ b/boards/sodaq-sara-sff/Makefile.features
@@ -1,0 +1,3 @@
+CPU_MODEL = samd21g18a
+
+include $(RIOTBOARD)/common/sodaq/Makefile.features

--- a/boards/sodaq-sara-sff/Makefile.include
+++ b/boards/sodaq-sara-sff/Makefile.include
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/sodaq/Makefile.include

--- a/boards/sodaq-sara-sff/board.c
+++ b/boards/sodaq-sara-sff/board.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 Kees Bakker
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-sff
+ * @{
+ *
+ * @file
+ * @brief       Board common implementations for the SODAQ SARA SFF board
+ *
+ * @author      Kees Bakker <kees@sodaq.com>
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* Disable power to the SARA/UBlox by default */
+    SARA_ENABLE_OFF;
+    gpio_init(SARA_ENABLE_PIN, GPIO_OUT);
+
+    /* Disable level shifters SARA/UBlox by default */
+    SARA_TX_ENABLE_OFF;
+    gpio_init(SARA_TX_ENABLE_PIN, GPIO_OUT);
+
+    /* The R4XX module has a PWR_ON pin. Make it low to
+     * switch on the module.
+     * Here it is made an input so that it will float HIGH.
+     */
+    SARA_R4XX_PWR_ON_ON;
+    gpio_init(SARA_R4XX_PWR_ON_PIN, GPIO_IN);
+
+    /* Disable GPS by default */
+    GPS_ENABLE_OFF;
+    gpio_init(GPS_ENABLE_PIN, GPIO_OUT);
+
+    /* Initialize the output ports for the LEDs */
+    LED_RED_OFF;
+    gpio_init(LED_RED_PIN, GPIO_OUT);
+
+    LED_BLUE_OFF;
+    gpio_init(LED_BLUE_PIN, GPIO_OUT);
+
+    LED_GREEN_OFF;
+    gpio_init(LED_GREEN_PIN, GPIO_OUT);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/sodaq-sara-sff/doc.txt
+++ b/boards/sodaq-sara-sff/doc.txt
@@ -1,0 +1,31 @@
+/**
+ * @defgroup    boards_sodaq-sara-sff SODAQ SARA SFF
+ * @ingroup     boards
+ * @brief       Support for the SODAQ SARA SFF boards
+ *
+ * ### General information
+ *
+ * General information about this board can be found on the
+ * [SODAQ support](https://support.sodaq.com/Boards/Sara_SFF/)
+ * website.
+ * Schematic can be found [here](https://learn.sodaq.com/Boards/Sara_SFF/sodaq_sara_sff_r2.pdf)
+)
+ *
+ * ### Flash the board
+ *
+ * Use `BOARD=sodaq-one` with the `make` command.<br/>
+ * Example with `hello-world` application:
+ * ```
+ *      make BOARD=sodaq-one -C examples/hello-world flash
+ * ```
+ *
+ * @note     If the application crashes, automatic reflashing via USB, as explained
+ *           above won't be possible. In this case, the board must be set in
+ *           bootloader mode by double tapping the reset button before running the
+ *           flash command.
+ *
+ * ### Accessing STDIO via UART
+ *
+ * STDIO of RIOT is directly available over the USB port.
+ *
+ */

--- a/boards/sodaq-sara-sff/include/arduino_board.h
+++ b/boards/sodaq-sara-sff/include/arduino_board.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C)  2020 Kees Bakker
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-sff
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Kees Bakker <kees@ijzerbout.nl>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The green of the RGB led is used as "the builtin led"
+ */
+#define ARDUINO_LED         (15)
+
+/**
+ * @brief   On-board serial port mapping
+ */
+#define ARDUINO_UART_DEV         UART_DEV(0)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    /* 0..3 Main IO Pins (D0-D3) Digital Properties */
+    GPIO_PIN(PA, 2),
+    GPIO_PIN(PA, 3),
+    GPIO_PIN(PB, 8),
+    GPIO_PIN(PB, 9),
+
+    /* 4..5 Other Digital Pins */
+    GPIO_PIN(PA, 21),
+    GPIO_PIN(PA, 20),
+
+    /* 6..13 Main IO Pins (D6-D13) Digital Properties */
+    GPIO_PIN(PA, 6),
+    GPIO_PIN(PA, 7),
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 9),
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+    GPIO_PIN(PB, 2),
+    GPIO_PIN(PB, 3),
+
+    /* 14..21 Other Digital Pins */
+    GPIO_PIN(PA, 15),
+    GPIO_PIN(PB, 10),
+    GPIO_PIN(PB, 11),
+    GPIO_PIN(PA, 14),
+    GPIO_PIN(PA, 18),
+    GPIO_PIN(PA, 16),
+    GPIO_PIN(PB, 22),
+    GPIO_PIN(PA, 17),
+
+    /* 22..33 Main IO Pins Analog Properties */
+    GPIO_PIN(PA, 2),
+    GPIO_PIN(PA, 3),
+    GPIO_PIN(PB, 8),
+    GPIO_PIN(PB, 9),
+    GPIO_PIN(PA, 6),
+    GPIO_PIN(PA, 7),
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 9),
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+    GPIO_PIN(PB, 2),
+    GPIO_PIN(PB, 3),
+
+    /* 34..36 Other Analog Pins */
+    GPIO_PIN(PA, 2),
+    GPIO_PIN(PA, 3),
+    GPIO_PIN(PA, 5),
+
+    /* 37..38 USB Pins */
+    GPIO_PIN(PA, 24),
+    GPIO_PIN(PA, 25),
+
+    /* 39..40 Serial */
+    GPIO_PIN(PB, 3),
+    GPIO_PIN(PB, 2),
+
+    /* 41..42 Serial1 */
+    GPIO_PIN(PA, 13),
+    GPIO_PIN(PA, 12),
+
+    /* 43..46 SPI  */
+    GPIO_PIN(PA, 8),
+    GPIO_PIN(PA, 9),
+    GPIO_PIN(PA, 10),
+    GPIO_PIN(PA, 11),
+
+    /* 47..48 I2C */
+    GPIO_PIN(PA, 22),
+    GPIO_PIN(PA, 23),
+
+    /* 49 */
+    GPIO_PIN(PA,  4),
+
+    /* 50 MAG_INT */
+    GPIO_PIN(PA, 19),
+
+    /* 51 SARA_TX_ENABLE */
+    GPIO_PIN(PA, 27),
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ADC_LINE(0),
+    ADC_LINE(1),
+    ADC_LINE(2),
+    ADC_LINE(3),
+    ADC_LINE(4),
+    ADC_LINE(5),
+    ADC_LINE(6),
+    ADC_LINE(7),
+    ADC_LINE(8),
+    ADC_LINE(9),
+    ADC_LINE(10),
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/sodaq-sara-sff/include/board.h
+++ b/boards/sodaq-sara-sff/include/board.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2019 Kees Bakker, SODAQ
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-sff
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the SODAQ SARA SFF board
+ *
+ * @author      Kees Bakker <kees@sodaq.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 16)
+#define LED0_PORT           PORT->Group[PA]
+#define LED0_MASK           (1 << 16)
+
+#define LED0_OFF            (LED0_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_ON             (LED0_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED0_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED_GREEN_PIN       LED0_PIN
+#define LED_GREEN_OFF       LED0_OFF
+#define LED_GREEN_ON        LED0_ON
+#define LED_GREEN_TOGGLE    LED0_TOGGLE
+
+#define LED1_PIN            GPIO_PIN(PA, 14)
+#define LED1_PORT           PORT->Group[PA]
+#define LED1_MASK           (1 << 14)
+
+#define LED1_OFF            (LED1_PORT.OUTSET.reg = LED1_MASK)
+#define LED1_ON             (LED1_PORT.OUTCLR.reg = LED1_MASK)
+#define LED1_TOGGLE         (LED1_PORT.OUTTGL.reg = LED1_MASK)
+
+#define LED_RED_PIN         LED1_PIN
+#define LED_RED_OFF         LED1_OFF
+#define LED_RED_ON          LED1_ON
+#define LED_RED_TOGGLE      LED1_TOGGLE
+
+#define LED2_PIN            GPIO_PIN(PA, 15)
+#define LED2_PORT           PORT->Group[PA]
+#define LED2_MASK           (1 << 15)
+
+#define LED2_OFF            (LED2_PORT.OUTSET.reg = LED2_MASK)
+#define LED2_ON             (LED2_PORT.OUTCLR.reg = LED2_MASK)
+#define LED2_TOGGLE         (LED2_PORT.OUTTGL.reg = LED2_MASK)
+
+#define LED_BLUE_PIN         LED2_PIN
+#define LED_BLUE_OFF         LED2_OFF
+#define LED_BLUE_ON          LED2_ON
+#define LED_BLUE_TOGGLE      LED2_TOGGLE
+/** @} */
+
+/**
+ * @name    User button
+ */
+#define BTN0_PIN            GPIO_PIN(PB, 8)
+#define BTN0_MODE           GPIO_IN
+/** @} */
+
+/**
+ * @name    GPS Time Pulse
+ * @{
+ */
+#define GPS_TIMEPULSE_PIN   GPIO_PIN(PA, 17)
+#define GPS_TIMEPULSE_MODE  GPIO_IN
+/** @} */
+
+/**
+ * @name    GPS Enable
+ * @{
+ */
+#define GPS_ENABLE_PIN      GPIO_PIN(PA, 18)
+
+#define GPS_ENABLE_PORT     PORT->Group[PA]
+#define GPS_ENABLE_MASK     (1 << 18)
+
+#define GPS_ENABLE_ON       (GPS_ENABLE_PORT.OUTSET.reg = GPS_ENABLE_MASK)
+#define GPS_ENABLE_OFF      (GPS_ENABLE_PORT.OUTCLR.reg = GPS_ENABLE_MASK)
+/** @} */
+
+/**
+ * @name    SARA (UBlox) Enable
+ *
+ * With this pin the power supply can be switched on or off.
+ * @{
+ */
+#define SARA_ENABLE_PIN     GPIO_PIN(PA, 4)
+
+#define SARA_ENABLE_PORT    PORT->Group[PA]
+#define SARA_ENABLE_MASK    (1 << 4)
+
+#define SARA_ENABLE_ON      (SARA_ENABLE_PORT.OUTSET.reg = SARA_ENABLE_MASK)
+#define SARA_ENABLE_OFF     (SARA_ENABLE_PORT.OUTCLR.reg = SARA_ENABLE_MASK)
+/** @} */
+
+/**
+ * @name    SARA (UBlox) TX Enable
+ *
+ * With this pin level shifters can be switched on or off.
+ * @{
+ */
+#define SARA_TX_ENABLE_PIN  GPIO_PIN(PA, 27)
+
+#define SARA_TX_ENABLE_PORT PORT->Group[PA]
+#define SARA_TX_ENABLE_MASK (1 << 27)
+
+#define SARA_TX_ENABLE_ON   (SARA_TX_ENABLE_PORT.OUTSET.reg = SARA_TX_ENABLE_MASK)
+#define SARA_TX_ENABLE_OFF  (SARA_TX_ENABLE_PORT.OUTCLR.reg = SARA_TX_ENABLE_MASK)
+/** @} */
+
+/**
+ * @name    SARA_R4XX PWR_ON
+ *
+ * This is the PWR_ON pin of the UBlox. It can be used to switch the unit on or off
+ * by lowering this pin (at least for 0.15 seconds). This is needed to switch on from
+ * power-off mode and from PSM deep sleep.
+ * @{
+ */
+#define SARA_R4XX_PWR_ON_PIN    GPIO_PIN(PB, 10)
+
+#define SARA_R4XX_PWR_ON_PORT   PORT->Group[PB]
+#define SARA_R4XX_PWR_ON_MASK   (1 << 10)
+
+#define SARA_R4XX_PWR_ON_ON     (SARA_R4XX_PWR_ON_PORT.OUTSET.reg = SARA_R4XX_PWR_ON_MASK)
+#define SARA_R4XX_PWR_ON_OFF    (SARA_R4XX_PWR_ON_PORT.OUTCLR.reg = SARA_R4XX_PWR_ON_MASK)
+/** @} */
+
+/**
+ * @name    INT_MAG
+ *
+ * The INT_MAG pin of the accelerometer (LSM303AGRTR)
+ * @{
+ */
+#define INT_MAG_PIN         GPIO_PIN(PA, 19)
+#define INT_MAG_MODE        GPIO_IN
+/** @} */
+
+/**
+ * @name    INT1_XL
+ *
+ * The INT1_XL pin of the accelerometer (LSM303AGRTR)
+ * @{
+ */
+#define INT1_XL_PIN         GPIO_PIN(PA, 20)
+#define INT1_XL_MODE        GPIO_IN
+/** @} */
+
+/**
+ * @name    INT2_XL
+ *
+ * The INT2_XL pin of the accelerometer (LSM303AGRTR)
+ * @{
+ */
+#define INT2_XL_PIN         GPIO_PIN(PA, 21)
+#define INT2_XL_MODE        GPIO_IN
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/sodaq-sara-sff/include/board.h
+++ b/boards/sodaq-sara-sff/include/board.h
@@ -27,13 +27,6 @@ extern "C" {
 #endif
 
 /**
- * @name    xtimer configuration
- * @{
- */
-#define XTIMER_WIDTH        (16)
-/** @} */
-
-/**
  * @name    LED pin definitions and handlers
  * @{
  */

--- a/boards/sodaq-sara-sff/include/gpio_params.h
+++ b/boards/sodaq-sara-sff/include/gpio_params.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 Kees Bakker, SODAQ
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-sff
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Kees Bakker <kees@sodaq.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED Green",
+        .pin = LED_GREEN_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name = "LED Red",
+        .pin = LED_RED_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name = "LED Blue",
+        .pin = LED_BLUE_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name = "Button",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/sodaq-sara-sff/include/periph_conf.h
+++ b/boards/sodaq-sara-sff/include/periph_conf.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2019 Kees Bakker, SODAQ
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-sff
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the SODAQ SARA SFF board
+ *
+ * @author      Kees Bakker <kees@sodaq.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
+#include "cfg_clock_default.h"
+#include "cfg_rtc_default.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+#include "cfg_usbdev_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM5->USART,
+        .rx_pin   = GPIO_PIN(PB, 3),  /* D0, RX Pin */
+        .tx_pin   = GPIO_PIN(PB, 2),  /* D1, TX Pin */
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {
+        /* Connected to the UBlox */
+        .dev      = &SERCOM2->USART,
+        .rx_pin   = GPIO_PIN(PA, 13),
+        .tx_pin   = GPIO_PIN(PA, 12),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom5
+#define UART_1_ISR          isr_sercom2
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_DIV2
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* A0 */
+    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},     /* A1 */
+    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},     /* A2 */
+    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3},     /* A3 */
+    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},     /* A4 */
+    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* A5 */
+    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},    /* A6 */
+    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A7 */
+    {GPIO_PIN(PA,10), ADC_INPUTCTRL_MUXPOS_PIN18},    /* A8 */
+    {GPIO_PIN(PA,11), ADC_INPUTCTRL_MUXPOS_PIN19},    /* A9 */
+#if 0
+    /* These pins are also used for RX/TX uart0 */
+    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A10, TX */
+    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A11, RX */
+#endif
+    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* BAT_VOLT */
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &SERCOM0->SPI,
+        .miso_pin = GPIO_PIN(PA, 8),
+        .mosi_pin = GPIO_PIN(PA, 10),
+        .clk_pin  = GPIO_PIN(PA, 11),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM3->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 23),
+        .sda_pin  = GPIO_PIN(PA, 22),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = SAM0_GCLK_MAIN,
+        .flags    = I2C_FLAG_NONE
+    }
+};
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -75,6 +75,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     sodaq-explorer \
     sodaq-one \
     sodaq-sara-aff \
+    sodaq-sara-sff \
     spark-core \
     stk3600 \
     stm32f030f4-demo \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -55,6 +55,7 @@ LOW_MEMORY_BOARDS += \
   sodaq-explorer \
   sodaq-one \
   sodaq-sara-aff \
+  sodaq-sara-sff \
   spark-core \
   stm32f0discovery \
   stm32l0538-disco \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -84,6 +84,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     sodaq-explorer \
     sodaq-one \
     sodaq-sara-aff \
+    sodaq-sara-sff \
     spark-core \
     stk3600 \
     stm32f030f4-demo \


### PR DESCRIPTION
### Contribution description

This adds support for the Sodaq SFF board.

The following features were tested (briefly):
* UART (the first, and the second connected to the UBlox SARA)
* xtimer
* I2C (using driver BMX280 and SHT2x)
* ADC
* WDT
* RGB-LEDs

SPI isn't tested, but it should be working.
