### PR TITLE
gnrc_ipv6_ext_frag: remove fragment header when n-th fragment is first [backport 2020.01]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
@@ -476,8 +476,10 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_frag_reass(gnrc_pktsnip_t *pkt)
         memcpy(((uint8_t *)rbuf->pkt->data) + offset, pkt->data, pkt->size);
         /* if entry was newly created above */
         if (rbuf->pkt->next == fh_snip->next) {
-            /* we don't need the payload anymore, headers are still kept to be
-             * reused when assembled, so just remove the payload. */
+            /* we don't need the payload and fragment header anymore, the
+             * remaining headers are still kept to be reused when assembled, so
+             * just remove the payload. */
+            gnrc_pktbuf_remove_snip(pkt, fh_snip);
             gnrc_pktbuf_remove_snip(pkt, pkt);
         }
         else {


### PR DESCRIPTION
# Backport of #13156



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The reassembly buffer only needs (and stores) the headers *before* the fragment header (called per-fragment headers in [RFC 8200, section 4.5](https://tools.ietf.org/html/rfc8200#section-4.5)). Currently, when a subsequent IPv6 fragment is received before the first fragment the fragment header is however not removed. With this fix it does.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
See [Release-Specs 4, Task 10](https://github.com/RIOT-OS/Release-Specs/blob/8f394349d965891c96dfa505db36b1e5127a5740/04-single-hop-6lowpan-icmp/example_test_guide.md#task-10-exprimental---icmpv6-echo-with-large-payload-ipv6-fragmentation). They should succeed for multiple runs, especially if packets get lost. To make sure loss is due to the first fragment missing I applied the following patch (which causes an `E` to appear in the output whenever a packet is lost under this circumstance in the given test run):

```diff
diff --git a/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c b/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
index e7025a4eff..2ecbabae87 100644
--- a/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
@@ -700,6 +700,7 @@ static gnrc_pktsnip_t *_completed(gnrc_ipv6_ext_frag_rbuf_t *rbuf)
         gnrc_ipv6_ext_frag_rbuf_free(rbuf);
         return res;
     }
+    puts("E");
     return NULL;
 }
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Cause of https://github.com/RIOT-OS/Release-Specs/issues/145#issuecomment-575227596
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
