### PR TITLE
dist/testbed-support: several improvements

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -55,7 +55,8 @@ iotlab-exp: $(IOTLAB_AUTH) all
 	$(Q)iotlab-experiment wait -i $(NEW_ID)
 
     ifdef IOTLAB_LOGGING
-	  $(Q)ssh -t $(IOTLAB_AUTHORITY) "tmux new -d -s riot-$(NEW_ID)\
+	  $(Q)ssh -t $(IOTLAB_AUTHORITY) \
+      "$(if $(IOTLAB_TMUX),tmux new -d -s riot-$(NEW_ID),) \
 	  'script -fac "'"'"serial_aggregator -i $(NEW_ID)"'"'"\
 	   RIOT_LOG-$(IOTLAB_EXP_NAME)-$(NEW_ID)'"
     endif
@@ -85,8 +86,8 @@ iotlab-term: $(IOTLABTERMFLASHDEPS)
 	                                iotlab-auth -u $(IOTLAB_USER)"
 
 	$(Q)ssh -t $(IOTLAB_AUTHORITY) \
-	"tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID) \
-	'$(if $(IOTLAB_LOGGING), \
+	"$(if $(IOTLAB_TMUX),tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID) ',) \
+	$(if $(IOTLAB_LOGGING), \
 	script -fac "'"'"serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE)"'"'" \
 	RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID), \
-	serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE))'"
+	serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE))$(if $(IOTLAB_TMUX),',)"

--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -77,7 +77,10 @@ iotlab-debug-server: $(IOTLAB_AUTH)
 iotlab-stop: $(IOTLAB_AUTH)
 	$(Q)iotlab-experiment stop -i $(IOTLAB_EXP_ID)
 
-iotlab-term:
+# wait for flash if it is provided e.g. with `make iotlab-flash iotlab-term`
+IOTLABTERMFLASHDEPS ?= $(filter iotlab-flash iotlab-exp,$(MAKECMDGOALS))
+
+iotlab-term: $(IOTLABTERMFLASHDEPS)
 	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get -r -i $(IOTLAB_EXP_ID) > /dev/null || \
 	                                iotlab-auth -u $(IOTLAB_USER)"
 

--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -10,8 +10,14 @@ IOTLAB_EXP_NAME     ?= RIOT_EXP
 IOTLAB_DEBUG_PORT   ?= 3333
 IOTLAB_DEBUG_NODE   ?= $(shell iotlab-experiment get -i $(IOTLAB_EXP_ID) --resources | \
                          grep -m 1 "network_address" | sed 's/.*-\([0-9]*\)\..*/\1/')
-
 IOTLAB_AUTHORITY    = "$(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info"
+
+ifeq (,$(filter iotlab-exp,$(MAKECMDGOALS)))
+  # derive experiment site from IOTLAB_EXP_ID, if not given and not used with
+  # `iotlab_exp`
+  IOTLAB_SITE     ?= $(shell iotlab-experiment --format=str --jmespath "keys(items[0])[0]" \
+                             get -ri -i $(IOTLAB_EXP_ID))
+endif
 
 ifneq (,$(findstring m3,$(IOTLAB_TYPE)))
   BINARY := $(ELFFILE)
@@ -54,13 +60,13 @@ iotlab-exp: $(IOTLAB_AUTH) all
 	   RIOT_LOG-$(IOTLAB_EXP_NAME)-$(NEW_ID)'"
     endif
 
-iotlab-flash: $(IOTLAB_AUTH) iotlab-check-exp all
+iotlab-flash: $(IOTLAB_AUTH) all
 	$(Q)iotlab-node --update $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
 
-iotlab-reset: $(IOTLAB_AUTH) iotlab-check-exp
+iotlab-reset: $(IOTLAB_AUTH)
 	$(Q)iotlab-node --reset -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
 
-iotlab-debug-server: $(IOTLAB_AUTH) iotlab-check-exp
+iotlab-debug-server: $(IOTLAB_AUTH)
 	$(eval DEBUG_TYPE := $(shell echo $(IOTLAB_TYPE) | cut -d: -f1))
 	$(eval DEBUG_NODE := $(shell echo $(IOTLAB_DEBUG_NODE) | sed 's/$(DEBUG_TYPE)-\([0-9]*\)/\1/'))
 
@@ -68,10 +74,10 @@ iotlab-debug-server: $(IOTLAB_AUTH) iotlab-check-exp
 	@echo "Debug on node $(IOTLAB_DEBUG_NODE)"
 	$(Q)ssh -N -L $(IOTLAB_DEBUG_PORT):$(IOTLAB_DEBUG_NODE):3333 $(IOTLAB_AUTHORITY)
 
-iotlab-stop: $(IOTLAB_AUTH) iotlab-check-exp
+iotlab-stop: $(IOTLAB_AUTH)
 	$(Q)iotlab-experiment stop -i $(IOTLAB_EXP_ID)
 
-iotlab-term: iotlab-check-exp
+iotlab-term:
 	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get -r > /dev/null || \
 	                                iotlab-auth -u $(IOTLAB_USER)"
 
@@ -81,5 +87,3 @@ iotlab-term: iotlab-check-exp
 	script -fac "'"'"serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE)"'"'" \
 	RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID), \
 	serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE))'"
