### PR TITLE
gnrc_sixlowpan_frag_stats: add average fragments per datagram statistic

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/stats.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/stats.h
@@ -35,6 +35,8 @@ typedef struct {
                              *   reassembly buffer is full */
     unsigned frag_full;     /**< counts the number of events that there where
                              *   no @ref gnrc_sixlowpan_frag_fb_t available */
+    unsigned datagrams;     /**< reassembled datagrams */
+    unsigned fragments;     /**< total fragments of reassembled fragments */
 #if defined(MODULE_GNRC_SIXLOWPAN_FRAG_VRB) || DOXYGEN
     unsigned vrb_full;      /**< counts the number of events where the virtual
                              *   reassembly buffer is full */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -580,6 +580,20 @@ static void _tmp_rm(gnrc_sixlowpan_frag_rb_t *rbuf)
 #endif  /* CONFIG_GNRC_SIXLOWPAN_FRAG_RBUF_DEL_TIMER */
 }
 
+#if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_STATS)
+static inline unsigned _count_frags(gnrc_sixlowpan_frag_rb_t *rbuf)
+{
+    unsigned frags = 0;
+    gnrc_sixlowpan_frag_rb_int_t *frag = rbuf->super.ints;
+
+    while (frag) {
+        frag = frag->next;
+        frags++;
+    }
+    return frags;
+}
+#endif
+
 int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,
                                                    gnrc_netif_hdr_t *netif_hdr)
 {
@@ -610,6 +624,10 @@ int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf
         new_netif_hdr->lqi = netif_hdr->lqi;
         new_netif_hdr->rssi = netif_hdr->rssi;
         LL_APPEND(rbuf->pkt, netif);
+#if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_STATS)
+        gnrc_sixlowpan_frag_stats_get()->fragments += _count_frags(rbuf);
+        gnrc_sixlowpan_frag_stats_get()->datagrams++;
+#endif
         gnrc_sixlowpan_dispatch_recv(rbuf->pkt, NULL, 0);
         _tmp_rm(rbuf);
     }

--- a/sys/shell/commands/sc_gnrc_6lo_frag_stats.c
+++ b/sys/shell/commands/sc_gnrc_6lo_frag_stats.c
@@ -28,6 +28,8 @@ int _gnrc_6lo_frag_stats(int argc, char **argv)
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_VRB
     printf("VRB full: %u\n", stats->vrb_full);
 #endif
+    printf("frags complete: %u\n", stats->fragments);
+    printf("dgs complete: %u\n", stats->datagrams);
     return 0;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I need this for my experiments. Just counts the number of successfully reassembled datagrams and from how many fragments they were reassembled.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `examples/gnrc_networking` on any board that utilizes 6LoWPAN for IPv6 communication with `USEMODULE=gnrc_sixlowpan_frag_stats`. Send fragmented packets (payload size >96) between them. The counters with `6lo_frag` for `fragments` and `datagrams` should go up.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
