### PR TITLE
gnrc_netapi: report errors on dispatch

### DIFF
--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <errno.h>
+
 #include "mbox.h"
 #include "msg.h"
 #include "net/gnrc/netreg.h"
@@ -91,20 +93,20 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
 
         while (sendto) {
 #if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
-            int release = 0;
+            uint32_t errno = 0;
             switch (sendto->type) {
                 case GNRC_NETREG_TYPE_DEFAULT:
                     if (_gnrc_netapi_send_recv(sendto->target.pid, pkt,
                                                cmd) < 1) {
                         /* unable to dispatch packet */
-                        release = 1;
+                        errno = EIO;
                     }
                     break;
 #ifdef MODULE_GNRC_NETAPI_MBOX
                 case GNRC_NETREG_TYPE_MBOX:
                     if (_snd_rcv_mbox(sendto->target.mbox, cmd, pkt) < 1) {
                         /* unable to dispatch packet */
-                        release = 1;
+                        errno = EIO;
                     }
                     break;
 #endif
@@ -115,16 +117,16 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
 #endif
                 default:
                     /* unknown dispatch type */
-                    release = 1;
+                    errno = ECANCELED;
                     break;
             }
-            if (release) {
-                gnrc_pktbuf_release(pkt);
+            if (errno != 0) {
+                gnrc_pktbuf_release_error(pkt, errno);
             }
 #else
             if (_gnrc_netapi_send_recv(sendto->target.pid, pkt, cmd) < 1) {
                 /* unable to dispatch packet */
-                gnrc_pktbuf_release(pkt);
+                gnrc_pktbuf_release_error(pkt, EIO);
             }
 #endif
             sendto = gnrc_netreg_getnext(sendto);

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -93,20 +93,20 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
 
         while (sendto) {
 #if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
-            uint32_t errno = 0;
+            uint32_t status = 0;
             switch (sendto->type) {
                 case GNRC_NETREG_TYPE_DEFAULT:
                     if (_gnrc_netapi_send_recv(sendto->target.pid, pkt,
                                                cmd) < 1) {
                         /* unable to dispatch packet */
-                        errno = EIO;
+                        status = EIO;
                     }
                     break;
 #ifdef MODULE_GNRC_NETAPI_MBOX
                 case GNRC_NETREG_TYPE_MBOX:
                     if (_snd_rcv_mbox(sendto->target.mbox, cmd, pkt) < 1) {
                         /* unable to dispatch packet */
-                        errno = EIO;
+                        status = EIO;
                     }
                     break;
 #endif
@@ -117,11 +117,11 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
 #endif
                 default:
                     /* unknown dispatch type */
-                    errno = ECANCELED;
+                    status = ECANCELED;
                     break;
             }
-            if (errno != 0) {
-                gnrc_pktbuf_release_error(pkt, errno);
+            if (status != 0) {
+                gnrc_pktbuf_release_error(pkt, status);
             }
 #else
             if (_gnrc_netapi_send_recv(sendto->target.pid, pkt, cmd) < 1) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds the error messages to `gnrc_netapi` in case `gnrc_neterr` is compiled in when a queue of a module is full (`EIO`) or if the `gnrc_netreg` type is not known (`ECANCELED`, should not happen in a properly configured stack).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flood test with `gnrc_sock_udp` with `gnrc_neterr` compiled in. If a queue runs full `gnrc_udp_send()` should return `-EIO`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
