### PR TITLE
tests/ps_schedstatistics: fix test on AVR + improve Python test script

### DIFF
--- a/tests/ps_schedstatistics/main.c
+++ b/tests/ps_schedstatistics/main.c
@@ -47,7 +47,7 @@ static void *_thread_fn(void *arg)
         for (int i = 0; i < (10 * (next + 1)); ++i) {
             _xtimer_now64();
         }
-        xtimer_usleep(XTIMER_BACKOFF * 3);
+        xtimer_usleep(XTIMER_BACKOFF * 10);
         msg_send(&m2, pids[next]);
     }
 

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -10,25 +10,25 @@ import sys
 from testrunner import run
 
 PS_EXPECTED = (
-    (r'\tpid | name                 | state    Q | pri | stack  ( used) | '
+    (r'\tpid | name                 | state    Q | pri | stack  \( used\) | '
      r'base addr  | current     | runtime  | switches'),
-    (r'\t  - | isr_stack            | -        - |   - | \d+  ( -?\d+) | '
+    (r'\t  - | isr_stack            | -        - |   - | \d+  \( -?\d+\) | '
      r'0x\d+ | 0x\d+'),
-    (r'\t  1 | idle                 | pending  Q |  15 | \d+  ( -?\d+) | '
+    (r'\t  1 | idle                 | pending  Q |  15 | \d+  \( -?\d+\) | '
      r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    (r'\t  2 | main                 | running  Q |   7 | \d+  ( -?\d+) | '
+    (r'\t  2 | main                 | running  Q |   7 | \d+  \( -?\d+\) | '
      r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    (r'\t  3 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+    (r'\t  3 | thread               | bl rx    _ |   6 | \d+  \( -?\d+\) | '
      r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    (r'\t  4 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+    (r'\t  4 | thread               | bl rx    _ |   6 | \d+  \( -?\d+\) | '
      r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    (r'\t  5 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+    (r'\t  5 | thread               | bl rx    _ |   6 | \d+  \( -?\d+\) | '
      r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    (r'\t  6 | thread               | bl mutex _ |   6 | \d+  ( -?\d+) | '
+    (r'\t  6 | thread               | bl mutex _ |   6 | \d+  \( -?\d+\) | '
      r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    (r'\t  7 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+    (r'\t  7 | thread               | bl rx    _ |   6 | \d+  \( -?\d+\) | '
      r'0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
-    (r'\t    | SUM                  |            |     | \d+  (\d+)')
+    (r'\t    | SUM                  |            |     | \d+  \(\d+\)')
 )
 
 
@@ -40,7 +40,7 @@ def _check_startup(child):
 
 def _check_help(child):
     child.sendline('')
-    child.expect('>')
+    child.expect_exact('>')
     child.sendline('help')
     child.expect_exact('Command              Description')
     child.expect_exact('---------------------------------------')
@@ -53,6 +53,8 @@ def _check_ps(child):
     child.sendline('ps')
     for line in PS_EXPECTED:
         child.expect(line)
+    # Wait for all lines of the ps output to be displayed
+    child.expect_exact('>')
 
 
 def testfunc(child):


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix the `tests/ps_schedstatistics` on AVR by simply increasing the XTIMER_BACKOFF value.

The PR also contains small cleanup in the Python test script:
- It ensures all lines are displayed before exiting the script
- It escapes the parenthesis that are not use for group regexp

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following command should succeed, also on AVR (where it fails on master):
```
make BOARD=<board of your choice> -C tests/ps_schedstatistics flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #12651 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
