### PR TITLE
tests/periph_cpuid: fix test script regex

### DIFF
--- a/tests/periph_cpuid/tests/01-run.py
+++ b/tests/periph_cpuid/tests/01-run.py
@@ -15,7 +15,7 @@ def testfunc(child):
     child.expect_exact('This test is reading out the CPUID of the platforms CPU')
     child.expect(r'CPUID_LEN: (\d+)')
     cpuid_len = int(child.match.group(1))
-    child.expect(r'CPUID:( 0x[0-9a-fA-F]{2})+\s*$')
+    child.expect(r'CPUID:( 0x[0-9a-fA-F]{2})+\s*\r\n')
     assert child.match.group(0).count(' 0x') == cpuid_len
 
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Trying a theory: I think the test breaks because the application's `printf()` is buffered, and thus might not arrive in a single `read()` to pexpect. The (counting) regexp matches as soon as the first `0x*` arrives, even on a partial buffer. Also, `$` doesn't match end of line in pexpect.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
