### PR TITLE
pkg/nimble/autoconn: collection of improvements

### DIFF
--- a/pkg/nimble/autoconn/include/nimble_autoconn.h
+++ b/pkg/nimble/autoconn/include/nimble_autoconn.h
@@ -143,6 +143,8 @@ typedef struct {
     uint32_t scan_itvl;
     /** scan window applied while in scanning state [in ms] */
     uint32_t scan_win;
+    /** opening a new connection is aborted after this time [in ms] */
+    uint32_t conn_timeout;
     /** connection interval used when opening a new connection [in ms] */
     uint32_t conn_itvl;
     /** slave latency used for new connections [in ms] */

--- a/pkg/nimble/autoconn/include/nimble_autoconn_params.h
+++ b/pkg/nimble/autoconn/include/nimble_autoconn_params.h
@@ -48,6 +48,9 @@ extern "C" {
 #define NIMBLE_AUTOCONN_SCAN_WIN            (110U)          /* 110ms */
 #endif
 
+#ifndef NIMBLE_AUTOCONN_CONN_TIMEOUT
+#define NIMBLE_AUTOCONN_CONN_TIMEOUT        (330U)          /* 3 * SCAN_WIN */
+#endif
 #ifndef NIMBLE_AUTOCONN_CONN_ITVL
 #define NIMBLE_AUTOCONN_CONN_ITVL           (75U)           /* 75ms */
 #endif
@@ -70,6 +73,7 @@ extern "C" {
       .adv_itvl      = NIMBLE_AUTOCONN_ADV_ITVL,      \
       .scan_itvl     = NIMBLE_AUTOCONN_SCAN_ITVL,     \
       .scan_win      = NIMBLE_AUTOCONN_SCAN_WIN,      \
+      .conn_timeout  = NIMBLE_AUTOCONN_CONN_TIMEOUT,  \
       .conn_itvl     = NIMBLE_AUTOCONN_CONN_ITVL,     \
       .conn_latency  = NIMBLE_AUTOCONN_CONN_LATENCY,  \
       .conn_super_to = NIMBLE_AUTOCONN_CONN_SUPER_TO, \

--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -166,6 +166,10 @@ static void _on_netif_evt(int handle, nimble_netif_event_t event,
     switch (event) {
         case NIMBLE_NETIF_ACCEPTING:
             en = 0;
+            _evt_dbg("ACCEPTING", handle, addr);
+            break;
+        case NIMBLE_NETIF_ACCEPT_STOP:
+            _evt_dbg("ACCEPT_STOP", handle, addr);
             break;
         case NIMBLE_NETIF_INIT_MASTER:
             _evt_dbg("CONN_INIT master", handle, addr);

--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -178,6 +178,7 @@ static void _on_netif_evt(int handle, nimble_netif_event_t event,
         case NIMBLE_NETIF_INIT_SLAVE:
             _evt_dbg("CONN_INIT slave", handle, addr);
             en = 0;
+            _state = STATE_CONN;
             break;
         case NIMBLE_NETIF_CONNECTED_MASTER:
             _evt_dbg("CONNECTED master", handle, addr);
@@ -186,6 +187,7 @@ static void _on_netif_evt(int handle, nimble_netif_event_t event,
             break;
         case NIMBLE_NETIF_CONNECTED_SLAVE:
             _evt_dbg("CONNECTED slave", handle, addr);
+            _state = STATE_IDLE;
             break;
         case NIMBLE_NETIF_CLOSED_MASTER:
             _evt_dbg("CLOSED master", handle, addr);
@@ -200,6 +202,7 @@ static void _on_netif_evt(int handle, nimble_netif_event_t event,
             break;
         case NIMBLE_NETIF_ABORT_SLAVE:
             _evt_dbg("[autoconn] ABORT slave", handle, addr);
+            _state = STATE_IDLE;
             break;
         case NIMBLE_NETIF_CONN_UPDATED:
             _evt_dbg("UPDATED", handle, addr);

--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -258,7 +258,7 @@ int nimble_autoconn_update(const nimble_autoconn_params_t *params,
     ble_npl_time_ms_to_ticks(params->period_jitter, &_period_jitter);
 
     /* populate the connection parameters */
-    _conn_params.scan_itvl = ((params->scan_itvl * 1000) / BLE_HCI_SCAN_ITVL);
+    _conn_params.scan_itvl = ((params->scan_win * 1000) / BLE_HCI_SCAN_ITVL);
     _conn_params.scan_window = ((params->scan_win * 1000) / BLE_HCI_SCAN_ITVL);
     _conn_params.itvl_min = ((params->conn_itvl * 1000) / BLE_HCI_CONN_ITVL);
     _conn_params.itvl_max = ((params->conn_itvl * 1000) / BLE_HCI_CONN_ITVL);

--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -42,8 +42,6 @@
 #error "NimBLE autoconn: please select a fitting submodule"
 #endif
 
-#define CONN_TIMEOUT_MUL            (5U)
-
 enum {
     STATE_SCAN,
     STATE_ADV,
@@ -268,7 +266,7 @@ int nimble_autoconn_update(const nimble_autoconn_params_t *params,
     _conn_params.supervision_timeout = (params->conn_super_to / 10);
     _conn_params.min_ce_len = 0;
     _conn_params.max_ce_len = 0;
-    _conn_timeout = params->adv_itvl * CONN_TIMEOUT_MUL;
+    _conn_timeout = ((params->conn_timeout * 1000) / BLE_HCI_SCAN_ITVL);
 
     /* we use the same values to updated existing connections */
     struct ble_gap_upd_params conn_update_params;

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -120,6 +120,7 @@ enum {
  */
 typedef enum {
     NIMBLE_NETIF_ACCEPTING,         /**< accepting incoming connections */
+    NIMBLE_NETIF_ACCEPT_STOP,       /**< stop accepting incoming connections */
     NIMBLE_NETIF_INIT_MASTER,       /**< conn. procedure started (as mater) */
     NIMBLE_NETIF_INIT_SLAVE,        /**< conn. procedure started (as slave) */
     NIMBLE_NETIF_CONNECTED_MASTER,  /**< connection established as master */

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -621,7 +621,7 @@ int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
                             adv_params, _on_gap_slave_evt, (void *)handle);
     assert(res == 0);
 
-    _notify(handle, NIMBLE_NETIF_ACCEPTING, NULL);
+    _notify(handle, NIMBLE_NETIF_ACCEPTING, _nimble_netif->l2addr);
 
     return NIMBLE_NETIF_OK;
 }
@@ -637,6 +637,7 @@ int nimble_netif_accept_stop(void)
     assert(res == 0);
     (void)res;
     nimble_netif_conn_free(handle, NULL);
+    _notify(handle, NIMBLE_NETIF_ACCEPT_STOP, _nimble_netif->l2addr);
 
     return NIMBLE_NETIF_OK;
 }


### PR DESCRIPTION
### Contribution description
This PR contains a small collection of improvements for `nimble_autoconn`:
- added event `ACCEPT_STOP` to `nimble_netif` -> needed for more coherent logs when tracking a nodes behavior
- adapt `nimble_autoconn` to output that event (if DEBUG enabled)
- allow to configure the timeout when initiating a new connection (`conn_timeout`) via the params struct -> more flexibility when evaluating timings
- fix `scan_itvl` in `_conn_params` by setting it to the same value as `scan_window` -> this leads to a 100% duty cycle when trying to open a new connection, meaning that the initiating node is now scanning (in RX) the full period of `conn_timeout`
- fix internal state (`_state`) when handling an incoming connection request (`CONN_x slave`)
- fix the enable/disable functions: i) introduce a global state to keep track if the module is enabled/disable by a higher-level user, ii) trigger 

### Testing procedure
Enable `DEBUG_ENABLE` in `pkg/nimble/autoconn/nimble_autoconn.c` and flash `tests/nimble_autoconn_gnrc` to at least two BLE nodes that can see each other. They should connect to each other fairly quick and continue to print `ACCEPTING` and `ACCEPT_STOP` messages.

### Issues/PRs references
none