### PR TITLE
makefiles/color: fix build on NixOS

### DIFF
--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -5,7 +5,7 @@ COLOR_GREEN  :=
 COLOR_RED    :=
 COLOR_PURPLE :=
 COLOR_RESET  :=
-COLOR_ECHO   := /bin/echo
+COLOR_ECHO   := /usr/bin/env echo
 
 # Check if colored output is not disabled by user, i.e: CC_NOCOLOR unset
 # or 0
@@ -22,7 +22,7 @@ ifneq ($(CC_NOCOLOR),1)
       COLOR_ECHO   := echo -e
       SHELL=bash
     else
-      COLOR_ECHO   := /bin/echo -e
+      COLOR_ECHO   := /usr/bin/env echo -e
     endif
   endif
 endif


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

On NixOS, there is no `/bin/echo`, instead
`which echo` will return

    /home/benpicco/.nix-profile/bin/echo

so hard-coding the path will break here.

However, the `-e` command seems to be well supported by the build-in
even, so there is no need to encode an absolute path.

(Should probably be tested on some more systems, only tried Ubuntu and NixOS.)

### Testing procedure

#### before

```
$ make -C examples/hello-world BOARD=samr21-xpro
make: Entering directory '/home/benpicco/RIOT/examples/hello-world'
make: /bin/echo: Command not found
make: *** [/home/benpicco/RIOT/examples/hello-world/../../Makefile.include:616: ..build-message] Error 127
make: Leaving directory '/home/benpicco/RIOT/examples/hello-world'
```

#### after

```
$ make -C examples/hello-world BOARD=samr21-xpro
make: Entering directory '/home/benpicco/RIOT/examples/hello-world'
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /home/benpicco/RIOT/boards/samr21-xpro
"make" -C /home/benpicco/RIOT/core
"make" -C /home/benpicco/RIOT/cpu/samd21
"make" -C /home/benpicco/RIOT/cpu/cortexm_common
"make" -C /home/benpicco/RIOT/cpu/cortexm_common/periph
"make" -C /home/benpicco/RIOT/cpu/sam0_common
"make" -C /home/benpicco/RIOT/cpu/sam0_common/periph
"make" -C /home/benpicco/RIOT/cpu/samd21/periph
"make" -C /home/benpicco/RIOT/drivers
"make" -C /home/benpicco/RIOT/drivers/periph_common
"make" -C /home/benpicco/RIOT/sys
"make" -C /home/benpicco/RIOT/sys/auto_init
"make" -C /home/benpicco/RIOT/sys/newlib_syscalls_default
"make" -C /home/benpicco/RIOT/sys/pm_layered
"make" -C /home/benpicco/RIOT/sys/stdio_uart
   text    data     bss     dec     hex filename
   8516     120    2560   11196    2bbc /home/benpicco/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
