### PR TITLE
cortexm_common/mpu: Only enable during low low level init

### DIFF
--- a/cpu/cortexm_common/mpu.c
+++ b/cpu/cortexm_common/mpu.c
@@ -67,10 +67,6 @@ int mpu_configure(uint_fast8_t region, uintptr_t base, uint_fast32_t attr) {
     MPU->RBAR = base & MPU_RBAR_ADDR_Msk;
     MPU->RASR = attr | MPU_RASR_ENABLE_Msk;
 
-    if (!mpu_enabled()) {
-        mpu_enable();
-    }
-
     return 0;
 #else
     (void)region;

--- a/cpu/cortexm_common/mpu.c
+++ b/cpu/cortexm_common/mpu.c
@@ -61,8 +61,6 @@ bool mpu_enabled(void) {
 int mpu_configure(uint_fast8_t region, uintptr_t base, uint_fast32_t attr) {
 /* Todo enable MPU support for Cortex-M23/M33 */
 #if __MPU_PRESENT && !defined(CPU_ARCH_CORTEX_M23)
-    assert(region < MPU_NUM_REGIONS);
-
     MPU->RNR  = region;
     MPU->RBAR = base & MPU_RBAR_ADDR_Msk;
     MPU->RASR = attr | MPU_RASR_ENABLE_Msk;

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -140,6 +140,7 @@ void reset_handler_default(void)
 #endif /* CPU_HAS_BACKUP_RAM */
 
 #ifdef MODULE_MPU_STACK_GUARD
+    mpu_enable();
     if (((uintptr_t)&_sstack) != SRAM_BASE) {
         mpu_configure(
             0,                                              /* MPU region 0 */
@@ -147,7 +148,6 @@ void reset_handler_default(void)
             MPU_ATTR(1, AP_RO_RO, 0, 1, 0, 1, MPU_SIZE_32B) /* Attributes and Size */
         );
 
-        mpu_enable();
     }
 #endif
 


### PR DESCRIPTION
### Contribution description

This PR modifies the MPU code by removing the conditional enabling of the MPU during the reconfiguration of the MPU regions. As this reconfiguration is in the hot path of the scheduler thread switch, this decreases the clock ticks required for a context switch. Instead, the MPU is enabled during the reset vector handler if the module is included.

I've also removed the assert check in the reconfiguration to shave of even more time. Please let me know if you agree with removing the assert or if it should be kept there and only removed when `DEVELHELP` is disabled.

### Benchmarks

benchmarks are run on an nRF52-dk board (cortex-m4@64Mhz) using `tests/bench_thread_flags_pingpong`:

|               | result |
|:-------------- | -----------------:|
| MPU disabled  | 116786           |
| MPU master    | 90266            |
| MPU enable removed        | 91558 |
| MPU enable and assert removed | 97410 |

### Testing procedure

Run `tests/mpu_stack_guard` on your favorite board with an MPU.

Optionally verify the benchmarks.

### Issues/PRs references

None