### PR TITLE
cpu/esp32: workaround for UART problems

### DIFF
--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -281,6 +281,8 @@ static void _uart_config (uart_t uart)
 
     /* setup the baudrate */
     if (uart == UART_DEV(0) || uart == UART_DEV(1)) {
+        /* wait until TX FIFO is empty */
+        while (_uarts[uart].regs->status.txfifo_cnt) { }
         /* for UART0 and UART1, we can us the ROM function */
         uart_div_modify(uart, (UART_CLK_FREQ << 4) / _uarts[uart].baudrate);
     }


### PR DESCRIPTION
### Contribution description

This PR provides a workaround for the following problems:

1. The UART peripheral clock seems to be sporadically set to wrong value when the CPU clock is changed. In this case, the UART clock is not set to 115.200 kbps but to 96 kbps, so that the output in the console seems like garbage. This can also cause automatic tests to fail.

    Therefore, the system clock is only changed if CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ defines a different default CPU clock than the one already used at boot time.

2. If `stdio` based outputs are mixed with direct calls of `uart_write`, e.g., in `sys/arduino/serialport.cpp`, the TX FIFO of the UART interface can be smashed. Automatic tests may fail in that case.

   Therefore, the TX FIFO buffer is flushed now before the next write operation with `uart_write`.

### Testing procedure

Defining different CPU clocks should work as before.

Use the default CPU clock of 80 MHz
```
make BOARD=esp32-wroom-32 -C tests/bench_sched_nop/ flash test
```
and a CPU of 160 MHz
```
CFLAGS='-DCONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ=160' make BOARD=esp32-wroom-32 -C tests/bench_sched_nop/ flash test
```
The result value in second case should be about the double of the value in the first case.

### Issues/PRs references

This PR is required for stability of automatic tests (issue #12763)