### PR TITLE
gnrc_sixlowpan_frag_rb: fix doc on DO_NOT_OVERRIDE

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -83,16 +83,16 @@ extern "C" {
 #endif
 
 /**
- * @brief   Keep all but oldest fragment when reassembly buffer is full
+ * @brief   Do not override oldest datagram when reassembly buffer is full
  *
  * @note    Only applicable with
  *          [gnrc_sixlowpan_frag_rb](@ref net_gnrc_sixlowpan_frag_rb) module
  *
- * When not set, it will cause the reassembly buffer to override the oldest entry
- * if a new entry has to be created and the reassembly buffer is full, no matter what.
- * When set to 1, only incomplete entries that are older than
- * @ref CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be overwritten (they will still
- * timeout normally).
+ * When not set, it will cause the reassembly buffer to override the oldest
+ * entry when a fragment for a new datagram is received. When set, only the
+ * oldest entry that is older than @ref
+ * CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be overwritten (they will
+ * still timeout normally if reassembly buffer is not full).
  */
 #ifdef DOXYGEN
 #define CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/Kconfig
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/Kconfig
@@ -21,13 +21,13 @@ config GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US
     default 3000000
 
 config GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE
-    bool "Keep all but oldest fragment when reassembly buffer is full"
+    bool "Do not override oldest datagram when reassembly buffer is full"
     help
-        When not set, it will cause the reassembly buffer to
-        override the oldest entry no matter what. When set, only the oldest
-        entry that is older than @ref CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US
-        will be overwritten (they will still timeout normally if reassembly
-        buffer is not full).
+        When not set, it will cause the reassembly buffer to override the oldest
+        entry when a fragment for a new datagram is received. When set, only the
+        oldest entry that is older than @ref
+        CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_TIMEOUT_US will be overwritten (they
+        will still timeout normally if reassembly buffer is not full).
 
 config GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER
     int "Deletion timer for reassembly buffer entries in microseconds"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While working on https://github.com/RIOT-OS/RIOT/pull/13244 I re-read the doc on the corresponding option in 6LoWPAN that this PR introduces, to have the two unified, and found it to be a bit misleading (even though we discussed the documentation at length in https://github.com/RIOT-OS/RIOT/pull/13129). This PR fixes the documentation to be a bit more clearer.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
