### PR TITLE
sys/usb: Add configurations to Doxygen configuration group

### DIFF
--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -25,6 +25,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup usb_conf USB peripheral compile time configurations
+ * @ingroup config
+ * @{
+ */
+/**
  * @brief USB peripheral device vendor ID
  *
  * @note You must provide your own VID/PID combination when manufacturing a
@@ -110,6 +115,7 @@ extern "C" {
 #ifndef USB_CONFIG_DEFAULT_LANGID
 #define USB_CONFIG_DEFAULT_LANGID   0x0409 /* EN-US */
 #endif
+/** @} */
 
 /**
  * @brief USB version definitions

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -26,19 +26,30 @@ extern "C" {
 
 /**
  * @brief USB peripheral device vendor ID
+ *
+ * @note You must provide your own VID/PID combination when manufacturing a
+ * device with USB.
  */
 #ifndef USB_CONFIG_VID
+#ifdef DOXYGEN
+#define USB_CONFIG_VID
+#else
 #error  Please supply your vendor ID by setting USB_CONFIG_VID
+#endif
 #endif
 
 /**
  * @brief USB peripheral device product ID
  *
- * You must provide your own VID/PID combination when manufacturing a device
- * with USB
+ * @note You must provide your own VID/PID combination when manufacturing a
+ * device with USB.
  */
 #ifndef USB_CONFIG_PID
+#ifdef DOXYGEN
+#define USB_CONFIG_PID
+#else
 #error  Please supply your vendor ID by setting USB_CONFIG_PID
+#endif
 #endif
 
 /**

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -41,6 +41,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup usb_usbus_conf    USBUS compile time configurations
+ * @ingroup usb_conf
+ * @{
+ */
+/**
  * @brief USBUS thread stack size
  */
 #ifndef USBUS_STACKSIZE
@@ -53,11 +58,6 @@ extern "C" {
 #ifndef USBUS_PRIO
 #define USBUS_PRIO                  (THREAD_PRIORITY_MAIN - 6)
 #endif
-
-/**
- * @brief USBUS thread name
- */
-#define USBUS_TNAME                 "usbus"
 
 /**
  * @brief USBUS auto attach setting
@@ -80,6 +80,12 @@ extern "C" {
 #ifndef USBUS_EP0_SIZE
 #define USBUS_EP0_SIZE              64
 #endif
+/** @} */
+
+/**
+ * @brief USBUS thread name
+ */
+#define USBUS_TNAME                 "usbus"
 
 /**
  * @name USBUS thread flags

--- a/sys/include/usb/usbus/cdc/acm.h
+++ b/sys/include/usb/usbus/cdc/acm.h
@@ -38,6 +38,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup usbus_cdc_acm_conf USBUS CDC ACM compile time configurations
+ * @ingroup usb_conf
+ * @{
+ */
+/**
  * @brief Buffer size for STDIN and STDOUT data to and from USB when using
  *        the USBUS_CDC_ACM_STDIO module
  */
@@ -51,6 +56,7 @@ extern "C" {
 #ifndef USBUS_CDC_ACM_BULK_EP_SIZE
 #define USBUS_CDC_ACM_BULK_EP_SIZE    (64)
 #endif
+/** @} */
 
 /**
  * @brief USBUS CDC ACM interrupt endpoint size.


### PR DESCRIPTION
### Contribution description
This PR adds the USB, USBUS and USBUS CDC ACM configuration macros to the 'Compile time configurations' Doxygen group. It also fixes the documentation for `USB_CONFIG_VID` and `USB_CONFIG_PID` which are not rendering properly.

### Testing procedure
Build the documentation `make doc`, you should see now USB in the compile time configurations group in Doxygen. 

### Issues/PRs references
None