### PR TITLE
Makefile.include: remove support for make <4

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,10 +1,9 @@
 MATCH_MAKE_VERSION = 4.%
 
 ifeq (,$(filter $(MATCH_MAKE_VERSION),$(MAKE_VERSION)))
-  $(warning GNU Make $(MAKE_VERSION) is DEPRECATED in RIOT. Support for \
-	    versions less than $(MATCH_MAKE_VERSION) will be removed in \
-	    release 2020.01. Please upgrade your system to use GNU Make \
-	    $(MATCH_MAKE_VERSION) or later.)
+  $(error GNU Make $(MAKE_VERSION) is not supported by RIOT since release \
+      2020.01. Please upgrade your system to use GNU Make \
+      $(MATCH_MAKE_VERSION) or later.)
 endif
 
 # 'Makefile.include' directory, must be evaluated before other 'include'


### PR DESCRIPTION
### Contribution description

This PR makes effective the removal of  #10554 by turning the warning into an error.

The removal was due by this release, should I back-port this change or should it just be merged in master so that know we effectively do not support it? In this case it was said it would be removed **in** the release, and not after as is the case for other deprecation warnings.

BTW: sorry for missing this.

### Testing procedure

```MAKE_VERSION=3.0 make -C examples/hello-world/```
```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/examples/hello-world/../../Makefile.include:4: *** GNU Make 3.0 is DEPRECATED in RIOT since release 2020.01. Please upgrade your system to use GNU Make 4.% or later..  Stop.
make: Leaving directory '/home/francisco/workspace/RIOT/examples/hello-world
```
