### PR TITLE
makefiles/kconfig: Include configuration symbols to build system

### DIFF
--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -36,6 +36,18 @@ KCONFIG_USER_CONFIG = $(APPDIR)/user.config
 # one that is used to generate the 'riotconf.h' header
 KCONFIG_MERGED_CONFIG = $(GENERATED_DIR)/merged.config
 
+# Include configuration symbols if available, only when not cleaning. This
+# allows to check for Kconfig symbols in makefiles.
+# Make tries to 'remake' all included files
+# (see https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html).
+# So if this file was included even when 'clean' is called, make would enter a
+# loop, as it always is out-of-date.
+# This has the side effect of requiring a Kconfig user to run 'clean' on a
+# separate call (e.g. 'make clean && make all'), to get the symbols correctly.
+ifneq ($(CLEAN),clean)
+  -include $(KCONFIG_MERGED_CONFIG)
+endif
+
 # Flag that indicates that the configuration has been edited
 KCONFIG_EDITED_CONFIG = $(GENERATED_DIR)/.editedconfig
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Besides the `autoconf.h` header file, which contains the configurations
 synbols in the form of C macros, Kconfig generates a `.config` file. This file has Makefile syntax and contains the same configuration symbols in the form of variables.

This is useful to check if a certain option is being set. E.g. to decide if a CFLAG should be used to configure something:
```makefile
ifndef CONFIG_FOO
  CFLAGS += -DCONFIG_FOO=BAR
endif
```
#### Note on how this is working
When `make all` is called, make starts reading all Makefiles. At some point it finds the `-include` directive for the `merged.config` file. If the file is there (i.e. it's not a clean build) it will jump to the file and read, if not, it will continue reading `kconfig.mk`. Once make has read all the files it will try to [remake all the included files](https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html). For that, it will look for implicit and explicit rules to remake the files. In the particular case of `merged.config` it will find this:
https://github.com/RIOT-OS/RIOT/blob/2027efa9f4830dcf1b2ca0e38598feeb169fe307/makefiles/kconfig.mk#L72-L83

If the file is updated (either because it was not there or because of a change on a source file) make will start from scratch reading all the (now updated) makefiles. This way, the user can check for Kconfig symbols in the application's Makefile (after including `Makefile.include`).

#### The problem with `clean`
In the case `make clean all` is called `merged.config` is not included.

**Why?** The reason is that it depends on the `generated` folder being created, which in turn depends on `$(CLEAN)` (which is actually `clean` if it was called). So if we always included the file, make would try to remake it, it would run `clean`, and create it again. The it would start over and try to remake it, it would run `clean` **again**, updating the file and re-triggering this mechanism forever.

Not including the file on `clean` has the side effect of not being able to include Kconfig symbols on build, when running `make clean all`. So far, if users want to use Kconfig they will have to call `make clean && make all`. Any proposal to solve this is appreciated :-)

### Testing procedure
You can add these messages to the `tests/kconfig` application:
```patch
diff --git a/tests/kconfig/Makefile b/tests/kconfig/Makefile
index e386d876b..eb8fcdab8 100644
--- a/tests/kconfig/Makefile
+++ b/tests/kconfig/Makefile
@@ -1,2 +1,8 @@
 include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
+
+ifdef CONFIG_APP_MSG_2
+  $(info "MSG 2 is active")
+else
+  $(info "MSG 2 is not active")
+endif
```
`app.config` sets the MSG 2 as active by default.
- Run `make clean && make all`, you should see that first *MSG 2 is not active* and then make starts over with *MSG 2 is active*.
- Run `make all` again, you should only see *MSG 2 is active* once.
- Run `make menuconfig` and disable the message. You should see *MSG 2 is not active* (once).
- Run `make clean all`, as the file is not included you will see *MSG 2 is not active*.

### Issues/PRs references
None