### PR TITLE
tests: compilation test for NDEBUG

### DIFF
--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -1,5 +1,6 @@
 # set default values for selected global variables
 FLASH_ADDR ?= 0x0
+CFLAGS+=-DNDEBUG
 
 export Q                     # Used in front of Makefile lines to suppress the printing of the command if user did not opt-in to see them.
 export QQ                    # as Q, but be more quiet


### PR DESCRIPTION
### Contribution description

This PR is used as a compilation test with defined `NDEBUG`. It is not intended to be merged, but only to detect potential compilation problems with defined `NDEBUG`.

### Testing procedure


### Issues/PRs references

Related to issue #13265 