### PR TITLE
tests/isr_yield_higher: Make use of US_PER_MS

### DIFF
--- a/tests/isr_yield_higher/main.c
+++ b/tests/isr_yield_higher/main.c
@@ -24,7 +24,7 @@
 #include "thread.h"
 #include "xtimer.h"
 
-#define TEST_TIME (200000U)
+#define TEST_TIME (200 * US_PER_MS)
 
 static char t2_stack[THREAD_STACKSIZE_MAIN];
 static uint32_t start_time;


### PR DESCRIPTION
### Contribution description

Exactly what the tile states.

### Testing procedure

The test sould still work

### Issues/PRs references

Should ideally not be merged before a solution to https://github.com/RIOT-OS/RIOT/pull/12776 is found. (Will break the test on AVR currently.)