### PR TITLE
gnrc_sock_udp: choose random ephemeral port

### DIFF
--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -56,14 +56,6 @@ extern "C" {
 #define GNRC_SOCK_DYN_PORTRANGE_ERR (0)
 
 /**
- * @brief   Offset for next dynamic port
- *
- * Currently set to a static (prime) offset, but could be random, too
- * see https://tools.ietf.org/html/rfc6056#section-3.3.3
- */
-#define GNRC_SOCK_DYN_PORTRANGE_OFF (17U)
-
-/**
  * @brief   Internal helper functions for GNRC
  * @internal
  * @{

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -25,14 +25,13 @@
 #include "net/gnrc/udp.h"
 #include "net/sock/udp.h"
 #include "net/udp.h"
+#include "random.h"
 
 #include "gnrc_sock_internal.h"
 
 #ifdef MODULE_GNRC_SOCK_CHECK_REUSE
 static sock_udp_t *_udp_socks = NULL;
 #endif
-
-static uint16_t _dyn_port_next = 0;
 
 /**
  * @brief   Checks if a given UDP port is already used by another sock
@@ -66,15 +65,15 @@ static bool _dyn_port_used(uint16_t port)
 /**
  * @brief   returns a UDP port, and checks for reuse if required
  *
- * complies to RFC 6056, see https://tools.ietf.org/html/rfc6056#section-3.3.3
+ * implements "Another Simple Port Randomization Algorithm" as specified in
+ * RFC 6056, see https://tools.ietf.org/html/rfc6056#section-3.3.2
  */
 static uint16_t _get_dyn_port(sock_udp_t *sock)
 {
     unsigned count = GNRC_SOCK_DYN_PORTRANGE_NUM;
     do {
         uint16_t port = GNRC_SOCK_DYN_PORTRANGE_MIN +
-               (_dyn_port_next * GNRC_SOCK_DYN_PORTRANGE_OFF) % GNRC_SOCK_DYN_PORTRANGE_NUM;
-        _dyn_port_next++;
+               (random_uint32() % GNRC_SOCK_DYN_PORTRANGE_NUM);
         if ((sock == NULL) || (sock->flags & SOCK_FLAGS_REUSE_EP) ||
                               !_dyn_port_used(port)) {
             return port;

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -74,8 +74,7 @@ static uint16_t _get_dyn_port(sock_udp_t *sock)
     do {
         uint16_t port = GNRC_SOCK_DYN_PORTRANGE_MIN +
                (random_uint32() % GNRC_SOCK_DYN_PORTRANGE_NUM);
-        if ((sock == NULL) || (sock->flags & SOCK_FLAGS_REUSE_EP) ||
-                              !_dyn_port_used(port)) {
+        if ((sock && (sock->flags & SOCK_FLAGS_REUSE_EP)) || !_dyn_port_used(port)) {
             return port;
         }
         --count;


### PR DESCRIPTION
### Contribution description

While writing a PoC for #12293 and #12382 I noticed that RIOT does not randomize its ephemeral currently. This circumstance also made it significantly easier to exploit #10739. The first port  value is `49152` and the value is simply sequential incremented after that. I consider this a security issue as it eases spoofing replies why this is a problem is hopefully illustrated by the previously mentioned issues.

While working on this change, I noticed that `gnrc_sock_udp` already depends on the `random` module in `Makefile.dep`, even though it does not use it. This made me curious and I discovered that it was removed, without much further discussion, in #6212: 

> I was kind of proud to get rid of the random() …

I personally think that this is a bad idea and an unnecessary security risk. If there is any specific reason why I should not be randomized please let me know.

### Testing procedure

I tested this change using `examples/asymcute_mqttsn/` simply build the application, start it. Try to connect to a non-existing MQTT server and check using wireshark/tcpdump that it uses a random port as the UDP source port.

### Related

* #12293 
* #12382
* #10739
* #6212