### PR TITLE
drivers/itg320x: small build system cleanup

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -280,6 +280,7 @@ endif
 
 ifneq (,$(filter itg320x,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter jc42,$(USEMODULE)))

--- a/drivers/itg320x/Makefile
+++ b/drivers/itg320x/Makefile
@@ -1,3 +1,1 @@
-MODULE = itg320x
-
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a couple of build system things with the itg320x driver (#10092):
- remove the use of `MODULE = itg320x` which is not needed in the driver main Makefile
- adds xtimer module as a dependency of the driver: an application using the `itg320x_int` module variant can omit the xtimer dependency and this would result in a build failure.
You can verify this second point by applying this patch:
```diff
diff --git a/tests/driver_itg320x/Makefile b/tests/driver_itg320x/Makefile
index 3e972cddd7..c7b44a2c3c 100644
--- a/tests/driver_itg320x/Makefile
+++ b/tests/driver_itg320x/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-USEMODULE += itg320x
-USEMODULE += xtimer
+USEMODULE += itg320x_int
+# USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
```
When itg320x_int is used there's no need for xtimer functions in the test application but xtimer is still required by the driver itself:
https://github.com/RIOT-OS/RIOT/blob/1c148ba2f2d4c851d88e1d113b2c7e9d2ce18ec5/drivers/itg320x/itg320x.c#L231
https://github.com/RIOT-OS/RIOT/blob/1c148ba2f2d4c851d88e1d113b2c7e9d2ce18ec5/drivers/itg320x/itg320x.c#L248

The `USEMODULE += xtimer`  is kept in the test application Makefile because xtimer is used by default in the application code.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Try applying the proposed diff and verify that in master the build fails but it works with this PR

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#10092 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
