### PR TITLE
boards: doc fix for several nucleo-f4xxxx boards

### DIFF
--- a/boards/nucleo-f411re/doc.txt
+++ b/boards/nucleo-f411re/doc.txt
@@ -30,8 +30,7 @@ content/uploads/2015/08/Figura2-500x467.png)
 | I2Cs       | 3                 |
 | RTC        | 1                 |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet  |
-[Datasheet](http://www.st.com/resource/en/datasheet/stm32f411re.pdf) |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f411re.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/resource/en/reference_manual/dm00119316.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
 | Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|

--- a/boards/nucleo-f446re/doc.txt
+++ b/boards/nucleo-f446re/doc.txt
@@ -30,8 +30,7 @@ content/uploads/2015/08/Figura2-500x467.png)
 | I2Cs       | 4                 |
 | RTC        | 1                 |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet  |
-[Datasheet](http://www.st.com/resource/en/datasheet/stm32f446re.pdf) |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f446re.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031936.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00051352.pdf) |
 | Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|

--- a/boards/nucleo-f446ze/doc.txt
+++ b/boards/nucleo-f446ze/doc.txt
@@ -30,8 +30,7 @@ content/uploads/2015/08/Figura2-500x467.png)
 | I2Cs       | 4                 |
 | RTC        | 1                 |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet  |
-[Datasheet](http://www.st.com/resource/en/datasheet/stm32f446re.pdf) |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f446re.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031936.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00051352.pdf) |
 | Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|


### PR DESCRIPTION
### Contribution description

This PR fixes the table with the links to the datasheet, the reference manual ... for `nucleo-f411re`, `nucleo-f446re` and `nucleo-f446ze`.

Rows in markdown tables must not contain a line break. Otherwise the table is broken.

### Testing procedure

Generate the doc without and with this PR and check the tables in documentation.

### Issues/PRs references