### PR TITLE
pkg: add library for Microchip CryptoAuth devices as package

### DIFF
--- a/pkg/cryptoauthlib/Makefile
+++ b/pkg/cryptoauthlib/Makefile
@@ -1,0 +1,61 @@
+PKG_NAME=cryptoauthlib
+PKG_URL=https://github.com/MicrochipTech/cryptoauthlib
+PKG_VERSION=af8187776cd3f3faf8bed412eaf6ff7221862e19
+PKG_LICENSE=LGPL-2.1
+PKG_TEST_NAME=cryptoauthlib_test
+PKG_TESTINCLDIR = $(PKG_BUILDDIR)/test
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+.PHONY: all..cmake_version_supported
+
+CMAKE_MINIMAL_VERSION = 3.6.0
+
+CFLAGS += -Wno-missing-field-initializers -Wno-unused-function
+CFLAGS += -Wno-type-limits -Wno-strict-aliasing -Wno-unused-variable -DATCA_HAL_I2C
+CFLAGS += -Wno-unused-parameter -Wno-sign-compare -Wno-overflow -Wno-pointer-to-int-cast
+
+TOOLCHAIN_FILE=$(PKG_BUILDDIR)/xcompile-toolchain.cmake
+
+ifneq (,$(filter $(PKG_TEST_NAME),$(USEMODULE)))
+    all: cryptoauth build_tests
+else
+    all: cryptoauth
+endif
+
+cryptoauth: $(PKG_BUILDDIR)/lib/Makefile
+	$(MAKE) -C $(PKG_BUILDDIR)/lib
+	cp $(PKG_BUILDDIR)/lib/libcryptoauth.a $(BINDIR)/$(PKG_NAME).a
+
+$(PKG_BUILDDIR)/lib/Makefile: $(TOOLCHAIN_FILE)
+	cd $(PKG_BUILDDIR)/lib && \
+	cmake -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
+		  -Wno-dev \
+		  -DBUILD_TESTS=OFF \
+		  -DATCA_HAL_I2C:BOOL=TRUE .
+
+$(TOOLCHAIN_FILE): git-download
+	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
+
+build_tests:
+	cp $(PKG_TESTINCLDIR)/*.c $(PKG_BUILDDIR)
+	cp $(PKG_TESTINCLDIR)/jwt/*.c $(PKG_BUILDDIR)
+	cp $(PKG_TESTINCLDIR)/tng/*.c $(PKG_BUILDDIR)
+	cp $(PKG_TESTINCLDIR)/atcacert/*.c $(PKG_BUILDDIR)
+
+	echo "MODULE = $(PKG_TEST_NAME)" > $(PKG_BUILDDIR)/Makefile
+	echo "include \$$(RIOTBASE)/Makefile.base" >> $(PKG_BUILDDIR)/Makefile
+
+	"$(MAKE)" -C $(PKG_BUILDDIR)
+
+git-download: | ..cmake_version_supported
+
+..cmake_version_supported:
+	@ # Remove '-rcX' from version as they are not well handled
+	$(Q)\
+	CMAKE_VERSION=$$(cmake --version | sed -n '1 {s/cmake version //;s/-rc.*//;p;}'); \
+	$(RIOTTOOLS)/has_minimal_version/has_minimal_version.sh "$${CMAKE_VERSION}" "$(CMAKE_MINIMAL_VERSION)" cmake
+
+clean::
+	@rm -rf $(BINDIR)/$(PKG_NAME).a
+	@rm -rf $(BINDIR)/$(PKG_TEST_NAME).a

--- a/pkg/cryptoauthlib/Makefile.cryptoauthlib
+++ b/pkg/cryptoauthlib/Makefile.cryptoauthlib
@@ -1,0 +1,3 @@
+MODULE = cryptoauthlib
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/cryptoauthlib/Makefile.dep
+++ b/pkg/cryptoauthlib/Makefile.dep
@@ -1,0 +1,4 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += auto_init_security
+USEMODULE += cryptoauthlib_contrib

