### PR TITLE
net/coap: Expose configurations to Kconfig

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -201,8 +201,8 @@ extern "C" {
 #endif
 
 /** @brief   Maximum number of retransmissions for a confirmable request */
-#ifndef COAP_MAX_RETRANSMIT
-#define COAP_MAX_RETRANSMIT     (4)
+#ifndef CONFIG_COAP_MAX_RETRANSMIT
+#define CONFIG_COAP_MAX_RETRANSMIT     (4)
 #endif
 /** @} */
 /** @} */

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -180,11 +180,11 @@ extern "C" {
  * This value is for the response to the *initial* confirmable message. The
  * timeout doubles for subsequent retries. To avoid synchronization of resends
  * across hosts, the actual timeout is chosen randomly between
- * @ref COAP_ACK_TIMEOUT and
- * (@ref COAP_ACK_TIMEOUT * @ref COAP_RANDOM_FACTOR_1000 / 1000).
+ * @ref CONFIG_COAP_ACK_TIMEOUT and
+ * (@ref CONFIG_COAP_ACK_TIMEOUT * @ref COAP_RANDOM_FACTOR_1000 / 1000).
  */
-#ifndef COAP_ACK_TIMEOUT
-#define COAP_ACK_TIMEOUT        (2U)
+#ifndef CONFIG_COAP_ACK_TIMEOUT
+#define CONFIG_COAP_ACK_TIMEOUT        (2U)
 #endif
 
 /**
@@ -194,7 +194,7 @@ extern "C" {
  * ([RFC 7252, section 4.2](https://tools.ietf.org/html/rfc7252#section-4.2))
  * multiplied by 1000, to avoid floating point arithmetic.
  *
- * See @ref COAP_ACK_TIMEOUT
+ * See @ref CONFIG_COAP_ACK_TIMEOUT
  */
 #ifndef COAP_RANDOM_FACTOR_1000
 #define COAP_RANDOM_FACTOR_1000      (1500)

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -181,7 +181,7 @@ extern "C" {
  * timeout doubles for subsequent retries. To avoid synchronization of resends
  * across hosts, the actual timeout is chosen randomly between
  * @ref CONFIG_COAP_ACK_TIMEOUT and
- * (@ref CONFIG_COAP_ACK_TIMEOUT * @ref COAP_RANDOM_FACTOR_1000 / 1000).
+ * (@ref CONFIG_COAP_ACK_TIMEOUT * @ref CONFIG_COAP_RANDOM_FACTOR_1000 / 1000).
  */
 #ifndef CONFIG_COAP_ACK_TIMEOUT
 #define CONFIG_COAP_ACK_TIMEOUT        (2U)
@@ -196,8 +196,8 @@ extern "C" {
  *
  * See @ref CONFIG_COAP_ACK_TIMEOUT
  */
-#ifndef COAP_RANDOM_FACTOR_1000
-#define COAP_RANDOM_FACTOR_1000      (1500)
+#ifndef CONFIG_COAP_RANDOM_FACTOR_1000
+#define CONFIG_COAP_RANDOM_FACTOR_1000      (1500)
 #endif
 
 /** @brief   Maximum number of retransmissions for a confirmable request */

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -517,7 +517,7 @@ extern "C" {
  * In normal operations the timeout between retransmissions doubles. When
  * CONFIG_GCOAP_NO_RETRANS_BACKOFF is defined this doubling does not happen.
  *
- * @see COAP_ACK_TIMEOUT
+ * @see CONFIG_COAP_ACK_TIMEOUT
  */
 #define CONFIG_GCOAP_NO_RETRANS_BACKOFF
 #endif

--- a/sys/net/application_layer/Kconfig
+++ b/sys/net/application_layer/Kconfig
@@ -6,6 +6,7 @@
 #
 menu "CoAP"
 
+rsource "Kconfig.coap"
 rsource "gcoap/Kconfig"
 rsource "nanocoap/Kconfig"
 

--- a/sys/net/application_layer/Kconfig.coap
+++ b/sys/net/application_layer/Kconfig.coap
@@ -1,0 +1,53 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config HAS_PROTOCOL_COAP
+    bool
+    help
+        Specifies that CoAP support is present.
+
+menuconfig KCONFIG_COAP
+    bool "Configure CoAP generic options"
+    depends on HAS_PROTOCOL_COAP
+    help
+        Configure CoAP generic options via Kconfig.
+
+if KCONFIG_COAP
+
+config COAP_ACK_TIMEOUT
+    int "Timeout in seconds for a response to a confirmable request"
+    default 2
+    help
+        This value is for the response to the initial confirmable message. The
+        timeout doubles for subsequent retries. To avoid synchronization of
+        resends across hosts, the actual timeout is chosen randomly between
+        @ref CONFIG_COAP_ACK_TIMEOUT and
+        (@ref CONFIG_COAP_ACK_TIMEOUT * @ref CONFIG_COAP_RANDOM_FACTOR_1000 / 1000).
+        The default of 2 seconds is taken from
+        [RFC 7252, section 4.8](https://tools.ietf.org/html/rfc7252#section-4.8).
+
+config COAP_RANDOM_FACTOR_1000
+    int "Timeout random factor (multiplied by 1000)"
+    default 1500
+    help
+        This value is used to calculate the upper bound for the timeout. It
+        represents the `ACK_RANDOM_FACTOR`
+        ([RFC 7252, section 4.2](https://tools.ietf.org/html/rfc7252#section-4.2))
+        multiplied by 1000, to avoid floating point arithmetic.
+        The default that represents 1.5 seconds is taken from
+        The default of 2 seconds is taken from
+        [RFC 7252, section 4.8](https://tools.ietf.org/html/rfc7252#section-4.8).
+
+config COAP_MAX_RETRANSMIT
+    int "Maximum number of retransmissions"
+    default 4
+    help
+        Maximum number of retransmissions for a confirmable request. The default
+        of 4 retransmissions is taken from
+        [RFC 7252, section 4.8](https://tools.ietf.org/html/rfc7252#section-4.8).
+
+endif # KCONFIG_COAP

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -247,7 +247,7 @@ static void _on_resp_timeout(void *arg) {
 #ifdef CONFIG_GCOAP_NO_RETRANS_BACKOFF
         unsigned i        = 0;
 #else
-        unsigned i        = COAP_MAX_RETRANSMIT - memo->send_limit;
+        unsigned i        = CONFIG_COAP_MAX_RETRANSMIT - memo->send_limit;
 #endif
         uint32_t timeout  = ((uint32_t)CONFIG_COAP_ACK_TIMEOUT << i) * US_PER_SEC;
 #if CONFIG_COAP_RANDOM_FACTOR_1000 > 1000
@@ -772,7 +772,7 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
                 }
             }
             if (memo->msg.data.pdu_buf) {
-                memo->send_limit  = COAP_MAX_RETRANSMIT;
+                memo->send_limit  = CONFIG_COAP_MAX_RETRANSMIT;
                 timeout           = (uint32_t)CONFIG_COAP_ACK_TIMEOUT * US_PER_SEC;
 #if CONFIG_COAP_RANDOM_FACTOR_1000 > 1000
                 timeout = random_uint32_range(timeout, TIMEOUT_RANGE_END * US_PER_SEC);

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -42,7 +42,7 @@
 #define GCOAP_RESOURCE_NO_PATH -2
 
 /* End of the range to pick a random timeout */
-#define TIMEOUT_RANGE_END (CONFIG_COAP_ACK_TIMEOUT * COAP_RANDOM_FACTOR_1000 / 1000)
+#define TIMEOUT_RANGE_END (CONFIG_COAP_ACK_TIMEOUT * CONFIG_COAP_RANDOM_FACTOR_1000 / 1000)
 
 /* Internal functions */
 static void *_event_loop(void *arg);
@@ -250,7 +250,7 @@ static void _on_resp_timeout(void *arg) {
         unsigned i        = COAP_MAX_RETRANSMIT - memo->send_limit;
 #endif
         uint32_t timeout  = ((uint32_t)CONFIG_COAP_ACK_TIMEOUT << i) * US_PER_SEC;
-#if COAP_RANDOM_FACTOR_1000 > 1000
+#if CONFIG_COAP_RANDOM_FACTOR_1000 > 1000
         uint32_t end = ((uint32_t)TIMEOUT_RANGE_END << i) * US_PER_SEC;
         timeout = random_uint32_range(timeout, end);
 #endif
@@ -774,7 +774,7 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
             if (memo->msg.data.pdu_buf) {
                 memo->send_limit  = COAP_MAX_RETRANSMIT;
                 timeout           = (uint32_t)CONFIG_COAP_ACK_TIMEOUT * US_PER_SEC;
-#if COAP_RANDOM_FACTOR_1000 > 1000
+#if CONFIG_COAP_RANDOM_FACTOR_1000 > 1000
                 timeout = random_uint32_range(timeout, TIMEOUT_RANGE_END * US_PER_SEC);
 #endif
             }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -42,7 +42,7 @@
 #define GCOAP_RESOURCE_NO_PATH -2
 
 /* End of the range to pick a random timeout */
-#define TIMEOUT_RANGE_END (COAP_ACK_TIMEOUT * COAP_RANDOM_FACTOR_1000 / 1000)
+#define TIMEOUT_RANGE_END (CONFIG_COAP_ACK_TIMEOUT * COAP_RANDOM_FACTOR_1000 / 1000)
 
 /* Internal functions */
 static void *_event_loop(void *arg);
@@ -249,7 +249,7 @@ static void _on_resp_timeout(void *arg) {
 #else
         unsigned i        = COAP_MAX_RETRANSMIT - memo->send_limit;
 #endif
-        uint32_t timeout  = ((uint32_t)COAP_ACK_TIMEOUT << i) * US_PER_SEC;
+        uint32_t timeout  = ((uint32_t)CONFIG_COAP_ACK_TIMEOUT << i) * US_PER_SEC;
 #if COAP_RANDOM_FACTOR_1000 > 1000
         uint32_t end = ((uint32_t)TIMEOUT_RANGE_END << i) * US_PER_SEC;
         timeout = random_uint32_range(timeout, end);
@@ -773,7 +773,7 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
             }
             if (memo->msg.data.pdu_buf) {
                 memo->send_limit  = COAP_MAX_RETRANSMIT;
-                timeout           = (uint32_t)COAP_ACK_TIMEOUT * US_PER_SEC;
+                timeout           = (uint32_t)CONFIG_COAP_ACK_TIMEOUT * US_PER_SEC;
 #if COAP_RANDOM_FACTOR_1000 > 1000
                 timeout = random_uint32_range(timeout, TIMEOUT_RANGE_END * US_PER_SEC);
 #endif

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -49,7 +49,7 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
     /* TODO: timeout random between between ACK_TIMEOUT and (ACK_TIMEOUT *
      * ACK_RANDOM_FACTOR) */
     uint32_t timeout = CONFIG_COAP_ACK_TIMEOUT * US_PER_SEC;
-    unsigned tries_left = COAP_MAX_RETRANSMIT + 1;  /* add 1 for initial transmit */
+    unsigned tries_left = CONFIG_COAP_MAX_RETRANSMIT + 1;  /* add 1 for initial transmit */
     while (tries_left) {
 
         res = sock_udp_send(&sock, buf, pdu_len, NULL);

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -48,7 +48,7 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
 
     /* TODO: timeout random between between ACK_TIMEOUT and (ACK_TIMEOUT *
      * ACK_RANDOM_FACTOR) */
-    uint32_t timeout = COAP_ACK_TIMEOUT * US_PER_SEC;
+    uint32_t timeout = CONFIG_COAP_ACK_TIMEOUT * US_PER_SEC;
     unsigned tries_left = COAP_MAX_RETRANSMIT + 1;  /* add 1 for initial transmit */
     while (tries_left) {
 

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -136,7 +136,7 @@ static ssize_t _nanocoap_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len)
 
     /* TODO: timeout random between between ACK_TIMEOUT and (ACK_TIMEOUT *
      * ACK_RANDOM_FACTOR) */
-    uint32_t timeout = COAP_ACK_TIMEOUT * US_PER_SEC;
+    uint32_t timeout = CONFIG_COAP_ACK_TIMEOUT * US_PER_SEC;
     uint32_t deadline = deadline_from_interval(timeout);
 
     /* add 1 for initial transmit */

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -140,7 +140,7 @@ static ssize_t _nanocoap_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len)
     uint32_t deadline = deadline_from_interval(timeout);
 
     /* add 1 for initial transmit */
-    unsigned tries_left = COAP_MAX_RETRANSMIT + 1;
+    unsigned tries_left = CONFIG_COAP_MAX_RETRANSMIT + 1;
 
     while (tries_left) {
         if (res == -EAGAIN) {


### PR DESCRIPTION
### Contribution description
This moves the configuration macros for our generic CoAP options to the `CONFIG_` namespace, and exposes them to Kconfig.

I didn't include a `range` constraint on `COAP_ACK_TIMEOUT` and `COAP_RANDOM_FACTOR_1000` yet as I am not sure which would be a valid maximum. According to [RFC 7252, section 4.8.1](https://tools.ietf.org/html/rfc7252#section-4.8.1):

>In particular, a decrease of ACK_TIMEOUT below 1 second would violate the guidelines of [RFC5405].

(So the minimum for `COAP_ACK_TIMEOUT` would be 1)

> ACK_RANDOM_FACTOR MUST NOT be decreased below 1.0, and it SHOULD have a value that is sufficiently different from 1.0 to provide some protection from synchronization effects.

(So the minimum for `COAP_RANDOM_FACTOR_1000` would be 1000)

Also, I made use of a 'feature' symbol (`HAS_PROTOCOL_COAP`) which indicates in a generic way that there is a module that provides this, as this options are generic. ~~When nanocoap has its own Kconfig file then it should be selected from there.~~

~~**Edit**: If #13243 is merged first, the `TODO` in the Kconfig file should be removed.~~

### Testing procedure
- Build `examples/gcoap`. By default everything should still work the same. 
- Modify some parameters (e.g. the number of retries or the random factor), changes should be applied.

### Issues/PRs references
Part of #12888
Related to #13243
