### PR TITLE
makefiles/info-global.inc.mk: reset BOARDSDIR

### DIFF
--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -108,3 +108,7 @@ info-boards-supported:
 
 info-boards-features-missing:
 	@for f in $(BOARDS_FEATURES_MISSING); do echo $${f}; done | column -t
+
+# Reset BOARDSDIR so unchanged for makefiles included after, for now only
+# needed for buildtests.inc.mk
+BOARDSDIR := $(BOARDSDIR_GLOBAL)


### PR DESCRIPTION
### Contribution description

This PR allows using build test to build on boards existing in `RIOTBOARD` as well as an external `BOARDSDIR`, It does that by resetting `BOARDSDIR` after `info-global.inc.mk` is parsed.

### Testing procedure

Configure `BOARDSDIR` to point to a directory where you have at least one external BOARD, see that it compiles it,  here `ba-native`

```
→ make buildtest
Building for acd52832 ... success.
Building for airfy-beacon ... success.
Building for arduino-due ... success.
Building for arduino-duemilanove ... success.
...
Building for b-l475e-iot01a ... success.
Building for ba-native ... success.
Building for blackpill ... success.
...
```

