### PR TITLE
board/arduino-nano-33-ble: add initial support

### DIFF
--- a/boards/arduino-nano-33-ble/Makefile
+++ b/boards/arduino-nano-33-ble/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-nano-33-ble/Makefile.dep
+++ b/boards/arduino-nano-33-ble/Makefile.dep
@@ -1,0 +1,17 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+# use arduino-bootloader only if no other stdio_% other than stdio_cdc_acm
+# is requested
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
+  # Provide stdio over USB by default
+  USEMODULE += stdio_cdc_acm
+
+  # This board requires support for Arduino bootloader.
+  FEATURES_REQUIRED += bootloader_arduino
+  USEMODULE += usb_board_reset
+endif
+
+# include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/arduino-nano-33-ble/Makefile.features
+++ b/boards/arduino-nano-33-ble/Makefile.features
@@ -1,0 +1,13 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrf802154
+FEATURES_PROVIDED += bootloader_arduino
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/arduino-nano-33-ble/Makefile.include
+++ b/boards/arduino-nano-33-ble/Makefile.include
@@ -1,0 +1,32 @@
+# Bossa is the default programmer
+PROGRAMMER ?= bossa
+
+ifeq ($(PROGRAMMER),bossa)
+  # The preinstalled Arduino bootloader must also be taken into account so
+  # ROM_OFFSET skips the space taken by such bootloader.
+  ROM_OFFSET ?= 0x10000
+
+  # This board requires a BOSSA version from arduino's fork and adapted to
+  # nrf52.
+  BOSSA_VERSION = nrf52
+  BOSSA_ARDUINO_PREFLASH = yes
+  PREFLASH_DELAY = 1
+
+  ifneq (,$(filter reset flash flash-only, $(MAKECMDGOALS)))
+    # Add 2 seconds delay before opening terminal: this is required when opening
+    # the terminal right after flashing. In this case, the stdio over USB needs
+    # some time after reset before being ready.
+    TERM_DELAY = 2
+    TERMDEPS += term-delay
+  endif
+
+  include $(RIOTMAKE)/tools/bossa.inc.mk
+endif
+
+term-delay:
+	sleep $(TERM_DELAY)
+
+TESTRUNNER_CONNECT_DELAY ?= 2
+$(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/arduino-nano-33-ble/board.c
+++ b/boards/arduino-nano-33-ble/board.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the Arduino Nano 33 BLE
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT); /* Orange LED */
+    gpio_init(LED1_PIN, GPIO_OUT); /* Red LED */
+    gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT); /* Green LED */
+    gpio_set(LED2_PIN);
+    gpio_init(LED3_PIN, GPIO_OUT); /* Blue LED */
+    gpio_set(LED3_PIN);
+    gpio_init(LED4_PIN, GPIO_OUT); /* PWR LED */
+    gpio_clear(LED4_PIN);
+}

--- a/boards/arduino-nano-33-ble/doc.txt
+++ b/boards/arduino-nano-33-ble/doc.txt
@@ -1,0 +1,34 @@
+/**
+@defgroup    boards_arduino-nano-33-ble Arduino Nano 33 BLE
+@ingroup     boards
+@brief       Support for the Arduino Nano 33 BLE
+
+### General information
+
+The [Arduino Nano 33 BLE](https://store.arduino.cc/arduino-nano-33-ble) board
+is an opensource, micro development kit using the nRF52840 SoC.
+This board provides 802.15.4 and BLE connectivity.
+
+### Pinout
+
+<img src="https://content.arduino.cc/assets/Pinout-NANOble_latest.png"
+     alt="pinout" style="height:800px;"/>
+
+### Flash the board
+
+Use `BOARD=arduino-nano-33-ble` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+    make BOARD=arduino-nano-33-ble -C examples/hello-world flash
+```
+
+### Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port. On a Linux host, it's
+generally mapped to `/dev/ttyACM0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+    make BOARD=arduino-nano-33-ble -C examples/hello-world term
+```
+ */

