### PR TITLE
cpu/esp*: remove dependencies on GNRC for ESP network device drivers

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -8,7 +8,6 @@ endif
 ifneq (,$(filter esp_eth,$(USEMODULE)))
     USEMODULE += esp_idf_eth
     USEMODULE += esp_idf_eth_phy
-    USEMODULE += gnrc
     USEMODULE += netdev_eth
     USEMODULE += netopt
     USEMODULE += riot_freertos
@@ -18,16 +17,12 @@ ifneq (,$(filter esp_eth,$(USEMODULE)))
 endif
 
 ifneq (,$(filter esp_now,$(USEMODULE)))
-    $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
     USEMODULE += esp_wifi_any
-    USEMODULE += gnrc
     USEMODULE += netopt
 endif
 
 ifneq (,$(filter esp_wifi,$(USEMODULE)))
-    $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
     USEMODULE += esp_wifi_any
-    USEMODULE += gnrc
     USEMODULE += netopt
     USEMODULE += netdev_eth
 endif

--- a/cpu/esp32/esp-eth/esp_eth_gnrc.c
+++ b/cpu/esp32/esp-eth/esp_eth_gnrc.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32_esp_eth
+ * @{
+ *
+ * @file
+ * @brief       GNRC network interface part for ESP32 Ethernet MAC (EMAC) interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#if defined(MODULE_ESP_ETH) && defined(MODULE_GNRC_NETIF_ETHERNET)
+
+#include "esp_eth_params.h"
+#include "esp_eth_netdev.h"
+#include "net/gnrc/netif/ethernet.h"
+
+/** the only ESP32 Ethernet MAC (EMAC) device */
+extern esp_eth_netdev_t _esp_eth_dev;
+
+/** statically allocated memory for the MAC layer thread */
+static char _esp_eth_stack[ESP_ETH_STACKSIZE];
+
+/** setup function for the ESP32 Ethernet MAC (EMAC) */
+extern void esp_eth_setup(esp_eth_netdev_t* dev);
+
+void auto_init_esp_eth(void)
+{
+    esp_eth_setup(&_esp_eth_dev);
+    gnrc_netif_ethernet_create(_esp_eth_stack, ESP_ETH_STACKSIZE, ESP_ETH_PRIO,
+                               "netif-esp-eth", (netdev_t *)&_esp_eth_dev);
+}
+
+#else /* defined(MODULE_ESP_ETH) && defined(MODULE_GNRC_NETIF_ETHERNET) */
+
+typedef int dont_be_pedantic;
+
+#endif /* defined(MODULE_ESP_ETH) && defined(MODULE_GNRC_NETIF_ETHERNET) */
+/**@}*/

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -69,9 +69,6 @@
  */
 esp_eth_netdev_t _esp_eth_dev;
 
-/* device thread stack */
-static char _esp_eth_stack[ESP_ETH_STACKSIZE];
-
 static void _eth_gpio_config_rmii(void)
 {
     DEBUG("%s\n", __func__);
@@ -405,16 +402,6 @@ void esp_eth_setup(esp_eth_netdev_t* dev)
     _esp_eth_dev.link_up = false;
     _esp_eth_dev.rx_len = 0;
     _esp_eth_dev.tx_len = 0;
-}
-
-void auto_init_esp_eth(void)
-{
-    esp_eth_setup(&_esp_eth_dev);
-    _esp_eth_dev.netif = gnrc_netif_ethernet_create(_esp_eth_stack,
-                                                    ESP_ETH_STACKSIZE,
-                                                    ESP_ETH_PRIO,
-                                                    "esp_eth",
-                                                    (netdev_t *)&_esp_eth_dev);
 }
 
 #endif /* MODULE_ESP_ETH */

--- a/cpu/esp32/esp-eth/esp_eth_netdev.h
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.h
@@ -19,6 +19,10 @@
 #ifndef ESP_ETH_NETDEV_H
 #define ESP_ETH_NETDEV_H
 
+#include <stdbool.h>
+
+#include "mutex.h"
+#include "net/ethernet.h"
 #include "net/netdev.h"
 
 #ifdef __cplusplus
@@ -45,8 +49,6 @@ typedef struct
 
     uint32_t event;                     /**< received event */
     bool     link_up;                   /**< indicates whether link is up */
-
-    gnrc_netif_t* netif;                /**< reference to the corresponding netif */
 
     mutex_t dev_lock;                   /**< device is already in use */
 

--- a/cpu/esp32/esp-wifi/esp_wifi_gnrc.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_gnrc.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32_esp_wifi
+ * @{
+ *
+ * @file
+ * @brief       GNRC network interface part for ESP32 WiFi interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#if defined(MODULE_ESP_WIFI) && defined(MODULE_GNRC_NETIF_ETHERNET)
+
+#include "esp_wifi_params.h"
+#include "esp_wifi_netdev.h"
+#include "net/gnrc/netif/ethernet.h"
+
+/** the only ESP WiFi device */
+extern esp_wifi_netdev_t _esp_wifi_dev;
+
+/** device thread stack */
+static char _esp_wifi_stack[ESP_WIFI_STACKSIZE];
+
+/** setup function for the ESP WiFi */
+extern void esp_wifi_setup (esp_wifi_netdev_t* dev);
+
+void auto_init_esp_wifi (void)
+{
+    esp_wifi_setup(&_esp_wifi_dev);
+    gnrc_netif_ethernet_create(_esp_wifi_stack, ESP_WIFI_STACKSIZE,
+#ifdef MODULE_ESP_NOW
+                                                ESP_WIFI_PRIO - 1,
+#else
+                                                ESP_WIFI_PRIO,
+#endif
+                                                "netif-esp-wifi",
+                                                (netdev_t *)&_esp_wifi_dev);
+}
+
+#else /* defined(MODULE_ESP_WIFI) && defined(MODULE_GNRC_NETIF_ETHERNET) */
+
+typedef int dont_be_pedantic;
+
+#endif /* defined(MODULE_ESP_WIFI) && defined(MODULE_GNRC_NETIF_ETHERNET) */
+/**@}*/

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -98,9 +98,6 @@ static rx_buf_t rx_buf[ESP_WIFI_MAX_RX_BUF] = { 0 };
 static unsigned int rx_buf_write = 0;
 static unsigned int rx_buf_read = 0;
 
-/* device thread stack */
-static char _esp_wifi_stack[ESP_WIFI_STACKSIZE];
-
 extern esp_err_t esp_system_event_add_handler (system_event_cb_t handler,
                                                void *arg);
 
@@ -571,22 +568,6 @@ static const netdev_driver_t _esp_wifi_driver =
     .get = _esp_wifi_get,
     .set = _esp_wifi_set,
 };
-
-void auto_init_esp_wifi (void)
-{
-    LOG_TAG_DEBUG("esp_wifi", "initializing ESP WiFi device\n");
-
-    esp_wifi_setup(&_esp_wifi_dev);
-    _esp_wifi_dev.netif = gnrc_netif_ethernet_create(_esp_wifi_stack,
-                                                    ESP_WIFI_STACKSIZE,
-#ifdef MODULE_ESP_NOW
-                                                    ESP_WIFI_PRIO - 1,
-#else
-                                                    ESP_WIFI_PRIO,
-#endif
-                                                    "esp-wifi",
-                                                    (netdev_t *)&_esp_wifi_dev);
-}
 
 #endif /* MODULE_ESP_WIFI */
 /**@}*/

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.h
@@ -19,6 +19,10 @@
 #ifndef ESP_WIFI_NETDEV_H
 #define ESP_WIFI_NETDEV_H
 
+#include <stdbool.h>
+
+#include "mutex.h"
+#include "net/ethernet.h"
 #include "net/netdev.h"
 
 #ifdef __cplusplus
@@ -39,8 +43,6 @@ typedef struct
 
     uint32_t event;                    /**< received event */
     bool connected;                    /**< indicates whether connected to AP */
-
-    gnrc_netif_t* netif;               /**< reference to the corresponding netif */
 
 } esp_wifi_netdev_t;
 

