### PR TITLE
USB: Use default VID/PID for RIOT-included peripherals

### DIFF
--- a/cpu/nrf52/periph/usbdev.c
+++ b/cpu/nrf52/periph/usbdev.c
@@ -19,6 +19,9 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  * @}
  */
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/cpu/sam0_common/periph/usbdev.c
+++ b/cpu/sam0_common/periph/usbdev.c
@@ -15,6 +15,9 @@
  * @author  Koen Zandberg <koen@bergzand.net>
  * @}
  */
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #ifdef MODULE_PERIPH_I2C
 #include "periph/i2c.h"
 #endif

--- a/sys/auto_init/netif/auto_init_cdcecm.c
+++ b/sys/auto_init/netif/auto_init_cdcecm.c
@@ -19,6 +19,8 @@
 
 #ifdef MODULE_USBUS_CDC_ECM
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include "log.h"
 #include "usb/usbus/cdc/ecm.h"
 #include "net/gnrc/netif/ethernet.h"

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -22,6 +22,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include "usb/usbus.h"
 
 #ifdef MODULE_USBUS_CDC_ECM

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -17,20 +17,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-/* These checks are deliberately outside the include guards, as they depend on
- * a define that only RIOT-internal users set */
-
-#if !(defined(CONFIG_USB_VID) && defined(CONFIG_USB_PID))
-#ifdef USB_H_USER_IS_RIOT_INTERNAL
-/* Reserved for RIOT standard peripherals as per http://pid.codes/1209/7D00/ */
-#define CONFIG_USB_VID (0x1209)
-#define CONFIG_USB_PID (0x7D00)
-#else
-#error Please configure your vendor and product IDs. For development, you may \
-    set CONFIG_USB_VID=0x1209 CONFIG_USB_PID=0x7D01.
-#endif
-#endif
-
 #ifndef USB_H
 #define USB_H
 
