### PR TITLE
pkg/nanopb: bump version to 0.4.1

### DIFF
--- a/pkg/nanopb/Makefile
+++ b/pkg/nanopb/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=nanopb
 PKG_URL=https://github.com/nanopb/nanopb
-PKG_VERSION=493adf3616bee052649c63c473f8355630c2797f # nanopb-0.3.9.4
+PKG_VERSION=3eb9a75c1e66e6182e87e2bd758ff2a4d16acbdc # nanopb-0.4.1
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nanopb/patches/0001-generator-nanopb_generator.py-use-python3.patch
+++ b/pkg/nanopb/patches/0001-generator-nanopb_generator.py-use-python3.patch
@@ -14,9 +14,9 @@ index 03f41a0..4f0ab47 100755
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python
 +#!/usr/bin/env python3
+ # kate: replace-tabs on; indent-width 4;
  
  from __future__ import unicode_literals
- 
 -- 
 2.23.0
 


### PR DESCRIPTION
### Contribution description

Update the version of the nanopb package to the [latest upstream release](https://github.com/nanopb/nanopb/tree/nanopb-0.4.1).

~~It didn't build with the Python3 patch applied, so I removed that. (I do have `python3-protobuf` installed).~~

### Testing procedure

Run `tests/pkg_nanopb`.

### Issues/PRs references

none