### PR TITLE
tests: fix tests matching varied sized group regex

### DIFF
--- a/examples/suit_update/tests/01-run.py
+++ b/examples/suit_update/tests/01-run.py
@@ -119,7 +119,7 @@ def testfunc(child):
 
     # get version of currently running image
     # "Image Version: 0x00000000"
-    child.expect(r"Image Version: (?P<app_ver>0x[0-9a-fA-F:]+)")
+    child.expect(r"Image Version: (?P<app_ver>0x[0-9a-fA-F:]+)\r\n")
     current_app_ver = int(child.match.group("app_ver"), 16)
 
     for version in [current_app_ver + 1, current_app_ver + 2]:
@@ -139,7 +139,7 @@ def testfunc(child):
         child.expect_exact("suit_coap: trigger received")
         child.expect_exact("suit: verifying manifest signature...")
         child.expect(
-            r"riotboot_flashwrite: initializing update to target slot (\d+)",
+            r"riotboot_flashwrite: initializing update to target slot (\d+)\r\n",
             timeout=MANIFEST_TIMEOUT,
         )
         target_slot = int(child.match.group(1))
@@ -148,7 +148,7 @@ def testfunc(child):
             pass
 
         # Verify running slot
-        child.expect(r"running from slot (\d+)")
+        child.expect(r"running from slot (\d+)\r\n")
         assert target_slot == int(child.match.group(1)), "BOOTED FROM SAME SLOT"
 
     print("TEST PASSED")

--- a/tests/gnrc_ipv6_ext/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext/tests/01-run.py
@@ -595,9 +595,9 @@ def testfunc(child):
 
     lladdr_src = get_host_lladdr(tap)
     child.sendline("ifconfig")
-    child.expect("HWaddr: (?P<hwaddr>[A-Fa-f:0-9]+)")
+    child.expect(r"HWaddr: (?P<hwaddr>[A-Fa-f:0-9]+)\s")
     hwaddr_dst = child.match.group("hwaddr").lower()
-    child.expect("(?P<lladdr>fe80::[A-Fa-f:0-9]+)")
+    child.expect(r"(?P<lladdr>fe80::[A-Fa-f:0-9]+)\s")
     lladdr_dst = child.match.group("lladdr").lower()
 
     def run(func):

--- a/tests/gnrc_ipv6_ext_frag/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext_frag/tests/01-run.py
@@ -260,7 +260,7 @@ def _fwd_setup(child, ll_dst, g_src, g_dst):
     child.expect(r"fe80::1 dev #7 lladdr\s+-")
     # get TAP MAC address
     child.sendline("ifconfig 6")
-    child.expect("HWaddr: ([0-9A-F:]+)")
+    child.expect(r"HWaddr: ([0-9A-F:]+)\s")
     hwaddr = child.match.group(1)
     # consume MTU for later calls of `ifconfig 7`
     child.expect(r"MTU:(\d+)")
@@ -337,7 +337,7 @@ def testfunc(child):
                 print("FAILED")
                 raise e
 
-    child.expect(r"Sending UDP test packets to port (\d+)")
+    child.expect(r"Sending UDP test packets to port (\d+)\r\n")
 
     port = int(child.match.group(1))
     with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as s:
@@ -368,7 +368,7 @@ def testfunc(child):
         # link-local address becomes valid
         time.sleep(1)
         child.sendline("ifconfig")
