### PR TITLE
net/gcoap: deprecate gcoap_finish()

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -739,6 +739,9 @@ int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
  * Assumes the PDU has been initialized with a gcoap_xxx_init() function, like
  * gcoap_req_init().
  *
+ * @deprecated  Will not be available after the 2020.07 release. Use
+ * coap_opt_finish() instead.
+ *
  * @warning To use this function, you only may have added an Option with
  * option number less than COAP_OPT_CONTENT_FORMAT. Otherwise, use the
  * struct-based API described with @link net_nanocoap nanocoap. @endlink With

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -388,6 +388,9 @@ extern "C" {
  *
  * Accommodates writing Content-Format option in gcoap_finish(). May set to
  * zero if function not used.
+ *
+ * @deprecated  Will not be available after the 2020.07 release. Used only by
+ * gcoap_finish(), which also is deprecated.
  */
 #ifndef GCOAP_REQ_OPTIONS_BUF
 #define GCOAP_REQ_OPTIONS_BUF   (4)
@@ -398,6 +401,9 @@ extern "C" {
  *
  * Accommodates writing Content-Format option in gcoap_finish(). May set to
  * zero if function not used.
+ *
+ * @deprecated  Will not be available after the 2020.07 release. Used only by
+ * gcoap_finish(), which also is deprecated.
  */
 #ifndef GCOAP_RESP_OPTIONS_BUF
 #define GCOAP_RESP_OPTIONS_BUF  (4)
@@ -408,6 +414,9 @@ extern "C" {
  *
  * Accommodates writing Content-Format option in gcoap_finish(). May set to
  * zero if function not used.
+ *
+ * @deprecated  Will not be available after the 2020.07 release. Used only by
+ * gcoap_finish(), which also is deprecated.
  */
 #ifndef GCOAP_OBS_OPTIONS_BUF
 #define GCOAP_OBS_OPTIONS_BUF   (4)


### PR DESCRIPTION
### Contribution description
gcoap's implementation has been transitioning to use a common API with nanocoap to build a message:

* #9085, in release 2018.07, introduced the API
* #9156, in release 2019.01, adapted gcoap to use this new API
* #10982, in release 2019.04, replaced existing users of `gcoap_finish()` from gcoap's original API with `coap_opt_finish()`

This PR deprecates gcoap_finish(), with removal scheduled for after the 2020.04 release. This PR also deprecates the three GCOAP_xxx_OPTIONS_BUF macros, which are used only to accommodate gcoap_finish().

Also, somehow a use of gcoap_finish() has crept into the code in cord_epsim. I plan to create a separate PR to replace that use.

### Testing procedure
Build the documentation and ensure deprecation notices appear for the function and the macros.

### Issues/PRs references
See above.
