### PR TITLE
saul: Ignore extra dimensions in read functions

### DIFF
--- a/drivers/saul/adc_saul.c
+++ b/drivers/saul/adc_saul.c
@@ -30,8 +30,6 @@ static int read_adc(const void *dev, phydat_t *res)
 {
     const saul_adc_params_t *params = *((const saul_adc_params_t **)dev);
     res->val[0] = adc_sample(params->line, params->res);
-    res->val[1] = 0;
-    res->val[2] = 0;
     /* Raw ADC reading has no unit */
     res->unit = UNIT_NONE;
     res->scale = 0;

--- a/drivers/saul/gpio_saul.c
+++ b/drivers/saul/gpio_saul.c
@@ -33,8 +33,6 @@ static int read(const void *dev, phydat_t *res)
 
     res->val[0] = (gpio_read(p->pin)) ? !inverted : inverted;
 
-    res->val[1] = 0;
-    res->val[2] = 0;
     res->unit = UNIT_BOOL;
     res->scale = 0;
     return 1;


### PR DESCRIPTION
### Contribution description

~~This PR modifies the current ADC and GPIO SAUL functions to not fill the extra dimensions of the `phydat_t` struct with zeros. This allows the calling function to automatically detect the dimensions used by the SAUL sensor or actuator by filling it with `PHYDAT_MIN` or `PHYDAT_MAX` and checking which of the `phydat::val[]`s are modified after a `saul_reg_read()`.~~

This PR is a small cleanup in the ADC and GPIO SAUL functions to not fill the unused dimensions of the `phydat_t` struct with zeros`

~~This PR can be ignored if there is a better way to automatically detect the number of dimensions used by a sensor (without hard coding).~~

The return value of the read call indicates the number of dimensions

~~@haukepetersen does this PR align with the concepts and ideas behind SAUL?~~

### Testing procedure

`examples/saul` should still read out ADC and GPIO-based SAUL devices (with `saul_gpio` and `saul_adc` included as modules).

### Issues/PRs references

None