### PR TITLE
pkg/lwip: start DHCP for a netif with lwip_dhcp

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -568,6 +568,10 @@ ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter lwip_dhcp_auto,$(USEMODULE)))
+  USEMODULE += lwip_dhcp
+endif
+
 ifneq (,$(filter sema,$(USEMODULE)))
   USEMODULE += xtimer
 endif

--- a/pkg/lwip/Makefile.include
+++ b/pkg/lwip/Makefile.include
@@ -4,6 +4,7 @@ INCLUDES += -I$(RIOTBASE)/pkg/lwip/include \
 PSEUDOMODULES += lwip_arp
 PSEUDOMODULES += lwip_autoip
 PSEUDOMODULES += lwip_dhcp
+PSEUDOMODULES += lwip_dhcp_auto
 PSEUDOMODULES += lwip_ethernet
 PSEUDOMODULES += lwip_igmp
 PSEUDOMODULES += lwip_ipv6_autoconfig

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -17,6 +17,9 @@
 #include <sys/uio.h>
 #include <inttypes.h>
 
+#if MODULE_LWIP_DHCP_AUTO
+#include "lwip/dhcp.h"
+#endif
 #include "lwip/err.h"
 #include "lwip/ethip6.h"
 #include "lwip/netif.h"
@@ -280,8 +283,14 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
                     DEBUG("lwip_netdev: error inputing packet\n");
                     return;
                 }
+                break;
             }
-            break;
+#ifdef MODULE_LWIP_DHCP_AUTO
+            case NETDEV_EVENT_LINK_UP: {
+                dhcp_start(netif);
+                break;
+            }
+#endif
             default:
                 break;
         }


### PR DESCRIPTION
### Contribution description

If `lwip_ipv4` is used together with `lwip_dhcp`, the netdev has to start DHCP explicitly with `dhcp_start()` when the link comes up. For that purpose, the `NETDEV_EVENT_LINK_UP` is used to call `dhcp_start()`.

This PR requires that the netdev generates the `NETDEV_EVENT_LINK_UP` event.

### Testing procedure

Flash any board with a network device that supports `lwip_ip4`, for example
```
LWIP_IPV4=1 USEMODULE=esp_wifi CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' \
make BOARD=esp32-wroom-32 -C tests/lwip flash term
```
and use `ifconfig`. The interface should have a valid IPv4 address.

### Issues/PRs references

Depends on PR #12966 