### PR TITLE
sys/xtimer: fix documentation about XTIMER_BACKOFF

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -142,7 +142,7 @@ static inline void xtimer_sleep(uint32_t seconds);
  *
  * When called from an ISR, this function will spin and thus block the MCU for
  * the specified amount in microseconds, so only use it there for *very* short
- * periods, e.g., less than XTIMER_BACKOFF.
+ * periods, e.g., less than XTIMER_BACKOFF converted to µs.
  *
  * @param[in] microseconds  the amount of microseconds the thread should sleep
  */
@@ -248,8 +248,8 @@ static inline void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset, kernel_
  * ticks in the future.
  *
  * @warning BEWARE! Callbacks from xtimer_set() are being executed in interrupt
- * context (unless offset < XTIMER_BACKOFF). DON'T USE THIS FUNCTION unless you
- * know *exactly* what that means.
+ * context (unless offset < XTIMER_BACKOFF converted to µs).
+ * DON'T USE THIS FUNCTION unless you know *exactly* what that means.
  *
  * @param[in] timer     the timer structure to use.
  *                      Its xtimer_t::target and xtimer_t::long_target
@@ -269,8 +269,8 @@ static inline void xtimer_set(xtimer_t *timer, uint32_t offset);
  * microseconds in the future.
  *
  * @warning BEWARE! Callbacks from xtimer_set() are being executed in interrupt
- * context (unless offset < XTIMER_BACKOFF). DON'T USE THIS FUNCTION unless you
- * know *exactly* what that means.
+ * context (unless offset < XTIMER_BACKOFF converted to µs).
+ * DON'T USE THIS FUNCTION unless you know *exactly* what that means.
  *
  * @param[in] timer       the timer structure to use.
  *                        Its xtimer_t::target and xtimer_t::long_target
@@ -478,7 +478,7 @@ static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
 /**
  * @brief xtimer backoff value
  *
- * All timers that are less than XTIMER_BACKOFF microseconds in the future will
+ * All timers that are less than XTIMER_BACKOFF ticks in the future will
  * just spin.
  *
  * This is supposed to be defined per-device in e.g., periph_conf.h.


### PR DESCRIPTION
### Contribution description

When `XTIMER_BACKOFF` is used by [`_xtimer_set()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/xtimer/xtimer_core.c#L136) , `offset` has already been converted to ticks.

So the documentation of the `xtimer_tsleepXX()` functions is correct, however for [`xtimer_usleep()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/xtimer/implementation.h#L180) `XTIMER_BACKOFF` has to be converted to µs to calculate the minimal sleep time.

### Testing procedure

Read the documentation and the source of [`_xtimer_set()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/xtimer/xtimer_core.c#L136) / [`xtimer_usleep()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/xtimer/implementation.h#L180)

### Issues/PRs references
discovered in #10710