### PR TITLE
[POC]: netif rework

### DIFF
--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -194,6 +194,31 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *va
  */
 int netdev_ieee802154_dst_filter(netdev_ieee802154_t *dev, const uint8_t *mhr);
 
+typedef struct {
+    uint8_t *psdu;
+    size_t psdu_len;
+    uint8_t lqi;
+    int16_t rssi;
+    void *ctx;
+} ieee802154_phy_ind_t;
+
+typedef struct {
+    iolist_t msdu;
+    uint8_t *src;
+    size_t src_len;
+    uint8_t *dst;
+    size_t dst_len;
+    uint8_t frame_pending;
+} ieee802154_mac_ind_t;
+
+void ieee802154_rf_rx_done(netdev_t *netdev);
+void ieee802154_mac_recv(netdev_ieee802154_t *dev, ieee802154_phy_ind_t *ind);
+void ieee802154_mac_ind(netdev_ieee802154_t *netdev, ieee802154_mac_ind_t *ind, ieee802154_phy_ind_t *phy_ind);
+void ieee802154_phy_ind(netdev_t *netdev, ieee802154_phy_ind_t *ind);
+int ieee802154_mac_send(netdev_ieee802154_t *netdev, iolist_t *msdu, int frame_pending,
+        uint8_t *src, size_t src_len, uint8_t *dst, size_t dst_len);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/netbuf.h
+++ b/sys/include/net/netbuf.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Allocate a network buffer with a given size.
+ * @brief   Get a network buffer with a given size.
  *
  * @note    Supposed to be implemented by the networking module.
  * @note    @p ctx must be NOT NULL if the function returns a valid pointer.
