### PR TITLE
nanocoap: add coap_opt_add_uquery2() with parameter key value length

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -976,6 +976,9 @@ ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val
 /**
  * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
  *
+ * @note Use this only for null-terminated string. See @ref coap_opt_add_uquery2()
+ *       for non null-terminated string.
+ *
  * @param[in,out] pkt         The package that is being build
  * @param[in]     key         Key to add to the query string
  * @param[in]     val         Value to assign to @p key (may be NULL)
@@ -986,6 +989,24 @@ ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val
  * @return  -1 on error
  */
 ssize_t coap_opt_add_uquery(coap_pkt_t *pkt, const char *key, const char *val);
+
+/**
+ * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
+ *
+ *
+ * @param[in,out] pkt         The package that is being build
+ * @param[in]     key         Key to add to the query string
+ * @param[in]     key_len     Length of @p key
+ * @param[in]     val         Value to assign to @p key (may be NULL)
+ * @param[in]     val_len     Length of @p val. 0 if @p val is NULL
+ *
+ * @pre     ((pkt != NULL) && (key != NULL) && (key_len > 0))
+ *
+ * @return  overall length of new query string
+ * @return  -1 on error
+ */
+ssize_t coap_opt_add_uquery2(coap_pkt_t *pkt, const char *key, size_t key_len,
+                             const char *val, size_t val_len);
 
 /**
  * @brief   Encode the given string as option(s) into pkt


### PR DESCRIPTION
### Contribution description

This PR introduces a variant of the function `coap_opt_add_uquery()` to nanocoap which also accepts requires value length and key length. The original function assumes the key and value are null-terminated, which may not be the case if the values are located in the same buffer, separated by a separator as discussed in https://github.com/RIOT-OS/RIOT/pull/10222#discussion_r358257934.

### Testing procedure

Run the nanocoap unittests from RIOT root: `make -C tests/unittests tests-nanocoap make all term`

It should not affect existing usages of `coap_opt_add_uquery()`.