### PR TITLE
cpu/fe310: factorize periph_gpio* provided features

### DIFF
--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -2,7 +2,6 @@ CPU = fe310
 CPU_MODEL = fe310_g000
 
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 #FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/hifive1b/Makefile.features
+++ b/boards/hifive1b/Makefile.features
@@ -2,7 +2,6 @@ CPU = fe310
 CPU_MODEL = fe310_g002
 
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 #FEATURES_PROVIDED += periph_i2c
 #FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/cpu/fe310/Makefile.features
+++ b/cpu/fe310/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_riscv
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pm


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is a simple PR that moves the `periph_gpio*` provided features from boards (hifive1/hifive1b) to cpu (fe310).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green murdock
- hifive1/hifive1b are still listed in board supported list of `tests/periph_gpio`:

<details>

```
$ make -C tests/periph_gpio --no-print-directory info-boards-supported | tr " " "\n" | grep hifive
hifive1
hifive1b
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
