### PR TITLE
Kconfig: Expose gnrc/ipv6 configurations

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -140,8 +140,8 @@ extern "C" {
 /**
  * @brief   Default message queue size to use for the IPv6 thread.
  */
-#ifndef GNRC_IPV6_MSG_QUEUE_SIZE
-#define GNRC_IPV6_MSG_QUEUE_SIZE    (8U)
+#ifndef CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE
+#define CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE    (8U)
 #endif
 
 #ifdef DOXYGEN

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -8,6 +8,7 @@ menu "GNRC Network stack"
     depends on MODULE_GNRC
 
 rsource "link_layer/lorawan/Kconfig"
+rsource "network_layer/ipv6/Kconfig"
 rsource "network_layer/ipv6/blacklist/Kconfig"
 rsource "network_layer/ipv6/whitelist/Kconfig"
 

--- a/sys/net/gnrc/network_layer/ipv6/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_IPV6
+    bool "Configure GNRC IPv6 module"
+    depends on MODULE_GNRC_IPV6
+    help
+        Configure GNRC IPv6 module using Kconfig.
+
+if KCONFIG_MODULE_GNRC_IPV6
+
+config GNRC_IPV6_MSG_QUEUE_SIZE
+    int "Default message queue size to use for the IPv6 thread"
+    default 8
+
+endif # KCONFIG_MODULE_GNRC_IPV6

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -172,12 +172,12 @@ static void _dispatch_next_header(gnrc_pktsnip_t *pkt, unsigned nh,
 
 static void *_event_loop(void *args)
 {
-    msg_t msg, reply, msg_q[GNRC_IPV6_MSG_QUEUE_SIZE];
+    msg_t msg, reply, msg_q[CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE];
     gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                             sched_active_pid);
 
     (void)args;
-    msg_init_queue(msg_q, GNRC_IPV6_MSG_QUEUE_SIZE);
+    msg_init_queue(msg_q, CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE);
 
     /* initialize fragmentation data-structures */
 #ifdef MODULE_GNRC_IPV6_EXT_FRAG


### PR DESCRIPTION
### Contribution description
This PR moves the configuration macros of `gnrc_ipv6` found [here](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/net/gnrc/ipv6.h) to the `CONFIG_` namespace, and exposes them to Kconfig.

As agreed offline with @leandrolanzieri I did not include the thread stacksize and priority parameters because these should be defined by the platform, if not changed manually. We might need a better solution to this in future.

In the configuration header file, some defines relate to the FIB & RPL (see [here](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/net/gnrc/ipv6.h#L177)). I think this should changed together with adding "GNRC IPv6 NIB compile configurations" as proposed in #12888.

### Testing procedure
- `examples/gnrc_networking` should still work as usual.
- You should be able to configure the module's parameters via `make menuconfig` in the test application.

### Issues/PRs references
Part of #12888 
