### PR TITLE
autoinit: interactive sync if no shell% in USEMODULE

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -97,7 +97,7 @@
 #endif
 
 #ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
-#ifndef MODULE_SHELL_COMMANDS
+#if !defined(MODULE_SHELL_COMMANDS) || !defined(MODULE_SHELL)
 #include "test_utils/interactive_sync.h"
 #endif
 #endif
@@ -605,7 +605,7 @@ void auto_init(void)
 #endif /* MODULE_SUIT */
 
 #ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
-#ifndef MODULE_SHELL_COMMANDS
+#if !defined(MODULE_SHELL_COMMANDS) || !defined(MODULE_SHELL)
     test_utils_interactive_sync();
 #endif
 #endif /* MODULE_TEST_UTILS_INTERACTIVE_SYNC */


### PR DESCRIPTION
### Contribution description

This PR fixes an issue where `tests_interactive_sync_utils` was not used in `auto_init` if `shell_commands` was included, this is a mistake since sometimes `shell_commands` is included while
`shell` is not, as was the case for #12632. This PR fixes this.

### Testing procedure

- Rebase on #12632, test fails without this PR

```
/home/francisco/workspace/RIOT/tests/memarray/bin/native/tests_memarray.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2020.01-devel-1119-gdc68d5-pr-12632)
MAX_NUMBER_BLOCKS: 10
NUMBER_OF_TESTS: 12
Starting (10, 8)
...
Finishing
        pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
          - | isr_stack            | -        - |   - |   8192 (   -1) | 0x565a8440 | 0x565a8440
          1 | idle                 | pending  Q |  15 |   8192 (  420) | 0x565a6160 | 0x565a7fd0 
          2 | main                 | running  Q |   7 |  12288 ( 2704) | 0x565a3160 | 0x565a5fd0 
            | SUM                  |            |     |  28672 ( 3124)

make: Leaving directory '/home/francisco/workspace/RIOT/tests/memarray'
```

- green murdock

### Issues/PRs references

#12632
