### PR TITLE
tests/pipe: cleanup application

### DIFF
--- a/tests/pipe/main.c
+++ b/tests/pipe/main.c
@@ -47,11 +47,12 @@ static void *run_middle(void *arg)
 
     unsigned read_total = 0;
     while (read_total < BYTES_TOTAL) {
-        char buf[4];
-        unsigned read = pipe_read(&pipes[0], buf, sizeof (buf));
+        char buf[5];
+        unsigned read = pipe_read(&pipes[0], buf, sizeof(buf) - 1);
+        buf[read] = 0;
         unsigned read_start = read_total;
         read_total += read;
-        printf("Middle read: <%.*s> [%u:%u]\n", read, buf,
+        printf("Middle read: <%s> [%u:%u]\n", buf,
                read_start, read_total);
 
         unsigned written_total = 0;
@@ -72,11 +73,12 @@ static void *run_end(void *arg)
 
     unsigned read_total = 0;
     while (read_total < BYTES_TOTAL) {
-        char buf[3];
-        int read = pipe_read(&pipes[1], buf, sizeof (buf));
+        char buf[4];
+        int read = pipe_read(&pipes[1], buf, sizeof(buf) - 1);
+        buf[read] = 0;
         unsigned read_start = read_total;
         read_total += read;
-        printf("End read: <%.*s> [%u:%u]\n", read, buf,
+        printf("End read: <%s> [%u:%u]\n", buf,
                read_start, read_total);
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is cleaning up the `tests/pipe` application to make it also work with AVR. I have to admit that I didn't know the printf syntax (`%.*s`) to print a string given a length and a buffer.
Apparently this doesn't work with the AVR toolchain so the fix is just to close the string with a null byte explicitly and use `%s` formatter in the print.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock with run tests enabled
- The following should also work now:
```
$ make BOARD=atmega256rfr2-xpro -C tests/pipe flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #12651 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
