### PR TITLE
sys/shell: correctly detect and handle long lines

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -175,7 +175,7 @@ static void handle_input_line(const shell_command_t *command_list, char *line)
             ++argc;
         }
 
-        /* zero out the current position (space or quotation mark) and advance */
+        /* zero out current position (space or quotation mark) and advance */
         if (*pos > 0) {
             *pos = 0;
             ++pos;
@@ -269,10 +269,11 @@ static int readline(char *buf, size_t size)
             return EOF;
         }
 
-        /* We allow Unix linebreaks (\n), DOS linebreaks (\r\n), and Mac linebreaks (\r). */
-        /* QEMU transmits only a single '\r' == 13 on hitting enter ("-serial stdio"). */
-        /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
-        /* Ctrl-C cancels the current line. */
+        /* We allow Unix linebreaks (\n), DOS linebreaks (\r\n), and Mac
+         * linebreaks (\r). QEMU transmits only a single '\r' == 13 on hitting
+         * enter ("-serial stdio"). DOS newlines are handled like hitting enter
+         * twice, but empty lines are ignored. Ctrl-C cancels the current line.
+         */
         if (c == '\r' || c == '\n' || c == ETX) {
             if (c == ETX) {
                 curr_pos = 0;
@@ -288,10 +289,12 @@ static int readline(char *buf, size_t size)
             return (length_exceeded) ? -ENOBUFS : curr_pos;
         }
 
-        /* QEMU uses 0x7f (DEL) as backspace, while 0x08 (BS) is for most terminals */
+        /* check for backspace:
+         * 0x7f (DEL) when using QEMU
+         * 0x08 (BS) for most terminals */
         if (c == 0x08 || c == 0x7f) {
             if (curr_pos == 0) {
-                /* The line is empty. */
+                /* ignore empty line */
                 continue;
             }
 

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, Freie Universitaet Berlin (FUB).
+ * Copyright (C) 2009, 2020 Freie Universität Berlin
  * Copyright (C) 2013, INRIA.
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
  *
@@ -21,6 +21,8 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
+ * @author      Juan Carrano <j.carrano@fu-berlin.de>
+ * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  *
  * @}
  */
@@ -29,6 +31,10 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <errno.h>
+
 #include "shell.h"
 #include "shell_commands.h"
 
@@ -227,14 +233,36 @@ static void handle_input_line(const shell_command_t *command_list, char *line)
     }
 }
 
