### PR TITLE
boards/mega-xplained: fix ADC line defintions

### DIFF
--- a/boards/mega-xplained/include/board.h
+++ b/boards/mega-xplained/include/board.h
@@ -113,9 +113,9 @@ extern "C" {
  * @name    ADC NTC, light sensor, and filter lines
  * @{
  */
-#define NTC_OUTPUT             GPIO_PIN(PORT_A, 5)
-#define LIGHT_SENSOR_OUTPUT    GPIO_PIN(PORT_A, 6)
-#define FILTER_OUTPUT          GPIO_PIN(PORT_A, 7)
+#define NTC_OUTPUT             ADC_LINE(7)
+#define LIGHT_SENSOR_OUTPUT    ADC_LINE(6)
+#define FILTER_OUTPUT          ADC_LINE(5)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

This PR fixes the following problems of the ADC line mapping for the analog on-board peripherals of the  [mega-xplained](http://ww1.microchip.com/downloads/en/Appnotes/doc8377.pdf) board definition:

1. Instead of defining the ADC line for the analog on-board peripherals, the corresponding GPIOs were specified in the board definition. However, for the ATmega platform, as for all other platforms, the ADC lines are not the GPIOs. Instead, they are defined from 0 to `ADC_NUMOF`-1. For the ATmega platform, the ADC line represents the bit in the corresponding ADC registers. The mapping of the ADC line to the corresponding ADC register/bit combination is realized by the peripheral/ADC implementation.

    Therefore, the definitions of the analogue on-board peripherals have use the `ADC_LINE` macro instead of the `GPIO_PIN` macro. For ATmega1284P, the ADC line is mapped to `PORTA:(1 << line)`. That is, the ADC line corresponds to the according bit in registers for port A.

2. The order of the definition was wrong. According to the data sheet it has to be:

    Pin | J2 | ATmega1284P pin | Shared with onboard functionality
    -----| ----| ------------------------- | --------------------------------------------
    6 | ADC5 | PA5 | Filter output
    7 | ADC6 | PA6 | Light sensor
    8 | ADC7 | PA7 | NTC sensor 

The problem was figured out while going through the compile errors of PR #12877 where the `gpio_t` is no longer compatible with `adc_t`.

### Testing procedure

The mapping is straight forward so that a source code review should be sufficient. If the hardware is at hand, flash and test:
```
make BOARD=mega-xplained -C examples/default flash term
```

### Issues/PRs references

Required for #12877 