### PR TITLE
gnrc_netif: add gnrc_netif_highlander function

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -274,6 +274,22 @@ gnrc_netif_t *gnrc_netif_create(char *stack, int stacksize, char priority,
 unsigned gnrc_netif_numof(void);
 
 /**
+ * @brief Check if there can only be one @ref gnrc_netif_t interface.
+ *
+ * > There can only be one!
+ *
+ * This function is used to allow compile time optimizations for
+ * single interface applications
+ *
+ * @return true, if there can only only one interface
+ * @return false, if there can be more than one interface
+ */
+static inline bool gnrc_netif_highlander(void)
+{
+    return (GNRC_NETIF_NUMOF == 1);
+}
+
+/**
  * @brief   Iterate over all network interfaces.
  *
  * @param[in] prev  previous interface in iteration. NULL to start iteration.

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -298,14 +298,15 @@ int gnrc_netif_ipv6_group_idx(gnrc_netif_t *netif,
  * @return  true, if the interface represents a router
  * @return  false, if the interface does not represent a router
  */
-#if defined(MODULE_GNRC_IPV6_ROUTER) || defined(DOXYGEN)
 static inline bool gnrc_netif_is_rtr(const gnrc_netif_t *netif)
 {
-    return (netif->flags & GNRC_NETIF_FLAGS_IPV6_FORWARDING);
+    if (IS_USED(MODULE_GNRC_IPV6_ROUTER)) {
+        return (netif->flags & GNRC_NETIF_FLAGS_IPV6_FORWARDING);
+    }
+    else {
+        return false;
+    }
 }
-#else
-#define gnrc_netif_is_rtr(netif)                (false)
-#endif
 
 /**
  * @brief   Checks if the interface is allowed to send out router advertisements
@@ -320,14 +321,15 @@ static inline bool gnrc_netif_is_rtr(const gnrc_netif_t *netif)
  * @return  false, if the interface is not allowed to send out router
  *          advertisements
  */
-#if defined(MODULE_GNRC_IPV6_ROUTER) || defined(DOXYGEN)
 static inline bool gnrc_netif_is_rtr_adv(const gnrc_netif_t *netif)
 {
-    return (netif->flags & GNRC_NETIF_FLAGS_IPV6_RTR_ADV);
+    if (IS_USED(MODULE_GNRC_IPV6_ROUTER)) {
+        return (netif->flags & GNRC_NETIF_FLAGS_IPV6_RTR_ADV);
+    }
+    else {
+        return false;
+    }
 }
-#else
-#define gnrc_netif_is_rtr_adv(netif)            (false)
-#endif
 
 /**
  * @brief   Checks if the device type associated to a @ref gnrc_netif_t
@@ -386,14 +388,15 @@ static inline bool gnrc_netif_is_6lo(const gnrc_netif_t *netif)
  * @return  true, if the interface represents a 6LN
  * @return  false, if the interface does not represent a 6LN
  */
-#if GNRC_IPV6_NIB_CONF_6LN || defined(DOXYGEN)
 static inline bool gnrc_netif_is_6ln(const gnrc_netif_t *netif)
 {
-    return (netif->flags & GNRC_NETIF_FLAGS_6LN);
+    if (IS_ACTIVE(GNRC_IPV6_NIB_CONF_6LN)) {
+        return (netif->flags & GNRC_NETIF_FLAGS_6LN);
+    }
+    else {
+        return false;
+    }
 }
-#else
-#define gnrc_netif_is_6ln(netif)                (false)
-#endif
 
 /**
  * @brief   Checks if the interface represents a 6Lo router (6LR) according to
@@ -436,15 +439,16 @@ static inline bool gnrc_netif_is_6lr(const gnrc_netif_t *netif)
  * @return  true, if the interface represents a 6LBR
  * @return  false, if the interface does not represent a 6LBR
  */
-#if GNRC_IPV6_NIB_CONF_6LBR
 static inline bool gnrc_netif_is_6lbr(const gnrc_netif_t *netif)
 {
-    return (netif->flags & GNRC_NETIF_FLAGS_6LO_ABR) &&
-           gnrc_netif_is_6lr(netif);
+    if (IS_ACTIVE(GNRC_IPV6_NIB_CONF_6LBR)) {
+        return (netif->flags & GNRC_NETIF_FLAGS_6LO_ABR) &&
+               gnrc_netif_is_6lr(netif);
+    }
+    else {
+        return false;
+    }
 }
-#else
-#define gnrc_netif_is_6lbr(netif)               (false)
-#endif
 
 /**
  * @name    Device type based function

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -330,6 +330,17 @@ static inline bool gnrc_netif_is_rtr_adv(const gnrc_netif_t *netif)
 #endif
 
 /**
+ * @brief   Checks if the device type associated to a @ref gnrc_netif_t
+ *          requires 6Lo to run
+ *
+ * @param[in] netif the network interface
+ *
+ * @return true if the device requires 6Lo
+ * @return false otherwise
+ */
+bool gnrc_netif_dev_is_6lo(const gnrc_netif_t *netif);
+
+/**
  * @brief   Checks if the interface uses a protocol that requires 6Lo to run
  *
  * @attention   Requires prior locking
@@ -351,20 +362,7 @@ static inline bool gnrc_netif_is_6lo(const gnrc_netif_t *netif)
     if ((!gnrc_netif_highlander() &&
        IS_USED(MODULE_GNRC_SIXLOWPAN)) || \
        IS_USED(MODULE_GNRC_SIXLOENC)) {
-        switch (netif->device_type) {
-#ifdef MODULE_GNRC_SIXLOENC
-            case NETDEV_TYPE_ETHERNET:
-                return (netif->flags & GNRC_NETIF_FLAGS_6LO);
-#endif
-            case NETDEV_TYPE_IEEE802154:
-            case NETDEV_TYPE_CC110X:
-            case NETDEV_TYPE_BLE:
-            case NETDEV_TYPE_NRFMIN:
-            case NETDEV_TYPE_ESP_NOW:
-                return true;
-            default:
-                return false;
-        }
+        return gnrc_netif_dev_is_6lo(netif);
     }
     else if (gnrc_netif_highlander() && IS_USED(MODULE_GNRC_SIXLOWPAN)) {
         return true;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -74,6 +74,24 @@ gnrc_netif_t *gnrc_netif_create(char *stack, int stacksize, char priority,
     return netif;
 }
 
+bool gnrc_netif_dev_is_6lo(const gnrc_netif_t *netif)
+{
+    switch (netif->device_type) {
+#ifdef MODULE_GNRC_SIXLOENC
+        case NETDEV_TYPE_ETHERNET:
+            return (netif->flags & GNRC_NETIF_FLAGS_6LO);
+#endif
+        case NETDEV_TYPE_IEEE802154:
+        case NETDEV_TYPE_CC110X:
+        case NETDEV_TYPE_BLE:
+        case NETDEV_TYPE_NRFMIN:
+        case NETDEV_TYPE_ESP_NOW:
+            return true;
+        default:
+            return false;
+    }
+}
+
 unsigned gnrc_netif_numof(void)
 {
     gnrc_netif_t *netif = NULL;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1158,28 +1158,6 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
 }
 #endif  /* MODULE_GNRC_IPV6 */
 
-#if ((GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)) || \
-    defined(MODULE_GNRC_SIXLOENC)
-bool gnrc_netif_is_6lo(const gnrc_netif_t *netif)
-{
-    switch (netif->device_type) {
-#ifdef MODULE_GNRC_SIXLOENC
-        case NETDEV_TYPE_ETHERNET:
-            return (netif->flags & GNRC_NETIF_FLAGS_6LO);
-#endif
-        case NETDEV_TYPE_IEEE802154:
-        case NETDEV_TYPE_CC110X:
-        case NETDEV_TYPE_BLE:
-        case NETDEV_TYPE_NRFMIN:
-        case NETDEV_TYPE_ESP_NOW:
-            return true;
-        default:
-            return false;
-    }
-}
-#endif  /* ((GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)) || \
-         * defined(MODULE_GNRC_SIXLOENC)*/
-
 static void _update_l2addr_from_dev(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -556,62 +556,62 @@ static void _send_multicast(gnrc_pktsnip_t *pkt, bool prep_hdr,
         }
     }
 
+    if (!gnrc_netif_highlander()) {
+        /* interface not given: send over all interfaces */
+        if (netif == NULL) {
+            /* send packet to link layer */
+            gnrc_pktbuf_hold(pkt, ifnum - 1);
 
-#if GNRC_NETIF_NUMOF > 1
-    /* interface not given: send over all interfaces */
-    if (netif == NULL) {
-        /* send packet to link layer */
-        gnrc_pktbuf_hold(pkt, ifnum - 1);
+            while ((netif = gnrc_netif_iter(netif))) {
+                gnrc_pktsnip_t *send_pkt = pkt;
+                /* for !prep_hdr just use pkt as we don't duplicate IPv6 header as
+                 * it is already filled and thus isn't filled with potentially
+                 * interface-specific data */
+                if (prep_hdr) {
+                    DEBUG("ipv6: prepare IPv6 header for sending\n");
+                    /* need to get second write access (duplication) to fill IPv6
+                     * header with interface-specific data */
+                    send_pkt = gnrc_pktbuf_start_write(pkt);
 
-        while ((netif = gnrc_netif_iter(netif))) {
-            gnrc_pktsnip_t *send_pkt = pkt;
-            /* for !prep_hdr just use pkt as we don't duplicate IPv6 header as
-             * it is already filled and thus isn't filled with potentially
-             * interface-specific data */
-            if (prep_hdr) {
-                DEBUG("ipv6: prepare IPv6 header for sending\n");
-                /* need to get second write access (duplication) to fill IPv6
-                 * header with interface-specific data */
-                send_pkt = gnrc_pktbuf_start_write(pkt);
-
-                if (send_pkt == NULL) {
-                    DEBUG("ipv6: unable to get write access to IPv6 header, "
-                          "for interface %" PRIkernel_pid "\n", netif->pid);
-                    gnrc_pktbuf_release(pkt);
-                    return;
-                }
-                if (_fill_ipv6_hdr(netif, send_pkt) < 0) {
-                    /* error on filling up header */
-                    if (send_pkt != pkt) {
-                        gnrc_pktbuf_release(send_pkt);
+                    if (send_pkt == NULL) {
+                        DEBUG("ipv6: unable to get write access to IPv6 header, "
+                              "for interface %" PRIkernel_pid "\n", netif->pid);
+                        gnrc_pktbuf_release(pkt);
+                        return;
                     }
-                    gnrc_pktbuf_release(pkt);
-                    return;
+                    if (_fill_ipv6_hdr(netif, send_pkt) < 0) {
+                        /* error on filling up header */
+                        if (send_pkt != pkt) {
+                            gnrc_pktbuf_release(send_pkt);
+                        }
+                        gnrc_pktbuf_release(pkt);
+                        return;
+                    }
                 }
+                _send_multicast_over_iface(send_pkt, prep_hdr, netif,
+                                           netif_hdr_flags);
             }
-            _send_multicast_over_iface(send_pkt, prep_hdr, netif,
-                                       netif_hdr_flags);
+        }
+        else {
+            if (_safe_fill_ipv6_hdr(netif, pkt, prep_hdr)) {
+                _send_multicast_over_iface(pkt, prep_hdr, netif, netif_hdr_flags);
+            }
         }
     }
     else {
+        (void)ifnum; /* not used in this build branch */
+        if (netif == NULL) {
+            netif = gnrc_netif_iter(NULL);
+
+            /* allocate interface header */
+            if ((pkt = _create_netif_hdr(NULL, 0, pkt, netif_hdr_flags)) == NULL) {
+                return;
+            }
+        }
         if (_safe_fill_ipv6_hdr(netif, pkt, prep_hdr)) {
             _send_multicast_over_iface(pkt, prep_hdr, netif, netif_hdr_flags);
         }
     }
-#else   /* GNRC_NETIF_NUMOF */
-    (void)ifnum; /* not used in this build branch */
-    if (netif == NULL) {
-        netif = gnrc_netif_iter(NULL);
-
-        /* allocate interface header */
-        if ((pkt = _create_netif_hdr(NULL, 0, pkt, netif_hdr_flags)) == NULL) {
-            return;
-        }
-    }
-    if (_safe_fill_ipv6_hdr(netif, pkt, prep_hdr)) {
-        _send_multicast_over_iface(pkt, prep_hdr, netif, netif_hdr_flags);
-    }
-#endif  /* GNRC_NETIF_NUMOF */
 }
 
 static void _send_to_self(gnrc_pktsnip_t *pkt, bool prep_hdr,

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
@@ -28,7 +28,7 @@
 
 void auto_init_gnrc_rpl(void)
 {
-    if (GNRC_NETIF_NUMOF == 1) {
+    if (gnrc_netif_highlander()) {
         gnrc_netif_t *netif = gnrc_netif_iter(NULL);
         if (netif == NULL) {
             /* XXX this is just a work-around ideally this would happen with
@@ -57,7 +57,8 @@ void auto_init_gnrc_rpl(void)
     else {
         /* XXX this is just a work-around ideally this should be defined in some
          * run-time interface configuration */
-        DEBUG("auto_init_gnrc_rpl: please specify an interface by setting GNRC_RPL_DEFAULT_NETIF\n");
+        DEBUG("auto_init_gnrc_rpl: please specify an interface "
+               "by setting GNRC_RPL_DEFAULT_NETIF\n");
     }
 }
 #else

--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -103,14 +103,14 @@ static inline void gnrc_ep_set(sock_ip_ep_t *out, const sock_ip_ep_t *in,
                                size_t in_size)
 {
     memcpy(out, in, in_size);
-#if GNRC_NETIF_NUMOF == 1
-    /* set interface implicitly */
-    gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+    if (gnrc_netif_highlander()) {
+        /* set interface implicitly */
+        gnrc_netif_t *netif = gnrc_netif_iter(NULL);
 
-    if (netif != NULL) {
-        out->netif = netif->pid;
+        if (netif != NULL) {
+            out->netif = netif->pid;
+        }
     }
-#endif
 }
 
 /**

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -187,11 +187,10 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
             if (iface) {
                 data->netif = gnrc_netif_get_by_pid(atoi(iface));
             }
-#if GNRC_NETIF_NUMOF == 1
-            else {
+            else if (gnrc_netif_highlander()) {
                 data->netif = gnrc_netif_iter(NULL);
             }
-#endif
+
             if (ipv6_addr_from_str(&data->host, data->hostname) == NULL) {
                 break;
             }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR defines a `gnrc_netif_single` function that indicates if there's only one GNRC network interface.
It has the same purpose of `GNRC_NETIF_NUMOF == 1` but having it as a function makes the migration to #12994 easier.
I also rearranged some functions to use standard ifs instead of macros, so the code is more readable and can be checked by static tests.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- `make doc`
- Check that generates the same binaries when changing GNRC_NETIF_NUMOF
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
