### PR TITLE
tests/bench_xtimer: decrease mem usage for some boards

### DIFF
--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -7,6 +7,7 @@ USEMODULE += xtimer
 LOW_MEMORY_BOARDS += \
   airfy-beacon \
   arduino-mega2560 \
+  atmega1284p \
   b-l072z-lrwan1 \
   blackpill \
   blackpill-128kib \
@@ -17,12 +18,15 @@ LOW_MEMORY_BOARDS += \
   cc2650-launchpad \
   cc2650stk \
   chronos \
+  derfmega128 \
   hifive1 \
   hifive1b \
   i-nucleo-lrwan1 \
   lsn50 \
   maple-mini \
+  mega-xplained \
   microbit \
+  microduino-corerf \
   msb-430 \
   msb-430h \
   nrf51dongle \
@@ -66,7 +70,7 @@ ifneq (, $(filter $(BOARD), $(LOW_MEMORY_BOARDS)))
 endif
 
 ifneq (, $(filter $(BOARD), $(SUPER_LOW_MEMORY_BOARDS)))
-  NUMOF_TIMERS ?= 20
+  NUMOF_TIMERS ?= 16
 endif
 
 NUMOF_TIMERS ?= 1000


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This reduces the number of timers used for the benchmark for the super low memory boards and adds some new boards to the  low memory boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Looking at the Makefile and compilation of Murdock should be enough since no code is changed.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
This is required for successful compilation of #9530 because the grown xtimer_t struct uses more memory.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
