### PR TITLE
sock_async: fix cyclic include problem

### DIFF
--- a/sys/include/net/sock/async.h
+++ b/sys/include/net/sock/async.h
@@ -23,63 +23,14 @@
 #ifndef NET_SOCK_ASYNC_H
 #define NET_SOCK_ASYNC_H
 
-#ifdef MODULE_SOCK_DTLS
-#include "net/sock/dtls.h"
-#endif
-
-#ifdef MODULE_SOCK_IP
-#include "net/sock/ip.h"
-#endif
-
-#ifdef MODULE_SOCK_TCP
-#include "net/sock/tcp.h"
-#endif
-
-#ifdef MODULE_SOCK_UDP
-#include "net/sock/udp.h"
-#endif
+#include "net/sock/async/types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
-#ifdef SOCK_HAS_ASYNC_CTX
-#include "sock_async_ctx.h"     /* defines sock_async_ctx_t */
-#endif
-
-/**
- * @brief   Flag types to signify asynchronous sock events
- * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
- */
-typedef enum {
-    SOCK_ASYNC_CONN_RDY  = 0x0001,  /**< Connection ready event */
-    SOCK_ASYNC_CONN_FIN  = 0x0002,  /**< Connection finished event */
-    SOCK_ASYNC_CONN_RECV = 0x0004,  /**< Listener received connection event */
-    SOCK_ASYNC_MSG_RECV  = 0x0010,  /**< Message received event */
-    SOCK_ASYNC_MSG_SENT  = 0x0020,  /**< Message sent event */
-    SOCK_ASYNC_PATH_PROP = 0x0040,  /**< Path property changed event */
-} sock_async_flags_t;
-
 #if defined(MODULE_SOCK_DTLS) || defined(DOXYGEN)
-/**
- * @brief   Event callback for @ref sock_dtls_t
- *
- * @pre `(sock != NULL)`
- *
- * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
- *
- * @param[in] sock  The sock the event happened on
- * @param[in] flags The event flags. Expected values are
- *                  - @ref SOCK_ASYNC_CONN_RDY (if a session you created becomes ready),
- *                  - @ref SOCK_ASYNC_CONN_FIN (if a created session was destroyed),
- *                  - @ref SOCK_ASYNC_CONN_RECV (if a peer tries to create a session),
- *                  - @ref SOCK_ASYNC_MSG_RECV,
- *                  - @ref SOCK_ASYNC_MSG_SENT,
- *                  - @ref SOCK_ASYNC_PATH_PROP, or
- *                  - a combination of them.
- */
-typedef void (*sock_dtls_cb_t)(sock_dtls_t *sock, sock_async_flags_t flags);
 
 /**
  * @brief   Gets the asynchronous event context from sock object
@@ -99,22 +50,6 @@ void sock_dtls_set_cb(sock_dtls_t *sock, sock_dtls_cb_t cb);
 
 #if defined(MODULE_SOCK_IP) || defined(DOXYGEN)
 /**
- * @brief   Event callback for @ref sock_ip_t
- *
- * @pre `(sock != NULL)`
- *
- * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
- *
- * @param[in] sock  The sock the event happened on
- * @param[in] flags The event flags. Expected values are
- *                  - @ref SOCK_ASYNC_MSG_RECV,
- *                  - @ref SOCK_ASYNC_MSG_SENT,
- *                  - @ref SOCK_ASYNC_PATH_PROP, or
- *                  - a combination of them.
- */
-typedef void (*sock_ip_cb_t)(sock_ip_t *sock, sock_async_flags_t flags);
-
-/**
  * @brief   Sets event callback for @ref sock_ip_t
  *
  * @pre `(sock != NULL)`
@@ -131,38 +66,6 @@ void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb);
 #endif  /* defined(MODULE_SOCK_IP) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_TCP) || defined(DOXYGEN)
-/**
- * @brief   Event callback for @ref sock_tcp_t
- *
- * @pre `(sock != NULL)`
- *
- * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
- *
- * @param[in] sock  The sock the event happened on
- * @param[in] flags The event flags. Expected values are
- *                  - @ref SOCK_ASYNC_CONN_RDY,
- *                  - @ref SOCK_ASYNC_CONN_FIN,
- *                  - @ref SOCK_ASYNC_MSG_RECV,
- *                  - @ref SOCK_ASYNC_MSG_SENT,
- *                  - @ref SOCK_ASYNC_PATH_PROP, or
- *                  - a combination of them.
- */
-typedef void (*sock_tcp_cb_t)(sock_tcp_t *sock, sock_async_flags_t flags);
-
-/**
- * @brief   Event callback for @ref sock_tcp_queue_t
- *
- * @pre `(queue != NULL)`
- *
- * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
- *
- * @param[in] queue The TCP listening queue the event happened on
- * @param[in] flags The event flags. The only expected value is @ref
- *                  SOCK_ASYNC_CONN_RECV.
- */
-typedef void (*sock_tcp_queue_cb_t)(sock_tcp_queue_t *queue,
-                                    sock_async_flags_t flags);
-
 /**
  * @brief   Sets event callback for @ref sock_tcp_t
  *
@@ -196,22 +99,6 @@ void sock_tcp_queue_set_cb(sock_tcp_queue_t *queue, sock_tcp_queue_cb_t cb);
 
 #if defined(MODULE_SOCK_UDP) || defined(DOXYGEN)
 /**
- * @brief   Event callback for @ref sock_udp_t
- *
- * @pre `(sock != NULL)`
- *
- * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
- *
- * @param[in] sock  The sock the event happened on
- * @param[in] flags The event flags. Expected values are
- *                  - @ref SOCK_ASYNC_MSG_RECV,
- *                  - @ref SOCK_ASYNC_MSG_SENT,
- *                  - @ref SOCK_ASYNC_PATH_PROP, or
- *                  - a combination of them.
- */
-typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t type);
-
-/**
  * @brief   Gets the asynchronous event context from sock object
  *
  * @pre `(sock != NULL)`
@@ -228,6 +115,8 @@ void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb);
 #endif  /* defined(MODULE_SOCK_UDP) || defined(DOXYGEN) */
 
 #if defined(SOCK_HAS_ASYNC_CTX) || defined(DOXYGEN)
