### PR TITLE
cpu/sam0: provide interface to query GCLK frequency

### DIFF
--- a/boards/arduino-mkrwan1300/include/periph_conf.h
+++ b/boards/arduino-mkrwan1300/include/periph_conf.h
@@ -48,7 +48,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     { /* LoRa module */
         .dev      = &SERCOM4->USART,
@@ -62,7 +62,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
 };
 
@@ -88,7 +88,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 

--- a/boards/arduino-mkrwan1300/include/periph_conf.h
+++ b/boards/arduino-mkrwan1300/include/periph_conf.h
@@ -48,7 +48,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     { /* LoRa module */
         .dev      = &SERCOM4->USART,
@@ -62,7 +62,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
 };
 
@@ -87,7 +87,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_C,
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
-        .mosi_pad = SPI_PAD_MOSI_0_SCK_1
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = 0,
     }
 };
 

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -295,6 +295,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
+        .gclk_src = 0
     }
 };
 /** @} */

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -90,10 +90,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -104,10 +104,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -140,7 +140,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM0->USART,
@@ -154,7 +154,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -238,7 +238,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -257,7 +257,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 23),
         .sda_pin  = GPIO_PIN(PA, 22),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
     }
 };
@@ -295,7 +295,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 /** @} */

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -90,10 +90,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -104,10 +104,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -140,7 +140,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM0->USART,
@@ -154,7 +154,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -237,7 +237,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_D,
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     }
 };
 
@@ -256,7 +257,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 23),
         .sda_pin  = GPIO_PIN(PA, 22),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -48,7 +48,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -73,7 +73,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM2->SPI,
@@ -85,7 +85,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -48,7 +48,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -72,7 +72,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_C,
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
-        .mosi_pad = SPI_PAD_MOSI_0_SCK_1
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM2->SPI,
@@ -83,7 +84,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_C,
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
-        .mosi_pad = SPI_PAD_MOSI_0_SCK_1
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = 0
     }
 };
 

--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -90,10 +90,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -104,10 +104,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -184,7 +184,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 9),
         .sda_pin  = GPIO_PIN(PA, 8),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -90,10 +90,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -104,10 +104,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -184,7 +184,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 9),
         .sda_pin  = GPIO_PIN(PA, 8),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
      }
 };
@@ -221,7 +221,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 /** @} */

--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -221,6 +221,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
+        .gclk_src = 0
     }
 };
 /** @} */

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -42,7 +42,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = GCLK_PCHCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -71,7 +71,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -96,8 +96,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_D,
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
-
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     }
 };
 
@@ -115,7 +115,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -42,7 +42,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -71,7 +71,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -97,7 +97,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -115,7 +115,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/common/sodaq/include/cfg_spi_default.h
+++ b/boards/common/sodaq/include/cfg_spi_default.h
@@ -43,7 +43,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
 };
 

--- a/boards/common/sodaq/include/cfg_spi_default.h
+++ b/boards/common/sodaq/include/cfg_spi_default.h
@@ -43,6 +43,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     },
 };
 

--- a/boards/common/sodaq/include/cfg_timer_default.h
+++ b/boards/common/sodaq/include/cfg_timer_default.h
@@ -39,10 +39,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -53,10 +53,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,

--- a/boards/common/sodaq/include/cfg_timer_default.h
+++ b/boards/common/sodaq/include/cfg_timer_default.h
@@ -39,10 +39,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -53,10 +53,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,

--- a/boards/common/sodaq/include/cfg_usbdev_default.h
+++ b/boards/common/sodaq/include/cfg_usbdev_default.h
@@ -38,7 +38,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 /** @} */

--- a/boards/common/sodaq/include/cfg_usbdev_default.h
+++ b/boards/common/sodaq/include/cfg_usbdev_default.h
@@ -38,6 +38,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
+        .gclk_src = 0
     }
 };
 /** @} */

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -274,6 +274,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
+        .gclk_src = 0
     }
 };
 /** @} */

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -85,10 +85,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -99,10 +99,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -135,7 +135,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -219,7 +219,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -237,7 +237,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 23),
         .sda_pin  = GPIO_PIN(PA, 22),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
      }
 };
@@ -274,7 +274,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 /** @} */

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -85,10 +85,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -99,10 +99,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -135,7 +135,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
     }
 };
 
@@ -218,7 +218,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_D,
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     }
 };
 
@@ -236,7 +237,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 23),
         .sda_pin  = GPIO_PIN(PA, 22),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -118,10 +118,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -132,10 +132,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -217,7 +217,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_F,
         .clk_mux  = GPIO_MUX_F,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0,
     }
 };
 
@@ -235,7 +236,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_D,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -118,10 +118,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -132,10 +132,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -218,7 +218,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_F,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -236,7 +236,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_D,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -96,10 +96,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -110,10 +110,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -146,7 +146,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {    /* EXT1 */
         .dev      = &SERCOM4->USART,
@@ -160,7 +160,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {    /* EXT2/3 */
         .dev      = &SERCOM4->USART,
@@ -174,7 +174,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -243,7 +243,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {   /* EXT2 */
         .dev      = &SERCOM1->SPI,
@@ -255,7 +255,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {   /* EXT3 */
         .dev      = &SERCOM5->SPI,
@@ -267,7 +267,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -285,7 +285,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 9),
         .sda_pin  = GPIO_PIN(PA, 8),
         .mux      = GPIO_MUX_D,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -96,10 +96,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -110,10 +110,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -146,7 +146,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {    /* EXT1 */
         .dev      = &SERCOM4->USART,
@@ -160,7 +160,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {    /* EXT2/3 */
         .dev      = &SERCOM4->USART,
@@ -174,7 +174,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -242,7 +242,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_D,
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     },
     {   /* EXT2 */
         .dev      = &SERCOM1->SPI,
@@ -253,7 +254,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_C,
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     },
     {   /* EXT3 */
         .dev      = &SERCOM5->SPI,
@@ -264,7 +266,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_D,
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     }
 };
 
@@ -282,7 +285,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 9),
         .sda_pin  = GPIO_PIN(PA, 8),
         .mux      = GPIO_MUX_D,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -131,7 +131,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PD, 9),
         .sda_pin  = GPIO_PIN(PD, 8),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = 6,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -42,7 +42,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBAMASK.reg,
         .mclk_mask      = MCLK_APBAMASK_TC0 | MCLK_APBAMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = 5,
+        .gclk_src       = SAM0_GCLK_8MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
         .flags          = TC_CTRLA_MODE_COUNT32,
     },
