### PR TITLE
cpu/lpc2387: implement periph/adc

### DIFF
--- a/boards/mcb2388/Makefile.features
+++ b/boards/mcb2388/Makefile.features
@@ -2,6 +2,7 @@ CPU = lpc2387
 CPU_MODEL = lpc2388
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/mcb2388/include/periph_conf.h
+++ b/boards/mcb2388/include/periph_conf.h
@@ -79,6 +79,21 @@ static const uart_conf_t uart_config[] = {
 #define SPI_NUMOF           (1)
 /** @} */
 
+/**
+ * @name ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    {
+        .chan       = 0,
+        .pinsel     = 1,
+        .pinsel_msk = BIT14,
+    },
+};
+
+#define ADC_NUMOF           (1)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -1,6 +1,7 @@
 CPU = lpc2387
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -121,6 +121,32 @@ static const uart_conf_t uart_config[] = {
 #define SPI_NUMOF           (1)
 /** @} */
 
+/**
+ * @name ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    {   /* P0.23 */
+        .chan       = 0,
+        .pinsel     = 1,
+        .pinsel_msk = BIT14,
+    },
+    {   /* P0.24 */
+        .chan       = 1,
+        .pinsel     = 1,
+        .pinsel_msk = BIT16,
+    },
+    {   /* P0.25 */
+        .chan       = 2,
+        .pinsel     = 1,
+        .pinsel_msk = BIT18,
+    },
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -153,6 +153,35 @@ typedef enum {
  */
 #define DAC_NUMOF           (1U)
 
+/**
+ * @brief   Possible ADC resolution settings
+ * @{
+ */
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_16BIT = 0xff,   /**< not applicable         */
+    ADC_RES_14BIT = 0xfe,   /**< not applicable         */
+    ADC_RES_12BIT = 0xfd,   /**< not applicable         */
+    ADC_RES_10BIT = 0b000,  /**< ADC resolution: 10 bit */
+    ADC_RES_9BIT  = 0b001,  /**< ADC resolution:  9 bit */
+    ADC_RES_8BIT  = 0b010,  /**< ADC resolution:  8 bit */
+    ADC_RES_7BIT  = 0b011,  /**< ADC resolution:  7 bit */
+    ADC_RES_6BIT  = 0b100,  /**< ADC resolution:  6 bit */
+    ADC_RES_5BIT  = 0b101,  /**< ADC resolution:  5 bit */
+    ADC_RES_4BIT  = 0b110,  /**< ADC resolution:  4 bit */
+    ADC_RES_3BIT  = 0b111,  /**< ADC resolution:  3 bit */
+} adc_res_t;
+/** @} */
+
+/**
+ * @brief   ADC device configuration
+ */
+typedef struct {
+    uint8_t  chan;          /**< which ADC to use (0…7)  */
+    uint8_t  pinsel;        /**< PINSEL# of the ADC pin  */
+    uint32_t pinsel_msk;    /**< PINSEL Mask for ADC pin */
+} adc_conf_t;
+
 /* @} */
 #ifdef __cplusplus
 }

