### PR TITLE
pkg/tinydtls: Only include contrib folder if using tinydtls_sock_dtls

### DIFF
--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -7,7 +7,6 @@ ifeq ($(TOOLCHAIN), llvm)
 endif
 
 INCLUDES += -I$(RIOTBASE)/pkg/tinydtls/include
-DIRS += $(RIOTBASE)/pkg/tinydtls/contrib
 
 ifneq (,$(filter tinydtls,$(USEMODULE)))
   INCLUDES += -I$(PKG_BUILDDIR)
@@ -55,4 +54,9 @@ endif
 
 ifneq (,$(filter tinydtls_ecc,$(USEMODULE)))
   DIRS += $(PKG_BUILDDIR)/ecc
+endif
+
+# For now contrib only contains sock_dtls adaption
+ifneq (,$(filter tinydtls_sock_dtls,$(USEMODULE)))
+  DIRS += $(RIOTBASE)/pkg/tinydtls/contrib
 endif


### PR DESCRIPTION
### Contribution description
As described in #13121, the `contrib` folder in tinydtls package is always included, which needs definitions for sock (`sock_types.h`).

This PR modifies the Makefile to only add this directory to the build if the module `tinydtls_sock_dtls` is used, which is the only case when the folder is needed.

### Testing procedure
- `examples/dtls-echo` and `examples/dtls-sock` should still work as usual
- The issue presented in #13121 should be fixed

### Issues/PRs references
Fixes #13121
