### PR TITLE
sys/arduino: fix of compilation error in with NDEBUG

### DIFF
--- a/sys/arduino/SPI.cpp
+++ b/sys/arduino/SPI.cpp
@@ -28,6 +28,8 @@ extern "C" {
 
 SPISettings::SPISettings(uint32_t clock_hz, uint8_t bitOrder, uint8_t dataMode)
 {
+    (void)bitOrder;
+
     static const spi_clk_t clocks[] = {
         SPI_CLK_10MHZ, SPI_CLK_5MHZ, SPI_CLK_1MHZ, SPI_CLK_400KHZ
     };
@@ -80,6 +82,9 @@ void SPIClass::beginTransaction(SPISettings settings)
                              settings.mode, settings.clock);
     /* No support for exceptions (at least on AVR), resort to assert() */
     assert(retval == SPI_OK);
+    if (retval != SPI_OK) {
+        return;
+    }
     is_transaction = true;
 }
 
@@ -99,6 +104,9 @@ void SPIClass::transfer(void *buf, size_t count)
                                  settings.mode, settings.clock);
         /* No support for exceptions (at least on AVR), resort to assert() */
         assert(retval == SPI_OK);
+        if (retval != SPI_OK) {
+            return;
+        }
     }
     spi_transfer_bytes(spi_dev, SPI_CS_UNDEF, false, buf, buf, count);
     if (!is_transaction) {
@@ -110,6 +118,7 @@ void SPIClass::transfer(void *buf, size_t count)
 
 void SPIClass::setBitOrder(uint8_t order)
 {
+    (void)order;
     assert(order == MSBFIRST);
 }
 


### PR DESCRIPTION
### Contribution description

This PR fixes the compilation problem caused by the SPI implementation in module `arduino` when the NDEBUG macro is defined.

When NDEBUG macro is defined during compilation, the assert macro produces empty code. Parameters or variables checked with `assert` are then unused. The compilation of the following applications fail:
```
examples/arduino_hello-world
tests/periph_gpio_arduino
tests/sys_arduino
tests/sys_arduino_analog
tests/sys_arduino_lib
```

Since the Arduino SPI methods don't define return values, assertions are used if acquiring the SPI bus fails. If NDEBUG is defined, `assert` produces empty code and the mechanism to catch errors doesn't work. In this case a check which simply returns in error case should help.

### Testing procedure

Compile one of the applications above for any board with `arduino` feature, for example:
```
CFLAGS='-DNDEBUG' make BOARD=esp32-wroom-32 -C examples/arduino_hello-world
```
The compilation fails wihtout this PR but should succeed with this PR.

### Issues/PRs references

Depends on #13263 for ATmega.