### PR TITLE
shell_commands: remove old and redundant lines

### DIFF
--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -90,11 +90,6 @@ extern int _gnrc_netif_send(int argc, char **argv);
 extern int _fib_route_handler(int argc, char **argv);
 #endif
 
-#ifdef MODULE_GNRC_IPV6_NC
-extern int _ipv6_nc_manage(int argc, char **argv);
-extern int _ipv6_nc_routers(int argc, char **argv);
-#endif
-
 #ifdef MODULE_GNRC_IPV6_WHITELIST
 extern int _whitelist(int argc, char **argv);
 #endif
@@ -116,9 +111,7 @@ extern int _gnrc_6ctx(int argc, char **argv);
 #endif
 
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
-#ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
 extern int _gnrc_6lo_frag_stats(int argc, char **argv);
-#endif
 #endif
 
 #ifdef MODULE_CCN_LITE_UTILS


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Looked at the `shell_commands.c` of `shell_commands` and found some lines that were redundant or for functions that don't exist for a long time. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Should still compile (let Murdock do the job)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