-
-iotlab-check-exp: IOTLAB_SITE ?= $(shell iotlab-experiment get -ri -i $(IOTLAB_EXP_ID) | sed -n 4p | cut -d\" -f2)

--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -78,7 +78,7 @@ iotlab-stop: $(IOTLAB_AUTH)
 	$(Q)iotlab-experiment stop -i $(IOTLAB_EXP_ID)
 
 iotlab-term:
-	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get -r > /dev/null || \
+	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get -r -i $(IOTLAB_EXP_ID) > /dev/null || \
 	                                iotlab-auth -u $(IOTLAB_USER)"
 
 	$(Q)ssh -t $(IOTLAB_AUTHORITY) \

--- a/dist/testbed-support/README.iotlab.md
+++ b/dist/testbed-support/README.iotlab.md
@@ -36,6 +36,7 @@ brackets):
  * IOTLAB_PROFILE
  * IOTLAB_EXCLUDE_NODES
  * IOTLAB_LOGGING
+ * IOTLAB_TMUX
 
 ### Format of a Resource ID
 Both variables `IOTLAB_PHY_NODES` and `IOTLAB_EXCLUDE_NODES` use the resource id
@@ -86,5 +87,6 @@ using the resource id string format as described above.
 Uses ssh to login the user on the IoT-LAB server of the specified site and
 start the `serial_aggregator` to communication with all registered nodes.
 If `IOTLAB_LOGGING` is set to `1`, then closing the connection with `CTRL+C/D` will also quit
-the logging process. Detach from the server-side tmux process with `CTRL+A-D`
-(or as defined in your server-side `.tmux.conf` file)
+the logging process. If you enabled TMUX with `IOTLAB_TMUX`, detach from the
+server-side tmux process with `CTRL+A-D` (or as defined in your server-side
+`.tmux.conf` file)

--- a/dist/testbed-support/README.iotlab.md
+++ b/dist/testbed-support/README.iotlab.md
@@ -73,15 +73,13 @@ into a file called "RIOT_LOG-<EXPNAME>-<EXPID>".
 This target updates the application on all registered nodes of the given
 experiment to the current version of the application.
 Certain nodes can be excluded by listing them in the `IOTLAB_EXCLUDE_NODES` variable
-using the resource id string format as described above. If you do not use the default site,
-then you must specify the site with `IOTLAB_SITE`.
+using the resource id string format as described above.
 
 #### iotlab-reset
 
 This target resets all registered nodes of the given experiment.
 Certain nodes can be excluded by listing them in the `IOTLAB_EXCLUDE_NODES` variable
-using the resource id string format as described above. If you do not use the default site,
-then you must specify the site with `IOTLAB_SITE`.
+using the resource id string format as described above.
 
 #### iotlab-term
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Some improvements in the multi-node IoT-LAB integration in the build system that finally annoyed me enough that I fixed them / cleaned them up.

1. `IOTLAB_SITE` is recognized automatically again.
2. `IOTLAB_EXP_ID` is used when trying to login / checking authentication at the IoT-LAB site with `iotlab-term`.
3. wait for `iotlab-flash` / `iotlab-exp` when used in parallel with `iotlab-term`.
4. TMUX is optional now with `iotlab-term`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
To test 1 run e.g. `make iotlab-term` after `make iotlab-exp` (or `iotlab-experiment submit` with provided firmware) was run with an application of your choice (that is supported by `iotlab-m3`).

To test 2 run `make iotlab-term` while more than one experiment is running with an application of your choice (that is supported by `iotlab-m3`).

To test 3 run `make -j 3 iotlab-flash iotlab-term` or `make -j 3 iotlab-exp iotlab-term`. `iotlab-term` will only be executed after `iotlab-flash`/`iotlab-exp` was finished

To test 4 run `make iotlab-term`. When `IOTLAB_TMUX` is set to `1` in the environment `serial_aggregator` is started in a tmux session will be started in the environment, if not, `serial_aggregator` will just start via SSH in the current terminal.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
