### PR TITLE
boards: use explicit paths for file inclusion

### DIFF
--- a/boards/arduino-mkrwan1300/Makefile.include
+++ b/boards/arduino-mkrwan1300/Makefile.include
@@ -7,4 +7,4 @@ endif
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.include
 
 # add arduino-mkrwan1300 include path
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += -I$(RIOTBOARD)/arduino-mkrwan1300/include

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -11,9 +11,9 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 include $(RIOTMAKE)/tools/renode.inc.mk
 
 # debugger config
-DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
+DEBUGGER = $(RIOTBOARD)/cc2538dk/dist/debug.sh
 DEBUGSERVER = JLinkGDBServer -device CC2538SF53
-RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+RESET ?= $(RIOTBOARD)/cc2538dk/dist/reset.sh
 
 # Define the flash-tool and default port:
 PROGRAMMER ?= cc2538-bsl
@@ -22,7 +22,7 @@ ifeq ($(PROGRAMMER),cc2538-bsl)
   FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
   FFLAGS  = -p "$(PROG_DEV)" -e -w -v $(FLASHFILE)
 else ifeq ($(PROGRAMMER),jlink)
-  FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
+  FLASHER = $(RIOTBOARD)/cc2538dk/dist/flash.sh
   FFLAGS  = $(BINDIR) $(FLASHFILE)
 endif
 

--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -3,6 +3,6 @@ FLASHFILE ?= $(HEXFILE)
 FLASHER = mspdebug
 FFLAGS = rf2500 "prog $(FLASHFILE)"
 
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/drivers/include
+INCLUDES += -I$(RIOTBOARD)/chronos/drivers/include
 
 USEMODULE += chronos-drivers

--- a/boards/common/arduino-mkr/Makefile.include
+++ b/boards/common/arduino-mkr/Makefile.include
@@ -18,6 +18,3 @@ else
 endif
 
 INCLUDES += -I$(RIOTBOARD)/common/arduino-mkr/include
-
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -10,10 +10,10 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # st-flash
 FLASHER = st-flash
-DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
+DEBUGGER = $(RIOTBOARD)/f4vi1/dist/debug.sh
 DEBUGSERVER = st-util
 
 # define st-flash parameters
 FLASHFILE ?= $(BINFILE)
 FFLAGS = write $(FLASHFILE) 0x8000000
-DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)
+DEBUGGER_FLAGS = $(RIOTBOARD)/f4vi1/dist/gdb.conf $(ELFFILE)

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -18,4 +18,4 @@ else
 endif
 
 # setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+include $(RIOTBOARD)/feather-m0/Makefile.dep

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -1,4 +1,4 @@
-FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
+FLASHER = $(RIOTBOARD)/mbed_lpc1768/dist/flash.sh
 DEBUGGER =
 DEBUGSERVER =
 

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -1,5 +1,5 @@
 export NATIVEINCLUDES += -DNATIVE_INCLUDES
-export NATIVEINCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
+export NATIVEINCLUDES += -I$(RIOTBOARD)/native/include/
 export NATIVEINCLUDES += -I$(RIOTBASE)/core/include/
 export NATIVEINCLUDES += -I$(RIOTBASE)/drivers/include/
 
@@ -11,7 +11,7 @@ else
   DEBUGGER ?= gdb
 endif
 
-RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+RESET ?= $(RIOTBOARD)/native/dist/reset.sh
 FLASHER = true
 FLASHFILE ?= $(ELFFILE)
 

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -5,7 +5,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # custom flasher to use with the bootloader
-FLASHER = $(RIOTBOARD)/$(BOARD)/dist/robotis-loader.py
+FLASHER = $(RIOTBOARD)/opencm904/dist/robotis-loader.py
 DEBUGGER =
 DEBUGSERVER =
 

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -25,7 +25,7 @@ else ifeq ($(PROGRAMMER),jlink)
   export FLASH_ADDR = 0x200000
   export JLINK_DEVICE = CC2538SF53
   export JLINK_IF = JTAG
-  export JLINK_RESET_FILE = $(RIOTBOARD)/$(BOARD)/dist/hw_reset.seg
+  export JLINK_RESET_FILE = $(RIOTBOARD)/openmote-b/dist/hw_reset.seg
   include $(RIOTMAKE)/tools/jlink.inc.mk
 endif
 

