### PR TITLE
pkg/lwip: overiddable settings in lwipopts.h

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -129,6 +129,12 @@ ifneq (,$(filter esp_wifi_any esp_eth,$(USEMODULE)))
   CFLAGS += -DSCHED_PRIO_LEVELS=32
 endif
 
+ifneq (,$(filter lwip,$(USEMODULE)))
+  # The thread for handling the WiFi hardware has the priority. The priority
+  # of the lwIP TCP/IP thread should be lower than this priority.
+  CFLAGS += -DTCPIP_THREAD_PRIO=2
+endif
+
 CFLAGS  += -DSDK_NOT_USED -DCONFIG_FREERTOS_UNICORE=1 -DESP_PLATFORM
 CFLAGS  += -DLOG_TAG_IN_BRACKETS
 CFLAGS  += -Wno-unused-parameter -Wformat=0

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -145,15 +145,6 @@ extern "C" {
 #define TCPIP_THREAD_STACKSIZE  (THREAD_STACKSIZE_DEFAULT)
 #endif
 
-#if defined(CPU_ESP32) && !defined(DOXYGEN)
-/**
- * In ESP32, the thread that is dealing with hardware interrupts of the WiFi
- * interface has a priority of 1. This thread should have a higher priority
- * than lwIP's TCP/IP thread.
- */
-#define TCPIP_THREAD_PRIO       (2)
-#endif
-
 #define MEM_ALIGNMENT           (4)
 #ifndef MEM_SIZE
 /* packet buffer size of GNRC + stack for TCP/IP */

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -141,7 +141,9 @@ extern "C" {
 #define MEMP_MEM_MALLOC         (1)
 #define NETIF_MAX_HWADDR_LEN    (GNRC_NETIF_HDR_L2ADDR_MAX_LEN)
 
+#ifndef TCPIP_THREAD_STACKSIZE
 #define TCPIP_THREAD_STACKSIZE  (THREAD_STACKSIZE_DEFAULT)
+#endif
 
 #if defined(CPU_ESP32) && !defined(DOXYGEN)
 /**


### PR DESCRIPTION
### Contribution description

This PR provides the following changes:

- `TCPIP_THREAD_STACKSIZE` is made overridable. On some platforms the default stack size is too small for `lwIP`'s `tcpip_thread` so that the default stack size has to be overriden.
- Platform dependent definition of `TCPIP_THREAD_PRIO` for ESP32 is removed. This is now defined by `CFLAGS` in ESP32's Makefile.

### Testing procedure

Flash `tests/lwip` with the definition of `TCPIP_THREAD_STACKSIZE` for any ESP32 board:
```
USEMODULE='esp_wifi' CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' \
make BOARD=esp32-wroom-32 -C tests/lwip flash term
```
Use command `ps`. The stack size for thread `tcpip_thread` should be 3072 instead of the default stack size of 2048.
```
  6 | tcpip_thread         | bl mbox  _ |   2 |   3072 ( 2892) | 0x3ffb98cc | 0x3ffba260 
```

### Issues/PRs references

Figured out when testing PR #12903 for ESP32.