### PR TITLE
dtls-sock: check msg_try_receive return value

### DIFF
--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -345,9 +345,7 @@ void *_dtls_server_wrapper(void *arg)
     }
 
     while (active) {
-
-        msg_try_receive(&msg); /* Check if we got an (thread) message */
-        if (msg.type == DTLS_STOP_SERVER_MSG) {
+        if ((msg_try_receive(&msg) == -1) && (msg.type == DTLS_STOP_SERVER_MSG)) {
             active = false;
         }
         else {

--- a/examples/dtls-sock/dtls-server.c
+++ b/examples/dtls-sock/dtls-server.c
@@ -108,8 +108,7 @@ void *dtls_server_wrapper(void *arg)
     }
 
     while (active) {
-        msg_try_receive(&msg);
-        if (msg.type == DTLS_STOP_SERVER_MSG) {
+        if ((msg_try_receive(&msg) == 1) && (msg.type == DTLS_STOP_SERVER_MSG)) {
             active = false;
         }
         else {


### PR DESCRIPTION
### Contribution description

Before accessing the msg itself. Thereby preventing an access of
uninitialized memory.

### Testing procedure

I think this is obvious from reading the code and the `msg_try_receive` documentation.

### Issues/PRs references

None.