### PR TITLE
tests/malloc: fix test regexp to consider whole line

### DIFF
--- a/tests/malloc/tests/01-run.py
+++ b/tests/malloc/tests/01-run.py
@@ -11,22 +11,22 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r'CHUNK_SIZE: (\d+)')
+    child.expect(r'CHUNK_SIZE: (\d+)\r\n')
     chunk_size = int(child.match.group(1))
-    child.expect(r'NUMBER_OF_TESTS: (\d+)')
+    child.expect(r'NUMBER_OF_TESTS: (\d+)\r\n')
     number_of_tests = int(child.match.group(1))
     initial_allocations = 0
     for _ in range(number_of_tests):
-        child.expect(r"Allocated {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+"
+        child.expect(r"Allocated {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+\r\n"
                      .format(chunk_size))
-        child.expect(r'Allocations count: (\d+)')
+        child.expect(r'Allocations count: (\d+)\r\n')
         allocations = int(child.match.group(1))
         assert allocations > 0
         if initial_allocations == 0:
             initial_allocations = allocations
         assert initial_allocations == allocations
         for _ in range(allocations):
-            child.expect(r"Free {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+"
+            child.expect(r"Free {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+\r\n"
                          .format(chunk_size))
     child.expect_exact("[SUCCESS]")
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes `tests/malloc` test pexpect script to consider whole lines in order to avoid partial matches.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- CI should sucessfully run the test, preferably more than once.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#12813
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