-        child.expect("HWaddr: (?P<hwaddr>[A-Fa-f:0-9]+)")
+        child.expect(r"HWaddr: (?P<hwaddr>[A-Fa-f:0-9]+)\s")
         hwaddr_dst = child.match.group("hwaddr").lower()
         res = child.expect([
             r"(?P<lladdr>fe80::[A-Fa-f:0-9]+)\s+scope:\s+link\s+VAL",

--- a/tests/gnrc_netif_ieee802154/tests/01-run.py
+++ b/tests/gnrc_netif_ieee802154/tests/01-run.py
@@ -19,7 +19,7 @@ ZEP_V2_TYPE_DATA = 1
 def testfunc(child):
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
         s.bind(("", 17754))
-        child.expect("l2_addr: ([0-9A-F:]+)")
+        child.expect(r"l2_addr: ([0-9A-F:]+)\r\n")
         dst = int(child.match.group(1).replace(':', ''), base=16)
 
         # first send valid packet to check if communication is set up correctly

--- a/tests/gnrc_rpl_srh/tests/01-run.py
+++ b/tests/gnrc_rpl_srh/tests/01-run.py
@@ -143,7 +143,7 @@ def unregister(child):
 
 def get_first_interface(child):
     child.sendline("ifconfig")
-    child.expect(r"Iface\s+(\d+)")
+    child.expect(r"Iface\s+(\d+)\s")
     return int(child.match.group(1))
 
 
@@ -342,9 +342,9 @@ def testfunc(child):
     print("." * int(child.match.group(1)), end="", flush=True)
     lladdr_src = get_host_lladdr(tap)
     child.sendline("ifconfig")
-    child.expect("HWaddr: (?P<hwaddr>[A-Fa-f:0-9]+)")
+    child.expect(r"HWaddr: (?P<hwaddr>[A-Fa-f:0-9]+)\s")
     hwaddr_dst = child.match.group("hwaddr").lower()
-    child.expect("(?P<lladdr>fe80::[A-Fa-f:0-9]+)")
+    child.expect(r"(?P<lladdr>fe80::[A-Fa-f:0-9]+)\s")
     lladdr_dst = child.match.group("lladdr").lower()
     sniffer = Sniffer(tap)
     sniffer.start()

--- a/tests/gnrc_tcp/tests/05-garbage-pkts.py
+++ b/tests/gnrc_tcp/tests/05-garbage-pkts.py
@@ -35,7 +35,7 @@ def testfunc(func):
         child.sendline('gnrc_tcp_open_passive AF_INET6 {}'.format(port))
         child.expect(r'gnrc_tcp_open_passive: argc=3, '
                      r'argv\[0\] = gnrc_tcp_open_passive, '
-                     r'argv\[1\] = AF_INET6, argv\[2\] = (\d+)')
+                     r'argv\[1\] = AF_INET6, argv\[2\] = (\d+)\r\n')
         assert int(child.match.group(1)) == port
 
         try:

--- a/tests/gnrc_tcp/tests/shared_func.py
+++ b/tests/gnrc_tcp/tests/shared_func.py
@@ -58,26 +58,26 @@ def get_host_ll_addr(interface):
 
 def get_riot_l2_addr(child):
     child.sendline('ifconfig')
-    child.expect('HWaddr: ([A-F-a-f0-9:]+)')
+    child.expect(r'HWaddr: ([A-F-a-f0-9:]+)\s')
     return child.match.group(1)
 
 
 def get_riot_ll_addr(child):
     child.sendline('ifconfig')
-    child.expect('(fe80:[0-9a-f:]+)')
+    child.expect(r'(fe80:[0-9a-f:]+)\s')
     return child.match.group(1).strip()
 
 
 def get_riot_if_id(child):
     child.sendline('ifconfig')
-    child.expect(r'Iface\s+(\d+)')
+    child.expect(r'Iface\s+(\d+)\s')
     return child.match.group(1).strip()
 
 
 def setup_internal_buffer(child):
     child.sendline('buffer_init')
     child.sendline('buffer_get_max_size')
-    child.expect(r'returns (\d+)')
+    child.expect(r'returns (\d+)\s')
     return int(child.match.group(1).strip())
 
 

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -185,7 +185,7 @@ class TestStrategy(ApplicationStrategy):
 
 def get_ipv6_address(spawn):
     spawn.sendline(u"ifconfig")
-    spawn.expect(u"[A-Za-z0-9]{2}_[0-9]+:  inet6 (fe80::[0-9a-f:]+)")
+    spawn.expect(r"[A-Za-z0-9]{2}_[0-9]+:  inet6 (fe80::[0-9a-f:]+)\s")
     return spawn.match.group(1)
 
 

--- a/tests/lwip_sock_ip/tests/01-run.py
+++ b/tests/lwip_sock_ip/tests/01-run.py
@@ -19,7 +19,7 @@ def _ipv4_tests(code):
 
 
 def testfunc(child):
-    child.expect(u"code (0x[0-9a-f]{2})")
+    child.expect(r"code (0x[0-9a-f]{2}\s)")
     code = int(child.match.group(1), base=16)
     if _ipv4_tests(code):
         child.expect_exact(u"Calling test_sock_ip_create4__EAFNOSUPPORT()")

--- a/tests/lwip_sock_tcp/tests/01-run.py
+++ b/tests/lwip_sock_tcp/tests/01-run.py
@@ -23,7 +23,7 @@ def _ipv4_tests(code):
 
 
 def testfunc(child):
-    child.expect(u"code (0x[0-9a-f]{2})")
+    child.expect(r"code (0x[0-9a-f]{2}\s)")
     code = int(child.match.group(1), base=16)
     if _ipv4_tests(code):
         if _reuse_tests(code):

--- a/tests/lwip_sock_udp/tests/01-run.py
+++ b/tests/lwip_sock_udp/tests/01-run.py
@@ -23,7 +23,7 @@ def _ipv4_tests(code):
 
 
 def testfunc(child):
-    child.expect(u"code (0x[0-9a-f]{2})")
+    child.expect(r"code (0x[0-9a-f]{2})\s")
     code = int(child.match.group(1), base=16)
     if _ipv4_tests(code):
         if _reuse_tests(code):

--- a/tests/periph_cpuid/tests/01-run.py
+++ b/tests/periph_cpuid/tests/01-run.py
@@ -13,7 +13,7 @@ from testrunner import run
 def testfunc(child):
     child.expect_exact('Test for the CPUID driver')
     child.expect_exact('This test is reading out the CPUID of the platforms CPU')
-    child.expect(r'CPUID_LEN: (\d+)')
+    child.expect(r'CPUID_LEN: (\d+)\r\n')
     cpuid_len = int(child.match.group(1))
     child.expect(r'CPUID:( 0x[0-9a-fA-F]{2})+\s*\r\n')
     assert child.match.group(0).count(' 0x') == cpuid_len

--- a/tests/periph_timer/tests/01-run.py
+++ b/tests/periph_timer/tests/01-run.py
@@ -11,7 +11,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r'Available timers: (\d+)')
+    child.expect(r'Available timers: (\d+)\r\n')
     timers_num = int(child.match.group(1))
     for timer in range(timers_num):
         child.expect_exact('Testing TIMER_{}'.format(timer))

