### PR TITLE
pkg/relic: use random module for seeding relic PRNG

### DIFF
--- a/pkg/relic/Makefile.dep
+++ b/pkg/relic/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += random
+USEMODULE += prng_xorshift

--- a/pkg/relic/patches/0001-use-modul-random-for-seeding.patch
+++ b/pkg/relic/patches/0001-use-modul-random-for-seeding.patch
@@ -1,0 +1,27 @@
+From 7a93775269a7bfc8f01aef9bf4af9760b11504b2 Mon Sep 17 00:00:00 2001
+From: maksim-ka <42pema1bif@hft-stuttgart.de>
+Date: Fri, 31 Jan 2020 15:15:46 +0100
+Subject: [PATCH 1/2] use modul random for seeding
+
+---
+ src/rand/relic_rand_core.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/rand/relic_rand_core.c b/src/rand/relic_rand_core.c
+index 5f453802..3e62c7fd 100644
+--- a/src/rand/relic_rand_core.c
++++ b/src/rand/relic_rand_core.c
+@@ -159,6 +159,10 @@ void rand_init(void) {
+ 		}
+ 	}
+ 
++#elif SEED == RIOTRND && defined(MODULE_RANDOM)
++
++	random_bytes(buf,SEED_SIZE);
++
+ #endif
+ 
+ #endif /* RAND == UDEV */
+-- 
+2.24.1
+

--- a/pkg/relic/patches/0002-add-flag-to-help-message.patch
+++ b/pkg/relic/patches/0002-add-flag-to-help-message.patch
@@ -1,0 +1,38 @@
+From 4bc0b2d2967cad0b6997623115049f169d2da0b0 Mon Sep 17 00:00:00 2001
+From: maksim-ka <42pema1bif@hft-stuttgart.de>
+Date: Fri, 31 Jan 2020 15:17:30 +0100
+Subject: [PATCH 2/2] add flag to help message
+
+---
+ cmake/rand.cmake        | 1 +
+ include/relic_conf.h.in | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/cmake/rand.cmake b/cmake/rand.cmake
+index c42f8412..7d8d90f9 100644
+--- a/cmake/rand.cmake
++++ b/cmake/rand.cmake
+@@ -7,6 +7,7 @@ message("   RAND=CALL      Override the generator with a callback.\n")
+ 
+ message(STATUS "Available random number generator seeders (default = UDEV):\n")
+ 
++message("   SEED=RIOTRND   Use RIOT's random module for seeding. (recommended on RIOT)")
+ message("   SEED=WCGR      Use Windows' CryptGenRandom. (recommended)")
+ message("   SEED=DEV       Use blocking /dev/random. (recommended)")
+ message("   SEED=UDEV      Use non-blocking /dev/urandom. (recommended)")
+diff --git a/include/relic_conf.h.in b/include/relic_conf.h.in
+index 66201795..6f064c32 100644
+--- a/include/relic_conf.h.in
++++ b/include/relic_conf.h.in
+@@ -685,6 +685,8 @@
+ #define LIBC     5
+ /** Null seed. */
+ #define	ZERO     6
++/** Use RIOT's random module for seeding */
++#define RIOTRND     7
+ /** Chosen random generator seeder. */
+ #define SEED     @SEED@
+ 
+-- 
+2.24.1
+

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -39,6 +39,6 @@ USEMODULE += embunit
 #  				platform.
 
 # The rest of the parameters are configuration parameters for RELIC described in its documentation.
-export RELIC_CONFIG_FLAGS=-DARCH=NONE -DOPSYS=NONE -DQUIET=off -DWORD=32 -DFP_PRIME=255 -DWITH="BN;MD;DV;FP;EP;CP;BC;EC" -DSEED=ZERO
+export RELIC_CONFIG_FLAGS=-DARCH=NONE -DOPSYS=NONE -DQUIET=off -DWORD=32 -DFP_PRIME=255 -DWITH="BN;MD;DV;FP;EP;CP;BC;EC" -DSEED=RIOTRND
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
To support seeding relic's PRNG from riot's random module I made a patch to add an option.
The patch provides a call to `random_bytes` from `rand_init` within relic which is used to initialize/seed the PRNG. 

The option/flag is called `RIOTRND`. To enable seeding through the random module you can set can set the `SEED` flag in  `RELIC_CONFIG_FLAGS` to it.

### Testing procedure

In your project's Makefile provide `SEED=RIOTRND` within the `RELIC_CONFIG_FLAGS`. 

E.g.
`export RELIC_CONFIG_FLAGS=-DARCH=NONE -DOPSYS=NONE -DQUIET=off -DWORD=32 -DFP_PRIME=255 -DWITH="BN;MD;DV;FP;EP;CP;BC;EC" -DSEED=RIOTRND`

<!--
### Issues/PRs references
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
