### PR TITLE
 drivers/ws281x: add VT100 backend for native

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -693,11 +693,6 @@ ifneq (,$(filter ws281x,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter ws281x_vt100,$(USEMODULE)))
-  CFLAGS += -DWS281X_HAVE_PREPARE_TRANSMISSION
-  CFLAGS += -DWS281X_HAVE_END_TRANSMISSION
-endif
-
 ifneq (,$(filter xbee,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
   FEATURES_REQUIRED += periph_gpio

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -678,15 +678,24 @@ endif
 
 ifneq (,$(filter ws281x,$(USEMODULE)))
   FEATURES_OPTIONAL += arch_avr8
+  FEATURES_OPTIONAL += arch_native
   ifeq (,$(filter ws281x_%,$(USEMODULE)))
     ifneq (,$(filter arch_avr8,$(FEATURES_USED)))
       USEMODULE += ws281x_atmega
+    endif
+    ifneq (,$(filter arch_native,$(FEATURES_USED)))
+      USEMODULE += ws281x_vt100
     endif
   endif
   ifneq (,$(filter ws281x_atmega,$(USEMODULE)))
     FEATURES_REQUIRED += arch_avr8
   endif
   USEMODULE += xtimer
+endif
+
+ifneq (,$(filter ws281x_vt100,$(USEMODULE)))
+  CFLAGS += -DWS281X_HAVE_PREPARE_TRANSMISSION
+  CFLAGS += -DWS281X_HAVE_END_TRANSMISSION
 endif
 
 ifneq (,$(filter xbee,$(USEMODULE)))

--- a/drivers/include/ws281x.h
+++ b/drivers/include/ws281x.h
@@ -59,6 +59,7 @@
 
 #include "color.h"
 #include "periph/gpio.h"
+#include "ws281x_backend.h"
 #include "ws281x_constants.h"
 #include "xtimer.h"
 
@@ -92,6 +93,7 @@ typedef struct {
     ws281x_params_t params;   /**< Parameters of the LED chain */
 } ws281x_t;
 
+#if defined(WS281X_HAVE_INIT) || defined(DOXYGEN)
 /**
  * @brief   Initialize an WS281x RGB LED chain
  *
@@ -103,6 +105,12 @@ typedef struct {
  * @retval  -EIO    Failed to initialize the data GPIO pin
  */
 int ws281x_init(ws281x_t *dev, const ws281x_params_t *params);
+#else
+static inline int ws281x_init(ws281x_t *dev, const ws281x_params_t *params) {
+    dev->params = *params;
+    return 0;
+}
+#endif
 
 /**
  * @brief   Writes the color data of the user supplied buffer

--- a/drivers/ws281x/atmega.c
+++ b/drivers/ws281x/atmega.c
@@ -203,3 +203,19 @@ void ws281x_write_buffer(ws281x_t *dev, const void *buf, size_t size)
 #error "No low level WS281x implementation for ATmega CPUs for your CPU clock"
 #endif
 }
+
+int ws281x_init(ws281x_t *dev, const ws281x_params_t *params)
+{
+    if (!dev || !params || !params->buf) {
+        return -EINVAL;
+    }
+
+    memset(dev, 0, sizeof(ws281x_t));
+    dev->params = *params;
+
+    if (gpio_init(dev->params.pin, GPIO_OUT)) {
+        return -EIO;
+    }
+
+    return 0;
+}

--- a/drivers/ws281x/include/ws281x_backend.h
+++ b/drivers/ws281x/include/ws281x_backend.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 Marian Buschsieweke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ws281x
+ *
+ * @{
+ * @file
+ * @brief       Backend configuration for WS2812/SK6812 RGB LEDs
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef WS281X_BACKEND_H
+#define WS281X_BACKEND_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Properties of the ATmega backend.
+ * @{
+ */
+#ifdef MODULE_WS281X_ATMEGA
+#define WS281X_HAVE_INIT                    (1)
+#endif
+/** @} */
+
+/**
+ * @name    Properties of the VT100 terminal backend.
+ * @{
+ */
+#ifdef MODULE_WS281X_VT100
+#define WS281X_HAVE_PREPARE_TRANSMISSION    (1)
+#define WS281X_HAVE_END_TRANSMISSION        (1)
+#endif
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WS281X_BACKEND_H */
+/** @} */

--- a/drivers/ws281x/vt100.c
+++ b/drivers/ws281x/vt100.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ws281x
+ *
+ * @{
+ *
+ * @file
+ * @brief       Implementation of `ws281x_write()` for VT100 terminals
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * @}
+ */
+#include <stdio.h>
+#include "ws281x.h"
+
+void ws281x_write_buffer(ws281x_t *dev, const void *buf, size_t size)
+{
+    (void) dev;
+    const uint8_t *src = buf;
+
+    for (unsigned i = 0; i < size; ++i) {
+        int r = src[WS281X_BYTES_PER_DEVICE * i + WS281X_OFFSET_R];
+        int g = src[WS281X_BYTES_PER_DEVICE * i + WS281X_OFFSET_G];
+        int b = src[WS281X_BYTES_PER_DEVICE * i + WS281X_OFFSET_B];
+        printf("\033[48;2;%d;%d;%dm ", r, g, b);
+    }
+}
+
+void ws281x_prepare_transmission(ws281x_t *dev)
+{
+    (void) dev;
+
+    /* clear the line and reset cursor position */
+    printf("\033[2K\r");
+}
+
+void ws281x_end_transmission(ws281x_t *dev)
+{
+    (void) dev;
+
+    /* set color back to normal */
+    printf("\033[0m");
+}

--- a/drivers/ws281x/ws281x.c
+++ b/drivers/ws281x/ws281x.c
@@ -31,25 +31,6 @@
 /* Default buffer used in ws281x_params.h. Will be optimized out if unused */
 uint8_t ws281x_buf[WS281X_PARAM_NUMOF * WS281X_BYTES_PER_DEVICE];
 
-/* Some backend will need a custom init function. Declaring this as weak symbol
- * allows them to provide their own. */
-int __attribute__((weak)) ws281x_init(ws281x_t *dev,
-                                      const ws281x_params_t *params)
-{
-    if (!dev || !params || !params->buf) {
-        return -EINVAL;
-    }
-
-    memset(dev, 0, sizeof(ws281x_t));
-    dev->params = *params;
-
-    if (gpio_init(dev->params.pin, GPIO_OUT)) {
-        return -EIO;
-    }
-
-    return 0;
-}
-
 void ws281x_set_buffer(void *_dest, uint16_t n, color_rgb_t c)
 {
     uint8_t *dest = _dest;

--- a/tests/driver_ws281x/Makefile
+++ b/tests/driver_ws281x/Makefile
@@ -7,7 +7,9 @@ N ?= 8
 
 USEMODULE += ws281x
 
-FEATURES_REQUIRED := arch_avr8 # <-- Currently only backend for AVR boards
+ifneq (native, $(BOARD))
+  FEATURES_REQUIRED += arch_avr8
+endif
 
 # Only AVR boards CPU clocked at 8MHz or 16 MHz are supported. The Waspmote Pro
 # is clocked at 14.7456 MHz :-/

--- a/tests/driver_ws281x/main.c
+++ b/tests/driver_ws281x/main.c
@@ -59,7 +59,7 @@ int main(void)
 
     while (1) {
         unsigned offset = 0;
-        puts("Animation: Moving rainbow...");
+        puts("\nAnimation: Moving rainbow...");
         xtimer_ticks32_t last_wakeup = xtimer_now();
         for (unsigned i = 0; i < 100; i++) {
             for (uint16_t j = 0; j < dev.params.numof; j++) {
@@ -70,7 +70,7 @@ int main(void)
             xtimer_periodic_wakeup(&last_wakeup, 100 * US_PER_MS);
         }
 
-        puts("Animation: Fading rainbow...");
+        puts("\nAnimation: Fading rainbow...");
         last_wakeup = xtimer_now();
         for (unsigned i = 0; i < RAINBOW_LEN; i++) {
             for (unsigned j = 0; j < 255; j++) {
@@ -93,7 +93,7 @@ int main(void)
             }
         }
 
-        puts("Animation: 100 rainbows. (You'll need a long chain for this)");
+        puts("\nAnimation: 100 rainbows. (You'll need a long chain for this)");
         uint8_t buf[RAINBOW_LEN * WS281X_BYTES_PER_DEVICE];
         for (unsigned i = 0; i < RAINBOW_LEN; i++) {
             ws281x_set_buffer(buf, i, rainbow[i]);


### PR DESCRIPTION
### Contribution description

To quickly iterate on animations it is handy to being able to simulate the output on native.
This adds a VT100 terminal backend to the ws281x driver that outputs the colors straight to the terminal.
It should work with any sufficiently modern terminal emulator.

### Testing procedure

run `tests/driver_ws281x` on `native`.

### Issues/PRs references

