### PR TITLE
make/cortexm: fix -mfpu flag value for CortexM7

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -80,7 +80,7 @@ ifneq (,$(filter $(CPU_ARCH),cortex-m4f cortex-m7))
         # clang assumes there is an FPU
         ifneq (llvm,$(TOOLCHAIN))
             ifeq ($(CPU_ARCH),cortex-m7)
-                CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-d16
+                CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
             else
                 CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
             endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes an issue when using FPU on Cortex-M7 CPU by using a different flag to use single precision instead of double precision (this is also the case with M4).

See https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html and search for `-mfpu=` to find available options.

From my tests (on nucleo-f746zg), this PR fixes #12286.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `compile_and_test_for_board.py` on a F7 board:

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . nucleo-f746zg --jobs=4 --with-test-only
```

With this PR, you get the following behavior with tests that failed in #12286:

<details>

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . nucleo-f746zg --jobs=4 --with-test-only --applications="tests/bloom_bytes tests/float tests/libfixmath_unittests tests/pkg_cn-cbor tests/pkg_lora-serialization tests/pkg_ubasic tests/rng tests/unittests"
INFO:nucleo-f746zg:Saving toolchain
INFO:nucleo-f746zg.tests/bloom_bytes:Board supported: True
INFO:nucleo-f746zg.tests/bloom_bytes:Board has enough memory: True
INFO:nucleo-f746zg.tests/bloom_bytes:Application has test: True
INFO:nucleo-f746zg.tests/bloom_bytes:Run compilation
INFO:nucleo-f746zg.tests/bloom_bytes:Run test
INFO:nucleo-f746zg.tests/bloom_bytes:Run test.flash
INFO:nucleo-f746zg.tests/bloom_bytes:Success
INFO:nucleo-f746zg.tests/float:Board supported: True
INFO:nucleo-f746zg.tests/float:Board has enough memory: True
INFO:nucleo-f746zg.tests/float:Application has test: True
INFO:nucleo-f746zg.tests/float:Run compilation
INFO:nucleo-f746zg.tests/float:Run test
INFO:nucleo-f746zg.tests/float:Run test.flash
INFO:nucleo-f746zg.tests/float:Success
INFO:nucleo-f746zg.tests/pkg_cn-cbor:Board supported: True
INFO:nucleo-f746zg.tests/pkg_cn-cbor:Board has enough memory: True
INFO:nucleo-f746zg.tests/pkg_cn-cbor:Application has test: True
INFO:nucleo-f746zg.tests/pkg_cn-cbor:Run compilation
INFO:nucleo-f746zg.tests/pkg_cn-cbor:Run test
INFO:nucleo-f746zg.tests/pkg_cn-cbor:Run test.flash
INFO:nucleo-f746zg.tests/pkg_cn-cbor:Success
INFO:nucleo-f746zg.tests/pkg_lora-serialization:Board supported: True
INFO:nucleo-f746zg.tests/pkg_lora-serialization:Board has enough memory: True
INFO:nucleo-f746zg.tests/pkg_lora-serialization:Application has test: True
INFO:nucleo-f746zg.tests/pkg_lora-serialization:Run compilation
INFO:nucleo-f746zg.tests/pkg_lora-serialization:Run test
INFO:nucleo-f746zg.tests/pkg_lora-serialization:Run test.flash
INFO:nucleo-f746zg.tests/pkg_lora-serialization:Success
INFO:nucleo-f746zg.tests/pkg_ubasic:Board supported: True
INFO:nucleo-f746zg.tests/pkg_ubasic:Board has enough memory: True
INFO:nucleo-f746zg.tests/pkg_ubasic:Application has test: True
INFO:nucleo-f746zg.tests/pkg_ubasic:Run compilation
INFO:nucleo-f746zg.tests/pkg_ubasic:Run test
INFO:nucleo-f746zg.tests/pkg_ubasic:Run test.flash
INFO:nucleo-f746zg.tests/pkg_ubasic:Success
INFO:nucleo-f746zg.tests/rng:Board supported: True
INFO:nucleo-f746zg.tests/rng:Board has enough memory: True
INFO:nucleo-f746zg.tests/rng:Application has test: True
INFO:nucleo-f746zg.tests/rng:Run compilation
INFO:nucleo-f746zg.tests/rng:Run test
INFO:nucleo-f746zg.tests/rng:Run test.flash
INFO:nucleo-f746zg.tests/rng:Success
INFO:nucleo-f746zg.tests/unittests:Board supported: True
INFO:nucleo-f746zg.tests/unittests:Board has enough memory: True
INFO:nucleo-f746zg.tests/unittests:Application has test: True
INFO:nucleo-f746zg.tests/unittests:Run compilation
INFO:nucleo-f746zg.tests/unittests:Run test
INFO:nucleo-f746zg.tests/unittests:Run test.flash
INFO:nucleo-f746zg.tests/unittests:Success
INFO:nucleo-f746zg:Tests successful
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #12286 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