@@ -52,7 +52,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBBMASK.reg,
         .mclk_mask      = MCLK_APBBMASK_TC2 | MCLK_APBBMASK_TC3,
         .gclk_id        = TC2_GCLK_ID,
-        .gclk_src       = 5,
+        .gclk_src       = SAM0_GCLK_8MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -86,7 +86,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -112,7 +112,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
 
     }
 };
@@ -131,7 +131,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PD, 9),
         .sda_pin  = GPIO_PIN(PD, 8),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 6,
+        .gclk_src = SAM0_GCLK_48MHZ,
         .flags    = I2C_FLAG_NONE
     }
 };
@@ -167,7 +167,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_H,
         .device = &USB->DEVICE,
-        .gclk_src = 6
+        .gclk_src = SAM0_GCLK_48MHZ,
     }
 };
 

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -167,6 +167,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_H,
         .device = &USB->DEVICE,
+        .gclk_src = 6
     }
 };
 

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -42,7 +42,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBAMASK.reg,
         .mclk_mask      = MCLK_APBAMASK_TC0 | MCLK_APBAMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = GCLK_PCHCTRL_GEN(5),
+        .gclk_src       = 5,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
         .flags          = TC_CTRLA_MODE_COUNT32,
     },
@@ -52,7 +52,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBBMASK.reg,
         .mclk_mask      = MCLK_APBBMASK_TC2 | MCLK_APBBMASK_TC3,
         .gclk_id        = TC2_GCLK_ID,
-        .gclk_src       = GCLK_PCHCTRL_GEN(5),
+        .gclk_src       = 5,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -86,7 +86,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -111,7 +111,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_C,
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
-        .mosi_pad = SPI_PAD_MOSI_0_SCK_1
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = 0
 
     }
 };
@@ -130,7 +131,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PD, 9),
         .sda_pin  = GPIO_PIN(PD, 8),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -45,7 +45,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -74,7 +74,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {    /* EXT1 header */
         .dev      = &SERCOM4->USART,
@@ -88,7 +88,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -114,7 +114,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -132,7 +132,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 9),
         .sda_pin  = GPIO_PIN(PA, 8),
         .mux      = GPIO_MUX_D,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -45,7 +45,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = GCLK_PCHCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -74,7 +74,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {    /* EXT1 header */
         .dev      = &SERCOM4->USART,
@@ -88,7 +88,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -113,8 +113,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_D,
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
-
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     }
 };
 
@@ -132,7 +132,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 9),
         .sda_pin  = GPIO_PIN(PA, 8),
         .mux      = GPIO_MUX_D,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -309,6 +309,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
+        .gclk_src = 0
     }
 };
 /** @} */

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -96,10 +96,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -110,10 +110,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -146,7 +146,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM5->USART,
@@ -160,7 +160,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -221,7 +221,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_F,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM5->SPI,
@@ -233,7 +233,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -251,7 +251,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_D,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
      }
 };
@@ -309,7 +309,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 /** @} */

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -96,10 +96,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -110,10 +110,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -146,7 +146,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM5->USART,
@@ -160,7 +160,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -220,7 +220,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_F,
         .clk_mux  = GPIO_MUX_F,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM5->SPI,
@@ -231,7 +232,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_D,
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     }
 };
 
@@ -249,7 +251,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_D,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -41,7 +41,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = GCLK_PCHCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -70,7 +70,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -94,7 +94,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_F,
         .clk_mux  = GPIO_MUX_F,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     }
 };
 
@@ -112,7 +113,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -41,7 +41,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -70,7 +70,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -95,7 +95,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_F,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -113,7 +113,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -42,7 +42,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = GCLK_PCHCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -72,7 +72,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0
+        .gclk_src = 0
     }
 };
 
@@ -96,7 +96,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_F,
         .clk_mux  = GPIO_MUX_F,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0
     }
 };
 
@@ -114,7 +115,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -42,7 +42,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -72,7 +72,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -97,7 +97,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_F,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -115,7 +115,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -86,10 +86,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -100,10 +100,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = 1,
+        .gclk_src       = SAM0_GCLK_1MHZ,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = 0,
+        .gclk_src       = SAM0_GCLK_MAIN,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -136,7 +136,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM4->USART,
@@ -150,7 +150,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -176,7 +176,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -193,7 +193,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 8),
         .sda_pin  = GPIO_PIN(PA, 9),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
     },
     {
@@ -202,7 +202,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 12),
         .sda_pin  = GPIO_PIN(PA, 13),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
     }
 };
@@ -253,7 +253,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 /** @} */

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -253,6 +253,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_G,
         .device = &USB->DEVICE,
+        .gclk_src = 0
     }
 };
 /** @} */

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -86,10 +86,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC3,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
@@ -100,10 +100,10 @@ static const tc32_conf_t timer_config[] = {
         .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .gclk_src       = 1,
         .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .gclk_src       = 0,
         .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
@@ -136,7 +136,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
     },
     {
         .dev      = &SERCOM4->USART,
@@ -150,7 +150,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
     }
 };
 
