### PR TITLE
pinetime: add MTD configuration

### DIFF
--- a/boards/pinetime/Makefile.dep
+++ b/boards/pinetime/Makefile.dep
@@ -1,5 +1,9 @@
 DEFAULT_MODULE += stdio_rtt
 
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_spi_nor
+endif
+
 # include common nrf52 dependencies
 include $(RIOTBOARD)/common/nrf52/nrf52832/Makefile.dep
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -23,7 +23,30 @@
 
 #include "cpu.h"
 #include "board.h"
+#include "mtd.h"
+#include "mtd_spi_nor.h"
 #include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef MODULE_MTD
+static mtd_spi_nor_t pinetime_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = PINETIME_NOR_PAGE_SIZE,
+        .pages_per_sector = PINETIME_NOR_PAGES_PER_SECTOR,
+        .sector_count = PINETIME_NOR_SECTOR_COUNT,
+    },
+    .flag = PINETIME_NOR_FLAGS,
+    .opcode = &mtd_spi_nor_opcode_default,
+    .spi = PINETIME_NOR_SPI_DEV,
+    .cs = PINETIME_NOR_SPI_CS,
+    .addr_width = 3,
+    .mode = PINETIME_NOR_SPI_MODE,
+    .clk = PINETIME_NOR_SPI_CLK,
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&pinetime_nor_dev;
+#endif /* MODULE_MTD */
 
 void board_init(void)
 {

--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "board_common.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,6 +65,28 @@ extern "C" {
 #define ILI9341_PARAM_RGB          1
 #define ILI9341_PARAM_INVERTED     1
 #define ILI9341_PARAM_NUM_LINES    240U
+/** @} */
+
+/**
+ * @name PineTime NOR flash hardware configuration
+ * @{
+ */
+#define PINETIME_NOR_PAGE_SIZE          (256)
+#define PINETIME_NOR_PAGES_PER_SECTOR   (16)
+#define PINETIME_NOR_SECTOR_COUNT       (2048)
+#define PINETIME_NOR_FLAGS              (SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K)
+#define PINETIME_NOR_SPI_DEV            SPI_DEV(0)
+#define PINETIME_NOR_SPI_CLK            SPI_CLK_10MHZ
+#define PINETIME_NOR_SPI_CS             GPIO_PIN(0, 5)
+#define PINETIME_NOR_SPI_MODE           SPI_MODE_3
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+extern mtd_dev_t *mtd0;
+#define MTD_0 mtd0
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

MTD configuration for the SPI NOR flash on the PineTime.

### Testing procedure

`tests/pkg_littlefs` should succeed. `examples/filesystem` should also work.

### Issues/PRs references

None