### PR TITLE
pkg/libcose: Add to documentation

### DIFF
--- a/pkg/libcose/doc.txt
+++ b/pkg/libcose/doc.txt
@@ -1,0 +1,45 @@
+/**
+ * @defgroup pkg_libcose  libcose for RIOT
+ * @ingroup  pkg
+ * @brief    Constrained node COSE library
+ * @see      https://github.com/bergzand/libcose
+ *
+ * Usage
+ * -----
+ *
+ * Add as a package in the Makefile of your application:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ * USEPKG += libcose
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * The main consumers of libcose are other libraries or system components, for
+ * example @ref sys_suit "SUIT".
+ *
+ * The use of the library itself [is described in the libcose
+ * documentation](https://bergzand.github.io/libcose/), and some example code
+ * can be found in
+ * [`tests/pkg_libcose/`](https://github.com/RIOT-OS/RIOT/tree/master/tests/pkg_libcose).
+ *
+ * Backends
+ * --------
+ *
+ * The libcose library does not implement cryptographic algorithms itself, but
+ * fans that out to other libraries (which are pulled into the dependency tree
+ * as packages) and exposes a consistent interface for the
+ * operations they provide.
+ *
+ * Backends are selected by any of those pseudomodules:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ * USEMODULE += libcose_crypt_hacl
+ * USEMODULE += libcose_crypt_monocypher
+ * USEMODULE += libcose_crypt_c25519
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * The selection of pseudomodules determines the available algorithms:
+ *
+ * * @ref pkg_hacl "HACL" and @ref pkg_monocypher "Monocypher" both provide ChaCha20-Poly1305 and Ed25519.
+ * * @ref pkg_c25519 "C25519" only provides the Ed25519 algorithm.
+ *
+ */


### PR DESCRIPTION
### Contribution description

The libcose package previously had no presence whatsoever in the RIOT documentation.

This adds a line on how to enable it and defers to the library documentation for details. An additional section outlines how its algorithm backends are selected.

### Issues/PRs references

This follows one of the styles currently discussed in #7094 for making the package visible.