@@ -40,9 +40,9 @@ extern "C" {
  *
  * @return          pointer to the buffer.
  * @return          packet context in @p ctx.
- * @return          NULL if there's not enough memory for allocation.
+ * @return          NULL on failure (e.g there's not enough memory for allocation)
  */
-void *netbuf_alloc(size_t size, void **ctx);
+void *netbuf_get(size_t size, void **ctx);
 
 /**
  * @brief Free the resources of a network buffer

--- a/sys/include/net/netbuf.h
+++ b/sys/include/net/netbuf.h
@@ -28,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Netbuf descriptor
- */
-typedef void netbuf_ctx_t;
-
-/**
  * @brief   Allocate a network buffer with a given size.
  *
  * @note    Supposed to be implemented by the networking module.
@@ -47,16 +42,16 @@ typedef void netbuf_ctx_t;
  * @return          packet context in @p ctx.
  * @return          NULL if there's not enough memory for allocation.
  */
-void *netbuf_alloc(size_t size, netbuf_ctx_t **ctx);
+void *netbuf_alloc(size_t size, void **ctx);
 
 /**
  * @brief Free the resources of a network buffer
  *
  * @note    Supposed to be implemented by the networking module.
  *
- * @param[in]       netbuf  pointer to the netbuf descriptor.
+ * @param[in]       ctx  pointer to the allocation context.
  */
-void netbuf_free(netbuf_ctx_t *ctx);
+void netbuf_free(void *ctx);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/netbuf.h
+++ b/sys/include/net/netbuf.h
@@ -31,9 +31,6 @@ extern "C" {
  * @brief   Get a network buffer with a given size.
  *
  * @note    Supposed to be implemented by the networking module.
- * @note    @p ctx must be NOT NULL if the function returns a valid pointer.
- *          If this function returns NULL, the value of @p ctx
- *          is undefined.
  *
  * @param[in]       size    size of the buffer to be allocated.
  * @param[out]      ctx     allocation context.

--- a/sys/include/net/netbuf.h
+++ b/sys/include/net/netbuf.h
@@ -21,6 +21,7 @@
 #define NET_NETBUF_H
 
 #include <stdbool.h>
+#include "iolist.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,7 +30,7 @@ extern "C" {
 /**
  * @brief Netbuf descriptor
  */
-typedef void netbuf_t;
+typedef void netbuf_ctx_t;
 
 /**
  * @brief   Allocate a network buffer with a given size.
@@ -41,22 +42,7 @@ typedef void netbuf_t;
  * @return          pointer to the netbuf with the allocated buffer.
  * @return          NULL if there's not enough memory for allocation.
  */
-netbuf_t *netbuf_alloc(size_t size);
-
-/**
- * @brief   Get the @ref iolist_t representation of the network buffer.
- *
- * @pre     @p netbuf not NULL.
- * @pre     @p iol not NULL.
- *
- * @note    Supposed to be implemented by the networking module.
- *
- * @param[in]       netbuf  pointer to the netbuf.
- * @param[out]      iol     iolist representation of the netbuf.
- *
- * @return          @ref iolist_t representation on @p iol.
- */
-void netbuf_get_iolist(netbuf_t *netbuf, iolist_t *iol);
+netbuf_ctx_t *netbuf_alloc(size_t size, void **buf);
 
 /**
  * @brief Free the resources of a network buffer
@@ -65,7 +51,7 @@ void netbuf_get_iolist(netbuf_t *netbuf, iolist_t *iol);
  *
  * @param[in]       netbuf  pointer to the netbuf descriptor.
  */
-void netbuf_free(netbuf_t *netbuf);
+void netbuf_free(netbuf_ctx_t *ctx);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/netbuf.h
+++ b/sys/include/net/netbuf.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_netbuf Network buffer abstraction
+ * @ingroup     net
+ * @brief       Provides an abstraction for network stack buffers
+ * @{
+ *
+ * @file
+ * @brief       Network buffer abstraction definition
+ *
+ * @author  Jose I. Alamos <jose.alamos@haw-hamburg.de>
+ */
+#ifndef NET_NETBUF_H
+#define NET_NETBUF_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Netbuf descriptor
+ */
+typedef void netbuf_t;
+
+/**
+ * @brief   Allocate a network buffer with a given size.
+ *
+ * @note    Supposed to be implemented by the networking module.
+ *
+ * @param[in]       size    size of the buffer to be allocated.
+ *
+ * @return          pointer to the netbuf with the allocated buffer.
+ * @return          NULL if there's not enough memory for allocation.
+ */
+netbuf_t *netbuf_alloc(size_t size);
+
+/**
+ * @brief   Get the @ref iolist_t representation of the network buffer.
+ *
+ * @pre     @p netbuf not NULL.
+ * @pre     @p iol not NULL.
+ *
+ * @note    Supposed to be implemented by the networking module.
+ *
+ * @param[in]       netbuf  pointer to the netbuf.
+ * @param[out]      iol     iolist representation of the netbuf.
+ *
+ * @return          @ref iolist_t representation on @p iol.
+ */
+void netbuf_get_iolist(netbuf_t *netbuf, iolist_t *iol);
+
+/**
+ * @brief Free the resources of a network buffer
+ *
+ * @note    Supposed to be implemented by the networking module.
+ *
+ * @param[in]       netbuf  pointer to the netbuf descriptor.
+ */
+void netbuf_free(netbuf_t *netbuf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_NETBUF_H */
+/** @} */

--- a/sys/include/net/netbuf.h
+++ b/sys/include/net/netbuf.h
@@ -36,13 +36,18 @@ typedef void netbuf_ctx_t;
  * @brief   Allocate a network buffer with a given size.
  *
  * @note    Supposed to be implemented by the networking module.
+ * @note    @p ctx must be NOT NULL if the function returns a valid pointer.
+ *          If this function returns NULL, the value of @p ctx
+ *          is undefined.
  *
  * @param[in]       size    size of the buffer to be allocated.
+ * @param[out]      ctx     allocation context.
  *
- * @return          pointer to the netbuf with the allocated buffer.
+ * @return          pointer to the buffer.
+ * @return          packet context in @p ctx.
  * @return          NULL if there's not enough memory for allocation.
  */
-netbuf_ctx_t *netbuf_alloc(size_t size, void **buf);
+void *netbuf_alloc(size_t size, netbuf_ctx_t **ctx);
 
 /**
  * @brief Free the resources of a network buffer

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -37,6 +37,7 @@
 
 #include "list.h"
 #include "net/netopt.h"
+#include "net/netbuf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,6 +58,21 @@ extern "C" {
 typedef struct {
     list_node_t node;  /**< Pointer to the next interface */
 } netif_t;
+
+typedef struct {
+    iolist_t msdu;
+    netbuf_ctx_t *ctx;
+    uint8_t *src_l2addr;
+    uint8_t *dst_l2addr;
+    int16_t rssi;
+    uint8_t lqi;
+    uint8_t src_l2addr_len;
+    uint8_t dst_l2addr_len;
+    uint8_t flags;
+} netif_pkt_t;
+
+
+int netif_recv(netif_t *netif, netif_pkt_t *pkt);
 
 /**
  * @brief   Iterator for the interfaces

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -61,7 +61,7 @@ typedef struct {
 
 typedef struct {
     iolist_t msdu;
-    netbuf_ctx_t *ctx;
+    void *ctx;
     uint8_t *src_l2addr;
     uint8_t *dst_l2addr;
     int16_t rssi;

--- a/sys/net/gnrc/netif/_netif.c
+++ b/sys/net/gnrc/netif/_netif.c
@@ -18,10 +18,50 @@
 #include <string.h>
 
 #include "fmt.h"
+#include "net/gnrc.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netif/internal.h"
 
 #include "net/netif.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+int netif_recv(netif_t *netif, netif_pkt_t *pkt)
+{
+    gnrc_pktsnip_t *gnrc_pkt = pkt->ctx;
+    gnrc_netif_t *gnrc_netif = (gnrc_netif_t*) netif;
+    netdev_t *dev = gnrc_netif->dev;
+
+    gnrc_pktsnip_t *netif_snip = gnrc_netif_hdr_build(pkt->src_l2addr, pkt->src_l2addr_len, pkt->dst_l2addr, pkt->dst_l2addr_len);
+
+    if (netif_snip == NULL) {
+        DEBUG("_recv_ieee802154: no space left in packet buffer\n");
+        gnrc_pktbuf_release(gnrc_pkt);
+        return 0;
+    }
+
+    gnrc_pktsnip_t *ieee802154_hdr = gnrc_pktbuf_mark(gnrc_pkt, ((uint8_t*) pkt->msdu.iol_base) - ((uint8_t*) gnrc_pkt->data), GNRC_NETTYPE_UNDEF);
+
+    gnrc_pktbuf_remove_snip(gnrc_pkt, ieee802154_hdr);
+    gnrc_pktbuf_realloc_data(gnrc_pkt, pkt->msdu.iol_len);
+    gnrc_netif_hdr_t *hdr = netif_snip->data;
+    hdr->lqi = pkt->lqi;
+    hdr->rssi = pkt->rssi;
+    gnrc_netif_hdr_set_netif(hdr, (gnrc_netif_t*) netif);
+    dev->driver->get(dev, NETOPT_PROTO, &gnrc_pkt->type, sizeof(gnrc_pkt->type));
+
+    hdr->flags |= pkt->flags;
+
+    LL_APPEND(gnrc_pkt, netif_snip);
+
+    if (!gnrc_netapi_dispatch_receive(gnrc_pkt->type, GNRC_NETREG_DEMUX_CTX_ALL, gnrc_pkt))
+    {
+        return 0;
+    }
+
+    return 1;
+}
 
 int netif_get_name(netif_t *iface, char *name)
 {

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -47,6 +47,7 @@ static void _configure_netdev(netdev_t *dev);
 static void *_gnrc_netif_thread(void *args);
 static void _event_cb(netdev_t *dev, netdev_event_t event);
 
+/* GNRC implementation of the netbuf_allocate function */
 netbuf_ctx_t *netbuf_alloc(size_t size, void **buf)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, size, GNRC_NETTYPE_UNDEF);
@@ -58,6 +59,7 @@ netbuf_ctx_t *netbuf_alloc(size_t size, void **buf)
     return pkt;
 }
 
+/* GNRC implementation of the netbuf_free function */
 void netbuf_free(netbuf_ctx_t *netbuf)
 {
     gnrc_pktbuf_release(netbuf);

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -47,8 +47,8 @@ static void _configure_netdev(netdev_t *dev);
 static void *_gnrc_netif_thread(void *args);
 static void _event_cb(netdev_t *dev, netdev_event_t event);
 
-/* GNRC implementation of the netbuf_allocate function */
-void *netbuf_alloc(size_t size, void **ctx)
+/* GNRC implementation of the netbuf_get function */
+void *netbuf_get(size_t size, void **ctx)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, size, GNRC_NETTYPE_UNDEF);
 

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -48,7 +48,7 @@ static void *_gnrc_netif_thread(void *args);
 static void _event_cb(netdev_t *dev, netdev_event_t event);
 
 /* GNRC implementation of the netbuf_allocate function */
-void *netbuf_alloc(size_t size, netbuf_ctx_t **ctx)
+void *netbuf_alloc(size_t size, void **ctx)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, size, GNRC_NETTYPE_UNDEF);
 
@@ -61,7 +61,7 @@ void *netbuf_alloc(size_t size, netbuf_ctx_t **ctx)
 }
 
 /* GNRC implementation of the netbuf_free function */
