### PR TITLE
tools/testrunner: make interactive test sync retries/delay configurable

### DIFF
--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -24,6 +24,10 @@ RIOTBASE = (os.environ.get('RIOTBASE') or
 # default value (3)
 MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
 
+# Allow customizing test interactive settings with environment variables
+TEST_INTERACTIVE_RETRIES = int(os.environ.get('TEST_INTERACTIVE_RETRIES') or 5)
+TEST_INTERACTIVE_DELAY = int(os.environ.get('TEST_INTERACTIVE_DELAY') or 1)
+
 
 def list_until(l, cond):
     return l[:([i for i, e in enumerate(l) if cond(e)][0])]
@@ -79,8 +83,10 @@ def sync_child(child):
     _test_utils_interactive_sync(child, modules)
 
 
-def _test_utils_interactive_sync(child, modules, retries=5, delay=1):
+def _test_utils_interactive_sync(child, modules):
     if 'test_utils_interactive_sync' not in modules:
         return
 
-    utils.test_utils_interactive_sync(child, retries=retries, delay=delay)
+    utils.test_utils_interactive_sync(child,
+                                      TEST_INTERACTIVE_RETRIES,
+                                      TEST_INTERACTIVE_DELAY)

--- a/dist/pythonlibs/testrunner/utils.py
+++ b/dist/pythonlibs/testrunner/utils.py
@@ -9,7 +9,7 @@
 import pexpect
 
 
-def test_utils_interactive_sync(child, retries=5, delay=1):
+def test_utils_interactive_sync(child, retries, delay):
     """Synchronisation for 'test_utils_interactive_sync' function.
 
     Interacts through input to wait for node being ready.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix (most of) the automatic tests on hifive1b.
On this board, with the new test_interactive_sync feature, sending too much characters on UART before the firmware is ready can lead to a crash. Example on master:
```
Bench Clock Reset Complete

ATE0-->ATE0
OK
AT+BLEINIT=0-->OK
AT+CWMODE=0-->OK

r
r
Unhandled trap:
  mcause: 0x00000002
  mepc:   0x00000000
  mtval:  0x00000000
*** RIOT kernel panic:
Unhandled trap

*** halted.
```

The proposed solution is to make the test_interactive_sync delay/retries configurable from environment variables and use a large enough delay value for hifive1b. 3 seconds is enough.

I also tried to find a fix by looking at the fe310 cpu initialization but couldn't find it and I have no idea how this could be fixed from there.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `compile_and_test_for_board.py` for hifive1b: on master almost all tests are failing with the above message. With this PR they are almost all passing. Some tests are failing because of a bug on fe310, some tests can randomly fail because the flasher fails or because some initialization sequence with the on-board ESP32 radio fails.

Here I give the final results (no output) with this PR (on master they all fail):

<details>

```
Failures during compilation:
- [tests/lwip_sock_ip](tests/lwip_sock_ip/compilation.failed)
- [tests/lwip_sock_tcp](tests/lwip_sock_tcp/compilation.failed)
- [tests/lwip_sock_udp](tests/lwip_sock_udp/compilation.failed)

Failures during test:
- [tests/bench_sizeof_coretypes](tests/bench_sizeof_coretypes/test.failed)
- [tests/bitarithm_timings](tests/bitarithm_timings/test.failed)
- [tests/gnrc_ipv6_fwd_w_sub](tests/gnrc_ipv6_fwd_w_sub/test.failed)
- [tests/gnrc_ipv6_nib](tests/gnrc_ipv6_nib/test.failed)
- [tests/gnrc_ndp](tests/gnrc_ndp/test.failed)
- [tests/pkg_nanopb](tests/pkg_nanopb/test.failed)
- [tests/pkg_tinycbor](tests/pkg_tinycbor/test.failed)
- [tests/ps_schedstatistics](tests/ps_schedstatistics/test.failed)
- [tests/pthread_barrier](tests/pthread_barrier/test.failed)
- [tests/pthread_condition_variable](tests/pthread_condition_variable/test.failed)
- [tests/pthread_tls](tests/pthread_tls/test.failed)
- [tests/shell](tests/shell/test.failed)
- [tests/stdin](tests/stdin/test.failed)
- [tests/thread_exit](tests/thread_exit/test.failed)
- [tests/xtimer_periodic_wakeup](tests/xtimer_periodic_wakeup/test.failed)
- [tests/xtimer_usleep](tests/xtimer_usleep/test.failed)

Failures during test.flash:
- [tests/events](tests/events/test.flash.failed)
- [tests/periph_timer](tests/periph_timer/test.flash.failed)
- [tests/pkg_ucglib](tests/pkg_ucglib/test.flash.failed)
- [tests/xtimer_msg_receive_timeout](tests/xtimer_msg_receive_timeout/test.flash.failed)
```

- lwip tests failed because of an issue during the download (error HTTP 502 when fetching the package)
- some xtimer tests don't work on this board
- some pthread test don't work on this board

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
