### PR TITLE
doc/driver-guide.md: add a note about float

### DIFF
--- a/doc/doxygen/src/driver-guide.md
+++ b/doc/doxygen/src/driver-guide.md
@@ -21,6 +21,10 @@ already converted values in some physical unit instead of RAW data, so that
 users can work directly with data from different devices directly without having
 to care about device specific conversion.
 
+However, please avoid the use of `float` or `double`. Instead, multiply to the
+next SI (or appropriate) unit. E.g. if an ADC would return values like `1.23 V`,
+chose to return `1230 mV` instead.
+
 Additionally towards ease of use, all device drivers in RIOT should provide a
 similar 'look and feel'. They should behave similar concerning things like their
 state after initialization, like their used data representation and so on.

--- a/doc/doxygen/src/driver-guide.md
+++ b/doc/doxygen/src/driver-guide.md
@@ -226,7 +226,7 @@ and sensors.
 
 As stated above, we check communication of a device during initialization, and
 handle error return values from the lower layers, where they exist. To prevent
-subsequent missuse by passing NULL pointers and similar to the subsequent
+subsequent misuse by passing NULL pointers and similar to the subsequent
 functions, the recommended way is to check parameter using `assert`, e.g.:
 
 @code{.c}


### PR DESCRIPTION
### Contribution description

The use of floating point variables should generally be avoided.
Not every MCU has a FPU and emulating floating point calculations in software adds significant overhead.

In the case of device drivers, no sane device will return float values, so converting to float will usually also come with a loss in precision.

### Testing procedure

Nothing to test.


### Issues/PRs references
follow-up on #12783
