### PR TITLE
netdev_ieeee802154: introduce ops and expose hardware address filter

### DIFF
--- a/cpu/cc2538/include/cc2538_rf_netdev.h
+++ b/cpu/cc2538/include/cc2538_rf_netdev.h
@@ -31,6 +31,11 @@ extern "C" {
  */
 extern const netdev_driver_t cc2538_rf_driver;
 
+/**
+ * @brief   Reference to the netdev_ieee802154 ops struct
+ */
+extern const netdev_ieee802154_ops_t cc2538_ieee802154_ops;
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -175,6 +175,7 @@ void cc2538_setup(cc2538_rf_t *dev)
     netdev_t *netdev = (netdev_t *)dev;
 
     netdev->driver = &cc2538_rf_driver;
+    dev->netdev.ops = &cc2538_ieee802154_ops;
 
     cc2538_init();
 }

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -36,6 +36,7 @@
 #include "debug.h"
 
 static const netdev_driver_t nrf802154_netdev_driver;
+static const netdev_ieee802154_ops_t nrf802154_ieee802154_ops;
 
 netdev_ieee802154_t nrf802154_dev = {
     {
@@ -54,7 +55,8 @@ netdev_ieee802154_t nrf802154_dev = {
     .short_addr = { 0, 0 },
     .long_addr = { 0, 0, 0, 0, 0, 0, 0, 0 },
     .chan = IEEE802154_DEFAULT_CHANNEL,
-    .flags = 0
+    .flags = 0,
+    .ops = &nrf802154_ieee802154_ops,
 };
 
 static uint8_t rxbuf[IEEE802154_FRAME_LEN_MAX + 3]; /* len PHR + PSDU + LQI */

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -42,6 +42,7 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
     netdev_t *netdev = (netdev_t *)dev;
 
     netdev->driver = &at86rf2xx_driver;
+    dev->netdev.ops = &at86rf2xx_ieee802154_ops;
     /* State to return after receiving or transmitting */
     dev->idle_state = AT86RF2XX_STATE_TRX_OFF;
     /* radio state is P_ON when first powered-on */

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -31,7 +31,7 @@
 #include "at86rf2xx_registers.h"
 #include "periph/spi.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG (1)
 #include "debug.h"
 
 #ifdef MODULE_AT86RF212B
@@ -132,38 +132,21 @@ static const uint8_t dbm_to_rx_sens[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                           0x0d, 0x0e, 0x0e, 0x0e, 0x0f };
 #endif
 
-void at86rf2xx_get_addr_short(const at86rf2xx_t *dev, network_uint16_t *addr)
-{
-    memcpy(addr, dev->netdev.short_addr, sizeof(*addr));
-}
-
 void at86rf2xx_set_addr_short(at86rf2xx_t *dev, const network_uint16_t *addr)
 {
-    memcpy(dev->netdev.short_addr, addr, sizeof(*addr));
-#ifdef MODULE_SIXLOWPAN
-    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
-     * 0 for unicast addresses */
-    dev->netdev.short_addr[0] &= 0x7F;
-#endif
     /* device use lsb first, not network byte order */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_0,
-                        dev->netdev.short_addr[1]);
+                        addr->u8[1]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_1,
-                        dev->netdev.short_addr[0]);
-}
-
-void at86rf2xx_get_addr_long(const at86rf2xx_t *dev, eui64_t *addr)
-{
-    memcpy(addr, dev->netdev.long_addr, sizeof(*addr));
+                        addr->u8[0]);
 }
 
 void at86rf2xx_set_addr_long(at86rf2xx_t *dev, const eui64_t *addr)
 {
-    memcpy(dev->netdev.long_addr, addr, sizeof(*addr));
     for (int i = 0; i < 8; i++) {
         /* device use lsb first, not network byte order */
         at86rf2xx_reg_write(dev, (AT86RF2XX_REG__IEEE_ADDR_0 + i),
-                dev->netdev.long_addr[IEEE802154_LONG_ADDRESS_LEN - 1 - i]);
+                addr->uint8[IEEE802154_LONG_ADDRESS_LEN - 1 - i]);
     }
 }
 
@@ -208,11 +191,6 @@ void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page)
     (void) dev;
     (void) page;
 #endif
