### PR TITLE
Kconfig: Expose pkg/tinydtls configurations

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -9,6 +9,10 @@ mainmenu "RIOT Configuration"
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
+rsource "drivers/Kconfig"
+rsource "sys/Kconfig"
+rsource "pkg/Kconfig"
+
 # The application may declare new symbols as well
 osource "$(APPDIR)/Kconfig"
 

--- a/Kconfig
+++ b/Kconfig
@@ -9,15 +9,12 @@ mainmenu "RIOT Configuration"
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
-rsource "drivers/Kconfig"
-rsource "sys/Kconfig"
-rsource "pkg/Kconfig"
-
 # The application may declare new symbols as well
 osource "$(APPDIR)/Kconfig"
 
 rsource "drivers/Kconfig"
 rsource "sys/Kconfig"
+rsource "pkg/Kconfig"
 
 comment "RIOT is in a migration phase."
 comment "Some configuration options may not be here. Use CFLAGS instead."

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -25,14 +25,15 @@ USEPKG += tinydtls
 DTLS_PORT ?= 20220
 CFLAGS += -DDTLS_DEFAULT_PORT=$(DTLS_PORT)
 
-# NOTE: If not cipher suite is selected, DTLS_PSK is used by default.
+# NOTE: If no cipher suite is selected, CONFIG_DTLS_PSK is used by default.
+# This section should be commented out if using Kconfig
 # This adds support for TLS_PSK_WITH_AES_128_CCM_8
-# CFLAGS += -DDTLS_PSK
+# CFLAGS += -DCONFIG_DTLS_PSK
 # This adds support for TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
-# CFLAGS += -DDTLS_ECC
+# CFLAGS += -DCONFIG_DTLS_ECC
 
 # Enable this line for setting tinyDTLS in debug mode.
-# CFLAGS += -DDTLS_DEBUG
+# CFLAGS += -DCONFIG_DTLS_DEBUG
 
 # FIXME: This is a temporary patch
 # TinyDTLS <= 0.8.6 requires around 426 bytes in RAM.

--- a/examples/dtls-echo/README.md
+++ b/examples/dtls-echo/README.md
@@ -45,13 +45,13 @@ compile time. Their default values are considered for having two DTLS
 contexts (for purpose of DTLS renegotiation).
 
 The resources handled by memarray are:
-* `DTLS_CONTEXT_MAX` (default 2) The maximum number of DTLS context at the
+* `CONFIG_DTLS_CONTEXT_MAX` (default 2) The maximum number of DTLS context at the
    same time.
-* `DTLS_PEER_MAX` (default 1) The maximum number DTLS peers (i.e. sessions).
-* `DTLS_HANDSHAKE_MAX` (default 1) The maximum number of concurrent DTLS handshakes.
+* `CONFIG_DTLS_PEER_MAX` (default 1) The maximum number DTLS peers (i.e. sessions).
+* `CONFIG_DTLS_HANDSHAKE_MAX` (default 1) The maximum number of concurrent DTLS handshakes.
 * `DTLS_SECURITY_MAX` (the sum of the previous two) The maximum number of
    concurrently used cipher keys.
-* `DTLS_HASH_MAX` (Default: `3 * DTLS_PEER_MAX`) The maximum number of hash
+* `DTLS_HASH_MAX` (Default: `3 * CONFIG_DTLS_PEER_MAX`) The maximum number of hash
   functions that can be used in parallel.
 
 ## Handling retransmissions

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -42,7 +42,7 @@
 #define MAX_TIMES_TRY_TO_SEND 10 /* Expected to be 1 - 255 */
 
 /* Delay to give time to the remote peer to do the compute (client only). */
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 #define DEFAULT_US_DELAY 10000000
 #else
 #define DEFAULT_US_DELAY 100
@@ -138,7 +138,7 @@ static int dtls_handle_read(dtls_context_t *ctx)
     return dtls_handle_message(ctx, &session, packet_rcvd, res);
 }
 
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
 static unsigned char psk_id[PSK_ID_MAXLEN] = PSK_DEFAULT_IDENTITY;
 static size_t psk_id_length = sizeof(PSK_DEFAULT_IDENTITY) - 1;
 static unsigned char psk_key[PSK_MAXLEN] = PSK_DEFAULT_KEY;
