### PR TITLE
boards: cc2538dk: remove `machine SetClockSource`.

### DIFF
--- a/boards/cc2538dk/dist/board.resc
+++ b/boards/cc2538dk/dist/board.resc
@@ -1,7 +1,6 @@
 mach create
 using sysbus
 machine LoadPlatformDescription @platforms/cpus/cc2538.repl
-machine SetClockSource cpu
 
 machine PyDevFromFile @scripts/pydev/rolling-bit.py 0x400D2004 0x4 True "sysctrl"
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

It causes errors on current Renode versions. It wasn't documented on the
Renode changelog, but SetClockSource property was removed. Before this
change it showed this error:

    There was an error executing command 'machine SetClockSource cpu'
    machine does not provide a field, method or property SetClockSource.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

You need to build an example or application for the `cc2538dk` board and then run it on Renode. Example:

    make BOARD=cc2538dk
    make emulate BOARD=cc2538dk

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references.

Doesn't apply, issue not created.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
