### PR TITLE
gnrc_ipv6_ext_frag: add configuration option to keep oldest entry

### DIFF
--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -88,6 +88,19 @@ extern "C" {
 #define CONFIG_GNRC_IPV6_EXT_FRAG_RBUF_TIMEOUT_US  (10U * US_PER_SEC)
 #endif
 
+/**
+ * @brief   Do not override oldest datagram when reassembly buffer is full
+ *
+ * @note    Only applicable with [gnrc_ipv6_ext_frag](@ref net_gnrc_ipv6_ext_frag) module
+ *
+ * When not set, it will cause the reassembly buffer to override the oldest
+ * entry when a fragment for a new datagram is received. When set to 1, no entry
+ * will be overwritten (they will still timeout normally)
+ */
+#ifdef DOXYGEN
+#define CONFIG_GNRC_IPV6_EXT_FRAG_RBUF_DO_NOT_OVERRIDE
+#endif
+
 /** @} **/
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/ext/frag/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/ext/frag/Kconfig
@@ -40,4 +40,11 @@ config GNRC_IPV6_EXT_FRAG_RBUF_TIMEOUT_US
     help
         This value is expressed in microseconds.
 
+config GNRC_IPV6_EXT_FRAG_RBUF_DO_NOT_OVERRIDE
+    bool "Do not override oldest datagram when reassembly buffer is full"
+    help
+        When not set, it will cause the reassembly buffer to override the oldest
+        entry when a fragment for a new datagram is received. When set to 1, no
+        entry will be overwritten (they will still timeout normally)
+
 endif # KCONFIG_MODULE_GNRC_IPV6_EXT_FRAG

--- a/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
@@ -557,7 +557,8 @@ gnrc_ipv6_ext_frag_rbuf_t *gnrc_ipv6_ext_frag_rbuf_get(ipv6_hdr_t *ipv6,
             oldest = tmp;
         }
     }
-    if (res == NULL) {
+    if ((res == NULL) &&
+        !IS_ACTIVE(CONFIG_GNRC_IPV6_EXT_FRAG_RBUF_DO_NOT_OVERRIDE)) {
         assert(oldest != NULL); /* reassembly buffer is full, so there needs
                                  * to be an oldest entry */
         DEBUG("ipv6_ext_frag: dropping oldest entry\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This gives a similar treatment to the reassembly buffer of `gnrc_ipv6_ext_frag` as I already introduced for `gnrc_sixlowpan_frag_rb`: a configuration option to turn of the overriding of the oldest entry when the reassembly buffer is full and a new incoming datagram tries to be reassembled.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/gnrc_ipv6_ext_frag` should still compile and the test should still be running.

If you want to test the new option, try compiling `tests/gnrc_udp` `-DCONFIG_GNRC_IPV6_EXT_FRAG_RBUF_DO_NOT_OVERRIDE` and do e.g. [Task 4.10 of the release specs](https://github.com/RIOT-OS/Release-Specs/blob/master/04-single-hop-6lowpan-icmp/04-single-hop-6lowpan-icmp.md#task-10-exprimental---icmpv6-echo-with-large-payload-ipv6-fragmentation).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