@@ -189,9 +189,9 @@ static int _peer_get_psk_info_handler(struct dtls_context_t *ctx,
 
     return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
 }
-#endif /* DTLS_PSK */
+#endif /* CONFIG_DTLS_PSK */
 
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 static int _peer_get_ecdsa_key_handler(struct dtls_context_t *ctx,
                                        const session_t *session,
                                        const dtls_ecdsa_key_t **result)
@@ -228,7 +228,7 @@ static int _peer_verify_ecdsa_key_handler(struct dtls_context_t *ctx,
 
     return 0;
 }
-#endif /* DTLS_ECC */
+#endif /* CONFIG_DTLS_ECC */
 
 /* Reception of a DTLS Application data record. */
 static int _read_from_peer_handler(struct dtls_context_t *ctx,
@@ -301,19 +301,19 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
         .write = _send_to_peer_handler,
         .read = _read_from_peer_handler,
         .event = _events_handler,
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
         .get_psk_info = _peer_get_psk_info_handler,
-#endif  /* DTLS_PSK */
-#ifdef DTLS_ECC
+#endif  /* CONFIG_DTLS_PSK */
+#ifdef CONFIG_DTLS_ECC
         .get_ecdsa_key = _peer_get_ecdsa_key_handler,
         .verify_ecdsa_key = _peer_verify_ecdsa_key_handler
-#endif  /* DTLS_ECC */
+#endif  /* CONFIG_DTLS_ECC */
     };
 
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
     DEBUG("Client support PSK\n");
 #endif
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
     DEBUG("Client support ECC\n");
 #endif
 

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -167,7 +167,7 @@ static int _send_to_peer_handler(struct dtls_context_t *ctx,
     return sock_udp_send(remote_peer->sock, buf, len, remote_peer->remote);
 }
 
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
 static unsigned char psk_id[PSK_ID_MAXLEN] = PSK_DEFAULT_IDENTITY;
 static size_t psk_id_length = sizeof(PSK_DEFAULT_IDENTITY) - 1;
 static unsigned char psk_key[PSK_MAXLEN] = PSK_DEFAULT_KEY;
@@ -220,9 +220,9 @@ static int _peer_get_psk_info_handler(struct dtls_context_t *ctx, const session_
 
     return dtls_alert_fatal_create(DTLS_ALERT_DECRYPT_ERROR);
 }
-#endif /* DTLS_PSK */
+#endif /* CONFIG_DTLS_PSK */
 
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 static int _peer_get_ecdsa_key_handler(struct dtls_context_t *ctx,
                                        const session_t *session,
                                        const dtls_ecdsa_key_t **result)
@@ -258,7 +258,7 @@ static int _peer_verify_ecdsa_key_handler(struct dtls_context_t *ctx,
 
     return 0;
 }
-#endif /* DTLS_ECC */
+#endif /* CONFIG_DTLS_ECC */
 
 /* DTLS variables and register are initialized. */
 dtls_context_t *_server_init_dtls(dtls_remote_peer_t *remote_peer)
@@ -269,19 +269,19 @@ dtls_context_t *_server_init_dtls(dtls_remote_peer_t *remote_peer)
         .write = _send_to_peer_handler,
         .read = _read_from_peer_handler,
         .event = NULL,
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
         .get_psk_info = _peer_get_psk_info_handler,
-#endif  /* DTLS_PSK */
-#ifdef DTLS_ECC
+#endif  /* CONFIG_DTLS_PSK */
+#ifdef CONFIG_DTLS_ECC
         .get_ecdsa_key = _peer_get_ecdsa_key_handler,
         .verify_ecdsa_key = _peer_verify_ecdsa_key_handler
-#endif  /* DTLS_ECC */
+#endif  /* CONFIG_DTLS_ECC */
     };
 
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
     DEBUG("Server support PSK\n");
 #endif
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
     DEBUG("Server support ECC\n");
 #endif
 