--- a/tests/periph_wdt/tests/01-run.py
+++ b/tests/periph_wdt/tests/01-run.py
@@ -38,7 +38,7 @@ def get_reset_time(child):
 
 def testfunc(child):
     child.sendline("range")
-    child.expect(r"lower_bound: (\d+) upper_bound: (\d+)",
+    child.expect(r"lower_bound: (\d+) upper_bound: (\d+)\s*\r\n",
                  timeout=1)
     wdt_lower_bound = int(child.match.group(1))
     wdt_upper_bound = int(child.match.group(2))

--- a/tests/pkg_libfixmath/tests/01-run.py
+++ b/tests/pkg_libfixmath/tests/01-run.py
@@ -5,28 +5,28 @@ from testrunner import run, test_utils_interactive_sync
 
 
 def expect_unary(child):
-    child.expect(r'COUNT: (\d+)')
+    child.expect(r'COUNT: (\d+)\r\n')
     count = int(child.match.group(1))
     assert count > 0
     for _ in range(count):
         for op_name in ('abs', 'sq', 'atan', 'exp'):
             child.expect(r'{}\(-?\d+\.\d+\) = -?\d+\.\d+'.format(op_name))
 
-    child.expect(r'COUNT: (\d+)')
+    child.expect(r'COUNT: (\d+)\r\n')
     count = int(child.match.group(1))
     assert count > 0
     for _ in range(count):
         for op_name in ('sin', 'cos', 'tan'):
             child.expect(r'{}\(-?\d+.\d+\) = -?\d+.\d+'.format(op_name))
 
-    child.expect(r'COUNT: (\d+)')
+    child.expect(r'COUNT: (\d+)\r\n')
     count = int(child.match.group(1))
     assert count > 0
     for _ in range(count):
         for op_name in ('asin', 'acos'):
             child.expect(r'{}\(-?\d+.\d+\) = -?\d+.\d+'.format(op_name))
 
-    child.expect(r'COUNT: (\d+)')
+    child.expect(r'COUNT: (\d+)\r\n')
     count = int(child.match.group(1))
     assert count > 0
     for _ in range(count):
@@ -35,7 +35,7 @@ def expect_unary(child):
 
 
 def expect_binary(child):
-    child.expect(r'COUNT: (\d+)')
+    child.expect(r'COUNT: (\d+)\r\n')
     count = int(child.match.group(1))
     assert count > 0
     for _ in range(count):

--- a/tests/pthread_barrier/tests/01-run.py
+++ b/tests/pthread_barrier/tests/01-run.py
@@ -5,7 +5,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r'NUM_CHILDREN: (\d+), NUM_ITERATIONS: (\d+)')
+    child.expect(r'NUM_CHILDREN: (\d+), NUM_ITERATIONS: (\d+)\r\n')
     children = int(child.match.group(1))
     iterations = int(child.match.group(2))
     for i in range(children):

