### PR TITLE
tests/Makefile.tests_common: interactive_sync only with testrunner

### DIFF
--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,6 +1,8 @@
 APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
 
-DEFAULT_MODULE += test_utils_interactive_sync
+ifneq (,$(wildcard $(CURDIR)/tests/.))
+  DEFAULT_MODULE += test_utils_interactive_sync
+endif
 
 ifneq (,$(filter tests_driver_%,$(APPLICATION)))
   BOARD ?= samr21-xpro


### PR DESCRIPTION
### Contribution description

This PR disables `test_utils_interactive_sync` if the is not `test-runner`. If there is no `test-runner` then running a test depends on a user. This PR only enables `test_utils_interactive_sync` when there is an automatic test by checking for a `<APP_DIR>/tests` directory.


### Testing procedure

`test_utils_interactive_sync` should only be compiled for applications with tests.

- No tests, no sync: `make -C tests/xtimer_drift/ all test --no-print-directory`

```
Building application "tests_xtimer_drift" for "native" with MCU "native".

"make" -C /home/francisco/workspace/RIOT/boards/native
"make" -C /home/francisco/workspace/RIOT/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/native
"make" -C /home/francisco/workspace/RIOT/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT/cpu/native/stdio_native
"make" -C /home/francisco/workspace/RIOT/cpu/native/vfs
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/div
```
"make" -C /home/francisco/workspace/RIOT/sys/xtimer

- test present so sync `make -C tests/xtimer_usleep/ all test --no-print-directory`

```
Building application "tests_xtimer_usleep" for "native" with MCU "native".

"make" -C /home/francisco/workspace/RIOT/boards/native
"make" -C /home/francisco/workspace/RIOT/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/native
"make" -C /home/francisco/workspace/RIOT/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT/cpu/native/stdio_native
"make" -C /home/francisco/workspace/RIOT/cpu/native/vfs
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
``` 
