### PR TITLE
waspmote-pro: don't build the boards_common_atmega module

### DIFF
--- a/boards/waspmote-pro/Makefile
+++ b/boards/waspmote-pro/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/atmega
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/waspmote-pro/Makefile.dep
+++ b/boards/waspmote-pro/Makefile.dep
@@ -1,4 +1,3 @@
-USEMODULE += boards_common_atmega
 #ifneq (,$(filter saul_default,$(USEMODULE)))
 #  USEMODULE += saul_gpio
 #endif


### PR DESCRIPTION
# Contribution description

This was discovered while implementing link time reordering in #13176. Without this change `board_init` would be defined twice. Once in `boards/waspmote-pro/board.c` and the other time in `boards/common/atmega/board.c`.

### Testing procedure

Similar to #13229 either apply #13176 or read the code and verify that `board_init` is defined twice for this board.

### Issues/PRs references

* #13176 
* #13229