### PR TITLE
sys/spp: randomize canary value on each build

### DIFF
--- a/dist/tools/randhex/README.md
+++ b/dist/tools/randhex/README.md
@@ -1,0 +1,7 @@
+randhex.py
+----------
+
+Usage: `randhex.py <MAXBITS>`
+
+This script generates a random hexadecimal value of the given maximum
+size in bits. If `MAXBITS` is not specified it defaults to 64.

--- a/dist/tools/randhex/randhex.py
+++ b/dist/tools/randhex/randhex.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2020 Sören Tempel <tempel@uni-bremen.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+import sys
+import secrets
+
+if len(sys.argv) >= 2:
+    maxbits = int(sys.argv[1])
+else:
+    maxbits = 64
+
+maxval = 2 ** maxbits
+print(hex(secrets.randbelow(maxval)))

--- a/sys/ssp/Makefile
+++ b/sys/ssp/Makefile
@@ -1,1 +1,17 @@
+# module name is used below, thus set explicitly
+MODULE = ssp
+
+ifeq (,$(RIOT_CI_BUILD))
+  # random canary value newly generated on each build
+  CANARY := $(shell $(RIOTTOOLS)/randhex/randhex.py)
+else
+  # hardcoded canary value to not break CI test cache
+  CANARY := 0xdeadbeef
+endif
+
+# pass the generated canary using a macro and mark the object file using
+# it as PHONY to ensure that a new canary value is used on each build.
+CFLAGS += -DSTACK_CHK_GUARD=$(CANARY)U
+.PHONY: $(BINDIR)/$(MODULE)/$(MODULE).o
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/ssp/ssp.c
+++ b/sys/ssp/ssp.c
@@ -22,9 +22,6 @@
 
 #include "panic.h"
 
-/* this should be randomized for each build */
-#define STACK_CHK_GUARD 0x595e9fbd94fda766
-
 uintptr_t __stack_chk_guard = (uintptr_t) STACK_CHK_GUARD;
 
 __attribute__((noreturn)) void __stack_chk_fail(void)


### PR DESCRIPTION
### Contribution description

The optional `ssp` module implements stack smash protections for RIOT. Stack smash protections are a very useful protection mechanisms against issues like #10739 and #12905 (stack-based buffer overflows). Unfortunately, the `ssp` module currently uses a hardcode canary value which renders it useless for protecting against malicious attackers.

The changes proposed here randomize the value on each `make` invocation. Randomization during compile-time was previously mentioned in a comment in `ssp.c`. On conventional operating systems, random stack canary values are usually generated on program startup. Unfortunately, many constrained devices do not have a hardware random number generator which makes generating cryptographic secure values challenging at run-time.

Generating the value at compile-time has various disadvantages, compared to generating it at run-time. For instance, it offers less protections as the canary value does not change at all for a given firmware image which is an issue if a malicious attacker gains access to it once. Nonetheless, I believe that the changes proposed here are an improvement over the hardcode value used currently. If run-time generation is implemented in the future this implementation may still be suitable as a fallback.

@kaspar030, you committed the initial SSP implementation. Any thoughts on the changes proposed here?

### Testing procedure

* Run `tests/ssp`
* Verify that the `STACK_CHK_GUARD` macro in `riotbuild.h` is different on each build.