### PR TITLE
drivers/adc_ng: Added common ADC API

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -10,6 +10,11 @@ ifneq (,$(filter adc%1c,$(USEMODULE)))
   USEMODULE += adcxx1c
 endif
 
+ifneq (,$(filter adc_ng,$(USEMODULE)))
+  FEATURES_REQUIRED += adc_ng
+  FEATURES_OPTIONAL += periph_adc_ng
+endif
+
 ifneq (,$(filter ads101%,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio_irq
   FEATURES_REQUIRED += periph_i2c

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -12,6 +12,10 @@ endif
 
 ifneq (,$(filter adc_ng,$(USEMODULE)))
   FEATURES_REQUIRED += adc_ng
+endif
+
+ifneq (,$(filter adc_ng_default,$(USEMODULE)))
+  USEMODULE += adc_ng
   FEATURES_OPTIONAL += periph_adc_ng
 endif
 

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -1,4 +1,7 @@
 # driver includes (in alphabetical order)
+ifneq (,$(filter adc_ng,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/adc_ng/include
+endif
 
 ifneq (,$(filter ad7746,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ad7746/include

--- a/drivers/adc_ng/Makefile
+++ b/drivers/adc_ng/Makefile
@@ -1,3 +1,6 @@
 SRC := adc_ng.c
+# Some adc_ng_<foo> pseudo module should be result in corresponding <foo>.c
+# to be included for compilation, but not every adc_ng_<foo> is a submodule
 SUBMODULES := 1
+SUBMODULES_NOFORCE := 1
 include $(RIOTBASE)/Makefile.base

--- a/drivers/adc_ng/Makefile
+++ b/drivers/adc_ng/Makefile
@@ -1,0 +1,3 @@
+SRC := adc_ng.c
+SUBMODULES := 1
+include $(RIOTBASE)/Makefile.base

--- a/drivers/adc_ng/adc_ng.c
+++ b/drivers/adc_ng/adc_ng.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_adc_ng
+ * @{
+ *
+ * @file
+ * @brief       Implementation of common functions of the ADC API
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @}
+ */
+
+#include <errno.h>
+
+#include "adc_ng.h"
+
+#if (ADC_NG_NUMOF == 1) && defined(MODULE_PERIPH_ADC_NG)
+extern const adc_ng_driver_t periph_adc_ng_driver;
+void * const adc_ng_handles[ADC_NG_NUMOF] = { NULL };
+const adc_ng_driver_t * const adc_ng_drivers[ADC_NG_NUMOF] = {
+    &periph_adc_ng_driver
+};
+#endif
+/* selected reference voltage in mV */
+uint16_t adc_ng_refs[ADC_NG_NUMOF];
+/* selected resolution */
+uint8_t adc_ng_res[ADC_NG_NUMOF];
+
+int adc_ng_init(uint8_t adc, uint8_t chan, uint8_t res, uint16_t *ref)
+{
+    assert(adc < ADC_NG_NUMOF);
+    assert(ref);
+    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
+    void *handle = adc_ng_handles[adc];
+
+    if (!(drv->res_supported & (1 << res))) {
+        return -ENOTSUP;
+    }
+
+    uint8_t idx = 0;
+
+    if (*ref == ADC_NG_MAX_REF) {
+        while (drv->refs[++idx]) { }
+        idx--;
+    }
+    else {
+        while ((drv->refs[idx] & ADC_NG_REF_MASK) < *ref) {
+            if (!drv->refs[++idx]) {
+                /* No reference big enough to fit value given in *ref */
+                return -ERANGE;
+            }
+        }
+    }
+
+    adc_ng_refs[adc] = *ref = drv->refs[idx] & ADC_NG_REF_MASK;
+    adc_ng_res[adc] = res;
+
+    return drv->init(handle, chan, res, (uint8_t)idx);
+}
+
+uint16_t adc_ng_convert(uint8_t adc, uint32_t sample)
+{
+    assert(adc < ADC_NG_NUMOF);
+    /* V_in = (sample * V_ref) / (2^resolution) */
+    uint64_t vin = sample;
+    vin *= adc_ng_refs[adc];
+    vin >>= adc_ng_res[adc];
+    return (uint16_t)vin;
+}
+
+int adc_ng_burst(uint8_t adc, uint32_t *dest, size_t num)
+{
+    assert(adc < ADC_NG_NUMOF);
+    assert(dest && num);
+    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
+    void * handle = adc_ng_handles[adc];
+#ifdef MODULE_ADC_BURST
+    if (drv->burst) {
+        return drv->burst(handle, dest, num);
+    }
+    else
+#endif
+    {
+        int retval;
+        for (size_t i = 0; i < num; i++) {
+            retval = drv->single(handle, &dest[i]);
+            if (retval) {
+                return retval;
+            }
+        }
+    }
+
+    return 0;
+}
+
+int adc_ng_measure_ref(uint8_t adc, uint8_t ref_idx, uint16_t *dest)
+{
+    assert(adc < ADC_NG_NUMOF);
+    assert(dest);
+    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
+    void *handle = adc_ng_handles[adc];
+    /* It makes no sense to use the same voltage source as reference and input */
+    assert(drv->fixed_ref_input != ref_idx);
+
+    int retval;
+    uint32_t sample;
+    uint8_t res_max = adc_ng_max_res(adc);
+    retval = drv->init(handle, ADC_NG_CHAN_FIXED_REF, res_max, ref_idx);
+    if (retval) {
+        return retval;
+    }
+    retval = drv->single(handle, &sample);
+    drv->off(handle);
+    if (retval) {
+        return retval;
+    }
+    /*
+     * The sample s with the resolution r has the value:
+     *
+     *     s = (V_in * 2^r) / V_ref
+     *
+     * In this case we're interested in V_ref and know V_in, so:
+     *
+     *     V_ref = (V_in * 2^r) / s
+     */
+    uint64_t vref = (1ULL << res_max);
+    vref *= drv->refs[drv->fixed_ref_input];
+    vref += sample >> 1; /* <- Scientific rounding */
+    vref /= sample;
+    *dest = (uint16_t)vref;
+    return 0;
+}

--- a/drivers/adc_ng/adc_ng.c
+++ b/drivers/adc_ng/adc_ng.c
@@ -92,7 +92,7 @@ int adc_ng_burst(uint8_t adc, int32_t *dest, size_t num)
     assert(adc < ADC_NG_NUMOF);
     assert(dest && num);
     const adc_ng_backend_t be = adc_ng_backends[adc];
-#ifdef MODULE_ADC_BURST
+#ifdef MODULE_ADC_NG_BURST
     if (be.driver->burst) {
         return be.driver->burst(be.handle, dest, num);
     }

--- a/drivers/adc_ng/adc_ng.c
+++ b/drivers/adc_ng/adc_ng.c
@@ -23,74 +23,85 @@
 
 #if (ADC_NG_NUMOF == 1) && defined(MODULE_PERIPH_ADC_NG)
 extern const adc_ng_driver_t periph_adc_ng_driver;
-void * const adc_ng_handles[ADC_NG_NUMOF] = { NULL };
-const adc_ng_driver_t * const adc_ng_drivers[ADC_NG_NUMOF] = {
-    &periph_adc_ng_driver
+const adc_ng_backend_t adc_ng_backends[ADC_NG_NUMOF] = {
+    {
+        .driver = &periph_adc_ng_driver,
+        .handle = NULL
+    }
 };
 #endif
 /* selected reference voltage in mV */
-uint16_t adc_ng_refs[ADC_NG_NUMOF];
+int16_t adc_ng_refs[ADC_NG_NUMOF];
 /* selected resolution */
 uint8_t adc_ng_res[ADC_NG_NUMOF];
 
-int adc_ng_init(uint8_t adc, uint8_t chan, uint8_t res, uint16_t *ref)
+int adc_ng_init(uint8_t adc, uint8_t chan, uint8_t res, int16_t *ref)
 {
     assert(adc < ADC_NG_NUMOF);
     assert(ref);
-    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
-    void *handle = adc_ng_handles[adc];
+    assert((res > 0) && (res <= 32));
+    const adc_ng_backend_t be = adc_ng_backends[adc];
 
-    if (!(drv->res_supported & (1 << res))) {
+    if (!(be.driver->res_supported & (1 << (res - 1)))) {
         return -ENOTSUP;
     }
 
     uint8_t idx = 0;
 
     if (*ref == ADC_NG_MAX_REF) {
-        while (drv->refs[++idx]) { }
+        while (be.driver->refs[++idx]) { }
         idx--;
     }
     else {
-        while ((drv->refs[idx] & ADC_NG_REF_MASK) < *ref) {
-            if (!drv->refs[++idx]) {
-                /* No reference big enough to fit value given in *ref */
+        if ((*ref < 0) && (*ref < be.driver->refs[0])) {
+            /* No reference small enough to cover the range [*ref; 0] */
+            return -ERANGE;
+        }
+        /* Positive reference voltage: Select the lowest reference that
+         * is equal to or greater than the requested reference */
+        while (be.driver->refs[idx] < *ref) {
+            if (!be.driver->refs[++idx]) {
+                if (*ref < 0) {
+                    idx--;
+                    break;
+                }
+                /* No reference big enough to cover the range [0; ref] */
                 return -ERANGE;
             }
         }
     }
 
-    adc_ng_refs[adc] = *ref = drv->refs[idx] & ADC_NG_REF_MASK;
+    adc_ng_refs[adc] = *ref = be.driver->refs[idx];
     adc_ng_res[adc] = res;
 
-    return drv->init(handle, chan, res, (uint8_t)idx);
+    return be.driver->init(be.handle, chan, res, (uint8_t)idx);
 }
 
-uint16_t adc_ng_convert(uint8_t adc, uint32_t sample)
+int16_t adc_ng_convert(uint8_t adc, int32_t sample)
 {
     assert(adc < ADC_NG_NUMOF);
-    /* V_in = (sample * V_ref) / (2^resolution) */
-    uint64_t vin = sample;
+    /* V_in = (sample * V_ref) / (2^resolution - 1) */
+    int64_t vin = sample;
     vin *= adc_ng_refs[adc];
-    vin >>= adc_ng_res[adc];
-    return (uint16_t)vin;
+    vin /= (1 << adc_ng_res[adc]) - 1;
+    return (int16_t)vin;
 }
 
-int adc_ng_burst(uint8_t adc, uint32_t *dest, size_t num)
+int adc_ng_burst(uint8_t adc, int32_t *dest, size_t num)
 {
     assert(adc < ADC_NG_NUMOF);
     assert(dest && num);
-    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
-    void * handle = adc_ng_handles[adc];
+    const adc_ng_backend_t be = adc_ng_backends[adc];
 #ifdef MODULE_ADC_BURST
-    if (drv->burst) {
-        return drv->burst(handle, dest, num);
+    if (be.driver->burst) {
+        return be.driver->burst(be.handle, dest, num);
     }
     else
 #endif
     {
         int retval;
         for (size_t i = 0; i < num; i++) {
-            retval = drv->single(handle, &dest[i]);
+            retval = be.driver->single(be.handle, &dest[i]);
             if (retval) {
                 return retval;
             }
@@ -100,24 +111,24 @@ int adc_ng_burst(uint8_t adc, uint32_t *dest, size_t num)
     return 0;
 }
 
-int adc_ng_measure_ref(uint8_t adc, uint8_t ref_idx, uint16_t *dest)
+int adc_ng_measure_ref(uint8_t adc, uint8_t ref_idx, int16_t *dest)
 {
     assert(adc < ADC_NG_NUMOF);
     assert(dest);
-    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
-    void *handle = adc_ng_handles[adc];
+    const adc_ng_backend_t be = adc_ng_backends[adc];
     /* It makes no sense to use the same voltage source as reference and input */
-    assert(drv->fixed_ref_input != ref_idx);
+    assert(be.driver->ref_input_idx != ref_idx);
 
     int retval;
-    uint32_t sample;
+    int32_t sample;
     uint8_t res_max = adc_ng_max_res(adc);
-    retval = drv->init(handle, ADC_NG_CHAN_FIXED_REF, res_max, ref_idx);
+    retval = be.driver->init(be.handle, ADC_NG_CHAN_FIXED_REF, res_max,
+                             ref_idx);
     if (retval) {
         return retval;
     }
-    retval = drv->single(handle, &sample);
-    drv->off(handle);
+    retval = be.driver->single(be.handle, &sample);
+    be.driver->off(be.handle);
     if (retval) {
         return retval;
     }
@@ -130,10 +141,10 @@ int adc_ng_measure_ref(uint8_t adc, uint8_t ref_idx, uint16_t *dest)
      *
      *     V_ref = (V_in * 2^r) / s
      */
-    uint64_t vref = (1ULL << res_max);
-    vref *= drv->refs[drv->fixed_ref_input];
+    int64_t vref = (1ULL << res_max);
+    vref *= be.driver->refs[be.driver->ref_input_idx];
     vref += sample >> 1; /* <- Scientific rounding */
     vref /= sample;
-    *dest = (uint16_t)vref;
+    *dest = (int16_t)vref;
     return 0;
 }

--- a/drivers/adc_ng/include/adc_ng_globals.h
+++ b/drivers/adc_ng/include/adc_ng_globals.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_adc
+ * @{
+ *
+ * @file
+ * @brief       Global variables used in the common ADC API
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef ADC_NG_GLOBALS_H
+#define ADC_NG_GLOBALS_H
+
+#include "adc_ng_internal.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(ADC_NG_NUMOF) || defined(DOXYGEN)
+/**
+ * @brief   Number of ADC devices supported
+ *
+ * If a board supports more than one ADC, it has to define `ADC_NG_NUMOF` in
+ * `perpih_conf.h` and implement (but not declare)
+ * `adc_ng_driver_t *adc_ng_drivers[ADC_NG_NUMOF]` and
+ * `void *adc_ng_handles[ADC_NG_NUMOF]` (e.g. in `board.c`).
+ */
+#define ADC_NG_NUMOF                    (1U)
+#endif
+
+/**
+ * @brief   Array containing the backends available
+ */
+extern const adc_ng_backend_t adc_ng_backends[ADC_NG_NUMOF];
+/**
+ * @brief   Currently selected reference voltage in mV
+ */
+extern int16_t adc_ng_refs[ADC_NG_NUMOF];
+/**
+ * @brief   Currently selected resolution
+ */
+extern uint8_t adc_ng_res[ADC_NG_NUMOF];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_NG_GLOBALS_H */
+/** @} */

--- a/drivers/adc_ng/include/adc_ng_internal.h
+++ b/drivers/adc_ng/include/adc_ng_internal.h
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_adc
+ * @{
+ *
+ * @file
+ * @brief       Internal types used in the common ADC API
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef ADC_NG_INTERNAL_H
+#define ADC_NG_INTERNAL_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(ADC_NG_NUMOF) || defined(DOXYGEN)
+/**
+ * @brief   Number of ADC devices supported
+ *
+ * If a board supports more than one ADC, it has to define `ADC_NG_NUMOF` in
+ * `perpih_conf.h` and implement (but not declare)
+ * `adc_ng_driver_t *adc_ng_drivers[ADC_NG_NUMOF]` and
+ * `void *adc_ng_handles[ADC_NG_NUMOF]` (e.g. in `board.c`).
+ */
+#define ADC_NG_NUMOF                    (1U)
+#endif
+
+/**
+ * @brief   This special channel must refer to an internal fixed reference
+ *          voltage used as input
+ *
+ * ADCs not supporting this will return `-ERANGE` when this channel is
+ * selected. If this is supported, it can be used to measure the correct value
+ * of voltage references depending on supply voltages (including the MCUs
+ * supply voltage, if selectable as reference voltage). This allows to
+ * compensate for differences between nominal and actual voltage reference
+ * during conversion to physical units.
+ *
+ * In case of boards running directly of a battery, measuring the supply
+ * voltage is particularly useful to estimate the remaining battery charge.
+ */
+#define ADC_NG_CHAN_FIXED_REF           (UINT8_MAX)
+
+/**
+ * @brief   This special channel must refer to an internally connected
+ *          thermistor
+ */
+#define ADC_NG_CHAN_NTC                 (UINT8_MAX - 1)
+
+/**
+ * @brief   This special channel must refer to a channel collecting entropy
+ *
+ * @note    When this channel is selected, a driver can (and likely should)
+ *          ignore the requested resolution and reference voltage.
+ *
+ * When this channel is used, the @ref adc_ng_driver_t::entropy_bits least
+ * significant of every sample obtained will contain a some (possibly weak)
+ * entropy. The contents of the remaining bits are undefined.
+ */
+#define ADC_NG_CHAN_ENTROPY             (UINT8_MAX - 2)
+
+/**
+ * @brief   Use this value in @ref adc_ng_driver_t::fixed_ref_input to
+ *          indicate that no fixed reference can be used as input
+ */
+#define ADC_NG_NO_FIXED_INPUT           (UINT8_MAX)
+
+/**
+ * @brief   Flag to indicate the MCUs supply voltage is used as reference
+ *
+ * When a known, lower reference voltage can be selected as input and is
+ * sampled using the MCU's VCC as reference, the MCU's VCC can be deduced.
+ */
+#define ADC_NG_REF_MCU_VCC              (0x8000U)
+
+/**
+ * @brief   Flag a reference voltage as calibrated
+ *
+ * E.g. the 1.1V bandgap voltage reference available on many ATmega has
+ * production variations of +-100mV, but is extremely stable; so it will
+ * consistently create the same voltage for a wide range of supply voltage and
+ * operating temperatures. So if the actual value of the reference is e.g.
+ * written to EEPROM and restored on boot, the reference value should be marked
+ * as calibrated.
+ */
+#define ADC_NG_REF_CALIBRATED           (0x4000U)
+/**
+ * @brief   Access the voltage value without flags
+ */
+#define ADC_NG_REF_MASK                 (0x3fffU)
+
+/**
+ * @brief   Description of an thermistor to use for temperature measurements
+ */
+typedef struct {
+    /**
+     * @brief   Contains the temperature coefficient of the NTC, or zero
+     *
+     * The coefficient is is given in 1/1024 mV per 0.1 °C. The resulting
+     * temperature in 0.1 °C is calculated from the measured voltage using:
+     *
+     *    T[d°C] = (coefficient * (mV - offset)) / 1024
+     */
+    uint16_t coefficient;
+    /**
+     * @brief   The offset in mV to use for obtaining the temperature
+     *
+     * See @ref adc_ng_ntc_t::coefficient
+     */
+    uint16_t offset;
+} adc_ng_ntc_t;
+
+/**
+ * @brief   Internal driver interface
+ */
+typedef struct {
+    /**
+     * @brief   Initialize the given ADC channel and prepare it for sampling
+     * @param           handle  Handle of the ADC
+     * @param[in]       chan    The ADC channel to initialize
+     * @param[in]       res     The resolution to select
+     * @param[in        ref     Index of the reference to use (@ref adc_ng_driver_t::refs)
+     *
+     * @retval  0               Success
+     * @retval  -ENXIO          Invalid channel given in @p channel
+     * @retval  -EALREADY       The ADC is already powered and configured
+     * @retval  <0              Other error (see device driver doc)
+     *
+     * @post    When 0 is returned, the channel @p channel is ready take samples
+     * @post    If @p res contains an unsupported resolution, an assert blows up
+     * @post    If `-EALREADY` is returned, the ADC is state remains unchanged
+     * @post    On other error codes the ADC is powered down
+     *
+     * @note    A call to @ref adc_ng_driver_t::off is needed to disable the channel
+     *          again and preserve power
+     */
+    int (*init)(void *handle, uint8_t chan, uint8_t res, uint8_t ref);
+    /**
+     * @brief   Disable the given ADC channel again and bring the ADC into a low
+     *          power state, unless other ADC channels are still onchannel
+     *
+     * @param           handle  Handle of the ADC
+     */
+    void (*off)(void *handle);
+    /**
+     * @brief   Runs a single conversion and returns the sample
+     *
+     * @param           handle  Handle of the ADC
+     * @param[out]      dest    The sample will be stored here
+     *
+     * @return  The result of the conversion
+     *
+     * @pre     The ADC has been initialized, see @ref adc_ng_driver_t::init
+     *
+     * @post    If the ADC is not initialized, an assertion blows up
+     *
+     * @retval  0           Success
+     * @retval  <0          Error (check device driver's doc for error codes)
+     */
+    int (*single)(void *handle, uint32_t *dest);
+#ifdef MODULE_ADC_BURST
+    /**
+     * @brief   Runs a burst conversion acquiring multiple samples in fast
+     *          succession
+     *
+     * @param           handle  Handle of the ADC
+     * @param[out]      dest    Buffer to write the results of the burst read to
+     * @param[in]       num     Number of samples to burst read
+     *
+     * @pre     The channel given in @p channel is currently initialized, see
+     *          @ref adc_ng_driver_t::init
+     *
+     * @post    If the ADC is not initialized, an assertion blows up
+     *
+     * @retval  0           Success
+     * @retval  <0          Error (check device driver's doc for error codes)
+     */
+    int (*burst)(void *handle, uint32_t *dest, size_t num);
+#endif /* MODULE_ADC_BURST */
+    /**
+     * @brief   Bitmap containing the supported ADC resolutions
+     *
+     * If e.g. the resolutions 4bit, 6bit and 8bit are supported it should have
+     * the value `BIT4 | BIT6 | BIT8`. Thus, currently the highest resolution
+     * supported is 31 bit.
+     */
+    uint32_t res_supported;
+    /**
+     * @brief   The reference voltages supported in ascending order
+     *
+     * This list should be sorted in ascending order and terminated with a
+     * value of zero. The reference voltage are a bitmask with the 14 least
+     * significant bits containing the voltage value in mV, and the two
+     * most significant bits indicate whether the reference voltage is
+     * calibrated (@ref ADC_NG_REF_CALIBRATED) and if the MCUs supply voltage
+     * is used as reference (@ref ADC_NG_REF_MCU_VCC).
+     */
+    const uint16_t *refs;
+    /**
+     * @brief   Parameters of the internally connected thermistor or `NULL`
+     */
+    const adc_ng_ntc_t *ntc;
+    /**
+     * @brief   The index of the reference voltage that can be used as input
+     *          using channel @ref ADC_NG_CHAN_FIXED_REF
+     *
+     * In case the fixed reference voltage can only be used as input, and not
+     * set up as reference during conversion, add this reference to @ref
+     * adc_ng_driver_t::refs after the last item (identified using value zero)
+     * and use that index here. This will prevent that reference to be used
+     * except as input.
+     *
+     * Use the special value @ref ADC_NG_NO_FIXED_INPUT if no fixed reference
+     * voltage can be used as input.
+     */
+    uint8_t fixed_ref_input;
+    /**
+     * @brief   The number of least significant bits containing entropy
+     *
+     * @note    This only refers to channel @ref ADC_NG_CHAN_ENTROPY
+     *
+     * A value of zero must be used when the ADC does not support harvesting
+     * entropy. Note that even a source of weak entropy can be useful, when
+     * fed into a entropy extractor. Often only taking only the least
+     * significant bit when measuring a noisy source is a good choice
+     * (so a value of `1`).
+     */
+    uint8_t entropy_bits;
+} adc_ng_driver_t;
+
+/**
+ * @brief   Array containing pointer to the ADC drivers to used
+ */
+extern const adc_ng_driver_t * const adc_ng_drivers[ADC_NG_NUMOF];
+/**
+ * @brief   Array containing pointers to the handles the ADC drivers work on
+ */
+extern void * const adc_ng_handles[ADC_NG_NUMOF];
+/**
+ * @brief   Currently selected reference voltage in mV
+ */
+extern uint16_t adc_ng_refs[ADC_NG_NUMOF];
+/**
+ * @brief   Currently selected resolution
+ */
+extern uint8_t adc_ng_res[ADC_NG_NUMOF];
+
+/**
+ * @brief   Convert an ADC sample to a voltage level in mV
+ *
+ * @param[in]       adc         ADC that was used to take the sample
+ * @param[in]       sample      The ADC sample to convert
+ *
+ * @return  The voltage level in mV
+ *
+ * @pre     The ADC identified by @p adc has not been re-initialized since
+ *          taking the sample. (But it can be offline.)
+ */
+uint16_t adc_ng_convert(uint8_t adc, uint32_t sample);
+
+/**
+ * @brief   Measure the actual value of a reference voltage by selecting
+ *          the constant voltage reference as input
+ *
+ * @param[in]       adc         ADC of which the reference voltage should be
+ *                              measured
+ * @param[in]       ref_idx     Index of the reference to measure
+ * @param[out]      dest_mv     Measured value of the voltage reference in mV
+ */
+int adc_ng_measure_ref(uint8_t adc, uint8_t ref_idx, uint16_t *dest_mv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_NG_INTERNAL_H */
+/** @} */

--- a/drivers/adc_ng/include/adc_ng_internal.h
+++ b/drivers/adc_ng/include/adc_ng_internal.h
@@ -65,18 +65,6 @@
 extern "C" {
 #endif
 
-#if !defined(ADC_NG_NUMOF) || defined(DOXYGEN)
-/**
- * @brief   Number of ADC devices supported
- *
- * If a board supports more than one ADC, it has to define `ADC_NG_NUMOF` in
- * `perpih_conf.h` and implement (but not declare)
- * `adc_ng_driver_t *adc_ng_drivers[ADC_NG_NUMOF]` and
- * `void *adc_ng_handles[ADC_NG_NUMOF]` (e.g. in `board.c`).
- */
-#define ADC_NG_NUMOF                    (1U)
-#endif
-
 /**
  * @brief   This special channel must refer to an internal fixed reference
  *          voltage used as input

--- a/drivers/adc_ng/include/adc_ng_internal.h
+++ b/drivers/adc_ng/include/adc_ng_internal.h
@@ -217,13 +217,13 @@ typedef struct {
      * @brief   Runs a single conversion and returns the sample
      */
     adc_ng_single_t single;
-#ifdef MODULE_ADC_BURST
+#ifdef MODULE_ADC_NG_BURST
     /**
      * @brief   Runs a burst conversion acquiring multiple samples in fast
      *          succession
      */
     adc_ng_burst_t burst;
-#endif /* MODULE_ADC_BURST */
+#endif /* MODULE_ADC_NG_BURST */
     /**
      * @brief   Bitmap containing the supported ADC resolutions
      *

--- a/drivers/adc_ng/util.c
+++ b/drivers/adc_ng/util.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_adc_ng
+ * @{
+ *
+ * @file
+ * @brief       Implementation of common functions of the ADC API
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @}
+ */
+
+#include <errno.h>
+
+#include "adc_ng_util.h"
+
+int adc_ng_vcc(uint8_t adc, uint16_t *dest_mv)
+{
+    assert(adc < ADC_NG_NUMOF);
+    assert(dest_mv);
+    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
+    uint8_t vcc_idx = 0;
+    while (!(drv->refs[vcc_idx] & ADC_NG_REF_MCU_VCC)) {
+        if (!(drv->refs[++vcc_idx])) {
+            return -ENOTSUP;
+        }
+    }
+
+    return adc_ng_measure_ref(adc, vcc_idx, dest_mv);
+}
+
+int adc_ng_ntc(uint8_t adc, uint8_t chan, const adc_ng_ntc_t *ntc, int16_t *temp)
+{
+    assert(adc < ADC_NG_NUMOF);
+    assert(ntc && temp);
+
+    uint8_t res = adc_ng_max_res(adc);
+    uint16_t ref_mv = ntc->offset << 1;
+    int retval = adc_ng_init(adc, chan, res, &ref_mv);
+    if (retval) {
+        return retval;
+    }
+
+    uint16_t vin;
+    retval = adc_ng_voltage(adc, &vin);
+    adc_ng_off(adc);
+    if (retval) {
+        return retval;
+    }
+
+    uint32_t tmp = vin;
+    tmp -= ntc->offset;
+    tmp *= (uint32_t)ntc->coefficient;
+    tmp >>= 10;
+    *temp = (int16_t)tmp;
+
+    return 0;
+}
+
+int adc_ng_entropy(uint8_t adc, void *_dest, size_t size)
+{
+    uint8_t *dest = _dest;
+    assert(adc < ADC_NG_NUMOF);
+    assert(dest && size);
+    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
+
+    if (!drv->entropy_bits) {
+        return -ENOTSUP;
+    }
+
+    uint8_t *end = dest + size;
+    void *handle = adc_ng_handles[adc];
+
+    uint8_t res = adc_ng_max_res(adc);
+    uint16_t ref_mv = 0;
+    int retval = adc_ng_init(adc, ADC_NG_CHAN_ENTROPY, res, &ref_mv);
+    if (retval) {
+        return retval;
+    }
+
+    uint16_t entropy = 0;
+    unsigned entropy_bits = 0;
+    const unsigned bytes_per_iteration = drv->entropy_bits / 8;
+    const unsigned bits_per_iteration = drv->entropy_bits % 8;
+    /* Bitmask to select only the bits_per_iteration least significant bits */
+    const uint8_t entropy_mask = (1 << bits_per_iteration) - 1;
+    while (dest < end) {
+        union {
+            uint32_t u32;
+            uint8_t u8[4];
+        } tmp;
+        retval = drv->single(handle, &tmp.u32);
+        if (retval) {
+            drv->off(handle);
+            return retval;
+        }
+
+        for (unsigned i = 0; i < bytes_per_iteration; i++) {
+            *dest++ = tmp.u8[i];
+            if (dest >= end) {
+                drv->off(handle);
+                return 0;
+            }
+        }
+        entropy <<= bits_per_iteration;
+        entropy |= tmp.u8[0] & entropy_mask;
+        entropy_bits += bits_per_iteration;
+        if (entropy_bits >= 8) {
+            *dest++ = (uint8_t)entropy;
+            entropy >>= 8;
+            entropy_bits -= 8;
+        }
+    }
+
+    drv->off(handle);
+    return 0;
+}

--- a/drivers/adc_ng/util.c
+++ b/drivers/adc_ng/util.c
@@ -21,19 +21,16 @@
 
 #include "adc_ng_util.h"
 
-int adc_ng_vcc(uint8_t adc, uint16_t *dest_mv)
+int adc_ng_vcc(uint8_t adc, int16_t *dest_mv)
 {
     assert(adc < ADC_NG_NUMOF);
     assert(dest_mv);
-    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
-    uint8_t vcc_idx = 0;
-    while (!(drv->refs[vcc_idx] & ADC_NG_REF_MCU_VCC)) {
-        if (!(drv->refs[++vcc_idx])) {
-            return -ENOTSUP;
-        }
+    const adc_ng_backend_t be = adc_ng_backends[adc];
+    if (be.driver->ref_vcc_idx == ADC_NG_NO_SUCH_REF) {
+        return -ENOTSUP;
     }
 
-    return adc_ng_measure_ref(adc, vcc_idx, dest_mv);
+    return adc_ng_measure_ref(adc, be.driver->ref_vcc_idx, dest_mv);
 }
 
 int adc_ng_ntc(uint8_t adc, uint8_t chan, const adc_ng_ntc_t *ntc, int16_t *temp)
@@ -42,20 +39,20 @@ int adc_ng_ntc(uint8_t adc, uint8_t chan, const adc_ng_ntc_t *ntc, int16_t *temp
     assert(ntc && temp);
 
     uint8_t res = adc_ng_max_res(adc);
-    uint16_t ref_mv = ntc->offset << 1;
+    int16_t ref_mv = ntc->offset << 1;
     int retval = adc_ng_init(adc, chan, res, &ref_mv);
     if (retval) {
         return retval;
     }
 
-    uint16_t vin;
+    int16_t vin;
     retval = adc_ng_voltage(adc, &vin);
     adc_ng_off(adc);
     if (retval) {
         return retval;
     }
 
-    uint32_t tmp = vin;
+    int32_t tmp = vin;
     tmp -= ntc->offset;
     tmp *= (uint32_t)ntc->coefficient;
     tmp >>= 10;
@@ -69,17 +66,16 @@ int adc_ng_entropy(uint8_t adc, void *_dest, size_t size)
     uint8_t *dest = _dest;
     assert(adc < ADC_NG_NUMOF);
     assert(dest && size);
-    const adc_ng_driver_t *drv = adc_ng_drivers[adc];
+    const adc_ng_backend_t be = adc_ng_backends[adc];
 
-    if (!drv->entropy_bits) {
+    if (!be.driver->entropy_bits) {
         return -ENOTSUP;
     }
 
     uint8_t *end = dest + size;
-    void *handle = adc_ng_handles[adc];
 
     uint8_t res = adc_ng_max_res(adc);
-    uint16_t ref_mv = 0;
+    int16_t ref_mv = 0;
     int retval = adc_ng_init(adc, ADC_NG_CHAN_ENTROPY, res, &ref_mv);
     if (retval) {
         return retval;
@@ -87,25 +83,25 @@ int adc_ng_entropy(uint8_t adc, void *_dest, size_t size)
 
     uint16_t entropy = 0;
     unsigned entropy_bits = 0;
-    const unsigned bytes_per_iteration = drv->entropy_bits / 8;
-    const unsigned bits_per_iteration = drv->entropy_bits % 8;
+    const unsigned bytes_per_iteration = be.driver->entropy_bits / 8;
+    const unsigned bits_per_iteration = be.driver->entropy_bits % 8;
     /* Bitmask to select only the bits_per_iteration least significant bits */
     const uint8_t entropy_mask = (1 << bits_per_iteration) - 1;
     while (dest < end) {
         union {
-            uint32_t u32;
+            int32_t s32;
             uint8_t u8[4];
         } tmp;
-        retval = drv->single(handle, &tmp.u32);
+        retval = be.driver->single(be.handle, &tmp.s32);
         if (retval) {
-            drv->off(handle);
+            be.driver->off(be.handle);
             return retval;
         }
 
         for (unsigned i = 0; i < bytes_per_iteration; i++) {
             *dest++ = tmp.u8[i];
             if (dest >= end) {
-                drv->off(handle);
+                be.driver->off(be.handle);
                 return 0;
             }
         }
@@ -119,6 +115,8 @@ int adc_ng_entropy(uint8_t adc, void *_dest, size_t size)
         }
     }
 
-    drv->off(handle);
+    if (be.driver->off) {
+        be.driver->off(be.handle);
+    }
     return 0;
 }

--- a/drivers/include/adc_ng.h
+++ b/drivers/include/adc_ng.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_adc_ng  Common ADC API
+ * @ingroup     drivers_periph
+ *
+ * This module contains a platform and hardware independent ADC API.
+ * It is intended to address both advanced and simple use cases and allow
+ * using both external and internal ADCs transparently.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition of the common ADC API
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef ADC_NG_H
+#define ADC_NG_H
+
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+
+#include "adc_ng_internal.h"
+#include "bitarithm.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Pass this special value as parameter `ref` in @ref adc_ng_init
+ *          to select the highest supported reference voltage
+ */
+#define ADC_NG_MAX_REF                  (0U)
+
+/**
+ * @name    Helper functions query supported ADC resolutions
+ *
+ * @{
+ */
+
+/**
+ * @brief   Check if the given ADC supports the given resolution
+ *
+ * @param[in]       adc     ADC device to check
+ * @param[in]       res     Resolution to check
+ *
+ * @retval  1               Resolution is supported
+ * @retval  0               Resolution is not supported
+ */
+static inline int adc_ng_supports_res(uint8_t adc, uint8_t res)
+{
+    assert(adc < ADC_NG_NUMOF);
+    assert(res < 32);
+    return ((res < 32) && (adc_ng_drivers[adc]->res_supported & (1 << res)));
+}
+
+/**
+ * @brief   Get the highest supported resolution of an ADC
+ *
+ * @param[in]       adc     ADC to get the highest supported resolution of
+ */
+static inline uint8_t adc_ng_max_res(uint8_t adc)
+{
+    assert(adc < ADC_NG_NUMOF);
+    return (uint8_t)bitarithm_msb(adc_ng_drivers[adc]->res_supported);
+}
+
+/**
+ * @brief   Get the highest supported resolution of an ADC
+ *
+ * @param[in]       adc     ADC to get the highest supported resolution of
+ */
+static inline uint8_t adc_ng_min_res(uint8_t adc)
+{
+    assert(adc < ADC_NG_NUMOF);
+    return (uint8_t)bitarithm_lsb(adc_ng_drivers[adc]->res_supported);
+}
+
+/** @} */
+
+/**
+ * @brief   Initialize and power up the ADC channel @p chan of device @p adc
+ *
+ * @param[in]       adc     ADC device to initialize a channel of
+ * @param[in]       chan    Channel to initialize
+ * @param[in]       res     Resolution to sample at
+ * @param[in,out]   ref     Reference voltage in mV to use (***see details!***)
+ *
+ * @retval  0               Success
+ * @retval  -ENOTSUP        Requested resolution not supported
+ * @retval  -ENXIO          No such channel
+ * @retval  -ERANGE         Requested reference voltage is higher than all
+ *                          available references
+ * @retval  -EALREADY       The ADC is already powered and configured
+ * @retval  <0              A driver specific error occurred
+ *
+ * @note    On success, the ADC is powered up and consumes additional power
+ *          until @ref adc_ng_off is called.
+ *
+ * The reference voltage to use is given with @p ref in millivolt. The driver
+ * will pick a reference voltage that is as close to @p ref as possible, but
+ * not smaller. The actually chosen reference voltage is stored in @p ref.
+ */
+int adc_ng_init(uint8_t adc, uint8_t chan, uint8_t res, uint16_t *ref);
+
+/**
+ * @brief   Turn of the given ADC device
+ *
+ * @param[in]       adc     ADC device to turn off
+ */
+static inline void adc_ng_off(uint8_t adc)
+{
+    assert(adc < ADC_NG_NUMOF);
+    adc_ng_drivers[adc]->off(adc_ng_handles[adc]);
+}
+
+/**
+ * @name    Functions access to access the raw ADC output
+ *
+ * These functions return the binary value returned by the ADC, rather than
+ * meaningful physical units.
+ *
+ * @{
+ */
+
+/**
+ * @brief   Perform a single conversion using the specified ADC channel
+ *
+ * @param[in]       adc     ADC device to use
+ * @param[out]      dest    The result is stored here
+ *
+ * @pre     The ADC @p adc is initialized using @ref adc_ng_init
+ *
+ * @retval  0               Success
+ * @retval  <0              A device specific error occurred
+ */
+static inline int adc_ng_single(uint8_t adc, uint32_t *dest)
+{
+    assert(adc < ADC_NG_NUMOF);
+    assert(dest);
+    return adc_ng_drivers[adc]->single(adc_ng_handles[adc], dest);
+}
+
+/**
+ * @brief   Perform a burst conversion using the specified ADC
+ *
+ * @param[in]       adc     ADC device to use
+ * @param[out]      dest    The results are stored here
+ * @param[in]       num     The number of conversions to perform
+ *
+ * @pre     The ADC @p adc is initialized using @ref adc_ng_init
+ *
+ * @retval  0               Success
+ * @retval  <0              A device specific error occurred
+ *
+ * With `USEMODULE += adc_ng_burst`, some ADC drivers might provide a highly
+ * efficient implementation e.g. using DMA. If either the driver does not
+ * provide such implementation, or the module `adc_ng_burst` is not used, a
+ * slower but ROM-efficient fallback implementation is used instead.
+ */
+int adc_ng_burst(uint8_t adc, uint32_t *dest, size_t num);
+
+/**
+ * @brief   Initialize an ADC channel, perform a single conversion with
+ *          maximum resolution and range, and power it off again
+ *
+ * @param[in]       adc     ADC device to use
+ * @param[in]       chan    Channel to use
+ * @param[out]      dest    The result is stored here
+ *
+ * @retval  0               Success
+ * @retval  <0              A driver specific error occurred
+ *
+ * Refer to the documentation of @ref adc_init for details on @p ref
+ */
+static inline int adc_ng_quick(uint8_t adc, uint8_t chan,
+                               uint32_t *dest)
+{
+    uint16_t ref = ADC_NG_MAX_REF;
+    int retval = adc_ng_init(adc, chan, adc_ng_max_res(adc), &ref);
+    if (retval) {
+        return retval;
+    }
+    retval = adc_ng_single(adc, dest);
+    adc_ng_off(adc);
+    return retval;
+}
+
+/** @} */
+
+/**
+ * @name    Functions to get measurements in voltage levels
+ *
+ * @{
+ */
+
+/**
+ * @brief   Run a single measurements and get the result in mV
+ *
+ * @param[in]       adc     ADC to use
+ * @param[out]      dest_mv Write the measurement result in mV here
+ *
+ * @pre     The state given in @p state has been initialized (see
+ *          @ref adc_ng_init) and the ADC currently is powered
+ *
+ * @retval  0               Success
+ * @retval  <0              A driver specific error occurred
+ *
+ * @note    Please note that a while a precision roughly in the order of µV
+ *          is with the right setup and ADC technically feasible, the accuracy
+ *          of the result is more likely in the order of mV.
+ */
+static inline int adc_ng_voltage(uint8_t adc, uint16_t *dest_mv)
+{
+    uint32_t sample;
+    int retval = adc_ng_single(adc, &sample);
+    if (retval) {
+        return retval;
+    }
+
+    *dest_mv = adc_ng_convert(adc, sample);
+    return 0;
+}
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_NG_H */
+/** @} */

--- a/drivers/include/adc_ng_util.h
+++ b/drivers/include/adc_ng_util.h
@@ -46,7 +46,7 @@ extern "C" {
  *
  * @pre     The ADC is currently offline, it will internally be initialized
  */
-int adc_ng_vcc(uint8_t adc, uint16_t *dest_mv);
+int adc_ng_vcc(uint8_t adc, int16_t *dest_mv);
 
 /**
  * @brief   Measure the temperature using a thermistor
@@ -79,11 +79,12 @@ int adc_ng_ntc(uint8_t adc, uint8_t chan, const adc_ng_ntc_t *ntc, int16_t *temp
 static inline int adc_ng_internal_ntc(uint8_t adc, int16_t *temp)
 {
     assert(adc < ADC_NG_NUMOF);
-    if (!adc_ng_drivers[adc]->ntc) {
+    const adc_ng_backend_t be = adc_ng_backends[adc];
+    if (!be.driver->ntc) {
         return -ENOTSUP;
     }
 
-    return adc_ng_ntc(adc, ADC_NG_CHAN_NTC, adc_ng_drivers[adc]->ntc, temp);
+    return adc_ng_ntc(adc, ADC_NG_CHAN_NTC, be.driver->ntc, temp);
 }
 
 /**

--- a/drivers/include/adc_ng_util.h
+++ b/drivers/include/adc_ng_util.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_adc_ng_util Utility functions for ADC NG
+ * @ingroup     drivers_adc_ng
+ *
+ * This module contains contains utility functions for the ADC NG API.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition of the ADC utility API
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef ADC_NG_UTIL_H
+#define ADC_NG_UTIL_H
+
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+
+#include "adc_ng.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Measure the MCU's supply voltage using the given ADC
+ *
+ * @param[in]       adc     ADC to use
+ * @param[out]      dest_mv Measured supply voltage in mV will be stored here
+ *
+ * @retval  0               Success
+ * @retval  -ENOTSUP        Measuring the supply voltage is not supported using
+ *                          the ADC @p adc
+ * @retval  <0              Error
+ *
+ * @pre     The ADC is currently offline, it will internally be initialized
+ */
+int adc_ng_vcc(uint8_t adc, uint16_t *dest_mv);
+
+/**
+ * @brief   Measure the temperature using a thermistor
+ *
+ * @param[in]       adc     ADC device to use
+ * @param[in]       chan    Channel the NTC is connected to
+ * @param[in]       ntc     Parameters of the NTC used
+ * @param[out]      temp    The temperature in 0.1°C will be stored here
+ *
+ * @retval  0               Success
+ * @retval  <0              Error
+ *
+ * @pre     The ADC identified by @p adc is currently offline
+ */
+int adc_ng_ntc(uint8_t adc, uint8_t chan, const adc_ng_ntc_t *ntc, int16_t *temp);
+
+/**
+ * @brief   Measure the temperature using a thermistor internally connected to
+ *          the ADC
+ *
+ * @param[in]       adc     ADC device to use
+ * @param[out]      temp    The temperature in 0.1°C will be stored here
+ *
+ * @retval  0               Success
+ * @retval  -ENOTSUP        No internal NTC connected to the given ADC
+ * @retval  <0              Other device specific error
+ *
+ * @pre     The ADC identified by @p adc is currently offline
+ */
+static inline int adc_ng_internal_ntc(uint8_t adc, int16_t *temp)
+{
+    assert(adc < ADC_NG_NUMOF);
+    if (!adc_ng_drivers[adc]->ntc) {
+        return -ENOTSUP;
+    }
+
+    return adc_ng_ntc(adc, ADC_NG_CHAN_NTC, adc_ng_drivers[adc]->ntc, temp);
+}
+
+/**
+ * @brief   Use the ADC to obtain entropy
+ *
+ * @param[in]       adc     ADC device to use
+ * @param[out]      dest    Buffer to store the collected entropy into
+ * @param[in]       size    Size of @p dest
+ *
+ * @retval  0               Success
+ * @retval  -ENOTSUP        The given ADC does not support collecting entropy
+ * @retval  <0              Other device specific error
+ *
+ * @pre     The ADC identified by @p adc is currently offline
+ *
+ * @warning The quality of the entropy generated from an ADC can depend on
+ *          many factors and even under ideal circumstances is usually not
+ *          well suited for direct use in cryptographic contexts. However, as
+ *          an additionally source of weak entropy used by an entropy extractor,
+ *          this should work well.
+ */
+int adc_ng_entropy(uint8_t adc, void *dest, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_NG_UTIL_H */
+/** @} */

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -1,3 +1,4 @@
+PSEUDOMODULES += adc_ng_%
 PSEUDOMODULES += at_urc
 PSEUDOMODULES += auto_init_dhcpv6_client
 PSEUDOMODULES += auto_init_gnrc_rpl


### PR DESCRIPTION
### Contribution description

This API aims to provided an alternative to the periph ADC API with the following improvements:

- Support for multiple ADC devices (both external and peripheral ADCs)
- Support for selecting the reference voltage
- Support for burst ADC conversions (e.g. via DMA)
- Convenience functions to convert into meaningful physical units

It is written to allow coexistence with the existing periph ADC API.

#### Design decisions

- Do not use a single "ADC line" identifier, but an "ADC device + ADC channel" identifier
    - This maps very naturally and intuitively with to the use of multiple ADCs
- Explicit initialization and de-initialization of the ADCs, rather than implicitly turning the ADC on and off for each call as done in the periph ADC API in `adc_sample()`
    - This is more efficient when performing multiple conversions in fast succession
    - This is more extensible: The actual implementation of triggering a conversion and retrieving the result is expected to be independent of the configuration. Adding an alternative `init` function (e.g. for differential mode to measure the difference of two inputs) would be easy to add, and the existing API could still be used to trigger a conversion and retrieve the result
- Add an internal API with an `adc_ng_driver_t` struct containing function pointers
    - This design has proven to work fine in the context of network drivers
    - This allows to only implement the actual hardware dependent stuff when adding drivers

### Testing procedure

https://github.com/RIOT-OS/RIOT/pull/13248 provides a proof of concept implementation of the ATmega ADC as well as a test application.

#### Proof that the API is feasible

- [x] PoC implementation of the basic API on an MCU internal (peripheral) ADC (see https://github.com/RIOT-OS/RIOT/pull/13248)
- [x] PoC implementation of the basic API on an external ADC (see https://github.com/RIOT-OS/RIOT/pull/10619)
- [ ] PoC implementation of utility features
    - [x] Access to internal thermistors (see https://github.com/RIOT-OS/RIOT/pull/13248)
    - [x] Using constant voltage reference as input (to allow measurement of the supply voltage or calibration of reference voltages) (see https://github.com/RIOT-OS/RIOT/pull/13248)
    - [ ] Accelerated burst access; e.g. performing conversions in background using DMA, or using ADC conversion completed interrupts
    - [x] "Entropy" ADC channel
- [x] Application using the API (the test application in https://github.com/RIOT-OS/RIOT/pull/13248)

### Issues/PRs references

- https://github.com/RIOT-OS/RIOT/pull/10527 tries to extend the existing periph ADC API to also support external ADCs. This PR instead provides a completely new API to address other limitations of the existing API (choice of reference, "burst" readings) as well
- https://github.com/RIOT-OS/RIOT/pull/12877 has similar goals but targets GPIO access rather than ADC access