### PR TITLE
boards: Improve documentation for pic32-clicker and pic32-wifire

### DIFF
--- a/boards/pic32-clicker/doc.txt
+++ b/boards/pic32-clicker/doc.txt
@@ -3,16 +3,91 @@
 @ingroup     boards
 @brief       Support for the MikroE PIC32 Clicker
 
-For instructions on reflashing see:
+## Overview
 
-https://docs.creatordev.io/clicker/guides/quick-start-guide/#programming-a-6lowpan-clicker
-
-The RIOT build generates a hexfile compatible with MPLAB-IPE.
+The `6lowpan clicker` is an evaluation board by Mikroe featuring a
+PIC32MX470F512H, a 6lowpan radio (CA810) by Cascoda and a Mikrobus
+socket for expansion boards.
 
 More general information on the board and related documentation can be found
-here:
+[here](https://www.mikroe.com/clicker-6lowpan). Schematics for the board can be
+found in the [manual](https://download.mikroe.com/documents/starter-boards/clicker/6lowpan/6lowpan-clicker-manual-v100.pdf).
 
-https://docs.creatordev.io/clicker/guides/quick-start-guide/#introduction
+## Hardware
+
+### MCU
+
+| MCU        | PIC32MX470F512H      |
+|:---------- |:-------------------- |
+| Family     | PIC32MX (MIPS M4K)   |
+| Vendor     | Microchip            |
+| RAM        | 128Kb                |
+| Flash      | 512Kb                |
+| Frequency  | 120MHz               |
+| FPU        | no                   |
+| Timers     | 5 (all 16-bit)       |
+| ADCs       | 1x 28-channel 10-bit |
+| USB 2.0    | 1                    |
+| UARTs      | 4                    |
+| SPIs       | 2                    |
+| I2Cs       | 2                    |
+| RTC        | yes                  |
+| RNG        | no                   |
+| Vcc        | 2.3V - 3.6V          |
+| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/PIC32MX330350370430450470_Datasheet_DS60001185H.pdf) |
+
+
+### User Interface
+
+2 Buttons:
+
+| NAME   |  T1  |  T2 |
+|:-----  |:---  |:--- |
+| Pin    | RE7  | RB0 |
+
+2 LEDs:
+
+| NAME  | LD1 | LD2 |
+| ----- | --- | --- |
+| Color | red | red |
+| Pin   | RB1 | RB2 |
+
+## Implementation Status
+
+| Device           | ID              | Supported | Comments               |
+|:---------------- |:--------------- |:--------- |:---------------------- |
+| MCU              | pic32mx470f512h | partly    |                        |
+| Low-level driver | GPIO            | partly    | gpio_irq not supported |
+|                  | ADC             | no        |                        |
+|                  | PWM             | no        |                        |
+|                  | UART            | partly    | only TX                |
+|                  | I2C             | no        |                        |
+|                  | SPI             | no        |                        |
+|                  | USB             | no        |                        |
+|                  | RTT             | no        |                        |
+|                  | RTC             | no        |                        |
+|                  | Timer           | no        |                        |
+
+## Using UART
+
+This board doesn't open an UART or serial interface through the USB
+automatically, and the USB device driver hasn't been implemented to RIOT.
+Therefore, to open an UART interface one has to connect a usb/ttl converter to
+the UART3 pins RF5 (RX) and RF4 (TX) available on the Mikrobus socket.
+
+## Flashing the device
+
+There are two ways to flash the MCU:
+  * Using MPLAB-IPE and a PICkit 3 (The RIOT build generates a hexfile
+    compatible with MPLAB-IPE)
+  * Using pic32prog and a PICkit 2 or a PICkit 3 (other devices might be
+    supported by pic32prog but were not tested). This is the preferred option
+    as it makes possible to flash the device using `make flash` command.
+
+## Supported Toolchains
+
+For using the pic32-clicker board we strongly recommend the usage of the
+[Codescape GNU Tools](https://codescape.mips.com) toolchain.
 
 
  */

--- a/boards/pic32-wifire/doc.txt
+++ b/boards/pic32-wifire/doc.txt
@@ -3,19 +3,89 @@
 @ingroup     boards
 @brief       Support for the Digilent PIC32 WiFire
 
-For instructions on reflashing see:
+## Overview
 
-https://docs.creatordev.io/wifire/guides/wifire-programming/
+The ChipKit Wifire is a development board by Digilent featuring a PIC32MZ and a Wifi module (MRF24WG0MA).
+General information about the board can be found [here](https://store.digilentinc.com/wi-fire-wifi-enabled-pic32mz-microcontroller-board/)
+Please do not use board rev A or B as they use a different MCU (PIC32MZ2048ECG100).
 
-The RIOT build generates a hexfile compatible with MPLAB-IPE.
+Additional documents:
+  * [Schematics](https://reference.digilentinc.com/_media/reference/microprocessor/wi-fire/chipkit_wifire_sch.pdf) for the Wifire board rev C
+  * [Schematics](https://reference.digilentinc.com/_media/reference/microprocessor/wi-fire/wifire_sch.pdf) for the Wifire board rev D
+  * [Reference manual](https://reference.digilentinc.com/_media/reference/microprocessor/wi-fire/wi-fire_rm_revd.pdf) for the Wifire board rev D
 
-More general information on the board and related documentation can be found
-here:
+## Hardware
 
-https://creatordev.io/wifire.html
+### MCU
 
-https://docs.creatordev.io/wifire/
+| MCU        | PIC32MZ2048EFG100    |
+|:---------- |:-------------------- |
+| Family     | PIC32MZ (MIPS M5150) |
+| Vendor     | Microchip            |
+| RAM        | 512Kb                |
+| Flash      | 2048Kb               |
+| Frequency  | 200MHz               |
+| FPU        | yes                  |
+| Timers     | 9 (all 16-bit)       |
+| ADCs       | 1x 40-channel 12-bit |
+| USB 2.0    | 1                    |
+| UARTs      | 6                    |
+| SPIs       | 6                    |
+| I2Cs       | 5                    |
+| RTC        | yes                  |
+| RNG        | yes                  |
+| Vcc        | 2.1V - 3.6V          |
+| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/PIC32MZ%20EF%20Family%20Datasheet_DS60001320G.pdf) |
 
 
+### User Interface
+
+3 Buttons:
+
+| NAME   | Reset  |  T1 |  T2 |
+|:-----  |:------ |:--- |:--- |
+| Pin    | nReset | RA5 | RA4 |
+
+4 LEDs:
+
+| NAME  | LD1   | LD2   | LD3   | LD4   |
+| ----- | ----- | ----- | ----- | ----- |
+| Color | green | green | green | green |
+| Pin   | RG6   | RD4   | RB11  | RG15  |
+
+## Implementation Status
+
+| Device           | ID                | Supported | Comments               |
+|:---------------- |:---------------   |:--------- |:---------------------- |
+| MCU              | pic32mz2048efg100 | partly    |                        |
+| Low-level driver | GPIO              | partly    | gpio_irq not supported |
+|                  | ADC               | no        |                        |
+|                  | PWM               | no        |                        |
+|                  | UART              | partly    | only TX                |
+|                  | I2C               | no        |                        |
+|                  | SPI               | no        |                        |
+|                  | USB               | no        |                        |
+|                  | RTT               | no        |                        |
+|                  | RTC               | no        |                        |
+|                  | RNG               | yes       |                        |
+|                  | Timer             | no        |                        |
+
+## Using UART
+
+This board opens a serial interface through the USB automatically.
+
+## Flashing the device
+
+There are three ways to flash the MCU:
+  * Using MPLAB-IPE and a PICkit 3 (The RIOT build generates a hexfile
+    compatible with MPLAB-IPE)
+  * Using pic32prog and a PICkit 2 or a PICkit 3 (other devices might be
+    supported by pic32prog but were not tested).
+  * Using a SEGGER J-Link probe. JTAG pins are available on the JP3 connector.
+
+## Supported Toolchains
+
+For using the pic32-wifire board we strongly recommend the usage of the
+[Codescape GNU Tools](https://codescape.mips.com) toolchain.
 
  */


### PR DESCRIPTION
### Contribution description

creatordev.io is no more so all links in pic32-clicker and pic32-wifire documentation files are dead. I took the opportunity to update the documentation for these two boards.

### Testing procedure

None

### Issues/PRs references

None