### PR TITLE
drivers/ws281x: Fixed issue in doc

### DIFF
--- a/drivers/ws281x/atmega.c
+++ b/drivers/ws281x/atmega.c
@@ -12,7 +12,7 @@
  * @{
  *
  * @file
- * @brief       Implementation of `ws281x_write()` for ATmega MCUs
+ * @brief       Implementation of `ws281x_write_buffer()` for ATmega MCUs
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  *


### PR DESCRIPTION
### Contribution description

Fixed issue in the documentation of the ATmega backend of the ws281x driver.

### Testing procedure

Doesn't apply.

### Issues/PRs references

None