### PR TITLE
sx127x: remove mandatory timeout timers

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -73,6 +73,21 @@ extern "C" {
  * @name    SX127X device default configuration
  * @{
  */
+
+/**
+ * @brief Watchdog timeout for RX single procedure
+ */
+#ifndef SX127X_RX_SINGLE_WDOG_MS_TIMEOUT
+#define SX127X_RX_SINGLE_WDOG_MS_TIMEOUT    (3000U)
+#endif
+
+/**
+ * @brief Watchdog timeout for TX procedure
+ */
+#ifndef SX127X_TX_WDOG_MS_TIMEOUT
+#define SX127X_TX_WDOG_MS_TIMEOUT           (3000U)
+#endif
+
 #define SX127X_MODEM_DEFAULT             (SX127X_MODEM_LORA)    /**< Use LoRa as default modem */
 #define SX127X_CHANNEL_DEFAULT           (868300000UL)          /**< Default channel frequency, 868.3MHz (Europe) */
 #define SX127X_HF_CHANNEL_DEFAULT        (868000000UL)          /**< Use to calibrate RX chain for LF and HF bands */
@@ -173,8 +188,6 @@ typedef struct {
     uint8_t coderate;                  /**< Error coding rate */
     uint8_t freq_hop_period;           /**< Frequency hop period */
     uint8_t flags;                     /**< Boolean flags */
-    uint32_t rx_timeout;               /**< RX timeout in microseconds */
-    uint32_t tx_timeout;               /**< TX timeout in microseconds */
 } sx127x_lora_settings_t;
 
 /**
@@ -192,8 +205,12 @@ typedef struct {
  */
 typedef struct {
     /* Data that will be passed to events handler in application */
+#if IS_USED(MODULE_SX127X_WDOG)
     xtimer_t tx_timeout_timer;         /**< TX operation timeout timer */
+#endif
+#if IS_USED(MODULE_SX127X_WDOG)
     xtimer_t rx_timeout_timer;         /**< RX operation timeout timer */
+#endif
     uint32_t last_channel;             /**< Last channel in frequency hopping sequence */
     bool is_last_cad_success;          /**< Sign of success of last CAD operation (activity detected) */
 } sx127x_internal_t;
@@ -625,22 +642,6 @@ void sx127x_set_preamble_length(sx127x_t *dev, uint16_t preamble);
  * @param[in] timeout                  The LoRa symbol timeout
  */
 void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout);
-
-/**
- * @brief   Sets the SX127X RX timeout
- *
- * @param[in] dev                      The sx127x device descriptor
- * @param[in] timeout                  The RX timeout
- */
-void sx127x_set_rx_timeout(sx127x_t *dev, uint32_t timeout);
-
-/**
- * @brief   Sets the SX127X TX timeout
- *
- * @param[in] dev                      The sx127x device descriptor
- * @param[in] timeout                  The TX timeout
- */
-void sx127x_set_tx_timeout(sx127x_t *dev, uint32_t timeout);
 
 /**
  * @brief   Checks if the SX127X LoRa inverted IQ mode is enabled/disabled

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -135,6 +135,9 @@ PSEUDOMODULES += mrf24j40m%
 PSEUDOMODULES += sx1272
 PSEUDOMODULES += sx1276
 
+# include watchdog of SX127X drivers as pseudo modules
+PSEUDOMODULES += sx127x_wdog
+
 # include variants of SHT1X drivers as pseudo modules
 PSEUDOMODULES += sht10
 PSEUDOMODULES += sht11

--- a/pkg/semtech-loramac/Makefile.dep
+++ b/pkg/semtech-loramac/Makefile.dep
@@ -6,6 +6,9 @@ USEMODULE += semtech_loramac_mac_region
 USEMODULE += semtech_loramac_crypto
 USEMODULE += semtech_loramac_arch
 
+#Enable SX127x watchdog
+USEMODULE += sx127x_wdog
+
 # The build fails on MSP430 because the toolchain doesn't provide
 # EXIT_SUCCESS/EXIT_FAILURE macros
 FEATURES_BLACKLIST += arch_msp430

--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -108,6 +108,7 @@ void SX127XSetTxConfig(RadioModems_t modem, int8_t power, uint32_t fdev,
 {
     (void) fdev;
     (void) fixLen;
+    (void) timeout;
     sx127x_set_modem(&sx127x, modem);
     sx127x_set_freq_hop(&sx127x, freqHopOn);
     sx127x_set_bandwidth(&sx127x, bandwidth);
@@ -122,7 +123,6 @@ void SX127XSetTxConfig(RadioModems_t modem, int8_t power, uint32_t fdev,
     sx127x_set_tx_power(&sx127x, power);
     sx127x_set_preamble_length(&sx127x, preambleLen);
     sx127x_set_rx_single(&sx127x, false);
-    sx127x_set_tx_timeout(&sx127x, timeout * US_PER_MS); /* base unit us, LoRaMAC ms */
 }
 
 uint32_t SX127XTimeOnAir(RadioModems_t modem, uint8_t pktLen)
@@ -153,7 +153,7 @@ void SX127XStandby(void)
 
 void SX127XRx(uint32_t timeout)
 {
-    sx127x_set_rx_timeout(&sx127x, timeout * US_PER_MS);
+    (void) timeout;
     sx127x_set_rx(&sx127x);
 }
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -94,10 +94,6 @@ void gnrc_lorawan_reset(gnrc_lorawan_t *mac)
                                                       : LORA_SYNCWORD_PRIVATE;
     netdev_set_pass(&mac->netdev, NETOPT_SYNCWORD, &syncword, sizeof(syncword));
 
