### PR TITLE
gnrc_gomac: don't use constant as argument for RTT callback

### DIFF
--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -162,7 +162,8 @@ static void _gomach_rtt_cb(void *arg)
 {
     msg_t msg;
 
-    msg.content.value = ((uint32_t) arg) & 0xffff;
+    (void)arg;
+    msg.content.value = GNRC_GOMACH_EVENT_RTT_NEW_CYCLE;
     msg.type = GNRC_GOMACH_EVENT_RTT_TYPE;
     msg_send(&msg, gomach_pid);
 
@@ -194,7 +195,7 @@ static void _gomach_rtt_handler(uint32_t event, gnrc_netif_t *netif)
             /* Set next cycle's starting time. */
             uint32_t alarm = netif->mac.prot.gomach.last_wakeup +
                              RTT_US_TO_TICKS(GNRC_GOMACH_SUPERFRAME_DURATION_US);
-            rtt_set_alarm(alarm, _gomach_rtt_cb, (void *) GNRC_GOMACH_EVENT_RTT_NEW_CYCLE);
+            rtt_set_alarm(alarm, _gomach_rtt_cb, NULL);
 
             /* Update neighbors' public channel phases. */
             gnrc_gomach_update_neighbor_pubchan(netif);
@@ -1451,7 +1452,7 @@ static void _gomach_phase_backoff(gnrc_netif_t *netif)
     uint32_t alarm = netif->mac.prot.gomach.last_wakeup +
                      RTT_US_TO_TICKS(GNRC_GOMACH_SUPERFRAME_DURATION_US);
 
-    rtt_set_alarm(alarm, _gomach_rtt_cb, (void *) GNRC_GOMACH_EVENT_RTT_NEW_CYCLE);
+    rtt_set_alarm(alarm, _gomach_rtt_cb, NULL);
 
     gnrc_gomach_update_neighbor_phase(netif);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The RTT callback for a super-frame cycle uses the `arg` pointer to set the message value that then is handed to the GoMacH thread. However, in both instances the timer is scheduled the constant `GNRC_GOMACH_EVENT_RTT_NEW_CYCLE` is provided. This means the argument is not really necessary.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
See #12853.

`examples/gnrc_networking_mac` should still work as well as in master (did not test this myself yet).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/12853
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