@@ -175,7 +175,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_C,
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
-        .mosi_pad = SPI_PAD_MOSI_0_SCK_1
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = 0
     }
 };
 
@@ -192,7 +193,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 8),
         .sda_pin  = GPIO_PIN(PA, 9),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     },
     {
@@ -201,7 +202,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 12),
         .sda_pin  = GPIO_PIN(PA, 13),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -52,7 +52,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM5->USART,
@@ -66,7 +66,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM4->USART,
@@ -80,7 +80,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM1->USART,
@@ -94,7 +94,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
 };
 
@@ -189,7 +189,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 13),
         .sda_pin  = GPIO_PIN(PA, 12),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -52,7 +52,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM5->USART,
@@ -66,7 +66,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM4->USART,
@@ -80,7 +80,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM1->USART,
@@ -94,7 +94,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
 };
 
@@ -189,7 +189,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 13),
         .sda_pin  = GPIO_PIN(PA, 12),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
      }
 };

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -48,7 +48,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM4->USART,
@@ -62,7 +62,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     { /* Connected to RN2483 */
         .dev      = &SERCOM0->USART,
@@ -76,7 +76,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
 };
 
@@ -128,7 +128,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE,
     },
     {
@@ -137,7 +137,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 9),
         .sda_pin  = GPIO_PIN(PA, 8),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -48,7 +48,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM4->USART,
@@ -62,7 +62,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     { /* Connected to RN2483 */
         .dev      = &SERCOM0->USART,
@@ -76,7 +76,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
 };
 
@@ -128,7 +128,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE,
     },
     {
@@ -137,7 +137,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 9),
         .sda_pin  = GPIO_PIN(PA, 8),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -51,7 +51,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM2->USART,
@@ -65,7 +65,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
 };
 
@@ -127,7 +127,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
@@ -145,7 +145,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 23),
         .sda_pin  = GPIO_PIN(PA, 22),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -51,7 +51,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM2->USART,
@@ -65,7 +65,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
 };
 
@@ -126,7 +126,8 @@ static const spi_conf_t spi_config[] = {
         .mosi_mux = GPIO_MUX_C,
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = 0,
     }
 };
 
@@ -144,7 +145,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 23),
         .sda_pin  = GPIO_PIN(PA, 22),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -54,7 +54,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
     {
         .dev      = &SERCOM0->USART,
@@ -68,7 +68,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = 0
+        .gclk_src = SAM0_GCLK_MAIN,
     },
 };
 
@@ -120,7 +120,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = 0,
+        .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -54,7 +54,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
     {
         .dev      = &SERCOM0->USART,
@@ -68,7 +68,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+        .gclk_src = 0
     },
 };
 
@@ -120,7 +120,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .gclk_src = 0,
         .flags    = I2C_FLAG_NONE
     }
 };

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -353,6 +353,22 @@ typedef struct {
 void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
 
 /**
+ * @brief   Returns the frequency of a GCLK provider.
+ *
+ * @param[in] id    The ID of the GCLK
+ *
+ * @return          The frequency of the GCLK with the given ID.
+ */
+uint32_t sam0_gclk_freq(uint8_t id);
+
+/**
+ * @brief   Enables an on-demand GCLK that has been configured in cpu.c
+ *
+ * @param[in] id    The ID of the GCLK
+ */
+void sam0_gclk_enable(uint8_t id);
+
+/**
  * @brief   Return the numeric id of a SERCOM device derived from its address
  *
  * @param[in] sercom    SERCOM device
@@ -488,6 +504,7 @@ static inline uint8_t _sercom_gclk_id_core(uint8_t sercom_id) {
 static inline void sercom_set_gen(void *sercom, uint8_t gclk)
 {
     const uint8_t id = sercom_id(sercom);
+    sam0_gclk_enable(gclk);
 #if defined(CPU_FAM_SAMD21)
     GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(gclk) |
                          (SERCOM0_GCLK_ID_CORE + id));
@@ -535,6 +552,7 @@ typedef struct {
     gpio_t dp;              /**< D+ line gpio                           */
     gpio_mux_t d_mux;       /**< alternate function (mux) for data pins */
     UsbDevice *device;      /**< ptr to the device registers            */
+    uint8_t gclk_src;       /**< GCLK source which supplys 48 MHz       */
 } sam0_common_usb_config_t;
 #endif /* USB_INST_NUM */
 

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -219,7 +219,7 @@ typedef struct {
     uart_rxpad_t rx_pad;    /**< pad selection for RX line */
     uart_txpad_t tx_pad;    /**< pad selection for TX line */
     uart_flag_t flags;      /**< set optional SERCOM flags */
-    uint32_t gclk_src;      /**< GCLK source which supplys SERCOM */
+    uint8_t gclk_src;       /**< GCLK source which supplys SERCOM */
 } uart_conf_t;
 
 /**
@@ -284,6 +284,7 @@ typedef struct {
     gpio_mux_t clk_mux;     /**< alternate function for CLK pin (mux) */
     spi_misopad_t miso_pad; /**< pad to use for MISO line */
     spi_mosipad_t mosi_pad; /**< pad to use for MOSI and CLK line */
+    uint8_t gclk_src;       /**< GCLK source which supplys SERCOM */
 } spi_conf_t;
 /** @} */
 
@@ -338,7 +339,7 @@ typedef struct {
     uint32_t pm_mask;       /**< PM_APBCMASK bits to enable Timer */
     uint16_t gclk_ctrl;     /**< GCLK_CLKCTRL_ID for the Timer */
 #endif
-    uint16_t gclk_src;      /**< GCLK source which supplys Timer */
+    uint8_t gclk_src;       /**< GCLK source which supplys Timer */
     uint16_t prescaler;     /**< prescaler used by the Timer */
     uint16_t flags;         /**< flags for CTRA, e.g. TC_CTRLA_MODE_COUNT32 */
 } tc32_conf_t;
