### PR TITLE
cpu/esp*: define esp_now as default netdev

### DIFF
--- a/boards/esp32-olimex-evb/Makefile.include
+++ b/boards/esp32-olimex-evb/Makefile.include
@@ -2,14 +2,10 @@ PSEUDOMODULES += olimex_esp32_gateway
 
 USEMODULE += boards_common_esp32
 
-# enables esp_eth as network device
+# enables esp_eth as default network device
+# cannot be done in Makefile.dep since Makefile.dep is included too late
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
-    # avoid multiple definitions when package depenedencies are resolved recursively
-    ifndef MODULE_ESP_ETH_ADDED
-        MODULE_ESP_ETH_ADDED = 1
-        USEMODULE += esp_eth
-        $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
-    endif
+  USEMODULE += esp_eth
 endif
 
 include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -109,7 +109,7 @@ INCLUDES += -I$(RIOTBOARD)/common/$(CPU)/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)
 
 # if any WiFi interface is used, the number of priority levels has to be 32
-ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
+ifneq (,$(filter esp_wifi_any esp_eth,$(USEMODULE)))
   CFLAGS += -DSCHED_PRIO_LEVELS=32
 endif
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -51,6 +51,10 @@ ifneq (,$(filter esp_wifi,$(USEMODULE)))
     USEMODULE += esp_wifi_any
 endif
 
+ifneq (,$(filter esp_eth,$(USEMODULE)))
+  $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
+endif
+
 ifneq (,$(filter spiffs,$(USEMODULE)))
   export RIOT_TEST_TIMEOUT = 300
 endif

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -41,6 +41,13 @@ ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
     USEMODULE += esp_gdb
 endif
 
+ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+  # use esp_now as default netdev if no other netdev module is enabled
+  ifeq (,$(filter esp_wifi esp_eth,$(USEMODULE)))
+    USEMODULE += esp_now
+  endif
+endif
+
 ifneq (,$(filter esp_now,$(USEMODULE)))
     $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
     USEMODULE += esp_wifi_any

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -19,10 +19,25 @@ endif
 # SPECIAL module dependencies
 # cannot be done in Makefile.dep since Makefile.dep is included too late
 
-ifneq (, $(filter esp_now esp_wifi, $(USEMODULE)))
+ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+  # use esp_now as default netdev if no other netdev module is enabled
+  ifeq (,$(filter esp_wifi esp_eth,$(USEMODULE)))
+    USEMODULE += esp_now
+  endif
+endif
+
+ifneq (, $(filter esp_wifi, $(USEMODULE)))
     $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
-    CFLAGS += -DSCHED_PRIO_LEVELS=32
     USEMODULE += esp_wifi_any
+endif
+
+ifneq (, $(filter esp_now, $(USEMODULE)))
+    $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
+    USEMODULE += esp_wifi_any
+endif
+
+ifneq (, $(filter esp_wifi_any, $(USEMODULE)))
+    CFLAGS += -DSCHED_PRIO_LEVELS=32
     USEMODULE += netopt
     USEMODULE += xtimer
 endif

--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -4,7 +4,8 @@ BOARD_PROVIDES_NETIF := airfy-beacon fox iotlab-m3 mulle native nrf51dk nrf51don
 	nrf6310 pba-d-01-kw2x samd21-xpro saml21-xpro samr21-xpro spark-core \
 	yunjia-nrf51822 msba2 \
     esp32-mh-et-live-minikit esp32-olimex-evb \
-    esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit
+    esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit \
+    esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing
 
 BOARD_WHITELIST += $(BOARD_PROVIDES_NETIF)
 


### PR DESCRIPTION
### Contribution description

For ESP32 and ESP8266 boards, various on-board `netdev`s can be enabled by the `esp-now`, `esp-wifi`, `esp-eth` pseudo modules.

Since `esp-wifi` requires additional configuration settings and `esp-eth` is not available on each board, `esp-now` is defined as default `netdev` if none of the other `netdev` modules is enabled explicitly.

It is possible to use multiple `netdev`s. `GNRC_NETIF_NUMOF` is determined automatically as long as dynamic approaches in PR #9903 and #12308 are not available.

### Testing procedure

Test the following configurations:

1. `esp-now` as default `netdev`
    ```
    make BOARD=esp32-wroom-32 -C tests/netstats_l2 flash test
    ```
    `esp-now` should be used as default `netdev` and the statistics should contain a L2-PDU size of 249.

2. `esp-wifi` as default `netdev`
    ```
    USEMODULE=esp_wifi make BOARD=esp32-wroom-32 -C tests/netstats_l2 flash test
    ```
    `esp-wifi` should be used as default `netdev` and the statistics should contain a L2-PDU size of 1500.

3. `esp-eth` as default `netdev`
    ```
    USEMODULE=esp_wifi make BOARD=esp32-olimex-evb -C tests/netstats_l2 flash test
    ```
    Check with command
    ```
    grep MODULE_ESP_ETH tests/netstats_l2/bin/esp32-olimex-evb/riotbuild/riotbuild.h
    ```
    that module `esp_eth` is used.

4. Multiple `netdev`s
    ```
    USEMODULE='esp_wifi esp_now' make BOARD=esp32-wroom-32 -C tests/netstats_l2 flash term
    ```
    There should be two `netdev`s with the `ifconfig` command.

5. Tests 1, 2 and 3 for `esp32-wroom-32` board should also work for `esp8266-esp-12x` board.

### Issues/PRs references

Makes #12756 obsolete