### PR TITLE
boards/cc1312-launchpad: correct config. for gdb_agent_server

### DIFF
--- a/boards/cc1312-launchpad/dist/cc1312r1f3_XDS110.dat
+++ b/boards/cc1312-launchpad/dist/cc1312r1f3_XDS110.dat
@@ -5,6 +5,7 @@ $ sepk
   pod_supply=1
   pod_voltage_selection=1
   pod_voltage=3.3
+  pod_power_isolate=0
 $ /
 $ product
   title="Texas Instruments XDS110 USB"
@@ -14,7 +15,7 @@ $ /
 $ uscif
   tdoedge=FALL
   tclk_program=DEFAULT
-  tclk_frequency=2.5MHz
+  tclk_frequency=5.5MHz
   jtag_isolate=disable
 $ /
 $ dot7
@@ -29,10 +30,10 @@ $ swd
   swd_debug=disabled
   swo_data=tdo_pin
 $ /
-@ icepick_c family=icepick_c irbits=6 drbits=1 subpaths=2
-  & subpath_2 address=0 default=no custom=yes force=yes pseudo=no cancelreset=0x0
+@ icepick_c family=icepick_c irbits=6 drbits=1 subpaths=2 systemresetsupported=1
+  & subpath_2 address=0 default=no custom=yes force=yes pseudo=no cancelreset=0x1
     @ bypass_0 family=bypass irbits=4 drbits=1
-  & subpath_0 address=16 default=no custom=yes force=yes pseudo=no cancelreset=0x0
+  & subpath_0 address=16 default=no custom=yes force=yes pseudo=no cancelreset=0x1
     @ cs_dap_0 family=cs_dap irbits=4 drbits=1 subpaths=1 identify=0x4BA00477 revision=Legacy systemresetwhileconnected=1
       & subpath_1 type=debug address=0 default=no custom=yes force=yes pseudo=no
         @ cortex_m4_0 family=cortex_mxx irbits=0 drbits=0 identify=0x02000000 traceid=0x0

--- a/boards/cc1312-launchpad/dist/cc1312r1f3_gdb.conf
+++ b/boards/cc1312-launchpad/dist/cc1312r1f3_gdb.conf
@@ -1,1 +1,1 @@
-target remote localhost:3333
+target extended-remote :3333


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Correct `.dat` files for debugging the `cc1312-launchpad` board. This file is automatically generated by CCS without any special options, previously these values came from the `cc1352-launchpad` board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `make debug-server`
- `make debug` and run monitor commands like `monitor reset`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
