### PR TITLE
tests/periph_backup_ram: disable test_utils_interactive_sync

### DIFF
--- a/tests/periph_backup_ram/Makefile
+++ b/tests/periph_backup_ram/Makefile
@@ -6,6 +6,8 @@ USEMODULE += pm_layered
 USEMODULE += periph_rtc
 USEMODULE += xtimer
 
+DISABLE_MODULE += test_utils_interactive_sync
+
 CFLAGS += -DLOG_LEVEL=LOG_WARNING
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

The `periph_backup_ram` test expects the CPU to enter Deep Sleep, wake up (causing a CPU reset) increment a counter and go back to sleep.

Introducing a requirement on interaction after reset breaks the test.


### Testing procedure

Run `tests/periph_backup_ram` on any supported board. (e.g. `samr54-xpro` or `msba2`).
On master you currently see this:
```
2019-12-05 22:50:51,832 # Help: Press s to start test, r to print it is ready
s
2019-12-05 22:51:01,336 # START
2019-12-05 22:51:01,337 # 
2019-12-05 22:51:01,337 # Backup RAM test
2019-12-05 22:51:01,337 # 
2019-12-05 22:51:01,370 # This test will increment the counter by 1, then enter deep sleep for 1s.
2019-12-05 22:51:01,370 # 
2019-12-05 22:51:01,372 #   Because some tools have trouble re-flashing/debugging in deep sleep,
2019-12-05 22:51:01,374 #   the test will wait for 3s before entering deep sleep.
2019-12-05 22:51:01,374 # 
2019-12-05 22:51:01,374 # counter: 1
2019-12-05 22:51:05,028 # Help: Press s to start test, r to print it is ready
```

with this patch the original behavior is restored:

```
2019-12-05 22:52:44,255 # 
2019-12-05 22:52:44,256 # Backup RAM test
2019-12-05 22:52:44,256 # 
2019-12-05 22:52:44,257 # This test will increment the counter by 1, then enter deep sleep for 1s.
2019-12-05 22:52:44,257 # 
2019-12-05 22:52:44,259 #   Because some tools have trouble re-flashing/debugging in deep sleep,
2019-12-05 22:52:44,260 #   the test will wait for 3s before entering deep sleep.
2019-12-05 22:52:44,260 # 
2019-12-05 22:52:44,260 # counter: 1
2019-12-05 22:52:47,037 # counter: 2
2019-12-05 22:52:51,033 # counter: 3
2019-12-05 22:52:55,028 # counter: 4
```

### Issues/PRs references
`tests/periph_pm` will exhibit the same problem when using `set 0`.
