### PR TITLE
Makefile.dep: auto_init_% as DEFAULT_MODULES

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -703,9 +703,10 @@ ifneq (,$(filter saul_reg,$(USEMODULE)))
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_saul
   USEMODULE += saul
   USEMODULE += saul_reg
-  USEMODULE += auto_init_saul
+  DEFAULT_MODULE += auto_init_saul
 endif
 
 ifneq (,$(filter saul_adc,$(USEMODULE)))
@@ -737,8 +738,9 @@ ifneq (,$(filter can_linux,$(USEMODULE)))
 endif
 
 ifneq (,$(filter can,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_can
   USEMODULE += can_raw
-  USEMODULE += auto_init_can
+  DEFAULT_MODULE += auto_init_can
   ifneq (,$(filter can_mbox,$(USEMODULE)))
     USEMODULE += core_mbox
   endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -754,7 +754,9 @@ ifneq (,$(filter puf_sram,$(USEMODULE)))
 endif
 
 ifneq (,$(filter random,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_random
   USEMODULE += prng
+  DEFAULT_MODULE += auto_init_random
   # select default prng
   ifeq (,$(filter prng_%,$(USEMODULE)))
     USEMODULE += prng_tinymt32

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -97,6 +97,7 @@ ifneq (,$(filter gnrc_dhcpv6_client,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_gnrc_uhcpc
   USEMODULE += uhcpc
   USEMODULE += gnrc_sock_udp
   USEMODULE += fmt
@@ -254,7 +255,9 @@ ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_gnrc_sixlowpan
   USEMODULE += sixlowpan
+  DEFAULT_MODULE += auto_init_gnrc_sixlowpan
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
@@ -322,6 +325,7 @@ ifneq (,$(filter gnrc_ipv6_router,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_gnrc_ipv6
   USEMODULE += inet_csum
   USEMODULE += ipv6_addr
   USEMODULE += gnrc_ipv6_hdr
@@ -366,6 +370,7 @@ ifneq (,$(filter gnrc_ipv6_nib_router,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_ipv6_nib,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_gnrc_ipv6_nib
   USEMODULE += evtimer
   USEMODULE += gnrc_ndp
   USEMODULE += gnrc_netif
@@ -377,11 +382,13 @@ ifneq (,$(filter gnrc_ipv6_nib,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_udp,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_gnrc_udp
   USEMODULE += inet_csum
   USEMODULE += udp
 endif
 
 ifneq (,$(filter gnrc_tcp,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_gnrc_tcp
   USEMODULE += inet_csum
   USEMODULE += random
   USEMODULE += tcp
@@ -398,6 +405,7 @@ ifneq (,$(filter gnrc_nettest,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_gnrc_pktdump
   USEMODULE += gnrc_pktbuf
   USEMODULE += od
 endif
@@ -636,6 +644,7 @@ ifneq (,$(filter gnrc_pktbuf, $(USEMODULE)))
   ifeq (gnrc_pktbuf_cmd,$(filter gnrc_pktbuf_%, $(USEMODULE)))
     USEMODULE += gnrc_pktbuf_static
   endif
+  DEFAULT_MODULE += auto_init_gnrc_pktbuf
   USEMODULE += gnrc_pkt
 endif
 

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -680,6 +680,7 @@ ifneq (,$(filter arduino_pwm,$(FEATURES_USED)))
 endif
 
 ifneq (,$(filter xtimer,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_xtimer
   FEATURES_REQUIRED += periph_timer
   USEMODULE += div
 endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1056,3 +1056,9 @@ USEPKG := $(sort $(USEPKG))
 ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
   include $(RIOTBASE)/Makefile.dep
 endif
+
+# Add auto_init_% DEFAULT_MODULES. This is done after the recursive cach since
+# none of these modules can trigger dependency resolution.
+ifneq (,$(filter auto_init,$(USEMODULE)))
+  USEMODULE += $(filter auto_init_%,$(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
+endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -43,6 +43,7 @@ endif
 
 ifneq (,$(filter at86rf%,$(USEMODULE)))
   USEMODULE += at86rf2xx
+  DEFAULT_MODULE += auto_init_at86rf2xx
   USEMODULE += xtimer
   USEMODULE += luid
   USEMODULE += netif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -1,6 +1,4 @@
 PSEUDOMODULES += at_urc
-PSEUDOMODULES += auto_init_dhcpv6_client
-PSEUDOMODULES += auto_init_gnrc_rpl
 PSEUDOMODULES += can_mbox
 PSEUDOMODULES += can_pm
 PSEUDOMODULES += can_raw
@@ -192,8 +190,7 @@ PSEUDOMODULES += stm32_periph_%
 PSEUDOMODULES += periph_%
 NO_PSEUDOMODULES += periph_common
 
-# Submodules and auto-init code provided by Skald
-PSEUDOMODULES += auto_init_skald
+# Submodules provided by Skald
 PSEUDOMODULES += skald_ibeacon
 PSEUDOMODULES += skald_eddystone
 
@@ -204,5 +201,15 @@ PSEUDOMODULES += ds18_optimized
 PSEUDOMODULES += crypto_aes_precalculated
 # This pseudomodule causes a loop in AES to be unrolled (more flash, less CPU)
 PSEUDOMODULES += crypto_aes_unroll
+
+# All auto_init modules are pseudomodules
+PSEUDOMODULES += auto_init_%
+NO_PSEUDOMODULES += auto_init_can
+NO_PSEUDOMODULES += auto_init_loramac
+NO_PSEUDOMODULES += auto_init_gnrc_netif
+NO_PSEUDOMODULES += auto_init_saul
+NO_PSEUDOMODULES += auto_init_security
+NO_PSEUDOMODULES += auto_init_storage
+NO_PSEUDOMODULES += auto_init_usbus
 
 # Packages may also add modules to PSEUDOMODULES in their `Makefile.include`.

--- a/pkg/cryptoauthlib/Makefile.dep
+++ b/pkg/cryptoauthlib/Makefile.dep
@@ -1,4 +1,4 @@
 USEMODULE += xtimer
 FEATURES_REQUIRED += periph_i2c
-USEMODULE += auto_init_security
+DEFAULT_MODULE += auto_init_security
 USEMODULE += cryptoauthlib_contrib

--- a/pkg/fatfs/Makefile.dep
+++ b/pkg/fatfs/Makefile.dep
@@ -1,5 +1,5 @@
 USEMODULE += fatfs_diskio_mtd
-USEMODULE += auto_init_storage
+DEFAULT_MODULE += auto_init_storage
 USEMODULE += mtd
 
 # Use RTC for timestamps if available

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -1,3 +1,5 @@
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 FEATURES_REQUIRED += arch_32bit
+
+DEFAULT_MODULE += auto_init_lwip

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -107,7 +107,7 @@
 
 void auto_init(void)
 {
-#ifdef MODULE_PRNG
+#ifdef MODULE_AUTO_INIT_RANDOM
     void auto_init_random(void);
     auto_init_random();
 #endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -28,11 +28,11 @@
 #include "xtimer.h"
 #endif
 
-#ifdef MODULE_GNRC_SIXLOWPAN
+#ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
 #include "net/gnrc/sixlowpan.h"
 #endif
 
-#ifdef MODULE_GNRC_IPV6
+#ifdef MODULE_AUTO_INIT_GNRC_IPV6
 #include "net/gnrc/ipv6.h"
 #endif
 
@@ -40,19 +40,19 @@
 #include "l2_ping.h"
 #endif
 
-#ifdef MODULE_GNRC_PKTBUF
+#ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
 #include "net/gnrc/pktbuf.h"
 #endif
 
-#ifdef MODULE_GNRC_PKTDUMP
+#ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
 #include "net/gnrc/pktdump.h"
 #endif
 
-#ifdef MODULE_GNRC_UDP
+#ifdef MODULE_AUTO_INIT_GNRC_UDP
 #include "net/gnrc/udp.h"
 #endif
 
-#ifdef MODULE_GNRC_TCP
+#ifdef MODULE_AUTO_INIT_GNRC_TCP
 #include "net/gnrc/tcp.h"
 #endif
 
@@ -72,7 +72,7 @@
 #include "net/gcoap.h"
 #endif
 
-#ifdef MODULE_GNRC_IPV6_NIB
+#ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
 #include "net/gnrc/ipv6/nib.h"
 #endif
 
@@ -130,27 +130,27 @@ void auto_init(void)
     extern void profiling_init(void);
     profiling_init();
 #endif
-#ifdef MODULE_GNRC_PKTBUF
+#ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
     DEBUG("Auto init gnrc_pktbuf module\n");
     gnrc_pktbuf_init();
 #endif
-#ifdef MODULE_GNRC_PKTDUMP
+#ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
     DEBUG("Auto init gnrc_pktdump module.\n");
     gnrc_pktdump_init();
 #endif
-#ifdef MODULE_GNRC_SIXLOWPAN
+#ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
     DEBUG("Auto init gnrc_sixlowpan module.\n");
     gnrc_sixlowpan_init();
 #endif
-#ifdef MODULE_GNRC_IPV6
+#ifdef MODULE_AUTO_INIT_GNRC_IPV6
     DEBUG("Auto init gnrc_ipv6 module.\n");
     gnrc_ipv6_init();
 #endif
-#ifdef MODULE_GNRC_UDP
+#ifdef MODULE_AUTO_INIT_GNRC_UDP
     DEBUG("Auto init UDP module.\n");
     gnrc_udp_init();
 #endif
-#ifdef MODULE_GNRC_TCP
+#ifdef MODULE_AUTO_INIT_GNRC_TCP
     DEBUG("Auto init TCP module\n");
     gnrc_tcp_init();
 #endif
@@ -173,7 +173,7 @@ void auto_init(void)
     extern void auto_init_devfs(void);
     auto_init_devfs();
 #endif
-#ifdef MODULE_GNRC_IPV6_NIB
+#ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
     DEBUG("Auto init gnrc_ipv6_nib module.\n");
     gnrc_ipv6_nib_init();
 #endif
@@ -342,7 +342,7 @@ void auto_init(void)
 
 #endif /* MODULE_AUTO_INIT_GNRC_NETIF */
 
-#ifdef MODULE_GNRC_UHCPC
+#ifdef MODULE_AUTO_INIT_GNRC_UHCPC
     extern void auto_init_gnrc_uhcpc(void);
     auto_init_gnrc_uhcpc();
 #endif
@@ -592,7 +592,7 @@ void auto_init(void)
 
 #ifdef MODULE_AUTO_INIT_GNRC_RPL
 
-#ifdef MODULE_GNRC_RPL
+#ifdef MODULE_AUTO_INIT_GNRC_RPL
     extern void auto_init_gnrc_rpl(void);
     auto_init_gnrc_rpl();
 #endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -154,7 +154,7 @@ void auto_init(void)
     DEBUG("Auto init TCP module\n");
     gnrc_tcp_init();
 #endif
-#ifdef MODULE_LWIP
+#ifdef MODULE_AUTO_INIT_LWIP
     DEBUG("Bootstraping lwIP.\n");
     lwip_bootstrap();
 #endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -223,7 +223,7 @@ void auto_init(void)
     auto_init_stm32_eth();
 #endif
 
-#ifdef MODULE_AT86RF2XX
+#ifdef MODULE_AUTO_INIT_AT86RF2XX
     extern void auto_init_at86rf2xx(void);
     auto_init_at86rf2xx();
 #endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -24,7 +24,7 @@
 #include "diskio.h"
 #endif
 
-#ifdef MODULE_XTIMER
+#ifdef MODULE_AUTO_INIT_XTIMER
 #include "xtimer.h"
 #endif
 
@@ -111,7 +111,7 @@ void auto_init(void)
     void auto_init_random(void);
     auto_init_random();
 #endif
-#ifdef MODULE_XTIMER
+#ifdef MODULE_AUTO_INIT_XTIMER
     DEBUG("Auto init xtimer module.\n");
     xtimer_init();
 #endif

--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -7,6 +7,6 @@ USEMODULE += xtimer
 
 USEMODULE += fmt
 
-DISABLE_MODULE += auto_init
+DISABLE_MODULE += auto_init_random
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/bloom_bytes/main.c
+++ b/tests/bloom_bytes/main.c
@@ -22,8 +22,6 @@
 #include <string.h>
 #include <inttypes.h>
 
-#include "test_utils/interactive_sync.h"
-
 #include "xtimer.h"
 #include "fmt.h"
 
@@ -61,11 +59,7 @@ static void buf_fill(uint32_t *buf, int len)
 
 int main(void)
 {
-    xtimer_init();
-
     bloom_init(&bloom, BLOOM_BITS, bf, hashes, BLOOM_HASHF);
-
-    test_utils_interactive_sync();
 
     printf("Testing Bloom filter.\n\n");
     printf("m: %" PRIu32 " k: %" PRIu32 "\n\n", (uint32_t) bloom.m,

--- a/tests/cpp_ctors/Makefile
+++ b/tests/cpp_ctors/Makefile
@@ -4,6 +4,4 @@ USEMODULE += embunit
 
 FEATURES_REQUIRED += cpp
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/cpp_ctors/main.c
+++ b/tests/cpp_ctors/main.c
@@ -9,7 +9,6 @@
 #include "embUnit.h"
 #include "tests-cpp_ctors.h"
 #include "thread.h" /* For thread_getpid() */
-#include "test_utils/interactive_sync.h"
 
 long tests_cpp_ctors_global_value(void);
 long tests_cpp_ctors_static_value(void);
@@ -59,8 +58,6 @@ Test *tests_cpp_ctors_tests(void)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     TESTS_START();
     TESTS_RUN(tests_cpp_ctors_tests());
     TESTS_END();

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
+DISABLE_MODULE += auto_init_at86rf2xx
 
 USEMODULE += od
 USEMODULE += shell

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -88,7 +88,6 @@ void *_recv_thread(void *arg)
 int main(void)
 {
     puts("AT86RF2xx device driver test");
-    xtimer_init();
 
     unsigned dev_success = 0;
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {

--- a/tests/float/Makefile
+++ b/tests/float/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 # for native we can go do a couple of more operations in reasonable time...
 ifneq (,$(filter native,$(BOARD)))
   CFLAGS += -DTEST_ITER=100000000

--- a/tests/float/main.c
+++ b/tests/float/main.c
@@ -23,8 +23,6 @@
 #include <stdio.h>
 #include <math.h>
 
-#include "test_utils/interactive_sync.h"
-
 #include "board.h"
 
 /* as default we run the test 100k times */
@@ -36,8 +34,6 @@
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     double x = 1234567.0 / 1024.0;
 
     puts("Testing floating point arithmetic...\n");

--- a/tests/gnrc_sixlowpan_frag/Makefile
+++ b/tests/gnrc_sixlowpan_frag/Makefile
@@ -4,7 +4,7 @@ USEMODULE += gnrc_sixlowpan_frag
 USEMODULE += embunit
 
 # GNRC modules should not be initialized unless we want to
-DISABLE_MODULE += auto_init
+DISABLE_MODULE += auto_init_gnrc_%
 
 # we don't need all this packet buffer space so reduce it a little
 CFLAGS += -DTEST_SUITES -DGNRC_PKTBUF_SIZE=2048

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -25,8 +25,6 @@
 #include "net/gnrc/sixlowpan/frag/rb.h"
 #include "xtimer.h"
 
-#include "test_utils/interactive_sync.h"
-
 #define TEST_NETIF_HDR_SRC      { 0xb3, 0x47, 0x60, 0x49, \
                                   0x78, 0xfe, 0x95, 0x48 }
 #define TEST_NETIF_HDR_DST      { 0xa4, 0xf2, 0xd2, 0xc9, \
@@ -648,10 +646,6 @@ static void run_unittests(void)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
-    /* no auto-init, so xtimer needs to be initialized manually*/
-    xtimer_init();
     /* netreg requires queue, but queue size one should be enough for us */
     msg_init_queue(&_msg_queue, 1U);
     run_unittests();

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -25,7 +25,7 @@ USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
 
-DISABLE_MODULE += auto_init
+DISABLE_MODULE += auto_init_lwip
 
 CFLAGS += -DSO_REUSE
 CFLAGS += -DLWIP_SO_RCVTIMEO

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -22,8 +22,6 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "test_utils/interactive_sync.h"
-
 #include "net/sock/ip.h"
 #include "xtimer.h"
 
@@ -1082,8 +1080,6 @@ static void test_sock_ip_send6__no_sock(void)
 int main(void)
 {
     uint8_t code = 0;
-
-    test_utils_interactive_sync();
 
 #ifdef SO_REUSE
     code |= 1;

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -137,7 +137,6 @@ static int _netdev_send(netdev_t *dev, const iolist_t *iolist)
 
 void _net_init(void)
 {
-    xtimer_init();
     msg_init_queue(_msg_queue, _MSG_QUEUE_SIZE);
     _check_pid = sched_active_pid;
 

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -24,7 +24,7 @@ USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
 
-DISABLE_MODULE += auto_init
+DISABLE_MODULE += auto_init_lwip
 
 CFLAGS += -DSO_REUSE
 CFLAGS += -DLWIP_SO_RCVTIMEO

--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -33,8 +33,6 @@
 #include "constants.h"
 #include "stack.h"
 
-#include "test_utils/interactive_sync.h"
-
 #define _TEST_BUFFER_SIZE   (128)
 #define _QUEUE_SIZE         (1)
 
@@ -960,8 +958,6 @@ static void test_tcp_write6__success(void)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     uint8_t code = 0;
 
 #ifdef SO_REUSE

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -25,7 +25,7 @@ USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
 
-DISABLE_MODULE += auto_init
+DISABLE_MODULE += auto_init_lwip
 
 CFLAGS += -DSO_REUSE
 CFLAGS += -DLWIP_SO_RCVTIMEO

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -28,8 +28,6 @@
 #include "constants.h"
 #include "stack.h"
 
-#include "test_utils/interactive_sync.h"
-
 #define _TEST_BUFFER_SIZE   (128)
 
 static uint8_t _test_buffer[_TEST_BUFFER_SIZE];
@@ -1319,8 +1317,6 @@ static void test_sock_udp_send6__no_sock(void)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     uint8_t code = 0;
 
 #ifdef SO_REUSE
@@ -1333,7 +1329,6 @@ int main(void)
     code |= (1 << 6);
 #endif
     printf("code 0x%02x\n", code);
-    xtimer_init();
     _net_init();
     tear_down();
 #ifdef MODULE_LWIP_IPV4

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -140,7 +140,6 @@ static int _netdev_send(netdev_t *dev, const iolist_t *iolist)
 
 void _net_init(void)
 {
-    xtimer_init();
     msg_init_queue(_msg_queue, _MSG_QUEUE_SIZE);
     _check_pid = sched_active_pid;
 

--- a/tests/msg_avail/Makefile
+++ b/tests/msg_avail/Makefile
@@ -1,5 +1,3 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/msg_avail/main.c
+++ b/tests/msg_avail/main.c
@@ -25,7 +25,6 @@
 
 #include "log.h"
 #include "msg.h"
-#include "test_utils/interactive_sync.h"
 
 #define MSG_QUEUE_LENGTH                (8)
 
@@ -33,8 +32,6 @@ msg_t msg_queue[MSG_QUEUE_LENGTH];
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     msg_t msges[MSG_QUEUE_LENGTH];
 
     msg_init_queue(msg_queue, MSG_QUEUE_LENGTH);

--- a/tests/mutex_unlock_and_sleep/Makefile
+++ b/tests/mutex_unlock_and_sleep/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 # stm32f030f4-demo doesn't have enough RAM to run the test
 # so we reduce the stack size for every thread
 ifneq (,$(filter stm32f030f4-demo,$(BOARD)))

--- a/tests/mutex_unlock_and_sleep/main.c
+++ b/tests/mutex_unlock_and_sleep/main.c
@@ -22,8 +22,6 @@
 #include "thread.h"
 #include "mutex.h"
 
-#include "test_utils/interactive_sync.h"
-
 static mutex_t mutex = MUTEX_INIT;
 static volatile int indicator;
 static kernel_pid_t main_pid;
@@ -49,8 +47,6 @@ static void *second_thread(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     uint32_t count = 0;
     uint32_t kcount = 0;
 

--- a/tests/netdev_test/Makefile
+++ b/tests/netdev_test/Makefile
@@ -4,7 +4,7 @@
 CFLAGS += -DNDEBUG
 include ../Makefile.tests_common
 
-DISABLE_MODULE = auto_init
+DISABLE_MODULE += auto_init_gnrc_%
 
 USEMODULE += gnrc
 USEMODULE += gnrc_neterr

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -28,8 +28,6 @@
 #include "thread.h"
 #include "utlist.h"
 
-#include "test_utils/interactive_sync.h"
-
 #define _EXP_LENGTH     (64)
 
 #define _MAC_STACKSIZE  (THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)
@@ -251,8 +249,6 @@ static int test_set_addr(void)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     /* initialization */
     gnrc_pktbuf_init();
     msg_init_queue(_main_msg_queue, _MAIN_MSG_QUEUE_SIZE);

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -3,6 +3,4 @@ include ../Makefile.tests_common
 USEMODULE += fmt
 USEMODULE += posix_semaphore
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -32,8 +32,6 @@
 #include "thread.h"
 #include "xtimer.h"
 
-#include "test_utils/interactive_sync.h"
-
 #define SEMAPHORE_MSG_QUEUE_SIZE        (8)
 #define SEMAPHORE_TEST_THREADS          (5)
 static char test1_thread_stack[THREAD_STACKSIZE_MAIN];
@@ -294,10 +292,7 @@ void test4(void)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     msg_init_queue(main_msg_queue, SEMAPHORE_MSG_QUEUE_SIZE);
-    xtimer_init();
     puts("######################### TEST1:");
     test1();
     puts("######################### TEST2:");

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -9,7 +9,6 @@ USEMODULE += ps
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
 
-DISABLE_MODULE += auto_init
 DISABLE_MODULE += test_utils_interactive_sync
 
 # chronos is missing a getchar implementation

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -68,10 +68,6 @@ int main(void)
 
     printf("test_shell.\n");
 
-#if MODULE_STDIO_RTT
-    xtimer_init();
-#endif
-
     /* define buffer to be used by the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 

--- a/tests/socket_zep/Makefile
+++ b/tests/socket_zep/Makefile
@@ -6,8 +6,6 @@ BOARD_WHITELIST = native    # socket_zep is only available on native
 #   ZEP: Unable to connect socket: Cannot assign requested address
 TEST_ON_CI_BLACKLIST += native
 
-DISABLE_MODULE += auto_init
-
 USEMODULE += od
 USEMODULE += socket_zep
 

--- a/tests/socket_zep/main.c
+++ b/tests/socket_zep/main.c
@@ -31,8 +31,6 @@
 #include "msg.h"
 #include "od.h"
 
-#include "test_utils/interactive_sync.h"
-
 #define MSG_QUEUE_SIZE  (8)
 #define MSG_TYPE_ISR    (0x3456)
 #define RECVBUF_SIZE    (IEEE802154_FRAME_LEN_MAX)
@@ -106,8 +104,6 @@ static void test_recv(void)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     puts("Socket ZEP device driver test");
     msg_init_queue(_msg_queue, MSG_QUEUE_SIZE);
     _main_pid = sched_active_pid;

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += timex

--- a/tests/thread_basic/Makefile
+++ b/tests/thread_basic/Makefile
@@ -1,5 +1,3 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_basic/main.c
+++ b/tests/thread_basic/main.c
@@ -21,8 +21,6 @@
 #include <stdio.h>
 #include "thread.h"
 
-#include "test_utils/interactive_sync.h"
-
 char t2_stack[THREAD_STACKSIZE_MAIN];
 
 void *second_thread(void *arg)
@@ -34,8 +32,6 @@ void *second_thread(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     (void) thread_create(
             t2_stack, sizeof(t2_stack),
             THREAD_PRIORITY_MAIN - 1,

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 ifneq (,$(filter nucleo-f042k6,$(BOARD)))
   PROBLEM ?= 3
 endif

--- a/tests/thread_cooperation/main.c
+++ b/tests/thread_cooperation/main.c
@@ -25,8 +25,6 @@
 #include "thread.h"
 #include "mutex.h"
 
-#include "test_utils/interactive_sync.h"
-
 #ifndef PROBLEM
 #define PROBLEM 12
 #endif
@@ -65,8 +63,6 @@ int main(void)
     msg_t args[PROBLEM];
     kernel_pid_t ths;
     uint32_t factorial = 1;
-
-    test_utils_interactive_sync();
 
     printf("[START] compute %d! (factorial).\n", PROBLEM);
 

--- a/tests/thread_exit/Makefile
+++ b/tests/thread_exit/Makefile
@@ -1,5 +1,3 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_exit/main.c
+++ b/tests/thread_exit/main.c
@@ -22,8 +22,6 @@
 
 #include "thread.h"
 
-#include "test_utils/interactive_sync.h"
-
 char second_thread_stack[THREAD_STACKSIZE_MAIN];
 char third_thread_stack[THREAD_STACKSIZE_MAIN];
 
@@ -80,7 +78,6 @@ void *second_thread(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
     puts("main: starting");
 
     if ((thread_create(

--- a/tests/thread_flood/Makefile
+++ b/tests/thread_flood/Makefile
@@ -1,5 +1,3 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_flood/main.c
+++ b/tests/thread_flood/main.c
@@ -27,8 +27,6 @@
 #include "thread.h"
 #include "kernel_types.h"
 
-#include "test_utils/interactive_sync.h"
-
 /* One stack for all threads. DON'T TRY THIS AT HOME!! */
 static char dummy_stack[THREAD_STACKSIZE_IDLE];
 
@@ -39,8 +37,6 @@ static void *thread_func(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     kernel_pid_t thr_id = KERNEL_PID_UNDEF;
     unsigned thr_cnt = 0;
 

--- a/tests/thread_msg/Makefile
+++ b/tests/thread_msg/Makefile
@@ -1,5 +1,3 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg/main.c
+++ b/tests/thread_msg/main.c
@@ -24,8 +24,6 @@
 #include "thread.h"
 #include "msg.h"
 
-#include "test_utils/interactive_sync.h"
-
 char t1_stack[THREAD_STACKSIZE_MAIN];
 char t2_stack[THREAD_STACKSIZE_MAIN];
 char t3_stack[THREAD_STACKSIZE_MAIN];
@@ -87,8 +85,6 @@ void *thread3(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     p_main = sched_active_pid;
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,

--- a/tests/thread_msg_block_race/Makefile
+++ b/tests/thread_msg_block_race/Makefile
@@ -2,7 +2,9 @@ DEVELHELP := 1
 
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
+DISABLE_MODULE += auto_init_xtimer
+DISABLE_MODULE += auto_init_random
+
 FEATURES_REQUIRED += periph_timer
 USEMODULE += random
 

--- a/tests/thread_msg_block_race/main.c
+++ b/tests/thread_msg_block_race/main.c
@@ -27,8 +27,6 @@
 #include "thread.h"
 #include "msg.h"
 
-#include "test_utils/interactive_sync.h"
-
 #define CANARY_TYPE         (0x21fd)
 
 #define TIMER_FREQ          (1000000LU)
@@ -81,8 +79,6 @@ static void *_thread(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     kernel_pid_t pid;
 
     timer_init(TIMER_DEV(0), TIMER_FREQ, _timer, NULL);

--- a/tests/thread_msg_block_w_queue/Makefile
+++ b/tests/thread_msg_block_w_queue/Makefile
@@ -1,5 +1,3 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg_block_w_queue/main.c
+++ b/tests/thread_msg_block_w_queue/main.c
@@ -25,8 +25,6 @@
 #include "thread.h"
 #include "msg.h"
 
-#include "test_utils/interactive_sync.h"
-
 char t1_stack[THREAD_STACKSIZE_MAIN];
 
 kernel_pid_t p_send = KERNEL_PID_UNDEF, p_recv = KERNEL_PID_UNDEF;
@@ -56,8 +54,6 @@ void *sender_thread(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     msg_t msg;
     p_recv = sched_active_pid;
 

--- a/tests/thread_msg_block_wo_queue/Makefile
+++ b/tests/thread_msg_block_wo_queue/Makefile
@@ -1,5 +1,3 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg_block_wo_queue/main.c
+++ b/tests/thread_msg_block_wo_queue/main.c
@@ -25,8 +25,6 @@
 #include "thread.h"
 #include "msg.h"
 
-#include "test_utils/interactive_sync.h"
-
 char t1_stack[THREAD_STACKSIZE_MAIN];
 
 kernel_pid_t p_send = KERNEL_PID_UNDEF, p_recv = KERNEL_PID_UNDEF;
@@ -56,8 +54,6 @@ void *thread1(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     msg_t msg;
     p_recv = sched_active_pid;
 

--- a/tests/thread_msg_seq/Makefile
+++ b/tests/thread_msg_seq/Makefile
@@ -1,5 +1,3 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg_seq/main.c
+++ b/tests/thread_msg_seq/main.c
@@ -25,8 +25,6 @@
 #include "thread.h"
 #include "msg.h"
 
-#include "test_utils/interactive_sync.h"
-
 char t1_stack[THREAD_STACKSIZE_MAIN];
 char t2_stack[THREAD_STACKSIZE_MAIN];
 char t3_stack[THREAD_STACKSIZE_MAIN];
@@ -53,8 +51,6 @@ void *sub_thread(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     puts("START");
     msg_t msg;
 

--- a/tests/thread_race/Makefile
+++ b/tests/thread_race/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
-
 # stm32f030f4-demo doesn't have enough RAM to run the test
 # so we reduce the stack size for every thread
 ifneq (,$(filter stm32f030f4-demo,$(BOARD)))

--- a/tests/thread_race/main.c
+++ b/tests/thread_race/main.c
@@ -26,8 +26,6 @@
 #include "sched.h"
 #include "thread.h"
 
-#include "test_utils/interactive_sync.h"
-
 char iqr_check_stack[THREAD_STACKSIZE_DEFAULT];
 
 static volatile uint8_t irq_occurred;
@@ -67,8 +65,6 @@ static void _spin(void)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     puts("Context swap race condition test application");
 
     kernel_pid_t pid;

--- a/tests/thread_zombie/Makefile
+++ b/tests/thread_zombie/Makefile
@@ -1,6 +1,5 @@
 include ../Makefile.tests_common
 
-DISABLE_MODULE += auto_init
 # For better testing use ps
 #USEMODULE += ps
 

--- a/tests/thread_zombie/main.c
+++ b/tests/thread_zombie/main.c
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include "thread.h"
-#include "test_utils/interactive_sync.h"
 #ifdef MODULE_PS
 #include "ps.h"
 #endif /* MODULE_PS */
@@ -45,8 +44,6 @@ void *second_thread(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     /* save thread count on test start */
     int current_thread_count;
     int start_thread_count = sched_num_threads;


### PR DESCRIPTION
### Contribution description

This PR looks to extend the granularity of `auto_init` MODULES. Currently only `auto_init` is a `DEFAULT_MODULE` which means its the only one that can be disabled, which translates into, get everything or nothing. As a user I could want to only deactivate one of this `auto_init` modules and keep the rest (for examples in our `tests`).

This PR wan't to achieve this by declaring all curent cases of `USEMODULE += auto_init_%` as `DEFAULT_MODULE += auto_init_%`, it also by default declares all `auto_init_%` as pseudomodules (except for those that are not).

As an example I add an `auto_init_xtimer` module and changes the gauards in `auto_init.c` to reflect this. IMO this could be done for all modules in `auto_init`, but that would mean a lot of changes, so maybe better to introduce when needed?

### Testing procedure

- green murdock

- try disabling a module, I added a `#error` in:

```
#ifdef MODULE_AUTO_INIT_XTIMER
    #error
    DEBUG("Auto init xtimer module.\n");
    xtimer_init();
#endif
```

and compiled with and without disabling `DISABLE_MODULE+=auto_init_xtimer make -C tests/xtimer_usleep`

### Issues/PRs references

Though of this because of #13052
