### PR TITLE
net/gnrc_lorawan: remove netdev layer from MAC

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -246,12 +246,6 @@ typedef enum {
     NETDEV_EVENT_CRC_ERROR,                 /**< wrong CRC */
     NETDEV_EVENT_FHSS_CHANGE_CHANNEL,       /**< channel changed */
     NETDEV_EVENT_CAD_DONE,                  /**< channel activity detection done */
-    NETDEV_EVENT_MLME_CONFIRM,              /**< MAC MLME confirm event */
-    NETDEV_EVENT_MLME_INDICATION,           /**< MAC MLME indication event */
-    NETDEV_EVENT_MCPS_CONFIRM,              /**< MAC MCPS confirm event */
-    NETDEV_EVENT_MCPS_INDICATION,           /**< MAC MCPS indication event */
-    NETDEV_EVENT_MLME_GET_BUFFER,           /**< MAC layer requests MLME buffer */
-    NETDEV_EVENT_MCPS_GET_BUFFER,           /**< MAC layer requests MCPS buffer */
     /* expand this list if needed */
 } netdev_event_t;
 

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -228,16 +228,50 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac, const mcps_request_t *mcps_r
 void gnrc_lorawan_recv(gnrc_lorawan_t *mac);
 
 /**
- * @brief Setup GNRC LoRaWAN netdev layers
+ * @brief MCPS indication callback
+ * @note Supposed to be implemented by the user of GNRC LoRaWAN
  *
- * @param mac pointer to the MAC descriptor
- * @param lower pointer to the lower netdev device (radio)
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] ind pointer of the indication (see @ref mcps_indication_t)
  */
-void gnrc_lorawan_setup(gnrc_lorawan_t *mac, netdev_t *lower);
 void gnrc_lorawan_mcps_indication(gnrc_lorawan_t *mac, mcps_indication_t *ind);
+
+/**
+ * @brief MLME indication callback
+ * @note Supposed to be implemented by the user of GNRC LoRaWAN
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] ind pointer of the indication (see @ref mlme_indication_t)
+ */
 void gnrc_lorawan_mlme_indication(gnrc_lorawan_t *mac, mlme_indication_t *ind);
+
+/**
+ * @brief MCPS Confirm callback
+ * @note Supposed to be implemented by the user of GNRC LoRaWAN
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] confirm pointer to the confirm (see @ref mcps_confirm_t)
+ */
 void gnrc_lorawan_mcps_confirm(gnrc_lorawan_t *mac, mcps_confirm_t *confirm);
+
+/**
+ * @brief MLME confirm callback
+ * @note Supposed to be implemented by the user of GNRC LoRaWAN
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] confirm pointer to the confirm (see @ref mlme_confirm_t)
+ */
 void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm);
+
+/**
+ * @brief Get netdev pointer from mac descriptor
+ * @note Supposed to be implemented by the user of GNRC LoRaWAN
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ *
+ * @return pointer to the @ref netdev_t structure
+ */
+netdev_t *gnrc_lorawan_get_netdev(gnrc_lorawan_t *mac);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -230,6 +230,10 @@ void gnrc_lorawan_recv(gnrc_lorawan_t *mac);
  * @param lower pointer to the lower netdev device (radio)
  */
 void gnrc_lorawan_setup(gnrc_lorawan_t *mac, netdev_t *lower);
