### PR TITLE
sys/xtimer: _xtimer_now64(): fix irq_disable() return value type [backport 2020.01]

### DIFF
--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -112,7 +112,7 @@ static inline uint64_t _xtimer_now64(void)
     uint32_t now, elapsed;
 
     /* time sensitive since _xtimer_current_time is updated here */
-    uint8_t state = irq_disable();
+    unsigned state = irq_disable();
     now = _xtimer_lltimer_now();
 #if XTIMER_MASK
     elapsed = _xtimer_lltimer_mask(now - _xtimer_lltimer_mask((uint32_t)_xtimer_current_time));


### PR DESCRIPTION
# Backport of #13182

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Small mistake, large impact. Use of the wrong type for the return value of `irq_disable()` basically chopped off part of the ISR state.

On the fe310, this lead to a trap right after xtimer ISR exit, *sometimes*.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Fix should be obvious.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #13109.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
