### PR TITLE
tests/sys_arduino: fix test synchronization issues

### DIFF
--- a/tests/sys_arduino/tests/01-run.py
+++ b/tests/sys_arduino/tests/01-run.py
@@ -11,6 +11,9 @@ from testrunner import run
 
 
 def testfunc(child):
+    # Wait for serial.begin() to complete
+    child.expect_exact("Hello Arduino!")
+
     # 1 Basic read+write test on serial with error command
     child.sendline("wrang")
     child.expect_exact("UNK")


### PR DESCRIPTION
### Contribution description

The test currently doesn't wait for synchronization of the serial
terminal the second time it is setup with `Serial.begin` this results
in the tests command being sent before the terminal is ready which
causes the test to fail. To fix this add an expect_exact on "Hello
arduino". (NOTE: this is different form `interactive_sync` which
synchronizes the start of the test, but here we must wait for the
uart to be started again.)

On slow platforms there might still be data in the Transmit shift register
when the uart is re-initialized, which causes the first character of the
print to be rubish, print an empty space to workaround this. A delay
also works but would have to be adapted to the baudrate, and would
lengthen startup code, it would also introduce timer depedencies in
unwanted places.

### Testing procedure

- Launch the test and open a serial terminal on `arduino-uno` "Hello Arduino" will be cleanly printed.

```
BOARD=arduino-uno make -C tests/sys_arduino flash term
```

```
019-12-16 11:55:04,560 # main(): This is RIOT! (Version: 2020.01-devel-1407-g755232-pr_sys_arduino_fix)!j
2019-12-16 11:55:04,576 # Hello Arduino!
```

- on master you see rubish:
```
2019-12-16 11:55:45,764 # main(): This is RIOT! (Version: 2020.01-devel-1406-g615fc-HEAD)!�����Arduino!
```

- The test passes on `arduino-uno` and other platforms, it will also pass rebased on #12862

<details><summary>BOARD=arduino-uno make -C tests/sys_arduino flash test </summary>

```
/home/francisco/workspace/RIOT-test/dist/tools/pyterm/pyterm -p "/dev/riot/tty-arduino-uno" -b "9600" --noprefix --no-repeat-command-on-empty-line
Connect to serial port /dev/riot/tty-arduino-uno
Welcome to pyterm!
Type '/exit' to exit.


He: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2020.01-devel-1410-g2b9c8-pr_sys_arduino_fix)!j
Hello Arduino!
wrang
UNK
echo quite long string echoing on arduino module test
ECHO: quite long string echoing on arduino module test
numb 4242
4242 4242 1092 10222
time
5503012 5544456 5586796 OK END
print
print(int, BIN): 1111101011000111
println(int, BIN): 1111101011000111
print(int, OCT): 175307
println(int, OCT): 175307
print(int, DEC): -1337
println(int, DEC): -1337
print(int, HEX): fac7
println(int, HEX): fac7
print(unsigned int, BIN): 101010
println(unsigned int, BIN): 101010
print(unsigned int, OCT): 52
println(unsigned int, OCT): 52
print(unsigned int, DEC): 42
println(unsigned int, DEC): 42
print(unsigned int, HEX): 2a
println(unsigned int, HEX): 2a
print(long, BIN): 10110110011010011111110100101110
println(long, BIN): 10110110011010011111110100101110
print(long, OCT): 26632376456
println(long, OCT): 26632376456
print(long, DEC): -1234567890
println(long, DEC): -1234567890
print(long, HEX): b669fd2e
println(long, HEX): b669fd2e
print(unsigned long, BIN): 1001001100101100000001011010010
println(unsigned long, BIN): 1001001100101100000001011010010
print(unsigned long, OCT): 11145401322
println(unsigned long, OCT): 11145401322
print(unsigned long, DEC): 1234567890
println(unsigned long, DEC): 1234567890
print(unsigned long, HEX): 499602d2
println(unsigned long, HEX): 499602d2

make: Leaving directory '/home/francisco/workspace/RIOT-test/tests/sys_arduino'
```
</details>


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
