### PR TITLE
tests/pkg_cryptoauthlib_internal_tests: add unsupported device handling

### DIFF
--- a/tests/pkg_cryptoauthlib_internal-tests/main.c
+++ b/tests/pkg_cryptoauthlib_internal-tests/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <stdio.h>
 #include "cryptoauthlib_test.h"
 
 int main(void)
@@ -26,8 +27,12 @@ int main(void)
     if (ATCA_DEVTYPE == ATECC608A) {
         atca_run_cmd("608");
     }
-    else {
+    else if (ATCA_DEVTYPE == ATECC508A) {
         atca_run_cmd("508");
+    }
+    else {
+        printf("This device is currently not supported.");
+        return 0;
     }
 
     atca_run_cmd("unit");


### PR DESCRIPTION
### Contribution description

The CryptoAuth Lib and their unit tests actually also support the predecessors of the ATECC508A and ATECC608A. 
Currently this application runs tests for 608 if it is defined and tests for 508 if anything else is defined. 

I added a third condition which prints out a message if the defined device is not supported.