### PR TITLE
cpu/atmega_common: Fixed atmega_exit_isr

### DIFF
--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -248,11 +248,12 @@ void thread_yield_higher(void)
 void atmega_exit_isr(void)
 {
     atmega_in_isr = 0;
-    atmega_context_save();
-    sched_run();
-    atmega_context_restore();
-
-    __asm__ volatile ("reti");
+    if (sched_context_switch_request) {
+        atmega_context_save();
+        sched_run();
+        atmega_context_restore();
+        __asm__ volatile ("reti");
+    }
 }
 
 __attribute__((always_inline)) static inline void atmega_context_save(void)


### PR DESCRIPTION
### Contribution description

A context switch at the end of the ISR should only occur, if requested. This fixes this.

### Testing procedure

Run the use scheduling tests on an ATmega board. They should still work. A good test would be `tests/ps_schedstatistics`, but this will only run with the load reduced, e.g. via:

```patch
diff --git a/tests/ps_schedstatistics/main.c b/tests/ps_schedstatistics/main.c
index a5086968da..b40e0f78ac 100644
--- a/tests/ps_schedstatistics/main.c
+++ b/tests/ps_schedstatistics/main.c
@@ -45,7 +45,7 @@ static void *_thread_fn(void *arg)
         for (int i = 0; i < (10 * (next + 1)); ++i) {
             _xtimer_now64();
         }
-        xtimer_usleep(XTIMER_BACKOFF * 3);
+        xtimer_usleep(XTIMER_BACKOFF * 30);
         msg_send(&m2, pids[next]);
     }
```

### Issues/PRs references

Fixes a regression introduced in https://github.com/RIOT-OS/RIOT/pull/12790