### PR TITLE
drivers/dose: add setter for MAC address

### DIFF
--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -487,6 +487,12 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t len)
     dose_t *ctx = (dose_t *) dev;
 
     switch (opt) {
+        case NETOPT_ADDRESS:
+            if (len < ETHERNET_ADDR_LEN) {
+                return -EINVAL;
+            }
+            memcpy(ctx->mac_addr.uint8, value, ETHERNET_ADDR_LEN);
+            return ETHERNET_ADDR_LEN;
         case NETOPT_PROMISCUOUSMODE:
             if (len < sizeof(netopt_enable_t)) {
                 return -EINVAL;


### PR DESCRIPTION
### Contribution description

This PR enhances the DOSE driver to make the interface's MAC address changeable.

### Testing procedure

Tested with `examples/gnrc_networking`:

```
> ifconfig
2020-01-05 23:05:36,028 #  ifconfig
2020-01-05 23:05:36,028 # Iface  6  HWaddr: 22:ED:CE:A6:52:26 
2020-01-05 23:05:36,073 #           L2-PDU:1500 MTU:1500  HL:64  RTR  
2020-01-05 23:05:36,073 #           RTR_ADV  
2020-01-05 23:05:36,073 #           Source address length: 6
2020-01-05 23:05:36,074 #           Link type: wired
2020-01-05 23:05:36,074 #           inet6 addr: fe80::20ed:ceff:fea6:5226  scope: link  VAL
2020-01-05 23:05:36,074 #           inet6 group: ff02::2
2020-01-05 23:05:36,075 #           inet6 group: ff02::1
2020-01-05 23:05:36,075 #           inet6 group: ff02::1:ffa6:5226
2020-01-05 23:05:36,075 #           inet6 group: ff02::1a
2020-01-05 23:05:36,075 #           
2020-01-05 23:05:36,076 #           Statistics for Layer 2
2020-01-05 23:05:36,076 #             RX packets 10  bytes 724
2020-01-05 23:05:36,076 #             TX packets 9 (Multicast: 7)  bytes 682
2020-01-05 23:05:36,077 #             TX succeeded 9 errors 0
2020-01-05 23:05:36,099 #           Statistics for IPv6
2020-01-05 23:05:36,099 #             RX packets 10  bytes 584
2020-01-05 23:05:36,100 #             TX packets 9 (Multicast: 7)  bytes 556
2020-01-05 23:05:36,100 #             TX succeeded 9 errors 0
2020-01-05 23:05:36,100 # 
> ifconfig 6 set addr 22:ED:CE:A6:52:27
2020-01-05 23:05:40,239 #  ifconfig 6 set addr 22:ED:CE:A6:52:27
2020-01-05 23:05:40,240 # success: set (short) address on interface 6 to 22:ED:CE:A6:52:27
> ifconfig
2020-01-05 23:05:44,653 #  ifconfig
2020-01-05 23:05:44,654 # Iface  6  HWaddr: 22:ED:CE:A6:52:27 
2020-01-05 23:05:44,655 #           L2-PDU:1500 MTU:1500  HL:64  RTR  
2020-01-05 23:05:44,655 #           RTR_ADV  
2020-01-05 23:05:44,656 #           Source address length: 6
2020-01-05 23:05:44,656 #           Link type: wired
2020-01-05 23:05:44,657 #           inet6 addr: fe80::20ed:ceff:fea6:5226  scope: link  VAL
2020-01-05 23:05:44,658 #           inet6 group: ff02::2
2020-01-05 23:05:44,658 #           inet6 group: ff02::1
2020-01-05 23:05:44,659 #           inet6 group: ff02::1:ffa6:5226
2020-01-05 23:05:44,659 #           inet6 group: ff02::1a
2020-01-05 23:05:44,660 #           
2020-01-05 23:05:44,660 #           Statistics for Layer 2
2020-01-05 23:05:44,661 #             RX packets 10  bytes 724
2020-01-05 23:05:44,685 #             TX packets 9 (Multicast: 7)  bytes 682
2020-01-05 23:05:44,686 #             TX succeeded 9 errors 0
2020-01-05 23:05:44,686 #           Statistics for IPv6
2020-01-05 23:05:44,687 #             RX packets 10  bytes 584
2020-01-05 23:05:44,688 #             TX packets 9 (Multicast: 7)  bytes 556
2020-01-05 23:05:44,688 #             TX succeeded 9 errors 0
2020-01-05 23:05:44,688 # 
```

### Issues/PRs references

#10710 #13028 
