### PR TITLE
make/boards: add pyocd as optional programmer for stm32

### DIFF
--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -1,6 +1,6 @@
 PROGRAMMER ?= openocd
 
-PROGRAMMERS_SUPPORTED := bmp dfu-util openocd
+PROGRAMMERS_SUPPORTED := bmp dfu-util openocd pyocd
 
 ifeq (,$(filter $(PROGRAMMER), $(PROGRAMMERS_SUPPORTED)))
   $(error Programmer $(PROGRAMMER) not supported)
@@ -55,4 +55,9 @@ ifeq (dfu-util,$(PROGRAMMER))
   FLASHFILE ?= $(BINFILE)
   DFU_FLAGS ?= -a 2
   FFLAGS = -d $(DFU_USB_ID) $(DFU_FLAGS) -D $(FLASHFILE)
+endif
+
+# Recent versions of PyOCD (>=0.24.1) supports several STM32 based boards
+ifeq (pyocd,$(PROGRAMMER))
+  include $(RIOTMAKE)/tools/pyocd.inc.mk
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR allows for using pyocd to flash some stm32 based boards.

Recent versions of pyocd (I tested with 0.24.1) offer the possibility to download a Keil pack that provide support for multiple STM32 (nucleo, etc) targets/boards.

Before using pyocd to flash the boards, the corresponding "packs" must be installed with the following command:
```
pyocd pack --install stm32*
```

I'd like to document this somewhere but don't know where :)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Verify that one of the [Nucleo boards supported](https://github.com/mbedmicro/pyOCD/blob/v0.24.1/pyocd/board/board_ids.py#L99) by pyocd can be flashed.

```
PROGRAMMER=pyocd make BOARD=nucleo-f103 -C examples/hello-world flash
PROGRAMMER=pyocd make BOARD=nucleo-f103 -C examples/hello-world reset
PROGRAMMER=pyocd make BOARD=nucleo-f103 -C examples/hello-world debug
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Started to look into this when reviewing #11895 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
