### PR TITLE
cpu/fe310: add cpp feature

### DIFF
--- a/cpu/fe310/Makefile.features
+++ b/cpu/fe310/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_riscv
+FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_pm


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR simply provides the cpp feature for the fe310 cpu (RISC-V). Nothing else is required, the toolchain provides c++ support: I tested successfully all cpp based applications in RIOT.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Manual test (automatic tests don't work with hifive1b board) of `examples/riot_and_cpp`, `tests/cpp_*` applications:
```
make BOARD=hifive1b -C examples/riot_and_cpp flash term
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
