### PR TITLE
driver/at86rf2xx use luid_get_eui64 to genenerate EUI

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -101,10 +101,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     }
 
     /* get an 8-byte unique ID to use as hardware address */
-    luid_get(addr_long.uint8, IEEE802154_LONG_ADDRESS_LEN);
-    /* make sure we mark the address as non-multicast and not globally unique */
-    addr_long.uint8[0] &= ~(0x01);
-    addr_long.uint8[0] |=  (0x02);
+    luid_get_eui64(addr_long);
     /* set short and long address */
     at86rf2xx_set_addr_long(dev, &addr_long);
     at86rf2xx_set_addr_short(dev, &addr_long.uint16[ARRAY_SIZE(addr_long.uint16) - 1]);


### PR DESCRIPTION
using luid_get_eui64 ensures:
- local admin address bit set
	was done manually before
- group address bit unset
	was done manually before
- count eui up
	was missing
	(luid_get counts up byte 0, the bit changes above make
	LSB and LSB<<1 of byte 0 constant -> 4 addresses are the same)

multiple devices will get the same eui
(since the same luid generation is used in in different drivers 
it might happen even though different devices are used)