@@ -484,22 +485,22 @@ static inline uint8_t _sercom_gclk_id_core(uint8_t sercom_id) {
  * @param[in] sercom    SERCOM device
  * @param[in] gclk      Generator clock
  */
-static inline void sercom_set_gen(void *sercom, uint32_t gclk)
+static inline void sercom_set_gen(void *sercom, uint8_t gclk)
 {
     const uint8_t id = sercom_id(sercom);
 #if defined(CPU_FAM_SAMD21)
-    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN | gclk |
+    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(gclk) |
                          (SERCOM0_GCLK_ID_CORE + id));
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 #elif defined(CPU_FAM_SAMD5X)
-    GCLK->PCHCTRL[_sercom_gclk_id_core(id)].reg = (GCLK_PCHCTRL_CHEN | gclk);
+    GCLK->PCHCTRL[_sercom_gclk_id_core(id)].reg = (GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN(gclk));
 #else
     if (id < 5) {
-        GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + id].reg = (GCLK_PCHCTRL_CHEN | gclk);
+        GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + id].reg = (GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN(gclk));
     }
 #if defined(CPU_FAM_SAML21)
     else {
-        GCLK->PCHCTRL[SERCOM5_GCLK_ID_CORE].reg = (GCLK_PCHCTRL_CHEN | gclk);
+        GCLK->PCHCTRL[SERCOM5_GCLK_ID_CORE].reg = (GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN(gclk));
     }
 #endif /* CPU_FAM_SAML21 */
 #endif

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -92,7 +92,7 @@ void i2c_init(i2c_t dev)
     sercom_clk_en(bus(dev));
 
     /* I2C using CLK GEN 0 */
-    sercom_set_gen(bus(dev),i2c_config[dev].gclk_src);
+    sercom_set_gen(bus(dev), i2c_config[dev].gclk_src);
 
     /* Check if module is enabled. */
     if (bus(dev)->CTRLA.reg & SERCOM_I2CM_CTRLA_ENABLE) {

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -137,7 +137,7 @@ void i2c_init(i2c_t dev)
             return;
     }
     /* Get the baudrate */
-    tmp_baud = (int32_t)(((CLOCK_CORECLOCK +
+    tmp_baud = (int32_t)(((sam0_gclk_freq(i2c_config[dev].gclk_src) +
                (2 * (i2c_config[dev].speed)) - 1) /
                (2 * (i2c_config[dev].speed))) -
                (i2c_config[dev].speed == I2C_SPEED_HIGH ? 1 : 5));

--- a/cpu/sam0_common/periph/rtc.c
+++ b/cpu/sam0_common/periph/rtc.c
@@ -65,8 +65,8 @@ static inline void _rtc_set_enabled(bool on)
 #ifdef CPU_SAMD21
 static void _rtc_clock_setup(void)
 {
-    /* Use 1024 Hz GCLK4 */
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(4) | GCLK_CLKCTRL_ID_RTC;
+    /* Use 1024 Hz GCLK3 */
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(3) | GCLK_CLKCTRL_ID_RTC;
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 }
 #else

--- a/cpu/sam0_common/periph/rtc.c
+++ b/cpu/sam0_common/periph/rtc.c
@@ -66,7 +66,7 @@ static inline void _rtc_set_enabled(bool on)
 static void _rtc_clock_setup(void)
 {
     /* Use 1024 Hz GCLK3 */
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(3) | GCLK_CLKCTRL_ID_RTC;
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(SAM0_GCLK_1KHZ) | GCLK_CLKCTRL_ID_RTC;
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 }
 #else

--- a/cpu/sam0_common/periph/rtt.c
+++ b/cpu/sam0_common/periph/rtt.c
@@ -65,7 +65,7 @@ static inline void _rtt_reset(void)
 static void _rtt_clock_setup(void)
 {
     /* Setup clock GCLK2 with OSC32K */
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(2) | GCLK_CLKCTRL_ID_RTC;
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(SAM0_GCLK_32KHZ) | GCLK_CLKCTRL_ID_RTC;
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 }
 #else

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -76,11 +76,7 @@ void spi_init(spi_t bus)
            (dev(bus)->SYNCBUSY.reg & SERCOM_SPI_SYNCBUSY_SWRST)) {}
 
     /* configure base clock: using GLK GEN 0 */
-#ifdef GCLK_CLKCTRL_GEN_GCLK0
-    sercom_set_gen(dev(bus), GCLK_CLKCTRL_GEN_GCLK0);
-#else
-    sercom_set_gen(dev(bus), GCLK_PCHCTRL_GEN_GCLK0);
-#endif
+    sercom_set_gen(dev(bus), spi_config[bus].gclk_src);
 
     /* enable receiver and configure character size to 8-bit
      * no synchronization needed, as SERCOM device is not enabled */
@@ -108,7 +104,7 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     /* configure bus clock, in synchronous mode its calculated from
      * BAUD.reg = (f_ref / (2 * f_bus) - 1)
      * with f_ref := CLOCK_CORECLOCK as defined by the board */
-    const uint8_t baud = (((uint32_t)CLOCK_CORECLOCK) / (2 * clk) - 1);
+    const uint8_t baud = (sam0_gclk_freq(spi_config[bus].gclk_src) / (2 * clk) - 1);
 
     /* configure device to be master and set mode and pads,
      *

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -88,10 +88,10 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     timer_stop(tim);
 
 #ifdef MCLK
-    GCLK->PCHCTRL[cfg->gclk_id].reg = cfg->gclk_src | GCLK_PCHCTRL_CHEN;
+    GCLK->PCHCTRL[cfg->gclk_id].reg = GCLK_PCHCTRL_GEN(cfg->gclk_src) | GCLK_PCHCTRL_CHEN;
     *cfg->mclk |= cfg->mclk_mask;
 #else
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | cfg->gclk_src | cfg->gclk_ctrl;
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(cfg->gclk_src) | cfg->gclk_ctrl;
     PM->APBCMASK.reg |= cfg->pm_mask;
 #endif
 

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -87,6 +87,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     /* make sure the timer is not running */
     timer_stop(tim);
 
+    sam0_gclk_enable(cfg->gclk_src);
 #ifdef MCLK
     GCLK->PCHCTRL[cfg->gclk_id].reg = GCLK_PCHCTRL_GEN(cfg->gclk_src) | GCLK_PCHCTRL_CHEN;
     *cfg->mclk |= cfg->mclk_mask;

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -116,7 +116,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     }
 
     /* calculate and set baudrate */
-    uint32_t baud = ((((uint32_t)CLOCK_CORECLOCK * 8) / baudrate) / 16);
+    uint32_t baud = (((sam0_gclk_freq(uart_config[uart].gclk_src) * 8) / baudrate) / 16);
     dev(uart)->BAUD.FRAC.FP = (baud % 8);
     dev(uart)->BAUD.FRAC.BAUD = (baud / 8);
 

--- a/cpu/sam0_common/periph/wdt.c
+++ b/cpu/sam0_common/periph/wdt.c
@@ -83,9 +83,9 @@ static uint32_t ms_to_per(uint32_t ms)
 #ifdef CPU_SAMD21
 static void _wdt_clock_setup(void)
 {
-    /* Connect to GCLK4 (~1.024 kHz) */
+    /* Connect to GCLK3 (~1.024 kHz) */
     GCLK->CLKCTRL.reg = GCLK_CLKCTRL_ID_WDT
-                      | GCLK_CLKCTRL_GEN_GCLK4
+                      | GCLK_CLKCTRL_GEN(SAM0_GCLK_1KHZ)
                       | GCLK_CLKCTRL_CLKEN;
 }
 #else

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -49,6 +49,30 @@
 #define WAITSTATES          ((CLOCK_CORECLOCK - 1) / 14000000)
 #endif
 
+void sam0_gclk_enable(uint8_t id)
+{
+    (void) id;
+    /* clocks are always running */
+}
+
+uint32_t sam0_gclk_freq(uint8_t id)
+{
+    switch (id) {
+    case 0:
+        return CLOCK_CORECLOCK;
+    case 1:
+        return 1000000;
+    case 2:
+        return 32768;
+    case 3:
+        return 32768;
+    case 4:
+        return 1024;
+    default:
+        return 0;
+    }
+}
+
 /**
  * @brief   Configure clock sources and the cpu frequency
  */

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -96,6 +96,22 @@ static void clk_init(void)
     while (!(SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_OSC8MRDY)) {}
 #endif
 
+    /* Setup GCLK2 with divider 1 (32.768kHz) */
+    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(2)  | GCLK_GENDIV_DIV(0));
+    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_GENEN
+                      | GCLK_GENCTRL_RUNSTDBY
+#if GEN2_ULP32K
+                      | GCLK_GENCTRL_SRC_OSCULP32K);
+#else
+                      | GCLK_GENCTRL_SRC_XOSC32K);
+
+    SYSCTRL->XOSC32K.reg = SYSCTRL_XOSC32K_ONDEMAND
+                         | SYSCTRL_XOSC32K_EN32K
+                         | SYSCTRL_XOSC32K_XTALEN
+                         | SYSCTRL_XOSC32K_STARTUP(6)
+                         | SYSCTRL_XOSC32K_ENABLE;
+#endif
+
 #if CLOCK_USE_PLL
     /* reset the GCLK module so it is in a known state */
     GCLK->CTRL.reg = GCLK_CTRL_SWRST;