-}
-
-uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev)
-{
-    return dev->netdev.pan;
 }
 
 void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan)

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -49,7 +49,7 @@ static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len);
 static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
-static void _set_addr_filter(void *dev, network_uint16_t *short_addr,
+static void _set_addr_filter(netdev_ieee802154_t *dev, network_uint16_t *short_addr,
                                eui64_t *ext_addr, uint16_t panid);
 
 const netdev_driver_t at86rf2xx_driver = {

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -300,6 +300,13 @@ netopt_state_t _get_state(at86rf2xx_t *dev)
     }
 }
 
+static inline void _set_addr_filter(at86rf2xx_t *dev, const ieee802154_addr_filter_params_t *filter)
+{
+    at86rf2xx_set_addr_short(dev, filter->short_addr);
+    at86rf2xx_set_addr_long(dev, filter->ext_addr);
+    at86rf2xx_set_pan(dev, filter->panid);
+}
+
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
     at86rf2xx_t *dev = (at86rf2xx_t *) netdev;
@@ -310,6 +317,10 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
     /* getting these options doesn't require the transceiver to be responsive */
     switch (opt) {
+        case NETOPT_AFILTER:
+            /* we just need something different to -ENOTSUP */
+            return 0;
+
         case NETOPT_CHANNEL_PAGE:
             assert(max_len >= sizeof(uint16_t));
             ((uint8_t *)val)[1] = 0;
@@ -454,6 +465,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     at86rf2xx_t *dev = (at86rf2xx_t *) netdev;
     uint8_t old_state = at86rf2xx_get_status(dev);
     int res = -ENOTSUP;
+    const ieee802154_addr_filter_params_t *filter;
 
     if (dev == NULL) {
         return -ENODEV;
@@ -468,20 +480,10 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     }
 
     switch (opt) {
-        case NETOPT_ADDRESS:
-            assert(len >= sizeof(network_uint16_t));
-            at86rf2xx_set_addr_short(dev, val);
-            /* don't set res to set netdev_ieee802154_t::short_addr */
-            break;
-        case NETOPT_ADDRESS_LONG:
-            assert(len >= sizeof(eui64_t));
-            at86rf2xx_set_addr_long(dev, val);
-            /* don't set res to set netdev_ieee802154_t::long_addr */
-            break;
-        case NETOPT_NID:
-            assert(len <= sizeof(uint16_t));
-            at86rf2xx_set_pan(dev, *((const uint16_t *)val));
-            /* don't set res to set netdev_ieee802154_t::pan */
+        case NETOPT_AFILTER:
+            filter = val;
+            _set_addr_filter(dev, filter);
+            res = sizeof(ieee802154_addr_filter_params_t);
             break;
         case NETOPT_CHANNEL:
             assert(len == sizeof(uint16_t));

--- a/drivers/at86rf2xx/include/at86rf2xx_netdev.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_netdev.h
@@ -30,6 +30,11 @@ extern "C" {
  */
 extern const netdev_driver_t at86rf2xx_driver;
 
+/**
+ * @brief   Reference to the netdev_ieee802154 ops struct
+ */
+extern const netdev_ieee802154_ops_t at86rf2xx_ieee802154_ops;
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -37,6 +37,7 @@ void cc2420_setup(cc2420_t * dev, const cc2420_params_t *params)
 {
     /* set pointer to the devices netdev functions */
     dev->netdev.netdev.driver = &cc2420_driver;
+    dev->netdev.ops = &cc2420_ieee802154_ops;
     /* pull in device configuration parameters */
     dev->params = *params;
     dev->state = CC2420_STATE_IDLE;

--- a/drivers/cc2420/cc2420_getset.c
+++ b/drivers/cc2420/cc2420_getset.c
@@ -70,25 +70,12 @@ void cc2420_set_addr_short(cc2420_t *dev, const uint8_t *addr)
     tmp[0] = addr[1];
     tmp[1] = addr[0];
 
-    memcpy(dev->netdev.short_addr, addr, 2);
-
-#ifdef MODULE_SIXLOWPAN
-    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
-     * 0 for unicast addresses */
-    dev->netdev.short_addr[0] &= 0x7F;
-#endif
-
     cc2420_ram_write(dev, CC2420_RAM_SHORTADR, tmp, 2);
 }
 
 void cc2420_get_addr_long(cc2420_t *dev, uint8_t *addr)
 {
     cc2420_ram_read(dev, CC2420_RAM_IEEEADR, addr, 8);
-
-    uint8_t *ap = (uint8_t *)(&addr);
-    for (int i = 0; i < 8; i++) {
-        ap[i] = dev->netdev.long_addr[i];
-    }
 }
 
 void cc2420_set_addr_long(cc2420_t *dev, const uint8_t *addr)
@@ -97,7 +84,6 @@ void cc2420_set_addr_long(cc2420_t *dev, const uint8_t *addr)
     uint8_t tmp[8];
 
     for (i = 0, j = 7; i < 8; i++, j--) {
-        dev->netdev.long_addr[i] = addr[i];
         tmp[j] = addr[i];
     }
 

--- a/drivers/cc2420/include/cc2420_netdev.h
+++ b/drivers/cc2420/include/cc2420_netdev.h
@@ -33,6 +33,11 @@ extern "C" {
  */
 extern const netdev_driver_t cc2420_driver;
 
+/**
+ * @brief   Reference to the netdev_ieee802154 ops struct
+ */
+const netdev_ieee802154_ops_t cc2420_ieee802154_ops;
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -133,6 +133,7 @@ struct netdev_ieee802154_ops {
      * @brief Set IEEE addresses to the hardware accelerator of an
      * network device
      *
+     * @pre (short_addr != NULL), (ext_addr != NULL)
      * @note Set to NULL if the device doesn't support address filtering.
      *
      * @param[in] dev           network device descriptor

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -121,7 +121,7 @@ typedef struct {
     uint8_t page;                           /**< channel page */
     uint16_t flags;                         /**< flags as defined above */
     int16_t txpower;                        /**< tx power in dBm */
-    const netdev_ieee802154_ops_t *ops;     /**< IEEE802.15.4 device ops */
+    const netdev_ieee802154_ops_t *ops;     /**< IEEE802.15.4 device ops. Must be set */
     /** @} */
 } netdev_ieee802154_t;
 

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -20,6 +20,7 @@
 #ifndef NET_NETDEV_IEEE802154_H
 #define NET_NETDEV_IEEE802154_H
 
+#include <stdbool.h>
 #include "net/ieee802154.h"
 #include "net/gnrc/nettype.h"
 #include "net/netopt.h"
@@ -118,10 +119,49 @@ typedef struct {
     /** @} */
 } netdev_ieee802154_t;
 
+
 /**
  * @brief   Received packet status information for IEEE 802.15.4 radios
  */
 typedef struct netdev_radio_rx_info netdev_ieee802154_rx_info_t;
+
+/**
+ * @brief Check whether a @ref netdev_ieee802154_t device has hardware address
+ *        filter support
+ *
+ * @param[in] dev       network device descriptor
+ *
+ * @return              true if the device supports address filtering
+ */
+static inline bool netdev_ieee802154_has_addr_filter(netdev_ieee802154_t *dev)
+{
+    netdev_t *netdev = (netdev_t*) dev;
+    return netdev->driver->get(netdev, NETOPT_AFILTER, NULL, 0) == 0;
+}
+
+/**
+ * @brief Configure hardware address filter in a given network device
+ *
+ * @param[i] dev        network device descriptor
+ * @param[i] short_addr IEEE802.15.4 short address
+ * @param[i] ext_addr   IEEE802.15.4 extended address
+ * @param[i] panid      IEEE802.15.4 PAN-ID
+ *
+ * @return              0 on success
+ * @return              -ENOTSUP if the device doesn't support address filtering.
+ */
+static inline int netdev_ieee802154_set_addr_filter(netdev_ieee802154_t *dev, network_uint16_t *short_addr, eui64_t *ext_addr, uint16_t panid)
+{
+    netdev_t *netdev = (netdev_t*) dev;
+
+    ieee802154_addr_filter_params_t filter = {
+        .short_addr = short_addr,
+        .ext_addr = ext_addr,
+        .panid = panid
+    };
+
+    return netdev->driver->set(netdev, NETOPT_AFILTER, &filter, sizeof(filter));
+}
 
 /**
  * @brief   Reset function for ieee802154 common fields

--- a/drivers/kw2xrf/include/kw2xrf_netdev.h
+++ b/drivers/kw2xrf/include/kw2xrf_netdev.h
@@ -28,6 +28,11 @@ extern "C" {
  */
 extern const netdev_driver_t kw2xrf_driver;
 
+/**
+ * @brief   Reference to the netdev_ieee802154 ops struct
+ */
+extern const netdev_ieee802154_ops_t kw2xrf_ieee802154_ops;
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -59,6 +59,7 @@ void kw2xrf_setup(kw2xrf_t *dev, const kw2xrf_params_t *params)
     netdev_t *netdev = (netdev_t *)dev;
 
     netdev->driver = &kw2xrf_driver;
+    dev->netdev.ops = &kw2xrf_ieee802154_ops;
     /* initialize device descriptor */
     dev->params = *params;
     dev->idle_state = XCVSEQ_RECEIVE;

--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -266,11 +266,6 @@ void kw2xrf_set_addr_short(kw2xrf_t *dev, uint16_t addr)
     uint8_t val_ar[2];
     val_ar[0] = (addr >> 8);
     val_ar[1] = (uint8_t)addr;
-#ifdef MODULE_SIXLOWPAN
-    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
-     * 0 for unicast addresses */
-    val_ar[0] &= 0x7F;
-#endif
     kw2xrf_write_iregs(dev, MKW2XDMI_MACSHORTADDRS0_LSB, val_ar,
                        IEEE802154_SHORT_ADDRESS_LEN);
 }

--- a/drivers/mrf24j40/include/mrf24j40_netdev.h
+++ b/drivers/mrf24j40/include/mrf24j40_netdev.h
@@ -32,6 +32,11 @@ extern "C" {
  */
 extern const netdev_driver_t mrf24j40_driver;
 
+/**
+ * @brief   Reference to the netdev_ieee802154 ops struct
+ */
+const netdev_ieee802154_ops_t mrf24j40_ieee802154_ops;
+
 
 #ifdef __cplusplus
 }

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -36,6 +36,7 @@ void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params)
     netdev_t *netdev = (netdev_t *)dev;
 
     netdev->driver = &mrf24j40_driver;
+    dev->netdev.ops = &mrf24j40_ieee802154_ops;
     /* initialize device descriptor */
     dev->params = *params;
 }

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -135,12 +135,6 @@ void mrf24j40_set_addr_short(mrf24j40_t *dev, uint16_t addr)
     network_uint16_t naddr;
     naddr.u16 = addr;
 
-#ifdef MODULE_SIXLOWPAN
-    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
-     * 0 for unicast addresses */
-    naddr.u8[0] &= 0x7F;
-#endif
-
     mrf24j40_reg_write_short(dev, MRF24J40_REG_SADRL,
                              naddr.u8[1]);
     mrf24j40_reg_write_short(dev, MRF24J40_REG_SADRH,
@@ -248,11 +242,6 @@ void mrf24j40_set_chan(mrf24j40_t *dev, uint8_t channel)
      * the RF State Machine Reset, to allow the RF circuitry to calibrate.
      */
     mrf24j40_reset_state_machine(dev);
-}
-
-uint16_t mrf24j40_get_pan(mrf24j40_t *dev)
-{
-    return dev->netdev.pan;
 }
 
 void mrf24j40_set_pan(mrf24j40_t *dev, uint16_t pan)

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -170,11 +170,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
     int res;
     switch (opt) {
-        case NETOPT_AFILTER:
-            /* we just need something different to -ENOTSUP */
-            res = 0;
-            break;
-
         case NETOPT_CHANNEL_PAGE:
             if (max_len < sizeof(uint16_t)) {
                 res = -EOVERFLOW;
@@ -347,11 +342,12 @@ static int _set_state(mrf24j40_t *dev, netopt_state_t state)
     return sizeof(netopt_state_t);
 }
 
-static inline void _set_addr_filter(mrf24j40_t *dev, const ieee802154_addr_filter_params_t* filter)
+static void _set_addr_filter(netdev_ieee802154_t *dev, network_uint16_t *short_addr,
+                               eui64_t *ext_addr, uint16_t panid)
 {
-    mrf24j40_set_addr_short(dev, *((const uint16_t *) filter->short_addr));
-    mrf24j40_set_addr_long(dev, *((const uint64_t *) filter->ext_addr));
-    mrf24j40_set_pan(dev, filter->panid );
+    mrf24j40_set_addr_short((mrf24j40_t *)dev, *((const uint16_t *) short_addr));
+    mrf24j40_set_addr_long((mrf24j40_t *)dev, *((const uint64_t *) ext_addr));
+    mrf24j40_set_pan((mrf24j40_t *)dev, panid);
 }
 
 static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
@@ -364,12 +360,6 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     }
 
     switch (opt) {
-        case NETOPT_AFILTER:
-            assert(len == sizeof(ieee802154_addr_filter_params_t));
-            _set_addr_filter(dev, val);
-            res = sizeof(ieee802154_addr_filter_params_t);
-            break;
-
         case NETOPT_CHANNEL:
             if (len != sizeof(uint16_t)) {
                 res = -EINVAL;
@@ -555,4 +545,8 @@ const netdev_driver_t mrf24j40_driver = {
     .isr = _isr,
     .get = _get,
     .set = _set,
+};
+
+const netdev_ieee802154_ops_t mrf24j40_ieee802154_ops = {
+    .set_hw_addr = _set_addr_filter
 };

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -185,6 +185,11 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *va
             assert(len <= sizeof(dev->short_addr));
             memset(dev->short_addr, 0, sizeof(dev->short_addr));
             memcpy(dev->short_addr, value, len);
+#ifdef MODULE_SIXLOWPAN
+            /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
+             * 0 for unicast addresses */
+            dev->short_addr[0] &= 0x7F;
+#endif
             res = sizeof(dev->short_addr);
             break;
         case NETOPT_ADDRESS_LONG:

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -190,12 +190,15 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *va
              * 0 for unicast addresses */
             dev->short_addr[0] &= 0x7F;
 #endif
+
+            netdev_ieee802154_set_addr_filter(dev, (network_uint16_t*) dev->short_addr, (eui64_t*) dev->long_addr, dev->pan);
             res = sizeof(dev->short_addr);
             break;
         case NETOPT_ADDRESS_LONG:
             assert(len <= sizeof(dev->long_addr));
             memset(dev->long_addr, 0, sizeof(dev->long_addr));
             memcpy(dev->long_addr, value, len);
+            netdev_ieee802154_set_addr_filter(dev, (network_uint16_t*) dev->short_addr, (eui64_t*) dev->long_addr, dev->pan);
             res = sizeof(dev->long_addr);
             break;
         case NETOPT_ADDR_LEN:
@@ -217,6 +220,7 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *va
         case NETOPT_NID:
             assert(len == sizeof(dev->pan));
             dev->pan = *((uint16_t *)value);
+            netdev_ieee802154_set_addr_filter(dev, (network_uint16_t*) dev->short_addr, (eui64_t*) dev->long_addr, dev->pan);
             res = sizeof(dev->pan);
             break;
         case NETOPT_ACK_REQ:

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -165,6 +165,15 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
 /** @} */
 
 /**
+ * @brief IEEE802.15.4 hardware address filter parameters
+ */
+typedef struct {
+    network_uint16_t *short_addr;       /**< IEEE802.15.4 short address */
+    eui64_t *ext_addr;                  /**< IEEE802.15.4 extended address */
+    uint16_t panid;                     /**< IEEE802.15.4 PAN-ID */
+} ieee802154_addr_filter_params_t;
+
+/**
  * @brief   Initializes an IEEE 802.15.4 MAC frame header in @p buf.
  *
  * @pre Resulting header must fit in memory allocated at @p buf.

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -694,6 +694,17 @@ typedef enum {
     NETOPT_LINK_CHECK,
 
     /**
+     * @brief (bool, ieee802154_addr_filter_params_t) Configure or check support
+     *        for hardware address filter
+     *
+     * When get, the network device should return 0 or -ENOTSUP (if the device
+     * doesn't support source address filtering)
+     * When set, it sets all L2 addresses from @ref ieee802154_addr_filter_params_t
+     * in the address filter of the network device
+     */
+    NETOPT_AFILTER,
+
+    /**
      * @brief   maximum number of options defined here.
      *
      * @note    Interfaces are not meant to respond to this option

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -694,17 +694,6 @@ typedef enum {
     NETOPT_LINK_CHECK,
 
     /**
-     * @brief (bool, ieee802154_addr_filter_params_t) Configure or check support
-     *        for hardware address filter
-     *
-     * When get, the network device should return 0 or -ENOTSUP (if the device
-     * doesn't support source address filtering)
-     * When set, it sets all L2 addresses from @ref ieee802154_addr_filter_params_t
-     * in the address filter of the network device
-     */
-    NETOPT_AFILTER,
-
-    /**
      * @brief   maximum number of options defined here.
      *
      * @note    Interfaces are not meant to respond to this option


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
EDIT: I decided to change a bit the direction of the PR. I'm introducing 2 features at one now.

### IEEE802.15.4 ops
Following the direction of the lower layer rework #12688 and having technology specific HAL, PHY and MAC layers, this PR introduces a `netdev_ieee802154_ops_t` structure that holds typical operations of IEEE802.15.4 network devices.

These ops are implemented in the drivers and should contain the minimal set of instruction in order to perform the task (e.g a "set_channel" ops shouldn't verify if a channel is valid, only set it in the device).
I'm adding here the first op (`set_hw_addr`), explained below.

In the long term, ieee802154 radios should be operated with the `netdev_ieee802154_t` in order to unify (sub) MAC tasks (CSMA, retransmissions, energy scan, etc).

Regarding the decision of  vtables (function pointers) vs switch-case, the binary is smaller in ROM if the operation is triggered (at least on Cortex-M0+):

Using the NETOPT_AFILTER in get() and set():
```
  text	  data	   bss	   dec	   hex
  24696	   504	  4548	 29748	  7434	
```
Using the ops approach:
```
  text	  data	   bss	   dec	   hex
  24684	   504	  4552	 29740	  742c
```
You can compare the latest commit (https://github.com/RIOT-OS/RIOT/pull/13220/commits/5955d990094596134eae26da7885616e9d8738fa) with the initial implementation (https://github.com/RIOT-OS/RIOT/pull/13220/commits/fb258d1160a4a6c721e1eb8347ebeec315278980)

### Hardware address filtering
Strictly speaking, a radio is not aware of an address (extended, short, panid) unless it supports hardware address filtering. This PR adds some helpers to directly access the hardware address filter of IEEE802.15.4 devices and moves the address set logic to `netdev_ieee802154`.

In current master the process of setting an address goes like this:
1. dev->driver-set with NETOPT_ADDRESS, NETOPT_ADDRESS_LONG or NETOPT_NID
2. Device sets address in hardware accelerator
3. Device calls the SubMAC component (`netdev_ieee802154`) in order to set address variables

With this PR:
1. netdev_ieee802154_set with NETOPT_ADDRESS, NETOPT_ADDRESS_LONG or NETOPT_NID
2. SubMAC (`netdev_ieee802154`) set address variables
3. If the underlying device supports address filtering, set the address there.

I removed all address entries from the IEEE802.15.4 network devices (NETOPT_ADDRESS, NETOPT_ADDRESS_LONG or NETOPT_NID) and implements the `netdev_ieee802154_ops->set_hw_addr` function in devices that support address filtering. For compatibility reasons, calling dev->driver->set with any of the address NETOPTs still work. However, I'm trying to remove the network devices dependency with `netdev_ieee802154`.

Also:
- I removed all dependencies to `netdev_ieee802154` address fields from network devices.
- The CC2420 getter was broken anyway, so this one should fix it
- The sixlowpan bit in short addresses was only being set in network devices, not in the SubMAC (`netdev_ieee802154`). So I suspect some radio were not setting it (e.g `nrf802154`)


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
List of radios:
- [ ] at86rf2xx
- [ ] cc2420
- [ ] mrf24j40
- [ ] cc2538
- [ ] nrf802154
- [ ] kw2xrf

- Check documentation with `make doc`
- Check that all radios can send and receive data right after boot
- Check that all radios can send and receive data after setting short address, long address and PANID

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
