### PR TITLE
doc: Add section on configuration to 'Getting started'

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -768,9 +768,9 @@ INPUT                  = ../../doc.txt \
                          src/getting-started.md \
                          ../../tests/README.md \
                          src/build-system-basics.md \
+                         src/kconfig/kconfig.md \
                          src/advanced-build-system-tricks.md \
                          src/changelog.md \
-                         src/kconfig/kconfig.md \
                          ../../LOSTANDFOUND.md
 
 # This tag can be used to specify the character encoding of the source files

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -140,3 +140,15 @@ make -C examples/gnrc_networking/ term \
     TERMPROG=gtkterm \
     TERMFLAGS="-s 115200 -p /dev/ttyACM0 -e"
 ~~~~~~~~
+
+Configuring an application                         {#configuring-an-application}
+--------------------------
+Many modules in RIOT offer configuration options that will be considered during
+compile-time.They are modeled as macros that can be overridden by the user.
+Currently there are two ways of doing this: using `CFLAGS` or via
+@ref kconfig-in-riot "Kconfig" (the last one is currently only possible for a
+subset of modules).
+
+For instructions on how to configure via `CFLAGS` check the
+@ref config "identified compile-time configurations". To learn how to use
+Kconfig in RIOT, please refer to the @ref kconfig-users-guide.


### PR DESCRIPTION
### Contribution description
This PR adds a small section on application configuration, which references the 'Compile-time configurations' group and the Kconfig section and user's guide. It also moves Kconfig section closer to build system in the doc menu.

### Testing procedure
- Build the docs and read

### Issues/PRs references
None