### PR TITLE
gnrc_netif: add NETDEV_EVENT_PDU_CHANGED event

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -252,6 +252,7 @@ typedef enum {
     NETDEV_EVENT_MCPS_INDICATION,           /**< MAC MCPS indication event */
     NETDEV_EVENT_MLME_GET_BUFFER,           /**< MAC layer requests MLME buffer */
     NETDEV_EVENT_MCPS_GET_BUFFER,           /**< MAC layer requests MCPS buffer */
+    NETDEV_EVENT_PDU_CHANGED,               /**< MAC layer PDU changed */
     /* expand this list if needed */
 } netdev_event_t;
 

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1497,6 +1497,9 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
                 netif->stats.tx_success++;
                 break;
 #endif
+            case NETDEV_EVENT_PDU_CHANGED:
+                gnrc_netif_ipv6_init_mtu(netif);
+                break;
             default:
                 DEBUG("gnrc_netif: warning: unhandled event %u.\n", event);
         }


### PR DESCRIPTION
### Contribution description

For some devices the maximum frame size is dependant on the configuration.

This adds a `NETDEV_EVENT_PDU_CHANGED` event that a network driver can generate
if a change in configuration resulted in a different PDU than before.

For this the driver must implement an answer to the `NETOPT_MAX_PDU_SIZE` `.get()` request.

### Testing procedure

nothing to test yet


### Issues/PRs references
Will be used by #12128
