### PR TITLE
tests/cpu_esp: tests for ESP specific modules

### DIFF
--- a/boards/common/esp8266/Makefile.features
+++ b/boards/common/esp8266/Makefile.features
@@ -1,7 +1,6 @@
 CPU = esp8266
 
 # MCU defined peripheral features provided by all boards in alphabetical order
-
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq

--- a/boards/esp32-olimex-evb/Makefile.features
+++ b/boards/esp32-olimex-evb/Makefile.features
@@ -12,7 +12,7 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 
 # unique features of the board
-FEATURES_PROVIDED += periph_eth     # Ethernet MAC (EMAC)
+FEATURES_PROVIDED += esp_eth        # Ethernet MAC (EMAC)
 FEATURES_PROVIDED += periph_can     # CAN peripheral interface
 FEATURES_PROVIDED += periph_ir      # IR peripheral interface
 

--- a/tests/cpu_esp_eth/Makefile
+++ b/tests/cpu_esp_eth/Makefile
@@ -1,0 +1,16 @@
+BOARD ?=esp32-olimex-evb
+
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += arch_esp32
+FEATURES_REQUIRED += esp_eth
+
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += esp_eth
+USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_icmpv6_echo
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_esp_eth/main.c
+++ b/tests/cpu_esp_eth/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *               2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the ESP32 Ethernet device driver
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8U)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("Test application for the esp_eth driver\n");
+    puts("This test just pulls in parts of the GNRC network stack, use the\n"
+         "provided shell commands (i.e. ifconfig, ping6) to interact with\n"
+         "your esp_eth device.\n");
+
+    /* start shell */
+    puts("Starting the shell now...");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}

--- a/tests/cpu_esp_hw_counter/Makefile
+++ b/tests/cpu_esp_hw_counter/Makefile
@@ -1,0 +1,13 @@
+BOARD ?= esp32-wroom-32
+
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += arch_esp32
+FEATURES_REQUIRED += periph_timer
+
+USEMODULE += esp_hw_counter
+
+TIMER_SPEED ?= 1000000
+
+CFLAGS += -DTIMER_SPEED=$(TIMER_SPEED)
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_esp_hw_counter/README.md
+++ b/tests/cpu_esp_hw_counter/README.md
@@ -1,0 +1,18 @@
+# ESP32 Periph Timer Test Using Hardware Counters
+
+## About
+
+The application corresponds exactly to the application `tests/periph_timer`.
+It is only for testing the timer implementation using hardware counters.
+In fact, the application is nothing more than the `tests/periph_timer`
+application compiled with the following command:
+
+```
+USEMODULE=esp_hw_counter make -C tests/periph_timer
+```
+
+## Expected Results
+
+Since the application corresponds exactly to the application
+`tests/periph_timer`, the expected results are the same as for
+`tests/periph_timer`.

