### PR TITLE
cord/ep: add proper user event notifications

### DIFF
--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -33,7 +33,7 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 #define NODE_INFO  "SOME NODE INFORMATION"
 
 /* we will use a custom event handler for dumping cord_ep events */
-static void _on_ep_event(cord_ep_standalone_event_t event)
+static void _on_ep_event(uint16_t event)
 {
     switch (event) {
         case CORD_EP_REGISTERED:
@@ -42,8 +42,11 @@ static void _on_ep_event(cord_ep_standalone_event_t event)
         case CORD_EP_DEREGISTERED:
             puts("RD endpoint event: dropped client registration");
             break;
-        case CORD_EP_UPDATED:
+        case CORD_EP_UPDATE_OK:
             puts("RD endpoint event: successfully updated client registration");
+            break;
+        case CORD_EP_UPDATE_FAILED:
+            puts("RD endpoint event: update failed, registration was dropped");
             break;
     }
 }
@@ -99,7 +102,7 @@ int main(void)
     gcoap_register_listener(&_listener);
 
     /* register event callback with cord_ep_standalone */
-    cord_ep_standalone_reg_cb(_on_ep_event);
+    cord_ep_standalone_event_cb(_on_ep_event, CORD_EP_EVENT_ALL);
 
     puts("Client information:");
     printf("  ep: %s\n", cord_common_get_ep());

--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -102,7 +102,7 @@ int main(void)
     gcoap_register_listener(&_listener);
 
     /* register event callback with cord_ep_standalone */
-    cord_ep_standalone_event_cb(_on_ep_event, CORD_EP_EVENT_ALL);
+    cord_ep_standalone_event_cb(_on_ep_event);
 
     puts("Client information:");
     printf("  ep: %s\n", cord_common_get_ep());

--- a/sys/include/net/cord/ep.h
+++ b/sys/include/net/cord/ep.h
@@ -40,9 +40,6 @@
 extern "C" {
 #endif
 
-#define CORD_EP_EVENT_NONE      (0x0000)
-#define CORD_EP_EVENT_ALL       (0xffff)
-
 /**
  * @brief   Return values and error codes used by this module
  */
@@ -140,9 +137,8 @@ int cord_ep_remove(void);
  *
  * @param[in] cb        callback to execute on RD endpoint state changes, may be
  *                      NULL to disable notifications
- * @param[in] evt_mask
  */
-void cord_ep_event_cb(cord_ep_cb_t cb, uint16_t evt_mask);
+void cord_ep_event_cb(cord_ep_cb_t cb);
 
 /**
  * @brief   Dump the current RD connection status to STDIO (for debugging)

--- a/sys/include/net/cord/ep.h
+++ b/sys/include/net/cord/ep.h
@@ -40,6 +40,9 @@
 extern "C" {
 #endif
 
+#define CORD_EP_EVENT_NONE      (0x0000)
+#define CORD_EP_EVENT_ALL       (0xffff)
+
 /**
  * @brief   Return values and error codes used by this module
  */
@@ -50,6 +53,26 @@ enum {
     CORD_EP_NORD      = -3,     /**< not connected to an RD */
     CORD_EP_OVERFLOW  = -4,     /**< internal buffers can not handle input */
 };
+
+/**
+ * @brief   Events that can be signaled via the event callback function
+ */
+enum {
+    CORD_EP_REGISTERED    = 0x0001,
+    CORD_EP_DEREGISTERED  = 0x0002,
+    CORD_EP_UPDATE_OK     = 0x0004,
+    CORD_EP_UPDATE_FAILED = 0x0008,
+};
+
+/**
+ * @brief   Callback function signature for RD endpoint state synchronization
+ *
+ * The registered callback function is executed in the context of the dedicated
+ * standalone RD endpoint's thread.
+ *
+ * @param[in] t         type of event
+ */
+typedef void(*cord_ep_cb_t)(uint16_t event);
 
 /**
  * @brief   Discover the registration interface resource of a RD
@@ -107,9 +130,25 @@ int cord_ep_update(void);
 int cord_ep_remove(void);
 
 /**
+ * @brief   Register a callback to be notified about RD endpoint state changes
+ *
+ * Only a single callback can be active at any point in time, so setting a new
+ * callback will override the existing one.
+ *
+ * @warning Do not register an event callback when using cord_ep_standalone. Use
+ *          cord_ep_standalone_event_cb() instead.
+ *
+ * @param[in] cb        callback to execute on RD endpoint state changes, may be
+ *                      NULL to disable notifications
+ * @param[in] evt_mask
+ */
+void cord_ep_event_cb(cord_ep_cb_t cb, uint16_t evt_mask);
+
+/**
  * @brief   Dump the current RD connection status to STDIO (for debugging)
  */
 void cord_ep_dump_status(void);
+
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/cord/ep_standalone.h
+++ b/sys/include/net/cord/ep_standalone.h
@@ -26,28 +26,11 @@
 #ifndef NET_CORD_EP_STANDALONE_H
 #define NET_CORD_EP_STANDALONE_H
 
+#include "net/cord/ep.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief   Possible types of events triggered by the cord_ep_standalone module
- */
-typedef enum {
-    CORD_EP_REGISTERED,
-    CORD_EP_DEREGISTERED,
-    CORD_EP_UPDATED,
-} cord_ep_standalone_event_t;
-
-/**
- * @brief   Callback function signature for RD endpoint state synchronization
- *
- * The registered callback function is executed in the context of the dedicated
- * standalone RD endpoint's thread.
- *
- * @param[in] t         type of event
- */
-typedef void(*cord_ep_standalone_cb_t)(cord_ep_standalone_event_t event);
 
 /**
  * @brief   Spawn a new thread that takes care of sending periodic updates to an
@@ -66,19 +49,11 @@ void cord_ep_standalone_run(void);
  *
  * @pre                     @p cb != NULL
  *
- * @param[in] cb            callback to execute on RD endpoint state changes
+ * @param[in] cb        callback to execute on RD endpoint state changes, my be
+ *                      NULL to disable event notifications
+ * @param[in] evt_mask  mask for selecting the events that trigger notifications
  */
-void cord_ep_standalone_reg_cb(cord_ep_standalone_cb_t cb);
-
-/**
- * @brief   Signal the cord_ep thread about connection status change
- *
- * @note    This function should not be called by a user, but it is called from
- *          within the cord_ep implementation
- *
- * @param[in] connected     set to true if we are connected to a RD
- */
-void cord_ep_standalone_signal(bool connected);
+void cord_ep_standalone_event_cb(cord_ep_cb_t cb, uint16_t evt_mask);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/cord/ep_standalone.h
+++ b/sys/include/net/cord/ep_standalone.h
@@ -47,13 +47,10 @@ void cord_ep_standalone_run(void);
  * Only a single callback can be active at any point in time, so setting a new
  * callback will override the existing one.
  *
- * @pre                     @p cb != NULL
- *
  * @param[in] cb        callback to execute on RD endpoint state changes, my be
  *                      NULL to disable event notifications
- * @param[in] evt_mask  mask for selecting the events that trigger notifications
  */
-void cord_ep_standalone_event_cb(cord_ep_cb_t cb, uint16_t evt_mask);
+void cord_ep_standalone_event_cb(cord_ep_cb_t cb);
 
 #ifdef __cplusplus
 }

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -58,7 +58,6 @@ static volatile thread_t *_waiter;
 static uint8_t buf[BUFSIZE];
 
 static cord_ep_cb_t _evt_cb = NULL;