@@ -148,19 +164,8 @@ static void clk_init(void)
                          GCLK_GENCTRL_ID(1));
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
-    /* Setup clock GCLK3 with divider 1 */
-    GCLK->GENDIV.reg = GCLK_GENDIV_ID(3) | GCLK_GENDIV_DIV(1);
-    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
-
-    /* Enable GCLK3 with XOSC32K as source */
-    GCLK->GENCTRL.reg = GCLK_GENCTRL_ID(3) |
-                        GCLK_GENCTRL_GENEN |
-                        GCLK_GENCTRL_RUNSTDBY |
-                        GCLK_GENCTRL_SRC_XOSC32K;
-    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
-
-    /* set GCLK3 as source for DFLL */
-    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_GEN_GCLK3 |
+    /* set GCLK2 as source for DFLL */
+    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_GEN_GCLK2 |
                          GCLK_CLKCTRL_ID_DFLL48 |
                          GCLK_CLKCTRL_CLKEN);
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
@@ -212,25 +217,9 @@ static void clk_init(void)
     /* make sure we synchronize clock generator 0 before we go on */
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
-    /* Setup GCLK2 with divider 1 (32.768kHz) */
-    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(2)  | GCLK_GENDIV_DIV(0));
-    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_GENEN
-                      | GCLK_GENCTRL_RUNSTDBY
-#if GEN2_ULP32K
-                      | GCLK_GENCTRL_SRC_OSCULP32K);
-#else
-                      | GCLK_GENCTRL_SRC_XOSC32K);
-
-    SYSCTRL->XOSC32K.reg = SYSCTRL_XOSC32K_ONDEMAND
-                         | SYSCTRL_XOSC32K_EN32K
-                         | SYSCTRL_XOSC32K_XTALEN
-                         | SYSCTRL_XOSC32K_STARTUP(6)
-                         | SYSCTRL_XOSC32K_ENABLE;
-#endif
-
-    /* Setup GCLK4 with divider 32 (1024 Hz) */
-    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(4)  | GCLK_GENDIV_DIV(4));
-    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(4) | GCLK_GENCTRL_GENEN
+    /* Setup GCLK3 with divider 32 (1024 Hz) */
+    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(3)  | GCLK_GENDIV_DIV(4));
+    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(3) | GCLK_GENCTRL_GENEN
                       | GCLK_GENCTRL_RUNSTDBY | GCLK_GENCTRL_DIVSEL
 #if GEN2_ULP32K
                       | GCLK_GENCTRL_SRC_OSCULP32K);

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -58,15 +58,13 @@ void sam0_gclk_enable(uint8_t id)
 uint32_t sam0_gclk_freq(uint8_t id)
 {
     switch (id) {
-    case 0:
+    case SAM0_GCLK_MAIN:
         return CLOCK_CORECLOCK;
-    case 1:
+    case SAM0_GCLK_1MHZ:
         return 1000000;
-    case 2:
+    case SAM0_GCLK_32KHZ:
         return 32768;
-    case 3:
-        return 32768;
-    case 4:
+    case SAM0_GCLK_1KHZ:
         return 1024;
     default:
         return 0;
@@ -97,8 +95,8 @@ static void clk_init(void)
 #endif
 
     /* Setup GCLK2 with divider 1 (32.768kHz) */
-    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(2)  | GCLK_GENDIV_DIV(0));
-    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_GENEN
+    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(SAM0_GCLK_32KHZ)  | GCLK_GENDIV_DIV(0));
+    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(SAM0_GCLK_32KHZ) | GCLK_GENCTRL_GENEN
                       | GCLK_GENCTRL_RUNSTDBY
 #if GEN2_ULP32K
                       | GCLK_GENCTRL_SRC_OSCULP32K);
