### PR TITLE
Particle boards: Support monofirmware builds and uploads

### DIFF
--- a/boards/common/particle-mesh/Makefile.dep
+++ b/boards/common/particle-mesh/Makefile.dep
@@ -2,5 +2,9 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+ifeq (1,$(PARTICLE_MONOFIRMWARE))
+  USEMODULE += usb_board_reset
+endif
+
 # include common nrf52 dependencies
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/common/particle-mesh/Makefile.include
+++ b/boards/common/particle-mesh/Makefile.include
@@ -18,6 +18,10 @@ ifeq (1,$(PARTICLE_MONOFIRMWARE))
   FFLAGS = -d 0x2B04:0xD00E -a 0 -s 0x30000:leave -D $(FLASHFILE)
   PROGRAMMER = dfu-util
   include $(RIOTMAKE)/tools/dfu.inc.mk
+  # If CDC-ACM is *not* enabled, any pre-flash resets will just not work -- but
+  # then again nothing can be done in that case anyway, and the preflash
+  # routines fall through without erring.
+  include $(RIOTMAKE)/tools/usb_board_reset.mk
 else
   # This board uses a DAP-Link programmer
   # Flashing support is provided through pyocd (default) and openocd.

--- a/boards/common/particle-mesh/Makefile.include
+++ b/boards/common/particle-mesh/Makefile.include
@@ -9,18 +9,36 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # add the common header files to the include path
 INCLUDES += -I$(RIOTBOARD)/common/particle-mesh/include
 
-# This board uses a DAP-Link programmer
-# Flashing support is provided through pyocd (default) and openocd.
-# For openocd, a version built against the development branch and containing
-# the support for nrf52 cpu is required.
-PROGRAMMER ?= pyocd
-ifeq (pyocd,$(PROGRAMMER))
-  # The board is not recognized automatically by pyocd, so the CPU target
-  # option is passed explicitly
-  FLASH_TARGET_TYPE ?= -t nrf52840
-  include $(RIOTMAKE)/tools/pyocd.inc.mk
-else ifeq (openocd,$(PROGRAMMER))
-  DEBUG_ADAPTER ?= dap
+ifeq (1,$(PARTICLE_MONOFIRMWARE))
+  CFLAGS += -DPARTICLE_MONOFIRMWARE
+  ROM_OFFSET = 0x30000
+  FW_ROM_LEN = 0xc4000
+  FLASHFILE = $(BINFILE)-checksummed
+  # Setting DFU_ARGS won't work as the implied --reset causes errors.
+  FFLAGS = -d 0x2B04:0xD00E -a 0 -s 0x30000:leave -D $(FLASHFILE)
+  PROGRAMMER = dfu-util
+  include $(RIOTMAKE)/tools/dfu.inc.mk
+else
+  # This board uses a DAP-Link programmer
+  # Flashing support is provided through pyocd (default) and openocd.
+  # For openocd, a version built against the development branch and containing
+  # the support for nrf52 cpu is required.
+  PROGRAMMER ?= pyocd
+  ifeq (pyocd,$(PROGRAMMER))
+    # The board is not recognized automatically by pyocd, so the CPU target
+    # option is passed explicitly
+    FLASH_TARGET_TYPE ?= -t nrf52840
+    include $(RIOTMAKE)/tools/pyocd.inc.mk
+  else ifeq (openocd,$(PROGRAMMER))
+    DEBUG_ADAPTER ?= dap
+  endif
 endif
