### PR TITLE
Kconfig: Expose gnrc/ipv6/whitelist configurations

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -9,6 +9,8 @@ mainmenu "RIOT Configuration"
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
+rsource "sys/Kconfig"
+
 # The application may declare new symbols as well
 osource "$(APPDIR)/Kconfig"
 

--- a/sys/Kconfig
+++ b/sys/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menu "System"
+
+endmenu # System

--- a/sys/include/net/gnrc/ipv6/whitelist.h
+++ b/sys/include/net/gnrc/ipv6/whitelist.h
@@ -37,8 +37,8 @@ extern "C" {
 /**
  * Maximum size of the whitelist.
  */
-#ifndef GNRC_IPV6_WHITELIST_SIZE
-#define GNRC_IPV6_WHITELIST_SIZE    (8)
+#ifndef CONFIG_GNRC_IPV6_WHITELIST_SIZE
+#define CONFIG_GNRC_IPV6_WHITELIST_SIZE    (8)
 #endif
 /** @} */
 

--- a/sys/net/Kconfig
+++ b/sys/net/Kconfig
@@ -4,8 +4,6 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
-menu "System"
+menu "Networking"
 
-rsource "net/Kconfig"
-
-endmenu # System
+endmenu # Networking

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -7,4 +7,6 @@
 menu "GNRC Network stack"
     depends on MODULE_GNRC
 
+rsource "network_layer/ipv6/whitelist/Kconfig"
+
 endmenu # GNRC Network Stack

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -4,8 +4,7 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
-menu "Networking"
+menu "GNRC Network stack"
+    depends on MODULE_GNRC
 
-rsource "gnrc/Kconfig"
-
-endmenu # Networking
+endmenu # GNRC Network Stack

--- a/sys/net/gnrc/network_layer/ipv6/whitelist/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/whitelist/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_IPV6_WHITELIST
+    bool "Configure GNRC IPv6 Whitelisting"
+    depends on MODULE_GNRC_IPV6_WHITELIST
+    help
+        Configure GNRC IPv6 Whitelisting module using Kconfig.
+
+if KCONFIG_MODULE_GNRC_IPV6_WHITELIST
+
+config GNRC_IPV6_WHITELIST_SIZE
+    int "Maximum size of the whitelist"
+    default 8
+
+endif # KCONFIG_MODULE_GNRC_IPV6_WHITELIST

--- a/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist.c
+++ b/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist.c
@@ -21,14 +21,14 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-ipv6_addr_t gnrc_ipv6_whitelist[GNRC_IPV6_WHITELIST_SIZE];
-BITFIELD(gnrc_ipv6_whitelist_set, GNRC_IPV6_WHITELIST_SIZE);
+ipv6_addr_t gnrc_ipv6_whitelist[CONFIG_GNRC_IPV6_WHITELIST_SIZE];
+BITFIELD(gnrc_ipv6_whitelist_set, CONFIG_GNRC_IPV6_WHITELIST_SIZE);
 
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 int gnrc_ipv6_whitelist_add(const ipv6_addr_t *addr)
 {
-    for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
+    for (int i = 0; i < CONFIG_GNRC_IPV6_WHITELIST_SIZE; i++) {
         if (!bf_isset(gnrc_ipv6_whitelist_set, i)) {
             bf_set(gnrc_ipv6_whitelist_set, i);
             memcpy(&gnrc_ipv6_whitelist[i], addr, sizeof(*addr));
@@ -42,7 +42,7 @@ int gnrc_ipv6_whitelist_add(const ipv6_addr_t *addr)
 
 void gnrc_ipv6_whitelist_del(const ipv6_addr_t *addr)
 {
-    for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
+    for (int i = 0; i < CONFIG_GNRC_IPV6_WHITELIST_SIZE; i++) {
         if (ipv6_addr_equal(addr, &gnrc_ipv6_whitelist[i])) {
             bf_unset(gnrc_ipv6_whitelist_set, i);
             DEBUG("IPv6 whitelist: unwhitelisted %s\n",
@@ -53,7 +53,7 @@ void gnrc_ipv6_whitelist_del(const ipv6_addr_t *addr)
 
 bool gnrc_ipv6_whitelisted(const ipv6_addr_t *addr)
 {
-    for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
+    for (int i = 0; i < CONFIG_GNRC_IPV6_WHITELIST_SIZE; i++) {
         if (bf_isset(gnrc_ipv6_whitelist_set, i) &&
             ipv6_addr_equal(addr, &gnrc_ipv6_whitelist[i])) {
             return true;

--- a/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist_print.c
+++ b/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist_print.c
@@ -20,13 +20,13 @@
 
 #include "net/gnrc/ipv6/whitelist.h"
 
-extern ipv6_addr_t gnrc_ipv6_whitelist[GNRC_IPV6_WHITELIST_SIZE];
-extern BITFIELD(gnrc_ipv6_whitelist_set, GNRC_IPV6_WHITELIST_SIZE);
+extern ipv6_addr_t gnrc_ipv6_whitelist[CONFIG_GNRC_IPV6_WHITELIST_SIZE];
+extern BITFIELD(gnrc_ipv6_whitelist_set, CONFIG_GNRC_IPV6_WHITELIST_SIZE);
 
 void gnrc_ipv6_whitelist_print(void)
 {
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
+    for (int i = 0; i < CONFIG_GNRC_IPV6_WHITELIST_SIZE; i++) {
         if (bf_isset(gnrc_ipv6_whitelist_set, i)) {
             puts(ipv6_addr_to_str(addr_str, &gnrc_ipv6_whitelist[i], sizeof(addr_str)));
         }


### PR DESCRIPTION
### Contribution description
This moves the `gnrc_ipv6_whitelist` module configuration macros to the `CONFIG_` namespace and exposes them to Kconfig.

### Testing procedure
- Compile `gnrc_networking` example application using this module (`USEMODULE=gnrc_ipv6_whitelist make all term`), the default configuration should still be the same.

- Call menuconfig using this module (`USEMODULE=gnrc_ipv6_whitelist make menuconfig`), you should the list size as an option. The default list size should still be the same. If you change the value it should change in the app.

### Issues/PRs references
Part of #12888