### PR TITLE
pkg/jerryscript: set -Wno-conversion for FreeBSD

### DIFF
--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -6,6 +6,8 @@ EXT_CFLAGS :=-D__TARGET_RIOT
 
 ifeq ($(TOOLCHAIN)_$(BOARD),llvm_native)
   EXT_CFLAGS :=-D__TARGET_RIOT -Wno-conversion
+else ifeq ($(OS)_$(BOARD),FreeBSD_native)
+  EXT_CFLAGS += -Wno-conversion
 else ifeq (esp32,$(CPU))
   # The esp32 C newlib version 2.2.0 has errors when compiling with warnings
   # that are enabled by jerryscript build system so disable them for this cpu:


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes compile issue on FreeBSD because of float to double conversion
by disabling the corresponding compiler warning.


### Testing procedure

Compile `examples/javascript` on FreeBSD for native, it fails on master with compile warning `-Wfloat-conversion`. This PR disables this warning similar to other exceptions already in place for jerryscript package.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
