### PR TITLE
tests: New test for xtimer_now with interrupts disabled

### DIFF
--- a/tests/xtimer_now_irq/Makefile
+++ b/tests/xtimer_now_irq/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+TEST_ON_CI_BLACKLIST += all
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_now_irq/README.md
+++ b/tests/xtimer_now_irq/README.md
@@ -1,0 +1,8 @@
+# README for xtimer_now_irq test
+
+This test checks, if the timer returns the correct time (xtimer_now_usec() is called), when interrupts are disabled. Specifically tested is if the time is correct after a low-level timer overflow.
+
+When the returned value is incorrect the test will print: "ERROR: wrong time with interrupts disabled".
+
+This test must be run over at least one full timer period. Meaning the test only finishes in reasonable short time on platforms with small timers up to 24 bit.
+This test does not work for 32 bit timers.

--- a/tests/xtimer_now_irq/main.c
+++ b/tests/xtimer_now_irq/main.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin,
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       testing xtimer_now_usec function with irq disabled
+ *
+ *
+ * @author      Julian Holzwarth <julian.holzwarth@fu-berlin.de>
+ *
+ */
+
+#include <stdio.h>
+#include "xtimer.h"
+#include "irq.h"
+
+#define TEST_COUNT 4
+
+int main(void)
+{
+    puts("xtimer_now_irq test application.\n");
+
+    uint8_t count = TEST_COUNT;
+    while (count) {
+        unsigned int state = irq_disable();
+        uint32_t t1 = xtimer_now_usec();
+        xtimer_spin(xtimer_ticks((uint32_t)(~XTIMER_MASK) / 2));
+        uint32_t t2 = xtimer_now_usec();
+        irq_restore(state);
+        if (t2 < t1) {
+            puts("ERROR: wrong time with interrupts disabled");
+            return -1;
+        }
+        puts("OK");
+        count --;
+    }
+    puts("SUCCESS");
+    return 0;
+}

--- a/tests/xtimer_now_irq/tests/01-run.py
+++ b/tests/xtimer_now_irq/tests/01-run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2020 Freie Universität Berlin,
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Julian Holzwarth <julian.holzwarth@fu-berlin.de>
+
+import sys
+from testrunner import run
+
+TIMEOUT = 20
+
+
+def testfunc(child):
+    for _ in range(4):
+        child.expect_exact("OK", timeout=TIMEOUT)
+    child.expect_exact("SUCCESS")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This is a new test for xtimer. It tests if xtimer now (`xtimer_now_usec`) returns the correct value when interrupts are disabled.

This test is for: #9530 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`BOARD=* make -C tests/xtimer_now_irq/ flash term` replace * with board
If it returns an Error it is not correct.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#9530 
