### PR TITLE
boards: add support for nrf52840-dongle

### DIFF
--- a/boards/nrf52840dongle/Makefile
+++ b/boards/nrf52840dongle/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nrf52840dongle/Makefile.dep
+++ b/boards/nrf52840dongle/Makefile.dep
@@ -1,0 +1,17 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
+  # Use stdio_cdc_acm only if no other stdio is requested explicitly.
+  USEMODULE += stdio_cdc_acm
+  # This does not *really* hinge on the choice of stdio, but this ensures
+  # compatibility with the test suite that uses stdio_null and would conflict
+  # with bootloader_nrfutil.
+  # (Having the feature in is generally a good thing because as an indicator
+  # that it the resulting program is meant to be flashed using nrfutil).
+  FEATURES_REQUIRED += bootloader_nrfutil
+endif
+# ... and fall back to the UART-based stdio
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/nrf52840dongle/Makefile.features
+++ b/boards/nrf52840dongle/Makefile.features
@@ -1,0 +1,11 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrf802154
+FEATURES_PROVIDED += bootloader_nrfutil
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52840dongle/Makefile.include
+++ b/boards/nrf52840dongle/Makefile.include
@@ -1,0 +1,27 @@
+# This board uses the vendor's serial bootloader
+
+PROGRAMMER ?= nrfutil
+
+ifeq (nrfutil,$(PROGRAMMER))
+
+  # Using nrfutil implies using the Nordic bootloader described at
+  # <https://devzone.nordicsemi.com/nordic/short-range-guides/b/getting-started/posts/nrf52840-dongle-programming-tutorial>.
+  #
+  # It has a static MBR at the first 4k, and an ample 128k Open USB Bootloader at
+  # the end, leaving 892k for the application. This overwrites any SoftDevice,
+  # but that's what the minimal working example for the dongle does as well.
+
+  ROM_OFFSET = 0x1000
+  ROM_LEN = 0xdf000
+
+  FLASHFILE = $(HEXFILE)
+  FLASHDEPS += $(HEXFILE).zip
+  FLASHER = nrfutil
+  FFLAGS = dfu usb-serial --port=${PORT} --package=$(HEXFILE).zip
+endif
+
+%.hex.zip: %.hex
+	$(call check_cmd,$(FLASHER),Flash program and preparation tool)
+	$(FLASHER) pkg generate --hw-version 52 --sd-req 0x00 --application-version 1 --application $< $@
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/nrf52840dongle/board.c
+++ b/boards/nrf52840dongle/board.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the nRF52840-dongle
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the board's single LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+
+    /* initialize the board's RGB LED */
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_set(LED2_PIN);
+    gpio_init(LED3_PIN, GPIO_OUT);
+    gpio_set(LED3_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/nrf52840dongle/doc.txt
+++ b/boards/nrf52840dongle/doc.txt
@@ -1,0 +1,58 @@
+/**
+@defgroup    boards_nrf52840dongle nRF52840-Dongle
+@ingroup     boards
+@brief       Support for the nRF52840-Dongle
+
+### General information
+
+The nRF52840-Dongle is a bare USB-stick shaped device that houses barely
+anything than the nRF52840 itself, which offers BLE and 802.15.4 and USB
+connectivity.
+
+Unlike similar sticks (like the @ref boards_nrf52840-mdk), it features no
+dedicated programmer hardware but relies on direct USB communication with a
+built-in bootloader.
+
+The board features two LEDs (LD1: green, LD2: RGB), a user (SW1) and a
+reset button as well as 15 configurable external pins.
+
+### Links
+
+- [nRF52840 web page](https://www.nordicsemi.com/?sc_itemid=%7BCDCCA013-FE4C-4655-B20C-1557AB6568C9%7D)
+- [documentation and hardware description](https://infocenter.nordicsemi.com/topic/ug_nrf52840_dongle/UG/nrf52840_Dongle/intro.html?cp=3_0_5)
+
+### Flash the board
+
+The board is flashed using its on-board boot loader; the
+[nrfutil](https://github.com/NordicSemiconductor/pc-nrfutil) program needs to
+be installed. That can turn the binary into a suitable zip file and send it to the
+bootloader.
+
+The process is automated in the usual `make flash` target. For that process to
+complete, you need to enter the bootloader manually by pressing the board's
+reset button. Readiness of the bootloader is indicated by LD2 pulsing in red.
+
+#### nrfutil installation
+
+On systems with Python 2 available, `pip install nrfutil` works.
+
+On systems with Python 3, a recent version of pip is required to install all dependencies;
+you may need to run `pip install --upgrade pip` before being able to run `pip install nrfutil` successfully.
+
+### Accessing STDIO
+
+The usual way to obtain a console on this board is using an emulated USB serial port (CDC-ACM).
+This is available automatically using the `stdio_cdc_acm` module,
+unless any other stdio module is enabled.
+
+On Linux systems with ModemManager < 1.10 installed,
+`make term` will, in some setups, fail for a few seconds after the device has come up.
+This is [fixed in its 1.12.4 version](https://gitlab.freedesktop.org/mobile-broadband/ModemManager/issues/164),
+but should not be more than a short annoyance in earlier versions.
+
+To ease debugging,
+pins 0.13 and 0.15 are configured as RX and TX, respectively.
+They provide stdio if no CDC-ACM is disabled,
+and can be used as a custom UART otherwise.
+
+ */

--- a/boards/nrf52840dongle/include/board.h
+++ b/boards/nrf52840dongle/include/board.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the nRF52840-Dongle
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+ /** @brief The LED labelled LD1 */
+#define LED0_PIN            GPIO_PIN(0, 6)
+
+ /** @brief The red channel of the LED labelled LD2 */
+#define LED1_PIN            GPIO_PIN(0, 8)
+ /** @brief The green channel of the LED labelled LD2 */
+#define LED2_PIN            GPIO_PIN(1, 9)
+ /** @brief The blue channel of the LED labelled LD2 */
+#define LED3_PIN            GPIO_PIN(0, 12)
+
+/** @} */
+
+/**
+ * @name    LED access macros
+ * @{
+ */
+
+/** Enable LD1 */
+#define LED0_ON gpio_clear(LED0_PIN)
+/** Disable LD1 */
+#define LED0_OFF gpio_set(LED0_PIN)
+/** Toggle LD1 */
+#define LED0_TOGGLE gpio_toggle(LED0_PIN)
+
+/** Enable LD2's red channel */
+#define LED1_ON gpio_clear(LED1_PIN)
+/** Disable LD2's red channel */
+#define LED1_OFF gpio_set(LED1_PIN)
+/** Toggle LD2's red channel */
+#define LED1_TOGGLE gpio_toggle(LED1_PIN)
+
+/** Enable LD2's green channel */
+#define LED2_ON gpio_clear(LED2_PIN)
+/** Disable LD2's green channel */
+#define LED2_OFF gpio_set(LED2_PIN)
+/** Toggle LD2's green channel */
+#define LED2_TOGGLE gpio_toggle(LED2_PIN)
+
+/** Enable LD2's blue channel */
+#define LED3_ON gpio_clear(LED3_PIN)
+/** Disable LD2's blue channel */
+#define LED3_OFF gpio_set(LED3_PIN)
+/** Toggle LD2's blue channel */
+#define LED3_TOGGLE gpio_toggle(LED3_PIN)
+
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+/** @brief The button labelled SW1 */
+#define BTN0_PIN            GPIO_PIN(1, 6)
+/** @brief The GPIO pin mode of the button labelled SW1 */
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/nrf52840dongle/include/gpio_params.h
+++ b/boards/nrf52840dongle/include/gpio_params.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED and button configuration for SAUL
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LD 1",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LD 2 Red",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LD 2 Green",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LD 2 Blue",
+        .pin   = LED3_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "SW 1",
+        .pin   = BTN0_PIN,
+        .mode  = GPIO_IN_PU,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/nrf52840dongle/include/periph_conf.h
+++ b/boards/nrf52840dongle/include/periph_conf.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the nRF52840-Dongle
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ *
+ * This board does not have explicit UART pins. These are set as UART 0 to
+ * provide an easy serial debug port when not using (or debugging) USB.
+ *
+ * @{
+ */
+
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 13),
+        .tx_pin     = GPIO_PIN(0, 15),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */


### PR DESCRIPTION
### Contribution description

This adds board support for he nrf52840-dongle. From the docs that are part of the PR:

> The nRF52840-Dongle is a bare USB-stick shaped device that houses barely
> anything than the nRF52840 itself, which offers BLE and 802.15.4 and USB
> connectivity.
> 
> Unlike similar sticks (like the boards_nrf52840-mdk), it features no
> dedicated programmer hardware but relies on direct USB communication with a
> built-in bootloader.
> 
> The board features two LEDs (LD1: green, LD2: RGB), a user (SW1) and a
> reset button as well as 15 configurable external pins.

### Testing procedure

* Get a dongle (they're cheap, about 10$ [from several distributors](https://www.nordicsemi.com/About-us/BuyOnline?search_token=nRF52840DONGLE&series_token=nRF52840)
* Pick any example; particularly funny are those with network support like `gcoap`.
* Add this to the Makefile (see later on why this is necessary)

    ```
    CFLAGS += -DCONFIG_USB_VID=0x1209
    CFLAGS += -DCONFIG_USB_PID=0x7D00
    ```

* Install the nrfutil USB programmer, typically using `pip install nrfutil` (see doc.txt for when it's not)
* Plug the device into a USB port with its reset button (the horizontal one) pressed, it'll breathe a red LED
* Build and flash the example with `make BOARD=nrf52840-dongle flash`
* Run `make BOARD=nrf52840-term` for a USB console, or chat up the network stack that just showed up as a new USB network device :-)

### Issues/PRs references

Fixes #12189.
Requires #13148

### Open issues

* [x] Default USB IDs are not available for devices that just out of the box (or by virtue of something like gnrc_netdev_default) ship a USB stack. I'd like to fix this properly with https://github.com/RIOT-OS/RIOT/issues/12273.
* [ ] The USB UART default might interact badly with examples that expect ethos (running which really makes no sense on such a board, that's what USB Ethernet aka CDC-ECM is for).
* [x] Pulling things like a USB UART or a USB Ethernet device in by default is relatively unexplored territory in RIOT. I think that it might make sense to have, in parallel to gnrc_netdev_default, a gnrc_netdev_default_host -- which pulls in a by-board picked hostward netdev, whether that's ethos, CDC-ECM or any future semihosted tuntap solution. Having a similar entry point for stdio would make sense as well -- if all stdio examples requested stdio_default, the board could decide whether that's stdio over UART or over USB. (Currently, I'm pulling in stdio_usb_acm when shell is active, which is a good-enough heuristic.)
* [x] ModemManager might gobble up the serial console for some time due to its heuristics. That's resolved in new versions of ModemManager and acknowledged in the doc.txt.
* [x] I've written a custom linker script that works with the shipped bootloader. Should this be somehow optional to be usable by people who program it externally? (I think the bootloader is a good default, as it just works out of the box -- and should be reconsidered when flashing own RIOT USB bootloaders becomes a thing).
* [x] I'm setting FLASHER and FFLAGS and add a preprocessing step (`FLASHFILE = $(HEXILFE).zip`) which the flasher needs. Should this be factored out into a generic makefiles/tools/nrfutil.inc.mk? (Note that my original hopes of using the same infrastructure to program the Thingy:52 have been swept away in #12829).
    * [x] In particular, this makes building on a murdock impossible right now.
* [ ] Did I (again) fail somewhere in the code style area? I hope that the automated tests that get triggered with the PR will tell me.

Final open question:

* Is any of that too bad that a few words in the docs (and a plan on how to do it better) would stop this from being mergeable?

[edit: Added open questions on flashing / bootloader]
[edit: Added checkmarks for easier tracking, ticking off ModemManager as all is confirmed now, and adding the murdock trouble miri64 pointed out]