--- a/pkg/cryptoauthlib/Makefile.include
+++ b/pkg/cryptoauthlib/Makefile.include
@@ -1,0 +1,20 @@
+PKG_BUILDDIR ?= $(PKGDIRBASE)/cryptoauthlib
+PKG_TESTINCLDIR = $(PKG_BUILDDIR)/test
+
+INCLUDES += -I$(PKG_BUILDDIR)
+INCLUDES += -I$(PKG_BUILDDIR)/lib
+INCLUDES += -I$(PKG_BUILDDIR)/app
+INCLUDES += -I$(RIOTPKG)/cryptoauthlib/include
+
+DIRS += $(RIOTPKG)/cryptoauthlib/contrib
+
+ifneq (,$(filter cryptoauthlib_test,$(USEMODULE)))
+  INCLUDES += -I$(PKG_TESTINCLDIR)
+  INCLUDES += -I$(PKG_TESTINCLDIR)/jwt
+  INCLUDES += -I$(PKG_TESTINCLDIR)/tng
+  INCLUDES += -I$(PKG_TESTINCLDIR)/atcacert
+endif
+
+ifneq (,$(filter cortex-m%,$(CPU_ARCH)))
+  TOOLCHAINS_BLACKLIST += llvm
+endif

--- a/pkg/cryptoauthlib/contrib/Makefile
+++ b/pkg/cryptoauthlib/contrib/Makefile
@@ -1,0 +1,3 @@
+MODULE = cryptoauthlib_contrib
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/cryptoauthlib/contrib/atca.c
+++ b/pkg/cryptoauthlib/contrib/atca.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_cryptoauthlib
+ * @{
+ *
+ * @file
+ * @brief       HAL implementation for the library Microchip CryptoAuth devices
+ *
+ * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
+ *
+ * @}
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include "xtimer.h"
+#include "periph/i2c.h"
+#include "periph/gpio.h"
+
+#include "atca.h"
+#include "atca_params.h"
+
+
+/* Timer functions */
+void atca_delay_us(uint32_t delay)
+{
+    xtimer_usleep(delay);
+}
+
+void atca_delay_10us(uint32_t delay)
+{
+    xtimer_usleep(delay * 10);
+}
+
+void atca_delay_ms(uint32_t delay)
+{
+    xtimer_usleep(delay * 1000);
+}
+
+/* Hal I2C implementation */
+ATCA_STATUS hal_i2c_init(void *hal, ATCAIfaceCfg *cfg)
+{
+    (void)hal;
+    if (cfg->iface_type != ATCA_I2C_IFACE) {
+        return ATCA_BAD_PARAM;
+    }
+
+    atcab_wakeup();
+
+    return ATCA_SUCCESS;
+}
+
+ATCA_STATUS hal_i2c_post_init(ATCAIface iface)
+{
+    (void)iface;
+    return ATCA_SUCCESS;
+}
+
+ATCA_STATUS hal_i2c_send(ATCAIface iface, uint8_t *txdata, int txlength)
+{
+    ATCAIfaceCfg *cfg = atgetifacecfg(iface);
+    int ret;
+
+    /* The first byte of the command package contains the word address */
+    txdata[0] = ATCA_DATA_ADDR;
+
+    i2c_acquire(cfg->atcai2c.bus);
+    ret = i2c_write_bytes(cfg->atcai2c.bus, (cfg->atcai2c.slave_address >> 1),
+                          txdata, txlength + 1, 0);
+    i2c_release(cfg->atcai2c.bus);
+
+    if (ret != 0) {
+        return ATCA_TX_FAIL;
+    }
+
+    return ATCA_SUCCESS;
+}
+
+ATCA_STATUS hal_i2c_receive(ATCAIface iface, uint8_t *rxdata,
+                            uint16_t *rxlength)
+{
+    ATCAIfaceCfg *cfg = atgetifacecfg(iface);
+    uint8_t retries = cfg->rx_retries;
+    uint8_t length_package = 0;
+    uint8_t bytes_to_read;
+    int ret = -1;
+
+    /* Every command needs some time to be executed. We check whether the device is done
+       by polling, so we don't have to wait for the max execution time. For that there's
+       a number of retries (specified in the device descriptor). If polling is not successful
+       this function returns an error code. */
+
+    i2c_acquire(cfg->atcai2c.bus);
+    while (retries-- > 0 && ret != 0) {
+        /* read first byte (size of output data) and store it in variable length_package
+           to check if output will fit into rxdata */
+        ret = i2c_read_byte(cfg->atcai2c.bus, (cfg->atcai2c.slave_address >> 1),
+                            &length_package, 0);
+    }
+    i2c_release(cfg->atcai2c.bus);
+
+    if (ret != 0) {
+        return ATCA_RX_TIMEOUT;
+    }
+
+    bytes_to_read = length_package - 1;
+
+    if (bytes_to_read > *rxlength) {
+        return ATCA_SMALL_BUFFER;
+    }
+
+    /* CRC function calculates value of the whole output package, so to get a correct
+       result we need to include the length of the package we got before into rxdata as first byte. */
+    rxdata[0] = length_package;
+
+    /* reset ret and retries to read the rest of the output */
+    ret = -1;
+    retries = cfg->rx_retries;
+
+    /* read rest of output and insert into rxdata array after first byte */
+    i2c_acquire(cfg->atcai2c.bus);
+    while (retries-- > 0 && ret != 0) {
+        ret = i2c_read_bytes(cfg->atcai2c.bus,
+                             (cfg->atcai2c.slave_address >> 1), (rxdata + 1),
+                             bytes_to_read, 0);
+    }
+    i2c_release(cfg->atcai2c.bus);
+
+    if (ret != 0) {
+        return ATCA_RX_TIMEOUT;
+    }
+
+    *rxlength = length_package;
+
+    return ATCA_SUCCESS;
+}
+
+ATCA_STATUS hal_i2c_wake(ATCAIface iface)
+{
+    ATCAIfaceCfg *cfg = atgetifacecfg(iface);
+    uint8_t data[4] = { 0 };
+
+    i2c_acquire(cfg->atcai2c.bus);
+    i2c_write_byte(cfg->atcai2c.bus, ATCA_WAKE_ADDR, data[0], 0);
+    i2c_release(cfg->atcai2c.bus);
+
+    atca_delay_us(cfg->wake_delay);
+
+    uint8_t retries = cfg->rx_retries;
+    int status = -1;
+
+    i2c_acquire(cfg->atcai2c.bus);
+    while (retries-- > 0 && status != 0) {
+        status = i2c_read_bytes(cfg->atcai2c.bus,
+                                (cfg->atcai2c.slave_address >> 1),
+                                &data[0], 4, 0);
+    }
+    i2c_release(cfg->atcai2c.bus);
+
+    if (status != ATCA_SUCCESS) {
+        return ATCA_COMM_FAIL;
+    }
+
+    return hal_check_wake(data, 4);
+}
+
+ATCA_STATUS hal_i2c_idle(ATCAIface iface)
+{
+    ATCAIfaceCfg *cfg = atgetifacecfg(iface);
+
+    i2c_acquire(cfg->atcai2c.bus);
+    i2c_write_byte(cfg->atcai2c.bus, (cfg->atcai2c.slave_address >> 1),
+                   ATCA_IDLE_ADDR, 0);
+    i2c_release(cfg->atcai2c.bus);
+    return ATCA_SUCCESS;
+}
+
+ATCA_STATUS hal_i2c_sleep(ATCAIface iface)
+{
+    ATCAIfaceCfg *cfg = atgetifacecfg(iface);
+
+    i2c_acquire(cfg->atcai2c.bus);
+    i2c_write_byte(cfg->atcai2c.bus, (cfg->atcai2c.slave_address >> 1),
+                   ATCA_SLEEP_ADDR, 0);
+    i2c_release(cfg->atcai2c.bus);
+    return ATCA_SUCCESS;
+}
+
+ATCA_STATUS hal_i2c_release(void *hal_data)
+{
+    (void)hal_data;
+    /* This function is unimplemented, because currently the bus gets acquired
+       and released before and after each read or write operation. It returns
+       a success code, in case it gets called somewhere in the library. */
+    return ATCA_SUCCESS;
+}
+
+ATCA_STATUS hal_i2c_discover_buses(int i2c_buses[], int max_buses)
+{
+    (void)i2c_buses;
+    (void)max_buses;
+    return ATCA_UNIMPLEMENTED;
+}
+
+ATCA_STATUS hal_i2c_discover_devices(int bus_num, ATCAIfaceCfg *cfg, int *found)
+{
+    (void)bus_num;
+    (void)cfg;
+    (void)found;
+    return ATCA_UNIMPLEMENTED;
+}

