### PR TITLE
cpu/uart: create common uart hw fc module

### DIFF
--- a/boards/arduino-mkrwan1300/include/periph_conf.h
+++ b/boards/arduino-mkrwan1300/include/periph_conf.h
@@ -40,7 +40,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,23),  /* ARDUINO_PIN_13, RX Pin */
         .tx_pin   = GPIO_PIN(PB,22),  /* ARDUINO_PIN_14, TX Pin */
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -54,7 +54,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PA,15),
         .tx_pin   = GPIO_PIN(PA,12),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -132,7 +132,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,23),
         .tx_pin   = GPIO_PIN(PB,22),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -146,7 +146,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,11),
         .tx_pin   = GPIO_PIN(PA,10),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/cc1312-launchpad/include/periph_conf.h
+++ b/boards/cc1312-launchpad/include/periph_conf.h
@@ -85,9 +85,10 @@ static const uart_conf_t uart_config[] = {
      .regs = UART0,
      .tx_pin = 3,
      .rx_pin = 2,
-     .rts_pin = 18,      /* ignored when flow_control is 0 */
-     .cts_pin = 19,      /* ignored when flow_control is 0 */
-     .flow_control = 0,
+#ifdef MODULE_PERIPH_UART_HW_FC
+     .rts_pin = 18,
+     .cts_pin = 19,
+#endif
      .intn = UART0_IRQN
  }
 };

--- a/boards/cc1352-launchpad/include/periph_conf.h
+++ b/boards/cc1352-launchpad/include/periph_conf.h
@@ -71,23 +71,30 @@ static const timer_conf_t timer_config[] = {
 * The TI CC1352 LaunchPad board only has access to a single UART device through
 * the debugger, so all we need to configure are the RX and TX pins.
 *
-* Optionally we can enable hardware flow control, by setting UART_HW_FLOW_CTRL
-* to 1 and defining pins for cts_pin and rts_pin.
-*
-* Add a second UART configuration if using external pins.
+* Optionally we can enable hardware flow control, by using periph_uart_hw_fc
+* module (USEMODULE += periph_uart_hw_fc) and defining pins for cts_pin and
+* rts_pin.
 * @{
 */
+/**
+ * @name    UART configuration
+ *
+ *
+ * Add a second UART configuration if using external pins.
+ * @{
+ */
 
 static const uart_conf_t uart_config[] = {
- {
-     .regs = UART0,
-     .tx_pin = 13,
-     .rx_pin = 12,
-     .rts_pin = 0,      /* ignored when flow_control is 0 */
-     .cts_pin = 0,      /* ignored when flow_control is 0 */
-     .flow_control = 0,
-     .intn = UART0_IRQN
- }
+    {
+        .regs = UART0,
+        .tx_pin = 13,
+        .rx_pin = 12,
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin = GPIO_UNDEF,
+        .cts_pin = GPIO_UNDEF,
+#endif
+        .intn = UART0_IRQN
+    }
 };
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -67,8 +67,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = UART0_BASEADDR,
         .rx_pin   = GPIO_PIN(0, 0),
         .tx_pin   = GPIO_PIN(0, 1),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin  = GPIO_UNDEF,
         .rts_pin  = GPIO_UNDEF
+#endif
     }
 };
 