--- a/examples/dtls-echo/tinydtls_keys.h
+++ b/examples/dtls-echo/tinydtls_keys.h
@@ -28,16 +28,16 @@ extern "C" {
 /*
  *  Default keys examples for tinyDTLS (for RIOT, Linux and Contiki)
  */
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
 #define PSK_DEFAULT_IDENTITY "Client_identity"
 #define PSK_DEFAULT_KEY "secretPSK"
 #define PSK_OPTIONS "i:k:"
 #define PSK_ID_MAXLEN 32
 #define PSK_MAXLEN 32
 
-#endif /* DTLS_PSK */
+#endif /* CONFIG_DTLS_PSK */
 
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 static const unsigned char ecdsa_priv_key[] = {
     0x41, 0xC1, 0xCB, 0x6B, 0x51, 0x24, 0x7A, 0x14,
     0x43, 0x21, 0x43, 0x5B, 0x7A, 0x80, 0xE7, 0x14,
@@ -58,7 +58,7 @@ static const unsigned char ecdsa_pub_key_y[] = {
     0xE9, 0x3F, 0x98, 0x72, 0x09, 0xDA, 0xED, 0x0B,
     0x4F, 0xAB, 0xC3, 0x6F, 0xC7, 0x72, 0xF8, 0x29
 };
-#endif /* DTLS_ECC */
+#endif /* CONFIG_DTLS_ECC */
 #ifdef __cplusplus
 }
 #endif

--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -29,14 +29,15 @@ USEMODULE += shell_commands
 DTLS_PORT ?= 20220
 CFLAGS += -DDTLS_DEFAULT_PORT=$(DTLS_PORT)
 
-# NOTE: If no cipher suite is selected, DTLS_PSK is used by default.
+# NOTE: If no cipher suite is selected, CONFIG_DTLS_PSK is used by default.
+# This section should be commented out if using Kconfig
 # This adds support for TLS_PSK_WITH_AES_128_CCM_8
-CFLAGS += -DDTLS_PSK
+# CFLAGS += -DCONFIG_DTLS_PSK
 # This adds support for TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
-# CFLAGS += -DDTLS_ECC
+# CFLAGS += -DCONFIG_DTLS_ECC
 
 # Uncomment to enable debug logs
-# CFLAGS += -DDTLS_DEBUG
+# CFLAGS += -DCONFIG_DTLS_DEBUG
 
 # FIXME: This is a temporary patch
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(2*THREAD_STACKSIZE_LARGE\)

--- a/examples/dtls-sock/README.md
+++ b/examples/dtls-sock/README.md
@@ -30,7 +30,7 @@ $ PORT=tap1 make all term
 
 ## Debug logs
 
-To enable debug logs uncomment `CFLAGS += -DDTLS_DEBUG` in the Makefile.
+To enable debug logs uncomment `CFLAGS += -DCONFIG_DTLS_DEBUG` in the Makefile.
 Tinydtls supports setting the log level. See Makefile for more info.
 
 ## Configs and constraints

--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -31,7 +31,7 @@
 
 #define SOCK_DTLS_CLIENT_TAG (2)
 
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 static const ecdsa_public_key_t other_pubkeys[] = {
     { .x = ecdsa_pub_key_x, .y = ecdsa_pub_key_y },
 };
@@ -52,7 +52,7 @@ static const credman_credential_t credential = {
     },
 };
 
-#else /* ifdef DTLS_PSK */
+#else /* ifdef CONFIG_DTLS_PSK */
 static const uint8_t psk_id_0[] = PSK_DEFAULT_IDENTITY;
 static const uint8_t psk_key_0[] = PSK_DEFAULT_KEY;
 

--- a/examples/dtls-sock/dtls-server.c
+++ b/examples/dtls-sock/dtls-server.c
@@ -39,7 +39,7 @@ char _dtls_server_stack[THREAD_STACKSIZE_MAIN +
 
 static kernel_pid_t _dtls_server_pid = KERNEL_PID_UNDEF;
 
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 static const ecdsa_public_key_t other_pubkeys[] = {
     { .x = ecdsa_pub_key_x, .y = ecdsa_pub_key_y },
 };
@@ -59,7 +59,7 @@ static const credman_credential_t credential = {
         },
     },
 };