-void netbuf_free(netbuf_ctx_t *netbuf)
+void netbuf_free(void *netbuf)
 {
     gnrc_pktbuf_release(netbuf);
 }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -48,15 +48,16 @@ static void *_gnrc_netif_thread(void *args);
 static void _event_cb(netdev_t *dev, netdev_event_t event);
 
 /* GNRC implementation of the netbuf_allocate function */
-netbuf_ctx_t *netbuf_alloc(size_t size, void **buf)
+void *netbuf_alloc(size_t size, netbuf_ctx_t **ctx)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, size, GNRC_NETTYPE_UNDEF);
 
     if(pkt) {
-        *buf = pkt->data;
+        *ctx = pkt;
+        return pkt->data;
     }
 
-    return pkt;
+    return NULL;
 }
 
 /* GNRC implementation of the netbuf_free function */

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -17,6 +17,8 @@
 #include "net/gnrc/netif/ieee802154.h"
 #include "net/netdev/ieee802154.h"
 
+#include "net/netbuf.h"
+
 #ifdef MODULE_GNRC_IPV6
 #include "net/ipv6/hdr.h"
 #endif
@@ -28,12 +30,11 @@
 #include "od.h"
 #endif
 
-static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
 static const gnrc_netif_ops_t ieee802154_ops = {
     .init = gnrc_netif_default_init,
-    .send = _send,
+    .send = NULL, /* to be migrated to netif->ops */
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
@@ -47,235 +48,39 @@ gnrc_netif_t *gnrc_netif_ieee802154_create(char *stack, int stacksize,
                              &ieee802154_ops);
 }
 