+
+MONOFIRMWARETOOL = ${RIOTBOARD}/common/particle-mesh/monofirmware-tool.py
+
+# Rule (variations) for building a monofirmware populated with the right
+# (lengths and) checksum in it; only used iuf PARTICLE_MONOFIRMWARE=1
+%.bin-checksummed: %.bin %.elf ${MONOFIRMWARETOOL}
+	${MONOFIRMWARETOOL} $*.elf $< $@
 
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/common/particle-mesh/board.c
+++ b/boards/common/particle-mesh/board.c
@@ -45,6 +45,31 @@ void board_nrfantenna_select(enum board_nrfantenna_selection choice)
 
 void board_init(void)
 {
+#ifdef PARTICLE_MONOFIRMWARE
+    /* For comparison with MicroPython's hook into this bootloader, they'd set
+     * SCB->VTOR here. That is necessary because while the particle bootloader
+     * largely mimics the ARM bootup by requiring a VTOR at the start of the
+     * writable firmware, it does not set the VTOR to the loaded data.
+     *
+     * That step is not executed *right* here as cpu_init will do it a few
+     * lines down anyway. */
+
+    /* Force keeping the metadata -- the __attribute__((used)) in their macro
+     * expansions and the KEEP on the section in the linker only almost do
+     * that: at least *something* from the object file needs to be referenced
+     * to pull them all in. */
+    extern uint32_t particle_monofirmware_padding;
+    uint32_t x;
+    x = (uint32_t)&particle_monofirmware_padding;
+    (void)x;
+
+    /* Clear out POWER_CLOCK and GPIOTE interrupts set by the bootloader. (If
+     * actual RIOT code enables them, it'll do so after the board_init call).
+     * */
+    NVIC_DisableIRQ(0);
+    NVIC_DisableIRQ(6);
+#endif
+
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_set(LED0_PIN);

--- a/boards/common/particle-mesh/bootloader.c
+++ b/boards/common/particle-mesh/bootloader.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2014-2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#ifdef PARTICLE_MONOFIRMWARE
+#include <stdint.h>
+#include "vectors_cortexm.h"
+
+extern const void *_isr_vectors;
+
+/* As described in Particle's dynalib/inc/module_info.h (there under LGPL-3
+ * terms; detailed license compatibility discussion skipped for not crossing
+ * any threshold of originality) */
+typedef struct module_info_t {
+    const void* module_start_address;
+    const void* module_end_address;
+    uint8_t reserved;
+    uint8_t flags;
+    uint16_t module_version;
+    uint16_t platform_id;
+    uint8_t  module_function;
+    uint8_t  module_index;
+    uint32_t dependency; /* was module_dependency_t; kept in here to ensure it's blank */
+    uint32_t dependency2; /* was module_dependency_t */
+} module_info_t;
+
+/* 64 words is the distance between the known ISR table and the fixed-position
+ * module_info at 0x200. If the ISR length is changed for any reason, this must
+ * be adapted until particle_monofirmware_module_info is precisely at 0x30200.
+ * (monofirmware-tool.py will complain if it isn't).
+ *
+ * This is not `static` as *something* from this module needs to be visible to
+ * the outside for the __attribute__((used)) and the KEEP on the section in the
+ * linker script to work; see also the reference to it in board.c. */
+ISR_VECTOR(50) const uint32_t particle_monofirmware_padding[64] = {0, };
+
+#ifdef PARTICLE_MONOFIRMWARE_CHECKSUMLIMIT
+/* Watch the ISR vector sequence here: This is placed *after* the module_info
+ * in the flash (52 > 51), but placed before it in the code to be referencable
+ * from there.
+ *
+ * The actual value is replaced by monofirmware-tool.py.
+ * */
+ISR_VECTOR(52) static const uint8_t particle_monofirmware_checksum[4] = {0, 0, 0, 0};
+#endif
+
+ISR_VECTOR(51) static const struct module_info_t particle_monofirmware_module_info = {
+    .module_start_address = &_isr_vectors,
+#ifdef PARTICLE_MONOFIRMWARE_CHECKSUMLIMIT
+    .module_end_address = &particle_monofirmware_checksum,
+    /* else, it is set by the monofirmware-tool.
+     *
+     * For that (more common) case where we check the full firmware, we would
+     * want to set set
+     *
+     * .module_end_address = &_etext + (&_erelocate - &_srelocate),
+     *
+     * but that can not be determined at compile time. Instead, this will be
+     * populated by monofirmware-tool.py, which needs to write in here anyway
+     * for the checksum. */
+#endif
+    .module_version = 0x138, /* module version that micropython uses */
+
+    .platform_id = PARTICLE_PLATFORM_ID,
+
+    .module_index = 3, /* MOD_FUNC_MONO_FIRMWARE from dynalib/inc/module_info.h */
+};
+
+#else
+typedef int dont_be_pedantic;
+#endif
+
+/** @} */

--- a/boards/common/particle-mesh/doc.txt
+++ b/boards/common/particle-mesh/doc.txt
@@ -35,6 +35,38 @@ To flash the board with OpenOCD, use the `PROGRAMMER` variable:
     PROGRAMMER=openocd make BOARD=<board name> -C examples/hello-world flash
 ```
 
+#### Alternative flashing procedure: Particle bootloader and DFU-Util
+
+As an alternative to using the Particle Mesh debugger,
+the USB DFU mode bootloader shipped with Particle Mesh devices can be used.
+That mode can be entered by keeping the SETUP/MODE button pressed after power-up or reset
+until the RGB LED **blinks yellow fast**.
+
+In this mode, the bootloader and Soft Device are kept in place,
+reducing the available flash memory to 784kB,
+but in turn, devices can easily be switched back to using Particle software.
+
+In order to use this mode, set `PARTICLE_MONOFIRMWARE=1` wherever you set the `BOARD`.
+This will trigger the use of the appropriate linker script,
+and switch in [`dfu-util`](http://dfu-util.sourceforge.net/) as the default programmer,
+which needs to be installed.
+<!-- Using PARTICLE_MONOFIRMWARE=1 images with an external programmer is untested but might just work once checksums are static. -->
+
+On Linux hosts, devices for the DFU mode are frequently only accessible to root,
+causing error messages like
+
+    dfu-util: Cannot open DFU device 2b04:d00e
+    dfu-util: No DFU capable USB device available
+
+To make Particle devices writable for all users,
+follow [Particle's instructions](https://docs.particle.io/support/particle-tools-faq/installing-dfu-util/)
+on setting up dfu-util.
+
+The Particle bootloader checks the firmware's checksum at startup time.
+As these checks would be frustrated by flash writes inside RIOT (typically using the @ref drivers_periph_flashpage),
+the CFLAG @ref PARTICLE_MONOFIRMWARE_CHECKSUMLIMIT "-DPARTICLE_MONOFIRMWARE_CHECKSUMLIMIT" can be set.
+Then, the checksum is only calculated over the memory region that contains the interrupt vector and the bootloader manifest.
+
 ### Reset the board
 
 The on-board reset button doesn't work, so to trigger a reset of the board, use

--- a/boards/common/particle-mesh/include/board.h
+++ b/boards/common/particle-mesh/include/board.h
@@ -27,6 +27,61 @@ extern "C" {
 #endif
 
 /**
+ *
+ * @name    Bootloader configuration options
+ * @{
+ */
+
+/** @brief Build a firmware suitable for the Particle bootloader
+ *
+ * If this is defined, additional metadata about the firmware is included in
+ * the firmware (called the module_info in Particle), and additional code is
+ * inserted in board setup.
+ *
+ * Do not define this manually; instead, set `PARTICLE_MONOFIRMWARE=1` as an
+ * variable in the build scripts like `BOARD` is defined, and the particle
+ * common make file defines it and configures suitable postprocessing of the
+ * binary.
+ *
+ * @see @ref boards_common_particle-mesh
+ *
+ */
+#ifdef DOXYGEN
+#define PARTICLE_MONOFIRMWARE
+#endif
+
+/** @brief Limit Particle bootloader checksumming to the binary start
+ *
+ * If this define is set in the Makefile, the binary size announced to the
+ * bootloader is limited to the reset vector and the firmware metadata, and
+ * only that part is checksummed.
+ *
+ * This is useful when @ref drivers_periph_flashpage is used, as otherwise the
+ * firmware's writes on itself would invalidate its checksum.
+ *
+ * @see @ref boards_common_particle-mesh
+ */
+#ifdef DOXYGEN
+#define PARTICLE_MONOFIRMWARE_CHECKSUMLIMIT
+#endif
+
+/** @brief Platform ID of the board for the Particle bootloader
+ *
+ * This is set by the individual board's build configuration, and gets used
+ * when building with @ref PARTICLE_MONOFIRMWARE; then, it is put into the
+ * module information for the board bootloader to verify that the firmware was
+ * built for the right device.
+ *
+ * The individual values are documented in the Particle DeviceOS source code in
+ * `build/platform-id.mk`.
+ */
+#ifdef DOXYGEN
+#define PARTICLE_PLATFORM_ID
+#endif
+
+/** @} */
+
+/**
  * @name    LED pin configuration
  * @{
  */

--- a/boards/common/particle-mesh/monofirmware-tool.py
+++ b/boards/common/particle-mesh/monofirmware-tool.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""Verify that a pair of .bin/.elf has the particle_monofirmware_module_info at
+the right place. If there is a particle_monofirmware_checksum symbol, verify
+that the module_info says the firmware ends at it, and populate the
+checksum. Otherwise, append the checksum and set the end-of-firmware field
+accordingly."""
+
+import os
+import sys
+import zlib
+import subprocess
+import argparse
+
+expected_romstart = 0x30000
+expected_moduleinfo_position = expected_romstart + 0x200
+expected_moduleinfo_size = 0x18
+# offsetof(module_end_address, module_info_t)
+end_field_offset = 4
+end_field_start = expected_moduleinfo_position - expected_romstart + end_field_offset
+end_field_end = end_field_start + 4
+
+
+def check(condition, message):
+    if not condition:
+        print(message, file=sys.stderr)
+        sys.exit(1)
+
+
+p = argparse.ArgumentParser(description=__doc__)
+p.add_argument("elf_in", help="Program in ELF form")
+p.add_argument("bin_in", help="objdump'd ROM binary of elf_in")
+p.add_argument("bin_out", help="File to write the modified bin to")
+args = p.parse_args()
+
+symbols = subprocess.check_output([
+    os.environ.get('NM', 'nm'),
+    "--format=posix",
+    "--print-size",
+    "--defined-only",
+    args.elf_in,
+    ])
+symbols = [line.split(' ') for line in symbols.decode('ascii').split('\n') if line]
+position = {s[0]: int(s[2], 16) for s in symbols}
+size = {s[0]: int(s[3], 16) for s in symbols if s[3]}
+symtype = {s[0]: s[1] for s in symbols}
+
+romstart = min(pos for (name, pos) in position.items() if symtype[name] not in '?A')
+
+check(romstart == expected_romstart, "Defined symbols do not start at %#x" % expected_romstart)
+
+check(position.get('particle_monofirmware_module_info') == expected_moduleinfo_position,
+      """Struct particle_monofirmware_module_info not found at %#x but on %#x,
+      adjust the size of particle_monofirmware_padding to match""" %
+      (expected_moduleinfo_position, position.get('particle_monofirmware_module_info')))
+check(size.get('particle_monofirmware_module_info') == expected_moduleinfo_size,
+      "Struct particle_monofirmware_module_info not of expected size %d" % expected_moduleinfo_size)
+
+binary = bytearray(open(args.bin_in, 'rb').read())
+
+indicated_start = int.from_bytes(binary[expected_moduleinfo_position - romstart:][:4], 'little')
+check(romstart == indicated_start,
+      "particle_monofirmware_module_info.module_start does not point to the module start")
+
+if 'particle_monofirmware_checksum' in position:
+    print("monifirmware-tool: Checksum symbol found, populating it.")
+    check(size.get('particle_monofirmware_checksum') == 4, "Checksum not of expected size 4")
+
+    checksum_until = position['particle_monofirmware_checksum'] - romstart
+
+    indicated_end = int.from_bytes(binary[end_field_start:end_field_end], 'little')
+    check(indicated_end == position['particle_monofirmware_checksum'],
+          "particle_monofirmware_module_info.module_end does not point to particle_monofirmware_checksum")
+else:
+    print("monifirmware-tool: No checksum symbol found, appending the checksum to the binary.")
+    checksum_until = len(binary)
+
+    # Populating the length: When the whole binary (including the rom
+    # initialization block) is checksummed, the end address can't be populated
+    # from C because that would require evaluating `&_etext + (&_erelocate -
+    # &_srelocate)` in advance
+    binary[end_field_start:end_field_end] = (checksum_until + romstart).to_bytes(4, 'little')
+
+checksum = zlib.crc32(binary[:checksum_until]).to_bytes(4, 'big')
+binary[checksum_until:checksum_until + 4] = checksum
+
+with open(args.bin_out, "wb") as o:
+    o.write(binary)

--- a/boards/common/particle-mesh/reset.c
+++ b/boards/common/particle-mesh/reset.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C)  2020 Christian Amsüss
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @brief       Management of bootloader resets
+ *
+ * This implements a reset procedure read from the code of the particle device
+ * OS at https://github.com/particle-iot/device-os/ (version
+ * c21d5b8f39c8a013e19f904800808673f369c6e3), primarily from
+ * hal/inc/syshealth_hal.h and its linker script.
+ *
+ * @file
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "cpu.h"
+
+/* from the eSystemHealth definition of hal/inc/syshealth_hal.h */
+#define ENTER_DFU_APP_REQUEST (0xEDFA)
+
+/* Start of the backup registers as per
+ * build/arm/linker/nrf52840/platform_ram.ld and hal/src/nRF52840/core_hal.c */
+#define BACKUP_REGISTERS ((volatile int32_t*)0x2003f380)
+
+void usb_board_reset_in_bootloader(void)
+{
+    /* This *is* a write into an arbitrary memory location -- as RIOT does not
+     * use any of the Particle system interrupt handlers any more, it's not
+     * abiding by its RAM layout either. The write immediately preceding the
+     * reboot should not have any effect on being-restarted system, but leaves
+     * the flag in memory for the starting-up system to introspect.
+     * */
+    BACKUP_REGISTERS[0] = ENTER_DFU_APP_REQUEST;
+    /* Going with a hard reset rather than a pm_off, as that might be altered
+     * to do *anything* -- which is not safe any more now that we've forsaken
+     * the RAM content */
+    NVIC_SystemReset();
+}

