### PR TITLE
make: remove use of export with LINKFLAGS variable

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -48,25 +48,25 @@ CXXUWFLAGS +=
 CXXEXFLAGS +=
 
 ifeq ($(OS_ARCH),x86_64)
-  export LINKFLAGS += -m32
+  LINKFLAGS += -m32
 endif
 ifeq ($(OS),FreeBSD)
   ifeq ($(OS_ARCH),amd64)
-    export LINKFLAGS += -m32 -DCOMPAT_32BIT -L/usr/lib32 -B/usr/lib32
+    LINKFLAGS += -m32 -DCOMPAT_32BIT -L/usr/lib32 -B/usr/lib32
   endif
-  export LINKFLAGS += -L $(BINDIR)
+  LINKFLAGS += -L $(BINDIR)
 else
-  export LINKFLAGS += -ldl
+  LINKFLAGS += -ldl
 endif
 
 # clean up unused functions
 CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(OS),Darwin)
-  export LINKFLAGS += -Wl,-dead_strip
+  LINKFLAGS += -Wl,-dead_strip
 else
-  export LINKFLAGS += -Wl,--gc-sections
+  LINKFLAGS += -Wl,--gc-sections
 endif
-export LINKFLAGS += -ffunction-sections
+LINKFLAGS += -ffunction-sections
 
 # set the tap interface for term/valgrind
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
@@ -96,10 +96,10 @@ all-valgrind: export NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
 all-debug: CFLAGS += -g3
 all-cachegrind: CFLAGS += -g3
 all-gprof: CFLAGS += -pg
-all-gprof: export LINKFLAGS += -pg
+all-gprof: LINKFLAGS += -pg
 all-asan: CFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
 all-asan: CFLAGS += -DNATIVE_IN_CALLOC
-all-asan: export LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
+all-asan: LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
 
 INCLUDES += $(NATIVEINCLUDES)
 

--- a/cpu/arm7_common/Makefile.include
+++ b/cpu/arm7_common/Makefile.include
@@ -19,8 +19,8 @@ CFLAGS_OPT  ?= -Os
 
 CFLAGS      += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 ASFLAGS     += $(CFLAGS_CPU) $(CFLAGS_DBG)
-export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU).ld
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
-export LINKFLAGS += -Wl,--gc-sections
+LINKFLAGS   += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU).ld
+LINKFLAGS   += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
+LINKFLAGS   += -Wl,--gc-sections
 
 export UNDEF += $(BINDIR)/cpu/startup.o

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -9,7 +9,7 @@ export USEMODULE += periph_timer
 
 ifeq ($(USE_UHI_SYSCALLS),1)
   #Use UHI to handle syscalls
-  export LINKFLAGS += -luhi
+  LINKFLAGS += -luhi
   export USEMODULE += newlib_syscalls_mips_uhi
   CFLAGS += -DHAVE_HEAP_STATS
 else

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -6,8 +6,8 @@ include $(RIOTMAKE)/arch/mips.inc.mk
 # define build specific options
 CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM
 
-export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
-export LINKFLAGS += -Tpic32mx512_12_128_uhi.ld
+LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
+LINKFLAGS += -Tpic32mx512_12_128_uhi.ld
 
 # the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
 OBJCOPY = objcopy #use system objcopy as toolchain one is broken.

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -7,8 +7,8 @@ include $(RIOTMAKE)/arch/mips.inc.mk
 CFLAGS += -march=m5101 -mmicromips -DSKIP_COPY_TO_RAM
 CFLAGS += -DMIPS_MICROMIPS
 
-export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
-export LINKFLAGS += -Tpic32mz2048_uhi.ld
+LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
+LINKFLAGS += -Tpic32mz2048_uhi.ld
 
 # the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
 OBJCOPY = objcopy #use system objcopy as toolchain one is broken.

