### PR TITLE
makefiles/boards.inc.mk: set RIOTBOARD [backport 2020.01]

### DIFF
--- a/makefiles/boards.inc.mk
+++ b/makefiles/boards.inc.mk
@@ -1,5 +1,6 @@
 # Default when RIOTBASE is not set and is executed from the RIOT directory
-BOARDSDIR ?= $(or $(RIOTBASE),$(CURDIR))/boards
+RIOTBOARD ?= $(or $(RIOTBASE),$(CURDIR))/boards
+BOARDSDIR ?= $(RIOTBOARD)
 
 # List all boards in a directory
 # By default, all directories in BOARDSDIR except 'common'

--- a/makefiles/boards.inc.mk
+++ b/makefiles/boards.inc.mk
@@ -12,8 +12,8 @@ ifneq ($(RIOTBOARD),$(BOARDSDIR))
   ALLBOARDS_RIOTBOARD ?= $(call _get_boards_in_directory,$(RIOTBOARD))
 endif
 
-# Get all boards
-ALLBOARDS ?= $(sort $(call _get_boards_in_directory,$(BOARDSDIR)) $(ALLBOARDS_RIOTBOARD))
+# Use `:=` so that it is evaluated before BOARDSDIR gets eventually changed
+ALLBOARDS := $(sort $(call _get_boards_in_directory,$(BOARDSDIR)) $(ALLBOARDS_RIOTBOARD))
 
 # Set the default value from `BOARDS`
 BOARDS ?= $(ALLBOARDS)


### PR DESCRIPTION
# Backport of #13198

### Contribution description

In #12972 I use `RIOTBOARD` as a backup for finding a `BOARD` that is not found in `BOARDSDIR`. This works fine except when called from `RIOTBASE` (there was even a comment on that... duh). Without this it will evaluate the other boards in `RIOTBOARD=""` so you will get `bin, boot, etc.`

### Testing procedure

pr

```
make info-boards
acd52832 airfy-beacon arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano arduino-uno arduino-zero atmega1284p atmega256rfr2-xpro atmega328p avr-rss2 avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib calliope-mini cc1312-launchpad cc1352-launchpad cc2538dk cc2650-launchpad cc2650stk chronos derfmega128 derfmega256 ek-lm4f120xl esp32-mh-et-live-minikit esp32-olimex-evb esp32-ttgo-t-beam esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing f4vi1 feather-m0 feather-nrf52840 firefly fox frdm-k22f frdm-k64f frdm-kw41z hamilton hifive1 hifive1b i-nucleo-lrwan1 ikea-tradfri iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lsn50 maple-mini mbed_lpc1768 mcb2388 mega-xplained microbit microduino-corerf msb-430 msb-430h msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 opencm904 openmote-b openmote-cc2538 p-l496g-cell02 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pic32-clicker pic32-wifire pinetime pyboard reel remote-pa remote-reva remote-revb ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeeduino_arch-pro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff spark-core stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery 
```

master
```
 make info-boards
acd52832 airfy-beacon arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano arduino-uno arduino-zero atmega1284p atmega256rfr2-xpro atmega328p avr-rss2 avsextrem b-l072z-lrwan1 b-l475e-iot01a bin blackpill blackpill-128kib bluepill bluepill-128kib boot calliope-mini cc1312-launchpad cc1352-launchpad cc2538dk cc2650-launchpad cc2650stk cdrom chronos derfmega128 derfmega256 dev ek-lm4f120xl esp32-mh-et-live-minikit esp32-olimex-evb esp32-ttgo-t-beam esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing etc f4vi1 feather-m0 feather-nrf52840 firefly fixtures fox frdm-k22f frdm-k64f frdm-kw41z hamilton hifive1 hifive1b home i-nucleo-lrwan1 ikea-tradfri iotlab-a8-m3 iotlab-m3 lib lib32 lib64 libx32 limifrog-v1 lobaro-lorabox lsn50 maple-mini mbed_lpc1768 mcb2388 media mega-xplained microbit microduino-corerf mnt msb-430 msb-430h msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 opencm904 openmote-b openmote-cc2538 opt p-l496g-cell02 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pic32-clicker pic32-wifire pinetime proc pyboard reel remote-pa remote-reva remote-revb run ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro sbin seeeduino_arch-pro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a snap sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff spark-core srv stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f723e-disco stm32f769i-disco stm32l0538-disco stm32l476g-disco sys teensy31 telosb thingy52 tmp ublox-c030-u201 udoo usb-kw41z usr var waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1

```
