### PR TITLE
boards/ruuvitag: fix stdio configuration

### DIFF
--- a/boards/ruuvitag/Makefile.include
+++ b/boards/ruuvitag/Makefile.include
@@ -1,7 +1,9 @@
 # for this board, we are using Segger's RTT as default terminal interface
-USEMODULE += stdio_rtt
-TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term-rtt
+ifeq (,$(filter stdio_%,$(USEMODULE)))
+  USEMODULE += stdio_rtt
+  TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
+  TERMFLAGS = term-rtt
+endif
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include


### PR DESCRIPTION
### Contribution description
The STDIO configuration for the `ruuvitag` is currently hard-coded to `stdio_rtt`. Now when using it without STDIO (`USEMODULE += stdio_null`) it will include both `stdio_null` and `stdio_rtt`.

This PR fixes this by not including `stdio_rtt` in case anything else is selected by the user.

### Testing procedure
Call `BOARD=ruuvitag USEMODULE=stdio_null make info-modules` in any application.

With this PR there should only be `stdio_null` in the list, without this PR there are both `stdio_null` AND `stdio_rtt` in the list of selected modules.

### Issues/PRs references
none