### PR TITLE
lpc2k_pgm: fix build warnings, add lpc2388

### DIFF
--- a/boards/common/msba2/tools/src/chipinfo.c
+++ b/boards/common/msba2/tools/src/chipinfo.c
@@ -138,6 +138,7 @@ struct chip_info_struct chip_info[] = {
     {"LPC2378 (500k)", "117702437",  0x40000200, 0x1000, 27, lpc2138_layout, boot_23xx},
     {"LPC2387 (500k)", "402716981",  0x40000200, 0x1000, 27, lpc2138_layout, boot_23xx},
     {"LPC2387 (500k)", "385941301",  0x40000200, 0x1000, 27, lpc2138_layout, boot_23xx},
+    {"LPC2388 (500k)", "402718517",  0x40000200, 0x1000, 27, lpc2138_layout, boot_23xx},
     {"LPC2468 (500k)", "100925237",  0x40000200, 0x1000, 27, lpc2138_layout, boot_23xx},
     {NULL, NULL, 0, 0, 0, NULL}
 };

--- a/boards/common/msba2/tools/src/download.c
+++ b/boards/common/msba2/tools/src/download.c
@@ -245,7 +245,7 @@ hardware you may be using.  Thanks :-)\r\n"
 
 static void download_main(int event)
 {
-    char buf[4096];
+    char buf[4096 + 32];
     unsigned char bytes[256];
     double xtal;
     int n;


### PR DESCRIPTION
### Contribution description

GCC now warns when `snprintf()`ing a buffer that, together with the format string, might be larger than the destination buffer.
    
To fix this increase the size of the destination buffer so that the source buffer and the format string will always fit - 32 bytes are enough.

This also adds the signature of the lpc2388 to `lpc2k_pgm`.
The MCU is very simmilar to lpc2387 and can be flashed with this tool too.

### Testing procedure

You should still be able to flash lpc23xx boards like the `msba2`, but without the distracting warnings.

### Issues/PRs references
split off #12669
