### PR TITLE
boards/esp32: enable GPS module on ESP32 TTGO T-Beam V1.0

### DIFF
--- a/boards/common/esp32/board_common.c
+++ b/boards/common/esp32/board_common.c
@@ -30,7 +30,7 @@
  extern "C" {
 #endif
 
-void board_init(void)
+void board_init_common(void)
 {
     #ifdef LED0_PIN
     gpio_init (LED0_PIN, GPIO_OUT);
@@ -54,7 +54,7 @@ extern void spi_print_config(void);
 extern void uart_print_config(void);
 extern void can_print_config(void);
 
-void print_board_config (void)
+void print_board_config(void)
 {
     ets_printf("\nBoard configuration:\n");
 

--- a/boards/common/esp32/include/board_common.h
+++ b/boards/common/esp32/include/board_common.h
@@ -147,23 +147,37 @@ extern mtd_dev_t *mtd0;
 
 
 /**
- * @brief Initialize board specific hardware
+ * @brief Initialize the hardware that is common for all ESP32 boards.
  *
- * Since all features of ESP32 boards are provided by the SOC, almost all
- * initializations are done during the CPU initialization that is called from
- * boot loader.
+ * This function has to be called from the board specific `board_init` function.
  */
-void board_init (void);
+void board_init_common(void);
 
 /**
   * @brief Print the board configuration in a human readable format
   */
-void print_board_config (void);
+void print_board_config(void);
 
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif
 
+#else /* ESP32_IDF_CODE */
+
+#ifndef DOXYGEN
+
+#ifdef __cplusplus
+extern "C"
+#endif
+
+/* declaration of `board_init_common` is required when compiling vendor code */
+extern void board_init_common(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
 #endif /* ESP32_IDF_CODE */
 #endif /* BOARD_COMMON_H */
 /** @} */

--- a/boards/esp32-mh-et-live-minikit/include/board.h
+++ b/boards/esp32-mh-et-live-minikit/include/board.h
@@ -58,5 +58,13 @@
 /* include definitions for optional hardware modules */
 #include "board_modules.h"
 
+/**
+ * @brief Initialize the board specific hardware
+ */
+static inline void board_init(void) {
+    /* there is nothing special to initialize on this board */
+    board_init_common();
+}
+
 #endif /* BOARD_H */
 /** @} */

--- a/boards/esp32-olimex-evb/include/board.h
+++ b/boards/esp32-olimex-evb/include/board.h
@@ -98,6 +98,14 @@ extern "C" {
 /* include common board definitions as last step */
 #include "board_common.h"
 
+/**
+ * @brief Initialize the board specific hardware
+ */
+static inline void board_init(void) {
+    /* there is nothing special to initialize on this board */
+    board_init_common();
+}
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/esp32-ttgo-t-beam/Makefile.dep
+++ b/boards/esp32-ttgo-t-beam/Makefile.dep
@@ -1,1 +1,5 @@
+ifneq (,$(filter esp32_ttgo_t_beam_v1_0,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-ttgo-t-beam/board.c
+++ b/boards/esp32-ttgo-t-beam/board.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_ttgo-t-beam
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for TTGO T-Beam board
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "board.h"
+
+#if MODULE_ESP32_TTGO_T_BEAM_V1_0
+#include "periph/i2c.h"
+#endif
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#define AXP192_I2C_ADDR         (0x34)
+#define AXP192_LDO234_DC23_CTL  (0x12)
+#define AXP192_LDO3OUT_VOL      (0x29)
+#define AXP192_LDO3_ON_BIT      (1 << 3)
+
+void board_init(void)
+{
+    board_init_common();
+
+#if MODULE_ESP32_TTGO_T_BEAM_V1_0
+    uint8_t reg;
+
+    i2c_acquire(I2C_DEV(0));
+    /* enable the LDO3 power control */
+    i2c_read_reg(I2C_DEV(0), AXP192_I2C_ADDR, AXP192_LDO234_DC23_CTL, &reg, 0);
+    reg |= AXP192_LDO3_ON_BIT;
+    i2c_write_reg(I2C_DEV(0), AXP192_I2C_ADDR, AXP192_LDO234_DC23_CTL, reg, 0);
+    /* set the output voltage to 3V3 */
+    i2c_write_reg(I2C_DEV(0), AXP192_I2C_ADDR, AXP192_LDO3OUT_VOL, 0xff, 0);
+    i2c_release(I2C_DEV(0));
+#endif
+}
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/esp32-ttgo-t-beam/include/board.h
+++ b/boards/esp32-ttgo-t-beam/include/board.h
@@ -79,5 +79,10 @@
 /* include common board definitions as last step */
 #include "board_common.h"
 
+/**
+ * @brief Initialize the board specific hardware
+ */
+void board_init(void);
+
 #endif /* BOARD_H */
 /** @} */

--- a/boards/esp32-wemos-lolin-d32-pro/include/board.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/board.h
@@ -80,5 +80,13 @@
 /* include common board definitions as last step */
 #include "board_common.h"
 
+/**
+ * @brief Initialize the board specific hardware
+ */
+static inline void board_init(void) {
+    /* there is nothing special to initialize on this board */
+    board_init_common();
+}
+
 #endif /* BOARD_H */
 /** @} */

--- a/boards/esp32-wroom-32/include/board.h
+++ b/boards/esp32-wroom-32/include/board.h
@@ -64,5 +64,13 @@
 /* include common board definitions as last step */
 #include "board_common.h"
 
+/**
+ * @brief Initialize the board specific hardware
+ */
+static inline void board_init(void) {
+    /* there is nothing special to initialize on this board */
+    board_init_common();
+}
+
 #endif /* BOARD_H */
 /** @} */

--- a/boards/esp32-wrover-kit/include/board.h
+++ b/boards/esp32-wrover-kit/include/board.h
@@ -108,5 +108,13 @@
 /* include common board definitions as last step */
 #include "board_common.h"
 
+/**
+ * @brief Initialize the board specific hardware
+ */
+static inline void board_init(void) {
+    /* there is nothing special to initialize on this board */
+    board_init_common();
+}
+
 #endif /* BOARD_H */
 /** @} */

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -314,9 +314,6 @@ static NORETURN void IRAM system_init (void)
     LOG_STARTUP("Heap free: %u bytes\n", get_free_heap_size());
     uart_tx_wait_idle(CONFIG_CONSOLE_UART_NUM);
 
-    /* initialize the board */
-    board_init();
-
     /* initialize stdio */
     stdio_init();
 
@@ -340,6 +337,9 @@ static NORETURN void IRAM system_init (void)
     extern void spi_flash_drive_init (void);
     spi_flash_drive_init();
     #endif
+
+    /* initialize the board */
+    board_init();
 
     /* route a software interrupt source to CPU as trigger for thread yields */
     intr_matrix_set(PRO_CPU_NUM, ETS_FROM_CPU_INTR0_SOURCE, CPU_INUM_SOFTWARE);


### PR DESCRIPTION
### Contribution description

This PR enables the GPS module on ESP32 TTGO T-Beam V1.0 boards.

PR #11418 introduced the board definition for ESP32 TTGO T-Beam boards which include a GPS module that is connected via UART1 interface and provides NMEA messages on that interface. 

However, on boards from version 1.0, the power supply of the GPS module is contolled with an AXP192 that is connected via I2C. The GPS module is powered off by default and has to be switched on explicitly.

For this purpose the, this PR introduces 

1. the possibility to have a board-specific initialization function that is usually simply a wrapper around the common board initialization function `board_init_common`
2. a board-specific initialization function for ESP32 TTGO T-Beam boards, which switches on the power supply of the GPS module for version 1.0 boards.

Since the board initialization function `board_init` has to use the I2C interface to switch on the GPS module, the `board_init` function has to be called after `periph_init`. Therefore, the order of these both functions is also changed by this PR.

### Testing procedure

Use a [version 1.0 board of ESP32 TTGO T-Beam](https://github.com/Xinyuan-LilyGO/TTGO-T-Beam), flash and use `tests/periph_uart` with command `init 1 9600` to observe the output from the GPS module with and without this PR:
```
USEMODULE=esp32_ttgo_t_beam_v1_0 make BOARD=esp32-ttgo-t-beam -C tests/periph_uart flash term
```
With this PR the output should something like
```
Success: UART_DEV(1) RX: [$GPRMC,,V,,,,,,,,,,N*530x0d]\n
Success: UART_DEV(1) RX: [$GPVTG,,,,,,,,,N*300x0d]\n
Success: UART_DEV(1) RX: [$GPGGA,,,,,,0,00,99.99,,,,,,*480x0d]\n
Success: UART_DEV(1) RX: [$GPGSA,A,1,,,,,,,,,,,,,99.99,99.99,99.99*300x0d]\n
Success: UART_DEV(1) RX: [$GPGSV,1,1,00*790x0d]\n
Success: UART_DEV(1) RX: [$GPGLL,,,,,,V,N*640x0d]\n
```
Without this PR there should be no output.

### Issues/PRs references