--- a/boards/cc2650-launchpad/include/periph_conf.h
+++ b/boards/cc2650-launchpad/include/periph_conf.h
@@ -71,21 +71,23 @@ static const timer_conf_t timer_config[] = {
 * The used CC26x0 CPU only supports a single UART device, so all we need to
 * configure are the RX and TX pins.
 *
-* Optionally we can enable hardware flow control, by setting flow_control
-* to 1 and defining pins for cts_pin and rts_pin.
+* Optionally we can enable hardware flow control, by using periph_uart_hw_fc
+* module (USEMODULE += periph_uart_hw_fc) and defining pins for cts_pin and
+* rts_pin.
 * @{
 */
 
 static const uart_conf_t uart_config[] = {
- {
-     .regs = UART0,
-     .tx_pin = 3,
-     .rx_pin = 2,
-     .rts_pin = 0,      /* ignored when flow_control is 0 */
-     .cts_pin = 0,      /* ignored when flow_control is 0 */
-     .flow_control = 0,
-     .intn = UART0_IRQN
- }
+    {
+        .regs = UART0,
+        .tx_pin = 3,
+        .rx_pin = 2,
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin = GPIO_UNDEF,
+        .cts_pin = GPIO_UNDEF,
+#endif
+        .intn = UART0_IRQN
+    }
 };
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */

--- a/boards/cc2650stk/include/periph_conf.h
+++ b/boards/cc2650stk/include/periph_conf.h
@@ -75,15 +75,16 @@ static const timer_conf_t timer_config[] = {
  */
 
 static const uart_conf_t uart_config[] = {
- {
-     .regs = UART0,
-     .tx_pin = 29,
-     .rx_pin = 28,
-     .rts_pin = 0,      /* ignored when flow_control is 0 */
-     .cts_pin = 0,      /* ignored when flow_control is 0 */
-     .flow_control = 0,
-     .intn = UART0_IRQN
- }
+    {
+        .regs = UART0,
+        .tx_pin = 29,
+        .rx_pin = 28,
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin = GPIO_UNDEF,
+        .cts_pin = GPIO_UNDEF,
+#endif
+        .intn = UART0_IRQN
+    }
 };
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -40,7 +40,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,23),  /* ARDUINO_PIN_13, RX Pin */
         .tx_pin   = GPIO_PIN(PB,22),  /* ARDUINO_PIN_14, TX Pin */
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/common/remote/include/cfg_uart_default.h
+++ b/boards/common/remote/include/cfg_uart_default.h
@@ -38,15 +38,19 @@ static const uart_conf_t uart_config[] = {
         .dev      = UART0_BASEADDR,
         .rx_pin   = GPIO_PIN(PORT_A, 0),
         .tx_pin   = GPIO_PIN(PORT_A, 1),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin  = GPIO_UNDEF,
         .rts_pin  = GPIO_UNDEF
+#endif
     },
     {
         .dev      = UART1_BASEADDR,
         .rx_pin   = GPIO_PIN(PORT_C, 1),
         .tx_pin   = GPIO_PIN(PORT_C, 0),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin  = GPIO_UNDEF,
         .rts_pin  = GPIO_UNDEF
+#endif
     }
 };
 

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -63,7 +63,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM2->USART,
         .rx_pin   = GPIO_PIN(PA, 25),
         .tx_pin   = GPIO_PIN(PA, 24),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -127,7 +127,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA, 11), /* RX pin */
         .tx_pin   = GPIO_PIN(PA, 10), /* TX pin */
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/feather-nrf52840/include/periph_conf.h
+++ b/boards/feather-nrf52840/include/periph_conf.h
@@ -39,8 +39,10 @@ static const uart_conf_t uart_config[] = {
         .dev        = NRF_UARTE0,
         .rx_pin     = GPIO_PIN(0,24),
         .tx_pin     = GPIO_PIN(0,25),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_UNDEF,
         .cts_pin    = GPIO_UNDEF,
+#endif
         .irqn       = UARTE0_UART0_IRQn,
     },
 };

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -40,8 +40,10 @@ static const uart_conf_t uart_config[] = {
         .dev        = NRF_UARTE0,
         .rx_pin     = GPIO_PIN(0,19),
         .tx_pin     = GPIO_PIN(0,20),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_UNDEF,
         .cts_pin    = GPIO_UNDEF,
+#endif
         .irqn       = UARTE0_UART0_IRQn,
     },
 };

