### PR TITLE
tests: cleanup tests/lua_loader, tests/pkg_cmsis-dsp Python test scripts

### DIFF
--- a/tests/lua_loader/tests/01-run.py
+++ b/tests/lua_loader/tests/01-run.py
@@ -9,8 +9,8 @@
 # Tell the lua interpreter running in riot to load some modules and print
 # the value of a variable inside that module.
 
-import os
 import sys
+from testrunner import run
 
 MODULE_QUERIES = [
     ("m1", "a", "Quando uma lua"),
@@ -31,6 +31,4 @@ def test(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
-    from testrunner import run
     sys.exit(run(test))

--- a/tests/pkg_cmsis-dsp/tests/01-run.py
+++ b/tests/pkg_cmsis-dsp/tests/01-run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import os
 import sys
+from testrunner import run
 
 
 def testfunc(child):
@@ -11,6 +11,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
-    from testrunner import run
     sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a small cleanup of the tests/lua_loader, tests/pkg_cmsis-dsp applications Python test scripts: instead of modifying the path from the script to import the `run` function of the `testrunner` module, use a global import.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The following commands should succeed:
```
$ make -C tests/lua_loader all test
$ make BOARD=samr21-xpro -C tests/pkg_cmsis-dsp flash test
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
