### PR TITLE
boards/sam[r/d]21-xpro: prefer XOSC32K for RTC/RTT (GCLK2)

### DIFF
--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -63,7 +63,16 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_USE_PLL       (1)
+#define CLOCK_USE_PLL               (1)
+#define CLOCK_USE_XOSC32_DFLL       (0)
+/*
+ * 0: use XOSC32K (always 32.768kHz) to clock GCLK2
+ * 1: use OSCULP32K factory calibrated (~32.768kHz) to clock GCLK2
+ *
+ * OSCULP32K is factory calibrated to be around 32.768kHz but this values can
+ * be of by a couple off % points, so prefer XOSC32K as default configuration.
+ */
+#define GEN2_ULP32K                 (0)
 
 #if CLOCK_USE_PLL
 /* edit these values to adjust the PLL output frequency */
@@ -76,7 +85,6 @@ extern "C" {
 #define CLOCK_CORECLOCK     (48000000U)
 #define CLOCK_XOSC32K       (32768UL)
 #define CLOCK_8MHZ          (1)
-#define GEN2_ULP32K         (1)
 #else
 /* edit this value to your needs */
 #define CLOCK_DIV           (1U)

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -63,7 +63,16 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_USE_PLL       (1)
+#define CLOCK_USE_PLL               (1)
+#define CLOCK_USE_XOSC32_DFLL       (0)
+/*
+ * 0: use XOSC32K (always 32.768kHz) to clock GCLK2
+ * 1: use OSCULP32K factory calibrated (~32.768kHz) to clock GCLK2
+ *
+ * OSCULP32K is factory calibrated to be around 32.768kHz but this values can
+ * be of by a couple off % points, so prefer XOSC32K as default configuration.
+ */
+#define GEN2_ULP32K                 (0)
 
 #if CLOCK_USE_PLL
 /* edit these values to adjust the PLL output frequency */
@@ -76,7 +85,6 @@ extern "C" {
 #define CLOCK_CORECLOCK     (48000000U)
 #define CLOCK_XOSC32K       (32768UL)
 #define CLOCK_8MHZ          (1)
-#define GEN2_ULP32K         (1)
 #else
 /* edit this value to your needs */
 #define CLOCK_DIV           (1U)

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -31,6 +31,10 @@
 #define GEN2_ULP32K         1
 #endif
 
+#ifndef GEN3_ULP32K
+#define GEN3_ULP32K         1
+#endif
+
 #ifndef VDD
 /**
  * @brief   Set system voltage level in mV (determines flash wait states)
@@ -223,7 +227,7 @@ static void clk_init(void)
     GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(SAM0_GCLK_1KHZ)  | GCLK_GENDIV_DIV(4));
     GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(SAM0_GCLK_1KHZ) | GCLK_GENCTRL_GENEN
                       | GCLK_GENCTRL_RUNSTDBY | GCLK_GENCTRL_DIVSEL
-#if GEN2_ULP32K
+#if GEN3_ULP32K
                       | GCLK_GENCTRL_SRC_OSCULP32K);
 #else
                       | GCLK_GENCTRL_SRC_XOSC32K);

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -108,7 +108,7 @@ static void clk_init(void)
     while (!(SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_OSC8MRDY)) {}
 #endif
 
-#if CLOCK_USE_XOSC32_DFLL || !GEN2_ULP32K || !GEN4_ULP32K
+#if CLOCK_USE_XOSC32_DFLL || !GEN2_ULP32K || !GEN3_ULP32K
     /* Use External 32.768KHz Oscillator */
     SYSCTRL->XOSC32K.reg =  SYSCTRL_XOSC32K_ONDEMAND |
                             SYSCTRL_XOSC32K_EN32K |
@@ -118,6 +118,10 @@ static void clk_init(void)
     /* Enable XOSC32 with Separate Call */
     SYSCTRL->XOSC32K.bit.ENABLE = 1;
 #endif
+
+    /* reset the GCLK module so it is in a known state */
+    GCLK->CTRL.reg = GCLK_CTRL_SWRST;
+    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
     /* Setup GCLK2 with divider 1 (32.768kHz) */
     GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(SAM0_GCLK_32KHZ)  | GCLK_GENDIV_DIV(0));
@@ -129,11 +133,8 @@ static void clk_init(void)
                       | GCLK_GENCTRL_SRC_XOSC32K);
 #endif
 
-#if CLOCK_USE_PLL
-    /* reset the GCLK module so it is in a known state */
-    GCLK->CTRL.reg = GCLK_CTRL_SWRST;
-    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 
+#if CLOCK_USE_PLL
     /* setup generic clock 1 to feed DPLL with 1MHz */
     GCLK->GENDIV.reg = (GCLK_GENDIV_DIV(8) |
                         GCLK_GENDIV_ID(SAM0_GCLK_1MHZ));
@@ -159,10 +160,6 @@ static void clk_init(void)
                          GCLK_GENCTRL_SRC_FDPLL |
                          GCLK_GENCTRL_ID(SAM0_GCLK_MAIN));
 #elif CLOCK_USE_XOSC32_DFLL