--- a/pkg/cryptoauthlib/doc.txt
+++ b/pkg/cryptoauthlib/doc.txt
@@ -1,0 +1,57 @@
+/**
+ * @defgroup pkg_cryptoauthlib Microchip CryptoAuthentication Library
+ * @ingroup  pkg drivers sys_crypto
+ * @brief    Provides the library for Microchip CryptoAuth devices
+ * @see      https://github.com/MicrochipTech/cryptoauthlib
+ *
+ * # Introduction
+ *
+ * This package provides support for the official library for Microchip CryptoAuth devices.
+ *
+ *
+ * ## Warning
+ *
+ * Some functions can only be used, when the data, config and otp zones of the
+ * device are locked. Locking is permanent and cannot be undone. Be careful if
+ * you're not sure you've configured everything correctly.
+ * For more information we refer to the data sheet of the device.
+ *
+ *
+ * ## Usage
+ *
+ * Add
+ * USEPKG += cryptoauthlib
+ * to your Makefile.
+ *
+ *
+ * ## Implementation status
+ *
+ * This implementation was partly tested with ATECC508A and ATECC608A devices.
+ * We haven't tested the functions that require locking the device, yet. There's
+ * a wrapper in the cryptoauthlib/contrib folder, which implements most of the
+ * HAL functions.
+ * Currently the functions hal_i2c_discover_devices and hal_i2c_discover_buses
+ * are unimplemented, as well as hal_i2c_post_init.
+ *
+ * ### Wake function
+ *
+ * The wake function only works when a 0x00 byte is sent on an i2c interface that
+ * runs with with 133kHz or less.
+ * Currently RIOT sets the baudrate to the default value of 100 kHz and there's
+ * no interface to change that. If the default speed ever changes to a value
+ * higher than 133 kHz the wake function needs to be adapted.
+ * For more information on how to send a proper wake condition we refer to the
+ * data sheet of the device.
+ *
+ * ## Tests
+ *
+ * The library provides unittests for the library functions. There
+ * is a directory called "pkg_cryptoauthlib_internal_tests" in the RIOT testfolder
+ * which runs part of the unittests.
+ * Some of the provided tests can only be run when the config, data and/or otp zones
+ * of the device are locked. Some tests (but not all) will automatically lock zones
+ * as needed. We omit those tests at the moment, because zones can only be locked
+ * permanently. Unlocking is not possible!
+ * Also there is a test for comparing the runtime of the RIOT software implementation
+ * and the CryptoAuth hardware implementation for calculating a SHA-256 hash value.
+ */

