### PR TITLE
boards/native: fix default value of PORT

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -71,8 +71,6 @@ export LINKFLAGS += -ffunction-sections
 # set the tap interface for term/valgrind
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
   PORT ?= tap0
-else
-  PORT =
 endif
 
 TERMFLAGS := $(PORT) $(TERMFLAGS)


### PR DESCRIPTION
### Contribution description
Setting the default value for the `PORT` variable for `native` is currently only working in conjunction with `GNRC`. When trying to set a custom value while not using GNRC, this value is always overridden with an empty string. A simple `?` fixes this.

Context: had this trouble when playing with a none-GNRC network stack under `native`...

### Testing procedure
Simply build an run `examples/hello-world` for `native`, while setting the `PORT` variable to any value. Without this fix, the call to the `.elf` file will not use that parameter, e.g.:
```
~/dev/riot/RIOT/examples/hello-world$ PORT=ohwieschoenistpanama make term
/home/hauke/dev/riot/RIOT/examples/hello-world/bin/native/hello-world.elf
RIOT native interrupts/signals initialized.
...
```
With this fix the value of the `PORT` variable is passed as 1st param when calling the binary:
```
~/dev/riot/RIOT/examples/hello-world$ PORT=ohwieschoenistpanama make term
/home/hauke/dev/riot/RIOT/examples/hello-world/bin/native/hello-world.elf ohwieschoenistpanama 
RIOT native interrupts/signals initialized.
...
```

### Issues/PRs references
none