### PR TITLE
dist/tools/compile_and_test_for_board: pass parser as main arg

### DIFF
--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -627,10 +627,8 @@ PARSER.add_argument(
     help="Parallel building (0 means not limit, like '--jobs')")
 
 
-def main():
+def main(args):
     """For one board, compile all examples and tests and run test on board."""
-    args = PARSER.parse_args()
-
     logger = logging.getLogger(args.board)
     if args.loglevel:
         loglevel = logging.getLevelName(args.loglevel.upper())
@@ -690,4 +688,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    main(PARSER.parse_args())


### PR DESCRIPTION
### Contribution description

This PR passes the parser as an argument to `main` this allows importing `dist/tools/compile_and_test_for_board` `main` from another script.

I'm not sure how much of a use case there is, I need this to modify the script a bit to run tests in a loop for multiple boards, I extended the parser to keep most of the arguments (see https://github.com/fjmolinas/ci-riot-tribe/blob/master/scripts/ci_test_all.py).

### Testing procedure

Script still works and arguments are parsed:

```
BUILD_IN_DOCKER=1 time python dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --with-test-only --applications='tests/xtimer_usleep'
```