--- a/tests/trace/tests/01-run.py
+++ b/tests/trace/tests/01-run.py
@@ -11,10 +11,10 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"TRACE_SIZE: (\d+)")
+    child.expect(r"TRACE_SIZE: (\d+)\r\n")
     trace_size = int(child.match.group(1))
     for i in range(trace_size):
-        child.expect("0x[0-9a-f]{7,8}")
+        child.expect(r"0x[0-9a-f]{7,8}")
 
     print("All tests successful")
 


### PR DESCRIPTION
### Contribution description

This PR fixes all regex expressions (unless I missed some) matching a group with 0/1 or more repetitions (`+` or `*`). This sometimes causes issues where only part of the output is matched which causes a test failure. This is specially annoying regarding Murdock since it causes hole builds to fail. I might be missing some.

~~I also added a doc entry in `tests` on this.~~

### Testing procedure

~~- Check the doc entry~~

- Green murdock

**[EDIT]**: I ran the modified tests locally, all passing.

<details><summary>sudo tests</summary>

```
python3 ~/workspace/RIOT/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . samr21-xpro --with-test-only --jobs=1 --clean-after --applications=" tests/gnrc_ipv6_ext tests/gnrc_ipv6_ext_frag tests/gnrc_netif_ieee802154 tests/gnrc_tcp tests/lwip_sock_ip tests/lwip_sock_tcp tests/lwip_sock_udp "tests/gnrc_rpl_srh
```
```
INFO:native:Saving toolchain
INFO:native.tests/gnrc_ipv6_ext:Board supported: True
INFO:native.tests/gnrc_ipv6_ext:Board has enough memory: True
INFO:native.tests/gnrc_ipv6_ext:Application has test: True
INFO:native.tests/gnrc_ipv6_ext:Run compilation
INFO:native.tests/gnrc_ipv6_ext:Run test
INFO:native.tests/gnrc_ipv6_ext:Run test.flash
INFO:native.tests/gnrc_ipv6_ext:Success
INFO:native.tests/gnrc_ipv6_ext_frag:Board supported: True
INFO:native.tests/gnrc_ipv6_ext_frag:Board has enough memory: True
INFO:native.tests/gnrc_ipv6_ext_frag:Application has test: True
INFO:native.tests/gnrc_ipv6_ext_frag:Run compilation
INFO:native.tests/gnrc_ipv6_ext_frag:Run test
INFO:native.tests/gnrc_ipv6_ext_frag:Run test.flash
INFO:native.tests/gnrc_ipv6_ext_frag:Success
INFO:native.tests/gnrc_netif_ieee802154:Board supported: True
INFO:native.tests/gnrc_netif_ieee802154:Board has enough memory: True
INFO:native.tests/gnrc_netif_ieee802154:Application has test: True
INFO:native.tests/gnrc_netif_ieee802154:Run compilation
INFO:native.tests/gnrc_netif_ieee802154:Run test
INFO:native.tests/gnrc_netif_ieee802154:Run test.flash
INFO:native.tests/gnrc_netif_ieee802154:Success
INFO:native.tests/gnrc_tcp:Board supported: True
INFO:native.tests/gnrc_tcp:Board has enough memory: True
INFO:native.tests/gnrc_tcp:Application has test: True
INFO:native.tests/gnrc_tcp:Run compilation
INFO:native.tests/gnrc_tcp:Run test
INFO:native.tests/gnrc_tcp:Run test.flash
INFO:native.tests/gnrc_tcp:Success
INFO:native.tests/lwip_sock_ip:Board supported: True
INFO:native.tests/lwip_sock_ip:Board has enough memory: True
INFO:native.tests/lwip_sock_ip:Application has test: True
INFO:native.tests/lwip_sock_ip:Run compilation
INFO:native.tests/lwip_sock_ip:Run test
INFO:native.tests/lwip_sock_ip:Run test.flash
INFO:native.tests/lwip_sock_ip:Success
INFO:native.tests/lwip_sock_tcp:Board supported: True
INFO:native.tests/lwip_sock_tcp:Board has enough memory: True
INFO:native.tests/lwip_sock_tcp:Application has test: True
INFO:native.tests/lwip_sock_tcp:Run compilation
INFO:native.tests/lwip_sock_tcp:Run test
INFO:native.tests/lwip_sock_tcp:Run test.flash
INFO:native.tests/lwip_sock_tcp:Success
INFO:native.tests/lwip_sock_udp:Board supported: True
INFO:native.tests/lwip_sock_udp:Board has enough memory: True
INFO:native.tests/lwip_sock_udp:Application has test: True
INFO:native.tests/lwip_sock_udp:Run compilation
INFO:native.tests/lwip_sock_udp:Run test
INFO:native.tests/lwip_sock_udp:Run test.flash
INFO:native.tests/lwip_sock_udp:Success
INFO:native:Tests successful
```

