### PR TITLE
sam0/periph_adc: Fix API to return `-1` on unsupported resolution

### DIFF
--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -87,7 +87,6 @@ static int _adc_configure(adc_res_t res)
     _adc_poweroff();
     if (ADC->CTRLA.reg & ADC_CTRLA_SWRST ||
         ADC->CTRLA.reg & ADC_CTRLA_ENABLE ) {
-        _done();
         DEBUG("adc: not ready\n");
         return -1;
     }

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -82,8 +82,10 @@ static int _adc_configure(adc_res_t res)
     /* Individual comparison necessary because ADC Resolution Bits are not
      * numerically in order and 16Bit (averaging - not currently supported)
      * falls between 12bit and 10bit.  See datasheet for details */
-    assert((res == ADC_RES_8BIT) || (res == ADC_RES_10BIT) ||
-           (res == ADC_RES_12BIT));
+    if (!((res == ADC_RES_8BIT) || (res == ADC_RES_10BIT) ||
+          (res == ADC_RES_12BIT))){
+        return -1;
+    }
     _adc_poweroff();
     if (ADC->CTRLA.reg & ADC_CTRLA_SWRST ||
         ADC->CTRLA.reg & ADC_CTRLA_ENABLE ) {


### PR DESCRIPTION
### Contribution description

According to the ADC API, the `sample()` call must return `-1` when the selected resolution is not supported. The sam0 implementation throws an assertion failure instead. This PR fixes that.

(It also removes a duplicate `_done()` call in the unhappy flow.)

### Testing procedure

Changing the resolution in `tests/periph_adc` to something unsupported (16 bit conversion for example) should result in an error message and not an assertion failure.

### Issues/PRs references

None