--- a/boards/nrf52840dk/include/periph_conf.h
+++ b/boards/nrf52840dk/include/periph_conf.h
@@ -50,16 +50,20 @@ static const uart_conf_t uart_config[] = {
         .dev        = NRF_UARTE0,
         .rx_pin     = GPIO_PIN(0,8),
         .tx_pin     = GPIO_PIN(0,6),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_UNDEF,
         .cts_pin    = GPIO_UNDEF,
+#endif
         .irqn       = UARTE0_UART0_IRQn,
     },
     { /* Mapped to Arduino D0/D1 pins */
         .dev        = NRF_UARTE1,
         .rx_pin     = GPIO_PIN(1,1),
         .tx_pin     = GPIO_PIN(1,2),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_UNDEF,
         .cts_pin    = GPIO_UNDEF,
+#endif
         .irqn       = UARTE1_IRQn,
     },
 };

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -95,8 +95,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = UART0_BASEADDR,
         .rx_pin   = GPIO_PIN(0, 0),
         .tx_pin   = GPIO_PIN(0, 1),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin  = GPIO_UNDEF,
         .rts_pin  = GPIO_UNDEF
+#endif
     }
 };
 

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -91,8 +91,10 @@ static const uart_conf_t uart_config[] = {
         .dev      = UART0_BASEADDR,
         .rx_pin   = GPIO_PIN(0, 0),
         .tx_pin   = GPIO_PIN(0, 1),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin  = GPIO_UNDEF,
         .rts_pin  = GPIO_UNDEF
+#endif
     }
 };
 

--- a/boards/p-l496g-cell02/include/periph_conf.h
+++ b/boards/p-l496g-cell02/include/periph_conf.h
@@ -85,7 +85,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART2_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_UNDEF,
         .rts_pin    = GPIO_UNDEF,
         .cts_af     = GPIO_AF7,
@@ -103,7 +103,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF8,
         .bus        = APB12,
         .irqn       = LPUART1_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_UNDEF,
         .rts_pin    = GPIO_UNDEF,
         .cts_af     = GPIO_AF7,
@@ -121,7 +121,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
         .irqn       = USART1_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_PIN(PORT_G, 11),
         .rts_pin    = GPIO_PIN(PORT_G, 12),
         .cts_af     = GPIO_AF7,

--- a/boards/particle-argon/Makefile.dep
+++ b/boards/particle-argon/Makefile.dep
@@ -1,3 +1,4 @@
 USEMODULE += boards_common_particle_mesh
+USEMODULE += periph_uart_hw_fc
 
 include $(RIOTBOARD)/common/particle-mesh/Makefile.dep

--- a/boards/particle-argon/include/periph_conf.h
+++ b/boards/particle-argon/include/periph_conf.h
@@ -36,16 +36,20 @@ static const uart_conf_t uart_config[] = {
         .dev        = NRF_UARTE0,
         .rx_pin     = GPIO_PIN(0,8),
         .tx_pin     = GPIO_PIN(0,6),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_UNDEF,
         .cts_pin    = GPIO_UNDEF,
+#endif
         .irqn       = UARTE0_UART0_IRQn,
     },
     {
         .dev        = NRF_UARTE1,
         .rx_pin     = GPIO_PIN(1,5),
         .tx_pin     = GPIO_PIN(1,4),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_PIN(1,6),
         .cts_pin    = GPIO_PIN(1,7),
+#endif
         .irqn       = UARTE1_IRQn,
     },
 };

--- a/boards/particle-boron/Makefile.dep
+++ b/boards/particle-boron/Makefile.dep
@@ -1,3 +1,4 @@
 USEMODULE += boards_common_particle_mesh
+USEMODULE += periph_uart_hw_fc
 
 include $(RIOTBOARD)/common/particle-mesh/Makefile.dep

