### PR TITLE
gnrc_sixlowpan_frag_rb: fix memory-leak in _rm_by_datagram()

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -156,6 +156,7 @@ void gnrc_sixlowpan_frag_rb_rm_by_datagram(const gnrc_netif_hdr_t *netif_hdr,
     gnrc_sixlowpan_frag_rb_t *e = _rbuf_get_by_tag(netif_hdr, tag);
 
     if (e != NULL) {
+        gnrc_pktbuf_release(e->pkt);
         gnrc_sixlowpan_frag_rb_remove(e);
     }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds a `gnrc_pktbuf_release()` to the function `gnrc_sixlowpan_frag_rm_by_datagram()`.

This fits with the semantics of this function which doesn't provide or uses any state of the reassembly buffer provided by the user, but finds the entry itself and then removes it. This gives the user no chance to remove the packet in the reassembly buffer entry, so `gnrc_sixlowpan_frag_rb_rm_by_datagram()` has to release the packet (other than `gnrc_sixlowpan_frag_rb_remove()` where not releasing the packet is desired as it might be handed up to an upper layer).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I adapted the tests for the reassembly buffer to check this error:

```
make -C tests/gnrc_sixlowpan_frag flash test
```

Without the fix (`git reset --hard HEAD~1`) it fails, with it it succeeds.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on/Bug fix for a feature introduced in #12349
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
