### PR TITLE
dist/tools/ci/print_toolchain_versions.sh: add ccache

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -108,6 +108,7 @@ printf "\n"
 printf "%s\n" "Installed development tools"
 printf "%s\n" "---------------------------"
 for c in \
+         ccache \
          cmake \
          cppcheck \
          doxygen \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`ccache` can make a different about how a binary is build (see https://github.com/RIOT-OS/RIOT/issues/12807), so we should include it into our `dist/tools/ci/print_toolchain_versions.sh` tool.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run

```C
dist/tools/ci/print_toolchain_versions.sh
```

When you have `ccache` installed it should show its version, otherwise it just prints `missing`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/issues/12807#issuecomment-558207088
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
