### PR TITLE
xtimer/xtimer.c:_mutex_timeout() improved

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -213,19 +213,22 @@ static void _mutex_timeout(void *arg)
 
     mutex_thread_t *mt = (mutex_thread_t *)arg;
 
-    mt->timeout = 1;
-    list_node_t *node = list_remove(&mt->mutex->queue,
-                                    (list_node_t *)&mt->thread->rq_entry);
+    if (mt->mutex->queue.next != MUTEX_LOCKED &&
+        mt->mutex->queue.next != NULL) {
+        mt->timeout = 1;
+        list_node_t *node = list_remove(&mt->mutex->queue,
+                                        (list_node_t *)&mt->thread->rq_entry);
 
-    /* if thread was removed from the list */
-    if (node != NULL) {
-        if (mt->mutex->queue.next == NULL) {
-            mt->mutex->queue.next = MUTEX_LOCKED;
+        /* if thread was removed from the list */
+        if (node != NULL) {
+            if (mt->mutex->queue.next == NULL) {
+                mt->mutex->queue.next = MUTEX_LOCKED;
+            }
+            sched_set_status(mt->thread, STATUS_PENDING);
+            irq_restore(irqstate);
+            sched_switch(mt->thread->priority);
+            return;
         }
-        sched_set_status(mt->thread, STATUS_PENDING);
-        irq_restore(irqstate);
-        sched_switch(mt->thread->priority);
-        return;
     }
     irq_restore(irqstate);
 }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This is PR is the same as  #11992 because this bug fix was removed on accident. 
Was removed in #9530 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
same as  #11992 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#11992
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
