### PR TITLE
pkg/nimble/autoconn: add user event callback

### DIFF
--- a/pkg/nimble/autoconn/include/nimble_autoconn.h
+++ b/pkg/nimble/autoconn/include/nimble_autoconn.h
@@ -111,6 +111,8 @@
 
 #include <stdint.h>
 
+#include "nimble_netif.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -167,6 +169,16 @@ typedef struct {
  */
 int nimble_autoconn_init(const nimble_autoconn_params_t *params,
                          const uint8_t *ad, size_t adlen);
+
+/**
+ * @brief   Register a callback that is called on netif events
+ *
+ * The registered callback function is a simple pass-through of nimble_netif
+ * events. The callback is executed in the context of NimBLE's host thread.
+ *
+ * @param[in] cb            event callback to register, may be NULL
+ */
+void nimble_autoconn_eventcb(nimble_netif_eventcb_t cb);
 
 /**
  * @brief   Update the used parameters (timing and node ID)

--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -140,7 +140,8 @@ static void _on_scan_evt(uint8_t type, const ble_addr_t *addr, int8_t rssi,
     }
 }
 
-static void _on_netif_evt(int handle, nimble_netif_event_t event)
+static void _on_netif_evt(int handle, nimble_netif_event_t event,
+                          const uint8_t *addr)
 {
     switch (event) {
         case NIMBLE_NETIF_CONNECTED_MASTER:

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -150,8 +150,11 @@ enum {
  *
  * @param[in] handle        handle to the connection that triggered the event
  * @param[in] event         type of the event
+ * @param[in] addr          BLE address of the peer in the effected connection
  */
-typedef void(*nimble_netif_eventcb_t)(int handle, nimble_netif_event_t event);
+typedef void(*nimble_netif_eventcb_t)(int handle,
+                                      nimble_netif_event_t event,
+                                      const uint8_t *addr);
 
 /**
  * @brief   Initialize the netif implementation, spawns the netif thread

--- a/pkg/nimble/netif/include/nimble_netif_conn.h
+++ b/pkg/nimble/netif/include/nimble_netif_conn.h
@@ -159,7 +159,7 @@ int nimble_netif_conn_start_adv(void);
 /**
  * @brief   Free the connection context with the given handle
  */
-void nimble_netif_conn_free(int handle);
+void nimble_netif_conn_free(int handle, uint8_t *addr);
 
 /**
  * @brief   Find the connection context with a given GAP handle and return a

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -79,10 +79,10 @@ static struct os_mempool _mem_pool;
 static struct os_mbuf_pool _mbuf_pool;
 
 /* notify the user about state changes for a connection context */
-static void _notify(int handle, nimble_netif_event_t event)
+static void _notify(int handle, nimble_netif_event_t event, uint8_t *addr)
 {
     if (_eventcb) {
-        _eventcb(handle, event);
+        _eventcb(handle, event, addr);
     }
 }
 
@@ -336,7 +336,7 @@ static int _on_l2cap_client_evt(struct ble_l2cap_event *event, void *arg)
             conn->coc = event->connect.chan;
             conn->state |= NIMBLE_NETIF_L2CAP_CLIENT;
             conn->state &= ~NIMBLE_NETIF_CONNECTING;
-            _notify(handle, NIMBLE_NETIF_CONNECTED_MASTER);
+            _notify(handle, NIMBLE_NETIF_CONNECTED_MASTER, conn->addr);
             break;
         case BLE_L2CAP_EVENT_COC_DISCONNECTED:
             assert(conn->coc);
@@ -374,7 +374,7 @@ static int _on_l2cap_server_evt(struct ble_l2cap_event *event, void *arg)
             conn->coc = event->connect.chan;
             conn->state |= NIMBLE_NETIF_L2CAP_SERVER;
             conn->state &= ~(NIMBLE_NETIF_ADV | NIMBLE_NETIF_CONNECTING);
