### PR TITLE
boards: move remaining uses of USEMODULE from Makefile.include to Makefile.dep

### DIFF
--- a/boards/airfy-beacon/Makefile.dep
+++ b/boards/airfy-beacon/Makefile.dep
@@ -1,1 +1,4 @@
+# include common nrf51 boards module into the build
+USEMODULE += boards_common_nrf51
+
 include $(RIOTBOARD)/common/nrf51/Makefile.dep

--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -1,6 +1,3 @@
-# include common nrf51 boards module into the build
-USEMODULE += boards_common_nrf51
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_arduino-atmega
-
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-mkr1000/Makefile.dep
+++ b/boards/arduino-mkr1000/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_arduino-mkr
+
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.dep

--- a/boards/arduino-mkr1000/Makefile.include
+++ b/boards/arduino-mkr1000/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_arduino-mkr
-
 ifeq ($(PROGRAMMER),jlink)
   export MKR_JLINK_DEVICE = atsamw25
 endif

--- a/boards/arduino-mkrfox1200/Makefile.dep
+++ b/boards/arduino-mkrfox1200/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_arduino-mkr
+
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.dep

--- a/boards/arduino-mkrfox1200/Makefile.include
+++ b/boards/arduino-mkrfox1200/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_arduino-mkr
-
 ifeq ($(PROGRAMMER),jlink)
   export MKR_JLINK_DEVICE = atsamd21
 endif

--- a/boards/arduino-mkrwan1300/Makefile.dep
+++ b/boards/arduino-mkrwan1300/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_arduino-mkr
+
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.dep

--- a/boards/arduino-mkrwan1300/Makefile.include
+++ b/boards/arduino-mkrwan1300/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_arduino-mkr
-
 ifeq ($(PROGRAMMER),jlink)
   export MKR_JLINK_DEVICE = atsamd21
 endif

--- a/boards/arduino-mkrzero/Makefile.dep
+++ b/boards/arduino-mkrzero/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_arduino-mkr
+
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.dep

--- a/boards/arduino-mkrzero/Makefile.include
+++ b/boards/arduino-mkrzero/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_arduino-mkr
-
 ifeq ($(PROGRAMMER),jlink)
   export MKR_JLINK_DEVICE = atsamd21
 endif

--- a/boards/blackpill-128kib/Makefile.dep
+++ b/boards/blackpill-128kib/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_blxxxpill
+
 include $(RIOTBOARD)/common/blxxxpill/Makefile.dep

--- a/boards/blackpill-128kib/Makefile.include
+++ b/boards/blackpill-128kib/Makefile.include
@@ -1,5 +1,3 @@
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/blxxxpill/dist/openocd-128kib.cfg
 
-USEMODULE += boards_common_blxxxpill
-
 include $(RIOTBOARD)/common/blxxxpill/Makefile.include

--- a/boards/blackpill/Makefile.dep
+++ b/boards/blackpill/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_blxxxpill
+
 include $(RIOTBOARD)/common/blxxxpill/Makefile.dep

--- a/boards/blackpill/Makefile.include
+++ b/boards/blackpill/Makefile.include
@@ -1,5 +1,3 @@
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/blxxxpill/dist/openocd.cfg
 
-USEMODULE += boards_common_blxxxpill
-
 include $(RIOTBOARD)/common/blxxxpill/Makefile.include

--- a/boards/bluepill-128kib/Makefile.dep
+++ b/boards/bluepill-128kib/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_blxxxpill
+
 include $(RIOTBOARD)/common/blxxxpill/Makefile.dep

--- a/boards/bluepill-128kib/Makefile.include
+++ b/boards/bluepill-128kib/Makefile.include
@@ -1,5 +1,3 @@
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/blxxxpill/dist/openocd-128kib.cfg
 
-USEMODULE += boards_common_blxxxpill
-
 include $(RIOTBOARD)/common/blxxxpill/Makefile.include

--- a/boards/bluepill/Makefile.dep
+++ b/boards/bluepill/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_blxxxpill
+
 include $(RIOTBOARD)/common/blxxxpill/Makefile.dep

--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -1,5 +1,3 @@
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/blxxxpill/dist/openocd.cfg
 
-USEMODULE += boards_common_blxxxpill
-
 include $(RIOTBOARD)/common/blxxxpill/Makefile.include

--- a/boards/chronos/Makefile.dep
+++ b/boards/chronos/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += chronos-drivers

