### PR TITLE
sam0/uart: remove useless read-modify-write op

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -121,7 +121,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         NVIC_EnableIRQ(SERCOM0_IRQn + sercom_id(dev(uart)));
 #endif /* UART_HAS_TX_ISR */
         dev(uart)->CTRLB.reg |= SERCOM_USART_CTRLB_RXEN;
-        dev(uart)->INTENSET.reg |= SERCOM_USART_INTENSET_RXC;
+        dev(uart)->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
         /* set wakeup receive from sleep if enabled */
         if (uart_config[uart].flags & UART_FLAG_WAKEUP) {
             dev(uart)->CTRLB.reg |= SERCOM_USART_CTRLB_SFDE;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR provides a really small cleanup of the SAM0 uart driver by remove an useless read-modify-write operation as the INTENSET register is designed to do this.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Test UART RX on any SAM0-based board.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
