### PR TITLE
core: debug: introduce DEBUG_PUTS()

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -56,7 +56,7 @@ extern "C" {
             printf(__VA_ARGS__); \
         } \
         else { \
-            puts("Cannot debug, stack too small"); \
+            puts("Cannot debug, stack too small. Consider using DEBUG_PUTS()."); \
         } \
     } while (0)
 #else
@@ -95,6 +95,14 @@ extern "C" {
  * @note Another name for ::DEBUG_PRINT
  */
 #define DEBUG(...) if (ENABLE_DEBUG) DEBUG_PRINT(__VA_ARGS__)
+
+/**
+ * @def DEBUG_PUTS
+ *
+ * @brief Print debug information to stdout using puts(), so no stack size
+ *        restrictions do apply.
+ */
+#define DEBUG_PUTS(str) if (ENABLE_DEBUG) puts(str)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

The `DEBUG()` function requires a minimal stack size for `printf()`.
This is not always available, but it's still handy to have static debug messages.
So this introduces `DEBUG_PUTS()` which gets resolved to `puts()` and does not carry such stack size requirements.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
All the `DEBUG()` statements in the various `pm.c` implementations will never be printed as the idle stack size is too small for `printf()`.