-    /* reset the GCLK module so it is in a known state */
-    GCLK->CTRL.reg = GCLK_CTRL_SWRST;
-    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
-
     /* setup generic clock 1 as 1MHz for timer.c */
     GCLK->GENDIV.reg = (GCLK_GENDIV_DIV(8) |
                         GCLK_GENDIV_ID(SAM0_GCLK_1MHZ));

--- a/tests/periph_wdt/tests/01-run.py
+++ b/tests/periph_wdt/tests/01-run.py
@@ -37,6 +37,7 @@ def get_reset_time(child):
 
 
 def testfunc(child):
+    child.expect_exact(">")
     child.sendline("range")
     child.expect(r"lower_bound: (\d+) upper_bound: (\d+)\s*\r\n",
                  timeout=1)
@@ -44,10 +45,12 @@ def testfunc(child):
     wdt_upper_bound = int(child.match.group(2))
 
     for rst_time in reset_times_ms:
+        child.expect_exact(">")
         child.sendline("setup 0 {}".format(rst_time))
         if rst_time < wdt_lower_bound or rst_time > wdt_upper_bound:
             child.expect_exact("invalid time, see \"range\"", timeout=1)
         else:
+            child.expect_exact(">")
             child.sendline("startloop")
             child.expect(r"start time: (\d+) us", timeout=1)
             start_time_us = int(child.match.group(1))


### PR DESCRIPTION
### Contribution description

For `samr21-xpro`, `GCLK2` is used to clock `RTC` and `RTT`. By default `OSCULP32K` is preferred to clock `GCLK2`. On other `sam0` boards the actual clock source can be chosen independent of `GCLK` but not for `samr`.

`OSCULP32K` needs calibration and although:

> OSCULP32K.CALIB is automatically loaded from Flash Factory Calibration during startup, and is used to compensate for process variation, as described in the Electrical Characteristics. The calibration value can be overridden by the user by writing to OSCULP32K.CALIB.

from practical use the clock still needs calibration leading to drifts in `RTC` and `RTT`, `samr21-xpro` has an external oscillator with a precise value out of the box, so this PR changes the current configuration to prefer that clock as `GCLK2` 32.768Khz clock source.

### Testing procedure

Look at the times of each print, this can optionally be verified with an oscilloscope (I did it).

- on master:

```
2020-02-06 15:28:53,357 # START
2020-02-06 15:28:53,358 # 
2020-02-06 15:28:53,360 # RIOT RTT low-level driver test
2020-02-06 15:28:53,364 # This test will display 'Hello' every 5 seconds
2020-02-06 15:28:53,364 # 
2020-02-06 15:28:53,367 # Initializing the RTT driver
2020-02-06 15:28:53,368 # RTT now: 2
2020-02-06 15:28:53,372 # Setting initial alarm to now + 5 s (163842)
2020-02-06 15:28:53,376 # Done setting up the RTT, wait for many Hellos
2020-02-06 15:28:58,352 # Hello
2020-02-06 15:29:03,337 # Hello
2020-02-06 15:29:08,321 # Hello
2020-02-06 15:29:13,306 # Hello
2020-02-06 15:29:18,290 # Hello
```

- on master using calibration, actual frequency of `32867Khz`:

```
2020-02-06 15:30:12,951 # START
2020-02-06 15:30:12,951 # 
2020-02-06 15:30:12,954 # RIOT RTT low-level driver test
2020-02-06 15:30:12,958 # This test will display 'Hello' every 5 seconds
2020-02-06 15:30:12,958 # 
2020-02-06 15:30:12,960 # Initializing the RTT driver
2020-02-06 15:30:12,962 # RTT now: 2
2020-02-06 15:30:12,966 # Setting initial alarm to now + 5 s (164337)
2020-02-06 15:30:12,970 # Done setting up the RTT, wait for many Hellos
2020-02-06 15:30:17,961 # Hello
2020-02-06 15:30:22,960 # Hello
2020-02-06 15:30:27,960 # Hello
2020-02-06 15:30:32,960 # Hello
2020-02-06 15:30:37,959 # Hello
2020-02-06 15:30:42,959 # Hello
2020-02-06 15:30:47,958 # Hello

```

- this pr:

```
2020-02-06 15:27:47,102 # RIOT RTT low-level driver test
2020-02-06 15:27:47,106 # This test will display 'Hello' every 5 seconds
2020-02-06 15:27:47,106 # 
2020-02-06 15:27:47,108 # Initializing the RTT driver
2020-02-06 15:27:47,110 # RTT now: 2
2020-02-06 15:27:47,117 # Setting initial alarm to now + 5 s (163842)
2020-02-06 15:27:47,118 # Done setting up the RTT, wait for many Hellos
2020-02-06 15:27:52,109 # Hello
2020-02-06 15:27:57,109 # Hello
2020-02-06 15:28:02,109 # Hello
2020-02-06 15:28:07,109 # Hello
```
