### PR TITLE
cpu: move cpu level dependencies in dedicated Makefile.dep files

### DIFF
--- a/cpu/arm7_common/Makefile.dep
+++ b/cpu/arm7_common/Makefile.dep
@@ -1,0 +1,4 @@
+# use common ARM7 periph code
+USEMODULE += arm7_common_periph
+# use the nano-specs of Newlib when available
+USEMODULE += newlib_nano

--- a/cpu/arm7_common/Makefile.include
+++ b/cpu/arm7_common/Makefile.include
@@ -3,11 +3,6 @@ export TARGET_ARCH ?= arm-none-eabi
 
 INCLUDES += -I$(RIOTBASE)/cpu/arm7_common/include/
 
-# use common ARM7 periph code
-USEMODULE += arm7_common_periph
-# use the nano-specs of Newlib when available
-USEMODULE += newlib_nano
-
 # currently only arm7tdmi-s is supported by RIOT, but allow overriding MCPU
 # if someone wants to add support for other ARM7 CPUs
 MCPU ?= arm7tdmi-s

--- a/cpu/atmega_common/Makefile.dep
+++ b/cpu/atmega_common/Makefile.dep
@@ -1,3 +1,6 @@
+# avr libc needs some RIOT-specific support code
+USEMODULE += avr_libc_extra
+
 # tell the build system to build the atmega common files
 USEMODULE += atmega_common
 

--- a/cpu/atmega_common/Makefile.dep
+++ b/cpu/atmega_common/Makefile.dep
@@ -4,6 +4,12 @@ USEMODULE += avr_libc_extra
 # tell the build system to build the atmega common files
 USEMODULE += atmega_common
 
+# peripheral drivers are linked into the final binary
+USEMODULE += atmega_common_periph
+
+# the atmel port uses stdio_uart
+USEMODULE += stdio_uart
+
 # expand atmega_pcint module
 ifneq (,$(filter atmega_pcint,$(USEMODULE)))
   USEMODULE += atmega_pcint0

--- a/cpu/atmega_common/Makefile.include
+++ b/cpu/atmega_common/Makefile.include
@@ -3,9 +3,6 @@ INCLUDES += -I$(RIOTCPU)/atmega_common/include \
             -isystem$(RIOTCPU)/atmega_common/avr_libc_extra/include \
             -isystem$(RIOTCPU)/atmega_common/avr_libc_extra/include/vendor
 
-# avr libc needs some RIOT-specific support code
-USEMODULE += avr_libc_extra
-
 PSEUDOMODULES += atmega_pcint
 PSEUDOMODULES += atmega_pcint%
 

--- a/cpu/cc13x2/Makefile.dep
+++ b/cpu/cc13x2/Makefile.dep
@@ -1,0 +1,1 @@
+include ${RIOTCPU}/cc26xx_cc13xx/Makefile.dep

--- a/cpu/cc26x0/Makefile.dep
+++ b/cpu/cc26x0/Makefile.dep
@@ -1,0 +1,1 @@
+include ${RIOTCPU}/cc26xx_cc13xx/Makefile.dep

--- a/cpu/cc26xx_cc13xx/Makefile.dep
+++ b/cpu/cc26xx_cc13xx/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += periph_common cc26xx_cc13xx_periph

--- a/cpu/cc26xx_cc13xx/Makefile.include
+++ b/cpu/cc26xx_cc13xx/Makefile.include
@@ -1,5 +1,4 @@
 VARIANT = $(shell echo $(CPU_VARIANT) | tr 'a-z-' 'A-Z_')
 CFLAGS += -DCPU_VARIANT_$(VARIANT)
 
-USEMODULE += periph_common cc26xx_cc13xx_periph
 INCLUDES += -I${RIOTCPU}/cc26xx_cc13xx/include

--- a/cpu/cc430/Makefile.dep
+++ b/cpu/cc430/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += periph
+
+include $(RIOTCPU)/msp430_common/Makefile.dep

--- a/cpu/cc430/Makefile.include
+++ b/cpu/cc430/Makefile.include
@@ -1,3 +1,1 @@
 include $(RIOTCPU)/msp430_common/Makefile.include
-
-export USEMODULE += periph

--- a/cpu/efm32/Makefile.dep
+++ b/cpu/efm32/Makefile.dep
@@ -5,3 +5,9 @@ endif
 ifneq (,$(filter periph_rtt,$(USEMODULE)))
   USEMODULE += periph_rtt_series$(EFM32_SERIES)
 endif
