### PR TITLE
github: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,124 @@
+## CODEOWNERS for autoreview assigning in github
+
+# https://help.github.com/en/articles/about-code-owners#codeowners-syntax
+
+# Order is important; for each modified file, the last matching
+# pattern takes the most precedence.
+
+*.md                                        @jia200x
+
+/.murdock                                   @kaspar030
+
+/boards/common/esp*/                        @gschorcht
+/boards/common/nrf*/                        @aabadie @haukepetersen
+/boards/common/nucleo*/                     @aabadie
+/boards/common/silabs/                      @basilfx
+/boards/common/slwstk6000b/                 @basilfx
+/boards/common/stm32/                       @aabadie @fjmolinas
+/boards/esp*/                               @gschorcht @yegorich
+/boards/hamilton/                           @Hyungsin
+/boards/ikea-tradfri/                       @basilfx
+/boards/lobaro-lorabox/                     @leandrolanzieri
+/boards/nrf*/                               @aabadie @haukepetersen
+/boards/nucleo*/                            @aabadie @fjmolinas
+/boards/phynode-kw41z/                      @jia200x
+/boards/sam*-xpro/                          @dylad
+/boards/same54-xpro/                        @benpicco
+/boards/sensebox_samd21/                    @leandrolanzieri @jia200x
+/boards/slstk340*/                          @basilfx
+/boards/sltb001a/                           @basilfx
+/boards/slwstk6000b/                        @basilfx
+/boards/sodaq-sara-aff/                     @leandrolanzieri
+/boards/stk3*00/                            @basilfx
+
+/core/                                      @kaspar030
+
+/cpu/arm7_common/                           @kaspar030 @maribu
+/cpu/atmega*/                               @kYc0o @roberthartung @maribu
+/cpu/cc2538/                                @hexluthor @smlng @fjmolinas
+/cpu/cc26x0/                                @hexluthor @smlng
+/cpu/cc26x2_cc13x2/                         @hexluthor @smlng
+/cpu/cc26xx_cc13xx/                         @hexluthor @smlng
+/cpu/cortexm_common/                        @haukepetersen @thomaseichinger @DipSwitch
+/cpu/efm32/                                 @basilfx
+/cpu/esp*/                                  @gschorcht
+/cpu/fe310/                                 @aabadie @kaspar030
+/cpu/kinetis/                               @fjmolinas
+/cpu/lpc2387/                               @benpicco @maribu
+/cpu/mips*/                                 @kaspar030 @francois-berder
+/cpu/msp430*/                               @kaspar030 @gschorcht
+/cpu/nrf*/                                  @aabadie @haukepetersen
+/cpu/nrf52/radio/nrf802154/                 @bergzand @SemjonKerner @jia200x
+/cpu/sam0_common/                           @benpicco @dylad @keestux
+/cpu/samd21/                                @dylad @biboc
+/cpu/samd5x/                                @benpicco @dylad
+/cpu/saml1x/                                @dylad
+/cpu/saml21/                                @dylad
+/cpu/stm32*/                                @aabadie @fjmolinas @DipSwitch @vincent-d
+
+/doc/                                       @aabadie @jia200x
+
+/drivers/ad7746/                            @leandrolanzieri
+/drivers/at24mac/                           @benpicco
+/drivers/at86rf2xx/                         @daniel-k @Hyungsin @jia200x @smlng @miri64
+/drivers/bh1900nux/                         @wosym
+/drivers/cc110x/                            @maribu
+/drivers/cc1xxx_common/                     @maribu
+/drivers/ccs811/                            @gschorcht
+/drivers/enc28j60/                          @haukepetersen
+/drivers/dcf77/                             @daexel
+/drivers/dose/                              @jue89
+/drivers/ds18/                              @leandrolanzieri
+/drivers/itg320x/                           @gschorcht
+/drivers/mrf24j40/                          @bergzand
+/drivers/pca9685/                           @gschorcht
+/drivers/sht3x/                             @gschorcht
+/drivers/si70xx/                            @basilfx
+/drivers/sx127x/                            @aabadie @jia200x
+/drivers/ws281x/                            @maribu
+/drivers/xbee/                              @haukepetersen @miri64
+
+/pkg/cryptoauthlib/                         @Einhornhool @PeterKietzmann
+/pkg/lua/                                   @jcarrano
+/pkg/lwip/                                  @miri64
+/pkg/gecko_sdk/                             @basilfx
+/pkg/lora-serialization/                    @leandrolanzieri
+/pkg/micropython/                           @bergzand @kaspar030
+/pkg/openthread/                            @Hyungsin @jia200x
+/pkg/semtech-loramac/                       @aabadie @jia200x
+/pkg/tinydtls/                              @rfuentess @leandrolanzieri
+/pkg/u8g2/                                  @basilfx
+/pkg/ucglib/                                @basilfx
+/pkg/wakaama/                               @leandrolanzieri
+
+/sys/clif/                                  @leandrolanzieri
+/sys/event/                                 @kaspar030
+/sys/evtimer/                               @kaspar030
+/sys/fmt/                                   @kaspar030
+/sys/net/application_layer/gcoap/           @haukepetersen @kb2ma
+/sys/net/application_layer/nanocoap/        @kaspar030 @haukepetersen @kb2ma
+/sys/net/netif/                             @miri64 @jia200x
+/sys/net/gnrc/network_layer/                @miri64
+/sys/net/gnrc/transport_layer/tcp/          @brummer-simon @miri64
+/sys/net/gnrc/transport_layer/udp/          @miri64
+/sys/net/gnrc/link_layer/lorawan/           @jia200x
+/sys/net/gnrc/netif/                        @miri64 @jia200x
+/sys/net/gnrc/routing/rpl/                  @cgundogan @emmanuelsearch
+/sys/net/                                   @miri64 @haukepetersen @PeterKietzmann @cgundogan
+/sys/pm_layered/                            @roberthartung @kaspar030
+/sys/random/fortuna/                        @basilfx
+/sys/riotboot/                              @kaspar030 @fjmolinas
+/sys/suit                                   @kaspar030 @fjmolinas @bergzand
+/sys/tsrb/                                  @kaspar030
+/sys/usb/                                   @bergzand @dylad @aabadie
+/sys/xtimer/                                @kaspar030 @MichelRottleuthner
+
+/tests/                                     @miri64 @MrKevinWeiss @smlng @leandrolanzieri @aabadie @MichelRottleuthner @fjmolinas
+/tests/cpu_efm32_features/                  @basilfx
+
+# KConfig maintainers will be notified about all KConfig changes
+Kconfig                                     @leandrolanzieri @jia200x @cgundogan
+Makefile.dep                                @aabadie @fjmolinas
+Makefile.features                           @aabadie @fjmolinas
+Makefile.include                            @aabadie @fjmolinas
+pm.c                                        @roberthartung @kaspar030


### PR DESCRIPTION
### Contribution description

Our handling of Pull Requests is not always optimal. Often things are lost or fizzle out, which can be a frustrating experience for contributors.

A lot of this comes down to the simple fact that maintainers only have a limited amount of time in a day, but there are some issues that can be improved by technical means:

- When creating a PR it is often not obvious who to request a review from.
- External contributors are not in the loop on future changes of their code.
- It is often not clear who should feel responsible for a PR

GitHub provides the option to create a [CODEOWNERS](https://help.github.com/en/articles/about-code-owners) file.
If someone creates a PR that touches files or directories matching a pattern in that file, a review is automatically requested from the assigned users.

### Testing procedure

The file provided is very rudimentary.
**Please feel free to push to this branch directly if you want to add your name to modules or drivers that you are involved in.**

If we have all directories covered in the future, we can add a check to Travis to ensure no new code gets added that doesn't have someone attached who is responsible for it.
This process is employed by Zephyr and the Linux kernel.

### Issues/PRs references
Discussed briefly at a previous Virtual Maintainer Assembly and the FOSEM BoF meeting.