### PR TITLE
drivers/cc110x: add support promiscuous mode

### DIFF
--- a/drivers/cc110x/cc110x_settings.c
+++ b/drivers/cc110x/cc110x_settings.c
@@ -84,7 +84,7 @@ const char cc110x_conf[CC110X_CONF_SIZE] = {
      *   (e.g. a huge frame is dropped before it fully received) which reduces
      *   the system's load. Thus, it is enabled.
      */
-    0x02,
+    CC110X_PKTCTRL1_VALUE | CC110X_PKTCTRL1_ADDR_MATCH,
     /*
      * PKTCTRL0; default: 0x45
      * Data whitening enabled, use RX/TX FIFOs, CRC enabled,
@@ -291,7 +291,7 @@ const char cc110x_conf[CC110X_CONF_SIZE] = {
      * Why not default:
      * Use a reasonable TX power level instead of the lowest.
      */
-    0x14,
+    0x10 | CC110X_TX_POWER_0_DBM,
     /*
      * FSCAL3, FSCAL2, FSCAL1, FSCAL0; defaults: 0xA9, 0x0A, 0x20, 0x0d
      * These values store calibration date of the CC1100/CC1101 transceiver.

--- a/drivers/cc110x/include/cc110x_constants.h
+++ b/drivers/cc110x/include/cc110x_constants.h
@@ -207,6 +207,27 @@ extern "C" {
 #define CC110X_REG_IOCFG0         0x02
 
 /**
+ * @brief   PKTCTRL1 configuration register
+ *
+ * This register contains multiple configuration settings.
+ *
+ * Layout:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *  7 6 5 4 3 2 1 0
+ * +-+-+-+-+-+-+-+-+
+ * | PQT |U|C|S|ADR|
+ * +-+-+-+-+-+-+-+-+
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * - PQT (bits 7-5): Preabmle quality estimator threshold
+ * - U (bit 4): unused, always 0
+ * - C (bit 3): Auto-clear RX FIFO on CRC mismatch (if frame fits in FIFO)
+ * - S (bit 2): Append status
+ * - ADR (bits 1-0): Address check setting
+ */
+#define CC110X_REG_PKTCTRL1       0x07
+
+/**
  * @brief   Device address
  */
 #define CC110X_REG_ADDR           0x09
@@ -515,6 +536,39 @@ extern "C" {
  * @brief   Size of the RX and TX FIFO
  */
 #define CC110X_FIFO_SIZE                64
+
+/**
+ * @brief   Value of the bits 7-2 of the PKTCTRL1 configuration register used
+ *          in this driver
+ */
+#define CC110X_PKTCTRL1_VALUE           0x00
+
+/**
+ * @name    Possible address matching policies
+ *
+ * See page 73 in the data sheet. The policy should be combined with
+ * @ref CC110X_PKTCTRL1_VALUE via bitwise or. (Only modes compatible with the
+ * driver are defined.)
+ *
+ * @{
+ */
+/**
+ * @brief   Accept incoming frames regardless of address
+ */
+#define CC110X_PKTCTRL1_ADDR_ALL        0x00
+/**
+ * @brief   Accept frames with matching address or broadcast address
+ */
+#define CC110X_PKTCTRL1_ADDR_MATCH      0x02
+/**
+ * @brief   Bitmask to access address matching mode of the CC110x from the
+ *          PKTCTRL1 register
+ *
+ * Apply this using bitwise and to the value of the PKTCTRL1 register to get the
+ * address matching mode currently used.
+ */
+#define CC110X_PKTCTRL1_GET_ADDR_MODE   0x03
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -303,7 +303,7 @@ typedef enum {
     CC110X_TX_POWER_0_DBM,                          /**< 0 dBm */
     CC110X_TX_POWER_PLUS_5_DBM,                     /**< 5 dBm */
     CC110X_TX_POWER_PLUS_7_DBM,                     /**< 7 dBm */
-    CC110X_TX_POWER_PLUS_10_DBM,                    /**< 1 dBm */
+    CC110X_TX_POWER_PLUS_10_DBM,                    /**< 10 dBm */
     CC110X_TX_POWER_NUMOF,                          /**< Number of TX power options */
 } cc110x_tx_power_t;
 


### PR DESCRIPTION
### Contribution description

Exactly what the title says. This PR actually adds only few lines of code (when not taking the doc into account).

### Testing procedure

1. Build flash an run `examples/default` e.g. on two MSB-A2s (or two of any other board with a CC1101 breakout board attached to it and `BOARD_PROVIDES_NETIF` extended).
2. Confirm using `txtsnd` the device A receives frames sent by device B with correct address, but does ***not*** receive frames with incorrect address
3. Run `ifconfig 4 promisc` on device A. Now A should receive all frames, regardless of address
4. Run `ifconfig 4 -promisc` on device A, now the original behavior should be restored

### Issues/PRs references

None
