### PR TITLE
boards/microduino-corerf: small fixups

### DIFF
--- a/boards/microduino-corerf/Makefile.features
+++ b/boards/microduino-corerf/Makefile.features
@@ -3,6 +3,7 @@ CPU = atmega128rfa1
 # This board is based on an atmega CPU, thus import the features from it
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/microduino-corerf/Makefile.include
+++ b/boards/microduino-corerf/Makefile.include
@@ -1,7 +1,7 @@
 # configure the terminal program
-PORT_LINUX  ?= /dev/ttyACM0
+PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-BAUD        ?= 57600
+BAUD        ?= 115200
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # PROGRAMMER defaults to UM232H which is a FT232H breakout board

--- a/boards/microduino-corerf/include/board.h
+++ b/boards/microduino-corerf/include/board.h
@@ -31,7 +31,7 @@ extern "C" {
  * @{
  */
 #ifndef STDIO_UART_BAUDRATE
-#define STDIO_UART_BAUDRATE (57600U)       /**< Sets Baudrate for e.g. Shell */
+#define STDIO_UART_BAUDRATE (115200U)      /**< Sets Baudrate for e.g. Shell */
 #endif
 /** @} */
 


### PR DESCRIPTION
### Contribution description

When doing the `microduino-corerf` port I was somehow beset by the cargo-cultish idea that ATmega couldn't do 115200 baud UART.
This is of course bogus and using half of 115200 for no good reason is just odd.
Now the board uses 115200 baud like everyone else and when attaching a serial terminal one no longer has to wonder what the proper baud rate was.

I also thought that the board was so bare-bones, it had no external oscillator, so I couldn't enable the RTT.
#12852 should also work on boards without oscillator, so I wanted to try that out. It worked, but upon closer inspection I found the oscillator and noticed the RTT was already working on `master`.

### Testing procedure

flash `tests/periph_rtt`.
You will see that RTT and the UART output at 115200 baud works.

### Issues/PRs references
none