### PR TITLE
tests/bench_xtimer: add printing of sizeof(xtimer_t)

### DIFF
--- a/tests/bench_xtimer/main.c
+++ b/tests/bench_xtimer/main.c
@@ -283,6 +283,8 @@ int main(void)
     _print_result("xtimer_now()", REPEAT, diff);
     assert(!_triggers);
 
+    _print_result("sizeof(xtimer_t)", NUMOF_TIMERS, sizeof(_timers));
+
     puts("done.");
 
     return 0;

--- a/tests/bench_xtimer/tests/01-run.py
+++ b/tests/bench_xtimer/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact("xtimer benchmark application.\r\n")
-    for i in range(12):
+    for i in range(13):
         child.expect(r"\s+[\w() _\+]+\s+\d+ / \d+ = \d+\r\n")
 
     child.expect_exact("done.\r\n")


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds printing of `sizeof(xtimer_t)` to tests/bench_xtimer.

### Testing procedure

Should be trivial, but compile and run tests/bench_xtimer on a board of your choice.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#9530 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
