### PR TITLE
drivers/ws281x: improve documentation

### DIFF
--- a/drivers/include/ws281x.h
+++ b/drivers/include/ws281x.h
@@ -21,7 +21,7 @@
  *
  * The protocol to communicate with the WS281x is custom, so no hardware
  * implementations can be used. Hence, the protocol needs to be bit banged in
- * software. As the timing requirements are to strict to do this using
+ * software. As the timing requirements are too strict to do this using
  * the platform independent APIs for accessing @ref drivers_periph_gpio and
  * @ref sys_xtimer, platform specific implementations of @ref ws281x_write are
  * needed.
@@ -30,7 +30,7 @@
  *
  * A bit banging implementation for ATmegas clocked at 8MHz and at 16MHz is
  * provided. Boards clocked at any other core frequency are not supported.
- * (But keep in mind that most (all?) ATmega MCUs do have an internal 8 MHz
+ * (But keep in mind that most (all?) ATmega MCUs do have an internal 8MHz
  * oscillator, that could be enabled by changing the fuse settings.)
  *
  * @warning On 8MHz ATmegas, only pins at GPIO ports B, C, and D are supported.


### PR DESCRIPTION




<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Replace 'to' with 'too' and remove the space between '8 MHz'.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make doc` and look at the WS2812/SK6812 RGB LED (NeoPixel) page.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


