### PR TITLE
sys/include/crypto/modes/ccm: specify implem limits

### DIFF
--- a/sys/include/crypto/modes/ccm.h
+++ b/sys/include/crypto/modes/ccm.h
@@ -48,7 +48,7 @@ extern "C" {
  *
  * @param cipher           Already initialized cipher struct
  * @param auth_data        Additional data to authenticate in MAC
- * @param auth_data_len    Length of additional data
+ * @param auth_data_len    Length of additional data, max (2^16 - 2^8)
  * @param mac_length       length of the appended MAC (between 4 and 16 - only
  *                         even values)
  * @param length_encoding  maximal supported length of plaintext
@@ -57,7 +57,7 @@ extern "C" {
  * @param nonce_len        Length of the nonce in octets
  *                         (maximum: 15-length_encoding)
  * @param input            pointer to input data to encrypt
- * @param input_len        length of the input data
+ * @param input_len        length of the input data, max 2^32
  * @param output           pointer to allocated memory for encrypted data. It
  *                         has to be of size data_len + mac_length.
  * @return                 Length of encrypted data on a successful encryption
@@ -76,7 +76,7 @@ int cipher_encrypt_ccm(cipher_t *cipher,
  *
  * @param cipher           Already initialized cipher struct
  * @param auth_data        Additional data to authenticate in MAC
- * @param auth_data_len    Length of additional data
+ * @param auth_data_len    Length of additional data, max (2^16 - 2^8)
  * @param mac_length       length of the appended MAC (between 4 and 16 - only
  *                         even values)
  * @param length_encoding  maximal supported length of plaintext
@@ -85,7 +85,7 @@ int cipher_encrypt_ccm(cipher_t *cipher,
  * @param nonce_len        Length of the nonce in octets
  *                         (maximum: 15-length_encoding)
  * @param input            pointer to input data to decrypt
- * @param input_len        length of the input data
+ * @param input_len        length of the input data, max 2^32
  * @param output           pointer to allocated memory for decrypted data. It
  *                         has to be of size data_len - mac_length.
  *


### PR DESCRIPTION
### Contribution description

This PR specifys the length limits according to our `ccm` implementation for `plaintext` and `adata`.
See #12362 and #12364 for reference.

### Testing procedure

- Verify limits in code:

adata: https://github.com/RIOT-OS/RIOT/blob/be0a24e5322b30dab4587fc6b8f081b3c51f6cf9/sys/crypto/modes/ccm.c#L115-L125

plaintext:
https://github.com/RIOT-OS/RIOT/blob/be0a24e5322b30dab4587fc6b8f081b3c51f6cf9/sys/crypto/modes/ccm.c#L41



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
