### PR TITLE
gcoap: Use random factor for timeout range

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -198,22 +198,6 @@ extern "C" {
 #define COAP_RANDOM_FACTOR_1000      (1500)
 #endif
 
-/**
- * @brief   Approximation for maximum variation for confirmable timeout
- *
- * Must be an integer, defined as:
- *
- *     (COAP_ACK_TIMEOUT * COAP_RANDOM_FACTOR) - COAP_ACK_TIMEOUT
- *
- * Like @ref COAP_ACK_TIMEOUT, this value is valid for the initial confirmable
- * message, and doubles for subsequent retries.
- *
- * This parameter is nanocoap-specific, and is not defined in RFC 7252.
- */
-#ifndef COAP_ACK_VARIANCE
-#define COAP_ACK_VARIANCE       (1U)
-#endif
-
 /** @brief   Maximum number of retransmissions for a confirmable request */
 #ifndef COAP_MAX_RETRANSMIT
 #define COAP_MAX_RETRANSMIT     (4)

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -178,15 +178,24 @@ extern "C" {
  * This value is for the response to the *initial* confirmable message. The
  * timeout doubles for subsequent retries. To avoid synchronization of resends
  * across hosts, the actual timeout is chosen randomly between
- * @ref COAP_ACK_TIMEOUT and (@ref COAP_ACK_TIMEOUT * @ref COAP_RANDOM_FACTOR).
+ * @ref COAP_ACK_TIMEOUT and
+ * (@ref COAP_ACK_TIMEOUT * @ref COAP_RANDOM_FACTOR_1000 / 1000).
  */
 #ifndef COAP_ACK_TIMEOUT
 #define COAP_ACK_TIMEOUT        (2U)
 #endif
 
-/** @brief   Used to calculate upper bound for timeout; see @ref COAP_ACK_TIMEOUT */
-#ifndef COAP_RANDOM_FACTOR
-#define COAP_RANDOM_FACTOR      (1.5)
+/**
+ * @brief   Used to calculate upper bound for timeout
+ *
+ * This represents the `ACK_RANDOM_FACTOR`
+ * ([RFC 7252, section 4.2](https://tools.ietf.org/html/rfc7252#section-4.2))
+ * multiplied by 1000, to avoid floating point arithmetic.
+ *
+ * See @ref COAP_ACK_TIMEOUT
+ */
+#ifndef COAP_RANDOM_FACTOR_1000
+#define COAP_RANDOM_FACTOR_1000      (1500)
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description
[RFC 7252](https://tools.ietf.org/html/rfc7252#section-4.2) specifies the usage of factor (`ACK_RANDOM_FACTOR`) to determine the range from where to pick a random value for timeouts. 

Currently we define `COAP_RANDOM_FACTOR` for this but we don't use it. We use `COAP_ACK_VARIANCE` which by documentation establishes the constraint of:
```
(COAP_ACK_TIMEOUT * COAP_RANDOM_FACTOR) - COAP_ACK_TIMEOUT
```
This PR modifies the factor representation so it is an integer, and uses this value to calculate the range for the random timeout.

### Testing procedure
- `examples/gcoap` should work as usual. You should test that the range for timeouts of retries remains the same.

My results are:
- Whit this PR:
```
> coap get -c fd00:bbbb::1 5683 /time
coap get -c fd00:bbbb::1 5683 /time
gcoap_cli: sending msg ID 59101, 11 bytes
timeout range: [2000000 - 3000000]
gcoap: udp recv failure: -22
> timeout range: [4000000 - 6000000]
timeout range: [8000000 - 12000000]
timeout range: [16000000 - 24000000]
timeout range: [32000000 - 48000000]
coap: received timeout message
gcoap: timeout for msg ID 59101
```
- On Master:
```
> coap get -c fd00:bbbb::1 5683 /time
coap get -c fd00:bbbb::1 5683 /time
gcoap_cli: sending msg ID 18368, 11 bytes
timeout range: [2000000 - 3000000]
gcoap: udp recv failure: -22
> timeout range: [4000000 - 6000000]
timeout range: [8000000 - 12000000]
timeout range: [16000000 - 24000000]
timeout range: [32000000 - 48000000]
coap: received timeout message
gcoap: timeout for msg ID 18368
```
### Issues/PRs references
None