### PR TITLE
pkg/nimble_netif: add additional events

### DIFF
--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -119,11 +119,15 @@ enum {
  * @brief   Event types triggered by the NimBLE netif module
  */
 typedef enum {
+    NIMBLE_NETIF_ACCEPTING,         /**< accepting incoming connections */
+    NIMBLE_NETIF_INIT_MASTER,       /**< conn. procedure started (as mater) */
+    NIMBLE_NETIF_INIT_SLAVE,        /**< conn. procedure started (as slave) */
     NIMBLE_NETIF_CONNECTED_MASTER,  /**< connection established as master */
     NIMBLE_NETIF_CONNECTED_SLAVE,   /**< connection established as slave */
     NIMBLE_NETIF_CLOSED_MASTER,     /**< connection closed (we were master) */
     NIMBLE_NETIF_CLOSED_SLAVE,      /**< connection closed (we were slave) */
-    NIMBLE_NETIF_CONNECT_ABORT,     /**< connection establishment aborted */
+    NIMBLE_NETIF_ABORT_MASTER,      /**< connection est. abort (as master) */
+    NIMBLE_NETIF_ABORT_SLAVE,       /**< connection est. abort (as slave) */
     NIMBLE_NETIF_CONN_UPDATED,      /**< connection parameter update done */
 } nimble_netif_event_t;
 

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -84,7 +84,8 @@ static void _on_ble_evt(int handle, nimble_netif_event_t event,
         case NIMBLE_NETIF_CLOSED_SLAVE:
             _print_evt("CONNECTION CLOSED", handle, addr);
             break;
-        case NIMBLE_NETIF_CONNECT_ABORT:
+        case NIMBLE_NETIF_ABORT_MASTER:
+        case NIMBLE_NETIF_ABORT_SLAVE:
             _print_evt("CONNECTION ABORT", handle, addr);
             break;
         case NIMBLE_NETIF_CONN_UPDATED:


### PR DESCRIPTION
### Contribution description
The events exposed by `nimble_netif` turned out to be insufficient when trying to keep more fine grained control/monitoring over the BLE connection management. So this PR adds some additional events and adapts the `sc_nimble_netif` shell command as well as the `nimble_autoconn` modules accordingly.

One use case for these additional and more fine grained events is to check my experiement logs for consistency.

I further intend to add functionality for enabling/disabling the events that are actually triggered, but can't say when I get to it...

### Testing procedure
Easiest way:
- enable DEBUG in `pkg/nimble/autoconn/nimble_autoconn.c`
- flash `gnrc_networking` with `autoconn`-enabled (`USEMODULE=nimble_autoconn_ipsp make ..`) to two supported boards (e.g. `nrf52dk`)
- look at their output, they should be a little more verbose on whats going on now
- to trigger some action, you can close existing connections using the `ble` shell command (`ble close 0`)

### Issues/PRs references
none
