### PR TITLE
MTD: Add module for remapping MTD sectors

### DIFF
--- a/drivers/include/mtd_mapper.h
+++ b/drivers/include/mtd_mapper.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mtd_mapper  MTD address mapper
+ * @ingroup     drivers_storage
+ * @brief       Driver for address remap for flash devices
+ *
+ * This MTD module allows for remapping multiple different regions on a single
+ * MTD device and present them as separate MTD devices. This is similar to
+ * partitions on a hard drive, although this system only allows hardcoded
+ * partitions and lacks a partition table.
+ *
+ * The use case for this module is to be able to split a single MTD device, for
+ * example a SPI NOR flash chip into multiple separate regions which all can
+ * contain their own content or file systems.
+ *
+ * ## Usage
+ *
+ * To use this module include it in your makefile:
+ *
+ * ```
+ * USEMODULE += mtd_mapper
+ * ```
+ *
+ * To define new regions with an existing MTD device the following is required:
+ *
+ * ```
+ * mtd_mapper_parent_t parent = MTD_PARENT_INIT(MTD_0);
+ *
+ * mtd_mapper_region_t region1 = {
+ *     .mtd = {
+ *         .driver = &mtd_mapper_driver,
+ *         .sector_count = SECTOR_COUNT / 2,
+ *         .pages_per_sector = PAGE_PER_SECTOR,
+ *         .page_size = PAGE_SIZE,
+ *     },
+ *     .parent = &parent,
+ *     .offset = PAGE_PER_SECTOR * PAGE_SIZE * SECTOR_COUNT / 2
+ * };
+ *
+ * mtd_dev_t *dev = &region.mtd;
+ * ```
+ * The snippet here defines a region within an existing `MTD_0` device of half
+ * the size of `MTD_0` and starting in the middle of the device.
+ *
+ * @warning Please ensure that the different configured regions do not overlap.
+ *
+ * @{
+ *
+ * @brief       Interface definitions for mtd mapper support
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef MTD_MAPPER_H
+#define MTD_MAPPER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "mtd.h"
+#include "mutex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Shortcut macro for initializing the members of an
+ *        @ref mtd_mapper_parent_t struct
+ */
+#define MTD_PARENT_INIT(_parent) \
+{ \
+    .mtd = _parent, \
+    .lock = MUTEX_INIT, \
+    .init = false, \
+}
+
+/**
+ * @brief MTD mapper backing device context
+ */
+typedef struct {
+    mtd_dev_t *mtd;     /**< Parent MTD device */
+    mutex_t lock;       /**< Mutex for guarding the backing device access */
+    bool init;          /**< Initialization flag */
+} mtd_mapper_parent_t;
+
+/**
+ * @brief MTD mapped region
+ */
+typedef struct {
+    mtd_dev_t mtd;                  /**< MTD context                         */
+    mtd_mapper_parent_t *parent;    /**< MTD mapper parent device            */
+    uint32_t offset;                /**< Offset address to start this region */
+} mtd_mapper_region_t;
+
+/**
+ * @brief Mapper MTD device operations table
+ */
+extern const mtd_desc_t mtd_mapper_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_MAPPER_H */
+/** @} */

--- a/drivers/mtd_mapper/Makefile
+++ b/drivers/mtd_mapper/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mtd_mapper/mtd_mapper.c
+++ b/drivers/mtd_mapper/mtd_mapper.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mtd_mapper
+ * @{
+ *
+ * @file
+ * @brief       Driver for flash memory remap support
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <errno.h>
+
+#include "kernel_defines.h"
+#include "mtd.h"
+#include "mtd_mapper.h"
+#include "mutex.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+static void _unlock(mtd_mapper_region_t *region)
+{
+    mutex_unlock(&region->parent->lock);
+}
+
+static void _lock(mtd_mapper_region_t *region)
+{
+    mutex_lock(&region->parent->lock);
+}
+
+static uint32_t _region_size(mtd_mapper_region_t *region)
+{
+    return region->mtd.page_size * region->mtd.pages_per_sector *
+           region->mtd.sector_count;
+}
+
+static int _init_target(mtd_mapper_region_t *region)
+{
+    mtd_mapper_parent_t *parent = region->parent;
+
+    if (!parent->init) {
+        parent->init = true;
+        return mtd_init(parent->mtd);
+    }
+    return 0;
+}
+
+static int _init(mtd_dev_t *mtd)
+{
+
+    mtd_mapper_region_t *region = container_of(mtd, mtd_mapper_region_t, mtd);
+    mtd_dev_t *backing_mtd = region->parent->mtd;
+
+    /* Configuration sanity checks */
+    assert(backing_mtd->page_size == region->mtd.page_size);
+    assert(backing_mtd->pages_per_sector == region->mtd.pages_per_sector);
+    assert(backing_mtd->sector_count >= region->mtd.sector_count);
+
+    /* offset + region size must not exceed the backing device */
+    assert(region->offset + _region_size(
+               region) <=
+           backing_mtd->pages_per_sector * backing_mtd->sector_count *
+           backing_mtd->page_size);
+
+    _lock(region);
+    int res = _init_target(region);
+    _unlock(region);
+    return res;
+}
+
+static int _write(mtd_dev_t *mtd, const void *src, uint32_t addr,
+                  uint32_t count)
+{
+    mtd_mapper_region_t *region = container_of(mtd, mtd_mapper_region_t, mtd);
+
+    if (addr + count > _region_size(region)) {
+        return -EOVERFLOW;
+    }
+
+    _lock(region);
+    int res = mtd_write(region->parent->mtd, src, addr + region->offset, count);
+    _unlock(region);
+    return res;
+}
+
+static int _read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count)
+{
+    mtd_mapper_region_t *region = container_of(mtd, mtd_mapper_region_t, mtd);
+
+    if (addr + count > _region_size(region)) {
+        return -EOVERFLOW;
+    }
+
+    _lock(region);
+    int res = mtd_read(region->parent->mtd, dest, addr + region->offset, count);
+    _unlock(region);
+    return res;
+}
+
+static int _erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count)
+{
+    mtd_mapper_region_t *region = container_of(mtd, mtd_mapper_region_t, mtd);
+
+    if (addr + count > _region_size(region)) {
+        return -EOVERFLOW;
+    }
+
+    _lock(region);
+    int res = mtd_erase(region->parent->mtd, addr + region->offset, count);
+    _unlock(region);
+    return res;
+}
+
+const mtd_desc_t mtd_mapper_driver = {
+    .init = _init,
+    .read = _read,
+    .write = _write,
+    .erase = _erase,
+};

