### PR TITLE
Makefile.dep: include package deps earlier

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -26,14 +26,6 @@ ifneq (,$(filter ssp,$(USEMODULE)))
   FEATURES_REQUIRED += ssp
 endif
 
-ifneq (,$(filter ndn-riot,$(USEPKG)))
-  USEMODULE += gnrc
-  USEMODULE += xtimer
-  USEMODULE += random
-  USEMODULE += hashes
-  USEPKG += micro-ecc
-endif
-
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += xtimer

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -106,25 +106,6 @@ ifneq (,$(filter uhcpc,$(USEMODULE)))
   USEMODULE += posix_inet
 endif
 
-ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
-  FEATURES_REQUIRED += ble_nordic_softdevice
-  USEMODULE += softdevice_handler
-  USEMODULE += ble_common
-  USEMODULE += ble_6lowpan
-  USEMODULE += gnrc_sixlowpan
-  USEMODULE += gnrc_sixlowpan_iphc
-  USEMODULE += gnrc_ipv6_nib_6ln
-  USEMODULE += gnrc_ipv6_default
-  # prevent application from being a router
-  # TODO: maybe find a nicer solution in future build system update
-  _ROUTER_MODULES = gnrc_ipv6_router% gnrc_rpl netstats_rpl auto_init_gnrc_rpl
-  ifneq (,$(filter $(_ROUTER_MODULES),$(USEMODULE)))
-    $(warning nordic_softdevice_ble: Disabling router modules:\
-      $(filter $(_ROUTER_MODULES),$(USEMODULE)))
-  endif
-  USEMODULE := $(filter-out $(_ROUTER_MODULES),$(USEMODULE))
-endif
-
 ifneq (,$(filter gnrc_%,$(filter-out gnrc_netapi gnrc_netreg gnrc_netif% gnrc_pkt%,$(USEMODULE))))
   USEMODULE += gnrc
 endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -19,6 +19,9 @@ OLD_USEPKG := $(sort $(USEPKG))
 include $(RIOTBASE)/sys/Makefile.dep
 include $(RIOTBASE)/drivers/Makefile.dep
 
+# pull dependencies from packages
+-include $(USEPKG:%=$(RIOTPKG)/%/Makefile.dep)
+
 ifneq (,$(filter ssp,$(USEMODULE)))
   FEATURES_REQUIRED += ssp
 endif
@@ -1047,9 +1050,6 @@ FEATURES_OPTIONAL += periph_gpio
 
 # always select power management if available
 FEATURES_OPTIONAL += periph_pm
-
-# include package dependencies
--include $(USEPKG:%=$(RIOTPKG)/%/Makefile.dep)
 
 # always select provided architecture features
 FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))

--- a/pkg/ndn-riot/Makefile.dep
+++ b/pkg/ndn-riot/Makefile.dep
@@ -1,4 +1,9 @@
 USEMODULE += ndn-encoding
+USEMODULE += gnrc
+USEMODULE += xtimer
+USEMODULE += random
+USEMODULE += hashes
+USEPKG += micro-ecc
 
 # Blacklist platforms using nimble_netif with gnrc netif, e.g providing
 # ble_nimble: NimBLE and ndn-riot use different crypto libraries that have

--- a/pkg/nordic_softdevice_ble/Makefile.dep
+++ b/pkg/nordic_softdevice_ble/Makefile.dep
@@ -1,0 +1,18 @@
+FEATURES_REQUIRED += ble_nordic_softdevice
+USEMODULE += softdevice_handler
+USEMODULE += ble_common
+USEMODULE += ble_6lowpan
+USEMODULE += gnrc_sixlowpan
+USEMODULE += gnrc_sixlowpan_iphc
+USEMODULE += gnrc_ipv6_nib_6ln
+USEMODULE += gnrc_ipv6_default
+
+# prevent application from being a router
+# TODO: maybe find a nicer solution in future build system update
+_ROUTER_MODULES = gnrc_ipv6_router% gnrc_rpl netstats_rpl auto_init_gnrc_rpl
+ifneq (,$(filter $(_ROUTER_MODULES),$(USEMODULE)))
+  $(warning nordic_softdevice_ble: Disabling router modules:\
+    $(filter $(_ROUTER_MODULES),$(USEMODULE)))
+endif
+
+USEMODULE := $(filter-out $(_ROUTER_MODULES),$(USEMODULE))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR modifies Makefile.dep to include the used pkgs dependencies earlier in the dependency resolution logic.

I'm not sure of all the consequences of such a change but it is required by #12304, see https://github.com/RIOT-OS/RIOT/pull/12304#discussion_r368050452 for details.
This PR just contains the commit (15de3cf) cherry-picked from #12304.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Check that packages dependencies are unchanged (or changes can be explained) compared to master

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Required by #12304

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
