### PR TITLE
cpu/cc430: rtc: remove dead code

### DIFF
--- a/cpu/cc430/periph/rtc.c
+++ b/cpu/cc430/periph/rtc.c
@@ -68,16 +68,6 @@ int rtc_set_time(struct tm *localt)
     return 0;
 }
 
-/*---------------------------------------------------------------------------
-time_t rtc_time(void) {
-    time_t sec;
-    struct tm t;
-    rtc_get_localtime(&t);
-    sec = mktime(&t);
-    return sec;
-}
-*/
-
 int rtc_get_time(struct tm *localt)
 {
     uint8_t success = 0;


### PR DESCRIPTION
### Contribution description

The commented-out block does provide no value and is confusing when using `grep`.

### Testing procedure

Only commented out code was removed, nothing to test.

### Issues/PRs references

none
