### PR TITLE
dist/pythonlibs/testrunner: reset before term

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -700,6 +700,12 @@ TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*[^~]),\
 # See #11762.
 TEST_DEPS += $(TERMDEPS)
 
+# Export TESTRUNNER_RESET_AFTER_TERM only for the test target. This allows for
+# it to be accessed through the environment from python test script.
+# This is currently needed only by `examples/%/tests` and should be removed in
+# the future since `make reset` after `term` is not a valid synch method across
+# all platforms.
+$(call target-export-variables,test,TESTRUNNER_RESET_AFTER_TERM)
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
 		$$t || exit 1; \

--- a/examples/micropython/Makefile
+++ b/examples/micropython/Makefile
@@ -27,4 +27,8 @@ RIOT_TERMINAL ?= miniterm
 FEATURES_OPTIONAL += periph_adc
 FEATURES_OPTIONAL += periph_spi
 
+# For now `examples/%/tests" still rely on the test applicaton being reset after
+# a terminal is opened to synchronize.
+TESTRUNNER_RESET_AFTER_TERM ?= 1
+
 include $(RIOTBASE)/Makefile.include

--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -85,6 +85,9 @@ endif
 # don't compile themselves and re-create signed images, thus add the required
 # files here so they will be submitted along with the test jobs.
 TEST_EXTRA_FILES += $(SLOT_RIOT_ELFS) $(SUIT_SEC) $(SUIT_PUB)
+# For now `examples/%/tests" still rely on the test applicaton being reset after
+# a terminal is opened to synchronize.
+TESTRUNNER_RESET_AFTER_TERM ?= 1
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
### Contribution description

For some boardw `make reset` is only possible if a serial connection
is not already open or its execution might disrupt it. This
causes some tests to fail since before running a test the board
is reset.

`make reset` is currently used as a synchronization mechanism between
the application and the test script. With `test_utils_interactive_sync`
this is no longer needed so call `make reset` before `cleanterm` instead
of after so avoid using it for those boards.

With the wide usage of `test_utils_interactive_sync` #12448 is not needed, only
a handful of tests remain that do not use it, and most of same need sudo.
This will be addressed in a followup PR.

### Testing procedure


- **This PR**

<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py  -j0 . iotlab-m3 . --with-test-only</summary>

```
#### iotlab-m3/failuresummary.md                          
Failures during test:                                                                                       
- [examples/suit_update](examples/suit_update/test.failed)                                                  
- [tests/driver_hd44780](tests/driver_hd44780/test.failed)                                                  
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)                                                    
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)                                          
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)                                                      
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)                                                    
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)                                                              
- [tests/pkg_fatfs_vfs](tests/pkg_fatfs_vfs/test.failed)
```
</details>


<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py  -j0 . remote-revb . --with-test-only</summary>

```         
#### remote-revb/failuresummary.md                                                                               
Failures during test:                                                   
- [tests/driver_grove_ledbar](tests/driver_grove_ledbar/test.failed)      
- [tests/driver_hd44780](tests/driver_hd44780/test.failed)    
- [tests/driver_my9221](tests/driver_my9221/test.failed)              
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)      
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)      
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)        
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)                            
- [tests/periph_timer](tests/periph_timer/test.failed)        
- [tests/pkg_fatfs_vfs](tests/pkg_fatfs_vfs/test.failed)            
- [tests/pkg_qdsa](tests/pkg_qdsa/test.failed)    
```
</details>


<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py  -j0 . native . --with-test-only</summary>

```
Failures during test:
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)                                                    
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)                                          
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)                                                      
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed) 
- [tests/netstats_l2](tests/netstats_l2/test.failed)
```
</details>

- **master**

<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py  -j0 . iotlab-m3 . --with-test-only</summary>

```
#### iotlab-m3/failuresummary.md                          
Failures during test:                                                                                       
- [examples/suit_update](examples/suit_update/test.failed)
- [tests/driver_hd44780](tests/driver_hd44780/test.failed)
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)
- [tests/periph_timer_short_relative_set](tests/periph_timer_short_relative_set/test.failed)
- [tests/pkg_fatfs_vfs](tests/pkg_fatfs_vfs/test.failed)
```
</details>


