### PR TITLE
makefiles: arch: mips: Allow CFLAGS_DBG and CFLAGS_OPT to be overridden

### DIFF
--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -34,8 +34,8 @@ ifeq (, $(filter -std=%, $(CFLAGS)))
 endif
 CFLAGS_CPU   = -EL -mabi=$(ABI)
 CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums -fdata-sections
-CFLAGS_DBG   = -g3
-CFLAGS_OPT   = -Os
+CFLAGS_DBG   ?= -g3
+CFLAGS_OPT   ?= -Os
 
 CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_OPT) $(CFLAGS_DBG)
 CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))


### PR DESCRIPTION
### Contribution description

When looking at #13081, I found that you could not override `CFLAGS_DBG` and `CFLAGS_OPT` when compiling for MIPS while you can override these variables for all other architecture. 

### Testing procedure

Try building hello-world for pic32-clicker or pic32-wifire while setting `CFLAGS_DBG` and `CFLAGS_OPT` to a different value. 

### Issues/PRs references

None