### PR TITLE
Kconfig: Expose gnrc/lorawan configurations

### DIFF
--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -35,15 +35,15 @@ extern "C" {
  * @{
  */
 /**
- * @brief maximum timer drift in percentage
+ * @brief maximum timer drift in per mille
  *
  * @note this is only a workaround to compensate inaccurate timers.
  *
- * E.g a value of 0.1 means there's a positive drift of 0.1% (set timeout to
+ * E.g a value of 1 means there's a positive drift of 0.1% (set timeout to
  * 1000 ms => triggers after 1001 ms)
  */
 #ifndef CONFIG_GNRC_LORAWAN_TIMER_DRIFT
-#define CONFIG_GNRC_LORAWAN_TIMER_DRIFT 1
+#define CONFIG_GNRC_LORAWAN_TIMER_DRIFT 10
 #endif
 
 /**

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -7,6 +7,7 @@
 menu "GNRC Network stack"
     depends on MODULE_GNRC
 
+rsource "link_layer/lorawan/Kconfig"
 rsource "network_layer/ipv6/blacklist/Kconfig"
 rsource "network_layer/ipv6/whitelist/Kconfig"
 

--- a/sys/net/gnrc/link_layer/lorawan/Kconfig
+++ b/sys/net/gnrc/link_layer/lorawan/Kconfig
@@ -1,0 +1,30 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_LORAWAN
+    bool "Configure GNRC LoRaWAN"
+    depends on MODULE_GNRC_LORAWAN
+    help
+        Configure GNRC LoRaWAN module using Kconfig.
+
+if KCONFIG_MODULE_GNRC_LORAWAN
+
+config GNRC_LORAWAN_TIMER_DRIFT
+    int "Maximum timer drift"
+    default 10
+    range -1000 1000
+    help
+        The value is expressed in per mille. This is only a workaround to
+        compensate inaccurate timers. E.g. a value of 1 means there's a
+        positive drift of 0.1% (set timeout to 1000 ms => triggers after
+        1001 ms)
+
+config GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT
+    int "Minimum symbols to detect a LoRa preamble"
+    default 30
+    range 0 1024
+
+endif # KCONFIG_MODULE_GNRC_LORAWAN

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -30,7 +30,7 @@
 /* This factor is used for converting "real" seconds into microcontroller
  * microseconds. This is done in order to correct timer drift.
  */
-#define _DRIFT_FACTOR (int) (US_PER_SEC * 100 / (100 + CONFIG_GNRC_LORAWAN_TIMER_DRIFT))
+#define _DRIFT_FACTOR (int) (US_PER_SEC * 100 / (100 + (CONFIG_GNRC_LORAWAN_TIMER_DRIFT / 10.0)))
 
 #define GNRC_LORAWAN_DL_RX2_DR_MASK       (0x0F)  /**< DL Settings DR Offset mask */
 #define GNRC_LORAWAN_DL_RX2_DR_POS        (0)     /**< DL Settings DR Offset pos */


### PR DESCRIPTION
### Contribution description
This PR changes the timer drift configuration for LoRaWAN to be expressed in per mille, instead of percentage. So now setting it to 1 means 0.1% drift correction. It also exposes GNRC LoRaWAN's configurations to Kconfig.

### Testing procedure
- `gnrc_lorawan` example application should work as usual.
- You should be able to configure GNRC LoRaWAN running `make menuconfig` in that application.

### Issues/PRs references
Part of #12888