### PR TITLE
boards/derfmega*: initial support

### DIFF
--- a/boards/derfmega128/Makefile
+++ b/boards/derfmega128/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/derfmega128/Makefile.dep
+++ b/boards/derfmega128/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += boards_common_atmega

--- a/boards/derfmega128/Makefile.features
+++ b/boards/derfmega128/Makefile.features
@@ -1,0 +1,7 @@
+CPU = atmega128rfa1
+
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/derfmega128/Makefile.include
+++ b/boards/derfmega128/Makefile.include
@@ -1,0 +1,22 @@
+FLASHFILE=$(BINFILE)
+
+# configure the terminal program
+PORT_LINUX  ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+# refine serial port information for pyterm
+BAUD        ?= 115200
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# PROGRAMMER defaults to wiring which is the internal flasher via USB
+# using avrdude. Can be overridden for debugging (which requires changes
+# that require to use an ISP)
+PROGRAMMER ?= wiring
+# Serial Baud rate for flasher is configured to 500kBaud
+# see /usr/include/asm-generic/termbits.h for availabel baudrates on your linux system
+
+# From current fuse configuration
+BOOTLOADER_SIZE ?= 4K
+ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+
+include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/derfmega128/doc.txt
+++ b/boards/derfmega128/doc.txt
@@ -1,0 +1,17 @@
+/**
+ * @defgroup    boards_deRFmega128 deRFmega128 modules from Dresden Elektronik
+ * @ingroup     boards
+ * @brief       Support for deRFmega128 modules produced by Dresden Elektronik
+
+# Overview
+deRFmega128 is a family of modules produced by Dresden Elektronik.
+deRFmega128 modules are based on [ATmega128rfa1](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8266-MCU_Wireless-ATmega128RFA1_Datasheet.pdf),
+MCUs. It include 16MHz main and 32K RTC crystalls and (depending on module type) integrated or not integrated 2.4GHz antenna.
+
+These modules are available in three variants: [deRFmega128-22M00](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m00.html) with integrated antenna,
+[deRFmega128-22M10](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m10.html), and [deRFmega128-22M12](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m12.html) without integrated antenna.
+
+# Hardware
+The [datasheet](https://usermanual.wiki/dresden-elektronik-ingenieurtechnik/MEGA23M12.15-MEGA23M12-User-Manual/info) for modules.
+
+ */