--- a/cpu/sam_common/Makefile.include
+++ b/cpu/sam_common/Makefile.include
@@ -5,6 +5,6 @@ CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 CFLAGS += -DDONT_USE_CMSIS_INIT
 
 # for the sam[drl] CPUs we hold all linkerscripts in the sam0 common folder
-export LINKFLAGS += -L$(RIOTCPU)/sam_common/ldscripts
+LINKFLAGS += -L$(RIOTCPU)/sam_common/ldscripts
 
 INCLUDES += -I$(RIOTCPU)/sam_common/include

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -7,7 +7,7 @@ USEMODULE += pm_layered
 USEMODULE += stm32_common stm32_common_periph
 
 # For stm32 cpu's we use the stm32_common.ld linker script
-export LINKFLAGS += -L$(RIOTCPU)/stm32_common/ldscripts
+LINKFLAGS += -L$(RIOTCPU)/stm32_common/ldscripts
 LINKER_SCRIPT ?= stm32_common.ld
 
 INCLUDES += -I$(RIOTCPU)/stm32_common/include

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -45,7 +45,7 @@ ifeq ($(USE_HARD_FLOAT),1)
 else
     #hard-float is the default so we must set soft-float
     CFLAGS += -msoft-float
-    export LINKFLAGS += -msoft-float
+    LINKFLAGS += -msoft-float
 endif
 
 ifeq ($(USE_DSP),1)
@@ -60,10 +60,10 @@ endif
 
 ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_OPT) $(CFLAGS_DBG)
 
-export LINKFLAGS += $(MIPS_HAL_LDFLAGS)
-export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT)
-export LINKFLAGS += -Wl,--gc-sections
+LINKFLAGS += $(MIPS_HAL_LDFLAGS)
+LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
+LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT)
+LINKFLAGS += -Wl,--gc-sections
 
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation

--- a/makefiles/arch/msp430.inc.mk
+++ b/makefiles/arch/msp430.inc.mk
@@ -13,7 +13,7 @@ CFLAGS_OPT  ?= -Os
 CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 # export linker flags
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
+LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
 
 OPTIONAL_CFLAGS_BLACKLIST += -fdiagnostics-color
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -7,11 +7,11 @@ CFLAGS_LINK  = -nostartfiles -ffunction-sections -fdata-sections
 CFLAGS_DBG  ?= -g3
 CFLAGS_OPT  ?= -Os
 
-export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
-export LINKER_SCRIPT ?= $(CPU_MODEL).ld
-export LINKFLAGS += -T$(LINKER_SCRIPT)
+LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
+LINKER_SCRIPT ?= $(CPU_MODEL).ld
+LINKFLAGS += -T$(LINKER_SCRIPT)
 
 CFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) $(CFLAGS_LINK)
 ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 # export linker flags
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
+LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -14,10 +14,10 @@ ifneq (,$(filter newlib_gnu_source,$(USEMODULE)))
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
-  export LINKFLAGS += -specs=nano.specs
+  LINKFLAGS += -specs=nano.specs
 endif
 
-export LINKFLAGS += -lc
+LINKFLAGS += -lc
 
 # Note on `realpath` vs `abspath`
 #

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -82,13 +82,13 @@ endif
 
 ifneq (,$(filter printf_float,$(USEMODULE)))
   ifneq (,$(filter newlib_nano,$(USEMODULE)))
-    export LINKFLAGS += -u _printf_float
+    LINKFLAGS += -u _printf_float
   endif
 endif
 
 ifneq (,$(filter scanf_float,$(USEMODULE)))
   ifneq (,$(filter newlib_nano,$(USEMODULE)))
-    export LINKFLAGS += -u _scanf_float
+    LINKFLAGS += -u _scanf_float
   endif
 endif
 

--- a/tests/pkg_libfixmath_unittests/Makefile
+++ b/tests/pkg_libfixmath_unittests/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += libfixmath-unittests
 
 ifneq (,$(filter native,$(BOARD)))
