### PR TITLE
cpu/fe310: add pwm peripheral driver

### DIFF
--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -2,7 +2,7 @@ CPU = fe310
 CPU_MODEL = fe310_g000
 
 # Put defined MCU peripherals here (in alphabetical order)
-#FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -142,7 +142,24 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define PWM_NUMOF                   (3)
+static const pwm_conf_t pwm_config[] = {
+    {   .addr  = PWM1_CTRL_ADDR,
+        .chan = {  /* GPIO pin, channel comparator index */
+                    { .pin = GPIO_PIN(0, 19), .cmp = 0 }, /* D3, on-board green LED */
+                    { .pin = GPIO_PIN(0, 20), .cmp = 1 }, /* D4 */
+                    { .pin = GPIO_PIN(0, 21), .cmp = 2 }, /* D5, On-board blue LED */
+                    { .pin = GPIO_PIN(0, 22), .cmp = 3 }} /* D6, On-board red LED */
+    },
+    {   .addr  = PWM2_CTRL_ADDR,
+        .chan = {  /* GPIO pin, channel comparator index */
+                    { .pin = GPIO_PIN(0, 10), .cmp = 0 }, /* D16 */
+                    { .pin = GPIO_PIN(0, 11), .cmp = 1 }, /* D17 */
+                    { .pin = GPIO_UNDEF, .cmp = 2 },
+                    { .pin = GPIO_UNDEF, .cmp = 3 }}
+    },
+};
+
+#define PWM_NUMOF                   ARRAY_SIZE(pwm_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/hifive1b/Makefile.features
+++ b/boards/hifive1b/Makefile.features
@@ -3,7 +3,7 @@ CPU_MODEL = fe310_g002
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
-#FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -143,7 +143,24 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define PWM_NUMOF                   (3)
+static const pwm_conf_t pwm_config[] = {
+    {   .addr  = PWM1_CTRL_ADDR,
+        .chan = {  /* GPIO pin, channel comparator index */
+                    { .pin = GPIO_PIN(0, 19), .cmp = 0 }, /* D3, on-board green LED */
+                    { .pin = GPIO_PIN(0, 20), .cmp = 1 }, /* D4 */
+                    { .pin = GPIO_PIN(0, 21), .cmp = 2 }, /* D5, On-board blue LED */
+                    { .pin = GPIO_PIN(0, 22), .cmp = 3 }} /* D6, On-board red LED */
+    },
+    {   .addr  = PWM2_CTRL_ADDR,
+        .chan = {  /* GPIO pin, channel comparator index */
+                    { .pin = GPIO_PIN(0, 10), .cmp = 0 }, /* D16 */
+                    { .pin = GPIO_PIN(0, 11), .cmp = 1 }, /* D17 */
+                    { .pin = GPIO_UNDEF, .cmp = 2 },
+                    { .pin = GPIO_UNDEF, .cmp = 3 }}
+    },
+};
+
+#define PWM_NUMOF                   ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -131,6 +131,22 @@ typedef struct {
     i2c_speed_t speed;          /**< I2C speed */
 } i2c_conf_t;
 
+/**
+ * @brief   PWM channel configuration data structure
+ */
+typedef struct {
+    gpio_t pin;                 /**< GPIO pin */
+    uint8_t cmp;                /**< PWM comparator to use */
+} pwm_conf_chan_t;
+
+/**
+ * @brief   PWM device configuration data structure
+ */
+typedef struct {
+    uint32_t addr;              /**< PWM address to use */
+    pwm_conf_chan_t chan[4];    /**< channel configuration */
+} pwm_conf_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/fe310/periph/pwm.c
+++ b/cpu/fe310/periph/pwm.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_fe310
+ * @ingroup     drivers_periph_pwm
+ * @{
+ *
+ * @file
+ * @brief       PWM driver implementation for the FE310
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @}
+ */
+
+#include <assert.h>
+
+#include "cpu.h"
+#include "periph/pwm.h"
+#include "periph/gpio.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define PWM_CMPSIZE     (0x4)
+#define PWM_CMPWIDTH    (16)
+
+uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
+{
+    assert(dev < PWM_NUMOF);
+
+    /* Compute PWM counter scale */
+    uint8_t scale = 0;
+    while ((scale < (PWM_CMPWIDTH - 1)) &&
+           (freq * res) > (uint32_t)(1 << (scale + PWM_CMPWIDTH))) {
+        scale++;
+    }
+
+    /* Prepare PWM counter scale and enable continuous mode */
+    uint32_t config = ((scale & PWM_CFG_SCALE) | PWM_CFG_ENALWAYS);
+
+    /* Configure wave forms */
+    if (mode == PWM_CENTER) {
+        config |= (PWM_CFG_CMP0CENTER | PWM_CFG_CMP1CENTER | \
+                   PWM_CFG_CMP2CENTER | PWM_CFG_CMP3CENTER);
+    }
+
+    /* setup the configured channels */
+    for (unsigned i = 0; i < ARRAY_SIZE(pwm_config[dev].chan); ++i) {
+        if (pwm_config[dev].chan[i].pin == GPIO_UNDEF) {
+            continue;
+        }
+        GPIO_REG(GPIO_IOF_SEL) |= (1 << pwm_config[dev].chan[i].pin);
+        GPIO_REG(GPIO_IOF_EN) |= (1 << pwm_config[dev].chan[i].pin);
+    }
+
+    /* Configure and enable device */
+    _REG32(pwm_config[dev].addr, PWM_CFG) = config;
+
+    /* and return the actual configured frequency */
+    return cpu_freq() / (uint32_t)(1 << (scale + PWM_CMPWIDTH));
+}
+
+uint8_t pwm_channels(pwm_t dev)
+{
+    assert(dev < PWM_NUMOF);
+    return (uint8_t)ARRAY_SIZE(pwm_config[dev].chan);
+}
+
+void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
+{
+    assert((dev < PWM_NUMOF) && (channel < ARRAY_SIZE(pwm_config[dev].chan)));
+
+    uint8_t scale = _REG32(pwm_config[dev].addr, PWM_CFG) & PWM_CFG_SCALE;
+    uint32_t freq = cpu_freq() / (uint32_t)(1 << (scale + PWM_CMPWIDTH)) ;
+
+    uint32_t cmp_reg = PWM_CMP0 + (PWM_CMPSIZE * pwm_config[dev].chan[channel].cmp);
+    _REG32(pwm_config[dev].addr, cmp_reg) = value * freq;
+}
+
+void pwm_poweron(pwm_t dev)
+{
+    assert(dev < PWM_NUMOF);
+    _REG32(pwm_config[dev].addr, PWM_CFG) |= PWM_CFG_ENALWAYS;
+}
+
+void pwm_poweroff(pwm_t dev)
+{
+    assert(dev < PWM_NUMOF);
+    _REG32(pwm_config[dev].addr, PWM_CFG) &= ~PWM_CFG_ENALWAYS;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR implements the PWM driver for RISC-V FE310 CPU and adds a basic configuration for Sifive HiFive1 and HiFive1b boards.

Since a valid core clock value is required, this PR is based on #12519.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash the `tests/periph_pwm` application on a Hifive1/b board:
```
$ make BOARD=hifive1b -C tests/periph_pwm flash term
```
- Call the `osci` shell command
```
> osci
```
You should see the on-board leds oscillate synchronously (they are connected to an RGD led, so the led oscillates in white). You can also plug a led on the other configured pins (Arduino D4, D16, D17) and watch them oscillate as well.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #12934 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
