### PR TITLE
pkg/cryptoauthlib: add includes to cflags for llvm

### DIFF
--- a/pkg/cryptoauthlib/Makefile
+++ b/pkg/cryptoauthlib/Makefile
@@ -11,9 +11,11 @@ include $(RIOTBASE)/pkg/pkg.mk
 
 CMAKE_MINIMAL_VERSION = 3.6.0
 
+CFLAGS += $(INCLUDES)
 CFLAGS += -Wno-missing-field-initializers -Wno-unused-function
 CFLAGS += -Wno-type-limits -Wno-strict-aliasing -Wno-unused-variable -DATCA_HAL_I2C
 CFLAGS += -Wno-unused-parameter -Wno-sign-compare -Wno-overflow -Wno-pointer-to-int-cast
+CFLAGS += -Wno-char-subscripts
 
 TOOLCHAIN_FILE=$(PKG_BUILDDIR)/xcompile-toolchain.cmake
 

--- a/pkg/cryptoauthlib/Makefile.include
+++ b/pkg/cryptoauthlib/Makefile.include
@@ -14,7 +14,3 @@ ifneq (,$(filter cryptoauthlib_test,$(USEMODULE)))
   INCLUDES += -I$(PKG_TESTINCLDIR)/tng
   INCLUDES += -I$(PKG_TESTINCLDIR)/atcacert
 endif
-
-ifneq (,$(filter cortex-m%,$(CPU_ARCH)))
-  TOOLCHAINS_BLACKLIST += llvm
-endif


### PR DESCRIPTION
### Contribution description

Compiling applications using the CryptoAuth library didn't work with the llvm toolchain before, because it didn't correctly include system header files.
I added the includes to the cflags and removed llvm from the toolchain blacklist.
Further I had to disable the error messages for char subscripts.

I tested building tests/pkg_cryptoauthlib_compare-sha256 for the boards saml11-xpro, samr21-xpro, and nucleo-l031k6 with llvm.