### PR TITLE
makefiles: Generate proper dependency files when using ccache

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -100,25 +100,25 @@ $(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(RIOTBUILD_CONFIG_HEADER_C)
 	$(Q)$(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
 $(GENOBJC): %.o: %.c $(RIOTBUILD_CONFIG_HEADER_C)
 	$(Q) $(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$<)\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $<
+		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
 
 $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.cpp $(RIOTBUILD_CONFIG_HEADER_C)
 	$(Q)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
 $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
 	$(Q)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
 $(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S $(RIOTBUILD_CONFIG_HEADER_C)
-	$(Q)$(CCAS) $(CCASFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+	$(Q)$(CCAS) $(CCASFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
 # pull in dependency info for *existing* .o files
 # deleted header files will be silently ignored

--- a/Makefile.include
+++ b/Makefile.include
@@ -23,7 +23,6 @@ include $(RIOT_MAKEFILES_GLOBAL_PRE)
 
 # set undefined variables
 RIOTBASE       ?= $(_riotbase)
-CCACHE_BASEDIR ?= $(RIOTBASE)
 RIOTCPU        ?= $(RIOTBASE)/cpu
 RIOTBOARD      ?= $(RIOTBASE)/boards
 RIOTMAKE       ?= $(RIOTBASE)/makefiles
@@ -55,7 +54,6 @@ __DIRECTORY_VARIABLES := \
   BUILD_DIR \
   BINDIRBASE \
   BINDIR \
-  CCACHE_BASEDIR \
   GITCACHE \
   PKGDIRBASE \
   DLCACHE_DIR \
@@ -63,7 +61,6 @@ __DIRECTORY_VARIABLES := \
 
 # Make all paths absolute.
 override RIOTBASE       := $(abspath $(RIOTBASE))
-override CCACHE_BASEDIR := $(abspath $(CCACHE_BASEDIR))
 override RIOTCPU        := $(abspath $(RIOTCPU))
 override RIOTBOARD      := $(abspath $(RIOTBOARD))
 override RIOTMAKE       := $(abspath $(RIOTMAKE))

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -92,9 +92,6 @@ export HEXFILE               # The 'intel hex' stripped result of the compilatio
 # RESET                      # The command to call on "make reset", this command resets/reboots the target.
 # RESET_FLAGS                # The parameters to supply to RESET.
 
-export CCACHE_BASEDIR        # ccache basedir, allows multiple riot build
-                             # directories to share a ccache directory
-
 export DLCACHE               # directory used to cache http downloads
 export DOWNLOAD_TO_FILE      # Use `$(DOWNLOAD_TO_FILE) $(DESTINATION) $(URL)` to download `$(URL)` to `$(DESTINATION)`.
 export DOWNLOAD_TO_STDOUT    # Use `$(DOWNLOAD_TO_STDOUT) $(URL)` to download `$(URL)` output `$(URL)` to stdout, e.g. to be piped into `tar xz`.


### PR DESCRIPTION
### Contribution description
In #12807 it has been reported that when a change is made in a header file (which is a dependency of a given object file) make does not take this into account, in consequence it does not re-trigger a build.

The cause of this issue are the dependency files generated by the compiler (placed under `$(BINDIR)/$(MODULE)/<filename>.d`). When ccache is used, if the `CCACHE_BASEDIR` environmental variable is set, then it will turn all paths into relative (see [ccache docs](https://ccache.dev/manual/latest.html)). This has the advantage of allowing one to reuse the cache across multiple RIOT folders, but in our case it passes a relative path to the object in the call to gcc. 

Here you can see a snippet of ccache log, the actual call to gcc. Note that paths are relative:
<details><summary><b>ccache log on master</b></summary>

```
 Running preprocessor
[2019-11-28T19:50:38.589228 23100] Executing /usr/bin/gcc -Werror -Wall -Wextra -pedantic
-std=gnu11 -m32 -fstack-protector-all -ffunction-sections -fdata-sections -fno-common -Wall
-Wextra -Wmissing-include-dirs -fno-delete-null-pointer-checks -fdiagnostics-color
-Wstrict-prototypes -Wold-style-definition -gz -Wformat=2 -Wformat-overflow -Wformat-truncation
-DRIOT_FILE_RELATIVE="examples/hello-world/main.c" -DRIOT_FILE_NOPATH="main.c"
-DDEVELHELP -DDEBUG_ASSERT_VERBOSE -DRIOT_APPLICATION="hello-world"
-DBOARD_NATIVE="native" -DRIOT_BOARD=BOARD_NATIVE -DCPU_NATIVE="native"
-DRIOT_CPU=CPU_NATIVE -DMCU_NATIVE="native"
-DRIOT_MCU=MCU_NATIVE -include bin/native/riotbuild/riotbuild.h -I../../core/include
-I../../drivers/include -I../../sys/include -I../../boards/native/include -DNATIVE_INCLUDES
-I../../boards/native/include -I../../core/include -I../../drivers/include -I../../cpu/native/include
-I../../sys/include -I../../cpu/native/include -MD -MP -MF bin/native/application_hello-world/main.d
-MQ bin/native/application_hello-world/main.o -E main.c
```
</details>

The compiler then will generate rules with relative paths:
<details><summary><b>main.d file with relative path to object</b></summary>

```makefile
bin/native/application_hello-world/main.o: main.c \
 /usr/include/stdc-predef.h bin/native/riotbuild/riotbuild.h \
 /usr/include/stdio.h /usr/include/bits/libc-header-start.h \
 /usr/include/features.h /usr/include/sys/cdefs.h \
 /usr/include/bits/wordsize.h /usr/include/bits/long-double.h \
 /usr/include/gnu/stubs.h /usr/include/gnu/stubs-32.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include/stddef.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include/stdarg.h \
 /usr/include/bits/types.h /usr/include/bits/timesize.h \
 /usr/include/bits/typesizes.h /usr/include/bits/time64.h \
 /usr/include/bits/types/__fpos_t.h /usr/include/bits/types/__mbstate_t.h \
 /usr/include/bits/types/__fpos64_t.h /usr/include/bits/types/__FILE.h \
 /usr/include/bits/types/FILE.h /usr/include/bits/types/struct_FILE.h \
 /usr/include/bits/stdio_lim.h /usr/include/bits/sys_errlist.h \
 ../../sys/include/net/gnrc/netapi.h ../../core/include/thread.h \
 ../../core/include/clist.h ../../core/include/list.h \
 ../../core/include/cib.h ../../core/include/assert.h \
 ../../core/include/panic.h ../../core/include/kernel_defines.h \
 ../../core/include/msg.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include/stdint.h /usr/include/stdint.h \
 /usr/include/bits/wchar.h /usr/include/bits/stdint-intn.h \
 /usr/include/bits/stdint-uintn.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include/stdbool.h \
 ../../core/include/kernel_types.h /usr/include/inttypes.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include-fixed/limits.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include-fixed/syslimits.h \
 /usr/include/limits.h /usr/include/bits/posix1_lim.h \
 /usr/include/bits/local_lim.h /usr/include/linux/limits.h \
 /usr/include/bits/posix2_lim.h ../../cpu/native/include/cpu_conf.h \
 ../../core/include/sched.h ../../core/include/bitarithm.h \
 ../../core/include/native_sched.h ../../sys/include/net/netopt.h \
 ../../sys/include/net/gnrc/nettype.h ../../sys/include/net/ethertype.h \
 ../../sys/include/net/protnum.h ../../sys/include/net/gnrc/pkt.h \
 /usr/include/stdlib.h /usr/include/bits/waitflags.h \
 /usr/include/bits/waitstatus.h /usr/include/bits/floatn.h \
 /usr/include/bits/floatn-common.h /usr/include/sys/types.h \
 /usr/include/bits/types/clock_t.h /usr/include/bits/types/clockid_t.h \
 /usr/include/bits/types/time_t.h /usr/include/bits/types/timer_t.h \
 /usr/include/endian.h /usr/include/bits/endian.h \
 /usr/include/bits/byteswap.h /usr/include/bits/uintn-identity.h \
 /usr/include/sys/select.h /usr/include/bits/select.h \
 /usr/include/bits/types/sigset_t.h /usr/include/bits/types/__sigset_t.h \
 /usr/include/bits/types/struct_timeval.h \
 /usr/include/bits/types/struct_timespec.h \
 /usr/include/bits/pthreadtypes.h /usr/include/bits/thread-shared-types.h \
 /usr/include/bits/pthreadtypes-arch.h /usr/include/alloca.h \
 /usr/include/bits/stdlib-float.h ../../core/include/kernel_types.h
```
</details>

The dependency files are included then in `Makefile.base`, but as the rules do not match out pattern in the objects rule, the objects are not updated when a dependency (e.g. a header file) is changed.

To solve this problem, we need absolute paths in the targets of the *.d files. While using ccache 3.6 I managed this just by not setting `CCACHE_BASEDIR`, so paths would be absolute. @cgundogan reported that this does not seem to fix the issue for version 3.7.6. That is why I modified the [gcc flags](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html) to pass an explicit absolute path as the target of the generated rule (only doing this for ccache does not solve the issue, as it detects the path and relativizes it). This should not affect users who don't use ccache.

With this PR, dependency files have absolute paths, and any changes to the files the objects depend on will be taken into account.

<details><summary><b>main.d with this PR</b></summary>

```makefile
/home/leandro/Work/RIOT/examples/hello-world/bin/native/application_hello-world/main.o: \
 /home/leandro/Work/RIOT/examples/hello-world/main.c \
 /usr/include/stdc-predef.h \
 /home/leandro/Work/RIOT/examples/hello-world/bin/native/riotbuild/riotbuild.h \
 /usr/include/stdio.h /usr/include/bits/libc-header-start.h \
 /usr/include/features.h /usr/include/sys/cdefs.h \
 /usr/include/bits/wordsize.h /usr/include/bits/long-double.h \
 /usr/include/gnu/stubs.h /usr/include/gnu/stubs-32.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include/stddef.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include/stdarg.h \
 /usr/include/bits/types.h /usr/include/bits/timesize.h \
 /usr/include/bits/typesizes.h /usr/include/bits/time64.h \
 /usr/include/bits/types/__fpos_t.h /usr/include/bits/types/__mbstate_t.h \
 /usr/include/bits/types/__fpos64_t.h /usr/include/bits/types/__FILE.h \
 /usr/include/bits/types/FILE.h /usr/include/bits/types/struct_FILE.h \
 /usr/include/bits/stdio_lim.h /usr/include/bits/sys_errlist.h \
 /home/leandro/Work/RIOT/sys/include/net/gnrc/netapi.h \
 /home/leandro/Work/RIOT/core/include/thread.h \
 /home/leandro/Work/RIOT/core/include/clist.h \
 /home/leandro/Work/RIOT/core/include/list.h \
 /home/leandro/Work/RIOT/core/include/cib.h \
 /home/leandro/Work/RIOT/core/include/assert.h \
 /home/leandro/Work/RIOT/core/include/panic.h \
 /home/leandro/Work/RIOT/core/include/kernel_defines.h \
 /home/leandro/Work/RIOT/core/include/msg.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include/stdint.h /usr/include/stdint.h \
 /usr/include/bits/wchar.h /usr/include/bits/stdint-intn.h \
 /usr/include/bits/stdint-uintn.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include/stdbool.h \
 /home/leandro/Work/RIOT/core/include/kernel_types.h \
 /usr/include/inttypes.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include-fixed/limits.h \
 /usr/lib/gcc/x86_64-linux-gnu/8/include-fixed/syslimits.h \
 /usr/include/limits.h /usr/include/bits/posix1_lim.h \
 /usr/include/bits/local_lim.h /usr/include/linux/limits.h \
 /usr/include/bits/posix2_lim.h \
 /home/leandro/Work/RIOT/cpu/native/include/cpu_conf.h \
 /home/leandro/Work/RIOT/core/include/sched.h \
 /home/leandro/Work/RIOT/core/include/bitarithm.h \
 /home/leandro/Work/RIOT/core/include/native_sched.h \
 /home/leandro/Work/RIOT/sys/include/net/netopt.h \
 /home/leandro/Work/RIOT/sys/include/net/gnrc/nettype.h \
 /home/leandro/Work/RIOT/sys/include/net/ethertype.h \
 /home/leandro/Work/RIOT/sys/include/net/protnum.h \
 /home/leandro/Work/RIOT/sys/include/net/gnrc/pkt.h /usr/include/stdlib.h \
 /usr/include/bits/waitflags.h /usr/include/bits/waitstatus.h \
 /usr/include/bits/floatn.h /usr/include/bits/floatn-common.h \
 /usr/include/sys/types.h /usr/include/bits/types/clock_t.h \
 /usr/include/bits/types/clockid_t.h /usr/include/bits/types/time_t.h \
 /usr/include/bits/types/timer_t.h /usr/include/endian.h \
 /usr/include/bits/endian.h /usr/include/bits/byteswap.h \
 /usr/include/bits/uintn-identity.h /usr/include/sys/select.h \
 /usr/include/bits/select.h /usr/include/bits/types/sigset_t.h \
 /usr/include/bits/types/__sigset_t.h \
 /usr/include/bits/types/struct_timeval.h \
 /usr/include/bits/types/struct_timespec.h \
 /usr/include/bits/pthreadtypes.h /usr/include/bits/thread-shared-types.h \
 /usr/include/bits/pthreadtypes-arch.h /usr/include/alloca.h \
 /usr/include/bits/stdlib-float.h \
 /home/leandro/Work/RIOT/core/include/kernel_types.h
```
</details>

Not setting `CCACHE_BASEDIR` will have the side effect of not sharing the cache between different RIOT folders that the user may have. If the user really wants this (and does not care about having to clean for every build), the variable can always be set externally.

### Testing procedure
Run the test under these two conditions:
1. **Using ccache**
- Make sure that you either have ccache in your path with symbolic links to it (as a wrapper of the compiler) or `CCACHE` environmental variable set: this depends on your installation.
2. **Not using ccache**
- Set the environmental variable `CCACHE_DISABLE`

*TIP*: To check if ccache is being used you can run `ccache -s` to see the statistics, the last access will change every time it's used.

**Test**:
Using the example application provided in #12807 (or a similar example):
- Run `rm -Rf bin` in the application directory.
-  Build `make all term`. You should see the current value in of the header file.
- Check that the `main.d` file has an absolute path to the object.
- Change the header file updating the value, and run `make all term` (NO CLEAN). `main.o` should be the only object re-built, and the number should be updated.

### Issues/PRs references
Fixes #12807