### PR TITLE
Makefile.dep: use puf_sram for random when available

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -732,6 +732,11 @@ endif
 
 ifneq (,$(filter random,$(USEMODULE)))
   USEMODULE += prng
+
+  ifneq (,$(filter puf_sram,$(FEATURES_PROVIDED)))
+    USEMODULE += puf_sram
+  endif
+
   # select default prng
   ifeq (,$(filter prng_%,$(USEMODULE)))
     USEMODULE += prng_tinymt32


### PR DESCRIPTION
### Contribution description

[`auto_init_random()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/random/random.c#L42) will seed from `puf_sram` when enabled, but `puf_sram` does not automatically get enabled when selecting the `random` module.

Thus if there is no CPU ID or HWRNG, a `"random: NO SEED AVAILABLE!"`
message is printed even though `puf_sram` could be enabled.

Unfortunately using

    FEATURES_OPTIONAL += puf_sram

instead did not have the desired effect.

### Testing procedure

Build `tests/gnrc_sock_udp` on a board without CPU ID and HWRNG, but with `puf_sram`. (`msba2` is a good candidate.)

On master you will see
```
random: NO SEED AVAILABLE!
```
printed on boot.

With this you should see

```
Makefile:1: Attention! Module PUF SRAM requires power-off in order to generate a high-entropy seed
```
when building, but no message on boot.

### Issues/PRs references
`buildsystem_sanity_check/check.sh` will not be happy about checking the contents of `FEATURES_PROVIDED`.
I encounter a similar issue in #12793 - maybe this check is too strict or the `FEATURES_*` macros are lacking in expressiveness? 