### PR TITLE
core/ringbuffer: compensate 'ringbuffer_remove' underflow error

### DIFF
--- a/core/ringbuffer.c
+++ b/core/ringbuffer.c
@@ -121,7 +121,7 @@ unsigned ringbuffer_remove(ringbuffer_t *restrict rb, unsigned n)
         rb->avail -= n;
 
         /* compensate underflow */
-        if (rb->start > rb->size) {
+        if (rb->start >= rb->size) {
             rb->start -= rb->size;
         }
     }

--- a/tests/unittests/tests-core/tests-core-ringbuffer.c
+++ b/tests/unittests/tests-core/tests-core-ringbuffer.c
@@ -131,11 +131,33 @@ static void tests_core_ringbuffer_remove(void)
 
 }
 
+static void tests_core_ringbuffer_remove_underflow(void)
+{
+    char mem[3];
+    ringbuffer_t buf;
+    ringbuffer_init(&buf, mem, sizeof(mem));
+
+    ringbuffer_add_one(&buf, 0);
+    ringbuffer_add_one(&buf, 1);
+
+    ringbuffer_remove(&buf, 2);
+    TEST_ASSERT_EQUAL_INT(1, ringbuffer_empty(&buf));
+
+    ringbuffer_add_one(&buf, 0);
+    ringbuffer_add_one(&buf, 1);
+
+    ringbuffer_remove(&buf,1);
+
+    TEST_ASSERT_EQUAL_INT(1, ringbuffer_get_one(&buf));
+    TEST_ASSERT_EQUAL_INT(1, ringbuffer_empty(&buf));
+}
+
 Test *tests_core_ringbuffer_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(tests_core_ringbuffer),
         new_TestFixture(tests_core_ringbuffer_remove),
+        new_TestFixture(tests_core_ringbuffer_remove_underflow),
     };
 
     EMB_UNIT_TESTCALLER(ringbuffer_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
    when rb->start = rb->size,the array is out of bounds. I've submitted this question before, but the format is substandard.So I resubmitted this request.