### PR TITLE
tests/stdin: fix automatic test on slow platforms

### DIFF
--- a/tests/stdin/main.c
+++ b/tests/stdin/main.c
@@ -18,7 +18,10 @@
 
 int main(void)
 {
-    int value = getchar();
-    printf("You entered '%c'\n", (char)value);
+    while (1) {
+        int value = getchar();
+        printf("You entered '%c'\n", (char)value);
+    }
+
     return 0;
 }

--- a/tests/stdin/tests/01-run.py
+++ b/tests/stdin/tests/01-run.py
@@ -7,12 +7,25 @@
 # directory for more details.
 
 import sys
+import pexpect
 from testrunner import run
 
 
+TEST_INPUT = 'O'
+RETRIES = 5
+TIMEOUT = 3
+
+
 def testfunc(child):
-    child.sendline('O')
-    child.expect_exact('You entered \'O\'')
+    expected_output = 'You entered \'{}\''.format(TEST_INPUT)
+    for _ in range(0, RETRIES):
+        child.sendline(TEST_INPUT)
+        ret = child.expect_exact([expected_output, pexpect.TIMEOUT],
+                                 timeout=TIMEOUT)
+        if ret == 0:
+            break
+    else:
+        child.expect_exact(expected_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the stdin tests on slow plaform. It could have been fixed with #12461 but as @fjmolinas told me IRL, it's a bit weird to use the feature tested by the test to sync the test.

The solution is proposed by this PR is then to add a small delay in the Python test script before it send the character that is testing stdin.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following command should succeed on supported platforms, including AVR based boards:
```
make BOARD=<board of your choice> -C tests/stdin flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Could have been added to #12651 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