+void gnrc_lorawan_mcps_indication(gnrc_lorawan_t *mac, mcps_indication_t *ind);
+void gnrc_lorawan_mlme_indication(gnrc_lorawan_t *mac, mlme_indication_t *ind);
+void gnrc_lorawan_mcps_confirm(gnrc_lorawan_t *mac, mcps_confirm_t *confirm);
+void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -74,7 +74,8 @@ typedef enum {
  */
 typedef enum {
     MIB_ACTIVATION_METHOD,     /**< type is activation method */
-    MIB_DEV_ADDR               /**< type is dev addr */
+    MIB_DEV_ADDR,              /**< type is dev addr */
+    MIB_RX2_DR,                /**< type is rx2 DR */
 } mlme_mib_type_t;
 
 /**
@@ -105,6 +106,7 @@ typedef struct {
     union {
         mlme_activation_t activation;   /**< holds activation mechanism */
         void *dev_addr;                 /**< pointer to the dev_addr */
+        uint8_t rx2_dr;                 /** datarate of second rx window */
     };
 } mlme_mib_t;
 

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -73,7 +73,8 @@ typedef enum {
  * @brief MAC Information Base attributes
  */
 typedef enum {
-    MIB_ACTIVATION_METHOD      /**< type is activation method */
+    MIB_ACTIVATION_METHOD,     /**< type is activation method */
+    MIB_DEV_ADDR               /**< type is dev addr */
 } mlme_mib_type_t;
 
 /**
@@ -103,6 +104,7 @@ typedef struct {
     mlme_mib_type_t type; /**< MIB attribute identifier */
     union {
         mlme_activation_t activation;   /**< holds activation mechanism */
+        void *dev_addr;                 /**< pointer to the dev_addr */
     };
 } mlme_mib_t;
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -269,39 +269,18 @@ void gnrc_lorawan_process_pkt(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt)
 
 int gnrc_lorawan_netdev_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 {
-    int res = 0;
-    gnrc_lorawan_t *mac = (gnrc_lorawan_t *) dev;
-    uint32_t tmp;
-
-    switch (opt) {
-        case NETOPT_ADDRESS:
-            assert(max_len >= sizeof(mac->dev_addr));
-            tmp = byteorder_swapl(mac->dev_addr.u32);
-            memcpy(value, &tmp, sizeof(mac->dev_addr));
-            res = sizeof(mac->dev_addr);
-            break;
-        default:
-            res = netdev_get_pass(dev, opt, value, max_len);
-            break;
-    }
-    return res;
+    return netdev_get_pass(dev, opt, value, max_len);
 }
 
 int gnrc_lorawan_netdev_set(netdev_t *dev, netopt_t opt, const void *value, size_t len)
 {
     gnrc_lorawan_t *mac = (gnrc_lorawan_t *) dev;
-    uint32_t tmp;
 
     if (mac->busy) {
         return -EBUSY;
     }
 
     switch (opt) {
-        case NETOPT_ADDRESS:
-            assert(len == sizeof(uint32_t));
-            tmp = byteorder_swapl(*((uint32_t *) value));
-            memcpy(&mac->dev_addr, &tmp, sizeof(uint32_t));
-            break;
         case NETOPT_LORAWAN_RX2_DR:
             assert(len == sizeof(uint8_t));
             _set_rx2_dr(mac, *((uint8_t *) value));

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -61,7 +61,7 @@ static inline void gnrc_lorawan_mcps_reset(gnrc_lorawan_t *mac)
     mac->mcps.fcnt_down = 0;
 }
 
-static inline void _set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr)
+void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr)
 {
     mac->dl_settings &= ~GNRC_LORAWAN_DL_RX2_DR_MASK;
     mac->dl_settings |= (rx2_dr << GNRC_LORAWAN_DL_RX2_DR_POS) &
@@ -98,7 +98,7 @@ void gnrc_lorawan_reset(gnrc_lorawan_t *mac)
     uint32_t rx_timeout = 0;
     netdev_set_pass(&mac->netdev, NETOPT_RX_TIMEOUT, &rx_timeout, sizeof(rx_timeout));
 
-    _set_rx2_dr(mac, LORAMAC_DEFAULT_RX2_DR);
+    gnrc_lorawan_set_rx2_dr(mac, LORAMAC_DEFAULT_RX2_DR);
 
     mac->toa = 0;
     gnrc_lorawan_mcps_reset(mac);
@@ -281,10 +281,6 @@ int gnrc_lorawan_netdev_set(netdev_t *dev, netopt_t opt, const void *value, size
     }
 
     switch (opt) {
-        case NETOPT_LORAWAN_RX2_DR:
-            assert(len == sizeof(uint8_t));
-            _set_rx2_dr(mac, *((uint8_t *) value));
-            break;
         default:
             netdev_set_pass(dev, opt, value, len);
             break;

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -70,9 +70,10 @@ void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr)
 
 static void _sleep_radio(gnrc_lorawan_t *mac)
 {
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
     netopt_state_t state = NETOPT_STATE_SLEEP;
 
-    netdev_set_pass((netdev_t *) mac, NETOPT_STATE, &state, sizeof(state));
+    dev->driver->set(dev, NETOPT_STATE, &state, sizeof(state));
 }
 
 void gnrc_lorawan_init(gnrc_lorawan_t *mac, uint8_t *nwkskey, uint8_t *appskey)
@@ -86,17 +87,18 @@ void gnrc_lorawan_init(gnrc_lorawan_t *mac, uint8_t *nwkskey, uint8_t *appskey)
 
 void gnrc_lorawan_reset(gnrc_lorawan_t *mac)
 {
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
     uint8_t cr = LORA_CR_4_5;
 
-    netdev_set_pass(&mac->netdev, NETOPT_CODING_RATE, &cr, sizeof(cr));
+    dev->driver->set(dev, NETOPT_CODING_RATE, &cr, sizeof(cr));
 
     uint8_t syncword = LORAMAC_DEFAULT_PUBLIC_NETWORK ? LORA_SYNCWORD_PUBLIC
                                                       : LORA_SYNCWORD_PRIVATE;
-    netdev_set_pass(&mac->netdev, NETOPT_SYNCWORD, &syncword, sizeof(syncword));
+    dev->driver->set(dev, NETOPT_SYNCWORD, &syncword, sizeof(syncword));
 
     /* Continuous reception */
     uint32_t rx_timeout = 0;
-    netdev_set_pass(&mac->netdev, NETOPT_RX_TIMEOUT, &rx_timeout, sizeof(rx_timeout));
+    dev->driver->set(dev, NETOPT_RX_TIMEOUT, &rx_timeout, sizeof(rx_timeout));
 
     gnrc_lorawan_set_rx2_dr(mac, LORAMAC_DEFAULT_RX2_DR);
 
@@ -108,21 +110,23 @@ void gnrc_lorawan_reset(gnrc_lorawan_t *mac)
 
 static void _config_radio(gnrc_lorawan_t *mac, uint32_t channel_freq, uint8_t dr, int rx)
 {
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
+
     if (channel_freq != 0) {
-        netdev_set_pass(&mac->netdev, NETOPT_CHANNEL_FREQUENCY, &channel_freq, sizeof(channel_freq));
+        dev->driver->set(dev, NETOPT_CHANNEL_FREQUENCY, &channel_freq, sizeof(channel_freq));
     }
 
     netopt_enable_t iq_invert = rx;
-    netdev_set_pass(&mac->netdev, NETOPT_IQ_INVERT, &iq_invert, sizeof(iq_invert));
+    dev->driver->set(dev, NETOPT_IQ_INVERT, &iq_invert, sizeof(iq_invert));
 
     gnrc_lorawan_set_dr(mac, dr);
 
     if (rx) {
         /* Switch to single listen mode */
         const netopt_enable_t single = true;
-        netdev_set_pass(&mac->netdev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
+        dev->driver->set(dev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
         const uint16_t timeout = CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT;
-        netdev_set_pass(&mac->netdev, NETOPT_RX_SYMBOL_TIMEOUT, &timeout, sizeof(timeout));
+        dev->driver->set(dev, NETOPT_RX_SYMBOL_TIMEOUT, &timeout, sizeof(timeout));
     }
 }
 
@@ -133,13 +137,14 @@ static void _configure_rx_window(gnrc_lorawan_t *mac, uint32_t channel_freq, uin
 
 void gnrc_lorawan_open_rx_window(gnrc_lorawan_t *mac)
 {
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
     mac->msg.type = MSG_TYPE_TIMEOUT;
     /* Switch to RX state */
     if (mac->state == LORAWAN_STATE_RX_1) {
         xtimer_set_msg(&mac->rx, _DRIFT_FACTOR, &mac->msg, thread_getpid());
     }
     uint8_t state = NETOPT_STATE_RX;
-    netdev_set_pass(&mac->netdev, NETOPT_STATE, &state, sizeof(state));
+    dev->driver->set(dev, NETOPT_STATE, &state, sizeof(state));
 }
 
 void gnrc_lorawan_event_tx_complete(gnrc_lorawan_t *mac)
@@ -183,7 +188,7 @@ void gnrc_lorawan_event_timeout(gnrc_lorawan_t *mac)
 }
 
 /* This function uses a precomputed table to calculate time on air without
- * using floating point arithmetics */
+ * using floating point arithmetic */
 static uint32_t lora_time_on_air(size_t payload_size, uint8_t dr, uint8_t cr)
 {
     assert(dr <= LORAMAC_DR_6);
@@ -219,6 +224,7 @@ static uint32_t lora_time_on_air(size_t payload_size, uint8_t dr, uint8_t cr)
 
 void gnrc_lorawan_send_pkt(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt, uint8_t dr)
 {
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
     mac->state = LORAWAN_STATE_TX;
 
     iolist_t iolist = {
@@ -233,11 +239,11 @@ void gnrc_lorawan_send_pkt(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt, uint8_t dr)
     mac->last_dr = dr;
 
     uint8_t cr;
-    netdev_get_pass(&mac->netdev, NETOPT_CODING_RATE, &cr, sizeof(cr));
+    dev->driver->get(dev, NETOPT_CODING_RATE, &cr, sizeof(cr));
 
     mac->toa = lora_time_on_air(gnrc_pkt_len(pkt), dr, cr + 4);
 
-    if (netdev_send_pass(&mac->netdev, &iolist) == -ENOTSUP) {
+    if (dev->driver->send(dev, &iolist) == -ENOTSUP) {
         DEBUG("gnrc_lorawan: Cannot send: radio is still transmitting");
     }
 
@@ -267,56 +273,20 @@ void gnrc_lorawan_process_pkt(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt)
     gnrc_lorawan_mac_release(mac);
 }
 
-int gnrc_lorawan_netdev_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
-{
-    return netdev_get_pass(dev, opt, value, max_len);
-}
-
-int gnrc_lorawan_netdev_set(netdev_t *dev, netopt_t opt, const void *value, size_t len)
-{
-    gnrc_lorawan_t *mac = (gnrc_lorawan_t *) dev;
-
-    if (mac->busy) {
-        return -EBUSY;
-    }
-
-    switch (opt) {
-        default:
-            netdev_set_pass(dev, opt, value, len);
-            break;
-    }
-    return 0;
-}
-
-const netdev_driver_t gnrc_lorawan_driver = {
-    .init = netdev_init_pass,
-    .send = netdev_send_pass,
-    .recv = netdev_recv_pass,
-    .get = gnrc_lorawan_netdev_get,
-    .set = gnrc_lorawan_netdev_set,
-    .isr = netdev_isr_pass,
-};
-
-void gnrc_lorawan_setup(gnrc_lorawan_t *mac, netdev_t *lower)
-{
-    mac->netdev.driver = &gnrc_lorawan_driver;
-    mac->netdev.lower = lower;
-    lower->context = mac;
-}
-
 void gnrc_lorawan_recv(gnrc_lorawan_t *mac)
 {
-    int bytes_expected = netdev_recv_pass((netdev_t *) mac, NULL, 0, 0);
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
+    int bytes_expected = dev->driver->recv(dev, NULL, 0, 0);
     int nread;
     struct netdev_radio_rx_info rx_info;
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected, GNRC_NETTYPE_UNDEF);
     if (pkt == NULL) {
         DEBUG("_recv_ieee802154: cannot allocate pktsnip.\n");
         /* Discard packet on netdev device */
-        netdev_recv_pass((netdev_t *) mac, NULL, bytes_expected, NULL);
+        dev->driver->recv(dev, NULL, bytes_expected, NULL);
         return;
     }
-    nread = netdev_recv_pass((netdev_t *) mac, pkt->data, bytes_expected, &rx_info);
+    nread = dev->driver->recv(dev, pkt->data, bytes_expected, &rx_info);
     _sleep_radio(mac);
     if (nread <= 0) {
         gnrc_pktbuf_release(pkt);

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -138,17 +138,17 @@ void gnrc_lorawan_mcps_process_downlink(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt
         pkt->type = GNRC_NETTYPE_LORAWAN;
         release = false;
 
-        mcps_indication_t *mcps_indication = gnrc_lorawan_mcps_allocate(mac);
-        mcps_indication->type = ack_req;
-        mcps_indication->data.pkt = pkt;
-        mcps_indication->data.port = *((uint8_t *) fport->data);
-        mac->netdev.event_callback((netdev_t *) mac, NETDEV_EVENT_MCPS_INDICATION);
+        mcps_indication_t mcps_indication;
+        mcps_indication.type = ack_req;
+        mcps_indication.data.pkt = pkt;
+        mcps_indication.data.port = *((uint8_t *) fport->data);
+        gnrc_lorawan_mcps_indication(mac, &mcps_indication);
     }
 
     if (lorawan_hdr_get_frame_pending(lw_hdr)) {
-        mlme_indication_t *mlme_indication = gnrc_lorawan_mlme_allocate(mac);
-        mlme_indication->type = MLME_SCHEDULE_UPLINK;
-        mac->netdev.event_callback((netdev_t *) mac, NETDEV_EVENT_MLME_INDICATION);
+        mlme_indication_t mlme_indication;
+        mlme_indication.type = MLME_SCHEDULE_UPLINK;
+        gnrc_lorawan_mlme_indication(mac, &mlme_indication);
     }
 
 out:
@@ -232,11 +232,11 @@ static void _end_of_tx(gnrc_lorawan_t *mac, int type, int status)
 {
     mac->mcps.waiting_for_ack = false;
 
-    mcps_confirm_t *mcps_confirm = gnrc_lorawan_mcps_allocate(mac);
+    mcps_confirm_t mcps_confirm;
 
-    mcps_confirm->type = type;
-    mcps_confirm->status = status;
-    mac->netdev.event_callback((netdev_t *) mac, NETDEV_EVENT_MCPS_CONFIRM);
+    mcps_confirm.type = type;
+    mcps_confirm.status = status;
+    gnrc_lorawan_mcps_confirm(mac, &mcps_confirm);
 
     mac->mcps.fcnt += 1;
 }

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -193,6 +193,10 @@ static void _mlme_set(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
             mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
             memcpy(&mac->dev_addr, mlme_request->mib.dev_addr, sizeof(uint32_t));
             break;
+        case MIB_RX2_DR:
+            mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
+            gnrc_lorawan_set_rx2_dr(mac, mlme_request->mib.rx2_dr);
+            break;
         default:
             break;
     }

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -189,6 +189,10 @@ static void _mlme_set(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
                 mac->mlme.activation = mlme_request->mib.activation;
             }
             break;
+        case MIB_DEV_ADDR:
+            mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
+            memcpy(&mac->dev_addr, mlme_request->mib.dev_addr, sizeof(uint32_t));
+            break;
         default:
             break;
     }
@@ -201,6 +205,10 @@ static void _mlme_get(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
         case MIB_ACTIVATION_METHOD:
             mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
             mlme_confirm->mib.activation = mac->mlme.activation;
+            break;
+        case MIB_DEV_ADDR:
+            mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
+            mlme_confirm->mib.dev_addr = &mac->dev_addr;
             break;
         default:
             mlme_confirm->status = -EINVAL;

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -59,7 +59,7 @@ static gnrc_pktsnip_t *_build_join_req_pkt(uint8_t *appeui, uint8_t *deveui, uin
 static int gnrc_lorawan_send_join_request(gnrc_lorawan_t *mac, uint8_t *deveui,
                                           uint8_t *appeui, uint8_t *appkey, uint8_t dr)
 {
-    netdev_t *dev = mac->netdev.lower;
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
 
     /* Dev Nonce */
     uint32_t random_number;
@@ -100,7 +100,7 @@ void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt)
         goto out;
     }
 
-    /* Substract 1 from join accept max size, since the MHDR was already read */
+    /* Subtract 1 from join accept max size, since the MHDR was already read */
     uint8_t out[GNRC_LORAWAN_JOIN_ACCEPT_MAX_SIZE - 1];
     uint8_t has_cflist = (pkt->size - 1) >= CFLIST_SIZE;
     gnrc_lorawan_decrypt_join_accept(mac->appskey, ((uint8_t *) pkt->data) + 1,

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
@@ -24,7 +24,7 @@ static uint8_t dr_bw[GNRC_LORAWAN_DATARATES_NUMOF] =
 
 int gnrc_lorawan_set_dr(gnrc_lorawan_t *mac, uint8_t datarate)
 {
-    netdev_t *dev = mac->netdev.lower;
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
 
     if (!gnrc_lorawan_validate_dr(datarate)) {
         return -EINVAL;
@@ -84,7 +84,7 @@ void gnrc_lorawan_channels_init(gnrc_lorawan_t *mac)
 
 uint32_t gnrc_lorawan_pick_channel(gnrc_lorawan_t *mac)
 {
-    netdev_t *netdev = mac->netdev.lower;
+    netdev_t *netdev = gnrc_lorawan_get_netdev(mac);
     uint32_t random_number;
 
     netdev->driver->get(netdev, NETOPT_RANDOM, &random_number,

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -446,6 +446,14 @@ static inline void gnrc_lorawan_mac_release(gnrc_lorawan_t *mac)
     mac->busy = false;
 }
 
+/**
+ * @brief Set the datarate of the second reception window
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] rx2_dr datarate of RX2
+ */
+void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -446,33 +446,6 @@ static inline void gnrc_lorawan_mac_release(gnrc_lorawan_t *mac)
     mac->busy = false;
 }
 
-/**
- * @brief Allocate memory to hold a GNRC LoRaWAN MCPS request
- *
- * @param[in] mac pointer to the MAC descriptor
- *
- * @return pointer the allocated buffer
- */
-static inline void *gnrc_lorawan_mcps_allocate(gnrc_lorawan_t *mac)
-{
-    mac->netdev.event_callback((netdev_t *) mac, NETDEV_EVENT_MCPS_GET_BUFFER);
-    return mac->mcps_buf;
-}
-
-/**
- * @brief Allocate memory to hold a GNRC LoRaWAN MLME request
- *
- * @param[in] mac pointer to the MAC descriptor
- *
- * @return pointer the allocated buffer
- */
-static inline void *gnrc_lorawan_mlme_allocate(gnrc_lorawan_t *mac)
-{
-    mac->netdev.event_callback((netdev_t *) mac, NETDEV_EVENT_MLME_GET_BUFFER);
-    return mac->mlme_buf;
-}
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -46,7 +46,7 @@ extern "C" {
 #define MTYPE_CNF_UPLINK     0x4                        /**< Confirmed uplink type */
 #define MTYPE_CNF_DOWNLINK   0x5                        /**< Confirmed downlink type */
 #define MTYPE_REJOIN_REQ     0x6                        /**< Re-join request type */
-#define MTYPE_PROPIETARY     0x7                        /**< Propietary frame type */
+#define MTYPE_PROPIETARY     0x7                        /**< Proprietary frame type */
 
 #define MAJOR_MASK     0x3                              /**< Major mtype mask */
 #define MAJOR_LRWAN_R1 0x0                              /**< LoRaWAN R1 version type */
@@ -143,7 +143,7 @@ typedef struct {
     uint32_t fcnt_down;             /**< downlink frame counter */
     gnrc_pktsnip_t *outgoing_pkt;   /**< holds the outgoing packet in case of retransmissions */
     int nb_trials;              /**< holds the remaining number of retransmissions */
-    int ack_requested;          /**< wether the network server requested an ACK */
+    int ack_requested;          /**< whether the network server requested an ACK */
     int waiting_for_ack;        /**< true if the MAC layer is waiting for an ACK */
 } gnrc_lorawan_mcps_t;
 
@@ -164,7 +164,6 @@ typedef struct {
 /**
  * @brief GNRC LoRaWAN mac descriptor */
 typedef struct {
-    netdev_t netdev;                                /**< netdev for the MAC layer */
     xtimer_t rx;                                    /**< RX timer */
     msg_t msg;                                      /**< MAC layer message descriptor */
     gnrc_lorawan_mcps_t mcps;                       /**< MCPS descriptor */
@@ -211,7 +210,7 @@ void gnrc_lorawan_decrypt_join_accept(const uint8_t *key, uint8_t *pkt, int has_
 /**
  * @brief Generate LoRaWAN session keys
  *
- * Intended to be called after a successfull Join Request in order to generate
+ * Intended to be called after a successful Join Request in order to generate
  * NwkSKey and AppSKey
  *
  * @param[in] app_nonce pointer to the app_nonce of the Join Accept message

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -361,6 +361,13 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
         case NETOPT_LINK_CHECK:
             netif->lorawan.flags |= GNRC_NETIF_LORAWAN_FLAGS_LINK_CHECK;
             break;
+        case NETOPT_LORAWAN_RX2_DR:
+            assert(opt->data_len == sizeof(uint8_t));
+            mlme_request.type = MLME_SET;
+            mlme_request.mib.type = MIB_RX2_DR;
+            mlme_request.mib.rx2_dr = *((uint8_t*) opt->data);
+            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
+            break;
         default:
             res = netif->lorawan.mac.netdev.driver->set(&netif->lorawan.mac.netdev, opt->opt, opt->data, opt->data_len);
             break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the MAC netdev layer in GNRC LoRaWAN.
The API of the LoRaWAN MAC layer is well known and the only user is the `gnrc_netif_lorawan` component (or a user that uses the MAC directly).
In both cases we don't need an abstraction layer because we already know we are operating a LoRaWAN MAC.

Besides simplifying the API, it saves some ROM and RAM:
Without this PR:
```
   text	  data	   bss	   dec	   hex	filename
  50416	   504	  6584	 57504	  e0a0
```
With this PR:
```
   text	  data	   bss	   dec	   hex	filename
  50228	   504	  6548	 57280	  dfc0
```

This PR removes the recently introduced NETDEV_EVENT_MLME and NETDEV_EVENT_MCPS.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Verify everything still works with `examples/gnrc_lorawan`.
Also, check the documentation with `make doc`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
