### PR TITLE
cpu/esp32: increase timeout for spiffs and littlefs tests

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -51,6 +51,14 @@ ifneq (,$(filter esp_wifi,$(USEMODULE)))
     USEMODULE += esp_wifi_any
 endif
 
+ifneq (,$(filter spiffs,$(USEMODULE)))
+  export RIOT_TEST_TIMEOUT = 300
+endif
+
+ifneq (,$(filter littlefs,$(USEMODULE)))
+  export RIOT_TEST_TIMEOUT = 300
+endif
+
 # ESP32 pseudomodules
 PSEUDOMODULES += esp_eth_hw
 PSEUDOMODULES += esp_gdb


### PR DESCRIPTION
### Contribution description

The time it takes to erase the entire flash memory of an ESP32 board requires increasing the timeout  for `tests/pkg_spiffs` and `tests/pkg_littlefs`.

Fixes the automatic tests of `tests/pkg_spiffs` and `tests/pkg_littlefs` for ESP32 boards.

This PR belongs to the series of PRs, each with very small changes that fix automatic tests on ESP32 boards.

### Testing procedure

Make, flash and execute the tests mentioned.
```
make BOARD=esp32-wroom-32 -C tests/pkg_spiffs flash test
make BOARD=esp32-wroom-32 -C tests/pkg_littlefs flash test
```

### Issues/PRs references

Requires #12752