### PR TITLE
doc: Fix cpu specific enum in doxygen

### DIFF
--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -67,6 +67,7 @@ typedef unsigned int gpio_t;
  */
 #define GPIO_PIN_NUMOF  (17)
 
+#ifndef DOXYGEN
 /**
  * @brief   Override flank selection values
  * @{
@@ -81,6 +82,7 @@ typedef enum {
     GPIO_HIGH    = 5         /**< emit interrupt on low level     */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 /** @} */
 
 /**

--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -131,7 +131,7 @@ typedef enum {
  *
  * @{
  */
-
+#ifndef DOXYGEN
 /**
  * @brief    Override I2C clock speed values
  *
@@ -147,7 +147,7 @@ typedef enum {
     I2C_SPEED_HIGH,         /**< not supported */
 } i2c_speed_t;
 /** @} */
-
+#endif /* ndef DOXYGEN */
 /**
  * @brief   I2C configuration structure type
  */

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -69,6 +69,7 @@ extern "C" {
  */
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 
+#ifndef DOXYGEN
 /**
  * @brief   Use a custom clock speed type
  */
@@ -88,7 +89,7 @@ typedef enum {
     SPI_CLK_10MHZ  = (10000000U)
 } spi_clk_t;
 /** @} */
-
+#endif /* ndef DOXYGEN */
 #endif /* MODULE_PERIPH_SPI | DOXYGEN */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

Exclude overridden typedefs as otherwise they appear multiple times in the generated documentation.

This series fixes documentation for GPIO, I2C and SPI drivers.

### Testing procedure

`make doc` read the periph driver enums for GPIO, I2C, and SPI


### Issues/PRs references

Related to #10964