### PR TITLE
Makefile.base: add variables for customizing C++ builds

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -55,7 +55,7 @@ ifeq ($(strip $(SRC))$(NO_AUTO_SRC),)
   SRC := $(filter-out $(SRC_NOLTO), $(wildcard *.c))
 endif
 ifeq ($(strip $(SRCXX))$(NO_AUTO_SRC),)
-  SRCXX := $(wildcard *.$(SRCXXEXT))
+  SRCXX := $(filter-out $(SRCXXEXCLUDE),$(wildcard *.$(SRCXXEXT)))
 endif
 ifeq ($(strip $(ASMSRC))$(NO_AUTO_SRC),)
   ASMSRC := $(wildcard *.s)

--- a/Makefile.base
+++ b/Makefile.base
@@ -48,11 +48,14 @@ ifeq (1, $(SUBMODULES))
   endif
 endif
 
+# By default consider C++ files has a .cpp extension
+SRCXXEXT ?= cpp
+
 ifeq ($(strip $(SRC))$(NO_AUTO_SRC),)
   SRC := $(filter-out $(SRC_NOLTO), $(wildcard *.c))
 endif
 ifeq ($(strip $(SRCXX))$(NO_AUTO_SRC),)
-  SRCXX := $(wildcard *.cpp)
+  SRCXX := $(wildcard *.$(SRCXXEXT))
 endif
 ifeq ($(strip $(ASMSRC))$(NO_AUTO_SRC),)
   ASMSRC := $(wildcard *.s)
@@ -68,7 +71,7 @@ GENOBJC     := $(GENSRC:%.c=%.o)
 OBJC_LTO    := $(SRC:%.c=$(BINDIR)/$(MODULE)/%.o)
 OBJC_NOLTO  := $(SRC_NOLTO:%.c=$(BINDIR)/$(MODULE)/%.o)
 OBJC        := $(OBJC_NOLTO) $(OBJC_LTO)
-OBJCXX      := $(SRCXX:%.cpp=$(BINDIR)/$(MODULE)/%.o)
+OBJCXX      := $(SRCXX:%.$(SRCXXEXT)=$(BINDIR)/$(MODULE)/%.o)
 ASMOBJ      := $(ASMSRC:%.s=$(BINDIR)/$(MODULE)/%.o)
 ASSMOBJ     := $(ASSMSRC:%.S=$(BINDIR)/$(MODULE)/%.o)
 
