### PR TITLE
periph_common/rtc: add rtc_mktime() & rtc_localtime() helper functions for RTC implementations

### DIFF
--- a/cpu/esp32/periph/rtc.c
+++ b/cpu/esp32/periph/rtc.c
@@ -136,7 +136,7 @@ int rtc_set_time(struct tm *ttime)
     _rtc_time_set = _rtc_get_time_raw();
     _rtc_time_set_us = _rtc_time_to_us(_rtc_time_set);
 
-    _sys_time_set = mktime(ttime);
+    _sys_time_set = rtc_mktime(ttime);
     _sys_time_set_us = system_get_time_64();
     _sys_time_off_us = 0;
 
@@ -148,31 +148,18 @@ int rtc_set_time(struct tm *ttime)
 
 int rtc_get_time(struct tm *ttime)
 {
-    time_t _sys_time = _sys_get_time();
+    rtc_localtime(_sys_get_time(), ttime);
 
     DEBUG("%s sys_time=%ld rtc_time=%lld rtc_time_us=%lld\n", __func__,
-          _sys_time, _rtc_get_time_raw(), _rtc_time_to_us(_rtc_get_time_raw()));
+          _sys_get_time(), _rtc_get_time_raw(), _rtc_time_to_us(_rtc_get_time_raw()));
 
-    struct tm* _time = localtime(&_sys_time);
-    if (_time) {
-        memcpy(ttime, _time, sizeof(struct tm));
-        return 0;
-    }
-    else {
-        return -1;
-    }
+    return 0;
 }
 
 int rtc_get_alarm(struct tm *time)
 {
-    struct tm* _time = localtime(&_sys_alarm_time);
-    if (_time) {
-        memcpy(time, _time, sizeof(struct tm));
-        return 0;
-    }
-    else {
-        return -1;
-    }
+    rtc_localtime(_sys_alarm_time, time);
+    return 0;
 }
 
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
@@ -181,7 +168,7 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
     _rtc_alarm_arg = arg;
 
     /* determine the offset of alarm time to the set time in seconds */
-    _sys_alarm_time = mktime(time);
+    _sys_alarm_time = rtc_mktime(time);
     time_t _sys_time_offset = _sys_alarm_time - _sys_time_set;
 
 #if MODULE_ESP_RTC_TIMER

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -37,6 +37,7 @@
 #ifndef PERIPH_RTC_H
 #define PERIPH_RTC_H
 
+#include <stdint.h>
 #include <time.h>
 #include "periph_conf.h"
 
@@ -146,6 +147,19 @@ void rtc_tm_normalize(struct tm *time);
  * @return              0 if a and b are equal
  */
 int rtc_tm_compare(const struct tm *a, const struct tm *b);
+
+/**
+ * @brief Convert time struct into timestamp.
+ *
+ * @pre   The time structs @p a and @p b are assumed to be normalized.
+ *        Use @ref rtc_tm_normalize to normalize a struct tm that has been
+ *        manually edited.
+ *
+ * @param[in] t       The time struct to convert
+ *
+ * @return            elapsed seconds since `RIOT_EPOCH`
+ */
+uint32_t rtc_mktime(struct tm *t);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -161,6 +161,14 @@ int rtc_tm_compare(const struct tm *a, const struct tm *b);
  */
 uint32_t rtc_mktime(struct tm *t);
 
+/**
+ * @brief Converts an RTC timestamp into a  time struct.
+ *
+ * @param[in]  time   elapsed seconds since `RIOT_EPOCH`
+ * @param[out] t      the corresponding timestamp
+ */
+void rtc_localtime(uint32_t time, struct tm *t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/periph_common/rtc.c
+++ b/drivers/periph_common/rtc.c
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include "periph/rtc.h"
 
 #ifndef RTC_NORMALIZE_COMPAT
@@ -194,6 +195,24 @@ uint32_t rtc_mktime(struct tm *t)
     time += (leap_years * 366 + common_years * 365) * DAY;
 
     return time;
+}
+
+void rtc_localtime(uint32_t time, struct tm *t)
+{
+    uint32_t y_secs = _is_leap_year(RIOT_EPOCH) ? (366 * DAY) : (365 * DAY);
+    unsigned year = RIOT_EPOCH;
+
+    while (time > y_secs) {
+        time -= y_secs;
+        ++year;
+        y_secs = _is_leap_year(year) ? (366 * DAY) : (365 * DAY);
+    }
+
+    memset(t, 0, sizeof(*t));
+    t->tm_sec  = time;
+    t->tm_year = year - 1900;
+
+    rtc_tm_normalize(t);
 }
 
 #define RETURN_IF_DIFFERENT(a, b, member)   \