+
+# include Gecko SDK package
+USEPKG += gecko_sdk
+
+# include layered power management
+USEMODULE += pm_layered

--- a/cpu/efm32/Makefile.include
+++ b/cpu/efm32/Makefile.include
@@ -9,9 +9,6 @@ RIOTBOOT_LEN ?= 0x2000
 # the em_device.h header requires a global define with the cpu model
 CFLAGS += -D$(call uppercase_and_underscore,$(CPU_MODEL))
 
-# include Gecko SDK package
-USEPKG += gecko_sdk
-
 # CMSIS-DSP is needed for arm_math.h on Cortex-M0+ architectures
 ifeq ($(CPU_ARCH),cortex-m0plus)
   USEPKG += cmsis-dsp
@@ -22,9 +19,6 @@ USEMODULE += cpu_$(EFM32_FAMILY)
 
 # vectors.o is provided by 'cpu_$(EFM32_FAMILY)' and not by 'cpu'
 VECTORS_O := $(BINDIR)/cpu_$(EFM32_FAMILY)/vectors.o
-
-# include layered power management
-USEMODULE += pm_layered
 
 # include vendor device headers
 INCLUDES += -I$(RIOTCPU)/efm32/families/$(EFM32_FAMILY)/include/vendor

--- a/cpu/fe310/Makefile.dep
+++ b/cpu/fe310/Makefile.dep
@@ -1,3 +1,11 @@
+USEMODULE += newlib_nano
+
+USEMODULE += newlib_syscalls_fe310
+USEMODULE += sifive_drivers_fe310
+
+USEMODULE += periph
+USEMODULE += periph_pm
+
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtt
 endif

--- a/cpu/fe310/Makefile.include
+++ b/cpu/fe310/Makefile.include
@@ -1,12 +1,3 @@
-
-USEMODULE += newlib_nano
-
-USEMODULE += newlib_syscalls_fe310
-USEMODULE += sifive_drivers_fe310
-
-USEMODULE += periph
-USEMODULE += periph_pm
-
 CFLAGS += -Wno-pedantic
 
 include $(RIOTMAKE)/arch/riscv.inc.mk

--- a/cpu/lpc1768/Makefile.dep
+++ b/cpu/lpc1768/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += pm_layered

--- a/cpu/lpc1768/Makefile.include
+++ b/cpu/lpc1768/Makefile.include
@@ -1,5 +1,3 @@
 CPU_ARCH = cortex-m3
 
-USEMODULE += pm_layered
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/lpc2387/Makefile.dep
+++ b/cpu/lpc2387/Makefile.dep
@@ -1,0 +1,7 @@
+USEMODULE += arm7_common
+USEMODULE += bitfield
+USEMODULE += newlib
+USEMODULE += periph
+USEMODULE += pm_layered
+
+include $(RIOTCPU)/arm7_common/Makefile.dep

--- a/cpu/lpc2387/Makefile.include
+++ b/cpu/lpc2387/Makefile.include
@@ -1,4 +1,1 @@
 include $(RIOTCPU)/arm7_common/Makefile.include
-
-USEMODULE += arm7_common periph bitfield newlib
-USEMODULE += pm_layered

--- a/cpu/mips32r2_common/Makefile.dep
+++ b/cpu/mips32r2_common/Makefile.dep
@@ -1,0 +1,14 @@
+USEMODULE += mips32r2_common
+USEMODULE += mips32r2_common_periph
+USEMODULE += newlib
+
+# mips32 needs periph_timer for its gettimeofday() implementation
+FEATURES_REQUIRED += periph_timer
+
+ifeq ($(USE_UHI_SYSCALLS),1)
+  #Use UHI to handle syscalls
+  USEMODULE += newlib_syscalls_mips_uhi
+else
+  #Use RIOT to handle syscalls (default)
+  USEMODULE += newlib_syscalls_default
+endif

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -1,18 +1,7 @@
 INCLUDES += -I$(RIOTCPU)/mips32r2_common/include
 
-export USEMODULE += mips32r2_common
-export USEMODULE += mips32r2_common_periph
-export USEMODULE += newlib
-
-# mips32 needs periph_timer for its gettimeofday() implementation
-export USEMODULE += periph_timer
-
 ifeq ($(USE_UHI_SYSCALLS),1)
   #Use UHI to handle syscalls
   LINKFLAGS += -luhi
-  export USEMODULE += newlib_syscalls_mips_uhi
   CFLAGS += -DHAVE_HEAP_STATS
