### PR TITLE
boards/pic32-clicker: cleanup uart configuration and initialization, cleanup header includes

### DIFF
--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -7,13 +7,9 @@
  * directory for more details.
  *
  */
-#include <stdio.h>
-#include <stdint.h>
-#include "periph/gpio.h"
-#include "periph/uart.h"
-#include "bitarithm.h"
+
 #include "board.h"
-#include "cpu.h"
+#include "periph/gpio.h"
 
 extern void dummy(void);
 

--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -26,11 +26,6 @@ void board_init(void)
     U3RXR =    0x2;          /*connect pin RPF5 to UART3 RX*/
     RPF4R =    0x1;          /*connect pin RPF4 to UART3 TX*/
 
-    /* intialise UART used for debug (printf) */
-#ifdef DEBUG_VIA_UART
-    uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
-#endif
-
     /* Turn off all LED's */
     gpio_init(LED1_PIN, GPIO_OUT);
     gpio_init(LED2_PIN, GPIO_OUT);

--- a/boards/pic32-clicker/include/board.h
+++ b/boards/pic32-clicker/include/board.h
@@ -26,6 +26,7 @@
 #ifndef BOARD_H
 #define BOARD_H
 
+#include "cpu.h"
 #include "periph_conf.h"
 
 #ifdef __cplusplus

--- a/boards/pic32-clicker/include/board.h
+++ b/boards/pic32-clicker/include/board.h
@@ -41,6 +41,13 @@ extern "C" {
 #define TICKS_PER_US (48)
 
 /**
+ * @brief   Use the 3rd UART for STDIO on this board
+ *
+ * This is the UART connected to the MikroBus.
+ */
+#define STDIO_UART_DEV      UART_DEV(3)
+
+/**
  * @brief   We are using an External Interrupt Controller (all pic32 devices use this mode)
  */
 #define EIC_IRQ (1)

--- a/boards/pic32-clicker/include/periph_conf.h
+++ b/boards/pic32-clicker/include/periph_conf.h
@@ -53,8 +53,6 @@ extern "C" {
   * @{
   */
 #define UART_NUMOF          (4)
-#define DEBUG_VIA_UART      (3)
-#define DEBUG_UART_BAUD     (9600)
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up the UART initialization and configuration similar to what was done in #12256.

This is an alternative to #12744.

This PR is untested. but maybe @francois-berder could give it a try.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- stdio UART works

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Alternative to #12744 (and thus closes #12744), leftover from #12256

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
