### PR TITLE
tests/external_board_native: only whitelist native board

### DIFF
--- a/tests/external_board_native/Makefile
+++ b/tests/external_board_native/Makefile
@@ -1,13 +1,13 @@
 APPLICATION = external_board
 RIOTBASE ?= $(CURDIR)/../../
 
-# Only support this board
-# No need for a `WHITELIST` as there is only one board in `external_boards`.
-#
 # HACK I named the external board as 'native' to be in murdock test path for
 # 'native'
 # In practice it should be something else
 BOARD ?= native
+
+# Only support this board
+BOARD_WHITELIST = native
 
 # Set without '?=' to also verify the docker integration when set with =
 BOARDSDIR = $(CURDIR)/external_boards


### PR DESCRIPTION
### Contribution description

The `compile_and_test_for_board.py` will try to build this test for the board specified there.

This will not work since no in-tree boards are available when external boards are used.

    ERROR:mcb2388.tests/external_board_native:Error during command:
    Makefile.features:16: *** CPU must be defined by board / board_common Makefile.features.  Stop.


### Testing procedure

Run

    dist/tools/compile_and_test_for_board/compile_and_test_for_board.py -j 0 --no-test . samr21-xpro

(you can replace `samr21-xpro` any other in-tree board)

### Issues/PRs references
#12183