### PR TITLE
 xtimer/xtimer.c: xtimer_mutex_lock_timeout fix with short timeout

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -202,7 +202,7 @@ void xtimer_now_timex(timex_t *out)
 
 static void _mutex_timeout(void *arg)
 {
-    /* interrupts a disabled because xtimer can spin
+    /* interrupts are disabled because xtimer can spin
      * if xtimer_set spins the callback is executed
      * in the thread context
      *

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -45,7 +45,15 @@
 typedef struct {
     mutex_t *mutex;
     thread_t *thread;
-    volatile int timeout;
+    /*
+     * @brief:  one means the thread was removed from the mutex thread waiting list
+     *          by _mutex_timeout()
+     */
+    volatile uint8_t dequeued;
+    /*
+     * @brief:  mutex_lock() should block because _mutex_timeout() did not shoot
+     */
+    volatile uint8_t blocking;
 } mutex_thread_t;
 
 static void _callback_unlock_mutex(void* arg)
@@ -200,6 +208,28 @@ void xtimer_now_timex(timex_t *out)
     out->microseconds = now - (out->seconds * US_PER_SEC);
 }
 
+static int _mutex_remove_thread_from_waiting_queue(mutex_t *mutex, thread_t *thread)
+{
+    unsigned irqstate = irq_disable();
+    assert(mutex != NULL && thread != NULL);
+
+    if (mutex->queue.next != MUTEX_LOCKED && mutex->queue.next != NULL) {
+        list_node_t *node = list_remove(&mutex->queue, (list_node_t *)&thread->rq_entry);
+        /* if thread was removed from the list */
+        if (node != NULL) {
+            if (mutex->queue.next == NULL) {
+                mutex->queue.next = MUTEX_LOCKED;
+            }
+            sched_set_status(thread, STATUS_PENDING);
+            irq_restore(irqstate);
+            sched_switch(thread->priority);
+            return 1;
+        }
+    }
+    irq_restore(irqstate);
+    return 0;
+}
+
 static void _mutex_timeout(void *arg)
 {
     /* interrupts are disabled because xtimer can spin
@@ -212,41 +242,27 @@ static void _mutex_timeout(void *arg)
     unsigned int irqstate = irq_disable();
 
     mutex_thread_t *mt = (mutex_thread_t *)arg;
-
-    if (mt->mutex->queue.next != MUTEX_LOCKED &&
-        mt->mutex->queue.next != NULL) {
-        mt->timeout = 1;
-        list_node_t *node = list_remove(&mt->mutex->queue,
-                                        (list_node_t *)&mt->thread->rq_entry);
-
-        /* if thread was removed from the list */
-        if (node != NULL) {
-            if (mt->mutex->queue.next == NULL) {
-                mt->mutex->queue.next = MUTEX_LOCKED;
-            }
-            sched_set_status(mt->thread, STATUS_PENDING);
-            irq_restore(irqstate);
-            sched_switch(mt->thread->priority);
-            return;
-        }
-    }
+    mt->blocking = 0;
+    mt->got_unlocked = _mutex_remove_thread_from_waiting_queue(mt->mutex, mt->thread);
     irq_restore(irqstate);
 }
 
 int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t timeout)
 {
     xtimer_t t;
-    mutex_thread_t mt = { mutex, (thread_t *)sched_active_thread, 0 };
+    mutex_thread_t mt = { mutex, (thread_t *)sched_active_thread, .dequeued=0, .blocking=1 };
 
     if (timeout != 0) {
         t.callback = _mutex_timeout;
         t.arg = (void *)((mutex_thread_t *)&mt);
         xtimer_set64(&t, timeout);
     }
-
-    mutex_lock(mutex);
+    int ret = _mutex_lock(mutex, mt.blocking);
+    if (ret == 0) {
+        return -1;
+    }
     xtimer_remove(&t);
-    return -mt.timeout;
+    return -mt.dequeued;
 }
 
 #ifdef MODULE_CORE_THREAD_FLAGS

--- a/tests/xtimer_mutex_lock_timeout/tests/01-run.py
+++ b/tests/xtimer_mutex_lock_timeout/tests/01-run.py
@@ -38,6 +38,14 @@ def testfunc(child):
     child.expect("THREAD low prio: exiting low")
     child.expect("threads = 2")
     child.expect_exact("> ")
+    child.sendline("mutex_timeout_short_locked")
+    child.expect("starting test: xtimer mutex lock timeout with short timeout and locked mutex")
+    child.expect("OK")
+    child.expect_exact("> ")
+    child.sendline("mutex_timeout_short_unlocked")
+    child.expect("starting test: xtimer mutex lock timeout with short timeout and unlocked mutex")
+    child.expect("OK")
+    child.expect_exact("> ")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
Tracking: pr #11660

### Contribution description
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Fixes **BUG**

This PR implements a new function to test `xtimer_mutex_lock_timeout` with a short timeout (spinning) and fixes the function `xtimer_mutex_lock_timeout` because without the fix in this PR the test fails. 

This PR also implements a new function `_mutex_remove_thread_from_waiting_queue`. This function is implemented to remove all code out of `xtimer_mutex_lock_timeout` and `_mutex_timeout` that edits the mutex struct. The function `_mutex_remove_thread_from_waiting_queue` should be moved to mutex.c in the future to removed all code out of xtimer that edits the mutex struct.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
To test the bug fix run the test. To see the bug revert to commit: "tests/xtimer_mutex_lock_timeout: minimal xtimer_mutex_lock_timeout test"  and run the test. (the test will fail)

`BOARD=native make -C tests/xtimer_mutex_lock_timeout/ flash test`

output:
```
...
> mutex_timeout_long_unlocked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked
mutex_timeout_long_locked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked_low
mutex_timeout_long_locked_low
starting test: xtimer mutex lock timeout with thread
threads = 2
THREAD low prio: start
MAIN THREAD: calling xtimer_mutex_lock_timeout
OK
threads = 3
MAIN THREAD: waiting for created thread to end
THREAD low prio: exiting low
threads = 2

> mutex_timeout_short_locked
mutex_timeout_short_locked
starting test: xtimer mutex lock timeout with short timeout and locked mutex
OK

> mutex_timeout_short_unlocked
mutex_timeout_short_unlocked
starting test: xtimer mutex lock timeout with short timeout and unlocked mutex
OK
```

output without fix:

```
...
> mutex_timeout_long_unlocked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked
mutex_timeout_long_locked
starting test: xtimer mutex lock timeout
OK

> mutex_timeout_long_locked_low
mutex_timeout_long_locked_low
starting test: xtimer mutex lock timeout with thread
threads = 2
THREAD low prio: start
MAIN THREAD: calling xtimer_mutex_lock_timeout
OK
threads = 3
MAIN THREAD: waiting for created thread to end
THREAD low prio: exiting low
threads = 2

> mutex_timeout_short_locked
mutex_timeout_short_locked
starting test: xtimer mutex lock timeout with short timeout and locked mutex
Timeout in expect script at "child.expect("OK")" (tests/xtimer_mutex_lock_timeout/tests/01-run.py:43)

...RIOT/tests/xtimer_mutex_lock_timeout/../../Makefile.include:735: recipe for target 'test' failed
make: *** [test] Error 1

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Tracking PR #11660 