### PR TITLE
Add IPv4 support for LWIP-stm32

### DIFF
--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -146,19 +146,35 @@ void lwip_bootstrap(void)
         }
     }
 #elif defined(MODULE_ESP_WIFI)
+#ifdef MODULE_LWIP_IPV4
+    if (netif_add(&netif[0], IP4_ADDR_ANY, IP4_ADDR_ANY, IP4_ADDR_ANY,
+                  &_esp_wifi_dev, lwip_netdev_init, tcpip_input) == NULL) {
+        DEBUG("Could not add esp_wifi device\n");
+        return;
+    }
+#else /* MODULE_LWIP_IPV4 */
     esp_wifi_setup(&_esp_wifi_dev);
     if (netif_add(&netif[0], &_esp_wifi_dev, lwip_netdev_init,
                   tcpip_input) == NULL) {
         DEBUG("Could not add esp_wifi device\n");
         return;
     }
+#endif /* MODULE_LWIP_IPV4 */
 #elif defined(MODULE_STM32_ETH)
     stm32_eth_netdev_setup(&stm32_eth);
-    if (netif_add(&netif[0], &stm32_eth, lwip_netdev_init,
-                tcpip_input) == NULL) {
+#ifdef MODULE_LWIP_IPV4
+    if (netif_add(&netif[0], IP4_ADDR_ANY, IP4_ADDR_ANY, IP4_ADDR_ANY,
+                  &stm32_eth, lwip_netdev_init, tcpip_input) == NULL) {
         DEBUG("Could not add stm32_eth device\n");
         return;
     }
+#else /* MODULE_LWIP_IPV4 */
+    if (netif_add(&netif[0], &stm32_eth, lwip_netdev_init,
+                  tcpip_input) == NULL) {
+        DEBUG("Could not add stm32_eth device\n");
+        return;
+    }
+#endif /* MODULE_LWIP_IPV4 */
 #endif
     if (netif[0].state != NULL) {
         /* state is set to a netdev_t in the netif_add() functions above */

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -97,7 +97,7 @@ static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
 
 #ifdef MODULE_ESP_WIFI
 extern esp_wifi_netdev_t _esp_wifi_dev;
-extern void esp_wifi_setup (esp_wifi_netdev_t* dev);
+extern void esp_wifi_setup(esp_wifi_netdev_t *dev);
 #endif
 
 #ifdef MODULE_STM32_ETH


### PR DESCRIPTION
### Contribution description
netif_add() for ipv4 uses an entirely different function prototype, and thus is not compatible with the lwip_ipv6 modules. Added a preprocessor conditional to pass the correct (number of) arguments to the netif_add() function, depending on what lwip module is loaded. 
