### PR TITLE
gnrc_tcp: externalize address/port storage

### DIFF
--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -47,10 +47,26 @@ int gnrc_tcp_init(void);
 /**
  * @brief Initialize Transmission Control Block (TCB)
  * @pre @p tcb must not be NULL.
+ * @pre @p address_family must not be NULL.
+ * @pre @p local_addr must not be NULL.
+ * @pre @p local_port must not be NULL.
+ * @pre @p local_addr must not be NULL.
+ * @pre @p local_port must not be NULL.
+ * @pre @p ll_iface must not be NULL.
  *
  * @param[in,out] tcb   TCB that should be initialized.
+ * @param[in]     address_family    Pointer to address family storage.
+ * @param[in]     local_addr        Pointer to local address storage.
+ * @param[in]     local_addr_size   size of memory behind @p local_addr.
+ * @param[in]     local_port        Pointer to local port number storage.
+ * @param[in]     peer_addr         Pointer to peer address storage.
+ * @param[in]     peer_addr_size    size of memory behind @p peer_addr.
+ * @param[in]     peer_port         Pointer to peer port number storage.
+ * @param[in]     ll_iface          Pointer to link-layer interface storage.
  */
-void gnrc_tcp_tcb_init(gnrc_tcp_tcb_t *tcb);
+void gnrc_tcp_tcb_init(gnrc_tcp_tcb_t *tcb, int *address_family, uint8_t *local_addr,
+                       size_t local_addr_size, uint16_t *local_port, uint8_t *peer_addr,
+                       size_t peer_addr_size, uint16_t *peer_port, int8_t *ll_iface);
 
 /**
  * @brief Opens a connection actively.
@@ -80,7 +96,7 @@ void gnrc_tcp_tcb_init(gnrc_tcp_tcb_t *tcb);
  *            -ETIMEDOUT if the connection could not be opened.
  *            -ECONNREFUSED if the connection was resetted by the peer.
  */
