### PR TITLE
Makefile.include: default to RIOTBOARD when BOARD not in BOARDSDIR

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -158,6 +158,20 @@ else
 
 all: link
 
+# Include Board and CPU configuration, if BOARD is not found in BOARDSDIR
+# e.g. when set by the environment fallback to searching in RIOTBOARD
+ifeq (,$(wildcard $(BOARDSDIR)/$(BOARD)/.))
+  ifneq ($(RIOTBOARD),$(BOARDSDIR))
+    # The specified board $(BOARD) was not found in $(BOARDSDIR) fallback to RIOTBOARD
+    BOARDSDIR = $(RIOTBOARD)
+  endif
+  ifeq ($(RIOTBOARD),$(BOARDSDIR))
+    ifeq (,$(wildcard $(BOARDSDIR)/$(BOARD)/.))
+      $(error The specified board $(BOARD) does not exist.)
+    endif
+  endif
+endif
+
 include $(RIOTMAKE)/info.inc.mk
 
 # Static code analysis tools provided by LLVM
@@ -264,9 +278,6 @@ LAZYSPONGE_FLAGS ?= $(if $(filter 1,$(QUIET)),,--verbose)
 
 ifeq (, $(APPLICATION))
     $(error An application name must be specified as APPLICATION.)
-endif
-ifneq (0,$(shell test -d $(BOARDSDIR)/$(BOARD); echo $$?))
-    $(error The specified board $(BOARD) does not exist.)
 endif
 
 # Use TOOLCHAIN environment variable to select the toolchain to use.

--- a/makefiles/boards.inc.mk
+++ b/makefiles/boards.inc.mk
@@ -1,10 +1,18 @@
 # Default when RIOTBASE is not set and is executed from the RIOT directory
 BOARDSDIR ?= $(or $(RIOTBASE),$(CURDIR))/boards
 
-# List all boards.
+# List all boards in a directory
 # By default, all directories in BOARDSDIR except 'common'
 #   use 'wildcard */.' to only list directories
