### PR TITLE
doc/gnrc/ipv6: Update documentation group for gnrc

### DIFF
--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -40,9 +40,9 @@ extern "C" {
 #endif
 
 /**
- * @defgroup    net_gnrc_ipv6_ext_conf IPv6 extension header compile configurations
+ * @defgroup    net_gnrc_ipv6_ext_conf GNRC IPv6 extension header compile configurations
  * @ingroup     net_gnrc_ipv6_ext
- * @ingroup     config
+ * @ingroup     net_gnrc_conf
  * @{
  */
 /**


### PR DESCRIPTION

### Contribution description

Since the GNRC_IPV6 is part of GNRC it should be a part of the gnrc compile time configuration group.
This adds information on the group to specify it is gnrc and changes the group from config to net_gnrc_conf.

### Testing procedure

run `make doc` and check the /group__config.html does not contain `IPv6 extension header compile configurations` and GNRC IPv6 extension header compile configurations is part of the /group__net__gnrc__conf.html

### Issues/PRs references
