### PR TITLE
cpu/atmega256rfr2: symbol counter based RTT support

### DIFF
--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -177,14 +177,32 @@ typedef struct {
 /** @} */
 
 /**
-￼* @name RTT configuration
-￼* @{
-￼*/
-#define RTT_MAX_VALUE    (0x00FFFFFF)    /* 24-bit timer */
+ * @name RTT configuration
+ * @{
+ */
+#if defined(SCCR0) && !defined(RTT_BACKEND_SC)
+#define RTT_BACKEND_SC   (1)
+#endif
 
+#if RTT_BACKEND_SC
+/* For MCU with MAC symbol counter */
+#ifndef RTT_MAX_VALUE
+#define RTT_MAX_VALUE    (0xFFFFFFFFUL)  /* 32-bit timer */
+#endif
+
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY    (62500UL)       /* in Hz. */
+#endif
+
+#else
+/* For MCU without MAC symbol counter */
+#ifndef RTT_MAX_VALUE
+#define RTT_MAX_VALUE    (0x00FFFFFF)    /* 24-bit timer */
+#endif
 /* possible values: 32, 128, 256, 512, 1024, 4096, 32768 */
 #ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY    (1024U)         /* in Hz. */
+#endif
 #endif
 /** @} */
 


### PR DESCRIPTION
### Contribution description

This adds RTT support to atmega256rfr2 based on MAC symbol counter. The MAC symbol conter is 32-bit wide working on 62.500 kHz derived from XTAL1 16MHz or TOSC1 32.786 kHz oscillator. Symbol counter automatically switches from XTAL1 oscillator to TOSC1 oscillator when CPU is going to sleep and fallback when CPU wakes up. 
Current implementation uses 32.786 kHz oscillator for both modes. The SCOCR2 compare register is used for alarm generation.

The RTT requires a 32.768 kHz oscillator to be connected to TOSC1, TOSC2 of MCU. All supported atmega256rfr2-based boards has it.

###Testing procedure
Tests were executed on two ConBee I USB dongles that are based on deRFmega256-23M12 modules.
`tests/periph_rtt` sucessfully executed.

Also `tests/gnrc_gomach` was adopted for testing. Packets were sent out succesfully (checked with 802.15.4 sniffer), but RIOT on receiver module crashed with kernel panic.

###Issues/PRs references
inspired by and based on #12815 