### PR TITLE
boards/openmote-b: fix defines

### DIFF
--- a/boards/openmote-b/board.c
+++ b/boards/openmote-b/board.c
@@ -33,12 +33,12 @@ void board_init(void)
     gpio_init(BOOT_PIN, GPIO_IN);
 
     gpio_init(USER_BUTTON_PIN, GPIO_IN);
-    gpio_init(RF_SWITCH_2_4_GHZ_PIN, GPIO_OUT);
-    gpio_init(RF_SWITCH_SUB_GHZ_PIN, GPIO_OUT);
+    gpio_init(RF24_SWITCH_CC2538_PIN, GPIO_OUT);
+    gpio_init(RF24_SWITCH_AT86RF215_PIN, GPIO_OUT);
 
     /* start with cc2538 2.4ghz radio*/
-    RF_SWITCH_2_4_GHZ_ON;
-    RF_SWITCH_SUB_GHZ_OFF;
+    RF24_SWITCH_CC2538_ON;
+    RF24_SWITCH_AT86RF215_OFF;
 
     /* initialize the CPU */
     cpu_init();

--- a/boards/openmote-b/board.c
+++ b/boards/openmote-b/board.c
@@ -32,7 +32,7 @@ void board_init(void)
     /* The boot pin must be set to input otherwise it may lock the bootloader */
     gpio_init(BOOT_PIN, GPIO_IN);
 
-    gpio_init(USER_BUTTON_PIN, GPIO_IN);
+    gpio_init(BTN0_PIN, BTN0_MODE);
     gpio_init(RF24_SWITCH_CC2538_PIN, GPIO_OUT);
     gpio_init(RF24_SWITCH_AT86RF215_PIN, GPIO_OUT);
 

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -38,8 +38,8 @@
 #define LED3_PIN                    GPIO_PIN(2, 5)
 #define LED3_PIN                    GPIO_PIN(2, 5)
 #define USER_BUTTON_PIN             GPIO_PIN(2, 5)
-#define RF_SWITCH_2_4_GHZ_PIN       GPIO_PIN(3, 4)  /**< PD4 -- 2.4ghz */
-#define RF_SWITCH_SUB_GHZ_PIN       GPIO_PIN(3, 3)  /**< PD3 -- subghz */
+#define RF24_SWITCH_CC2538_PIN      GPIO_PIN(3, 4)  /**< PD4 -- CC2538 */
+#define RF24_SWITCH_AT86RF215_PIN   GPIO_PIN(3, 3)  /**< PD3 -- AT86RF215 */
 
 #define LED_PORT                    GPIO_C
 #define LED0_MASK                   (1 << 4)
@@ -48,8 +48,8 @@
 #define LED3_MASK                   (1 << 5)
 
 #define RF_SWITCH_PORT              GPIO_D
-#define RF_SWITCH_2_4_GHZ_MASK      (1 << 4)
-#define RF_SWITCH_SUB_GHZ_MASK      (1 << 3)
+#define RF24_SWITCH_CC2538_MASK     (1 << 4)
+#define RF24_SWITCH_AT86RF215_MASK  (1 << 3)
 
 #define LED0_ON                     (LED_PORT->DATA &= ~LED0_MASK)
 #define LED0_OFF                    (LED_PORT->DATA |=  LED0_MASK)
@@ -67,13 +67,13 @@
 #define LED3_OFF                    (LED_PORT->DATA |=  LED3_MASK)
 #define LED3_TOGGLE                 (LED_PORT->DATA ^=  LED3_MASK)
 
-#define RF_SWITCH_2_4_GHZ_ON        (RF_SWITCH_PORT->DATA &= ~RF_SWITCH_2_4_GHZ_MASK)
-#define RF_SWITCH_2_4_GHZ_OFF       (RF_SWITCH_PORT->DATA |=  RF_SWITCH_2_4_GHZ_MASK)
-#define RF_SWITCH_2_4_GHZ_TOGGLE    (RF_SWITCH_PORT->DATA ^=  RF_SWITCH_2_4_GHZ_MASK)
+#define RF24_SWITCH_CC2538_ON       (RF_SWITCH_PORT->DATA &= ~RF24_SWITCH_CC2538_MASK)
+#define RF24_SWITCH_CC2538_OFF      (RF_SWITCH_PORT->DATA |=  RF24_SWITCH_CC2538_MASK)
+#define RF24_SWITCH_CC2538_TOGGLE   (RF_SWITCH_PORT->DATA ^=  RF24_SWITCH_CC2538_MASK)
 
-#define RF_SWITCH_SUB_GHZ_ON        (RF_SWITCH_PORT->DATA &= ~RF_SWITCH_SUB_GHZ_MASK)
-#define RF_SWITCH_SUB_GHZ_OFF       (RF_SWITCH_PORT->DATA |=  RF_SWITCH_SUB_GHZ_MASK)
-#define RF_SWITCH_SUB_GHZ_TOGGLE    (RF_SWITCH_PORT->DATA ^=  RF_SWITCH_SUB_GHZ_MASK)
+#define RF24_SWITCH_AT86RF215_ON     (RF_SWITCH_PORT->DATA &= ~RF24_SWITCH_AT86RF215_MASK)
+#define RF24_SWITCH_AT86RF215_OFF    (RF_SWITCH_PORT->DATA |=  RF24_SWITCH_AT86RF215_MASK)
+#define RF24_SWITCH_AT86RF215_TOGGLE (RF_SWITCH_PORT->DATA ^=  RF24_SWITCH_AT86RF215_MASK)
 /** @} */
 
 /**

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -36,8 +36,8 @@
 #define LED1_PIN                    GPIO_PIN(2, 7)
 #define LED2_PIN                    GPIO_PIN(2, 6)
 #define LED3_PIN                    GPIO_PIN(2, 5)
-#define LED3_PIN                    GPIO_PIN(2, 5)
-#define USER_BUTTON_PIN             GPIO_PIN(2, 5)
+#define BTN0_PIN                    GPIO_PIN(3, 5)
+#define BTN0_MODE                   GPIO_IN
 #define RF24_SWITCH_CC2538_PIN      GPIO_PIN(3, 4)  /**< PD4 -- CC2538 */
 #define RF24_SWITCH_AT86RF215_PIN   GPIO_PIN(3, 3)  /**< PD3 -- AT86RF215 */
 


### PR DESCRIPTION
### Contribution description

This aligns the code in RIOT more with the data sheet:

 - the SubGHz Antenna is permanently connected to the AT86RF215, the antenna switch pin is to switch the 2.4 GHz antenna between AT86RF215 and CC2538
 - the button is connected to `PD5`, not `PC5`.

### Testing procedure

Make sure the radio & button works. 

### Issues/PRs references
discovered in #12128