### PR TITLE
drivers/bmx280: Fix incorrect endian conversion

### DIFF
--- a/drivers/bmx280/bmx280.c
+++ b/drivers/bmx280/bmx280.c
@@ -123,20 +123,12 @@ static int _read_burst(const bmx280_t *dev, uint8_t reg, void *buf, size_t len)
 
 static uint16_t _to_u16_le(const uint8_t *buffer, size_t offset)
 {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    return (((uint16_t)buffer[offset + 1]) << 8) + buffer[offset];
-#else
-    return (((uint16_t)buffer[offset]) << 8) + buffer[offset + 1];
-#endif
+    return (((uint16_t)buffer[offset + 1]) << 8) | buffer[offset];
 }
 
 static int16_t _to_i16_le(const uint8_t *buffer, size_t offset)
 {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    return (((int16_t)buffer[offset + 1]) << 8) + buffer[offset];
-#else
-    return (((int16_t)buffer[offset]) << 8) + buffer[offset + 1];
-#endif
+    return (((int16_t)buffer[offset + 1]) << 8) | buffer[offset];
 }
 
 /**


### PR DESCRIPTION
### Contribution description

Fixed the byte order conversion in the BMx280 driver.

The binary shift operators in C are defined via the change of their values, not the change of the memory representation of them. When reading a value from little endian out of buffer `buf`, `((uint16_t)buf[1] << 8) | buf[0]` will thus work regardless of the byte order of the host system.

### Testing procedure

Ideally running the driver on a big endian system. But if I remember correctly, we do not have support for a big endian system. (Are there even working big endian systems still available?)

### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/8383