### PR TITLE
cpu/lpc2387: use the same default stack sizes as cortexm_common

### DIFF
--- a/cpu/lpc2387/include/cpu_conf.h
+++ b/cpu/lpc2387/include/cpu_conf.h
@@ -42,11 +42,10 @@ extern "C" {
  * @name Kernel configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF_FLOAT  (4096)
-#define THREAD_EXTRA_STACKSIZE_PRINTF        (2048)
+#define THREAD_EXTRA_STACKSIZE_PRINTF        (512)
 
 #ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (512)
+#define THREAD_STACKSIZE_DEFAULT   (1024)
 #endif
 
 #define THREAD_STACKSIZE_IDLE      (160)


### PR DESCRIPTION
### Contribution description

Both architectures are variants of the ARM architecture and use the same toolchain.
There is no reason to have such wildly different defaults.

This results in some tests passing that would crash before:

 - [x] `tests/pkg_libcose` (test takes ~20s)
 - [x] `tests/pkg_qdsa` (test fails, but was crashing before)
 - [x] `tests/pkg_relic`
 - [x] `tests/pkg_tweetnacl`
 - [x] `tests/pthread_tls`

`THREAD_EXTRA_STACKSIZE_PRINTF_FLOAT` is not used anywhere in RIOT
anymore, so just drop it.

### Testing procedure

Run the mentioned tests and ensure that they are now working.

The reduced printf extra results in less excessive stacks for normal applications:

```
2019-12-08 22:22:23,141 # 	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
2019-12-08 22:22:23,144 # 	  - | isr_stack            | -        - |   - |    400 (  136) | 0x400011d4 | 0x400011d4
2019-12-08 22:22:23,146 # 	  1 | idle                 | pending  Q |  15 |    160 (  152) | 0x40001534 | 0x4000153c 
2019-12-08 22:22:23,149 # 	  2 | main                 | running  Q |   7 |   1536 (  668) | 0x400015d4 | 0x40001a14 
2019-12-08 22:22:23,151 # 	    | SUM                  |            |     |   2096 (  956)
```

### Issues/PRs references
discovered in #12669