@@ -108,7 +111,7 @@ $(GENOBJC): %.o: %.c $(RIOTBUILD_CONFIG_HEADER_C) $(KCONFIG_GENERATED_AUTOCONF_H
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
 
-$(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.cpp $(RIOTBUILD_CONFIG_HEADER_C) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+$(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(RIOTBUILD_CONFIG_HEADER_C) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
 	$(Q)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \

--- a/tests/cpp_exclude/Makefile
+++ b/tests/cpp_exclude/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += cpp
+
+USEMODULE += module_exclude
+EXTERNAL_MODULE_DIRS += $(CURDIR)/module_exclude
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpp_exclude/Makefile.ci
+++ b/tests/cpp_exclude/Makefile.ci
@@ -1,0 +1,6 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    stm32f030f4-demo \
+    stm32f0discovery \
+    #

--- a/tests/cpp_exclude/main.cpp
+++ b/tests/cpp_exclude/main.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Sample C++ application
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <cstdio>
+#include "module.hpp"
+
+int main() {
+    puts("Hello from C++");
+
+    module_class obj;
+    obj.print_hello();
+
+    return 0;
+}

--- a/tests/cpp_exclude/module_exclude/Makefile
+++ b/tests/cpp_exclude/module_exclude/Makefile
@@ -1,0 +1,5 @@
+MODULE = module_exclude
+
+SRCXXEXCLUDE := module_excluded.cpp
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/cpp_exclude/module_exclude/Makefile.dep
+++ b/tests/cpp_exclude/module_exclude/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += cpp

--- a/tests/cpp_exclude/module_exclude/Makefile.include
+++ b/tests/cpp_exclude/module_exclude/Makefile.include
@@ -1,0 +1,3 @@
+# Use an immediate variable to evaluate `MAKEFILE_LIST` now
+USEMODULE_INCLUDES_module_exclude := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_module_exclude)

--- a/tests/cpp_exclude/module_exclude/module.cpp
+++ b/tests/cpp_exclude/module_exclude/module.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Sample module C++ class
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <cstdio>
+
+#include "module.hpp"
+
+module_class::module_class() {}
+
+module_class::~module_class() {}
+
+void module_class::print_hello(void)
+{
+    puts("Hello from C++ module");
+}

--- a/tests/cpp_exclude/module_exclude/module.hpp
+++ b/tests/cpp_exclude/module_exclude/module.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Sample module C++ class
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef MODULE_H
+#define MODULE_H
+
+#include <cstdio>
+
+class module_class
+{
+public:
+    /**
+     * @brief constructor
+     */
+    module_class();
+
+    /**
+     * @brief destructor
+     */
+    ~module_class();
+
+    /**
+     * @brief public function
+     */
+    void print_hello(void);
+};
+
+/** @} */
+#endif /* MODULE_H */

--- a/tests/cpp_exclude/module_exclude/module_excluded.cpp
+++ b/tests/cpp_exclude/module_exclude/module_excluded.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Sample module C++ class
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <cstdio>
+
+#include "module.hpp"
+
+#error "This should not be built"
+
+module_class::module_class() {}
+
+module_class::~module_class() {}
+
+void module_class::print(void)
+{
+    puts("Hello from C++ module");
+}

--- a/tests/cpp_exclude/tests/01-run.py
+++ b/tests/cpp_exclude/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('Hello from C++')
+    child.expect_exact('Hello from C++ module')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/cpp_ext/Makefile
+++ b/tests/cpp_ext/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += cpp
+
+USEMODULE += module
+EXTERNAL_MODULE_DIRS += $(CURDIR)/module
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpp_ext/Makefile.ci
+++ b/tests/cpp_ext/Makefile.ci
@@ -1,0 +1,6 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    stm32f030f4-demo \
+    stm32f0discovery \
+    #

--- a/tests/cpp_ext/main.cpp
+++ b/tests/cpp_ext/main.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Sample C++ application
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <cstdio>
+
+#include "module.hh"
+
+int main() {
+    puts("Hello from C++");
+
+    module_class obj;
+    obj.print_hello();
+
+    return 0;
+}

--- a/tests/cpp_ext/module/Makefile
+++ b/tests/cpp_ext/module/Makefile
@@ -1,0 +1,5 @@
+MODULE = module
+
+SRCXXEXT = cc
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/cpp_ext/module/Makefile.dep
+++ b/tests/cpp_ext/module/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += cpp

--- a/tests/cpp_ext/module/Makefile.include
+++ b/tests/cpp_ext/module/Makefile.include
@@ -1,0 +1,3 @@
+# Use an immediate variable to evaluate `MAKEFILE_LIST` now
+USEMODULE_INCLUDES_module := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_module)

--- a/tests/cpp_ext/module/module.cc
+++ b/tests/cpp_ext/module/module.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Sample module C++ class
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <cstdio>
+
+#include "module.hh"
+
+module_class::module_class() {}
+
+module_class::~module_class() {}
+
+void module_class::print_hello(void)
+{
+    puts("Hello from C++ module");
+}

--- a/tests/cpp_ext/module/module.cpp
+++ b/tests/cpp_ext/module/module.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Sample module C++ class
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <cstdio>
+
+#include "module.hh"
+
+#error "This should not be built"
+
+module_class::module_class() {}
+
+module_class::~module_class() {}
+
+void module_class::print(void)
+{
+    puts("Hello from C++ module");
+}

--- a/tests/cpp_ext/module/module.hh
+++ b/tests/cpp_ext/module/module.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Sample module C++ class
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef MODULE_H
+#define MODULE_H
+
+class module_class
+{
+public:
+    /**
+     * @brief constructor
+     */
+    module_class();
+
+    /**
+     * @brief destructor
+     */
+    ~module_class();
+
+    /**
+     * @brief public function
+     */
+    void print_hello(void);
+};
+
+/** @} */
+#endif /* MODULE_H */

--- a/tests/cpp_ext/tests/01-run.py
+++ b/tests/cpp_ext/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('Hello from C++')
+    child.expect_exact('Hello from C++ module')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR proposes a small modification of Makefile.base for C++ module builds:
- it adds a `CXXEXT` variable to be able to build C++ files with extension other than .cpp, which remains the default
- it add a CXXEXCLUDE variable that could contain c++ files that are not expected to be built by default in a module directory

I need this to be able to integrate as package a couple of C++ external projects (that will be PRed soon).

2 test application are provided to verify that each new features is working.

I tried to also apply this to files in the application directory but it doesn't seem to be as straightforward: one has to pass them from the application Makefile to the application build via environment variables.

Maybe there's a better approach, comments are welcome.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following commands should work:
```
make BOARD=<board of your choice> -C tests/cpp_ext flash test
make BOARD=<board of your choice> -C tests/cpp_exclude flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
