### PR TITLE
doc: Update CSS for readable @retval tables

### DIFF
--- a/doc/doxygen/src/css/riot.css
+++ b/doc/doxygen/src/css/riot.css
@@ -516,3 +516,6 @@ dl.todo > dt {
   background-color: #f5f5f5;
   padding: 4px 6px;
 }
+table.retval > tbody > tr > td.paramname {
+  padding-right: 2em;
+}

--- a/doc/doxygen/src/css/riot.less
+++ b/doc/doxygen/src/css/riot.less
@@ -458,3 +458,6 @@ dl.todo > dt {
   background-color: @well-bg;
   padding: 4px 6px;
 }
+table.retval > tbody > tr > td.paramname {
+  padding-right: 2em;
+}


### PR DESCRIPTION
### Contribution description

Currently now margin between the return value and its description are added in return value tables generated with the `@retval` command. This adds a `2em` margin, which is consistent with the margin after parameter names in the parameter table.

### Testing procedure

E.g. the documentation of the [`dht_init()`](http://api.riot-os.org/group__drivers__dht.html#gad4b3e8fd7f2df9101095e9e19217125d) function should be more readable with this.

### Issues/PRs references

Noticed in https://github.com/RIOT-OS/RIOT/pull/13046