### PR TITLE
drivers/ili9341: add number of lines parameter

### DIFF
--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -63,6 +63,7 @@ extern "C" {
 #define ILI9341_PARAM_RST          LCD_RESET
 #define ILI9341_PARAM_RGB          1
 #define ILI9341_PARAM_INVERTED     1
+#define ILI9341_PARAM_NUM_LINES    240U
 /** @} */
 
 #ifdef __cplusplus

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 #include "byteorder.h"
 #include "periph/spi.h"
@@ -85,6 +86,7 @@ static void _ili9341_set_area(ili9341_t *dev, uint16_t x1, uint16_t x2,
 
 int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
 {
+    assert(params->lines >= 16 && params->lines <= 320 && !(params->lines & 0x7));
     dev->params = params;
     uint8_t command_params[4] = { 0 };
     gpio_init(dev->params->dcx_pin, GPIO_OUT);
@@ -139,9 +141,9 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
     /* Display function control */
     command_params[0] = 0x08;
     command_params[1] = 0x82;
-    command_params[2] = 0x27; /* 320 lines */
+    /* number of lines, see datasheet p. 166 (DISCTRL::NL) */
+    command_params[2] = (params->lines >> 3) - 1;
     _write_cmd(dev, ILI9341_CMD_DFUNC, command_params, 3);
-
 
     /* Pixel format */
     command_params[0] = 0x55; /* 16 bit mode */

--- a/drivers/ili9341/include/ili9341_params.h
+++ b/drivers/ili9341/include/ili9341_params.h
@@ -55,6 +55,10 @@ extern "C" {
 #define ILI9341_PARAM_INVERTED     0
 #endif
 
+#ifndef ILI9341_PARAM_NUM_LINES
+#define ILI9341_PARAM_NUM_LINES    320U
+#endif
+
 #ifndef ILI9341_PARAMS
 #define ILI9341_PARAMS              { .spi = ILI9341_PARAM_SPI, \
                                       .spi_clk = ILI9341_PARAM_SPI_CLK, \
@@ -64,6 +68,7 @@ extern "C" {
                                       .rst_pin = ILI9341_PARAM_RST, \
                                       .rgb = ILI9341_PARAM_RGB, \
                                       .inverted = ILI9341_PARAM_INVERTED, \
+                                      .lines = ILI9341_PARAM_NUM_LINES, \
                                     }
 #endif
 /**@}*/

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -91,6 +91,7 @@ typedef struct {
     bool rgb;           /**< True when display is connected in RGB mode
                           *  False when display is connected in BGR mode */
     bool inverted;      /**< Display works in inverted color mode */
+    uint16_t lines;     /**< Number of lines, from 16 to 320 in 8 line steps */
 } ili9341_params_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, the driver was hard-coded to 320 lines. This PR makes that a parameter.

Tested on the PineTime (which has only 240 lines).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run test application, confirm that it still works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
