### PR TITLE
cpu/esp*: fixes for tests/pkg_spiffs and tests/pkg_littlefs

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -63,11 +63,11 @@ ifneq (,$(filter esp_eth,$(USEMODULE)))
 endif
 
 ifneq (,$(filter spiffs,$(USEMODULE)))
-  export RIOT_TEST_TIMEOUT = 300
+  export RIOT_TEST_TIMEOUT = 120
 endif
 
 ifneq (,$(filter littlefs,$(USEMODULE)))
-  export RIOT_TEST_TIMEOUT = 300
+  export RIOT_TEST_TIMEOUT = 120
 endif
 
 # ESP32 pseudomodules

--- a/cpu/esp32/ld/esp32.common.ld
+++ b/cpu/esp32/ld/esp32.common.ld
@@ -101,8 +101,9 @@ SECTIONS
     *esp_idf_spi_flash.a:*(.literal .text .literal.* .text.*)
     /* parts of RIOT that should to run in IRAM */
     *core.a:*(.literal .text .literal.* .text.*)
-    /* *spiffs_fs.a:*(.literal .text .literal.* .text.*) */
-    /* *spiffs.a:*(.literal .text .literal.* .text.*) */
+    *spiffs_fs.a:*(.literal .text .literal.* .text.*)
+    *spiffs.a:*(.literal .text .literal.* .text.*)
+    *vfs.a:*(.literal .text .literal.* .text.*)
 
     /* part of RIOT ports that should run in IRAM */
     *cpu.a:*(.literal .text .literal.* .text.*)

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -47,11 +47,11 @@ ifneq (, $(filter esp_gdbstub, $(USEMODULE)))
 endif
 
 ifneq (, $(filter spiffs, $(USEMODULE)))
-    export RIOT_TEST_TIMEOUT = 300
+    export RIOT_TEST_TIMEOUT = 200
 endif
 
 ifneq (, $(filter littlefs, $(USEMODULE)))
-    export RIOT_TEST_TIMEOUT = 300
+    export RIOT_TEST_TIMEOUT = 200
 endif
 
 # regular Makefile


### PR DESCRIPTION
### Contribution description

This PR fixes the problem with `tests/pkg_spiffs` that occurred in #11449 after merging PR #12810.

SPI flash write operations require to disable the cache for the program code in SPI flash memory. Therefore, the program code required during SPI flash write operations has to be placed in IRAM. With this PR, the code of `pkg_spiffs` and `vfs` is therefore placed in IRAM by the linker script.

Furthermore, this PR reduces the configured test timeout for `tests/pkg_spiffs` and `tests/pkg_littlefs` to avoid that murdock times out before these tests time out. The configured timeout is now 200 seconds which should be enough. An ESP32 needs an average of 60 seconds for these tests, while an ESP8266 needs in average 100 seconds.

### Testing procedure

Flash and test `tests/pkg_spiffs` with and without this PR.
```
make BOARD=esp32-wroom-32 -C tests/pkg_littlefs flash test
```
The test should crash or timeout without this PR and should work as expected with the PR.

### Issues/PRs references

Solves the problem with `tests/pkg_spiffs` in #11449.