### PR TITLE
boards/native: fix all-asan Makefile target

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -98,7 +98,7 @@ all-cachegrind: CFLAGS += -g3
 all-gprof: CFLAGS += -pg
 all-gprof: LINKFLAGS += -pg
 all-asan: CFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
-all-asan: CFLAGS += -DNATIVE_IN_CALLOC
+all-asan: CFLAGS += -DNATIVE_MEMORY
 all-asan: LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
 
 INCLUDES += $(NATIVEINCLUDES)

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -142,7 +142,7 @@ void _native_syscall_leave(void)
 /* make use of TLSF if it is included, except when building with valgrind
  * support, where one probably wants to make use of valgrind's memory leak
  * detection abilities*/
-#if !(defined MODULE_TLSF) || (defined(HAVE_VALGRIND_H))
+#if (!(defined MODULE_TLSF) && !(defined NATIVE_MEMORY)) || (defined(HAVE_VALGRIND_H))
 int _native_in_malloc = 0;
 void *malloc(size_t size)
 {
@@ -176,11 +176,7 @@ void free(void *ptr)
     _native_syscall_leave();
 }
 
-#ifdef NATIVE_IN_CALLOC
-int _native_in_calloc = 1;
-#else
 int _native_in_calloc = 0;
-#endif
 void *calloc(size_t nmemb, size_t size)
 {
     /* dynamically load calloc when it's needed - this is necessary to


### PR DESCRIPTION
### Contribution description

Without this change a RIOT application compiled with all-asan will
segfault as RIOT provides its own malloc by default. Add a define for
disabling custom malloc, calloc and realloc implementations and use it
when compiling with all-asan.

The previous implementation did not overwrite the malloc implementation.

### Testing procedure

On `native` without this patch applied:

```
$ make -C examples/hello-world/ all-asan
…
$ make -C examples/hello-world/ term
make: Entering directory '/home/nmeum/RIOT/examples/hello-world'
/home/nmeum/RIOT/examples/hello-world/bin/native/hello-world.elf
make: *** [/home/nmeum/RIOT/examples/hello-world/../../Makefile.include:684: term] Segmentation fault
make: Leaving directory '/home/nmeum/RIOTexamples/hello-world'
```

On `native` with this patch applied:

```
$ make -C examples/hello-world/ clean
…
$ make -C examples/hello-world/ all-asan
…
$ make -C examples/hello-world/ term
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.01-devel-1687-ge2b8-pr/fix_asan_target)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
==19795==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0xffb97000; bottom 0x565a1000; size: 0xa95f6000 (-1453367296)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
```