--- a/boards/particle-boron/include/periph_conf.h
+++ b/boards/particle-boron/include/periph_conf.h
@@ -36,16 +36,20 @@ static const uart_conf_t uart_config[] = {
         .dev        = NRF_UARTE0,
         .rx_pin     = GPIO_PIN(0,8),
         .tx_pin     = GPIO_PIN(0,6),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_UNDEF,
         .cts_pin    = GPIO_UNDEF,
+#endif
         .irqn       = UARTE0_UART0_IRQn,
     },
     {
         .dev        = NRF_UARTE1,
         .rx_pin     = GPIO_PIN(1,4),
         .tx_pin     = GPIO_PIN(1,5),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_PIN(1,7),
         .cts_pin    = GPIO_PIN(1,6),
+#endif
         .irqn       = UARTE1_IRQn,
     },
 };

--- a/boards/particle-xenon/include/periph_conf.h
+++ b/boards/particle-xenon/include/periph_conf.h
@@ -36,8 +36,10 @@ static const uart_conf_t uart_config[] = {
         .dev        = NRF_UARTE0,
         .rx_pin     = GPIO_PIN(0,8),
         .tx_pin     = GPIO_PIN(0,6),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_UNDEF,
         .cts_pin    = GPIO_UNDEF,
+#endif
         .irqn       = UARTE0_UART0_IRQn,
     },
 };

