### PR TITLE
gnrc_ipv6_ext_frag: initial import of statistics module

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -18,6 +18,7 @@ PSEUDOMODULES += event_%
 PSEUDOMODULES += fmt_%
 PSEUDOMODULES += gnrc_dhcpv6_%
 PSEUDOMODULES += gnrc_ipv6_default
+PSEUDOMODULES += gnrc_ipv6_ext_frag_stats
 PSEUDOMODULES += gnrc_ipv6_router
 PSEUDOMODULES += gnrc_ipv6_router_default
 PSEUDOMODULES += gnrc_ipv6_nib_6lbr

--- a/sys/include/net/gnrc/ipv6/ext/frag.h
+++ b/sys/include/net/gnrc/ipv6/ext/frag.h
@@ -94,6 +94,18 @@ typedef struct {
 } gnrc_ipv6_ext_frag_rbuf_t;
 
 /**
+ * @brief   Statistics on reassembly and reassembly
+ */
+typedef struct {
+    unsigned rbuf_full;     /**< counts the number of events where the
+                             *   reassembly buffer is full */
+    unsigned frag_full;     /**< counts the number of events that there where
+                             *   no @ref gnrc_sixlowpan_frag_fb_t available */
+    unsigned datagrams;     /**< reassembled datagrams */
+    unsigned fragments;     /**< total fragments of reassembled fragments */
+} gnrc_ipv6_ext_frag_stats_t;
+
+/**
  * @brief   Initializes IPv6 fragmentation and reassembly
  * @internal
  */
@@ -186,6 +198,14 @@ static inline void gnrc_ipv6_ext_frag_rbuf_del(gnrc_ipv6_ext_frag_rbuf_t *rbuf)
  */
 void gnrc_ipv6_ext_frag_rbuf_gc(void);
 /** @} */
+
+/**
+ * @brief   Get the current statistics on reassembly and fragmentation
+ *
+ * @return  The current statistics on reassembly and fragmentation.
+ * @return  NULL, if module `gnrc_ipv6_ext_frag_stats` is not compiled in.
+ */
+gnrc_ipv6_ext_frag_stats_t *gnrc_ipv6_ext_frag_stats(void);
 
 #ifdef __cplusplus
 }

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -32,6 +32,9 @@ endif
 ifneq (,$(filter fib,$(USEMODULE)))
   SRC += sc_fib.c
 endif
+ifneq (,$(filter gnrc_ipv6_ext_frag_stats,$(USEMODULE)))
+  SRC += sc_gnrc_ipv6_frag_stats.c
+endif
 ifneq (,$(filter gnrc_ipv6_nib,$(USEMODULE)))
   SRC += sc_gnrc_ipv6_nib.c
 endif

--- a/sys/shell/commands/sc_gnrc_ipv6_frag_stats.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_frag_stats.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include <stdio.h>
+#include "net/gnrc/ipv6/ext/frag.h"
+
+int _gnrc_ipv6_frag_stats(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    if (IS_USED(MODULE_GNRC_IPV6_EXT_FRAG_STATS)) {
+        gnrc_ipv6_ext_frag_stats_t *stats = gnrc_ipv6_ext_frag_stats();
+
+        printf("rbuf full: %u\n", stats->rbuf_full);
+        printf("frag full: %u\n", stats->frag_full);
+        printf("frags complete: %u\n", stats->fragments);
+        printf("dgs complete: %u\n", stats->datagrams);
+    }
+    return 0;
+}
+
+
+/** @} */

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -90,6 +90,10 @@ extern int _gnrc_netif_send(int argc, char **argv);
 extern int _fib_route_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_GNRC_IPV6_EXT_FRAG_STATS
+extern int _gnrc_ipv6_frag_stats(int argc, char **argv);
+#endif
+
 #ifdef MODULE_GNRC_IPV6_WHITELIST
 extern int _whitelist(int argc, char **argv);
 #endif
@@ -213,6 +217,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_FIB
     {"fibroute", "Manipulate the FIB (info: 'fibroute [add|del]')", _fib_route_handler},
+#endif
+#ifdef MODULE_GNRC_IPV6_EXT_FRAG_STATS
+    {"ip6_frag", "IPv6 fragmentation statistics", _gnrc_ipv6_frag_stats },
 #endif
 #ifdef MODULE_GNRC_IPV6_WHITELIST
     {"whitelist", "whitelists an address for receival ('whitelist [add|del|help]')", _whitelist },


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Similarly to `gnrc_sixlowpan_frag_stats` this new pseudo-module provides statistics on IPv6 fragmentation and reassembly.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `tests/gnrc_udp` on any board is capable of network communication with `USEMODULE=gnrc_ipv6_ext_frag_stats`. Send fragmented packets (IPv6 packet size >MTU) between them. The counters with `ip6_frag` for `fragments` and `datagrams` should go up.
<!--

Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
