### PR TITLE
drivers/bmx280: add temp_measurement to methods

### DIFF
--- a/drivers/bmx280/bmx280.c
+++ b/drivers/bmx280/bmx280.c
@@ -355,10 +355,11 @@ int16_t bmx280_read_temperature(bmx280_t *dev)
     return (dev->t_fine * 5 + 128) >> 8;
 }
 
-uint32_t bmx280_read_pressure(const bmx280_t *dev)
+uint32_t bmx280_read_pressure(bmx280_t *dev)
 {
     assert(dev);
 
+    bmx280_read_temperature(dev);
     const bmx280_calibration_t *cal = &dev->calibration; /* helper variable */
 
     /* Read the uncompensated pressure */
@@ -397,10 +398,11 @@ uint32_t bmx280_read_pressure(const bmx280_t *dev)
 }
 
 #if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
-uint16_t bme280_read_humidity(const bmx280_t *dev)
+uint16_t bme280_read_humidity(bmx280_t *dev)
 {
     assert(dev);
 
+    bmx280_read_temperature(dev);
     const bmx280_calibration_t *cal = &dev->calibration; /* helper variable */
 
     /* Read the uncompensated pressure */

--- a/drivers/bmx280/bmx280_saul.c
+++ b/drivers/bmx280/bmx280_saul.c
@@ -35,7 +35,7 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 static int read_pressure(const void *dev, phydat_t *res)
 {
-    res->val[0] = bmx280_read_pressure((const bmx280_t *)dev) / 100;
+    res->val[0] = bmx280_read_pressure((bmx280_t *)dev) / 100;
     res->unit = UNIT_PA;
     res->scale = 2;
 
@@ -45,7 +45,7 @@ static int read_pressure(const void *dev, phydat_t *res)
 #if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
 static int read_relative_humidity(const void *dev, phydat_t *res)
 {
-    res->val[0] = bme280_read_humidity((const bmx280_t *)dev);
+    res->val[0] = bme280_read_humidity((bmx280_t *)dev);
     res->unit = UNIT_PERCENT;
     res->scale = -2;
 

--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -283,7 +283,7 @@ int16_t bmx280_read_temperature(bmx280_t* dev);
  *
  * @return  air pressure in PA
  */
-uint32_t bmx280_read_pressure(const bmx280_t *dev);
+uint32_t bmx280_read_pressure(bmx280_t *dev);
 
 #if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C) || defined(DOXYGEN)
 /**
@@ -302,7 +302,7 @@ uint32_t bmx280_read_pressure(const bmx280_t *dev);
  *
  * @return  humidity in centi %RH (i.e. the percentage times 100)
  */
-uint16_t bme280_read_humidity(const bmx280_t *dev);
+uint16_t bme280_read_humidity(bmx280_t *dev);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR is providing a bugfix for humidity and pressure measurement. The variable t_fine is used in pressure and humidity compensation formulas. So you must read the sensor and calculate the temperature before calculate current humidity or pressure.

- Add the method `bmx280_read_temperature` to humidity and pressure measurement.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