--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -4,5 +4,3 @@ FLASHER = mspdebug
 FFLAGS = rf2500 "prog $(FLASHFILE)"
 
 INCLUDES += -I$(RIOTBOARD)/chronos/drivers/include
-
-USEMODULE += chronos-drivers

--- a/boards/common/arduino-due/Makefile.dep
+++ b/boards/common/arduino-due/Makefile.dep
@@ -1,3 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_arduino_due

--- a/boards/common/arduino-due/Makefile.include
+++ b/boards/common/arduino-due/Makefile.include
@@ -1,5 +1,4 @@
 # export this module and its includes
-USEMODULE += boards_common_arduino_due
 INCLUDES  += -I$(RIOTBOARD)/common/arduino-due/include
 
 # define the default port depending on the host OS

--- a/boards/common/nrf52xxxdk/Makefile.include
+++ b/boards/common/nrf52xxxdk/Makefile.include
@@ -1,6 +1,5 @@
 # include this module into the build
 INCLUDES += -I$(RIOTBOARD)/common/nrf52xxxdk/include
-USEMODULE += boards_common_nrf52xxdk
 
 # include common configuration for nrf52 based boards
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/common/nucleo/Makefile.dep
+++ b/boards/common/nucleo/Makefile.dep
@@ -1,3 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_nucleo

--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -1,5 +1,4 @@
 # export this module and its includes
-USEMODULE += boards_common_nucleo
 INCLUDES  += -I$(RIOTBOARD)/common/nucleo/include
 
 # we use shared STM32 configuration snippets

--- a/boards/common/saml1x/Makefile.dep
+++ b/boards/common/saml1x/Makefile.dep
@@ -1,3 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_saml1x

--- a/boards/common/saml1x/Makefile.include
+++ b/boards/common/saml1x/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_saml1x
-
 include $(RIOTMAKE)/boards/sam0.inc.mk
 
 # add the common header files to the include path

--- a/boards/common/slwstk6000b/Makefile.dep
+++ b/boards/common/slwstk6000b/Makefile.dep
@@ -3,5 +3,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += si7021
 endif
 
+# add board common drivers
+USEMODULE += boards_common_silabs
+USEMODULE += silabs_aem
+USEMODULE += silabs_bc
+
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep

--- a/boards/common/slwstk6000b/Makefile.include
+++ b/boards/common/slwstk6000b/Makefile.include
@@ -15,10 +15,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 export JLINK_DEVICE := $(MODULE_JLINK_DEVICE)
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
-# add board common drivers
-USEMODULE += boards_common_silabs
-USEMODULE += silabs_aem
-USEMODULE += silabs_bc
-
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/common/wsn430/Makefile.dep
+++ b/boards/common/wsn430/Makefile.dep
@@ -1,0 +1,2 @@
+# include this module in the build
+USEMODULE += boards_common_wsn430

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -1,5 +1,3 @@
-# include this module in the build
-USEMODULE += boards_common_wsn430
 # use common wsn430 includes
 INCLUDES += -I$(RIOTBOARD)/common/wsn430/include
 

--- a/boards/esp32-mh-et-live-minikit/Makefile.dep
+++ b/boards/esp32-mh-et-live-minikit/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_esp32
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-mh-et-live-minikit/Makefile.include
+++ b/boards/esp32-mh-et-live-minikit/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32
-
 include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-ttgo-t-beam/Makefile.dep
