### PR TITLE
make/mips: cleanup include makefile

### DIFF
--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -1,7 +1,7 @@
 # Target triple for the build.
 export TARGET_ARCH ?= mips-mti-elf
 
-export ABI=32
+ABI = 32
 
 # Default values for the linker script symbols listed below are
 # defined in the linker script.
@@ -21,7 +21,7 @@ comma := ,
 MIPS_HAL_LDFLAGS = $(foreach a,$(priv_symbols),$(if $($a),-Wl$(comma)--defsym$(comma)__$(call lowercase,$(a))=$($a)))
 
 ifeq ($(ROMABLE),1)
-MIPS_HAL_LDFLAGS += -T bootcode.ld
+  MIPS_HAL_LDFLAGS += -T bootcode.ld
 endif
 
 # define build specific options
@@ -41,21 +41,21 @@ CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_OPT) $(CFLAGS_DBG)
 CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))
 
 ifeq ($(USE_HARD_FLOAT),1)
-    CFLAGS += -mhard-float -DMIPS_HARD_FLOAT
+  CFLAGS += -mhard-float -DMIPS_HARD_FLOAT
 else
-    #hard-float is the default so we must set soft-float
-    CFLAGS += -msoft-float
-    LINKFLAGS += -msoft-float
+  #hard-float is the default so we must set soft-float
+  CFLAGS += -msoft-float
+  LINKFLAGS += -msoft-float
 endif
 
 ifeq ($(USE_DSP),1)
-    CFLAGS += -mdsp -DMIPS_DSP
+  CFLAGS += -mdsp -DMIPS_DSP
 endif
 
 ifeq ($(TOOLCHAIN),llvm)
-# The MIPS toolchain headers in assembly mode are not compatible with Clang
-CCAS = $(PREFIX)gcc
-CCASUWFLAGS += -target $(TARGET_ARCH)
+  # The MIPS toolchain headers in assembly mode are not compatible with Clang
+  CCAS = $(PREFIX)gcc
+  CCASUWFLAGS += -target $(TARGET_ARCH)
 endif
 
 ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_OPT) $(CFLAGS_DBG)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is cleaning the mips.inc.mk file:
- it removes a useless export of the ABI variable
- it fixes the indentation used in this file to make compliant with RIOT conventions

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This PR is quite straight forward so a green Murdock is enough.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while doing other cleanups in #13078 and #13080.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
