### PR TITLE
cpu/esp*: esp_wifi used as default netdev for lwip

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -42,9 +42,16 @@ ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
 endif
 
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
-  # use esp_now as default netdev if no other netdev module is enabled
-  ifeq (,$(filter esp_wifi esp_eth,$(USEMODULE)))
-    USEMODULE += esp_now
+  ifneq (,$(filter lwip,$(USEMODULE)))
+    # for lwip, use esp_wifi as default netdev if no other netdev is enabled
+    ifeq (,$(filter esp_eth,$(USEMODULE)))
+      USEMODULE += esp_wifi
+    endif
+  else
+    # otherwise use esp_now as default netdev if no other netdev is enabled
+    ifeq (,$(filter esp_wifi esp_eth,$(USEMODULE)))
+      USEMODULE += esp_now
+    endif
   endif
 endif
 

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -20,9 +20,14 @@ endif
 # cannot be done in Makefile.dep since Makefile.dep is included too late
 
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
-  # use esp_now as default netdev if no other netdev module is enabled
-  ifeq (,$(filter esp_wifi esp_eth,$(USEMODULE)))
-    USEMODULE += esp_now
+  ifneq (,$(filter lwip,$(USEMODULE)))
+    # for lwip, use esp_wifi as default netdev if no other netdev is enabled
+      USEMODULE += esp_wifi
+  else
+    # otherwise use esp_now as default netdev if no other netdev is enabled
+    ifeq (,$(filter esp_wifi esp_eth,$(USEMODULE)))
+      USEMODULE += esp_now
+    endif
   endif
 endif
 


### PR DESCRIPTION
### Contribution description

With this PR, `esp-wifi` is defined as default network device for `pkg/lwip`.

Normally, `esp_now` is used as the default network device for ESP modules. However, `esp_now` cannot be used together with `pkg/lwip`. Therefore, `esp_wifi` is used instead as the default network device if module `lwip` is enabled.


### Testing procedure

Flash `tests/lwip` to any ESP32 and any ESP8266 board and ping the nodes from any machine in the LAN.
```
LWIP_IPV4=1 CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' \
make BOARD=esp32-wroom-32 -C tests/lwip flash term
```
```
LWIP_IPV4=1 CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' \
make BOARD=esp8266-esp-12x -C tests/lwip flash term
```

### Issues/PRs references