### PR TITLE
shell_commands: make 6Lo compression contexts configurable on non-6LBR

### DIFF
--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -53,9 +53,7 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     SRC += sc_gnrc_rpl.c
 endif
 ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
-ifneq (,$(filter gnrc_ipv6_nib_6lbr,$(USEMODULE)))
     SRC += sc_gnrc_6ctx.c
-endif
 endif
 ifneq (,$(filter gnrc_sixlowpan_frag_stats,$(USEMODULE)))
   SRC += sc_gnrc_6lo_frag_stats.c

--- a/sys/shell/commands/sc_gnrc_6ctx.c
+++ b/sys/shell/commands/sc_gnrc_6ctx.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "kernel_defines.h"
 #include "net/ipv6/addr.h"
 #include "net/gnrc/sixlowpan/ctx.h"
 #include "net/sixlowpan/nd.h"
@@ -69,6 +70,9 @@ int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_s
         _usage(cmd_str);
         return 1;
     }
+    if (!IS_USED(MODULE_GNRC_IPV6_NIB_6LBR)) {
+        puts("WARNING: context dissemination by non-6LBR not supported");
+    }
     addr_str = strtok_r(prefix_str, "/", &save_ptr);
     if (addr_str == NULL) {
         _usage(cmd_str);
@@ -106,7 +110,10 @@ int _gnrc_6ctx_del(char *cmd_str, char *ctx_str)
         _usage(cmd_str);
         return 1;
     }
-    else if (del_timer[cid].callback == NULL) {
+    if (!IS_USED(MODULE_GNRC_IPV6_NIB_6LBR)) {
+        puts("WARNING: context dissemination by non-6LBR not supported");
+    }
+    if (del_timer[cid].callback == NULL) {
         ctx = gnrc_sixlowpan_ctx_lookup_id(cid);
         if (ctx != NULL) {
             ctx->flags_id &= ~GNRC_SIXLOWPAN_CTX_FLAGS_COMP;

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -112,9 +112,7 @@ extern int _gnrc_rpl(int argc, char **argv);
 #endif
 
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX
-#ifdef MODULE_GNRC_IPV6_NIB_6LBR
 extern int _gnrc_6ctx(int argc, char **argv);
-#endif
 #endif
 
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
@@ -236,9 +234,7 @@ const shell_command_t _shell_command_list[] = {
     {"rpl", "rpl configuration tool ('rpl help' for more information)", _gnrc_rpl },
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX
-#ifdef MODULE_GNRC_IPV6_NIB_6LBR
     {"6ctx", "6LoWPAN context configuration tool", _gnrc_6ctx },
-#endif
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
     {"6lo_frag", "6LoWPAN fragment statistics", _gnrc_6lo_frag_stats },


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides the `6ctx` command for not just 6LBR but all 6LoWPAN nodes. For an experimental setup this is really use full if you can't or don't want to rely on compression context dissemination.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `examples/gnrc_networking` on two 6LoWPAN-capable nodes. E.g.

```
BOARD=iotlab-m3 IOTLAB_NODES=2 IOTLAB_SITE=saclay make -C examples/gnrc_networking iotlab-exp iotlab-term
``` 

Configure a global address for each and add a compression context on both for the prefix of the global addresses (note the warning for non-6LBRs that I added). Ping shoud still work as before (maybe even a little bit faster).

```
m3-10;ifconfig 7 add 2001:db8::1
1576852359.881157;m3-10;> ifconfig 7 add 2001:db8::1
1576852359.882008;m3-10;success: added 2001:db8::1/64 to interface 7
m3-11;ifconfig 7 add 2001:db8::2
1576852364.552015;m3-11;> ifconfig 7 add 2001:db8::2
1576852364.552240;m3-11;success: added 2001:db8::2/64 to interface 7
6ctx add 0 2001:db8::/64 120
1576852386.801102;m3-11;> 6ctx add 0 2001:db8::/64 120
1576852386.801412;m3-10;> 6ctx add 0 2001:db8::/64 120
1576852386.801915;m3-10;WARNING: context dissemination by non-6LBR not supported
1576852386.802865;m3-11;WARNING: context dissemination by non-6LBR not supported
m3-10;ping6 2001:db8::2
1576852404.289988;m3-10;> ping6 2001:db8::2
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
