### PR TITLE
cpu/esp32: fix xtimer dependency

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -12,6 +12,7 @@ ifneq (,$(filter esp_eth,$(USEMODULE)))
     USEMODULE += netdev_eth
     USEMODULE += netopt
     USEMODULE += riot_freertos
+    USEMODULE += xtimer
     INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/ethernet
     INCLUDES += -I$(ESP32_SDK_DIR)/components/ethernet/include
 endif
@@ -38,6 +39,7 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     USEMODULE += esp_idf_wpa_supplicant_port
     USEMODULE += esp_idf_nvs_flash
     USEMODULE += riot_freertos
+    USEMODULE += xtimer
 
     # crypto and hashes produce symbol conflicts with esp_idf_wpa_supplicant_crypto
     DISABLE_MODULE += crypto
@@ -48,11 +50,6 @@ ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))
     # add additional modules required by esp_idf_nvs_flash
     USEMODULE += mtd
     USEMODULE += pthread
-endif
-
-ifneq (,$(filter riot_freertos,$(USEMODULE)))
-    # add additional modules required by riot_freertos
-    USEMODULE += xtimer
 endif
 
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
@@ -89,7 +86,6 @@ endif
 
 ifneq (,$(filter shell,$(USEMODULE)))
     USEMODULE += ps
-    USEMODULE += xtimer
 endif
 
 # if SPI RAM is enabled, ESP-IDF heap and quot flash mode have to be used

--- a/cpu/esp32/freertos/timers.c
+++ b/cpu/esp32/freertos/timers.c
@@ -10,6 +10,8 @@
 
 #ifndef DOXYGEN
 
+#ifdef MODULE_XTIMER
+
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
@@ -102,5 +104,7 @@ BaseType_t xTimerStop  (TimerHandle_t xTimer, TickType_t xBlockTime)
 
     return pdTRUE;
 }
+
+#endif /* MODULE_XTIMER */
 
 #endif /* DOXYGEN */


### PR DESCRIPTION
### Contribution description

Removes the dependency of the `riot_freertos` module from module `xtimer`. This avoids that `xtimer` is used even if it is not really needed which in turn occupies the first timer device so `tests/periph_timer` fails.

Fixes the automatic test output of `tests/periph_timers` for ESP32.

This PR belongs to the series of PRs, each with very small changes that fix automatic tests on ESP32 boards.

### Testing procedure

Make, flash and test `tests/periph_timer.
```
make BOARD=esp32-wroom-32 -C tests/periph_timer flash test
```

### Issues/PRs references

Requires #12752