### PR TITLE
sys/shell: add missing stdio include in sc_loramac.c

### DIFF
--- a/sys/shell/commands/sc_loramac.c
+++ b/sys/shell/commands/sc_loramac.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <stdio.h>
 #include <string.h>
 
 #include "shell.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a minor missing stdio.h include in `sc_loramac.c`. Since this file uses a lot of puts/printf, it makes sense to add this include here.

This PR will also fix a build issues with Hifive1 boards when the SPI support will be merged. See [here](https://github.com/RIOT-OS/RIOT/compare/master...aabadie:pr/sys/sc_loramac_fix_include?expand=1).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Use the branch from #12957 and cherry-pick the commit from this PR.
```
make BOARD=hifive1b -C tests/pkg_semtech-loramac
```
This command fails without this PR but works with this PR.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will be required by #12957.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
