### PR TITLE
tinydtls: remove TINYDTLS_LOG and cleanup

### DIFF
--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -31,13 +31,8 @@ CFLAGS += -DDTLS_DEFAULT_PORT=$(DTLS_PORT)
 # This adds support for TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
 # CFLAGS += -DDTLS_ECC
 
-# Define the log entry for the tinydtls package.
-# Values: 0:EMERG (Default), 1:ALERT 2:CRIT 3:WARN 4:NOTICE 5:INFO 6:DEBUG
-TINYDTLS_LOG ?= 0
-
 # Enable this line for setting tinyDTLS in debug mode.
-# This overrides TINYDTLS_LOG to 6
-# CFLAGS += -DTINYDTLS_DEBUG
+# CFLAGS += -DDTLS_DEBUG
 
 # FIXME: This is a temporary patch
 # TinyDTLS <= 0.8.6 requires around 426 bytes in RAM.

--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -37,9 +37,6 @@ CFLAGS += -DDTLS_PSK
 
 # Uncomment to enable debug logs
 # CFLAGS += -DDTLS_DEBUG
-# When DTLS_DEBUG is set and using tinydtls, verbosity of debug log can be set with
-# Values: 0:EMERG (Default), 1:ALERT 2:CRIT 3:WARN 4:NOTICE 5:INFO 6:DEBUG
-# TINYDTLS_LOG=3
 
 # FIXME: This is a temporary patch
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(2*THREAD_STACKSIZE_LARGE\)

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -7,45 +7,31 @@ ifeq ($(TOOLCHAIN), llvm)
 endif
 
 INCLUDES += -I$(RIOTBASE)/pkg/tinydtls/include
+INCLUDES += -I$(PKG_BUILDDIR)
+# Mandatory for tinyDTLS
+CFLAGS += -DDTLSv12 -DWITH_SHA256
 
-ifneq (,$(filter tinydtls,$(USEMODULE)))
-  INCLUDES += -I$(PKG_BUILDDIR)
-  # Mandatory for tinyDTLS
-  CFLAGS += -DDTLSv12 -DWITH_SHA256
+# Dependencies partially under control of the App's requirements
 
-  # Dependencies partially under control of the App's requirements
+# The configuration for socket overrides Sock
+ifeq (,$(filter posix_sockets,$(USEMODULE)))
+  CFLAGS += -DWITH_RIOT_GNRC
+endif
 
-  # The configuration for socket overrides Sock
-  ifeq (,$(filter posix_sockets,$(USEMODULE)))
-    CFLAGS += -DWITH_RIOT_GNRC
+# NOTE: PSK should be enabled by default BUT if the user define any other cipher
+#       suite(s) it should not be enabled.
+# TODO: Create the flag DTLS_CIPHERS with keywords PSK, ECC (and future)
+ifeq (,$(filter -DDTLS_PSK,$(CFLAGS)))
+  ifeq (,$(filter -DDTLS_ECC,$(CFLAGS)))
+    CFLAGS += -DDTLS_PSK
   endif
+endif
 
-  # NOTE: PSK should be enabled by default BUT if the user define any other cipher
-  #       suite(s) it should not be enabled.
-  # TODO: Create the flag DTLS_CIPHERS with keywords PSK, ECC (and future)
-  ifeq (,$(filter -DDTLS_PSK,$(CFLAGS)))
-    ifeq (,$(filter -DDTLS_ECC,$(CFLAGS)))
-      CFLAGS += -DDTLS_PSK
-    endif
-  endif
-
-  # Enable debug when using tinydtls_sock_dtls
-  ifneq (,$(filter -DDTLS_DEBUG,$(CFLAGS)))
-    ifeq (,$(TINYDTLS_LOG))
-      CFLAGS += -DTINYDTLS_DEBUG
-    endif
-  endif
-
-  # Handles the verbosity of tinyDTLS. Default: Minimum or just error messages.
-  ifeq (,$(filter -DTINYDTLS_DEBUG,$(CFLAGS)))
-    ifeq ( , $(TINYDTLS_LOG))
-      CFLAGS += -DTINYDTLS_LOG_LVL=0
-    else
-      CFLAGS += -DTINYDTLS_LOG_LVL=$(TINYDTLS_LOG)
-    endif
-  else
-    CFLAGS += -DTINYDTLS_LOG_LVL=6
-  endif
+# Handles the verbosity of tinyDTLS. Default: Minimum or just error messages.
+ifeq (,$(filter -DDTLS_DEBUG,$(CFLAGS)))
+  CFLAGS += -DTINYDTLS_LOG_LVL=0
+else
+  CFLAGS += -DTINYDTLS_LOG_LVL=6
 endif
 
 ifneq (,$(filter tinydtls_aes,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

`TINYDTLS_LOG` currently just sets another flag `TINYDTLS_LOG_LVL`. This PR removes `TINYDTLS_LOG` from tinydtls Makefiles and its usage in the dtls-echo and dtls-sock example application. Applications that want to set the log level of tinydtls manually can still use `TINYDTLS_LOG_LVL` directly. This simplifies the logic in tinydtls `Makefile.include`.

This PR also removes the redundant check for tinydtls in the `Makefile.include`.

### Testing procedure

Check the dtls-echo and the dtls-sock example still compiles and the debug log is enabled when `DTLS_DEBUG` is added to CFLAGS