### PR TITLE
drivers/ncv7356: Add documentation

### DIFF
--- a/cpu/stm32_common/include/candev_stm32.h
+++ b/cpu/stm32_common/include/candev_stm32.h
@@ -15,7 +15,10 @@
  * The STM32Fx microcontroller can have an integrated CAN controller (bxCAN)
  *
  * This driver has been tested with a STM32F0,STM32F2 and STM32F4 MCU
- * but should work on others
+ * but should work on others.
+ *
+ * The default bitrate is set to 500 kbps and the default sample point is set to
+ * 87.5%.
  * @{
  *
  * @file

--- a/drivers/include/ncv7356.h
+++ b/drivers/include/ncv7356.h
@@ -7,10 +7,19 @@
  */
 
 /**
- * @defgroup    drivers_ncv7356 NCV7356
- * @ingroup     drivers_can
- * @ingroup     drivers_can_trx
- * @brief       ncv7356 Single Wire CAN transceiver driver
+* @defgroup    drivers_ncv7356 NCV7356 Single Wire CAN Transceiver
+* @ingroup     drivers_can
+* @ingroup     drivers_can_trx
+* @brief       Device driver for the NCV7356 Single Wire CAN Transceiver
+*
+* The NCV7356 is a physical layer device for a single wire data connection
+* such as Bosch's Controller Area Network (CAN) protocol.
+* The device is capable of transmissions of up to 100 kbps and operates in a
+* voltage range of 5 to 27 V. All logic inputs are compatible with 3.3 V and
+* 5 V supply systems. The pins MODE0 and MODE1 indicate the mode of the
+* transceiver, with the transceiver being initially in sleep mode.
+* An example application circuitry for the 8 pin package can be found at page
+* 15 of https://www.onsemi.com/pub/Collateral/NCV7356-D.PDF.
  *
  * @{
  *

--- a/tests/conn_can/README.md
+++ b/tests/conn_can/README.md
@@ -70,52 +70,52 @@ make term
 The CAN interfaces are registered at startup to the dll. The list of registered
 interfaces and their RIOT names can be retrieved with:
 ```
-can list
+test_can list
 ```
 
 To send a raw CAN frame, id 0x100 with 2 bytes of data 01 02 on interface 0:
 ```
-can send 0 100 01 02
+test_can send 0 100 01 02
 ```
 
 Two threads are launched to enable receiving frames. To receive raw CAN frames,
 ids 0x100 and 0x500 with thread 0 on interface 1, with 10s timeout:
 ```
-can recv 1 0 10000000 100 500
+test_can recv 1 0 10000000 100 500
 ```
 
 A connection can be closed with its thread id, for instance:
 ```
-can close 0
+test_can close 0
 ```
 
 
 To send an ISO-TP datagram, first bind a connection with one of the threads,
 source id 700, dest id 708, thread 1 and interface 0:
 ```
-can bind_isotp 0 1 700 708
+test_can bind_isotp 0 1 700 708
 ```
 Then send the data 01 02 03 04 05 0a 0b 0c:
 ```
-can send_isotp 1 01 02 03 04 05 0a 0b 0c
+test_can send_isotp 1 01 02 03 04 05 0a 0b 0c
 ```
 
 To receive from an ISO-TP channel, it must be bound, then with the previous channel,
 and 10s timeout:
 ```
-can recv_isotp 1 10000000
+test_can recv_isotp 1 10000000
 ```
 
 An ISO-TP channel can be closed with:
 ```
-can close_isotp 1
+test_can close_isotp 1
 ```
 
 You can also set a bitrate (this won't work on native with vcan, only with real
 interfaces, but then root access are needed), for instance 250000 bit/s with
 sampling point 87.5%:
 ```
-can set_bitrate 250000 875
+test_can set_bitrate 250000 875
 ```
 
 Linux CAN basic commands


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds the documentation for the NCV77356 Single Wire CAN Transceiver.
It also edits the README for the test class under tests/conn_can and the documentation under cpu/stm32_common.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

None.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
None.