### PR TITLE
tests: adapt tests so they can use `tests_utils_interactive_sync`

### DIFF
--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -35,8 +35,6 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-DISABLE_MODULE += test_utils_interactive_sync
-
 # The test requires some setup and to be run as root
 # So it cannot currently be run
 TEST_ON_CI_BLACKLIST += all

--- a/tests/gnrc_ipv6_ext_frag/Makefile
+++ b/tests/gnrc_ipv6_ext_frag/Makefile
@@ -44,8 +44,6 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-DISABLE_MODULE += test_utils_interactive_sync
-
 # The test requires some setup and to be run as root
 # So it cannot currently be run
 TEST_ON_CI_BLACKLIST += all

--- a/tests/gnrc_ipv6_ext_frag/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext_frag/tests/01-run.py
@@ -318,6 +318,7 @@ def test_ipv6_ext_frag_fwd_too_big(child, s, iface, ll_dst):
 def testfunc(child):
     tap = get_bridge(os.environ["TAP"])
 
+    child.sendline("unittests")
     child.expect(r"OK \((\d+) tests\)")     # wait for and check result of unittests
     print("." * int(child.match.group(1)), end="", flush=True)
 
@@ -337,6 +338,7 @@ def testfunc(child):
                 print("FAILED")
                 raise e
 
+    child.sendline("send-test-pkt")
     child.expect(r"Sending UDP test packets to port (\d+)\r\n")
 
     port = int(child.match.group(1))

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -39,8 +39,6 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-DISABLE_MODULE += test_utils_interactive_sync
-
 # The test requires some setup and to be run as root
 # So it cannot currently be run
 TEST_ON_CI_BLACKLIST += all

--- a/tests/gnrc_rpl_srh/main.c
+++ b/tests/gnrc_rpl_srh/main.c
@@ -234,11 +234,6 @@ static int _ipreg(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "ip", "Registers pktdump to protocol number 59 (no next header)", _ipreg },
-    { NULL, NULL, NULL }
-};
-
 static void run_unittests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -255,9 +250,23 @@ static void run_unittests(void)
     TESTS_END();
 }
 
+static int _unittests(int argc, char** argv)
+{
+    (void) argc;
+    (void) argv;
+
+    run_unittests();
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "ip", "Registers pktdump to protocol number 59 (no next header)", _ipreg },
+    { "unittests", "Runs unitest", _unittests},
+    { NULL, NULL, NULL }
+};
+
 int main(void)
 {
-    run_unittests();
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }

--- a/tests/gnrc_rpl_srh/tests/01-run.py
+++ b/tests/gnrc_rpl_srh/tests/01-run.py
@@ -337,7 +337,7 @@ def test_time_exc(child, iface, hw_dst, ll_dst, ll_src):
 def testfunc(child):
     global sniffer
     tap = get_bridge(os.environ["TAP"])
-
+    child.sendline("unittests")
     child.expect(r"OK \((\d+) tests\)")     # wait for and check result of unittests
     print("." * int(child.match.group(1)), end="", flush=True)
     lladdr_src = get_host_lladdr(tap)

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -32,8 +32,6 @@ USEMODULE += shell_commands
 
 USEMODULE += posix_inet
 
-DISABLE_MODULE += test_utils_interactive_sync
-
 LOW_MEMORY_BOARDS := nucleo-f334r8 msb-430 msb-430h
 
 ifeq ($(BOARD),$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -39,8 +39,6 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += od
 
-DISABLE_MODULE += test_utils_interactive_sync
-
 # Export used tap device to environment
 export TAPDEV = $(TAP)
 

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -63,9 +63,6 @@ def check_cmd(child, cmd, expected):
 
 
 def testfunc(child):
-    # check startup message
-    child.expect('test_shell.')
-
     # loop other defined commands and expected output
     for cmd, expected in CMDS:
         check_cmd(child, cmd, expected)


### PR DESCRIPTION
### Contribution description

This PR removes the need to reset after `cleanterm` from the remaining tests that where not using `tests_utils_interactive_sync`. For some of them it was just a matter of removing `DISABLE_MODULE+=tests_utils_interactive_sync`

Two of them had to me modified a little more:
    - `tests/gnrc_rpl_srh`
    - `tests/gnrc_ipv6_ext_frag`

~~`tests/stdin` is missing but should be fixed in #12816~~ uses a different sync method.

### Testing procedure

All tests ares still working:

- `sudo make -C tests/gnrc_ipv6_ext_frag/ test`
```
...................SUCCESS
```

 - `sudo make -C tests/gnrc_ipv6_ext/ test --no-print-directory`
```
...................SUCCESS
```

- `sudo make -C tests/gnrc_rpl_srh/ test --no-print-directory`
```
..............SUCCESS
```

- `sudo make -C tests/gnrc_tcp/ test --no-print-directory`
<details>

```
03-send_data.py: success

06-receive_data_closed_conn.py: success

- test_short_payload SUCCESS

- test_short_header SUCCESS

- test_send_ack_instead_of_syn SUCCESS

- test_option_parsing_term SUCCESS

05-garbage-pkts.py: success

04-receive_data.py: success

02-conn_lifecycle_as_server.py: success

01-conn_lifecycle_as_client.py: success
```
</details>

- `make -C tests/shell/ --no-print-directory test`
<details>

```
/home/francisco/workspace/RIOT/tests/shell/bin/native/tests_shell.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.01-devel-1190-g7817c-pr_tests_no_reset_dep)
test_shell.
> start_test
start_test
[TEST_START]
> end_test
end_test
[TEST_END]
> 

123456789012345678901234567890123456789012345678901234567890

> 
> 123456789012345678901234567890123456789012345678901234567890
shell: command not found: 123456789012345678901234567890123456789012345678901234567890
> unknown_command
unknown_command
shell: command not found: unknown_command
> help
help
Command              Description
---------------------------------------
start_test           starts a test
end_test             ends a test
echo                 prints the input command
reboot               Reboot the node
ps                   Prints information about running threads.
app_metadata         Returns application metadata
> echo a string
echo a string
"echo""a""string"
> ps
ps
        pid | state    Q | pri 
          1 | pending  Q |  15
          2 | running  Q |   7
> garbage1234
help
garbage1234
> 
> help
Command              Description
---------------------------------------
start_test           starts a test
end_test             ends a test
echo                 prints the input command
reboot               Reboot the node
ps                   Prints information about running threads.
app_metadata         Returns application metadata
> reboot
reboot


                !! REBOOT !!

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.01-devel-1190-g7817c-pr_tests_no_reset_dep)
test_shell.
```
</details>

- `sudo make -C tests/gnrc_sock_dns/ test --no-print-directory`
```
..............SUCCESS
```
### Issues/PRs references

Part of #12448.
Related to #12862.