### PR TITLE
drivers/dose: Optional sense pin

### DIFF
--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -115,10 +115,10 @@ static dose_signal_t state_transit_recv(dose_t *ctx, dose_signal_t signal)
     if (signal == DOSE_SIGNAL_UART) {
         /* We received a new octet */
         int esc = (ctx->flags & DOSE_FLAG_ESC_RECEIVED);
-        if (!esc && ctx->uart_octet == DOSE_OCTECT_ESC) {
+        if (!esc && ctx->uart_octet == DOSE_OCTET_ESC) {
             SETBIT(ctx->flags, DOSE_FLAG_ESC_RECEIVED);
         }
-        else if (!esc && ctx->uart_octet == DOSE_OCTECT_END) {
+        else if (!esc && ctx->uart_octet == DOSE_OCTET_END) {
             SETBIT(ctx->flags, DOSE_FLAG_END_RECEIVED);
             rc = DOSE_SIGNAL_END;
         }
@@ -374,8 +374,8 @@ static int send_data_octet(dose_t *ctx, uint8_t c)
     int rc;
 
     /* Escape special octets */
-    if (c == DOSE_OCTECT_ESC || c == DOSE_OCTECT_END) {
-        rc = send_octet(ctx, DOSE_OCTECT_ESC);
+    if (c == DOSE_OCTET_ESC || c == DOSE_OCTET_END) {
+        rc = send_octet(ctx, DOSE_OCTET_ESC);
         if (rc) {
             return rc;
         }
@@ -432,7 +432,7 @@ send:
     }
 
     /* Send END octet */
-    if (send_octet(ctx, DOSE_OCTECT_END)) {
+    if (send_octet(ctx, DOSE_OCTET_END)) {
         goto collision;
     }
 

--- a/drivers/dose/include/dose_params.h
+++ b/drivers/dose/include/dose_params.h
@@ -36,7 +36,7 @@ extern "C" {
 #define DOSE_PARAM_BAUDRATE     (115200)
 #endif
 #ifndef DOSE_PARAM_SENSE_PIN
-#define DOSE_PARAM_SENSE_PIN    (GPIO_PIN(0, 0))
+#define DOSE_PARAM_SENSE_PIN    (GPIO_UNDEF)
 #endif
 
 #ifndef DOSE_PARAMS

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -71,8 +71,8 @@ extern "C" {
  * @name    Escape octet definitions
  * @{
  */
-#define DOSE_OCTECT_END          (0xFF)     /**< Magic octet indicating the end of frame */
-#define DOSE_OCTECT_ESC          (0xFE)     /**< Magic octet escaping 0xFF in byte stream */
+#define DOSE_OCTET_END  (0xFF)     /**< Magic octet indicating the end of frame */
+#define DOSE_OCTET_ESC  (0xFE)     /**< Magic octet escaping 0xFF in byte stream */
 /** @} */
 
 /**

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -17,7 +17,7 @@
  * This driver enables RIOT nodes to communicate by Ethernet over a serial bus.
  * This enables them to interact in an easy and cheap manner using a single
  * bus wire with very low hardware requirements: The used microcontrollers just
- * need to feature at least one UART and one GPIO that is able to raise
+ * need to feature at least one UART and one optional GPIO that is able to raise
  * interrupts.
  *
  * Wiring
@@ -31,8 +31,9 @@
  * you could use an IC such as the SN65HVD233.)
  *
  * Basically, UART TX and RX are connected to respective pins of the
- * transceiver. In addition, the RX pin is also connected to the sense GPIO.
- * It is used to detect bus allocation.
+ * transceiver. In addition, the RX pin can also be connected to the sense GPIO.
+ * In this case, the bus allocation can be detected more precisely and
+ * collisions are less likely.
  *
  * How it works
  * ============


### PR DESCRIPTION
### Contribution description

This PR makes the DOSE (cf. #10710) sense pin optional.

This pin has the purpose of decting the the falling edge of the start bit of the first octet. Thus, the bus allocation can be detected quickly.

If the sense pin is not connected, we have to wait for the complete reception of the first octet before any interrupt is raised. Bus allocation is detected after the first octet being received.

All in all, omitting the sense pin raises the probability of bus collisions.

### Testing procedure

Set `DOSE_PARAM_SENSE_PIN` to `GPIO_UNDEF`. The driver should still be able to send and receive Ethernet frames.

### Issues/PRs references

Follow-up of #10710