### PR TITLE
gnrc_nettype: deprecate IOVEC type

### DIFF
--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -43,6 +43,10 @@ typedef enum {
     /**
      * @brief   Not so much protocol but data type that is passed to network
      *          devices using the netdev interface
+     *
+     * @deprecated  Unused since https://github.com/RIOT-OS/RIOT/pull/11193.
+     *              Will be removed after 2020.10 release.
+     *
      */
     GNRC_NETTYPE_IOVEC = -2,
     /**


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
It is unused since https://github.com/RIOT-OS/RIOT/pull/11193 and not expected to be re-used in the future. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
With `make doc` it should show up in `deprecated.html`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
