### PR TITLE
boards: pic32-clicker: check for periph_uart

### DIFF
--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -27,7 +27,7 @@ void board_init(void)
     RPF4R =    0x1;          /*connect pin RPF4 to UART3 TX*/
 
     /* intialise UART used for debug (printf) */
-#ifdef DEBUG_VIA_UART
+#if MODULE_PERIPH_UART && defined(DEBUG_VIA_UART)
     uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
 #endif
 


### PR DESCRIPTION
### Contribution description
If there is no dependency on `periph_uart`, then `uart_init` is not available. This ensure that this will compile fine if `periph_uart` is not available.

### Testing procedure
Not sure how to test it, but Murdock would fail without this patch in #10741. I also don't have the hardware to test it on real hardware.

### Issues/PRs references
#10741