### PR TITLE
pkg/wolfssl: bump version to 4.3.0

### DIFF
--- a/pkg/wolfssl/Makefile
+++ b/pkg/wolfssl/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=wolfssl
 PKG_URL=https://github.com/wolfssl/wolfssl.git
-PKG_VERSION=eaeaaf12c11dd52ab0cd6833252ed559656e9826 # v4.1.0+
+PKG_VERSION=3f13b49fa318fbd3216d7da36d942e7c276d3413 # v4.3.0
 PKG_LICENSE=GPLv2
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/wolfssl/Makefile.include
+++ b/pkg/wolfssl/Makefile.include
@@ -1,3 +1,4 @@
+CFLAGS += -Wno-unused-parameter -Wno-unused
 CFLAGS += -DWOLFSSL_USER_SETTINGS=1
 CFLAGS += -DWOLFSSL_RIOT_OS=1
 INCLUDES += -I$(PKGDIRBASE)/../../../


### PR DESCRIPTION
### Contribution description

Update to the latest upstream release

https://www.wolfssl.com/docs/wolfssl-changelog/

Unfortunately the new version introduced some unused parameter warnings, so I disabled them for this pkg.

### Testing procedure

I ran both `tests/pkg_wolfssl` and `tests/pkg_wolfcrypt-ed25519-verify` on `native` and esp32.

### Issues/PRs references
none
