### PR TITLE
boards/esp32: fix compilation error due to C linkage in examples/posix_sockets

### DIFF
--- a/boards/esp32-mh-et-live-minikit/include/board.h
+++ b/boards/esp32-mh-et-live-minikit/include/board.h
@@ -33,10 +33,6 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 /**
  * @name    LED (on-board) configuration
  *
@@ -48,15 +44,15 @@
 #define LED_BLUE_PIN    GPIO2
 /** @} */
 
-#ifdef __cplusplus
-} /* end extern "C" */
-#endif
-
 /* include common board definitions as last step */
 #include "board_common.h"
 
 /* include definitions for optional hardware modules */
 #include "board_modules.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Initialize the board specific hardware
@@ -65,6 +61,10 @@ static inline void board_init(void) {
     /* there is nothing special to initialize on this board */
     board_init_common();
 }
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/esp32-olimex-evb/include/board.h
+++ b/boards/esp32-olimex-evb/include/board.h
@@ -36,10 +36,6 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @name    Button pin definitions
  * @{
@@ -97,6 +93,10 @@ extern "C" {
 
 /* include common board definitions as last step */
 #include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Initialize the board specific hardware

--- a/boards/esp32-ttgo-t-beam/include/board.h
+++ b/boards/esp32-ttgo-t-beam/include/board.h
@@ -32,10 +32,6 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 /**
  * @name    Button pin definitions
  * @{
@@ -58,10 +54,6 @@
 #endif
 /** @} */
 
-#ifdef __cplusplus
-} /* end extern "C" */
-#endif
-
 /**
  * @name        SX127X
  *
@@ -79,10 +71,18 @@
 /* include common board definitions as last step */
 #include "board_common.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Initialize the board specific hardware
  */
 void board_init(void);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/esp32-wemos-lolin-d32-pro/include/board.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/board.h
@@ -44,10 +44,6 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 /**
  * @name LED (on-board) configuration
  * @{
@@ -73,12 +69,12 @@
 #endif
 /** @} */
 
-#ifdef __cplusplus
-} /* end extern "C" */
-#endif
-
 /* include common board definitions as last step */
 #include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Initialize the board specific hardware
@@ -87,6 +83,10 @@ static inline void board_init(void) {
     /* there is nothing special to initialize on this board */
     board_init_common();
 }
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/esp32-wroom-32/include/board.h
+++ b/boards/esp32-wroom-32/include/board.h
@@ -33,14 +33,6 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
-#ifdef __cplusplus
-} /* end extern "C" */
-#endif
-
 /**
  * @name    Button pin definitions
  * @{
@@ -64,6 +56,10 @@
 /* include common board definitions as last step */
 #include "board_common.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Initialize the board specific hardware
  */
@@ -71,6 +67,10 @@ static inline void board_init(void) {
     /* there is nothing special to initialize on this board */
     board_init_common();
 }
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/esp32-wrover-kit/include/board.h
+++ b/boards/esp32-wrover-kit/include/board.h
@@ -47,10 +47,6 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 /**
  * @name    LED (on-board) configuration
  * @{
@@ -101,12 +97,12 @@
 #endif
 /** @} */
 
-#ifdef __cplusplus
-} /* end extern "C" */
-#endif
-
 /* include common board definitions as last step */
 #include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Initialize the board specific hardware
@@ -115,6 +111,10 @@ static inline void board_init(void) {
     /* there is nothing special to initialize on this board */
     board_init_common();
 }
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
 
 #endif /* BOARD_H */
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR fixes a compilation problem with `examples/posix_sockets` and `esp32-olimex-evb` that occured in PR #13291 

The reason for the problem was that the `board_common.h` header was included inside the `extern "C"` linkage block which in turn led to the inclusion of `atomic_base.h` inside `extern "C"` linkage block.

### Testing procedure

Compile `examples/posix_sockets` with enabled module `esp_wifi` for `esp32-olimex-evb`:
```
USEMODULE=esp_wifi make BOARD=esp32-olimex-evb -C examples/posix_sockets
```
In current master the compilation fails, with this PR it should succeed.

### Issues/PRs references

Found while testing PR #13291 