### PR TITLE
cpu/atmega_common/periph/uart: use TX_ISR to check TX end

### DIFF
--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -210,19 +210,23 @@ extern "C" {
     /* UART0 is used for stdio */
     #define UART_0              MEGA_UART0
     #define UART_0_ISR          USART0_RX_vect
+    #define UART_0_ISR_TX       USART0_TX_vect
 
     #define UART_1              MEGA_UART1
     #define UART_1_ISR          USART1_RX_vect
+    #define UART_1_ISR_TX       USART1_TX_vect
 #elif defined(CPU_ATMEGA328P)
     #define UART_NUMOF          (1U)
 
     #define UART_0              MEGA_UART0
     #define UART_0_ISR          USART_RX_vect
+    #define UART_0_ISR_TX       USART_TX_vect
 #elif defined(CPU_ATMEGA32U4)
     #define UART_NUMOF          (1U)
 
     #define UART_0              MEGA_UART1
     #define UART_0_ISR          USART1_RX_vect
+    #define UART_0_ISR_TX       USART1_TX_vect
 #else
     #define UART_NUMOF          (0U)
 #endif


### PR DESCRIPTION
### Contribution description

For atmega boards a TX has not actually completed until UDRn is empty
as well as the Transmit Shift Register.

To avoid resetting an UART before a TX has completed we use the TXCn
flash and ISR to set a variables that indicates TX is ongoing. This
allows not reseting the UART while there are ongoing TX pending.

This fixes an issue where part of the last byte is not shifted out
of the TX shift register causing rubish on the first TX following an
uart_init.

### Testing procedure

- Run `BOARD=arduino-uno make -C tests/sys_arduino flash term` and see a clean print.

```
BOARD=arduino-uno make -C tests/sys_arduino flash term
```

```
2019-12-17 10:43:41,162 # main(): This is RIOT! (Version: 2020.01-devel-1408-g3ef6d-pr_atmega_tx_isr)
2019-12-17 10:43:41,178 # Hello Arduino!
```

- on master you see rubbish:
```
2019-12-16 11:55:45,764 # main(): This is RIOT! (Version: 2020.01-devel-1406-g615fc-HEAD)!�����Arduino!
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