+/**
+ * @brief   Read a single line from standard input into a buffer.
+ *
+ * In addition to copying characters, this routine echoes the line back to
+ * stdout and also supports primitive line editing.
+ *
+ * If the input line is too long, the input will still be consumed until the end
+ * to prevent the next line from containing garbage.
+ *
+ * @param   buf     Buffer where the input will be placed.
+ * @param   size    Size of the buffer. The maximum line length will be one less
+ *                  than size, to accommodate for the null terminator.
+ *                  The minimum buffer size is 1.
+ *
+ * @return  length of the read line, excluding the terminator, if reading was
+ *          successful.
+ * @return  EOF, if the end of the input stream was reached.
+ * @return  ENOBUFS if the buffer size was exceeded.
+ */
 static int readline(char *buf, size_t size)
 {
-    char *line_buf_ptr = buf;
+    int curr_pos = 0;
+    bool length_exceeded = false;
+
+    assert((size_t) size > 0);
 
     while (1) {
-        if ((line_buf_ptr - buf) >= ((int) size) - 1) {
-            return -1;
-        }
+        /* At the start of the loop, cur_pos should point inside of
+         * buf. This ensures the terminator can always fit. */
+        assert((size_t) curr_pos < size);
 
         int c = getchar();
         if (c < 0) {
@@ -246,23 +274,32 @@ static int readline(char *buf, size_t size)
         /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
         /* Ctrl-C cancels the current line. */
         if (c == '\r' || c == '\n' || c == ETX) {
-            *line_buf_ptr = '\0';
+            if (c == ETX) {
+                curr_pos = 0;
+                length_exceeded = false;
+            }
+
+            buf[curr_pos] = '\0';
 #ifndef SHELL_NO_ECHO
             _putchar('\r');
             _putchar('\n');
 #endif
 
-            /* return 1 if line is empty, 0 otherwise */
-            return c == ETX || line_buf_ptr == buf;
+            return (length_exceeded) ? -ENOBUFS : curr_pos;
         }
+
         /* QEMU uses 0x7f (DEL) as backspace, while 0x08 (BS) is for most terminals */
-        else if (c == 0x08 || c == 0x7f) {
-            if (line_buf_ptr == buf) {
+        if (c == 0x08 || c == 0x7f) {
+            if (curr_pos == 0) {
                 /* The line is empty. */
                 continue;
             }
 
-            *--line_buf_ptr = '\0';
+            /* after we dropped characters don't edit the line, yet keep the
+             * visual effects */
+            if (!length_exceeded) {
+                buf[--curr_pos] = '\0';
+            }
             /* white-tape the character */
 #ifndef SHELL_NO_ECHO
             _putchar('\b');
@@ -271,7 +308,13 @@ static int readline(char *buf, size_t size)
 #endif
         }
         else {
-            *line_buf_ptr++ = c;
+            /* Always consume characters, but do not not always store them */
+            if ((size_t) curr_pos < size - 1) {
+                buf[curr_pos++] = c;
+            }
+            else {
+                length_exceeded = true;
+            }
 #ifndef SHELL_NO_ECHO
             _putchar(c);
 #endif
@@ -298,12 +341,18 @@ void shell_run_once(const shell_command_t *shell_commands,
     while (1) {
         int res = readline(line_buf, len);
 
-        if (res == EOF) {
-            break;
-        }
+        switch (res) {
 
-        if (!res) {
-            handle_input_line(shell_commands, line_buf);
+            case EOF:
+                return;
+
+            case -ENOBUFS:
+                puts("shell: maximum line length exceeded");
+                break;
+
+            default:
+                handle_input_line(shell_commands, line_buf);
+                break;
         }
 
         print_prompt();

--- a/tests/driver_pca9685/Makefile.ci
+++ b/tests/driver_pca9685/Makefile.ci
@@ -1,6 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
+    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega32u4 \
     #

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -56,7 +56,17 @@ static int print_echo(int argc, char **argv)
     return 0;
 }
 
+static int print_shell_bufsize(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    printf("%d\n", SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
+    { "bufsize", "Get the shell's buffer size", print_shell_bufsize },
     { "start_test", "starts a test", print_teststart },
     { "end_test", "ends a test", print_testend },
     { "echo", "prints the input command", print_echo },

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -7,6 +7,7 @@
 # directory for more details.
 
 import sys
+import os
 from testrunner import run
 
 
@@ -56,6 +57,7 @@ CMDS = (
     ('reboot', ('test_shell.'))
 )
 
+BOARD = os.environ['BOARD']
 
 def check_cmd(child, cmd, expected):
     child.sendline(cmd)
@@ -72,6 +74,10 @@ def check_and_get_bufsize(child):
 
 
 def testfunc(child):
+    # avoid sending an extra empty line on native.
+    if BOARD == 'native':
+        child.crlf = '\n'
+
     bufsize = check_and_get_bufsize(child)
 
     # loop other defined commands and expected output

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -57,9 +57,12 @@ CMDS = (
     ('reboot', ('test_shell.'))
 )
 
+PROMPT = '> '
+
 BOARD = os.environ['BOARD']
 
 def check_cmd(child, cmd, expected):
+    child.expect(PROMPT)
     child.sendline(cmd)
     for line in expected:
         child.expect_exact(line)

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -40,23 +40,23 @@ DLE = '\x16'
 CONTROL_C = DLE+'\x03'
 CONTROL_D = DLE+'\x04'
 
+PROMPT = '> '
+
 CMDS = (
-    (CONTROL_C, ('>')),
-    ('start_test', ('[TEST_START]')),
-    ('end_test', ('[TEST_END]')),
-    ('\n', ('>')),
+    ('start_test', '[TEST_START]'),
+    (CONTROL_C, PROMPT),
+    ('\n', PROMPT),
     ('123456789012345678901234567890123456789012345678901234567890',
-        ('shell: command not found: '
-         '123456789012345678901234567890123456789012345678901234567890')),
-    ('unknown_command', ('shell: command not found: unknown_command')),
+     'shell: command not found: '
+     '123456789012345678901234567890123456789012345678901234567890'),
+    ('unknown_command', 'shell: command not found: unknown_command'),
     ('help', EXPECTED_HELP),
-    ('echo a string', ('\"echo\"\"a\"\"string\"')),
+    ('echo a string', '\"echo\"\"a\"\"string\"'),
     ('ps', EXPECTED_PS),
     ('help', EXPECTED_HELP),
-    ('reboot', ('test_shell.'))
+    ('reboot', 'test_shell.'),
+    ('end_test', '[TEST_END]'),
 )
-
-PROMPT = '> '
 
 BOARD = os.environ['BOARD']
 

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -52,7 +52,6 @@ CMDS = (
     ('help', EXPECTED_HELP),
     ('echo a string', ('\"echo\"\"a\"\"string\"')),
     ('ps', EXPECTED_PS),
-    ('garbage1234'+CONTROL_C, ('>')),  # test cancelling a line
     ('help', EXPECTED_HELP),
     ('reboot', ('test_shell.'))
 )
@@ -81,6 +80,15 @@ def check_and_get_bufsize(child):
     return bufsize
 
 
+def check_line_canceling(child):
+    child.expect(PROMPT)
+    child.sendline('garbage1234' + CONTROL_C)
+    garbage_expected = 'garbage1234\r\r\n'
+    garbage_received = child.read(len(garbage_expected))
+
+    assert garbage_expected == garbage_received
+
+
 def testfunc(child):
     # avoid sending an extra empty line on native.
     if BOARD == 'native':
@@ -89,6 +97,8 @@ def testfunc(child):
     check_startup(child)
 
     bufsize = check_and_get_bufsize(child)
+
+    check_line_canceling(child)
 
     # loop other defined commands and expected output
     for cmd, expected in CMDS:

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -65,6 +65,11 @@ def check_cmd(child, cmd, expected):
         child.expect_exact(line)
 
 
+def check_startup(child):
+    child.sendline(CONTROL_C)
+    child.expect_exact(PROMPT)
+
+
 def check_and_get_bufsize(child):
     child.sendline('bufsize')
     child.expect('([0-9]+)\r\n')
@@ -77,6 +82,8 @@ def testfunc(child):
     # avoid sending an extra empty line on native.
     if BOARD == 'native':
         child.crlf = '\n'
+
+    check_startup(child)
 
     bufsize = check_and_get_bufsize(child)
 

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -63,7 +63,17 @@ def check_cmd(child, cmd, expected):
         child.expect_exact(line)
 
 
+def check_and_get_bufsize(child):
+    child.sendline('bufsize')
+    child.expect('([0-9]+)\r\n')
+    bufsize = int(child.match.group(1))
+
+    return bufsize
+
+
 def testfunc(child):
+    bufsize = check_and_get_bufsize(child)
+
     # loop other defined commands and expected output
     for cmd, expected in CMDS:
         check_cmd(child, cmd, expected)


### PR DESCRIPTION
### Contribution description

With this PR I simply copied PR #10635 authored by @jcarrano. Since he left the team, I hereby offer to take care of rebasing and implement required changes.

The numeric value for EOF is (-1). This caused the shell to return the same code when EOF was encountered and when the line length was exceeded. Additionally, if the line length is exceeded, the correct behaviour is to consume the remaining characters until the end of the line, to prevent the following line from containing (potentially dangerous) garbage.

### Testing procedure

This PR adds a test to `tests/shell`. It adds a command to retrieve buffer size and then forces an extremely long line. This is failing right now because of a bug in the shell, which is fixed with this PR.

In case of problems with testing on a real board, please refer to #10639 first.

### Issues/PRs references
Copy of #10635

Dependency for #13196 and #13197