### PR TITLE
tests/shell: wait for prompt at beginning

### DIFF
--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -40,6 +40,7 @@ CONTROL_C = DLE+'\x03'
 CONTROL_D = DLE+'\x04'
 
 CMDS = (
+    (CONTROL_C, ('>')),
     ('start_test', ('[TEST_START]')),
     ('end_test', ('[TEST_END]')),
     ('\n', ('>')),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, the test would start sending the first test commands right
at the beginning. This fails on boards whose UART is not ready at that
point.

This PR makes the test script explicitly wait for the prompt to be
ready.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Verify that tests/shell works on your boards and  CI.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