@@ -119,12 +117,12 @@ static void clk_init(void)
 
     /* setup generic clock 1 to feed DPLL with 1MHz */
     GCLK->GENDIV.reg = (GCLK_GENDIV_DIV(8) |
-                        GCLK_GENDIV_ID(1));
+                        GCLK_GENDIV_ID(SAM0_GCLK_1MHZ));
     GCLK->GENCTRL.reg = (GCLK_GENCTRL_GENEN |
                          GCLK_GENCTRL_SRC_OSC8M |
-                         GCLK_GENCTRL_ID(1));
-    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_GEN(1) |
-                         GCLK_CLKCTRL_ID(1) |
+                         GCLK_GENCTRL_ID(SAM0_GCLK_1MHZ));
+    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_GEN(SAM0_GCLK_1MHZ) |
+                         GCLK_CLKCTRL_ID_FDPLL |
                          GCLK_CLKCTRL_CLKEN);
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
@@ -137,10 +135,10 @@ static void clk_init(void)
 
     /* select the PLL as source for clock generator 0 (CPU core clock) */
     GCLK->GENDIV.reg =  (GCLK_GENDIV_DIV(CLOCK_PLL_DIV) |
-                        GCLK_GENDIV_ID(0));
+                        GCLK_GENDIV_ID(SAM0_GCLK_MAIN));
     GCLK->GENCTRL.reg = (GCLK_GENCTRL_GENEN |
                          GCLK_GENCTRL_SRC_FDPLL |
-                         GCLK_GENCTRL_ID(0));
+                         GCLK_GENCTRL_ID(SAM0_GCLK_MAIN));
 #elif CLOCK_USE_XOSC32_DFLL
     /* Use External 32.768KHz Oscillator */
     SYSCTRL->XOSC32K.reg =  SYSCTRL_XOSC32K_ONDEMAND |
@@ -158,14 +156,14 @@ static void clk_init(void)
 
     /* setup generic clock 1 as 1MHz for timer.c */
     GCLK->GENDIV.reg = (GCLK_GENDIV_DIV(8) |
-                        GCLK_GENDIV_ID(1));
+                        GCLK_GENDIV_ID(SAM0_GCLK_1MHZ));
     GCLK->GENCTRL.reg = (GCLK_GENCTRL_GENEN |
                          GCLK_GENCTRL_SRC_OSC8M |
-                         GCLK_GENCTRL_ID(1));
+                         GCLK_GENCTRL_ID(SAM0_GCLK_1MHZ));
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
     /* set GCLK2 as source for DFLL */
-    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_GEN_GCLK2 |
+    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_GEN(SAM0_GCLK_32KHZ) |
                          GCLK_CLKCTRL_ID_DFLL48 |
                          GCLK_CLKCTRL_CLKEN);
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
@@ -197,9 +195,13 @@ static void clk_init(void)
     while ((SYSCTRL->PCLKSR.reg & mask) != mask) { } /* Wait for DFLL lock */
 
     /* select the DFLL as source for clock generator 0 (CPU core clock) */
-    GCLK->GENDIV.reg =  (GCLK_GENDIV_DIV(1U) | GCLK_GENDIV_ID(0));
-    GCLK->GENCTRL.reg = (GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_DFLL48M | GCLK_GENCTRL_ID(0));
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0;
+    GCLK->GENDIV.reg =  (GCLK_GENDIV_DIV(1U) | GCLK_GENDIV_ID(SAM0_GCLK_MAIN));
+    GCLK->GENCTRL.reg = GCLK_GENCTRL_GENEN
+                      | GCLK_GENCTRL_SRC_DFLL48M
+                      | GCLK_GENCTRL_ID(SAM0_GCLK_MAIN);
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN
+                      | GCLK_CLKCTRL_ID_DFLL48
+                      | GCLK_CLKCTRL_GEN(SAM0_GCLK_MAIN);
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
     SYSCTRL->DFLLCTRL.bit.ONDEMAND = 1;
