### PR TITLE
makefiles/tools/jlink.inc.mk: DEBUG_ADAPTER_ID as JLINK_SERIAL

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -658,7 +658,7 @@ term: $(TERMDEPS)
 	$(TERMPROG) $(TERMFLAGS)
 
 # Term without the pyterm added logging
-# TERMFLAGS must be exported for `jlink.sh term_rtt`.
+# PYTERMFLAGS must be exported for `jlink.sh term-rtt`.
 cleanterm: export PYTERMFLAGS += --noprefix --no-repeat-command-on-empty-line
 cleanterm: $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)

--- a/boards/hamilton/Makefile.include
+++ b/boards/hamilton/Makefile.include
@@ -5,7 +5,7 @@ OFLAGS := --gap-fill 0xff
 
 # Configure terminal, hamilton doesn't provide any UART, thus use RTT
 TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term_rtt
+TERMFLAGS = term-rtt
 
 USEMODULE += stdio_rtt
 

--- a/boards/ruuvitag/Makefile.include
+++ b/boards/ruuvitag/Makefile.include
@@ -1,7 +1,7 @@
 # for this board, we are using Segger's RTT as default terminal interface
 USEMODULE += stdio_rtt
 TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term_rtt
+TERMFLAGS = term-rtt
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -1,7 +1,7 @@
 # for this board, we are using Segger's RTT as default terminal interface
 USEMODULE += stdio_rtt
 TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term_rtt
+TERMFLAGS = term-rtt
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -50,6 +50,9 @@
 # reset:        triggers a hardware reset of the target board
 #
 #
+# term-rtt:     opens a serial terminal using jlink RTT(reak time transfer)
+#
+#
 # @author       Hauke Peteresen <hauke.petersen@fu-berlin.de>
 
 # Set IMAGE_OFFSET to zero by default.
@@ -286,12 +289,12 @@ case "${ACTION}" in
     echo "### Resetting Target ###"
     do_reset "$@"
     ;;
-  term_rtt)
+  term-rtt)
     echo "### Starting RTT terminal ###"
     do_term
     ;;
   *)
-    echo "Usage: $0 {flash|debug|debug-server|reset}"
+    echo "Usage: $0 {flash|debug|debug-server|reset|term-rtt}"
     echo "          flash <binfile>"
     echo "          debug <elffile>"
     ;;

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -9,3 +9,9 @@ FFLAGS ?= flash $(FLASHFILE)
 DEBUGGER_FLAGS ?= debug $(ELFFILE)
 DEBUGSERVER_FLAGS ?= debug-server
 RESET_FLAGS ?= reset
+
+JLINK_SERIAL ?= $(DEBUG_ADAPTER_ID)
+
+# Export JLINK_SERIAL to required targets
+JLINK_TARGETS = debug% flash% reset term-rtt
+$(call target-export-variables,$(JLINK_TARGETS),JLINK_SERIAL)


### PR DESCRIPTION
### Contribution description

This PR uses DEBUG_ADAPTER_ID as the default value for JLINK_SERIAL. This way all
programmers use the same variable.

It also cleans-up the documentation for `jlink.sh`:

- change `term_rtt` to `term-rtt` (common target namestyle)
- adds missing `term-rtt` documentation

### Testing procedure

- Variable is correctly set.

```
JLINK_SERIAL=riot DEBUG_ADAPTER_ID=toto BOARD=nrf52dk make -C examples/hello-world/ info-debug-variable-JLINK_SERIAL
riot
```
```
DEBUG_ADAPTER_ID=toto BOARD=nrf52dk make -C examples/hello-world/ info-debug-variable-JLINK_SERIAL
toto
```

- can reset the right `BOARD`, this fails in master:

I have 3 jlink devices connected  `nrf52dk`, `nrf52840dk`, `slstk3402a`
```
PORT=/dev/ttyACM2 ~/workspace/RIOT/dist/tools/usb-serial/list-ttys.sh 
/sys/bus/usb/devices/4-1.5.7: SEGGER J-Link, serial: '000682770831', tty(s): ttyACM2
/sys/bus/usb/devices/4-1.5.3: SEGGER J-Link, serial: '000683890121', tty(s): ttyACM0
/sys/bus/usb/devices/4-1.5.4: Silicon Labs J-Link OB, serial: '000440113873', tty(s): ttyACM3
```

<details><summary>BOARD=slstk3402a make -C examples/hello-world/ reset</summary>

```
/home/francisco/workspace/RIOT/dist/tools/jlink/jlink.sh reset
### Resetting Target ###
SEGGER J-Link Commander V6.54c (Compiled Nov  7 2019 17:05:53)
DLL version V6.54c, compiled Nov  7 2019 17:05:41

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: Silicon Labs J-Link OB compiled Feb  1 2017 16:00:37
Hardware version: V1.00
S/N: 440113873
License(s): RDI
VTref=3.277V
Target connection not established yet but required for command.
Device "EFM32PG12BXXXF1024" selected.


Connecting to target via SWD
InitTarget() start
InitTarget() end
Found SW-DP with ID 0x2BA01477
Scanning AP map to find all available APs
AP[1]: Stopped AP scan as end of AP map has been reached
AP[0]: AHB-AP (IDR: 0x24770011)
Iterating through AP map to find AHB-AP to use
AP[0]: Core found
AP[0]: AHB-AP ROM base: 0xE00FF000
CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
Found Cortex-M4 r0p1, Little endian.
FPUnit: 6 code (BP) slots and 2 literal slots
CoreSight components:
ROMTbl[0] @ E00FF000
ROMTbl[0][0]: E000E000, CID: B105E00D, PID: 000BB00C SCS-M7
ROMTbl[0][1]: E0001000, CID: B105E00D, PID: 003BB002 DWT
ROMTbl[0][2]: E0002000, CID: B105E00D, PID: 002BB003 FPB
ROMTbl[0][3]: E0000000, CID: B105E00D, PID: 003BB001 ITM
ROMTbl[0][4]: E0040000, CID: B105900D, PID: 003BB923 TPIU-Lite
ROMTbl[0][5]: E0041000, CID: B105900D, PID: 000BB925 ETM
Cortex-M4 identified.
Reset delay: 0 ms
Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
Reset: Halt core after reset via DEMCR.VC_CORERESET.
Reset: Reset device via AIRCR.SYSRESETREQ.



Script processing completed.

make: Leaving directory '/home/francisco/workspace/RIOT/examples/hello-world'
```
</details>

