### PR TITLE
cpu/esp8266: enable lwIP for ESP8266

### DIFF
--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -54,12 +54,6 @@ ifneq (, $(filter littlefs, $(USEMODULE)))
     export RIOT_TEST_TIMEOUT = 200
 endif
 
-ifneq (,$(filter lwip,$(USEMODULE)))
-  # The threads for handling the ESP hardware have the priorities from 2 to 4.
-  # The priority of lwIP TCPIP thread should be lower than these priorities.
-  CFLAGS += -DTCPIP_THREAD_PRIO=5
-endif
-
 ifneq (,$(filter log_color,$(USEMODULE)))
     USEMODULE += esp_log_colored
 endif
@@ -139,6 +133,12 @@ ASFLAGS += --longcalls --text-section-literals
 
 # thin archives trigger a reboot loop - see #12258, #12035, #12346
 ARFLAGS = rcs
+
+ifneq (,$(filter lwip,$(USEMODULE)))
+  # The threads for handling the ESP hardware have the priorities from 2 to 4.
+  # The priority of lwIP TCPIP thread should be lower than these priorities.
+  CFLAGS += -DTCPIP_THREAD_PRIO=5
+endif
 
 ifneq (, $(filter esp_gdbstub, $(USEMODULE)))
     GDBSTUB_DIR ?= $(RIOTCPU)/$(CPU)/vendor/esp-gdbstub

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -54,6 +54,12 @@ ifneq (, $(filter littlefs, $(USEMODULE)))
     export RIOT_TEST_TIMEOUT = 200
 endif
 
+ifneq (,$(filter lwip,$(USEMODULE)))
+  # The threads for handling the ESP hardware have the priorities from 2 to 4.
+  # The priority of lwIP TCPIP thread should be lower than these priorities.
+  CFLAGS += -DTCPIP_THREAD_PRIO=5
+endif
+
 ifneq (,$(filter log_color,$(USEMODULE)))
     USEMODULE += esp_log_colored
 endif

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -74,6 +74,23 @@
 #define CONFIG_TCP_OVERSIZE_MSS 1
 #define LL_ALIGN(s)             (((uint32_t)s + 3) & 0xfffffffcU)
 
+/**
+ * The SDK interface of the WiFi module uses the lwIP `pbuf` structure for
+ * packets sent to and received from the WiFi interface. For compatibility
+ * reasons with the binary SDK libraries we need to incclude the SDK lwIP
+ * `pbuf` header here.
+ *
+ * To avoid compilation errors, we need to undefine all our pkg/lwIP settings
+ * that are also defined by SDK lwIP header files. These definitions do not
+ * affect the implementation of this module.
+ */
+#undef ETHARP_SUPPORT_STATIC_ENTRIES
+#undef LWIP_HAVE_LOOPIF
+#undef LWIP_NETIF_LOOPBACK
+#undef SO_REUSE
+#undef TCPIP_THREAD_PRIO
+#undef TCPIP_THREAD_STACKSIZE
+
 #include "lwip/pbuf.h"
 
 #endif /* MCU_ESP8266 */

--- a/cpu/esp8266/include/cpu_conf.h
+++ b/cpu/esp8266/include/cpu_conf.h
@@ -64,6 +64,10 @@ extern "C" {
 #ifndef ESP_NOW_STACKSIZE
 #define ESP_NOW_STACKSIZE             (2560)
 #endif
+
+#ifndef TCPIP_THREAD_STACKSIZE
+#define TCPIP_THREAD_STACKSIZE        (3072)
+#endif
 /** @} */
 
 /**

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -1,6 +1,3 @@
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 FEATURES_REQUIRED += arch_32bit
-
-# lwip currently doesn't compile on esp8266
-FEATURES_BLACKLIST += arch_esp8266

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -174,6 +174,7 @@ void lwip_bootstrap(void)
     }
 #endif /* MODULE_LWIP_IPV4 */
 #elif defined(MODULE_ESP_WIFI)
+    esp_wifi_setup(&_esp_wifi_dev);
 #ifdef MODULE_LWIP_IPV4
     if (netif_add(&netif[0], IP4_ADDR_ANY, IP4_ADDR_ANY, IP4_ADDR_ANY,
                   &_esp_wifi_dev, lwip_netdev_init, tcpip_input) == NULL) {
@@ -181,7 +182,6 @@ void lwip_bootstrap(void)
         return;
     }
 #else /* MODULE_LWIP_IPV4 */
-    esp_wifi_setup(&_esp_wifi_dev);
     if (netif_add(&netif[0], &_esp_wifi_dev, lwip_netdev_init,
                   tcpip_input) == NULL) {
         DEBUG("Could not add esp_wifi device\n");


### PR DESCRIPTION
### Contribution description

This PR provides very small changes that make it possible to use `pkg/lwip` also with ESP8266.

#### Background

The SDK interface of the WiFi module uses the `lwIP`'s `pbuf` structure for packets sent to and received from the WiFi interface. For compatibility reasons with the binary SDK libraries, module `esp_wifi` has to  include the SDK `lwIP` `pbuf` header and can't use that from `pkg/lwip`. 

To avoid compilation errors, all settings in `pkg/lwIP` that are also defined by SDK `lwIP` header files have to be undefined in `esp_wifi`.

#### Tests

The following tests were executed:
- `tests/lwip`
   - IPv6 works with `esp_wifi`
   - IPv4 version is not available.
- `tests/lwip_sock_ip`
   - IPv6 works without `esp_wifi`
   - IPv6 fails with `esp_wifi` in `test_sock_ip_recv6__socket` with `EAGAIN`
   - IPv4 works with `esp_wifi`
- `tests/lwip_sock_tcp`
   - IPv6 works with `esp_wifi`
   - IPv6 fails in `test_tcp_connect6__EINVAL_netif` with 0 (means `sock_tcp_connect` success)
   - IPv4 fails in `test_tcp_connect6__EINVAL_netif` with 0 (means `sock_tcp_connect` success)
- `tests/lwip_sock_udp`
   - IPv6 works with `esp_wifi`
   - IPv6 hangs in `test_sock_udp_recv6__socketed` but the node is reachable with `ping`
   - IPv4 works with `esp_wifi`

It seems that the tests 'fail' when they are executed with enabled `esp_wifi` because of the existence of the real network interface or because packets injected to the test device are interfered by incoming packets from the WiFi interface.

### Testing procedure

Flash `tests/lwip` with enabled module `esp_wifi` on any ESP8266 board
```
USEMODULE=esp_wifi CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"'\
make BOARD=esp8266-esp-12x -C tests/lwip flash term
```
and execute `ifconfig` on ESP8266 node and ping the node from any machine in the LAN.

### Issues/PRs references

Depends on PR #12948.
Depends on PR #12903 for IPv4.