```
make -C examples/suit_update/ flash test -j3
...
...
----> ethos: hello received
Failed to send flush request: Operation not permitted
gnrc_uhcpc: Using 5 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2020.01-devel-1100-gf644b-pr_fix_eol)
RIOT SUIT update example application
running from slot 0
TEST PASSED
```

```
sudo make -C tests/lwip/ flash test
true 
Testing for (<Board 'native',port='tap0',serial=None>, <Board 'native',port='tap1',serial=None>): 
....
make: Leaving directory '/home/francisco/workspace/RIOT/tests/lwip'
```

```
sudo make -C tests/gnrc_rpl_srh/ flash test
...
...
true 
..............SUCCESS
```
</details>

<details><summary>no-sudo tests</summary>

```
time python3 ~/workspace/RIOT/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . samr21-xpro --with-test-only --jobs=1 --clean-after --applications="tests/malloc tests/periph_cpuid tests/periph_timer tests/periph_wdt tests/pkg_libfixmath tests/pthread_barrier tests/trace"
```
```
INFO:samr21-xpro:Saving toolchain
INFO:samr21-xpro.tests/malloc:Board supported: True
INFO:samr21-xpro.tests/malloc:Board has enough memory: True
INFO:samr21-xpro.tests/malloc:Application has test: True
INFO:samr21-xpro.tests/malloc:Run compilation
INFO:samr21-xpro.tests/malloc:Run test
INFO:samr21-xpro.tests/malloc:Run test.flash
INFO:samr21-xpro.tests/malloc:Success
INFO:samr21-xpro.tests/periph_cpuid:Board supported: True
INFO:samr21-xpro.tests/periph_cpuid:Board has enough memory: True
INFO:samr21-xpro.tests/periph_cpuid:Application has test: True
INFO:samr21-xpro.tests/periph_cpuid:Run compilation
INFO:samr21-xpro.tests/periph_cpuid:Run test
INFO:samr21-xpro.tests/periph_cpuid:Run test.flash
INFO:samr21-xpro.tests/periph_cpuid:Success
INFO:samr21-xpro.tests/periph_timer:Board supported: True
INFO:samr21-xpro.tests/periph_timer:Board has enough memory: True
INFO:samr21-xpro.tests/periph_timer:Application has test: True
INFO:samr21-xpro.tests/periph_timer:Run compilation
INFO:samr21-xpro.tests/periph_timer:Run test
INFO:samr21-xpro.tests/periph_timer:Run test.flash
INFO:samr21-xpro.tests/periph_timer:Success
INFO:samr21-xpro.tests/periph_wdt:Board supported: True
INFO:samr21-xpro.tests/periph_wdt:Board has enough memory: True
INFO:samr21-xpro.tests/periph_wdt:Application has test: True
INFO:samr21-xpro.tests/periph_wdt:Run compilation
INFO:samr21-xpro.tests/periph_wdt:Run test
INFO:samr21-xpro.tests/periph_wdt:Run test.flash
INFO:samr21-xpro.tests/periph_wdt:Success
INFO:samr21-xpro.tests/pkg_libfixmath:Board supported: True
INFO:samr21-xpro.tests/pkg_libfixmath:Board has enough memory: True
INFO:samr21-xpro.tests/pkg_libfixmath:Application has test: True
INFO:samr21-xpro.tests/pkg_libfixmath:Run compilation
INFO:samr21-xpro.tests/pkg_libfixmath:Run test
INFO:samr21-xpro.tests/pkg_libfixmath:Run test.flash
INFO:samr21-xpro.tests/pkg_libfixmath:Success
INFO:samr21-xpro.tests/pthread_barrier:Board supported: True
INFO:samr21-xpro.tests/pthread_barrier:Board has enough memory: True
INFO:samr21-xpro.tests/pthread_barrier:Application has test: True
INFO:samr21-xpro.tests/pthread_barrier:Run compilation
INFO:samr21-xpro.tests/pthread_barrier:Run test
INFO:samr21-xpro.tests/pthread_barrier:Run test.flash
INFO:samr21-xpro.tests/pthread_barrier:Success
INFO:samr21-xpro.tests/trace:Board supported: False
INFO:samr21-xpro:Tests successful
```
</details>

### Issues/PRs references

~~#12821 addressed the same issue., so waiting for it.~~
Affected by this issue:
- #12461
- #11843