### PR TITLE
boards: initial import of Adafruit Feather nRF52840 Express

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -468,8 +468,10 @@ endif
 
 ifneq (,$(filter stdio_uart,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
+endif
 
-  # stdio_rtt cannot be used when stdio_uart is loaded
+ifneq (,$(filter stdio_cdc_acm stdio_null stdio_uart,$(USEMODULE)))
+  # stdio_rtt cannot be used when another STDIO is loaded
   DISABLE_MODULE += stdio_rtt
 endif
 

--- a/boards/feather-nrf52840/Makefile
+++ b/boards/feather-nrf52840/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/feather-nrf52840/Makefile.dep
+++ b/boards/feather-nrf52840/Makefile.dep
@@ -1,0 +1,9 @@
+# Use Segger's RTT by default for stdio on this board
+DEFAULT_MODULE += stdio_rtt
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+# include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/feather-nrf52840/Makefile.features
+++ b/boards/feather-nrf52840/Makefile.features
@@ -1,0 +1,12 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrf802154
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/feather-nrf52840/Makefile.include
+++ b/boards/feather-nrf52840/Makefile.include
@@ -1,0 +1,10 @@
+# HACK: replicate dependency resolution in Makefile.dep, only works
+# if `USEMODULE` or `DEFAULT_MODULE` is set by the command line or in the
+# application Makefile.
+ifeq (,$(filter stdio_%,$(DISABLE_MODULE) $(USEMODULE)))
+  RIOT_TERMINAL ?= jlink
+endif
+
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/feather-nrf52840/board.c
+++ b/boards/feather-nrf52840/board.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_clear(LED0_PIN);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_clear(LED1_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}
+
+/** @} */

--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -1,0 +1,42 @@
+/**
+@defgroup    boards_feather-nrf52840 Adafruit Feather nRF52840 Express
+@ingroup     boards
+@brief       Support for the Adafruit Feather nRF52840 Express
+
+### General information
+
+[The Feather nRF52840 Express][feather-nrf52840] is a development board
+from Adafruits Feather board family. It provides native USB support, Bluetooth
+Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
+
+![top-down view on feather-nrf52840][top-down view]
+
+[feather-nrf52840]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/
+[top-down view]: https://cdn-learn.adafruit.com/assets/assets/000/068/578/medium800/circuitpython_Screenshot_2019-01-02_at_12.04.27.png
+
+### Flash the board
+
+See the **Flashing** section in @ref boards_common_nrf52. The easiest way is to
+use an external Segger J-Link Progammer connected to the [SWD Connector].
+
+[SWD Connector]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/pinouts#swd-connector-3-12
+
+### Terminal
+To connect a terminal to the Feather, RIOT chooses Segger RTT per default.
+This lets you use the Segger J-Link Programmer as a serial interface to the
+device.
+
+You have several alternative possibilities to connect to the board.
+
+1. With
+   ~~~~~~~~~~~~~~~~~~~~~ {.mk}
+   USEMODULE += stdio_uart
+   ~~~~~~~~~~~~~~~~~~~~~
+   and an FTDI adapter connected to the Feather's RX and TX ports you can use
+   UART-based terminals to connect to the feather
+2. With
+   ~~~~~~~~~~~~~~~~~~~~~ {.mk}
+   USEMODULE += stdio_cdc_acm
+   ~~~~~~~~~~~~~~~~~~~~~
+   you can access the Feather with a terminal directly over USB.
+*/

--- a/boards/feather-nrf52840/include/board.h
+++ b/boards/feather-nrf52840/include/board.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Adafruit Feather nRF52840
+ *              Express
+ *
+ * @author      Martine S. Lenders <m.lenders@fu-berlin.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(1, 15)
+#define LED1_PIN            GPIO_PIN(1, 10)
+
+#define LED_PORT            (NRF_P1)
+#define LED0_MASK           (1 << 15)
+#define LED1_MASK           (1 << 10)
+#define LED_MASK            (LED0_MASK | LED1_MASK)
+
+#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(1, 2)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/feather-nrf52840/include/gpio_params.h
+++ b/boards/feather-nrf52840/include/gpio_params.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Martine S. Lenders <m.lenders@fu-berlin.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED Red (D3)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Blue (Conn)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "UserSw",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/feather-nrf52840/include/periph_conf.h
+++ b/boards/feather-nrf52840/include/periph_conf.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Adafruit Feather nRF52840
+ *              Express
+ *
+ * @author      Martine S. Lenders <m.lenders@fu-berlin.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0,24),
+        .tx_pin     = GPIO_PIN(0,25),
+        .rts_pin    = (uint8_t)GPIO_UNDEF,
+        .cts_pin    = (uint8_t)GPIO_UNDEF,
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = 14,
+        .mosi = 13,
+        .miso = 15
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = 11,
+        .sda = 12,
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/pinetime/Makefile.dep
+++ b/boards/pinetime/Makefile.dep
@@ -1,3 +1,5 @@
+DEFAULT_MODULE += stdio_rtt
+
 # include common nrf52 dependencies
 include $(RIOTBOARD)/common/nrf52/nrf52832/Makefile.dep
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/pinetime/Makefile.include
+++ b/boards/pinetime/Makefile.include
@@ -1,7 +1,6 @@
-# for this board, we are using Segger's RTT as default terminal interface
-USEMODULE += stdio_rtt
-TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
-TERMFLAGS = term-rtt
+# use JLink Segger RTT by default
+RIOT_TERMINAL ?= jlink
+include $(RIOTMAKE)/tools/serial.inc.mk
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides support initial support for the [Adafruit Feather nRF52840 Express][feather-nrf52840]. The current feature set includes:

- Default flashing via Segger J-Link
- UART, SPI, and I2C exposed in accordance to the Feather [pinout]
- SAUL support for on-board LEDs and button
- `stdio_cdc_acm` using the [RIOT standard peripheral PID][pid.codes]

[feather-nrf52840]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/
[pinout]: https://cdn-learn.adafruit.com/assets/assets/000/046/243/original/adafruit_products_Feather_M0_Adalogger_v2.2-1.png
[pid.codes]: http://pid.codes/1209/7D00/
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
1. Have a careful look at [the schematic](https://learn.adafruit.com/assets/68545) if all pins for the peripherals were chosen correctly
2. `BOARD=feather-nrf52840 make -C examples/hello-world flash term` should work with a Segger JLink Programmer connected for flashing. USB CDC ACM is used for stdio.
3. `PORT=/dev/ttyUSB0 USEMODULE=stdio_uart BOARD=feather-nrf52840 make -C examples/hello-world flash term` should work with a UART-Adapter connected.
4. `BOARD=feather-nrf52840 make -C examples/saul flash term` allows you to toggle the on-board LEDs and read out the status of the user switch.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
