### PR TITLE
core/sched: sched.h: remove not needed bitarithm include to avoid conflict

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -82,7 +82,6 @@
 
 #include <stddef.h>
 #include "kernel_defines.h"
-#include "bitarithm.h"
 #include "kernel_types.h"
 #include "native_sched.h"
 #include "clist.h"

--- a/cpu/nrf52/periph/usbdev.c
+++ b/cpu/nrf52/periph/usbdev.c
@@ -31,6 +31,7 @@
 #include "periph/usbdev.h"
 #include "usb.h"
 #include "usb/descriptor.h"
+#include "bitarithm.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/cpu/sam0_common/periph/rtt.c
+++ b/cpu/sam0_common/periph/rtt.c
@@ -32,7 +32,8 @@
  * effects, but simplifies the code. (This bit is always set on SAML21xxxxA)
  */
 #ifndef RTC_MODE0_CTRLA_COUNTSYNC
-#define RTC_MODE0_CTRLA_COUNTSYNC   BIT15
+#define RTC_MODE0_CTRLA_COUNTSYNC_Pos   15
+#define RTC_MODE0_CTRLA_COUNTSYNC       (0x1ul << RTC_MODE0_CTRLA_COUNTSYNC_Pos)
 #endif
 
 static rtt_cb_t _overflow_cb;

--- a/sys/frac/frac.c
+++ b/sys/frac/frac.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include "assert.h"
 #include "frac.h"
+#include "bitarithm.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"


### PR DESCRIPTION
bitarithm.h is not needed for the interface of shed but may cause conflicts
due to different definitions of SETBIT and CLRBIT

common implementations are: 

SETBIT(value, offset)  value |= (1<<offset) 
xor 
SETBIT(value, mask) value |= mask 

bitarithm implements the later
