### PR TITLE
examples/nimble_x: fix building without DEVELHELP

### DIFF
--- a/examples/nimble_gatt/main.c
+++ b/examples/nimble_gatt/main.c
@@ -310,6 +310,7 @@ int main(void)
     puts("NimBLE GATT Server Example");
 
     int rc = 0;
+    (void)rc;
 
     /* verify and add our custom services */
     rc = ble_gatts_count_cfg(gatt_svr_svcs);

--- a/examples/nimble_heart_rate_sensor/main.c
+++ b/examples/nimble_heart_rate_sensor/main.c
@@ -286,6 +286,7 @@ static void _hr_update(event_t *e)
     assert(om != NULL);
     int res = ble_gattc_notify_custom(_conn_handle, _hrs_val_handle, om);
     assert(res == 0);
+    (void)res;
 
     /* schedule next update event */
     event_timeout_set(&_update_timeout_evt, UPDATE_INTERVAL);
@@ -296,6 +297,7 @@ int main(void)
     puts("NimBLE Heart Rate Sensor Example");
 
     int res = 0;
+    (void)res;
 
     /* setup local event queue (for handling heart rate updates) */
     event_queue_init(&_eq);


### PR DESCRIPTION
### Contribution description
Just discovered, that `examples/nimble_gatt` and `examples/nimble_heart_rate_sensor` do not build without DEVELHELP, as some return values are only used in assertions and lead to `unused variable` warnings when compiling. This PR fixes those...

### Testing procedure
Build both examples with `DEVELHELP=0` -> without this fix they fail to build, with this fix they build just fine.

### Issues/PRs references
none