### PR TITLE
boards/hifive1b: add arduino feature

### DIFF
--- a/boards/hifive1b/Makefile.features
+++ b/boards/hifive1b/Makefile.features
@@ -9,3 +9,6 @@ FEATURES_PROVIDED += periph_rtt
 #FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += arduino

--- a/boards/hifive1b/include/arduino_board.h
+++ b/boards/hifive1b/include/arduino_board.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_hifive1b
+ * @{
+ *
+ * @file
+ * @brief       Configuration of the Arduino API for the SiFive HiFive1b board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   One on-board red LED is connected to pin 6 on this board
+ */
+#define ARDUINO_LED         (6)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    ARDUINO_PIN_15,
+    ARDUINO_PIN_16,
+    ARDUINO_PIN_17,
+    ARDUINO_PIN_18,
+    ARDUINO_PIN_19,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/hifive1b/include/arduino_pinmap.h
+++ b/boards/hifive1b/include/arduino_pinmap.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_hifive1b
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins for the SiFive HiFive1b board
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ * @{
+ */
+
+/* Digital pins */
+#define ARDUINO_PIN_0           GPIO_PIN(0, 16) /* UART0_RX */
+#define ARDUINO_PIN_1           GPIO_PIN(0, 17) /* UART0_TX */
+#define ARDUINO_PIN_2           GPIO_PIN(0, 18)
+#define ARDUINO_PIN_3           GPIO_PIN(0, 19) /* PWM1 */
+#define ARDUINO_PIN_4           GPIO_PIN(0, 20) /* PWM1 */
+#define ARDUINO_PIN_5           GPIO_PIN(0, 21) /* PWM1 */
+#define ARDUINO_PIN_6           GPIO_PIN(0, 22) /* PWM1 */
+#define ARDUINO_PIN_7           GPIO_PIN(0, 23)
+#define ARDUINO_PIN_8           GPIO_PIN(0, 0)  /* PWM0 */
+#define ARDUINO_PIN_9           GPIO_PIN(0, 1)  /* PWM0 */
+#define ARDUINO_PIN_10          GPIO_PIN(0, 2)  /* SPI SS/PWM0 */
+#define ARDUINO_PIN_11          GPIO_PIN(0, 3)  /* SPI MOSI/PWM0 */
+#define ARDUINO_PIN_12          GPIO_PIN(0, 4)  /* SPI MISO */
+#define ARDUINO_PIN_13          GPIO_PIN(0, 5)  /* SPI SCK */
+#define ARDUINO_PIN_14          GPIO_UNDEF
+#define ARDUINO_PIN_15          GPIO_PIN(0, 9)
+#define ARDUINO_PIN_16          GPIO_PIN(0, 10) /* PWM2 */
+#define ARDUINO_PIN_17          GPIO_PIN(0, 11) /* PWM2 */
+#define ARDUINO_PIN_18          GPIO_PIN(0, 12) /* SDA/PWM2 */
+#define ARDUINO_PIN_19          GPIO_PIN(0, 13) /* SCL/PWM2 */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/hifive1b/include/board.h
+++ b/boards/hifive1b/include/board.h
@@ -21,7 +21,8 @@
 #ifndef BOARD_H
 #define BOARD_H
 
-#include "periph/gpio.h"
+#include "cpu.h"
+#include "arduino_pinmap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/fe310/include/cpu.h
+++ b/cpu/fe310/include/cpu.h
@@ -25,6 +25,8 @@
 #ifndef CPU_H
 #define CPU_H
 
+#include "thread.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is adding the Arduino feature to the hifive1b board.
It also does a minor cleanup in cpu.h/periph_cpu.h/cpu.c with isr functions declaration and includes. This fixes some compilation issues about ARRAY_SIZE is not defined.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- `make BOARD=hifive1b -C tests/sys_arduino flash test` should work when used with #12891.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
