### PR TITLE
cpu: fix I2C compilation problems with NDEBUG for several CPUs

### DIFF
--- a/cpu/atmega_common/periph/i2c.c
+++ b/cpu/atmega_common/periph/i2c.c
@@ -135,6 +135,7 @@ void i2c_init(i2c_t dev)
 int i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len,
                    uint8_t flags)
 {
+    (void)dev;
     assert(dev < I2C_NUMOF);
 
     /* Check for unsupported operations */
@@ -184,6 +185,7 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len,
 int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len,
                     uint8_t flags)
 {
+    (void)dev;
     assert(dev < I2C_NUMOF);
 
     /* Check for unsupported operations */

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -243,6 +243,7 @@ int i2c_acquire(i2c_t dev)
 
 void i2c_release(i2c_t dev)
 {
+    (void)dev;
     assert(dev < I2C_NUMOF);
     DEBUG("%s\n", __FUNCTION__);
     mutex_unlock(&lock);

--- a/cpu/cc26x0/periph/i2c.c
+++ b/cpu/cc26x0/periph/i2c.c
@@ -129,6 +129,7 @@ void i2c_init(i2c_t devnum)
 
 int i2c_acquire(i2c_t dev)
 {
+    (void)dev;
     assert(dev < I2C_NUMOF);
     mutex_lock(&_lock);
     return 0;
@@ -136,6 +137,7 @@ int i2c_acquire(i2c_t dev)
 
 void i2c_release(i2c_t dev)
 {
+    (void)dev;
     assert(dev < I2C_NUMOF);
     mutex_unlock(&_lock);
 }


### PR DESCRIPTION
### Contribution description

This PR fixes the I2C compilation problem for ATmega MCUs, CC26x0 MCUs and CC2538 MCUs when the NDEBUG macro is defined.

When the NDEBUG macro is defined during the compilation, the `assert` macro produces empty code. The `dev` parameter was then unused.


### Testing procedure

Compilation of
```
CFLAGS='-DNDEBUG' make -C tests/periph_i2c BOARD=arduino-mega2560
CFLAGS='-DNDEBUG' make -C tests/periph_i2c BOARD=cc2538dk
CFLAGS='-DNDEBUG' make -C tests/periph_i2c BOARD=cc2650stk
```
fails without this PR and should succeed with this PR.

### Issues/PRs references