### PR TITLE
Kconfig: add Drivers menu

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -9,6 +9,7 @@ mainmenu "RIOT Configuration"
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
+rsource "drivers/Kconfig"
 rsource "sys/Kconfig"
 
 # The application may declare new symbols as well

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+menu "Drivers"
+endmenu # Drivers


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds the Drivers section into Kconfig. So far nothing is shown up (since there are no driver configurations so far) but you should be able to see the "Drivers" group next to "System"

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
E.g `make -C examples/default menuconfig`. Check the "Drivers" group if shown
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
