### PR TITLE
tools/avrdude: Fix `make reset` with bootloader

### DIFF
--- a/makefiles/tools/avrdude.inc.mk
+++ b/makefiles/tools/avrdude.inc.mk
@@ -20,4 +20,9 @@ PROGRAMMER_FLAGS += $(FFLAGS_EXTRA)
 # don't force to flash HEXFILE, but set it as default
 FLASHFILE ?= $(HEXFILE)
 FFLAGS += -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -U flash:w:$(FLASHFILE)
-RESET ?= $(FLASHER) -c $(PROGRAMMER) $(PROGRAMMER_FLAGS)
+
+ifeq (,$(filter $(PROGRAMMER),arduino avr109 stk500v1 stk500v2 wiring))
+  # Use avrdude to trigger a reset, if programming is not done via UART and a
+  # bootloader.
+  RESET ?= $(FLASHER) -c $(PROGRAMMER) $(PROGRAMMER_FLAGS)
+endif


### PR DESCRIPTION
### Contribution description

The generic approach of calling avrdude to perform a reset with `make reset` does also work on board with a bootloader, but only if no other process is also accessing the serial (e.g. via `make term`). `make test` first accesses the serial and then performs `make reset` to not miss any output on the serial. This however blocks when `make reset` also wants to access that serial.

As workaround, `make reset` is no only provided if the ATmega device is not programmed via bootloader. Normally, those boards reset anyway upon `make term`, which allows `make test` to work normally again.

### Testing procedure

`make test` should work again with an ATmega board with a bootloader, e.g. an Arudino Uno, Nano, or Mega2560.

### Issues/PRs references

Messed up by me in 135a37a4d1b