### PR TITLE
pkg/nimble_netif: catch L2CAP connection failures

### DIFF
--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -333,6 +333,12 @@ static int _on_l2cap_client_evt(struct ble_l2cap_event *event, void *arg)
 
     switch (event->type) {
         case BLE_L2CAP_EVENT_COC_CONNECTED:
+            if (event->connect.status != 0) {
+                /* in the unlikely event the L2CAP connection establishment
+                 * fails, we close the GAP connection */
+                ble_gap_terminate(conn->gaphandle, BLE_ERR_REM_USER_CONN_TERM);
+                break;
+            }
             conn->coc = event->connect.chan;
             conn->state |= NIMBLE_NETIF_L2CAP_CLIENT;
             conn->state &= ~NIMBLE_NETIF_CONNECTING;
@@ -371,6 +377,13 @@ static int _on_l2cap_server_evt(struct ble_l2cap_event *event, void *arg)
             handle = nimble_netif_conn_get_by_gaphandle(event->connect.conn_handle);
             conn = nimble_netif_conn_get(handle);
             assert(conn);
+
+            if (event->connect.status != 0) {
+                /* in the unlikely event the L2CAP connection establishment
+                 * fails, we close the GAP connection */
+                ble_gap_terminate(conn->gaphandle, BLE_ERR_REM_USER_CONN_TERM);
+                break;
+            }
             conn->coc = event->connect.chan;
             conn->state |= NIMBLE_NETIF_L2CAP_SERVER;
             conn->state &= ~(NIMBLE_NETIF_ADV | NIMBLE_NETIF_CONNECTING);


### PR DESCRIPTION
### Contribution description
When connecting L2CAP connection oriented channels, there is a possiblity in the NimBLE API, that the connection setup might fail and the according status is signaled using the `status` filed of the `event->connect` event. Although I have not yet seen this ever happen in practice, it should be handled by `nimble_netif` in any case to make sure we don't end up in inconsistent state at any time...

This PR will simply make the device close the underlying GAP connection, which in turn will be signaled to the upper layer, and hence will leave the overall connection state consistent.

### Testing procedure
As I was never able to even trigger this behavior, this is more a theoretical fix. Simply making sure the code change does not break anything should suffice, right?!

### Issues/PRs references
none