--- a/tests/cpu_esp_hw_counter/main.c
+++ b/tests/cpu_esp_hw_counter/main.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Peripheral timer test application
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "periph/timer.h"
+
+/**
+ * @brief   Make sure, the maximum number of timers is defined
+ */
+#ifndef TIMER_NUMOF
+#error "TIMER_NUMOF not defined!"
+#endif
+
+#define MAX_CHANNELS        (10U)
+#define CHAN_OFFSET         (5000U)     /* fire every 5ms */
+#define COOKIE              (100U)      /* for checking if arg is passed */
+
+static volatile int fired;
+static volatile uint32_t sw_count;
+static volatile uint32_t timeouts[MAX_CHANNELS];
+static volatile unsigned args[MAX_CHANNELS];
+
+static void cb(void *arg, int chan)
+{
+    timeouts[chan] = sw_count;
+    args[chan] = (unsigned)arg + chan;
+    fired++;
+}
+
+static int test_timer(unsigned num)
+{
+    int set = 0;
+
+    /* reset state */
+    sw_count = 0;
+    fired = 0;
+    for (unsigned i = 0; i < MAX_CHANNELS; i++) {
+        timeouts[i] = 0;
+        args[i] = UINT_MAX;
+    }
+
+    /* initialize and halt timer */
+    if (timer_init(TIMER_DEV(num), TIMER_SPEED, cb, (void *)(COOKIE * num)) < 0) {
+        printf("TIMER_%u: ERROR on initialization - skipping\n\n", num);
+        return 0;
+    }
+    else {
+        printf("TIMER_%u: initialization successful\n", num);
+    }
+    timer_stop(TIMER_DEV(num));
+    printf("TIMER_%u: stopped\n", num);
+    /* set each available channel */
+    for (unsigned i = 0; i < MAX_CHANNELS; i++) {
+        unsigned timeout = ((i + 1) * CHAN_OFFSET);
+        if (timer_set(TIMER_DEV(num), i, timeout) < 0) {
+            break;
+        }
+        else {
+            ++set;
+            printf("TIMER_%u: set channel %u to %u\n", num, i, timeout);
+        }
+    }
+    if (set == 0) {
+        printf("TIMER_%u: ERROR setting any channel\n\n", num);
+        return 0;
+    }
+    /* start the timer */
+    printf("TIMER_%u: starting\n", num);
+    timer_start(TIMER_DEV(num));
+    /* wait for all channels to fire */
+    do {
+        ++sw_count;
+    } while (fired != set);
+    /* collect results */
+    for (int i = 0; i < fired; i++) {
+        if (args[i] != ((COOKIE * num) + i)) {
+            printf("TIMER_%u: ERROR callback argument mismatch\n\n", num);
+            return 0;
+        }
+        printf("TIMER_%u: channel %i fired at SW count %8u",
+               num, i, (unsigned)timeouts[i]);
+        if (i == 0) {
+            printf(" - init: %8u\n", (unsigned)timeouts[i]);
+        }
+        else {
+            printf(" - diff: %8u\n", (unsigned)(timeouts[i] - timeouts[i - 1]));
+        }
+    }
+    return 1;
+}
+
+int main(void)
+{
+    int res = 0;
+
+    puts("\nTest for peripheral TIMERs\n");
+
+    printf("Available timers: %i\n", TIMER_NUMOF);
+
+    /* test all configured timers */
+    for (unsigned i = 0; i < TIMER_NUMOF; i++) {
+        printf("\nTesting TIMER_%u:\n", i);
+        res += test_timer(i);
+    }
+    /* draw conclusion */
+    if (res == TIMER_NUMOF) {
+        puts("\nTEST SUCCEEDED");
+    }
+    else {
+        puts("\nTEST FAILED");
+    }
+
+    return 0;
+}

--- a/tests/cpu_esp_hw_counter/tests/01-run.py
+++ b/tests/cpu_esp_hw_counter/tests/01-run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'Available timers: (\d+)\r\n')
+    timers_num = int(child.match.group(1))
+    for timer in range(timers_num):
+        child.expect_exact('Testing TIMER_{}'.format(timer))
+        child.expect_exact('TIMER_{}: initialization successful'.format(timer))
+        child.expect_exact('TIMER_{}: stopped'.format(timer))
+        child.expect_exact('TIMER_{}: starting'.format(timer))
+    child.expect('TEST SUCCEEDED')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/cpu_esp_i2c_hw/Makefile
+++ b/tests/cpu_esp_i2c_hw/Makefile
@@ -1,0 +1,11 @@
+BOARD ?= esp32-wroom-32
+
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += arch_esp32
+FEATURES_REQUIRED += periph_i2c
+
+USEMODULE += esp_i2c_hw
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_esp_i2c_hw/README.md
+++ b/tests/cpu_esp_i2c_hw/README.md
@@ -1,0 +1,17 @@
+# ESP Hardware I2C Test
+
+## About
+
+The application corresponds exactly to the application `tests/periph_i2c`.
+It is only for testing the timer implementation using hardware counters.
+In fact, the application is nothing more than the `tests/periph_i2c`
+application compiled with the following command:
+
+```
+USEMODULE=esp_i2c_hw make -C tests/periph_i2c
+```
+
+## Expected Results
+
+Since the application corresponds exactly to the application `tests/periph_i2c`,
+it can be used in same way.

