### PR TITLE
pkg/micropython: bump version for FreeBSD fix

### DIFF
--- a/pkg/micropython/Makefile
+++ b/pkg/micropython/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=micropython
 PKG_URL=https://github.com/kaspar030/micropython
-PKG_VERSION=5c45688d431a4d0f626d86478ad490cfb6d8ac30
+PKG_VERSION=bb8e51f6da3e3e3fc65a8b9abaea1b0ebbbe104d
 PKG_LICENSE=MIT
 
 CFLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-error


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This update the micro python RIOT port to the latest version, which should fix
compile errors for RIOT native on FreeBSD


### Testing procedure

compile `examples/micropython` for native on Linux and (if available) FreeBSD.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
