### PR TITLE
drivers: fix alphabetical order in Makefile.include

### DIFF
--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -62,10 +62,6 @@ ifneq (,$(filter dht,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/dht/include
 endif
 
-ifneq (,$(filter sht1x,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sht1x/include
-endif
-
 ifneq (,$(filter ds1307,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ds1307/include
 endif
@@ -272,6 +268,10 @@ endif
 
 ifneq (,$(filter sds011,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sds011/include
+endif
+
+ifneq (,$(filter sht1x,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sht1x/include
 endif
 
 ifneq (,$(filter sht2x,$(USEMODULE)))

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -1,3 +1,5 @@
+# driver includes (in alphabetical order)
+
 ifneq (,$(filter ad7746,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ad7746/include
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is a small PR for fixing the alphabetical order in the `drivers/Makefile.include` file.

(we need a static test for this!)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Just check the alphabetical order is fixed
- A green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
