### PR TITLE
pkg/wakaama: small cleanup

### DIFF
--- a/examples/wakaama/Makefile.ci
+++ b/examples/wakaama/Makefile.ci
@@ -1,27 +1,7 @@
 BOARD_BLACKLIST := \
-    arduino-duemilanove \
-    arduino-leonardo \
-    arduino-mega2560 \
-    arduino-nano \
-    arduino-uno \
-    atmega1284p \
-    atmega256rfr2-xpro \
-    atmega328p \
-    avr-rss2 \
-    chronos \
-    derfmega128 \
-    derfmega256 \
-    mega-xplained \
-    microduino-corerf \
-    msb-430 \
-    msb-430h \
     pic32-clicker \
     pic32-wifire \
-    telosb \
-    waspmote-pro \
-    wsn430-v1_3b \
-    wsn430-v1_4 \
-    z1
+    #
 
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \

--- a/examples/wakaama/Makefile.ci
+++ b/examples/wakaama/Makefile.ci
@@ -1,8 +1,3 @@
-BOARD_BLACKLIST := \
-    pic32-clicker \
-    pic32-wifire \
-    #
-
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
     b-l072z-lrwan1 \

--- a/examples/wakaama/Makefile.ci
+++ b/examples/wakaama/Makefile.ci
@@ -32,4 +32,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \
-    yunjia-nrf51822
+    yunjia-nrf51822 \
+    #

--- a/pkg/tlsf/Makefile.dep
+++ b/pkg/tlsf/Makefile.dep
@@ -7,3 +7,6 @@ ifneq (,$(filter tlsf-malloc,$(USEMODULE)))
     $(warning tlsf-malloc can only be used on native or on platforms using newlib)
   endif
 endif
+
+# tlsf is not compatible with 8bit and 16bit architectures
+FEATURES_REQUIRED += arch_32bit

--- a/pkg/wakaama/contrib/lwm2m_client.c
+++ b/pkg/wakaama/contrib/lwm2m_client.c
@@ -176,12 +176,12 @@ static void *_lwm2m_client_run(void *arg)
             lwm2m_client_connection_t *conn = lwm2m_client_connection_find(
                                             _client_data->conn_list, &remote);
             if (conn) {
-                DEBUG("lwm2m_connection_handle_packet(%d)\n", rcv_len);
+                DEBUG("lwm2m_connection_handle_packet(%i)\n", (int)rcv_len);
                 int result = lwm2m_connection_handle_packet(conn, rcv_buf,
                                                             rcv_len,
                                                             _client_data);
                 if (0 != result) {
-                    DEBUG("error handling message %d\n", result);
+                    DEBUG("error handling message %i\n", result);
                 }
             }
             else {
@@ -190,10 +190,10 @@ static void *_lwm2m_client_run(void *arg)
         }
         else if ((rcv_len < 0) &&
                  ((rcv_len != -EAGAIN) && (rcv_len != -ETIMEDOUT))) {
-            DEBUG("Unexpected sock_udp_recv error code %i\n", rcv_len);
+            DEBUG("Unexpected sock_udp_recv error code %i\n", (int)rcv_len);
         }
         else {
-            DEBUG("UDP error code: %d\n", rcv_len);
+            DEBUG("UDP error code: %i\n", (int)rcv_len);
         }
     }
     return NULL;

--- a/pkg/wakaama/contrib/lwm2m_client_connection.c
+++ b/pkg/wakaama/contrib/lwm2m_client_connection.c
@@ -261,7 +261,7 @@ static int _connection_send(lwm2m_client_connection_t *conn, uint8_t *buffer,
     ssize_t sent_bytes = sock_udp_send(&(client_data->sock), buffer,
                                        buffer_size, &(conn->remote));
     if (sent_bytes <= 0) {
-        DEBUG("[_connection_send] Could not send UDP packet: %d\n", sent_bytes);
+        DEBUG("[_connection_send] Could not send UDP packet: %i\n", (int)sent_bytes);
         return -1;
     }
     conn->last_send = lwm2m_gettime();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides some small cleanups in the wakaama package:
- it whitelists 32bit architecture in the tlsf package, so there's no need to blacklist 8bit and 16bit architecture in the wakaama example. Question: is it possible to get rid of the tlsf dependency ? I thought libc's malloc could be used instead and it's working on 8bit/16bit architectures.
- it fixes some string formatting with signed integers, so the build doesn't fail on pic32
- it removes the BOARD_BLACKLIST from the example Makefile.ci
- it cleans up a bit the example Makefile.ci

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- a green Murdock
- examples/wakaama should still work

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
