### PR TITLE
cpu/efm32: fix incorrect ADC status register

### DIFF
--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -88,7 +88,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     /* start conversion and block until it completes */
     ADC_Start(adc_config[dev].dev, adcStartSingle);
 
-    while (adc_config[dev].dev->STATUS & ADC_STATUS_SINGLEACT);
+    while ((adc_config[dev].dev->STATUS & ADC_STATUS_SINGLEDV) == 0);
 
     int result = ADC_DataSingleGet(adc_config[dev].dev);
 


### PR DESCRIPTION
### Contribution description
The `adc_sample` method should wait before a sample is ready. This was incorrectly asserting, by checking the wrong bits. This PR fixes this.

For some reason, even the [sample code](https://www.silabs.com/documents/public/example-code/an0021-efm32-adc.zip) by Silicon Labs has this bug, so that's why it was introduced in the first place.

### Testing procedure
Unfortunately, this issue is hard to exploit, and probably the reason it wasn't noticed before. If the ADC is fast enough (depending on the MCU), it will run 'just fine'.

Here are some test results for a custom application I used to read the internal temperature sensor, connected to the ADC. Without the fix, the first ADC read *always* returns zero. After that, the ADC is probably 'warm' and runs quicker. This did not happen on the STK3600 (Series 0), and the SLSTK3402a (Series 1), but did happen on the SLSTK3401a and SLTB001a (both Series 1).

Without the fix (SLTB001a):

```
main(): This is RIOT! (Version: 2020.01-devel-1619-ga1cd6-feature/knx)
Testing internal EFM32 temperature driver.
Driver initialization OK.
Sample value is 0
Temperature: -260.-15 C
Testing internal EFM32 temperature driver.
Driver initialization OK.
Sample value is 2210
Temperature: 27.67 C
```

With the fix (SLTB001a):

```
main(): This is RIOT! (Version: 2020.01-devel-1619-ga1cd6-feature/knx)
Testing internal EFM32 temperature driver.
Driver initialization OK.
Sample value is 2212
Temperature: 27.33 C
Testing internal EFM32 temperature driver.
Driver initialization OK.
Sample value is 2211
Temperature: 27.50 C
```

Tested this on the:
* SLTB001a (Series 1)
* SLSTK3401a (Series 1)
* SLSKT3402a (Series 1)
* STK3600 (Series 0)

### Issues/PRs references
- For the EFM32 series 0 (STK3x00 boards): section 25.5.3 of the [reference manual](https://www.silabs.com/documents/public/data-sheets/efm32wg-datasheet.pdf)
- For the EFM32 series 1 (SLSTK3x0x boards): section 24.5.3 of the [reference manual](https://www.silabs.com/documents/public/reference-manuals/efr32xg1-rm.pdf).

