### PR TITLE
gnrc/sixlowpan: add deprecation note for GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -21,6 +21,7 @@
 #ifndef NET_GNRC_SIXLOWPAN_CONFIG_H
 #define NET_GNRC_SIXLOWPAN_CONFIG_H
 
+#include "kernel_defines.h"
 #include "timex.h"
 
 #ifdef __cplusplus
@@ -82,6 +83,22 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Keep all but oldest fragment when reassembly buffer is full
+ *
+ * @note    Only applicable with
+ *          [gnrc_sixlowpan_frag_rb](@ref net_gnrc_sixlowpan_frag_rb) module
+ *
+ * When not set, it will cause the reassembly buffer to override the oldest entry
+ * if a new entry has to be created and the reassembly buffer is full, no matter what.
+ * When set to 1, only incomplete entries that are older than
+ * @ref GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be overwritten (they will still timeout
+ * normally).
+ */
+#ifdef DOXYGEN
+#define GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE
+#endif
+
+/**
  * @brief   Aggressively override reassembly buffer when full
  *
  * @note    Only applicable with
@@ -92,10 +109,17 @@ extern "C" {
  * entry that is older than @ref GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be
  * overwritten (they will still timeout normally if reassembly buffer is not
  * full).
+ *
+ * @deprecated Use inverse @ref GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE instead.
+ *             Will be removed after 2020.10 release.
  */
 #ifndef GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE
+#if IS_ACTIVE(GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE)
+#define GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE    (0)
+#else /* GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE */
 #define GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE    (1)
-#endif
+#endif /* GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE */
+#endif /* GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE */
 
 /**
  * @brief   Deletion timer for reassembly buffer entries in microseconds


### PR DESCRIPTION
### Contribution description

When migrating configurations to Kconfig in #13123 we found that `GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE` is a simple on/off switch which should be represented as a boolean. In Kconfig, a symbol is defined when enabled and it is not generated at all when disabled. In the latter case, the value would be set anyway in the [config file](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/net/gnrc/sixlowpan/config.h) : 

```
#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE
#define GNRC_SIXLOWPAN_FRAG_RBUF_AGGRESSIVE_OVERRIDE    (1)
#endif
```

Offline we agreed with @jia200x and @leandrolanzieri that inverting the logic of the macro is the cleanest solution to this problem. As the semantics change, we changed the macro name and added a compile time error in case someone tries to use the old macro and we added a deprecation note to the documentation. 


### Testing procedure

1. `make doc` and check if documentation looks alright.
2. With *examples/gnrc_networking* send large ping requests between two nodes so that fragmentation takes place, e.g: `ping6 -c 10 -i 1000 -s 1000 <IPv6 dst addr>` .
3. Build with `CFLAGS=-DGNRC_SIXLOWPAN_FRAG_RBUF_KEEP_ENTRIES=1` and re-run 2. on nodes.


### Issues/PRs references
#12888, #13123
