### PR TITLE
tests/netstat_l2: workaround for esp32 boards

### DIFF
--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -2,9 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_PROVIDES_NETIF := airfy-beacon fox iotlab-m3 mulle native nrf51dk nrf51dongle \
 	nrf6310 pba-d-01-kw2x samd21-xpro saml21-xpro samr21-xpro spark-core \
-	yunjia-nrf51822 msba2 \
-    esp32-mh-et-live-minikit esp32-olimex-evb \
-    esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit
+	yunjia-nrf51822 msba2
 
 BOARD_WHITELIST += $(BOARD_PROVIDES_NETIF)
 

--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_PROVIDES_NETIF := airfy-beacon fox iotlab-m3 mulle native nrf51dk nrf51dongle \
+BOARD_PROVIDES_NETIF ?= airfy-beacon fox iotlab-m3 mulle native nrf51dk nrf51dongle \
 	nrf6310 pba-d-01-kw2x samd21-xpro saml21-xpro samr21-xpro spark-core \
 	yunjia-nrf51822 msba2
 


### PR DESCRIPTION
### Contribution description

Since ESP32 boards only have network interfaces if the `esp_wifi`, `esp_now` and `esp_eth` modules are explicitly enabled, they are removed from the list of boards that provide network interfaces. 

Instead, the variable BOARD_PROVIDES_NETIF is made adjustable in the environment. Thus the test can be used for ESP32 with and without network interfaces.

Fixes the test `tests/netstat_l2` for ESP32.

This PR belongs to the series of PRs, each with very small changes that fix automatic tests on ESP32 boards.

### Testing procedure

Make, flash and test with
```
BOARD_PROVIDES_NETIF=esp32-wroom-32 USEMODULE=esp_wifi make BOARD=esp32-wroom-32 -C tests/netstats_l2 flash test
```
and without network interfaces.
```
make BOARD=esp32-wroom-32 -C tests/netstats_l2
```

### Issues/PRs references

Requires #12752