--- a/boards/sensebox_samd21/Makefile.include
+++ b/boards/sensebox_samd21/Makefile.include
@@ -18,4 +18,4 @@ else
 endif
 
 # setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+include $(RIOTBOARD)/sensebox_samd21/Makefile.dep

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -220,6 +220,22 @@ checks_develhelp_not_defined_via_cflags() {
         | error_with_message "Use DEVELHELP ?= 1 instead of using CFLAGS directly"
 }
 
+
+# Common code in boards should not use $(BOARD) to reference files
+check_files_in_boards_not_reference_board_var() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e '/$(BOARD)/')
+
+    pathspec+=('boards/')
+    # boards/common/nrf52 uses a hack to resolve dependencies early
+    pathspec+=(':!boards/common/nrf52/Makefile.include')
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message 'Code in boards/ should not use $(BOARDS) to reference files since this breaks external BOARDS changing BOARDSDIR"'
+}
+
 error_on_input() {
     ! grep ''
 }
@@ -234,6 +250,7 @@ all_checks() {
     check_board_insufficient_memory_not_in_makefile
     checks_tests_application_not_defined_in_makefile
     checks_develhelp_not_defined_via_cflags
+    check_files_in_boards_not_reference_board_var
 }
 
 main() {


### PR DESCRIPTION
### Contribution description

While testing #12972 I realized that when having an external `native` board name e.g.: `BOARD=native-external` it will try to include headers in `RIOTBASE` with the external BOARD name, thus failing.

**EDIT**: I extended this to all of the cases of:

<details><summary>git grep \/\$\(BOARD\) boards/ </summary>

```
boards/arduino-mkrwan1300/Makefile.include:INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
boards/cc2538dk/Makefile.include:DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
boards/cc2538dk/Makefile.include:RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
boards/cc2538dk/Makefile.include:  FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
boards/chronos/Makefile.include:INCLUDES += -I$(RIOTBOARD)/$(BOARD)/drivers/include
boards/common/arduino-mkr/Makefile.include:include $(RIOTBOARD)/$(BOARD)/Makefile.dep
boards/common/nrf52/Makefile.include:include $(RIOTBOARD)/$(BOARD)/Makefile.dep
boards/f4vi1/Makefile.include:DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
boards/f4vi1/Makefile.include:DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)
boards/feather-m0/Makefile.include:include $(RIOTBOARD)/$(BOARD)/Makefile.dep
boards/mbed_lpc1768/Makefile.include:FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
boards/native/Makefile.include:export NATIVEINCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
boards/native/Makefile.include:RESET ?= $(RIOTBOARD)/$(BOARD)/dist/reset.sh
boards/opencm904/Makefile.include:FLASHER = $(RIOTBOARD)/$(BOARD)/dist/robotis-loader.py
boards/openmote-b/Makefile.include:  export JLINK_RESET_FILE = $(RIOTBOARD)/$(BOARD)/dist/hw_reset.seg
boards/sensebox_samd21/Makefile.include:include $(RIOTBOARD)/$(BOARD)/Makefile.dep
```
</details>

Except for `boards/common/nrf52/Makefile.include:include $(RIOTBOARD)/$(BOARD)/Makefile.dep` since it is a hack for dependency resolution.

### Testing procedure


- cp external-native to whatever directory out of riotbase

```
cp -r tests/external_board_native/external_boards/ <dir/external-boards>
```

- change native to externalnative  `mv native/ external-native`


- compile on external BOARD, fails without this change.

```
BOARDSDIR=<dir/external-boards> BOARD=native make -C examples/hello-world/
```

- No change in any of the touched variables.

```
for board in arduino-mkrwan1300 cc2538dk chronos f4vi1 feather-m0 mbed_lpc1768 native opencm904 openmote-b sensebox_samd21; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-USEMODULE info-debug-variable-JLINK_RESET_FILE info-debug-variable-FLASHER info-debug-variable-RESET info-debug-variable-DEBUGGER_FLAGS info-debug-variable-INCLUDES info-debug-variable-DEBUGGER; done > pr.txt; git checkout upstream/master; for board in arduino-mkrwan1300 cc2538dk chronos f4vi1 feather-m0 mbed_lpc1768 native opencm904 openmote-b sensebox_samd21; do BOARD=${board} make --no-print-directory -C examples/hello-world/ info-debug-variable-BOARD info-debug-variable-USEMODULE info-debug-variable-JLINK_RESET_FILE info-debug-variable-FLASHER info-debug-variable-RESET info-debug-variable-DEBUGGER_FLAGS info-debug-variable-INCLUDES info-debug-variable-DEBUGGER; done > master.txt; diff pr.txt master.txt; git checkout pr-12999
# no diff
```
