### PR TITLE
pkg/lwip: fix memory issue when sending with empty sock

### DIFF
--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -492,6 +492,7 @@ ssize_t lwip_sock_send(struct netconn **conn, const void *data, size_t len,
     int res;
     err_t err;
     u16_t remote_port = 0;
+    int noconn = 0;
 
 #if LWIP_IPV6
     assert(!(type & NETCONN_TYPE_IPV6));
@@ -512,6 +513,9 @@ ssize_t lwip_sock_send(struct netconn **conn, const void *data, size_t len,
         (netbuf_take(buf, data, len) != ERR_OK)) {
         netbuf_delete(buf);
         return -ENOMEM;
+    }
+    if (conn == NULL) {
+        noconn = 1;
     }
     if (((conn == NULL) || (*conn == NULL)) && (remote != NULL)) {
         if ((res = _create(type, proto, 0, &tmp)) < 0) {
@@ -567,6 +571,9 @@ ssize_t lwip_sock_send(struct netconn **conn, const void *data, size_t len,
             break;
     }
     netbuf_delete(buf);
+    if (noconn) {
+        netconn_delete(tmp);
+    }
     return res;
 }
 


### PR DESCRIPTION
### Contribution description
Memory-issue described in #12859 fixed by calling extra netconn_delete() on *tmp.


### Testing procedure
 in tests/lwip: _udp send IP_HERE 123 ff 30 500_
**Before fix:**  +/- 20 successful sends, memory errors on all later sends
**After fix:** All sends are successful. 

Behaviour has also been tested with _ip send_. Before fix: memory issues after n successful sends. After fix: infinite successful sends. 


### Issues/PRs references
Fixes #12859

