### PR TITLE
lwip_sock: clean-up connection handling without a sock.

### DIFF
--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -174,7 +174,7 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
 {
     assert((sock != NULL) || (remote != NULL));
     assert((len == 0) || (data != NULL)); /* (len != 0) => (data != NULL) */
-    return lwip_sock_send(sock ? &sock->conn : NULL, data, len, proto,
+    return lwip_sock_send(sock ? sock->conn : NULL, data, len, proto,
                           (struct _sock_tl_ep *)remote, NETCONN_RAW);
 }
 

--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -174,7 +174,7 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
 {
     assert((sock != NULL) || (remote != NULL));
     assert((len == 0) || (data != NULL)); /* (len != 0) => (data != NULL) */
-    return lwip_sock_send(&sock->conn, data, len, proto,
+    return lwip_sock_send(sock ? &sock->conn : NULL, data, len, proto,
                           (struct _sock_tl_ep *)remote, NETCONN_RAW);
 }
 

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -564,6 +564,9 @@ ssize_t lwip_sock_send(struct netconn *conn, const void *data, size_t len,
             break;
     }
     netbuf_delete(buf);
+    if (conn == NULL) {
+        netconn_delete(tmp);
+    }
     return res;
 }
 

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -483,7 +483,7 @@ int lwip_sock_recv(struct netconn *conn, uint32_t timeout, struct netbuf **buf)
 }
 #endif /* defined(MODULE_LWIP_SOCK_UDP) || defined(MODULE_LWIP_SOCK_IP) */
 
-ssize_t lwip_sock_send(struct netconn **conn, const void *data, size_t len,
+ssize_t lwip_sock_send(struct netconn *conn, const void *data, size_t len,
                        int proto, const struct _sock_tl_ep *remote, int type)
 {
     ip_addr_t remote_addr;
@@ -513,23 +513,23 @@ ssize_t lwip_sock_send(struct netconn **conn, const void *data, size_t len,
         netbuf_delete(buf);
         return -ENOMEM;
     }
-    if (((conn == NULL) || (*conn == NULL)) && (remote != NULL)) {
+    if ((conn == NULL) && (remote != NULL)) {
         if ((res = _create(type, proto, 0, &tmp)) < 0) {
             netbuf_delete(buf);
             return res;
         }
     }
-    else if (*conn != NULL) {
+    else if (conn != NULL) {
         ip_addr_t addr;
         u16_t port;
 
         if (((remote != NULL) &&
              (remote->netif != SOCK_ADDR_ANY_NETIF) &&
-             (netconn_getaddr(*conn, &addr, &port, 1) == 0) &&
+             (netconn_getaddr(conn, &addr, &port, 1) == 0) &&
              (remote->netif != lwip_sock_bind_addr_to_netif(&addr)))) {
             return -EINVAL;
         }
-        tmp = *conn;
+        tmp = conn;
     }
     else {
         netbuf_delete(buf);
@@ -549,9 +549,6 @@ ssize_t lwip_sock_send(struct netconn **conn, const void *data, size_t len,
     }
     switch (err) {
         case ERR_OK:
-            if (conn != NULL) {
-                *conn = tmp;
-            }
             break;
         case ERR_BUF:
         case ERR_MEM:

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -366,7 +366,7 @@ ssize_t sock_tcp_write(sock_tcp_t *sock, const void *data, size_t len)
     mutex_unlock(&sock->mutex); /* we won't change anything to sock here
                                    (lwip_sock_send neither, since it remote is
                                    NULL) so we can leave the mutex */
-    res = lwip_sock_send(&conn, data, len, 0, NULL, NETCONN_TCP);
+    res = lwip_sock_send(conn, data, len, 0, NULL, NETCONN_TCP);
     return res;
 }
 

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -128,7 +128,7 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
     if ((remote != NULL) && (remote->port == 0)) {
         return -EINVAL;
     }
-    return lwip_sock_send((sock) ? &sock->conn : NULL, data, len, 0,
+    return lwip_sock_send((sock) ? sock->conn : NULL, data, len, 0,
                           (struct _sock_tl_ep *)remote, NETCONN_UDP);
 }
 

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -128,8 +128,8 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
     if ((remote != NULL) && (remote->port == 0)) {
         return -EINVAL;
     }
-    return lwip_sock_send(&sock->conn, data, len, 0, (struct _sock_tl_ep *)remote,
-                          NETCONN_UDP);
+    return lwip_sock_send((sock) ? &sock->conn : NULL, data, len, 0,
+                          (struct _sock_tl_ep *)remote, NETCONN_UDP);
 }
 
 /** @} */

--- a/pkg/lwip/include/lwip/sock_internal.h
+++ b/pkg/lwip/include/lwip/sock_internal.h
@@ -56,7 +56,7 @@ int lwip_sock_get_addr(struct netconn *conn, struct _sock_tl_ep *ep, u8_t local)
 #if defined(MODULE_LWIP_SOCK_UDP) || defined(MODULE_LWIP_SOCK_IP)
 int lwip_sock_recv(struct netconn *conn, uint32_t timeout, struct netbuf **buf);
 #endif
-ssize_t lwip_sock_send(struct netconn **conn, const void *data, size_t len,
+ssize_t lwip_sock_send(struct netconn *conn, const void *data, size_t len,
                        int proto, const struct _sock_tl_ep *remote, int type);
 /**
  * @}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This is an enhanced version of #12927. In addition to the fix there, it removes the unnecessary additional indirection of `conn` as either the sock is provided with `sock_*_send()` or not. In the first case the indirection is not necessary, and in the second we need to delete the created `conn` within `lwip_sock_send()` anyway (as introduced in #12927, so returning it makes no sense.

It also adds a check for the call to `lwip_sock_send()` by the respective protocol callers, so that `sock` is not dereferenced when it is `NULL`
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`lwip_sock` tests should still compile and run for both IPv4 and IPv6 and both network layer protocols combined:

```sh
for prot in ip udp tcp; do
    LWIP_IPV4=1 make -C tests/lwip_sock_${prot}/ flash test
    LWIP_IPV6=1 make -C tests/lwip_sock_${prot} flash test
    LWIP_IPV4=1 LWIP_IPV6=1 make -C tests/lwip_sock_${prot} flash test
done
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->Either the sock is provided with `sock_*_send()` or not. In the first
case the indirection is not necessary, and in the second we need to
delete the created `conn` within `lwip_sock_send()` anyway, so returning
it makes no sense.


### Issues/PRs references
Contains a modified version of #12927.
Fixes #12859.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
