### PR TITLE
sys/test_utils: add expect() header

### DIFF
--- a/core/include/panic.h
+++ b/core/include/panic.h
@@ -36,6 +36,7 @@ typedef enum {
     PANIC_SOFT_REBOOT,
     PANIC_HARD_REBOOT,
     PANIC_ASSERT_FAIL,
+    PANIC_EXPECT_FAIL,
 #ifdef MODULE_CORTEXM_COMMON
     PANIC_NMI_HANDLER,       /**< non maskable interrupt */
     PANIC_HARD_FAULT,        /**< hard fault */

--- a/sys/include/test_utils/expect.h
+++ b/sys/include/test_utils/expect.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2015 INRIA
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    test_utils_expect expect() utility function
+ * @ingroup     sys
+ *
+ * @{
+ * @file
+ * @brief       test "expect condition" utility function
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      René Kijewski <rene.kijewski@fu-berlin.de>
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef TEST_UTILS_EXPECT_H
+#define TEST_UTILS_EXPECT_H
+
+#include <stdio.h>
+#include "panic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef RIOT_FILE_RELATIVE
+#define RIOT_FILE_RELATIVE  (__FILE__)
+#endif
+
+/**
+ * @brief   Function to handle failed expectation
+ *
+ * @note    This function was introduced for memory size optimization
+ *
+ * @warning this function **NEVER** returns!
+ *
+ * @param[in] file  The file name of the file the expectation failed in
+ * @param[in] line  The code line of @p file the expectation failed in
+ * @param[in] cond  The failed condition as string
+ */
+NORETURN static inline void _expect_failure(const char *file, unsigned line,
+                                            const char *cond)
+{
+    printf("%s:%u => failed condition \"%s\"\n", file, line, cond);
+    core_panic(PANIC_EXPECT_FAIL, "CONDITION FAILED.");
+}
+
+/**
+ * @brief    abort the program if condition is false
+ *
+ * This is similar to assert(), but will not be excluded from a build even if
+ * NDEBUG is set. Use e.g., in test application to "assert" conditions, in
+ * order to prevent a different compilation mode (a release build?) from making
+ * the test non-functional.
+ *
+ * Otherwise, the macro expect() prints an error message to standard error and
+ * terminates the application by calling core_panic().
+ *
+ * The purpose of this macro is to help programmers find bugs in their
+ * programs.
+ *
+ * A failed condition generates output similar to:
+ *
+ *     0x89abcdef
+ *     *** RIOT kernel panic:
+ *     FAILED CONDITION.
+ *
+ *     ...
+ *
+ * Where 0x89abcdef is an address. This address can be used with tools like
+ * `addr2line` (or e.g. `arm-none-eabi-addr2line` for ARM-based code), `objdump`,
+ * or `gdb` (with the command `info line *(0x89abcdef)`) to identify the line
+ * the condition failed in.
+ *
+ */
+#define expect(cond) ((cond) ? (void)0 :  _expect_failure(RIOT_FILE_RELATIVE, \
+                                                          __LINE__, #cond))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEST_UTILS_EXPECT_H */
+/** @} */

--- a/tests/README.md
+++ b/tests/README.md
@@ -85,6 +85,17 @@ pattern like `\r\n`, `\s`, `\)`, etc..
     child.expect(r'some string: (\d+) ,')
 ~~~
 
+Use expect() instead of assert()
+--------------------------------
+
+In order to make a test application functional in all cases, use `expect()`
+instead of `assert()`. The former works like the latter, but will still be
+compiled in if `NDEBUG` is defined. This is useful to keep a test application
+working even when compiling with -DNDEBUG, allowing for the code-under-test to
+be compiled with that flag.  Otherwise, the application would force compiling
+all tested code with assertions enabled.
+`expect()` is defined in the header `test_utils/expect.h`.
+
 Interaction through the uart
 ----------------------------
 

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -71,7 +71,7 @@ ifneq (, $(filter $(BOARD), $(LOW_MEMORY_BOARDS)))
 endif
 
 ifneq (, $(filter $(BOARD), $(SUPER_LOW_MEMORY_BOARDS)))
-  NUMOF_TIMERS ?= 16
+  NUMOF_TIMERS ?= 12
 endif
 
 NUMOF_TIMERS ?= 1000

--- a/tests/bench_xtimer/main.c
+++ b/tests/bench_xtimer/main.c
@@ -19,7 +19,7 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
+#include <test_utils/expect.h>
 
 #include "msg.h"
 #include "thread.h"
@@ -45,7 +45,7 @@ static xtimer_t _timers[NUMOF_TIMERS];
 
 /* This variable is set by any timer that actually triggers.  As the test is
  * only testing set/remove/now operations, timers are not supposed to trigger.
- * Thus, after every test there's an 'assert(!_triggers)'
+ * Thus, after every test there's an 'expect(!_triggers)'
  */
 static unsigned _triggers;
 
@@ -114,7 +114,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("set() one", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test removing one unset timer REPEAT times
@@ -128,7 +128,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("remove() one", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test setting / removing one timer REPEAT times
@@ -144,7 +144,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("set() + remove() one", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test setting NUMOF_TIMERS timers with increasing targets
@@ -159,7 +159,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("set() many increasing target", NUMOF_TIMERS, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test re-setting first timer REPEAT times
@@ -174,7 +174,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("re-set()  first", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test setting middle timer REPEAT times
@@ -189,7 +189,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("re-set() middle", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test setting last timer REPEAT times
@@ -204,7 +204,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("re-set()   last", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test removing / setting first timer REPEAT times
@@ -220,7 +220,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("remove() + set()  first", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test removing / setting middle timer REPEAT times
@@ -236,7 +236,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("remove() + set() middle", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test removing / setting last timer REPEAT times
@@ -252,7 +252,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("remove() + set()   last", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test removing NUMOF_TIMERS timers (latest first)
@@ -266,7 +266,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("remove() many decreasing", NUMOF_TIMERS, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     /*
      * test xtimer_now()
@@ -281,7 +281,7 @@ int main(void)
     diff = xtimer_now_usec() - before;
 
     _print_result("xtimer_now()", REPEAT, diff);
-    assert(!_triggers);
+    expect(!_triggers);
 
     _print_result("sizeof(xtimer_t)", NUMOF_TIMERS, sizeof(_timers));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a version of "assert()" that does not compile out when compiling with NDEBUG=1.
Supposed to be used by test applications.

`tests/bench_xtimer` is modified to make use of the new function.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. ensure `tests/bench_xtimer` works as expected
2. maybe confirm a failed expectaion still works by changing one of the `expect(!_triggers)` to `expect(_triggers)`
3. maybe confirm that on master, `CFLAGS=-NDEBUG make ...` removes the asserts but not the expects
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
