### PR TITLE
sys/crypto: Use `FEATURE_REQUIRED += arch_32bit` instead of manual blacklists

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -3,6 +3,10 @@ ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_OPTIONAL += periph_spi
 endif
 
+ifneq (,$(filter crypto,$(USEMODULE)))
+  FEATURES_REQUIRED += arch_32bit
+endif
+
 ifneq (,$(filter eepreg,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eeprom
 endif

--- a/tests/sys_crypto/Makefile
+++ b/tests/sys_crypto/Makefile
@@ -1,26 +1,5 @@
 include ../Makefile.tests_common
 
-# Issue with integer width
-BOARD_BLACKLIST += arduino-duemilanove
-BOARD_BLACKLIST += arduino-leonardo
-BOARD_BLACKLIST += arduino-mega2560
-BOARD_BLACKLIST += arduino-nano
-BOARD_BLACKLIST += arduino-uno
-BOARD_BLACKLIST += atmega256rfr2-xpro
-BOARD_BLACKLIST += avr-rss2
-BOARD_BLACKLIST += atmega328p
-BOARD_BLACKLIST += atmega1284p
-BOARD_BLACKLIST += chronos
-BOARD_BLACKLIST += mega-xplained
-BOARD_BLACKLIST += microduino-corerf
-BOARD_BLACKLIST += msb-430
-BOARD_BLACKLIST += msb-430h
-BOARD_BLACKLIST += telosb
-BOARD_BLACKLIST += waspmote-pro
-BOARD_BLACKLIST += wsn430-v1_3b
-BOARD_BLACKLIST += wsn430-v1_4
-BOARD_BLACKLIST += z1
-
 USEMODULE += embunit
 
 USEMODULE += crypto


### PR DESCRIPTION
### Contribution description

- Added `FEATURE_REQUIRED += arch_32bit` to `sys/crypto`
- Removed the now needless board blacklist in the test

### Testing procedure

Run `make -C tests/sys_crypto info-boards-supported` with master and this PR. The `diff` should be empty.

### Issues/PRs references

None