### PR TITLE
boards: add cc1312-launchpad board.

### DIFF
--- a/boards/cc1312-launchpad/Makefile
+++ b/boards/cc1312-launchpad/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/cc1312-launchpad/Makefile.features
+++ b/boards/cc1312-launchpad/Makefile.features
@@ -1,0 +1,8 @@
+CPU = cc13x2
+CPU_MODEL = cc1312r1f3
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_gpio_irq
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/cc1312-launchpad/Makefile.include
+++ b/boards/cc1312-launchpad/Makefile.include
@@ -1,0 +1,11 @@
+XDEBUGGER = XDS110
+
+# set default port depending on operating system
+PORT_LINUX  ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# configure the flash tool
+include $(RIOTMAKE)/tools/uniflash.inc.mk

--- a/boards/cc1312-launchpad/board.c
+++ b/boards/cc1312-launchpad/board.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C)    2016 Nicholas Jackson
+ *                  2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_cc1312_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Board specific implementations for TI CC1312 LaunchPad
+ *
+ * @author          Nicholas Jackson <nicholas.jackson@griffithuni.edu.au>
+ * @author          Sebastian Meiling <s@mlng.net>
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+/**
+ * @brief           Initialise the board.
+ */
+
+void board_init(void)
+{
+    cpu_init();
+
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+}

--- a/boards/cc1312-launchpad/dist/cc1312r1f3_XDS110.ccxml
+++ b/boards/cc1312-launchpad/dist/cc1312r1f3_XDS110.ccxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configurations XML_version="1.2" id="configurations_0">
+    <configuration XML_version="1.2" id="configuration_0">
+        <instance XML_version="1.2" desc="Texas Instruments XDS110 USB Debug Probe" href="connections/TIXDS110_Connection.xml" id="Texas Instruments XDS110 USB Debug Probe" xml="TIXDS110_Connection.xml" xmlpath="connections"/>
+        <connection XML_version="1.2" id="Texas Instruments XDS110 USB Debug Probe">
+            <instance XML_version="1.2" href="drivers/tixds510icepick_c.xml" id="drivers" xml="tixds510icepick_c.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cs_dap.xml" id="drivers" xml="tixds510cs_dap.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cortexM.xml" id="drivers" xml="tixds510cortexM.xml" xmlpath="drivers"/>
+            <property Type="choicelist" Value="1" id="Power Selection">
+                <choice Name="Probe supplied power" value="1">
+                    <property Type="stringfield" Value="3.3" id="Voltage Level"/>
+                </choice>
+            </property>
+            <property Type="choicelist" Value="0" id="JTAG Signal Isolation"/>
+            <property Type="choicelist" Value="4" id="SWD Mode Settings">
+                <choice Name="cJTAG (1149.7) 2-pin advanced modes" value="enable">
+                    <property Type="choicelist" Value="1" id="XDS110 Aux Port"/>
+                </choice>
+            </property>
+            <platform XML_version="1.2" id="platform_0">
+                <instance XML_version="1.2" desc="CC1312R1F3" href="devices/cc1312r1f3.xml" id="CC1312R1F3" xml="cc1312r1f3.xml" xmlpath="devices"/>
+            </platform>
+        </connection>
+    </configuration>
+</configurations>

--- a/boards/cc1312-launchpad/dist/cc1312r1f3_XDS110.dat
+++ b/boards/cc1312-launchpad/dist/cc1312r1f3_XDS110.dat
@@ -1,0 +1,41 @@
+# config version=3.5
+$ sepk
+  pod_drvr=libjioxds110.so
+  pod_port=0
+  pod_supply=1
+  pod_voltage_selection=1
+  pod_voltage=3.3
+$ /
+$ product
+  title="Texas Instruments XDS110 USB"
+  alias=TI_XDS110_USB
+  name=XDS110
+$ /
+$ uscif
+  tdoedge=FALL
+  tclk_program=DEFAULT
+  tclk_frequency=2.5MHz
+  jtag_isolate=disable
+$ /
+$ dot7
+  dts_usage=enable
+  dts_type=xds110
+  dts_program=emulator
+  dts_frequency=1.0MHz
+  ts_format=oscan2
+  ts_pin_width=only_two
+$ /
+$ swd
+  swd_debug=disabled
+  swo_data=tdo_pin
+$ /
+@ icepick_c family=icepick_c irbits=6 drbits=1 subpaths=2
+  & subpath_2 address=0 default=no custom=yes force=yes pseudo=no cancelreset=0x0
+    @ bypass_0 family=bypass irbits=4 drbits=1
+  & subpath_0 address=16 default=no custom=yes force=yes pseudo=no cancelreset=0x0
+    @ cs_dap_0 family=cs_dap irbits=4 drbits=1 subpaths=1 identify=0x4BA00477 revision=Legacy systemresetwhileconnected=1
+      & subpath_1 type=debug address=0 default=no custom=yes force=yes pseudo=no
+        @ cortex_m4_0 family=cortex_mxx irbits=0 drbits=0 identify=0x02000000 traceid=0x0
+      & /
+  & /
+# /

--- a/boards/cc1312-launchpad/dist/cc1312r1f3_gdb.conf
+++ b/boards/cc1312-launchpad/dist/cc1312r1f3_gdb.conf
@@ -1,0 +1,1 @@
+target remote localhost:3333

