### PR TITLE
pkg/lwip: add support for esp32 Ethernet device

### DIFF
--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -280,7 +280,7 @@ static int _esp_eth_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_le
 
     switch (opt) {
         case NETOPT_ADDRESS:
-            assert(max_len == ETHERNET_ADDR_LEN);
+            assert(max_len >= ETHERNET_ADDR_LEN);
             esp_eth_get_mac((uint8_t *)val);
             return ETHERNET_ADDR_LEN;
         case NETOPT_LINK_CONNECTED:

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -67,7 +67,7 @@
  * not provide an argument that could be used as pointer to the ESP-ETH
  * device which triggers the interrupt.
  */
-static esp_eth_netdev_t _esp_eth_dev;
+esp_eth_netdev_t _esp_eth_dev;
 
 /* device thread stack */
 static char _esp_eth_stack[ESP_ETH_STACKSIZE];

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -385,8 +385,10 @@ static const netdev_driver_t _esp_eth_driver =
 extern esp_err_t esp_system_event_add_handler (system_event_cb_t handler,
                                                void *arg);
 
-void auto_init_esp_eth (void)
+void esp_eth_setup(esp_eth_netdev_t* dev)
 {
+    (void)dev;
+
     LOG_TAG_INFO("esp_eth", "initializing ESP32 Ethernet MAC (EMAC) device\n");
 
     /* initialize locking */
@@ -403,11 +405,16 @@ void auto_init_esp_eth (void)
     _esp_eth_dev.link_up = false;
     _esp_eth_dev.rx_len = 0;
     _esp_eth_dev.tx_len = 0;
+}
+
+void auto_init_esp_eth(void)
+{
+    esp_eth_setup(&_esp_eth_dev);
     _esp_eth_dev.netif = gnrc_netif_ethernet_create(_esp_eth_stack,
-                                                   ESP_ETH_STACKSIZE,
-                                                   ESP_ETH_PRIO,
-                                                   "netdev-esp-eth",
-                                                   (netdev_t *)&_esp_eth_dev);
+                                                    ESP_ETH_STACKSIZE,
+                                                    ESP_ETH_PRIO,
+                                                    "esp_eth",
+                                                    (netdev_t *)&_esp_eth_dev);
 }
 
 #endif /* MODULE_ESP_ETH */

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -160,11 +160,19 @@ void lwip_bootstrap(void)
     }
 #elif defined(MODULE_ESP_ETH)
     esp_eth_setup(&_esp_eth_dev);
-    if (netif_add(&netif[0], &_esp_eth_dev, lwip_netdev_init,
-                  tcpip_input) == NULL) {
-        DEBUG("Could not add esp_wifi device\n");
+#ifdef MODULE_LWIP_IPV4
+    if (netif_add(&netif[0], IP4_ADDR_ANY, IP4_ADDR_ANY, IP4_ADDR_ANY,
+                  &_esp_eth_dev, lwip_netdev_init, tcpip_input) == NULL) {
+        DEBUG("Could not add esp_eth device\n");
         return;
     }
+#else /* MODULE_LWIP_IPV4 */
+    if (netif_add(&netif[0], &_esp_eth_dev, lwip_netdev_init,
+                  tcpip_input) == NULL) {
+        DEBUG("Could not add esp_eth device\n");
+        return;
+    }
+#endif /* MODULE_LWIP_IPV4 */
 #elif defined(MODULE_ESP_WIFI)
     esp_wifi_setup(&_esp_wifi_dev);
     if (netif_add(&netif[0], &_esp_wifi_dev, lwip_netdev_init,


### PR DESCRIPTION
### Contribution description

This PR adds the support for ESP32 Ethernet device to `pkg/lwip` in same way as PR #12895 does. Addititionally, it adds the IPv4 support for the ESP32 Ethernet device as PR #12903.

### Testing procedure

Flash `tests/lwip` with enabled module `esp_wifi` on any ESP32 board with an Ethernet interface (for example Olimex ESP32-EVB)
```
USEMODULE=esp_eth make BOARD=esp32-olimex-evb -C tests/lwip flash term
```
and execute `ifconfig` on ESP32 node and ping the node from any machine in the LAN.

### Issues/PRs references

Related to PR #12903.