--- a/boards/reel/include/periph_conf.h
+++ b/boards/reel/include/periph_conf.h
@@ -39,8 +39,10 @@ static const uart_conf_t uart_config[] = {
         .dev        = NRF_UARTE0,
         .rx_pin     = GPIO_PIN(0,8),
         .tx_pin     = GPIO_PIN(0,6),
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin    = GPIO_UNDEF,
         .cts_pin    = GPIO_UNDEF,
+#endif
         .irqn       = UARTE0_UART0_IRQn,
     },
 };

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -146,7 +146,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM3->USART,
         .rx_pin   = GPIO_PIN(PA,23),
         .tx_pin   = GPIO_PIN(PA,22),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -160,7 +160,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB,9),
         .tx_pin   = GPIO_PIN(PB,8),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -174,7 +174,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB,11),
         .tx_pin   = GPIO_PIN(PB,10),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -78,7 +78,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM2->USART,
         .rx_pin   = GPIO_PIN(PB, 24),
         .tx_pin   = GPIO_PIN(PB, 25),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -66,7 +66,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM3->USART,
         .rx_pin   = GPIO_PIN(PA,23),
         .tx_pin   = GPIO_PIN(PA,22),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -80,7 +80,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB, 9),
         .tx_pin   = GPIO_PIN(PB, 8),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -146,7 +146,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,5),
         .tx_pin   = GPIO_PIN(PA,4),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -160,7 +160,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PA,23),
         .tx_pin   = GPIO_PIN(PA,22),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -62,7 +62,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,5),
         .tx_pin   = GPIO_PIN(PA,4),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -64,7 +64,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA, 5),
         .tx_pin   = GPIO_PIN(PA, 4),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -128,7 +128,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM3->USART,
         .rx_pin   = GPIO_PIN(PA, 23),
         .tx_pin   = GPIO_PIN(PA, 22),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -142,7 +142,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB, 9),
         .tx_pin   = GPIO_PIN(PB, 8),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -44,7 +44,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,9),
         .tx_pin   = GPIO_PIN(PA,10),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -58,7 +58,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,31),
         .tx_pin   = GPIO_PIN(PB,30),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -72,7 +72,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB,13),
         .tx_pin   = GPIO_PIN(PB,14),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -86,7 +86,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM1->USART,
         .rx_pin   = GPIO_PIN(PA,17),
         .tx_pin   = GPIO_PIN(PA,18),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -40,7 +40,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,31),  /* D0, RX Pin */
         .tx_pin   = GPIO_PIN(PB,30),  /* D1, TX Pin */
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -54,7 +54,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM4->USART,
         .rx_pin   = GPIO_PIN(PB,13),
         .tx_pin   = GPIO_PIN(PB,14),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -68,7 +68,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,5),
         .tx_pin   = GPIO_PIN(PA,6),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -43,7 +43,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB,3),  /* D0, RX Pin */
         .tx_pin   = GPIO_PIN(PB,2),  /* D1, TX Pin */
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -57,7 +57,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM2->USART,
         .rx_pin   = GPIO_PIN(PA,13),
         .tx_pin   = GPIO_PIN(PA,12),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -46,7 +46,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM5->USART,
         .rx_pin   = GPIO_PIN(PB, 30),  /* D0, RX Pin */
         .tx_pin   = GPIO_PIN(PB, 31),  /* D1, TX Pin */
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif
@@ -60,7 +60,7 @@ static const uart_conf_t uart_config[] = {
         .dev      = &SERCOM0->USART,
         .rx_pin   = GPIO_PIN(PA,5),
         .tx_pin   = GPIO_PIN(PA,6),
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
 #endif

--- a/boards/stm32f723e-disco/Makefile.dep
+++ b/boards/stm32f723e-disco/Makefile.dep
@@ -1,4 +1,4 @@
-USEMODULE += stm32_periph_uart_hw_fc
+USEMODULE += periph_uart_hw_fc
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio

--- a/boards/stm32f723e-disco/include/periph_conf.h
+++ b/boards/stm32f723e-disco/include/periph_conf.h
@@ -91,7 +91,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF8,
         .bus        = APB2,
         .irqn       = USART6_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_UNDEF,
         .rts_pin    = GPIO_UNDEF,
         .cts_af     = GPIO_AF8,
@@ -107,7 +107,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART2_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_UNDEF,
         .rts_pin    = GPIO_UNDEF,
         .cts_af     = GPIO_AF8,
@@ -123,7 +123,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF8,
         .bus        = APB1,
         .irqn       = UART7_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_PIN(PORT_F, 9),
         .rts_pin    = GPIO_PIN(PORT_F, 8),
         .cts_af     = GPIO_AF8,
@@ -139,7 +139,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF8,
         .bus        = APB1,
         .irqn       = UART5_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_UNDEF,
         .rts_pin    = GPIO_UNDEF,
         .cts_af     = GPIO_AF8,

--- a/boards/ublox-c030-u201/Makefile.dep
+++ b/boards/ublox-c030-u201/Makefile.dep
@@ -1,4 +1,4 @@
-USEMODULE += stm32_periph_uart_hw_fc
+USEMODULE += periph_uart_hw_fc
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio

--- a/boards/ublox-c030-u201/include/periph_conf.h
+++ b/boards/ublox-c030-u201/include/periph_conf.h
@@ -71,7 +71,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
         .irqn       = USART1_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_UNDEF,
         .rts_pin    = GPIO_UNDEF,
         .cts_af     = GPIO_AF7,
@@ -87,7 +87,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART2_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_PIN(PORT_D, 3),
         .rts_pin    = GPIO_PIN(PORT_D, 4),
         .cts_af     = GPIO_AF7,
@@ -103,7 +103,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF8,
         .bus        = APB2,
         .irqn       = USART6_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_UNDEF,
         .rts_pin    = GPIO_UNDEF,
         .cts_af     = GPIO_AF8,
@@ -119,7 +119,7 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART3_IRQn,
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
         .cts_pin    = GPIO_UNDEF,
         .rts_pin    = GPIO_UNDEF,
         .cts_af     = GPIO_AF7,

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -167,8 +167,10 @@ typedef struct {
     cc2538_uart_t *dev;       /**< pointer to the used UART device */
     gpio_t rx_pin;            /**< pin used for RX */
     gpio_t tx_pin;            /**< pin used for TX */
+#ifdef MODULE_PERIPH_UART_HW_FC
     gpio_t cts_pin;           /**< CTS pin - set to GPIO_UNDEF when not using */
     gpio_t rts_pin;           /**< RTS pin - set to GPIO_UNDEF when not using */
+#endif
 } uart_conf_t;
 /** @} */
 

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -99,6 +99,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     u->CC = 0;
 
     /* On the CC2538, hardware flow control is supported only on UART1 */
+#ifdef MODULE_PERIPH_UART_HW_FC
     if (uart_config[uart].rts_pin != GPIO_UNDEF) {
         assert(u != UART0_BASEADDR);
         gpio_init_af(uart_config[uart].rts_pin, UART1_RTS, GPIO_OUT);
@@ -110,6 +111,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         gpio_init_af(uart_config[uart].cts_pin, UART1_CTS, GPIO_IN);
         u->cc2538_uart_ctl.CTLbits.CTSEN = 1;
     }
+#endif
 
     /*
      * UART Interrupt Setup:

--- a/cpu/cc26xx_cc13xx/include/periph_cpu_common.h
+++ b/cpu/cc26xx_cc13xx/include/periph_cpu_common.h
@@ -119,9 +119,10 @@ typedef struct {
    uart_regs_t *regs;
    int tx_pin;
    int rx_pin;
+#ifdef MODULE_PERIPH_UART_HW_FC
    int rts_pin;
    int cts_pin;
-   int flow_control;
+#endif
    int intn;
 } uart_conf_t;
 /** @} */

--- a/cpu/cc26xx_cc13xx/periph/uart.c
+++ b/cpu/cc26xx_cc13xx/periph/uart.c
@@ -33,7 +33,7 @@
 /**
  * @brief   Get the enable mask depending on enabled HW flow control
  */
-#if UART_HW_FLOW_CONTROL
+#ifdef MODULE_PERIPH_UART_HW_FC
 #define ENABLE_MASK         (UART_CTSEN | UART_CTL_RTSEN | \
                              UART_CTL_RXE | UART_CTL_TXE | UART_CTL_UARTEN)
 #else