-static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
-{
-    gnrc_netif_hdr_t *hdr;
-    gnrc_pktsnip_t *snip;
-    uint8_t src[IEEE802154_LONG_ADDRESS_LEN], dst[IEEE802154_LONG_ADDRESS_LEN];
-    int src_len, dst_len;
-    le_uint16_t _pan_tmp;   /* TODO: hand-up PAN IDs to GNRC? */
-
-    dst_len = ieee802154_get_dst(mhr, dst, &_pan_tmp);
-    src_len = ieee802154_get_src(mhr, src, &_pan_tmp);
-    if ((dst_len < 0) || (src_len < 0)) {
-        DEBUG("_make_netif_hdr: unable to get addresses\n");
-        return NULL;
-    }
-    /* allocate space for header */
-    snip = gnrc_netif_hdr_build(src, (size_t)src_len, dst, (size_t)dst_len);
-    if (snip == NULL) {
-        DEBUG("_make_netif_hdr: no space left in packet buffer\n");
-        return NULL;
-    }
-    hdr = snip->data;
-    /* set broadcast flag for broadcast destination */
-    if ((dst_len == 2) && (dst[0] == 0xff) && (dst[1] == 0xff)) {
-        hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
-    }
-    /* set flags for pending frames */
-    if (mhr[0] & IEEE802154_FCF_FRAME_PEND) {
-        hdr->flags |= GNRC_NETIF_HDR_FLAGS_MORE_DATA;
-    }
-    return snip;
-}
-
-#if MODULE_GNRC_NETIF_DEDUP
-static inline bool _already_received(gnrc_netif_t *netif,
-                                     gnrc_netif_hdr_t *netif_hdr,
-                                     uint8_t *mhr)
-{
-    const uint8_t seq = ieee802154_get_seq(mhr);
-
-    return  (netif->last_pkt.seq == seq) &&
-            (netif->last_pkt.src_len == netif_hdr->src_l2addr_len) &&
-            (memcmp(netif->last_pkt.src, gnrc_netif_hdr_get_src_addr(netif_hdr),
-                    netif_hdr->src_l2addr_len) == 0);
-}
-#endif /* MODULE_GNRC_NETIF_DEDUP */
-
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
-    netdev_ieee802154_rx_info_t rx_info;
-    gnrc_pktsnip_t *pkt = NULL;
-    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
-
-    if (bytes_expected >= (int)IEEE802154_MIN_FRAME_LEN) {
-        int nread;
-
-        pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected, GNRC_NETTYPE_UNDEF);
-        if (pkt == NULL) {
-            DEBUG("_recv_ieee802154: cannot allocate pktsnip.\n");
-            /* Discard packet on netdev device */
-            dev->driver->recv(dev, NULL, bytes_expected, NULL);
-            return NULL;
-        }
-        nread = dev->driver->recv(dev, pkt->data, bytes_expected, &rx_info);
-        if (nread <= 0) {
-            gnrc_pktbuf_release(pkt);
-            return NULL;
-        }
-#ifdef MODULE_NETSTATS_L2
-        netif->stats.rx_count++;
-        netif->stats.rx_bytes += nread;
-#endif
-
-        if (netif->flags & GNRC_NETIF_FLAGS_RAWMODE) {
-            /* Raw mode, skip packet processing, but provide rx_info via
-             * GNRC_NETTYPE_NETIF */
-            gnrc_pktsnip_t *netif_snip = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
-            if (netif_snip == NULL) {
-                DEBUG("_recv_ieee802154: no space left in packet buffer\n");
-                gnrc_pktbuf_release(pkt);
-                return NULL;
-            }
-            gnrc_netif_hdr_t *hdr = netif_snip->data;
-            hdr->lqi = rx_info.lqi;
-            hdr->rssi = rx_info.rssi;
-            gnrc_netif_hdr_set_netif(hdr, netif);
-            LL_APPEND(pkt, netif_snip);
-        }
-        else {
-            /* Normal mode, try to parse the frame according to IEEE 802.15.4 */
-            gnrc_pktsnip_t *ieee802154_hdr, *netif_hdr;
-            gnrc_netif_hdr_t *hdr;
-#if ENABLE_DEBUG
-            char src_str[GNRC_NETIF_HDR_L2ADDR_PRINT_LEN];
-#endif
-            size_t mhr_len = ieee802154_get_frame_hdr_len(pkt->data);
-
-            /* nread was checked for <= 0 before so we can safely cast it to
-             * unsigned */
-            if ((mhr_len == 0) || ((size_t)nread < mhr_len)) {
-                DEBUG("_recv_ieee802154: illegally formatted frame received\n");
-                gnrc_pktbuf_release(pkt);
-                return NULL;
-            }
-            nread -= mhr_len;
-            /* mark IEEE 802.15.4 header */
-            ieee802154_hdr = gnrc_pktbuf_mark(pkt, mhr_len, GNRC_NETTYPE_UNDEF);
-            if (ieee802154_hdr == NULL) {
-                DEBUG("_recv_ieee802154: no space left in packet buffer\n");
-                gnrc_pktbuf_release(pkt);
-                return NULL;
-            }
-            netif_hdr = _make_netif_hdr(ieee802154_hdr->data);
-            if (netif_hdr == NULL) {
-                DEBUG("_recv_ieee802154: no space left in packet buffer\n");
-                gnrc_pktbuf_release(pkt);
-                return NULL;
-            }
-
-            hdr = netif_hdr->data;
-
-#ifdef MODULE_L2FILTER
-            if (!l2filter_pass(dev->filter, gnrc_netif_hdr_get_src_addr(hdr),
-                               hdr->src_l2addr_len)) {
-                gnrc_pktbuf_release(pkt);
-                gnrc_pktbuf_release(netif_hdr);
-                DEBUG("_recv_ieee802154: packet dropped by l2filter\n");
-                return NULL;
-            }
-#endif
-#ifdef MODULE_GNRC_NETIF_DEDUP
-            if (_already_received(netif, hdr, ieee802154_hdr->data)) {
-                gnrc_pktbuf_release(pkt);
-                gnrc_pktbuf_release(netif_hdr);
-                DEBUG("_recv_ieee802154: packet dropped by deduplication\n");
-                return NULL;
-            }
-            memcpy(netif->last_pkt.src, gnrc_netif_hdr_get_src_addr(hdr),
-                   hdr->src_l2addr_len);
-            netif->last_pkt.src_len = hdr->src_l2addr_len;
-            netif->last_pkt.seq = ieee802154_get_seq(ieee802154_hdr->data);
-#endif /* MODULE_GNRC_NETIF_DEDUP */
-
-            hdr->lqi = rx_info.lqi;
-            hdr->rssi = rx_info.rssi;
-            gnrc_netif_hdr_set_netif(hdr, netif);
-            dev->driver->get(dev, NETOPT_PROTO, &pkt->type, sizeof(pkt->type));
-#if ENABLE_DEBUG
-            DEBUG("_recv_ieee802154: received packet from %s of length %u\n",
-                  gnrc_netif_addr_to_str(gnrc_netif_hdr_get_src_addr(hdr),
-                                         hdr->src_l2addr_len,
-                                         src_str),
-                  nread);
-#if defined(MODULE_OD)
-            od_hex_dump(pkt->data, nread, OD_WIDTH_DEFAULT);
-#endif
-#endif
-            gnrc_pktbuf_remove_snip(pkt, ieee802154_hdr);
-            LL_APPEND(pkt, netif_hdr);
-        }
-
-        DEBUG("_recv_ieee802154: reallocating.\n");
-        gnrc_pktbuf_realloc_data(pkt, nread);
-    } else if (bytes_expected > 0) {
-        DEBUG("_recv_ieee802154: received frame is too short\n");
-        dev->driver->recv(dev, NULL, bytes_expected, NULL);
-    }
-
-    return pkt;
+    ieee802154_rf_rx_done(netif->dev);
+    return NULL;
 }
 
