### PR TITLE
Kconfig: Expose gnrc/sixlowpan configurations

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -58,8 +58,8 @@ extern "C" {
  * @note    Only applicable with
  *          [gnrc_sixlowpan_frag_fb](@ref net_gnrc_sixlowpan_frag_fb) module
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_FB_SIZE
-#define GNRC_SIXLOWPAN_FRAG_FB_SIZE         (1U)
+#ifndef CONFIG_GNRC_SIXLOWPAN_FRAG_FB_SIZE
+#define CONFIG_GNRC_SIXLOWPAN_FRAG_FB_SIZE         (1U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -91,11 +91,11 @@ extern "C" {
  * When not set, it will cause the reassembly buffer to override the oldest entry
  * if a new entry has to be created and the reassembly buffer is full, no matter what.
  * When set to 1, only incomplete entries that are older than
- * @ref GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be overwritten (they will still timeout
- * normally).
+ * @ref CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be overwritten (they will still
+ * timeout normally).
  */
 #ifdef DOXYGEN
-#define GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE
+#define CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE
 #endif
 
 /**
@@ -110,15 +110,15 @@ extern "C" {
  * overwritten (they will still timeout normally if reassembly buffer is not
  * full).
  *
- * @deprecated Use inverse @ref GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE instead.
+ * @deprecated Use inverse @ref CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE instead.
  *             Will be removed after 2020.10 release.
  */
 #ifndef GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE
-#if IS_ACTIVE(GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE)
+#if IS_ACTIVE(CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE)
 #define GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE    (0)
-#else /* GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE */
+#else /* CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE */
 #define GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE    (1)
-#endif /* GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE */
+#endif /* CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE */
 #endif /* GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE */
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -78,8 +78,8 @@ extern "C" {
  * @note    Only applicable with
  *          [gnrc_sixlowpan_frag_rb](@ref net_gnrc_sixlowpan_frag_rb) module
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US
-#define GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US (3U * US_PER_SEC)
+#ifndef CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US
+#define CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US (3U * US_PER_SEC)
 #endif
 
 /**
@@ -106,7 +106,7 @@ extern "C" {
  *
  * When set to a non-zero value this will cause the reassembly buffer to
  * override the oldest entry no matter what. When set to zero only the oldest
- * entry that is older than @ref GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be
+ * entry that is older than @ref CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be
  * overwritten (they will still timeout normally if reassembly buffer is not
  * full).
  *

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -150,8 +150,8 @@ extern "C" {
  *          provides capabilities to build the address registration option as a
  *          @ref gnrc_pktsnip_t
  */
-#ifndef GNRC_SIXLOWPAN_ND_AR_LTIME
-#define GNRC_SIXLOWPAN_ND_AR_LTIME          (15U)
+#ifndef CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME
+#define CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME          (15U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -45,8 +45,8 @@ extern "C" {
 /**
  * @brief   Default message queue size to use for the 6LoWPAN thread.
  */
-#ifndef GNRC_SIXLOWPAN_MSG_QUEUE_SIZE
-#define GNRC_SIXLOWPAN_MSG_QUEUE_SIZE       (8U)
+#ifndef CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE
+#define CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE       (8U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -132,8 +132,8 @@ extern "C" {
  * immediately. Use this value to prevent re-creation of a reassembly buffer
  * entry on late arriving link-layer duplicates.
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER
-#define GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER              (0U)
+#ifndef CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER
+#define CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER              (0U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -176,9 +176,9 @@ extern "C" {
  * @note    Only applicable with
  *          [gnrc_sixlowpan_frag_vrb](@ref net_gnrc_sixlowpan_frag_vrb) module.
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US
-#define GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US  (GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US)
-#endif  /* GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US */
+#ifndef CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US
+#define CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US  (CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US)
+#endif  /* CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US */
 
 /**
  * @name Selective fragment recovery configuration

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -162,16 +162,11 @@ extern "C" {
  * @note    Only applicable with
  *          [gnrc_sixlowpan_frag_vrb](@ref net_gnrc_sixlowpan_frag_vrb) module,
  *          but has also a direct influence on the number of available
- *          gnrc_sixlowpan_frag_rb_int_t entries (even when
- *          `gnrc_sixlowpan_frag_vrb` is not compiled in).
+ *          gnrc_sixlowpan_frag_rb_int_t entries.
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_VRB_SIZE
-#if defined(MODULE_GNRC_SIXLOWPAN_FRAG_VRB) || defined(DOXYGEN)
-#define GNRC_SIXLOWPAN_FRAG_VRB_SIZE        (16U)
-#else   /* defined(MODULE_GNRC_SIXLOWPAN_FRAG_VRB) || defined(DOXYGEN) */
-#define GNRC_SIXLOWPAN_FRAG_VRB_SIZE        (0U)
-#endif  /* defined(MODULE_GNRC_SIXLOWPAN_FRAG_VRB) || defined(DOXYGEN) */
-#endif  /* GNRC_SIXLOWPAN_FRAG_VRB_SIZE */
+#ifndef CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE
+#define CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE        (16U)
+#endif  /* CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE */
 
 /**
  * @brief   Timeout for a VRB entry in microseconds

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -68,8 +68,8 @@ extern "C" {
  * @note    Only applicable with
  *          [gnrc_sixlowpan_frag_rb](@ref net_gnrc_sixlowpan_frag_rb) module
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_SIZE
-#define GNRC_SIXLOWPAN_FRAG_RBUF_SIZE       (4U)
+#ifndef CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE
+#define CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE       (4U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/nd.h
+++ b/sys/include/net/gnrc/sixlowpan/nd.h
@@ -27,6 +27,7 @@
 
 #include "kernel_types.h"
 #include "net/gnrc/pkt.h"
+#include "net/gnrc/sixlowpan/config.h"
 #include "net/ipv6/addr.h"
 #include "net/ndp.h"
 #include "net/sixlowpan/nd.h"
@@ -34,20 +35,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME
-/**
- * @brief   Registration lifetime in minutes for the address registration option
- *
- * This value should be adapted to the devices power-lifecycle so that it is greater than the
- * time the device spends sleeping.
- *
- * @see <a href="https://tools.ietf.org/html/rfc6775#section-5.8.1">
- *          RFC 6775, section 5.8.1
- *      </a>
- */
-#define CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME          (15U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/nd.h
+++ b/sys/include/net/gnrc/sixlowpan/nd.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifndef GNRC_SIXLOWPAN_ND_AR_LTIME
+#ifndef CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME
 /**
  * @brief   Registration lifetime in minutes for the address registration option
  *
@@ -47,7 +47,7 @@ extern "C" {
  *          RFC 6775, section 5.8.1
  *      </a>
  */
-#define GNRC_SIXLOWPAN_ND_AR_LTIME          (15U)
+#define CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME          (15U)
 #endif
 
 /**

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -12,5 +12,6 @@ rsource "netif/Kconfig"
 rsource "network_layer/ipv6/Kconfig"
 rsource "network_layer/ipv6/blacklist/Kconfig"
 rsource "network_layer/ipv6/whitelist/Kconfig"
+rsource "network_layer/sixlowpan/Kconfig"
 
 endmenu # GNRC Network Stack

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -50,7 +50,7 @@ void _snd_ns(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
             DEBUG("nib: can't get EUI-64 of the interface for ARO\n");
             return;
         }
-        ext_opt = gnrc_sixlowpan_nd_opt_ar_build(0, GNRC_SIXLOWPAN_ND_AR_LTIME,
+        ext_opt = gnrc_sixlowpan_nd_opt_ar_build(0, CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME,
                                                  &eui64, NULL);
         if (ext_opt == NULL) {
             DEBUG("nib: error allocating ARO.\n");

--- a/sys/net/gnrc/network_layer/sixlowpan/Kconfig
+++ b/sys/net/gnrc/network_layer/sixlowpan/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+menuconfig KCONFIG_MODULE_GNRC_SIXLOWPAN
+    bool "Configure GNRC 6LoWPAN"
+    depends on MODULE_GNRC_SIXLOWPAN
+    help
+        Configure GNRC 6LoWPAN module using Kconfig.
+
+if KCONFIG_MODULE_GNRC_SIXLOWPAN
+
+rsource "frag/Kconfig"
+rsource "nd/Kconfig"
+
+config GNRC_SIXLOWPAN_MSG_QUEUE_SIZE
+    int "Message queue size for the 6LoWPAN thread"
+    default 8
+
+endif # KCONFIG_MODULE_GNRC_SIXLOWPAN

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/Kconfig
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+if MODULE_GNRC_SIXLOWPAN_FRAG
+
+rsource "fb/Kconfig"
+rsource "rb/Kconfig"
+rsource "vrb/Kconfig"
+
+endif # MODULE_GNRC_SIXLOWPAN_FRAG

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/fb/Kconfig
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/fb/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_FB
+    bool "Configure GNRC 6LoWPAN Fragmentation buffer"
+    depends on MODULE_GNRC_SIXLOWPAN_FRAG_FB
+    help
+        Configure GNRC 6LoWPAN Fragmentation buffer using Kconfig.
+
+if KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_FB
+
+config GNRC_SIXLOWPAN_FRAG_FB_SIZE
+    int "Number of datagrams that can be fragmented simultaneously"
+    default 1
+    help
+        This determines the number of @ref gnrc_sixlowpan_frag_fb_t instances
+        available.
+
+endif # KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_FB

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/fb/gnrc_sixlowpan_frag_fb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/fb/gnrc_sixlowpan_frag_fb.c
@@ -22,7 +22,7 @@
 #include "net/gnrc/sixlowpan/frag/stats.h"
 #endif
 
-static gnrc_sixlowpan_frag_fb_t _fbs[GNRC_SIXLOWPAN_FRAG_FB_SIZE];
+static gnrc_sixlowpan_frag_fb_t _fbs[CONFIG_GNRC_SIXLOWPAN_FRAG_FB_SIZE];
 static uint16_t _current_tag;
 
 #ifdef TEST_SUITES
@@ -35,7 +35,7 @@ void gnrc_sixlowpan_frag_fb_reset(void)
 
 gnrc_sixlowpan_frag_fb_t *gnrc_sixlowpan_frag_fb_get(void)
 {
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_FB_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_FB_SIZE; i++) {
         if (_fbs[i].pkt == NULL) {
             return &_fbs[i];
         }
@@ -48,7 +48,7 @@ gnrc_sixlowpan_frag_fb_t *gnrc_sixlowpan_frag_fb_get(void)
 
 gnrc_sixlowpan_frag_fb_t *gnrc_sixlowpan_frag_fb_get_by_tag(uint16_t tag)
 {
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_FB_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_FB_SIZE; i++) {
         if ((_fbs[i].pkt != NULL) && (_fbs[i].tag == tag)) {
             return &_fbs[i];
         }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/Kconfig
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/Kconfig
@@ -1,0 +1,42 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_RB
+    bool "Configure GNRC 6LoWPAN Reassembly buffer"
+    depends on MODULE_GNRC_SIXLOWPAN_FRAG_RB
+    help
+        Configure GNRC 6LoWPAN Reassembly buffer using Kconfig.
+
+if KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_RB
+
+config GNRC_SIXLOWPAN_FRAG_RBUF_SIZE
+    int "Size of the reassembly buffer"
+    default 4
+
+config GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US
+    int "Timeout for reassembly buffer entries in microseconds"
+    default 3000000
+
+config GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE
+    bool "Keep all but oldest fragment when reassembly buffer is full"
+    help
+        When not set, it will cause the reassembly buffer to
+        override the oldest entry no matter what. When set, only the oldest
+        entry that is older than @ref CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US
+        will be overwritten (they will still timeout normally if reassembly
+        buffer is not full).
+
+config GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER
+    int "Deletion timer for reassembly buffer entries in microseconds"
+    default 0
+    help
+        Time to pass between completion of a datagram and the deletion
+        of its reassembly buffer entry. If this value is 0, the entry
+        is dropped immediately. Use this value to prevent re-creation
+        of a reassembly buffer entry on late arriving link-layer
+        uplicates.
+
+endif # KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_RB

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -383,7 +383,7 @@ void gnrc_sixlowpan_frag_rb_gc(void)
         /* since pkt occupies pktbuf, aggressivly collect garbage */
         if (!gnrc_sixlowpan_frag_rb_entry_empty(&rbuf[i]) &&
               ((now_usec - rbuf[i].super.arrival) >
-               GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US)) {
+               CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US)) {
             DEBUG("6lo rfrag: entry (%s, ",
                   gnrc_netif_addr_to_str(rbuf[i].super.src,
                                          rbuf[i].super.src_len,
@@ -405,7 +405,7 @@ void gnrc_sixlowpan_frag_rb_gc(void)
 
 static inline void _set_rbuf_timeout(void)
 {
-    xtimer_set_msg(&_gc_timer, GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US,
+    xtimer_set_msg(&_gc_timer, CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US,
                    &_gc_timer_msg, sched_active_pid);
 }
 
@@ -467,7 +467,7 @@ static int _rbuf_get(const void *src, size_t src_len,
         assert(!gnrc_sixlowpan_frag_rb_entry_empty(oldest));
         if (GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE ||
             ((now_usec - oldest->super.arrival) >
-            GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US)) {
+            CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US)) {
             DEBUG("6lo rfrag: reassembly buffer full, remove oldest entry\n");
             gnrc_pktbuf_release(oldest->pkt);
             gnrc_sixlowpan_frag_rb_remove(oldest);
@@ -567,10 +567,10 @@ static void _tmp_rm(gnrc_sixlowpan_frag_rb_t *rbuf)
         /* use garbage-collection to leave the entry for at least
          * GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER in the reassembly buffer by
          * setting the arrival time to
-         * (GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US - GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER)
+         * (CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US - GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER)
          * microseconds in the past */
         rbuf->super.arrival = xtimer_now_usec() -
-                              (GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US -
+                              (CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US -
                                GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER);
         /* reset current size to prevent late duplicates to trigger another
          * dispatch */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -364,7 +364,7 @@ static bool _rbuf_update_ints(gnrc_sixlowpan_frag_rb_base_t *entry,
 
 static void _gc_pkt(gnrc_sixlowpan_frag_rb_t *rbuf)
 {
-#if GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0
+#if CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0
     if (rbuf->super.current_size == 0) {
         /* packet is scheduled for deletion, but was complete, i.e. pkt is
          * already handed up to other layer, i.e. no need to release */
@@ -433,7 +433,7 @@ static int _rbuf_get(const void *src, size_t src_len,
                                          rbuf[i].super.dst_len,
                                          l2addr_str),
                   (unsigned)rbuf[i].super.datagram_size, rbuf[i].super.tag);
-#if GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0
+#if CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0
             if (rbuf[i].super.current_size == 0) {
                 /* ensure that only empty reassembly buffer entries and entries
                  * scheduled for deletion have `current_size == 0` */
@@ -563,21 +563,21 @@ void gnrc_sixlowpan_frag_rb_base_rm(gnrc_sixlowpan_frag_rb_base_t *entry)
 
 static void _tmp_rm(gnrc_sixlowpan_frag_rb_t *rbuf)
 {
-#if GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0U
+#if CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER > 0U
         /* use garbage-collection to leave the entry for at least
-         * GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER in the reassembly buffer by
+         * CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER in the reassembly buffer by
          * setting the arrival time to
-         * (CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US - GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER)
+         * (CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US - CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER)
          * microseconds in the past */
         rbuf->super.arrival = xtimer_now_usec() -
                               (CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US -
-                               GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER);
+                               CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER);
         /* reset current size to prevent late duplicates to trigger another
          * dispatch */
         rbuf->super.current_size = 0;
-#else   /* GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER == 0U */
+#else   /* CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER == 0U */
         gnrc_sixlowpan_frag_rb_remove(rbuf);
-#endif  /* GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER */
+#endif  /* CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER */
 }
 
 int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -49,12 +49,12 @@
 /* same as ((int) ceil((double) N / D)) */
 #define DIV_CEIL(N, D) (((N) + (D) - 1) / (D))
 #define RBUF_INT_SIZE (DIV_CEIL(IPV6_MIN_MTU, GNRC_SIXLOWPAN_FRAG_SIZE) * \
-                       GNRC_SIXLOWPAN_FRAG_RBUF_SIZE)
+                       CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE)
 #endif
 
 static gnrc_sixlowpan_frag_rb_int_t rbuf_int[RBUF_INT_SIZE];
 
-static gnrc_sixlowpan_frag_rb_t rbuf[GNRC_SIXLOWPAN_FRAG_RBUF_SIZE];
+static gnrc_sixlowpan_frag_rb_t rbuf[CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE];
 
 static char l2addr_str[3 * IEEE802154_LONG_ADDRESS_LEN];
 
@@ -164,7 +164,7 @@ static gnrc_sixlowpan_frag_rb_t *_rbuf_get_by_tag(const gnrc_netif_hdr_t *netif_
     const uint8_t src_len = netif_hdr->src_l2addr_len;
     const uint8_t dst_len = netif_hdr->dst_l2addr_len;
 
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         gnrc_sixlowpan_frag_rb_t *e = &rbuf[i];
 
         if ((e->pkt != NULL) && (e->super.tag == tag) &&
@@ -379,7 +379,7 @@ void gnrc_sixlowpan_frag_rb_gc(void)
     uint32_t now_usec = xtimer_now_usec();
     unsigned int i;
 
-    for (i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         /* since pkt occupies pktbuf, aggressivly collect garbage */
         if (!gnrc_sixlowpan_frag_rb_entry_empty(&rbuf[i]) &&
               ((now_usec - rbuf[i].super.arrival) >
@@ -417,7 +417,7 @@ static int _rbuf_get(const void *src, size_t src_len,
     gnrc_sixlowpan_frag_rb_t *res = NULL, *oldest = NULL;
     uint32_t now_usec = xtimer_now_usec();
 
-    for (unsigned int i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned int i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         /* check first if entry already available */
         if ((rbuf[i].pkt != NULL) && (rbuf[i].super.datagram_size == size) &&
             (rbuf[i].super.tag == tag) && (rbuf[i].super.src_len == src_len) &&
@@ -533,7 +533,7 @@ void gnrc_sixlowpan_frag_rb_reset(void)
 {
     xtimer_remove(&_gc_timer);
     memset(rbuf_int, 0, sizeof(rbuf_int));
-    for (unsigned int i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned int i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         if ((rbuf[i].pkt != NULL) &&
             (rbuf[i].pkt->users > 0)) {
             _gc_pkt(&rbuf[i]);

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/Kconfig
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/Kconfig
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_VRB
+    bool "Configure GNRC 6LoWPAN Virtual reassembly buffer"
+    depends on MODULE_GNRC_SIXLOWPAN_FRAG_VRB
+    help
+        Configure GNRC 6LoWPAN Virtual reassembly buffer module using Kconfig.
+
+if KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_VRB
+
+config GNRC_SIXLOWPAN_FRAG_VRB_SIZE
+    int "Size of the virtual reassembly buffer"
+    default 16
+    help
+        Has a direct influence on the number of available
+        gnrc_sixlowpan_frag_rb_int_t entries.
+
+config GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US
+    int "Timeout for a virtual reassembly buffer entry in microseconds"
+    default 3000000
+
+endif # KCONFIG_MODULE_GNRC_SIXLOWPAN_FRAG_VRB

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -30,7 +30,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static gnrc_sixlowpan_frag_vrb_t _vrb[GNRC_SIXLOWPAN_FRAG_VRB_SIZE];
+static gnrc_sixlowpan_frag_vrb_t _vrb[CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE];
 #ifdef MODULE_GNRC_IPV6_NIB
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #else   /* MODULE_GNRC_IPV6_NIB */
@@ -57,7 +57,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
     assert(out_netif != NULL);
     assert(out_dst != NULL);
     assert(out_dst_len > 0);
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         gnrc_sixlowpan_frag_vrb_t *ptr = &_vrb[i];
 
         if (gnrc_sixlowpan_frag_vrb_entry_empty(ptr) ||
@@ -171,7 +171,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
 {
     DEBUG("6lo vrb: trying to get entry for (%s, %u)\n",
           gnrc_netif_addr_to_str(src, src_len, addr_str), src_tag);
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         gnrc_sixlowpan_frag_vrb_t *vrbe = &_vrb[i];
 
         if (_equal_index(vrbe, src, src_len, src_tag)) {
@@ -190,7 +190,7 @@ void gnrc_sixlowpan_frag_vrb_gc(void)
 {
     uint32_t now_usec = xtimer_now_usec();
 
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         if (!gnrc_sixlowpan_frag_vrb_entry_empty(&_vrb[i]) &&
             (now_usec - _vrb[i].super.arrival) > GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US) {
             DEBUG("6lo vrb: entry (%s, ",

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -192,7 +192,7 @@ void gnrc_sixlowpan_frag_vrb_gc(void)
 
     for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         if (!gnrc_sixlowpan_frag_vrb_entry_empty(&_vrb[i]) &&
-            (now_usec - _vrb[i].super.arrival) > GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US) {
+            (now_usec - _vrb[i].super.arrival) > CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US) {
             DEBUG("6lo vrb: entry (%s, ",
                   gnrc_netif_addr_to_str(_vrb[i].super.src,
                                          _vrb[i].super.src_len,

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -308,12 +308,12 @@ static void _send(gnrc_pktsnip_t *pkt)
 
 static void *_event_loop(void *args)
 {
-    msg_t msg, reply, msg_q[GNRC_SIXLOWPAN_MSG_QUEUE_SIZE];
+    msg_t msg, reply, msg_q[CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE];
     gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                             sched_active_pid);
 
     (void)args;
-    msg_init_queue(msg_q, GNRC_SIXLOWPAN_MSG_QUEUE_SIZE);
+    msg_init_queue(msg_q, CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE);
 
     /* register interest in all 6LoWPAN packets */
     gnrc_netreg_register(GNRC_NETTYPE_SIXLOWPAN, &me_reg);

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/Kconfig
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_SIXLOWPAN_ND
+    bool "Configure GNRC 6LoWPAN Neighbor Discovery"
+    depends on MODULE_GNRC_SIXLOWPAN_ND
+    help
+        Configure GNRC 6LoWPAN Neighbor Discovery module using Kconfig.
+
+if KCONFIG_MODULE_GNRC_SIXLOWPAN_ND
+
+config GNRC_SIXLOWPAN_ND_AR_LTIME
+    int "Registration lifetime for the address registration option in minutes"
+    depends on MODULE_GNRC_IPV6_NIB
+    default 15
+    help
+        This value should be adapted to the devices power-lifecycle so that it is
+        greater than the time the device spends sleeping. See RFC 6775, section
+        5.8.1.
+
+endif # KCONFIG_MODULE_GNRC_SIXLOWPAN_ND

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -210,7 +210,7 @@ static const gnrc_sixlowpan_frag_rb_t *_first_non_empty_rbuf(void)
 {
     const gnrc_sixlowpan_frag_rb_t *rbuf = gnrc_sixlowpan_frag_rb_array();
 
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         if (!gnrc_sixlowpan_frag_rb_entry_empty(&rbuf[i])) {
             return rbuf;
         }
@@ -390,7 +390,7 @@ static void test_rbuf_add__full_rbuf(void)
     gnrc_pktsnip_t *pkt;
     const gnrc_sixlowpan_frag_rb_t *rbuf;
 
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         pkt = gnrc_pktbuf_add(NULL, _fragment1, sizeof(_fragment1),
                               GNRC_NETTYPE_SIXLOWPAN);
         TEST_ASSERT_NOT_NULL(pkt);
@@ -407,7 +407,7 @@ static void test_rbuf_add__full_rbuf(void)
             &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT1_OFFSET, TEST_PAGE
         ));
     rbuf = gnrc_sixlowpan_frag_rb_array();
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         const gnrc_sixlowpan_frag_rb_t *entry = &rbuf[i];
 
         TEST_ASSERT_MESSAGE(!gnrc_sixlowpan_frag_rb_entry_empty(entry),
@@ -467,7 +467,7 @@ static void test_rbuf_add__overlap_lhs(void)
             &_test_netif_hdr.hdr, pkt2, pkt2_offset, TEST_PAGE
         ));
     rbuf = gnrc_sixlowpan_frag_rb_array();
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         const gnrc_sixlowpan_frag_rb_t *entry = &rbuf[i];
         if (!gnrc_sixlowpan_frag_rb_entry_empty(entry)) {
             static const size_t pkt3_offset = TEST_FRAGMENT3_OFFSET - 8U - 1;
@@ -516,7 +516,7 @@ static void test_rbuf_add__overlap_rhs(void)
             &_test_netif_hdr.hdr, pkt2, pkt2_offset, TEST_PAGE
         ));
     rbuf = gnrc_sixlowpan_frag_rb_array();
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         const gnrc_sixlowpan_frag_rb_t *entry = &rbuf[i];
         if (!gnrc_sixlowpan_frag_rb_entry_empty(entry)) {
             static const size_t pkt3_offset = TEST_FRAGMENT3_OFFSET + 8U - 1U;

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -35,7 +35,7 @@
 #define TEST_TAG                (0x690e)
 #define TEST_PAGE               (0)
 #define TEST_RECEIVE_TIMEOUT    (100U)
-#define TEST_GC_TIMEOUT         (GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US + TEST_RECEIVE_TIMEOUT)
+#define TEST_GC_TIMEOUT         (CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US + TEST_RECEIVE_TIMEOUT)
 
 /* test date taken from an experimental run (uncompressed ICMPv6 echo reply with
  * 300 byte payload)*/
@@ -591,8 +591,8 @@ static void test_rbuf_gc__manually(void)
             &_test_netif_hdr.hdr, pkt, TEST_FRAGMENT1_OFFSET, TEST_PAGE
         )));
     TEST_ASSERT_NOT_NULL(entry);
-    /* set arrival GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US into the past */
-    entry->super.arrival -= GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US;
+    /* set arrival CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US into the past */
+    entry->super.arrival -= CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US;
     gnrc_sixlowpan_frag_rb_gc();
     /* reassembly buffer is now empty */
     TEST_ASSERT_NULL(_first_non_empty_rbuf());

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/main.c
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/main.c
@@ -208,7 +208,7 @@ static void test_recv__vrb_full(void)
 
     TEST_ASSERT_NOT_NULL(pkt);
     /* Fill up VRB */
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         base.tag++;
         base.arrival = xtimer_now_usec();
         TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_vrb_add(&base, _mock_netif,

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/main.c
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/main.c
@@ -142,7 +142,7 @@ static bool _rb_is_empty(void)
     const gnrc_sixlowpan_frag_rb_t *rb = gnrc_sixlowpan_frag_rb_array();
     unsigned res = 0;
 
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         res += gnrc_sixlowpan_frag_rb_entry_empty(&rb[i]);
     }
     return res;
@@ -158,7 +158,7 @@ static void _test_no_vrbe_but_rbe_exists(void)
                                                  sizeof(_test_src),
                                                  TEST_TAG));
     /* and one reassembly buffer entry exists with the source and tag exists */
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_SIZE; i++) {
         if (!gnrc_sixlowpan_frag_rb_entry_empty(&rb[i])) {
             rbs++;
             TEST_ASSERT_EQUAL_INT(sizeof(_test_src), rb[i].super.src_len);

--- a/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
+++ b/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
@@ -108,7 +108,7 @@ static void test_vrb_add__full(void)
     gnrc_sixlowpan_frag_rb_base_t base = _base;
 
     /* fill up VRB */
-    for (unsigned i = 0; i < GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         TEST_ASSERT_NOT_NULL(gnrc_sixlowpan_frag_vrb_add(&base,
                                                          &_dummy_netif,
                                                          _out_dst,

--- a/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
+++ b/tests/unittests/tests-gnrc_sixlowpan_frag_vrb/tests-gnrc_sixlowpan_frag_vrb.c
@@ -161,7 +161,7 @@ static void test_vrb_gc(void)
     gnrc_sixlowpan_frag_rb_base_t base = _base;
     gnrc_sixlowpan_frag_vrb_t *res;
 
-    base.arrival = xtimer_now_usec() - GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US - 1000;
+    base.arrival = xtimer_now_usec() - CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_TIMEOUT_US - 1000;
     TEST_ASSERT_NOT_NULL((res = gnrc_sixlowpan_frag_vrb_add(&base,
                                                             &_dummy_netif,
                                                             _out_dst,


### PR DESCRIPTION
### Contribution description
This PR moves the configuration macros of `gnrx/sixlowpan` found [here](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/net/gnrc/sixlowpan/config.h) to the `CONFIG_` namespace, and exposes them to Kconfig for individual modules.

As agreed offline with @leandrolanzieri I did not include the default thread priority parameter because this should be defined by the platform, if not changed manually. We might need a better solution to this in future.

Furthermore, I did not include parameters that relate to selective fragment recovery. As agreed with @miri64, these should be changed in #12648.

### Testing procedure
- `examples/gnrc_networking` should still work as usual.
- `tests/gnrc_sixlowpan_frag` should still work as usual.
- `tests/gnrc_sixlowpan_iphc_w_vrb` should still work as usual.
- `tests/unittests/tests-gnrc_sixlowpan_frag_vrb` should still work as usual.
- You should be able to configure the module's parameters via `make menuconfig` in all applications.

### Issues/PRs references
Part of #12888 
