### PR TITLE
print_toolchain_versions: print system and make's default shell.

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -51,6 +51,44 @@ get_os_info() {
     printf "%s %s" "$osname" "$osvers"
 }
 
+extract_shell_version() {
+    SHELL_NAME=$"(basename $1)"
+    SHELL_VERSION="$($1 --version 2>/dev/null)"
+    ERR=$?
+    if [ $ERR -ne 0 ] ; then # if it does not like the --version switch, it is probably dash
+        printf "%s" "$1"
+        # we do not say "probably dash" if we are sure it IS dash
+        if [ "$SHELL_NAME" != dash ] ; then
+            printf " (probably dash)"
+        fi
+    else
+        printf "%s" "$(echo "$SHELL_VERSION" | head -n 1)"
+    fi
+}
+
+get_sys_shell() {
+    case "$(uname -s)" in
+        MINGW*)
+            # MINGW has no realpath, but also no (meaningful) symlinks
+            SH_PATH=/bin/sh
+            ;;
+        *)
+            SH_PATH="$(realpath /bin/sh)"
+            ;;
+    esac
+    extract_shell_version "$SH_PATH"
+}
+
+_get_make_shell() {
+    make -sf - 2>/dev/null <<MAKEFILE
+\$(info \$(realpath \$(SHELL)))
+MAKEFILE
+}
+
+get_make_shell() {
+    extract_shell_version "$(_get_make_shell)"
+}
+
 newlib_version() {
     if [ -z "$1" ]; then
         printf "%s" "error"
@@ -75,6 +113,8 @@ printf "%s\n" "Operating System Environment"
 printf "%s\n" "-----------------------------"
 printf "%25s: %s\n" "Operating System" "$(get_os_info)"
 printf "%25s: %s\n" "Kernel" "$(get_kernel_info)"
+printf "%25s: %s\n" "System shell" "$(get_sys_shell)"
+printf "%25s: %s\n" "make's shell" "$(get_make_shell)"
 printf "\n"
 
 printf "%s\n" "Installed compiler toolchains"


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Overtook #10991 to fix conflicts as authors is not available (anymore).

Some systems use dash as system shell, others use bash. The shell used
by make can also be different, and unrelated to the system shell.
Differences in this variable can cause problems when testing PRs and
reporting bugs.

The default shell is important system information that should be reported.



### Testing procedure

run `./dist/tools/ci/print_toolchain_versions.sh` from RIOTBASE on your system - and if you like report the output here.


### Issues/PRs references

- #10991 