--- a/cpu/lpc2387/periph/adc.c
+++ b/cpu/lpc2387/periph/adc.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_periph
+ * @{
+ *
+ * @file
+ * @brief       Low-level ADC driver implementation for lpc23xx family
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "kernel_defines.h"
+#include "periph/adc.h"
+#include "periph_conf.h"
+
+int adc_init(adc_t line)
+{
+    /* check if the line is valid */
+    if (line >= ADC_NUMOF) {
+        return -1;
+    }
+
+    /* enable clock/power for ADC */
+    PCONP |= BIT12;
+
+    /* set ADC PCLK to CCLK/8 */
+    PCLKSEL0 |= BIT25 + BIT25;
+
+    /* configure AF for ADC pin */
+    *(&PINSEL0 + adc_config[line].pinsel) |= adc_config[line].pinsel_msk;
+
+    /* power down ADC */
+    AD0CR = 0;
+
+    return 0;
+}
+
+int32_t adc_sample(adc_t line, adc_res_t res)
+{
+    uint32_t val;
+
+    /* check if the line is valid */
+    if (line >= ADC_NUMOF) {
+        return -1;
+    }
+
+    /* check if resolution is applicable */
+    if (res > 0xf0) {
+        return -1;
+    }
+
+    /* Enable & configure ADC.
+     * burst mode is used even though we only do one conversion here
+     * in order to being able to configure the resolution.
+     */
+    AD0CR = (1   << adc_config[line].chan)  /* select channel      */
+          | (1   << 8)                      /* clocked at 4.5 MHz  */
+          | (1   << 16)                     /* enable burst mode   */
+          | (res << 17)                     /* select resolution   */
+          | (1   << 21)                     /* enable ADC          */
+          | (1   << 24);                    /* start conversion    */
+
+    do {
+        val = *(&AD0DR0 + adc_config[line].chan);
+    } while (!(val & BIT31));
+
+    /* power down ADC */
+    AD0CR = 0;
+
+    return val & 0xFFFF;
+}


### PR DESCRIPTION
### Contribution description

lpc23xx has a 10 bit ADC with up to 8 channels, this adds a driver for it.
This implements the ADC peripheral driver using the ADC API.

It uses burst mode even though the RIOT API only supports one conversion at a time, in order to be able to select the resolution.
(In manual mode the full 10 bits/11 clock cycles are used always.)

This also configures the three ADC pins on the AD/DA header of the `msba2`.

### Testing procedure

Run `tests/periph_adc` on `msba2`.

I ran the test on `mcb2388` which conveniently has a potentiometer attached to `P0.23`

<details><summary>results</summary>
<p>

```
2019-12-09 20:06:21,234 # main(): This is RIOT! (Version: 2020.01-devel-1316-gfc03a-mcb2388)
2019-12-09 20:06:21,234 # 
2019-12-09 20:06:21,236 # RIOT ADC peripheral driver test
2019-12-09 20:06:21,236 # 
2019-12-09 20:06:21,238 # This test will sample all available ADC lines once every 100ms with
2019-12-09 20:06:21,239 # a 10-bit resolution and print the sampled results to STDIO
2019-12-09 20:06:21,239 # 
2019-12-09 20:06:21,240 # 
2019-12-09 20:06:21,241 # Successfully initialized ADC_LINE(0)
2019-12-09 20:06:21,241 # ADC_LINE(0): 4032
2019-12-09 20:06:21,313 # ADC_LINE(0): 4032
2019-12-09 20:06:21,409 # ADC_LINE(0): 4032
2019-12-09 20:06:21,505 # ADC_LINE(0): 4032
2019-12-09 20:06:21,618 # ADC_LINE(0): 4032
2019-12-09 20:06:21,714 # ADC_LINE(0): 4032
2019-12-09 20:06:21,810 # ADC_LINE(0): 4032
2019-12-09 20:06:21,907 # ADC_LINE(0): 4032
2019-12-09 20:06:22,019 # ADC_LINE(0): 4032
2019-12-09 20:06:22,115 # ADC_LINE(0): 4032
2019-12-09 20:06:22,211 # ADC_LINE(0): 4032
2019-12-09 20:06:22,308 # ADC_LINE(0): 4032
2019-12-09 20:06:22,404 # ADC_LINE(0): 4032
2019-12-09 20:06:22,516 # ADC_LINE(0): 4096
2019-12-09 20:06:22,613 # ADC_LINE(0): 4096
2019-12-09 20:06:22,709 # ADC_LINE(0): 4096
2019-12-09 20:06:22,805 # ADC_LINE(0): 4160
2019-12-09 20:06:22,918 # ADC_LINE(0): 4096
2019-12-09 20:06:23,014 # ADC_LINE(0): 4032
2019-12-09 20:06:23,110 # ADC_LINE(0): 3968
2019-12-09 20:06:23,206 # ADC_LINE(0): 3904
2019-12-09 20:06:23,318 # ADC_LINE(0): 3904
2019-12-09 20:06:23,415 # ADC_LINE(0): 3840
2019-12-09 20:06:23,511 # ADC_LINE(0): 3840
2019-12-09 20:06:23,608 # ADC_LINE(0): 3776
2019-12-09 20:06:23,704 # ADC_LINE(0): 3712
2019-12-09 20:06:23,816 # ADC_LINE(0): 256
2019-12-09 20:06:23,912 # ADC_LINE(0): 384
2019-12-09 20:06:24,009 # ADC_LINE(0): 256
2019-12-09 20:06:24,105 # ADC_LINE(0): 64
2019-12-09 20:06:24,217 # ADC_LINE(0): 128
2019-12-09 20:06:24,314 # ADC_LINE(0): 192
2019-12-09 20:06:24,410 # ADC_LINE(0): 0
2019-12-09 20:06:24,506 # ADC_LINE(0): 0
2019-12-09 20:06:24,618 # ADC_LINE(0): 0
2019-12-09 20:06:24,715 # ADC_LINE(0): 0
2019-12-09 20:06:24,811 # ADC_LINE(0): 0
2019-12-09 20:06:24,907 # ADC_LINE(0): 64
2019-12-09 20:06:25,004 # ADC_LINE(0): 0
2019-12-09 20:06:25,116 # ADC_LINE(0): 0
2019-12-09 20:06:25,212 # ADC_LINE(0): 0
2019-12-09 20:06:25,309 # ADC_LINE(0): 7104
2019-12-09 20:06:25,405 # ADC_LINE(0): 8128
2019-12-09 20:06:25,517 # ADC_LINE(0): 8128
2019-12-09 20:06:25,614 # ADC_LINE(0): 8064
2019-12-09 20:06:25,710 # ADC_LINE(0): 8064
2019-12-09 20:06:25,806 # ADC_LINE(0): 14336
2019-12-09 20:06:25,918 # ADC_LINE(0): 14592
2019-12-09 20:06:26,015 # ADC_LINE(0): 14528
2019-12-09 20:06:26,111 # ADC_LINE(0): 18880
2019-12-09 20:06:26,207 # ADC_LINE(0): 37248
2019-12-09 20:06:26,319 # ADC_LINE(0): 37184
2019-12-09 20:06:26,416 # ADC_LINE(0): 37312
2019-12-09 20:06:26,512 # ADC_LINE(0): 64896
2019-12-09 20:06:26,608 # ADC_LINE(0): 65152
2019-12-09 20:06:26,705 # ADC_LINE(0): 65024
2019-12-09 20:06:26,817 # ADC_LINE(0): 65344
2019-12-09 20:06:26,913 # ADC_LINE(0): 65280
2019-12-09 20:06:27,009 # ADC_LINE(0): 65408
2019-12-09 20:06:27,106 # ADC_LINE(0): 65472
2019-12-09 20:06:27,218 # ADC_LINE(0): 65472
2019-12-09 20:06:27,314 # ADC_LINE(0): 65472
2019-12-09 20:06:27,411 # ADC_LINE(0): 65280
2019-12-09 20:06:27,507 # ADC_LINE(0): 65408
2019-12-09 20:06:27,619 # ADC_LINE(0): 65408
2019-12-09 20:06:27,716 # ADC_LINE(0): 65472
2019-12-09 20:06:27,812 # ADC_LINE(0): 65472
2019-12-09 20:06:27,908 # ADC_LINE(0): 65472
2019-12-09 20:06:28,004 # ADC_LINE(0): 64704
2019-12-09 20:06:28,117 # ADC_LINE(0): 64704
2019-12-09 20:06:28,213 # ADC_LINE(0): 64512
2019-12-09 20:06:28,309 # ADC_LINE(0): 35712
2019-12-09 20:06:28,406 # ADC_LINE(0): 19904
2019-12-09 20:06:28,518 # ADC_LINE(0): 19840
2019-12-09 20:06:28,614 # ADC_LINE(0): 18112
2019-12-09 20:06:28,710 # ADC_LINE(0): 576
2019-12-09 20:06:28,807 # ADC_LINE(0): 448
2019-12-09 20:06:28,919 # ADC_LINE(0): 0
2019-12-09 20:06:29,015 # ADC_LINE(0): 0
2019-12-09 20:06:29,112 # ADC_LINE(0): 0
2019-12-09 20:06:29,208 # ADC_LINE(0): 0
```
</p>
</details>

### Issues/PRs references
previous driver was removed in #6558 as it did not comply with the current ADC API.