-    /* Continuous reception */
-    uint32_t rx_timeout = 0;
-    netdev_set_pass(&mac->netdev, NETOPT_RX_TIMEOUT, &rx_timeout, sizeof(rx_timeout));
-
     _set_rx2_dr(mac, LORAMAC_DEFAULT_RX2_DR);
 
     mac->toa = 0;

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -262,8 +262,6 @@ int listen_cmd(int argc, char **argv)
     /* Switch to continuous listen mode */
     const netopt_enable_t single = false;
     netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
-    const uint32_t timeout = 0;
-    netdev->driver->set(netdev, NETOPT_RX_TIMEOUT, &timeout, sizeof(timeout));
 
     /* Switch to RX state */
     uint8_t state = NETOPT_STATE_RX;
@@ -428,10 +426,6 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
                 break;
 
             case NETDEV_EVENT_CAD_DONE:
-                break;
-
-            case NETDEV_EVENT_TX_TIMEOUT:
-                sx127x_set_sleep(&sx127x);
                 break;
 
             default:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the mandatory dependency of the rx and tx timeout timer in the SX127x device.
These timers are used in the semtech package only to recover against lost interrupts or wrong SPI transactions. In practice, these timers should never be triggered (if so there's something wrong with the hardware).

Also I'm making the timeout values to be configured at compile time instead of dynamically choosing a value. I'm aware the Semtech package chooses the timeout values depending on the datarate, but in practice:
1. A LoRaWAN packet will never have a Time On Air > 3 seconds
2. If there's a lost interrupt, there's something wrong anyway. Waiting a couple of seconds longer before putting the hardware in a known state shouldn't harm.

We should decide in a follow up what to do when these faulty hardware scenarios happen.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
It's hard to test since this should never happen. However, the following patch simulates a broken interrupt line and sets the watchdog timeout for 5 seconds, both in RX and TX.
```
diff --git a/drivers/sx127x/sx127x.c b/drivers/sx127x/sx127x.c
index 4fcf07300..7e608526a 100644
--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -281,7 +281,7 @@ static int _init_gpios(sx127x_t *dev)
     int res;
 
     /* Check if DIO0 pin is defined */
-    if (dev->params.dio0_pin != GPIO_UNDEF) {
+    if (0) {
         res = gpio_init_int(dev->params.dio0_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio0_isr, dev);
         if (res < 0) {
@@ -296,7 +296,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* Check if DIO1 pin is defined */
-    if (dev->params.dio1_pin != GPIO_UNDEF) {
+    if (0) {
         res = gpio_init_int(dev->params.dio1_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio1_isr, dev);
         if (res < 0) {
@@ -306,7 +306,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* check if DIO2 pin is defined */
-    if (dev->params.dio2_pin != GPIO_UNDEF) {
+    if (0) {
         res = gpio_init_int(dev->params.dio2_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio2_isr, dev);
         if (res < 0) {
@@ -316,7 +316,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* check if DIO3 pin is defined */
-    if (dev->params.dio3_pin != GPIO_UNDEF) {
+    if (0) {
         res = gpio_init_int(dev->params.dio3_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio3_isr, dev);
         if (res < 0) {
diff --git a/tests/driver_sx127x/Makefile b/tests/driver_sx127x/Makefile
index 7a8f670d6..53ebf38ac 100644
--- a/tests/driver_sx127x/Makefile
+++ b/tests/driver_sx127x/Makefile
@@ -8,6 +8,10 @@ USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += xtimer
 
+USEMODULE += sx127x_wdog
+CFLAGS += -DSX127X_TX_WDOG_MS_TIMEOUT=5000
+CFLAGS += -DSX127X_RX_SINGLE_WDOG_MS_TIMEOUT=5000
+
 DRIVER ?= sx1276
 
 # use SX1276 by default
diff --git a/tests/driver_sx127x/main.c b/tests/driver_sx127x/main.c
index adadef746..ae2cc3dc0 100644
--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -260,7 +260,7 @@ int listen_cmd(int argc, char **argv)
 
     netdev_t *netdev = (netdev_t *)&sx127x;
     /* Switch to continuous listen mode */
-    const netopt_enable_t single = false;
+    const netopt_enable_t single = true;
     netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
 
     /* Switch to RX state */
@@ -424,6 +424,10 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
                 sx127x_set_sleep(&sx127x);
                 puts("Transmission completed");
                 break;
+            case NETDEV_EVENT_RX_TIMEOUT:
+            case NETDEV_EVENT_TX_TIMEOUT:
+                puts("WATCHDOG!");
+                break;
 
             case NETDEV_EVENT_CAD_DONE:
                 break;
```

To test, use `drivers_sx127x`:
1. Send something using the send command.
```
send RIOT
```
After 5 seconds, a "WATCHDOG" message should appear, since we "lost" the interrupt.
2. Put the radio in listening mode (I hardcoded it to use the RX single mode, so we would expect an RX timeout interrupt)
```
listen
```
Same as above, a "WATCHDOG" message should appear after 5 seconds.

Also, test that at least `examples/gnrc_lorawan` , `example/lorawan` and `drivers/pkk_semtech_loramac` compile.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
