### PR TITLE
boards: unexport PROGRAMMER

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -16,7 +16,7 @@ DEBUGSERVER = JLinkGDBServer -device CC2538SF53
 RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 
 # Define the flash-tool and default port:
-export PROGRAMMER ?= cc2538-bsl
+PROGRAMMER ?= cc2538-bsl
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
   FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -5,7 +5,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup flash tool
-export PROGRAMMER ?= olimex
+PROGRAMMER ?= olimex
 MSPDEBUGFLAGS += -j $(PROGRAMMER)
 ifeq ($(strip $(PROGRAMMER)),uif)
   MSPDEBUGFLAGS += -d $(PROG_DEV)

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -1,5 +1,5 @@
 # define the default flash-tool
-export PROGRAMMER ?= cc2538-bsl
+PROGRAMMER ?= cc2538-bsl
 
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -6,7 +6,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # Set default flash tool
-export PROGRAMMER ?= cc2538-bsl
+PROGRAMMER ?= cc2538-bsl
 
 # For backward compatibility
 ifneq (,$(PORT_BSL))

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -5,7 +5,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 # Set default flash tool
-export PROGRAMMER ?= cc2538-bsl
+PROGRAMMER ?= cc2538-bsl
 
 ifeq ($(PROGRAMMER),jlink)
   # setup JLink for flashing


### PR DESCRIPTION
### Contribution description

This PR removes the un-needed PROGRAMMER export. The export also has the unwanted effect of overriding setting the variable in the `ENV`

### Testing procedure

There is no usage of `PROGRAMMER` in any `shell` call.

Can still flash `openmote-b`

```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/dist/tools/cc2538-bsl/cc2538-bsl.py -p "/dev/ttyUSB1" --bootloader-invert-lines -e -w -v -b 460800 /home/francisco/workspace/RIOT/examples/hello-world/bin/openmote-b/hello-world.hex
Opening port /dev/ttyUSB1, baud 460800
Reading data from /home/francisco/workspace/RIOT/examples/hello-world/bin/openmote-b/hello-world.hex
Your firmware looks like an Intel Hex file
Connecting to target...
CC2538 PG2.0: 512KB Flash, 32KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:14:B5:B6:35
Erasing 524288 bytes starting at address 0x00200000
    Erase done
Writing 524288 bytes starting at address 0x00200000
Write 16 bytes at 0x0027FFF0F8
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0xe63aded5)
make: Leaving directory '/home/francisco/workspace/RIOT/examples/hello-world'
```
