### PR TITLE
boards/ikea-tradfri: add SPI NOR Flash configuration

### DIFF
--- a/boards/ikea-tradfri/Makefile.dep
+++ b/boards/ikea-tradfri/Makefile.dep
@@ -1,3 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_spi_nor
+endif

--- a/boards/ikea-tradfri/board.c
+++ b/boards/ikea-tradfri/board.c
@@ -20,6 +20,38 @@
 
 #include "board.h"
 #include "cpu.h"
+#include "mtd.h"
+#include "mtd_spi_nor.h"
+#include "timex.h"
+
+#ifdef MODULE_MTD
+static const mtd_spi_nor_params_t _ikea_tradfri_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 2LU * US_PER_SEC,
+    .wait_32k_erase = 500LU *US_PER_MS,
+    .wait_sector_erase = 300LU * US_PER_MS,
+    .wait_4k_erase = 300LU * US_PER_MS,
+    .wait_chip_wake_up = 1LU * US_PER_MS,
+    .clk = IKEA_TRADFRI_NOR_SPI_CLK,
+    .flag = IKEA_TRADFRI_NOR_FLAGS,
+    .spi = IKEA_TRADFRI_NOR_SPI_DEV,
+    .mode = IKEA_TRADFRI_NOR_SPI_MODE,
+    .cs = IKEA_TRADFRI_NOR_SPI_CS,
+    .addr_width = 3,
+};
+
+static mtd_spi_nor_t ikea_tradfri_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = IKEA_TRADFRI_NOR_PAGE_SIZE,
+        .pages_per_sector = IKEA_TRADFRI_NOR_PAGES_PER_SECTOR,
+        .sector_count = IKEA_TRADFRI_NOR_SECTOR_COUNT,
+    },
+    .params = &_ikea_tradfri_nor_params,
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&ikea_tradfri_nor_dev;
+#endif /* MODULE_MTD */
 
 void board_init(void)
 {
@@ -30,5 +62,13 @@ void board_init(void)
     /* initialize the LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
+#endif
+
+#ifdef MODULE_MTD
+    /* enable NOR flash (only on the ICC-1-A) */
+    if (gpio_is_valid(IKEA_TRADFRI_NOR_EN)) {
+        gpio_init(IKEA_TRADFRI_NOR_EN, GPIO_OUT);
+        gpio_set(IKEA_TRADFRI_NOR_EN);
+    }
 #endif
 }

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -24,6 +24,8 @@
 #include "periph/gpio.h"
 #include "periph/spi.h"
 
+#include "mtd.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -63,6 +65,31 @@ extern "C" {
 #define LED1_ON             gpio_set(LED1_PIN)
 #define LED1_OFF            gpio_clear(LED1_PIN)
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
+/** @} */
+
+/**
+ * @name    SPI NOR Flash hardware configuration
+ *
+ * The board has a IS25LQ020B flash chip (2MBit).
+ */
+/** @{ */
+#define IKEA_TRADFRI_NOR_PAGE_SIZE          (256)
+#define IKEA_TRADFRI_NOR_PAGES_PER_SECTOR   (16)
+#define IKEA_TRADFRI_NOR_SECTOR_COUNT       (64)
+#define IKEA_TRADFRI_NOR_FLAGS              (SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K)
+#define IKEA_TRADFRI_NOR_SPI_DEV            SPI_DEV(0)
+#define IKEA_TRADFRI_NOR_SPI_CLK            SPI_CLK_1MHZ
+#define IKEA_TRADFRI_NOR_SPI_CS             GPIO_PIN(PB, 11)
+#define IKEA_TRADFRI_NOR_SPI_MODE           SPI_MODE_0
+#define IKEA_TRADFRI_NOR_EN                 GPIO_PIN(PF, 3) /**< only on the ICC-1-A */
+/** @} */
+
+/**
+ * @name    MTD configuration
+ */
+/** @{ */
+extern mtd_dev_t *mtd0;
+#define MTD_0 mtd0
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description
This PR exposes the configuration to access the SPI NOR Flash on the IKEA TRÅDFRI modules. They have a IS25LQ020B flash chip, that is 2MBit in size.

The timings are based on maximum ratings of the [datasheet](http://www.issi.com/WW/pdf/25LQ025B-512B-010B-020B-040B.pdf).

### Testing procedure
Running `BOARD=ikea-tradfri make -C tests/pkg_littlefs test` and/or `BOARD=ikea-tradfri make -C tests/pkg_littlefs test` should pass.

### Issues/PRs references
None