### PR TITLE
pinetime: Fix battery ADC line define

### DIFF
--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -48,7 +48,7 @@ extern "C" {
 #define VCC33                       GPIO_PIN(0, 24)
 #define POWER_PRESENCE              GPIO_PIN(0, 19)
 #define CHARGING_ACTIVE             GPIO_PIN(0, 12)
-#define BATTERY_ADC                 NRF52
+#define BATTERY_ADC                 NRF52_AIN7
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

I don't know what happened, but `NRF52` is not an ADC line. Original change request to include this define is [here](https://github.com/RIOT-OS/RIOT/pull/12552#discussion_r365722367)

### Testing procedure

Easiest is probably to modify `tests/periph_adc` to make use of this define.

### Issues/PRs references

#12552 