--- a/cpu/esp8266/esp-wifi/esp_wifi_gnrc.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_gnrc.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp8266_esp_wifi
+ * @{
+ *
+ * @file
+ * @brief       GNRC network interface part for ESP8266 WiFi interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#if defined(MODULE_ESP_WIFI) && defined(MODULE_GNRC_NETIF_ETHERNET)
+
+#include "esp_wifi_params.h"
+#include "esp_wifi_netdev.h"
+#include "net/gnrc/netif/ethernet.h"
+
+/** the only ESP WiFi device */
+extern esp_wifi_netdev_t _esp_wifi_dev;
+
+/** device thread stack */
+static char _esp_wifi_stack[ESP_WIFI_STACKSIZE];
+
+/** setup function for the ESP WiFi */
+extern void esp_wifi_setup (esp_wifi_netdev_t* dev);
+
+void auto_init_esp_wifi (void)
+{
+    esp_wifi_setup(&_esp_wifi_dev);
+    gnrc_netif_ethernet_create(_esp_wifi_stack, ESP_WIFI_STACKSIZE,
+#ifdef MODULE_ESP_NOW
+                                                ESP_WIFI_PRIO - 1,
+#else
+                                                ESP_WIFI_PRIO,
+#endif
+                                                "netif-esp-wifi",
+                                                (netdev_t *)&_esp_wifi_dev);
+}
+
+#else /* defined(MODULE_ESP_WIFI) && defined(MODULE_GNRC_NETIF_ETHERNET) */
+
+typedef int dont_be_pedantic;
+
+#endif /* defined(MODULE_ESP_WIFI) && defined(MODULE_GNRC_NETIF_ETHERNET) */
+/**@}*/

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -104,9 +104,6 @@
 esp_wifi_netdev_t _esp_wifi_dev;
 static const netdev_driver_t _esp_wifi_driver;
 
-/* device thread stack */
-static char _esp_wifi_stack[ESP_WIFI_STACKSIZE];
-
 /** guard variable to avoid reentrance to _esp_wifi_send function */
 static bool _esp_wifi_send_is_in = false;
 
@@ -823,22 +820,5 @@ void esp_wifi_setup (esp_wifi_netdev_t* dev)
     dev->event_conn = 0;
     dev->event_disc = 0;
 }
