### PR TITLE
net/coap: deprecate gcoap_add_qstring() and update uses

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -921,6 +921,9 @@ ssize_t gcoap_encode_link(const coap_resource_t *resource, char *buf,
  * To add multiple Uri-Query options, simply call this function multiple times.
  * The Uri-Query options will be added in the order those calls.
  *
+ * @deprecated  Will not be available after the 2020.10 release. Use
+ * coap_opt_add_uquery() instead.
+ *
  * @param[out] pdu      The package that is being build
  * @param[in]  key      Key to add to the query string
  * @param[in]  val      Value to assign to @p key (may be NULL)

--- a/sys/net/application_layer/cord/common/cord_common.c
+++ b/sys/net/application_layer/cord/common/cord_common.c
@@ -57,7 +57,7 @@ void cord_common_init(void)
 int cord_common_add_qstring(coap_pkt_t *pkt)
 {
     /* extend the url with some query string options */
-    int res = gcoap_add_qstring(pkt, "ep", cord_common_ep);
+    int res = coap_opt_add_uquery(pkt, "ep", cord_common_ep);
     if (res < 0) {
         return res;
     }
@@ -66,7 +66,7 @@ int cord_common_add_qstring(coap_pkt_t *pkt)
 #if CORD_LT
     char lt[11];
     lt[fmt_u32_dec(lt, CORD_LT)] = '\0';
-    res = gcoap_add_qstring(pkt, "lt", lt);
+    res = coap_opt_add_uquery(pkt, "lt", lt);
     if (res < 0) {
         return res;
     }
@@ -74,7 +74,7 @@ int cord_common_add_qstring(coap_pkt_t *pkt)
 
     /* [optional] set the domain parameter */
 #ifdef CORD_D
-    res = gcoap_add_qstring(pkt, "d", CORD_D);
+    res = coap_opt_add_uquery(pkt, "d", CORD_D);
     if (res < 0) {
         return res;
     }

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -221,7 +221,7 @@ static int _discover_internal(const sock_udp_ep_t *remote,
         return CORD_EP_ERR;
     }
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
-    gcoap_add_qstring(&pkt, "rt", "core.rd");
+    coap_opt_add_uquery(&pkt, "rt", "core.rd");
     size_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
     res = gcoap_req_send(buf, pkt_len, remote, _on_discover, NULL);
     if (res < 0) {


### PR DESCRIPTION
### Contribution description
#13213 added the function `coap_opt_add_uquery()` to the nanocoap Packet API as part of the effort to move this API to nanocoap. This PR follows up on that work to deprecate the gcoap function, `gcoap_add_qstring()`, and update uses of the gcoap function to the new nanocoap function.

`gcoap_add_qstring()` will not be available after the 2020.10 release. 

### Testing procedure
Build the documentation and verify the deprecation notice. Verify that the cord_ep example registers to an RD server as expected.

### Issues/PRs references
Final step for #9309