### PR TITLE
tools/ethos: fix compilation warning in strncpy

### DIFF
--- a/dist/tools/ethos/ethos.c
+++ b/dist/tools/ethos/ethos.c
@@ -156,7 +156,7 @@ typedef struct {
  **************************************************************************/
 int tun_alloc(char *dev, int flags) {
 
-  struct ifreq ifr;
+  struct ifreq ifr = { 0 };
   int fd, err;
 
   if( (fd = open("/dev/net/tun", O_RDWR)) < 0 ) {
@@ -164,12 +164,10 @@ int tun_alloc(char *dev, int flags) {
     return fd;
   }
 
-  memset(&ifr, 0, sizeof(ifr));
-
   ifr.ifr_flags = flags;
 
   if (*dev) {
-    strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+    strncpy(ifr.ifr_name, dev, IFNAMSIZ - 1);
   }
 
   if( (err = ioctl(fd, TUNSETIFF, (void *)&ifr)) < 0 ) {
@@ -515,8 +513,8 @@ int main(int argc, char *argv[])
         serial_option = argv[3];
     }
 
-    char ifname[IFNAMSIZ];
-    strncpy(ifname, argv[1], IFNAMSIZ);
+    char ifname[IFNAMSIZ] = { 0 };
+    strncpy(ifname, argv[1], IFNAMSIZ - 1);
     int tap_fd = tun_alloc(ifname, IFF_TAP | IFF_NO_PI);
 
     if (tap_fd < 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While reviewing #12149, I noticed that a couple of warnings were raised when building ethos (gcc 9.2.1 on Ubuntu 19.10):

<details><summary>Output:</summary>

```
$ make -C dist/tools/ethos --no-print-directory 
cc -O3 -Wall ethos.c -o ethos
In file included from /usr/include/string.h:494,
                 from ethos.c:10:
In function ‘strncpy’,
    inlined from ‘tun_alloc’ at ethos.c:172:5:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ specified bound 16 equals destination size [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘main’ at ethos.c:519:5:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ specified bound 16 equals destination size [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

</details>

This PR is fixing these warning:
- by ensuring the string copied is one character less than the destination
- by ensuring that the destination string always ends with a terminating character (`0`), using memset is not needed if the struct is initialized with zeros.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Any application that is using ethos should still work: `examples/gnrc_border_router`, `examples/suit_update` and some gnrc test applications.
- No warning when building ethos:
```
make -C dist/tools/ethos clean all
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while reviewing #12149 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
