### PR TITLE
 makefiles/color.inc.mk: don't set CC_NOCOLOR to avoid setting CFLAGS

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -15,7 +15,7 @@ OPTIONAL_CFLAGS += -fno-delete-null-pointer-checks
 
 # Use colored compiler output if the compiler supports this and if this is not
 # disabled by the user
-ifeq ($(CC_NOCOLOR),0)
+ifneq ($(CC_NOCOLOR),1)
   OPTIONAL_CFLAGS += -fdiagnostics-color
 endif
 

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -7,25 +7,22 @@ COLOR_PURPLE :=
 COLOR_RESET  :=
 COLOR_ECHO   := /bin/echo
 
-ifeq ($(CC_NOCOLOR),)
+# Check if colored output is not disabled by user, i.e: CC_NOCOLOR unset
+# or 0
+ifneq ($(CC_NOCOLOR),1)
   IS_TERMINAL = $(if $(MAKE_TERMOUT),$(MAKE_TERMERR),)
-  ifeq ($(IS_TERMINAL),)
-    CC_NOCOLOR = 1
-  else
-    CC_NOCOLOR = 0
-  endif
-endif
-
-ifeq ($(CC_NOCOLOR),0)
-  COLOR_GREEN  := \033[1;32m
-  COLOR_RED    := \033[1;31m
-  COLOR_YELLOW := \033[1;33m
-  COLOR_PURPLE := \033[1;35m
-  COLOR_RESET  := \033[0m
-  ifeq ($(OS),Darwin)
-    COLOR_ECHO   := echo -e
-    SHELL=bash
-  else
-    COLOR_ECHO   := /bin/echo -e
+  # Check if terminal support colored output
+  ifneq ($(IS_TERMINAL),)
+    COLOR_GREEN  := \033[1;32m
+    COLOR_RED    := \033[1;31m
+    COLOR_YELLOW := \033[1;33m
+    COLOR_PURPLE := \033[1;35m
+    COLOR_RESET  := \033[0m
+    ifeq ($(OS),Darwin)
+      COLOR_ECHO   := echo -e
+      SHELL=bash
+    else
+      COLOR_ECHO   := /bin/echo -e
+    endif
   endif
 endif


### PR DESCRIPTION
### Contribution description

If CC_NOCOLOR was not set by the user it was set according to the
terminal support of colored output.

But since CC_NOCOLOR is also used to set `-fdiagnostics-color` flags
this means changing `CFLAGS` according to terminal support of colored
output.

This is not needed for `-fdiagnostics-color` since this option is by
default `auto` if the compiler supports colored output, and `auto`
means it will only use color when standard error is a terminal.

GNU GCC doc

```
-fno-diagnostics-color

    Use color in diagnostics. WHEN is ‘never’, ‘always’, or ‘auto’. The default depends on how the compiler has been configured, it can be any of the above WHEN options or also ‘never’ if GCC_COLORS environment variable isn’t present in the environment, and ‘auto’ otherwise. ‘auto’ means to use color only when the standard error is a terminal. The forms -fdiagnostics-color and -fno-diagnostics-color are aliases for -fdiagnostics-color=always and -fdiagnostics-color=never, respectively.
```

LLVM GCC doc

```
-f[no-]color-diagnostics

    This option, which defaults to on when a color-capable terminal is detected, controls whether or not Clang prints diagnostics in color.

    When this option is enabled, Clang will use colors to highlight specific parts of the diagnostic, e.g.,
```


### Testing procedure

From #12834:

> #### Steps to reproduce the issue
> 1. `QUIET=0 make all` and directly after that ..
> 2. `QUIET=0 make all | cat -`
> 
> #### Expected results
> * The first make invocation should build all modules
> * The second invocation should *not* rebuild all modules
> 
> #### Actual results
> * The second invocation rebuilds all modules

- User can still force disabling colors.

- Green murdock

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/12834
