### PR TITLE
Enable stack smash protections by default

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -19,6 +19,10 @@ OLD_USEPKG := $(sort $(USEPKG))
 include $(RIOTBASE)/sys/Makefile.dep
 include $(RIOTBASE)/drivers/Makefile.dep
 
+ifeq (,$(RIOTINSECURE))
+  USEMODULE += ssp
+endif
+
 ifneq (,$(filter ndn-riot,$(USEPKG)))
   USEMODULE += gnrc
   USEMODULE += xtimer

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -28,6 +28,7 @@ export APPDEPS               # Files / Makefile targets that need to be created 
 export RIOTBASE              # The root folder of RIOT. The folder where this very file lives in.
 export RIOTCPU               # For third party CPUs this folder is the base of the CPUs.
 export RIOTBOARD             # This folder is the base of the riot boards.
+export RIOTINSECURE          # Disable security features (e.g. stack smash protection). NOT RECOMMENDED.
 export BOARDSDIR             # For third party BOARDs this folder is the base of the BOARDs.
 export RIOTPKG               # For overriding RIOT's pkg directory
 export RIOTTOOLS             # Location of host machine tools


### PR DESCRIPTION
### Contribution description

The RIOT website describes RIOT as the "friendly Operating System for
the Internet of Things" and further claims that it is "Developer
Friendly" [\[1\]][riot website]. Scientific publications, linked on the
website, acknowledge a "rising high demand for security and privacy of
systems and applications" in the Internet of Things.  Additionally, the
cited publication claims that "the sheer number of deployed IoT devices
poses a severe threat to the general Internet infrastructure" [\[2\]][riot paper].

Regarding this emphasize on security it seems surprising that RIOT does
not come with any system security features enabled by default. This is
also in contrast to the developer friendless mentioned above as it
requires novice users to become security experts, investigate on their
own which security features are available, and manually enable them.

To improve this situation this PR enables a central system security
feature (stack smash protections) by default. While the current
implementation isn't perfect (see #13119) it is still better than having
no stack smash protections at all. Since the current implementation
generates the canary value at compile time the introduced overhead is
minimal. I did some experiments with `BOARD=bluepill` and the binary
size does not seem to change at all on this platform. The change only
has an impact on runtime memory consumption, however, currently stack
canaries are only added to functions "with buffers larger than 8 bytes".
As such, the overhead is deemed negligible. If you have any tooling to
investigate runtime memory consumption further let me know.

Since the current SSP implementation does have an impact on reproducible
builds it can be disabled explicitly using the appropriately named
`RIOTINSECURE` environment variable.

[riot website]: https://riot-os.org/
[riot paper]: https://riot-os.org/docs/riot-ieeeiotjournal-2018.pdf

### Testing procedure

* Build an example application with any further configuration, check that `sys/ssp` is included in the output.
* Build an example application with `RIOTINSECURE=1` check that `sys/ssp` is not included in the output.

### Issues/PRs references

* #13119 

---

CC: @kaspar030 