### PR TITLE
sys/puf_sram: counter based seed after soft reset

### DIFF
--- a/sys/include/puf_sram.h
+++ b/sys/include/puf_sram.h
@@ -90,6 +90,13 @@ extern uint32_t puf_sram_seed;
 extern uint32_t puf_sram_state;
 
 /**
+ * @brief Counter variable allocated in puf_sram.c. It is incremented
+          during each soft reset when no new PUF measurement was taken
+          and it gets reset to zero after a power cycle was detected.
+ */
+extern uint32_t puf_sram_softreset_cnt;
+
+/**
  * @brief checks source of reboot by @p puf_sram_softreset and conditionally
           calls @p puf_sram_generate
  *

--- a/sys/puf_sram/puf_sram.c
+++ b/sys/puf_sram/puf_sram.c
@@ -24,6 +24,9 @@ PUF_SRAM_ATTRIBUTES uint32_t puf_sram_seed;
 /* Allocation of the PUF seed state */
 PUF_SRAM_ATTRIBUTES uint32_t puf_sram_state;
 
+/* Allocation of the PUF soft reset conter*/
+PUF_SRAM_ATTRIBUTES uint32_t puf_sram_softreset_cnt;
+
 /* Allocation of the memory marker */
 PUF_SRAM_ATTRIBUTES uint32_t puf_sram_marker;
 
@@ -42,6 +45,8 @@ void puf_sram_generate(const uint8_t *ram, size_t len)
     puf_sram_marker = PUF_SRAM_MARKER;
     /* setting state to 0 means seed was generated from SRAM pattern */
     puf_sram_state = 0;
+    /* reset counter of detected soft resets */
+    puf_sram_softreset_cnt = 0;
 }
 
 bool puf_sram_softreset(void)
@@ -51,5 +56,12 @@ bool puf_sram_softreset(void)
         return 0;
     }
     puf_sram_state = 1;
+
+    /* increment number of detected soft resets */
+    puf_sram_softreset_cnt++;
+
+    /* generate alterntive seed value */
+    puf_sram_seed ^= puf_sram_softreset_cnt;
+    puf_sram_seed = dek_hash((uint8_t *)&puf_sram_seed, sizeof(puf_sram_seed));
     return 1;
 }

--- a/tests/puf_sram/Makefile
+++ b/tests/puf_sram/Makefile
@@ -3,5 +3,6 @@ BOARD ?= nucleo-f411re
 include ../Makefile.tests_common
 
 USEMODULE += puf_sram
+DISABLE_MODULE += test_utils_interactive_sync
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

The SRAM seeder implements a detection mechanisms which avoids creating seeds from low entropy memory pattern after a soft reset. Currently, the old seed is reused in these cases which provides zero variance after a soft reset (see #12166). 

This PR adds a soft reset counter which is mixed into the "old" seed to create a "new" seed for the soft restart. The counter is set to zero after a power cycle was detected and a fresh seed is created from the SRAM pattern as usual.

Additionally, this PR contains a commit that disables the "interactive sync" module in the test application because there is no testrunner available anyway. Hitting "s" after each reboot is annoying.

### Testing procedure

1. I've added `printf("puf_sram_softreset_cnt: [0x%08" PRIX32 "]\n", puf_sram_softreset_cnt);` to the SRAM seeder [test application](https://github.com/RIOT-OS/RIOT/blob/master/tests/puf_sram/main.c#L28) and repeatedly reset the to watch the counter increase and reset after a power cycle. 

2. I've set up a nucleo-l073rz board similar to the [Example Setup](https://github.com/RIOT-OS/RIOT/tree/master/tests/puf_sram#example-setup) **but** applied continuous power and toggled the NRST pin. Then I ran [example_test.py](https://github.com/RIOT-OS/RIOT/blob/master/tests/puf_sram/tests/example_test.py) (500 iterations by default) which lead to a total min. entropy of ~55% between soft resets. This is not perfect and might improve with an other hash function, but it is a huge improvement to zero change.

### Issues/PRs references
 #12166, #12991