### PR TITLE
Kconfig: Expose gnrc/ipv6/blacklist configurations

### DIFF
--- a/sys/include/net/gnrc/ipv6/blacklist.h
+++ b/sys/include/net/gnrc/ipv6/blacklist.h
@@ -39,8 +39,8 @@ extern "C" {
 /**
  * Maximum size of the blacklist.
  */
-#ifndef GNRC_IPV6_BLACKLIST_SIZE
-#define GNRC_IPV6_BLACKLIST_SIZE    (8)
+#ifndef CONFIG_GNRC_IPV6_BLACKLIST_SIZE
+#define CONFIG_GNRC_IPV6_BLACKLIST_SIZE    (8)
 #endif
 /** @} */
 

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -7,6 +7,7 @@
 menu "GNRC Network stack"
     depends on MODULE_GNRC
 
+rsource "network_layer/ipv6/blacklist/Kconfig"
 rsource "network_layer/ipv6/whitelist/Kconfig"
 
 endmenu # GNRC Network Stack

--- a/sys/net/gnrc/network_layer/ipv6/blacklist/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/blacklist/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_IPV6_BLACKLIST
+    bool "Configure GNRC IPv6 Blacklisting"
+    depends on MODULE_GNRC_IPV6_BLACKLIST
+    help
+        Configure GNRC IPv6 Blacklisting module using Kconfig.
+
+if KCONFIG_MODULE_GNRC_IPV6_BLACKLIST
+
+config GNRC_IPV6_BLACKLIST_SIZE
+    int "Maximum size of the blacklist"
+    default 8
+
+endif # KCONFIG_MODULE_GNRC_IPV6_BLACKLIST

--- a/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c
+++ b/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c
@@ -22,14 +22,14 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-ipv6_addr_t gnrc_ipv6_blacklist[GNRC_IPV6_BLACKLIST_SIZE];
-BITFIELD(gnrc_ipv6_blacklist_set, GNRC_IPV6_BLACKLIST_SIZE);
+ipv6_addr_t gnrc_ipv6_blacklist[CONFIG_GNRC_IPV6_BLACKLIST_SIZE];
+BITFIELD(gnrc_ipv6_blacklist_set, CONFIG_GNRC_IPV6_BLACKLIST_SIZE);
 
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 int gnrc_ipv6_blacklist_add(const ipv6_addr_t *addr)
 {
-    for (int i = 0; i < GNRC_IPV6_BLACKLIST_SIZE; i++) {
+    for (int i = 0; i < CONFIG_GNRC_IPV6_BLACKLIST_SIZE; i++) {
         if (!bf_isset(gnrc_ipv6_blacklist_set, i)) {
             bf_set(gnrc_ipv6_blacklist_set, i);
             memcpy(&gnrc_ipv6_blacklist[i], addr, sizeof(*addr));
@@ -43,7 +43,7 @@ int gnrc_ipv6_blacklist_add(const ipv6_addr_t *addr)
 
 void gnrc_ipv6_blacklist_del(const ipv6_addr_t *addr)
 {
-    for (int i = 0; i < GNRC_IPV6_BLACKLIST_SIZE; i++) {
+    for (int i = 0; i < CONFIG_GNRC_IPV6_BLACKLIST_SIZE; i++) {
         if (ipv6_addr_equal(addr, &gnrc_ipv6_blacklist[i])) {
             bf_unset(gnrc_ipv6_blacklist_set, i);
             DEBUG("IPv6 blacklist: unblacklisted %s\n",
@@ -54,7 +54,7 @@ void gnrc_ipv6_blacklist_del(const ipv6_addr_t *addr)
 
 bool gnrc_ipv6_blacklisted(const ipv6_addr_t *addr)
 {
-    for (int i = 0; i < GNRC_IPV6_BLACKLIST_SIZE; i++) {
+    for (int i = 0; i < CONFIG_GNRC_IPV6_BLACKLIST_SIZE; i++) {
         if (bf_isset(gnrc_ipv6_blacklist_set, i) &&
             ipv6_addr_equal(addr, &gnrc_ipv6_blacklist[i])) {
             return true;

--- a/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist_print.c
+++ b/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist_print.c
@@ -21,13 +21,13 @@
 
 #include "net/gnrc/ipv6/blacklist.h"
 
-extern ipv6_addr_t gnrc_ipv6_blacklist[GNRC_IPV6_BLACKLIST_SIZE];
-extern BITFIELD(gnrc_ipv6_blacklist_set, GNRC_IPV6_BLACKLIST_SIZE);
+extern ipv6_addr_t gnrc_ipv6_blacklist[CONFIG_GNRC_IPV6_BLACKLIST_SIZE];
+extern BITFIELD(gnrc_ipv6_blacklist_set, CONFIG_GNRC_IPV6_BLACKLIST_SIZE);
 
 void gnrc_ipv6_blacklist_print(void)
 {
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    for (int i = 0; i < GNRC_IPV6_BLACKLIST_SIZE; i++) {
+    for (int i = 0; i < CONFIG_GNRC_IPV6_BLACKLIST_SIZE; i++) {
         if (bf_isset(gnrc_ipv6_blacklist_set, i)) {
             puts(ipv6_addr_to_str(addr_str, &gnrc_ipv6_blacklist[i], sizeof(addr_str)));
         }


### PR DESCRIPTION
### Contribution description
Like #12893, this moves the `gnrc_ipv6_blacklist` module configuration macros to the `CONFIG_` namespace and exposes them to Kconfig.

### Testing procedure
- Compile `gnrc_networking` example application using this module (`USEMODULE=gnrc_ipv6_blacklist make all term`), the default configuration should still be the same.

- Call menuconfig using this module (`USEMODULE=gnrc_ipv6_blacklist make menuconfig`), you should the list size as an option. The default list size should still be the same. If you change the value it should change in the app.

### Issues/PRs references
Part of #12888