### PR TITLE
tests/pkg_semtech_loramac: fix i-nucleo-lrwan1 board name

### DIFF
--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 
 BOARD_WITHOUT_LORAMAC_RX := \
     arduino-mega2560 \
-    i-nuncleo-lrwan1 \
+    i-nucleo-lrwan1 \
     stm32f0discovery \
     waspmote-pro \
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes `i-nucleo-lrwan` board name in the `BOARD_WITHOUT_LORAMAC_RX` in application makefile. For boards that are listed, the RX function of `pkg/semtech_loramac` is disabled which saves 1302 bytes RAM and about 2 kByte of code on the `i-nucleo-lrwan1` board.

Sizes w/o this PR:
```
   text	   data	    bss	    dec	    hex	filename
  55252	    620	   7556	  63428	   f7c4	tests_pkg_semtech-loramac.elf
```
Sizes with this PR:
```
   text	   data	    bss	    dec	    hex	filename
  54732	    620	   6252	  61604	   f0a4	tests_pkg_semtech-loramac.elf
```

### Testing procedure

Compile `pkg/semtech_loramac` for the `i-nucleo-lrwan1` board and compare the sizes.
```
make BOARD=i-nucleo-lrwan1 -C tests/pkg_semtech-loramac
```

### Issues/PRs references

Figured out during the analyzes of failed compilation in PR #12877 