### PR TITLE
tests/periph_adc: fix printf content on failure

### DIFF
--- a/tests/periph_adc/main.c
+++ b/tests/periph_adc/main.c
@@ -52,7 +52,7 @@ int main(void)
         for (unsigned i = 0; i < ADC_NUMOF; i++) {
             sample = adc_sample(ADC_LINE(i), RES);
             if (sample < 0) {
-                printf("ADC_LINE(%u): 10-bit resolution not applicable\n", i);
+                printf("ADC_LINE(%u): selected resolution not applicable\n", i);
             } else {
                 printf("ADC_LINE(%u): %i\n", i, sample);
             }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While testing #12828, I noticed something was wrong with a failure printf.
E.g select 16-bit resolution for tests/periph_adc, if hardware doesn't support it, test will report 10-bit resolution (the test default) is wrong so replaces it by a more generic wording.


### Testing procedure
Use tests/periph_adc and test different tests output (on a failure case), check printf content
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#12828 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
