### PR TITLE
pkg: add support for FlatBuffers serialization library

### DIFF
--- a/dist/tools/flatc/.gitignore
+++ b/dist/tools/flatc/.gitignore
@@ -1,0 +1,2 @@
+flatc
+bin

--- a/dist/tools/flatc/Makefile
+++ b/dist/tools/flatc/Makefile
@@ -1,0 +1,28 @@
+PKG_NAME=flatc
+PKG_URL=https://github.com/google/flatbuffers
+PKG_VERSION=9e7e8cbe9f675123dd41b7c62868acad39188cae
+PKG_LICENSE=Apache2.0
+
+PKG_BUILDDIR=$(CURDIR)/bin
+
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
+GITCACHE ?= $(RIOTTOOLS)/git/git-cache
+
+CMAKE_OPTIONS = \
+    -DCMAKE_BUILD_TYPE=Release       \
+    -DFLATBUFFERS_BUILD_TESTS=OFF    \
+    -DFLATBUFFERS_BUILD_FLATHASH=OFF \
+    -DFLATBUFFERS_BUILD_FLATLIB=OFF  \
+    #
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	@cd "$(PKG_BUILDDIR)" && env -i PATH="$(PATH)" cmake -G "Unix Makefiles" $(CMAKE_OPTIONS) .
+	"$(MAKE)" -C "$(PKG_BUILDDIR)"
+	@mv "$(PKG_BUILDDIR)"/flatc $(CURDIR)/flatc
+
+distclean::
+	@rm -f $(CURDIR)/flatc

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -34,3 +34,8 @@ $(RIOTTOOLS)/setsid/setsid: $(RIOTTOOLS)/setsid/Makefile
 	@echo "[INFO] setsid binary not found - building it from source now"
 	@make -C $(RIOTTOOLS)/setsid
 	@echo "[INFO] setsid binary successfully built!"
+
+$(RIOTTOOLS)/flatc/flatc: $(RIOTTOOLS)/flatc/Makefile
+	@echo "[INFO] flatc binary not found - building it from source now"
+	make -C $(RIOTTOOLS)/flatc
+	@echo "[INFO] flatc binary successfully built!"

--- a/pkg/flatbuffers/Makefile
+++ b/pkg/flatbuffers/Makefile
@@ -1,0 +1,9 @@
+PKG_NAME=flatbuffers
+PKG_URL=https://github.com/google/flatbuffers
+PKG_VERSION=v1.11.0
+PKG_LICENSE=Apache2.0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/flatbuffers/Makefile.dep
+++ b/pkg/flatbuffers/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += cpp11-compat

--- a/pkg/flatbuffers/Makefile.flatbuffers
+++ b/pkg/flatbuffers/Makefile.flatbuffers
@@ -1,0 +1,5 @@
+MODULE = flatbuffers
+
+NO_AUTO_SRC := 1
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/flatbuffers/Makefile.include
+++ b/pkg/flatbuffers/Makefile.include
@@ -1,0 +1,11 @@
+INCLUDES += -I$(PKGDIRBASE)/flatbuffers/include
+
+FLATC ?= flatc
+
+ifneq (0,$(shell which flatc 2>&1 > /dev/null ; echo $$?))
+  FLATC = $(RIOTTOOLS)/flatc/flatc
+  $(call target-export-variables,all,FLATC)
+endif
+
+# This module requires cpp11 support
+CXXEXFLAGS += -std=c++11

--- a/pkg/flatbuffers/doc.txt
+++ b/pkg/flatbuffers/doc.txt
@@ -1,0 +1,8 @@
+/**
+ * @defgroup pkg_flatbuffers FlatBuffers
+ * @ingroup  pkg
+ * @ingroup  sys_serialization
+ * @brief    FlatBuffers: Memory Efficient Serialization Library
+ *
+ * @see      http://google.github.io/flatbuffers/
+ */

--- a/tests/pkg_flatbuffers/.gitignore
+++ b/tests/pkg_flatbuffers/.gitignore
@@ -1,0 +1,1 @@
+monster_generated.h

--- a/tests/pkg_flatbuffers/Makefile
+++ b/tests/pkg_flatbuffers/Makefile
@@ -1,0 +1,13 @@
+include ../Makefile.tests_common
+
+USEPKG += flatbuffers
+
+# Skip warning raised when building monster_generated.h
+CXXEXFLAGS += -Wno-type-limits
+
+BUILDDEPS += monster_generated.h
+
+include $(RIOTBASE)/Makefile.include
+
+monster_generated.h: $(FLATC)
+	$(Q)$(FLATC) --cpp $(CURDIR)/monster.fbs

--- a/tests/pkg_flatbuffers/Makefile.ci
+++ b/tests/pkg_flatbuffers/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    stm32f030f4-demo \
+    #

