### PR TITLE
tests/malloc: reduce default chunk size

### DIFF
--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -28,7 +28,7 @@
 #ifdef BOARD_NATIVE
 #define CHUNK_SIZE          (1024 * 1024U)
 #else
-#define CHUNK_SIZE          (1024U)
+#define CHUNK_SIZE          (512U)
 #endif
 #endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR reduces the default value of CHUNK_SIZE from 1024 to 512. This allows to automatically run the test on very constrained platforms such as arduino-uno (2KB RAM).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run:
```
make BOARD=arduino-uno -C tests/malloc flash test
```
On master it fails because to allocations are performed and the automatic test script checks that at least one allocation is made.
With this PR, there's one allocation performed by the test application so the automatic test script works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