-else
-  #Use RIOT to handle syscalls (default)
-  export USEMODULE += newlib_syscalls_default
 endif

--- a/cpu/mips_pic32_common/Makefile.dep
+++ b/cpu/mips_pic32_common/Makefile.dep
@@ -1,0 +1,4 @@
+USEMODULE += mips_pic32_common
+USEMODULE += mips_pic32_common_periph
+
+include $(RIOTCPU)/mips32r2_common/Makefile.dep

--- a/cpu/mips_pic32_common/Makefile.include
+++ b/cpu/mips_pic32_common/Makefile.include
@@ -1,6 +1,3 @@
 include $(RIOTCPU)/mips32r2_common/Makefile.include
 
 INCLUDES += -I$(RIOTCPU)/mips_pic32_common/include
-
-USEMODULE += mips_pic32_common
-USEMODULE += mips_pic32_common_periph

--- a/cpu/mips_pic32mx/Makefile.dep
+++ b/cpu/mips_pic32mx/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/mips_pic32_common/Makefile.dep

--- a/cpu/mips_pic32mz/Makefile.dep
+++ b/cpu/mips_pic32mz/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/mips_pic32_common/Makefile.dep

--- a/cpu/msp430_common/Makefile.dep
+++ b/cpu/msp430_common/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += msp430_common msp430_common_periph msp430_malloc
+
+DEFAULT_MODULE += oneway_malloc

--- a/cpu/msp430_common/Makefile.include
+++ b/cpu/msp430_common/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTCPU)/msp430_common/include/
 CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))
 
 export UNDEF += $(BINDIR)/msp430_common/startup.o
-export USEMODULE += msp430_common msp430_common_periph msp430_malloc
-
-DEFAULT_MODULE += oneway_malloc
 
 # include the msp430 common Makefile
 include $(RIOTMAKE)/arch/msp430.inc.mk

--- a/cpu/msp430fxyz/Makefile.dep
+++ b/cpu/msp430fxyz/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += periph stdio_uart
+
+include $(RIOTCPU)/msp430_common/Makefile.dep

--- a/cpu/msp430fxyz/Makefile.include
+++ b/cpu/msp430fxyz/Makefile.include
@@ -1,3 +1,1 @@
 include $(RIOTCPU)/msp430_common/Makefile.include
-
-export USEMODULE += periph stdio_uart

--- a/cpu/nrf51/Makefile.dep
+++ b/cpu/nrf51/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/nrf5x_common/Makefile.dep

--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -4,3 +4,5 @@ ifneq (,$(filter nrf802154,$(USEMODULE)))
   USEMODULE += luid
   USEMODULE += netdev_ieee802154
 endif
+
+include $(RIOTCPU)/nrf5x_common/Makefile.dep

--- a/cpu/nrf5x_common/Makefile.dep
+++ b/cpu/nrf5x_common/Makefile.dep
@@ -1,0 +1,5 @@
+# include nrf5x common periph drivers
+USEMODULE += nrf5x_common_periph
+
+# link common cpu code
+USEMODULE += cpu_common

--- a/cpu/nrf5x_common/Makefile.include
+++ b/cpu/nrf5x_common/Makefile.include
@@ -1,9 +1,3 @@
 CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 
-# include nrf5x common periph drivers
-USEMODULE += nrf5x_common_periph
-
-# link common cpu code
-USEMODULE += cpu_common
-
 INCLUDES += -I$(RIOTCPU)/nrf5x_common/include

--- a/cpu/sam0_common/Makefile.dep
+++ b/cpu/sam0_common/Makefile.dep
@@ -1,3 +1,9 @@
 ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
   USEMODULE += tsrb
 endif
+
+# All SAM0 based CPUs provide PM
+USEMODULE += pm_layered
+
+# include sam0 common periph drivers
+USEMODULE += sam0_common_periph

--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -31,7 +31,4 @@ LINKER_SCRIPT ?= cortexm.ld
 # define sam0 specific pseudomodules
 PSEUDOMODULES += sam0_periph_uart_hw_fc
 
-# include sam0 common periph drivers
-USEMODULE += sam0_common_periph
-
 INCLUDES += -I$(RIOTCPU)/sam0_common/include

--- a/cpu/samd21/Makefile.include
+++ b/cpu/samd21/Makefile.include
@@ -1,7 +1,5 @@
 CPU_ARCH = cortex-m0plus
 CPU_FAM  = samd21
 