--- a/tests/pkg_flatbuffers/README.md
+++ b/tests/pkg_flatbuffers/README.md
@@ -1,0 +1,26 @@
+FlatBuffer sample application
+=============================
+
+This application shows how to use the FlatBuffer library from Google for
+serializing/deserializing a runtime C++ object to/from a binary buffer.
+
+The application is
+[taken as is from the upstream repository](https://github.com/google/flatbuffers/blob/master/samples/sample_binary.cpp).
+
+More details are available on
+[the FlatBuffers website](http://google.github.io/flatbuffers/).
+
+Usage
+-----
+
+Simply flash and run the application on the board of your choice using:
+
+    make BOARD=<board of your choice> -C tests/pkg_flatbuffers flash term
+
+Expected result
+---------------
+
+The application creates an object, serialize it in a FlatBuffer and after
+reloading the serialized object it displays:
+
+    "The FlatBuffer was successfully created and verified!"

--- a/tests/pkg_flatbuffers/main.cpp
+++ b/tests/pkg_flatbuffers/main.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include "monster_generated.h"  // Already includes "flatbuffers/flatbuffers.h".
+
+using namespace MyGame::Sample;
+
+// Example how to use FlatBuffers to create and read binary buffers.
+
+int main(int /*argc*/, const char * /*argv*/[]) {
+  // Build up a serialized buffer algorithmically:
+  flatbuffers::FlatBufferBuilder builder;
+
+  // First, lets serialize some weapons for the Monster: A 'sword' and an 'axe'.
+  auto weapon_one_name = builder.CreateString("Sword");
+  short weapon_one_damage = 3;
+
+  auto weapon_two_name = builder.CreateString("Axe");
+  short weapon_two_damage = 5;
+
+  // Use the `CreateWeapon` shortcut to create Weapons with all fields set.
+  auto sword = CreateWeapon(builder, weapon_one_name, weapon_one_damage);
+  auto axe = CreateWeapon(builder, weapon_two_name, weapon_two_damage);
+
+  // Create a FlatBuffer's `vector` from the `std::vector`.
+  std::vector<flatbuffers::Offset<Weapon>> weapons_vector;
+  weapons_vector.push_back(sword);
+  weapons_vector.push_back(axe);
+  auto weapons = builder.CreateVector(weapons_vector);
+
+  // Second, serialize the rest of the objects needed by the Monster.
+  auto position = Vec3(1.0f, 2.0f, 3.0f);
+
+  auto name = builder.CreateString("MyMonster");
+
+  unsigned char inv_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  auto inventory = builder.CreateVector(inv_data, 10);
+
+  // Shortcut for creating monster with all fields set:
+  auto orc = CreateMonster(builder, &position, 150, 80, name, inventory,
+                           Color_Red, weapons, Equipment_Weapon, axe.Union());
+
+  builder.Finish(orc);  // Serialize the root of the object.
+
+  // We now have a FlatBuffer we can store on disk or send over a network.
+
+  // ** file/network code goes here :) **
+  // access builder.GetBufferPointer() for builder.GetSize() bytes
+
+  // Instead, we're going to access it right away (as if we just received it).
+
+  // Get access to the root:
+  auto monster = GetMonster(builder.GetBufferPointer());
+
+  // Get and test some scalar types from the FlatBuffer.
+  assert(monster->hp() == 80);
+  assert(monster->mana() == 150);  // default
+  assert(monster->name()->str() == "MyMonster");
+
+  // Get and test a field of the FlatBuffer's `struct`.
+  auto pos = monster->pos();
+  assert(pos);
+  assert(pos->z() == 3.0f);
+  (void)pos;
+
+  // Get a test an element from the `inventory` FlatBuffer's `vector`.
+  auto inv = monster->inventory();
+  assert(inv);
+  assert(inv->Get(9) == 9);
+  (void)inv;
+
+  // Get and test the `weapons` FlatBuffers's `vector`.
+  std::string expected_weapon_names[] = { "Sword", "Axe" };
+  short expected_weapon_damages[] = { 3, 5 };
+  auto weps = monster->weapons();
+  for (unsigned int i = 0; i < weps->size(); i++) {
+    assert(weps->Get(i)->name()->str() == expected_weapon_names[i]);
+    assert(weps->Get(i)->damage() == expected_weapon_damages[i]);
+  }
+  (void)expected_weapon_names;
+  (void)expected_weapon_damages;
+
+  // Get and test the `Equipment` union (`equipped` field).
+  assert(monster->equipped_type() == Equipment_Weapon);
+  auto equipped = static_cast<const Weapon *>(monster->equipped());
+  assert(equipped->name()->str() == "Axe");
+  assert(equipped->damage() == 5);
+  (void)equipped;
+
+  printf("The FlatBuffer was successfully created and verified!\n");
+}

--- a/tests/pkg_flatbuffers/monster.fbs
+++ b/tests/pkg_flatbuffers/monster.fbs
@@ -1,0 +1,33 @@
+// Example IDL file for our monster's schema.
+
+namespace MyGame.Sample;
+
+enum Color:byte { Red = 0, Green, Blue = 2 }
+
+union Equipment { Weapon } // Optionally add more tables.
+
+struct Vec3 {
+  x:float;
+  y:float;
+  z:float;
+}
+
+table Monster {
+  pos:Vec3;
+  mana:short = 150;
+  hp:short = 100;
+  name:string;
+  friendly:bool = false (deprecated);
+  inventory:[ubyte];
+  color:Color = Blue;
+  weapons:[Weapon];
+  equipped:Equipment;
+  path:[Vec3];
+}
+
+table Weapon {
+  name:string;
+  damage:short;
+}
+
+root_type Monster;

--- a/tests/pkg_flatbuffers/tests/01-run.py
+++ b/tests/pkg_flatbuffers/tests/01-run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('The FlatBuffer was successfully created and verified!')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [FlatBuffers serialization library](https://google.github.io/flatbuffers/).

The principle is to compile a schema (.fbs) to a c++ file that is added to the build. Thus, this PR also adds some logic to the build system for compiling on the fly the `flatc` compiler.

The test application provided is copied as is from [one of the sample](https://github.com/google/flatbuffers/blob/master/samples/sample_binary.cpp).

The serializable C++ object is built on the fly when building the application.

Some comments:
- The integration as a package only require headers from the libray. So I'm wondering if the package approach makes sense
- I tried to apply the same strategy as the one done for the ubasic package to directly use the `sample_binary.cpp` from the repo but had some problems during link. If someone knows how to achieve this, that would be great.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

Build and run the provided test application:
```
make BOARD=<board of your choice> -C tests/pkg_flatbuffers flash tests
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
