### PR TITLE
cpu/lpc2387: timer: implement timer_set()

### DIFF
--- a/cpu/lpc23xx/include/periph_cpu.h
+++ b/cpu/lpc23xx/include/periph_cpu.h
@@ -129,6 +129,11 @@ typedef struct {
 #define TIMER_CHANNEL_NUMOF (4U)
 
 /**
+ * @brief   Prevent shared timer functions from being used
+ */
+#define PERIPH_TIMER_PROVIDES_SET
+
+/**
  * @brief   Declare needed generic SPI functions
  * @{
  */

--- a/cpu/lpc23xx/periph/timer.c
+++ b/cpu/lpc23xx/periph/timer.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "irq.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
 #include "periph/timer.h"
@@ -167,6 +168,37 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     dev->MR[channel] = value;
     /* Match Interrupt */
     dev->MCR |= (1 << (channel * 3));
+
+    return 0;
+}
+
+int timer_set(tim_t tim, int channel, unsigned int timeout)
+{
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNEL_NUMOF)) {
+        return -1;
+    }
+
+    /* Interrupt will only be generated on increment,
+       so a 0 timeout is not possible */
+    if (timeout == 0) {
+        timeout = 1;
+    }
+
+    lpc23xx_timer_t *dev = get_dev(tim);
+
+    unsigned state = irq_disable();
+    dev->TCR = 0;
+
+    unsigned absolute = timeout + dev->TC;
+    unsigned mask = 1 << (channel * 3);
+
+    dev->MR[channel] = absolute;
+    dev->MCR |= mask;
+    set_oneshot(tim, channel);
+
+    dev->TCR = 1;
+    irq_restore(state);
+
     return 0;
 }
 

--- a/cpu/lpc23xx/periph/timer.c
+++ b/cpu/lpc23xx/periph/timer.c
@@ -258,13 +258,6 @@ void timer_stop(tim_t tim)
 
 static inline void chan_handler(lpc23xx_timer_t *dev, unsigned tim_num, unsigned chan_num)
 {
-    const uint32_t mask = (1 << chan_num);
-
-    if ((dev->IR & mask) == 0) {
-        return;
-    }
-
-    dev->IR |= mask;
     if (is_oneshot(tim_num, chan_num)) {
         dev->MCR &= ~(1 << (chan_num * 3));
     }
@@ -274,8 +267,15 @@ static inline void chan_handler(lpc23xx_timer_t *dev, unsigned tim_num, unsigned
 
 static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
 {
-    for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; ++i) {
-        chan_handler(dev, tim_num, i);
+    uint32_t state = dev->IR;
+    uint8_t chan = 0;
+
+    /* clear interrupt flags */
+    dev->IR = state;
+
+    while (state) {
+        state = bitarithm_test_and_clear(state, &chan);
+        chan_handler(dev, tim_num, chan);
     }
 
     /* we must not forget to acknowledge the handling of the interrupt */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

We can achieve greater accuracy for the relative `timer_set()` if we don't use the generic implementation.

If timeout is 0, just execute the callback directly as no interrupt is generated when we set `MR` = `TC`.

`tests/periph_timer_short_relative_set` should now succeed for all intervals.

### Testing procedure

Run `tests/periph_timer_short_relative_set`.

#### before:

```
…
2019-12-25 17:40:34,087 - INFO # interval 2 ok
2019-12-25 17:40:34,088 - INFO # ERROR: too long delay, aborted after 1001 (TEST_MAX_DIFF=1000)
```

#### with this patch

```
…
2019-12-25 18:45:41,098 # interval 4 ok
2019-12-25 18:45:41,098 # interval 3 ok
2019-12-25 18:45:41,099 # interval 2 ok
2019-12-25 18:45:41,099 # interval 1 ok
2019-12-25 18:45:41,100 # interval 0 ok
2019-12-25 18:45:41,100 # 
2019-12-25 18:45:41,100 # TEST SUCCEEDED
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
