### PR TITLE
pkg/gecko_sdk: correct SHA-1 of package.

### DIFF
--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=5d699ba8b9a69cfb5ada555cac6db74bb68ae0d2
+PKG_VERSION=06b00b68333ea05db1c78fe6626dcfe005a80cb6
 PKG_LICENSE=Zlib
 
 ifneq ($(CPU),efm32)


### PR DESCRIPTION
### Contribution description
For some reason, the old SHA-1 is dangling and cannot be found when checking out a fresh copy. This PR fixes this issue. `06b00b68333ea05db1c78fe6626dcfe005a80cb6` is the version of [master](https://github.com/basilfx/RIOT-gecko-sdk).

### Testing procedure
An invocation of `make -C tests/cpu_efm32_features` should pass with a clean repository and no `git-cache`.  Otherwise, if Murdock is happy, than this will also work.

### Issues/PRs references
None