### PR TITLE
periph/adc: Change return type of `adc_sample()` to `int32_t`

### DIFF
--- a/cpu/atmega_common/periph/adc.c
+++ b/cpu/atmega_common/periph/adc.c
@@ -99,7 +99,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int sample = 0;
 

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -51,7 +51,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     /* check if adc line valid */
     if (line >= ADC_NUMOF) {

--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -59,7 +59,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     /* resolutions larger than 12 bits are not supported */
     if (res >= ADC_MODE_UNDEF(0)) {

--- a/cpu/esp32/periph/adc.c
+++ b/cpu/esp32/periph/adc.c
@@ -149,7 +149,7 @@ int adc_init(adc_t line)
 }
 
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     CHECK_PARAM_RET (line < ADC_NUMOF, -1)
     CHECK_PARAM_RET (res <= ADC_RES_12BIT, -1)

--- a/cpu/esp8266/periph/adc.c
+++ b/cpu/esp8266/periph/adc.c
@@ -42,7 +42,7 @@ int adc_init(adc_t line)
 }
 
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     CHECK_PARAM_RET (line < ADC_NUMOF, -1)
     CHECK_PARAM_RET (res == ADC_RES_10BIT, -1)

--- a/cpu/kinetis/periph/adc.c
+++ b/cpu/kinetis/periph/adc.c
@@ -207,7 +207,7 @@ int adc_init(adc_t line)
     return res;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/lm4f120/periph/adc.c
+++ b/cpu/lm4f120/periph/adc.c
@@ -100,7 +100,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int value[2];
 

--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -55,7 +55,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int val;
 

--- a/cpu/nrf52/periph/adc.c
+++ b/cpu/nrf52/periph/adc.c
@@ -103,7 +103,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     assert(line < ADC_NUMOF);
 

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -164,7 +164,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     if (line >= ADC_NUMOF) {
         DEBUG("adc: line arg not applicable\n");

--- a/cpu/sam3/periph/adc.c
+++ b/cpu/sam3/periph/adc.c
@@ -68,7 +68,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     assert(line < ADC_NUMOF);
 

--- a/cpu/stm32f0/periph/adc.c
+++ b/cpu/stm32f0/periph/adc.c
@@ -75,7 +75,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line,  adc_res_t res)
+int32_t adc_sample(adc_t line,  adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f1/periph/adc.c
+++ b/cpu/stm32f1/periph/adc.c
@@ -125,7 +125,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f2/periph/adc.c
+++ b/cpu/stm32f2/periph/adc.c
@@ -111,7 +111,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -94,7 +94,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l0/periph/adc.c
+++ b/cpu/stm32l0/periph/adc.c
@@ -123,7 +123,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line,  adc_res_t res)
+int32_t adc_sample(adc_t line,  adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l1/periph/adc.c
+++ b/cpu/stm32l1/periph/adc.c
@@ -152,7 +152,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l4/periph/adc.c
+++ b/cpu/stm32l4/periph/adc.c
@@ -179,7 +179,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -56,6 +56,7 @@
 #define PERIPH_ADC_H
 
 #include <limits.h>
+#include <stdint.h>
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
@@ -125,7 +126,7 @@ int adc_init(adc_t line);
  * @return                  the sampled value on success
  * @return                  -1 if resolution is not applicable
  */
-int adc_sample(adc_t line, adc_res_t res);
+int32_t adc_sample(adc_t line, adc_res_t res);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

Changes the return type of `adc_sample()` to `int32_t`. This allows supporting ADCs with resolution greater than 16 bit on 8 bit and 16 bit platforms.

### Testing procedure

I'd say the CI will do fine confirming that this worked as expected.

### Issues/PRs references

None