### PR TITLE
core: cleanup kernel_init.c

### DIFF
--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -37,9 +37,10 @@
 #endif
 
 extern int main(void);
+
 static void *main_trampoline(void *arg)
 {
-    (void) arg;
+    (void)arg;
 
 #ifdef MODULE_AUTO_INIT
     auto_init();
@@ -48,12 +49,13 @@ static void *main_trampoline(void *arg)
     LOG_INFO("main(): This is RIOT! (Version: " RIOT_VERSION ")\n");
 
     main();
+
     return NULL;
 }
 
 static void *idle_thread(void *arg)
 {
-    (void) arg;
+    (void)arg;
 
     while (1) {
         pm_set_lowest();
@@ -62,25 +64,22 @@ static void *idle_thread(void *arg)
     return NULL;
 }
 
-const char *main_name = "main";
-const char *idle_name = "idle";
-
 static char main_stack[THREAD_STACKSIZE_MAIN];
 static char idle_stack[THREAD_STACKSIZE_IDLE];
 
 void kernel_init(void)
 {
-    (void) irq_disable();
+    irq_disable();
 
     thread_create(idle_stack, sizeof(idle_stack),
-            THREAD_PRIORITY_IDLE,
-            THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
-            idle_thread, NULL, idle_name);
+                  THREAD_PRIORITY_IDLE,
+                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  idle_thread, NULL, "idle");
 
     thread_create(main_stack, sizeof(main_stack),
-            THREAD_PRIORITY_MAIN,
-            THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
-            main_trampoline, NULL, main_name);
+                  THREAD_PRIORITY_MAIN,
+                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  main_trampoline, NULL, "main");
 
     cpu_switch_context_exit();
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR does some cleanup in core/kernel_init.c:

1. remove global `main_name` and `idle_name` symbols (not used anywhere)
1. uncrustify
1. sprinkle some empty lines

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI should be fine.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
