### PR TITLE
boards/esp32*: use espreset tool for reset in make test

### DIFF
--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -4,5 +4,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration
-RESET ?= esptool.py
-RESET_FLAGS ?= --port $(PROG_DEV) --before default_reset run
+RESET ?= $(RIOTTOOLS)/esptool/espreset.py
+RESET_FLAGS ?= --port $(PROG_DEV)


### PR DESCRIPTION
### Contribution description

The ESP8266 port in PR #11108 introduced the reset tool `/dist/tools/esptool/espreset.py` to reset the ESP8266. Using this tool also for ESP32 allows automatic testing of ESP32 boards with the `make tests` command.

This PR is the first in a series of upcoming PRs, each with very small changes that will make it possible to perform automatic tests on ESP32 boards using the `make tests` command.

### Testing procedure

Make, flash and execute an automatic test, for example,
```
make BOARD=esp32-wroom-32 -C tests/thread_basic flash test
```

### Issues/PRs references

Requires #12750