### PR TITLE
tests/lwip: enable IPv4

### DIFF
--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -1,10 +1,25 @@
 include ../Makefile.tests_common
 
+LWIP_IPV4 ?= 0
+
+ifneq (0, $(LWIP_IPV4))
+  USEMODULE += ipv4_addr
+  USEMODULE += lwip_arp
+  USEMODULE += lwip_ipv4
+  USEMODULE += lwip_dhcp_auto
+  CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
+  LWIP_IPV6 ?= 0
+else
+  USEMODULE += ipv6_addr
+  USEMODULE += lwip_ipv6
+  USEMODULE += lwip_ipv6_autoconfig
+  LWIP_IPV6 ?= 1
+endif
+
 # including lwip_ipv6_mld would currently break this test on at86rf2xx radios
-USEMODULE += lwip lwip_ipv6_autoconfig lwip_sock_ip lwip_netdev
+USEMODULE += lwip lwip_sock_ip lwip_netdev
 USEMODULE += lwip_udp lwip_sock_udp
 USEMODULE += lwip_tcp lwip_sock_tcp
-USEMODULE += ipv6_addr
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/tests/lwip/main.c
+++ b/tests/lwip/main.c
@@ -25,7 +25,11 @@
 #include "common.h"
 #include "lwip.h"
 #include "lwip/netif.h"
+#if LWIP_IPV4
 #include "net/ipv6/addr.h"
+#else
+#include "net/ipv4/addr.h"
+#endif
 #include "shell.h"
 
 static int ifconfig(int argc, char **argv)
@@ -42,6 +46,11 @@ static int ifconfig(int argc, char **argv)
                                                        sizeof(addrstr)));
             }
         }
+#endif
+#ifdef MODULE_LWIP_IPV4
+        char addrstr[IPV4_ADDR_MAX_STR_LEN];
+        printf(" inet %s\n", ipv4_addr_to_str(addrstr, (ipv4_addr_t *)&iface->ip_addr,
+                                              sizeof(addrstr)));
 #endif
         puts("");
     }
@@ -61,6 +70,7 @@ static const shell_command_t shell_commands[] = {
     { "ifconfig", "Shows assigned IPv6 addresses", ifconfig },
     { NULL, NULL, NULL }
 };
+
 static char line_buf[SHELL_DEFAULT_BUFSIZE];
 
 int main(void)

--- a/tests/lwip/tcp.c
+++ b/tests/lwip/tcp.c
@@ -24,10 +24,17 @@
 #include "od.h"
 #include "net/af.h"
 #include "net/sock/tcp.h"
-#include "net/ipv6.h"
 #include "shell.h"
 #include "thread.h"
 #include "xtimer.h"
+
+#ifdef MODULE_LWIP_IPV6
+#include "net/ipv6.h"
+#define SOCK_IP_EP_ANY  SOCK_IPV6_EP_ANY
+#else
+#include "net/ipv4.h"
+#define SOCK_IP_EP_ANY  SOCK_IPV4_EP_ANY
+#endif
 
 #ifdef MODULE_SOCK_TCP
 static char sock_inbuf[SOCK_INBUF_SIZE];
