### PR TITLE
Kconfig: Expose net/sock/util configurations

### DIFF
--- a/makefiles/suit.v4.inc.mk
+++ b/makefiles/suit.v4.inc.mk
@@ -14,7 +14,7 @@ SUIT_NOTIFY_VERSION ?= latest
 SUIT_NOTIFY_MANIFEST ?= $(APPLICATION)-riot.suitv4_signed.$(SUIT_NOTIFY_VERSION).bin
 
 # Long manifest names require more buffer space when parsing
-export CFLAGS += -DSOCK_URLPATH_MAXLEN=128
+export CFLAGS += -DCONFIG_SOCK_URLPATH_MAXLEN=128
 
 SUIT_VENDOR ?= "riot-os.org"
 SUIT_SEQNR ?= $(APP_VER)

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -53,9 +53,9 @@ int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint, char *addr_str, uint16_t *por
  * "host.name:1234" and "/url/path".
  *
  * @note Caller has to make sure hostport and urlpath can hold the results!
- *       Make sure to provide space for @ref SOCK_HOSTPORT_MAXLEN respectively
- *       @ref SOCK_URLPATH_MAXLEN bytes, if pointers are not NULL.
- *       Scheme part of the URL is limited to @ref SOCK_SCHEME_MAXLEN length.
+ *       Make sure to provide space for @ref CONFIG_SOCK_HOSTPORT_MAXLEN respectively
+ *       @ref CONFIG_SOCK_URLPATH_MAXLEN bytes, if pointers are not NULL.
+ *       Scheme part of the URL is limited to @ref CONFIG_SOCK_SCHEME_MAXLEN length.
  *
  * @pre `url != NULL`
  *
@@ -109,22 +109,22 @@ bool sock_udp_ep_equal(const sock_udp_ep_t *a, const sock_udp_ep_t *b);
  *
  * Ensures a hard limit on the string iterator
  * */
-#ifndef SOCK_SCHEME_MAXLEN
-#define SOCK_SCHEME_MAXLEN      (16U)
+#ifndef CONFIG_SOCK_SCHEME_MAXLEN
+#define CONFIG_SOCK_SCHEME_MAXLEN      (16U)
 #endif
 
 /**
  * @brief maximum length of host:port part for sock_urlsplit()
  */
-#ifndef SOCK_HOSTPORT_MAXLEN
-#define SOCK_HOSTPORT_MAXLEN    (64U)
+#ifndef CONFIG_SOCK_HOSTPORT_MAXLEN
+#define CONFIG_SOCK_HOSTPORT_MAXLEN    (64U)
 #endif
 
 /**
  * @brief maximum length path for sock_urlsplit()
  */
-#ifndef SOCK_URLPATH_MAXLEN
-#define SOCK_URLPATH_MAXLEN     (64U)
+#ifndef CONFIG_SOCK_URLPATH_MAXLEN
+#define CONFIG_SOCK_URLPATH_MAXLEN     (64U)
 #endif
 
 /** @} */

--- a/sys/net/Kconfig
+++ b/sys/net/Kconfig
@@ -7,5 +7,6 @@
 menu "Networking"
 
 rsource "gnrc/Kconfig"
+rsource "sock/Kconfig"
 
 endmenu # Networking

--- a/sys/net/sock/Kconfig
+++ b/sys/net/sock/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_SOCK_UTIL
+    bool "Configure SOCK utility functions"
+    depends on MODULE_SOCK_UTIL
+
+if KCONFIG_MODULE_SOCK_UTIL
+
+config SOCK_SCHEME_MAXLEN
+    int "Maximum length of the scheme part"
+    default 16
+    help
+        This value is used in sock_urlsplit().
+
+config SOCK_HOSTPORT_MAXLEN
+    int "Maximum length of host:port part"
+    default 64
+    help
+        This value is used in sock_urlsplit().
+
+config SOCK_URLPATH_MAXLEN
+    int "Maximum path length"
+    default 64
+    help
+        This value is used in sock_urlsplit().
+
+endif # KCONFIG_MODULE_SOCK_UTIL

