### PR TITLE
usbus_fmt: Add missing alt iface size increase

### DIFF
--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -199,6 +199,7 @@ static size_t _fmt_descriptors_iface_alts(usbus_t *usbus,
          alt = alt->next) {
         usb_descriptor_interface_t usb_iface;
         _fmt_descriptor_iface(iface, &usb_iface);
+        len += sizeof(usb_descriptor_interface_t);
         usb_iface.alternate_setting = alts++;
         usb_iface.num_endpoints = _num_endpoints_alt(alt);
         usbus_control_slicer_put_bytes(usbus, (uint8_t *)&usb_iface,


### PR DESCRIPTION
### Contribution description

The configuration length verification was not taking additional alt
interface descriptors into account. This breaks situations where an alt
interface is used such as is the case with CDC ECM

### Testing procedure

Without this PR, `tests/usbus_cdc_ecm` fails with an assertion failure when connected to an USB host. This PR fixes that

### Issues/PRs references

Caused by #12557 