### PR TITLE
boards/pinetime: add pyocd support

### DIFF
--- a/boards/pinetime/Makefile.include
+++ b/boards/pinetime/Makefile.include
@@ -2,5 +2,11 @@
 RIOT_TERMINAL ?= jlink
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# define pyocd as programmer to program with stlink
+ifeq (pyocd,$(PROGRAMMER))
+  export FLASH_TARGET_TYPE ?= -t $(CPU)
+  include $(RIOTMAKE)/tools/pyocd.inc.mk
+endif
+
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52/Makefile.include


### PR DESCRIPTION
### Contribution description

Adds a programmer option to the pinetime board definition. This way the pinetime can be programmed using the st link v2.

### Testing procedure

Can be used by adding `PROGRAMMER=pyocd` to your RIOT app.

Proceed with flashing the board as usual.