### PR TITLE
makefiles/kconfig: Change autoconf.h comment style

### DIFF
--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -18,7 +18,7 @@ CFLAGS += -include '$(KCONFIG_GENERATED_AUTOCONF_HEADER_C)'
 
 # Header for the generated header file
 define KCONFIG_AUTOHEADER_HEADER
-/* RIOT Configuration File */
+$(if $(filter MINGW% CYGWIN% MSYS%,$(OS)),/)/* RIOT Configuration File */
 
 endef
 export KCONFIG_AUTOHEADER_HEADER


### PR DESCRIPTION
### Contribution description
In Windows setups using MSYS, environment variables which start with a slash get the 'root path' added. This changes the content of KCONFIG_AUTOHEADER_HEADER to use single-line comment. That way the first slash is escaped.

**Note**: There are 3 slashes as the first one is removed when executed on Windows.

### Testing procedure
Build some application and check the generated header file:
```
make all -C examples/hello-world/
cat examples/hello-world/bin/native/generated/autoconf.h
```
The build should succeed. On Linux you will see the comment starting with 3 slashes, on Windows with 2.

### Issues/PRs references
Fixes the issue [reported](https://github.com/RIOT-OS/RIOT/pull/12934#issuecomment-567268862) in #12934.