-  export LINKFLAGS += -lm
+  LINKFLAGS += -lm
 endif
 
 USEMODULE += printf_float


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes the remaining unnecessary uses of export along with the LINKFLAGS variable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Verify that firmwares are unchanged on the related platforms:

**STM32**

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make BOARD=nucleo-l073rz -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
   8356	    120	   2568	  11044	   2b24	/work/riot/RIOT/examples/hello-world/bin/nucleo-l073rz/hello-world.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make BOARD=nucleo-l073rz -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
   8356	    120	   2568	  11044	   2b24	/work/riot/RIOT/examples/hello-world/bin/nucleo-l073rz/hello-world.elf
```

</details>

**SAM**

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make BOARD=samr21-xpro -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
   8488	    120	   2560	  11168	   2ba0	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make BOARD=samr21-xpro -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
   8488	    120	   2560	  11168	   2ba0	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
```

</details>

**RISCV**

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make BOARD=hifive1b -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  10580	    112	   2408	  13100	   332c	/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make BOARD=hifive1b -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  10580	    112	   2408	  13100	   332c	/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf
```

</details>

**MIPS**

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make BOARD=pic32-clicker -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  71284	   2412	   6008	  79704	  13758	/work/riot/RIOT/examples/hello-world/bin/pic32-clicker/hello-world.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make BOARD=pic32-clicker -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  71284	   2412	   6008	  79704	  13758	/work/riot/RIOT/examples/hello-world/bin/pic32-clicker/hello-world.elf

```

</details>

**MSP430**

<details><summary>This PR:</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=z1 -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
   4358	      6	    984	   5348	   14e4	/data/riotbuild/riotbase/examples/hello-world/bin/z1/hello-world.elf
```

</details>

<details><summary>master:</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=z1 -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
   4358	      6	    984	   5348	   14e4	/data/riotbuild/riotbase/examples/hello-world/bin/z1/hello-world.elf
```

</details>

**native**

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make BOARD=native -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  24784	    576	  47728	  73088	  11d80	/work/riot/RIOT/examples/hello-world/bin/native/hello-world.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make BOARD=native -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  24784	    576	  47728	  73088	  11d80	/work/riot/RIOT/examples/hello-world/bin/native/hello-world.elf
```

</details>

**ARMv7**

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make BOARD=msba2 -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  11416	    124	   6936	  18476	   482c	/work/riot/RIOT/examples/hello-world/bin/msba2/hello-world.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make BOARD=msba2 -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  11416	    124	   6936	  18476	   482c	/work/riot/RIOT/examples/hello-world/bin/msba2/hello-world.elf
```

</details>

- Verify that libfixmath-unittests is unchanged (only on native here):

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make BOARD=native -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  87200	    608	  47728	 135536	  21170	/work/riot/RIOT/tests/pkg_libfixmath_unittests/bin/native/tests_pkg_libfixmath_unittests.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make BOARD=native -C examples/hello-world clean all
[...]
   text	   data	    bss	    dec	    hex	filename
  87200	    608	  47728	 135536	  21170	/work/riot/RIOT/tests/pkg_libfixmath_unittests/bin/native/tests_pkg_libfixmath_unittests.elf
```

</details>

- Verify that printf-float unittest is unchanged (only on native here):

<details><summary>This PR:</summary>

```
$ RIOT_VERSION=test make -C tests/unittests/ tests-printf_float
[...]
   text	   data	    bss	    dec	    hex	filename
  28300	    652	  47752	  76704	  12ba0	/work/riot/RIOT/tests/unittests/bin/native/tests_unittests.elf
```

</details>

<details><summary>master:</summary>

```
$ RIOT_VERSION=test make -C tests/unittests/ tests-printf_float
[...]
   text	   data	    bss	    dec	    hex	filename
  28300	    652	  47752	  76704	  12ba0	/work/riot/RIOT/tests/unittests/bin/native/tests_unittests.elf
```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Ticks the LINKFLAGS item in #10850

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
