### PR TITLE
pkg/local.mk: fix local pkg build

### DIFF
--- a/pkg/local.mk
+++ b/pkg/local.mk
@@ -6,7 +6,9 @@
 #
 # WARNING: any local changes made to $(PKG_BUILDDIR) *will* get lost!
 
-.PHONY: prepare clean
+.PHONY: prepare clean all
+
+all: $(PKG_BUILDDIR)/.prepared
 
 prepare: $(PKG_BUILDDIR)/.prepared
 	@true


### PR DESCRIPTION

### Contribution description

In #13036 a test case was missed and with the change in wasn't building local pkg. Still not sure what broke it but this at least fixes the issue. See #13055

Re-added phony since the ifdef prevents reaching the declaration in `pkg/pkg.mk`

### Testing procedure

See #13055

### Issues/PRs references

Introduced by #13036
Fixes #13055