@@ -39,7 +46,7 @@ static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
 static void *_server_thread(void *args)
 {
-    sock_tcp_ep_t server_addr = SOCK_IPV6_EP_ANY;
+    sock_tcp_ep_t server_addr = SOCK_IP_EP_ANY;
     int res;
 
     msg_init_queue(server_msg_queue, SERVER_MSG_QUEUE_SIZE);
@@ -68,8 +75,13 @@ static void *_server_thread(void *args)
             sock_tcp_ep_t client;
 
             sock_tcp_get_remote(sock, &client);
+#ifdef MODULE_LWIP_IPV6
             ipv6_addr_to_str(client_addr, (ipv6_addr_t *)&client.addr.ipv6,
                              sizeof(client_addr));
+#else
+            ipv4_addr_to_str(client_addr, (ipv4_addr_t *)&client.addr.ipv4,
+                             sizeof(client_addr));
+#endif
             client_port = client.port;
             printf("TCP client [%s]:%u connected\n",
                    client_addr, client_port);
@@ -96,7 +108,7 @@ static void *_server_thread(void *args)
 
 static int tcp_connect(char *addr_str, char *port_str, char *local_port_str)
 {
-    sock_tcp_ep_t dst = SOCK_IPV6_EP_ANY;
+    sock_tcp_ep_t dst = SOCK_IP_EP_ANY;
     uint16_t local_port = 0;
 
     if (client_running) {
@@ -104,7 +116,11 @@ static int tcp_connect(char *addr_str, char *port_str, char *local_port_str)
     }
 
     /* parse destination address */
+#ifdef MODULE_LWIP_IPV6
     if (ipv6_addr_from_str((ipv6_addr_t *)&dst.addr.ipv6, addr_str) == NULL) {
+#else
+    if (ipv4_addr_from_str((ipv4_addr_t *)&dst.addr.ipv4, addr_str) == NULL) {
+#endif
         puts("Error: unable to parse destination address");
         return 1;
     }

--- a/tests/lwip/udp.c
+++ b/tests/lwip/udp.c
@@ -24,10 +24,17 @@
 #include "od.h"
 #include "net/af.h"
 #include "net/sock/udp.h"
-#include "net/ipv6.h"
 #include "shell.h"
 #include "thread.h"
 #include "xtimer.h"
+
+#ifdef MODULE_LWIP_IPV6
+#include "net/ipv6.h"
+#define SOCK_IP_EP_ANY  SOCK_IPV6_EP_ANY
+#else
+#include "net/ipv4.h"
+#define SOCK_IP_EP_ANY  SOCK_IPV4_EP_ANY
+#endif
 
 #ifdef MODULE_SOCK_UDP
 static char sock_inbuf[SOCK_INBUF_SIZE];
@@ -38,7 +45,7 @@ static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
 static void *_server_thread(void *args)
 {
-    sock_udp_ep_t server_addr = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t server_addr = SOCK_IP_EP_ANY;
     int res;
 
     msg_init_queue(server_msg_queue, SERVER_MSG_QUEUE_SIZE);
@@ -66,9 +73,15 @@ static void *_server_thread(void *args)
         else {
             char addrstr[IPV6_ADDR_MAX_STR_LEN];
 
+#ifdef MODULE_LWIP_IPV6
             printf("Received UDP data from [%s]:%" PRIu16 ":\n",
                    ipv6_addr_to_str(addrstr, (ipv6_addr_t *)&src.addr.ipv6,
                                     sizeof(addrstr)), src.port);
+#else
+            printf("Received UDP data from [%s]:%" PRIu16 ":\n",
+                   ipv4_addr_to_str(addrstr, (ipv4_addr_t *)&src.addr.ipv4,
+                                    sizeof(addrstr)), src.port);
+#endif
             od_hex_dump(sock_inbuf, res, 0);
         }
     }
@@ -78,12 +91,16 @@ static void *_server_thread(void *args)
 static int udp_send(char *addr_str, char *port_str, char *data, unsigned int num,
                     unsigned int delay)
 {
-    sock_udp_ep_t dst = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t dst = SOCK_IP_EP_ANY;
     uint8_t byte_data[SHELL_DEFAULT_BUFSIZE / 2];
     size_t data_len;
 
     /* parse destination address */
+#ifdef MODULE_LWIP_IPV6
     if (ipv6_addr_from_str((ipv6_addr_t *)&dst.addr.ipv6, addr_str) == NULL) {
+#else
+    if (ipv4_addr_from_str((ipv4_addr_t *)&dst.addr.ipv4, addr_str) == NULL) {
+#endif
         puts("Error: unable to parse destination address");
         return 1;
     }


### PR DESCRIPTION
### Contribution description

This PR provides some small changes that are necessary to use use `tests/lwip` with IPv4. It doesn't provide a test script for IPv4.

### Testing procedure

Flash any board with a network device that supports `lwip_ip4`, for example
```
LWIP_IPV4=1 USEMODULE=esp_wifi CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' \
make BOARD=esp32-wroom-32 -C tests/lwip flash term
```
and use `ifconfig` and start a TCP server:
```
> ifconfig
ET_00:  inet 192.168.1.156
> tcp server start 8888
Success: started TCP server on port 8888
```
Start `netcat` on any machine in the LAN and use:
```
nc 192.168.1.156 8888
Hello
^C
```
On RIOT node you should see somthing like the following:
```
TCP client [192.168.1.3]:34328 connected
Received TCP data from client [192.168.1.3]:34328:
00000000  48  65  6C  6C  6F  0A
TCP connection to [192.168.1.3]:34328 reset, starting to accept again
```

### Issues/PRs references

Depends on #12965