### PR TITLE
cpu/esp32: fix heap command output

### DIFF
--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -271,7 +271,7 @@ unsigned int IRAM get_free_heap_size (void)
 
 void heap_stats(void)
 {
-    printf("heap: %u (used %u free %u)\n", (unsigned)(&_eheap - &_sheap),
+    printf("heap: %u (used %u, free %u) [bytes]\n", (unsigned)(&_eheap - &_sheap),
            &_eheap - &_sheap - get_free_heap_size(), get_free_heap_size());
 }
 


### PR DESCRIPTION
### Contribution description

This PR fixes the output of the heap command. The has to have an output format that is compatible with the test. With this PR, `tests/heap_cmd` works for ESP32 boards.

This PR belongs to the series of PRs, each with very small changes that fix automatic tests on ESP32 boards.

### Testing procedure

Make, flash and execute `tests/heap`.
```
make BOARD=esp32-wroom-32 -C tests/heap_cmd flash test
```

### Issues/PRs references

Requires #12752