### PR TITLE
CODING_CONVENTIONS: Add reference to IS_ACTIVE and IS_USED macros

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -26,6 +26,11 @@
       [completely different](https://www.kernel.org/doc/html/latest/process/coding-style.html#typedefs)
       (see below) (BTW: Do we have any reason to do so?)
     * Comments should be C-style comments (see below)
+* In order to follow Linux's recommendation on
+  [conditional compilation](https://www.kernel.org/doc/html/latest/process/coding-style.html#conditional-compilation)
+  make use of `IS_ACTIVE` and `IS_USED` macros from `kernel_defines.h` with C
+  conditionals. If a symbol is not going to be defined under a certain
+  condition, the usage of preprocessor `#if defined()` is fine.
 * You can use [uncrustify](http://uncrustify.sourceforge.net/) with the provided
   option files: https://github.com/RIOT-OS/RIOT/blob/master/uncrustify-riot.cfg
 


### PR DESCRIPTION
### Contribution description
According to the discussion in #12626, there was a [common agreement](https://github.com/RIOT-OS/RIOT/pull/12626#issuecomment-550224766) on reducing the use of C preprocessor conditionals in favor of C conditionals, where possible. This is actually mentioned in the Linux [coding conventions](https://www.kernel.org/doc/html/latest/process/coding-style.html#conditional-compilation). 

This PR adds a reference to the `IS_USED` and `IS_ACTIVE` macros introduced by #12626, as means to follow this recommendation. Also a link to this particular section in Linux's coding convention is added, where the rationale behind this is explained in detailed. I think it doesn't make much sense to repeat what's already explained there.


### Testing procedure
Read the document, check the links.

### Issues/PRs references
#12626 
