### PR TITLE
makefiles/kconfig: Only run Kconfig if it could generate configurations

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -99,19 +99,25 @@ CCASFLAGS = $(filter-out $(CCASUWFLAGS), $(CFLAGS)) $(CCASEXFLAGS)
 
 $(OBJC_LTO): CFLAGS+=$(LTOFLAGS)
 
-$(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(RIOTBUILD_CONFIG_HEADER_C) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+# Define dependencies for object files
+OBJ_DEPS += $(RIOTBUILD_CONFIG_HEADER_C)
+ifneq (,$(SHOULD_RUN_KCONFIG))
+  OBJ_DEPS += $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+endif
+
+$(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(OBJ_DEPS)
 	$(Q)$(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
-$(GENOBJC): %.o: %.c $(RIOTBUILD_CONFIG_HEADER_C) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+$(GENOBJC): %.o: %.c $(OBJ_DEPS)
 	$(Q) $(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$<)\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
 
-$(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(RIOTBUILD_CONFIG_HEADER_C) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+$(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(OBJ_DEPS)
 	$(Q)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
@@ -120,7 +126,7 @@ $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(RIOTBUILD_CONFIG_HEADER_C) $
 $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
 	$(Q)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
-$(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S $(RIOTBUILD_CONFIG_HEADER_C) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+$(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S $(OBJ_DEPS)
 	$(Q)$(CCAS) $(CCASFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
 # pull in dependency info for *existing* .o files

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -10,12 +10,6 @@ GENERATED_DIR = $(BINDIR)/generated
 # This file will contain all generated configuration from kconfig
 export KCONFIG_GENERATED_AUTOCONF_HEADER_C = $(GENERATED_DIR)/autoconf.h
 
-# Add configuration header to build dependencies
-BUILDDEPS += $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
-
-# Include configuration header when building
-CFLAGS += -include '$(KCONFIG_GENERATED_AUTOCONF_HEADER_C)'
-
 # Header for the generated header file
 define KCONFIG_AUTOHEADER_HEADER
 /* RIOT Configuration File */
@@ -47,6 +41,28 @@ MERGE_SOURCES += $(wildcard $(KCONFIG_USER_CONFIG))
 # Create directory to place generated files
 $(GENERATED_DIR): $(CLEAN)
 	$(Q)mkdir -p $@
+
+# During migration this checks if Kconfig should run. It will run if any of
+# the following is true:
+# - A file with '.config' extension is present in the application directory
+# - A 'Kconfig' file is present in the application directory
+# - A previous configuration file is present (e.g. from a previous call to
+#   menuconfig)
+# - menuconfig is being called
+#
+# NOTE: This assumes that Kconfig will not generate any default configurations
+# just from the Kconfig files outside the application folder (i.e. module
+# configuration via Kconfig is disabled by default). Should this change, the
+# check would not longer be valid, and Kconfig would have to run on every
+# build.
+SHOULD_RUN_KCONFIG := $(or $(wildcard $(APPDIR)/*.config), $(wildcard $(APPDIR)/Kconfig), $(wildcard $(KCONFIG_MERGED_CONFIG)), $(filter menuconfig, $(MAKECMDGOALS)))
+
+ifneq (,$(SHOULD_RUN_KCONFIG))
+# Add configuration header to build dependencies
+BUILDDEPS += $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+
+# Include configuration header when building
+CFLAGS += -include '$(KCONFIG_GENERATED_AUTOCONF_HEADER_C)'
 
 USEMODULE_W_PREFIX = $(addprefix MODULE_,$(USEMODULE))
 USEPKG_W_PREFIX = $(addprefix PKG_,$(USEPKG))
@@ -90,3 +106,4 @@ $(KCONFIG_MERGED_CONFIG): $(MERGECONFIG) $(KCONFIG_GENERATED_DEPENDENCIES) FORCE
 # any unnecessary rewrites of the header file if no configurations changed.
 $(KCONFIG_GENERATED_AUTOCONF_HEADER_C): $(KCONFIG_GENERATED_DEPENDENCIES) $(GENCONFIG) $(KCONFIG_MERGED_CONFIG) FORCE
 	$(Q)KCONFIG_CONFIG=$(KCONFIG_MERGED_CONFIG) $(GENCONFIG) --header-path $@ $(KCONFIG)
+endif


### PR DESCRIPTION
### Contribution description
This adds a check to decide if Kconfig should run on a build (proposed [here](https://github.com/RIOT-OS/RIOT/issues/12920#issuecomment-566142649)). It will run if any of the following conditions is true:
- A file with '.config' extension is present in the application folder
- A 'Kconfig' file is present in the application folder
- A previous configuration file is present (e.g. from a previous call to menuconfig)
- menuconfig is being called

This assumes that Kconfig will not generate any default configurations just from the Kconfig files outside the application folder (i.e. module configuration via Kconfig is disabled by default). Should this change, the check would not longer be valid, and Kconfig would have to run on every build.

### Testing procedure
- Remove the tooling by deleting all `*.py` files and the `bin` directory from `dist/tools/kconfiglib`.
- Build an application that does not use Kconfig (e.g. `examples/default`) -> Should build normally without downloading the tooling nor trying to run Kconfig.
- Build `tests/kconfig` -> It should download the tools and apply the configurations from the `app.config` file.
- Test `make menuconfig` in the previous application, it should still work.

### Issues/PRs references
Fixes #12920
