### PR TITLE
examples/filesystem: include fflush in `cat` command

### DIFF
--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -199,6 +199,7 @@ static int _cat(int argc, char **argv)
     }
     close(fd);
 #endif
+    fflush(stdout);
     return 0;
 }
 


### PR DESCRIPTION
### Contribution description

While testing the mtd device in the PineTime, I found it rather confusing that no newline was included in the output of the `cat` shell command on the device. Without it RIOT appears to hang and the content of the file was not printed until I executed a next shell command. While the `cat` shell command is not to blame here, including a `\n` in the output makes it a bit more user friendly.

output on the PineTime **without** this PR:
```
2020-01-17 20:40:22,648 #  main(): This is RIOT! (Version: 2020.01-devel-1908-g670c5-work/pinetime)
2020-01-17 20:40:22,648 # constfs mounted successfully
> mount
2020-01-17 20:40:25,360 #  mount
2020-01-17 20:40:25,370 # /sda successfully mounted
> cat /sda/test
2020-01-17 20:40:28,066 #  cat /sda/test
help
2020-01-17 20:40:30,566 # testtesttest> help
2020-01-17 20:40:30,566 # Command              Description
2020-01-17 20:40:30,566 # ---------------------------------------
2020-01-17 20:40:30,567 # mount                mount flash filesystem
2020-01-17 20:40:30,567 # format               format flash file system
2020-01-17 20:40:30,578 # umount               unmount flash filesystem
...
```
output on the PineTime **with** this PR:
```
2020-01-17 20:42:11,440 # main(): This is RIOT! (Version: 2020.01-devel-1908-g670c5-work/pinetime)
2020-01-17 20:42:11,440 # constfs mounted successfully
> mount
2020-01-17 20:42:12,637 #  mount
2020-01-17 20:42:12,637 # /sda successfully mounted
> cat /sda/test
2020-01-17 20:42:15,644 #  cat /sda/test
2020-01-17 20:42:15,644 # testtesttest
>
```

On native the `cat` command (without this PR) produces output along the lines of:
```
testtesttest>
```
(note the trailing `>` of the prompt)

### Testing procedure

Reproduce the above on master with and without this PR.

### Issues/PRs references

None