### PR TITLE
make.dep: fix sock_udp deps for stnp

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -62,7 +62,7 @@ ifneq (,$(filter nhdp,$(USEMODULE)))
 endif
 
 ifneq (,$(filter sntp,$(USEMODULE)))
-  USEMODULE += gnrc_sock_udp
+  USEMODULE += sock_udp
   USEMODULE += xtimer
 endif
 

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -614,6 +614,9 @@ ifneq (,$(filter gnrc,$(USEMODULE)))
   USEMODULE += gnrc_netif
   USEMODULE += gnrc_netif_hdr
   USEMODULE += gnrc_pktbuf
+  ifneq (,$(filter sock_udp, $(USEMODULE)))
+    USEMODULE += gnrc_sock_udp
+  endif
 endif
 
 ifneq (,$(filter gnrc_pktbuf, $(USEMODULE)))


### PR DESCRIPTION
### Contribution description
IMHO, the dependecies for `sntp` and `gcoap` are a little off currently: both directly depend on `gnrc_sock_udp`, but both are not tied to `GNRC` (anymore). So the correct dependency should be to `sock_udp`, right?

This PR changes this dependency slightly by doing two things:
- if GNRC is used, include `gnrc_sock_udp` in the case `sock_udp` is selected (-> sub dependency in the `gnrc` block in `Makefile.dep`)
- make `sntp` and `gcoap` simply depend on `sock_udp` instead of `gnrc_sock_udp`

Context is once more, that I played around with using `gcoap` on top of a non-GNRC network stack... So does this work for everyone or can you think of a better solution?

### Testing procedure
Build `sntp` and `gcoap` examples. The output of `make info-modules` should be unchanged.

### Issues/PRs references
none