### PR TITLE
makefiles/dependencies_debug.inc.mk: add DEPENDENCY_DEBUG_SORT_VARS

### DIFF
--- a/makefiles/dependencies_debug.inc.mk
+++ b/makefiles/dependencies_debug.inc.mk
@@ -50,6 +50,13 @@ file_save_dependencies_variables = $(call file_save_variable,$(DEPENDENCY_DEBUG_
 # Remove file before to be sure appending is started with an empty file
 file_save_variable = $(shell mkdir -p $(dir $1); rm -f $1)$(foreach v,$2,$(file >>$1,$(call _print_var,$v)))
 
+# print variables sorted, this can eliminate false positives but will not allow
+# to tell in what order the variables where updated.
+DEPENDENCY_DEBUG_SORT_VARS ?= 0
 # Remove spaces in case of empty value
 # Remove spaces around value as it happens
-_print_var = $(strip $1 = $(strip $($1)))
+ifneq (1,$(DEPENDENCY_DEBUG_SORT_VARS))
+  _print_var = $(strip $1 = $(strip $($1)))
+else
+  _print_var = $(sort $(strip $1 = $(strip $($1))))
+endif


### PR DESCRIPTION

### Contribution description

Define `DEPENDENCY_DEBUG_SORT_VARS` that can be set as 1 so that
`DEPS_DEBUG_VARS` are sorted before saving to file.

I'm not sure why @cladmi only sorted `FEATURES_REQUIRED` and `FEATURES_PROVIDED`. As far what I can tell, sorting hides a lot of debug information on the order the variable was added and by whom. For this reason I leave the option as disabled by default. But being able to set this can reduce the noise significantly when comparing the dependencies for the whole tree, e.g. as was done in #12898.

### Testing procedure

- `BOARD=pic32-clicker make dependency-debug -C examples/hello-world/`
```
BOARD = pic32-clicker
CPU = mips_pic32mx
CPU_MODEL = p32mx470f512h
CPU_FAM =
FEATURES_PROVIDED = periph_gpio periph_timer periph_uart periph_cpuid arch_32bit arch_mips32r2 cpp periph_pm
_FEATURES_PROVIDED_SORTED = arch_32bit arch_mips32r2 cpp periph_cpuid periph_gpio periph_pm periph_timer periph_uart
FEATURES_REQUIRED = periph_uart arch_32bit arch_mips32r2 periph_uart arch_32bit arch_mips32r2
_FEATURES_REQUIRED_SORTED = arch_32bit arch_mips32r2 periph_uart
FEATURES_OPTIONAL = periph_gpio periph_pm periph_gpio periph_pm
FEATURES_USED = arch_32bit arch_mips32r2 periph_gpio periph_pm periph_uart
FEATURES_MISSING =
FEATURES_CONFLICT =
FEATURES_CONFLICTING =
USEMODULE = auto_init board core core_msg cpu mips32r2_common mips32r2_common_periph mips_pic32_common mips_pic32_common_periph newlib newlib_syscalls_mips_uhi periph_common periph_gpio periph_pm periph_timer periph_uart stdio_uart sys
DEFAULT_MODULE = board cpu core core_msg sys auto_init
DISABLE_MODULE = stdio_rtt stdio_rtt
```

- `DEPENDENCY_DEBUG_SORT_VARS=1 BOARD=pic32-clicker make dependency-debug -C examples/hello-world/`

```
= BOARD pic32-clicker
= CPU mips_pic32mx
= CPU_MODEL p32mx470f512h
= CPU_FAM
= FEATURES_PROVIDED arch_32bit arch_mips32r2 cpp periph_cpuid periph_gpio periph_pm periph_timer periph_uart
= _FEATURES_PROVIDED_SORTED arch_32bit arch_mips32r2 cpp periph_cpuid periph_gpio periph_pm periph_timer periph_uart
= FEATURES_REQUIRED arch_32bit arch_mips32r2 periph_uart
= _FEATURES_REQUIRED_SORTED arch_32bit arch_mips32r2 periph_uart
= FEATURES_OPTIONAL periph_gpio periph_pm
= FEATURES_USED arch_32bit arch_mips32r2 periph_gpio periph_pm periph_uart
= FEATURES_MISSING
= FEATURES_CONFLICT
= FEATURES_CONFLICTING
= USEMODULE auto_init board core core_msg cpu mips32r2_common mips32r2_common_periph mips_pic32_common mips_pic32_common_periph newlib newlib_syscalls_mips_uhi periph_common periph_gpio periph_pm periph_timer periph_uart stdio_uart sys
= DEFAULT_MODULE auto_init board core core_msg cpu sys
= DISABLE_MODULE stdio_rtt
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
