### PR TITLE
net/nanocoap: Expose configurations to Kconfig

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -24,7 +24,7 @@ static const uint8_t block2_mcu[] = " board with a ";
 static ssize_t _echo_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
 {
     (void)context;
-    char uri[NANOCOAP_URI_MAX];
+    char uri[CONFIG_NANOCOAP_URI_MAX];
 
     if (coap_get_uri_path(pkt, (uint8_t *)uri) <= 0) {
         return coap_reply_simple(pkt, COAP_CODE_INTERNAL_SERVER_ERROR, buf,

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -124,8 +124,8 @@ extern "C" {
  * @{
  */
 /** @brief   Maximum number of Options in a message */
-#ifndef NANOCOAP_NOPTS_MAX
-#define NANOCOAP_NOPTS_MAX          (16)
+#ifndef CONFIG_NANOCOAP_NOPTS_MAX
+#define CONFIG_NANOCOAP_NOPTS_MAX          (16)
 #endif
 
 /**
@@ -182,14 +182,14 @@ typedef struct {
  * @brief   CoAP PDU parsing context structure
  */
 typedef struct {
-    coap_hdr_t *hdr;                            /**< pointer to raw packet   */
-    uint8_t *token;                             /**< pointer to token        */
-    uint8_t *payload;                           /**< pointer to payload      */
-    uint16_t payload_len;                       /**< length of payload       */
-    uint16_t options_len;                       /**< length of options array */
-    coap_optpos_t options[NANOCOAP_NOPTS_MAX];  /**< option offset array     */
+    coap_hdr_t *hdr;                                  /**< pointer to raw packet   */
+    uint8_t *token;                                   /**< pointer to token        */
+    uint8_t *payload;                                 /**< pointer to payload      */
+    uint16_t payload_len;                             /**< length of payload       */
+    uint16_t options_len;                             /**< length of options array */
+    coap_optpos_t options[CONFIG_NANOCOAP_NOPTS_MAX]; /**< option offset array     */
 #ifdef MODULE_GCOAP
-    uint32_t observe_value;                     /**< observe value           */
+    uint32_t observe_value;                           /**< observe value           */
 #endif
 } coap_pkt_t;
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -139,8 +139,8 @@ extern "C" {
 /**
  * @brief    Maximum size for a blockwise transfer as a power of 2
  */
-#ifndef NANOCOAP_BLOCK_SIZE_EXP_MAX
-#define NANOCOAP_BLOCK_SIZE_EXP_MAX  (6)
+#ifndef CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX
+#define CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX  (6)
 #endif
 
 /** @brief   Maximum length of a query string written to a message */
@@ -616,7 +616,7 @@ ssize_t coap_opt_get_opaque(const coap_pkt_t *pkt, unsigned opt_num, uint8_t **v
  * @param[in]    blknum     offset from the beginning of content, in terms of
                             @p blksize byte blocks
  * @param[in]    blksize    size of each block; must be a power of 2 between 16
- *                          and 2 raised to #NANOCOAP_BLOCK_SIZE_EXP_MAX
+ *                          and 2 raised to #CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX
  * @param[in]    more       more blocks? use 1 if yes; 0 if no or unknown
  */
 void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
@@ -686,7 +686,7 @@ void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer);
  * @param[in]    blknum     offset from the beginning of content, in terms of
                             @p blksize byte blocks
  * @param[in]    blksize    size of each block; must be a power of 2 between 16
- *                          and 2 raised to #NANOCOAP_BLOCK_SIZE_EXP_MAX
+ *                          and 2 raised to #CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX
  */
 void coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
                             size_t blksize);

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -144,8 +144,8 @@ extern "C" {
 #endif
 
 /** @brief   Maximum length of a query string written to a message */
-#ifndef NANOCOAP_QS_MAX
-#define NANOCOAP_QS_MAX             (64)
+#ifndef CONFIG_NANOCOAP_QS_MAX
+#define CONFIG_NANOCOAP_QS_MAX             (64)
 #endif
 /** @} */
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -132,8 +132,8 @@ extern "C" {
  * @brief    Maximum length of a resource path string read from or written to
  *           a message
  */
-#ifndef NANOCOAP_URI_MAX
-#define NANOCOAP_URI_MAX            (64)
+#ifndef CONFIG_NANOCOAP_URI_MAX
+#define CONFIG_NANOCOAP_URI_MAX            (64)
 #endif
 
 /**
@@ -516,18 +516,18 @@ static inline ssize_t coap_get_location_query(const coap_pkt_t *pkt,
  * This function decodes the pkt's URI option into a "/"-separated and
  * '\0'-terminated string.
  *
- * Caller must ensure @p target can hold at least NANOCOAP_URI_MAX bytes!
+ * Caller must ensure @p target can hold at least CONFIG_NANOCOAP_URI_MAX bytes!
  *
  * @param[in]   pkt     pkt to work on
  * @param[out]  target  buffer for target URI
  *
- * @returns     -ENOSPC     if URI option is larger than NANOCOAP_URI_MAX
+ * @returns     -ENOSPC     if URI option is larger than CONFIG_NANOCOAP_URI_MAX
  * @returns     nr of bytes written to @p target (including '\0')
  */
 static inline ssize_t coap_get_uri_path(const coap_pkt_t *pkt, uint8_t *target)
 {
     return coap_opt_get_string(pkt, COAP_OPT_URI_PATH, target,
-                               NANOCOAP_URI_MAX, '/');
+                               CONFIG_NANOCOAP_URI_MAX, '/');
 }
 
 /**
@@ -536,18 +536,18 @@ static inline ssize_t coap_get_uri_path(const coap_pkt_t *pkt, uint8_t *target)
  * This function decodes the pkt's URI_QUERY option into a "&"-separated and
  * '\0'-terminated string.
  *
- * Caller must ensure @p target can hold at least NANOCOAP_URI_MAX bytes!
+ * Caller must ensure @p target can hold at least CONFIG_NANOCOAP_URI_MAX bytes!
  *
  * @param[in]   pkt     pkt to work on
  * @param[out]  target  buffer for target URI
  *
- * @returns     -ENOSPC     if URI option is larger than NANOCOAP_URI_MAX
+ * @returns     -ENOSPC     if URI option is larger than CONFIG_NANOCOAP_URI_MAX
  * @returns     nr of bytes written to @p target (including '\0')
  */
 static inline ssize_t coap_get_uri_query(const coap_pkt_t *pkt, uint8_t *target)
 {
     return coap_opt_get_string(pkt, COAP_OPT_URI_QUERY, target,
-                               NANOCOAP_URI_MAX, '&');
+                               CONFIG_NANOCOAP_URI_MAX, '&');
 }
 
 /**

--- a/sys/net/application_layer/Kconfig
+++ b/sys/net/application_layer/Kconfig
@@ -7,5 +7,6 @@
 menu "CoAP"
 
 rsource "gcoap/Kconfig"
+rsource "nanocoap/Kconfig"
 
 endmenu # CoAP

--- a/sys/net/application_layer/Kconfig
+++ b/sys/net/application_layer/Kconfig
@@ -1,13 +1,11 @@
-# Copyright (c) 2019 HAW Hamburg
+# Copyright (c) 2020 HAW Hamburg
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
-menu "Networking"
+menu "CoAP"
 
-rsource "application_layer/Kconfig"
-rsource "gnrc/Kconfig"
-rsource "sock/Kconfig"
+rsource "gcoap/Kconfig"
 
-endmenu # Networking
+endmenu # CoAP

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -48,8 +48,8 @@
 static char *_regif_buf;
 static size_t _regif_buf_len;
 
-static char _rd_loc[NANOCOAP_URI_MAX];
-static char _rd_regif[NANOCOAP_URI_MAX];
+static char _rd_loc[CONFIG_NANOCOAP_URI_MAX];
+static char _rd_regif[CONFIG_NANOCOAP_URI_MAX];
 static sock_udp_ep_t _rd_remote;
 
 static mutex_t _mutex = MUTEX_INIT;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -379,7 +379,7 @@ static int _find_resource(coap_pkt_t *pdu, const coap_resource_t **resource_ptr,
     /* Find path for CoAP msg among listener resources and execute callback. */
     gcoap_listener_t *listener = _coap_state.listeners;
 
-    uint8_t uri[NANOCOAP_URI_MAX];
+    uint8_t uri[CONFIG_NANOCOAP_URI_MAX];
     if (coap_get_uri_path(pdu, uri) <= 0) {
         return GCOAP_RESOURCE_NO_PATH;
     }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -962,12 +962,12 @@ ssize_t gcoap_encode_link(const coap_resource_t *resource, char *buf,
 
 int gcoap_add_qstring(coap_pkt_t *pdu, const char *key, const char *val)
 {
-    char qs[NANOCOAP_QS_MAX];
+    char qs[CONFIG_NANOCOAP_QS_MAX];
     size_t len = strlen(key);
     size_t val_len = (val) ? (strlen(val) + 1) : 0;
 
     /* test if the query string fits, account for the zero termination */
-    if ((len + val_len + 1) >= NANOCOAP_QS_MAX) {
+    if ((len + val_len + 1) >= CONFIG_NANOCOAP_QS_MAX) {
         return -1;
     }
 

--- a/sys/net/application_layer/nanocoap/Kconfig
+++ b/sys/net/application_layer/nanocoap/Kconfig
@@ -1,0 +1,37 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+# Nanocoap provides CoAP functionalities
+config MODULE_NANOCOAP
+    select HAS_PROTOCOL_COAP
+
+menuconfig KCONFIG_MODULE_NANOCOAP
+    bool "Configure Nanocoap module"
+    depends on MODULE_NANOCOAP
+
+if KCONFIG_MODULE_NANOCOAP
+
+config NANOCOAP_NOPTS_MAX
+    int "Maximum number of options in a message"
+    default 16
+
+config NANOCOAP_URI_MAX
+    int "Maximum length of a resource path"
+    default 64
+    help
+        Maximum length of a resource path string read from or written to a
+        message.
+
+config NANOCOAP_BLOCK_SIZE_EXP_MAX
+    int "Maximum size for a blockwise fransfer (as exponent of 2^n)"
+    default 6
+
+config NANOCOAP_QS_MAX
+    int "Maximum length of a query string written to a message"
+    default 64
+
+endif # KCONFIG_MODULE_NANOCOAP

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -395,7 +395,7 @@ ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
 {
     coap_method_flags_t method_flag = coap_method2flag(coap_get_code_detail(pkt));
 
-    uint8_t uri[NANOCOAP_URI_MAX];
+    uint8_t uri[CONFIG_NANOCOAP_URI_MAX];
     if (coap_get_uri_path(pkt, uri) <= 0) {
         return -EBADMSG;
     }

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -951,8 +951,8 @@ void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
     if (coap_get_blockopt(pkt, COAP_OPT_BLOCK2, &blknum, &szx) >= 0) {
         /* Use the client requested block size if it is smaller than our own
          * maximum block size */
-        if (NANOCOAP_BLOCK_SIZE_EXP_MAX - 4 < szx) {
-            szx = NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
+        if (CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4 < szx) {
+            szx = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
         }
     }
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -108,7 +108,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
             DEBUG("option count=%u nr=%u len=%i\n", option_count, option_nr, option_len);
 
             if (option_delta) {
-                if (option_count >= NANOCOAP_NOPTS_MAX) {
+                if (option_count >= CONFIG_NANOCOAP_NOPTS_MAX) {
                     DEBUG("nanocoap: max nr of options exceeded\n");
                     return -ENOMEM;
                 }
@@ -783,7 +783,7 @@ size_t coap_opt_put_uint(uint8_t *buf, uint16_t lastonum, uint16_t onum,
 static ssize_t _add_opt_pkt(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val,
                             size_t val_len)
 {
-    if (pkt->options_len >= NANOCOAP_NOPTS_MAX) {
+    if (pkt->options_len >= CONFIG_NANOCOAP_NOPTS_MAX) {
         return -ENOSPC;
     }
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -862,12 +862,12 @@ ssize_t coap_opt_add_uri_query2(coap_pkt_t *pkt, const char *key, size_t key_len
     assert(key_len);
     assert(!val_len || (val && val_len));
 
-    char qs[NANOCOAP_QS_MAX];
+    char qs[CONFIG_NANOCOAP_QS_MAX];
     /* length including '=' */
     size_t qs_len = key_len + ((val && val_len) ? (val_len + 1) : 0);
 
     /* test if the query string fits */
-    if (qs_len > NANOCOAP_QS_MAX) {
+    if (qs_len > CONFIG_NANOCOAP_QS_MAX) {
         return -1;
     }
 

--- a/sys/shell/commands/sc_cord_ep.c
+++ b/sys/shell/commands/sc_cord_ep.c
@@ -73,7 +73,7 @@ int _cord_ep_handler(int argc, char **argv)
             printf("usage: %s discover <server address>\n", argv[0]);
             return 1;
         }
-        char regif[NANOCOAP_URI_MAX];
+        char regif[CONFIG_NANOCOAP_URI_MAX];
         sock_udp_ep_t remote;
         if (make_sock_ep(&remote, argv[2]) < 0) {
             printf("error: unable to parse address\n");

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -88,7 +88,7 @@ static void test_gcoap__client_get_req(void)
                           coap_get_total_hdr_len(&pdu));
     TEST_ASSERT_EQUAL_INT(COAP_TYPE_NON, coap_get_type(&pdu));
 
-    char uri[NANOCOAP_URI_MAX] = {0};
+    char uri[CONFIG_NANOCOAP_URI_MAX] = {0};
     coap_get_uri_path(&pdu, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING(&path[0], &uri[0]);
     TEST_ASSERT_EQUAL_INT(0, pdu.payload_len);
@@ -198,7 +198,7 @@ static void test_gcoap__client_get_path_defer(void)
 
     coap_parse(&pdu, buf, len);
 
-    char uri[NANOCOAP_URI_MAX] = {0};
+    char uri[CONFIG_NANOCOAP_URI_MAX] = {0};
     coap_get_uri_path(&pdu, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING(&path[0], &uri[0]);
 }
@@ -238,7 +238,7 @@ static void test_gcoap__server_get_req(void)
     TEST_ASSERT_EQUAL_INT(COAP_TYPE_NON, coap_get_type(&pdu));
     TEST_ASSERT_EQUAL_INT(0, pdu.payload_len);
 
-    char uri[NANOCOAP_URI_MAX] = {0};
+    char uri[CONFIG_NANOCOAP_URI_MAX] = {0};
     coap_get_uri_path(&pdu, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING("/cli/stats", &uri[0]);
 }

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -223,13 +223,13 @@ static void test_nanocoap__get_max_path(void)
     len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
-    char uri[NANOCOAP_URI_MAX] = {0};
+    char uri[CONFIG_NANOCOAP_URI_MAX] = {0};
     coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
 /*
- * Builds on get_req test, to test path longer than NANOCOAP_URI_MAX. We
+ * Builds on get_req test, to test path longer than CONFIG_NANOCOAP_URI_MAX. We
  * expect coap_get_uri_path() to return -ENOSPC.
  */
 static void test_nanocoap__get_path_too_long(void)
@@ -250,7 +250,7 @@ static void test_nanocoap__get_path_too_long(void)
     len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
-    char uri[NANOCOAP_URI_MAX] = {0};
+    char uri[CONFIG_NANOCOAP_URI_MAX] = {0};
     int get_len = coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_INT(-ENOSPC, get_len);
 }

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -535,7 +535,7 @@ static void test_nanocoap__server_option_count_overflow_check(void)
 {
     /* this test passes a forged CoAP packet containing 42 options (provided by
      * @nmeum in #10753, 42 is a random number which just needs to be higher
-     * than NANOCOAP_NOPTS_MAX) to coap_parse().  The used coap_pkt_t is part
+     * than CONFIG_NANOCOAP_NOPTS_MAX) to coap_parse().  The used coap_pkt_t is part
      * of a struct, followed by an array of 42 coap_option_t.  The array is
      * cleared before the call to coap_parse().  If the overflow protection is
      * working, the array must still be clear after parsing the packet, and the
@@ -553,8 +553,8 @@ static void test_nanocoap__server_option_count_overflow_check(void)
         0x11, 0x17, 0x11, 0x17, 0x11, 0x17, 0x11, 0x17, 0x11, 0x17, 0x11, 0x17,
         0x11, 0x17, 0x11, 0x17 };
 
-    /* ensure NANOCOAP_NOPTS_MAX is actually lower than 42 */
-    TEST_ASSERT(NANOCOAP_NOPTS_MAX < 42);
+    /* ensure CONFIG_NANOCOAP_NOPTS_MAX is actually lower than 42 */
+    TEST_ASSERT(CONFIG_NANOCOAP_NOPTS_MAX < 42);
 
     struct {
       coap_pkt_t pkt;
@@ -588,7 +588,7 @@ static void test_nanocoap__server_option_count_overflow(void)
      * path, but only 1 entry in the options array.
      * Size buf to accept an extra 2-byte option */
     unsigned base_len = 17;
-    uint8_t buf[17 + (2 * NANOCOAP_NOPTS_MAX)] = {
+    uint8_t buf[17 + (2 * CONFIG_NANOCOAP_NOPTS_MAX)] = {
         0x42, 0x01, 0xbe, 0x16, 0x35, 0x61, 0xb4, 0x72,
         0x69, 0x6f, 0x74, 0x05, 0x76, 0x61, 0x6c, 0x75,
         0x65
@@ -600,7 +600,7 @@ static void test_nanocoap__server_option_count_overflow(void)
 
     /* fill pkt with maximum options; should succeed */
     int i = 0;
-    for (; i < (2 * (NANOCOAP_NOPTS_MAX - 1)); i+=2) {
+    for (; i < (2 * (CONFIG_NANOCOAP_NOPTS_MAX - 1)); i+=2) {
         memcpy(&buf[base_len+i], fill_opt, 2);
     }
 


### PR DESCRIPTION
### Contribution description
This moves configuration macros from nanocoap to the `CONFIG_` namespace, and exposes them to Kconfig.

`MODULE_NANOCOAP` now is selecting a hidden symbol introduced in #13227 to indicate that CoAP support is present, and that the generic configurations should be shown. There is no issue on selecting an undefined symbol, so we can merge this directly. In case #13227 is merged first I'll remove the default value that was added there.

### Testing procedure
- `examples/gcoap` and `examples/nanocoap_server` should be working as usual.
- Changing configurations should reflect on the application.

### Issues/PRs references
Part of #12888
Related to #13227 
