### PR TITLE
pkg/nimble: ver bump + config  improvement

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = fb7651b773734a075c47ff10210b92e6d55ef55b
+PKG_VERSION = 946cfb7ff27fcf3adacebcd50c159b89d854fbf2
 PKG_LICENSE = Apache-2.0
 
 TDIR = $(RIOTPKG)/$(PKG_NAME)

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -90,6 +90,11 @@ ifneq (,$(filter nimble_netif,$(USEMODULE)))
   # NimBLEs internal buffer need to hold one IPv6 MTU per connection
   # for the internal MTU of 256 byte, we need 10 mbufs per connection...
   CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=35
+
+  # optimize the NimBLE controller for IP traffic
+  ifneq (,$(filter nimble_controller,$(USEMODULE)))
+    CFLAGS += -DMYNEWT_VAL_BLE_LL_CFG_FEAT_DATA_LEN_EXT=1
+  endif
 endif
 ifneq (,$(filter nimble_scanlist,$(USEMODULE)))
   INCLUDES += -I$(RIOTPKG)/nimble/scanlist/include

--- a/tests/nimble_l2cap/main.c
+++ b/tests/nimble_l2cap/main.c
@@ -143,7 +143,10 @@ static void _filter_and_connect(struct ble_gap_disc_desc *disc)
     int res;
     bluetil_ad_t ad;
 
-    bluetil_ad_init(&ad, disc->data,
+
+    /* we use the bluetil module read-only here, so its save to cast the AD
+     * buffer to non-const */
+    bluetil_ad_init(&ad, (uint8_t *)disc->data,
                     (size_t)disc->length_data, (size_t)disc->length_data);
     res = bluetil_ad_find_and_cmp(&ad, BLE_GAP_AD_NAME,
                                   APP_NODENAME, (sizeof(APP_NODENAME) - 1));


### PR DESCRIPTION
### Contribution description
In the last month some (for us) relevant bugs in NimBLE got fixed (e.g. https://github.com/apache/mynewt-nimble/pull/650), so its time for another version bump.

On top, this PR includes a configuration improvement to enable the link layer data length extension to be used whenever `nimble_netif` is used -> this improves network performance quite a bit.

Both commits are included in the same PR, as testing is identical and therefore this reduces the workload...

### Testing procedure
Verify that `examples/nimble_gatt`, `examples/gnrc_networking`, and `tests/nimble_l2cap` are still working. Any `nrf52xxx`-based platform does the job to test this.

### Issues/PRs references
none