@@ -53,10 +53,10 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     int tx_pin = uart_config[uart].tx_pin;
     int rx_pin = uart_config[uart].rx_pin;
     int intn = uart_config[uart].intn;
-    int flow = uart_config[uart].flow_control;
+#ifdef MODULE_PERIPH_UART_HW_FC
     int rts_pin = uart_config[uart].rts_pin;
     int cts_pin = uart_config[uart].cts_pin;
-
+#endif
     /* enable clocks: serial power domain and UART */
     PRCM->PDCTL0SERIAL = 1;
     while (!(PRCM->PDSTAT0 & PDSTAT0_SERIAL_ON)) ;
@@ -72,10 +72,12 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     /* configure pins */
     IOC->CFG[tx_pin] =  IOCFG_PORTID_UART0_TX;
     IOC->CFG[rx_pin] = (IOCFG_PORTID_UART0_RX | IOCFG_INPUT_ENABLE);
-    if (flow == 1) {
-      IOC->CFG[rts_pin] =  IOCFG_PORTID_UART0_RTS;
-      IOC->CFG[cts_pin] = (IOCFG_PORTID_UART0_CTS | IOCFG_INPUT_ENABLE);
+#ifdef MODULE_PERIPH_UART_HW_FC
+    if (rts_pin != GPIO_UNDEF && cts_pin != GPIO_UNDEF) {
+        IOC->CFG[rts_pin] =  IOCFG_PORTID_UART0_RTS;
+        IOC->CFG[cts_pin] = (IOCFG_PORTID_UART0_CTS | IOCFG_INPUT_ENABLE);
     }
+#endif
 
     /* calculate baud-rate */
     uint32_t tmp = (CLOCK_CORECLOCK * 4);

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -169,8 +169,10 @@ typedef struct {
     NRF_UARTE_Type *dev;    /**< UART with EasyDMA device base register address */
     gpio_t rx_pin;          /**< RX pin */
     gpio_t tx_pin;          /**< TX pin */
-    gpio_t rts_pin;         /**< RTS pin - set to GPIO_UNDEF when not using HW flow control */
-    gpio_t cts_pin;         /**< CTS pin - set to GPIO_UNDEF when not using HW flow control */
+#ifdef MODULE_PERIPH_UART_HW_FC
+    gpio_t rts_pin;         /**< RTS pin */
+    gpio_t cts_pin;         /**< CTS pin */
+#endif
     uint8_t irqn;           /**< IRQ channel */
 } uart_conf_t;
 #endif

--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -31,7 +31,4 @@ CFLAGS += -DDONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
 # For Cortex-M cpu we use the common cortexm.ld linker script
 LINKER_SCRIPT ?= cortexm.ld
 
-# define sam0 specific pseudomodules
-PSEUDOMODULES += sam0_periph_uart_hw_fc
-
 INCLUDES += -I$(RIOTCPU)/sam0_common/include

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -212,7 +212,7 @@ typedef struct {
     SercomUsart *dev;       /**< pointer to the used UART device */
     gpio_t rx_pin;          /**< pin used for RX */
     gpio_t tx_pin;          /**< pin used for TX */
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
     gpio_t rts_pin;          /**< pin used for RTS */
     gpio_t cts_pin;          /**< pin used for CTS */
 #endif

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -80,7 +80,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     gpio_set(uart_config[uart].tx_pin);
     gpio_init_mux(uart_config[uart].tx_pin, uart_config[uart].mux);
 
-#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
     /* If RTS/CTS needed, enable them */
     if (uart_config[uart].tx_pad == UART_PAD_TX_0_RTS_2_CTS_3) {
         /* Ensure RTS is defined */

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -461,7 +461,7 @@ typedef struct {
 #endif
     uint8_t bus;            /**< APB bus */
     uint8_t irqn;           /**< IRQ channel */
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
     gpio_t cts_pin;         /**< CTS pin - set to GPIO_UNDEF when not using HW flow control */
     gpio_t rts_pin;         /**< RTS pin */
 #ifndef CPU_FAM_STM32F1

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -75,7 +75,7 @@ static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate);
 #endif
 #endif
 
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
 static inline void uart_init_rts_pin(uart_t uart)
 {
     if (uart_config[uart].rts_pin != GPIO_UNDEF) {
@@ -117,7 +117,7 @@ static inline void uart_init_pins(uart_t uart, uart_rx_cb_t rx_cb)
         gpio_init_af(uart_config[uart].rx_pin, uart_config[uart].rx_af);
 #endif
     }
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
     uart_init_cts_pin(uart);
     uart_init_rts_pin(uart);
 #endif
@@ -187,7 +187,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         dev(uart)->CR1 = (USART_CR1_UE | USART_CR1_TE);
     }
 
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
     if (uart_config[uart].cts_pin != GPIO_UNDEF) {
         dev(uart)->CR3 |= USART_CR3_CTSE;
     }
@@ -372,7 +372,7 @@ void uart_poweron(uart_t uart)
 
     dev(uart)->CR1 |= (USART_CR1_UE);
 
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
     /* STM32F4 errata 2.10.9: nRTS is active while RE or UE = 0
      * we should only configure nRTS pin after setting UE */
     uart_init_rts_pin(uart);
@@ -383,7 +383,7 @@ void uart_poweroff(uart_t uart)
 {
     assert(uart < UART_NUMOF);
 
-#ifdef MODULE_STM32_PERIPH_UART_HW_FC
+#ifdef MODULE_PERIPH_UART_HW_FC
     /* the uart peripheral does not put RTS high from hardware when
      * UE flag is cleared, so we need to do this manually */
     if (uart_config[uart].rts_pin != GPIO_UNDEF) {


### PR DESCRIPTION

### Contribution description
This PR merges the ~~STM32_PERIPH_UART_HW_FC and SAM0_PERIPH_UART_HW_FC~~ STM32, SAM0, NRF, CC25xx and CC26xx UART implementation to use the generic PERIPH_UART_HW_FC so it can be reuse by other MCU families in order to provide hardware flow control support for UART driver.

### Testing procedure
CI test should be enough I guess ?

### Issues/PRs references
Change was proposed in #13001(comment)
