### PR TITLE
cpu/esp32: fix to be able to use SPI flash drive with pkg_littlefs

### DIFF
--- a/cpu/esp32/ld/esp32.common.ld
+++ b/cpu/esp32/ld/esp32.common.ld
@@ -107,6 +107,7 @@ SECTIONS
     /* part of RIOT ports that should run in IRAM */
     *cpu.a:*(.literal .text .literal.* .text.*)
     *periph.a:*(.literal .text .literal.* .text.*)
+    *mtd.a:**(.literal .text .literal.* .text.*)
 
     INCLUDE esp32.spiram.rom-functions-iram.ld
     _iram_text_end = ABSOLUTE(.);

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -311,12 +311,6 @@ static NORETURN void IRAM system_init (void)
                _sys_time.tm_year + 1900, _sys_time.tm_mon + 1, _sys_time.tm_mday,
                _sys_time.tm_hour, _sys_time.tm_min, _sys_time.tm_sec);
 
-    #if MODULE_MTD
-    /* init flash drive */
-    extern void spi_flash_drive_init (void);
-    spi_flash_drive_init();
-    #endif
-
     /* initialize the board */
     board_init();
 
@@ -328,6 +322,12 @@ static NORETURN void IRAM system_init (void)
 
     /* print the board config */
     print_board_config();
+
+    #if MODULE_MTD
+    /* init flash drive */
+    extern void spi_flash_drive_init (void);
+    spi_flash_drive_init();
+    #endif
 
     /* route a software interrupt source to CPU as trigger for thread yields */
     intr_matrix_set(PRO_CPU_NUM, ETS_FROM_CPU_INTR0_SOURCE, CPU_INUM_SOFTWARE);


### PR DESCRIPTION
### Contribution description

This PR provides a fix to be able to use `pkg_littlefs` with the EPS32 SPI flash drive. `pkg_littlefs` uses the `mtd` module which has to be in IRAM. Otherwise the first access to the SPI flash drive leads to crash with optimized code. Furthermore, `spi_flash_drive_init has to be called after `stdio_init` to see debug or error messages during SPI flash drive initialization.

With this PR, `tests/pkg_littlefs` works for ESP32 boards.

This PR belongs to the series of PRs, each with very small changes that fix automatic tests on ESP32 boards.

### Testing procedure
Make, flash and test with and without this PR.
```
make BOARD=esp32-wroom-32 -C tests/pkg_littlefs flash
```
Without this PR, the test should crash.

### Issues/PRs references
