### PR TITLE
boards/cc1352-launchpad: add periph_gpio_irq feature.

### DIFF
--- a/boards/cc1352-launchpad/Makefile.features
+++ b/boards/cc1352-launchpad/Makefile.features
@@ -3,5 +3,6 @@ CPU_MODEL = cc1352r1
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/cc1352-launchpad/Makefile.include
+++ b/boards/cc1352-launchpad/Makefile.include
@@ -1,4 +1,4 @@
-export XDEBUGGER = XDS110
+XDEBUGGER = XDS110
 
 # set default port depending on operating system
 PORT_LINUX  ?= /dev/ttyACM0

--- a/boards/cc1352-launchpad/include/periph_conf.h
+++ b/boards/cc1352-launchpad/include/periph_conf.h
@@ -8,11 +8,11 @@
  */
 
 /**
- * @ingroup         boards_cc2650_launchpad
+ * @ingroup         boards_cc1352_launchpad
  * @{
  *
  * @file
- * @brief           Peripheral MCU configuration for TI CC2650 LaunchPad
+ * @brief           Peripheral MCU configuration for TI CC1352 LaunchPad
  *
  * @author          Nicholas Jackson <nicholas.jackson@griffithuni.edu.au>
  * @author          Sebastian Meiling <s@mlng.net>
@@ -68,22 +68,15 @@ static const timer_conf_t timer_config[] = {
 /**
 * @name    UART configuration
 *
-* The used CC26x0 CPU only supports a single UART device, so all we need to
-* configure are the RX and TX pins.
+* The TI CC1352 LaunchPad board only has access to a single UART device through
+* the debugger, so all we need to configure are the RX and TX pins.
 *
 * Optionally we can enable hardware flow control, by setting UART_HW_FLOW_CTRL
-* to 1 and defining pins for UART_CTS_PIN and UART_RTS_PIN.
+* to 1 and defining pins for cts_pin and rts_pin.
+*
+* Add a second UART configuration if using external pins.
 * @{
 */
-/**
- * @name    UART configuration
- *
- * We can enable hardware flow control, by setting flow_control
- * to 1 and defining pins for cts_pin and rts_pin.
- *
- * Add a second UART configuration if using external pins.
- * @{
- */
 
 static const uart_conf_t uart_config[] = {
  {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

- Add `periph_gpio_irq` feature (it's supported by the cpu).
- Fix the `cc1352-launchpad` UART documentation.
- Remove `export` from `XDEBUGGER` variable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

On any test or example:

```bash
BOARD=cc1352-launchpad make
```

To test `tests/periph_gpio` go to `periph_gpio_irq`, it will run tests on the GPIO pins, you can reset the board and later test with the `enable_int` command.

```bash
BOARD=cc1352-launchpad make flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

See also #13134.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