+++ b/boards/esp32-ttgo-t-beam/Makefile.dep
@@ -2,4 +2,6 @@ ifneq (,$(filter esp32_ttgo_t_beam_v1_0,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+USEMODULE += boards_common_esp32
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-ttgo-t-beam/Makefile.include
+++ b/boards/esp32-ttgo-t-beam/Makefile.include
@@ -1,5 +1,3 @@
 PSEUDOMODULES += esp32_ttgo_t_beam_v1_0
 
-USEMODULE += boards_common_esp32
-
 include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.dep
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.dep
@@ -1,1 +1,4 @@
+USEMODULE += boards_common_esp32
+USEMODULE += esp_spi_ram
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.include
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.include
@@ -1,6 +1,3 @@
 PSEUDOMODULES += esp_lolin_tft
 
-USEMODULE += boards_common_esp32
-USEMODULE += esp_spi_ram
-
 include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-wroom-32/Makefile.dep
+++ b/boards/esp32-wroom-32/Makefile.dep
@@ -1,3 +1,5 @@
+USEMODULE += boards_common_esp32
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep
 
 # default parameter definitions when module enc28j60 is used

--- a/boards/esp32-wroom-32/Makefile.include
+++ b/boards/esp32-wroom-32/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32
-
 include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-wrover-kit/Makefile.dep
+++ b/boards/esp32-wrover-kit/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_esp32
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-wrover-kit/Makefile.include
+++ b/boards/esp32-wrover-kit/Makefile.include
@@ -1,7 +1,5 @@
 PSEUDOMODULES += esp32_wrover_kit_camera
 
-USEMODULE += boards_common_esp32
-
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB1
 

--- a/boards/esp8266-esp-12x/Makefile.dep
+++ b/boards/esp8266-esp-12x/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_esp8266
+
 include $(RIOTBOARD)/common/esp8266/Makefile.dep

--- a/boards/esp8266-esp-12x/Makefile.include
+++ b/boards/esp8266-esp-12x/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp8266
-
 include $(RIOTBOARD)/common/esp8266/Makefile.include

--- a/boards/esp8266-olimex-mod/Makefile.dep
+++ b/boards/esp8266-olimex-mod/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_esp8266
+
 include $(RIOTBOARD)/common/esp8266/Makefile.dep

--- a/boards/esp8266-olimex-mod/Makefile.include
+++ b/boards/esp8266-olimex-mod/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp8266
-
 include $(RIOTBOARD)/common/esp8266/Makefile.include

--- a/boards/esp8266-sparkfun-thing/Makefile.dep
+++ b/boards/esp8266-sparkfun-thing/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_esp8266
+
 include $(RIOTBOARD)/common/esp8266/Makefile.dep

--- a/boards/esp8266-sparkfun-thing/Makefile.include
+++ b/boards/esp8266-sparkfun-thing/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp8266
-
 include $(RIOTBOARD)/common/esp8266/Makefile.include

--- a/boards/firefly/Makefile.dep
+++ b/boards/firefly/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_remote
+
 include $(RIOTBOARD)/common/remote/Makefile.dep

--- a/boards/firefly/Makefile.include
+++ b/boards/firefly/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_remote
-
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/frdm-kw41z/Makefile.dep
+++ b/boards/frdm-kw41z/Makefile.dep
@@ -2,4 +2,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += fxos8700
 endif
 
+# This board uses the shared board_init function
+USEMODULE += boards_common_kw41z
+
 include $(RIOTBOARD)/common/kw41z/Makefile.dep

--- a/boards/frdm-kw41z/Makefile.include
+++ b/boards/frdm-kw41z/Makefile.include
@@ -1,4 +1,1 @@
-# This board uses the shared board_init function
-USEMODULE += boards_common_kw41z
-
 include $(RIOTBOARD)/common/kw41z/Makefile.include

--- a/boards/iotlab-a8-m3/Makefile.dep
+++ b/boards/iotlab-a8-m3/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_iotlab
+
 include $(RIOTBOARD)/common/iotlab/Makefile.dep

--- a/boards/iotlab-a8-m3/Makefile.include
+++ b/boards/iotlab-a8-m3/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_iotlab
-
 include $(RIOTBOARD)/common/iotlab/Makefile.include

--- a/boards/iotlab-m3/Makefile.dep
+++ b/boards/iotlab-m3/Makefile.dep
@@ -4,3 +4,5 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += isl29020
   USEMODULE += lps331ap
 endif
+
+USEMODULE += boards_common_iotlab

--- a/boards/iotlab-m3/Makefile.include
+++ b/boards/iotlab-m3/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_iotlab
-
 include $(RIOTBOARD)/common/iotlab/Makefile.include

--- a/boards/msb-430/Makefile.dep
+++ b/boards/msb-430/Makefile.dep
@@ -1,3 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += sht11
 endif
+
+USEMODULE += boards_common_msb-430

--- a/boards/msb-430/Makefile.include
+++ b/boards/msb-430/Makefile.include
@@ -1,2 +1,1 @@
-USEMODULE += boards_common_msb-430
 include $(RIOTBOARD)/common/msb-430/Makefile.include

--- a/boards/msb-430h/Makefile.dep
+++ b/boards/msb-430h/Makefile.dep
@@ -1,3 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += sht11
 endif
+
+USEMODULE += boards_common_msb-430

--- a/boards/msb-430h/Makefile.include
+++ b/boards/msb-430h/Makefile.include
@@ -1,2 +1,1 @@
-USEMODULE += boards_common_msb-430
 include $(RIOTBOARD)/common/msb-430/Makefile.include

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -19,3 +19,5 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += checksum
   USEMODULE += random
 endif
+
+USEMODULE += native-drivers

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -3,8 +3,6 @@ export NATIVEINCLUDES += -I$(RIOTBOARD)/native/include/
 export NATIVEINCLUDES += -I$(RIOTBASE)/core/include/
 export NATIVEINCLUDES += -I$(RIOTBASE)/drivers/include/
 
-USEMODULE += native-drivers
-
 ifeq ($(OS),Darwin)
   DEBUGGER ?= lldb
 else

--- a/boards/nrf52840dk/Makefile.dep
+++ b/boards/nrf52840dk/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_nrf52xxdk
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep

--- a/boards/nrf52dk/Makefile.dep
+++ b/boards/nrf52dk/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_nrf52xxdk
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep

--- a/boards/particle-argon/Makefile.dep
+++ b/boards/particle-argon/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_particle_mesh
+
 include $(RIOTBOARD)/common/particle-mesh/Makefile.dep

--- a/boards/particle-argon/Makefile.include
+++ b/boards/particle-argon/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_particle_mesh
-
 include $(RIOTBOARD)/common/particle-mesh/Makefile.include

--- a/boards/particle-boron/Makefile.dep
+++ b/boards/particle-boron/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_particle_mesh
+
 include $(RIOTBOARD)/common/particle-mesh/Makefile.dep

--- a/boards/particle-boron/Makefile.include
+++ b/boards/particle-boron/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_particle_mesh
-
 include $(RIOTBOARD)/common/particle-mesh/Makefile.include

--- a/boards/particle-xenon/Makefile.dep
+++ b/boards/particle-xenon/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_particle_mesh
+
 include $(RIOTBOARD)/common/particle-mesh/Makefile.dep

--- a/boards/particle-xenon/Makefile.include
+++ b/boards/particle-xenon/Makefile.include
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_particle_mesh
-
 include $(RIOTBOARD)/common/particle-mesh/Makefile.include

--- a/boards/remote-pa/Makefile.dep
+++ b/boards/remote-pa/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_remote
+
 include $(RIOTBOARD)/common/remote/Makefile.dep

--- a/boards/remote-pa/Makefile.include
+++ b/boards/remote-pa/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_remote
-
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/remote-reva/Makefile.dep
+++ b/boards/remote-reva/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_remote
+
 include $(RIOTBOARD)/common/remote/Makefile.dep

--- a/boards/remote-reva/Makefile.include
+++ b/boards/remote-reva/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_remote
-
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/remote-revb/Makefile.dep
+++ b/boards/remote-revb/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += boards_common_remote
+
 include $(RIOTBOARD)/common/remote/Makefile.dep

--- a/boards/remote-revb/Makefile.include
+++ b/boards/remote-revb/Makefile.include
@@ -1,5 +1,3 @@
-USEMODULE += boards_common_remote
-
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/ruuvitag/Makefile.dep
+++ b/boards/ruuvitag/Makefile.dep
@@ -7,4 +7,6 @@ endif
 # Use Segger's RTT by default for stdio on this board
 DEFAULT_MODULE += stdio_rtt
 
+USEMODULE += boards_common_nrf52xxdk
+
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/slstk3401a/Makefile.dep
+++ b/boards/slstk3401a/Makefile.dep
@@ -3,5 +3,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += si7021
 endif
 
+# add board common drivers
+USEMODULE += boards_common_silabs
+USEMODULE += silabs_aem
+USEMODULE += silabs_bc
+
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep

--- a/boards/slstk3401a/Makefile.include
+++ b/boards/slstk3401a/Makefile.include
@@ -10,10 +10,5 @@ export JLINK_DEVICE := $(CPU_MODEL)
 export JLINK_PRE_FLASH = r
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
-# add board common drivers
-USEMODULE += boards_common_silabs
-USEMODULE += silabs_aem
-USEMODULE += silabs_bc
-
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/slstk3402a/Makefile.dep
+++ b/boards/slstk3402a/Makefile.dep
@@ -3,5 +3,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += si7021
 endif
 
+# add board common drivers
+USEMODULE += boards_common_silabs
+USEMODULE += silabs_aem
+USEMODULE += silabs_bc
+
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep

--- a/boards/slstk3402a/Makefile.include
+++ b/boards/slstk3402a/Makefile.include
@@ -10,10 +10,5 @@ export JLINK_DEVICE := $(CPU_MODEL)
 export JLINK_PRE_FLASH = r
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
-# add board common drivers
-USEMODULE += boards_common_silabs
-USEMODULE += silabs_aem
-USEMODULE += silabs_bc
-
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/sltb001a/Makefile.dep
+++ b/boards/sltb001a/Makefile.dep
@@ -4,5 +4,9 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += si7021
 endif
 
+# add board common drivers
+USEMODULE += boards_common_silabs
+USEMODULE += silabs_pic
+
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep

--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -10,9 +10,5 @@ export JLINK_DEVICE := EFR32MG1PxxxF256
 export JLINK_PRE_FLASH = r
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
-# add board common drivers
-USEMODULE += boards_common_silabs
-USEMODULE += silabs_pic
-
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3600/Makefile.dep
+++ b/boards/stk3600/Makefile.dep
@@ -2,5 +2,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+# add board common drivers
+USEMODULE += boards_common_silabs
+USEMODULE += silabs_aem
+USEMODULE += silabs_bc
+
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep

--- a/boards/stk3600/Makefile.include
+++ b/boards/stk3600/Makefile.include
@@ -9,10 +9,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 export JLINK_DEVICE := $(CPU_MODEL)
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
-# add board common drivers
-USEMODULE += boards_common_silabs
-USEMODULE += silabs_aem
-USEMODULE += silabs_bc
-
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3700/Makefile.dep
+++ b/boards/stk3700/Makefile.dep
@@ -2,5 +2,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+# add board common drivers
+USEMODULE += boards_common_silabs
+USEMODULE += silabs_aem
+USEMODULE += silabs_bc
+
 # include board common dependencies
 include $(RIOTBOARD)/common/silabs/Makefile.dep

--- a/boards/stk3700/Makefile.include
+++ b/boards/stk3700/Makefile.include
@@ -9,10 +9,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 export JLINK_DEVICE := $(CPU_MODEL)
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
-# add board common drivers
-USEMODULE += boards_common_silabs
-USEMODULE += silabs_aem
-USEMODULE += silabs_bc
-
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stm32f723e-disco/Makefile.dep
+++ b/boards/stm32f723e-disco/Makefile.dep
@@ -3,3 +3,6 @@ USEMODULE += stm32_periph_uart_hw_fc
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+# TODO: remove the stdin dependency
+USEMODULE += stdin

--- a/boards/stm32f723e-disco/Makefile.include
+++ b/boards/stm32f723e-disco/Makefile.include
@@ -11,8 +11,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # this board has an on-board ST-link adapter
 DEBUG_ADAPTER ?= stlink
 
-# TODO: remove the stdin dependency
-USEMODULE += stdin
-
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/usb-kw41z/Makefile.dep
+++ b/boards/usb-kw41z/Makefile.dep
@@ -1,1 +1,4 @@
+# This board uses the shared board_init function
+USEMODULE += boards_common_kw41z
+
 include $(RIOTBOARD)/common/kw41z/Makefile.dep

--- a/boards/usb-kw41z/Makefile.include
+++ b/boards/usb-kw41z/Makefile.include
@@ -1,4 +1,1 @@
-# This board uses the shared board_init function
-USEMODULE += boards_common_kw41z
-
 include $(RIOTBOARD)/common/kw41z/Makefile.include

--- a/boards/wsn430-v1_3b/Makefile.dep
+++ b/boards/wsn430-v1_3b/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/wsn430/Makefile.dep

--- a/boards/wsn430-v1_4/Makefile.dep
+++ b/boards/wsn430-v1_4/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/wsn430/Makefile.dep

--- a/boards/yunjia-nrf51822/Makefile.dep
+++ b/boards/yunjia-nrf51822/Makefile.dep
@@ -1,1 +1,4 @@
+# include common nrf51 boards module into the build
+USEMODULE += boards_common_nrf51
+
 include $(RIOTBOARD)/common/nrf51/Makefile.dep

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -1,6 +1,3 @@
-# include common nrf51 boards module into the build
-USEMODULE += boards_common_nrf51
-
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR moves all remaining uses of `USEMODULE += <module>` from boards Makefile.include to the corresponding Makefile.dep.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- for each modified board, check the list of modules included in a build and compare to master

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#9913

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
