### PR TITLE
cpu/lpc2387: implement periph/dac

### DIFF
--- a/cpu/lpc2387/Makefile.features
+++ b/cpu/lpc2387/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_dac
 
 -include $(RIOTCPU)/arm7_common/Makefile.features

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -141,6 +141,18 @@ typedef enum {
 /** @} */
 #endif /* ndef DOXYGEN */
 
+/**
+ * @brief   DAC configuration, valid for all boards using this CPU
+ *
+ * lpc23xx has a fixed mapping of DAC pins and a fixed number of DAC channels,
+ * so this DAC configuration is valid for all boards using this CPU. No need for
+ * any board specific configuration.
+ *
+ * The DAC of the lpc23xx is mapped to the following fixed pin:
+ * - line 0 (ch0): P0.26
+ */
+#define DAC_NUMOF           (1U)
+
 /* @} */
 #ifdef __cplusplus
 }

--- a/cpu/lpc2387/periph/dac.c
+++ b/cpu/lpc2387/periph/dac.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_lpc2387
+ * @{
+ *
+ * @file
+ * @brief       Low-level DAC driver implementation
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/dac.h"
+
+int8_t dac_init(dac_t line)
+{
+    (void) line;
+
+    /* P0.26 is the only valid DAC pin */
+    PINSEL1 |=  BIT21;
+    PINSEL1 &= ~BIT20;
+
+    return 0;
+}
+
+void dac_set(dac_t line, uint16_t value)
+{
+    (void) line;
+
+    /* Bits 5:0 are reserved for future, higher-resolution D/A converters. */
+    DACR = value & 0xFFE0;
+}
+
+void dac_poweron(dac_t line)
+{
+    /* The DAC is always on. */
+    (void) line;
+}
+
+void dac_poweroff(dac_t line)
+{
+    /* The DAC is always on. */
+    (void) line;
+}


### PR DESCRIPTION
### Contribution description

The 10 bit DAC on the lpc23xx is very simple.
It only has one channel and can only be mapped to a single pin (P0.26/AOUT).

After setting the pin mode to DAC no further configuration in needed.


### Testing procedure

Run `tests/periph_dac` and observe / listen to the output on `P0.26`.
This should produce a 10Hz saw tooth signal.

### Issues/PRs references
none
