### PR TITLE
net/gcoap: add macro to delay initialization of gcoap

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -153,8 +153,10 @@ void auto_init(void)
     openthread_bootstrap();
 #endif
 #ifdef MODULE_GCOAP
-    DEBUG("Auto init gcoap module.\n");
-    gcoap_init();
+    if (!IS_ACTIVE(GCOAP_NO_AUTO_INIT)) {
+        DEBUG("Auto init gcoap module.\n");
+        gcoap_init();
+    }
 #endif
 #ifdef MODULE_DEVFS
     DEBUG("Mounting /dev\n");

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -447,6 +447,16 @@ extern "C" {
 #define GCOAP_PAYLOAD_MARKER    (0xFF)
 
 /**
+ * @ingroup net_gcoap_conf
+ * @brief   Disables gcoap startup during system auto init
+ *
+ * If disabled, gcoap_init() must be called by some other means.
+ */
+#ifndef GCOAP_NO_AUTO_INIT
+#define GCOAP_NO_AUTO_INIT      0
+#endif
+
+/**
  * @name    States for the memo used to track waiting for a response
  * @{
  */


### PR DESCRIPTION
### Contribution description
Sometimes we do not wish gcoap to start at auto-initialization time. For example, #12104 must initialize its credman tool for DTLS before the gcoap thread starts. We wish to facilitate this use case without breaking existing applications. This PR adds a macro, `GCOAP_INIT_DELAY`, to accomplish this goal. When set to 1, gcoap must be started explicitly.

### Testing procedure
In the gcoap example `main()`, insert the snippet below before the call to `gcoap_cli_init()`.
```
   if (IS_ACTIVE(GCOAP_INIT_DELAY)) {
        kernel_pid_t pid = gcoap_init();
        printf("gcoap init: %u\n", pid);
    }
```

Test with and without defining the macro at compile time with something like:
```
$ CFLAGS="${CFLAGS} -DGCOAP_INIT_DELAY=1" make clean all
```

When defined, you should see the following at startup, and be able to send/receive gcoap messages as usual.
```
main(): This is RIOT! (Version: 2020.01-devel-1032-g41e2-gcoap/init_delay)
gcoap init: 6
gcoap example app
All up, running the shell now
```

### Issues/PRs references
Alternative to #12529.
