### PR TITLE
boards/nucleo-f767zi: add correct flash bank openocd config

### DIFF
--- a/boards/common/stm32/dist/stm32f7.cfg
+++ b/boards/common/stm32/dist/stm32f7.cfg
@@ -1,3 +1,9 @@
 source [find target/stm32f7x.cfg]
+
+# specify flash start address: since target/stm32f7x.cfg doesn't, this
+# can be used as backup in case probing fails. When correct address is
+# given, the flash size is obtained from hardware so no need to specify.
+flash bank $_FLASHNAME.riot stm32f2x 0x08000000 0 0 0 $_TARGETNAME
+
 reset_config srst_only
 $_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f767zi/Makefile.include
+++ b/boards/nucleo-f767zi/Makefile.include
@@ -1,2 +1,12 @@
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include
+
+# openocd configuration file for `stm32f7` relies on probing to find out
+# FLASH_ADDR. On this board probing (`flash probe 0`) fails when `srst` is
+# asserted, but `srst` needs to be asserted to be able to flash the `BOARD`
+# when sleeping or after a hardfault.
+# To circumvent this in boards/common/stm32/dist/stm32f7.cfg we define a new
+# flash bank with the appropriate flash start address and specify that this is
+# the flash bank to be used as default configuration instead of the default (1)
+FLASH_BANK ?= 4
+$(call target-export-variables,flash flash-only,FLASH_BANK)

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -105,6 +105,10 @@
 # Valid values: elf, hex, s19, bin (see OpenOCD manual for more information)
 : ${IMAGE_TYPE:=}
 
+# flash bank to read default configuration when probing fails, default to first
+# bank
+: ${FLASH_BANK:=1}
+
 #
 # Examples of alternative debugger configurations
 #
@@ -265,8 +269,7 @@ do_flash() {
     # In case of binary file, IMAGE_OFFSET should include the flash base address
     # This allows flashing normal binary files without env configuration
     if _is_binfile "${IMAGE_FILE}" "${IMAGE_TYPE}"; then
-        # hardwritten to use the first bank
-        FLASH_ADDR=$(_flash_address 1)
+        FLASH_ADDR=$(_flash_address ${FLASH_BANK})
         echo "Binfile detected, adding ROM base address: ${FLASH_ADDR}"
         IMAGE_TYPE=bin
         IMAGE_OFFSET=$(printf "0x%08x\n" "$((${IMAGE_OFFSET} + ${FLASH_ADDR}))")


### PR DESCRIPTION
### Contribution description

This pr fixes flashing bin files on `nucleo-f767zi`, this issue is not present on all `nucleo-f7*` boards.

Flashing bin files on `nucleo-f767zi` fails for two reasons:

- fails to probe flash

```
### Flashing Target ###
WARN: Failed to probe board flash.
WARN: Falling back to using the openocd configuration value.
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00000000
```

- backup openocd configuration value is wrong
```
set _FLASHNAME $_CHIPNAME.flash
flash bank $_FLASHNAME stm32f2x 0 0 0 0 $_TARGETNAME
flash bank $_CHIPNAME.otp stm32f2x 0x1ff0f000 0 0 0 $_TARGETNAME
```
Playing around with `openocd.sh` I have found that `flash probe 0` fails on this `BOARD` when `srst` is `asserted`, but if `srst` is `deasserted` probing fails anyway if the device is `hardfaulted` or in `sleep mode`.

I couldn't find the reason why probing fails in this case, but to keep asserting `srst` I added the correct `FLASH_ADDR` in our `stm32f7.cfg` file and added `FLASH_BANK` to allow specifying which `flash bank` to use as configuration input and not use the one in `target/stm32f7x.cfg`

### Testing procedure

`make -C tests/riotboot/ BOARD=nucleo-f767zi flash`
