### PR TITLE
doc: fix doxygen groups for atmega CPUs

### DIFF
--- a/cpu/atmega128rfa1/include/periph_cpu.h
+++ b/cpu/atmega128rfa1/include/periph_cpu.h
@@ -38,6 +38,7 @@ enum {
     PORT_F  = 5,        /**< port F */
     PORT_G  = 6,        /**< port G */
 };
+/** @} */
 
 /**
  * @brief   Available external interrupt pins on the ATmega128rfa1 MCU

--- a/cpu/atmega256rfr2/include/periph_cpu.h
+++ b/cpu/atmega256rfr2/include/periph_cpu.h
@@ -38,6 +38,7 @@ enum {
     PORT_F  = 5,        /**< port F */
     PORT_G  = 6,        /**< port G */
 };
+/** @} */
 
 /**
  * @brief   Available external interrupt pins on the ATmega256rfr family

--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -96,7 +96,7 @@ typedef enum {
 #define SPI_MODE_SEL(pol, pha)          ((pol << 3) | (pha << 2))
 
 /**
- * @brief   Override the SPI mode values
+ * @name   Override the SPI mode values
  *
  * As the mode is set in bit 3 and 2 of the configuration register, we put the
  * correct configuration there
@@ -120,7 +120,7 @@ typedef enum {
 #define SPI_CLK_SEL(s2x, pr1, pr0)    ((s2x << 2) | (pr1 << 1) | pr0)
 
 /**
- * @brief   Override SPI speed values
+ * @name   Override SPI speed values
  *
  * We assume a master clock speed of 16MHz here.
  * @{
@@ -134,10 +134,10 @@ typedef enum {
     SPI_CLK_10MHZ  = SPI_CLK_SEL(1, 0, 0)       /**< 16/2   -> 8MHz */
 } spi_clk_t;
 /** @} */
-#endif /* ndef DOXYGEN */
+#endif /* ifndef DOXYGEN */
 
 /**
- * @brief  Bitmasks indicating which are the possible dividers for a timer
+ * @name  Bitmasks indicating which are the possible dividers for a timer
  * @{
  */
 typedef enum {
@@ -147,7 +147,7 @@ typedef enum {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name   PWM configuration
  * @{
  */
 typedef struct {

--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -174,7 +174,6 @@ typedef struct {
  * @brief   WDT can be stopped on AVR
  */
 #define WDT_HAS_STOP                    (1)
-/** @} */
 
 /**
  * @name RTT configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This fixes doxygen errors in atmega CPUs related to grouping, i.e., unbalanced group ending and replacing `@brief` with `@name` for groups.


### Testing procedure

Run `make doc` on master and here, you should see less (3) errors.



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
