### PR TITLE
gnrc_lwmac: use uintptr_t to get value of pointer

### DIFF
--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -676,7 +676,7 @@ static void rtt_cb(void *arg)
 {
     msg_t msg;
 
-    msg.content.value = ((uint32_t) arg) & 0xffff;
+    msg.content.value = (uint16_t)((uintptr_t) arg);
     msg.type = GNRC_LWMAC_EVENT_RTT_TYPE;
     msg_send(&msg, lwmac_pid);
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A pointer is not 32 bit on all platforms.
Since gnrc_lwmac only stores 16 bit in the pointer variable it is still save to cast like this even on AVR, but cast to `uintptr_t` instead of `uint32_t`.


### Testing procedure
`tests/gnrc_lwmac` should still work as well as in master

### Issues/PRs references
fixes #12869
