### PR TITLE
sys/puf_sram: extend documentation

### DIFF
--- a/sys/include/puf_sram.h
+++ b/sys/include/puf_sram.h
@@ -7,11 +7,44 @@
  */
 
 /**
- * @defgroup    sys_puf_sram SRAM PUF
- * @ingroup     sys
+ * @defgroup     sys_puf_sram SRAM PUF
+ * @ingroup      sys
+ * @brief        SRAM based physically unclonable function (PUF)
+ * @experimental This API is experimental and in an early state - expect
+ *               changes!
+ * @warning      The SRAM based seed mechanism it not cryptographically secure in its current
+                 state.
  *
- * @brief       SRAM based physically unclonable function (PUF)
- * @experimental
+ * # About
+ *
+ * Transistor variations of SRAM memory cells lead to different states
+ * after device power-on. The startup state of multiple memory
+ * blocks form a device-unique pattern plus additional noise ("weak PUF").
+ * The noise is used to generate random numbers for PRNG seeding.
+ *
+ * # Preliminaries
+ *
+ * High entropy numbers can only be generated when the device starts from power-off (including
+ * low-power modes that turn of the RAM partly)
+ * and before the memory has been used. That's why the SRAM PUF procedure is implemented
+ * even before kernel initialization.
+ * Memory properties are hardware specific and can depend on environmental conditions.
+ * Thus, they should be evaluated for each individual deployment. A basic
+ * testing tool is provided in /RIOT/tests/puf_sram.
+ *
+ * # Soft-reset detection
+ *
+ * In order to detect a software reboot without preceding power-off phase, a soft-reset
+ * detection mechanism writes a marker memory @p PUF_SRAM_MARKER into SRAM. If the marker
+ * is still present after a restart, a soft-reset is expected and the PUF procedure
+ * is skipped.
+ *
+ * # Random Seed Generation
+ *
+ * Uninitialized memory pattern are compressed by the lightweight DEK hash function
+ * to generate a high entropy 32-bit integer which can be used to seed a PRNG. This hash
+ * function is not cryptographically secure and as such, adversaries might be able to
+ * track parts of the initial SRAM response by analyzing PRNG sequences.
  *
  * @{
  * @file


### PR DESCRIPTION
### Contribution description
This PR extends the documentation for the SRAM based PRNG seed generator. 

### Testing procedure
`make doc`

### Issues/PRs references
#12991