--- a/boards/arduino-nano-33-ble/include/board.h
+++ b/boards/arduino-nano-33-ble/include/board.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino Nano 33 BLE
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LEDs pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 13)
+#define LED0_MASK           (1 << 13)
+#define LED0_ON             (NRF_P0->OUTCLR = LED0_MASK)
+#define LED0_OFF            (NRF_P0->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (NRF_P0->OUT   ^= LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(0, 24)
+#define LED1_MASK           (1 << 24)
+#define LED1_ON             (NRF_P0->OUTCLR = LED1_MASK)
+#define LED1_OFF            (NRF_P0->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (NRF_P0->OUT   ^= LED1_MASK)
+
+#define LED2_PIN            GPIO_PIN(0, 16)
+#define LED2_MASK           (1 << 16)
+#define LED2_ON             (NRF_P0->OUTCLR = LED2_MASK)
+#define LED2_OFF            (NRF_P0->OUTSET = LED2_MASK)
+#define LED2_TOGGLE         (NRF_P0->OUT   ^= LED2_MASK)
+
+#define LED3_PIN            GPIO_PIN(0, 6)
+#define LED3_MASK           (1 << 6)
+#define LED3_ON             (NRF_P0->OUTCLR = LED3_MASK)
+#define LED3_OFF            (NRF_P0->OUTSET = LED3_MASK)
+#define LED3_TOGGLE         (NRF_P0->OUT   ^= LED3_MASK)
+
+#define LED4_PIN            GPIO_PIN(1, 9)
+#define LED4_MASK           (1 << 9)
+#define LED4_ON             (NRF_P1->OUTCLR = LED4_MASK)
+#define LED4_OFF            (NRF_P1->OUTSET = LED4_MASK)
+#define LED4_TOGGLE         (NRF_P1->OUT   ^= LED4_MASK)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/arduino-nano-33-ble/include/gpio_params.h
+++ b/boards/arduino-nano-33-ble/include/gpio_params.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED0 (Orange)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+    },
+    {
+        .name  = "LED1 (RED)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED2 (GREEN)",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED3 (BLUE)",
+        .pin   = LED3_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED4 (PWR)",
+        .pin   = LED4_PIN,
+        .mode  = GPIO_OUT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/arduino-nano-33-ble/include/periph_conf.h
+++ b/boards/arduino-nano-33-ble/include/periph_conf.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Arduino Nano 33 BLE
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(1, 10),
+        .tx_pin     = GPIO_PIN(1, 3),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM0,
+        .scl = GPIO_PIN(0, 2),
+        .sda = GPIO_PIN(0, 31),
+        .speed = I2C_SPEED_NORMAL
+    },
+};
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = GPIO_PIN(0, 13),
+        .mosi = GPIO_PIN(1, 1),
+        .miso = GPIO_PIN(1, 8),
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/arduino-nano-33-ble/reset.c
+++ b/boards/arduino-nano-33-ble/reset.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble
+ * @{
+ * @file
+ * @brief       Implementation for managing the Arduino bootloader
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_USB_BOARD_RESET
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
+#include "usb_board_reset.h"
+
+/* Set the value used by the bootloader to select between boot in
+   application and boot in bootloader mode. */
+#define NRF52_DOUBLE_TAP_MAGIC_NUMBER       (0xb0)
+
+void usb_board_reset_in_bootloader(void)
+{
+    NRF_POWER->GPREGRET = NRF52_DOUBLE_TAP_MAGIC_NUMBER;
+
+    usb_board_reset_in_application();
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_USB_BOARD_RESET */

--- a/dist/tools/bossa-nrf52/.gitignore
+++ b/dist/tools/bossa-nrf52/.gitignore
@@ -1,0 +1,2 @@
+bossac
+bin

--- a/dist/tools/bossa-nrf52/Makefile
+++ b/dist/tools/bossa-nrf52/Makefile
@@ -1,0 +1,15 @@
+PKG_NAME     = bossa
+PKG_URL      = https://github.com/arduino/BOSSA
+PKG_VERSION  = 52e0a4a28721296e64083de7780b30580e0fad16
+PKG_LICENSE  = BSD-3-Clause
+PKG_BUILDDIR = $(CURDIR)/bin
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	@echo "[INFO] compiling bossac from source now"
+	@env -u CXX COMMON_CXXFLAGS="-std=c++11" $(MAKE) BINDIR=$(PKG_BUILDDIR) -C $(PKG_BUILDDIR) strip-bossac
+	@mv $(PKG_BUILDDIR)/bossac $(CURDIR)/bossac
+
+distclean::
+	@rm -f $(CURDIR)/bossac

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -34,7 +34,8 @@ USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 
-BOARD_PROVIDES_NETIF := acd52832 adafruit-clue airfy-beacon atmega256rfr2-xpro avr-rss2 b-l072z-lrwan1 cc2538dk fox \
+BOARD_PROVIDES_NETIF := acd52832 adafruit-clue airfy-beacon atmega256rfr2-xpro \
+        arduino-nano-33-ble avr-rss2 b-l072z-lrwan1 cc2538dk fox \
         derfmega128 derfmega256 hamilton iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \
         microduino-corerf native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf6310 \
         nucleo-f207zg nucleo-f767zi openmote-b openmote-cc2538 pba-d-01-kw2x remote-pa \

--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -1,7 +1,14 @@
 BOSSA_VERSION ?= 1.9
 FLASHFILE ?= $(BINFILE)
 FLASHER ?= $(RIOTTOOLS)/bossa-$(BOSSA_VERSION)/bossac
-FFLAGS  ?= -p $(PROG_DEV) -o $(ROM_OFFSET) -e -i -w -v -b -R $(FLASHFILE)
+FFLAGS_OPTS ?=
+
+# Only use ROM_OFFSET with Bossa version 1.9
+ifeq (1.9,$(BOSSA_VERSION))
+  FFLAGS_OPTS += -o $(ROM_OFFSET)
+endif
+
+FFLAGS  ?= -p $(PROG_DEV) $(FFLAGS_OPTS) -e -i -w -v -b -R $(FLASHFILE)
 
 # some arduino boards need to toggle the serial interface a little bit to get
 # them ready for flashing...


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [Arduino Nano 33 BLE](https://store.arduino.cc/arduino-nano-33-ble) board which runs on an nRF52840 CPUs and thus provides 802.15.4 and BLE radio.

To flash this board, Arduino uses the same approach as with other samd21 based boards (MKR, etc): there's a bootloader at beginning of the flash. This bootloader can communicate with the Bossa tool but not the one from the [upstream project](https://github.com/shumatech/BOSSA) because it doesn't support the nrf52 cpu. Arduino added support on [his fork](https://github.com/arduino/BOSSA) and as a consequence, this PR changes the Bossa repository to use the Arduino one.

Note that this PR is based on #12304 because I could adapt the same strategy for the nrf CPUs.

Timers, I2C were tested with success.

UART was also tested with success, using the following patch:

<details>

```
diff --git a/tests/periph_uart/main.c b/tests/periph_uart/main.c
index 81c08362947..c5aed5eb97a 100644
--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -69,10 +69,10 @@ static int parse_dev(char *arg)
         printf("Error: Invalid UART_DEV device specified (%u).\n", dev);
         return -1;
     }
-    else if (UART_DEV(dev) == STDIO_UART_DEV) {
-        printf("Error: The selected UART_DEV(%u) is used for the shell!\n", dev);
-        return -2;
-    }
+    // else if (UART_DEV(dev) == STDIO_UART_DEV) {
+    //     printf("Error: The selected UART_DEV(%u) is used for the shell!\n", dev);
+    //     return -2;
+    // }
     return dev;
 }
```

</details>

SPI is untested.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Check that you can flash the board, interact with the on-board LEDs using the `examples/saul` application:
```
make BOARD=arduino-nano-33-ble -C examples/saul flash term
```
- Run more complete tests using the `compile_and_test_for_board.py`. Using #13089 might help here.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #12304 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
