### PR TITLE
cpu/efm32: add Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -9,6 +9,7 @@ mainmenu "RIOT Configuration"
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
+rsource "cpu/Kconfig"
 rsource "sys/Kconfig"
 
 # The application may declare new symbols as well

--- a/cpu/Kconfig
+++ b/cpu/Kconfig
@@ -6,4 +6,6 @@
 #
 menu "CPU"
 
+rsource "efm32/Kconfig"
+
 endmenu # CPU

--- a/cpu/Kconfig
+++ b/cpu/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2019 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menu "CPU"
+
+endmenu # CPU

--- a/cpu/efm32/Kconfig
+++ b/cpu/efm32/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 Bas Stottelaar <basstottelaar@gmail.com>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_CPU_EFM32
+    bool "Configure EFM32 CPU"
+    depends on MODULE_CPU_EFM32GG || MODULE_CPU_EFM32LG || MODULE_CPU_EFM32PG1B || MODULE_CPU_EFM3232PG12B || MODULE_CPU_EFR32MG1P || MODULE_CPU_EFR32MG12P
+    help
+        Configure EFM32 CPU via Kconfig.
+
+if KCONFIG_CPU_EFM32
+
+menu "Features"
+
+config EFM32_FEATURE_LEUART
+    bool "Enable LEUART peripheral support"
+    default y
+    help
+        Enable the LEUART peripheral in the UART driver.
+
+endmenu # Features
+
+config EFM32_EMLIB_ASSERTIONS
+    bool "Enable EMLIB assertions"
+    help
+        Additional assertions can be enabled within the EMLIB peripheral
+        library, for debugging. EMLIB is part of the Gecko SDK by Silicon Labs.
+
+endif # KCONFIG_CPU_EFM32

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -21,4 +21,8 @@ ifndef CONFIG_KCONFIG_CPU_EFM32
   endif
 endif
 
+ifdef CONFIG_EFM32_EMLIB_ASSERTIONS
+  CFLAGS += -DDEBUG_EFM
+endif
+
 include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -1,4 +1,6 @@
-include $(RIOTCPU)/efm32/efm32-features.mk
+ifndef CONFIG_KCONFIG_CPU_EFM32
+  include $(RIOTCPU)/efm32/efm32-features.mk
+endif
 
 FEATURES_PROVIDED += arch_efm32
 FEATURES_PROVIDED += periph_cpuid
@@ -13,8 +15,10 @@ ifeq (1,$(EFM32_TNRG))
   FEATURES_PROVIDED += periph_hwrng
 endif
 
-ifeq (1,$(EFM32_LEUART_ENABLED))
-  CFLAGS += -DEFM32_LEUART_ENABLED=1
+ifndef CONFIG_KCONFIG_CPU_EFM32
+  ifeq (1,$(CONFIG_EFM32_FEATURE_LEUART))
+    CFLAGS += -DCONFIG_EFM32_FEATURE_LEUART=1
+  endif
 endif
 
 include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/efm32/doc.txt
+++ b/cpu/efm32/doc.txt
@@ -64,8 +64,8 @@
  * The EFM32/EFR32/EZR32 MCUs have support for low-power peripherals. Support
  * is enabled by default, but can be disabled if not used.
  *
- * - Setting `EFM32_LEUART_ENABLED=0` will disable support for the LEUART
- *   in the UART driver peripheral and save approximately 400 bytes.
+ * - Setting `CONFIG_EFM32_FEATURE_LEUART=0` will disable support for the
+ *   LEUART in the UART driver peripheral and save approximately 400 bytes.
  *
  * Refer to `cpu/efm32/efm32-features.mk` for more options.
  */

--- a/cpu/efm32/efm32-features.mk
+++ b/cpu/efm32/efm32-features.mk
@@ -1,4 +1,4 @@
 # This file provides defaults for additional EFM32-specific features. You
 # should override them from the command line, or in your Makefile. Note that
 # some features may not be applicable to all EFM32 boards or CPUs.
-export EFM32_LEUART_ENABLED ?= 1
+export CONFIG_EFM32_FEATURE_LEUART ?= 1

--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -31,7 +31,7 @@
 /**
  * @brief   Defines whether LEUART is enabled and supported
  */
-#if EFM32_LEUART_ENABLED && defined(LEUART_COUNT) && LEUART_COUNT > 0
+#if CONFIG_EFM32_FEATURE_LEUART && defined(LEUART_COUNT) && LEUART_COUNT > 0
 #define USE_LEUART
 #endif
 

--- a/tests/cpu_efm32_features/Makefile
+++ b/tests/cpu_efm32_features/Makefile
@@ -11,6 +11,6 @@ BOARD_WHITELIST := ikea-tradfri \
                    stk3700
 
 # see cpu/efm32/efm32-features.mk for the supported flags
-EFM32_LEUART_ENABLED = 0
+CONFIG_EFM32_FEATURE_LEUART = 0
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_efm32_features/main.c
+++ b/tests/cpu_efm32_features/main.c
@@ -20,8 +20,8 @@
 
 #include "periph/uart.h"
 
-#if EFM32_LEUART_ENABLED
-#error "Expected EFM32_LEUART_ENABLED feature to be disabled."
+#ifdef CONFIG_EFM32_FEATURE_LEUART
+#error "Expected CONFIG_EFM32_FEATURE_LEUART feature to be undefined."
 #endif
 
 int main(void)


### PR DESCRIPTION
### Contribution description
This is my attempt to get acquainted with Kconfig. I tried to migrate the existing EFM32 features into Kconfig, while still being backwards compatible (note that some of the features are part of the documentation, e.g. [this](https://github.com/RIOT-OS/RIOT/blob/1243955886b4f7faed54f8567ccd84771e92f0d5/boards/slstk3401a/doc.txt#L171) example).

### Testing procedure
There are currently two config options available.

To test `EFM32_FEATURE_LEUART`, use the `tests/cpu_efm32_features`. Without Kconfig, this compiles as-is. When using Kconfig, deliberatly set `EFM32_FEATURE_LEUART=y` and notice that compilation will fail (as intended).

To test `EFM32_EMLIB_ASSERTIONS`, run (for instance) `QUIET=0 BOARD=slstk3401a make -C examples/default` and observe that `-DDEBUG_EFM` is not added to `CFLAGS`. Then set `EFM32_EMLIB_ASSERTIONS=y` and compile again. This time, the flag is present (and the resulting binary is now a bit bigger).

### Issues/PRs references
None
