### PR TITLE
Relink wiki.stm32duino.com to web.archive.org

### DIFF
--- a/boards/bluepill-128kib/include/board.h
+++ b/boards/bluepill-128kib/include/board.h
@@ -13,7 +13,7 @@
  * This board can be bought very cheaply on sides like eBay or
  * AliExpress. Although the MCU nominally has 64 KiB ROM, most of them
  * have 128 KiB ROM. For more information see:
- * http://wiki.stm32duino.com/index.php?title=Blue_Pill
+ * https://web.archive.org/web/20190527040051/http://wiki.stm32duino.com/index.php?title=Blue_Pill
  *
  * @{
  *

--- a/boards/bluepill/include/board.h
+++ b/boards/bluepill/include/board.h
@@ -13,7 +13,7 @@
  * This board can be bought very cheaply on sides like eBay or
  * AliExpress. Although the MCU nominally has 64 KiB ROM, most of them
  * have 128 KiB ROM. For more information see:
- * http://wiki.stm32duino.com/index.php?title=Blue_Pill
+ * https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?title=Blue_Pill
  *
  * @{
  *

--- a/boards/bluepill/include/board.h
+++ b/boards/bluepill/include/board.h
@@ -13,7 +13,7 @@
  * This board can be bought very cheaply on sides like eBay or
  * AliExpress. Although the MCU nominally has 64 KiB ROM, most of them
  * have 128 KiB ROM. For more information see:
- * https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?title=Blue_Pill
+ * https://web.archive.org/web/20190527040051/http://wiki.stm32duino.com/index.php?title=Blue_Pill
  *
  * @{
  *


### PR DESCRIPTION
Fix broken links from wiki.stm32duino.com to web.archive.org