### PR TITLE
cpu/esp32: esp_wifi send buffer should not be on stack

### DIFF
--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -347,6 +347,9 @@ static int _esp_wifi_init(netdev_t *netdev)
     return 0;
 }
 
+/* transmit buffer should bot be on stack */
+static uint8_t _tx_buf[ETHERNET_MAX_LEN];
+
 static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
 {
     ESP_WIFI_DEBUG("%p %p", netdev, iolist);
@@ -360,7 +363,6 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
     }
 
     uint16_t tx_len = 0;              /**< number of bytes in transmit buffer */
-    uint8_t tx_buf[ETHERNET_MAX_LEN]; /**< transmit buffer */
 
     /* load packet data into TX buffer */
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
@@ -368,7 +370,7 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
             return -EOVERFLOW;
         }
         if (iol->iol_len) {
-            memcpy (tx_buf + tx_len, iol->iol_base, iol->iol_len);
+            memcpy (_tx_buf + tx_len, iol->iol_base, iol->iol_len);
             tx_len += iol->iol_len;
         }
     }


### PR DESCRIPTION
### Contribution description

This PR fixes a problem when using `lwIP` together with `esp_wifi` and ESP32.

`_esp_wifi_send` uses a buffer of size `EHTHERNET_MAX_LEN` to convert the `iolist` of the given packet to a plain buffer for the WiFi interface. This buffer should not be on the stack to prevent the sending thread's stack from overflowing.

### Testing procedure

Use `tests/lwip` with and without this PR.
```
USEMODULE='esp_wifi' CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' make BOARD=esp32-wroom-32 -C tests/lwip flash test
```
Without the PR, the application crashes after some seconds when the first packet is sent from `tcpip_thread`.

### Issues/PRs references

Figured out when experimenting with `lwIP` and ESP8266 for PR #12903.