### PR TITLE
dist/tools/kconfiglib: remove git-downloaded dependency

### DIFF
--- a/dist/tools/kconfiglib/Makefile
+++ b/dist/tools/kconfiglib/Makefile
@@ -6,7 +6,7 @@ PKG_BUILDDIR=$(CURDIR)/bin
 
 .PHONY: all
 
-all: git-download
+all:
 	cp $(PKG_BUILDDIR)/kconfiglib.py $(PKG_BUILDDIR)/menuconfig.py \
 	   $(PKG_BUILDDIR)/genconfig.py $(PKG_BUILDDIR)/examples/merge_config.py \
 	   .


### PR DESCRIPTION
### Contribution description

While digging through some Makefiles, I found that `dist/tools/kconfiglib/Makefile` uses the `git-downloaded` dependency on the `all` target. Since #11753 removed this from all packages, I believe it also applies to this one.

### Testing procedure
Clean `dist/tools/kconfiglib`, then build any application with `make menuconfig`.

### Issues/PRs references
#11753