### PR TITLE
cpu/esp32: fix of thread priorities levels

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -99,7 +99,11 @@ INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/include
 INCLUDES += -I$(RIOTBOARD)/common/$(CPU)/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)
 
-CFLAGS  += -DSCHED_PRIO_LEVELS=32
+# if any WiFi interface is used, the number of priority levels has to be 32
+ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
+  CFLAGS += -DSCHED_PRIO_LEVELS=32
+endif
+
 CFLAGS  += -DSDK_NOT_USED -DCONFIG_FREERTOS_UNICORE=1 -DESP_PLATFORM
 CFLAGS  += -DLOG_TAG_IN_BRACKETS
 CFLAGS  += -Wno-unused-parameter -Wformat=0


### PR DESCRIPTION
### Contribution description

If the WiFi interface is enabled with module `esp_wifi` or `esp_now`, a number of high priority threads are created to handle the WiFi hardware events. In this case, the number of thread priority levels has to be 32. However, a number of tests insist that the number of thread priority levels is 16.

This PR introduces the conditional setting of `SCHED_PRIO_LEVELS` to satisfy number of tests:

`tests/cond_order`
`tests/mutex_order`
`tests/rmutex_cpp`
`tests/rmutex`
`tests/posix_semaphore`
`tests/shell`
`tests/xtimer_mutex_lock_timeout`

This PR belongs to the series of PRs, each with very small changes that fix automatic tests on ESP32 boards.

### Testing procedure

Make, flash and execute one of the tests mentioned above, for example,
```
make BOARD=esp32-wroom-32 -C tests/cond_order flash test
```

### Issues/PRs references

Requires #12752 