### PR TITLE
cpu/esp32: fix compilation when esp_gdb is enabled

### DIFF
--- a/cpu/esp32/vendor/esp-idf/esp_funcs.c
+++ b/cpu/esp32/vendor/esp-idf/esp_funcs.c
@@ -108,7 +108,7 @@ void IRAM_ATTR esp_log_write(esp_log_level_t level,
      * We use the log level set for the given tag instead of using
      * the given log level.
      */
-    esp_log_level_t act_level;
+    esp_log_level_t act_level = LOG_DEBUG;
     size_t i;
     for (i = 0; i < ARRAY_SIZE(_log_levels); i++) {
         if (strcmp(tag, _log_levels[i].tag) == 0) {


### PR DESCRIPTION
### Contribution description

This PR fixes a compilation problem that only happens when module `esp_gdb` is enabled.

### Testing procedure

Compile any application using module `esp_gdb` with and without this PR, for example:
```
USEMODULE=esp_gdb make BOARD=esp32-wroom-32 -C tests/thread_basic
```
Without this PR the compilation should fail with:
```
cpu/esp32/vendor/esp-idf/esp_funcs.c: In function 'esp_log_write':
cpu/esp32/vendor/esp-idf/esp_funcs.c:148:5: error: 'act_level' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     switch (act_level) {
```

### Issues/PRs references