-#else /* #ifdef DTLS_PSK */
+#else /* #ifdef CONFIG_DTLS_PSK */
 static const uint8_t psk_key_0[] = PSK_DEFAULT_KEY;
 
 static const credman_credential_t credential = {

--- a/examples/dtls-sock/tinydtls_keys.h
+++ b/examples/dtls-sock/tinydtls_keys.h
@@ -28,16 +28,16 @@ extern "C" {
 /*
  *  Default keys examples for tinyDTLS (for RIOT, Linux and Contiki)
  */
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
 #define PSK_DEFAULT_IDENTITY "Client_identity"
 #define PSK_DEFAULT_KEY "secretPSK"
 #define PSK_OPTIONS "i:k:"
 #define PSK_ID_MAXLEN 32
 #define PSK_MAXLEN 32
 
-#endif /* DTLS_PSK */
+#endif /* CONFIG_DTLS_PSK */
 
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 static const unsigned char ecdsa_priv_key[] = {
     0x41, 0xC1, 0xCB, 0x6B, 0x51, 0x24, 0x7A, 0x14,
     0x43, 0x21, 0x43, 0x5B, 0x7A, 0x80, 0xE7, 0x14,
@@ -58,7 +58,7 @@ static const unsigned char ecdsa_pub_key_y[] = {
     0xE9, 0x3F, 0x98, 0x72, 0x09, 0xDA, 0xED, 0x0B,
     0x4F, 0xAB, 0xC3, 0x6F, 0xC7, 0x72, 0xF8, 0x29
 };
-#endif /* DTLS_ECC */
+#endif /* CONFIG_DTLS_ECC */
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/Kconfig
+++ b/pkg/Kconfig
@@ -6,6 +6,6 @@
 #
 menu "Packages"
 
+rsource "tinydtls/Kconfig"
 
 endmenu # Packages
-

--- a/pkg/Kconfig
+++ b/pkg/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menu "Packages"
+
+
+endmenu # Packages
+

--- a/pkg/tinydtls/Kconfig
+++ b/pkg/tinydtls/Kconfig
@@ -1,0 +1,51 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_PKG_TINYDTLS
+    bool "Configure tinydtls"
+    depends on PKG_TINYDTLS
+    help
+        Configure tinydtls package via Kconfig.
+
+if KCONFIG_PKG_TINYDTLS
+
+# TODO change to multiple choice after DTLS application support enabling more than one types of cypher suites
+choice
+    bool "Cipher suite to enable"
+    default DTLS_PSK
+
+config DTLS_PSK
+    bool "TLS_PSK_WITH_AES_128_CCM_8"
+
+config DTLS_ECC
+    bool "TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8"
+
+endchoice
+
+config DTLS_DEBUG
+    bool "Enable debug log"
+    help
+        Enable debug log output for tinydtls
+
+config DTLS_CONTEXT_MAX
+    int "Max DTLS context"
+    default 2
+    help
+        The maximum number of DTLS context at the same time.
+
+config DTLS_PEER_MAX
+    int "Max number of peers"
+    default 1
+    help
+        The maximum number of DTLS peers.
+
+config DTLS_HANDSHAKE_MAX
+    int "Max concurrent handshake"
+    default 1
+    help
+        The maximum number of concurrent DTLS handshakes.
+
+endif # KCONFIG_PKG_TINYDTLS

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -18,20 +18,27 @@ ifeq (,$(filter posix_sockets,$(USEMODULE)))
   CFLAGS += -DWITH_RIOT_GNRC
 endif
 
-# NOTE: PSK should be enabled by default BUT if the user define any other cipher
-#       suite(s) it should not be enabled.
-# TODO: Create the flag DTLS_CIPHERS with keywords PSK, ECC (and future)
-ifeq (,$(filter -DDTLS_PSK,$(CFLAGS)))
-  ifeq (,$(filter -DDTLS_ECC,$(CFLAGS)))
-    CFLAGS += -DDTLS_PSK
+# Default cipher suite when not using Kconfig
+ifeq (,$(CONFIG_KCONFIG_PKG_TINYDTLS))
+  # NOTE: PSK should be enabled by default BUT if the user define any other cipher
+  #       suite(s) it should not be enabled.
+  # TODO: Create the flag DTLS_CIPHERS with keywords PSK, ECC (and future)
+  PSK_ENABLED := $(or $(filter -DCONFIG_DTLS_PSK,$(CFLAGS)), $(filter -DDTLS_PSK,$(CFLAGS)))
+  ECC_ENABLED := $(or $(filter -DCONFIG_DTLS_ECC,$(CFLAGS)), $(filter -DDTLS_ECC,$(CFLAGS)))
+  ifeq (, $(or $(PSK_ENABLED),$(ECC_ENABLED)))
+    CFLAGS += -DCONFIG_DTLS_PSK
   endif
 endif
 
-# Handles the verbosity of tinyDTLS. Default: Minimum or just error messages.
-ifeq (,$(filter -DDTLS_DEBUG,$(CFLAGS)))
-  CFLAGS += -DTINYDTLS_LOG_LVL=0
-else
+ifneq (,$(filter -DDTLS_DEBUG,$(CFLAGS)))
+  # For backwards compability. This can be removed after release 2020.10
+  $(warning Warning! DTLS_DEBUG is deprecated use CONFIG_DTLS_DEBUG)
+  CFLAGS += -DCONFIG_DTLS_DEBUG
+endif
+ifneq (,$(or $(CONFIG_DTLS_DEBUG),$(filter -DCONFIG_DTLS_DEBUG,$(CFLAGS))))
   CFLAGS += -DTINYDTLS_LOG_LVL=6
+else
+  CFLAGS += -DTINYDTLS_LOG_LVL=0
 endif
 
 ifneq (,$(filter tinydtls_aes,$(USEMODULE)))
@@ -45,4 +52,40 @@ endif
 # For now contrib only contains sock_dtls adaption
 ifneq (,$(filter tinydtls_sock_dtls,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/tinydtls/contrib
+endif
+
+# Translate 'CONFIG_' options to package specific flags. This checks if the
+# option is being set via Kconfig or CFLAGS
+
+ifneq (,$(filter -DDTLS_PSK,$(CFLAGS)))
+  # For backwards compability. This can be removed after release 2020.10
+  $(warning Warning! DTLS_PSK is deprecated use CONFIG_DTLS_PSK)
+  CFLAGS += -DCONFIG_DTLS_PSK
+endif
+ifneq (,$(or $(CONFIG_DTLS_PSK),$(filter -DCONFIG_DTLS_PSK,$(CFLAGS))))
+    CFLAGS += -DDTLS_PSK
+endif
+
+ifneq (,$(filter -DDTLS_ECC,$(CFLAGS)))
+  # For backwards compability. This can be removed after release 2020.10
+  $(warning Warning! DTLS_ECC is deprecated use CONFIG_DTLS_ECC)
+  CFLAGS += -DCONFIG_DTLS_ECC
+endif
+ifneq (,$(or $(CONFIG_DTLS_ECC),$(filter -DCONFIG_DTLS_ECC,$(CFLAGS))))
+    CFLAGS += -DDTLS_ECC
+endif
+
+CONTEXT_MAX := $(or $(CONFIG_DTLS_CONTEXT_MAX),$(patsubst -DCONFIG_DTLS_CONTEXT_MAX=%,%,$(filter -DCONFIG_DTLS_CONTEXT_MAX=%,$(CFLAGS))))
+ifneq (,$(CONTEXT_MAX))
+    CFLAGS += -DDTLS_CONTEXT_MAX=$(CONTEXT_MAX)
+endif
+
+PEER_MAX := $(or $(CONFIG_DTLS_PEER_MAX),$(patsubst -DCONFIG_DTLS_PEER_MAX=%,%,$(filter -DCONFIG_DTLS_PEER_MAX=%,$(CFLAGS))))
+ifneq (,$(PEER_MAX))
+    CFLAGS += -DDTLS_PEER_MAX=$(PEER_MAX)
+endif
+
+HANDSHAKE_MAX := $(or $(CONFIG_DTLS_HANDSHAKE_MAX),$(patsubst -DCONFIG_DTLS_HANDSHAKE_MAX=%,%,$(filter -DCONFIG_DTLS_HANDSHAKE_MAX=%,$(CFLAGS))))
+ifneq (,$(HANDSHAKE_MAX))
+    CFLAGS += -DDTLS_HANDSHAKE_MAX=$(HANDSHAKE_MAX)
 endif

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -29,22 +29,22 @@
 #define DTLS_HANDSHAKE_BUFSIZE  (256)       /**< Size buffer used in handshake
                                                 to hold credentials */
 /* ECC handshake takes more time */
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 #define DTLS_HANDSHAKE_TIMEOUT  (30 * US_PER_SEC)
 #else
 #define DTLS_HANDSHAKE_TIMEOUT  (1 * US_PER_SEC)
-#endif  /* DTLS_ECC */
+#endif  /* CONFIG_DTLS_ECC */
 
 static void _timeout_callback(void *arg);
 
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
 static int _get_psk_info(struct dtls_context_t *ctx, const session_t *session,
                          dtls_credentials_type_t type,
                          const unsigned char *id, size_t id_len,
                          unsigned char *result, size_t result_length);
-#endif /* DTLS_PSK */
+#endif /* CONFIG_DTLS_PSK */
 
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 static int _get_ecdsa_key(struct dtls_context_t *ctx, const session_t *session,
                           const dtls_ecdsa_key_t **result);
 
@@ -53,7 +53,7 @@ static int _verify_ecdsa_key(struct dtls_context_t *ctx,
                              const unsigned char *other_pub_x,
                              const unsigned char *other_pub_y,
                              size_t key_size);
-#endif /* DTLS_ECC */
+#endif /* CONFIG_DTLS_ECC */
 
 static int _write(struct dtls_context_t *ctx, session_t *session, uint8_t *buf,
                   size_t len);
@@ -70,13 +70,13 @@ static dtls_handler_t _dtls_handler = {
     .event = _event,
     .write = _write,
     .read = _read,
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
     .get_psk_info = _get_psk_info,
-#endif /* DTLS_PSK */
-#ifdef DTLS_ECC
+#endif /* CONFIG_DTLS_PSK */
+#ifdef CONFIG_DTLS_ECC
     .get_ecdsa_key = _get_ecdsa_key,
     .verify_ecdsa_key = _verify_ecdsa_key,
-#endif /* DTLS_ECC */
+#endif /* CONFIG_DTLS_ECC */
 };
 
 static int _read(struct dtls_context_t *ctx, session_t *session, uint8_t *buf,
@@ -132,7 +132,7 @@ static int _event(struct dtls_context_t *ctx, session_t *session,
     return 0;
 }
 
-#ifdef DTLS_PSK
+#ifdef CONFIG_DTLS_PSK
 static int _get_psk_info(struct dtls_context_t *ctx, const session_t *session,
                          dtls_credentials_type_t type,
                          const unsigned char *desc, size_t desc_len,
@@ -190,9 +190,9 @@ static int _get_psk_info(struct dtls_context_t *ctx, const session_t *session,
     memcpy(result, c, c_len);
     return c_len;
 }
-#endif /* DTLS_PSK */
+#endif /* CONFIG_DTLS_PSK */
 
-#ifdef DTLS_ECC
+#ifdef CONFIG_DTLS_ECC
 static int _get_ecdsa_key(struct dtls_context_t *ctx, const session_t *session,
                           const dtls_ecdsa_key_t **result)
 {
@@ -229,7 +229,7 @@ static int _verify_ecdsa_key(struct dtls_context_t *ctx,
 
     return 0;
 }
-#endif /* DTLS_ECC */
+#endif /* CONFIG_DTLS_ECC */
 
 int sock_dtls_create(sock_dtls_t *sock, sock_udp_t *udp_sock,
                      credman_tag_t tag, unsigned version, unsigned role)

--- a/pkg/tinydtls/doc.txt
+++ b/pkg/tinydtls/doc.txt
@@ -23,12 +23,12 @@
  *
  * For `TLS_PSK_WITH_AES_128_CCM_8` support (default):
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
- * CFLAGS += -DDTLS_PSK
+ * CFLAGS += -DCONFIG_DTLS_PSK
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * For `TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8` support:
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
- * CFLAGS += -DDTLS_ECC
+ * CFLAGS += -DCONFIG_DTLS_ECC
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 
@@ -42,51 +42,51 @@
 
  /**
  * @brief Adds support for TLS_PSK_WITH_AES_128_CCM_8 when defined
- * @note  Activated by default if @ref DTLS_ECC is not defined
+ * @note  Activated by default if @ref CONFIG_DTLS_ECC is not defined
  */
-#ifndef DTLS_PSK
-#define DTLS_PSK
+#ifndef CONFIG_DTLS_PSK
+#define CONFIG_DTLS_PSK
 #endif
 
 /**
  * @brief Adds support for TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 when defined
  */
-#ifndef DTLS_ECC
-#define DTLS_ECC
+#ifndef CONFIG_DTLS_ECC
+#define CONFIG_DTLS_ECC
 #endif
 
 /**
  * @brief The maximum number of DTLS context at the same time
  */
-#ifndef DTLS_CONTEXT_MAX
-#define DTLS_CONTEXT_MAX    (2)
+#ifndef CONFIG_DTLS_CONTEXT_MAX
+#define CONFIG_DTLS_CONTEXT_MAX    (2)
 #endif
 
  /**
  * @brief The maximum number DTLS peers (i.e. sessions)
  */
-#ifndef DTLS_PEER_MAX
-#define DTLS_PEER_MAX       (1)
+#ifndef CONFIG_DTLS_PEER_MAX
+#define CONFIG_DTLS_PEER_MAX       (1)
 #endif
 
  /**
  * @brief The maximum number of concurrent DTLS handshakes
  */
-#ifndef DTLS_HANDSHAKE_MAX
-#define DTLS_HANDSHAKE_MAX  (2)
+#ifndef CONFIG_DTLS_HANDSHAKE_MAX
+#define CONFIG_DTLS_HANDSHAKE_MAX  (2)
 #endif
 
  /**
  * @brief The maximum number of concurrently used cipher keys
  */
 #ifndef DTLS_SECURITY_MAX
-#define DTLS_SECURITY_MAX   (DTLS_HANDSHAKE_MAX + DTLS_PEER_MAX)
+#define DTLS_SECURITY_MAX   (CONFIG_DTLS_HANDSHAKE_MAX + CONFIG_DTLS_PEER_MAX)
 #endif
 
  /**
  * @brief The maximum number of hash functions that can be used in parallel
  */
 #ifndef DTLS_HASH_MAX
-#define DTLS_HASH_MAX       (3 * DTLS_PEER_MAX)
+#define DTLS_HASH_MAX       (3 * CONFIG_DTLS_PEER_MAX)
 #endif
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR moves the tinydtls configuration macros to the CONFIG_ namespace and exposes them to Kconfig.

### Testing procedure

- `dtls-echo`, `dtls-sock` with tinydtls should work as usual
- You should be able to configure the client by running `make menuconfig`. Test e.g. changing cipher suites, enable debug log.

Test each configuration option, e.g. set `CONFIG_DTLS_DEBUG` through:
  - `make menuconfig` and enable/disable debug log
  - Pass `CFLAGS=CONFIG_DTLS_DEBUG` to `make` when building the application
  - Neither of the above. Use the default value set by the application

The example applications should build as usual and use the configured option values.

### Issues/PRs references

Part of #12888 
Depends on ~#12913~, #12974 
