### PR TITLE
boards/b-l475e-iot01a: set OPENOCD_RESET_USE_CONNECT_ASSERT_SRST

### DIFF
--- a/boards/b-l475e-iot01a/Makefile.include
+++ b/boards/b-l475e-iot01a/Makefile.include
@@ -11,5 +11,9 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # this board has an on-board ST-link adapter
 DEBUG_ADAPTER ?= stlink
 
+# The board can become un-flashable after some execution,
+# use connect_assert_srst to always be able to flash or reset the board.
+export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
+
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk


### PR DESCRIPTION
### Contribution description

b-l475e-iot01a can become unflashable when hardfaults occure.
To make sure flashing succeeds `connect_assert_srst` is called
before connecting to flash through openocd.

### Testing procedure

On master running this twice in a row fails `BOARD=b-l475e-iot01a make -C tests/driver_hd44780 flash test`, with this PR it succeeds.
