### PR TITLE
boards/arduino-nano-33-iot: add initial support

### DIFF
--- a/boards/arduino-nano-33-iot/Kconfig
+++ b/boards/arduino-nano-33-iot/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-nano-33-iot" if BOARD_ARDUINO_NANO_33_IOT
+
+config BOARD_ARDUINO_NANO_33_IOT
+    bool
+    default y
+    select CPU_MODEL_SAMD21G18A
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_HIGHLEVEL_STDIO

--- a/boards/arduino-nano-33-iot/Makefile
+++ b/boards/arduino-nano-33-iot/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/samd21-arduino-bootloader
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-nano-33-iot/Makefile.dep
+++ b/boards/arduino-nano-33-iot/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep

--- a/boards/arduino-nano-33-iot/Makefile.features
+++ b/boards/arduino-nano-33-iot/Makefile.features
@@ -1,0 +1,14 @@
+CPU = samd21
+CPU_MODEL = samd21g18a
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += highlevel_stdio

--- a/boards/arduino-nano-33-iot/Makefile.include
+++ b/boards/arduino-nano-33-iot/Makefile.include
@@ -1,0 +1,8 @@
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# Include all definitions for flashing with bossa over USB
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.include
+
+# Include handling of serial and non-bossa programmers (if selected by user)
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/arduino-nano-33-iot/board.c
+++ b/boards/arduino-nano-33-iot/board.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-iot
+ * @{
+ * @file
+ * @brief       Board common implementations for the Arduino Nano 33 IoT
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the on-board "Yellow" LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/arduino-nano-33-iot/doc.txt
+++ b/boards/arduino-nano-33-iot/doc.txt
@@ -1,0 +1,27 @@
+/**
+@defgroup    boards_arduino-nano-33-iot Arduino Nano 33 IoT
+@ingroup     boards
+@brief       Support for the Arduino Nano 33 IoT board.
+
+### General information
+
+The [Arduino Nano 33 IoT](https://store.arduino.cc/arduino-nano-33-iot) board is
+a learning and development board that provides Sigfox connectivity and is
+powered by an Atmel SAMD21 microcontroller.
+
+### Flash the board
+
+Use `BOARD=arduino-nano-33-iot` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+     make BOARD=arduino-nano-33-iot -C examples/hello-world flash
+```
+
+### Accessing STDIO via UART
+
+STDIO of RIOT is directly available over the USB port.
+
+The `TERM_DELAY` environment variable can be used to add a delay (in second)
+before opening the serial terminal. The default value is 2s which should be
+enough in most of the situation.
+ */

--- a/boards/arduino-nano-33-iot/include/board.h
+++ b/boards/arduino-nano-33-iot/include/board.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-iot
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arduino Nano 33 IoT
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 17)
+
+#define LED_PORT            PORT->Group[PA]
+#define LED0_MASK           (1 << 17)
+
+#define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED0_NAME           "LED(Yellow)"
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/arduino-nano-33-iot/include/gpio_params.h
+++ b/boards/arduino-nano-33-iot/include/gpio_params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-iot
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = LED0_NAME,
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/arduino-nano-33-iot/include/periph_conf.h
+++ b/boards/arduino-nano-33-iot/include/periph_conf.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-iot
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for Arduino Nano 33 IoT
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+/* generate the actual used core clock frequency */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC3,
+        .irq            = TC3_IRQn,
+        .pm_mask        = PM_APBCMASK_TC3,
+        .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
+#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
+        .gclk_src       = SAM0_GCLK_1MHZ,
+#else
+        .gclk_src       = SAM0_GCLK_MAIN,
+#endif
+        .flags          = TC_CTRLA_MODE_COUNT16,
+    },
+    {   /* Timer 1 */
+        .dev            = TC4,
+        .irq            = TC4_IRQn,
+        .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
+        .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
+#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
+        .gclk_src       = SAM0_GCLK_1MHZ,
+#else
+        .gclk_src       = SAM0_GCLK_MAIN,
+#endif
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+#define TIMER_0_MAX_VALUE   0xffff
+
+/* interrupt function name mapping */
+#define TIMER_0_ISR         isr_tc3
+#define TIMER_1_ISR         isr_tc4
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM5->USART,
+        .rx_pin   = GPIO_PIN(PB,23),
+        .tx_pin   = GPIO_PIN(PB,22),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_3,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    }
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom5
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM4->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PB, 9),
+        .sda_pin  = GPIO_PIN(PB, 8),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = SAM0_GCLK_MAIN,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {   /* Connected to NINA W102 */
+        .dev      = &SERCOM4->SPI,
+        .miso_pin = GPIO_PIN(PA, 13),
+        .mosi_pin = GPIO_PIN(PA, 12),
+        .clk_pin  = GPIO_PIN(PA, 15),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_1,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#endif
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    }
+};
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mkrfox1200 \
     arduino-mkrwan1300 \
     arduino-mkrzero \
+    arduino-nano-33-iot \
     arduino-zero \
     b-l072z-lrwan1 \
     blackpill \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -11,6 +11,7 @@ LOW_MEMORY_BOARDS += \
   arduino-mkrfox1200 \
   arduino-mkrwan1300 \
   arduino-mkrzero \
+  arduino-nano-33-iot \
   atmega1284p \
   b-l072z-lrwan1 \
   blackpill \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mkrwan1300 \
     arduino-mkrzero \
     arduino-nano \
+    arduino-nano-33-iot \
     arduino-uno \
     arduino-zero \
     atmega256rfr2-xpro \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [Arduino Nano 33 IoT](https://store.arduino.cc/arduino-nano-33-iot).

What was tested:
- USB
- RTC
- Timers
- I2C

RTT could be added but it doesn't seem to work. I tested UART with the `tests/periph_uart` application but it was not working. Note that this UART is connected to the U-Blox WiFi/Ble module present on the board. SPI is not tested as well: the SPI interface configured is also connected to the U-Blox WiFi/BLE module.

To simplify board usage, this PR is based on #12304.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `compile_and_test_for_board.py` for this board and most of the tests should work. I haven't run it for the moment.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #12304

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
