### PR TITLE
cpu/atmega32u4: remove obsolete -DCOREIF_NG=1

### DIFF
--- a/cpu/atmega32u4/Makefile.include
+++ b/cpu/atmega32u4/Makefile.include
@@ -1,6 +1,3 @@
-# this CPU implementation is using the new core/CPU interface
-CFLAGS += -DCOREIF_NG=1
-
 # define path to atmega common module, which is needed for this CPU
 export ATMEGA_COMMON = $(RIOTCPU)/atmega_common/
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes a leftover COREIF_NG define.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Confirm this:

```
[kaspar@ng riot (atmega32u4_remove_coreifng)]$ git grep COREIF_NG
[kaspar@ng riot (atmega32u4_remove_coreifng)]$ 
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/7781 removed COREIF_NG.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
