### PR TITLE
netdev_ieee802154: return PDU based on PHY mode

### DIFF
--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -94,7 +94,21 @@ extern "C" {
 #define IEEE802154_CHANNEL_MAX          (26U)   /**< Maximum channel for 2.4 GHz band */
 /** @} */
 
-#define IEEE802154_FRAME_LEN_MAX        (127U)  /**< maximum frame length */
+#define IEEE802154_FRAME_LEN_MAX        (127U)  /**< maximum 802.15.4 frame length */
+#define IEEE802154G_FRAME_LEN_MAX      (2047U)  /**< maximum 802.15.4g-2012 frame length */
+
+/**
+ * @brief   802.15.4 PHY modes
+ */
+enum {
+    IEEE802154_PHY_DISABLED,        /**< PHY disabled, no mode selected */
+    IEEE802154_PHY_BPSK,            /**< Binary Phase Shift Keying */
+    IEEE802154_PHY_ASK,             /**< Amplitude-Shift Keying */
+    IEEE802154_PHY_OQPSK,           /**< Offset Quadrature Phase-Shift Keying */
+    IEEE802154_PHY_MR_OQPSK,        /**< Multi-Rate Offset Quadrature Phase-Shift Keying */
+    IEEE802154_PHY_MR_OFDM,         /**< Multi-Rate Orthogonal Frequency-Division Multiplexing */
+    IEEE802154_PHY_MR_FSK           /**< Multi-Rate Frequency Shift Keying */
+};
 
 /**
  * @brief   Special address definitions

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -652,6 +652,11 @@ typedef enum {
     NETOPT_LORAWAN_MIN_RX_SYMBOL,
 
     /**
+     * @brief   (uint8_t) 802.15.4 PHY mode
+     */
+    NETOPT_IEEE802154_PHY,
+
+    /**
      * @brief   (uint8_t*) phy layer syncword
      */
     NETOPT_SYNCWORD,


### PR DESCRIPTION
### Contribution description
IEEE 802.15.4g-2012 defines new PHY modes (MR-O-QPSK, MR-OFDM and MR-FSK) with a PDU of 2047 bytes.

Devices like at86rf215 can support both the old mode(s) as well as the new ones, so the IP stack has to be informed about the PDU change when the modulation changes.

I introduced a new `NETOPT_IEEE802154_PHY` to get/set the phy mode.

For GNRC to use the new MTU, `gnrc_netif_ipv6_init_mtu()` has to be called.
Now I don't know where this should be called.

Calling it in `gnrc_netif_set_from_netdev()` won't work since at this point the command hasn't reached the driver yet and the old PDU would be returned.

Another option would be calling it in the driver, but that would mean a layering violation.

Or is there a way to register a callback to be executed *after* a netif command?

### Testing procedure

nothing to test yet


### Issues/PRs references
alternative to #12835