-int gnrc_tcp_open_active(gnrc_tcp_tcb_t *tcb,  uint8_t address_family,
+int gnrc_tcp_open_active(gnrc_tcp_tcb_t *tcb,  int address_family,
                          char *target_addr, uint16_t target_port,
                          uint16_t local_port);
 
@@ -111,7 +127,7 @@ int gnrc_tcp_open_active(gnrc_tcp_tcb_t *tcb,  uint8_t address_family,
  *            -ENOMEM if the receive buffer for the TCB could not be allocated.
  *            Hint: Increase "GNRC_TCP_RCV_BUFFERS".
  */
-int gnrc_tcp_open_passive(gnrc_tcp_tcb_t *tcb, uint8_t address_family,
+int gnrc_tcp_open_passive(gnrc_tcp_tcb_t *tcb, int address_family,
                           const char *local_addr, uint16_t local_port);
 
 /**

--- a/sys/include/net/gnrc/tcp/tcb.h
+++ b/sys/include/net/gnrc/tcp/tcb.h
@@ -47,14 +47,12 @@ extern "C" {
  * @brief Transmission control block of GNRC TCP.
  */
 typedef struct _transmission_control_block {
-    uint8_t address_family;                   /**< Address Family of local_addr / peer_addr */
-#ifdef MODULE_GNRC_IPV6
-    uint8_t local_addr[sizeof(ipv6_addr_t)];  /**< Local IP address */
-    uint8_t peer_addr[sizeof(ipv6_addr_t)];   /**< Peer IP address */
-    int8_t  ll_iface;                         /**< Link layer interface id to use. */
-#endif
-    uint16_t local_port;   /**< Local connections port number */
-    uint16_t peer_port;    /**< Peer connections port number */
+    int *address_family;       /**< Address Family in use */
+    uint8_t *local_addr;       /**< Pointer to local address storage */
+    uint16_t *local_port;      /**< Pointer to local port storage */
+    uint8_t *peer_addr;        /**< Pointer to peer address storage */
+    uint16_t *peer_port;       /**< Pointer to peer port storage */
+    int8_t *ll_iface;          /**< Pointer to link-layer interface storage */
     uint8_t state;         /**< Connections state */
     uint8_t status;        /**< A connections status flags */
     uint32_t snd_una;      /**< Send unacknowledged */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -184,10 +184,10 @@ static int _receive(gnrc_pktsnip_t *pkt)
     while (tcb) {
 #ifdef MODULE_GNRC_IPV6
         /* Check if current TCB is fitting for the incomming packet */
-        if (ip->type == GNRC_NETTYPE_IPV6 && tcb->address_family == AF_INET6) {
+        if (ip->type == GNRC_NETTYPE_IPV6 && *(tcb->address_family) == AF_INET6) {
             /* If SYN is set, a connection is listening on that port ... */
             ipv6_addr_t *tmp_addr = NULL;
-            if (syn && tcb->local_port == dst && tcb->state == FSM_STATE_LISTEN) {
+            if (syn && *(tcb->local_port) == dst && tcb->state == FSM_STATE_LISTEN) {
                 /* ... and local addr is unspec or pre configured */
                 tmp_addr = &((ipv6_hdr_t *)ip->data)->dst;
                 if (ipv6_addr_equal((ipv6_addr_t *) tcb->local_addr, (ipv6_addr_t *) tmp_addr) ||
@@ -197,7 +197,7 @@ static int _receive(gnrc_pktsnip_t *pkt)
             }
 
             /* If SYN is not set and the ports match ... */
-            if (!syn && tcb->local_port == dst && tcb->peer_port == src) {
+            if (!syn && *(tcb->local_port) == dst && *(tcb->peer_port) == src) {
                 /* .. and the IPv6 addresses match */
                 tmp_addr = &((ipv6_hdr_t * )ip->data)->src;
                 if (ipv6_addr_equal((ipv6_addr_t *) tcb->peer_addr, (ipv6_addr_t *) tmp_addr)) {

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -159,8 +159,8 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
     }
 
     /* Fill TCP header */
-    tcp_hdr.src_port = byteorder_htons(tcb->local_port);
-    tcp_hdr.dst_port = byteorder_htons(tcb->peer_port);
+    tcp_hdr.src_port = byteorder_htons(*(tcb->local_port));
+    tcp_hdr.dst_port = byteorder_htons(*(tcb->peer_port));
     tcp_hdr.checksum = byteorder_htons(0);
     tcp_hdr.seq_num = byteorder_htonl(seq_num);
     tcp_hdr.ack_num = byteorder_htonl(ack_num);
@@ -227,7 +227,7 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
     }
 
     /* Prepend network interface header if an interface id was specified */
-    if (tcb->ll_iface > 0) {
+    if (*(tcb->ll_iface) > 0) {
         gnrc_pktsnip_t *net_snp = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
         if (net_snp == NULL) {
             DEBUG("gnrc_tcp_pkt.c : _pkt_build() : Can't allocate buffer for netif header.\n");
@@ -236,7 +236,7 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
             return -ENOMEM;
         }
         else {
-            ((gnrc_netif_hdr_t *)net_snp->data)->if_pid = (kernel_pid_t)tcb->ll_iface;
+            ((gnrc_netif_hdr_t *) net_snp->data)->if_pid = (kernel_pid_t) *(tcb->ll_iface);
             LL_PREPEND(ip6_snp, net_snp);
             *(out_pkt) = net_snp;
         }

--- a/tests/gnrc_tcp/main.c
+++ b/tests/gnrc_tcp/main.c
@@ -19,6 +19,12 @@
 
 static msg_t main_msg_queue[MAIN_QUEUE_SIZE];
 static gnrc_tcp_tcb_t tcb;
+static int address_family;
+static ipv6_addr_t local_addr;
+static uint16_t local_port;
+static ipv6_addr_t peer_addr;
+static uint16_t peer_port;
+static int8_t ll_iface;
 static char buffer[BUFFER_SIZE];
 
 void dump_args(int argc, char **argv)
@@ -94,7 +100,10 @@ int buffer_read_cmd(int argc, char **argv)
 int gnrc_tcp_tcb_init_cmd(int argc, char **argv)
 {
     dump_args(argc, argv);
-    gnrc_tcp_tcb_init(&tcb);
+
+    gnrc_tcp_tcb_init(&tcb, &address_family, (uint8_t *) &local_addr, sizeof(local_addr),
+                      &local_port, (uint8_t *) &peer_addr, sizeof(peer_addr), &peer_port,
+                      &ll_iface);
     return 0;
 }
 


### PR DESCRIPTION
This PR move the address storage outside of the gnrc_tcp_tcb_t - struct. This is a necessary step towards integrating gnrc_tcp into the sock interface.

Beware this PR contains an API change for gnrc_tcp.  


@miri64 - I kept my promise :D