### PR TITLE
net/gnrc: Group compile configuration Doxygen groups and add GNRC LoRaWAN

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -120,7 +120,7 @@ extern "C" {
 /**
  * @defgroup    net_gnrc_ipv6_conf  GNRC IPv6 compile configurations
  * @ingroup     net_gnrc_ipv6
- * @ingroup     config
+ * @ingroup     net_gnrc_conf
  * @{
  */
 /**

--- a/sys/include/net/gnrc/ipv6/blacklist.h
+++ b/sys/include/net/gnrc/ipv6/blacklist.h
@@ -33,7 +33,7 @@ extern "C" {
 /**
  * @defgroup    net_gnrc_ipv6_blacklist_conf GNRC IPv6 address blacklisting compile configurations
  * @ingroup     net_gnrc_ipv6_blacklist
- * @ingroup     config
+ * @ingroup     net_gnrc_conf
  * @{
  */
 /**

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    net_gnrc_ipv6_nib_conf  GNRC IPv6 NIB compile configurations
  * @ingroup     net_gnrc_ipv6_nib
- * @ingroup     config
+ * @ingroup     net_gnrc_conf
  * @brief       Configuration macros for neighbor information base
  * @{
  *

--- a/sys/include/net/gnrc/ipv6/whitelist.h
+++ b/sys/include/net/gnrc/ipv6/whitelist.h
@@ -31,7 +31,7 @@ extern "C" {
 /**
  * @defgroup    net_gnrc_ipv6_whitelist_conf GNRC IPv6 address whitelisting compile configurations
  * @ingroup     net_gnrc_ipv6_whitelist
- * @ingroup     config
+ * @ingroup     net_gnrc_conf
  * @{
  */
 /**

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -30,6 +30,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup net_gnrc_lorawan_conf GNRC LoRaWAN compile configurations
+ * @ingroup net_gnrc_conf
+ * @{
+ */
+/**
  * @brief maximum timer drift in percentage
  *
  * @note this is only a workaround to compensate inaccurate timers.
@@ -47,6 +52,7 @@ extern "C" {
 #ifndef CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT
 #define CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT 30
 #endif
+/** @} */
 
 #define GNRC_LORAWAN_REQ_STATUS_SUCCESS (0)     /**< MLME or MCPS request successful status */
 #define GNRC_LORAWAN_REQ_STATUS_DEFERRED (1)    /**< the MLME or MCPS confirm message is asynchronous */

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    net_gnrc_netif_conf GNRC network interface configurations
  * @ingroup     net_gnrc_netif
- * @ingroup     config
+ * @ingroup     net_gnrc_conf
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    net_gnrc_sixlowpan_config GNRC 6LoWPAN compile configurations
  * @ingroup     net_gnrc_sixlowpan
- * @ingroup     config
+ * @ingroup     net_gnrc_conf
  * @brief
  * @{
  *

--- a/sys/net/gnrc/doc.txt
+++ b/sys/net/gnrc/doc.txt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_conf GNRC compile configurations
+ * @ingroup     config
+ * @brief       Group of GNRC network stack compile time configurations
+ */


### PR DESCRIPTION
### Contribution description
The 'Compile time configurations' list in Doxygen is getting larger, this PR groups all GNRC configuration modules into `net_gnrc_conf`. It also adds GNRC LoRaWAN configurations to the documentation group.

### Testing procedure
Run `make doc`. Under `Modules > Compile time configurations` now you should see only one entry for GNRC compile configurations.

### Issues/PRs references
Part of #10566