-static uint16_t _evt_mask = 0;
 
 static void _lock(void)
 {
@@ -68,7 +67,7 @@ static void _lock(void)
 
 static void _notify(uint16_t evt)
 {
-    if (_evt_mask & evt) {
+    if (_evt_cb) {
         _evt_cb(evt);
     }
 }
@@ -351,15 +350,9 @@ int cord_ep_remove(void)
     return CORD_EP_OK;
 }
 
-void cord_ep_event_cb(cord_ep_cb_t cb, uint16_t evt_mask)
+void cord_ep_event_cb(cord_ep_cb_t cb)
 {
-    /* disable all events to guard against NULL pointer exceptions */
-    _evt_mask = 0;
     _evt_cb = cb;
-    /* only enable notifications if a callback was specified */
-    if (cb) {
-        _evt_mask = evt_mask;
-    }
 }
 
 void cord_ep_dump_status(void)


### PR DESCRIPTION
### Contribution description
The solution I proposed in #12996 does not work properly for all cases and has its limitations. As alternative, this PR implements asynchronous event notifications for `cord_ep`, which in term are used and passed on by `cord_ep_standalone`. The code for `ep_standalone` should be a little simpler now, and if I am not mistaken there should be no duplicate event notifications anymore.

As further future, it is up to the user to select the actual events one wants be be notified about using the `mask` parameter int he `xyz_event_cb()` functions.

Caveats: the `xyz_event_cb()` functions are code duplicates right now, there is room for improvement...

**NOTE: some doxygen etc is still missing, will add this once the concept of this PR is approved...**

### Testing procedure
Run the endpoint example (`examples/cord_ep`) and register to a RD. Then play around with killing the RD (-> update should fail and the registration should be removed), unregistering manually (-> proper event notification should be displayed).

### Issues/PRs references
Alternative to #12996