<details><summary>python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py  -j0 . remote-revb . --with-test-only</summary>

```         
#### remote-revb/failuresummary.md                                                                               
Failures during test:
- [tests/bench_msg_pingpong](tests/bench_msg_pingpong/test.failed)                                                                       
- [tests/bench_mutex_pingpong](tests/bench_mutex_pingpong/test.failed)                                                                   
- [tests/bench_runtime_coreapis](tests/bench_runtime_coreapis/test.failed)                                                               
- [tests/bench_sched_nop](tests/bench_sched_nop/test.failed)                                                                             
- [tests/bench_sizeof_coretypes](tests/bench_sizeof_coretypes/test.failed)                                                               
- [tests/bench_thread_flags_pingpong](tests/bench_thread_flags_pingpong/test.failed)                                                     
- [tests/bench_thread_yield_pingpong](tests/bench_thread_yield_pingpong/test.failed)                                                     
- [tests/bitarithm_timings](tests/bitarithm_timings/test.failed)                                                                         
- [tests/blob](tests/blob/test.failed)                                                                                                   
- [tests/bloom_bytes](tests/bloom_bytes/test.failed)                                                                                     
- [tests/build_system_cflags_spaces](tests/build_system_cflags_spaces/test.failed)                                                       
- [tests/buttons](tests/buttons/test.failed)                                                                                             
- [tests/cb_mux](tests/cb_mux/test.failed)                                                                                               
- [tests/cb_mux_bench](tests/cb_mux_bench/test.failed)                                                                                   
- [tests/cond_order](tests/cond_order/test.failed)                                                                                       
- [tests/cpp11_condition_variable](tests/cpp11_condition_variable/test.failed)                                                           
- [tests/cpp11_mutex](tests/cpp11_mutex/test.failed)                                                                                     
- [tests/cpp11_thread](tests/cpp11_thread/test.failed)                                                                                   
- [tests/cpp_ctors](tests/cpp_ctors/test.failed)                                                                                         
- [tests/devfs](tests/devfs/test.failed)                                                                                                 
- [tests/driver_ds1307](tests/driver_ds1307/test.failed)                                                                                 
- [tests/driver_grove_ledbar](tests/driver_grove_ledbar/test.failed)                                                                     
- [tests/driver_hd44780](tests/driver_hd44780/test.failed)                                                                               
- [tests/driver_my9221](tests/driver_my9221/test.failed)                                                                                 
- [tests/embunit](tests/embunit/test.failed)                                                                                             
- [tests/event_wait_timeout](tests/event_wait_timeout/test.failed)                                                                       
- [tests/events](tests/events/test.failed)                                                                                               
- [tests/evtimer_msg](tests/evtimer_msg/test.failed)                                                                                     
- [tests/evtimer_underflow](tests/evtimer_underflow/test.failed)                                                                         
- [tests/float](tests/float/test.failed)                                                                                                 
- [tests/fmt_print](tests/fmt_print/test.failed)                                                                                         
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)                                                                                 
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)                                                                       
- [tests/gnrc_ipv6_fwd_w_sub](tests/gnrc_ipv6_fwd_w_sub/test.failed)                                                                     
- [tests/gnrc_ipv6_nib](tests/gnrc_ipv6_nib/test.failed)                                                                                 
- [tests/gnrc_ipv6_nib_6ln](tests/gnrc_ipv6_nib_6ln/test.failed)                                                                         
- [tests/gnrc_ndp](tests/gnrc_ndp/test.failed)                                                                                           
- [tests/gnrc_netif](tests/gnrc_netif/test.failed)                                                                                       
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)                                                                                   
- [tests/gnrc_sixlowpan](tests/gnrc_sixlowpan/test.failed)                                                                               
- [tests/gnrc_sixlowpan_frag](tests/gnrc_sixlowpan_frag/test.failed)                                                                     
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)                                                                                 
- [tests/gnrc_sock_ip](tests/gnrc_sock_ip/test.failed)                                                                                   
- [tests/gnrc_sock_neterr](tests/gnrc_sock_neterr/test.failed)                                                                           
- [tests/gnrc_sock_udp](tests/gnrc_sock_udp/test.failed)                                                                                 
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)                                                                                           
- [tests/heap_cmd](tests/heap_cmd/test.failed)                                                                                           
- [tests/irq](tests/irq/test.failed)                                                                                                     
- [tests/isr_yield_higher](tests/isr_yield_higher/test.failed)                                                                           
- [tests/l2util](tests/l2util/test.failed)                                                                                               
- [tests/libc_newlib](tests/libc_newlib/test.failed)                                                                                     
- [tests/log_color](tests/log_color/test.failed)                                                                                         
- [tests/log_printfnoformat](tests/log_printfnoformat/test.failed)                                                                       
- [tests/lwip_sock_ip](tests/lwip_sock_ip/test.failed)                                                                                   
- [tests/lwip_sock_tcp](tests/lwip_sock_tcp/test.failed)                                                                                 
- [tests/lwip_sock_udp](tests/lwip_sock_udp/test.failed)                                                                                 
- [tests/malloc](tests/malloc/test.failed)                                                                                               
- [tests/memarray](tests/memarray/test.failed)                                                                                           
- [tests/msg_avail](tests/msg_avail/test.failed)
- [tests/msg_send_receive](tests/msg_send_receive/test.failed)
- [tests/msg_try_receive](tests/msg_try_receive/test.failed)
- [tests/mutex_order](tests/mutex_order/test.failed)
- [tests/mutex_unlock_and_sleep](tests/mutex_unlock_and_sleep/test.failed)
- [tests/netdev_test](tests/netdev_test/test.failed)
- [tests/nhdp](tests/nhdp/test.failed)
- [tests/od](tests/od/test.failed)
- [tests/periph_cpuid](tests/periph_cpuid/test.failed)
- [tests/periph_gpio](tests/periph_gpio/test.failed)
- [tests/periph_hwrng](tests/periph_hwrng/test.failed)
- [tests/periph_timer](tests/periph_timer/test.failed)
- [tests/periph_timer_short_relative_set](tests/periph_timer_short_relative_set/test.failed)
- [tests/pipe](tests/pipe/test.failed)
- [tests/pkg_c25519](tests/pkg_c25519/test.failed
- [tests/pkg_cayenne-lpp](tests/pkg_cayenne-lpp/test.failed)
- [tests/pkg_cifra](tests/pkg_cifra/test.failed)
- [tests/pkg_cn-cbor](tests/pkg_cn-cbor/test.failed)
- [tests/pkg_fatfs_vfs](tests/pkg_fatfs_vfs/test.failed)
- [tests/pkg_hacl](tests/pkg_hacl/test.failed)                                             
- [tests/pkg_heatshrink](tests/pkg_heatshrink/test.failed)
- [tests/pkg_jsmn](tests/pkg_jsmn/test.failed)
- [tests/pkg_libb2](tests/pkg_libb2/test.failed)
- [tests/pkg_libcoap](tests/pkg_libcoap/test.failed)
- [tests/pkg_libcose](tests/pkg_libcose/test.failed)
- [tests/pkg_libfixmath](tests/pkg_libfixmath/test.failed)
- [tests/pkg_libfixmath_unittests](tests/pkg_libfixmath_unittests/test.failed)
- [tests/pkg_libhydrogen](tests/pkg_libhydrogen/test.failed)
- [tests/pkg_littlefs](tests/pkg_littlefs/test.failed)
- [tests/pkg_lora-serialization](tests/pkg_lora-serialization/test.failed)
- [tests/pkg_micro-ecc](tests/pkg_micro-ecc/test.failed)
- [tests/pkg_micro-ecc-with-hwrng](tests/pkg_micro-ecc-with-hwrng/test.failed)
- [tests/pkg_minmea](tests/pkg_minmea/test.failed)
- [tests/pkg_monocypher](tests/pkg_monocypher/test.failed)
- [tests/pkg_nanocbor](tests/pkg_nanocbor/test.failed)
- [tests/pkg_nanopb](tests/pkg_nanopb/test.failed)
- [tests/pkg_qdsa](tests/pkg_qdsa/test.failed)
- [tests/pkg_relic](tests/pkg_relic/test.failed)
- [tests/pkg_spiffs](tests/pkg_spiffs/test.failed)
- [tests/pkg_tiny-asn1](tests/pkg_tiny-asn1/test.failed)
- [tests/pkg_tinycbor](tests/pkg_tinycbor/test.failed)
- [tests/pkg_tweetnacl](tests/pkg_tweetnacl/test.failed)
- [tests/pkg_u8g2](tests/pkg_u8g2/test.failed)
- [tests/pkg_ubasic](tests/pkg_ubasic/test.failed)
- [tests/pkg_ucglib](tests/pkg_ucglib/test.failed)
- [tests/pkg_umorse](tests/pkg_umorse/test.failed)
- [tests/posix_semaphore](tests/posix_semaphore/test.failed)
- [tests/posix_time](tests/posix_time/test.failed)
- [tests/ps_schedstatistics](tests/ps_schedstatistics/test.failed)
- [tests/pthread](tests/pthread/test.failed)
- [tests/pthread_barrier](tests/pthread_barrier/test.failed)
- [tests/pthread_cleanup](tests/pthread_cleanup/test.failed)
- [tests/pthread_condition_variable](tests/pthread_condition_variable/test.failed)
- [tests/pthread_cooperation](tests/pthread_cooperation/test.failed)
- [tests/pthread_flood](tests/pthread_flood/test.failed)
- [tests/pthread_rwlock](tests/pthread_rwlock/test.failed)
- [tests/pthread_tls](tests/pthread_tls/test.failed)
- [tests/riotboot_hdr](tests/riotboot_hdr/test.failed)
- [tests/rmutex](tests/rmutex/test.failed)
- [tests/rmutex_cpp](tests/rmutex_cpp/test.failed)
- [tests/rng](tests/rng/test.failed)
- [tests/sched_testing](tests/sched_testing/test.failed)
- [tests/shell](tests/shell/test.failed)
- [tests/ssp](tests/ssp/test.failed)
- [tests/stdin](tests/stdin/test.failed)
- [tests/struct_tm_utility](tests/struct_tm_utility/test.failed)
- [tests/sys_crypto](tests/sys_crypto/test.failed)
- [tests/test_tools](tests/test_tools/test.failed)
- [tests/thread_basic](tests/thread_basic/test.failed)
- [tests/thread_cooperation](tests/thread_cooperation/test.failed)
- [tests/thread_exit](tests/thread_exit/test.failed)
- [tests/thread_flags](tests/thread_flags/test.failed)
- [tests/thread_flags_xtimer](tests/thread_flags_xtimer/test.failed)
- [tests/thread_flood](tests/thread_flood/test.failed)
- [tests/thread_msg](tests/thread_msg/test.failed)
- [tests/thread_msg_block_race](tests/thread_msg_block_race/test.failed)
- [tests/thread_msg_block_w_queue](tests/thread_msg_block_w_queue/test.failed)
- [tests/thread_msg_block_wo_queue](tests/thread_msg_block_wo_queue/test.failed)
- [tests/thread_msg_seq](tests/thread_msg_seq/test.failed)
- [tests/thread_race](tests/thread_race/test.failed)
- [tests/trickle](tests/trickle/test.failed)
- [tests/unittests](tests/unittests/test.failed)
- [tests/xtimer_hang](tests/xtimer_hang/test.failed)
- [tests/xtimer_msg](tests/xtimer_msg/test.failed)
- [tests/xtimer_msg_receive_timeout](tests/xtimer_msg_receive_timeout/test.failed)
- [tests/xtimer_mutex_lock_timeout](tests/xtimer_mutex_lock_timeout/test.failed)
- [tests/xtimer_now64_continuity](tests/xtimer_now64_continuity/test.failed)
- [tests/xtimer_periodic_wakeup](tests/xtimer_periodic_wakeup/test.failed)
- [tests/xtimer_remove](tests/xtimer_remove/test.failed)
- [tests/xtimer_reset](tests/xtimer_reset/test.failed)
- [tests/xtimer_usleep](tests/xtimer_usleep/test.failed)
- [tests/xtimer_usleep_short](tests/xtimer_usleep_short/test.failed)

```
</details>

NOTE: `- [tests/periph_timer_short_relative_set](tests/periph_timer_short_relative_set/test.failed)` is not fixed by this PR, but my branch didn't have the new test at the time I ran the tests.

### Issues/PRs references

#12448
Alternative to #12520