### PR TITLE
boards/nrf52840dk: disable UART HWFC

### DIFF
--- a/boards/nrf52840dk/include/periph_conf.h
+++ b/boards/nrf52840dk/include/periph_conf.h
@@ -50,8 +50,8 @@ static const uart_conf_t uart_config[] = {
         .dev        = NRF_UARTE0,
         .rx_pin     = GPIO_PIN(0,8),
         .tx_pin     = GPIO_PIN(0,6),
-        .rts_pin    = GPIO_PIN(0,5),
-        .cts_pin    = GPIO_PIN(0,7),
+        .rts_pin    = (uint8_t)GPIO_UNDEF,
+        .cts_pin    = (uint8_t)GPIO_UNDEF,
         .irqn       = UARTE0_UART0_IRQn,
     },
     { /* Mapped to Arduino D0/D1 pins */


### PR DESCRIPTION
### Contribution description
This PR disables UART hardware flow control (HWFC) for `UART_DEV(0)` on the `nrf52840dk` boards.

The UART hardware flow control runtime auto-detection applied by the on-board `J-Link OB` (see https://wiki.segger.com/J-Link_OB) on the `nrf52840dk` does not always work reliable. This was for example causing a lot of trouble when using that board in the `iotlab` testbed.

Also, there is IMHO no sense in having a different HWFC setting for the `nrf52dk` and the `nrf52840dk`, where both use an identical `J-Link OB` setup.

Not using HWFC has actually shown to be the more reliable option on both boards, at least with our default baudrate of `115200`.

### Testing procedure
Grab a `nrf52840dk` baord and run some example applications that use the STDIO, e.g. `tests/shell` or `exmaples/default`. The shell should still be working...

### Issues/PRs references
none
