### PR TITLE
tools/testrunner: add variable for customizing a delay before reset

### DIFF
--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -14,3 +14,6 @@ export JLINK_DEVICE := FE310
 export JLINK_IF := JTAG
 export FLASH_ADDR := 0x20010000
 include $(RIOTMAKE)/tools/jlink.inc.mk
+
+TESTRUNNER_RESET_DELAY = 1
+$(call target-export-variables,test,TESTRUNNER_RESET_DELAY)

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -24,6 +24,10 @@ RIOTBASE = (os.environ.get('RIOTBASE') or
 # default value (3)
 MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
 
+# Setting an empty 'TESTRUNNER_RESET_DELAY' environment variable use the
+# default value (0, no delay)
+MAKE_RESET_DELAY = int(os.environ.get('TESTRUNNER_RESET_DELAY') or 0)
+
 # Allow customizing test interactive settings with environment variables
 TEST_INTERACTIVE_RETRIES = int(os.environ.get('TEST_INTERACTIVE_RETRIES') or 5)
 TEST_INTERACTIVE_DELAY = int(os.environ.get('TEST_INTERACTIVE_DELAY') or 1)
@@ -35,6 +39,9 @@ TESTRUNNER_RESET_AFTER_TERM = int(os.environ.get('TESTRUNNER_RESET_AFTER_TERM')
 
 
 def _reset_board(env):
+    if MAKE_RESET_DELAY > 0:
+        time.sleep(MAKE_RESET_DELAY)
+
     try:
         subprocess.check_output(('make', 'reset'), env=env,
                                 stderr=subprocess.PIPE)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a new variable in the testrunner that allows for setting a custom delay before resetting a board under test.
The default value is set to 0, e.g. no delay but for the hifive1b it's set to 1s. On this board, when calling reset too early after flashing, the firmware crashes (with the red led blinking).
The variable is only set with the `test` target.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

```
make BOARD=hifive1b -C tests/bench_msg_pingpong flash test
```
on master, the test fails and the firmware is in a broken state (red led blinking), with this PR, the test runs normally (and succeeds).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while testing #12934 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
