### PR TITLE
gnrc_sixlowpan_frag_stats: actualize pseudo-module

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -33,7 +33,6 @@ PSEUDOMODULES += gnrc_sixloenc
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default
 PSEUDOMODULES += gnrc_sixlowpan_frag_hint
-PSEUDOMODULES += gnrc_sixlowpan_frag_stats
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc
 PSEUDOMODULES += gnrc_sixlowpan_nd_border_router
 PSEUDOMODULES += gnrc_sixlowpan_router

--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -42,31 +42,6 @@
 extern "C" {
 #endif
 
-#if defined(MODULE_GNRC_SIXLOWPAN_FRAG_STATS) || DOXYGEN
-/**
- * @brief   Statistics on fragmentation and reassembly
- *
- * @note    Only available with the `gnrc_sixlowpan_frag_stats` module
- */
-typedef struct {
-    unsigned rbuf_full;     /**< counts the number of events where the
-                             *   reassembly buffer is full */
-    unsigned frag_full;     /**< counts the number of events that there where
-                             *   no @ref gnrc_sixlowpan_frag_fb_t available */
-#if defined(MODULE_GNRC_SIXLOWPAN_FRAG_VRB) || DOXYGEN
-    unsigned vrb_full;      /**< counts the number of events where the virtual
-                             *   reassembly buffer is full */
-#endif
-} gnrc_sixlowpan_frag_stats_t;
-
-/**
- * @brief   Get the current statistics on fragmentation and reassembly
- *
- * @return  The current statistics on fragmentation and reassembly
- */
-gnrc_sixlowpan_frag_stats_t *gnrc_sixlowpan_frag_stats_get(void);
-#endif
-
 /**
  * @brief   Sends a packet fragmented
  *

--- a/sys/include/net/gnrc/sixlowpan/frag/stats.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/stats.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_sixlowpan_frag_stats Fragmentation and reassembly statistics
+ * @ingroup     net_gnrc_sixlowpan_frag
+ * @brief       Counter for certain 6LoWPAN fragmentation and reassembly events.
+ * @{
+ *
+ * @file
+ * @brief   Fragmentation and reassembly statistics definitions
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_STATS_H
+#define NET_GNRC_SIXLOWPAN_FRAG_STATS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @brief   Statistics on fragmentation and reassembly
+ *
+ * @note    Only available with the `gnrc_sixlowpan_frag_stats` module
+ */
+typedef struct {
+    unsigned rbuf_full;     /**< counts the number of events where the
+                             *   reassembly buffer is full */
+    unsigned frag_full;     /**< counts the number of events that there where
+                             *   no @ref gnrc_sixlowpan_frag_fb_t available */
+#if defined(MODULE_GNRC_SIXLOWPAN_FRAG_VRB) || DOXYGEN
+    unsigned vrb_full;      /**< counts the number of events where the virtual
+                             *   reassembly buffer is full */
+#endif
+} gnrc_sixlowpan_frag_stats_t;
+
+/**
+ * @brief   Get the current statistics on fragmentation and reassembly
+ *
+ * @return  The current statistics on fragmentation and reassembly
+ */
+gnrc_sixlowpan_frag_stats_t *gnrc_sixlowpan_frag_stats_get(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_STATS_H */
+/** @} */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -100,6 +100,9 @@ endif
 ifneq (,$(filter gnrc_sixlowpan_frag_rb,$(USEMODULE)))
   DIRS += network_layer/sixlowpan/frag/rb
 endif
+ifneq (,$(filter gnrc_sixlowpan_frag_stats,$(USEMODULE)))
+  DIRS += network_layer/sixlowpan/frag/stats
+endif
 ifneq (,$(filter gnrc_sixlowpan_frag_vrb,$(USEMODULE)))
   DIRS += network_layer/sixlowpan/frag/vrb
 endif

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -22,6 +22,9 @@
 #include "net/gnrc.h"
 #include "net/gnrc/sixlowpan.h"
 #include "net/gnrc/sixlowpan/config.h"
+#ifdef  MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+#include "net/gnrc/sixlowpan/frag/stats.h"
+#endif  /* MODULE_GNRC_SIXLOWPAN_FRAG_STATS */
 #ifdef  MODULE_GNRC_SIXLOWPAN_FRAG_VRB
 #include "net/gnrc/sixlowpan/frag/vrb.h"
 #endif  /* MODULE_GNRC_SIXLOWPAN_FRAG_VRB */
@@ -88,15 +91,6 @@ enum {
     RBUF_ADD_REPEAT = -2,
     RBUF_ADD_DUPLICATE = -3,
 };
-
-#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
-static gnrc_sixlowpan_frag_stats_t _stats;
-
-gnrc_sixlowpan_frag_stats_t *gnrc_sixlowpan_frag_stats_get(void)
-{
-    return &_stats;
-}
-#endif
 
 static int _check_fragments(gnrc_sixlowpan_frag_rb_base_t *entry,
                             size_t frag_size, size_t offset)
@@ -474,12 +468,12 @@ static int _rbuf_get(const void *src, size_t src_len,
             res = oldest;
 #if GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE && \
     defined(MODULE_GNRC_SIXLOWPAN_FRAG_STATS)
-            _stats.rbuf_full++;
+            gnrc_sixlowpan_frag_stats_get()->rbuf_full++;
 #endif
         }
         else {
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
-            _stats.rbuf_full++;
+            gnrc_sixlowpan_frag_stats_get()->rbuf_full++;
 #endif
             return -1;
         }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/stats/Makefile
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/stats/Makefile
@@ -1,0 +1,3 @@
+MODULE := gnrc_sixlowpan_frag_stats
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/stats/gnrc_sixlowpan_frag_stats.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/stats/gnrc_sixlowpan_frag_stats.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "net/gnrc/sixlowpan/frag/stats.h"
+
+static gnrc_sixlowpan_frag_stats_t _stats;
+
+gnrc_sixlowpan_frag_stats_t *gnrc_sixlowpan_frag_stats_get(void)
+{
+    return &_stats;
+}
+
+/** @} */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -22,6 +22,9 @@
 #include "xtimer.h"
 
 #include "net/gnrc/sixlowpan/frag/fb.h"
+#ifdef  MODULE_GNRC_SIXLOWPAN_FRAG_STATS
+#include "net/gnrc/sixlowpan/frag/stats.h"
+#endif  /* MODULE_GNRC_SIXLOWPAN_FRAG_STATS */
 #include "net/gnrc/sixlowpan/frag/vrb.h"
 
 #define ENABLE_DEBUG    (0)

--- a/sys/shell/commands/sc_gnrc_6lo_frag_stats.c
+++ b/sys/shell/commands/sc_gnrc_6lo_frag_stats.c
@@ -15,7 +15,7 @@
 
 #include <stdio.h>
 
-#include "net/gnrc/sixlowpan/frag.h"
+#include "net/gnrc/sixlowpan/frag/stats.h"
 
 int _gnrc_6lo_frag_stats(int argc, char **argv)
 {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Having the definitions sit in the `net/gnrc/sixlowpan/frag.h` header does not make much sense, when using Selective Fragment Forwarding (and the fragmentation buffer already includes a `net/gnrc/sixlowpan/frag/stats.h` header), so they are moved to their own header. Since with this change it makes more sense to have the statistics stored in their own sub-module, the pseudo-module is also actualized.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and run `examples/gnrc_networking` with `gnrc_sixlowpan_frag_stats` on a 6LoWPAN compatible board. It should still work as in master

```
USEMODULE=gnrc_sixlowpan_frag_stats BOARD=samr21-xpro make -C examples/gnrc_networking flash term
```

```
2019-12-18 13:40:48,111 #  6lo_frag
2019-12-18 13:40:48,112 # rbuf full: 0
2019-12-18 13:40:48,113 # frag full: 0
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
