### PR TITLE
boards/adafruit-clue: add initial support

### DIFF
--- a/boards/adafruit-clue/Makefile
+++ b/boards/adafruit-clue/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/adafruit-clue/Makefile.dep
+++ b/boards/adafruit-clue/Makefile.dep
@@ -1,0 +1,18 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += apds9960
+  USEMODULE += bmp280_i2c
+  USEMODULE += lis3mdl
+  USEMODULE += sht3x
+endif
+
+# use nrfutil-bootloader/stdio_cdc_acm only if no other stdio_% other than stdio_cdc_acm
+# is requested
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
+  FEATURES_REQUIRED += bootloader_nrfutil
+  USEMODULE += usb_board_reset
+  USEMODULE += stdio_cdc_acm
+endif
+
+# include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/adafruit-clue/Makefile.features
+++ b/boards/adafruit-clue/Makefile.features
@@ -1,0 +1,13 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrf802154
+FEATURES_PROVIDED += bootloader_nrfutil
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/adafruit-clue/Makefile.include
+++ b/boards/adafruit-clue/Makefile.include
@@ -1,0 +1,26 @@
+# Adafruit-nrfutil is the default programmer
+PROGRAMMER ?= adafruit-nrfutil
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include
+
+ifeq ($(PROGRAMMER),adafruit-nrfutil)
+  # The preinstalled bootloader must also be taken into account so
+  # ROM_OFFSET skips the space taken by such bootloader.
+  ROM_OFFSET = 0x26000
+
+  ifneq (,$(filter reset flash flash-only, $(MAKECMDGOALS)))
+    # Add 2 seconds delay before opening terminal: this is required when opening
+    # the terminal right after flashing. In this case, the stdio over USB needs
+    # some time after reset before being ready.
+    TERM_DELAY = 2
+    TERMDEPS += term-delay
+  endif
+
+  include $(RIOTMAKE)/tools/adafruit-nrfutil.inc.mk
+endif
+
+term-delay:
+	sleep $(TERM_DELAY)
+
+TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
+$(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)

--- a/boards/adafruit-clue/board.c
+++ b/boards/adafruit-clue/board.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-clue
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the Adafruit Clue
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT); /* Red LED */
+
+    /* initialize the screen backlight, turn it off by default */
+    gpio_init(BACKLIGHT_PIN, GPIO_OUT);
+    gpio_clear(BACKLIGHT_PIN);
+}

--- a/boards/adafruit-clue/doc.txt
+++ b/boards/adafruit-clue/doc.txt
@@ -1,0 +1,45 @@
+/**
+@defgroup    boards_adafruit-clue Adafruit Clue
+@ingroup     boards
+@brief       Support for the Adafruit Clue
+
+### General information
+
+The [Adafruit Clue](https://www.adafruit.com/clue) board
+is an opensource, micro development kit using the nRF52840 SoC.
+This board provides 802.15.4 and BLE connectivity.
+
+<img src="https://raw.githubusercontent.com/adafruit/Adafruit-CLUE-PCB/master/assets/4500.jpg"
+     alt="Adafruit Clue" style="height:800px;"/>
+
+### Schematics
+
+The board detailed description and schematic is available
+[here](https://github.com/adafruit/Adafruit-CLUE-PCB).
+
+### Flash the board
+
+The board is flashed using the `adafruit-nrfutil` Python package:
+```
+    $ pip install --user adafruit-nrfutil
+```
+
+Example with `hello-world` application:
+```
+    make BOARD=adafruit-clue -C examples/hello-world flash
+```
+
+### Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port. On a Linux host, it's
+generally mapped to `/dev/ttyACM0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+    make BOARD=adafruit-clue -C examples/hello-world term
+```
+
+The `TERM_DELAY` environment variable can be used to add a delay (in second)
+before opening the serial terminal. The default value is 2s which should be
+enough in most of the situations.
+ */

