### PR TITLE
cpu/sam0_common/periph/spi: power off spi bus on release

### DIFF
--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -73,7 +73,7 @@ void spi_init(spi_t bus)
     /* reset all device configuration */
     dev(bus)->CTRLA.reg |= SERCOM_SPI_CTRLA_SWRST;
     while ((dev(bus)->CTRLA.reg & SERCOM_SPI_CTRLA_SWRST) ||
-           (dev(bus)->SYNCBUSY.reg & SERCOM_SPI_SYNCBUSY_SWRST));
+           (dev(bus)->SYNCBUSY.reg & SERCOM_SPI_SYNCBUSY_SWRST)) {}
 
     /* configure base clock: using GLK GEN 0 */
 #ifdef GCLK_CLKCTRL_GEN_GCLK0
@@ -103,7 +103,7 @@ void spi_init_pins(spi_t bus)
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
-    (void) cs;
+    (void)cs;
 
     /* configure bus clock, in synchronous mode its calculated from
      * BAUD.reg = (f_ref / (2 * f_bus) - 1)
@@ -116,9 +116,9 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
      * efficiency reason we do that here, so we can do all in one single write
      * to the CTRLA register */
     const uint32_t ctrla = SERCOM_SPI_CTRLA_MODE(0x3)       /* 0x3 -> master */
-                         | SERCOM_SPI_CTRLA_DOPO(spi_config[bus].mosi_pad)
-                         | SERCOM_SPI_CTRLA_DIPO(spi_config[bus].miso_pad)
-                         | (mode << SERCOM_SPI_CTRLA_CPHA_Pos);
+                           | SERCOM_SPI_CTRLA_DOPO(spi_config[bus].mosi_pad)
+                           | SERCOM_SPI_CTRLA_DIPO(spi_config[bus].miso_pad)
+                           | (mode << SERCOM_SPI_CTRLA_CPHA_Pos);
 
     /* get exclusive access to the device */
     mutex_lock(&locks[bus]);


### PR DESCRIPTION
### Contribution description

Concerns:

Proper handling of enable / disable of the SPI bus for sam0_common based CPUs to avoid that bus errors affect application code.

Solves:

After first `spi_acquire` the bus previously stayed enabled. Triggering a reset on a peripheral module of our custom board led to dysfunctional SPI communication (no valid information received any more). The peripheral reset might have triggered a receiver overflow (not checked). Disabling and reenabling the device recovers this error without checking for error flags. This also corresponds to the assumed behavior mentioned in the RIOT documentation.

### Testing procedure

Our custom board is equipped with a mt3333 based gnss peripheral. This chip provides a simple SPI protocol which will transmit non-zero bytes and assumes a regular read/write of 255 bytes with a write padding character of 0xFF. Some delays are required and were set to overly high values for this test.

For this peripheral, the following section of code was used to verify the fix:

```C
#include "board.h"
#include "stdio.h"
#include "periph/gpio.h"
#include "periph/spi.h"
#include "xtimer.h"

void spi_xfer(void) {
    uint8_t in[256] = { 0x00 };
    uint8_t out[255] = { 0xFF };
    printf("SPI ");
    if (spi_acquire(SPI_DEV(2), GPIO_PIN(PA, 9), SPI_MODE_3,
            SPI_CLK_1MHZ) == SPI_OK) {
        spi_transfer_bytes(SPI_DEV(2), GPIO_PIN(PA, 9),
                false, out, in, 255);
        if (in[0] != 0x00) {
            puts("received payload");
        }
        else {
            puts("no payload");
        }
        spi_release(SPI_DEV(2));
    }
    else {
        puts("ERROR");
    }
}

int main(void)
{
    LED0_ON;
    xtimer_usleep(1000000);
    LED0_OFF;

    board_enable_gnss();
    xtimer_usleep(3000000UL);
    puts("+++++++++++++++++++++++++++++ START");
    size_t jj;
    for (jj = 0; jj < 100; jj++) {
        spi_xfer();
        xtimer_usleep(50000UL);
    }
    puts("++++++ RESETTING DEVICE");
    gpio_clear(MT3333_PARAM_NRESET);
    xtimer_usleep(3000000UL);
    gpio_set(MT3333_PARAM_NRESET);
    xtimer_usleep(3000000UL);
    for (jj = 0; jj < 100; jj++) {
        spi_xfer();
        xtimer_usleep(50000UL);
    }

    puts("+++++++++++++++++++++++++++++ END");
    while(true) {
    }
    return 0;
}
```

The result of the test was that without this contribution the process always received an SPI payload from the peripheral before the reset but never after. With this contribution the process always received a payload before and after the reset.

It is not clear to me whether the same issue will reproduce when using a different peripheral.

### Issues/PRs references

None.