### PR TITLE
random: generate random seed at compile-time

### DIFF
--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -34,14 +34,6 @@
 extern "C" {
 #endif
 
-#ifndef RANDOM_SEED_DEFAULT
-/**
- * @brief   Seed selected when all tries to collect seeds from a random source
- *          failed
- */
-#define RANDOM_SEED_DEFAULT (1)
-#endif
-
 /**
  * @brief Enables support for floating point random number generation
  */

--- a/sys/random/Makefile
+++ b/sys/random/Makefile
@@ -1,4 +1,4 @@
-SRC := random.c
+SRC := random.c init.c
 
 BASE_MODULE := prng
 SUBMODULES := 1

--- a/sys/random/Makefile
+++ b/sys/random/Makefile
@@ -1,3 +1,6 @@
+# module name is used below, thus set explicitly
+MODULE = random
+
 SRC := random.c init.c
 
 BASE_MODULE := prng
@@ -9,6 +12,30 @@ endif
 
 ifneq (,$(filter prng_tinymt32,$(USEMODULE)))
   DIRS += tinymt32
+endif
+
+ifeq (,$(RIOT_CI_BUILD))
+  # random seed value newly generated on each build
+  RANDOM_SEED := $(shell $(RIOTTOOLS)/randhex/randhex.py 32)
+else
+  # hardcoded canary value to not break CI test cache
+  RANDOM_SEED := 0x1
+endif
+
+# This has to be kept in sync with sys/random/init.c
+ifneq (,$(filter puf_sram periph_hwrng periph_cpuid,$(USEMODULE)))
+  HAS_RNG = 1
+endif
+
+# If no run-time random number generation facility is available for
+# generating an initial seed, generate a random value at compile-time.
+# Also mark the file using it as PHONY to use a new seed on each build.
+ifndef HAS_RNG
+  $(warning Attention! The random module is using a compile-time seed. \
+    The same seed will be used for the same firmware image.)
+
+  CFLAGS += -DRANDOM_SEED_DEFAULT=$(RANDOM_SEED)U
+  .PHONY: $(BINDIR)/$(MODULE)/init.o
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/random/init.c
+++ b/sys/random/init.c
@@ -40,7 +40,7 @@ void auto_init_random(void)
 #elif defined (MODULE_PERIPH_CPUID)
     luid_get(&seed, 4);
 #else
-    LOG_WARNING("random: NO SEED AVAILABLE!\n");
+    LOG_WARNING("random: USING COMPILE-TIME GENERATED SEED!\n");
     seed = RANDOM_SEED_DEFAULT;
 #endif
     DEBUG("random: using seed value %u\n", (unsigned)seed);

--- a/sys/random/init.c
+++ b/sys/random/init.c
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2019 Freie Universität Berlin
+ *               2020 Sören Tempel <tempel@uni-bremen.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+
+#include "log.h"
+#include "random.h"
+
+#ifdef MODULE_PUF_SRAM
+#include "puf_sram.h"
+#endif
+#ifdef MODULE_PERIPH_HWRNG
+#include "periph/hwrng.h"
+#endif
+#ifdef MODULE_PERIPH_CPUID
+#include "luid.h"
+#endif
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void auto_init_random(void)
+{
+    uint32_t seed;
+#ifdef MODULE_PUF_SRAM
+    /* TODO: hand state to application? */
+    if (puf_sram_state) {
+        LOG_WARNING("random: PUF SEED not fresh\n");
+    }
+    seed = puf_sram_seed;
+#elif defined (MODULE_PERIPH_HWRNG)
+    hwrng_read(&seed, 4);
+#elif defined (MODULE_PERIPH_CPUID)
+    luid_get(&seed, 4);
+#else
+    LOG_WARNING("random: NO SEED AVAILABLE!\n");
+    seed = RANDOM_SEED_DEFAULT;
+#endif
+    DEBUG("random: using seed value %u\n", (unsigned)seed);
+    random_init(seed);
+}

--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -26,39 +26,8 @@
 #include "random.h"
 #include "bitarithm.h"
 
-#ifdef MODULE_PUF_SRAM
-#include "puf_sram.h"
-#endif
-#ifdef MODULE_PERIPH_HWRNG
-#include "periph/hwrng.h"
-#endif
-#ifdef MODULE_PERIPH_CPUID
-#include "luid.h"
-#endif
-
 #define ENABLE_DEBUG (0)
 #include "debug.h"
-
-void auto_init_random(void)
-{
-    uint32_t seed;
-#ifdef MODULE_PUF_SRAM
-    /* TODO: hand state to application? */
-    if (puf_sram_state) {
-        LOG_WARNING("random: PUF SEED not fresh\n");
-    }
-    seed = puf_sram_seed;
-#elif defined (MODULE_PERIPH_HWRNG)
-    hwrng_read(&seed, 4);
-#elif defined (MODULE_PERIPH_CPUID)
-    luid_get(&seed, 4);
-#else
-    LOG_WARNING("random: NO SEED AVAILABLE!\n");
-    seed = RANDOM_SEED_DEFAULT;
-#endif
-    DEBUG("random: using seed value %u\n", (unsigned)seed);
-    random_init(seed);
-}
 
 void random_bytes(uint8_t *target, size_t n)
 {


### PR DESCRIPTION
### Contribution description

If the device does not support run-time random number generation RIOT currently uses a hardcoded seed. I discovered this while working on #13253. This PR uses the technique from #13119 to randomize the `RANDOM_DEFAULT_SEED` on each build. Currently, this technique is used unconditionally. Alternatively, it would be possible to only use it if run-time random number generation is not supported. However, the current code has some other issues, for instance `puf_sram` may not necessarily return a fresh value. For this reason, I decided to combine the compile-time generated seed with a run-time generated one (if available) using a multiply operation. **I am not a cryptographic expert but this shouldn't have a negative impact on the entropy**.

### Testing procedure

I tested this with `tests/rng`. I also disabled the `periph_cpuid` and `periph_hwrng` feature for `BOARD=native` to make sure the fallback code works.

### Issues/PRs references

* #13253 
* #13119 
