### PR TITLE
makefiles: Use simple expansion for widely used variables

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -14,7 +14,8 @@ endif
 unexport DIRS
 DIRS := $(sort $(abspath $(DIRS)))
 
-MODULE ?= $(shell basename $(CURDIR))
+_MOD := $(shell basename $(CURDIR))
+MODULE ?= $(_MOD)
 
 .PHONY: all clean $(DIRS:%=ALL--%) $(DIRS:%=CLEAN--%)
 

--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -13,12 +13,14 @@ export NM         = $(PREFIX)nm
 export LINK       = $(PREFIX)gcc
 export LINKXX     = $(PREFIX)g++
 export SIZE       = $(PREFIX)size
-export OBJCOPY   ?= $(shell command -v $(PREFIX)objcopy || command -v gobjcopy || command -v objcopy)
+_OBJCOPY          := $(shell command -v $(PREFIX)objcopy || command -v gobjcopy || command -v objcopy)
+export OBJCOPY   ?= $(_OBJCOPY)
 ifeq ($(OBJCOPY),)
 $(warning objcopy not found. Hex file will not be created.)
 export OBJCOPY    = true
 endif
 # Default to the native (g)objdump, helps when using toolchain from docker
-export OBJDUMP   ?= $(or $(shell command -v $(PREFIX)objdump || command -v gobjdump),objdump)
+_OBJDUMP         := $(or $(shell command -v $(PREFIX)objdump || command -v gobjdump),objdump)
+export OBJDUMP   ?= $(_OBJDUMP)
 # We use GDB for debugging
 include $(RIOTMAKE)/tools/gdb.inc.mk

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -20,13 +20,15 @@ export LINK        = $(PREFIX)gcc
 export LINKXX      = $(PREFIX)g++
 # objcopy does not have a clear substitute in LLVM, use GNU binutils
 #export OBJCOPY     = $(LLVMPREFIX)objcopy
-export OBJCOPY    ?= $(shell command -v $(PREFIX)objcopy || command -v gobjcopy || command -v objcopy)
+_OBJCOPY          := $(shell command -v $(PREFIX)objcopy || command -v gobjcopy || command -v objcopy)
+export OBJCOPY    ?= $(_OBJCOPY)
 ifeq ($(OBJCOPY),)
 $(warning objcopy not found. Hex file will not be created.)
 export OBJCOPY     = true
 endif
 # Default to the native (g)objdump, helps when using toolchain from docker
-export OBJDUMP    ?= $(or $(shell command -v $(LLVMPREFIX)objdump || command -v gobjdump),objdump)
+_OBJDUMP          := $(or $(shell command -v $(LLVMPREFIX)objdump || command -v gobjdump),objdump)
+export OBJDUMP    ?= $(_OBJDUMP)
 export SIZE        = $(LLVMPREFIX)size
 # LLVM lacks a binutils strip tool as well...
 #export STRIP      = $(LLVMPREFIX)strip


### PR DESCRIPTION
### Contribution description
This PR changes some Makefile variable assignments to simple expansion, so we don't have to shell out multiple times when not required on widely used variables.

One can see all the calls to `basename`, for instance, by doing `make SHELL='/bin/sh -x' 2>&1 | less`.

### Test results 
I built **50 times** a couple of applications, for different boards, and measured with `time` each build. These are the averages:
#### samr21-xpro:`examples/gcoap`
- On master:
  - Real    3.85 s
  - User    2.95 s
  - System  0.96 s

- With this PR:
  - Real    3.02 s
  - User    2.38 s
  - System  0.66 s

**Time decreases in ~21.5%**.

#### native:`examples/gnrc_networking`
- On master:
  - Real    2.28 s
  - User    1.63 s
  - System  0.70 s

- With this PR:
  - Real    1.91 s
  - User    1.33 s
  - System  0.60 s

**Time decreases in ~16.2%**.

### Testing procedure
- Green Murdock
- You can measure time with something like:
```bash
BOARD=samr21-xpro make -C examples/gcoap clean
time -p BOARD=samr21-xpro make -C examples/gcoap all
```

### Issues/PRs references
None
