### PR TITLE
Kconfig: Expose Gcoap configurations

### DIFF
--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -9,18 +9,6 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-## Uncomment to redefine port, for example use 61616 for RFC 6282 UDP compression.
-#GCOAP_PORT = 5683
-#CFLAGS += -DCONFIG_GCOAP_PORT=$(GCOAP_PORT)
-
-## Uncomment to redefine request token length, max 8.
-#GCOAP_TOKENLEN = 2
-#CFLAGS += -DCONFIG_GCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
-
-# Increase from default for confirmable block2 follow-on requests
-CONFIG_GCOAP_RESEND_BUFS_MAX ?= 2
-CFLAGS += -DCONFIG_GCOAP_RESEND_BUFS_MAX=$(CONFIG_GCOAP_RESEND_BUFS_MAX)
-
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
@@ -48,3 +36,20 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+# For now this goes after the inclusion of Makefile.include so Kconfig symbols
+# are available. Only set configuration via CFLAGS if Kconfig is not being used
+# for this module.
+ifndef CONFIG_KCONFIG_MODULE_GCOAP
+## Uncomment to redefine port, for example use 61616 for RFC 6282 UDP compression.
+#GCOAP_PORT = 5683
+#CFLAGS += -DCONFIG_GCOAP_PORT=$(GCOAP_PORT)
+
+## Uncomment to redefine request token length, max 8.
+#GCOAP_TOKENLEN = 2
+#CFLAGS += -DCONFIG_GCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
+
+# Increase from default for confirmable block2 follow-on requests
+GCOAP_RESEND_BUFS_MAX ?= 2
+CFLAGS += -DCONFIG_GCOAP_RESEND_BUFS_MAX=$(GCOAP_RESEND_BUFS_MAX)
+endif

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -11,15 +11,15 @@ RIOTBASE ?= $(CURDIR)/../..
 
 ## Uncomment to redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683
-#CFLAGS += -DGCOAP_PORT=$(GCOAP_PORT)
+#CFLAGS += -DCONFIG_GCOAP_PORT=$(GCOAP_PORT)
 
 ## Uncomment to redefine request token length, max 8.
 #GCOAP_TOKENLEN = 2
-#CFLAGS += -DGCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
+#CFLAGS += -DCONFIG_GCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
 
 # Increase from default for confirmable block2 follow-on requests
-GCOAP_RESEND_BUFS_MAX ?= 2
-CFLAGS += -DGCOAP_RESEND_BUFS_MAX=$(GCOAP_RESEND_BUFS_MAX)
+CONFIG_GCOAP_RESEND_BUFS_MAX ?= 2
+CFLAGS += -DCONFIG_GCOAP_RESEND_BUFS_MAX=$(CONFIG_GCOAP_RESEND_BUFS_MAX)
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/gcoap/Makefile.slip
+++ b/examples/gcoap/Makefile.slip
@@ -12,11 +12,11 @@ RIOTBASE ?= $(CURDIR)/../..
 
 # Redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683
-#CFLAGS += -DGCOAP_PORT=$(GCOAP_PORT)
+#CFLAGS += -DCONFIG_GCOAP_PORT=$(GCOAP_PORT)
 
 # Redefine request token length, max 8.
 #GCOAP_TOKENLEN = 2
-#CFLAGS += -DGCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
+#CFLAGS += -DCONFIG_GCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
 
 # Border router requirements
 ifeq (,$(SLIP_UART))

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -137,7 +137,7 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
                 return;
             }
 
