### PR TITLE
pkg/cryptoauthlib: add no poll mode to documentation

### DIFF
--- a/pkg/cryptoauthlib/doc.txt
+++ b/pkg/cryptoauthlib/doc.txt
@@ -23,6 +23,13 @@
  * USEPKG += cryptoauthlib
  * to your Makefile.
  *
+ * ### No poll mode
+ *
+ * After sending a command to the device, responses are usually polled to enable
+ * quicker response times.
+ * Alternatively ATCA_NO_POLL can be enabled through CFLAGS to simply
+ * wait for the max execution time of a command before reading the response.
+ *
  *
  * ## Implementation status
  *


### PR DESCRIPTION
### Contribution description

Update of the CryptoAuth Lib documentation to include information on how to switch to no poll mode (usually the device response after executing a command gets polled, in no poll mode we wait for the max execution time before receiving data).