@@ -43,6 +29,18 @@ extern "C" {
  * @ingroup config
  * @{
  */
+
+#if !(defined(CONFIG_USB_VID) && defined(CONFIG_USB_PID))
+#ifdef USB_H_USER_IS_RIOT_INTERNAL
+/* Reserved for RIOT standard peripherals as per http://pid.codes/1209/7D00/ */
+#define CONFIG_USB_VID (0x1209)
+#define CONFIG_USB_PID (0x7D00)
+#else
+#error Please configure your vendor and product IDs. For development, you may \
+    set CONFIG_USB_VID=0x1209 CONFIG_USB_PID=0x7D01.
+#endif
+#endif
+
 /**
  * @brief USB peripheral device vendor ID
  *
@@ -132,8 +130,10 @@ extern "C" {
 /**
  * @brief RIOT-internal USB peripheral clearance indicator
  *
- * This define must only be set by RIOT internal users of `usb.h`, and only when
- * they implement peripherals that can be considered default RIOT peripherals.
+ * This define must only be set in compilation units that are RIOT internal,
+ * and only when they implement peripherals that can be considered default RIOT
+ * peripherals.
+ *
  * When this is defined in all uses of `usb.h`, the board can use the
  * 0x1209/0x7D00 VID/PID pair unless explicit configuration using @ref
  * CONFIG_USB_VID and @ref CONFIG_USB_PID say otherwise.

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -138,6 +138,16 @@ extern "C" {
  * 0x1209/0x7D00 VID/PID pair unless explicit configuration using @ref
  * CONFIG_USB_VID and @ref CONFIG_USB_PID say otherwise.
  *
+ * There is no sharp characterization of what consititutes an internal
+ * peripheral; a good check is this: If an application can, just by switching
+ * between boards, can have a feature provided by either RIOT's USB stack or a
+ * different mechanism, the USB version is a default RIOT peripheral.
+ *
+ * Examples are stdio access (is provided by most boards using a UART and an
+ * external USB UART adapter), Ethernet (is provided by other boards using
+ * ethos) and firmware upload and reset (is provided by other boards using an
+ * on-board programmer).
+ *
  * See http://pid.codes/1209/7D00/ for the allocation of that code.
  * @{
  */

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -17,6 +17,20 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
+/* These checks are deliberately outside the include guards, as they depend on
+ * a define that only RIOT-internal users set */
+
+#if !(defined(CONFIG_USB_VID) && defined(CONFIG_USB_PID))
+#ifdef USB_H_USER_IS_RIOT_INTERNAL
+/* Reserved for RIOT standard peripherals as per http://pid.codes/1209/7D00/ */
+#define CONFIG_USB_VID (0x1209)
+#define CONFIG_USB_PID (0x7D00)
+#else
+#error Please configure your vendor and product IDs. For development, you may \
+    set CONFIG_USB_VID=0x1209 CONFIG_USB_PID=0x7D01.
+#endif
+#endif
+
 #ifndef USB_H
 #define USB_H
 
@@ -35,12 +49,8 @@ extern "C" {
  * @note You must provide your own VID/PID combination when manufacturing a
  * device with USB.
  */
-#ifndef CONFIG_USB_VID
 #ifdef DOXYGEN
 #define CONFIG_USB_VID
-#else
-#error  Please supply your vendor ID by setting CONFIG_USB_VID
-#endif
 #endif
 
 /**
@@ -49,12 +59,8 @@ extern "C" {
  * @note You must provide your own VID/PID combination when manufacturing a
  * device with USB.
  */
-#ifndef CONFIG_USB_PID
 #ifdef DOXYGEN
 #define CONFIG_USB_PID
-#else
-#error  Please supply your vendor ID by setting CONFIG_USB_PID
-#endif
 #endif
 
 /**
@@ -120,6 +126,23 @@ extern "C" {
  */
 #ifndef CONFIG_USB_DEFAULT_LANGID
 #define CONFIG_USB_DEFAULT_LANGID   0x0409 /* EN-US */
+#endif
+/** @} */
+
+/**
+ * @brief RIOT-internal USB peripheral clearance indicator
+ *
+ * This define must only be set by RIOT internal users of `usb.h`, and only when
+ * they implement peripherals that can be considered default RIOT peripherals.
+ * When this is defined in all uses of `usb.h`, the board can use the
+ * 0x1209/0x7D00 VID/PID pair unless explicit configuration using @ref
+ * CONFIG_USB_VID and @ref CONFIG_USB_PID say otherwise.
+ *
+ * See http://pid.codes/1209/7D00/ for the allocation of that code.
+ * @{
+ */
+#ifdef DOXYGEN
+#define USB_H_USER_IS_RIOT_INTERNAL
 #endif
 /** @} */
 

--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -16,6 +16,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include <string.h>
 
 #include "tsrb.h"

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include <stdio.h>
 
 #include "isrpipe.h"

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm.c
@@ -15,6 +15,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include "event.h"
 #include "fmt.h"
 #include "kernel_defines.h"

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -15,6 +15,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include <string.h>
 
 #include "kernel_defines.h"

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -16,6 +16,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include "bitarithm.h"
 #include "event.h"
 #include "thread.h"

--- a/sys/usb/usbus/usbus_control.c
+++ b/sys/usb/usbus/usbus_control.c
@@ -15,6 +15,9 @@
  * @author  Koen Zandberg <koen@bergzand.net>
  * @}
  */
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include "periph/usbdev.h"
 #include "usb/descriptor.h"
 #include "usb/usbus.h"

--- a/sys/usb/usbus/usbus_control_slicer.c
+++ b/sys/usb/usbus/usbus_control_slicer.c
@@ -16,6 +16,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include <string.h>
 #include "periph/usbdev.h"
 #include "usb/usbus.h"

--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -16,6 +16,8 @@
  * @}
  */
 
+#define USB_H_USER_IS_RIOT_INTERNAL
+
 #include <string.h>
 #include <stdio.h>
 #include "usb/descriptor.h"


### PR DESCRIPTION
### Contribution description

This adds a check for whether any custom user code (ie. anything but built-in peripherals) uses USB, and if nothing does, allows for 1209/7D00 to be the default VID/PID pair.

It follows the action plan of https://github.com/RIOT-OS/RIOT/issues/12273#issuecomment-575257426, with the simplification that it operates per compilation unit, and thus the ifdef/define combination can be inside the include guard where those things usually are.

### Alternatives

If the build system can tell RIOT's compilation units apart from application compilation units or packages, it could set USB_H_USER_IS_RIOT on all modules. That would significantly reduce the number of files this touches. (But then again, any helpers for creating custom HID devices would need to unset the flag again, so meh).

The name USB_H_USER_IS_RIOT is up for bikeshedding.

### Testing procedure

* Pick a board with USB support (eg. samr21-xpro).
* In any example that does not do anything USB-related, add the `usbus_cdc_ecm`, `auto_init_usbus` and `auto_init_gnrc_netif` modules without setting CONFIG_USB_VID. (`stdio_cdc_acm` would work the same).
* The example builds fine, and now has an additional Ethernet interface.
* For comparison, take an example that does anything custom USB, like usbus_uart_adapter from https://github.com/RIOT-OS/RIOT/pull/12268
* In that example, remove the CONFIG_USB_PID settings (incidentally, if you right now merge master into that PR, currently that is already the case as the renaming of USB_CONFIG_PID to CONFIG_USB_PID is not in there yet).
* Building this will result in an error message that you need to set a VID/PID, and recommends the 1209/7D01 pair reserved for RIOT demos, tests and experiments.

### Issues/PRs references

This is a first step in properly addressing https://github.com/RIOT-OS/RIOT/issues/12273.

A follow-up (preferably in an own PR, but if you prefer I can pull it in here as well) should move the usb_id_check that's currently replicated across examples into common make infrastructure. In the end, the only USB related lines in a USB example makefile should be `USB_VID = 1209` / `USB_PID = 7D00` (or `${RIOT_TESTING_[VP]ID}`) and the appropriate USEMODULE. Boards that get USB by default (eg. because their default stdio is CDC-ACM, or because gnrc_netdev_default pulls in CEC-ECM) already don't need anything that says "USB" in their Makefiles with this PR.