### PR TITLE
cpu/cortexm: cleanup cortexm.inc.mk

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -3,20 +3,20 @@ ifeq (,$(CPU_MODEL))
 endif
 
 # Target triple for the build. Use arm-none-eabi if you are unsure.
-export TARGET_ARCH ?= arm-none-eabi
+TARGET_ARCH ?= arm-none-eabi
 
 # define build specific options
 CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)
 
 ifneq (llvm,$(TOOLCHAIN))
-# Clang (observed with v3.7) does not understand  -mno-thumb-interwork, only add if
-# not building with LLVM
-CFLAGS      += -mno-thumb-interwork
+  # Clang (observed with v3.7) does not understand  -mno-thumb-interwork, only add if
+  # not building with LLVM
+  CFLAGS += -mno-thumb-interwork
 
-# work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85606
-ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
-  CFLAGS_CPU += -march=armv6s-m
-endif
+  # work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85606
+  ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
+    CFLAGS_CPU += -march=armv6s-m
+  endif
 endif
 
 CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
@@ -26,22 +26,22 @@ CFLAGS_OPT  ?= -Os
 CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 
 ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
-export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
-export LINKER_SCRIPT ?= $(CPU_MODEL).ld
-export LINKFLAGS += -T$(LINKER_SCRIPT) -Wl,--fatal-warnings
+LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
+LINKER_SCRIPT ?= $(CPU_MODEL).ld
+LINKFLAGS += -T$(LINKER_SCRIPT) -Wl,--fatal-warnings
 
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
-export LINKFLAGS += -Wl,--gc-sections
+LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
+LINKFLAGS += -Wl,--gc-sections
 
 # Tell the build system that the CPU depends on the Cortex-M common files:
-export USEMODULE += cortexm_common
+USEMODULE += cortexm_common
 # Export the peripheral drivers to be linked into the final binary:
-export USEMODULE += periph
+USEMODULE += periph
 # include common periph code
-export USEMODULE += cortexm_common_periph
+USEMODULE += cortexm_common_periph
 
 # all cortex MCU's use newlib as libc
-export USEMODULE += newlib
+USEMODULE += newlib
 
 
 # extract version inside the first parentheses
@@ -73,54 +73,54 @@ CFLAGS += -DCPU_ARCH_$(call uppercase_and_underscore,$(CPU_ARCH))
 
 # set the compiler specific CPU and FPU options
 ifneq (,$(filter $(CPU_ARCH),cortex-m4f cortex-m7))
-    ifneq (,$(filter cortexm_fpu,$(DISABLE_MODULE)))
-        CFLAGS_FPU ?= -mfloat-abi=soft
-    else
-        USEMODULE += cortexm_fpu
-        # clang assumes there is an FPU
-        ifneq (llvm,$(TOOLCHAIN))
-            ifeq ($(CPU_ARCH),cortex-m7)
-                CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
-            else
-                CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
-            endif
-        endif
+  ifneq (,$(filter cortexm_fpu,$(DISABLE_MODULE)))
+    CFLAGS_FPU ?= -mfloat-abi=soft
+  else
+    USEMODULE += cortexm_fpu
+    # clang assumes there is an FPU
+    ifneq (llvm,$(TOOLCHAIN))
+      ifeq ($(CPU_ARCH),cortex-m7)
+        CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
+      else
+        CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
+      endif
     endif
-    ifeq ($(CPU_ARCH),cortex-m4f)
-        export MCPU := cortex-m4
-    else
-        export MCPU ?= $(CPU_ARCH)
-    endif
+  endif
 else
-CFLAGS_FPU ?= -mfloat-abi=soft
-export MCPU ?= $(CPU_ARCH)
+  CFLAGS_FPU ?= -mfloat-abi=soft
+endif
+
+ifeq ($(CPU_ARCH),cortex-m4f)
+  MCPU = cortex-m4
+else
+  MCPU ?= $(CPU_ARCH)
 endif
 
 # CMSIS DSP needs to know about the CPU core
 ifneq (,$(filter cmsis-dsp,$(USEPKG)))
-# definition needed to use cmsis-dsp headers
-ifeq ($(CPU_ARCH),cortex-m0)
-CFLAGS += -DARM_MATH_CM0
-else ifeq ($(CPU_ARCH),cortex-m0plus)
-CFLAGS += -DARM_MATH_CM0PLUS
-else ifeq ($(CPU_ARCH),cortex-m3)
-CFLAGS += -DARM_MATH_CM3
-else ifeq ($(CPU_ARCH),cortex-m4)
-CFLAGS += -DARM_MATH_CM4
-else ifeq ($(CPU_ARCH),cortex-m4f)
-CFLAGS += -DARM_MATH_CM4
-else ifeq ($(CPU_ARCH),cortex-m7)
-CFLAGS += -DARM_MATH_CM7
-else ifeq ($(CPU_ARCH),cortex-m23)
-CFLAGS += -DARM_MATH_CM23
-endif
+  # definition needed to use cmsis-dsp headers
+  ifeq ($(CPU_ARCH),cortex-m0)
+    CFLAGS += -DARM_MATH_CM0
+  else ifeq ($(CPU_ARCH),cortex-m0plus)
+    CFLAGS += -DARM_MATH_CM0PLUS
+  else ifeq ($(CPU_ARCH),cortex-m3)
+    CFLAGS += -DARM_MATH_CM3
+  else ifeq ($(CPU_ARCH),cortex-m4)
+    CFLAGS += -DARM_MATH_CM4
+  else ifeq ($(CPU_ARCH),cortex-m4f)
+    CFLAGS += -DARM_MATH_CM4
+  else ifeq ($(CPU_ARCH),cortex-m7)
+    CFLAGS += -DARM_MATH_CM7
+  else ifeq ($(CPU_ARCH),cortex-m23)
+    CFLAGS += -DARM_MATH_CM23
+  endif
 endif
 
 # Explicitly tell the linker to link the startup code.
 #   Without this the interrupt vectors will not be linked correctly!
 VECTORS_O ?= $(BINDIR)/cpu/vectors.o
 ifeq ($(COMMON_STARTUP),)
-export UNDEF += $(VECTORS_O)
+  UNDEF += $(VECTORS_O)
 endif
 
 # CPU depends on the cortex-m common module, so include it:
@@ -128,6 +128,7 @@ include $(RIOTCPU)/cortexm_common/Makefile.include
 
 # use the nano-specs of Newlib when available
 USEMODULE += newlib_nano
+
 # Avoid overriding the default rule:
 all:
 

--- a/pkg/jerryscript/Makefile.include
+++ b/pkg/jerryscript/Makefile.include
@@ -1,2 +1,6 @@
 INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-core/include
 INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-ext/include
+
+# Ensure MCPU is correctly exported to CMake variables when configuring the
+# Jerrycript build
+$(call target-export-variables,libjerry,MCPU)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up the cortexm.inc.mk file:
- it fixes the Makefile indentation to make it more readable
- it removes the unnecessary use of export
- there's also a small simplification when setting the MCPU variable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock is ok
- Verify a firmware built for an ARM target is unchanged:

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make BOARD=nucleo-l073rz -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
   8356	    120	   2568	  11044	   2b24	/work/riot/RIOT/examples/hello-world/bin/nucleo-l073rz/hello-world.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make BOARD=nucleo-l073rz -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
   8356	    120	   2568	  11044	   2b24	/work/riot/RIOT/examples/hello-world/bin/nucleo-l073rz/hello-world.elf
```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Related to #10850 (for LINKFLAGS)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
