### PR TITLE
native: fix c11_atomic sizes on FreeBSD

### DIFF
--- a/cpu/native/include/c11_atomics_compat_cpu.hpp
+++ b/cpu/native/include/c11_atomics_compat_cpu.hpp
@@ -41,10 +41,17 @@
 #define ATOMIC_INT_LEAST64_T_SAME_SIZED_TYPE            uint64_t
 #define ATOMIC_UINT_LEAST64_T_SIZE                      (8U)
 #define ATOMIC_UINT_LEAST64_T_SAME_SIZED_TYPE           uint64_t
+#ifdef __FreeBSD__
+#define ATOMIC_INT_FAST8_T_SIZE                         (4U)
+#define ATOMIC_INT_FAST8_T_SAME_SIZED_TYPE              uint32_t
+#define ATOMIC_UINT_FAST8_T_SIZE                        (4U)
+#define ATOMIC_UINT_FAST8_T_SAME_SIZED_TYPE             uint32_t
+#else
 #define ATOMIC_INT_FAST8_T_SIZE                         (1U)
 #define ATOMIC_INT_FAST8_T_SAME_SIZED_TYPE              uint8_t
 #define ATOMIC_UINT_FAST8_T_SIZE                        (1U)
 #define ATOMIC_UINT_FAST8_T_SAME_SIZED_TYPE             uint8_t
+#endif
 #define ATOMIC_INT_FAST16_T_SIZE                        (4U)
 #define ATOMIC_INT_FAST16_T_SAME_SIZED_TYPE             uint32_t
 #define ATOMIC_UINT_FAST16_T_SIZE                       (4U)


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There is size difference for atomic_int_fast8 and atomiic_uint_fast8
on FreeBSD, i.e., they match uint32_t with size of 4 bytes instead of
uint8_t with size of 8. Hence, tests/c11_atomics_cpp_compat buildtest
fails on FreeBSD.


### Testing procedure

Compile and run `tests/c11_atomics_cpp_compat` on Linux and (if available) FreeBSD,
should both work.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
