### PR TITLE
net/coap: Packet API function to add Uri-Query option

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -142,11 +142,9 @@ extern "C" {
 #define NANOCOAP_BLOCK_SIZE_EXP_MAX  (6)
 #endif
 
-#if defined(MODULE_GCOAP) || defined(DOXYGEN)
 /** @brief   Maximum length of a query string written to a message */
 #ifndef NANOCOAP_QS_MAX
 #define NANOCOAP_QS_MAX             (64)
-#endif
 #endif
 /** @} */
 
@@ -963,6 +961,20 @@ static inline ssize_t coap_opt_add_format(coap_pkt_t *pkt, uint16_t format)
  * @return        -ENOSPC if no available options
  */
 ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val, size_t val_len);
+
+/**
+ * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
+ *
+ * @param[in,out] pkt         The package that is being build
+ * @param[in]     key         Key to add to the query string
+ * @param[in]     val         Value to assign to @p key (may be NULL)
+ *
+ * @pre     ((pkt != NULL) && (key != NULL))
+ *
+ * @return  overall length of new query string
+ * @return  -1 on error
+ */
+ssize_t coap_opt_add_uquery(coap_pkt_t *pkt, const char *key, const char *val);
 
 /**
  * @brief   Encode the given string as option(s) into pkt

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -846,6 +846,29 @@ ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string
     return write_len;
 }
 
+ssize_t coap_opt_add_uquery(coap_pkt_t *pdu, const char *key, const char *val)
+{
+    char qs[NANOCOAP_QS_MAX];
+    size_t len = strlen(key);
+    size_t val_len = (val) ? (strlen(val) + 1) : 0;
+
+    /* test if the query string fits, account for the zero termination */
+    if ((len + val_len + 1) >= NANOCOAP_QS_MAX) {
+        return -1;
+    }
+
+    memcpy(&qs[0], key, len);
+    if (val) {
+        qs[len] = '=';
+        /* the `=` character was already counted in `val_len`, so subtract it here */
+        memcpy(&qs[len + 1], val, (val_len - 1));
+        len += val_len;
+    }
+    qs[len] = '\0';
+
+    return coap_opt_add_string(pdu, COAP_OPT_URI_QUERY, qs, '&');
+}
+
 ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val, size_t val_len)
 {
     return _add_opt_pkt(pkt, optnum, val, val_len);

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -177,38 +177,6 @@ static void test_gcoap__client_put_req_overfill(void)
 }
 
 /*
- * Builds on get_req test, to test gcoap_add_qstring() to add Uri-Query
- * options.
- */
-static void test_gcoap__client_get_query(void)
-{
-    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
-    coap_pkt_t pdu;
-    char path[] = "/time";
-    char key1[] = "ab";
-    char val1[] = "cde";
-    char key2[] = "f";
-    char expected[] = "ab=cde&f";
-    int optlen;
-
-    gcoap_req_init(&pdu, buf, CONFIG_GCOAP_PDU_BUF_SIZE, COAP_METHOD_GET, path);
-
-    optlen = gcoap_add_qstring(&pdu, key1, val1);
-    TEST_ASSERT_EQUAL_INT(7, optlen);
-    optlen = gcoap_add_qstring(&pdu, key2, NULL);
-    TEST_ASSERT_EQUAL_INT(2, optlen);
-
-    size_t len = coap_opt_finish(&pdu, COAP_OPT_FINISH_NONE);
-
-    coap_parse(&pdu, buf, len);
-
-    char query[20] = {0};
-    coap_get_uri_query(&pdu, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
-    TEST_ASSERT_EQUAL_STRING(&expected[0], &query[1]);
-}
-
-/*
  * Builds on get_req test, to test use of NULL path with gcoap_req_init().
  * Then separately add Uri-Path option later.
  */
@@ -402,7 +370,6 @@ Test *tests_gcoap_tests(void)
         new_TestFixture(test_gcoap__client_get_resp),
         new_TestFixture(test_gcoap__client_put_req),
         new_TestFixture(test_gcoap__client_put_req_overfill),
-        new_TestFixture(test_gcoap__client_get_query),
         new_TestFixture(test_gcoap__client_get_path_defer),
         new_TestFixture(test_gcoap__server_get_req),
         new_TestFixture(test_gcoap__server_get_resp),

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -306,8 +306,10 @@ static void test_nanocoap__get_multi_query(void)
     coap_pkt_t pkt;
     uint16_t msgid = 0xABCD;
     uint8_t token[2] = {0xDA, 0xEC};
-    char qs[] = "ab=cde&f=gh";
-    size_t query_opt_len = 13;    /* first opt header is 2 bytes long */
+    char key1[] = "ab";
+    char val1[] = "cde";
+    char key2[] = "f";
+    char qs[] = "ab=cde&f";
 
     size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
                                 &token[0], 2, COAP_METHOD_GET, msgid);
@@ -315,8 +317,11 @@ static void test_nanocoap__get_multi_query(void)
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
 
     uint8_t *query_pos = &pkt.payload[0];
-    len = coap_opt_add_string(&pkt, COAP_OPT_URI_QUERY, &qs[0], '&');
-    TEST_ASSERT_EQUAL_INT(query_opt_len, len);
+    /* first opt header is 2 bytes long */
+    ssize_t optlen = coap_opt_add_uquery(&pkt, key1, val1);
+    TEST_ASSERT_EQUAL_INT(8, optlen);
+    optlen = coap_opt_add_uquery(&pkt, key2, NULL);
+    TEST_ASSERT_EQUAL_INT(2, optlen);
 
     char query[20] = {0};
     coap_get_uri_query(&pkt, (uint8_t *)&query[0]);


### PR DESCRIPTION
# Contribution description
#9309 is a tracking issue for the migration of CoAP Option functionality to the nanocoap Packet API. The last remaining function for the migration is `gcoap_add_qstring()`. This PR adds `coap_opt_add_uquery()` to nanocoap, renamed to be more descriptive and conform to the Packet API naming convention. We plan to create a follow-on PR to migrate existing uses and deprecate `gcoap_add_qstring()`.

### Testing procedure
Build the documentation to ensure the new function appears as part of the Options Write Packet API section of the nanocoap documentation. Also run the gcoap unit tests.

### Issues/PRs references
Part of #9309.