### PR TITLE
tools: correctly detect and print FreeBSD OS

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -44,6 +44,9 @@ get_os_info() {
     elif [ "$os" = "Darwin" ]; then
         osname="$(sw_vers -productName)"
         osvers="$(sw_vers -productVersion)"
+    elif [ "$os" = "FreeBSD" ]; then
+        osname="$os"
+        osvers="$(freebsd-version)"
     fi
     printf "%s %s" "$osname" "$osvers"
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Currently the `print_toolchain_versions` script only supports Linux
and Apple macOS when printing OS name and version. This adds support
for FreeBSD.


### Testing procedure

run `./dist/tools/ci/print_toolchain_versions.sh` on your favourite OS, and compare output with master. Linux and macOS should be the same, with this PR FreeBSD is now detected, while it is reported as `unknown unknown` on master.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
