### PR TITLE
dist/tools/riotboot_gen_hdr/genhdr: use unsigned long

### DIFF
--- a/dist/tools/riotboot_gen_hdr/genhdr.c
+++ b/dist/tools/riotboot_gen_hdr/genhdr.c
@@ -49,9 +49,9 @@ int genhdr(int argc, char *argv[])
     uint8_t *hdr_buf;
 
     /* arguments storage variables */
-    long app_ver_arg = 0;
-    long start_addr_arg = 0;
-    long hdr_len_arg = 0;
+    unsigned long app_ver_arg = 0;
+    unsigned long start_addr_arg = 0;
+    unsigned long hdr_len_arg = 0;
 
     /* header variables */
     size_t hdr_len = 0;


### PR DESCRIPTION
### Contribution description

@cladmi had noticed the following:

> While reviewing #12446 I found out another issue with compiling the tool on the raspberry PI.
> 
> ```
> compiling /tmp/dwq.0.20579331210052065/5c38a93b2e9b62fea1be9c23e3b3971c/dist/tools/riotboot_gen_hdr/bin/genhdr...
> genhdr.c: In function 'genhdr':
> genhdr.c:71:49: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
>      if (errno != 0 || *p != '\0' || app_ver_arg > UINT32_MAX) {
>                                                  ^
> genhdr.c:79:52: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
>      if (errno != 0 || *p != '\0' || start_addr_arg > UINT32_MAX) {
>                                                     ^
> genhdr.c:87:76: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
>      if (errno != 0 || *p != '\0' || hdr_len_arg % HDR_ALIGN || hdr_len_arg > UINT32_MAX) {
>                                                                             ^
> ```
> 
> When testing a change on this, the `test caching` must also be disabled as of course these files are ignored for it.
> 
> EDIT: a nightly output for reference https://ci.riot-os.org/RIOT-OS/RIOT/master/02ae803acc06b662b73a37f70b8b2e3580d2c8d3/output/run_test/tests/riotboot/samr21-xpro:llvm.txt
> 
> _Originally posted by @cladmi in https://github.com/RIOT-OS/RIOT/issues/12003#issuecomment-543050109_

This PR fixes it.

### Testing procedure

The fix should be pretty straight forward. But to test compile `dist/tools/riotboot_gen_hdr/Makefile` in 32bits:

```
CFLAGS+=-m32 make -C dist/tools/riotboot_gen_hdr/
```

- green murdock should be enough as well.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
