### PR TITLE
 gnrc_sixlowpan_frag_vrb: fix issues with interval marker inherited from base

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -25,6 +25,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "kernel_defines.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/sixlowpan/config.h"
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG
@@ -123,9 +124,9 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
  */
 static inline void gnrc_sixlowpan_frag_vrb_rm(gnrc_sixlowpan_frag_vrb_t *vrb)
 {
-#ifdef MODULE_GNRC_SIXLOWPAN_FRAG
-    gnrc_sixlowpan_frag_rb_base_rm(&vrb->super);
-#endif  /* MODULE_GNRC_SIXLOWPAN_FRAG */
+    if (IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_RB)) {
+        gnrc_sixlowpan_frag_rb_base_rm(&vrb->super);
+    }
     vrb->super.src_len = 0;
 }
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -307,6 +307,12 @@ static int _rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
         memcpy(((uint8_t *)entry->pkt->data) + offset, data,
                frag_size);
     }
+    else {
+        /* no space left in rbuf interval buffer*/
+        gnrc_pktbuf_release(entry->pkt);
+        gnrc_sixlowpan_frag_rb_remove(entry);
+        res = RBUF_ADD_ERROR;
+    }
     /* no errors and not consumed => release packet */
     gnrc_pktbuf_release(pkt);
     return res;

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -80,6 +80,34 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
                                              vrbe->super.dst_len,
                                              addr_str), vrbe->out_tag);
             }
+            /* _equal_index() => append intervals of `base`, so they don't get
+             * lost. We use append, so we don't need to change base! */
+            else if (base->ints != NULL) {
+                gnrc_sixlowpan_frag_rb_int_t *tmp = vrbe->super.ints;
+
+                if (tmp != base->ints) {
+                    /* base->ints is not already vrbe->super.ints */
+                    if (tmp != NULL) {
+                        /* iterate before appending and check if `base->ints` is
+                         * not already part of list */
+                        while (tmp->next != NULL) {
+                            if (tmp == base->ints) {
+                                tmp = NULL;
+                            }
+                            /* cppcheck-suppress nullPointer
+                             * (reason: possible bug in cppcheck, tmp can't
+                             * clearly be a NULL pointer here) */
+                            tmp = tmp->next;
+                        }
+                        if (tmp != NULL) {
+                            tmp->next = base->ints;
+                        }
+                    }
+                    else {
+                        vrbe->super.ints = base->ints;
+                    }
+                }
+            }
             break;
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`gnrc_sixlowpan_frag_rb_base_rm()` cleans up the intervals which is part of `gnrc_sixlowpan_frag_rb`, not `gnrc_sixlowpan_frag`, so when the `gnrc_sixlowpan_frag` is not compiled in, but `gnrc_sixlowpan_frag_rb`, the intervals allocated in the reassembly buffer and inherited by the virtual reassembly buffer are never released.

This also adds an error return for the reassembly buffer, when the interval buffer is full.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
make -C tests/unittests/ tests-gnrc_sixlowpan_frag_vrb flash-only tests
```

Should still pass.

When applying the following patch

```diff
diff --git a/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c b/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
index d00a54ee0d..6cb6a4aa31 100644
--- a/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
+++ b/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
@@ -36,12 +36,12 @@
  * reference for forwarding) so an uninitialized one is enough */
 static gnrc_netif_t _dummy_netif;
 
-static const gnrc_sixlowpan_frag_rb_int_t _interval = {
+static gnrc_sixlowpan_frag_rb_int_t _interval = {
     .next = NULL,
     .start = 0,
     .end = 116U,
 };
-static const gnrc_sixlowpan_frag_rb_base_t _base = {
+static gnrc_sixlowpan_frag_rb_base_t _base = {
     .ints = (gnrc_sixlowpan_frag_rb_int_t *)&_interval,
     .src = TEST_SRC,
     .dst = TEST_DST,
@@ -58,6 +58,7 @@ static void set_up(void)
 {
     gnrc_sixlowpan_frag_vrb_reset();
     gnrc_sixlowpan_frag_fb_reset();
+    _interval.end = 116U;
 }
 
 static void test_vrb_add__success(void)
@@ -154,6 +155,7 @@ static void test_vrb_rm(void)
     gnrc_sixlowpan_frag_vrb_rm(res);
     TEST_ASSERT_NULL(gnrc_sixlowpan_frag_vrb_get(_base.src, _base.src_len,
                                                  _base.tag));
+    TEST_ASSERT_EQUAL_INT(0U, _interval.end);
 }
 
 static void test_vrb_gc(void)
```

(so the interval provided with the base can be changed and reset after each test and the removal (end == 0) is checked in the remove test).

```
USEMODULE=gnrc_sixlowpan_frag_rb make -C tests/unittests/ tests-gnrc_sixlowpan_frag_vrb flash-only tests
```

should also succeed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
