### PR TITLE
sys/stdio: add stdio_none

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -403,7 +403,7 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   ifeq (,$(filter newlib_syscalls_%,$(USEMODULE)))
     USEMODULE += newlib_syscalls_default
   endif
-  ifeq (,$(filter stdio_rtt stdio_cdc_acm,$(USEMODULE)))
+  ifeq (,$(filter stdio_rtt stdio_cdc_acm stdio_none,$(USEMODULE)))
     USEMODULE += stdio_uart
   endif
 endif

--- a/sys/stdio_none/Makefile
+++ b/sys/stdio_none/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/stdio_none/stdio_none.c
+++ b/sys/stdio_none/stdio_none.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       Dummy STDIO implementation that does nothing to preserve energy
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "stdio_base.h"
+
+void stdio_init(void)
+{
+    /* do nothing */
+}
+
+ssize_t stdio_read(void* buffer, size_t count)
+{
+    (void)buffer;
+    (void)count;
+    return 0;
+}
+
+ssize_t stdio_write(const void* buffer, size_t len)
+{
+    (void)buffer;
+    return (ssize_t)len;
+}


### PR DESCRIPTION
### Contribution description
Right now, almost every platform is build using either `stdio_uart` or `stdio_rtt` as backend for outputting STDIO, even applications like `tests/minimal` that don't even use any STDIO. As this might be ok for code size reasons, this behavior is quite bad in terms of power consumption. In the case of `stdio_uart`, the configured UART device is always initialized and activated and thereby consuming significant power - if when not used... 

This PR provides a very simple way for disabling the STDIO in/output by simply doing nothing on calls to `stdio_init/read/write()`, and hence it will prevent the system from initialization unused/unwanted hardware peripherals ans such.

Caveat: all platforms that manually specify a `stdio_x` module at the moment will not compile if `USEMODULE += stdio_none` is specified manually, as those preconfigured modules will collide with `stdio_none`. I haven't figured out a good way to handle that, yet.

### Testing procedure
Compile any application (e.g. `hello-world`) for any board that is using `stdio_uart` as default. Using `make info-modules` you can verify, that with `stdio_none` no uart dependencies will be pulled.

### Issues/PRs references
none