### PR TITLE
boards/atmega_common: remove weak led_init()

### DIFF
--- a/boards/common/atmega/board.c
+++ b/boards/common/atmega/board.c
@@ -29,13 +29,6 @@
 
 void led_init(void);
 
-/*
- * Add an empty led_init() as fall back.
- * If at link time another implementation of led_init() not marked as weak
- * (a.k.a. a strong symbol) is present, it will be linked in instead.
- */
-void __attribute__((weak)) led_init(void) {}
-
 void board_init(void)
 {
 #ifdef CPU_ATMEGA32U4


### PR DESCRIPTION
### Contribution description

`led_init()` is already protected by an `#ifdef`, so no need for the weak symbol.

The problem is that the weak function does not get overridden, even when the board provides it's own `led_init()`, resulting in no LEDs being initialized.

### Testing procedure

On any ATmega board, run `tests/leds`.

On master, no LEDs are flashing.
With this PR they should be properly initialized again.

### Issues/PRs references
discovered in #12668
