### PR TITLE
net/gcoap: remove gcoap_req_send2()

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -792,29 +792,6 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
                       gcoap_resp_handler_t resp_handler, void *context);
 
 /**
- * @brief   Sends a buffer containing a CoAP request to the provided endpoint
- *
- * @deprecated  Migration alias for @ref gcoap_req_send(). Will be removed after
- *              the 2020.01 release.
- *
- * @param[in] buf           Buffer containing the PDU
- * @param[in] len           Length of the buffer
- * @param[in] remote        Destination for the packet
- * @param[in] resp_handler  Callback when response received, may be NULL
- * @param[in] context       User defined context passed to the response handler
- *
- * @return  length of the packet
- * @return  0 if cannot send
- */
-static inline size_t gcoap_req_send2(const uint8_t *buf, size_t len,
-                                     const sock_udp_ep_t *remote,
-                                     gcoap_resp_handler_t resp_handler,
-                                     void *context)
-{
-    return gcoap_req_send(buf, len, remote, resp_handler, context);
-}
-
-/**
  * @brief   Initializes a CoAP response packet on a buffer
  *
  * Initializes payload location within the buffer based on packet setup.


### PR DESCRIPTION
### Contribution description
#11445 deprecated `gcoap_req_send2()`, with removal scheduled for after the 2020.01 release. However, the recent merge of #9857 changed the signature of gcoap_req_send2() (and gcoap_req_send()) to include a context pointer. This PR removes gcoap_req_send2() now because any existing uses must be touched anyway.

### Testing procedure
Expect a text search of the code base for the function will not find any instances.

### Issues/PRs references
See #11445 for deprecation discussion.