-static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
+/* Implementation of netif_ieee802144 send function.
+ * This function sits on top of the IEEE802154 MAC layer.
+ * Nothe this functions is (mostly) GNRC agnostic! */
+void netif_ieee802154_send(netif_t *netif, netif_pkt_t *pkt)
 {
-    netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
-    gnrc_netif_hdr_t *netif_hdr;
-    const uint8_t *src, *dst = NULL;
-    int res = 0;
+    //const uint8_t *src, *dst = NULL;
+    uint8_t *src, *dst = NULL;
     size_t src_len, dst_len;
-    uint8_t mhr[IEEE802154_MAX_HDR_LEN];
-    uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
-    le_uint16_t dev_pan = byteorder_btols(byteorder_htons(state->pan));
 
-    flags |= IEEE802154_FCF_TYPE_DATA;
-    if (pkt == NULL) {
-        DEBUG("_send_ieee802154: pkt was NULL\n");
-        return -EINVAL;
-    }
-    if (pkt->type != GNRC_NETTYPE_NETIF) {
-        DEBUG("_send_ieee802154: first header is not generic netif header\n");
-        return -EBADMSG;
-    }
-    netif_hdr = pkt->data;
-    if (netif_hdr->flags & GNRC_NETIF_HDR_FLAGS_MORE_DATA) {
-        /* Set frame pending field */
-        flags |= IEEE802154_FCF_FRAME_PEND;
-    }
     /* prepare destination address */
-    if (netif_hdr->flags & /* If any of these flags is set assume broadcast */
+    if (pkt->flags & /* If any of these flags is set assume broadcast */
         (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-        dst = ieee802154_addr_bcast;
+        dst = (uint8_t*) ieee802154_addr_bcast;
         dst_len = IEEE802154_ADDR_BCAST_LEN;
     }
     else {
-        dst = gnrc_netif_hdr_get_dst_addr(netif_hdr);
-        dst_len = netif_hdr->dst_l2addr_len;
+        dst = pkt->dst_l2addr;
+        dst_len = pkt->dst_l2addr_len;
     }
-    src_len = netif_hdr->src_l2addr_len;
+    src_len = pkt->src_l2addr_len;
     if (src_len > 0) {
-        src = gnrc_netif_hdr_get_src_addr(netif_hdr);
+        src = pkt->src_l2addr;
     }
     else {
-        src_len = netif->l2addr_len;
-        src = netif->l2addr;
+        src_len = ((gnrc_netif_t*) netif)->l2addr_len;
+        src = ((gnrc_netif_t*) netif)->l2addr;
     }
-    /* fill MAC header, seq should be set by device */
-    if ((res = ieee802154_set_frame_hdr(mhr, src, src_len,
-                                        dst, dst_len, dev_pan,
-                                        dev_pan, flags, state->seq++)) == 0) {
-        DEBUG("_send_ieee802154: Error preperaring frame\n");
-        return -EINVAL;
-    }
-
-    /* prepare iolist for netdev / mac layer */
-    iolist_t iolist = {
-        .iol_next = (iolist_t *)pkt->next,
-        .iol_base = mhr,
-        .iol_len = (size_t)res
-    };
 
 #ifdef MODULE_NETSTATS_L2
     if (netif_hdr->flags &
@@ -286,19 +91,49 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         netif->stats.tx_unicast_count++;
     }
 #endif
-#ifdef MODULE_GNRC_MAC
-    if (netif->mac.mac_info & GNRC_NETIF_MAC_INFO_CSMA_ENABLED) {
-        res = csma_sender_csma_ca_send(dev, &iolist, &netif->mac.csma_conf);
-    }
-    else {
-        res = dev->driver->send(dev, &iolist);
-    }
-#else
-    res = dev->driver->send(dev, &iolist);
-#endif
+
+    
+    gnrc_netif_t *gnrc_netif = (gnrc_netif_t*) netif;
+    ieee802154_mac_send((netdev_ieee802154_t*) gnrc_netif->dev, &pkt->msdu, pkt->flags & GNRC_NETIF_HDR_FLAGS_MORE_DATA,
+            src, src_len, dst, dst_len);
 
     /* release old data */
-    gnrc_pktbuf_release(pkt);
-    return res;
+    netbuf_free(pkt->ctx);
+}
+
+void netif_send(netif_t *netif, netif_pkt_t *pkt)
+{
+    /* netif->ops->send(netif, pkt); */
+    netif_ieee802154_send(netif, pkt); /* We use this one, since there's no netif->ops yet :( */
+}
+
+int gnrc_netif_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
+{
+    /* ========== BEGIN GNRC_NETIF_GLUE_CODE ========== */
+    gnrc_netif_hdr_t *netif_hdr;
+    netif_pkt_t netif_pkt = {0};
+
+    if (pkt->type != GNRC_NETTYPE_NETIF) {
+        DEBUG("_send_ieee802154: first header is not generic netif header\n");
+        return -EBADMSG;
+    }
+    if (pkt == NULL) {
+        DEBUG("_send_ieee802154: pkt was NULL\n");
+        return -EINVAL;
+    }
+
+    netif_hdr = pkt->data;
+
+    netif_pkt.flags = netif_hdr->flags;
+    netif_pkt.src_l2addr = gnrc_netif_hdr_get_src_addr(netif_hdr);
+    netif_pkt.src_l2addr_len = netif_hdr->src_l2addr_len;
+    netif_pkt.dst_l2addr = gnrc_netif_hdr_get_dst_addr(netif_hdr);
+    netif_pkt.dst_l2addr_len = netif_hdr->dst_l2addr_len;
+    memcpy(&netif_pkt.msdu, pkt->next, sizeof(iolist_t));
+    netif_pkt.ctx = pkt;
+
+    netif_send((netif_t*) netif, &netif_pkt);
+    /* ========== END GNRC_NETIF_GLUE_CODE ========== */
+    return 0;
 }
 /** @} */

--- a/sys/net/link_layer/ieee802154/ieee802154.c
+++ b/sys/net/link_layer/ieee802154/ieee802154.c
@@ -17,7 +17,12 @@
 #include <errno.h>
 #include <string.h>
 
+#include "net/netbuf.h"
+
 #include "net/ieee802154.h"
+#include "net/netdev/ieee802154.h"
+
+#include "net/gnrc/netif.h"
 
 const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN] = IEEE802154_ADDR_BCAST;
 

--- a/sys/net/link_layer/ieee802154/ieee802154_mac.c
+++ b/sys/net/link_layer/ieee802154/ieee802154_mac.c
@@ -1,0 +1,158 @@
+#include "net/netdev/ieee802154.h"
+#include "net/netbuf.h"
+#include "net/netif.h"
+#include "net/gnrc/netif.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* Note all IEEE802.15.4 MAC layers will have this signature.
+ * There's probably no need for an interface here, unless there are co-existent
+ * IEEE802.15.4 MAC layers. */
+void ieee802154_mac_recv(netdev_ieee802154_t *dev, ieee802154_phy_ind_t *ind)
+{
+    ieee802154_mac_ind_t mac_ind;
+    if (ind->psdu_len < (int)IEEE802154_MIN_FRAME_LEN) {
+        DEBUG("_recv_ieee802154: received frame is too short\n");
+        netbuf_free(ind->ctx);
+        return;
+    }
+
+    /* Normal mode, try to parse the frame according to IEEE 802.15.4 */
+#if ENABLE_DEBUG
+    char src_str[GNRC_NETIF_HDR_L2ADDR_PRINT_LEN];
+#endif
+    uint8_t *mhr = ind->psdu;
+    size_t mhr_len = ieee802154_get_frame_hdr_len(mhr);
+
+    /* nread was checked for <= 0 before so we can safely cast it to
+     * unsigned */
+    if ((mhr_len == 0) || ((size_t)ind->psdu_len < mhr_len)) {
+        DEBUG("_recv_ieee802154: illegally formatted frame received\n");
+        netbuf_free(ind->ctx);
+        return;
+    }
+    /* mark IEEE 802.15.4 header */
+    mac_ind.msdu.iol_base = mhr + mhr_len;
+    mac_ind.msdu.iol_len = ind->psdu_len-mhr_len;
+
+    uint8_t src[IEEE802154_LONG_ADDRESS_LEN], dst[IEEE802154_LONG_ADDRESS_LEN];
+    int src_len, dst_len;
+    le_uint16_t _pan_tmp;   /* TODO: hand-up PAN IDs to GNRC? */
+
+    dst_len = ieee802154_get_dst(mhr, dst, &_pan_tmp);
+    src_len = ieee802154_get_src(mhr, src, &_pan_tmp);
+
+    if ((dst_len < 0) || (src_len < 0)) {
+        DEBUG("_make_netif_hdr: unable to get addresses\n");
+        netbuf_free(ind->ctx);
+        return;
+    }
+    mac_ind.src = src;
+    mac_ind.src_len = src_len;
+    mac_ind.dst = dst;
+    mac_ind.dst_len = dst_len;
+
+#ifdef MODULE_L2FILTER
+    if (!l2filter_pass(dev->filter, src,
+                       src_len)) {
+        netbuf_free(ind->ctx);
+        DEBUG("_recv_ieee802154: packet dropped by l2filter\n");
+        return NULL;
+    }
+#endif
+#ifdef MODULE_GNRC_NETIF_DEDUP
+    /* NOTE!!: This should be implemented by the IEEE802.15.4 layer! */
+    const uint8_t seq = ieee802154_get_seq(mhr);
+
+    int received = (netif->last_pkt.seq == seq) &&
+            (netif->last_pkt.src_len == src_len) &&
+            (memcmp(netif->last_pkt.src, src,
+            src_len) == 0);
+
+    if (received) {
+        netbuf_free(ind->ctx);
+        DEBUG("_recv_ieee802154: packet dropped by deduplication\n");
+        return NULL;
+    }
+
+    memcpy(netif->last_pkt.src, src,
+           src_len);
+    netif->last_pkt.src_len = src_len;
+    netif->last_pkt.seq = ieee802154_get_seq(mhr);
+#endif /* MODULE_GNRC_NETIF_DEDUP */
+    ieee802154_mac_ind(dev, &mac_ind, ind);
+}
+
+/* Interface here? */
+void ieee802154_phy_ind(netdev_t *netdev, ieee802154_phy_ind_t *ind)
+{
+#ifdef MODULE_NETSTATS_L2
+    netif->stats.rx_count++;
+    netif->stats.rx_bytes += nread;
+#endif
+
+    if (((gnrc_netif_t*) netdev->context)->flags & GNRC_NETIF_FLAGS_RAWMODE) {
+        /* Raw mode, skip packet processing, but provide rx_info via
+         * GNRC_NETTYPE_NETIF */
+        netif_pkt_t pkt = {0};
+        pkt.lqi = ind->lqi;
+        pkt.rssi = ind->rssi;
+        pkt.ctx = ind->ctx;
+        pkt.msdu.iol_base = ind->psdu;
+        pkt.msdu.iol_len = ind->psdu_len;
+        if(!netif_recv((netif_t*) netdev->context, &pkt)) {
+            netbuf_free(ind->ctx);
+        }
+    }
+    else {
+        ieee802154_mac_recv((netdev_ieee802154_t*) netdev, ind);
+    }
+}
+
+int ieee802154_mac_send(netdev_ieee802154_t *netdev, iolist_t *msdu, int frame_pending,
+        uint8_t *src, size_t src_len, uint8_t *dst, size_t dst_len)
+{
+    netdev_ieee802154_t *state = netdev;
+    netdev_t *dev = &netdev->netdev;
+
+    int res = 0;
+    uint8_t mhr[IEEE802154_MAX_HDR_LEN];
+    le_uint16_t dev_pan = byteorder_btols(byteorder_htons(state->pan));
+    uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
+
+    flags |= IEEE802154_FCF_TYPE_DATA;
+
+    if (frame_pending) {
+        /* Set frame pending field */
+        flags |= IEEE802154_FCF_FRAME_PEND;
+    }
+    /* fill MAC header, seq should be set by device */
+    if ((res = ieee802154_set_frame_hdr(mhr, src, src_len,
+                                        dst, dst_len, dev_pan,
+                                        dev_pan, flags, state->seq++)) == 0) {
+        DEBUG("_send_ieee802154: Error preperaring frame\n");
+        return -EINVAL;
+    }
+
+    /* prepare iolist for netdev / mac layer */
+    iolist_t iolist = {
+        .iol_next = msdu,
+        .iol_base = mhr,
+        .iol_len = (size_t)res
+    };
+
+#ifdef MODULE_GNRC_MAC
+    if (netif->mac.mac_info & GNRC_NETIF_MAC_INFO_CSMA_ENABLED) {
+        res = csma_sender_csma_ca_send(dev, &iolist, &netif->mac.csma_conf);
+    }
+    else {
+        res = dev->driver->send(dev, &iolist);
+    }
+#else
+    res = dev->driver->send(dev, &iolist);
+#endif
+
+    return res;
+}
+

--- a/sys/net/link_layer/ieee802154/ieee802154_netif.c
+++ b/sys/net/link_layer/ieee802154/ieee802154_netif.c
@@ -1,0 +1,48 @@
+#include "net/netdev.h"
+#include "net/netdev/ieee802154.h"
+#include "net/netif.h"
+#include "net/gnrc/netif.h"
+#include "net/gnrc/netif/hdr.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+void ieee802154_mac_ind(netdev_ieee802154_t *netdev, ieee802154_mac_ind_t *ind, ieee802154_phy_ind_t *phy_ind)
+{
+    netif_pkt_t pkt = {0};
+
+    /* set broadcast flag for broadcast destination */
+    if ((ind->dst_len == 2) && (ind->dst[0] == 0xff) && (ind->dst[1] == 0xff)) {
+        pkt.flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
+    }
+
+    /* set flags for pending frames */
+    if (ind->frame_pending & IEEE802154_FCF_FRAME_PEND) {
+        pkt.flags |= GNRC_NETIF_HDR_FLAGS_MORE_DATA;
+    }
+
+    pkt.lqi = phy_ind->lqi;
+    pkt.rssi = phy_ind->rssi;
+    pkt.ctx = phy_ind->ctx;
+    pkt.msdu = ind->msdu;
+    pkt.src_l2addr = ind->src;
+    pkt.src_l2addr_len = ind->src_len;
+    pkt.dst_l2addr = ind->dst;
+    pkt.dst_l2addr_len = ind->dst_len;
+
+#if ENABLE_DEBUG
+    DEBUG("_recv_ieee802154: received packet from %s of length %u\n",
+          gnrc_netif_addr_to_str(src,
+                                 src_len,
+                                 src_str),
+          pkt.msdu.iol_len);
+#if defined(MODULE_OD)
+    od_hex_dump(mhr, pkt.msdu.iol_len, OD_WIDTH_DEFAULT);
+#endif
+#endif
+
+    netif_t *netif = ((netdev_t*) netdev)->context;
+    if(!netif_recv(netif, &pkt)) {
+        netbuf_free(phy_ind->ctx);
+    }
+}

--- a/sys/net/link_layer/ieee802154/ieee802154_netif.c
+++ b/sys/net/link_layer/ieee802154/ieee802154_netif.c
@@ -7,6 +7,10 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+/* Implementation of the MAC indication.
+ * This function generates the `netif_pkt` from the MAC layer output,
+ * and calls the `netif_recv` function.
+ */
 void ieee802154_mac_ind(netdev_ieee802154_t *netdev, ieee802154_mac_ind_t *ind, ieee802154_phy_ind_t *phy_ind)
 {
     netif_pkt_t pkt = {0};
@@ -42,6 +46,10 @@ void ieee802154_mac_ind(netdev_ieee802154_t *netdev, ieee802154_mac_ind_t *ind, 
 #endif
 
     netif_t *netif = ((netdev_t*) netdev)->context;
+
+    /* We call the `netif_recv` function to pass the packet
+     * to the stack. If the stack doesn't want the packet,
+     * we release it via the netbuf API. */
     if(!netif_recv(netif, &pkt)) {
         netbuf_free(phy_ind->ctx);
     }

--- a/sys/net/link_layer/ieee802154/ieee802154_phy.c
+++ b/sys/net/link_layer/ieee802154/ieee802154_phy.c
@@ -24,7 +24,7 @@ void ieee802154_rf_rx_done(netdev_t *dev)
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
     ieee802154_phy_ind_t ind = {0};
 
-    void *psdu = netbuf_alloc(bytes_expected, &ind.ctx);
+    void *psdu = netbuf_get(bytes_expected, &ind.ctx);
 
     if (psdu == NULL) {
         DEBUG("_recv_ieee802154: cannot allocate netbuf.\n");

--- a/sys/net/link_layer/ieee802154/ieee802154_phy.c
+++ b/sys/net/link_layer/ieee802154/ieee802154_phy.c
@@ -26,7 +26,7 @@ void ieee802154_rf_rx_done(netdev_t *dev)
 
     void *psdu = netbuf_alloc(bytes_expected, &ind.ctx);
 
-    if (ind.ctx == NULL) {
+    if (psdu == NULL) {
         DEBUG("_recv_ieee802154: cannot allocate netbuf.\n");
 
         /* Discard packet on netdev device */

--- a/sys/net/link_layer/ieee802154/ieee802154_phy.c
+++ b/sys/net/link_layer/ieee802154/ieee802154_phy.c
@@ -1,0 +1,42 @@
+#include "net/netdev.h"
+#include "net/netdev/ieee802154.h"
+
+#include "net/netbuf.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* This function is the same for all IEEE802154 devices! */
+void ieee802154_rf_rx_done(netdev_t *dev)
+{
+    netdev_ieee802154_rx_info_t rx_info;
+    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
+    void *psdu;
+    netbuf_ctx_t *ctx = netbuf_alloc(bytes_expected, &psdu);
+
+    if (ctx == NULL) {
+        DEBUG("_recv_ieee802154: cannot allocate netbuf.\n");
+
+        /* Discard packet on netdev device */
+        dev->driver->recv(dev, NULL, bytes_expected, NULL);
+        return;
+    }
+
+    int nread = dev->driver->recv(dev, psdu, bytes_expected, &rx_info);
+
+    if (nread <= 0) {
+        netbuf_free(ctx);
+        return;
+    }
+
+    ieee802154_phy_ind_t ind;
+    ind.lqi = rx_info.lqi;
+    ind.rssi = rx_info.rssi;
+    ind.psdu = psdu;
+    ind.psdu_len = nread;
+    ind.ctx = ctx;
+
+    /* Interface here? */
+    ieee802154_phy_ind(dev, &ind);
+}
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
### Contribution description
This POC shows a (very early) IEEE802.15.4 stack independent network interface that sends and receives data from GNRC.
This POC uses some concept and ideas discussed for several months with some contributors (@PeterKietzmann, @miri64, @haukepetersen, @bergzand, @kaspar030, @leandrolanzieri, @cgundogan  ). I wouldn't call it more than a pseudocode that compiles, but at least it shows the role of different actors and how the lower network architecture could look like.

Please note implementation details shouldn't go in this discussion, since the idea is to show how the whole architecture could look like. There are still some (straightforward to remove) dependencies with GNRC netif that I didn't consider for the scope of this POC.

This POC shows:
- How a stack independent network interface looks like.
- The role of the HAL, PHY and MAC layers.
- How packet data can be allocated without stack dependent functions.
- How a network stack independent MAC layer looks like.

This POC doesn't show:
- How events are handled by the OS (ISR, etc) (hint: #12474 would probably be the way to go).
- Where there should be interfaces (this assumes the IEEE802.15.4 will always call the PHY layer on top, and the PHY layer will always call the MAC layer).
- Where the code should reside (the code is still scattered between `netdev` and pure `ieee802154`).
- How the structures will look like, this only shows how to interact with them.

Please feel free to provide all kind of feedback (E.g if the approach makes sense, if there's something we haven't considered, etc).

## Architecture
![netif_arch](https://user-images.githubusercontent.com/1260616/69797792-9e9a3f00-11d0-11ea-83a1-025c252abfc8.png)

This is a generic representation of network interface, based on the current approach of `gnrc_netif`.
The key elements are:
- Link Layer dependent code is abstracted via the `netif_ops` interface ([same as `gnrc_netif_t`](https://doc.riot-os.org/structgnrc__netif__ops.html) but with support for other stacks). `netif_ieee802154`, `netif_ethernet` and `netif_lorawan` are implementations of the `netif_ops` interface.
- The upper layer sends data with the `netif_send` data and receives via `netif_recv`. It also configures and get Link Layer or netif params via `netif_get` and `netif_set`. Note this API is independent of the LL underneath.
- Note that each network stack that implements `netif_recv`, `netif_get` and `netif_set` (and `netbuf` for packet abstraction, not included in the picture) is able to use the link layers.

## What's new

### Stack independent packet allocation
To allocate stack independent packets, the `netbuf` interface (#12691) is proposed. It's a wrapper of the internal packet representation (gnrc_pktsnips, static input buffers, etc).

The interface is defined by 2 functions that must be implemented by the stack:
- `netbuf_ctx_t *netbuf_alloc(size, buf)`: Allocate a buffer with the given size. Return the allocation context in `netbuf_ctx_t`.
- `void netbuf_free(netbuf_ctx_t *netbuf)`: Free the resources associated to the netbuf.

This POC provides the [GNRC implementation of the `netbuf` API](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/gnrc/netif/gnrc_netif.c#L51)

### Stack independent receive
Let's see how GNRC can receive a packet from a GNRC independent netif.
1. The transceiver HAL calls a callback function (transceiver indication) to indicate there's data in the framebuffer (analog to NETDEV_EVENT_RX_DONE). In this POC, the event is called from the `recv` function of GNRC (as seen [here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c#L53)), but this will eventually be in the transceiver HAL.
2. The PHY layer implements the transceiver indication. It will use the netbuf + transceiver HAL API (netdev in the context of the POC) to allocate and fetch the received packet. It will then generate a PHY indication with the PSDU + PHY specific metadata (RSSI, LQI, SNR, etc) ([see it here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/link_layer/ieee802154/ieee802154_phy.c#L21))
4. The MAC layer implements the PHY indication. It process the PSDU and generates the MSDU + link layer metadata (source address, destination address, flags, etc). Then it generates a MAC indication with the MSDU + link layer metadata. (see it [here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/link_layer/ieee802154/ieee802154_mac.c#L109) and [here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/link_layer/ieee802154/ieee802154_mac.c#L97)).
6. The netif component implements the MAC indication function. It fills in the `netif_pkt_t` structure with the output of the MAC layer and calls the `netif_recv` function. ([see it here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/link_layer/ieee802154/ieee802154_netif.c#L14)).
7. The `netif_recv` function (stack dependent) converts the `netif_pkt_t` representation in the internal network stack representation and passes the packet to the stack. [Check the GNRC implementation of the `netif_recv` function here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/gnrc/netif/_netif.c#L50)

### Stack independent send
Let's see how GNRC can send a packet via a GNRC independent netif.

1. The `gnrc_netif_send` function converts the internal representation of a packet (gnrc_pktbuf + gnrc_netif_hdr)) into a `netif_pkt_t` structure and calls `netif_send(netif, netif_pkt)`. ([see it here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c#L151)).
2. The `netif_send` function calls the L2 specific send function (in this case ieee802154_mac_send) via the `netif_ops` interface (`netif->ops->send(netif, netif_pkt)`). This is not implemented with an interface, but you can see the call [here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c#L115).
3. The netif specific send function operates directly with the MAC layer underneath. E.g an IEEE802.15.4 will perform an IEEE802.15.4 MCPS-DATA request, an Ethernet will just call the Ethernet send function and a RAW ("no MAC") will directly interact with the PHY layer. In this case, the `netif_ieee802154` implementation calls ieee802154 specific functions to send (as seen [here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c#L60)).
4. The MAC layer will eventually call the PHY layer send function (and handle retransmissions, device busy, etc). As explained above, it's assumed `netdev` represents the PHY layer. ([see it here](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/sys/net/link_layer/ieee802154/ieee802154_mac.c#L177)).
5. The PHY layer will use the transceiver HAL in order to set the transceiver state, write data to the framebuffer and trigger send. Since we don't have a IEEE802.15.4 layer, the PHY layer is implemented in the driver. You can see this process e.g in the [`send` function of the netdev implementation of the AT86RF2XX radios](https://github.com/RIOT-OS/RIOT/blob/8ec3ba2934a0cb78465850828f8b2d53eec91671/drivers/at86rf2xx/at86rf2xx_netdev.c#L113).

### Receive from static framebuffer
Some device drivers and external implementation already implement a PHY layer (callback with buffer, size and metadata). An example of this is the ESP WIFI driver.
With this POC, it's possible to avoid extra copy and process the MAC layer **from the static buffer and then convert it to the internal network stack representation!!**.

E.g, we could think of:
```c
void external_driver_phy_indication(void *buf, size_t size, int16_t rssi, uint8_t lqi)
{
    ieee802154_phy_ind_t ind; 
    ind.lqi = lqi;
    ind.rssi = rssi;
    ind.psdu = buf;
    ind.psdu_len = size;
    ind.ctx = NULL; /* Intentionally set to NULL to indicate the packet was not allocated by the stack */

    ieee802154_phy_ind(dev, &ind); 
}
```
And then in the `netif_recv` function:
```c
if(pkt->ctx == NULL) {
    /* We know the packet was not allocated in the stack. We copy only the MSDU (L2 payload) */
    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(pkt->msdu.iol_base, pkt->msdu.iol_len, GNRC_NETTYPE_UNDEF);
    gnrc_netapi_dispatch_receive(pkt, ...);
}
```
### Devices with multiple PHY layers
Some devices have multiple PHY layers (LoRa/FSK, IEEE802.15.4 2.4 GHz and SubGHZ, etc).
Since in this POC the PHY layer is a user of the transceiver (via the transceiver HAL), it's possible to map 2 PHY layers to the same device.

E.g 2 PHYs (LoRa and FSK) can use the same HAL API to implement the LoRa PHY and FSK PHY.
Then, the driver implements the transceiver HAL that hides the dual operation so the PHY layer only sees a single device.

## Testing procedure

It's possible to test it using e.g a `samr21-xpro` with `examples/default`, although the intention
is to show how the code would look like.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


## Issues/PRs references
#12688 
#11483
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
