### PR TITLE
boards: pic32-clicker: Use pic32prog as default programmer

### DIFF
--- a/boards/pic32-clicker/Makefile.include
+++ b/boards/pic32-clicker/Makefile.include
@@ -1,4 +1,18 @@
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
 
-FLASHFILE ?= $(HEXFILE)
+# use pic32prog by default to program this board
+PROGRAMMER ?= pic32prog
+
+ifeq ($(PROGRAMMER),pic32prog)
+  # pic32prog
+  #
+  # For PICkit3:
+  #
+  # * Connect the chipKIT-Wi-Fire to USB
+  # * Connect the PICkit3 to ICSP holes
+  # * https://docs.creatordev.io/wifire/guides/wifire-programming/
+  # * The triangle `▶` goes into the port number 1 (a hole with a square around it)
+  #   opposite side of the JP1 ICSP text.
+  include $(RIOTMAKE)/tools/pic32prog.inc.mk
+endif


### PR DESCRIPTION
### Contribution description

This PR adds a default programmer for the pic32-clicker board such that you can use `make flash` to program your board.

### Testing procedure

I flashed `hello-world` example on a pic32-clicker and I verified that I received the right message on the serial port.

### Issues/PRs references

This should close #8052.