### PR TITLE
Makefile.dep: make `stdio_uart` a feature required by `ethos`

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -404,7 +404,7 @@ ifneq (,$(filter newlib,$(USEMODULE)))
     USEMODULE += newlib_syscalls_default
   endif
   ifeq (,$(filter stdio_rtt stdio_cdc_acm,$(USEMODULE)))
-    USEMODULE += stdio_uart
+    FEATURES_PROVIDED += stdio_uart
   endif
 endif
 
@@ -432,7 +432,7 @@ endif
 ifneq (,$(filter stdio_ethos,$(USEMODULE)))
   USEMODULE += ethos
   USEMODULE += stdin
-  USEMODULE += stdio_uart
+  FEATURES_REQUIRED += stdio_uart
 endif
 
 ifneq (,$(filter stdin,$(USEMODULE)))
@@ -443,7 +443,7 @@ endif
 
 ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
   USEMODULE += isrpipe
-  USEMODULE += stdio_uart
+  FEATURES_PROVIDED += stdio_uart
 endif
 
 ifneq (,$(filter stdio_uart,$(USEMODULE)))

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -7,9 +7,6 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-# The following boards do not have an available UART
-BOARD_BLACKLIST += pic32-wifire pic32-clicker ruuvitag thingy52
-
 # use ethos (ethernet over serial) for network communication and stdio over
 # UART, but not on native, as native has a tap interface towards the host.
 ifeq (,$(filter native,$(BOARD)))

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -2,9 +2,6 @@ DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common
 
-# chronos, hamilton and ruuvitag boards don't support ethos
-BOARD_BLACKLIST := chronos hamilton ruuvitag
-
 export TAP ?= tap0
 
 # use Ethernet as link-layer protocol

--- a/tests/gnrc_ipv6_ext_frag/Makefile
+++ b/tests/gnrc_ipv6_ext_frag/Makefile
@@ -2,9 +2,6 @@ DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common
 
-# chronos, hamilton, ruuvitag, and thingy52 boards don't support ethos
-BOARD_BLACKLIST := chronos hamilton ruuvitag thingy52
-
 export TAP ?= tap0
 
 CFLAGS += -DOUTPUT=TEXT

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -2,9 +2,6 @@ DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common
 
-# chronos, hamilton and ruuvitag boards don't support ethos
-BOARD_BLACKLIST := chronos hamilton ruuvitag
-
 export TAP ?= tap0
 
 CFLAGS += -DOUTPUT=TEXT

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -2,9 +2,6 @@ include ../Makefile.tests_common
 
 RIOTBASE ?= $(CURDIR)/../..
 
-# chronos, hamilton and ruuvitag boards don't support ethos
-BOARD_BLACKLIST := chronos hamilton ruuvitag
-
 export TAP ?= tap0
 
 USEMODULE += sock_dns

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -8,9 +8,6 @@ TAP ?= tap0
 MSL_US ?= 1000000
 TIMEOUT_US ?= 3000000
 
-# unsupported by ethos: chronos, hamilton, ruuvitag
-BOARD_BLACKLIST := chronos hamilton ruuvitag thingy52
-
 # This test depends on tap device setup (only allowed by root)
 # Suppress test execution to avoid CI errors
 TEST_ON_CI_BLACKLIST += all


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
An alternative proposal to https://github.com/RIOT-OS/RIOT/pull/12724. Without touching any boards, with `stdio_uart` being the deciding factor if the application builds or not.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Take any of the applications changed in this PR and try to build them for one of the boards previously blacklisted. It still fails:

```
$ BOARD=ruuvitag make -C tests/gnrc_ipv6_ext
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/gnrc_ipv6_ext'
There are unsatisfied feature requirements: stdio_uart
/home/mlenders/Repositories/RIOT-OS/RIOT/tests/gnrc_ipv6_ext/../../Makefile.include:811: *** You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line.  Stop.
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/gnrc_ipv6_ext'
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to https://github.com/RIOT-OS/RIOT/pull/12724
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
