### PR TITLE
tests/event_wait_timeout: Fix for 8bit platforms

### DIFF
--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -31,27 +31,27 @@ extern "C" {
 /**
  * @brief The number of microseconds per second
  */
-#define US_PER_SEC (1000000U)
+#define US_PER_SEC          (1000000LU)
 
 /**
  * @brief The number of seconds per minute
  */
-#define SEC_PER_MIN  (60U)
+#define SEC_PER_MIN         (60LU)
 
 /**
  * @brief The number of centiseconds per second
  */
-#define CS_PER_SEC   (100U)
+#define CS_PER_SEC          (100LU)
 
 /**
  * @brief The number of milliseconds per second
  */
-#define MS_PER_SEC   (1000U)
+#define MS_PER_SEC          (1000LU)
 
 /**
  * @brief The number of microseconds per millisecond
  */
-#define US_PER_MS  (1000U)
+#define US_PER_MS           (1000LU)
 
 /**
  * @brief The number of microseconds per centisecond
@@ -61,7 +61,7 @@ extern "C" {
 /**
  * @brief The number of nanoseconds per microsecond
  */
-#define NS_PER_US  (1000U)
+#define NS_PER_US           (1000LU)
 
 /**
  * @brief The number of nanoseconds per second

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -155,10 +155,10 @@ void gnrc_ipv6_nib_pl_print(gnrc_ipv6_nib_pl_t *entry)
            entry->pfx_len);
     printf("dev #%u ", entry->iface);
     if (entry->valid_until < UINT32_MAX) {
-        printf(" expires %" PRIu32 "sec", (entry->valid_until - now) / MS_PER_SEC);
+        printf(" expires %lu sec", (entry->valid_until - now) / MS_PER_SEC);
     }
     if (entry->pref_until < UINT32_MAX) {
-        printf(" deprecates %" PRIu32 "sec", (entry->pref_until - now) / MS_PER_SEC);
+        printf(" deprecates %lu sec", (entry->pref_until - now) / MS_PER_SEC);
     }
     puts("");
 }

--- a/tests/event_wait_timeout/main.c
+++ b/tests/event_wait_timeout/main.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <stdint.h>
+#include <stdatomic.h>
 #include <stdio.h>
 
 #include "event.h"
@@ -40,13 +42,13 @@ static event_t _evt = { .handler = _on_evt };
 static char _stack[STACKSIZE];
 static thread_t *_thread_main;
 
-static unsigned _wakeup_evt = 0;
-static unsigned _wakeup_timeout = 0;
+static atomic_uint _wakeup_evt = ATOMIC_VAR_INIT(0);
+static atomic_uint _wakeup_timeout = ATOMIC_VAR_INIT(0);
 
 static void _on_evt(event_t *evt)
 {
     (void)evt;
-    ++_wakeup_evt;
+    atomic_fetch_add(&_wakeup_evt, 1);
 }
 
 static void *_cnt_thread(void *arg)
@@ -60,7 +62,7 @@ static void *_cnt_thread(void *arg)
             evt->handler(evt);
         }
         else {
-            ++_wakeup_timeout;
+            atomic_fetch_add(&_wakeup_timeout, 1);
         }
     }
 
@@ -123,8 +125,8 @@ int main(void)
     /* finally, wait 60ms and collect results -> +1 timeout wakeup */
     xtimer_usleep(60U * US_PER_MS);
 
-    unsigned events = _wakeup_evt;
-    unsigned timeouts = _wakeup_timeout;
+    unsigned events = atomic_load(&_wakeup_evt);
+    unsigned timeouts = atomic_load(&_wakeup_timeout);
 
     /* rate results */
     printf("finished: %u/4 events and %u/4 timeouts recorded\n",

--- a/tests/xtimer_msg/main.c
+++ b/tests/xtimer_msg/main.c
@@ -60,7 +60,7 @@ void *timer_thread(void *arg)
         msg_receive(&m);
         struct timer_msg *tmsg = m.content.ptr;
         uint32_t now = xtimer_now_usec();
-        printf("now=%" PRIu32 ":%" PRIu32 " -> every %" PRIu32 ".%" PRIu32 "s: %s\n",
+        printf("now=%lu:%lu -> every %lu.%lus: %s\n",
                (now / US_PER_SEC),
                (now % US_PER_SEC),
                tmsg->interval / US_PER_SEC,

--- a/tests/ztimer_msg/main.c
+++ b/tests/ztimer_msg/main.c
@@ -69,7 +69,7 @@ void *timer_thread(void *arg)
         msg_receive(&m);
         struct timer_msg *tmsg = m.content.ptr;
         uint32_t now = ztimer_now(ZTIMER);
-        printf("now=%" PRIu32 ":%" PRIu32 " -> every %" PRIu32 ".%" PRIu32 "s: %s\n",
+        printf("now=%lu:%lu -> every %lu.%lus: %s\n",
                (now / TICKS_PER_SEC),
                (now % TICKS_PER_SEC),
                tmsg->interval / TICKS_PER_SEC,


### PR DESCRIPTION
### Contribution description

- Fix a potential issue with the use of a regular global variable for communication between thread and IRQ context
- Fixed `US_PER_MS` and friends to be safely used when `sizeof(unsigned) < sizeof(uint32_t)`. Citing the commit message:

> The macros US_PER_MS and friends are assumed to be 32 bit unsigned integers by users. However, e.g. on AVR a `1000U` is only 16 bit long. Thus, e.g. `xtimer_usleep(100 * US_PER_MS)`  will wrap around and only sleep for ~34ms.

This commit ensures that they are treated as 32 bit unsigned integers on all
platforms.

### Testing procedure

- `tests/event_wait_timeout` should now work on ATmega

### Issues/PRs references

Tick second item in https://github.com/RIOT-OS/RIOT/issues/12651