### PR TITLE
gnrc_sixlowpan_iphc: add support for IPv6 extension header compression

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -25,6 +25,11 @@
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/ipv6/ext/frag.h"
 #include "net/gnrc/ipv6/ext/rh.h"
+#if defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) && \
+    defined(MODULE_GNRC_IPV6_EXT_FRAG)
+#include "net/udp.h"
+#endif  /* defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) &&
+         * defined(MODULE_GNRC_IPV6_EXT_FRAG) */
 
 #include "net/gnrc/ipv6/ext.h"
 
@@ -101,7 +106,22 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_process_all(gnrc_pktsnip_t *pkt,
                                           uint8_t *protnum)
 {
     bool is_ext = true;
+#if defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) && \
+    defined(MODULE_GNRC_IPV6_EXT_FRAG)
+    bool is_frag = false;
+#endif  /* defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) &&
+         * defined(MODULE_GNRC_IPV6_EXT_FRAG) */
+
     while (is_ext) {
+#if defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) && \
+    defined(MODULE_GNRC_IPV6_EXT_FRAG)
+        if (*protnum == PROTNUM_IPV6_EXT_FRAG) {
+            /* just assigning the if expression might override it if
+             * fragment header is not the last extension header ;-) */
+            is_frag = true;
+        }
+#endif  /* defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) &&
+         * defined(MODULE_GNRC_IPV6_EXT_FRAG) */
         switch (*protnum) {
             case PROTNUM_IPV6_EXT_DST:
             case PROTNUM_IPV6_EXT_RH:
@@ -127,6 +147,34 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_process_all(gnrc_pktsnip_t *pkt,
                 }
                 break;
             }
+#if defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) && \
+    defined(MODULE_GNRC_IPV6_EXT_FRAG)
+            case PROTNUM_UDP:
+                if (is_frag) {
+                    DEBUG("gnrc_ipv6_ext: adapting compressed header length\n");
+                    /* we can only really now determine the length of the UDP
+                     * packet, after the IPv6 datagram is fully reassembled */
+                    udp_hdr_t *udp_hdr = pkt->data;
+
+                    udp_hdr->length = byteorder_htons((uint16_t)pkt->size);
+                }
+                is_ext = false;
+                break;
+            case PROTNUM_IPV6:
+                if (is_frag) {
+                    DEBUG("gnrc_ipv6_ext: adapting compressed header length\n");
+                    /* we can only really now determine the length of the
+                     * encapsulated IPv6 header, after the IPv6 datagram is
+                     * fully reassembled */
+                    ipv6_hdr_t *ipv6_hdr = pkt->data;
+
+                    ipv6_hdr->len = byteorder_htons((uint16_t)pkt->size -
+                                                    sizeof(ipv6_hdr_t));
+                }
+                is_ext = false;
+                break;
+#endif  /* defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC) &&
+         * defined(MODULE_GNRC_IPV6_EXT_FRAG) */
             default:
                 is_ext = false;
                 break;

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
@@ -19,4 +19,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    wsn430-v1_3b \
+    wsn430-v1_4 \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Up until now there was still a part of RFC 6282 missing: [IPv6 extension header compression](https://tools.ietf.org/html/rfc6282#section-4.1). This PR completes IPHC according to RFC 6282 by adding both compression and decompression for extension headers and encapsulated IPv6 headers (which is part of IPv6 extension header compression in RFC 6282).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Up until now i only confirmed that the current functionality is not regressed by using `tests/gnrc_udp` on two `iotlab-m3`s and sending:

- unfragmented packets without NHC:
  ```
  ping6 <link-local addres of 2nd node>
  ```
- fragmented packets without NHC:
  ```
  ping6 -s 160 <link-local addres of 2nd node>
  ```
- unfragmented packets with NHC
  ```
  // start server on 2nd node with `udp server start 61616`
  udp send <link-local addres of 2nd node> 61616 8
  ```
- fragmented packets with NHC
  ```
  // start server on 2nd node with `udp server start 61616`
  udp send <link-local addres of 2nd node> 61616 160
  ```

Additionally I tested the use case that caused me implementing this: sending IPv6 fragmented packets compressed:

  ```
  ping6 -s 1500 <link-local addres of 2nd node>
  // start server on 2nd node with `udp server start 61616`
  udp send <link-local addres of 2nd node> 61616 1500
  ```

And confirmed with Wireshark, that the packets are sensible (as far as I can judge).

~~I plan to provide a dedicated test application utilizing `socket_zep` and `scapy` to have more coverage, but that I will do if I find the time for that (this is why this PR is still WIP).~~ ([no NHC support for `scapy` yet](https://github.com/secdev/scapy/blob/ff43e450709605314c4739287e83c588a974a502/scapy/layers/sixlowpan.py#L669-L672))
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None technically, however I cherry-picked be7b6d3872d72a434a42e89a01811ffcae4e78bd out of #12629 to avoid conflicts between this PR and the clean-ups in #12629.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
