### PR TITLE
drivers: fix alphabetical order in Makefile.dep/include files

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -130,6 +130,12 @@ ifneq (,$(filter ccs811,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter dcf77,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_gpio_irq
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter dht,$(USEMODULE)))
   USEMODULE += xtimer
   FEATURES_REQUIRED += periph_gpio
@@ -137,6 +143,11 @@ endif
 
 ifneq (,$(filter ds1307,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter ds18,$(USEMODULE)))
+    USEMODULE += xtimer
+    FEATURES_REQUIRED += periph_gpio
 endif
 
 ifneq (,$(filter ds3234,$(USEMODULE)))
@@ -156,11 +167,6 @@ endif
 
 ifneq (,$(filter dynamixel,$(USEMODULE)))
   USEMODULE += uart_half_duplex
-endif
-
-ifneq (,$(filter ds18,$(USEMODULE)))
-    USEMODULE += xtimer
-    FEATURES_REQUIRED += periph_gpio
 endif
 
 ifneq (,$(filter enc28j60,$(USEMODULE)))
@@ -658,10 +664,4 @@ ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += xtimer
   USEMODULE += netif
-endif
-
-ifneq (,$(filter dcf77,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  USEMODULE += xtimer
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -54,6 +54,10 @@ ifneq (,$(filter ccs811,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ccs811/include
 endif
 
+ifneq (,$(filter dcf77,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/dcf77/include
+endif
+
 ifneq (,$(filter dht,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/dht/include
 endif
@@ -64,6 +68,10 @@ endif
 
 ifneq (,$(filter ds1307,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ds1307/include
+endif
+
+ifneq (,$(filter ds18,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ds18/include
 endif
 
 ifneq (,$(filter ds3234,$(USEMODULE)))
@@ -250,6 +258,10 @@ ifneq (,$(filter sdcard_spi,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sdcard_spi/include
 endif
 
+ifneq (,$(filter sds011,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sds011/include
+endif
+
 ifneq (,$(filter sht2x,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sht2x/include
 endif
@@ -260,10 +272,6 @@ endif
 
 ifneq (,$(filter si114x,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/si114x/include
-endif
-
-ifneq (,$(filter ds18,$(USEMODULE)))
-    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ds18/include
 endif
 
 ifneq (,$(filter si70xx,$(USEMODULE)))
@@ -324,12 +332,4 @@ endif
 
 ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/xbee/include
-endif
-
-ifneq (,$(filter sds011,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sds011/include
-endif
-
-ifneq (,$(filter dcf77,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/dcf77/include
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the alphabetical order in `drivers/Makefile.include` and `drivers/Makefile.dep`. Initially, I just wanted to fix the changes related to dcf77 (from #12259) but noticed other drivers were breaking this "rule". This is done in one go by this PR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#12259, #10011 and #10458 didn't respect the alphabetical order.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
