### PR TITLE
makefiles: fix LOG_LEVEL handling

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -179,7 +179,7 @@ endif
 # Override LOG_LEVEL if variable is set and if CFLAGS doesn't already contain
 # a LOG_LEVEL config
 ifdef LOG_LEVEL
-  ifneq (,$(filter -DLOG_LEVEL=%,$(CFLAGS)))
+  ifeq (,$(filter -DLOG_LEVEL=%,$(CFLAGS)))
     CFLAGS += -DLOG_LEVEL=$(LOG_LEVEL)
   endif
 endif


### PR DESCRIPTION
### Contribution description

This PR fixes the test of `CFLAGS` in the handling of the `LOG_LEVEL` variable.

PR #11592 introduced a change that should make it possible to define the `LOG_LEVEL` at the make command line if `LOG_LEVEL` isn't already set in `CFLAGS`. However, a wrong test of the variable `CFLAGS` has avoided this.

### Testing procedure


### Issues/PRs references

Fixes the change in PR #11592