### PR TITLE
tests/periph_uart: fix shell buffer size

### DIFF
--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -31,8 +31,12 @@
 #include "stdio_uart.h"
 #include "xtimer.h"
 
+#ifndef SHELL_BUFSIZE
 #define SHELL_BUFSIZE       (128U)
+#endif
+#ifndef UART_BUFSIZE
 #define UART_BUFSIZE        (128U)
+#endif
 
 #define PRINTER_PRIO        (THREAD_PRIORITY_MAIN - 1)
 #define PRINTER_TYPE        (0xabcd)
@@ -295,7 +299,7 @@ int main(void)
                                 PRINTER_PRIO, 0, printer, NULL, "printer");
 
     /* run the shell */
-    char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    char line_buf[SHELL_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_BUFSIZE);
     return 0;
 }


### PR DESCRIPTION
### Contribution description
When trying something with the `tests/periph_uart` test application, I just noticed that the `SHELL_BUFSIZE` define is set, but never used. So this PR fixes that test so that it actually uses the local `SHELL_BUFSIZE` define in favor of `SHELL_BUFSIZE_DEFAULT`.

As further add-on, this  PR now enables to override `SHELL_BUFSIZE` and `UART_BUFSIZE` via environment vars/Makefile.

### Testing procedure
Build test should do, as the default size of `SHELL_BUFSIZE` and `SHELL_BUSIZE_DEFAULT` are equal.

### Issues/PRs references
none