### PR TITLE
fe310: fix power management configuration

### DIFF
--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -28,6 +28,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    Power management configuration
+ * @{
+ */
+#define PROVIDES_PM_SET_LOWEST
+/** @} */
+
+/**
  * @brief   Length of the CPU_ID in octets
  */
 #define CPUID_LEN           (12U)

--- a/cpu/fe310/periph/pm.c
+++ b/cpu/fe310/periph/pm.c
@@ -26,10 +26,6 @@ void pm_set_lowest(void)
     __asm__ volatile ("wfi");
 }
 
-void pm_off(void)
-{
-}
-
 void pm_reboot(void)
 {
     AON_REG(AON_WDOGKEY) = AON_WDOGKEY_VALUE;


### PR DESCRIPTION
### Contribution description

This issue was discovered while implementing link time reordering in #13176. The FE310 provides its own implementation of `pm_off` and `pm_set_lowest`. Without this change the common implementation of these functions would be compiled as well and the linker would (in the default order) disable on of the two. This is why it doesn't result on a build failure without #13176, the change proposed here makes sure that the FE310 version of these functions is used.

### Testing procedure

Either apply #13176 or just read the code, i.e. verify that a custom implementation of these functions is provided in `cpu/fe310/periph/pm.c`.

### Issues/PRs references

#13176