--- a/pkg/cryptoauthlib/include/atca.h
+++ b/pkg/cryptoauthlib/include/atca.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_cryptoauthlib
+ * @{
+ *
+ * @file
+ * @brief       Default addresses and device descriptor for CryptoAuth devices
+ *
+ * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
+ *
+ */
+
+#ifndef ATCA_H
+#define ATCA_H
+
+#include "periph/i2c.h"
+#include "cryptoauthlib.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Default device and word addresses for ATECC508A
+ */
+#define ATCA_I2C_ADDR (0xC0)    /**< Default device address is 0xC0 */
+
+#define ATCA_WAKE_ADDR   (0x00) /**< Word address to write 0 to device */
+#define ATCA_SLEEP_ADDR  (0x01) /**< Word address to write to for sleep mode */
+#define ATCA_IDLE_ADDR   (0x02) /**< Word address to write to for idle mode */
+#define ATCA_DATA_ADDR   (0x03) /**< Word address to read and write to data area */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ATCA_H */
+/** @} */

--- a/pkg/cryptoauthlib/include/atca_params.h
+++ b/pkg/cryptoauthlib/include/atca_params.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_cryptoauthlib
+ * @{
+ *
+ * @file
+ * @brief       Default configuration for Microchip CryptoAuth devices
+ *
+ * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
+ *
+ */
+
+#ifndef ATCA_PARAMS_H
+#define ATCA_PARAMS_H
+
+#include "cryptoauthlib.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    Set default configuration parameters for the ATCA device
+ *
+ *          The CryptoAuth library defines the data structure ATCAIfaceCfg for
+ *          device initialization. We use this instead of a self defined params
+ *          struct and store it in the params array.
+ *          ATCAIfaceCfg contains a variable for the bus address, which is never
+ *          used by the library. We use it to store RIOT's I2C_DEV.
+ *          We also initialize the baud rate with zero, because RIOT doesn't have
+ *          an API to change baud.
+ *
+ * @ingroup  config
+ * @{
+ */
+
+#ifndef ATCA_PARAM_I2C
+#define ATCA_PARAM_I2C           I2C_DEV(0)
+#endif
+#ifndef ATCA_PARAM_ADDR
+#define ATCA_PARAM_ADDR          (ATCA_I2C_ADDR)
+#endif
+#ifndef ATCA_RX_RETRIES
+#define ATCA_RX_RETRIES          (20)
+#endif
+
+#ifndef ATCA_PARAMS
+#define ATCA_PARAMS                {    .iface_type = ATCA_I2C_IFACE, \
+                                        .devtype = ATECC508A, \
+                                        .atcai2c.slave_address = ATCA_PARAM_ADDR, \
+                                        .atcai2c.bus = ATCA_PARAM_I2C, \
+                                        .atcai2c.baud = -1,                        /**< Not used in RIOT */ \
+                                        .wake_delay = 1500, \
+                                        .rx_retries = ATCA_RX_RETRIES }
+#endif
+
+/**@}*/
+
+/**
+ * @brief   Allocation of ATCA device descriptors
+ */
+static const ATCAIfaceCfg atca_params[] =
+{
+    ATCA_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ATCA_PARAMS_H */
+/** @} */

--- a/pkg/cryptoauthlib/include/cryptoauthlib_test.h
+++ b/pkg/cryptoauthlib/include/cryptoauthlib_test.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_cryptoauthlib
+ * @{
+ *
+ * @file
+ *
+ * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
+ *
+ */
+
+#ifndef CRYPTOAUTHLIB_TEST_H
+#define CRYPTOAUTHLIB_TEST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "cryptoauthlib.h"
+#include "atca.h"
+#include "atca_params.h"
+
+/**
+ * @brief   Helper function to use the library's unittests
+ *          This function is defined in the cryptoauth library via patch.
+ *          It is used to pass commands to run built-in unit tests of the library.
+ */
+int atca_run_cmd(const char *command);
+
+/**
+ * @brief   Function switches the default cfg in cryptoauthlib test to RIOT cfg
+ */
+void riot_switch_cfg(ATCAIfaceCfg *cfg)
+{
+    *cfg = atca_params[0];
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CRYPTOAUTHLIB_TEST_H */
+/** @} */

--- a/pkg/cryptoauthlib/patches/0001-change-include_directories-to-target_include_directo.patch
+++ b/pkg/cryptoauthlib/patches/0001-change-include_directories-to-target_include_directo.patch
@@ -1,0 +1,25 @@
+From ab9a5b8af22158512060079e931c964fb0bc2303 Mon Sep 17 00:00:00 2001
+From: Lena Boeckmann <einhornhool@mobi31.inet.haw-hamburg.de>
+Date: Tue, 7 Jan 2020 14:36:09 +0100
+Subject: [PATCH 1/2] change include_directories to target_include_directories
+
+---
+ lib/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index b15ec66..2168e47 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -123,7 +123,7 @@ if(ATCA_PRINTF)
+ add_definitions(-DATCAPRINTF)
+ endif(ATCA_PRINTF)
+
+-include_directories(cryptoauth PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ../third_party/hidapi/hidapi ${USB_INCLUDE_DIR})
++target_include_directories(cryptoauth PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ../third_party/hidapi/hidapi ${USB_INCLUDE_DIR})
+
+ if(WIN32)
+ set_target_properties(cryptoauth PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
+--
+2.23.0
+

--- a/pkg/cryptoauthlib/patches/0002-add-defines-and-functions-for-riot-usage.patch
+++ b/pkg/cryptoauthlib/patches/0002-add-defines-and-functions-for-riot-usage.patch
@@ -1,0 +1,65 @@
+From ee9792298bffa657e016d64790a4489ad1ead80f Mon Sep 17 00:00:00 2001
+From: Lena Boeckmann <einhornhool@mobi31.inet.haw-hamburg.de>
+Date: Tue, 7 Jan 2020 14:37:10 +0100
+Subject: [PATCH 2/2] add defines and functions for riot usage
+
+---
+ test/cmd-processor.c | 15 ++++++++++++++-
+ test/cmd-processor.h |  1 +
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/test/cmd-processor.c b/test/cmd-processor.c
+index 2be06a8..c450b2f 100644
+--- a/test/cmd-processor.c
++++ b/test/cmd-processor.c
+@@ -28,7 +28,7 @@
+ // Undefine the Unity FAIL macro so it doesn't conflict with the ASF definition
+ #undef FAIL
+
+-#if !defined(_WIN32) && !defined(__linux__) && !defined(__XC32__) && !defined(__APPLE__) && !defined(ESP32)
++#if !defined(_WIN32) && !defined(__linux__) && !defined(__XC32__) && !defined(__APPLE__) && !defined(ESP32) && !defined(RIOT_APPLICATION)
+ #ifdef ATMEL_START
+ #include "atmel_start.h"
+ #else
+@@ -155,6 +155,15 @@ int main(int argc, char* argv[])
+
+     return exit_code;
+ }
++#elif defined(RIOT_APPLICATION)
++#include <stdio.h>
++#include <stdlib.h>
++#include "cmd-processor.h"
++
++int atca_run_cmd(const char *command)
++{
++    return parse_cmd(command);
++}
+ #else
+ int processCmd(void)
+ {
+@@ -927,6 +936,10 @@ static ATCA_STATUS set_test_config(ATCADeviceType deviceType)
+     gCfg->atcai2c.bus = 1;
+     #endif
+
++    #ifdef MODULE_CRYPTOAUTHLIB_TEST
++    riot_switch_cfg(gCfg);
++    #endif
++
+     return ATCA_SUCCESS;
+ }
+
+diff --git a/test/cmd-processor.h b/test/cmd-processor.h
+index a8af58a..fe51b6a 100644
+--- a/test/cmd-processor.h
++++ b/test/cmd-processor.h
+@@ -52,6 +52,7 @@ typedef struct
+     fp_menu_handler fp_handler;
+ }t_menu_info;
+
++void riot_switch_cfg(ATCAIfaceCfg*);
+
+ int run_tests(int test);
+
+--
+2.23.0
+

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -22,4 +22,8 @@ ifneq (,$(filter auto_init_usbus,$(USEMODULE)))
   DIRS += usb
 endif
 
+ifneq (,$(filter auto_init_security,$(USEMODULE)))
+  DIRS += security
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -619,6 +619,15 @@ void auto_init(void)
     suit_init_conditions();
 #endif /* MODULE_SUIT */
 
+#ifdef MODULE_AUTO_INIT_SECURITY
+
+#ifdef MODULE_CRYPTOAUTHLIB
+    extern void auto_init_atca(void);
+    auto_init_atca();
+#endif  /* MODULE_CRYPTOAUTHLIB */
+
+#endif  /* MODULE_AUTO_INIT_SECURITY */
+
 #ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
 #if !defined(MODULE_SHELL_COMMANDS) || !defined(MODULE_SHELL)
     test_utils_interactive_sync();

--- a/sys/auto_init/security/Makefile
+++ b/sys/auto_init/security/Makefile
@@ -1,0 +1,3 @@
+MODULE = auto_init_security
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/security/auto_init_atca.c
+++ b/sys/auto_init/security/auto_init_atca.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_auto_init
+ * @{
+ * @file
+ * @brief       Initializes cryptoauth devices
+ *
+ * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
+ * @}
+ */
+
+#ifdef MODULE_CRYPTOAUTHLIB
+#include "log.h"
+#include "atca.h"
+#include "atca_params.h"
+
+#define ENABLE_DEBUG                (0)
+#include "debug.h"
+
+#define ATCA_NUMOF (ARRAY_SIZE(atca_params))
+
+void auto_init_atca(void)
+{
+    for (unsigned i = 0; i < ATCA_NUMOF; i++) {
+        if (atcab_init((ATCAIfaceCfg *)&atca_params[i]) != ATCA_SUCCESS) {
+            LOG_ERROR("[auto_init_atca] error initializing cryptoauth device #%u\n", i);
+            continue;
+        }
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif

--- a/tests/pkg_cryptoauthlib_compare_sha256/Makefile
+++ b/tests/pkg_cryptoauthlib_compare_sha256/Makefile
@@ -1,0 +1,11 @@
+include ../Makefile.tests_common
+
+# Test fails to build for these boards fails due to
+# redefinition of define AES_COUNT in library, which
+# is also defined in efm32 header files
+BOARD_BLACKLIST := stk3600 stk3700
+
+USEPKG += cryptoauthlib
+USEMODULE += hashes
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_cryptoauthlib_compare_sha256/main.c
+++ b/tests/pkg_cryptoauthlib_compare_sha256/main.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       This test was written to compare the runtime of the RIOT software
+ *              implementation and the CryptoAuth hardware implementation of SHA-256.
+ *
+ * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "hashes/sha256.h"
+#include "atca.h"
+#include "atca_params.h"
+
+#define SHA256_HASH_SIZE (32)
+
+/**
+ * Function to call RIOT software implementation of SHA-256
+ */
+static int test_riot_sha256(uint8_t *teststring, uint16_t len,
+                            uint8_t *expected,
+                            uint8_t *result)
+{
+    sha256_context_t ctx;
+
+    sha256_init(&ctx);
+    sha256_update(&ctx, (void *)teststring, len);
+    sha256_final(&ctx, result);
+    return memcmp(expected, result, SHA256_HASH_SIZE);
+}
+
+/**
+ * Function to call CryptoAuth hardware implementation of SHA-256
+ */
+static int test_atca_sha(uint8_t *teststring, uint16_t len, uint8_t *expected,
+                         uint8_t *result)
+{
+    atcab_sha_start();
+    atcab_sha_end(result, len, teststring);
+    return memcmp(expected, result, SHA256_HASH_SIZE);
+}
+
+int main(void)
+{
+    uint8_t teststring[] = "chili cheese fries";
+    uint8_t expected[] =
+    { 0x36, 0x46, 0xEF, 0xD6, 0x27, 0x6C, 0x0D, 0xCB, 0x4B, 0x07, 0x73, 0x41,
+      0x88, 0xF4, 0x17, 0xB4, 0x38, 0xAA, 0xCF, 0xC6, 0xAE, 0xEF, 0xFA, 0xBE,
+      0xF3, 0xA8, 0x5D, 0x67, 0x42, 0x0D, 0xFE, 0xE5 };
+
+    uint8_t result[SHA256_HASH_SIZE];                       /* +3 to fit 1 byte length and 2 bytes checksum */
+
+    memset(result, 0, SHA256_HASH_SIZE);                    /* alles in result auf 0 setzen */
+
+    uint16_t test_string_size = (sizeof(teststring) - 1);   /* -1 to ignore \0 */
+
+    if (test_riot_sha256(teststring, test_string_size, expected, result) == 0) {
+        printf("RIOT SHA256: Success\n");
+    }
+    else {
+        printf("RIOT SHA256: Failure.\n");
+    }
+    atca_delay_us(10);
+    memset(result, 0, SHA256_HASH_SIZE);
+
+    if (test_atca_sha(teststring, test_string_size, expected, result) == 0) {
+        printf("ATCA SHA256: Success\n");
+    }
+    else {
+        printf("ATCA SHA256: Failure.\n");
+    }
+
+    return 0;
+}

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile
@@ -1,0 +1,13 @@
+include ../Makefile.tests_common
+
+# Test fails to build for these boards fails due to
+# redefinition of define AES_COUNT in library, which
+# is also defined in board header files
+BOARD_BLACKLIST := stk3600 stk3700
+
+# due to memory constrains we ignore the cert test
+CFLAGS += -DDO_NOT_TEST_CERT
+USEPKG += cryptoauthlib
+USEMODULE += cryptoauthlib_test
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
@@ -1,0 +1,20 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    sam10-xpro \
+    saml11-xpro \
+    blackpill \
+    bluepill \
+    i-nucleo-lrwan1 \
+    nucleo-f302r8 \
+    nucleo-l031k6 \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega1284p \
+    atmega328p \
+    derfmega128 \
+    mega-xplained \
+    microduino-corerf \
+    saml10-xpro \
+    waspmote-pro

--- a/tests/pkg_cryptoauthlib_internal-tests/main.c
+++ b/tests/pkg_cryptoauthlib_internal-tests/main.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Calls some of the unit tests from the CryptoAuth Library
+ *
+ * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "cryptoauthlib_test.h"
+
+int main(void)
+{
+    /* Set device to ATECC508A */
+    atca_run_cmd("508");
+
+    atca_run_cmd("unit");
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This contribution adds the official library for Microchip CryptoAuth devices as a package. This is basically a driver included as a package, so this also adds a new auto_init function for ATCA devices and, since it didn't fit into any of the other auto init modules, a new module called "security".

I did my best to comply with the Riot coding standards for drivers, so there's an atca_params.h and an atca.h file for device descriptors and default configuration parameters. These can be found in the pkg/cryptoauthlib folder. Instead of declaring our own device descriptor, this implementation uses the already existing configuration structure declared and used by the library. They get stored in the atca_params array. 
There's a wrapper in pkg/cryptoauthlib/contrib, which implements most of the HAL functions. Currently the functions hal_i2c_discover_devices and hal_i2c_discover_buses are unimplemented, as well as hal_i2c_post_init (I don't think they're needed – this assumption may need to be corrected in the future after more testing). 

The library provides a basic interface. It implements high level functions for the use of standard configurations and defaults. It is easy to use and recommended for understanding the basic usage and operational flow of the library.
Further information on using the basic api can be found here: https://microchiptech.github.io/cryptoauthlib/a11680.html

### Testing procedure

There's a folder test/pkg_cryptoauthlib_compare_sha256 in which I use the library to compare the runtime of the Riot software implementation and the CryptoAuth hardware implementation of SHA-256. 
Currently the software implementation is much faster. The reason for this is my implementation of the hal_i2c_wake function in the wrapper, which gets called in the beginning of every command execution of the library. It drives the SDA pin low for 30 us, reinitializes the bus and then waits 1500 us before proceeding the operation. Another possible way to wake up the device described in the reference manual is writing to the address 0x00 at a very low baud rate. Since I couldn't find a way in Riot to set the baud rate that low I choose the first solution. Since this is obviously not ideal, I'm working on fixing that in the near future.

Time measurements for SHA-256 calculation:
Riot software implementation: 27 ms
ATECC508A: 51 ms 
Wake function: 19 ms, gets called twice
Overhead due to wake function: 38 ms

The library provides unit tests, which I'm also trying to run with Riot, instead of writing them myself. Currently the way to achieve this is to write a conditional into the package's makefile that checks whether the module "cryptoauthlib_test" is defined. If so, the package gets built and all sourcefiles of its internal test folder are copied to one place and built for the testing application. 
A first example of doing this can be found in test/pkg_cryptoauthlib_internal_tests. This application builds the tests of the library and runs some of them. Information on using the tests can be found in their readme file and documentation: https://github.com/MicrochipTech/cryptoauthlib
The goal is to add the library's unit tests to Riot's tests/unittests folder and be able to run them from there.

The main function of the cryptoauthlib unit tests (can be found in the binary folder after building the package: cryptoauthlib/tests/cmd_processor.c) implements a circular buffer to receive commands for testing. I haven't found out how to correctly use it, yet, so I'm using  the following workaround:
Via patch I define a self written function for running commands in the cmd_processor.c file, which I call in test/pkg_cryptoauthlib_internal_tests to run the commands for defining the device and running the unit-tests.
Also the library's unit tests overwrite the device descriptor used by Riot so I had to define another function to change it back, that also gets called in cmd_processor.c.

Until now I have used the library with the ATECC508A on the cryptoauth-xpro extension (with samr21-xpro board) and the saml11-xpro. Some functions can only be tested if the data, config and otp zones of the device are locked. Since locking is permanent and cannot be undone I haven't tested those functions, yet.