### PR TITLE
cpu/stm32/eth: Use luid_get_eui48 to generate local, non group EUI

### DIFF
--- a/cpu/stm32_common/periph/eth.c
+++ b/cpu/stm32_common/periph/eth.c
@@ -226,7 +226,7 @@ int stm32_eth_init(void)
       stm32_eth_set_mac(eth_config.mac);
     }
     else {
-      luid_get(hwaddr, ETHERNET_ADDR_LEN);
+      luid_get_eui48(hwaddr);
       stm32_eth_set_mac(hwaddr);
     }
 

--- a/cpu/stm32_common/periph/eth.c
+++ b/cpu/stm32_common/periph/eth.c
@@ -170,7 +170,6 @@ static void _init_buffer(void)
 
 int stm32_eth_init(void)
 {
-    char hwaddr[ETHERNET_ADDR_LEN];
     /* enable APB2 clock */
     RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
 
@@ -226,8 +225,9 @@ int stm32_eth_init(void)
       stm32_eth_set_mac(eth_config.mac);
     }
     else {
-      luid_get_eui48(hwaddr);
-      stm32_eth_set_mac(hwaddr);
+      eui48_t hwaddr;
+      luid_get_eui48(&hwaddr);
+      stm32_eth_set_mac((const char *)hwaddr.uint8);
     }
 
     _init_buffer();


### PR DESCRIPTION
luid_get may generate non compliant EUI (MAC-address) luid_get_eui48
fixes that.

I had MAC been generated that was marked as group (multicast) so Wireshark complained, i looked into it found that there is allready a function in Riot to generate appropriate EUI, and ei changed and testet.

It worked (no more complain by wireshark) and the interface is still answering echo requests.