-            gcoap_req_init(pdu, (uint8_t *)pdu->hdr, GCOAP_PDU_BUF_SIZE,
+            gcoap_req_init(pdu, (uint8_t *)pdu->hdr, CONFIG_GCOAP_PDU_BUF_SIZE,
                            COAP_METHOD_GET, _last_req_path);
             if (msg_type == COAP_TYPE_ACK) {
                 coap_hdr_set_type(pdu->hdr, COAP_TYPE_CON);
@@ -270,7 +270,7 @@ int gcoap_cli_cmd(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
     char *method_codes[] = {"get", "post", "put"};
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
     size_t len;
 
@@ -282,7 +282,7 @@ int gcoap_cli_cmd(int argc, char **argv)
     if (strcmp(argv[1], "info") == 0) {
         uint8_t open_reqs = gcoap_op_state();
 
-        printf("CoAP server is listening on port %u\n", GCOAP_PORT);
+        printf("CoAP server is listening on port %u\n", CONFIG_GCOAP_PORT);
         printf(" CLI requests sent: %u\n", req_count);
         printf("CoAP open requests: %u\n", open_reqs);
         return 0;
@@ -314,7 +314,7 @@ int gcoap_cli_cmd(int argc, char **argv)
      */
     if (((argc == apos + 3) && (code_pos == 0)) ||
         ((argc == apos + 4) && (code_pos != 0))) {
-        gcoap_req_init(&pdu, &buf[0], GCOAP_PDU_BUF_SIZE, code_pos+1, argv[apos+2]);
+        gcoap_req_init(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE, code_pos+1, argv[apos+2]);
         coap_hdr_set_type(pdu.hdr, msg_type);
 
         memset(_last_req_path, 0, _LAST_REQ_PATH_MAX);
@@ -346,7 +346,7 @@ int gcoap_cli_cmd(int argc, char **argv)
         }
         else {
             /* send Observe notification for /cli/stats */
-            switch (gcoap_obs_init(&pdu, &buf[0], GCOAP_PDU_BUF_SIZE,
+            switch (gcoap_obs_init(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE,
                     &_resources[0])) {
             case GCOAP_OBS_INIT_OK:
                 DEBUG("gcoap_cli: creating /cli/stats notification\n");

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -159,7 +159,7 @@ void auto_init(void)
     openthread_bootstrap();
 #endif
 #ifdef MODULE_GCOAP
-    if (!IS_ACTIVE(GCOAP_NO_AUTO_INIT)) {
+    if (!IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
         DEBUG("Auto init gcoap module.\n");
         gcoap_init();
     }

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -42,7 +42,7 @@
  *
  * ## Server Operation ##
  *
- * gcoap listens for requests on GCOAP_PORT, 5683 by default. You can redefine
+ * gcoap listens for requests on CONFIG_GCOAP_PORT, 5683 by default. You can redefine
  * this by uncommenting the appropriate lines in gcoap's make file.
  *
  * gcoap allows an application to specify a collection of request resource paths
@@ -193,7 +193,7 @@
  *
  * By default, the value for the Observe option in a notification is three
  * bytes long. For resources that change slowly, this length can be reduced via
- * GCOAP_OBS_VALUE_WIDTH.
+ * CONFIG_GCOAP_OBS_VALUE_WIDTH.
  *
  * A client always may re-register for a resource with the same token or with
  * a new token to indicate continued interest in receiving notifications about
@@ -365,22 +365,22 @@ extern "C" {
 /**
  * @brief  Size for module message queue
  */
-#ifndef GCOAP_MSG_QUEUE_SIZE
-#define GCOAP_MSG_QUEUE_SIZE    (4)
+#ifndef CONFIG_GCOAP_MSG_QUEUE_SIZE
+#define CONFIG_GCOAP_MSG_QUEUE_SIZE    (4)
 #endif
 
 /**
  * @brief   Server port; use RFC 7252 default if not defined
  */
-#ifndef GCOAP_PORT
-#define GCOAP_PORT              (5683)
+#ifndef CONFIG_GCOAP_PORT
+#define CONFIG_GCOAP_PORT              (5683)
 #endif
 
 /**
  * @brief   Size of the buffer used to build a CoAP request or response
  */
-#ifndef GCOAP_PDU_BUF_SIZE
-#define GCOAP_PDU_BUF_SIZE      (128)
+#ifndef CONFIG_GCOAP_PDU_BUF_SIZE
+#define CONFIG_GCOAP_PDU_BUF_SIZE      (128)
 #endif
 
 /**
@@ -392,8 +392,8 @@ extern "C" {
  * @deprecated  Will not be available after the 2020.07 release. Used only by
  * gcoap_finish(), which also is deprecated.
  */
-#ifndef GCOAP_REQ_OPTIONS_BUF
-#define GCOAP_REQ_OPTIONS_BUF   (4)
+#ifndef CONFIG_GCOAP_REQ_OPTIONS_BUF
+#define CONFIG_GCOAP_REQ_OPTIONS_BUF   (4)
 #endif
 
 /**
@@ -405,8 +405,8 @@ extern "C" {
  * @deprecated  Will not be available after the 2020.07 release. Used only by
  * gcoap_finish(), which also is deprecated.
  */
-#ifndef GCOAP_RESP_OPTIONS_BUF
-#define GCOAP_RESP_OPTIONS_BUF  (4)
+#ifndef CONFIG_GCOAP_RESP_OPTIONS_BUF
+#define CONFIG_GCOAP_RESP_OPTIONS_BUF  (4)
 #endif
 
 /**
@@ -418,15 +418,15 @@ extern "C" {
  * @deprecated  Will not be available after the 2020.07 release. Used only by
  * gcoap_finish(), which also is deprecated.
  */
-#ifndef GCOAP_OBS_OPTIONS_BUF
-#define GCOAP_OBS_OPTIONS_BUF   (4)
+#ifndef CONFIG_GCOAP_OBS_OPTIONS_BUF
+#define CONFIG_GCOAP_OBS_OPTIONS_BUF   (4)
 #endif
 
 /**
  * @brief   Maximum number of requests awaiting a response
  */
-#ifndef GCOAP_REQ_WAITING_MAX
-#define GCOAP_REQ_WAITING_MAX   (2)
+#ifndef CONFIG_GCOAP_REQ_WAITING_MAX
+#define CONFIG_GCOAP_REQ_WAITING_MAX   (2)
 #endif
 /** @} */
 
@@ -446,8 +446,8 @@ extern "C" {
  *
  * Value must be in the range 0 to @ref GCOAP_TOKENLEN_MAX.
  */
-#ifndef GCOAP_TOKENLEN
-#define GCOAP_TOKENLEN          (2)
+#ifndef CONFIG_GCOAP_TOKENLEN
+#define CONFIG_GCOAP_TOKENLEN          (2)
 #endif
 
 /**
@@ -461,8 +461,8 @@ extern "C" {
  *
  * If disabled, gcoap_init() must be called by some other means.
  */
-#ifndef GCOAP_NO_AUTO_INIT
-#define GCOAP_NO_AUTO_INIT      0
+#ifndef CONFIG_GCOAP_NO_AUTO_INIT
+#define CONFIG_GCOAP_NO_AUTO_INIT      0
 #endif
 
 /**
@@ -485,8 +485,8 @@ extern "C" {
  * @ingroup net_gcoap_conf
  * @brief   Time in usec that the event loop waits for an incoming CoAP message
  */
-#ifndef GCOAP_RECV_TIMEOUT
-#define GCOAP_RECV_TIMEOUT      (1 * US_PER_SEC)
+#ifndef CONFIG_GCOAP_RECV_TIMEOUT
+#define CONFIG_GCOAP_RECV_TIMEOUT      (1 * US_PER_SEC)
 #endif
 
 #ifdef DOXYGEN
@@ -495,12 +495,12 @@ extern "C" {
  * @brief   Turns off retransmission backoff when defined (undefined per default)
  *
  * In normal operations the timeout between retransmissions doubles. When
- * GCOAP_NO_RETRANS_BACKOFF is defined this doubling does not happen.
+ * CONFIG_GCOAP_NO_RETRANS_BACKOFF is defined this doubling does not happen.
  *
  * @see COAP_ACK_TIMEOUT
  * @see COAP_ACK_VARIANCE
  */
-#define GCOAP_NO_RETRANS_BACKOFF
+#define CONFIG_GCOAP_NO_RETRANS_BACKOFF
 #endif
 
 /**
@@ -509,8 +509,8 @@ extern "C" {
  *
  * Set to 0 to disable timeout.
  */
-#ifndef GCOAP_NON_TIMEOUT
-#define GCOAP_NON_TIMEOUT       (5000000U)
+#ifndef CONFIG_GCOAP_NON_TIMEOUT
+#define CONFIG_GCOAP_NON_TIMEOUT       (5000000U)
 #endif
 
 /**
@@ -530,16 +530,16 @@ extern "C" {
  * @ingroup net_gcoap_conf
  * @brief   Maximum number of Observe clients
  */
-#ifndef GCOAP_OBS_CLIENTS_MAX
-#define GCOAP_OBS_CLIENTS_MAX   (2)
+#ifndef CONFIG_GCOAP_OBS_CLIENTS_MAX
+#define CONFIG_GCOAP_OBS_CLIENTS_MAX   (2)
 #endif
 
 /**
  * @ingroup net_gcoap_conf
  * @brief   Maximum number of registrations for Observable resources
  */
-#ifndef GCOAP_OBS_REGISTRATIONS_MAX
-#define GCOAP_OBS_REGISTRATIONS_MAX     (2)
+#ifndef CONFIG_GCOAP_OBS_REGISTRATIONS_MAX
+#define CONFIG_GCOAP_OBS_REGISTRATIONS_MAX     (2)
 #endif
 
 /**
@@ -571,18 +571,18 @@ extern "C" {
  * sec). For resources that change only slowly, the reduced message length is
  * useful when packet size is limited.
  */
-#ifndef GCOAP_OBS_VALUE_WIDTH
-#define GCOAP_OBS_VALUE_WIDTH   (3)
+#ifndef CONFIG_GCOAP_OBS_VALUE_WIDTH
+#define CONFIG_GCOAP_OBS_VALUE_WIDTH   (3)
 #endif
 
 /**
- * @brief   See GCOAP_OBS_VALUE_WIDTH
+ * @brief   See CONFIG_GCOAP_OBS_VALUE_WIDTH
  */
-#if (GCOAP_OBS_VALUE_WIDTH == 3)
+#if (CONFIG_GCOAP_OBS_VALUE_WIDTH == 3)
 #define GCOAP_OBS_TICK_EXPONENT (5)
-#elif (GCOAP_OBS_VALUE_WIDTH == 2)
+#elif (CONFIG_GCOAP_OBS_VALUE_WIDTH == 2)
 #define GCOAP_OBS_TICK_EXPONENT (16)
-#elif (GCOAP_OBS_VALUE_WIDTH == 1)
+#elif (CONFIG_GCOAP_OBS_VALUE_WIDTH == 1)
 #define GCOAP_OBS_TICK_EXPONENT (24)
 #endif
 
@@ -607,8 +607,8 @@ extern "C" {
  * @ingroup net_gcoap_conf
  * @brief   Count of PDU buffers available for resending confirmable messages
  */
-#ifndef GCOAP_RESEND_BUFS_MAX
-#define GCOAP_RESEND_BUFS_MAX      (1)
+#ifndef CONFIG_GCOAP_RESEND_BUFS_MAX
+#define CONFIG_GCOAP_RESEND_BUFS_MAX      (1)
 #endif
 
 /**

--- a/sys/net/Kconfig
+++ b/sys/net/Kconfig
@@ -6,6 +6,7 @@
 #
 menu "Networking"
 
+rsource "application_layer/gcoap/Kconfig"
 rsource "gnrc/Kconfig"
 rsource "sock/Kconfig"
 

--- a/sys/net/application_layer/gcoap/Kconfig
+++ b/sys/net/application_layer/gcoap/Kconfig
@@ -1,0 +1,144 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GCOAP
+    bool "Configure Gcoap"
+    depends on MODULE_GCOAP
+    help
+        Configure Gcoap module using Kconfig. If not set default values and
+        CFLAGS will be used.
+
+if KCONFIG_MODULE_GCOAP
+
+menu "Buffer Sizes"
+
+config GCOAP_PDU_BUF_SIZE
+    int "Request or response buffer size"
+    default 128
+    help
+        Size of the buffer used to build a CoAP request or response.
+
+config GCOAP_REQ_OPTIONS_BUF
+    int "Request options buffer size"
+    default 4
+    help
+        Reduce payload length by this value for a request.
+        Accommodates writing Content-Format option in gcoap_finish(). May be
+        set to zero if the function is not used.
+
+config GCOAP_RESP_OPTIONS_BUF
+    int "Response options buffer size"
+    default 4
+    help
+        Reduce payload length by this value for a response.
+        Accommodates writing Content-Format option in gcoap_finish(). May be
+        set to zero if the function is not used.
+
+config GCOAP_OBS_OPTIONS_BUF
+    int "Observe notification options buffer size"
+    default 4
+    help
+        Reduce payload length by this value for an observe notification.
+        Accommodates writing Content-Format option in gcoap_finish(). May be
+        set to zero if the function is not used.
+
+endmenu # Buffer Sizes
+
+menu "Observe options"
+
+config GCOAP_OBS_CLIENTS_MAX
+    int "Maximum number of Observe clients"
+    default 2
+
+config GCOAP_OBS_REGISTRATIONS_MAX
+    int "Maximum number of registrations for Observable resources"
+    default 2
+
+config GCOAP_OBS_VALUE_WIDTH
+    int "Width of the Observe option value for a notification"
+    default 3
+    range 1 3
+    help
+        This width, expressed in bytes, is used to determine the length of the
+        'tick' used to measure the time between observable changes to a
+        resource. A tick is expressed internally as GCOAP_OBS_TICK_EXPONENT,
+        which is the base 2 log value of the tick length in microseconds.
+
+        The canonical setting for the value is 3 (exponent 5), which results in
+        a tick length of 32 usec, per sec. 3.4, 4.4 of the RFC. Width 2
+        (exponent 16) results in a tick length of ~64 msec, and width 1
+        (exponent 24) results in a tick length of ~17 sec.
+
+        The tick length must be short enough so that the Observe value strictly
+        increases for each new notification. The purpose of the value is to
+        allow a client to detect message reordering withing the network latency
+        period (128 sec). For resources that change slowly, the reduced
+        message length is useful when packet size is limited.
+
+endmenu # Observe options
+
+menu "Timeouts and retries"
+
+config GCOAP_RECV_TIMEOUT
+    int "Incoming message timeout"
+    default 1000000
+    help
+        Time, expressed in microseconds, that the event loop waits for an
+        incoming CoAP message.
+
+config GCOAP_NON_TIMEOUT
+    int "Non-confirmable response timeout"
+    default 5000000
+    help
+        Time, expressed in microseconds, to wait for a non-confirmable
+        response. Set to 0 to disable timeout.
+
+config GCOAP_NO_RETRANS_BACKOFF
+    bool "Disable retransmission backoff"
+    help
+        In normal operations the timeout between retransmissions doubles.
+        When this option is selected the doubling does not happen, as the
+        retransmission backoff is disabled.
+
+config GCOAP_RESEND_BUFS_MAX
+    int "PDU buffers available for resending confirmable messages"
+    default 1
+
+endmenu # Timeouts and retries
+
+config GCOAP_MSG_QUEUE_SIZE
+    int "Message queue size"
+    default 4
+
+config GCOAP_PORT
+    int "Server port"
+    default 5683
+    help
+        Server port, the default is the one specified in RFC 7252.
+
+config GCOAP_REQ_WAITING_MAX
+    int "Maximum awaiting requests"
+    default 2
+    help
+       Maximum amount of requests awaiting for a response.
+
+# defined in gcoap.h as GCOAP_TOKENLEN_MAX
+gcoap-tokenlen-max = 8
+
+config GCOAP_TOKENLEN
+    int "Token length"
+    default 2
+    range 0 $(gcoap-tokenlen-max)
+    help
+        Lenght for a token, expressed in bytes.
+
+config GCOAP_NO_AUTO_INIT
+    bool "Disable auto-initialization"
+    help
+        Disable gcoap startup during system auto init. If disabled,
+        gcoap_init() must be called by some other means.
+
+endif # KCONFIG_MODULE_GCOAP

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -54,36 +54,38 @@ static const char *resource_list_str = "</act/switch>,</sensor/temp>,</test/info
 /*
  * Client GET request success case. Test request generation.
  * Request /time resource from libcoap example
- * Includes token of length GCOAP_TOKENLEN.
+ * Includes token of length CONFIG_GCOAP_TOKENLEN.
  */
 static void test_gcoap__client_get_req(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
     size_t len;
     char path[] = "/time";
 
-    /* Create expected pdu_data, with token length from GCOAP_TOKENLEN. */
+    /* Create expected pdu_data, with token length from CONFIG_GCOAP_TOKENLEN. */
     size_t hdr_fixed_len = 4;
     uint8_t hdr_fixed[]  = { 0x52, 0x01, 0xe6, 0x02 };
     size_t options_len   = 5;
     uint8_t options[]    = { 0xb4, 0x74, 0x69, 0x6d, 0x65 };
 
-    uint8_t pdu_data[hdr_fixed_len + GCOAP_TOKENLEN + options_len];
+    uint8_t pdu_data[hdr_fixed_len + CONFIG_GCOAP_TOKENLEN + options_len];
 
     memcpy(&pdu_data[0], &hdr_fixed[0], hdr_fixed_len);
-#if GCOAP_TOKENLEN
+#if CONFIG_GCOAP_TOKENLEN
     /* actual value is random */
-    memset(&pdu_data[hdr_fixed_len], 0x9b, GCOAP_TOKENLEN);
+    memset(&pdu_data[hdr_fixed_len], 0x9b, CONFIG_GCOAP_TOKENLEN);
 #endif
-    memcpy(&pdu_data[hdr_fixed_len + GCOAP_TOKENLEN], &options[0], options_len);
+    memcpy(&pdu_data[hdr_fixed_len + CONFIG_GCOAP_TOKENLEN], &options[0],
+           options_len);
 
-    len = gcoap_request(&pdu, &buf[0], GCOAP_PDU_BUF_SIZE, COAP_METHOD_GET,
-                                                           &path[0]);
+    len = gcoap_request(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE,
+                                                COAP_METHOD_GET, &path[0]);
 
     TEST_ASSERT_EQUAL_INT(COAP_METHOD_GET, coap_get_code(&pdu));
-    TEST_ASSERT_EQUAL_INT(GCOAP_TOKENLEN, coap_get_token_len(&pdu));
-    TEST_ASSERT_EQUAL_INT(hdr_fixed_len + GCOAP_TOKENLEN, coap_get_total_hdr_len(&pdu));
+    TEST_ASSERT_EQUAL_INT(CONFIG_GCOAP_TOKENLEN, coap_get_token_len(&pdu));
+    TEST_ASSERT_EQUAL_INT(hdr_fixed_len + CONFIG_GCOAP_TOKENLEN,
+                          coap_get_total_hdr_len(&pdu));
     TEST_ASSERT_EQUAL_INT(COAP_TYPE_NON, coap_get_type(&pdu));
 
     char uri[NANOCOAP_URI_MAX] = {0};
@@ -100,7 +102,7 @@ static void test_gcoap__client_get_req(void)
  */
 static void test_gcoap__client_get_resp(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
     int res;
     size_t hdr_fixed_len = 4;
@@ -135,13 +137,13 @@ static void test_gcoap__client_get_resp(void)
  */
 static void test_gcoap__client_put_req(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE]; /* header 4, token 2, path 11 */
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE]; /* header 4, token 2, path 11 */
     coap_pkt_t pdu;
     size_t len;
     char path[] = "/riot/value";
     char payload[] = "1";
 
-    gcoap_req_init(&pdu, buf, GCOAP_PDU_BUF_SIZE, COAP_METHOD_PUT, path);
+    gcoap_req_init(&pdu, buf, CONFIG_GCOAP_PDU_BUF_SIZE, COAP_METHOD_PUT, path);
     coap_opt_add_format(&pdu, COAP_FORMAT_TEXT);
     len = coap_opt_finish(&pdu, COAP_OPT_FINISH_PAYLOAD);
     memcpy(pdu.payload, payload, 1);
@@ -159,7 +161,7 @@ static void test_gcoap__client_put_req(void)
 static void test_gcoap__client_put_req_overfill(void)
 {
     /* header 4, token 2, path 11, format 1, marker 1 = 19 */
-    uint8_t buf[18+GCOAP_REQ_OPTIONS_BUF];
+    uint8_t buf[18+CONFIG_GCOAP_REQ_OPTIONS_BUF];
     coap_pkt_t pdu;
     ssize_t len;
     char path[] = "/riot/value";
@@ -180,7 +182,7 @@ static void test_gcoap__client_put_req_overfill(void)
  */
 static void test_gcoap__client_get_query(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
     char path[] = "/time";
     char key1[] = "ab";
@@ -189,7 +191,7 @@ static void test_gcoap__client_get_query(void)
     char expected[] = "ab=cde&f";
     int optlen;
 
-    gcoap_req_init(&pdu, buf, GCOAP_PDU_BUF_SIZE, COAP_METHOD_GET, path);
+    gcoap_req_init(&pdu, buf, CONFIG_GCOAP_PDU_BUF_SIZE, COAP_METHOD_GET, path);
 
     optlen = gcoap_add_qstring(&pdu, key1, val1);
     TEST_ASSERT_EQUAL_INT(7, optlen);
@@ -212,18 +214,19 @@ static void test_gcoap__client_get_query(void)
  */
 static void test_gcoap__client_get_path_defer(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
     size_t len, optlen;
     char path[] = "/time";
 
-    gcoap_req_init(&pdu, buf, GCOAP_PDU_BUF_SIZE, COAP_METHOD_GET, NULL);
+    gcoap_req_init(&pdu, buf, CONFIG_GCOAP_PDU_BUF_SIZE, COAP_METHOD_GET, NULL);
     coap_opt_add_uint(&pdu, COAP_OPT_OBSERVE, 0);
     coap_opt_add_string(&pdu, COAP_OPT_URI_PATH, path, '/');
     optlen = 6;
 
     len = coap_opt_finish(&pdu, COAP_OPT_FINISH_NONE);
-    TEST_ASSERT_EQUAL_INT(len, sizeof(coap_hdr_t) + GCOAP_TOKENLEN + optlen);
+    TEST_ASSERT_EQUAL_INT(len,
+                          sizeof(coap_hdr_t) + CONFIG_GCOAP_TOKENLEN +optlen);
 
     coap_parse(&pdu, buf, len);
 
@@ -255,7 +258,7 @@ static int _read_cli_stats_req(coap_pkt_t *pdu, uint8_t *buf)
 /* Server GET request success case. Validate request example. */
 static void test_gcoap__server_get_req(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
 
     int res = _read_cli_stats_req(&pdu, &buf[0]);
@@ -278,7 +281,7 @@ static void test_gcoap__server_get_req(void)
  */
 static void test_gcoap__server_get_resp(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
 
     /* read request */
@@ -327,7 +330,7 @@ static int _read_cli_stats_req_con(coap_pkt_t *pdu, uint8_t *buf)
 /* Server CON GET request success case. Validate request is confirmable. */
 static void test_gcoap__server_con_req(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
 
     int res = _read_cli_stats_req_con(&pdu, &buf[0]);
@@ -343,7 +346,7 @@ static void test_gcoap__server_con_req(void)
  */
 static void test_gcoap__server_con_resp(void)
 {
-    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
 
     /* read request */


### PR DESCRIPTION
### Contribution description
This PR adds the `CONFIG_` prefix to Gcoap's configuration macros and then exposes those options to Kconfig.

The approach is to have a menuconfig entry for the module (`KCONFIG_MODULE_GCOAP`) which enables/disables the configuration of Gcoap via Kconfig. This entry will only show when the module is being used (`depends on MODULE_GCOAP`).

`MODULE_` symbols are declared in the `Kconfig.dep` file generated from `USEMODULES`:
https://github.com/RIOT-OS/RIOT/blob/c6b9f9509c9ec1608489a9718380d3bbabb5fefe/makefiles/kconfig.mk#L54-L58

### Testing procedure
- Gcoap's example application should still be working as usual (`make all`). In this case the applied configurations should be the ones declared in `gcoap.h`.
- Running `make menuconfig` in Gcoap's example application should reveal the menuconfig interface and Gcoap's configurations. Configurations selected via this interface should be applied to the application.

### Issues/PRs references
#12888