### PR TITLE
shell_commands: provide command to print version

### DIFF
--- a/sys/shell/commands/sc_sys.c
+++ b/sys/shell/commands/sc_sys.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <stdio.h>
+
 #include "periph/pm.h"
 
 int _reboot_handler(int argc, char **argv)
@@ -26,6 +28,16 @@ int _reboot_handler(int argc, char **argv)
     (void) argv;
 
     pm_reboot();
+
+    return 0;
+}
+
+int _version_handler(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    puts(RIOT_VERSION);
 
     return 0;
 }

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -24,6 +24,7 @@
 #include "shell_commands.h"
 
 extern int _reboot_handler(int argc, char **argv);
+extern int _version_handler(int argc, char **argv);
 
 #ifdef MODULE_CONFIG
 extern int _id_handler(int argc, char **argv);
@@ -172,6 +173,7 @@ extern int _suit_handler(int argc, char **argv);
 
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
+    {"version", "Prints current RIOT_VERSION", _version_handler},
 #ifdef MODULE_CONFIG
     {"id", "Gets or sets the node's id.", _id_handler},
 #endif

--- a/tests/periph_wdt/Makefile.ci
+++ b/tests/periph_wdt/Makefile.ci
@@ -1,0 +1,8 @@
+# workaround to make this test compilable on CI with `shell_commands` in.
+# Remove when https://github.com/RIOT-OS/RIOT/pull/13613 is merged.
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I sometimes come in the situation that I'm not sure, if the version of RIOT I'm currently running is really the one I wanted to run or it is running for longer and I want to have another look to be sure. Currently, the only for me way to do that is either rebooting the node or using a debugger. This provides a shell command `version` to print the string stored at `RIOT_VERSION` to determine the RIOT version (if provided) at run-time.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run any application using the `shell_commands` module. E.g.

```sh
make -C examples/default flash term
```

and type `version`

```
> version
version
2020.04-devel-22-g5fd88-shell_commands/enh/version
```

Depending on your checkout and your build configuration (e.g. with `RIOT_CI_BUILD`) this string may differ of course.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
