### PR TITLE
cpu/lpc2387: add support for backup RAM

### DIFF
--- a/cpu/arm7_common/arm7_init.c
+++ b/cpu/arm7_common/arm7_init.c
@@ -27,61 +27,66 @@
 #include "cpu.h"
 #include "log.h"
 
-static inline void
-_init_data(void)
+static inline void _init_data(void)
 {
+    /* (linker script ensures that data is 32-bit aligned) */
     extern unsigned int _etext;
     extern unsigned int _data;
     extern unsigned int _edata;
     extern unsigned int __bss_start;
     extern unsigned int __bss_end;
 
-/* Support for LPRAM. */
+/* Support for Battery Backup RAM */
 #ifdef CPU_HAS_BACKUP_RAM
     extern unsigned int _sbackup_data_load[];
     extern unsigned int _sbackup_data[];
     extern unsigned int _ebackup_data[];
     extern unsigned int _sbackup_bss[];
     extern unsigned int _ebackup_bss[];
-#endif /* CPU_HAS_BACKUP_RAM */
+#endif
 
-    register unsigned int *p1;
-    register unsigned int *p2;
-    register unsigned int *p3;
+    register unsigned int *src;
+    register unsigned int *dst;
+    register unsigned int *end;
 
-    // initialize data from flash
-    // (linker script ensures that data is 32-bit aligned)
-    p1 = &_etext;
-    p2 = &_data;
-    p3 = &_edata;
+    /* initialize data from flash */
+    src = &_etext;
+    dst = &_data;
+    end = &_edata;
 
-    while (p2 < p3) {
-        *p2++ = *p1++;
+    while (dst < end) {
+        *dst++ = *src++;
     }
 
-    // clear bss
-    // (linker script ensures that bss is 32-bit aligned)
-    p1 = &__bss_start;
-    p2 = &__bss_end;
+    /* clear bss */
+    dst = &__bss_start;
+    end = &__bss_end;
 
-    while (p1 < p2) {
-        *p1++ = 0;
+    while (dst < end) {
+        *dst++ = 0;
     }
 
 #ifdef CPU_HAS_BACKUP_RAM
+    /* only initialize battery backup on cold boot */
     if (cpu_woke_from_backup()) {
+        return;
+    }
 
-        /* load low-power data section. */
-        for (p1 = _sbackup_data, p2 = _sbackup_data_load;
-             p1 < _ebackup_data;
-             p1++, p2++) {
-            *p1 = *p2;
-        }
+    /* load low-power data section. */
+    src = _sbackup_data_load;
+    dst = _sbackup_data;
+    end = _ebackup_data;
 
-        /* zero-out low-power bss. */
-        for (p1 = _sbackup_bss; p1 < _ebackup_bss; p1++) {
-            *p1 = 0;
-        }
+    while (dst < end) {
+        *dst++ = *src++;
+    }
+
+    /* zero-out low-power bss. */
+    dst = _sbackup_bss;
+    end = _ebackup_bss;
+
+    while (dst < end) {
+        *dst++ = 0;
     }
 #endif /* CPU_HAS_BACKUP_RAM */
 }

--- a/cpu/lpc2387/Makefile.features
+++ b/cpu/lpc2387/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += backup_ram
 FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 
 -include $(RIOTCPU)/arm7_common/Makefile.features

--- a/cpu/lpc2387/cpu.c
+++ b/cpu/lpc2387/cpu.c
@@ -136,4 +136,37 @@ void cpu_init(void)
     periph_init();
 }
 
+/* RSIR will only have POR bit set even when waking up from Deep Power Down
+ * Use signature in battery RAM to discriminate between Deep Power Down and POR
+ */
+bool cpu_woke_from_backup(void)
+{
+    static char signature[] __attribute__((section(".backup.data"))) = {
+        'R', 'I', 'O', 'T'
+    };
+
+    /* external reset */
+    if (RSIR & RSIR_EXTR) {
+        return false;
+    }
+
+    if (signature[0] != 'R') {
+        return false;
+    }
+
+    if (signature[1] != 'I') {
+        return false;
+    }
+
+    if (signature[2] != 'O') {
+        return false;
+    }
+
+    if (signature[3] != 'T') {
+        return false;
+    }
+
+    return true;
+}
+
 /** @} */

--- a/cpu/lpc2387/include/cpu.h
+++ b/cpu/lpc2387/include/cpu.h
@@ -57,6 +57,16 @@ static inline void cpu_print_last_instruction(void)
     printf("%p\n", (void*) lr_ptr);
 }
 
