### PR TITLE
cpu/efm32/periph/rtc_series1: normalize time [backport 2020.01]

### DIFF
--- a/cpu/efm32/periph/rtc_series1.c
+++ b/cpu/efm32/periph/rtc_series1.c
@@ -70,6 +70,8 @@ void rtc_init(void)
 
 int rtc_set_time(struct tm *time)
 {
+    rtc_tm_normalize(time);
+
     RTCC_DateSet(
         RTCC_Year2BCD(time->tm_year - RTC_YEAR_OFFSET) |
         RTCC_Month2BCD(time->tm_mon) |
@@ -101,6 +103,8 @@ int rtc_get_time(struct tm *time)
 
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
+    rtc_tm_normalize(time);
+
     rtc_state.alarm_cb = cb;
     rtc_state.alarm_arg = arg;
     rtc_state.alarm_year = time->tm_year;


### PR DESCRIPTION
# Backport of #13181

### Contribution description

This PR fixes add normalization to `periph/rtc_series1` (series0 uses `mktime` so doesn't need it). The test had been changed some time ago to force testing an overflow situation, this implementation hadn't been checked.

### Testing procedure

The following fails in master and succeeds with this PR:

`BOARD=slstk3402a make --no-print-directory -C tests/periph_rtc flash test` (any series1 board can be used)

```
2020-01-22 10:06:40,943 # main(): This is RIOT! (Version: 2020.04-devel-1-ge700a-pr_efm32_series1_rtc_normalize)
2020-01-22 10:06:40,943 # 
2020-01-22 10:06:40,944 # RIOT RTC low-level driver test
2020-01-22 10:06:40,952 # This test will display 'Alarm!' every 2 seconds for 4 times
2020-01-22 10:06:40,954 #   Setting clock to   2011-12-13 14:15:57
2020-01-22 10:06:40,963 # Clock value is now   2011-12-13 14:15:57
2020-01-22 10:06:40,964 #   Setting alarm to   2011-12-13 14:15:59
2020-01-22 10:06:40,965 #    Alarm is set to   2011-12-13 14:15:59
2020-01-22 10:06:40,966 # 
2020-01-22 10:06:42,900 # Alarm!
2020-01-22 10:06:44,899 # Alarm!
2020-01-22 10:06:46,899 # Alarm!
2020-01-22 10:06:48,899 # Alarm!
```

### Issues/PRs references

Found in https://github.com/RIOT-OS/Release-Specs/issues/145
