### PR TITLE
tests/periph_timer_short_relative_set: fix diff for non 32 bit timers

### DIFF
--- a/tests/periph_timer_short_relative_set/Makefile
+++ b/tests/periph_timer_short_relative_set/Makefile
@@ -8,8 +8,9 @@ USEMODULE += core_thread_flags
 # TEST_TIMER_DEV takes a 0-based index to the periph_timer instance defined in
 # the board's periph_conf.h. TEST_TIMER_FREQ as an integer number which will
 # be used as "freq" parameter in the timer_init() call.
+# TEST_TIMER_WIDTH defines the timer width in number of bits.
 # Note: not all implementations support arbitrary frequencies.
-#CFLAGS += -DTEST_TIMER_DEV=foo -DTEST_TIMER_FREQ=bar
+#CFLAGS += -DTEST_TIMER_DEV=foo -DTEST_TIMER_FREQ=bar -DTEST_TIMER_WIDTH=n
 
 # this test currently fails all CI boards and native
 TEST_ON_CI_BLACKLIST += all

--- a/tests/periph_timer_short_relative_set/main.c
+++ b/tests/periph_timer_short_relative_set/main.c
@@ -32,6 +32,7 @@
 # include "xtimer.h"
 # define TEST_TIMER_DEV      XTIMER_DEV
 # define TEST_TIMER_FREQ     XTIMER_HZ
+# define TEST_TIMER_WIDTH    XTIMER_WIDTH
 #else
 # ifndef TEST_TIMER_FREQ
 #  define TEST_TIMER_FREQ     (1000000LU)
@@ -40,6 +41,12 @@
 
 #ifndef TEST_MAX_DIFF
 #define TEST_MAX_DIFF   (1000LU)
+#endif
+
+#if TEST_TIMER_WIDTH == 32
+# define TEST_TIMER_MAX      (0xFFFFFFFFLU)
+#else
+# define TEST_TIMER_MAX      ((1UL << TEST_TIMER_WIDTH) - 1)
 #endif
 
 static void cb(void *arg, int chan)
@@ -65,7 +72,8 @@ int main(void)
         uint32_t before = timer_read(TEST_TIMER_DEV);
         timer_set(TEST_TIMER_DEV, 0, interval);
         while(!thread_flags_clear(1)) {
-            uint32_t diff = timer_read(TEST_TIMER_DEV) - before;
+            uint32_t diff = (timer_read(TEST_TIMER_DEV) - before)
+                            & TEST_TIMER_MAX;
             if (diff > TEST_MAX_DIFF) {
                 printf("ERROR: too long delay, aborted after %" PRIu32
                         " (TEST_MAX_DIFF=%lu)\n"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes the problem described in[ #12610 (comment)](https://github.com/RIOT-OS/RIOT/pull/12610#pullrequestreview-325086424): the diff calculation between two timestamps is not working properly for timers that are not 32 bit.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Look at the code, run `/tests/periph_timer_short_relative_set` on a platform with 16 bit timer (e.g. iotlab-m3).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#10493, #12610
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
