### PR TITLE
core: compile kernel_init and core_panic conditionally

### DIFF
--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#ifndef RIOTBOOT /* RIOTBOOT provides its own implementation */
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <errno.h>
@@ -84,3 +86,5 @@ void kernel_init(void)
 
     cpu_switch_context_exit();
 }
+
+#endif /* RIOTBOOT */

--- a/core/panic.c
+++ b/core/panic.c
@@ -21,6 +21,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
+#ifndef RIOTBOOT /* RIOTBOOT provides its own implementation */
+
 #include <string.h>
 #include <stdio.h>
 
@@ -85,3 +87,5 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
        (even if we actually won't even get here...) */
     UNREACHABLE();
 }
+
+#endif /* RIOTBOOT */


### PR DESCRIPTION
### Contribution description

riotboot provides its own implementation of these functions in `bootloaders/riotboot/main.c`. Compiling them unconditionally causes two symbols with the same name to be present for `core_panic` and `kernel_init`, the linker will discard one of them.

### Testing procedure

This was discovered during the implementation of link time reordering in #13176. Either test this using the aforementioned PR or read the code and check with `tests/riotboot` that both `bootloaders/riotboot/main.c` and `core/kernel_init.c` as well as `core/panic.c` are compiled and contain symbols with the same name.

### Issues/PRs references

* #13176
* #13229 
* #13230