### PR TITLE
gnrc/ipv6: Remove unused 'GNRC_IPV6_STATIC_LLADDR' macro

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -36,12 +36,6 @@ USEMODULE += netstats_rpl
 # development process:
 DEVELHELP ?= 1
 
-# Uncomment the following 2 lines to specify static link lokal IPv6 address
-# this might be useful for testing, in cases where you cannot or do not want to
-# run a shell with ifconfig to get the real link lokal address.
-#IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
-#CFLAGS += -DGNRC_IPV6_STATIC_LLADDR=$(IPV6_STATIC_LLADDR)
-
 # Uncomment this to join RPL DODAGs even if DIOs do not contain
 # DODAG Configuration Options (see the doc for more info)
 # CFLAGS += -DGNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN

--- a/examples/gnrc_networking_mac/Makefile
+++ b/examples/gnrc_networking_mac/Makefile
@@ -45,12 +45,6 @@ USEMODULE += gnrc_gomach
 # development process:
 DEVELHELP ?= 1
 
-# Uncomment the following 2 lines to specify static link lokal IPv6 address
-# this might be useful for testing, in cases where you cannot or do not want to
-# run a shell with ifconfig to get the real link lokal address.
-#IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
-#CFLAGS += -DGNRC_IPV6_STATIC_LLADDR=$(IPV6_STATIC_LLADDR)
-
 # Uncomment this to join RPL DODAGs even if DIOs do not contain
 # DODAG Configuration Options (see the doc for more info)
 # CFLAGS += -DGNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -144,26 +144,6 @@ extern "C" {
 #define GNRC_IPV6_MSG_QUEUE_SIZE    (8U)
 #endif
 
-#ifdef DOXYGEN
-/**
- * @brief   Add a static IPv6 link local address to any network interface
- *
- * This macro allows to specify a certain link local IPv6 address to be assigned
- * to a network interface on startup, which might be handy for testing.
- * Note: a) a interface will keep its auto-generated link local address, too
- *       b) the address is incremented by 1, if multiple interfaces are present
- *
- * To use the macro just add it to `CFLAGS` in the application's Makefile, like:
- *
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
- * IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
- * CFLAGS += -DGNRC_IPV6_STATIC_LLADDR=$(STATIC_IPV6_LLADDR)
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- */
-#define GNRC_IPV6_STATIC_LLADDR
-#endif /* DOXYGEN */
-/** @} */
-
 /**
  * @brief   The PID to the IPv6 thread.
  *

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -143,6 +143,7 @@ extern "C" {
 #ifndef GNRC_IPV6_MSG_QUEUE_SIZE
 #define GNRC_IPV6_MSG_QUEUE_SIZE    (8U)
 #endif
+/** @} */
 
 /**
  * @brief   The PID to the IPv6 thread.


### PR DESCRIPTION
### Contribution description
The usage of `GNRC_IPV6_STATIC_LLADDR` (introduced in #6623) has been removed from `GNRC netif` some releases ago, but it is still documented and referenced in some examples.

This PR removes the macro from documentation and example Makefiles.

### Testing procedure
- `examples/gnrc_networking` should work as usual

### Issues/PRs references
None