-
-void auto_init_esp_wifi (void)
-{
-    ESP_WIFI_DEBUG("initializing ESP WiFi device");
-
-    esp_wifi_setup(&_esp_wifi_dev);
-    _esp_wifi_dev.netif = gnrc_netif_ethernet_create(_esp_wifi_stack,
-                                                    ESP_WIFI_STACKSIZE,
-#ifdef MODULE_ESP_NOW
-                                                    ESP_WIFI_PRIO - 1,
-#else
-                                                    ESP_WIFI_PRIO,
-#endif
-                                                    "esp_wifi",
-                                                    (netdev_t *)&_esp_wifi_dev);
-}
-
 #endif /* MODULE_ESP_WIFI */
 /**@}*/

--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.h
@@ -19,6 +19,10 @@
 #ifndef ESP_WIFI_NETDEV_H
 #define ESP_WIFI_NETDEV_H
 
+#include <stdbool.h>
+
+#include "mutex.h"
+#include "net/ethernet.h"
 #include "net/netdev.h"
 #include "ringbuffer.h"
 
@@ -56,8 +60,6 @@ typedef struct
     uint8_t event_disc;                /**< number of pending disc events */
 
     bool connected;                    /**< indicates whether connected to AP */
-
-    gnrc_netif_t* netif;               /**< reference to the corresponding netif */
 
     mutex_t dev_lock;                  /**< device is already in use */
 

--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -214,7 +214,7 @@ void auto_init_esp_now(void)
     } else {
         gnrc_netif_esp_now_create(_esp_now_stack, sizeof(_esp_now_stack),
                                   ESP_NOW_PRIO,
-                                  "esp-now",
+                                  "netif-esp-now",
                                   &esp_now_dev->netdev);
     }
 }


### PR DESCRIPTION
### Contribution description

This PR removes the dependencies of ESP network device drivers on GNRC.

### Testing procedure

The following compilations should still succeed:

- [ ] `esp_eth`: ```make BOARD=esp32-olimex-evb -C tests/shell```
- [ ] `esp_now`: ```make BOARD=esp32-wroom-32 -C tests/lwip```
- [ ] `esp_wifi`: ```USEMODULE=esp_wifi make BOARD=esp32-wroom-32 -C tests/lwip```


### Issues/PRs references

Fixes #12964
Prerequisite for PR #12931