-            _notify(handle, NIMBLE_NETIF_CONNECTED_SLAVE);
+            _notify(handle, NIMBLE_NETIF_CONNECTED_SLAVE, conn->addr);
             break;
         case BLE_L2CAP_EVENT_COC_DISCONNECTED:
             conn = nimble_netif_conn_from_gaphandle(event->disconnect.conn_handle);
@@ -425,8 +425,9 @@ static int _on_gap_master_evt(struct ble_gap_event *event, void *arg)
     switch (event->type) {
         case BLE_GAP_EVENT_CONNECT: {
             if (event->connect.status != 0) {
-                nimble_netif_conn_free(handle);
-                _notify(handle, NIMBLE_NETIF_CONNECT_ABORT);
+                uint8_t addr[BLE_ADDR_LEN];
+                nimble_netif_conn_free(handle, addr);
+                _notify(handle, NIMBLE_NETIF_CONNECT_ABORT, addr);
                 return 0;
             }
             _on_gap_connected(conn, event->connect.conn_handle);
@@ -442,12 +443,14 @@ static int _on_gap_master_evt(struct ble_gap_event *event, void *arg)
             assert(res == 0);
             break;
         }
-        case BLE_GAP_EVENT_DISCONNECT:
-            nimble_netif_conn_free(handle);
-            _notify(handle, NIMBLE_NETIF_CLOSED_MASTER);
+        case BLE_GAP_EVENT_DISCONNECT: {
+            uint8_t addr[BLE_ADDR_LEN];
+            nimble_netif_conn_free(handle, addr);
+            _notify(handle, NIMBLE_NETIF_CLOSED_MASTER, addr);
             break;
+        }
         case BLE_GAP_EVENT_CONN_UPDATE:
-            _notify(handle, NIMBLE_NETIF_CONN_UPDATED);
+            _notify(handle, NIMBLE_NETIF_CONN_UPDATED, conn->addr);
             break;
         case BLE_GAP_EVENT_CONN_UPDATE_REQ:
         case BLE_GAP_EVENT_MTU:
@@ -469,8 +472,9 @@ static int _on_gap_slave_evt(struct ble_gap_event *event, void *arg)
     switch (event->type) {
         case BLE_GAP_EVENT_CONNECT: {
             if (event->connect.status != 0) {
-                nimble_netif_conn_free(handle);
-                _notify(handle, NIMBLE_NETIF_CONNECT_ABORT);
+                uint8_t addr[BLE_ADDR_LEN];
+                nimble_netif_conn_free(handle, addr);
+                _notify(handle, NIMBLE_NETIF_CONNECT_ABORT, addr);
                 break;
             }
             _on_gap_connected(conn, event->connect.conn_handle);
@@ -478,12 +482,14 @@ static int _on_gap_slave_evt(struct ble_gap_event *event, void *arg)
             conn->state = NIMBLE_NETIF_GAP_SLAVE;
             break;
         }
-        case BLE_GAP_EVENT_DISCONNECT:
-            nimble_netif_conn_free(handle);
-            _notify(handle, NIMBLE_NETIF_CLOSED_SLAVE);
+        case BLE_GAP_EVENT_DISCONNECT: {
+            uint8_t addr[BLE_ADDR_LEN];
+            nimble_netif_conn_free(handle, addr);
+            _notify(handle, NIMBLE_NETIF_CLOSED_SLAVE, addr);
             break;
+        }
         case BLE_GAP_EVENT_CONN_UPDATE:
-            _notify(handle, NIMBLE_NETIF_CONN_UPDATED);
+            _notify(handle, NIMBLE_NETIF_CONN_UPDATED, conn->addr);
             break;
         case BLE_GAP_EVENT_CONN_UPDATE_REQ:
             /* nothing to do here */
@@ -609,7 +615,7 @@ int nimble_netif_accept_stop(void)
     int res = ble_gap_adv_stop();
     assert(res == 0);
     (void)res;
-    nimble_netif_conn_free(handle);
+    nimble_netif_conn_free(handle, NULL);
 
     return NIMBLE_NETIF_OK;
 }

--- a/pkg/nimble/netif/nimble_netif_conn.c
+++ b/pkg/nimble/netif/nimble_netif_conn.c
@@ -156,12 +156,15 @@ int nimble_netif_conn_start_adv(void)
     return handle;
 }
 
