### PR TITLE
sam0/uart: add hardware flow control support

### DIFF
--- a/boards/arduino-mkrwan1300/include/periph_conf.h
+++ b/boards/arduino-mkrwan1300/include/periph_conf.h
@@ -40,6 +40,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,23),  /* ARDUINO_PIN_13, RX Pin */
         .tx_pin   = GPIO_PIN(PB,22),  /* ARDUINO_PIN_14, TX Pin */
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
@@ -50,6 +54,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PA,15),
         .tx_pin   = GPIO_PIN(PA,12),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_0,

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -132,6 +132,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,23),
         .tx_pin   = GPIO_PIN(PB,22),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,
@@ -142,6 +146,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,11),
         .tx_pin   = GPIO_PIN(PA,10),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_C,
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -40,6 +40,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,23),  /* ARDUINO_PIN_13, RX Pin */
         .tx_pin   = GPIO_PIN(PB,22),  /* ARDUINO_PIN_14, TX Pin */
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -61,8 +61,12 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {    /* Virtual COM Port */
         .dev      = &SERCOM2->USART,
-        .rx_pin   = GPIO_PIN(PA,25),
-        .tx_pin   = GPIO_PIN(PA,24),
+        .rx_pin   = GPIO_PIN(PA, 25),
+        .tx_pin   = GPIO_PIN(PA, 24),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_3,
         .tx_pad   = UART_PAD_TX_2,

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -124,13 +124,17 @@ static const tc32_conf_t timer_config[] = {
  */
 static const uart_conf_t uart_config[] = {
     {
-        .dev    = &SERCOM0->USART,
-        .rx_pin = GPIO_PIN(PA, 11), /* RX pin */
-        .tx_pin = GPIO_PIN(PA, 10), /* TX pin */
-        .mux    = GPIO_MUX_C,
-        .rx_pad = UART_PAD_RX_3,
-        .tx_pad = UART_PAD_TX_2,
-        .flags  = UART_FLAG_NONE,
+        .dev      = &SERCOM0->USART,
+        .rx_pin   = GPIO_PIN(PA, 11), /* RX pin */
+        .tx_pin   = GPIO_PIN(PA, 10), /* TX pin */
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_3,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
         .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
     }
 };

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -138,6 +138,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM3->USART,
         .rx_pin   = GPIO_PIN(PA,23),
         .tx_pin   = GPIO_PIN(PA,22),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_C,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
@@ -145,23 +149,31 @@ static const uart_conf_t uart_config[] = {
         .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
     },
     {    /* EXT1 */
-        .dev    = &SERCOM4->USART,
-        .rx_pin = GPIO_PIN(PB,9),
-        .tx_pin = GPIO_PIN(PB,8),
-        .mux    = GPIO_MUX_D,
-        .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_0,
-        .flags  = UART_FLAG_NONE,
+        .dev      = &SERCOM4->USART,
+        .rx_pin   = GPIO_PIN(PB,9),
+        .tx_pin   = GPIO_PIN(PB,8),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
         .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
     },
     {    /* EXT2/3 */
-        .dev    = &SERCOM4->USART,
-        .rx_pin = GPIO_PIN(PB,11),
-        .tx_pin = GPIO_PIN(PB,10),
-        .mux    = GPIO_MUX_D,
-        .rx_pad = UART_PAD_RX_3,
-        .tx_pad = UART_PAD_TX_2,
-        .flags  = UART_FLAG_NONE,
+        .dev      = &SERCOM4->USART,
+        .rx_pin   = GPIO_PIN(PB,11),
+        .tx_pin   = GPIO_PIN(PB,10),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_3,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
         .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
     }
 };

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -76,8 +76,12 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {    /* Virtual COM Port */
         .dev      = &SERCOM2->USART,
-        .rx_pin   = GPIO_PIN(PB,24),
-        .tx_pin   = GPIO_PIN(PB,25),
+        .rx_pin   = GPIO_PIN(PB, 24),
+        .tx_pin   = GPIO_PIN(PB, 25),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -66,6 +66,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM3->USART,
         .rx_pin   = GPIO_PIN(PA,23),
         .tx_pin   = GPIO_PIN(PA,22),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_C,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
@@ -76,6 +80,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB, 9),
         .tx_pin   = GPIO_PIN(PB, 8),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -135,23 +135,31 @@ static const tc32_conf_t timer_config[] = {
  */
 static const uart_conf_t uart_config[] = {
     {
-        .dev    = &SERCOM0->USART,
-        .rx_pin = GPIO_PIN(PA,5),
-        .tx_pin = GPIO_PIN(PA,4),
-        .mux    = GPIO_MUX_D,
-        .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_0,
-        .flags  = UART_FLAG_NONE,
+        .dev      = &SERCOM0->USART,
+        .rx_pin   = GPIO_PIN(PA,5),
+        .tx_pin   = GPIO_PIN(PA,4),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
         .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
     },
     {
-        .dev    = &SERCOM5->USART,
-        .rx_pin = GPIO_PIN(PA,23),
-        .tx_pin = GPIO_PIN(PA,22),
-        .mux    = GPIO_MUX_D,
-        .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_0,
-        .flags  = UART_FLAG_NONE,
+        .dev      = &SERCOM5->USART,
+        .rx_pin   = GPIO_PIN(PA,23),
+        .tx_pin   = GPIO_PIN(PA,22),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
         .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
     }
 };

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -62,6 +62,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,5),
         .tx_pin   = GPIO_PIN(PA,4),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -64,6 +64,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA, 5),
         .tx_pin   = GPIO_PIN(PA, 4),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -125,23 +125,31 @@ static const tc32_conf_t timer_config[] = {
  */
 static const uart_conf_t uart_config[] = {
     {
-        .dev    = &SERCOM3->USART,
-        .rx_pin = GPIO_PIN(PA, 23),
-        .tx_pin = GPIO_PIN(PA, 22),
-        .mux    = GPIO_MUX_C,
-        .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_0,
-        .flags  = UART_FLAG_NONE,
+        .dev      = &SERCOM3->USART,
+        .rx_pin   = GPIO_PIN(PA, 23),
+        .tx_pin   = GPIO_PIN(PA, 22),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
         .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
     },
     {
-        .dev    = &SERCOM4->USART,
-        .rx_pin = GPIO_PIN(PB, 9),
-        .tx_pin = GPIO_PIN(PB, 8),
-        .mux    = GPIO_MUX_D,
-        .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_0,
-        .flags  = UART_FLAG_NONE,
+        .dev      = &SERCOM4->USART,
+        .rx_pin   = GPIO_PIN(PB, 9),
+        .tx_pin   = GPIO_PIN(PB, 8),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
         .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
     }
 };

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -44,6 +44,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,9),
         .tx_pin   = GPIO_PIN(PA,10),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_C,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
