### PR TITLE
cpu/lpc2387: implement periph/pm

### DIFF
--- a/cpu/arm7_common/include/arm7_common.h
+++ b/cpu/arm7_common/include/arm7_common.h
@@ -72,9 +72,10 @@ extern "C" {
 #define BORD        (BIT4)
 #define PM2         (BIT7)
 
-#define PM_IDLE         (PM0)
-#define PM_SLEEP        (PM2|PM0)
-#define PM_POWERDOWN    (PM1)
+#define PM_IDLE             (PM0)
+#define PM_SLEEP            (PM2|PM0)
+#define PM_POWERDOWN        (PM1)
+#define PM_DEEP_POWERDOWN   (PM2|PM1)
 /** @} */
 
 /**

--- a/cpu/lpc2387/Makefile.include
+++ b/cpu/lpc2387/Makefile.include
@@ -1,3 +1,4 @@
 include $(RIOTCPU)/arm7_common/Makefile.include
 
 USEMODULE += arm7_common periph bitfield newlib
+USEMODULE += pm_layered

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -33,6 +33,13 @@ extern "C" {
 #define __IO volatile
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (4)
+/** @} */
+
+/**
  * @brief Fast GPIO register definition struct
  */
 typedef struct {

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -61,13 +61,32 @@ typedef struct {
     __IO uint32_t CLR;
 } FIO_PORT_t;
 
+/**
+ * @brief   Pointer to the Fast GPIO register
+ */
 #define FIO_PORTS   ((FIO_PORT_t*)FIO_BASE_ADDR)
+
+/**
+ * @brief   Pointer to the PINSEL register
+ */
 #define PINSEL      ((__IO uint32_t *)(PINSEL_BASE_ADDR))
+
+/**
+ * @brief   Pointer to the PINMODE register
+ */
 #define PINMODE     ((__IO uint32_t *)(PINSEL_BASE_ADDR + 0x40))
 
+/**
+ * @brief   Set up alternate function (PMUX setting) for a PORT pin
+ *
+ * @param[in] pin   Pin to set the multiplexing for
+ * @param[in] mux   Mux value
+ */
 int gpio_init_mux(unsigned pin, unsigned mux);
-void gpio_init_states(void);
 
+/**
+ * @brief   Macro for accessing GPIO pins
+ */
 #define GPIO_PIN(port, pin) (port<<5 | pin)
 
 #ifndef DOXYGEN

--- a/cpu/lpc2387/periph/pm.c
+++ b/cpu/lpc2387/periph/pm.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_lpc2387
+ * @ingroup     drivers_periph_pm
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels power management interface
+ *
+ * @note        Handling of wake-up from POWERDOWN & SLEEP is not implemented
+ *              yet, so those states are disabled.
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ *
+ * @}
+ */
+
+#include "periph/pm.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void pm_set(unsigned mode)
+{
+    switch (mode) {
+        case 0:
+            /* Everything except battery backup is powered down */
+            DEBUG_PUTS("pm_set(): setting Deep Power Down mode.");
+            PCON |= PM_DEEP_POWERDOWN;
+            break;
+        case 1:
+            /* PLL & Flash are powered down */
+            DEBUG_PUTS("pm_set(): setting Power Down mode.");
+            /* PCON |= PM_POWERDOWN; */
+            PCON |= PM_IDLE; /* fixme */
+            break;
+        case 2:
+            /* PLL is powered down */
+            DEBUG_PUTS("pm_set(): setting Sleep mode.");
+            /* PCON |= PM_SLEEP; */
+            PCON |= PM_IDLE; /* fixme */
+            break;
+        default: /* Falls through */
+        case 3:
+            DEBUG_PUTS("pm_set(): setting Idle mode.");
+            PCON |= PM_IDLE;
+            break;
+    }
+}


### PR DESCRIPTION
### Contribution description

Enable IDLE and Deep Powerdown mode.

IDLE is pretty straightforward - insteady of busy waiting, the CPU will enter an idle state from which it will resume on any event.

Deep Power Down shuts off the entite system except for the battery backup power domain.
That means the CPU will reset on resume and can be woken by e.g. RTC.

SLEEP and POWERDOWN disable the PLL and the PLL and Flash respectively.
This requires some proper wake-up handling.

Just re-initializing the PLL didn't turn out to be enough, the code would enter the interrupt handler of the interrupt that caused the wake-up, but it didn't seem to know where to return.

Since this turned out to be a major time sink and those modes are currently never used in RIOT outside of tests, I left this as an exercise for a future reader.

### Testing procedure

Everything should keep operating as normal, but you will see a slight drop in power consumption as the CPU is now using IDLE mode instead of busy waiting.

On `mcb2388` I saw:

master: 152 mA
this PR: 109 mA

with a simple application that updates the LCD based on the RTC every second.

You can run `tests/periph_pm` but without SLEEP and POWERDOWN it's not very exciting. 

### Issues/PRs references
needed for #12748
