### PR TITLE
periph/adc: Extended documentation

### DIFF
--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -87,6 +87,10 @@ typedef unsigned int adc_t;
 
 /**
  * @brief   Possible ADC resolution settings
+ *
+ * @details This type has to be provided by the underlying implementation if
+ *          the set of supported resolutions is different. Only resolutions
+ *          actually supported by the board must be defined.
  */
 #ifndef HAVE_ADC_RES_T
 typedef enum {
@@ -104,10 +108,11 @@ typedef enum {
  *
  * The ADC line is initialized in synchronous, blocking mode.
  *
- * @param[in] line          line to initialize
+ * @param[in]   line        line to initialize
  *
- * @return                  0 on success
- * @return                  -1 on invalid ADC line
+ * @retval      0           success
+ * @retval      -1          on invalid ADC line
+ * @retval      <-1         on internal errors
  */
 int adc_init(adc_t line);
 
@@ -119,11 +124,21 @@ int adc_init(adc_t line);
  * at the same time (e.g. from different threads), the one called secondly waits
  * for the first to finish before its conversion starts.
  *
- * @param[in] line          line to sample
- * @param[in] res           resolution to use for conversion
+ * @pre     The line given by @p line must be valid. An @ref assert will blow
+ *          up, if not.
+ * @pre     @ref adc_init has been called for the ADC line given by @p line
+ *          prior to this call.
+ * @pre     The resolution given by @p res is supported. An @ref assert will
+ *          blow up if the resolution is not valid.
+ *
+ * @note    All constants provided by the `enum` in @ref adc_res_t are valid
+ *          resolutions, except for `ADC_RES_NUMOF`, if it is provided.
+ *
+ * @param[in]   line        line to sample
+ * @param[in]   res         resolution to use for conversion
  *
  * @return                  the sampled value on success
- * @return                  -1 if resolution is not applicable
+ * @retval      <0          on internal errors
  */
 int adc_sample(adc_t line, adc_res_t res);
 


### PR DESCRIPTION
### Contribution description

Extended/changed API documentation:
- Add preconditions to `adc_sample()`
- Point out that `adc_res_t` should only provide actually supported resolutions
- Point out that `adc_sample()` should use an `assert()` to verify the line parameter
- Changed error handling of `adc_sample()` on incorrect resolutions: This now should lead to an `assert()` blowing up rather returning `-1`

### Testing procedure

- Check the output of the CI that the documentation is still correctly generated
- Check that the added/changed documentation is reasonable, easy to understand, and grammatically and orthographically correct

### Issues/PRs references

None