### PR TITLE
cpu: mips_pic32*: Fix unused .gcc_except_table section warning

### DIFF
--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -18,7 +18,6 @@ OFLAGS += \
     --change-section-lma .init-0x80000000 \
     --change-section-lma .fini-0x80000000 \
     --change-section-lma .eh_frame-0x80000000 \
-    --change-section-lma .gcc_except_table-0x80000000 \
     --change-section-lma .jcr-0x80000000 \
     --change-section-lma .ctors-0x80000000 \
     --change-section-lma .dtors-0x80000000 \
@@ -26,3 +25,7 @@ OFLAGS += \
     --change-section-lma .data-0x80000000 \
     --change-section-lma .bss-0x80000000 \
     --change-section-lma .startdata-0x80000000 \
+
+ifneq (,$(filter cpp,$(FEATURES_USED)))
+OFLAGS += --change-section-lma .gcc_except_table-0x80000000
+endif

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -21,7 +21,6 @@ OFLAGS += \
     --change-section-lma .init-0x80000000 \
     --change-section-lma .fini-0x80000000 \
     --change-section-lma .eh_frame-0x80000000 \
-    --change-section-lma .gcc_except_table-0x80000000 \
     --change-section-lma .jcr-0x80000000 \
     --change-section-lma .ctors-0x80000000 \
     --change-section-lma .dtors-0x80000000 \
@@ -29,3 +28,7 @@ OFLAGS += \
     --change-section-lma .data-0x80000000 \
     --change-section-lma .bss-0x80000000 \
     --change-section-lma .startdata-0x80000000
+
+ifneq (,$(filter cpp,$(FEATURES_USED)))
+OFLAGS += --change-section-lma .gcc_except_table-0x80000000
+endif


### PR DESCRIPTION
### Contribution description

When compiling C applications for pic32-clicker and pic32-wifire boards, objcopy always emits a warning about unused section `.gcc_except_table`. This PR removes the parameter to objcopy that causes this warning if this is not an C++ application.

### Testing procedure

When compiling `examples/hello_world` in verbose mode, you should not see `--change-section-lma .gcc_except_table-0x80000000` in objcopy's parameters and the warning should not be printed.
On the other hand, while compiling `examples/riot_and_cpp`, you should see  `--change-section-lma .gcc_except_table-0x80000000` in objcopy's parameters.

### Issues/PRs references

None