@@ -208,18 +210,18 @@ static void clk_init(void)
     }
 #else /* do not use PLL, use internal 8MHz oscillator directly */
     GCLK->GENDIV.reg =  (GCLK_GENDIV_DIV(CLOCK_DIV) |
-                        GCLK_GENDIV_ID(0));
+                        GCLK_GENDIV_ID(SAM0_GCLK_MAIN));
     GCLK->GENCTRL.reg = (GCLK_GENCTRL_GENEN |
                          GCLK_GENCTRL_SRC_OSC8M |
-                         GCLK_GENCTRL_ID(0));
+                         GCLK_GENCTRL_ID(SAM0_GCLK_MAIN));
 #endif
 
     /* make sure we synchronize clock generator 0 before we go on */
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
     /* Setup GCLK3 with divider 32 (1024 Hz) */
-    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(3)  | GCLK_GENDIV_DIV(4));
-    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(3) | GCLK_GENCTRL_GENEN
+    GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(SAM0_GCLK_1KHZ)  | GCLK_GENDIV_DIV(4));
+    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(SAM0_GCLK_1KHZ) | GCLK_GENCTRL_GENEN
                       | GCLK_GENCTRL_RUNSTDBY | GCLK_GENCTRL_DIVSEL
 #if GEN2_ULP32K
                       | GCLK_GENCTRL_SRC_OSCULP32K);

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -45,6 +45,18 @@ extern "C" {
 /** @} */
 
 /**
+ * @name   SAMD21 GCLK definitions
+ * @{
+ */
+enum {
+    SAM0_GCLK_MAIN = 0,                 /**< 48 MHz main clock      */
+    SAM0_GCLK_1MHZ,                     /**< 1 MHz clock for xTimer */
+    SAM0_GCLK_32KHZ,                    /**< 32 kHz clock           */
+    SAM0_GCLK_1KHZ,                     /**< 1 kHz clock            */
+};
+/** @} */
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 static const int8_t exti_config[2][32] = {

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -110,16 +110,20 @@ void sam0_gclk_enable(uint8_t id)
     /* clocks 0 & 1 are always running */
 
     switch (id) {
-    case 5:
+    case SAM0_GCLK_8MHZ:
         /* 8 MHz clock used by xtimer */
 #if USE_DPLL
-        gclk_connect(5, GCLK_SOURCE_DPLL0, GCLK_GENCTRL_DIV(DPLL_DIV * CLOCK_CORECLOCK / 8000000));
+        gclk_connect(SAM0_GCLK_8MHZ,
+                     GCLK_SOURCE_DPLL0,
+                     GCLK_GENCTRL_DIV(DPLL_DIV * CLOCK_CORECLOCK / 8000000));
 #else
-        gclk_connect(5, GCLK_SOURCE_DFLL, GCLK_GENCTRL_DIV(SAM0_DFLL_FREQ_HZ / 8000000));
+        gclk_connect(SAM0_GCLK_8MHZ,
+                     GCLK_SOURCE_DFLL,
+                     GCLK_GENCTRL_DIV(SAM0_DFLL_FREQ_HZ / 8000000));
 #endif
         break;
-    case 6:
-        gclk_connect(6, GCLK_SOURCE_DFLL, 0);
+    case SAM0_GCLK_48MHZ:
+        gclk_connect(SAM0_GCLK_48MHZ, GCLK_SOURCE_DFLL, 0);
         break;
     }
 }
@@ -127,13 +131,13 @@ void sam0_gclk_enable(uint8_t id)
 uint32_t sam0_gclk_freq(uint8_t id)
 {
     switch (id) {
-    case 0:
+    case SAM0_GCLK_MAIN:
         return CLOCK_CORECLOCK;
-    case 1:
+    case SAM0_GCLK_32KHZ:
         return 32768;
-    case 5:
+    case SAM0_GCLK_8MHZ:
         return 8000000;
-    case 6:
+    case SAM0_GCLK_48MHZ:
         return SAM0_DFLL_FREQ_HZ;
     default:
         return 0;
@@ -179,19 +183,19 @@ void cpu_init(void)
     CMCC->CTRL.bit.CEN = 1;
 
     xosc32k_init();
-    gclk_connect(1, GCLK_SOURCE_XOSC32K, 0);
+    gclk_connect(SAM0_GCLK_32KHZ, GCLK_SOURCE_XOSC32K, 0);
 
     /* make sure main clock is not sourced from DPLL */
     dfll_init();
-    gclk_connect(0, GCLK_SOURCE_DFLL, 0);
+    gclk_connect(SAM0_GCLK_MAIN, GCLK_SOURCE_DFLL, 0);
 
 #if USE_DPLL
     fdpll0_init(CLOCK_CORECLOCK * DPLL_DIV);
 
     /* source main clock from DPLL */
-    gclk_connect(0, GCLK_SOURCE_DPLL0, GCLK_GENCTRL_DIV(DPLL_DIV));
+    gclk_connect(SAM0_GCLK_MAIN, GCLK_SOURCE_DPLL0, GCLK_GENCTRL_DIV(DPLL_DIV));
 #else
-    gclk_connect(0, GCLK_SOURCE_DFLL, GCLK_GENCTRL_DIV(SAM0_DFLL_FREQ_HZ / CLOCK_CORECLOCK));
+    gclk_connect(SAM0_GCLK_MAIN, GCLK_SOURCE_DFLL, GCLK_GENCTRL_DIV(SAM0_DFLL_FREQ_HZ / CLOCK_CORECLOCK));
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -44,6 +44,18 @@ extern "C" {
 #define SAM0_DPLL_FREQ_MAX_HZ   (200000000U)
 
 /**
+ * @name   SAMD5x GCLK definitions
+ * @{
+ */
+enum {
+    SAM0_GCLK_MAIN = 0,                 /**< 120 MHz main clock     */
+    SAM0_GCLK_32KHZ,                    /**< 32 kHz clock           */
+    SAM0_GCLK_8MHZ,                     /**< 8 MHz clock for xTimer */
+    SAM0_GCLK_48MHZ,                    /**< 48 MHz DFLL clock      */
+};
+/** @} */
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 static const int8_t exti_config[4][32] = {

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -80,9 +80,9 @@ void sam0_gclk_enable(uint8_t id)
 uint32_t sam0_gclk_freq(uint8_t id)
 {
     switch (id) {
-    case 0:
+    case SAM0_GCLK_MAIN:
         return CLOCK_CORECLOCK;
-    case 1:
+    case SAM0_GCLK_32KHZ:
         return 32768;
     default:
         return 0;
@@ -132,11 +132,11 @@ void cpu_init(void)
     _xosc32k_setup();
 
     /* Setup GCLK generators */
-    _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
+    _gclk_setup(SAM0_GCLK_MAIN, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
 #if EXTERNAL_OSC32_SOURCE
-    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_XOSC32K);
+    _gclk_setup(SAM0_GCLK_32KHZ, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_XOSC32K);
 #else
-    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
+    _gclk_setup(SAM0_GCLK_32KHZ, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -71,6 +71,24 @@ static void _xosc32k_setup(void)
 #endif
 }
 
+void sam0_gclk_enable(uint8_t id)
+{
+    (void) id;
+    /* clocks are always running */
+}
+
+uint32_t sam0_gclk_freq(uint8_t id)
+{
+    switch (id) {
+    case 0:
+        return CLOCK_CORECLOCK;
+    case 1:
+        return 32768;
+    default:
+        return 0;
+    }
+}
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */
@@ -115,6 +133,11 @@ void cpu_init(void)
 
     /* Setup GCLK generators */
     _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
+#if EXTERNAL_OSC32_SOURCE
+    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_XOSC32K);
+#else
+    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
+#endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     stdio_init();

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -33,6 +33,16 @@ extern "C" {
 #define PM_BLOCKER_INITIAL  { .val_u32 = 0x00000001 }
 
 /**
+ * @name   SAML1x GCLK definitions
+ * @{
+ */
+enum {
+    SAM0_GCLK_MAIN = 0,                 /**< 16 MHz main clock      */
+    SAM0_GCLK_32KHZ,                    /**< 32 kHz clock           */
+};
+/** @} */
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 static const int8_t exti_config[1][32] = {

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -64,6 +64,24 @@ static void _xosc32k_setup(void)
 #endif
 }
 
+void sam0_gclk_enable(uint8_t id)
+{
+    (void) id;
+    /* clocks are always running */
+}
+
+uint32_t sam0_gclk_freq(uint8_t id)
+{
+    switch (id) {
+    case 0:
+        return CLOCK_CORECLOCK;
+    case 1:
+        return 32768;
+    default:
+        return 0;
+    }
+}
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */
@@ -109,6 +127,11 @@ void cpu_init(void)
 
     /* Setup GCLK generators */
     _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
+#if EXTERNAL_OSC32_SOURCE
+    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_XOSC32K);
+#else
+    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
+#endif
 
 #ifdef MODULE_PERIPH_PM
     PM->CTRLA.reg = PM_CTRLA_MASK & (~PM_CTRLA_IORET);

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -73,9 +73,9 @@ void sam0_gclk_enable(uint8_t id)
 uint32_t sam0_gclk_freq(uint8_t id)
 {
     switch (id) {
-    case 0:
+    case SAM0_GCLK_MAIN:
         return CLOCK_CORECLOCK;
-    case 1:
+    case SAM0_GCLK_32KHZ:
         return 32768;
     default:
         return 0;
@@ -126,11 +126,11 @@ void cpu_init(void)
     _xosc32k_setup();
 
     /* Setup GCLK generators */
-    _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
+    _gclk_setup(SAM0_GCLK_MAIN, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
 #if EXTERNAL_OSC32_SOURCE
-    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_XOSC32K);
+    _gclk_setup(SAM0_GCLK_32KHZ, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_XOSC32K);
 #else
-    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
+    _gclk_setup(SAM0_GCLK_32KHZ, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
 #endif
 
 #ifdef MODULE_PERIPH_PM

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -32,6 +32,16 @@ extern "C" {
 #define CPU_BACKUP_RAM_NOT_RETAINED (1)
 
 /**
+ * @name   SAML21 GCLK definitions
+ * @{
+ */
+enum {
+    SAM0_GCLK_MAIN = 0,                 /**< 16 MHz main clock      */
+    SAM0_GCLK_32KHZ,                    /**< 32 kHz clock           */
+};
+/** @} */
+
+/**
  * @brief   Mapping of pins to EXTI lines, -1 means not EXTI possible
  */
 #if defined(CPU_MODEL_SAML21E18A) || defined(CPU_MODEL_SAML21E18B) || \


### PR DESCRIPTION
### Contribution description

The sam0 family offers multiple GCLKs that can be sourced from different timers.
However, all peripherals were effectively always clocked by the hard-coded `CLOCK_CORECLOCK`.

This causes several issues:

 - on high CPU frequencies (> 51 MHz) the available I2C divider is too small to produce the required I2C baud rate 
- on low CPU frequencies the available frequency is too low to produce high UART baudrates.

This introduces a `sam0_gclk_freq()` function to query the frequency of  the individual GCLKs, so other GCLKs than 0 can be used for peripherals.

This would also allow to change the CPU frequency at run-time without affecting peripherals, unless they use GCLKs sourced from GCLK0.

The first commit in this series also changes the `.gclk_src` config struct from a bit mask to the GCLK ID.
While not strictly necessary, it cleans up the board configurations and removes the need to differentiate between samd2x and later MCUs.

### Testing procedure

In only tested the changes on `samr21-xpro` and `same54-xpro`

On `same54-xpro` you will find that `i2c_scan` (and I2C in general) now works (`USEMODULE += i2c_scan`), before it would get stuck due to a wrong clock frequency.

### Issues/PRs references
fixes #12037