### PR TITLE
ili9341: Add color mode and inversion parameters

### DIFF
--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -127,7 +127,8 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
     _write_cmd(dev, ILI9341_CMD_VMCTRL2, command_params, 1);
 
     /* Memory access CTL */
-    command_params[0] = ILI9341_MADCTL_HORZ_FLIP | ILI9341_MADCTL_BGR;
+    command_params[0] = ILI9341_MADCTL_HORZ_FLIP;
+    command_params[0] |= dev->params->rgb ? 0 : ILI9341_MADCTL_BGR;
     _write_cmd(dev, ILI9341_CMD_MADCTL, command_params, 1);
 
     /* Frame control */
@@ -193,6 +194,10 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
         _write_cmd(dev, ILI9341_CMD_NGAMCTRL, gamma_neg,
                    sizeof(gamma_neg));
 
+    }
+
+    if (dev->params->inverted) {
+        _write_cmd(dev, ILI9341_CMD_DINVON, NULL, 0);
     }
     /* Sleep out (turn off sleep mode) */
     _write_cmd(dev, ILI9341_CMD_SLPOUT, NULL, 0);
@@ -290,12 +295,18 @@ void ili9341_pixmap(ili9341_t *dev, uint16_t x1, uint16_t x2,
 
 void ili9341_invert_on(ili9341_t *dev)
 {
-    ili9341_write_cmd(dev, ILI9341_CMD_DINVON, NULL, 0);
+    uint8_t command = (dev->params->inverted) ? ILI9341_CMD_DINVOFF
+                                              : ILI9341_CMD_DINVON;
+
+    ili9341_write_cmd(dev, command, NULL, 0);
 }
 
 void ili9341_invert_off(ili9341_t *dev)
 {
-    ili9341_write_cmd(dev, ILI9341_CMD_DINVOFF, NULL, 0);
+    uint8_t command = (dev->params->inverted) ? ILI9341_CMD_DINVON
+                                              : ILI9341_CMD_DINVOFF;
+
+    ili9341_write_cmd(dev, command, NULL, 0);
 }
 
 void ili9341_set_brightness(ili9341_t *dev, uint8_t brightness)

--- a/drivers/ili9341/include/ili9341_params.h
+++ b/drivers/ili9341/include/ili9341_params.h
@@ -46,7 +46,13 @@ extern "C" {
 #define ILI9341_PARAM_RST          GPIO_UNDEF
 #endif
 #ifndef ILI9341_PARAM_SPI_MODE
-#define ILI9341_PARAM_SPI_MODE      SPI_MODE_0
+#define ILI9341_PARAM_SPI_MODE     SPI_MODE_0
+#endif
+#ifndef ILI9341_PARAM_RGB
+#define ILI9341_PARAM_RGB          0
+#endif
+#ifndef ILI9341_PARAM_INVERTED
+#define ILI9341_PARAM_INVERTED     0
 #endif
 
 #ifndef ILI9341_PARAMS
@@ -56,6 +62,8 @@ extern "C" {
                                       .cs_pin = ILI9341_PARAM_CS, \
                                       .dcx_pin = ILI9341_PARAM_DCX, \
                                       .rst_pin = ILI9341_PARAM_RST, \
+                                      .rgb = ILI9341_PARAM_RGB, \
+                                      .inverted = ILI9341_PARAM_INVERTED, \
                                     }
 #endif
 /**@}*/

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -88,6 +88,9 @@ typedef struct {
     gpio_t cs_pin;      /**< pin connected to the CHIP SELECT line */
     gpio_t dcx_pin;     /**< pin connected to the DC line */
     gpio_t rst_pin;     /**< pin connected to the reset line */
+    bool rgb;           /**< True when display is connected in RGB mode
+                          *  False when display is connected in BGR mode */
+    bool inverted;      /**< Display works in inverted color mode */
 } ili9341_params_t;
 
 /**


### PR DESCRIPTION
### Contribution description

This PR enhances the ILI9341 driver with additional config parameters:
 - Add RBG mode in addition to the default BGR mode
 - Add display inverted mode, for when the TFT display is connected in inverted mode.

### Testing procedure

Check if compilation of the test still works. I think @aabadie has an stm32f429i-disc1 available for the run-time checks :)

 Furthermore on the PineTime, with RGB mode and inversion enabled, the colors should be correct.

### Issues/PRs references

None, but maybe we should rename this driver to something more generic, e.g. `spi_display` and alias both `ili9341` and `st7789v` modules to this.