### PR TITLE
make: replace GNU `cp -t` with standard `cp`

### DIFF
--- a/dist/tools/kconfiglib/Makefile
+++ b/dist/tools/kconfiglib/Makefile
@@ -7,7 +7,8 @@ PKG_BUILDDIR=$(CURDIR)/bin
 .PHONY: all
 
 all: git-download
-	cp -t . $(PKG_BUILDDIR)/kconfiglib.py $(PKG_BUILDDIR)/menuconfig.py \
-		$(PKG_BUILDDIR)/genconfig.py $(PKG_BUILDDIR)/examples/merge_config.py
+	cp $(PKG_BUILDDIR)/kconfiglib.py $(PKG_BUILDDIR)/menuconfig.py \
+	   $(PKG_BUILDDIR)/genconfig.py $(PKG_BUILDDIR)/examples/merge_config.py \
+	   .
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/makefiles/suit.v4.inc.mk
+++ b/makefiles/suit.v4.inc.mk
@@ -90,7 +90,7 @@ suit/manifest: $(SUIT_MANIFESTS)
 
 suit/publish: $(SUIT_MANIFESTS) $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 	@mkdir -p $(SUIT_COAP_FSROOT)/$(SUIT_COAP_BASEPATH)
-	@cp -t $(SUIT_COAP_FSROOT)/$(SUIT_COAP_BASEPATH) $^
+	@cp $^ $(SUIT_COAP_FSROOT)/$(SUIT_COAP_BASEPATH)
 	@for file in $^; do \
 		echo "published \"$$file\""; \
 		echo "       as \"$(SUIT_COAP_ROOT)/$$(basename $$file)\""; \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

UNIX `cp` command does not have the `-t` option like its GNU variant.
Hence, it usage breaks building RIOT e.g. on FreeBSD.


### Testing procedure

If CI is happy this should be good.


### Issues/PRs references

`cp -t` was introduces by #12695 and #11818