--- a/drivers/periph_common/rtc.c
+++ b/drivers/periph_common/rtc.c
@@ -138,6 +138,10 @@ void rtc_tm_normalize(struct tm *t)
 {
     div_t d;
 
+    if (t->tm_mday == 0) {
+        t->tm_mday = 1;
+    }
+
     d = div(t->tm_sec, 60);
     t->tm_min += d.quot;
     t->tm_sec  = d.rem;

--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -60,11 +60,11 @@ static void cb(void *arg)
 int main(void)
 {
     struct tm time = {
-        .tm_year = 2011 - TM_YEAR_OFFSET,   /* years are counted from 1900 */
-        .tm_mon  = 11,                      /* 0 = January, 11 = December */
-        .tm_mday = 13,
-        .tm_hour = 14,
-        .tm_min  = 15,
+        .tm_year = 2020 - TM_YEAR_OFFSET,   /* years are counted from 1900 */
+        .tm_mon  =  1,                      /* 0 = January, 11 = December */
+        .tm_mday = 28,
+        .tm_hour = 23,
+        .tm_min  = 59,
         .tm_sec  = 57
     };
 

--- a/tests/unittests/tests-rtc/tests-rtc.c
+++ b/tests/unittests/tests-rtc/tests-rtc.c
@@ -199,6 +199,31 @@ static void test_rtc_compare(void)
     TEST_ASSERT(rtc_tm_compare(&t1, &t2) < 0);
 }
 
+static void test_rtc_mktime(void)
+{
+    struct tm t  = {
+        .tm_sec  =  11,
+        .tm_min  =  12,
+        .tm_hour =  13,
+        .tm_mday =  1,
+        .tm_mon  =  0,
+        .tm_year = 120,
+        .tm_wday =   0,
+        .tm_yday =   1,
+    };
+
+    mktime(&t);
+    TEST_ASSERT_EQUAL_INT(47531, rtc_mktime(&t));
+
+    t.tm_mday += 40;
+    mktime(&t);
+    TEST_ASSERT_EQUAL_INT(3503531, rtc_mktime(&t));
+
+    t.tm_year += 3;
+    mktime(&t);
+    TEST_ASSERT_EQUAL_INT(98197931, rtc_mktime(&t));
+}
+
 Test *tests_rtc_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -209,6 +234,7 @@ Test *tests_rtc_tests(void)
         new_TestFixture(test_rtc_ywrap),
         new_TestFixture(test_rtc_year),
         new_TestFixture(test_rtc_compare),
+        new_TestFixture(test_rtc_mktime),
     };
 
     EMB_UNIT_TESTCALLER(rtc_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-rtc/tests-rtc.c
+++ b/tests/unittests/tests-rtc/tests-rtc.c
@@ -224,6 +224,58 @@ static void test_rtc_mktime(void)
     TEST_ASSERT_EQUAL_INT(98197931, rtc_mktime(&t));
 }
 
+static void test_rtc_localtime(void)
+{
+    struct tm t;
+
+    const struct tm t1  = {
+        .tm_sec  =  11,
+        .tm_min  =  12,
+        .tm_hour =  13,
+        .tm_mday =  1,
+        .tm_mon  =  0,
+        .tm_year = 120,
+        .tm_wday =   3,
+        .tm_yday =   0
+    };
+
+    const struct tm t2  = {
+        .tm_sec  =  11,
+        .tm_min  =  12,
+        .tm_hour =  13,
+        .tm_mday =  10,
+        .tm_mon  =  1,
+        .tm_year = 120,
+        .tm_wday =   1,
+        .tm_yday =  40,
+    };
+
+    const struct tm t3  = {
+        .tm_sec  =  11,
+        .tm_min  =  12,
+        .tm_hour =  13,
+        .tm_mday =  10,
+        .tm_mon  =  1,
+        .tm_year = 123,
+        .tm_wday =   5,
+        .tm_yday =  40,
+    };
+
+    rtc_localtime(100, &t);
+    TEST_ASSERT_EQUAL_INT(40, t.tm_sec);
+    TEST_ASSERT_EQUAL_INT(1, t.tm_min);
+    TEST_ASSERT_EQUAL_INT(120, t.tm_year);
+
+    rtc_localtime(47531, &t);
+    _test_equal_tm(&t1, &t);
+
+    rtc_localtime(3503531, &t);
+    _test_equal_tm(&t2, &t);
+
+    rtc_localtime(98197931, &t);
+    _test_equal_tm(&t3, &t);
+}
+
 Test *tests_rtc_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -235,6 +287,7 @@ Test *tests_rtc_tests(void)
         new_TestFixture(test_rtc_year),
         new_TestFixture(test_rtc_compare),
         new_TestFixture(test_rtc_mktime),
+        new_TestFixture(test_rtc_localtime),
     };
 
     EMB_UNIT_TESTCALLER(rtc_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

Some RTC implementations are based on a 1 Hz RTT and use a Unix timestamp and `mktime()`/`localtime()` to convert the `struct tm` to a timestamp and back.
While convenient, it is not necessary to start there, but worse it will also stop working on 2038-01-19.

This introduces two new functions:

 - `rtc_mktime()`
 - `rtc_localtime()`

They function similar to `mktime()` and `localtime_r()` but forego POSIX compatibility to be used by RTC implementations where this is not needed.

Key differences are:
 - timestamp is unsigned
 - epoch starts in 2020

Since RTC is unlikely to be set to a time in the past, we can use this to easily push the Y2038 problem to the year 2156 (2156-02-07 06:28:15).

Since RTC does not need to handle dailight savings time, timezone and such, the `rtc_` implementation saves ~9k compared to using the newlib functions. 

### Testing procedure

I only converted the stm32f1 RTC as an example.

Run `tests/periph_rtc` on e.g. a `bluepill` board.

### Issues/PRs references

possible solution for #13277