--- a/boards/adafruit-clue/include/board.h
+++ b/boards/adafruit-clue/include/board.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-clue
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Adafruit Clue board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LEDs pin configuration
+ * @{
+ */
+#define LED0_PIN                        GPIO_PIN(1, 1)
+#define LED0_MASK                       (1 << 1)
+#define LED0_ON                         (NRF_P1->OUTSET = LED0_MASK)
+#define LED0_OFF                        (NRF_P1->OUTCLR = LED0_MASK)
+#define LED0_TOGGLE                     (NRF_P1->OUT   ^= LED0_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN                        GPIO_PIN(1, 2)  /* Button A */
+#define BTN0_MODE                       GPIO_IN_PU
+
+#define BTN1_PIN                        GPIO_PIN(1, 10) /* Button B */
+#define BTN1_MODE                       GPIO_IN_PU
+/** @} */
+
+/**
+ * @name    APDS9960 sensor configuration
+ * @{
+ */
+#define APDS99XX_PARAM_DEV              I2C_DEV(1)
+#define APDS99XX_PARAM_INT_PIN          GPIO_PIN(0, 9)
+/** @} */
+
+/**
+ * @name    BMP280 sensor configuration
+ * @{
+ */
+#define BMX280_PARAM_I2C_DEV            I2C_DEV(1)
+/** @} */
+
+/**
+ * @name    LIS3MDL 3-axis magnetometer I2C address
+ */
+#define LIS3MDL_PARAM_I2C               I2C_DEV(1)
+#define LIS3MDL_PARAM_ADDR              (0x1C)
+/** @} */
+
+/**
+ * @name    STH31 temperature and humidity sensor I2C address
+ */
+#define SHT3X_PARAM_I2C_DEV             I2C_DEV(1)
+#define SHT3X_PARAM_I2C_ADDR            (SHT3X_I2C_ADDR_1)
+/** @} */
+
+/**
+ * @name    Speaker pin
+ * @{
+ */
+#define SPKR_PIN                        GPIO_PIN(1, 0)
+/** @ */
+
+/**
+ * @name    Backlight control defines, default uses LCD_BACKLIGHT_LOW values
+ * @{
+ */
+#define BACKLIGHT_PIN                   GPIO_PIN(1, 5)
+#define BACKLIGHT_MASK                  (1 << 5)
+#define BACKLIGHT_ON                    (NRF_P1->OUTSET = BACKLIGHT_MASK)
+#define BACKLIGHT_OFF                   (NRF_P1->OUTCLR = BACKLIGHT_MASK)
+/** @ */
+
+/**
+ * @name    Display configuration
+ * @{
+ */
+#define ILI9341_PARAM_SPI               SPI_DEV(1)
+#define ILI9341_PARAM_CS                GPIO_PIN(0, 12)
+#define ILI9341_PARAM_DCX               GPIO_PIN(0, 13)
+#define ILI9341_PARAM_RST               GPIO_PIN(1, 3)
+#define ILI9341_PARAM_NUM_LINES         (240U)
+#define ILI9341_PARAM_RGB               (1)
+#define ILI9341_PARAM_INVERTED          (1)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/adafruit-clue/include/gpio_params.h
+++ b/boards/adafruit-clue/include/gpio_params.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-clue
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED0 (Red)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+    },
+    {
+        .name = "Button A",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "Button B",
+        .pin  = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/adafruit-clue/include/periph_conf.h
+++ b/boards/adafruit-clue/include/periph_conf.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-clue
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Adafruit Clue board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 4),
+        .tx_pin     = GPIO_PIN(0, 5),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {   /* External connectors */
+        .dev = NRF_TWIM0,
+        .scl = GPIO_PIN(0, 0),      /* D19 */
+        .sda = GPIO_PIN(0, 30),     /* D20 */
+        .speed = I2C_SPEED_NORMAL
+    },
+    {   /* On board sensors */
+        .dev = NRF_TWIM1,
+        .scl = GPIO_PIN(0, 25),
+        .sda = GPIO_PIN(0, 24),
+        .speed = I2C_SPEED_NORMAL
+    },
+};
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {   /* External connectors */
+        .dev  = NRF_SPI0,
+        .sclk = GPIO_PIN(0, 23),    /* D13 */
+        .mosi = GPIO_PIN(0, 21),    /* D15 */
+        .miso = GPIO_PIN(0, 22),    /* D14 */
+    },
+    {   /* TFT LCD screen */
+        .dev  = NRF_SPI1,
+        .sclk = GPIO_PIN(0, 14),
+        .mosi = GPIO_PIN(0, 15),
+        .miso = GPIO_PIN(0, 0),
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/adafruit-clue/reset.c
+++ b/boards/adafruit-clue/reset.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-clue
+ * @{
+ * @file
+ * @brief       Implementation for managing the nrfutil bootloader
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_USB_BOARD_RESET
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
+#include "usb_board_reset.h"
+
+/* Set the value used by the bootloader to select between boot in
+   application and boot in bootloader mode. */
+#define NRF52_DOUBLE_TAP_MAGIC_NUMBER       (0x4e)
+
+void usb_board_reset_in_bootloader(void)
+{
+    NRF_POWER->GPREGRET = NRF52_DOUBLE_TAP_MAGIC_NUMBER;
+
+    usb_board_reset_in_application();
+}
+
+#endif /* MODULE_USB_BOARD_RESET */

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -34,7 +34,7 @@ USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 
-BOARD_PROVIDES_NETIF := acd52832 airfy-beacon atmega256rfr2-xpro avr-rss2 b-l072z-lrwan1 cc2538dk fox \
+BOARD_PROVIDES_NETIF := acd52832 adafruit-clue airfy-beacon atmega256rfr2-xpro avr-rss2 b-l072z-lrwan1 cc2538dk fox \
         derfmega128 derfmega256 hamilton iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \
         microduino-corerf native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf6310 \
         nucleo-f207zg nucleo-f767zi openmote-b openmote-cc2538 pba-d-01-kw2x remote-pa \

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -44,7 +44,8 @@ ifneq (,$(filter stdio_uart,$(USEMODULE)))
 endif
 
 ifeq (,$(filter stdio_cdc_acm,$(USEMODULE)))
-  # The arduino bootloader feature cannot be used if the stdio_cdc_acm module
-  # is not used
+  # The arduino and nrfutil bootloader features cannot be used if the
+  # stdio_cdc_acm module is not used
   FEATURES_BLACKLIST += bootloader_arduino
+  FEATURES_BLACKLIST += bootloader_nrfutil
 endif

--- a/makefiles/tools/adafruit-nrfutil.inc.mk
+++ b/makefiles/tools/adafruit-nrfutil.inc.mk
@@ -1,0 +1,8 @@
+FLASHFILE = $(HEXFILE)
+FLASHDEPS += $(HEXFILE).zip
+FLASHER = adafruit-nrfutil
+FFLAGS = dfu serial --port=${PORT} --baudrate=${BAUD} --touch=1200 --package=$(HEXFILE).zip --singlebank
+
+%.hex.zip: %.hex
+	$(call check_cmd,$(FLASHER),Flash program and preparation tool)
+	$(FLASHER) dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $< $@

--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -5,6 +5,7 @@ USEMODULE += ssp
 # This test intentionally crashes the firmware and when using a board with a
 # preflashed bootloader, it cannot be reflashed automatically afterwards.
 FEATURES_BLACKLIST += bootloader_arduino
+FEATURES_BLACKLIST += bootloader_nrfutil
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -13,11 +13,12 @@ endif
 
 DISABLE_MODULE += auto_init auto_init_%
 
-# boards using arduino bootloader require auto_init to
+# boards using a preflashed bootloader require auto_init to
 # automatically initialize stdio over USB. Without this, the bootloader
 # management feature cannot be used (auto reset and auto reboot in bootloader
 # mode)
 FEATURES_BLACKLIST += bootloader_arduino
+FEATURES_BLACKLIST += bootloader_nrfutil
 
 # Pull in `Makefile.include`s from the test suites:
 -include $(UNIT_TESTS:%=$(RIOTBASE)/tests/unittests/%/Makefile.include)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an initial support for the [Adafruit Clue](https://www.adafruit.com/clue) board. This board has the same form factor as the micro:bit but is running on an nrf52840 MCU, which gives much more possibilities. There are also plenty of sensors and a TFT LCD screen.

Almost all sensors are already supported by RIOT: bmp280, sth31, lis3mdl. Support for the apds9960 is provided by #10420 (I tested it and the basic version works).

What was tested with success:
- I2C: all configured sensors are working
- second SPI: it is connected to the screen, which is ILI9341 compliant => `tests/driver_ili9341` works

The accelerometer, an LSM6DS33, is not tested/supported yet (maybe it's similar to the LSM6DSL) ?

The board is flashed using nrfutil as it is the tool used by the Arduino IDE: I added a new makefile for managing nrfutil.
The other thing is the management of the bootloader: I reuse the same approach used for the `arduino-nano-33-ble` board (see #13194) to trigger a reboot in bootloader mode. nrfutil is able to handle the serial "touch" at 1200bauds and to flash afterwards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Verify sensors/LEDs/buttons are correctly configured:
```
make BOARD=adafruit-clue -C example/default flash term
```
- Eventually run `compile_and_test_for_board.py` and check the results (but will need #13089 to work well).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This PR is based on #12304 for the bootloader management.
 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
