### PR TITLE
boards/slstk3402a: update documentation

### DIFF
--- a/boards/slstk3402a/doc.txt
+++ b/boards/slstk3402a/doc.txt
@@ -1,41 +1,44 @@
 /**
-@defgroup    boards_slstk3402a Silicon Labs SLSTK3402A starter kit
-@ingroup     boards
-@brief       Support for Silicon Labs SLSTK3402A starter kit
+ * @defgroup    boards_slstk3402a Silicon Labs SLSTK3402A starter kit
+ * @ingroup     boards
+ * @brief       Support for Silicon Labs SLSTK3402A starter kit
 
 ## Overview
-Silicon Labs EFM32 Pearl Gecko PG12 Starter Kit is equipped with the EFM32 microcontroller. It is specifically designed for low-power applications, having energy-saving peripherals, different energy modes and short wake-up times.
+Silicon Labs EFM32 Pearl Gecko PG12 Starter Kit is equipped with the EFM32
+microcontroller. It is specifically designed for low-power applications, having
+energy-saving peripherals, different energy modes and short wake-up times.
 
-The starter kit is equipped with an Advanced Energy Monitor. This allows you to actively measure the power consumption of your hardware and code, in real-time.
+The starter kit is equipped with an Advanced Energy Monitor. This allows you to
+actively measure the power consumption of your hardware and code, in real-time.
 
 ## Hardware
 
 ### MCU
-| MCU             | EFM32PG12B500F1024GL125                              |
-|-----------------|------------------------------------------------------|
-| Family          | ARM Cortex-M4F                                       |
-| Vendor          | Silicon Labs                                         |
-| Vendor Family   | EFM32 Pearl Gecko 12B                                |
-| RAM             | 256.0KB                                              |
-| Flash           | 1024.0KB                                             |
-| EEPROM          | no                                                   |
-| Frequency       | up to 40 MHz                                         |
-| FPU             | yes                                                  |
-| MPU             | yes                                                  |
-| DMA             | 8 channels                                           |
-| Timers          | 2x 16-bit + 1x 16-bit (low power)                    |
-| ADCs            | 12-bit ADC                                           |
-| UARTs           | 2x USART, 1x LEUART                                  |
-| SPIs            | 2x USART                                             |
-| I2Cs            | 1x                                                   |
-| Vcc             | 1.85V - 3.8V                                         |
-| Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efm32pg12-datasheet.pdf)                                 |
-| Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/efm32pg12-rm.pdf)                                     |
-| Board Manual    | [Board Manual](https://www.silabs.com/documents/public/user-guides/ug257-stk3402-usersguide.pdf)                         |
-| Board Schematic | [Board Schematic]()                                                                                                      |
+| MCU           | EFM32PG12B500F1024GL125                                                                          |
+|---------------|--------------------------------------------------------------------------------------------------|
+| Family        | ARM Cortex-M4F                                                                                   |
+| Vendor        | Silicon Labs                                                                                     |
+| Vendor Family | EFM32 Pearl Gecko 12B                                                                            |
+| RAM           | 256.0KB                                                                                          |
+| Flash         | 1024.0KB                                                                                         |
+| EEPROM        | no                                                                                               |
+| Frequency     | up to 40 MHz                                                                                     |
+| FPU           | yes                                                                                              |
+| MPU           | yes                                                                                              |
+| DMA           | 8 channels                                                                                       |
+| Timers        | 2x 32-bit, 2x 16-bit, 1x 16-bit (low power)                                                      |
+| ADCs          | 12-bit ADC                                                                                       |
+| UARTs         | 4x USART, 1x LEUART                                                                              |
+| SPIs          | 4x USART                                                                                         |
+| I2Cs          | 2x                                                                                               |
+| Vcc           | 1.85V - 3.8V                                                                                     |
+| Datasheet     | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efm32pg12-datasheet.pdf)         |
+| Manual        | [Manual](https://www.silabs.com/documents/public/reference-manuals/efm32pg12-rm.pdf)             |
+| Board Manual  | [Board Manual](https://www.silabs.com/documents/public/user-guides/ug257-stk3402-usersguide.pdf) |
 
 ### Pinout
-This is the pinout of the expansion header on the right side of the board. PIN 1 is the bottom-left contact when the header faces  you horizontally.
+This is the pinout of the expansion header on the right side of the board.
+PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|
@@ -55,83 +58,98 @@ This is the pinout of the expansion header on the right side of the board. PIN 1
 **Note:** some pins are connected to the board controller, when enabled!
 
 ### Peripheral mapping
-| Peripheral | Number  | Hardware          | Pins                            | Comments                                                  |
-|------------|---------|-------------------|---------------------------------|-----------------------------------------------------------|
-| ADC        | 0       | ADC0              | CHAN0: internal temperature     | Ports are fixed, 14/16-bit resolution not supported       |
-| I2C        | 0       | I2C0              | SDA: PC10, CLK: PC11            | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate  |
-| HWCRYPTO   | &mdash; | &mdash;           |                                 | AES128/AES256, SHA1, SHA256                               |
-| HWRNG      | &mdash; | TNRG0             |                                 | Hardware-based true random number generator               |
-| RTT        | &mdash; | RTCC              |                                 | 1 Hz interval. Either RTT or RTC (see below)              |
-| RTC        | &mdash; | RTCC              |                                 | 1 Hz interval. Either RTC or RTT (see below)              |
-| SPI        | 0       | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8  |                                                           |
-| Timer      | 0       | WTIMER0 + WTIMER1 |                                 | WTIMER0 is used as prescaler (must be adjecent)            |
-| UART       | 0       | USART0            | RX: PA1, TX: PA0                | Default STDIO output                                      |
-|            | 1       | USART1            | RX: PC6, TX: PC7                |                                                           |
-|            | 2       | LEUART0           | RX: PD11, TX: PD10              | Baud rate limited (see below)                             |
+| Peripheral | Number  | Hardware          | Pins                           | Comments                                                 |
+|------------|---------|-------------------|--------------------------------|----------------------------------------------------------|
+| ADC        | 0       | ADC0              | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
+| I2C        | 0       | I2C0              | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| HWCRYPTO   | &mdash; | &mdash;           |                                | AES128/AES256, SHA1, SHA256                              |
+| HWRNG      | &mdash; | TNRG0             |                                | Hardware-based true random number generator              |
+| RTT        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTT or RTC (see below)             |
+| RTC        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTC or RTT (see below)             |
+| SPI        | 0       | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
+| Timer      | 0       | WTIMER0 + WTIMER1 |                                | WTIMER0 is used as prescaler (must be adjecent)          |
+| UART       | 0       | USART0            | RX: PA1, TX: PA0               | Default STDIO output                                     |
+|            | 1       | USART1            | RX: PC6, TX: PC7               |                                                          |
+|            | 2       | LEUART0           | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
 
 ### User interface
-| Peripheral | Mapped to | Pin  | Comments   |
-|------------|-----------|------|------------|
-| Button      | PB0      | PF6  |            |
-|             | PB1      | PF7  |            |
-| LED         | LED0     | PF4  | Yellow LED |
-|             | LED1     | PF5  | Yellow LED |
+| Peripheral | Mapped to | Pin | Comments   |
+|------------|-----------|-----|------------|
+| Button     | PB0       | PF6 |            |
+|            | PB1       | PF7 |            |
+| LED        | LED0      | PF4 | Yellow LED |
+|            | LED1      | PF5 | Yellow LED |
 
 ## Implementation Status
-| Device                        | ID                                  | Supported | Comments                                                       |
-|-------------------------------|-------------------------------------|-----------|----------------------------------------------------------------|
-| MCU                           | EFM32PG12B                          | yes       | Power modes supported                                          |
-| Low-level driver              | ADC                                 | yes       |                                                                |
-|                               | Flash                               | yes       |                                                                |
-|                               | GPIO                                | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto                           | yes       |                                                                |
-|                               | HW RNG                              | yes       |                                                                |
-|                               | I2C                                 | yes       |                                                                |
-|                               | PWM                                 | yes       |                                                                |
-|                               | RTCC                                | yes       | As RTT or RTC                                                  |
-|                               | SPI                                 | partially | Only master mode                                               |
-|                               | Timer                               | yes       |                                                                |
-|                               | UART                                | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
-|                               | USB                                 | no        |                                                                |
-| LCD driver                    | LS013B7DH03                         | yes       | Sharp Low Power Memory LCD                                     |
-| Temperature + humidity sensor | Si7021                              | yes       | Silicon Labs Temperature + Humidity sensor                     |
-
-
+| Device                        | ID          | Supported | Comments                                                       |
+|-------------------------------|-------------|-----------|----------------------------------------------------------------|
+| MCU                           | EFM32PG12B  | yes       | Power modes supported                                          |
+| Low-level driver              | ADC         | yes       |                                                                |
+|                               | Flash       | yes       |                                                                |
+|                               | GPIO        | yes       | Interrupts are shared across pins (see reference manual)       |
+|                               | HW Crypto   | yes       |                                                                |
+|                               | HW RNG      | yes       |                                                                |
+|                               | I2C         | yes       |                                                                |
+|                               | PWM         | yes       |                                                                |
+|                               | RTCC        | yes       | As RTT or RTC                                                  |
+|                               | SPI         | partially | Only master mode                                               |
+|                               | Timer       | yes       |                                                                |
+|                               | UART        | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
+|                               | USB         | no        |                                                                |
+| LCD driver                    | LS013B7DH03 | yes       | Sharp Low Power Memory LCD                                     |
+| Temperature + humidity sensor | Si7021      | yes       | Silicon Labs Temperature + Humidity sensor                     |
 
 ## Board configuration
 
 ### Board controller
-The starter kit is equipped with a Board Controller. This controller provides a virtual serial port. The board controller is enabled via a GPIO pin.
+The starter kit is equipped with a Board Controller. This controller provides a
+virtual serial port. The board controller is enabled via a GPIO pin.
 
-By default, this pin is enabled. You can disable the board controller module by passing `DISABLE_MODULE=silabs_bc` to the `make` command.
+By default, this pin is enabled. You can disable the board controller module by
+passing `DISABLE_MODULE=silabs_bc` to the `make` command.
 
-**Note:** to use the virtual serial port, ensure you have the latest board controller firmware installed.
+**Note:** to use the virtual serial port, ensure you have the latest board
+controller firmware installed.
 
-**Note:** the board controller *always* configures the virtual serial port at 115200 baud with 8 bits, no parity and one stop bit. This also means that it expects data from the MCU with the same settings.
+**Note:** the board controller *always* configures the virtual serial port at
+115200 baud with 8 bits, no parity and one stop bit. This also means that it
+expects data from the MCU with the same settings.
 
-The low power LCD is also used by the board controller when the `DISP_SELECTED` pin is low. This pin is not initialized by the board, so you have to ensure this pin is initialized by your application if you want to control the low power LCD.
+The low power LCD is also used by the board controller when the `DISP_SELECTED`
+pin is low. This pin is not initialized by the board, so you have to ensure
+this pin is initialized by your application if you want to control the low
+power LCD.
 
 ### Advanced Energy Monitor
-This development kit has an Advanced Energy Monitor. It can be connected to the Simplicity Studio development software.
+This development kit has an Advanced Energy Monitor. It can be connected to the
+Simplicity Studio development software.
 
-This development kit can measure energy consumption and correlate this with the code. It allows you to measure energy consumption on code-level.
+This development kit can measure energy consumption and correlate this with the
+code. It allows you to measure energy consumption on code-level.
 
-The board controller is responsible for measuring energy consumption. For real-time code correlation, the CoreDebug peripheral will be configured to output MCU register data and interrupt data via the SWO port.
+The board controller is responsible for measuring energy consumption. For
+real-time code correlation, the CoreDebug peripheral will be configured to
+output MCU register data and interrupt data via the SWO port.
 
-By default, this feature is enabled. It can be disabled by passing `DISABLE_MODULE=silabs_aem` to the `make` command.
+By default, this feature is enabled. It can be disabled by passing
+`DISABLE_MODULE=silabs_aem` to the `make` command.
 
-Note that Simplicity Studio requires debug symbols to correlate code. RIOT-OS defaults to GDB debug symbols, but Simplicity Studio requires DWARF-2 debug symbols (`-gdwarf-2` for GCC).
+Note that Simplicity Studio requires debug symbols to correlate code. RIOT-OS
+defaults to GDB debug symbols, but Simplicity Studio requires DWARF-2 debug
+symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
-There are several clock sources that are available for the different peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf) to get familiar with the different clocks.
+There are several clock sources that are available for the different
+peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf)
+to get familiar with the different clocks.
 
-| Source  | Internal | Speed                            | Comments                           |
-|---------|----------|----------------------------------|------------------------------------|
-| HFRCO   | Yes      | 19 MHz                           | Enabled during startup, changeable |
-| HFXO    | No       | 40 MHz                           |                                    |
-| LFRCO   | Yes      | 32.768 kHz                       |                                    |
-| LFXO    | No       | 32.768 kHz                       |                                    |
-| ULFRCO  | No       | 1.000 kHz                        | Not very reliable as a time source |
+| Source | Internal | Speed      | Comments                           |
+|--------|----------|------------|------------------------------------|
+| HFRCO  | Yes      | 19 MHz     | Enabled during startup, changeable |
+| HFXO   | No       | 40 MHz     |                                    |
+| LFRCO  | Yes      | 32.768 kHz |                                    |
+| LFXO   | No       | 32.768 kHz |                                    |
+| ULFRCO | No       | 1.000 kHz  | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 
@@ -142,45 +160,74 @@ The sources can be used to clock following branches:
 | LFB    | LFRCO, LFXO, CORELEDIV2 | Low-power UART               |
 | LFE    | LFRCO, LFXO             | Real-time Clock and Calendar |
 
-CORELEDIV2 is a source that depends on the clock source that powers the core. It is divided by 2 or 4 to not exceed maximum clock frequencies (emlib takes care of this).
+CORELEDIV2 is a source that depends on the clock source that powers the core.
+It is divided by 2 or 4 to not exceed maximum clock frequencies (EMLIB takes
+care of this).
 
-The frequencies mentioned in the tables above are specific for this starter kit.
+The frequencies mentioned in the tables above are specific for this starter
+kit.
 
-It is important that the clock speeds are known to the code, for proper calculations of speeds and baud rates. If the HFXO or LFXO are different from the speeds above, ensure to pass `EFM32_HFXO_FREQ=freq_in_hz` and `EFM32_LFXO_FREQ=freq_in_hz` to your compiler.
+It is important that the clock speeds are known to the code, for proper
+calculations of speeds and baud rates. If the HFXO or LFXO are different from
+the speeds above, ensure to pass `EFM32_HFXO_FREQ=freq_in_hz` and
+`EFM32_LFXO_FREQ=freq_in_hz` to your compiler.
 
-You can override the branch's clock source by adding `CLOCK_LFA=source` to your compiler defines, e.g. `CLOCK_LFA=cmuSelect_LFRCO`.
+You can override the branch's clock source by adding `CLOCK_LFA=source` to your
+compiler defines, e.g. `CLOCK_LFA=cmuSelect_LFRCO`.
 
 ### Low-power peripherals
-The low-power UART is capable of providing an UART peripheral using a low-speed clock. When the LFB clock source is the LFRCO or LFXO, it can still be used in EM2. However, this limits the baud rate to 9600 baud. If a higher baud rate is desired, set the clock source to CORELEDIV2.
+The low-power UART is capable of providing an UART peripheral using a low-speed
+clock. When the LFB clock source is the LFRCO or LFXO, it can still be used in
+EM2. However, this limits the baud rate to 9600 baud. If a higher baud rate is
+desired, set the clock source to CORELEDIV2.
 
-**Note:** peripheral mappings in your board definitions will not be affected by this setting. Ensure you do not refer to any low-power peripherals.
+**Note:** peripheral mappings in your board definitions will not be affected by
+this setting. Ensure you do not refer to any low-power peripherals.
 
 ### RTC or RTT
 RIOT-OS has support for *Real-Time Tickers* and *Real-Time Clocks*.
 
-However, this board MCU family has support for a 32-bit *Real-Time Clock and Calendar*, which can be configured in ticker mode **or** calendar mode. Therefore, only one of both peripherals can be enabled at the same time.
+However, this board MCU family has support for a 32-bit *Real-Time Clock and
+Calendar*, which can be configured in ticker mode **or** calendar mode.
+Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Hardware crypto
-This MCU is equipped with a hardware accelerated crypto peripheral that can speed up AES128, AES256, SHA1, SHA256 and several other cryptographic computations.
+This MCU is equipped with a hardware accelerated crypto peripheral that can
+speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
+computations.
 
 A peripheral driver interface for RIOT-OS is proposed, but not yet implemented.
 
-### Usage of emlib
-This port makes uses of emlib by Silicon Labs to abstract peripheral registers. While some overhead is to be expected, it ensures proper setup of devices, provides chip errata and simplifies development. The exact overhead depends on the application and peripheral usage, but the largest overhead is expected during peripheral setup. A lot of read/write/get/set methods are implemented as inline methods or macros (which have no overhead).
+### Usage of EMLIB
+This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+While some overhead is to be expected, it ensures proper setup of devices,
+provides chip errata and simplifies development. The exact overhead depends on
+the application and peripheral usage, but the largest overhead is expected
+during peripheral setup. A lot of read/write/get/set methods are implemented as
+inline methods or macros (which have no overhead).
 
-Another advantage of emlib are the included assertions. These assertions ensure that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your compiler.
+Another advantage of EMLIB are the included assertions. These assertions ensure
+that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
+compiler.
 
 ### Pin locations
-The EFM32 platform supports peripherals to be mapped to different pins (predefined locations). The definitions in `periph_conf.h` mostly consist of a location number and the actual pins. The actual pins are required to configure the pins via GPIO driver, while the location is used to map the peripheral to these pins.
+The EFM32 platform supports peripherals to be mapped to different pins
+(predefined locations). The definitions in `periph_conf.h` mostly consist of a
+location number and the actual pins. The actual pins are required to configure
+the pins via GPIO driver, while the location is used to map the peripheral to
+these pins.
 
-In other words, these definitions must match. Refer to the data sheet for more information.
+In other words, these definitions must match. Refer to the data sheet for more
+information.
 
-This MCU has extended pin mapping support. Each pin of a peripheral can be connected separately to one of the predefined pins for that peripheral.
+This MCU has extended pin mapping support. Each pin of a peripheral can be
+connected separately to one of the predefined pins for that peripheral.
 
 ## Flashing the device
-To flash, [SEGGER JLink](https://www.segger.com/jlink-software.html) is required.
+To flash, [SEGGER JLink](https://www.segger.com/jlink-software.html) is
+required.
 
 Flashing is supported by RIOT-OS using the command below:
 
@@ -207,8 +254,10 @@ make emulate
 ```
 
 ## Supported Toolchains
-For using the Silicon Labs SLSTK3402A starter kit we strongly recommend the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm) toolchain.
+For using the Silicon Labs SLSTK3402A starter kit we strongly recommend the
+usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+toolchain.
 
 ## License information
-* Silicon Labs' emlib: zlib-style license (permits distribution of source).
+* Silicon Labs' EMLIB: zlib-style license (permits distribution of source).
  */


### PR DESCRIPTION
### Contribution description
This updates the documentation for the SLSTK3402a.

- Updated links
- Updated specifications
- Enforced line length

### Testing procedure
Documentation should build and show the page.

### Issues/PRs references
#13099