--- a/tests/cpu_esp_i2c_hw/main.c
+++ b/tests/cpu_esp_i2c_hw/main.c
@@ -1,0 +1,468 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the low-level I2C peripheral driver
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "periph_conf.h"
+#include "periph/i2c.h"
+#include "shell.h"
+
+#ifndef I2C_ACK
+#define I2C_ACK         (0)
+#endif
+
+#define INVALID_ARGS    puts("Error: Invalid number of arguments");
+
+#define BUFSIZE         (128U)
+
+#define CONVERT_ERROR   (-32768)
+
+#define ARG_ERROR       (-1)
+
+/* i2c_buf is global to reduce stack memory consumtion */
+static uint8_t i2c_buf[BUFSIZE];
+
+static inline void _print_i2c_read(i2c_t dev, uint16_t *reg, uint8_t *buf,
+    int len)
+{
+    printf("Success: i2c_%i read %i byte(s) ", dev, len);
+    if (reg != NULL) {
+        printf("from reg 0x%02x ", *reg);
+    }
+    printf(": [");
+    for (int i = 0; i < len; i++) {
+        if (i != 0) {
+            printf(", ");
+        }
+        printf("0x%02x", buf[i]);
+    }
+    printf("]\n");
+}
+
+static inline int _get_num(const char *str)
+{
+    errno = 0;
+    char *temp;
+    long val = strtol(str, &temp, 0);
+
+    if (temp == str || *temp != '\0' ||
+        ((val == LONG_MIN || val == LONG_MAX) && errno == ERANGE)) {
+        val = CONVERT_ERROR;
+    }
+    return (int)val;
+}
+
+
+static int _check_param(int argc, char **argv, int c_min, int c_max, char *use)
+{
+    int dev;
+
+    if (argc - 1 < c_min || argc - 1 > c_max) {
+        printf("Usage: %s %s\n", argv[0], use);
+        INVALID_ARGS;
+        return ARG_ERROR;
+    }
+
+    dev = _get_num(argv[1]);
+    if (dev < 0 || dev >= (int)I2C_NUMOF) {
+        printf("Error: No device, only %d supported\n", (int)I2C_NUMOF);
+        return ARG_ERROR;
+    }
+    return dev;
+}
+
+static int _print_i2c_error(int res)
+{
+    if (res == -EOPNOTSUPP) {
+        printf("Error: EOPNOTSUPP [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -EINVAL) {
+        printf("Error: EINVAL [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -EAGAIN) {
+        printf("Error: EAGAIN [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -ENXIO) {
+        printf("Error: ENXIO [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -EIO) {
+        printf("Error: EIO [%d]\n", -res);
+        return 1;
+    }
+    else if (res == -ETIMEDOUT) {
+        printf("Error: ETIMEDOUT [%d]\n", -res);
+        return 1;
+    }
+    else if (res == I2C_ACK) {
+        printf("Success: I2C_ACK [%d]\n", res);
+        return 0;
+    }
+    printf("Error: Unknown error [%d]\n", res);
+    return 1;
+}
+
+int cmd_i2c_acquire(int argc, char **argv)
+{
+    int res;
+    int dev;
+
+    dev = _check_param(argc, argv, 1, 1, "DEV");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    printf("Command: i2c_acquire(%i)\n", dev);
+    res = i2c_acquire(dev);
+    if (res == I2C_ACK) {
+        printf("Success: i2c_%i acquired\n", dev);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_release(int argc, char **argv)
+{
+    int dev;
+
+    dev = _check_param(argc, argv, 1, 1, "DEV");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    printf("Command: i2c_release(%i)\n", dev);
+    i2c_release(dev);
+
+    printf("Success: i2c_%i released\n", dev);
+    return 0;
+}
+
+int cmd_i2c_read_reg(int argc, char **argv)
+{
+    int res;
+    uint16_t addr;
+    uint16_t reg;
+    uint8_t flags = 0;
+    uint8_t data;
+    int dev;
+
+    dev = _check_param(argc, argv, 4, 4, "DEV ADDR REG FLAG");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    addr = _get_num(argv[2]);
+    reg = _get_num(argv[3]);
+    flags = _get_num(argv[4]);
+
+    printf("Command: i2c_read_reg(%i, 0x%02x, 0x%02x, 0x%02x)\n", dev, addr,
+           reg, flags);
+    res = i2c_read_reg(dev, addr, reg, &data, flags);
+
+    if (res == I2C_ACK) {
+        _print_i2c_read(dev, &reg, &data, 1);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_read_regs(int argc, char **argv)
+{
+    int res;
+    uint16_t addr;
+    uint16_t reg;
+    uint8_t flags = 0;
+    int len;
+    int dev;
+
+    dev = _check_param(argc, argv, 5, 5, "DEV ADDR REG LEN FLAG");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    addr = _get_num(argv[2]);
+    reg = _get_num(argv[3]);
+    len = _get_num(argv[4]);
+    flags = _get_num(argv[5]);
+
+    if (len < 1 || len > (int)BUFSIZE) {
+        puts("Error: invalid LENGTH parameter given");
+        return 1;
+    }
+    else {
+        printf("Command: i2c_read_regs(%i, 0x%02x, 0x%02x, %i, 0x%02x)\n", dev,
+            addr, reg, len, flags);
+        res = i2c_read_regs(dev, addr, reg, i2c_buf, len, flags);
+    }
+
+    if (res == I2C_ACK) {
+        _print_i2c_read(dev, &reg, i2c_buf, len);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_read_byte(int argc, char **argv)
+{
+    int res;
+    uint16_t addr;
+    uint8_t flags = 0;
+    uint8_t data;
+    int dev;
+
+    dev = _check_param(argc, argv, 3, 3, "DEV ADDR FLAG");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    addr = _get_num(argv[2]);
+    flags = _get_num(argv[3]);
+
+    printf("Command: i2c_read_byte(%i, 0x%02x, 0x%02x)\n", dev, addr, flags);
+    res = i2c_read_byte(dev, addr, &data, flags);
+
+    if (res == I2C_ACK) {
+        _print_i2c_read(dev, NULL, &data, 1);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_read_bytes(int argc, char **argv)
+{
+    int res;
+    uint16_t addr;
+    uint8_t flags = 0;
+    int len;
+    int dev;
+
+    dev = _check_param(argc, argv, 4, 4, "DEV ADDR LENGTH FLAG");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    addr = _get_num(argv[2]);
+    len = _get_num(argv[3]);
+    flags = _get_num(argv[4]);
+
+    if (len < 1 || len > (int)BUFSIZE) {
+        puts("Error: invalid LENGTH parameter given");
+        return 1;
+    }
+    else {
+        printf("Command: i2c_read_bytes(%i, 0x%02x, %i, 0x%02x)\n", dev,
+         addr, len, flags);
+        res = i2c_read_bytes(dev, addr, i2c_buf, len, flags);
+    }
+
+    if (res == I2C_ACK) {
+        _print_i2c_read(dev, NULL, i2c_buf, len);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_write_byte(int argc, char **argv)
+{
+    int res;
+    uint16_t addr;
+    uint8_t flags = 0;
+    uint8_t data;
+    int dev;
+
+    dev = _check_param(argc, argv, 4, 4, "DEV ADDR BYTE FLAG");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    addr = _get_num(argv[2]);
+    data = _get_num(argv[3]);
+    flags = _get_num(argv[4]);
+
+    printf("Command: i2c_write_byte(%i, 0x%02x, 0x%02x, [0x%02x", dev, addr,
+        flags, data);
+    puts("])");
+    res = i2c_write_byte(dev, addr, data, flags);
+
+    if (res == I2C_ACK) {
+        printf("Success: i2c_%i wrote 1 byte to the bus\n", dev);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_write_bytes(int argc, char **argv)
+{
+    int res;
+    uint16_t addr;
+    uint8_t flags = 0;
+    int len = argc - 4;
+    int dev;
+
+    dev = _check_param(argc, argv, 4, 3 + BUFSIZE,
+                       "DEV ADDR FLAG BYTE0 [BYTE1 [BYTE_n [...]]]");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    addr = _get_num(argv[2]);
+    flags = _get_num(argv[3]);
+    for (int i = 0; i < len; i++) {
+        i2c_buf[i] = _get_num(argv[i + 4]);
+    }
+
+    printf("Command: i2c_write_bytes(%i, 0x%02x, 0x%02x, [", dev, addr,
+        flags);
+    for (int i = 0; i < len; i++) {
+        if (i != 0) {
+            printf(", ");
+        }
+        printf("0x%02x", i2c_buf[i]);
+    }
+    puts("])");
+    res = i2c_write_bytes(dev, addr, i2c_buf, len, flags);
+
+    if (res == I2C_ACK) {
+        printf("Success: i2c_%i wrote %i bytes\n", dev, len);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_write_reg(int argc, char **argv)
+{
+    int res;
+    uint16_t addr;
+    uint16_t reg;
+    uint8_t flags = 0;
+    uint8_t data;
+    int dev;
+
+    dev = _check_param(argc, argv, 5, 5, "DEV ADDR REG BYTE FLAG");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    addr = _get_num(argv[2]);
+    reg = _get_num(argv[3]);
+    data = _get_num(argv[4]);
+    flags = _get_num(argv[5]);
+
+    printf("Command: i2c_write_reg(%i, 0x%02x, 0x%02x, 0x%02x, [0x%02x", dev,
+        addr, reg, flags, data);
+    puts("])");
+    res = i2c_write_reg(dev, addr, reg, data, flags);
+
+    if (res == I2C_ACK) {
+        printf("Success: i2c_%i wrote 1 byte\n", dev);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_write_regs(int argc, char **argv)
+{
+    int res;
+    uint16_t addr;
+    uint16_t reg;
+    uint8_t flags = 0;
+    int len = argc - 5;
+    int dev;
+
+    dev = _check_param(argc, argv, 5, 4 + BUFSIZE,
+                       "DEV ADDR REG FLAG BYTE0 [BYTE1 ...]");
+    if (dev == ARG_ERROR) {
+        return 1;
+    }
+
+    addr = _get_num(argv[2]);
+    reg = _get_num(argv[3]);
+    flags = _get_num(argv[4]);
+    for (int i = 0; i < len; i++) {
+        i2c_buf[i] = _get_num(argv[i + 5]);
+    }
+
+    printf("Command: i2c_write_regs(%i, 0x%02x, 0x%02x, 0x%02x, [", dev,
+        addr, reg, flags);
+    for (int i = 0; i < len; i++) {
+        if (i != 0) {
+            printf(", ");
+        }
+        printf("0x%02x", i2c_buf[i]);
+    }
+    puts("])");
+    res = i2c_write_regs(dev, addr, reg, i2c_buf, len, flags);
+
+    if (res == I2C_ACK) {
+        printf("Success: i2c_%i wrote %i bytes to reg 0x%02x\n",
+            dev, len, reg);
+        return 0;
+    }
+    return _print_i2c_error(res);
+}
+
+int cmd_i2c_get_devs(int argc, char **argv)
+{
+    (void)argv;
+    (void)argc;
+    printf("Command: return I2C_NUMOF\n");
+    printf("Success: Amount of i2c devices: [%d]\n", I2C_NUMOF);
+    return 0;
+}
+
+int cmd_i2c_get_id(int argc, char **argv)
+{
+    (void)argv;
+    (void)argc;
+    puts("Success: [periph_i2c]");
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "i2c_acquire", "Get access to the I2C bus", cmd_i2c_acquire },
+    { "i2c_release", "Release to the I2C bus", cmd_i2c_release },
+    { "i2c_read_reg", "Read byte from register", cmd_i2c_read_reg },
+    { "i2c_read_regs", "Read bytes from registers", cmd_i2c_read_regs },
+    { "i2c_read_byte", "Read byte from the I2C device", cmd_i2c_read_byte },
+    { "i2c_read_bytes", "Read bytes from the I2C device", cmd_i2c_read_bytes },
+    { "i2c_write_byte", "Write byte to the I2C device", cmd_i2c_write_byte },
+    { "i2c_write_bytes", "Write bytes to the I2C device", cmd_i2c_write_bytes },
+    { "i2c_write_reg", "Write byte to register", cmd_i2c_write_reg },
+    { "i2c_write_regs", "Write bytes to registers", cmd_i2c_write_regs },
+    { "i2c_get_devs", "Gets amount of supported i2c devices", cmd_i2c_get_devs },
+    { "i2c_get_id", "Get the id of the fw", cmd_i2c_get_id },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("Start: Test for the low-level I2C driver");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/cpu_esp_idf_heap/Makefile
+++ b/tests/cpu_esp_idf_heap/Makefile
@@ -1,0 +1,15 @@
+BOARD ?= esp32-wroom-32
+
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += arch_esp
+
+USEMODULE += esp_idf_heap
+
+include $(RIOTBASE)/Makefile.include
+
+ifneq (,$(filter esp_spi_ram,$(FEATURES_PROVIDED)))
+  export RIOT_TEST_TIMEOUT=100
+  USEMODULE += esp_spi_ram
+  CFLAGS += -DCHUNK_SIZE=8192
+endif

--- a/tests/cpu_esp_idf_heap/main.c
+++ b/tests/cpu_esp_idf_heap/main.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2013 Benjamin Valentin <benpicco@zedat.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   Simple malloc/free test
+ *
+ *
+ * @author  Benjamin Valentin <benpicco@zedat.fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#ifndef CHUNK_SIZE
+#ifdef BOARD_NATIVE
+#define CHUNK_SIZE          (1024 * 1024U)
+#else
+#define CHUNK_SIZE          (512U)
+#endif
+#endif
+
+#ifndef NUMBER_OF_TESTS
+#define NUMBER_OF_TESTS     3
+#endif
+
+#ifndef MAX_MEM
+#define MAX_MEM             (256 * 1024UL * 1024UL)
+#endif
+
+struct node {
+    struct node *next;
+    void *ptr;
+};
+
+static uint32_t total = 0;
+
+static void fill_memory(struct node *head)
+{
+    uint32_t allocations = 0;
+
+    if (head) {
+        head->next = NULL;
+    }
+
+    total = 0;
+    while (head && (head->ptr = malloc(CHUNK_SIZE)) && total < MAX_MEM) {
+        printf("Allocated %"PRIu32" Bytes at 0x%p, total %"PRIu32"\n",
+               (uint32_t)CHUNK_SIZE, head->ptr, total += CHUNK_SIZE);
+        memset(head->ptr, '@', CHUNK_SIZE);
+        head = head->next = malloc(sizeof(struct node));
+        if (head) {
+            total += sizeof(struct node);
+            head->ptr  = 0;
+            head->next = 0;
+        }
+        allocations++;
+    }
+
+    printf("Allocations count: %"PRIu32"\n", allocations);
+}
+
+static void free_memory(struct node *head)
+{
+    struct node *old_head;
+
+    while (head) {
+        if (head->ptr) {
+            if (total > CHUNK_SIZE) {
+                total -= CHUNK_SIZE;
+            }
+            printf("Free %"PRIu32" Bytes at 0x%p, total %"PRIu32"\n",
+                   (uint32_t)CHUNK_SIZE, head->ptr, total);
+            free(head->ptr);
+        }
+
+        if (head->next) {
+            old_head = head;
+            head = head->next;
+            free(old_head);
+        }
+        else {
+            free(head);
+            head = 0;
+        }
+
+        total -= sizeof(struct node);
+    }
+}
+
+int main(void)
+{
+    printf("CHUNK_SIZE: %"PRIu32"\n", (uint32_t)CHUNK_SIZE);
+    printf("NUMBER_OF_TESTS: %d\n", NUMBER_OF_TESTS);
+
+    uint8_t test = NUMBER_OF_TESTS;
+    while (test--) {
+        struct node *head = malloc(sizeof(struct node));
+        total += sizeof(struct node);
+
+        fill_memory(head);
+        free_memory(head);
+    }
+
+    puts("[SUCCESS]");
+
+    return 0;
+}

--- a/tests/cpu_esp_idf_heap/tests/01-run.py
+++ b/tests/cpu_esp_idf_heap/tests/01-run.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'CHUNK_SIZE: (\d+)\r\n')
+    chunk_size = int(child.match.group(1))
+    child.expect(r'NUMBER_OF_TESTS: (\d+)\r\n')
+    number_of_tests = int(child.match.group(1))
+    initial_allocations = 0
+    for _ in range(number_of_tests):
+        child.expect(r"Allocated {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+\r\n"
+                     .format(chunk_size))
+        child.expect(r'Allocations count: (\d+)\r\n')
+        allocations = int(child.match.group(1))
+        assert allocations > 0
+        if initial_allocations == 0:
+            initial_allocations = allocations
+        assert initial_allocations == allocations
+        for _ in range(allocations):
+            child.expect(r"Free {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+\r\n"
+                         .format(chunk_size))
+    child.expect_exact("[SUCCESS]")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/cpu_esp_log/Makefile
+++ b/tests/cpu_esp_log/Makefile
@@ -1,0 +1,23 @@
+BOARD ?= esp32-wroom-32
+DEVELHELP=0
+LOG_LEVEL=4
+
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += arch_esp
+
+USEMODULE += esp_log_tagged
+USEMODULE += app_metadata
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+# Use a terminal that does not introduce extra characters into the stream.
+RIOT_TERMINAL ?= socat
+
+DISABLE_MODULE += auto_init
+DISABLE_MODULE += test_utils_interactive_sync
+
+APP_SHELL_FMT ?= NONE
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_esp_log/README.md
+++ b/tests/cpu_esp_log/README.md
@@ -1,0 +1,28 @@
+# ESP log output test
+
+## About
+
+The application corresponds exactly to the application `tests/shell`.
+It is only for testing the ESP-specific logging functions enabled by the
+`esp_log_startup` and `esp_log_tagged` modules. In fact, the application is
+nothing more than the `tests/shell` application compiled with the following
+command:
+
+```
+LOG_LEVEL=4 USEMODULE=esp_log_tagged make -C tests/shell
+```
+
+## Expected Results
+
+Since the application corresponds exactly to the application `tests/shell`,
+it can be used in same way. However, with this application, you should get
+a log with additional information, including the board configuration, at
+startup. All output is in a tagged format such as
+
+```
+D (1470) [system_init] Heap free: 185612 bytes
+```
+
+where the `D` stands for a debug message, the number in parentheses is the
+system time in milliseconds and the name in brackets is the module name or
+the function that generated the output.

--- a/tests/cpu_esp_log/main.c
+++ b/tests/cpu_esp_log/main.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2013 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2013 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       shows how to set up own and use the system shell commands.
+ *              By typing help in the serial console, all the supported commands
+ *              are listed.
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "shell_commands.h"
+#include "shell.h"
+
+#if MODULE_STDIO_RTT
+#include "xtimer.h"
+#endif
+
+static int print_teststart(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    printf("[TEST_START]\n");
+
+    return 0;
+}
+
+static int print_testend(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    printf("[TEST_END]\n");
+
+    return 0;
+}
+
+static int print_echo(int argc, char **argv)
+{
+    for (int i = 0; i < argc; ++i) {
+        printf("\"%s\"", argv[i]);
+    }
+    puts("");
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "start_test", "starts a test", print_teststart },
+    { "end_test", "ends a test", print_testend },
+    { "echo", "prints the input command", print_echo },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+
+    printf("test_shell.\n");
+
+#if MODULE_STDIO_RTT
+    xtimer_init();
+#endif
+
+    /* define buffer to be used by the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+
+    /* define own shell commands */
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* or use only system shell commands */
+    /*
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+    */
+
+    return 0;
+}

--- a/tests/cpu_esp_log/tests/01-run.py
+++ b/tests/cpu_esp_log/tests/01-run.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Alexandre Abadie <alexandre.abadie@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+EXPECTED_HELP = (
+    'Command              Description',
+    '---------------------------------------',
+    'start_test           starts a test',
+    'end_test             ends a test',
+    'echo                 prints the input command',
+    'reboot               Reboot the node',
+    'ps                   Prints information about running threads.',
+    'app_metadata         Returns application metadata'
+)
+
+EXPECTED_PS = (
+    '\tpid | state    Q | pri',
+    '\t  1 | pending  Q |  15',
+    '\t  2 | running  Q |   7'
+)
+
+# In native we are directly executing the binary (no terminal program). We must
+# therefore use Ctrl-V (DLE or "data link escape") before Ctrl-C to send a
+# literal ETX instead of SIGINT.
+# When using a board it is also a problem because we are using a "user friendly"
+# terminal that interprets Ctrl-C. So until we have rawterm we must also use
+# ctrl-v in boards.
+
+DLE = '\x16'
+
+CONTROL_C = DLE+'\x03'
+CONTROL_D = DLE+'\x04'
+
+CMDS = (
+    (CONTROL_C, ('>')),
+    ('start_test', ('[TEST_START]')),
+    ('end_test', ('[TEST_END]')),
+    ('\n', ('>')),
+    ('123456789012345678901234567890123456789012345678901234567890',
+        ('shell: command not found: '
+         '123456789012345678901234567890123456789012345678901234567890')),
+    ('unknown_command', ('shell: command not found: unknown_command')),
+    ('help', EXPECTED_HELP),
+    ('echo a string', ('\"echo\"\"a\"\"string\"')),
+    ('ps', EXPECTED_PS),
+    ('garbage1234'+CONTROL_C, ('>')),  # test cancelling a line
+    ('help', EXPECTED_HELP),
+    ('reboot', ('test_shell.'))
+)
+
+
+def check_cmd(child, cmd, expected):
+    child.sendline(cmd)
+    for line in expected:
+        child.expect_exact(line)
+
+
+def testfunc(child):
+    # loop other defined commands and expected output
+    for cmd, expected in CMDS:
+        check_cmd(child, cmd, expected)
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/cpu_esp_wifi/Makefile
+++ b/tests/cpu_esp_wifi/Makefile
@@ -1,0 +1,16 @@
+BOARD ?= esp32-wroom-32
+
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += arch_esp
+FEATURES_REQUIRED += esp_wifi
+
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += esp_wifi
+USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_icmpv6_echo
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_esp_wifi/main.c
+++ b/tests/cpu_esp_wifi/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *               2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the ESP Wifi device driver
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8U)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("Test application for the esp_wifi driver\n");
+    puts("This test just pulls in parts of the GNRC network stack, use the\n"
+         "provided shell commands (i.e. ifconfig, ping6) to interact with\n"
+         "your esp_wifi device.\n");
+
+    /* start shell */
+    puts("Starting the shell now...");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

A number of optional features of ESP boards have to be explicitly activated by enabling the corresponding modules. However, because these modules are not enabled by default, the CI compilation test cannot detect potential compilation problems. As a result, PRs can be merged that cause compilation problems when an optional ESP feature is enabled through the corresponding module.

To make it possible for CI compilation tests to recognize potential compilation problems when optional ESP features are enabled, a number of specific tests are provided by this PR. Some of them are only for compilation tests, but others can also be used to test the optional feature.

- `cpu_esp_eth`:
   Compile test for module `esp_eth` using a shell-based GNRC networking application for ESP32 boards that provides feature `esp_eth`.
- `cpu_esp_hw_counter`:
   Uses `tests/periph_timer` with hardware counters on ESP32 boards (module `esp_hw_counter`).
- `cpu_esp_i2c_hw`:
   Uses `tests/periph_i2c` with hardware I2C on ESP32 boards (module `esp_i2c_hw`).
- `cpu_esp_heap`:
   Uses `tests/malloc` with SDK heap on ESP8266/ESP32 boards (module `esp_idf_heap`) and the SPI RAM (module `esp_spi_ram`) for ESP32 boards that provide the feature `esp_spi_ram`.
- `cpu_esp_log`:
   Uses `tests/shell` with enabled startup information (module `esp_log_startup`) and tagged output format (module `esp_log_tagged`).
- `cpu_esp_wifi`:
   Compile test for module `esp_wifi` using a shell-based GNRC networking application .

### Testing procedure

Compilation and automatic tests should succeed on Murdock.

### Issues/PRs references

Tracked in issue #12960 