### PR TITLE
pkg/tinydtls: bump version

### DIFF
--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -161,7 +161,7 @@ static int _peer_get_psk_info_handler(struct dtls_context_t *ctx,
     switch (type) {
         case DTLS_PSK_IDENTITY:
             if (id_len) {
-                dtls_debug("got psk_identity_hint: '%.*s'\n", id_len, id);
+                dtls_debug("got psk_identity_hint: '%.*s'\n", (int)id_len, id);
             }
 
             if (result_length < psk_id_length) {

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinydtls
 PKG_URL=https://github.com/eclipse/tinydtls.git
-PKG_VERSION=865ca387cd9d05e52943e5641ad0eefafef218a3
+PKG_VERSION=7a0420bfe3c041789cc0fe87822832f2fd12d0c3
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 CFLAGS += -Wno-implicit-fallthrough


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This version bump fixes an issues when using RIOT native on FreeBSD with
the tinydtls package, e.g. for native tests of sock_dtls.

### Testing procedure

Murdock showing all green should be enough, otherwise run any number of tests
using dtls-* examples.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
