### PR TITLE
cpu/fe310: add spi peripheral driver

### DIFF
--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -5,6 +5,6 @@ CPU_MODEL = fe310_g000
 #FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
-#FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -110,6 +110,23 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name    SPI device configuration
+ *
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .addr       = SPI1_CTRL_ADDR,
+        .mosi       = GPIO_PIN(0, 3), /* D11 */
+        .miso       = GPIO_PIN(0, 4), /* D12 */
+        .sclk       = GPIO_PIN(0, 5), /* D13 */
+    },
+};
+
+#define SPI_NUMOF                  ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
  * @name    RTT/RTC configuration
  *
  * @{

--- a/boards/hifive1b/Makefile.features
+++ b/boards/hifive1b/Makefile.features
@@ -6,7 +6,7 @@ CPU_MODEL = fe310_g002
 #FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
-#FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -111,6 +111,23 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name    SPI device configuration
+ *
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .addr       = SPI1_CTRL_ADDR,
+        .mosi       = GPIO_PIN(0, 3), /* D11 */
+        .miso       = GPIO_PIN(0, 4), /* D12 */
+        .sclk       = GPIO_PIN(0, 5), /* D13 */
+    },
+};
+
+#define SPI_NUMOF                  ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
  * @name    RTT/RTC configuration
  *
  * @{

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -71,6 +71,25 @@ typedef struct {
 #define UART_ISR_PRIO       (2)
 
 /**
+ * @name    This CPU makes use of the following shared SPI functions
+ * @{
+ */
+#define PERIPH_SPI_NEEDS_TRANSFER_BYTE  1
+#define PERIPH_SPI_NEEDS_TRANSFER_REG   1
+#define PERIPH_SPI_NEEDS_TRANSFER_REGS  1
+/** @} */
+
+/**
+ * @brief   Structure for SPI configuration data
+ */
+typedef struct {
+    uint32_t addr;          /**< SPI control register address */
+    gpio_t mosi;            /**< MOSI pin */
+    gpio_t miso;            /**< MISO pin */
+    gpio_t sclk;            /**< SCLK pin */
+} spi_conf_t;
+
+/**
  * @brief   Prevent shared timer functions from being used
  */
 #define PERIPH_TIMER_PROVIDES_SET

--- a/cpu/fe310/periph/spi.c
+++ b/cpu/fe310/periph/spi.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2019 Tristan Bruns
+ *               2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_fe310
+ * @ingroup     drivers_periph_spi
+ *
+ * @{
+ *
+ * @file        spi.c
+ * @brief       Low-level SPI driver implementation
+ *
+ * @author      Tristan Bruns
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "mutex.h"
+#include "assert.h"
+#include "periph/spi.h"
+
+#include "vendor/spi.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+static const uint32_t _spi_clks[] = {
+    100000,
+    400000,
+    1000000,
+    5000000,
+    10000000,
+};
+
+#define SPI_CLK_NUMOF       ARRAY_SIZE(_spi_clks)
+
+static uint32_t _spi_clks_config[SPI_CLK_NUMOF] = { 0 };
+
+/* DIV_UP is division which rounds up instead of down */
+#define SPI_DIV_UP(a,b) (((a) + ((b) - 1)) / (b))
+
+/**
+ * @brief   Allocation device locks
+ */
+static mutex_t lock;
+
+void spi_init(spi_t dev)
+{
+    /* make sure given bus device is valid */
+    assert(dev < SPI_NUMOF);
+
+    /* initialize the buses lock */
+    mutex_init(&lock);
+
+    for (uint8_t i = 0; i < SPI_CLK_NUMOF; ++i) {
+        _spi_clks_config[i] = SPI_DIV_UP(cpu_freq(), 2 * _spi_clks[i]) - 1;
+    }
+
+    /* trigger pin initialization */
+    spi_init_pins(dev);
+
+    /* disable hardware chip select
+       (hardware chip select only supports one-byte transfers...) */
+    _REG32(spi_config[dev].addr, SPI_REG_CSMODE) = SPI_CSMODE_OFF;
+}
+
+void spi_init_pins(spi_t dev)
+{
+    assert(dev < SPI_NUMOF);
+
+    const gpio_t spi1_pins =
+        (1 << spi_config[dev].mosi) |
+        (1 << spi_config[dev].miso) |
+        (1 << spi_config[dev].sclk);
+
+    /* Enable I/O Function 0 */
+    GPIO_REG(GPIO_IOF_EN)  |=  spi1_pins;
+    GPIO_REG(GPIO_IOF_SEL) &= ~spi1_pins;
+}
+
+int spi_init_cs(spi_t dev, spi_cs_t cs)
+{
+    (void)dev;
+    assert(dev < SPI_NUMOF);
+
+    /* setting the CS high before configuring it as an
+       output should be fine on FE310. */
+    gpio_set(cs);
+
+    if (gpio_init(cs, GPIO_OUT)) {
+        return SPI_NOCS;
+    }
+
+    return SPI_OK;
+}
+
+int spi_acquire(spi_t dev, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+{
+    (void)cs;
+    assert(dev < SPI_NUMOF);
+
+    mutex_lock(&lock);
+
+    _REG32(spi_config[dev].addr, SPI_REG_SCKDIV)  = _spi_clks_config[clk];
+    _REG32(spi_config[dev].addr, SPI_REG_SCKMODE) = mode;
+
+    return SPI_OK;
+}
+
+void spi_release(spi_t dev)
+{
+    (void)dev;
+
+    mutex_unlock(&lock);
+}
+
+void spi_transfer_bytes(spi_t dev, spi_cs_t cs, bool cont,
+                        const void *out_, void *in_, size_t len)
+{
+    assert(dev < SPI_NUMOF);
+    assert((out_ || in_) && len > 0);
+    assert(_REG32(spi_config[dev].addr, SPI_REG_RXFIFO) & SPI_RXFIFO_EMPTY);
+    assert(!(_REG32(spi_config[dev].addr, SPI_REG_TXFIFO) & SPI_TXFIFO_FULL));
+
+    const uint8_t *out = out_;
+    uint8_t *in = in_;
+
+    if (cs != SPI_CS_UNDEF) {
+        gpio_clear(cs);
+    }
+
+    for (size_t i = 0; i < len; i++) {
+        _REG32(spi_config[dev].addr, SPI_REG_TXFIFO) = out ? out[i] : 0;
+
+        uint32_t rxdata;
+        do  {
+            rxdata = _REG32(spi_config[dev].addr, SPI_REG_RXFIFO);
+        } while (rxdata & SPI_RXFIFO_EMPTY);
+
+        if (in) {
+            in[i] = (uint8_t)rxdata;
+        }
+    }
+
+    if (cs != SPI_CS_UNDEF && !cont) {
+        gpio_set(cs);
+    }
+}

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -9,6 +9,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill \
     bluepill \
     derfmega128 \
+    hifive1 \
+    hifive1b \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

**this PR is a rework of the original PR #10833 from @pyropeter.**

It adds an implementation of the SPI peripheral driver for RISC-V FE310 cpu and configure 2 peripherals on hifive1 and hifive1b boards.

The PR was just tested with success using a bmp280 sensor plugged on the board. I'll try to find time for checking the bus with a logic analyzer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Simply plug an SPI device on the SPI pins available on the Arduino pinout and test it.
Example with bmp280:
- Alter the default BMX280_PARAM_CS value in  `bmpx280_params.h` as follows:
```diff
diff --git a/drivers/bmx280/include/bmx280_params.h b/drivers/bmx280/include/bmx280_params.h
index 09296398d0..8f6726b004 100644
--- a/drivers/bmx280/include/bmx280_params.h
+++ b/drivers/bmx280/include/bmx280_params.h
@@ -44,7 +44,7 @@ extern "C" {
 #define BMX280_PARAM_CLK            SPI_CLK_5MHZ
 #endif
 #ifndef BMX280_PARAM_CS
-#define BMX280_PARAM_CS             GPIO_PIN(0, 0)
+#define BMX280_PARAM_CS             GPIO_PIN(0, 2) /* Use Arduino D10 */
 #endif
 #else
 /* I2C configuration */
```
- Build and run the test application with the `bmp280_spi` version:
```
DRIVER=bmp280_spi make BOARD=hifive1b -C tests/driver_bmx280 flash term
```

<details><summary>Test output</summary>

```
2019-12-16 10:44:32,568 # main(): This is RIOT! (Version: 2020.01-devel-1427-g2bc10-pr/cpu/fe310_spi)
2019-12-16 10:44:32,570 # BMX280 test application
2019-12-16 10:44:32,570 # 
2019-12-16 10:44:32,574 # +------------Initializing------------+
2019-12-16 10:44:32,578 # Initialization successful
2019-12-16 10:44:32,579 # 
2019-12-16 10:44:32,582 # +------------Calibration Data------------+
2019-12-16 10:44:32,584 # dig_T1: 27404
2019-12-16 10:44:32,586 # dig_T2: 26504
2019-12-16 10:44:32,587 # dig_T3: -1000
2019-12-16 10:44:32,588 # dig_P1: 37215
2019-12-16 10:44:32,589 # dig_P2: -10579
2019-12-16 10:44:32,590 # dig_P3: 3024
2019-12-16 10:44:32,591 # dig_P4: 846
2019-12-16 10:44:32,592 # dig_P5: 302
2019-12-16 10:44:32,593 # dig_P6: 249
2019-12-16 10:44:32,594 # dig_P7: 0
2019-12-16 10:44:32,595 # dig_P8: 0
2019-12-16 10:44:32,596 # dig_P9: 0
2019-12-16 10:44:32,597 # 
2019-12-16 10:44:32,600 # +--------Starting Measurements--------+
2019-12-16 10:44:32,609 # Temperature [°C]: 23.46
2019-12-16 10:44:32,611 #    Pressure [Pa]: 98756
2019-12-16 10:44:32,612 # 
2019-12-16 10:44:32,615 # +-------------------------------------+
2019-12-16 10:44:32,615 # 
2019-12-16 10:44:34,618 # Temperature [°C]: 23.46
2019-12-16 10:44:34,620 #    Pressure [Pa]: 98764
2019-12-16 10:44:34,620 # 
2019-12-16 10:44:34,624 # +-------------------------------------+
2019-12-16 10:44:34,624 # 
2019-12-16 10:44:36,625 # Temperature [°C]: 23.45
2019-12-16 10:44:36,627 #    Pressure [Pa]: 98760
2019-12-16 10:44:36,628 # 
2019-12-16 10:44:36,631 # +-------------------------------------+
2019-12-16 10:44:36,631 # 
2019-12-16 10:44:38,633 # Temperature [°C]: 23.45
2019-12-16 10:44:38,635 #    Pressure [Pa]: 98768
2019-12-16 10:44:38,635 # 
2019-12-16 10:44:38,638 # +-------------------------------------+
2019-12-16 10:44:38,639 # 
2019-12-16 10:44:40,640 # Temperature [°C]: 23.46
2019-12-16 10:44:40,642 #    Pressure [Pa]: 98767
2019-12-16 10:44:40,642 # 
2019-12-16 10:44:40,646 # +-------------------------------------+
2019-12-16 10:44:40,646 # 
2019-12-16 10:44:42,648 # Temperature [°C]: 23.46
2019-12-16 10:44:42,650 #    Pressure [Pa]: 98762
2019-12-16 10:44:42,650 # 
2019-12-16 10:44:42,653 # +-------------------------------------+
2019-12-16 10:44:42,654 # 
2019-12-16 10:44:44,655 # Temperature [°C]: 23.46
2019-12-16 10:44:44,657 #    Pressure [Pa]: 98761
2019-12-16 10:44:44,658 # 
2019-12-16 10:44:44,661 # +-------------------------------------+
2019-12-16 10:44:44,661 # 
2019-12-16 10:44:46,663 # Temperature [°C]: 27.57
2019-12-16 10:44:46,665 #    Pressure [Pa]: 98769
2019-12-16 10:44:46,665 # 
2019-12-16 10:44:46,668 # +-------------------------------------+
2019-12-16 10:44:46,668 # 
2019-12-16 10:44:48,670 # Temperature [°C]: 25.53
2019-12-16 10:44:48,672 #    Pressure [Pa]: 98771
2019-12-16 10:44:48,673 # 
2019-12-16 10:44:48,676 # +-------------------------------------+
2019-12-16 10:44:48,676 # 
2019-12-16 10:44:50,678 # Temperature [°C]: 25.65
2019-12-16 10:44:50,680 #    Pressure [Pa]: 98775
2019-12-16 10:44:50,680 # 
2019-12-16 10:44:50,683 # +-------------------------------------+
2019-12-16 10:44:50,683 # 
```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #12934, closes #10833

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
