### PR TITLE
tools/edbg: update to latest upstream version 

### DIFF
--- a/boards/arduino-zero/Makefile.include
+++ b/boards/arduino-zero/Makefile.include
@@ -1,4 +1,1 @@
-# set edbg device type
-EDBG_DEVICE_TYPE = atmel_cm0p
-
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/common/saml1x/Makefile.include
+++ b/boards/common/saml1x/Makefile.include
@@ -1,6 +1,3 @@
-# set edbg device type
-EDBG_DEVICE_TYPE = mchp_cm23
-
 USEMODULE += boards_common_saml1x
 
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/samd21-xpro/Makefile.include
+++ b/boards/samd21-xpro/Makefile.include
@@ -1,4 +1,1 @@
-# set edbg device type
-EDBG_DEVICE_TYPE = atmel_cm0p
-
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/same54-xpro/Makefile.include
+++ b/boards/same54-xpro/Makefile.include
@@ -1,4 +1,1 @@
-# set edbg device type
-EDBG_DEVICE_TYPE = atmel_cm4v2
-
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/saml21-xpro/Makefile.include
+++ b/boards/saml21-xpro/Makefile.include
@@ -1,6 +1,3 @@
 CFLAGS += -D__SAML21J18A__
 
-# set edbg device type
-EDBG_DEVICE_TYPE = atmel_cm0p
-
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -1,4 +1,1 @@
-# set edbg device type
-EDBG_DEVICE_TYPE = atmel_cm0p
-
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/samr30-xpro/Makefile.include
+++ b/boards/samr30-xpro/Makefile.include
@@ -1,4 +1,1 @@
-# set edbg device type
-EDBG_DEVICE_TYPE = atmel_cm0p
-
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/samr34-xpro/Makefile.include
+++ b/boards/samr34-xpro/Makefile.include
@@ -1,4 +1,1 @@
-# set edbg device type
-EDBG_DEVICE_TYPE = atmel_cm0p
-
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=edbg
 PKG_URL=https://github.com/ataradov/edbg
-PKG_VERSION=4f5d490bfffc7fd10855e513e6e88be5a9a3f789
+PKG_VERSION=99d15460fcff723f73b16c29c8ca14bff4b33b20
 PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR=$(CURDIR)/bin
 

--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -39,9 +39,7 @@ endif
 
 # use edbg if selected and a device type has been set
 ifeq ($(PROGRAMMER),edbg)
-  ifneq (,$(EDBG_DEVICE_TYPE))
-    include $(RIOTMAKE)/tools/edbg.inc.mk
-  endif
+  include $(RIOTMAKE)/tools/edbg.inc.mk
 endif
 
 ifeq ($(PROGRAMMER),jlink)

--- a/makefiles/tools/edbg-devices.inc.mk
+++ b/makefiles/tools/edbg-devices.inc.mk
@@ -1,0 +1,92 @@
+# Atmel SAM C/D/L/R series:
+ifneq (,$(findstring samd09,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samd09
+else ifneq (,$(findstring samd10,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samd10
+else ifneq (,$(findstring samd11,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samd11
+else ifneq (,$(findstring samd20,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samd20
+else ifneq (,$(findstring samd21,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samd21
+else ifneq (,$(findstring samc21,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samc21
+else ifneq (,$(findstring saml21,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = saml21
+else ifneq (,$(findstring saml22,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = saml22
+else ifneq (,$(findstring samr21,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samr21
+else ifneq (,$(findstring samr30,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samr30
+else ifneq (,$(findstring samr34,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samr34
+else ifneq (,$(findstring samr35,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samr35
+else ifneq (,$(findstring samda1,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samda1
+endif
+
+# Atmel SAM3X/A/U series:
+ifneq (,$(findstring samg51,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samg51
+else ifneq (,$(findstring samg53,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samg53
+else ifneq (,$(findstring samg54,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samg54
+else ifneq (,$(findstring samg55,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samg55
+else ifneq (,$(findstring sam4sd,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = sam4sd
+else ifneq (,$(findstring sam4sa,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = sam4sa
+else ifneq (,$(findstring sam4s,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = sam4s
+else ifneq (,$(findstring sam4e,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = sam4e
+else ifneq (,$(findstring sam4n,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = sam4n
+endif
+
+# Atmel SAM E7x/S7x/V7x series:
+ifneq (,$(findstring same70,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = same70
+else ifneq (,$(findstring sams70,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = sams70
+else ifneq (,$(findstring samv71,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samv71
+else ifneq (,$(findstring samv70,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samv70
+endif
+
+# Atmel SAM D5x/E5x:
+ifneq (,$(findstring same51,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = same51
+else ifneq (,$(findstring samd51,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = samd51
+else ifneq (,$(findstring same53,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = same53
+else ifneq (,$(findstring same54,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = same54
+endif
+
+# Microchip SAM L10/L11:
+ifneq (,$(findstring saml10,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = saml10
+else ifneq (,$(findstring saml11,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = saml11
+endif
+
+# STMicroelectronics STM32G0 series:
+ifneq (,$(findstring stm32g0,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = stm32g0
+endif
+
+# GigaDevice GD32F4xx series:
+ifneq (,$(findstring gd32f4,$(CPU_MODEL)))
+  EDBG_DEVICE_TYPE = gd32f4xx
+endif
+
+ifeq (,$(EDBG_DEVICE_TYPE))
+  $(error "Device not supported by edbg.")
+endif

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -1,3 +1,5 @@
+include $(RIOTMAKE)/tools/edbg-devices.inc.mk
+
 RIOT_EDBG = $(RIOTTOOLS)/edbg/edbg
 EDBG ?= $(RIOT_EDBG)
 FLASHER ?= $(EDBG)


### PR DESCRIPTION
### Contribution description

Upstream `edbg` changed the target names (they already generated a deprecation warning before).
While updating this I moved the cpu -> target name mapping to `edbg-devices.inc.mk` and removed the `EDBG_DEVICE_TYPE` declaration from the board Makefiles.

I chose to generate a mapping even for MCUs that are not supported by RIOT yet, this allowed for automated generation of the file and no further work should we gain support for these processors in the future.

### Testing procedure

You should still be able to flash the boards as before.
I tested this on `same54-xpro` and `samr21-xpro`.

### Issues/PRs references
none
