### PR TITLE
README: add badge for the Matrix chat network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Nightly CI status master][master-ci-badge]][master-ci-link]
 [![IRC][irc-badge]][irc-link]
+[![Matrix][matrix-badge]][matrix-link]
 
                           ZZZZZZ
                         ZZZZZZZZZZZZ
@@ -127,3 +128,5 @@ https://www.riot-os.org
 [master-ci-link]: https://ci.riot-os.org/nightlies.html#master
 [irc-badge]: https://img.shields.io/badge/IRC-join%20chat%20%E2%86%92-blue.svg
 [irc-link]: https://webchat.freenode.net?channels=%23riot-os
+[matrix-badge]: https://img.shields.io/badge/Matrix-join%20chat%20%E2%86%92-blue.svg
+[matrix-link]: https://matrix.to/#/#riot-os:matrix.org


### PR DESCRIPTION
### Contribution description

This PR adds a ~~shield~~ badge for the [Matrix] communications network including a link to the RIOT room currently used. Adding this ~~shield~~ badge to the readme gives users another way to request help/chat, which for some might be easier and more friendly compared to using IRC.

The room on matrix is [bridged] to the current IRC channel, messages are transparently proxied between both chat protocols without having to use a proxy bot. Fragmentation between IRC and Matrix is not an issue due to this bridge construction. It is purely up to the end user to pick one based on his/her preferences.

### Testing procedure

* Look at the ~~shield~~ badge and decide whether the colors should be identical or different from the IRC ~~shield~~ badge.
* Click the ~~shield~~ badge, a Matrix web interface with suggestions for chat clients, all showing instructions for joining the `#riot-os:matrix.org` room, should appear.

### Issues/PRs references

None

[Matrix]: https://matrix.org/
[bridged]: https://matrix.org/bridges