--- a/tests/mtd_mapper/Makefile
+++ b/tests/mtd_mapper/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += mtd_mapper
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mtd_mapper/Makefile.ci
+++ b/tests/mtd_mapper/Makefile.ci
@@ -1,0 +1,13 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    chronos \
+    msb-430 \
+    msb-430h \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    stm32f030f4-demo \
+    #

--- a/tests/mtd_mapper/main.c
+++ b/tests/mtd_mapper/main.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       mtd_mapper module test
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <errno.h>
+#include <string.h>
+
+#include "embUnit.h"
+
+#include "mtd.h"
+#include "mtd_mapper.h"
+
+/* Test mock object implementing a simple RAM-based mtd */
+#ifndef SECTOR_COUNT
+#define SECTOR_COUNT 16
+#endif
+#ifndef PAGE_PER_SECTOR
+#define PAGE_PER_SECTOR 4
+#endif
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 64
+#endif
+
+#define MEMORY_SIZE         PAGE_SIZE * PAGE_PER_SECTOR * SECTOR_COUNT
+
+#define REGION_FLASH_SIZE    MEMORY_SIZE / 2
+
+static uint8_t _dummy_memory[MEMORY_SIZE];
+
+static uint8_t _buffer[PAGE_SIZE];
+
+static int _init(mtd_dev_t *dev)
+{
+    (void)dev;
+
+    return 0;
+}
+
+static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
+{
+    (void)dev;
+
+    if (addr + size > sizeof(_dummy_memory)) {
+        return -EOVERFLOW;
+    }
+    memcpy(buff, _dummy_memory + addr, size);
+
+    return size;
+}
+
+static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr,
+                  uint32_t size)
+{
+    (void)dev;
+
+    if (addr + size > sizeof(_dummy_memory)) {
+        return -EOVERFLOW;
+    }
+    if (size > PAGE_SIZE) {
+        return -EOVERFLOW;
+    }
+    memcpy(_dummy_memory + addr, buff, size);
+
+    return size;
+}
+
+static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
+{
+    (void)dev;
+
+    if (size % (PAGE_PER_SECTOR * PAGE_SIZE) != 0) {
+        return -EOVERFLOW;
+    }
+    if (addr % (PAGE_PER_SECTOR * PAGE_SIZE) != 0) {
+        return -EOVERFLOW;
+    }
+    if (addr + size > sizeof(_dummy_memory)) {
+        return -EOVERFLOW;
+    }
+    memset(_dummy_memory + addr, 0xff, size);
+
+    return 0;
+}
+
+static int _power(mtd_dev_t *dev, enum mtd_power_state power)
+{
+    (void)dev;
+    (void)power;
+    return 0;
+}
+
+static const mtd_desc_t driver = {
+    .init = _init,
+    .read = _read,
+    .write = _write,
+    .erase = _erase,
+    .power = _power,
+};
+
+static mtd_dev_t dev = {
+    .driver = &driver,
+    .sector_count = SECTOR_COUNT,
+    .pages_per_sector = PAGE_PER_SECTOR,
+    .page_size = PAGE_SIZE,
+};
+
+static mtd_mapper_parent_t _parent = MTD_PARENT_INIT(&dev);
+
+static mtd_mapper_region_t _region_a = {
+    .mtd = {
+        .driver = &mtd_mapper_driver,
+        .sector_count = SECTOR_COUNT / 2,
+        .pages_per_sector = PAGE_PER_SECTOR,
+        .page_size = PAGE_SIZE,
+    },
+    .parent = &_parent,
+    .offset = 0,
+};
+
+static mtd_mapper_region_t _region_b = {
+    .mtd = {
+        .driver = &mtd_mapper_driver,
+        .sector_count = SECTOR_COUNT / 2,
+        .pages_per_sector = PAGE_PER_SECTOR,
+        .page_size = PAGE_SIZE,
+    },
+    .parent = &_parent,
+    .offset = PAGE_PER_SECTOR * PAGE_SIZE * SECTOR_COUNT / 2,
+};
+
+static mtd_dev_t *_dev_a = &_region_a.mtd;
+static mtd_dev_t *_dev_b = &_region_b.mtd;
+
+static void _test_mem(uint8_t *buffer, size_t len, uint8_t expected)
+{
+    for (size_t i = 0; i < len; i++) {
+        TEST_ASSERT_EQUAL_INT(expected, buffer[i]);
+    }
+}
+
+static void test_mtd_init(void)
+{
+    int ret = mtd_init(_dev_a);
+
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    ret = mtd_init(_dev_b);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+static void test_mtd_erase(void)
+{
+    /* Erase first region */
+    int ret = mtd_erase(_dev_a, 0, REGION_FLASH_SIZE);
+
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    /* Erase second region */
+    ret = mtd_erase(_dev_b, 0, REGION_FLASH_SIZE);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    ret = mtd_erase(_dev_a, REGION_FLASH_SIZE, 1);
+    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+
+    ret = mtd_erase(_dev_b, REGION_FLASH_SIZE, 1);
+    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+}
+
+static void test_mtd_read(void)
+{
+    for (uint32_t i = 0; i < REGION_FLASH_SIZE; i += PAGE_SIZE) {
+        mtd_read(_dev_a, _buffer, i, PAGE_SIZE);
+        _test_mem(_buffer, PAGE_SIZE, 0xff);
+    }
+
+    for (uint32_t i = 0; i < REGION_FLASH_SIZE; i += PAGE_SIZE) {
+        mtd_read(_dev_b, _buffer, i, PAGE_SIZE);
+        _test_mem(_buffer, PAGE_SIZE, 0xff);
+    }
+}
+
+static void test_mtd_write(void)
+{
+    static const uint8_t test_val_a = 0xAA;
+
+    memset(_buffer, test_val_a, PAGE_SIZE);
+
+    /* Write first region */
+    for (uint32_t i = 0; i < REGION_FLASH_SIZE; i += PAGE_SIZE) {
+        mtd_write(_dev_a, _buffer, i, PAGE_SIZE);
+    }
+
+    /* Check second region, should still be 0xFF */
+    for (uint32_t i = 0; i < REGION_FLASH_SIZE; i += PAGE_SIZE) {
+        mtd_read(_dev_b, _buffer, i, PAGE_SIZE);
+        _test_mem(_buffer, PAGE_SIZE, 0xFF);
+    }
+
+    static const uint8_t test_val_b = 0xBB;
+    memset(_buffer, test_val_b, PAGE_SIZE);
+
+    /* Write second region */
+    for (uint32_t i = 0; i < REGION_FLASH_SIZE; i += PAGE_SIZE) {
+        mtd_write(_dev_b, _buffer, i, PAGE_SIZE);
+    }
+
+    /* Check second region after write, should now be 0xBB */
+    for (uint32_t i = 0; i < REGION_FLASH_SIZE; i += PAGE_SIZE) {
+        mtd_read(_dev_b, _buffer, i, PAGE_SIZE);
+        _test_mem(_buffer, PAGE_SIZE, 0xBB);
+    }
+
+    /* Check first region, should still be 0xAA */
+    for (uint32_t i = 0; i < REGION_FLASH_SIZE; i += PAGE_SIZE) {
+        mtd_read(_dev_a, _buffer, i, PAGE_SIZE);
+        _test_mem(_buffer, PAGE_SIZE, 0xAA);
+    }
+}
+
+Test *tests_mtd_mapper_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_mtd_init),
+        new_TestFixture(test_mtd_erase),
+        new_TestFixture(test_mtd_read),
+        new_TestFixture(test_mtd_write),
+    };
+
+    EMB_UNIT_TESTCALLER(mtd_flashpage_tests, NULL, NULL, fixtures);
+
+    return (Test *)&mtd_flashpage_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_mtd_mapper_tests());
+    TESTS_END();
+    return 0;
+}

--- a/tests/mtd_mapper/tests/01-run.py
+++ b/tests/mtd_mapper/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'OK \(\d+ tests\)')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This MTD module allows for remapping multiple different regions on a single 
MTD device and present them as separate MTD devices. This is similar to     
partitions on a hard drive, although this system only allows hardcoded      
partitions and lacks a partition table.

The use case for this module is to be able to split a single MTD device, for
example a SPI NOR flash chip into multiple separate regions which all can   
contain their own content or file systems.

### Testing procedure

- run the provided test
- check the generated docs


### Issues/PRs references

None
