### PR TITLE
boards/common: ADD environment variable SERIAL

### DIFF
--- a/boards/common/stm32/dist/stm32f0.cfg
+++ b/boards/common/stm32/dist/stm32f0.cfg
@@ -1,3 +1,7 @@
 source [find target/stm32f0x.cfg]
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}

--- a/boards/common/stm32/dist/stm32f1.cfg
+++ b/boards/common/stm32/dist/stm32f1.cfg
@@ -1,3 +1,7 @@
 source [find target/stm32f1x.cfg]
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}

--- a/boards/common/stm32/dist/stm32f2.cfg
+++ b/boards/common/stm32/dist/stm32f2.cfg
@@ -1,3 +1,7 @@
 source [find target/stm32f2x.cfg]
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}

--- a/boards/common/stm32/dist/stm32f3.cfg
+++ b/boards/common/stm32/dist/stm32f3.cfg
@@ -1,3 +1,7 @@
 source [find target/stm32f3x.cfg]
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}

--- a/boards/common/stm32/dist/stm32f4.cfg
+++ b/boards/common/stm32/dist/stm32f4.cfg
@@ -1,3 +1,7 @@
 source [find target/stm32f4x.cfg]
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}

--- a/boards/common/stm32/dist/stm32f7.cfg
+++ b/boards/common/stm32/dist/stm32f7.cfg
@@ -1,3 +1,7 @@
 source [find target/stm32f7x.cfg]
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}

--- a/boards/common/stm32/dist/stm32l0.cfg
+++ b/boards/common/stm32/dist/stm32l0.cfg
@@ -7,3 +7,7 @@ try {
 }
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}

--- a/boards/common/stm32/dist/stm32l1.cfg
+++ b/boards/common/stm32/dist/stm32l1.cfg
@@ -1,3 +1,7 @@
 source [find target/stm32l1.cfg]
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}

--- a/boards/common/stm32/dist/stm32l4.cfg
+++ b/boards/common/stm32/dist/stm32l4.cfg
@@ -1,3 +1,7 @@
 source [find target/stm32l4x.cfg]
 reset_config srst_only
 $_TARGETNAME configure -rtos auto
+
+if { [info exists ::env(SERIAL) ] } {
+         hla_serial  $::env(SERIAL)
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I've tried programming multiple STM microcontroller of the same kind, which wasn't possible. By adding an environment variable called `SERIAL`, it is possible to check for and distinguish between different serial numbers of the devices, which gives the opportunity to programm two microcontrollers of the same kind.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I've tested this using two nucleo-f207zg boards and running the example under `examples/gnrc_networking`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