--- a/boards/derfmega128/include/board.h
+++ b/boards/derfmega128/include/board.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Alexander Chudov <chudov@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_deRFmega128
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the deRFmega128 modules
+ *
+ * @author      Alexander Chudov <chudov@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name xtimer configuration values
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_HZ           (CLOCK_CORECLOCK / 64)
+#define XTIMER_BACKOFF      (40)
+
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/derfmega128/include/periph_conf.h
+++ b/boards/derfmega128/include/periph_conf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Alexander Chudov <chudov@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup boards_deRFmega128
+ * @{
+ *
+ * @file
+ * @brief   Peripheral MCU configuration for the deRFmega128 module
+ *
+ * @author  Alexander Chudov <chudov@gmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_conf_atmega_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/derfmega256/Makefile
+++ b/boards/derfmega256/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/derfmega256/Makefile.dep
+++ b/boards/derfmega256/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += boards_common_atmega

--- a/boards/derfmega256/Makefile.features
+++ b/boards/derfmega256/Makefile.features
@@ -1,0 +1,7 @@
+CPU = atmega256rfr2
+
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/derfmega256/Makefile.include
+++ b/boards/derfmega256/Makefile.include
@@ -1,0 +1,22 @@
+FLASHFILE=$(BINFILE)
+
+# configure the terminal program
+PORT_LINUX  ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+# refine serial port information for pyterm
+BAUD        ?= 115200
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# PROGRAMMER defaults to wiring which is the internal flasher via USB
+# using avrdude. Can be overridden for debugging (which requires changes
+# that require to use an ISP)
+PROGRAMMER ?= wiring
+# Serial Baud rate for flasher is configured to 500kBaud
+# see /usr/include/asm-generic/termbits.h for availabel baudrates on your linux system
+
+# From current fuse configuration
+BOOTLOADER_SIZE ?= 4K
+ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+
+include $(RIOTMAKE)/tools/avrdude.inc.mk
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/derfmega256/doc.txt
+++ b/boards/derfmega256/doc.txt
@@ -1,0 +1,18 @@
+/**
+ * @defgroup    boards_deRFmega256 deRFmega256 modules from Dresden Elektronik
+ * @ingroup     boards
+ * @brief       Support for deRFmega256 modules produced by Dresden Elektronik
+
+# Overview
+deRFmega256 is a family of modules produced by Dresden Elektronik.
+deRFmega256 modules are based on [ATmega256rfr2](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8393-MCU_Wireless-ATmega256RFR2-ATmega128RFR2-ATmega64RFR2_Datasheet.pdf)
+MCUs. It include 16MHz main and 32K RTC crystalls and (depending on module type) integrated or not integrated 2.4GHz antenna.
+
+These modules are available in three variants: [deRFmega256-23M00](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega256-23m00.html) with integrated antenna,
+[deRFmega256-23M10](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega256-23m10.html) and [deRFmega256-23M12](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega256-23m12.html) without integrated antenna
+as separate products or as a main part of other products like [RaspBee](https://phoscon.de/en/raspbee) and [ConBee I](https://phoscon.de/en/conbee)
+
+# Hardware
+The [datasheet](https://usermanual.wiki/dresden-elektronik-ingenieurtechnik/MEGA23M12.15-MEGA23M12-User-Manual/info) for modules.
+
+ */

--- a/boards/derfmega256/include/board.h
+++ b/boards/derfmega256/include/board.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Alexander Chudov <chudov@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_deRFmega256
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the deRFmega256 modules
+ *
+ * @author      Alexander Chudov <chudov@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name xtimer configuration values
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_HZ           (CLOCK_CORECLOCK / 64)
+#define XTIMER_BACKOFF      (40)
+
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/derfmega256/include/periph_conf.h
+++ b/boards/derfmega256/include/periph_conf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Alexander Chudov <chudov@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup boards_deRFmega256
+ * @{
+ *
+ * @file
+ * @brief   Peripheral MCU configuration for the deRFmega256 module
+ *
+ * @author  Alexander Chudov <chudov@gmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_conf_atmega_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     chronos \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     chronos \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -35,7 +35,7 @@ USEMODULE += ps
 USEMODULE += saul_default
 
 BOARD_PROVIDES_NETIF := acd52832 airfy-beacon atmega256rfr2-xpro avr-rss2 b-l072z-lrwan1 cc2538dk fox \
-        hamilton iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \
+        derfmega128 derfmega256 hamilton iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \
         microduino-corerf native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf6310 \
         nucleo-f207zg nucleo-f767zi openmote-b openmote-cc2538 pba-d-01-kw2x remote-pa \
         remote-reva ruuvitag samr21-xpro samr30-xpro spark-core telosb thingy52 yunjia-nrf51822 z1

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     chronos \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     chronos \
+    derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     cc1352-launchpad \
     cc2650-launchpad \
     cc2650stk \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill \
     calliope-mini \
     chronos \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/examples/gnrc_tftp/Makefile.ci
+++ b/examples/gnrc_tftp/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill \
     calliope-mini \
     chronos \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/examples/nanocoap_server/Makefile.ci
+++ b/examples/nanocoap_server/Makefile.ci
@@ -6,10 +6,11 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     chronos \
+    derfmega128 \
     i-nucleo-lrwan1 \
+    microduino-corerf \
     msb-430 \
     msb-430h \
-    microduino-corerf \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/examples/ndn-ping/Makefile.ci
+++ b/examples/ndn-ping/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     chronos \
+    derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     chronos \
+    derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     blackpill \
     bluepill \
+    derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/tests/driver_enc28j60/Makefile.ci
+++ b/tests/driver_enc28j60/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     blackpill \
     bluepill \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     cc2650-launchpad \
     cc2650stk \
     chronos \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     chronos \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     calliope-mini \
     chronos \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/pkg_libb2/Makefile.ci
+++ b/tests/pkg_libb2/Makefile.ci
@@ -7,6 +7,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega256rfr2-xpro \
     atmega328p \
     chronos \
+    derfmega128 \
+    derfmega256 \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/tests/pkg_microcoap/Makefile.ci
+++ b/tests/pkg_microcoap/Makefile.ci
@@ -6,10 +6,11 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     chronos \
+    derfmega128 \
     i-nucleo-lrwan1 \
+    microduino-corerf \
     msb-430 \
     msb-430h \
-    microduino-corerf \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -9,6 +9,8 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     atmega256rfr2-xpro \
                     atmega328p \
                     chronos \
+                    derfmega128 \
+                    derfmega256 \
                     f4vi1 \
                     hifive1 \
                     hifive1b \

--- a/tests/pkg_tweetnacl/Makefile.ci
+++ b/tests/pkg_tweetnacl/Makefile.ci
@@ -6,6 +6,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega256rfr2-xpro \
     atmega328p \
+    derfmega128 \
+    derfmega256 \
     mega-xplained \
     microduino-corerf \
     nucleo-f031k6 \

--- a/tests/pthread_cooperation/Makefile.ci
+++ b/tests/pthread_cooperation/Makefile.ci
@@ -6,6 +6,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega256rfr2-xpro \
     atmega328p \
+    derfmega128 \
+    derfmega256 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/sntp/Makefile.ci
+++ b/tests/sntp/Makefile.ci
@@ -6,7 +6,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     chronos \
+    derfmega128 \
     i-nucleo-lrwan1 \
+    microduino-corerf \
     msb-430 \
     msb-430h \
     nucleo-f030r8 \
@@ -16,7 +18,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-l031k6 \
     nucleo-l053r8 \
-    microduino-corerf \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -22,6 +22,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     cc2650-launchpad \
     cc2650stk \
     chronos \
+    derfmega128 \
+    derfmega256 \
     ek-lm4f120xl \
     esp8266-esp-12x \
     esp8266-olimex-mod \


### PR DESCRIPTION
### Contribution description

Initial support for boards/derfmega128 (based on ATMega128RFA1) and boards/derfmega256 (based on ATMega256RFR2) modules produced by Dresden Elektronik.  See doc.txt for detail.  deRFmega256 is base for the [RaspBee](https://phoscon.de/en/raspbee/): the ZigBee add-on board for RaspberryPi. The RaspBee is available [at Amazon](https://www.amazon.de/dp/B00E6300DO?ref_=ast_bbp_dp) 

### Testing procedure

Tested on two deRFmega256 modules:
-  with examples/default using txtsnd 
- examples/gnrc_networking  using ping6 RPL over 6LowPAN.
