### PR TITLE
Fix cordep eventcbs

### DIFF
--- a/sys/net/application_layer/cord/ep/cord_ep_standalone.c
+++ b/sys/net/application_layer/cord/ep/cord_ep_standalone.c
@@ -76,9 +76,6 @@ static void *_reg_runner(void *arg)
                 _set_timer();
                 _notify(CORD_EP_UPDATED);
             }
-            else {
-                _notify(CORD_EP_DEREGISTERED);
-            }
         }
     }
 


### PR DESCRIPTION
### Contribution description
fixes #12884

### Testing procedure
a) connect to a RD, watch for the `"RD endpoint event: successfully updated client registration"` messages, kill the RD, wait for the `"RD endpoint event: dropped client registration"` message -> it should only appear once
b) @MatthiasBraeuer could you verify that reconnecting from the event callback does not lead to deadlocks anymore? Thanks

### Issues/PRs references
fixes #12884