### PR TITLE
tools/serial.inc.mk: add support miniterm.py

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -21,4 +21,9 @@ else ifeq ($(RIOT_TERMINAL),socat)
 else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
   TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"
+else ifeq ($(RIOT_TERMINAL),miniterm)
+  TERMPROG  ?= miniterm.py
+  # The RIOT shell will still transmit back a CRLF, but at least with --eol LF
+  # we avoid sending two lines on every "enter".
+  TERMFLAGS ?= --eol LF "$(PORT)" "$(BAUD)"
 endif


### PR DESCRIPTION
miniterm.py is a simple terminal program that is included with pyserial.
This means that it is available wherever pyterm can work. It allows raw
access, does line translation and passes through special characters.

Co-authored-by: Juan Carrano <j.carrano@fu-berlin.de>

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for miniterm as alternative for `RIOT_TERMINAL`.

It's a rework of the initial PR: #11003

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following should launch miniterm instead of pyterm:
```
RIOT_TERMINAL=miniterm make BOARD=samr21-xpro -C examples/default flash term
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will be useful for #2968 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
