### PR TITLE
tests/pthread_barrier: improve test script

### DIFF
--- a/tests/pthread_barrier/main.c
+++ b/tests/pthread_barrier/main.c
@@ -56,7 +56,8 @@ int main(void)
 {
     random_init(RAND_SEED);
 
-    puts("START\n");
+    printf("NUM_CHILDREN: %d, NUM_ITERATIONS: %d\n", NUM_CHILDREN,
+           NUM_ITERATIONS);
     pthread_barrier_init(&barrier, NULL, NUM_CHILDREN);
 
     pthread_t children[NUM_CHILDREN];

--- a/tests/pthread_barrier/tests/01-run.py
+++ b/tests/pthread_barrier/tests/01-run.py
@@ -5,9 +5,13 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect('START')
-    for i in range(4):
+    child.expect(r'NUM_CHILDREN: (\d+), NUM_ITERATIONS: (\d+)')
+    children = int(child.match.group(1))
+    iterations = int(child.match.group(2))
+    for i in range(children):
         child.expect('Start {}'.format(i + 1))
+    for _ in range(children * iterations):
+        child.expect(r'Child \d sleeps for [" "\d]+ us.')
     child.expect('Done 2')
     child.expect('Done 1')
     child.expect('Done 3')


### PR DESCRIPTION
### Contribution description

This PR adds intermediate `child_expect` to avoid timeouts if time between last `start` and `done` i longer than 10s.

### Testing procedure

- Run locally:

`BOARD=arduino-mega2560 make -C tests/pthread_barrier/ test`

<details>

```
ssh -t ci@ci-riot-tribe.saclay.inria.fr 'BOARD=arduino-mega2560 QUIET=0 make --no-print-directory -C /builds/boards term'
/builds/boards/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/tty-arduino-mega2560" -b "9600" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2019-11-21 09:56:40,648 # Connect to serial port /dev/riot/tty-arduino-mega2560
Welcome to pyterm!
Type '/exit' to exit.
2019-11-21 09:56:41,651 # e 1
2019-11-21 09:56:41,652 # Done 3
2019-11-21 09:56:41,652 # Done 4
2019-11-21 09:56:41,652 # 
2019-11-21 09:56:41,653 # SUCCESS
2019-11-21 09:56:41,653 # 

2019-11-21 09:56:41,656 # main(): This is RIOT! (Version: 2020.01-devel-760-g00c21e-HEAD)
2019-11-21 09:56:41,676 # NUM_CHILDREN: 4, NUM_ITERATIONS: 5
2019-11-21 09:56:41,684 # Start 1
2019-11-21 09:56:41,692 # Start 2
2019-11-21 09:56:41,701 # Start 3
2019-11-21 09:56:41,713 # Start 4
2019-11-21 09:56:41,713 # 
2019-11-21 09:56:41,754 # ======================================
2019-11-21 09:56:41,754 # 
2019-11-21 09:56:41,787 # Child 4 sleeps for  1752298 us.
2019-11-21 09:56:41,820 # Child 3 sleeps for  1772042 us.
2019-11-21 09:56:41,852 # Child 2 sleeps for  1287734 us.
2019-11-21 09:56:41,885 # Child 1 sleeps for  2386493 us.
2019-11-21 09:56:43,540 # 
2019-11-21 09:56:43,581 # ======================================
2019-11-21 09:56:43,581 # 
2019-11-21 09:56:44,306 # Child 1 sleeps for  1514587 us.
2019-11-21 09:56:44,339 # Child 3 sleeps for  1706397 us.
2019-11-21 09:56:44,371 # Child 4 sleeps for  1265353 us.
2019-11-21 09:56:44,404 # Child 2 sleeps for  2085252 us.
2019-11-21 09:56:45,637 # 
2019-11-21 09:56:45,678 # ======================================
2019-11-21 09:56:45,678 # 
2019-11-21 09:56:46,522 # Child 2 sleeps for  2406092 us.
2019-11-21 09:56:46,554 # Child 3 sleeps for  2184134 us.
2019-11-21 09:56:46,591 # Child 1 sleeps for   921395 us.
2019-11-21 09:56:46,624 # Child 4 sleeps for   107980 us.
2019-11-21 09:56:46,730 # 
2019-11-21 09:56:46,771 # ======================================
2019-11-21 09:56:46,772 # 
2019-11-21 09:56:48,963 # Child 2 sleeps for    76940 us.
2019-11-21 09:56:48,995 # Child 3 sleeps for  2273767 us.
2019-11-21 09:56:49,028 # Child 1 sleeps for  1868346 us.
2019-11-21 09:56:49,061 # Child 4 sleeps for  1650360 us.
2019-11-21 09:56:50,712 # 
2019-11-21 09:56:50,753 # ======================================
2019-11-21 09:56:50,753 # 
2019-11-21 09:56:51,301 # Child 3 sleeps for  1729994 us.
2019-11-21 09:56:51,334 # Child 1 sleeps for  1288040 us.
2019-11-21 09:56:51,367 # Child 4 sleeps for  2397307 us.
2019-11-21 09:56:51,400 # Child 2 sleeps for   580990 us.
2019-11-21 09:56:51,985 # Done 2
2019-11-21 09:56:52,628 # Done 1
2019-11-21 09:56:53,038 # Done 3
2019-11-21 09:56:53,771 # Done 4
2019-11-21 09:56:53,771 # 
2019-11-21 09:56:53,779 # SUCCESS

make: Leaving directory '/home/francisco/workspace/RIOT/tests/pthread_barrier'
```
</details>

- Happy murdock
### Issues/PRs references

#12461