+#include "sock_async_ctx.h"     /* defines sock_async_ctx_t */
+
 #if defined(MODULE_SOCK_DTLS) || defined(DOXYGEN)
 /**
  * @brief   Gets the asynchronous event context from sock object

--- a/sys/include/net/sock/async/types.h
+++ b/sys/include/net/sock/async/types.h
@@ -15,6 +15,12 @@
 extern "C" {
 #endif
 
+/* This header needs to re-typedef the sock types to prevent cyclic includes */
+#if defined (__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wtypedef-redefinition"
+#endif
+
 #if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
 /**
  * @brief   Flag types to signify asynchronous sock events
@@ -133,10 +139,15 @@ typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t type);
 #ifdef MODULE_SOCK_DTLS
 #include "sock_dtls_types.h"
 #endif  /* MODULE_SOCK_DTLS */
+
 #ifdef SOCK_HAS_ASYNC_CTX
 #include "sock_async_ctx.h"
 #endif
 #endif  /* defined(SOCK_HAS_ASYNC) || defined(DOXYGEN) */
+
+#if defined (__clang__)
+# pragma clang diagnostic pop
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/sock/async/types.h
+++ b/sys/include/net/sock/async/types.h
@@ -1,0 +1,146 @@
+/**
+ * @addtogroup      net_sock_async  Sock extension for asynchronous access
+ *
+ * @{
+ *
+ * @file
+ * @brief   Definitions for sock extension for asynchronous access
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NET_SOCK_ASYNC_TYPES_H
+#define NET_SOCK_ASYNC_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+/**
+ * @brief   Flag types to signify asynchronous sock events
+ * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
+ */
+typedef enum {
+    SOCK_ASYNC_CONN_RDY  = 0x0001,  /**< Connection ready event */
+    SOCK_ASYNC_CONN_FIN  = 0x0002,  /**< Connection finished event */
+    SOCK_ASYNC_CONN_RECV = 0x0004,  /**< Listener received connection event */
+    SOCK_ASYNC_MSG_RECV  = 0x0010,  /**< Message received event */
+    SOCK_ASYNC_MSG_SENT  = 0x0020,  /**< Message sent event */
+    SOCK_ASYNC_PATH_PROP = 0x0040,  /**< Path property changed event */
+} sock_async_flags_t;
+
+#if defined(MODULE_SOCK_DTLS) || defined(DOXYGEN)
+typedef struct sock_dtls sock_dtls_t;       /**< forward declare for async */
+
+/**
+ * @brief   Event callback for @ref sock_dtls_t
+ *
+ * @pre `(sock != NULL)`
+ *
+ * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
+ *
+ * @param[in] sock  The sock the event happened on
+ * @param[in] flags The event flags. Expected values are
+ *                  - @ref SOCK_ASYNC_CONN_RDY (if a session you created becomes ready),
+ *                  - @ref SOCK_ASYNC_CONN_FIN (if a created session was destroyed),
+ *                  - @ref SOCK_ASYNC_CONN_RECV (if a peer tries to create a session),
+ *                  - @ref SOCK_ASYNC_MSG_RECV,
+ *                  - @ref SOCK_ASYNC_MSG_SENT,
+ *                  - @ref SOCK_ASYNC_PATH_PROP, or
+ *                  - a combination of them.
+ */
+typedef void (*sock_dtls_cb_t)(sock_dtls_t *sock, sock_async_flags_t flags);
+#endif  /* defined(MODULE_SOCK_DTLS) || defined(DOXYGEN) */
+
+#if defined(MODULE_SOCK_IP) || defined(DOXYGEN)
+typedef struct sock_ip sock_ip_t;       /**< forward declare for async */
+
+/**
+ * @brief   Event callback for @ref sock_ip_t
+ *
+ * @pre `(sock != NULL)`
+ *
+ * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
+ *
+ * @param[in] sock  The sock the event happened on
+ * @param[in] flags The event flags. Expected values are
+ *                  - @ref SOCK_ASYNC_MSG_RECV,
+ *                  - @ref SOCK_ASYNC_MSG_SENT,
+ *                  - @ref SOCK_ASYNC_PATH_PROP, or
+ *                  - a combination of them.
+ */
+typedef void (*sock_ip_cb_t)(sock_ip_t *sock, sock_async_flags_t flags);
+#endif  /* defined(MODULE_SOCK_IP) || defined(DOXYGEN) */
+
+#if defined(MODULE_SOCK_TCP) || defined(DOXYGEN)
+typedef struct sock_tcp sock_tcp_t;         /**< forward declare for async */
+typedef struct sock_tcp sock_tcp_quee_t;    /**< forward declare for async */
+
+/**
+ * @brief   Event callback for @ref sock_tcp_t
+ *
+ * @pre `(sock != NULL)`
+ *
+ * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
+ *
+ * @param[in] sock  The sock the event happened on
+ * @param[in] flags The event flags. Expected values are
+ *                  - @ref SOCK_ASYNC_CONN_RDY,
+ *                  - @ref SOCK_ASYNC_CONN_FIN,
+ *                  - @ref SOCK_ASYNC_MSG_RECV,
+ *                  - @ref SOCK_ASYNC_MSG_SENT,
+ *                  - @ref SOCK_ASYNC_PATH_PROP, or
+ *                  - a combination of them.
+ */
+typedef void (*sock_tcp_cb_t)(sock_tcp_t *sock, sock_async_flags_t flags);
+
+/**
+ * @brief   Event callback for @ref sock_tcp_queue_t
+ *
+ * @pre `(queue != NULL)`
+ *
+ * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
+ *
+ * @param[in] queue The TCP listening queue the event happened on
+ * @param[in] flags The event flags. The only expected value is @ref
+ *                  SOCK_ASYNC_CONN_RECV.
+ */
+typedef void (*sock_tcp_queue_cb_t)(sock_tcp_queue_t *queue,
+                                    sock_async_flags_t flags);
+#endif  /* defined(MODULE_SOCK_TCP) || defined(DOXYGEN) */
+
+#if defined(MODULE_SOCK_UDP) || defined(DOXYGEN)
+typedef struct sock_udp sock_udp_t;     /**< forward declare for async */
+
+/**
+ * @brief   Event callback for @ref sock_udp_t
+ *
+ * @pre `(sock != NULL)`
+ *
+ * @note    Only applicable with @ref SOCK_HAS_ASYNC defined.
+ *
+ * @param[in] sock  The sock the event happened on
+ * @param[in] flags The event flags. Expected values are
+ *                  - @ref SOCK_ASYNC_MSG_RECV,
+ *                  - @ref SOCK_ASYNC_MSG_SENT,
+ *                  - @ref SOCK_ASYNC_PATH_PROP, or
+ *                  - a combination of them.
+ */
+typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t type);
+#endif  /* defined(MODULE_SOCK_UDP) || defined(DOXYGEN) */
+
+#include "sock_types.h"
+#ifdef MODULE_SOCK_DTLS
+#include "sock_dtls_types.h"
+#endif  /* MODULE_SOCK_DTLS */
+#ifdef SOCK_HAS_ASYNC_CTX
+#include "sock_async_ctx.h"
+#endif
+#endif  /* defined(SOCK_HAS_ASYNC) || defined(DOXYGEN) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_SOCK_ASYNC_TYPES_H */
+/** @} */

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -461,6 +461,13 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+/* net/sock/async/types.h included by net/sock.h needs to re-typedef the
+ * `sock_dtls_t` to prevent cyclic includes */
+#if defined (__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wtypedef-redefinition"
+#endif
+
 #include "net/sock.h"
 #include "net/sock/udp.h"
 #include "net/credman.h"
