### PR TITLE
cpu/lpc2387: rtc: set rtc callback arg [backport 2020.01]

### DIFF
--- a/cpu/lpc2387/periph/rtc.c
+++ b/cpu/lpc2387/periph/rtc.c
@@ -114,7 +114,6 @@ int rtc_get_time(struct tm *localt)
 
 int rtc_set_alarm(struct tm *localt, rtc_alarm_cb_t cb, void *arg)
 {
-    (void) arg;
     if (localt != NULL) {
         /* normalize input */
         rtc_tm_normalize(localt);
@@ -132,6 +131,7 @@ int rtc_set_alarm(struct tm *localt, rtc_alarm_cb_t cb, void *arg)
               RTC_ALDOM, RTC_ALMON, RTC_ALYEAR, RTC_ALHOUR, RTC_ALMIN, RTC_ALSEC);
 
         _cb = cb;
+        _cb_arg = arg;
         return 0;
     }
     else if (cb == NULL) {


### PR DESCRIPTION
# Backport of #13234

### Contribution description

`_cb_arg` was never set, it was simply ignored in `rtc_set_alarm()`.
The fix is trivial: just set `_cb_arg` to the assigned argument.

### Testing procedure

Set a RTC alarm with a callback argument, as is done in #13035.

### Issues/PRs references

discovered in #13035