### PR TITLE
drivers/periph_common/timer: protect timer_set from IRQs

### DIFF
--- a/drivers/periph_common/timer.c
+++ b/drivers/periph_common/timer.c
@@ -19,10 +19,14 @@
  */
 
 #include "periph/timer.h"
+#include "irq.h"
 
 #ifndef PERIPH_TIMER_PROVIDES_SET
 int timer_set(tim_t dev, int channel, unsigned int timeout)
 {
-    return timer_set_absolute(dev, channel, timer_read(dev) + timeout);
+    unsigned int state = irq_disable();
+    int res = timer_set_absolute(dev, channel, timer_read(dev) + timeout);
+    irq_restore(state);
+    return res;
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This fixes a concurrency problem in the timer_set implementation.
Somewhere between getting the current time from timer_read(), adding the timeout, and then actually writing it to the timer a thread might be de-scheduled causing the targeted time to be already passed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Reading the code + thinking ;)
Running `tests/periph_timer` and `tests/bench_timer`  but that didn't really show errors before...
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
