### PR TITLE
cpu/atmega: fix PWM compilation error with NDEBUG

### DIFF
--- a/cpu/atmega_common/periph/pwm.c
+++ b/cpu/atmega_common/periph/pwm.c
@@ -60,6 +60,7 @@ static inline unsigned get_prescaler(pwm_t dev, uint32_t *scale)
 
 uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
+    (void)mode;
     /* only left implemented, max resolution 256 */
     assert(dev < PWM_NUMOF && mode == PWM_LEFT && res <= 256);
     /* resolution != 256 only valid if ch0 not used */


### PR DESCRIPTION
### Contribution description

This PR fixes the PWM compilation problem for ATmega MCUs when the NDEBUG macro is defined. 

When NDEBUG macro is defined during compilation, the assert macro produces empty code. The `mode` parameter is then unused.

### Testing procedure

Compilation of
```
CFLAGS='-DNDEBUG' make -C tests/periph_pwm BOARD=arduino-mega2560
```
fails without this PR and should succeed with this PR.

### Issues/PRs references
