### PR TITLE
makefiles: tools: fix DEBUGSERVER value for uniflash.inc.mk

### DIFF
--- a/makefiles/tools/uniflash.inc.mk
+++ b/makefiles/tools/uniflash.inc.mk
@@ -5,7 +5,7 @@ UNIFLASH_CONFIG_CCXML ?= $(BOARDSDIR)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).cc
 UNIFLASH_CONFIG_DAT ?= $(BOARDSDIR)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).dat
 UNIFLASH_CONFIG_GDB ?= $(BOARDSDIR)/$(BOARD)/dist/$(CPU_MODEL)_gdb.conf
 
-export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
+UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
 # check which uniflash version is available, either 4.x or 3.x
 ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   FLASHER ?= $(UNIFLASH_PATH)/dslite.sh

--- a/makefiles/tools/uniflash.inc.mk
+++ b/makefiles/tools/uniflash.inc.mk
@@ -24,8 +24,10 @@ else
   RESET ?= $(UNIFLASH_PATH)/uniflash.sh
   RESET_FLAGS ?= -ccxml $(UNIFLASH_CONFIG_CCXML) -reset
 endif
+
+CCS_PATH ?= "CCS_PATH unconfigured"
 # configure the debug server
-DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console
+DEBUGSERVER = $(CCS_PATH)/ccs/ccs_base/common/uscif/gdb_agent_console
 DEBUGSERVER_FLAGS = -p 3333 $(UNIFLASH_CONFIG_DAT)
 
 # configure the debugging tool


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

It seems that this script has been removed from Uniflash version 5.2.0 and
resides now on the Code Composer Studio IDE.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make debug-server` to launch the debug server on a RIOT application, you need to specify a `BOARD` that uses the `uniflash.inc.mk` file like the `cc1312-launchpad`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #13158 .

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