<details><summary>BOARD=nrf52840dk make -C examples/hello-world/ reset</summary>

```
/home/francisco/workspace/RIOT/dist/tools/jlink/jlink.sh reset
### Resetting Target ###
SEGGER J-Link Commander V6.54c (Compiled Nov  7 2019 17:05:53)
DLL version V6.54c, compiled Nov  7 2019 17:05:41

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-SAM3U128-V2-NordicSemi compiled Jan  7 2019 14:07:15
Hardware version: V1.00
S/N: 683890121
VTref=3.300V
Target connection not established yet but required for command.
Device "NRF52" selected.


Connecting to target via SWD
InitTarget() start
InitTarget() end
Found SW-DP with ID 0x2BA01477
Scanning AP map to find all available APs
AP[2]: Stopped AP scan as end of AP map has been reached
AP[0]: AHB-AP (IDR: 0x24770011)
AP[1]: JTAG-AP (IDR: 0x02880000)
Iterating through AP map to find AHB-AP to use
AP[0]: Core found
AP[0]: AHB-AP ROM base: 0xE00FF000
CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
Found Cortex-M4 r0p1, Little endian.
FPUnit: 6 code (BP) slots and 2 literal slots
CoreSight components:
ROMTbl[0] @ E00FF000
ROMTbl[0][0]: E000E000, CID: B105E00D, PID: 000BB00C SCS-M7
ROMTbl[0][1]: E0001000, CID: B105E00D, PID: 003BB002 DWT
ROMTbl[0][2]: E0002000, CID: B105E00D, PID: 002BB003 FPB
ROMTbl[0][3]: E0000000, CID: B105E00D, PID: 003BB001 ITM
ROMTbl[0][4]: E0040000, CID: B105900D, PID: 000BB9A1 TPIU
ROMTbl[0][5]: E0041000, CID: B105900D, PID: 000BB925 ETM
Cortex-M4 identified.
Reset delay: 0 ms
Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
Reset: Halt core after reset via DEMCR.VC_CORERESET.
Reset: Reset device via AIRCR.SYSRESETREQ.



Script processing completed.

make: Leaving directory '/home/francisco/workspace/RIOT/examples/hello-world'

```
</details>

<details><summary>BOARD=nrf52dk make -C examples/hello-world/ reset</summary>

```
/home/francisco/workspace/RIOT/dist/tools/jlink/jlink.sh reset
### Resetting Target ###
SEGGER J-Link Commander V6.54c (Compiled Nov  7 2019 17:05:53)
DLL version V6.54c, compiled Nov  7 2019 17:05:41

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-SAM3U128-V2-NordicSemi compiled Jan  7 2019 14:07:15
Hardware version: V1.00
S/N: 682770831
VTref=3.300V
Target connection not established yet but required for command.
Device "NRF52" selected.


Connecting to target via SWD
InitTarget() start
InitTarget() end
Found SW-DP with ID 0x2BA01477
Scanning AP map to find all available APs
AP[2]: Stopped AP scan as end of AP map has been reached
AP[0]: AHB-AP (IDR: 0x24770011)
AP[1]: JTAG-AP (IDR: 0x02880000)
Iterating through AP map to find AHB-AP to use
AP[0]: Core found
AP[0]: AHB-AP ROM base: 0xE00FF000
CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
Found Cortex-M4 r0p1, Little endian.
FPUnit: 6 code (BP) slots and 2 literal slots
CoreSight components:
ROMTbl[0] @ E00FF000
ROMTbl[0][0]: E000E000, CID: B105E00D, PID: 000BB00C SCS-M7
ROMTbl[0][1]: E0001000, CID: B105E00D, PID: 003BB002 DWT
ROMTbl[0][2]: E0002000, CID: B105E00D, PID: 002BB003 FPB
ROMTbl[0][3]: E0000000, CID: B105E00D, PID: 003BB001 ITM
ROMTbl[0][4]: E0040000, CID: B105900D, PID: 000BB9A1 TPIU
ROMTbl[0][5]: E0041000, CID: B105900D, PID: 000BB925 ETM
Cortex-M4 identified.
Reset delay: 0 ms
Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
Reset: Halt core after reset via DEMCR.VC_CORERESET.
Reset: Reset device via AIRCR.SYSRESETREQ.



Script processing completed.

make: Leaving directory '/home/francisco/workspace/RIOT/examples/hello-world'

```
</details>
- fixed doc:

```
./dist/tools/jlink/jlink.sh help
Usage: ./dist/tools/jlink/jlink.sh {flash|debug|debug-server|reset|term-rtt}
          flash <binfile>
          debug <elffile>
```