--- a/boards/cc1312-launchpad/doc.txt
+++ b/boards/cc1312-launchpad/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup        boards_cc1312_launchpad TI CC1312 LaunchPad
+ * @ingroup         boards
+ * @brief           Texas Instruments SimpleLink(TM) CC1312 Wireless MCU LaunchPad(TM) Kit
+ */

--- a/boards/cc1312-launchpad/include/board.h
+++ b/boards/cc1312-launchpad/include/board.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C)    2016 Nicholas Jackson
+ *                  2017 Sebastian Meiling
+ *                  2018 Anton Gerasimov
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_cc1352_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Board specific definitions for TI CC1352 LaunchPad
+ *
+ * @author          Nicholas Jackson <nicholas.jackson@griffithuni.edu.au>
+ * @author          Sebastian Meiling <s@mlng.net>
+ * @author          Anton Gerasimov <tossel@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      (25)
+#define XTIMER_ISR_BACKOFF  (20)
+/** @} */
+
+/**
+ * @name    On-board button configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 13)
+#define BTN0_MODE           GPIO_IN_PU
+
+#define BTN1_PIN            GPIO_PIN(0, 14)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief   On-board LED configuration and controlling
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 6)          /**< red   */
+#define LED1_PIN            GPIO_PIN(0, 7)          /**< green */
+
+#define LED0_ON             gpio_set(LED0_PIN)
+#define LED0_OFF            gpio_clear(LED0_PIN)
+#define LED0_TOGGLE         gpio_toggle(LED0_PIN)
+
+#define LED1_ON             gpio_set(LED1_PIN)
+#define LED1_OFF            gpio_clear(LED1_PIN)
+#define LED1_TOGGLE         gpio_toggle(LED1_PIN)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/cc1312-launchpad/include/periph_conf.h
+++ b/boards/cc1312-launchpad/include/periph_conf.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C)    2016 Nicholas Jackson
+ *                  2017 HAW Hamburg
+ *                  2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         boards_cc1312_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Peripheral MCU configuration for TI CC1312 LaunchPad
+ *
+ * @author          Nicholas Jackson <nicholas.jackson@griffithuni.edu.au>
+ * @author          Sebastian Meiling <s@mlng.net>
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @name    Clock configuration
+* @{
+*/
+/* the main clock is fixed to 48MHZ */
+#define CLOCK_CORECLOCK     (48000000U)
+/** @} */
+
+/**
+* @name    Timer configuration
+*
+* General purpose timers (GPT[0-3]) are configured consecutively and in order
+* (without gaps) starting from GPT0, i.e. if multiple timers are enabled.
+*
+* @{
+*/
+static const timer_conf_t timer_config[] = {
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ },
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ }
+};
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ *
+ * The used LAUNCHXL-CC1312R board has available a single UART device throught
+ * the debugger, so all we need to configure are the RX and TX pins.
+ *
+ * Optionally we can enable hardware flow control, by setting UART_HW_FLOW_CTRL
+ * to 1 and defining pins for cts_pin and rts_pin.
+ *
+ * Add a second UART configuration if using external pins.
+ * @{
+ */
+
+static const uart_conf_t uart_config[] = {
+ {
+     .regs = UART0,
+     .tx_pin = 3,
+     .rx_pin = 2,
+     .rts_pin = 18,      /* ignored when flow_control is 0 */
+     .cts_pin = 19,      /* ignored when flow_control is 0 */
+     .flow_control = 0,
+     .intn = UART0_IRQN
+ }
+};
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill \
     bluepill-128kib \
     calliope-mini \
+    cc1312-launchpad \
     cc1352-launchpad \
     cc2650-launchpad \
     cc2650stk \
@@ -33,9 +34,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml10-xpro \
     saml11-xpro \
     spark-core \
-    stm32f0discovery \
     stm32f030f4-demo \
+    stm32f0discovery \
     stm32l0538-disco \
     stm32mindev \
-    yunjia-nrf51822
+    yunjia-nrf51822 \
     #

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill \
     bluepill-128kib \
     calliope-mini \
+    cc1312-launchpad \
     cc1352-launchpad \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill \
     bluepill-128kib \
     calliope-mini \
+    cc1312-launchpad \
     cc1352-launchpad \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill \
     bluepill-128kib \
     calliope-mini \
+    cc1312-launchpad \
     cc1352-launchpad \
     cc2538dk \
     cc2650-launchpad \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -14,6 +14,7 @@ LOW_MEMORY_BOARDS += \
   bluepill \
   bluepill-128kib \
   calliope-mini \
+  cc1312-launchpad \
   cc1352-launchpad \
   cc2650-launchpad \
   cc2650stk \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill \
     bluepill-128kib \
     calliope-mini \
+    cc1312-launchpad \
     cc1352-launchpad \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -9,15 +9,16 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mkrzero \
     arduino-nano \
     arduino-uno \
+    arduino-zero \
     atmega256rfr2-xpro \
     atmega328p \
-    arduino-zero \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
     calliope-mini \
+    cc1312-launchpad \
     cc1352-launchpad \
     cc2650-launchpad \
     cc2650stk \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see x.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

It is essentially the same buttons and leds pins, what changes is the
CCXML files used to flash with `make flash`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Go to any examples and execute `make flash BOARD=cc1312-launchpad`, the code should build correctly and get flashed on a connected CC1312 at the port `ttyACM0`.

### Issues/PRs references

See also #9813, #6715.