### PR TITLE
cpu/fe310: some uart fixes

### DIFF
--- a/cpu/fe310/periph/uart.c
+++ b/cpu/fe310/periph/uart.c
@@ -41,7 +41,9 @@ static inline void _uart_isr(uart_t dev)
 
     /* Intr cleared automatically when data is read */
     while ((data & UART_RXFIFO_EMPTY) != (uint32_t)UART_RXFIFO_EMPTY) {
-        isr_ctx[dev].rx_cb(isr_ctx[dev].arg, (uint8_t)(data & 0xff));
+        if (isr_ctx[dev].rx_cb) {
+            isr_ctx[dev].rx_cb(isr_ctx[dev].arg, (uint8_t)(data & 0xff));
+        }
         data = _REG32(uart_config[dev].addr, UART_REG_RXFIFO);
     }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides two fixes to the fe310 periph/uart implementation:

1. don't call rx_cb if it is not configured
2. drain RX FIFO before enabling RX IRQ

The latter currently prevents tests to run in master.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. should be trivial

For 2., on master, flash any application. Open a terminal. Wait just long enough for the AT commands to finish, then hit enter a couple of times. The board should crash on master and work fine with this PR.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#9530
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
