### PR TITLE
cpu/esp32: fixes for tests/ssp for ESP32 boards

### DIFF
--- a/cpu/esp32/exceptions.c
+++ b/cpu/esp32/exceptions.c
@@ -193,15 +193,22 @@ void init_exceptions (void)
 void IRAM NORETURN panic_arch(void)
 {
     #if defined(DEVELHELP)
+
     #ifdef MODULE_ESP_IDF_HEAP
     heap_caps_print_heap_info(MALLOC_CAP_DEFAULT);
     #else
     ets_printf("\nheap: %u (free %u) byte\n", &_eheap - &_sheap, get_free_heap_size());
     #endif /* MODULE_ESP_IDF_HEAP */
-    #endif /* DEVELHELP */
+
+    /* break in debugger or reboot after WDT */
+    __asm__ volatile ("break 0,0");
+
+    #else /* DEVELHELP */
 
     /* restart */
     software_reset();
+
+    #endif /* DEVELHELP */
 
     UNREACHABLE();
 }

--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -6,3 +6,7 @@ FEATURES_BLACKLIST += arch_avr8 arch_esp8266 arch_mips32r2 arch_msp430
 USEMODULE += ssp
 
 include $(RIOTBASE)/Makefile.include
+
+ifneq (,$(shell $(CC) --help=warnings | grep '\-Wstringop-overflow='))
+  CFLAGS += -Wstringop-overflow=0
+endif

--- a/tests/ssp/main.c
+++ b/tests/ssp/main.c
@@ -24,6 +24,14 @@
 #include <stdio.h>
 #include <string.h>
 
+__attribute__((weak)) void
+_prevent_memset_lto(void *const  s, int c, const size_t n)
+{
+    (void) s;
+    (void) c;
+    (void) n;
+}
+
 void test_func(void)
 {
     char buf[16];
@@ -35,6 +43,9 @@ void test_func(void)
     /* cppcheck-suppress bufferAccessOutOfBounds
      * (reason: deliberately overflowing stack) */
     memset(buffer_to_confuse_compiler, 0, 32);
+
+    /* prevent that memset call is optimized out by LTO */
+    _prevent_memset_lto(buf, 0, 32);
 }
 
 int main(void)


### PR DESCRIPTION
### Contribution description

To get automatic testing of `tests/ssp` working on ESP32 boards, the following changes were necessary:

1. The `test_func` has to call another function with the local buffer variable to prevent that `memset` is optimized out by LTO. Should also work for other platforms.
2. `panic_arch` must not reboot immediately to get the asynchronous UART output from the test. A `break` instruction is therefore inserted.

Fixes the automatic tests of `tests/ssp` for ESP32 boards.

This PR belongs to the series of PRs, each with very small changes that fix automatic tests on ESP32 boards.

### Testing procedure

Make, flash and test
```
make BOARD=esp32-wroom-32 -C tests/ssp flash test
```

### Issues/PRs references

Makes PR #12034 obsolete.