### PR TITLE
pkg/gecko_sdk: update to version 2.7

### DIFF
--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=06b00b68333ea05db1c78fe6626dcfe005a80cb6
+PKG_VERSION=ec942b9f430193b5b3ddaf4cf2a85fc29e44696a
 PKG_LICENSE=Zlib
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description
This PR updates the Gecko SDK to version 2.7. This is a minor update from 2.6.

I have tested several EFM32 boards I own, and all of them still work. Most of them don't even change in binary size (series 0).

Since version 2.6, Silicon Labs does not provide a release notes anymore. So the changes can be found in the [commit](https://github.com/basilfx/RIOT-gecko-sdk/commit/ec942b9f430193b5b3ddaf4cf2a85fc29e44696a) only.

### Testing procedure
All EFM32 boards compile fine.

Pick any EFM32 board and test some examples to see if they still work.

### Issues/PRs references
None