@@ -54,6 +58,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,31),
         .tx_pin   = GPIO_PIN(PB,30),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
@@ -64,6 +72,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB,13),
         .tx_pin   = GPIO_PIN(PB,14),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_C,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
@@ -74,6 +86,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM1->USART,
         .rx_pin   = GPIO_PIN(PA,17),
         .tx_pin   = GPIO_PIN(PA,18),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_C,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -40,6 +40,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,31),  /* D0, RX Pin */
         .tx_pin   = GPIO_PIN(PB,30),  /* D1, TX Pin */
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
@@ -50,6 +54,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB,13),
         .tx_pin   = GPIO_PIN(PB,14),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_C,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,
@@ -60,6 +68,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,5),
         .tx_pin   = GPIO_PIN(PA,6),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -43,6 +43,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,3),  /* D0, RX Pin */
         .tx_pin   = GPIO_PIN(PB,2),  /* D1, TX Pin */
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
@@ -53,6 +57,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM2->USART,
         .rx_pin   = GPIO_PIN(PA,13),
         .tx_pin   = GPIO_PIN(PA,12),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_C,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -46,6 +46,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB, 30),  /* D0, RX Pin */
         .tx_pin   = GPIO_PIN(PB, 31),  /* D1, TX Pin */
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
@@ -56,6 +60,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,5),
         .tx_pin   = GPIO_PIN(PA,6),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_2,

--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -28,6 +28,9 @@ CFLAGS += -DDONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
 # For Cortex-M cpu we use the common cortexm.ld linker script
 LINKER_SCRIPT ?= cortexm.ld
 
+# define sam0 specific pseudomodules
+PSEUDOMODULES += sam0_periph_uart_hw_fc
+
 # include sam0 common periph drivers
 USEMODULE += sam0_common_periph
 

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -211,6 +211,10 @@ typedef struct {
     SercomUsart *dev;       /**< pointer to the used UART device */
     gpio_t rx_pin;          /**< pin used for RX */
     gpio_t tx_pin;          /**< pin used for TX */
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+    gpio_t rts_pin;          /**< pin used for RTS */
+    gpio_t cts_pin;          /**< pin used for CTS */
+#endif
     gpio_mux_t mux;         /**< alternative function for pins */
     uart_rxpad_t rx_pad;    /**< pad selection for RX line */
     uart_txpad_t tx_pad;    /**< pad selection for TX line */

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -80,6 +80,19 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     gpio_set(uart_config[uart].tx_pin);
     gpio_init_mux(uart_config[uart].tx_pin, uart_config[uart].mux);
 
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+    /* If RTS/CTS needed, enable them */
+    if (uart_config[uart].tx_pad == UART_PAD_TX_0_RTS_2_CTS_3) {
+        /* Ensure RTS is defined */
+        if (uart_config[uart].rts_pin != GPIO_UNDEF) {
+            gpio_init_mux(uart_config[uart].rts_pin, uart_config[uart].mux);
+        }
+        /* Ensure CTS is defined */
+        if (uart_config[uart].cts_pin != GPIO_UNDEF) {
+            gpio_init_mux(uart_config[uart].cts_pin, uart_config[uart].mux);
+        }
+    }
+#endif
     /* enable peripheral clock */
     sercom_clk_en(dev(uart));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds hardware flow control for the SAM0 UART driver. The pseudomodule idea is taken from the STM32 driver. This is very useful to be able to communicate with some external modules.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Declare  your RTS and CTS pin in periph_conf.h, switch the tx_pad field to UART_PAD_TX_0_RTS_2_CTS_3, connect your wires and test your RX/TX with tests/periph_uart for example.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
