### PR TITLE
boards/mulle: move nvram init into auto_init

### DIFF
--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -28,7 +28,6 @@
 #include "periph/spi.h"
 #include "nvram-spi.h"
 #include "nvram.h"
-#include "xtimer.h"
 #include "vfs.h"
 #include "fs/devfs.h"
 #include "mtd_spi_nor.h"
@@ -103,9 +102,6 @@ void board_init(void)
 
     /* initialize the CPU */
     cpu_init();
-
-    /* NVRAM requires xtimer for timing */
-    xtimer_init();
 
     /* Initialize NOR flash */
     mulle_nor_init();

--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -81,8 +81,6 @@ int mulle_nor_init(void);
 
 void board_init(void)
 {
-    int status;
-
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
@@ -109,15 +107,18 @@ void board_init(void)
     /* NVRAM requires xtimer for timing */
     xtimer_init();
 
+    /* Initialize NOR flash */
+    mulle_nor_init();
+}
+
+void mulle_board_init_late(void)
+{
     /* Initialize NVRAM */
-    status = mulle_nvram_init();
+    int status = mulle_nvram_init();
     if (status == 0) {
         /* Increment boot counter */
         increase_boot_count();
     }
-
-    /* Initialize NOR flash */
-    mulle_nor_init();
 }
 
 static inline void power_pins_init(void)

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -115,6 +115,10 @@ void auto_init(void)
     DEBUG("Auto init xtimer module.\n");
     xtimer_init();
 #endif
+#ifdef BOARD_MULLE
+    void mulle_board_init_late(void);
+    mulle_board_init_late();
+#endif
 #ifdef MODULE_SCHEDSTATISTICS
     init_schedstatistics();
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Currently, mulle has an extra call to `xtimer_init()` in its `board_init()`, as the following nvram init used by a boot counter needs it.
This does not work as is when xtimer is not needed / wanted. E.g., #11874 breaks due to this.

This PR moves the nvram initialization and boot counter stuff into its own function, which is then called in auto_init right after xtimer initialization. The mulle specific `xtimer_init()` call is removed.

I'm not happy to see board specific stuff in auto init, but more unhappy to have `xtimer_init()` called in `board_init()`...

Could we maybe just remove the boot counter and nvram init?

### Testing procedure

- flash on mulle, maybe ensure boot counter is still updated
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#11874

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