-USEMODULE += pm_layered
-
 include $(RIOTCPU)/sam0_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/samd5x/Makefile.include
+++ b/cpu/samd5x/Makefile.include
@@ -6,8 +6,6 @@ CPU_FAM  = samd5x
 # flash cannot be divided by two slots while staying FLASHPAGE_SIZE aligned.
 RIOTBOOT_LEN ?= 0x4000
 
-USEMODULE += pm_layered
-
 BACKUP_RAM_ADDR = 0x47000000
 BACKUP_RAM_LEN  = 0x2000
 

--- a/cpu/saml1x/Makefile.include
+++ b/cpu/saml1x/Makefile.include
@@ -1,6 +1,4 @@
 CPU_ARCH = cortex-m23
 
-USEMODULE += pm_layered
-
 include $(RIOTCPU)/sam0_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/saml21/Makefile.include
+++ b/cpu/saml21/Makefile.include
@@ -1,8 +1,6 @@
 CPU_ARCH = cortex-m0plus
 CPU_FAM  = saml21
 
-USEMODULE += pm_layered
-
 ifneq (,$(filter saml21j18b saml21j18a samr30g18a samr34j18b,$(CPU_MODEL)))
   BACKUP_RAM_ADDR = 0x30000000
   BACKUP_RAM_LEN  = 0x2000

--- a/cpu/stm32_common/Makefile.dep
+++ b/cpu/stm32_common/Makefile.dep
@@ -1,0 +1,5 @@
+# All stm32 families provide pm support
+USEMODULE += pm_layered
+
+# include stm32 common functions and stm32 common periph drivers
+USEMODULE += stm32_common stm32_common_periph

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -1,11 +1,5 @@
 CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 
-# All stm32 families provide pm support
-USEMODULE += pm_layered
-
-# include stm32 common functions and stm32 common periph drivers
-USEMODULE += stm32_common stm32_common_periph
-
 # For stm32 cpu's we use the stm32_common.ld linker script
 LINKFLAGS += -L$(RIOTCPU)/stm32_common/ldscripts
 LINKER_SCRIPT ?= stm32_common.ld

--- a/cpu/stm32f0/Makefile.dep
+++ b/cpu/stm32f0/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f1/Makefile.dep
+++ b/cpu/stm32f1/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f2/Makefile.dep
+++ b/cpu/stm32f2/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f3/Makefile.dep
+++ b/cpu/stm32f3/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f4/Makefile.dep
+++ b/cpu/stm32f4/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f7/Makefile.dep
+++ b/cpu/stm32f7/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32l0/Makefile.dep
+++ b/cpu/stm32l0/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32l1/Makefile.dep
+++ b/cpu/stm32l1/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32l4/Makefile.dep
+++ b/cpu/stm32l4/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/makefiles/arch/atmega.inc.mk
+++ b/makefiles/arch/atmega.inc.mk
@@ -11,15 +11,6 @@ ASFLAGS   += $(CFLAGS_CPU) $(CFLAGS_DBG)
 LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -e reset_handler -Wl,--gc-sections
 OFLAGS    += -j .text -j .data
 
-# Tell the build system that the CPU depends on the atmega common files:
-USEMODULE += atmega_common
-
-# export the peripheral drivers to be linked into the final binary
-USEMODULE += atmega_common_periph
-
-# the atmel port uses stdio_uart
-USEMODULE += stdio_uart
-
 # explicitly tell the linker to link the syscalls and startup code.
 # without this the interrupt vectors will not be linked correctly!
 UNDEF += $(BINDIR)/atmega_common/startup.o


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR moves some modules dependencies defined at CPU level (with `USEMODULE`, `FEATURES_REQUIRED`, `DEFAULT_MODULE`) from `Makefile.include` to `Makefile.dep`.

Note that `$(RIOTCPU)/$(CPU)/Makefile.dep` is automatically included in `$(RIOTBASE)/Makefile.dep`:
https://github.com/RIOT-OS/RIOT/blob/f2dbd3ba4addd0b776b25e69ed4593d4eee1910e/Makefile.dep#L8-L9

That's why new `Makefile.dep` files were introduced (for stm32, mips, etc).

Some CPU families are not fully "fixed": kinetis, efm32 and esp. They should be handled in separate PRs because more work is needed there.

Each CPU family is modified in a separate commit, that should simply the review.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- At least a green Murdock
- Maybe we should also check the modules loaded for each boards on each application ?

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Part of the work needed in #9913

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
