### PR TITLE
cpu/esp8266: fix of esp_wifi_send function

### DIFF
--- a/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp8266/esp-wifi/esp_wifi_netdev.c
@@ -530,12 +530,10 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
 #if ENABLE_DEBUG
     ESP_WIFI_DEBUG("send %d byte", dev->tx_len);
 #if MODULE_OD && ENABLE_DEBUG_HEXDUMP
-    od_hex_dump(dev->tx_buf, dev->tx_le, OD_WIDTH_DEFAULT);
+    od_hex_dump(dev->tx_buf, dev->tx_len, OD_WIDTH_DEFAULT);
 #endif /* MODULE_OD && ENABLE_DEBUG_HEXDUMP */
 #endif
     critical_exit();
-
-    int ret = 0;
 
     /* send the the packet to the peer(s) mac address */
     if (esp_wifi_internal_tx(ESP_IF_WIFI_STA, dev->tx_buf, dev->tx_len) == ESP_OK) {
@@ -544,14 +542,13 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
         _esp_wifi_send_is_in = false;
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
 #endif
+        return dev->tx_len;
     }
     else {
         _esp_wifi_send_is_in = false;
         ESP_WIFI_DEBUG("sending WiFi packet failed");
-        ret = -EIO;
+        return -EIO;
     }
-
-    return ret;
 }
 
 static int _esp_wifi_recv(netdev_t *netdev, void *buf, size_t len, void *info)


### PR DESCRIPTION
### Contribution description

This PR fixes the send function of the `esp_wifi` netdev driver for the ESP8266. If successful, the send function should return the number of bytes sent. However, the send function `esp_wifi` always returned 0 if successful. This led to a large number of duplicate ACKs and data packets. `lwIP` did not work for TCP.

### Testing procedure

Flash `test/lwip` to any ESP8266 node with
```
LWIP_IPV4=1 USEMODULE='esp_wifi' CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' \
make BOARD=esp8266-esp-12x -C tests/lwip flash term
```
Use `netcat` on any machine in the LAN and obsever the network interface with `wireshark`.
```
nc -l 33333
```
On ESP8266 connect to the machine in LAN.
```
tcp connect <ipv6addr> 33333
```
Without this PR, the three-way-handshake is finished with a duplicate ACK. When sending a data packet from ESP8266 with
```
tcp send 313233
```
a large number of retransmissions and duplicate ACKs can be observed in `wirshark`. After disconnecting, it is not possible to establish a new TCP connection.

With this PR all is working as it should.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
