### PR TITLE
drivers/xbee: Fix reference to device from netif in send function [backport 2020.01]

### DIFF
--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -116,12 +116,12 @@ static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     hdr = (gnrc_netif_hdr_t *)pkt->data;
     if (hdr->flags & BCAST) {
         uint16_t addr = 0xffff;
-        res = xbee_build_hdr((xbee_t *)netif, xhdr, size, &addr, 2);
+        res = xbee_build_hdr((xbee_t *)netif->dev, xhdr, size, &addr, 2);
         DEBUG("[xbee-gnrc] send: preparing to send broadcast\n");
     }
     else {
         uint8_t *addr = gnrc_netif_hdr_get_dst_addr(hdr);
-        res = xbee_build_hdr((xbee_t *)netif, xhdr, size, addr,
+        res = xbee_build_hdr((xbee_t *)netif->dev, xhdr, size, addr,
                              hdr->dst_l2addr_len);
         if (res < 0) {
             if (res == -EOVERFLOW) {


### PR DESCRIPTION
# Backport of #13192

### Contribution description
The `xbee_adpt_send` function casts the `gnrc_netif_t *` to `xbee_t *`, but the first member of it is not a `netdev_t` pointer. This fixes the issue reported [here](https://github.com/RIOT-OS/Release-Specs/issues/146#issuecomment-577725216).

### Testing procedure
Use an xbee device and try pinging, this should work now.

### Issues/PRs references
Issue reported in https://github.com/RIOT-OS/Release-Specs/issues/146#issuecomment-577725216