--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -83,10 +83,10 @@ int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint, char *addr_str, uint16_t *por
 
 static char* _find_hoststart(const char *url)
 {
-    /* Increment SOCK_SCHEME_MAXLEN due to comparison with the colon after the
+    /* Increment CONFIG_SOCK_SCHEME_MAXLEN due to comparison with the colon after the
      * scheme part
      */
-    size_t remaining = SOCK_SCHEME_MAXLEN + 1;
+    size_t remaining = CONFIG_SOCK_SCHEME_MAXLEN + 1;
     char *urlpos = (char*)url;
     while(*urlpos && remaining) {
         remaining--;
@@ -103,7 +103,7 @@ static char* _find_hoststart(const char *url)
 
 static char* _find_pathstart(const char *url)
 {
-    size_t remaining = SOCK_HOSTPORT_MAXLEN;
+    size_t remaining = CONFIG_SOCK_HOSTPORT_MAXLEN;
     char *urlpos = (char*)url;
     while(*urlpos && remaining) {
         remaining--;
@@ -127,9 +127,9 @@ int sock_urlsplit(const char *url, char *hostport, char *urlpath)
 
     if (hostport) {
         size_t hostlen = pathstart - hoststart;
-        /* hostlen must be smaller SOCK_HOSTPORT_MAXLEN to have space for the null
+        /* hostlen must be smaller CONFIG_SOCK_HOSTPORT_MAXLEN to have space for the null
         * terminator */
-        if (hostlen > SOCK_HOSTPORT_MAXLEN - 1) {
+        if (hostlen > CONFIG_SOCK_HOSTPORT_MAXLEN - 1) {
             return -EOVERFLOW;
         }
         memcpy(hostport, hoststart, hostlen);
@@ -138,7 +138,7 @@ int sock_urlsplit(const char *url, char *hostport, char *urlpath)
 
     if (urlpath) {
         size_t pathlen = strlen(pathstart);
-        if (pathlen > SOCK_URLPATH_MAXLEN - 1) {
+        if (pathlen > CONFIG_SOCK_URLPATH_MAXLEN - 1) {
             return -EOVERFLOW;
         }
         memcpy(urlpath, pathstart, pathlen);
@@ -153,7 +153,7 @@ int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str)
     char *hoststart = (char*)str;
     char *hostend;
 
-    char hostbuf[SOCK_HOSTPORT_MAXLEN];
+    char hostbuf[CONFIG_SOCK_HOSTPORT_MAXLEN];
 
     memset(ep_out, 0, sizeof(sock_udp_ep_t));
 

--- a/sys/suit/coap.c
+++ b/sys/suit/coap.c
@@ -268,8 +268,8 @@ int suit_coap_get_blockwise_url(const char *url,
                                coap_blksize_t blksize,
                                coap_blockwise_cb_t callback, void *arg)
 {
-    char hostport[SOCK_HOSTPORT_MAXLEN];
-    char urlpath[SOCK_URLPATH_MAXLEN];
+    char hostport[CONFIG_SOCK_HOSTPORT_MAXLEN];
+    char urlpath[CONFIG_SOCK_URLPATH_MAXLEN];
     sock_udp_ep_t remote;
 
     if (strncmp(url, "coap://", 7)) {

--- a/tests/unittests/tests-sock_util/tests-sock_util.c
+++ b/tests/unittests/tests-sock_util/tests-sock_util.c
@@ -62,8 +62,8 @@
 #define TEST_STR2EP_INVALID         "[2001:db8:a:b:c:d:e:f:1]"
 #define TEST_STR2EP_INVALID2        "[2001:db8:a:b:c:d:e:f]:66000"
 
-static char addr[SOCK_URLPATH_MAXLEN];
-static char urlpath[SOCK_URLPATH_MAXLEN];
+static char addr[CONFIG_SOCK_URLPATH_MAXLEN];
+static char urlpath[CONFIG_SOCK_URLPATH_MAXLEN];
 
 
 static void setup(void)


### PR DESCRIPTION
### Contribution description
This PR moves configuration macros of SOCK utilities module to the `CONFIG_` namespace. It also exposes them to Kconfig.

### Testing procedure
You can check the values in some application that uses this module (e.g. `examples/gcoap`). Make sure configurations take the default values as usual from the header files. Run `make menuconfig`, enable the configuration of the module and change the values.

You can use this patch:
```diff
diff --git a/examples/gcoap/main.c b/examples/gcoap/main.c
index 3757922d0..cbea87001 100644
--- a/examples/gcoap/main.c
+++ b/examples/gcoap/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include "msg.h"
 
+#include "net/sock/util.h"
 #include "net/gcoap.h"
 #include "kernel_types.h"
 #include "shell.h"
@@ -42,7 +43,9 @@ int main(void)
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
     gcoap_cli_init();
     puts("gcoap example app");
-
+    printf("Scheme length: %d\n", CONFIG_SOCK_SCHEME_MAXLEN);
+    printf("Host:Port length: %d\n", CONFIG_SOCK_HOSTPORT_MAXLEN);
+    printf("URL path length: %d\n", CONFIG_SOCK_URLPATH_MAXLEN);
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
```

### Issues/PRs references
Part of #12888