-ALLBOARDS ?= $(sort $(filter-out common,$(patsubst $(BOARDSDIR)/%/.,%,$(wildcard $(BOARDSDIR)/*/.))))
+_get_boards_in_directory = $(filter-out common,$(patsubst $1/%/.,%,$(wildcard $1/*/.)))
+
+# If BOARDSDIR is not in RIOTBOARD also list BOARDS in RIOTBOARD
+ifneq ($(RIOTBOARD),$(BOARDSDIR))
+  ALLBOARDS_RIOTBOARD ?= $(call _get_boards_in_directory,$(RIOTBOARD))
+endif
+
+# Get all boards
+ALLBOARDS ?= $(sort $(call _get_boards_in_directory,$(BOARDSDIR)) $(ALLBOARDS_RIOTBOARD))
 
 # Set the default value from `BOARDS`
 BOARDS ?= $(ALLBOARDS)

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -1,6 +1,7 @@
 .PHONY: info-buildsizes info-buildsizes-diff info-features-missing \
         info-boards-features-missing
 
+BOARDSDIR_GLOBAL := $(BOARDSDIR)
 USEMODULE_GLOBAL := $(USEMODULE)
 USEPKG_GLOBAL := $(USEPKG)
 FEATURES_REQUIRED_GLOBAL := $(FEATURES_REQUIRED)
@@ -13,6 +14,7 @@ FEATURES_BLACKLIST_GLOBAL := $(FEATURES_BLACKLIST)
 
 define board_unsatisfied_features
   BOARD             := $(1)
+  BOARDSDIR         := $(BOARDSDIR_GLOBAL)
   USEMODULE         := $(USEMODULE_GLOBAL)
   USEPKG            := $(USEPKG_GLOBAL)
   DISABLE_MODULE    := $(DISABLE_MODULE_GLOBAL)
@@ -30,6 +32,12 @@ define board_unsatisfied_features
   # Some are sometime set as `?=`
   undefine CPU
   undefine CPU_MODEL
+
+  # Replicate Makefile.include handling that sets BOARDSDIR to RIOTBOARD
+  # when BOARD is not found in BOARDSDIR
+  ifeq (,$(wildcard $(BOARDSDIR_GLOBAL)/$(BOARD)/.))
+    BOARDSDIR = $(RIOTBOARD)
+  endif
 
   include $(RIOTBASE)/Makefile.features
 

--- a/tests/external_board_native/Makefile
+++ b/tests/external_board_native/Makefile
@@ -9,6 +9,10 @@ RIOTBASE ?= $(CURDIR)/../../
 # In practice it should be something else
 BOARD ?= native
 
+# Require arch_native feature so this is not compiled for other boards in
+# $(RIOTBOARD)/
+FEATURES_REQUIRED += arch_native
+
 # Set without '?=' to also verify the docker integration when set with =
 BOARDSDIR = $(CURDIR)/external_boards
 


### PR DESCRIPTION
### Contribution description

#12183 defined `BOARDSDIR` as a new variable to allow setting external directories where to set a `BOARD`.

But when `BOARDSDIR` is set to an external directory it wont see `BOARDS` that are not in `BORDSDIR`, so no `BOARD` in `RIOTBOARD`.

```
BOARD=samr21-xpro make -C tests/external_board_native/
make: Entering directory '/home/francisco/workspace/RIOT-test/tests/external_board_native'
/home/francisco/workspace/RIOT-test/tests/external_board_native/../..//Makefile.include:269: *** The specified board samr21-xpro does not exist..  Stop.
make: Leaving directory '/home/francisco/workspace/RIOT-test/tests/external_board_native'
```

This PR wants to use `RIOTBOARD` as a fallback for `BOARDSDIR` when the `BOARD` is not found in the external directory. The handling is replicated in `info-global.inc.mk` so info-boards-supported would see `BOARDS` in `BOARDSDIR` and `RIOTBOARD`.

### Testing procedure

- Finds the `samr21-xpro` (this fails in master)

<details><summary>BOARDSDIR=/home/ BOARD=samr21-xpro make -C examples/hello-world/</summary>

```
make: Entering directory '/home/francisco/workspace/RIOT-test/examples/hello-world'
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /home/francisco/workspace/RIOT-test/boards/samr21-xpro
"make" -C /home/francisco/workspace/RIOT-test/core
"make" -C /home/francisco/workspace/RIOT-test/cpu/samd21
```
</details>

<details><summary>BOARDSDIR=/home/ BOARD=samr21-xpro make -C examples/hello-world</summary>

```
BOARDSDIR=/home/ BOARD=samr21-xpro make -C examples/hello-world/ info-boards-supported 
make: Entering directory '/home/francisco/workspace/RIOT-test/examples/hello-world'
acd52832 airfy-beacon arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano arduino-uno arduino-zero atmega1284p atmega256rfr2-xpro atmega328p avr-rss2 avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib calliope-mini cc1352-launchpad cc2538dk cc2650-launchpad cc2650stk chronos derfmega128 derfmega256 ek-lm4f120xl esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing f4vi1 feather-m0 firefly fox frdm-k22f frdm-k64f frdm-kw41z hamilton hifive1 hifive1b i-nucleo-lrwan1 ikea-tradfri iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lsn50 maple-mini mbed_lpc1768 mega-xplained microbit microduino-corerf msb-430 msb-430h msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 opencm904 openmote-b openmote-cc2538 p-l496g-cell02 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pic32-clicker pic32-wifire pyboard reel remote-pa remote-reva remote-revb ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeeduino_arch-pro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff spark-core stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f723e-disco stm32f769i-disco stm32l0538-disco stm32l476g-disco teensy31 telosb thingy52 ublox-c030-u201 udoo usb-kw41z waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
make: Leaving directory '/home/francisco/workspace/RIOT-test/examples/hello-world
```
</details>


- Test with an external BOARD, easy way just copy the current external native to an external directory:

```
mkdir <your-dir>
cp -r tests/external_board_native/external_boards/native/ <your-dir>/native-2/
BOARDSDIR=/home/francisco/workspace/external-boards/ BOARD=native-2 make -C examples/hello-world
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