+/**
+ * @brief   Returns true if the CPU woke from Deep Sleep
+ */
+bool cpu_woke_from_backup(void);
+
+/**
+ * @brief   The CPU has RAM that is retained in the deepest sleep mode.
+ */
+#define CPU_HAS_BACKUP_RAM  (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/lpc2387/include/vendor/lpc23xx.h
+++ b/cpu/lpc2387/include/vendor/lpc23xx.h
@@ -424,6 +424,10 @@ Reset, and Code Security/Debugging */
 
 /* Reset, reset source identification */
 #define RSIR           (*(volatile unsigned long *)(SCB_BASE_ADDR + 0x180))
+#define RSIR_POR       (BIT0)
+#define RSIR_EXTR      (BIT1)
+#define RSIR_WDTR      (BIT2)
+#define RSIR_BODR      (BIT3)
 
 /* RSID, code security protection */
 #define CSPR           (*(volatile unsigned long *)(SCB_BASE_ADDR + 0x184))

--- a/cpu/lpc2387/ldscripts/lpc2387.ld
+++ b/cpu/lpc2387/ldscripts/lpc2387.ld
@@ -171,7 +171,7 @@ SECTIONS
      * collect all initialized .data sections that go into RAM
      * initial values get placed at the end of .text in flash
      */
-    .data : AT (_etext)
+    .data :
     {
         . = ALIGN(4);                   /* ensure data is aligned so relocation can use 4-byte operations */
         _data = .;                      /* create a global symbol marking the start of the .data section  */
@@ -196,7 +196,7 @@ SECTIONS
         KEEP(*(SORT(.fini_array.*)))
             KEEP(*(.fini_array))
             PROVIDE_HIDDEN (__fini_array_end = .);
-    } >ram                              /* put all the above into RAM (but load the LMA copy into FLASH) */
+    } >ram AT > flash                   /* put all the above into RAM (but load the LMA copy into FLASH) */
     . = ALIGN(4);                       /* ensure data is aligned so relocation can use 4-byte operations */
     _edata = .;                         /* define a global symbol marking the end of the .data section  */
 
@@ -287,9 +287,20 @@ SECTIONS
     } > ram_usb
     __heap_size = SIZEOF(.heap3);
 
-
-    .batteryram (NOLOAD) :              /* battery ram stays on during powerdown but needs to be handled specially */
-    {
-        *(.batteryram)
+    .backup.bss (NOLOAD) : ALIGN(4) {
+        _sbackup_bss = .;
+        *(.backup.bss)
+        _ebackup_bss = .;
+        /* Round size so that we can use 4 byte copy in init */
+        . = ALIGN(4);
     } > ram_battery
+
+    _sbackup_data_load = LOADADDR(.backup.data);
+    .backup.data : ALIGN(4) {
+        _sbackup_data = .;
+        *(.backup.data)
+        _ebackup_data = .;
+        /* Round size so that we can use 4 byte copy in init */
+        . = ALIGN(4);
+    } > ram_battery AT> flash
 }


### PR DESCRIPTION
### Contribution description

lpc23xx has 2k of battery RAM that is retained in Deep Power Down mode.

To not overwrite that data it must only be initialized on Power On Reset.
However, `RSIR` looks the same when waking up from Deep Power Down as it does on the power-on case.

So use 4 bytes of the backup RAM to keep a signature that is only valid if memory was retained (no power-on Reset).

A small change to the linker script is required so two sections can be placed into flash.

### Testing procedure

Run `tests/periph_backup_ram` on e.g. `msba2`.

### Issues/PRs references
requires #12747 to be useful