-void nimble_netif_conn_free(int handle)
+void nimble_netif_conn_free(int handle, uint8_t *addr)
 {
     assert((handle >= 0) && (handle < CONN_CNT));
 
     DEBUG("nimble_netif_conn_free, handle %i\n", handle);
     mutex_lock(&_lock);
+    if (addr) {
+        memcpy(addr, _conn[handle].addr, BLE_ADDR_LEN);
+    }
     memset(&_conn[handle], 0, sizeof(nimble_netif_conn_t));
     _conn[handle].state = NIMBLE_NETIF_UNUSED;
     mutex_unlock(&_lock);

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -58,13 +58,19 @@ static void _scan_for_name(uint8_t type, const ble_addr_t *addr, int8_t rssi,
     }
 }
 
-static void _on_ble_evt(int handle, nimble_netif_event_t event)
+static void _print_evt(const char *msg, int handle, const uint8_t *addr)
+{
+    printf("event: handle %i -> %s (", handle, msg);
+    bluetil_addr_print(addr);
+    puts(")");
+}
+
+static void _on_ble_evt(int handle, nimble_netif_event_t event,
+                        const uint8_t *addr)
 {
     switch (event) {
         case NIMBLE_NETIF_CONNECTED_MASTER: {
-            printf("event: handle %i -> CONNECTED as MASTER (", handle);
-            bluetil_addr_print(nimble_netif_conn_get(handle)->addr);
-            puts(")");
+            _print_evt("CONNECTED as MASTER", handle, addr);
             if (_name_to_connect != NULL) {
                 printf("connection to '%s' established\n", _name_to_connect);
                 _name_to_connect = NULL;
@@ -72,16 +78,14 @@ static void _on_ble_evt(int handle, nimble_netif_event_t event)
             break;
         }
         case NIMBLE_NETIF_CONNECTED_SLAVE:
-            printf("event: handle %i -> CONNECTED as SLAVE (", handle);
-            bluetil_addr_print(nimble_netif_conn_get(handle)->addr);
-            puts(")");
+            _print_evt("CONNECTED as SLAVE", handle, addr);
             break;
         case NIMBLE_NETIF_CLOSED_MASTER:
         case NIMBLE_NETIF_CLOSED_SLAVE:
-            printf("event: handle %i -> CONNECTION CLOSED\n", handle);
+            _print_evt("CONNECTION CLOSED", handle, addr);
             break;
         case NIMBLE_NETIF_CONNECT_ABORT:
-            printf("event: handle %i -> CONNECTION ABORT\n", handle);
+            _print_evt("CONNECTION ABORT", handle, addr);
             break;
         case NIMBLE_NETIF_CONN_UPDATED:
         default:


### PR DESCRIPTION
### Contribution description
When working with `nimble_autoconn` it would sometimes be very useful as a user, to get notified on connection change events, e.g. to trigger certain high-level network protocol events on connection state changes. 

This PR adds the possibility to register a user callback with `nimble_autoconn`, that simply passes through the `nimble_netif` events.

The PR also contains some improvements on the DEBUG output for `autoconn`.

### Testing procedure
Run `gnrc_networking` for any `nrf52x` board using `USEMODULE=nimble_autoconn_ipsp`. Everything should work just as before.

When enabling the DEBUG output for `pkg/nimble/autoconn/nimble_autoconn.c`, you should see a little nicer output like `[autoconn] CONNECT master ([HANDLE]|[BLE ADDRESS])`, where handle and address are now printed for every event instead of just the `CONNECT` ones.

### Issues/PRs references
none
