### PR TITLE
cpu/lpc2387: rtc: remove use of localtime()

### DIFF
--- a/cpu/arm7_common/arm7_init.c
+++ b/cpu/arm7_common/arm7_init.c
@@ -88,7 +88,7 @@ static inline void _init_data(void)
 
 #ifdef CPU_HAS_BACKUP_RAM
     /* only initialize battery backup on cold boot */
-    if (cpu_woke_from_backup()) {
+    if (cpu_backup_ram_is_initialized()) {
         return;
     }
 

--- a/cpu/lpc2387/cpu.c
+++ b/cpu/lpc2387/cpu.c
@@ -139,7 +139,7 @@ void cpu_init(void)
 /* RSIR will only have POR bit set even when waking up from Deep Power Down
  * Use signature in battery RAM to discriminate between Deep Power Down and POR
  */
-bool cpu_woke_from_backup(void)
+bool cpu_backup_ram_is_initialized(void)
 {
     static char signature[] __attribute__((section(".backup.data"))) = {
         'R', 'I', 'O', 'T'

--- a/cpu/lpc2387/cpu.c
+++ b/cpu/lpc2387/cpu.c
@@ -145,6 +145,13 @@ bool cpu_backup_ram_is_initialized(void)
         'R', 'I', 'O', 'T'
     };
 
+    /* Only in case when a reset occurs and the POR = 0, the BODR bit
+     * indicates if the V_DD (3V3) voltage was below 2.6 V or not.
+     */
+    if ((RSIR & (RSIR_BODR | RSIR_POR)) == (RSIR_BODR | RSIR_POR)) {
+        RSIR |= RSIR_BODR;
+    }
+
     /* external reset */
     if (RSIR & RSIR_EXTR) {
         return false;

--- a/cpu/lpc2387/cpu.c
+++ b/cpu/lpc2387/cpu.c
@@ -166,6 +166,11 @@ bool cpu_woke_from_backup(void)
         return false;
     }
 
+    /* When we wake from Deep Sleep only POR is set, just like in the real
+     * POR case. Clear the bit to create a new, distinct state.
+     */
+    RSIR |= RSIR_POR;
+
     return true;
 }
 

--- a/cpu/lpc2387/include/cpu.h
+++ b/cpu/lpc2387/include/cpu.h
@@ -60,7 +60,14 @@ static inline void cpu_print_last_instruction(void)
 /**
  * @brief   Returns true if the CPU woke from Deep Sleep
  */
-bool cpu_woke_from_backup(void);
+static inline bool cpu_woke_from_backup(void) {
+    return RSIR == 0;
+}
+
+/**
+ * @brief   Returns true if the backup RAM has been initialized
+ */
+bool cpu_backup_ram_is_initialized(void);
 
 /**
  * @brief   The CPU has RAM that is retained in the deepest sleep mode.

--- a/cpu/lpc2387/periph/rtc.c
+++ b/cpu/lpc2387/periph/rtc.c
@@ -40,9 +40,6 @@ static rtc_alarm_cb_t _cb;
 /* Argument to alarm callback */
 static void *_cb_arg;
 
-/* internal function to set time based on time_t */
-static void _rtc_set(time_t time);
-
 void RTC_IRQHandler(void) __attribute__((interrupt("IRQ")));
 
 void rtc_init(void)
@@ -56,10 +53,10 @@ void rtc_init(void)
 
     RTC_CCR = CCR_CLKSRC;                   /* Clock from external 32 kHz Osc. */
 
-    /* initialize clock with valid unix compatible values
-     * If RTC_YEAR contains an value larger unix time_t we must reset. */
+    /* initialize clock with valid unix compatible values */
     if (RTC_YEAR > 2037) {
-        _rtc_set(0);
+        struct tm localt = { .tm_year = 70 };
+        rtc_set_time(&localt);
     }
 
     rtc_poweron();
@@ -200,11 +197,4 @@ void RTC_IRQHandler(void)
     }
 
     VICVectAddr = 0;                        /* Acknowledge Interrupt */
-}
-
-static void _rtc_set(time_t time)
-{
-    struct tm *localt;
-    localt = localtime(&time);                      /* convert seconds to broken-down time */
-    rtc_set_time(localt);
 }

--- a/cpu/lpc2387/periph/rtc.c
+++ b/cpu/lpc2387/periph/rtc.c
@@ -53,8 +53,10 @@ void rtc_init(void)
 
     RTC_CCR = CCR_CLKSRC;                   /* Clock from external 32 kHz Osc. */
 
-    /* initialize clock with valid unix compatible values */
-    if (RTC_YEAR > 2037) {
+    /* Initialize clock to a a sane and predictable default
+     * after cold boot or external reset.
+     */
+    if ((RSIR == RSIR_POR) || (RSIR == (RSIR_POR | RSIR_EXTR))) {
         struct tm localt = { .tm_year = 70 };
         rtc_set_time(&localt);
     }


### PR DESCRIPTION
### Contribution description

`rtc_init()` was needlessly pulling in `localtime()` just to initialize the RTC.
This added quite some ROM overhead:

master:
```
   text    data     bss     dec     hex
  31328     240   98064  129632   1fa60
```

this patch:
```
   text    data     bss     dec     hex
  20036     140   98168  118344   1ce48
```
(when building `tests/periph_rtc`)


Now this raised the question why we need to reset the RTC at all?
It is certainly not constrained to being below 2037, the YEAR register is 11 bits wide.

If we don't reset it, we will get random dates (without any sanity checking) like `5867-11-13 13:62:32`.
(After the first minute rolled over, this normalized itself to `5867-11-13 14:11:03`).

But is this so much better than `1970-01-01 00:00:00`?

We could reset the RTC in early boot when the `cpu_woke_from_backup()` check is done.
Or have a static variable inside `cpu_woke_from_backup()` that stores the result of the signature comparison so it's possible to call the function multiple times. While this would benefit the semantics of the function, it would for the most part just waste a byte for a prettier (yet still invalid) date.

### Testing procedure
`tests/periph_rtc` still works.
Use `rtc gettime` in `examples/default` to observe the date after cold boot.

### Issues/PRs references

