### PR TITLE
pkg/cryptoauthlib: make atca device type configurable

### DIFF
--- a/pkg/cryptoauthlib/include/atca_params.h
+++ b/pkg/cryptoauthlib/include/atca_params.h
@@ -50,10 +50,13 @@ extern "C" {
 #ifndef ATCA_RX_RETRIES
 #define ATCA_RX_RETRIES          (20)
 #endif
+#ifndef ATCA_DEVTYPE
+#define ATCA_DEVTYPE            (ATECC508A)
+#endif
 
 #ifndef ATCA_PARAMS
 #define ATCA_PARAMS                {    .iface_type = ATCA_I2C_IFACE, \
-                                        .devtype = ATECC508A, \
+                                        .devtype = ATCA_DEVTYPE, \
                                         .atcai2c.slave_address = ATCA_PARAM_ADDR, \
                                         .atcai2c.bus = ATCA_PARAM_I2C, \
                                         .atcai2c.baud = -1,                        /**< Not used in RIOT */ \

--- a/tests/pkg_cryptoauthlib_internal-tests/main.c
+++ b/tests/pkg_cryptoauthlib_internal-tests/main.c
@@ -23,7 +23,12 @@
 int main(void)
 {
     /* Set device to ATECC508A */
-    atca_run_cmd("508");
+    if (ATCA_DEVTYPE == ATECC608A) {
+        atca_run_cmd("608");
+    }
+    else {
+        atca_run_cmd("508");
+    }
 
     atca_run_cmd("unit");
 


### PR DESCRIPTION
### Contribution description

When using boards with more than one CryptoAuth device (the cryptoauth xplained pro extension shield for example), the user can decide which device to use.

To make this easier I made the device type configurable in the params file.

Since some of the features and commands changed, there are different tests for the devices, so I also adapted tests/pkg_cryptoauthlib_internal-tests, so it sets the correct target device. 