--- a/boards/particle-argon/Makefile.include
+++ b/boards/particle-argon/Makefile.include
@@ -1,1 +1,2 @@
+CFLAGS += "-DPARTICLE_PLATFORM_ID=12"
 include $(RIOTBOARD)/common/particle-mesh/Makefile.include

--- a/boards/particle-boron/Makefile.include
+++ b/boards/particle-boron/Makefile.include
@@ -1,1 +1,2 @@
+CFLAGS += "-DPARTICLE_PLATFORM_ID=13"
 include $(RIOTBOARD)/common/particle-mesh/Makefile.include

--- a/boards/particle-xenon/Makefile.include
+++ b/boards/particle-xenon/Makefile.include
@@ -1,1 +1,2 @@
+CFLAGS += "-DPARTICLE_PLATFORM_ID=14"
 include $(RIOTBOARD)/common/particle-mesh/Makefile.include


### PR DESCRIPTION
### Contribution description

This introduces a settable environment and preprocessor flag PARTICLE_MONOFIRMWARE which makes RIOT ready for upload to Particle mesh (Xenon tested, others shouldn't need more work than flag settings) boards using their shipped USB bootloader.
 
I did not find a good description of the bootloader interface, which is normally used to load firmware built from the Particle SDK, so much of how this is done is based on looking into the bootloader's code and input from @dpgeorge who did something similar for MicroPython. In overview, the chain loading process looks like an odd hybrid of manifest-based loading and emulating the ARM reset process: It expects something that looks like VTOR at the firmware start and jumps based on information there, but doesn't disable all interrupts; in parallel there is an information struct a few hundred bytes into the firmware, and a checksum at the end (or an end). The bootloader support separation of operating system and application, which is not used in RIOT; builds like ours where everything is in a blob they call "monofirmware". A question for documentation or clarification of the odder points is yet unanswered [in the Particle forum](https://community.particle.io/t/replace-xenon-co-firmware-with-riot-os/52382).

The relevant steps for implementation are:
* Use a dedicated linker script that restricts flash to the relevant regions, keeping the bootloader (and the softdevice, which the bootloader probably depends on) untouched. 
* Fix some things during board setup (disable interrupts that the bootloader kept alive)
* Place the manifest struct at the right place in the binary.
* Set binary length in the manifest, and a checksum at the end. Not all of this can be done from the linker, so a few lines of Python code in the Makefile fix this. Practically, the bootloader can be used to upload a larger firmware image than indicated in the manifest. I'm using that to only checksum up to and including the manifest and have the rest of the code unchecksummed, so that applications are free to use flash writes on pages they set aside as static consts.
* Use dfu-util with the right arguments to actually upload the code.

### Testing procedure

Get a Particle, preferably a Xenon (or not, and see where it breaks ;-) ) with factory firmware.

Plug in at USB, and press reset briefly while keeping the mode button down. Wait for the purple blinks to end and the yellow blinks to start and then release mode.

A USB device "Particle Xenon DFU Mode" appears, and may need chgrp'ing depending on your udev rules.

`make BOARD=particle-xenon PARTICLE_MONOFIRMWARE=1 all flash` builds the application (I recommend usbus_minimal), flashes it (board blinks yellow more slowly during that) and releases it to reboot, whereupon it enumerates as a RIOT device on USB.

### Open points

* [ ]  It would be handy to have instructions for installing the upstream bootloader after the full-memory RIOT applications that were the only supported way so far. Help on this would be appreciated given I don't have suitable cables to reprogram via the 50mil header. [edit: thus "won't fix" here]
* [x] Non-Xenon boards probably don't need more than a different constant in the manifest (but the current process doesn't even set the constants I'd assume would be needed, so a test with an Argon or Krypton board should fail). [edit: implemented but not tested for lack of devices]
* [x] Which precise area to checksum might be worth making flexible. Do we have a convention that all application-writable flash areas need to be placed in a particular section? If so, the linker script could possibly arrange them in a way that all static code is checked. (Then again, this would make the linker script and the checksumming process more complicated). [edit: there's a switch for the two simplest options: "check everything" and "check only up to the bootloader information block"]
* [x] There are some to-be-researched points still in the C code (like "Do I need to manually set VTOR in there?", "Why is \_\_attribute__((used)) not sufficient to keep particle_monofirmware_module_info in the binary?", "Is there a cleaner way to place the module_info at 0x200 than having a padding padding array in the ISR_VECTOR() before it, and verifying in the make file that the calculation went right?"). [edit: VTOR setting was shown to be needless and has a comment to that; the \_\_attribute))((used)) is indeed needed like that, and much was tried with the padding but the alternatives are even worse.]
* [ ] I'd feel more comfortable with all this if the bootloader interface were documented (but hey it works...). [edit: probably won't-fix because particle is phasing out this series of devices]

#### Unsorted remarks

When used like this, the reset button just works. I wonder whether that's set up inside the bootloader (and therefore won't work if RIOT is started directly by the chip), or the documentation on the particle boards is wrong.

### Issues/PRs references

* Fixes #12320, which also contains lots of notes on previous experimentation.