### PR TITLE
gcoap: Remove reference to COAP_ACK_VARIANCE in docs

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -498,7 +498,6 @@ extern "C" {
  * GCOAP_NO_RETRANS_BACKOFF is defined this doubling does not happen.
  *
  * @see COAP_ACK_TIMEOUT
- * @see COAP_ACK_VARIANCE
  */
 #define GCOAP_NO_RETRANS_BACKOFF
 #endif


### PR DESCRIPTION
### Contribution description
In 4e85241270c741cf7f9d6133cda5f6bed4e50bbf I removed the macro `COAP_ACK_VARIANCE` as now the random factor is being used, but missed one documentation reference to it :-/

This PR removes that reference.

### Testing procedure
Build the docs.

### Issues/PRs references
#13211