### PR TITLE
drivers/dht: Worked around doxygen bug

### DIFF
--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -107,10 +107,10 @@ int dht_init(dht_t *dev, const dht_params_t *params);
  * @param[out] temp     temperature value [in °C * 10^-1]
  * @param[out] hum      relative humidity value [in percent * 10^-1]
  *
- * @retval `DHT_OK`         Success
- * @retval `DHT_NOCSUM`     Checksum error
- * @retval `DHT_TIMEOUT`    Reading data timed out (check wires!)
- * @retval `DHT_NODEV`      Unsupported device type specified
+ * @retval DHT_OK       Success
+ * @retval DHT_NOCSUM   Checksum error
+ * @retval DHT_TIMEOUT  Reading data timed out (check wires!)
+ * @retval DHT_NODEV    Unsupported device type specified
  */
 int dht_read(dht_t *dev, int16_t *temp, int16_t *hum);
 


### PR DESCRIPTION
### Contribution description

Markdown in `@retval` values is currently broken in Doxygen. This removes use of markdown there.


### Testing procedure

Check if the generated doc for `dht_read()` no longer has broken @retval table

### Issues/PRs references

Found in https://github.com/RIOT-OS/RIOT/pull/13047