@@ -499,6 +506,10 @@ enum {
  *          an implementation-specific `sock_dtls_types.h`.
  */
 typedef struct sock_dtls sock_dtls_t;
+
+#if defined (__clang__)
+# pragma clang diagnostic pop
+#endif
 
 /**
  * @brief Information about a created session.

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -273,6 +273,13 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+/* net/sock/async/types.h included by net/sock.h needs to re-typedef the
+ * `sock_ip_t` to prevent cyclic includes */
+#if defined (__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wtypedef-redefinition"
+#endif
+
 #include "net/sock.h"
 
 #ifdef __cplusplus
@@ -286,6 +293,10 @@ extern "C" {
  *       implementation-specific `sock_types.h`.
  */
 typedef struct sock_ip sock_ip_t;
+
+#if defined (__clang__)
+# pragma clang diagnostic pop
+#endif
 
 /**
  * @brief   Creates a new raw IPv4/IPv6 sock object

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -303,6 +303,13 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+/* net/sock/async/types.h included by net/sock.h needs to re-typedef the
+ * `sock_tcp_t` and `sock_tcp_queue_t` to prevent cyclic includes */
+#if defined (__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wtypedef-redefinition"
+#endif
+
 #include "net/sock.h"
 
 #ifdef __cplusplus
@@ -326,6 +333,10 @@ typedef struct sock_tcp sock_tcp_t;
  *                          implementation-specific `sock_types.h`.
  */
 typedef struct sock_tcp_queue sock_tcp_queue_t;
+
+#if defined (__clang__)
+# pragma clang diagnostic pop
+#endif
 
 /**
  * @brief   Establishes a new TCP sock connection

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -273,6 +273,13 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+/* net/sock/async/types.h included by net/sock.h needs to re-typedef the
+ * `sock_ip_t` to prevent cyclic includes */
+#if defined (__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wtypedef-redefinition"
+#endif
+
 #include "net/sock.h"
 
 #ifdef __cplusplus
@@ -288,6 +295,10 @@ typedef struct _sock_tl_ep sock_udp_ep_t;   /**< An end point for a UDP sock obj
  *         implementation-specific `sock_types.h`.
  */
 typedef struct sock_udp sock_udp_t;
+
+#if defined (__clang__)
+# pragma clang diagnostic pop
+#endif
 
 /**
  * @brief   Creates a new UDP sock object

--- a/sys/net/gnrc/sock/include/sock_types.h
+++ b/sys/net/gnrc/sock/include/sock_types.h
@@ -30,7 +30,7 @@
 #include "net/gnrc.h"
 #include "net/gnrc/netreg.h"
 #ifdef SOCK_HAS_ASYNC
-#include "net/sock/async.h"
+#include "net/sock/async/types.h"
 #endif
 #include "net/sock/ip.h"
 #include "net/sock/udp.h"

--- a/tests/gnrc_sock_async/main.c
+++ b/tests/gnrc_sock_async/main.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include "net/ipv6/addr.h"
 #include "net/ipv6/hdr.h"
+#include "net/sock/async.h"
 #include "net/sock/ip.h"
 #include "net/sock/udp.h"
 #include "net/gnrc.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Typically a stack needs to add the callback for a sock as a member of its respective `sock` type so `sock_types.h` needs to include `net/sock/async.h` at the moment. As those however include
`net/sock/<prot>.h`, which in turn include `sock_types.h`, we create a cyclic dependency.

This fix resolves this cyclic dependency, by putting the callback definitions in its own header that then in turn can be also included by `sock_types.h`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/gnrc_sock_async` should still work and run

```sh
make -C tests/gnrc_sock_async flash test
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Required for #12601, #12602, and #12907 to work.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
