### PR TITLE
cpu/esp32: fix esp_wifi compile error

### DIFF
--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -348,7 +348,7 @@ static int _esp_wifi_init(netdev_t *netdev)
 }
 
 /* transmit buffer should bot be on stack */
-static uint8_t _tx_buf[ETHERNET_MAX_LEN];
+static uint8_t tx_buf[ETHERNET_MAX_LEN];
 
 static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
 {
@@ -370,7 +370,7 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
             return -EOVERFLOW;
         }
         if (iol->iol_len) {
-            memcpy (_tx_buf + tx_len, iol->iol_base, iol->iol_len);
+            memcpy (tx_buf + tx_len, iol->iol_base, iol->iol_len);
             tx_len += iol->iol_len;
         }
     }


### PR DESCRIPTION
### Contribution description

This PR fixes a compilation error with the `esp_wifi` module enabled that was introduced with PR #12947.

### Testing procedure

The compilation error occurs when the `esp_wifi` module is enabled. This means that a successful compilation of any application with the `esp_wifi` module enabled is sufficient as a test.
```
USEMODULE='esp_wifi' make BOARD=esp32-wroom-32 -C tests/shell
```
fails without the PR and succeeds with this PR.

### Issues/PRs references

Fixes compilation problem of PR #12947.