### PR TITLE
stdio_native: initial import

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -423,7 +423,7 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   ifeq (,$(filter newlib_syscalls_%,$(USEMODULE)))
     USEMODULE += newlib_syscalls_default
   endif
-  ifeq (,$(filter stdio_cdc_acm stdio_null stdio_rtt,$(USEMODULE)))
+  ifeq (,$(filter stdio_cdc_acm stdio_native stdio_null stdio_rtt,$(USEMODULE)))
     USEMODULE += stdio_uart
   endif
 endif

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -15,6 +15,10 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   DIRS += socket_zep
 endif
 
+ifneq (,$(filter stdio_native,$(USEMODULE)))
+  DIRS += stdio_native
+endif
+
 ifneq (,$(filter mtd_native,$(USEMODULE)))
   DIRS += mtd
 endif

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter periph_spi,$(USEMODULE)))
   USEMODULE += periph_spidev_linux
 endif
+ifeq (,$(filter stdio_%,$(USEMODULE)))
+  USEMODULE += stdio_native
+endif

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -41,6 +41,7 @@
 
 #include "board_internal.h"
 #include "native_internal.h"
+#include "stdio_base.h"
 #include "tty_uart.h"
 
 #include "periph/init.h"
@@ -399,6 +400,8 @@ static void _reset_handler(void)
 __attribute__((constructor)) static void startup(int argc, char **argv, char **envp)
 {
     _native_init_syscalls();
+    /* initialize stdio as early as possible */
+    stdio_init();
 
     _native_argv = argv;
     _progname = argv[0];

--- a/cpu/native/stdio_native/Makefile
+++ b/cpu/native/stdio_native/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/cpu/native/stdio_native/stdio_native.c
+++ b/cpu/native/stdio_native/stdio_native.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "kernel_defines.h"
+#include "native_internal.h"
+#include "vfs.h"
+
+#include "stdio_base.h"
+
+void stdio_init(void)
+{
+    if (IS_USED(MODULE_VFS)) {
+        vfs_bind_stdio();
+    }
+}
+
+ssize_t stdio_read(void* buffer, size_t max_len)
+{
+    return real_read(STDIN_FILENO, buffer, max_len);
+}
+
+ssize_t stdio_write(const void* buffer, size_t len)
+{
+    return real_write(STDOUT_FILENO, buffer, len);
+}
+
+/** @} */

--- a/tests/vfs_plus_stdio/Makefile
+++ b/tests/vfs_plus_stdio/Makefile
@@ -1,0 +1,7 @@
+DEVELHELP=0
+include ../Makefile.tests_common
+
+USEMODULE += vfs
+USEMODULE += fmt
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/vfs_plus_stdio/main.c
+++ b/tests/vfs_plus_stdio/main.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Tests VFS together with stdio on a board
+ *
+ * @author      Martine S. Lenders <m.lenders@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "fmt.h"
+
+int main(void)
+{
+    print_str("SUCCESS\n");
+    return 0;
+}

--- a/tests/vfs_plus_stdio/tests/01-run.py
+++ b/tests/vfs_plus_stdio/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('SUCCESS')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=1))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides a `stdio` module for native, so the abstraction of stdio is the same as on other boards.

While implementing tests for #12975, I noticed, that on `native` when using `vfs` the `fmt` print functions would not work. This is because the `fmt` module uses the `write()` system call which is bend by the `native_vfs` module (or the `newlib_syscalls_default` module for real boards) to use `vfs_write()`. However, since `native` doesn't use a `stdio` module without this PR to print, but just writes to the hosts standard I/O directly, the STDIN, STDOUT, and STDERR are never initialized for `vfs`, `vfs` fails here:

https://github.com/RIOT-OS/RIOT/blob/33b1f9ecf7dfad6ce39361f85d0580d4ee8a5a86/sys/vfs/vfs.c#L320-L323

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Without `stdio_native` (revert all commits related to it; the HEAD when opening), the provided test application `tests/vfs_and_stdio` will fail on `native`:

```
BOARD=native make -C tests/vfs_plus_stdio flash test
```

With `stdio_native` available it will succeed.

```
BOARD=native make -C examples/hello-world all term
```

and

```
BOARD=native make -C tests/shell all test
```

should also still work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
