### PR TITLE
cpu/esp32: fix C linkage compilation error [backport 2020.01]

### DIFF
--- a/boards/common/esp32/include/board_common.h
+++ b/boards/common/esp32/include/board_common.h
@@ -35,8 +35,12 @@
 #include "periph/gpio.h"
 #include "sdk_conf.h"
 
+#if MODULE_MTD
+#include "mtd.h"
+#endif
+
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -103,7 +107,6 @@
  * Built-in SPI flash memory is used as MTD system drive.
  * @{
  */
-#include "mtd.h"
 
 /**
  * @brief   MTD drive start address in SPI flash memory

--- a/cpu/esp32/include/sdk_conf.h
+++ b/cpu/esp32/include/sdk_conf.h
@@ -24,11 +24,11 @@
 
 #ifndef DOXYGEN
 
+#include "board.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "board.h"
 
 /**
  * @brief   Defines the CPU frequency [values = 2, 40, 80, 160 and 240]


### PR DESCRIPTION
# Backport of #13141

### Contribution description

This PR fixes a C linkage compilation error with the new version of the ESP32 toolchain in https://github.com/RIOT-OS/riotdocker/pull/97. The C linkage compilation error happens for example for `examples/posix_socket` and all applications that use `esp_wifi` or `esp_now`.

The reason for the C linking error was that `drivers/include/mtd.h` was included in `boards/esp32/board_common.h` within the `external C` block. This caused `atomic_base.h` to be included inside the `external C` block, which in turn caused the C linking error for the template definitions in that file, for example: 

```
xtensa-esp32-elf/include/c++/5.2.0/bits/atomic_base.h:109:3: error: template with C linkage
   template<typename _Tp>
```
<details>

```
make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C ./examples/posix_sockets clean all
Building application "posix_sockets_example" for "esp32-wroom-32" with MCU "esp32".

In file included from /home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:41:0,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/sys/include/vfs.h:61,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/drivers/include/mtd.h:28,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/boards/common/esp32/include/board_common.h:106,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/boards/esp32-wroom-32/include/board.h:65,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/include/sdk_conf.h:31,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf/include/spi_flash/esp_spi_flash.h:22,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf/nvs_flash/nvs_page.hpp:23,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf/nvs_flash/nvs_page.cpp:14:
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/atomic_base.h:109:3: error: template with C linkage
   template<typename _Tp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/atomic_base.h:119:3: error: template with C linkage
   template<typename _IntTp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/atomic_base.h:125:3: error: template with C linkage
   template<typename _Tp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/atomic_base.h:128:3: error: template with C linkage
   template<typename _Tp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/atomic_base.h:237:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/atomic_base.h:564:3: error: template with C linkage
   template<typename _PTp>
   ^
In file included from /home/gs/src/RIOT-Xtensa-ESP.git/sys/include/vfs.h:61:0,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/drivers/include/mtd.h:28,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/boards/common/esp32/include/board_common.h:106,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/boards/esp32-wroom-32/include/board.h:65,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/include/sdk_conf.h:31,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf/include/spi_flash/esp_spi_flash.h:22,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf/nvs_flash/nvs_page.hpp:23,
                 from /home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf/nvs_flash/nvs_page.cpp:14:
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:52:3: error: template with C linkage
   template<typename _Tp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:57:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:164:3: error: template with C linkage
   template<typename _Tp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:319:3: error: template with C linkage
   template<typename _Tp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:509:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:528:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:547:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:566:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:585:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:604:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:623:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:642:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:661:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:680:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:699:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:718:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:737:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:756:3: error: template specialization with C linkage
   template<>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic: In function 'bool std::atomic_flag_test_and_set_explicit(volatile std::atomic_flag*, std::memory_order)':
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:898:27: error: conflicting declaration of C function 'bool std::atomic_flag_test_and_set_explicit(volatile std::atomic_flag*, std::memory_order)'
         memory_order __m) noexcept
                           ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:892:3: note: previous declaration 'bool std::atomic_flag_test_and_set_explicit(std::atomic_flag*, std::memory_order)'
   atomic_flag_test_and_set_explicit(atomic_flag* __a,
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic: In function 'void std::atomic_flag_clear_explicit(volatile std::atomic_flag*, std::memory_order)':
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:907:27: error: conflicting declaration of C function 'void std::atomic_flag_clear_explicit(volatile std::atomic_flag*, std::memory_order)'
         memory_order __m) noexcept
                           ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:902:3: note: previous declaration 'void std::atomic_flag_clear_explicit(std::atomic_flag*, std::memory_order)'
   atomic_flag_clear_explicit(atomic_flag* __a, memory_order __m) noexcept
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic: In function 'bool std::atomic_flag_test_and_set(volatile std::atomic_flag*)':
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:915:55: error: conflicting declaration of C function 'bool std::atomic_flag_test_and_set(volatile std::atomic_flag*)'
   atomic_flag_test_and_set(volatile atomic_flag* __a) noexcept
                                                       ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:911:3: note: previous declaration 'bool std::atomic_flag_test_and_set(std::atomic_flag*)'
   atomic_flag_test_and_set(atomic_flag* __a) noexcept
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic: In function 'void std::atomic_flag_clear(volatile std::atomic_flag*)':
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:923:48: error: conflicting declaration of C function 'void std::atomic_flag_clear(volatile std::atomic_flag*)'
   atomic_flag_clear(volatile atomic_flag* __a) noexcept
                                                ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:919:3: note: previous declaration 'void std::atomic_flag_clear(std::atomic_flag*)'
   atomic_flag_clear(atomic_flag* __a) noexcept
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic: At global scope:
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:928:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:933:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:938:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:943:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:948:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:954:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:960:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:965:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:971:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:977:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:983:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:991:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:999:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1007:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1016:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1021:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1026:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1031:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1036:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1041:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1046:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1056:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1066:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1076:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1090:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1096:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1102:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1108:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1114:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1120:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1126:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1132:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1138:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1144:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1150:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1155:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1160:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1165:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1170:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1175:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1180:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1185:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1190:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1195:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1202:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1208:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1214:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1219:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1224:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1230:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1236:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/tmp/crosstool-NG/builds/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/atomic:1241:3: error: template with C linkage
   template<typename _ITp>
   ^
/home/gs/src/RIOT-Xtensa-ESP.git/Makefile.base:121: recipe for target '/home/gs/src/RIOT-Xtensa-ESP.git/examples/posix_sockets/bin/esp32-wroom-32/esp_idf_nvs_flash/nvs_page.o' failed
make[5]: *** [/home/gs/src/RIOT-Xtensa-ESP.git/examples/posix_sockets/bin/esp32-wroom-32/esp_idf_nvs_flash/nvs_page.o] Error 1
/home/gs/src/RIOT-Xtensa-ESP.git/Makefile.base:29: recipe for target 'ALL--/home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf/nvs_flash' failed
make[4]: *** [ALL--/home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf/nvs_flash] Error 2
/home/gs/src/RIOT-Xtensa-ESP.git/Makefile.base:29: recipe for target 'ALL--/home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf' failed
make[3]: *** [ALL--/home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor/esp-idf] Error 2
/home/gs/src/RIOT-Xtensa-ESP.git/Makefile.base:29: recipe for target 'ALL--/home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor' failed
make[2]: *** [ALL--/home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32/vendor] Error 2
/home/gs/src/RIOT-Xtensa-ESP.git/Makefile.base:29: recipe for target 'ALL--/home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32' failed
make[1]: *** [ALL--/home/gs/src/RIOT-Xtensa-ESP.git/cpu/esp32] Error 2
/home/gs/src/RIOT-Xtensa-ESP.git/examples/posix_sockets/../../Makefile.include:540: recipe for target '/home/gs/src/RIOT-Xtensa-ESP.git/examples/posix_sockets/bin/esp32-wroom-32/application_posix_sockets_example.a' failed
make: *** [/home/gs/src/RIOT-Xtensa-ESP.git/examples/posix_sockets/bin/esp32-wroom-32/application_posix_sockets_example.a] Error 2

Return value: 2
```

</details>

### Testing procedure

Compilation in Murdock should succeed with current ESP32 toolchain.

### Issues/PRs references

Prerequisite for https://github.com/RIOT-OS/riotdocker/pull/97
Part of the fix of issue #13133