### PR TITLE
cpu/sam*: pm: make use of DEBUG_PUTS()

### DIFF
--- a/cpu/samd5x/periph/pm.c
+++ b/cpu/samd5x/periph/pm.c
@@ -22,12 +22,7 @@
 #include "periph/pm.h"
 
 #define ENABLE_DEBUG (0)
-
-#if ENABLE_DEBUG
-#define DEBUG(s) puts(s)
-#else
-#define DEBUG(s)
-#endif
+#include "debug.h"
 
 void pm_set(unsigned mode)
 {
@@ -36,23 +31,23 @@ void pm_set(unsigned mode)
 
     switch (mode) {
         case 0:
-            DEBUG("pm_set(): setting BACKUP mode.");
+            DEBUG_PUTS("pm_set(): setting BACKUP mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
             deep = 1;
             break;
         case 1:
-            DEBUG("pm_set(): setting HIBERNATE mode.");
+            DEBUG_PUTS("pm_set(): setting HIBERNATE mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_HIBERNATE;
             deep = 1;
             break;
         case 2:
-            DEBUG("pm_set(): setting STANDBY mode.");
+            DEBUG_PUTS("pm_set(): setting STANDBY mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
             deep = 1;
             break;
         default: /* Falls through */
         case 3:
-            DEBUG("pm_set(): setting IDLE2 mode.");
+            DEBUG_PUTS("pm_set(): setting IDLE2 mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_IDLE2;
             break;
     }

--- a/cpu/saml1x/periph/pm.c
+++ b/cpu/saml1x/periph/pm.c
@@ -31,12 +31,12 @@ void pm_set(unsigned mode)
 
         switch (mode) {
             case 0:
-                DEBUG("pm_set(): setting STANDBY mode.\n");
+                DEBUG_PUTS("pm_set(): setting STANDBY mode.");
                 _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
                 break;
             default: /* Falls through */
             case 1:
-                DEBUG("pm_set(): setting IDLE mode.\n");
+                DEBUG_PUTS("pm_set(): setting IDLE mode.");
                 _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
                 break;
         }

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -31,16 +31,16 @@ void pm_set(unsigned mode)
 
         switch (mode) {
             case 0:
-                DEBUG("pm_set(): setting BACKUP mode.\n");
+                DEBUG_PUTS("pm_set(): setting BACKUP mode.");
                 _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
                 break;
             case 1:
-                DEBUG("pm_set(): setting STANDBY mode.\n");
+                DEBUG_PUTS("pm_set(): setting STANDBY mode.");
                 _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
                 break;
             default: /* Falls through */
             case 2:
-                DEBUG("pm_set(): setting IDLE mode.\n");
+                DEBUG_PUTS("pm_set(): setting IDLE mode.");
 #if defined(CPU_MODEL_SAMR30G18A) || defined(CPU_MODEL_SAMR34J18B)
                 _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
 #else


### PR DESCRIPTION
### Contribution description

`pm_set()` gets called by the idle thread whose stack is too small for normal DEBUG()/printf().

Use `DEBUG_PUTS()` instead to print the static debug strings.

### Testing procedure
Set `#define ENABLE_DEBUG 1`.

### Issues/PRs references
follow-up on #12760
