### PR TITLE
periph/rtt: clarify rtt_set_alarm() documentation

### DIFF
--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -144,7 +144,7 @@ uint32_t rtt_get_counter(void);
 void rtt_set_counter(uint32_t counter);
 
 /**
- * @brief Set an alarm for RTT to the specified value.
+ * @brief Set an alarm for RTT to the specified absolute target time.
  *
  * @param[in] alarm         The value to trigger an alarm when hit
  * @param[in] cb            Callback executed when alarm is hit


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The documentation for `rtt_set_alarm()` is somewhat vague on the fact that it expects the alarm value as an absolute trigger time. This PR tries to improve that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
