### PR TITLE
net/ipv6/ext/rh.h: remove unneeded header includes

### DIFF
--- a/sys/include/net/ipv6/ext/rh.h
+++ b/sys/include/net/ipv6/ext/rh.h
@@ -24,10 +24,6 @@
 
 #include <stdint.h>
 
-#include "net/ipv6/addr.h"
-#include "net/ipv6/ext.h"
-#include "net/ipv6/hdr.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Only `<stdint.h>` is used by that header so all the other ones can go.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Everything should still compile (let's have Murdock do the job).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
