### PR TITLE
cpu/native: add missing header in socket zep

### DIFF
--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <sys/socket.h>
 #include <sys/time.h>
 
 #include "async_read.h"


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Building e.g. gnrc_border_router example on FreeBSD fails due to
missing defines related to sockets. This adds the missing header
<sys/socket.h> to fix compiling.


### Testing procedure

Compile `examples/gnrc_border_router` on FreeBSD, it fails on master due to missing defines,
and should succeed with this PR which adds `sys/socket.h`.


### Issues/PRs references

maybe #3392 
