### PR TITLE
cpu/sam0_common: update samr21 vendor files to version 1.1.72

### DIFF
--- a/cpu/sam0_common/include/vendor/README.md
+++ b/cpu/sam0_common/include/vendor/README.md
@@ -53,6 +53,16 @@ saml11: `Atmel.SAML11_DFP.1.0.91.atpack`
 Each atpack has an include subdirectory with the files we copy into
 RIOT. The files are copied unmodified.
 
+## SAMR21 files
+
+samr21: `Atmel.SAMR21_DFP.1.1.72.atpack`
+
+Each atpack has an include subdirectory with the files we copy into
+RIOT. The following replacements were done for compatibility with newlib:
+
+    find -name '*.h' -exec sed -ie 's/_U(/_U_(/g' {} \;
+    find -name '*.h' -exec sed -ie 's/_L(/_L_(/g' {} \;
+
 ## SAMR34 files
 
 samr34: `Atmel.SAMR34_DFP.1.0.11.atpacks`

--- a/cpu/sam0_common/include/vendor/samr21/include/component-version.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component-version.h
@@ -1,0 +1,65 @@
+/**
+ * \file
+ *
+ * \brief Component version header file
+ *
+ * Copyright (c) 2017 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 1
+#define COMPONENT_VERSION_MINOR 1
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version, with leading zeros. The COMPONENT_VERSION
+// is at least 8 digits long.
+//
+#define COMPONENT_VERSION 00010001
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 72
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "1.1"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2017-02-07 07:43:46"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/cpu/sam0_common/include/vendor/samr21/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/ac.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for AC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -68,18 +53,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_CTRLA_OFFSET             0x00         /**< \brief (AC_CTRLA offset) Control A */
-#define AC_CTRLA_RESETVALUE         0x00ul       /**< \brief (AC_CTRLA reset_value) Control A */
+#define AC_CTRLA_RESETVALUE         _U_(0x00)     /**< \brief (AC_CTRLA reset_value) Control A */
 
 #define AC_CTRLA_SWRST_Pos          0            /**< \brief (AC_CTRLA) Software Reset */
-#define AC_CTRLA_SWRST              (0x1ul << AC_CTRLA_SWRST_Pos)
+#define AC_CTRLA_SWRST              (_U_(0x1) << AC_CTRLA_SWRST_Pos)
 #define AC_CTRLA_ENABLE_Pos         1            /**< \brief (AC_CTRLA) Enable */
-#define AC_CTRLA_ENABLE             (0x1ul << AC_CTRLA_ENABLE_Pos)
+#define AC_CTRLA_ENABLE             (_U_(0x1) << AC_CTRLA_ENABLE_Pos)
 #define AC_CTRLA_RUNSTDBY_Pos       2            /**< \brief (AC_CTRLA) Run in Standby */
-#define AC_CTRLA_RUNSTDBY_Msk       (0x1ul << AC_CTRLA_RUNSTDBY_Pos)
+#define AC_CTRLA_RUNSTDBY_Msk       (_U_(0x1) << AC_CTRLA_RUNSTDBY_Pos)
 #define AC_CTRLA_RUNSTDBY(value)    (AC_CTRLA_RUNSTDBY_Msk & ((value) << AC_CTRLA_RUNSTDBY_Pos))
 #define AC_CTRLA_LPMUX_Pos          7            /**< \brief (AC_CTRLA) Low-Power Mux */
-#define AC_CTRLA_LPMUX              (0x1ul << AC_CTRLA_LPMUX_Pos)
-#define AC_CTRLA_MASK               0x87ul       /**< \brief (AC_CTRLA) MASK Register */
+#define AC_CTRLA_LPMUX              (_U_(0x1) << AC_CTRLA_LPMUX_Pos)
+#define AC_CTRLA_MASK               _U_(0x87)     /**< \brief (AC_CTRLA) MASK Register */
 
 /* -------- AC_CTRLB : (AC Offset: 0x01) ( /W  8) Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -98,16 +83,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_CTRLB_OFFSET             0x01         /**< \brief (AC_CTRLB offset) Control B */
-#define AC_CTRLB_RESETVALUE         0x00ul       /**< \brief (AC_CTRLB reset_value) Control B */
+#define AC_CTRLB_RESETVALUE         _U_(0x00)     /**< \brief (AC_CTRLB reset_value) Control B */
 
 #define AC_CTRLB_START0_Pos         0            /**< \brief (AC_CTRLB) Comparator 0 Start Comparison */
 #define AC_CTRLB_START0             (1 << AC_CTRLB_START0_Pos)
 #define AC_CTRLB_START1_Pos         1            /**< \brief (AC_CTRLB) Comparator 1 Start Comparison */
 #define AC_CTRLB_START1             (1 << AC_CTRLB_START1_Pos)
 #define AC_CTRLB_START_Pos          0            /**< \brief (AC_CTRLB) Comparator x Start Comparison */
-#define AC_CTRLB_START_Msk          (0x3ul << AC_CTRLB_START_Pos)
+#define AC_CTRLB_START_Msk          (_U_(0x3) << AC_CTRLB_START_Pos)
 #define AC_CTRLB_START(value)       (AC_CTRLB_START_Msk & ((value) << AC_CTRLB_START_Pos))
-#define AC_CTRLB_MASK               0x03ul       /**< \brief (AC_CTRLB) MASK Register */
+#define AC_CTRLB_MASK               _U_(0x03)     /**< \brief (AC_CTRLB) MASK Register */
 
 /* -------- AC_EVCTRL : (AC Offset: 0x02) (R/W 16) Event Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -135,28 +120,28 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_EVCTRL_OFFSET            0x02         /**< \brief (AC_EVCTRL offset) Event Control */
-#define AC_EVCTRL_RESETVALUE        0x0000ul     /**< \brief (AC_EVCTRL reset_value) Event Control */
+#define AC_EVCTRL_RESETVALUE        _U_(0x0000)   /**< \brief (AC_EVCTRL reset_value) Event Control */
 
 #define AC_EVCTRL_COMPEO0_Pos       0            /**< \brief (AC_EVCTRL) Comparator 0 Event Output Enable */
 #define AC_EVCTRL_COMPEO0           (1 << AC_EVCTRL_COMPEO0_Pos)
 #define AC_EVCTRL_COMPEO1_Pos       1            /**< \brief (AC_EVCTRL) Comparator 1 Event Output Enable */
 #define AC_EVCTRL_COMPEO1           (1 << AC_EVCTRL_COMPEO1_Pos)
 #define AC_EVCTRL_COMPEO_Pos        0            /**< \brief (AC_EVCTRL) Comparator x Event Output Enable */
-#define AC_EVCTRL_COMPEO_Msk        (0x3ul << AC_EVCTRL_COMPEO_Pos)
+#define AC_EVCTRL_COMPEO_Msk        (_U_(0x3) << AC_EVCTRL_COMPEO_Pos)
 #define AC_EVCTRL_COMPEO(value)     (AC_EVCTRL_COMPEO_Msk & ((value) << AC_EVCTRL_COMPEO_Pos))
 #define AC_EVCTRL_WINEO0_Pos        4            /**< \brief (AC_EVCTRL) Window 0 Event Output Enable */
 #define AC_EVCTRL_WINEO0            (1 << AC_EVCTRL_WINEO0_Pos)
 #define AC_EVCTRL_WINEO_Pos         4            /**< \brief (AC_EVCTRL) Window x Event Output Enable */
-#define AC_EVCTRL_WINEO_Msk         (0x1ul << AC_EVCTRL_WINEO_Pos)
+#define AC_EVCTRL_WINEO_Msk         (_U_(0x1) << AC_EVCTRL_WINEO_Pos)
 #define AC_EVCTRL_WINEO(value)      (AC_EVCTRL_WINEO_Msk & ((value) << AC_EVCTRL_WINEO_Pos))
 #define AC_EVCTRL_COMPEI0_Pos       8            /**< \brief (AC_EVCTRL) Comparator 0 Event Input */
 #define AC_EVCTRL_COMPEI0           (1 << AC_EVCTRL_COMPEI0_Pos)
 #define AC_EVCTRL_COMPEI1_Pos       9            /**< \brief (AC_EVCTRL) Comparator 1 Event Input */
 #define AC_EVCTRL_COMPEI1           (1 << AC_EVCTRL_COMPEI1_Pos)
 #define AC_EVCTRL_COMPEI_Pos        8            /**< \brief (AC_EVCTRL) Comparator x Event Input */
-#define AC_EVCTRL_COMPEI_Msk        (0x3ul << AC_EVCTRL_COMPEI_Pos)
+#define AC_EVCTRL_COMPEI_Msk        (_U_(0x3) << AC_EVCTRL_COMPEI_Pos)
 #define AC_EVCTRL_COMPEI(value)     (AC_EVCTRL_COMPEI_Msk & ((value) << AC_EVCTRL_COMPEI_Pos))
-#define AC_EVCTRL_MASK              0x0313ul     /**< \brief (AC_EVCTRL) MASK Register */
+#define AC_EVCTRL_MASK              _U_(0x0313)   /**< \brief (AC_EVCTRL) MASK Register */
 
 /* -------- AC_INTENCLR : (AC Offset: 0x04) (R/W  8) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -179,21 +164,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_INTENCLR_OFFSET          0x04         /**< \brief (AC_INTENCLR offset) Interrupt Enable Clear */
-#define AC_INTENCLR_RESETVALUE      0x00ul       /**< \brief (AC_INTENCLR reset_value) Interrupt Enable Clear */
+#define AC_INTENCLR_RESETVALUE      _U_(0x00)     /**< \brief (AC_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define AC_INTENCLR_COMP0_Pos       0            /**< \brief (AC_INTENCLR) Comparator 0 Interrupt Enable */
 #define AC_INTENCLR_COMP0           (1 << AC_INTENCLR_COMP0_Pos)
 #define AC_INTENCLR_COMP1_Pos       1            /**< \brief (AC_INTENCLR) Comparator 1 Interrupt Enable */
 #define AC_INTENCLR_COMP1           (1 << AC_INTENCLR_COMP1_Pos)
 #define AC_INTENCLR_COMP_Pos        0            /**< \brief (AC_INTENCLR) Comparator x Interrupt Enable */
-#define AC_INTENCLR_COMP_Msk        (0x3ul << AC_INTENCLR_COMP_Pos)
+#define AC_INTENCLR_COMP_Msk        (_U_(0x3) << AC_INTENCLR_COMP_Pos)
 #define AC_INTENCLR_COMP(value)     (AC_INTENCLR_COMP_Msk & ((value) << AC_INTENCLR_COMP_Pos))
 #define AC_INTENCLR_WIN0_Pos        4            /**< \brief (AC_INTENCLR) Window 0 Interrupt Enable */
 #define AC_INTENCLR_WIN0            (1 << AC_INTENCLR_WIN0_Pos)
 #define AC_INTENCLR_WIN_Pos         4            /**< \brief (AC_INTENCLR) Window x Interrupt Enable */
-#define AC_INTENCLR_WIN_Msk         (0x1ul << AC_INTENCLR_WIN_Pos)
+#define AC_INTENCLR_WIN_Msk         (_U_(0x1) << AC_INTENCLR_WIN_Pos)
 #define AC_INTENCLR_WIN(value)      (AC_INTENCLR_WIN_Msk & ((value) << AC_INTENCLR_WIN_Pos))
-#define AC_INTENCLR_MASK            0x13ul       /**< \brief (AC_INTENCLR) MASK Register */
+#define AC_INTENCLR_MASK            _U_(0x13)     /**< \brief (AC_INTENCLR) MASK Register */
 
 /* -------- AC_INTENSET : (AC Offset: 0x05) (R/W  8) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -216,21 +201,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_INTENSET_OFFSET          0x05         /**< \brief (AC_INTENSET offset) Interrupt Enable Set */
-#define AC_INTENSET_RESETVALUE      0x00ul       /**< \brief (AC_INTENSET reset_value) Interrupt Enable Set */
+#define AC_INTENSET_RESETVALUE      _U_(0x00)     /**< \brief (AC_INTENSET reset_value) Interrupt Enable Set */
 
 #define AC_INTENSET_COMP0_Pos       0            /**< \brief (AC_INTENSET) Comparator 0 Interrupt Enable */
 #define AC_INTENSET_COMP0           (1 << AC_INTENSET_COMP0_Pos)
 #define AC_INTENSET_COMP1_Pos       1            /**< \brief (AC_INTENSET) Comparator 1 Interrupt Enable */
 #define AC_INTENSET_COMP1           (1 << AC_INTENSET_COMP1_Pos)
 #define AC_INTENSET_COMP_Pos        0            /**< \brief (AC_INTENSET) Comparator x Interrupt Enable */
-#define AC_INTENSET_COMP_Msk        (0x3ul << AC_INTENSET_COMP_Pos)
+#define AC_INTENSET_COMP_Msk        (_U_(0x3) << AC_INTENSET_COMP_Pos)
 #define AC_INTENSET_COMP(value)     (AC_INTENSET_COMP_Msk & ((value) << AC_INTENSET_COMP_Pos))
 #define AC_INTENSET_WIN0_Pos        4            /**< \brief (AC_INTENSET) Window 0 Interrupt Enable */
 #define AC_INTENSET_WIN0            (1 << AC_INTENSET_WIN0_Pos)
 #define AC_INTENSET_WIN_Pos         4            /**< \brief (AC_INTENSET) Window x Interrupt Enable */
-#define AC_INTENSET_WIN_Msk         (0x1ul << AC_INTENSET_WIN_Pos)
+#define AC_INTENSET_WIN_Msk         (_U_(0x1) << AC_INTENSET_WIN_Pos)
 #define AC_INTENSET_WIN(value)      (AC_INTENSET_WIN_Msk & ((value) << AC_INTENSET_WIN_Pos))
-#define AC_INTENSET_MASK            0x13ul       /**< \brief (AC_INTENSET) MASK Register */
+#define AC_INTENSET_MASK            _U_(0x13)     /**< \brief (AC_INTENSET) MASK Register */
 
 /* -------- AC_INTFLAG : (AC Offset: 0x06) (R/W  8) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -253,21 +238,21 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_INTFLAG_OFFSET           0x06         /**< \brief (AC_INTFLAG offset) Interrupt Flag Status and Clear */
-#define AC_INTFLAG_RESETVALUE       0x00ul       /**< \brief (AC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define AC_INTFLAG_RESETVALUE       _U_(0x00)     /**< \brief (AC_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define AC_INTFLAG_COMP0_Pos        0            /**< \brief (AC_INTFLAG) Comparator 0 */
 #define AC_INTFLAG_COMP0            (1 << AC_INTFLAG_COMP0_Pos)
 #define AC_INTFLAG_COMP1_Pos        1            /**< \brief (AC_INTFLAG) Comparator 1 */
 #define AC_INTFLAG_COMP1            (1 << AC_INTFLAG_COMP1_Pos)
 #define AC_INTFLAG_COMP_Pos         0            /**< \brief (AC_INTFLAG) Comparator x */
-#define AC_INTFLAG_COMP_Msk         (0x3ul << AC_INTFLAG_COMP_Pos)
+#define AC_INTFLAG_COMP_Msk         (_U_(0x3) << AC_INTFLAG_COMP_Pos)
 #define AC_INTFLAG_COMP(value)      (AC_INTFLAG_COMP_Msk & ((value) << AC_INTFLAG_COMP_Pos))
 #define AC_INTFLAG_WIN0_Pos         4            /**< \brief (AC_INTFLAG) Window 0 */
 #define AC_INTFLAG_WIN0             (1 << AC_INTFLAG_WIN0_Pos)
 #define AC_INTFLAG_WIN_Pos          4            /**< \brief (AC_INTFLAG) Window x */
-#define AC_INTFLAG_WIN_Msk          (0x1ul << AC_INTFLAG_WIN_Pos)
+#define AC_INTFLAG_WIN_Msk          (_U_(0x1) << AC_INTFLAG_WIN_Pos)
 #define AC_INTFLAG_WIN(value)       (AC_INTFLAG_WIN_Msk & ((value) << AC_INTFLAG_WIN_Pos))
-#define AC_INTFLAG_MASK             0x13ul       /**< \brief (AC_INTFLAG) MASK Register */
+#define AC_INTFLAG_MASK             _U_(0x13)     /**< \brief (AC_INTFLAG) MASK Register */
 
 /* -------- AC_STATUSA : (AC Offset: 0x08) (R/   8) Status A -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -288,25 +273,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_STATUSA_OFFSET           0x08         /**< \brief (AC_STATUSA offset) Status A */
-#define AC_STATUSA_RESETVALUE       0x00ul       /**< \brief (AC_STATUSA reset_value) Status A */
+#define AC_STATUSA_RESETVALUE       _U_(0x00)     /**< \brief (AC_STATUSA reset_value) Status A */
 
 #define AC_STATUSA_STATE0_Pos       0            /**< \brief (AC_STATUSA) Comparator 0 Current State */
 #define AC_STATUSA_STATE0           (1 << AC_STATUSA_STATE0_Pos)
 #define AC_STATUSA_STATE1_Pos       1            /**< \brief (AC_STATUSA) Comparator 1 Current State */
 #define AC_STATUSA_STATE1           (1 << AC_STATUSA_STATE1_Pos)
 #define AC_STATUSA_STATE_Pos        0            /**< \brief (AC_STATUSA) Comparator x Current State */
-#define AC_STATUSA_STATE_Msk        (0x3ul << AC_STATUSA_STATE_Pos)
+#define AC_STATUSA_STATE_Msk        (_U_(0x3) << AC_STATUSA_STATE_Pos)
 #define AC_STATUSA_STATE(value)     (AC_STATUSA_STATE_Msk & ((value) << AC_STATUSA_STATE_Pos))
 #define AC_STATUSA_WSTATE0_Pos      4            /**< \brief (AC_STATUSA) Window 0 Current State */
-#define AC_STATUSA_WSTATE0_Msk      (0x3ul << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0_Msk      (_U_(0x3) << AC_STATUSA_WSTATE0_Pos)
 #define AC_STATUSA_WSTATE0(value)   (AC_STATUSA_WSTATE0_Msk & ((value) << AC_STATUSA_WSTATE0_Pos))
-#define   AC_STATUSA_WSTATE0_ABOVE_Val    0x0ul  /**< \brief (AC_STATUSA) Signal is above window */
-#define   AC_STATUSA_WSTATE0_INSIDE_Val   0x1ul  /**< \brief (AC_STATUSA) Signal is inside window */
-#define   AC_STATUSA_WSTATE0_BELOW_Val    0x2ul  /**< \brief (AC_STATUSA) Signal is below window */
+#define   AC_STATUSA_WSTATE0_ABOVE_Val    _U_(0x0)   /**< \brief (AC_STATUSA) Signal is above window */
+#define   AC_STATUSA_WSTATE0_INSIDE_Val   _U_(0x1)   /**< \brief (AC_STATUSA) Signal is inside window */
+#define   AC_STATUSA_WSTATE0_BELOW_Val    _U_(0x2)   /**< \brief (AC_STATUSA) Signal is below window */
 #define AC_STATUSA_WSTATE0_ABOVE    (AC_STATUSA_WSTATE0_ABOVE_Val  << AC_STATUSA_WSTATE0_Pos)
 #define AC_STATUSA_WSTATE0_INSIDE   (AC_STATUSA_WSTATE0_INSIDE_Val << AC_STATUSA_WSTATE0_Pos)
 #define AC_STATUSA_WSTATE0_BELOW    (AC_STATUSA_WSTATE0_BELOW_Val  << AC_STATUSA_WSTATE0_Pos)
-#define AC_STATUSA_MASK             0x33ul       /**< \brief (AC_STATUSA) MASK Register */
+#define AC_STATUSA_MASK             _U_(0x33)     /**< \brief (AC_STATUSA) MASK Register */
 
 /* -------- AC_STATUSB : (AC Offset: 0x09) (R/   8) Status B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -326,18 +311,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_STATUSB_OFFSET           0x09         /**< \brief (AC_STATUSB offset) Status B */
-#define AC_STATUSB_RESETVALUE       0x00ul       /**< \brief (AC_STATUSB reset_value) Status B */
+#define AC_STATUSB_RESETVALUE       _U_(0x00)     /**< \brief (AC_STATUSB reset_value) Status B */
 
 #define AC_STATUSB_READY0_Pos       0            /**< \brief (AC_STATUSB) Comparator 0 Ready */
 #define AC_STATUSB_READY0           (1 << AC_STATUSB_READY0_Pos)
 #define AC_STATUSB_READY1_Pos       1            /**< \brief (AC_STATUSB) Comparator 1 Ready */
 #define AC_STATUSB_READY1           (1 << AC_STATUSB_READY1_Pos)
 #define AC_STATUSB_READY_Pos        0            /**< \brief (AC_STATUSB) Comparator x Ready */
-#define AC_STATUSB_READY_Msk        (0x3ul << AC_STATUSB_READY_Pos)
+#define AC_STATUSB_READY_Msk        (_U_(0x3) << AC_STATUSB_READY_Pos)
 #define AC_STATUSB_READY(value)     (AC_STATUSB_READY_Msk & ((value) << AC_STATUSB_READY_Pos))
 #define AC_STATUSB_SYNCBUSY_Pos     7            /**< \brief (AC_STATUSB) Synchronization Busy */
-#define AC_STATUSB_SYNCBUSY         (0x1ul << AC_STATUSB_SYNCBUSY_Pos)
-#define AC_STATUSB_MASK             0x83ul       /**< \brief (AC_STATUSB) MASK Register */
+#define AC_STATUSB_SYNCBUSY         (_U_(0x1) << AC_STATUSB_SYNCBUSY_Pos)
+#define AC_STATUSB_MASK             _U_(0x83)     /**< \brief (AC_STATUSB) MASK Register */
 
 /* -------- AC_STATUSC : (AC Offset: 0x0A) (R/   8) Status C -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -358,25 +343,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_STATUSC_OFFSET           0x0A         /**< \brief (AC_STATUSC offset) Status C */
-#define AC_STATUSC_RESETVALUE       0x00ul       /**< \brief (AC_STATUSC reset_value) Status C */
+#define AC_STATUSC_RESETVALUE       _U_(0x00)     /**< \brief (AC_STATUSC reset_value) Status C */
 
 #define AC_STATUSC_STATE0_Pos       0            /**< \brief (AC_STATUSC) Comparator 0 Current State */
 #define AC_STATUSC_STATE0           (1 << AC_STATUSC_STATE0_Pos)
 #define AC_STATUSC_STATE1_Pos       1            /**< \brief (AC_STATUSC) Comparator 1 Current State */
 #define AC_STATUSC_STATE1           (1 << AC_STATUSC_STATE1_Pos)
 #define AC_STATUSC_STATE_Pos        0            /**< \brief (AC_STATUSC) Comparator x Current State */
-#define AC_STATUSC_STATE_Msk        (0x3ul << AC_STATUSC_STATE_Pos)
+#define AC_STATUSC_STATE_Msk        (_U_(0x3) << AC_STATUSC_STATE_Pos)
 #define AC_STATUSC_STATE(value)     (AC_STATUSC_STATE_Msk & ((value) << AC_STATUSC_STATE_Pos))
 #define AC_STATUSC_WSTATE0_Pos      4            /**< \brief (AC_STATUSC) Window 0 Current State */
-#define AC_STATUSC_WSTATE0_Msk      (0x3ul << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_WSTATE0_Msk      (_U_(0x3) << AC_STATUSC_WSTATE0_Pos)
 #define AC_STATUSC_WSTATE0(value)   (AC_STATUSC_WSTATE0_Msk & ((value) << AC_STATUSC_WSTATE0_Pos))
-#define   AC_STATUSC_WSTATE0_ABOVE_Val    0x0ul  /**< \brief (AC_STATUSC) Signal is above window */
-#define   AC_STATUSC_WSTATE0_INSIDE_Val   0x1ul  /**< \brief (AC_STATUSC) Signal is inside window */
-#define   AC_STATUSC_WSTATE0_BELOW_Val    0x2ul  /**< \brief (AC_STATUSC) Signal is below window */
+#define   AC_STATUSC_WSTATE0_ABOVE_Val    _U_(0x0)   /**< \brief (AC_STATUSC) Signal is above window */
+#define   AC_STATUSC_WSTATE0_INSIDE_Val   _U_(0x1)   /**< \brief (AC_STATUSC) Signal is inside window */
+#define   AC_STATUSC_WSTATE0_BELOW_Val    _U_(0x2)   /**< \brief (AC_STATUSC) Signal is below window */
 #define AC_STATUSC_WSTATE0_ABOVE    (AC_STATUSC_WSTATE0_ABOVE_Val  << AC_STATUSC_WSTATE0_Pos)
 #define AC_STATUSC_WSTATE0_INSIDE   (AC_STATUSC_WSTATE0_INSIDE_Val << AC_STATUSC_WSTATE0_Pos)
 #define AC_STATUSC_WSTATE0_BELOW    (AC_STATUSC_WSTATE0_BELOW_Val  << AC_STATUSC_WSTATE0_Pos)
-#define AC_STATUSC_MASK             0x33ul       /**< \brief (AC_STATUSC) MASK Register */
+#define AC_STATUSC_MASK             _U_(0x33)     /**< \brief (AC_STATUSC) MASK Register */
 
 /* -------- AC_WINCTRL : (AC Offset: 0x0C) (R/W  8) Window Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -391,22 +376,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_WINCTRL_OFFSET           0x0C         /**< \brief (AC_WINCTRL offset) Window Control */
-#define AC_WINCTRL_RESETVALUE       0x00ul       /**< \brief (AC_WINCTRL reset_value) Window Control */
+#define AC_WINCTRL_RESETVALUE       _U_(0x00)     /**< \brief (AC_WINCTRL reset_value) Window Control */
 
 #define AC_WINCTRL_WEN0_Pos         0            /**< \brief (AC_WINCTRL) Window 0 Mode Enable */
-#define AC_WINCTRL_WEN0             (0x1ul << AC_WINCTRL_WEN0_Pos)
+#define AC_WINCTRL_WEN0             (_U_(0x1) << AC_WINCTRL_WEN0_Pos)
 #define AC_WINCTRL_WINTSEL0_Pos     1            /**< \brief (AC_WINCTRL) Window 0 Interrupt Selection */
-#define AC_WINCTRL_WINTSEL0_Msk     (0x3ul << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_Msk     (_U_(0x3) << AC_WINCTRL_WINTSEL0_Pos)
 #define AC_WINCTRL_WINTSEL0(value)  (AC_WINCTRL_WINTSEL0_Msk & ((value) << AC_WINCTRL_WINTSEL0_Pos))
-#define   AC_WINCTRL_WINTSEL0_ABOVE_Val   0x0ul  /**< \brief (AC_WINCTRL) Interrupt on signal above window */
-#define   AC_WINCTRL_WINTSEL0_INSIDE_Val  0x1ul  /**< \brief (AC_WINCTRL) Interrupt on signal inside window */
-#define   AC_WINCTRL_WINTSEL0_BELOW_Val   0x2ul  /**< \brief (AC_WINCTRL) Interrupt on signal below window */
-#define   AC_WINCTRL_WINTSEL0_OUTSIDE_Val 0x3ul  /**< \brief (AC_WINCTRL) Interrupt on signal outside window */
+#define   AC_WINCTRL_WINTSEL0_ABOVE_Val   _U_(0x0)   /**< \brief (AC_WINCTRL) Interrupt on signal above window */
+#define   AC_WINCTRL_WINTSEL0_INSIDE_Val  _U_(0x1)   /**< \brief (AC_WINCTRL) Interrupt on signal inside window */
+#define   AC_WINCTRL_WINTSEL0_BELOW_Val   _U_(0x2)   /**< \brief (AC_WINCTRL) Interrupt on signal below window */
+#define   AC_WINCTRL_WINTSEL0_OUTSIDE_Val _U_(0x3)   /**< \brief (AC_WINCTRL) Interrupt on signal outside window */
 #define AC_WINCTRL_WINTSEL0_ABOVE   (AC_WINCTRL_WINTSEL0_ABOVE_Val << AC_WINCTRL_WINTSEL0_Pos)
 #define AC_WINCTRL_WINTSEL0_INSIDE  (AC_WINCTRL_WINTSEL0_INSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)
 #define AC_WINCTRL_WINTSEL0_BELOW   (AC_WINCTRL_WINTSEL0_BELOW_Val << AC_WINCTRL_WINTSEL0_Pos)
 #define AC_WINCTRL_WINTSEL0_OUTSIDE (AC_WINCTRL_WINTSEL0_OUTSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)
-#define AC_WINCTRL_MASK             0x07ul       /**< \brief (AC_WINCTRL) MASK Register */
+#define AC_WINCTRL_MASK             _U_(0x07)     /**< \brief (AC_WINCTRL) MASK Register */
 
 /* -------- AC_COMPCTRL : (AC Offset: 0x10) (R/W 32) Comparator Control n -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -435,41 +420,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_COMPCTRL_OFFSET          0x10         /**< \brief (AC_COMPCTRL offset) Comparator Control n */
-#define AC_COMPCTRL_RESETVALUE      0x00000000ul /**< \brief (AC_COMPCTRL reset_value) Comparator Control n */
+#define AC_COMPCTRL_RESETVALUE      _U_(0x00000000) /**< \brief (AC_COMPCTRL reset_value) Comparator Control n */
 
 #define AC_COMPCTRL_ENABLE_Pos      0            /**< \brief (AC_COMPCTRL) Enable */
-#define AC_COMPCTRL_ENABLE          (0x1ul << AC_COMPCTRL_ENABLE_Pos)
+#define AC_COMPCTRL_ENABLE          (_U_(0x1) << AC_COMPCTRL_ENABLE_Pos)
 #define AC_COMPCTRL_SINGLE_Pos      1            /**< \brief (AC_COMPCTRL) Single-Shot Mode */
-#define AC_COMPCTRL_SINGLE          (0x1ul << AC_COMPCTRL_SINGLE_Pos)
+#define AC_COMPCTRL_SINGLE          (_U_(0x1) << AC_COMPCTRL_SINGLE_Pos)
 #define AC_COMPCTRL_SPEED_Pos       2            /**< \brief (AC_COMPCTRL) Speed Selection */
-#define AC_COMPCTRL_SPEED_Msk       (0x3ul << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED_Msk       (_U_(0x3) << AC_COMPCTRL_SPEED_Pos)
 #define AC_COMPCTRL_SPEED(value)    (AC_COMPCTRL_SPEED_Msk & ((value) << AC_COMPCTRL_SPEED_Pos))
-#define   AC_COMPCTRL_SPEED_LOW_Val       0x0ul  /**< \brief (AC_COMPCTRL) Low speed */
-#define   AC_COMPCTRL_SPEED_HIGH_Val      0x1ul  /**< \brief (AC_COMPCTRL) High speed */
+#define   AC_COMPCTRL_SPEED_LOW_Val       _U_(0x0)   /**< \brief (AC_COMPCTRL) Low speed */
+#define   AC_COMPCTRL_SPEED_HIGH_Val      _U_(0x1)   /**< \brief (AC_COMPCTRL) High speed */
 #define AC_COMPCTRL_SPEED_LOW       (AC_COMPCTRL_SPEED_LOW_Val     << AC_COMPCTRL_SPEED_Pos)
 #define AC_COMPCTRL_SPEED_HIGH      (AC_COMPCTRL_SPEED_HIGH_Val    << AC_COMPCTRL_SPEED_Pos)
 #define AC_COMPCTRL_INTSEL_Pos      5            /**< \brief (AC_COMPCTRL) Interrupt Selection */
-#define AC_COMPCTRL_INTSEL_Msk      (0x3ul << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_Msk      (_U_(0x3) << AC_COMPCTRL_INTSEL_Pos)
 #define AC_COMPCTRL_INTSEL(value)   (AC_COMPCTRL_INTSEL_Msk & ((value) << AC_COMPCTRL_INTSEL_Pos))
-#define   AC_COMPCTRL_INTSEL_TOGGLE_Val   0x0ul  /**< \brief (AC_COMPCTRL) Interrupt on comparator output toggle */
-#define   AC_COMPCTRL_INTSEL_RISING_Val   0x1ul  /**< \brief (AC_COMPCTRL) Interrupt on comparator output rising */
-#define   AC_COMPCTRL_INTSEL_FALLING_Val  0x2ul  /**< \brief (AC_COMPCTRL) Interrupt on comparator output falling */
-#define   AC_COMPCTRL_INTSEL_EOC_Val      0x3ul  /**< \brief (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only) */
+#define   AC_COMPCTRL_INTSEL_TOGGLE_Val   _U_(0x0)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output toggle */
+#define   AC_COMPCTRL_INTSEL_RISING_Val   _U_(0x1)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output rising */
+#define   AC_COMPCTRL_INTSEL_FALLING_Val  _U_(0x2)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output falling */
+#define   AC_COMPCTRL_INTSEL_EOC_Val      _U_(0x3)   /**< \brief (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only) */
 #define AC_COMPCTRL_INTSEL_TOGGLE   (AC_COMPCTRL_INTSEL_TOGGLE_Val << AC_COMPCTRL_INTSEL_Pos)
 #define AC_COMPCTRL_INTSEL_RISING   (AC_COMPCTRL_INTSEL_RISING_Val << AC_COMPCTRL_INTSEL_Pos)
 #define AC_COMPCTRL_INTSEL_FALLING  (AC_COMPCTRL_INTSEL_FALLING_Val << AC_COMPCTRL_INTSEL_Pos)
 #define AC_COMPCTRL_INTSEL_EOC      (AC_COMPCTRL_INTSEL_EOC_Val    << AC_COMPCTRL_INTSEL_Pos)
 #define AC_COMPCTRL_MUXNEG_Pos      8            /**< \brief (AC_COMPCTRL) Negative Input Mux Selection */
-#define AC_COMPCTRL_MUXNEG_Msk      (0x7ul << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_Msk      (_U_(0x7) << AC_COMPCTRL_MUXNEG_Pos)
 #define AC_COMPCTRL_MUXNEG(value)   (AC_COMPCTRL_MUXNEG_Msk & ((value) << AC_COMPCTRL_MUXNEG_Pos))
-#define   AC_COMPCTRL_MUXNEG_PIN0_Val     0x0ul  /**< \brief (AC_COMPCTRL) I/O pin 0 */
-#define   AC_COMPCTRL_MUXNEG_PIN1_Val     0x1ul  /**< \brief (AC_COMPCTRL) I/O pin 1 */
-#define   AC_COMPCTRL_MUXNEG_PIN2_Val     0x2ul  /**< \brief (AC_COMPCTRL) I/O pin 2 */
-#define   AC_COMPCTRL_MUXNEG_PIN3_Val     0x3ul  /**< \brief (AC_COMPCTRL) I/O pin 3 */
-#define   AC_COMPCTRL_MUXNEG_GND_Val      0x4ul  /**< \brief (AC_COMPCTRL) Ground */
-#define   AC_COMPCTRL_MUXNEG_VSCALE_Val   0x5ul  /**< \brief (AC_COMPCTRL) VDD scaler */
-#define   AC_COMPCTRL_MUXNEG_BANDGAP_Val  0x6ul  /**< \brief (AC_COMPCTRL) Internal bandgap voltage */
-#define   AC_COMPCTRL_MUXNEG_DAC_Val      0x7ul  /**< \brief (AC_COMPCTRL) DAC output */
+#define   AC_COMPCTRL_MUXNEG_PIN0_Val     _U_(0x0)   /**< \brief (AC_COMPCTRL) I/O pin 0 */
+#define   AC_COMPCTRL_MUXNEG_PIN1_Val     _U_(0x1)   /**< \brief (AC_COMPCTRL) I/O pin 1 */
+#define   AC_COMPCTRL_MUXNEG_PIN2_Val     _U_(0x2)   /**< \brief (AC_COMPCTRL) I/O pin 2 */
+#define   AC_COMPCTRL_MUXNEG_PIN3_Val     _U_(0x3)   /**< \brief (AC_COMPCTRL) I/O pin 3 */
+#define   AC_COMPCTRL_MUXNEG_GND_Val      _U_(0x4)   /**< \brief (AC_COMPCTRL) Ground */
+#define   AC_COMPCTRL_MUXNEG_VSCALE_Val   _U_(0x5)   /**< \brief (AC_COMPCTRL) VDD scaler */
+#define   AC_COMPCTRL_MUXNEG_BANDGAP_Val  _U_(0x6)   /**< \brief (AC_COMPCTRL) Internal bandgap voltage */
+#define   AC_COMPCTRL_MUXNEG_DAC_Val      _U_(0x7)   /**< \brief (AC_COMPCTRL) DAC output */
 #define AC_COMPCTRL_MUXNEG_PIN0     (AC_COMPCTRL_MUXNEG_PIN0_Val   << AC_COMPCTRL_MUXNEG_Pos)
 #define AC_COMPCTRL_MUXNEG_PIN1     (AC_COMPCTRL_MUXNEG_PIN1_Val   << AC_COMPCTRL_MUXNEG_Pos)
 #define AC_COMPCTRL_MUXNEG_PIN2     (AC_COMPCTRL_MUXNEG_PIN2_Val   << AC_COMPCTRL_MUXNEG_Pos)
@@ -479,39 +464,39 @@ typedef union {
 #define AC_COMPCTRL_MUXNEG_BANDGAP  (AC_COMPCTRL_MUXNEG_BANDGAP_Val << AC_COMPCTRL_MUXNEG_Pos)
 #define AC_COMPCTRL_MUXNEG_DAC      (AC_COMPCTRL_MUXNEG_DAC_Val    << AC_COMPCTRL_MUXNEG_Pos)
 #define AC_COMPCTRL_MUXPOS_Pos      12           /**< \brief (AC_COMPCTRL) Positive Input Mux Selection */
-#define AC_COMPCTRL_MUXPOS_Msk      (0x3ul << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_Msk      (_U_(0x3) << AC_COMPCTRL_MUXPOS_Pos)
 #define AC_COMPCTRL_MUXPOS(value)   (AC_COMPCTRL_MUXPOS_Msk & ((value) << AC_COMPCTRL_MUXPOS_Pos))
-#define   AC_COMPCTRL_MUXPOS_PIN0_Val     0x0ul  /**< \brief (AC_COMPCTRL) I/O pin 0 */
-#define   AC_COMPCTRL_MUXPOS_PIN1_Val     0x1ul  /**< \brief (AC_COMPCTRL) I/O pin 1 */
-#define   AC_COMPCTRL_MUXPOS_PIN2_Val     0x2ul  /**< \brief (AC_COMPCTRL) I/O pin 2 */
-#define   AC_COMPCTRL_MUXPOS_PIN3_Val     0x3ul  /**< \brief (AC_COMPCTRL) I/O pin 3 */
+#define   AC_COMPCTRL_MUXPOS_PIN0_Val     _U_(0x0)   /**< \brief (AC_COMPCTRL) I/O pin 0 */
+#define   AC_COMPCTRL_MUXPOS_PIN1_Val     _U_(0x1)   /**< \brief (AC_COMPCTRL) I/O pin 1 */
+#define   AC_COMPCTRL_MUXPOS_PIN2_Val     _U_(0x2)   /**< \brief (AC_COMPCTRL) I/O pin 2 */
+#define   AC_COMPCTRL_MUXPOS_PIN3_Val     _U_(0x3)   /**< \brief (AC_COMPCTRL) I/O pin 3 */
 #define AC_COMPCTRL_MUXPOS_PIN0     (AC_COMPCTRL_MUXPOS_PIN0_Val   << AC_COMPCTRL_MUXPOS_Pos)
 #define AC_COMPCTRL_MUXPOS_PIN1     (AC_COMPCTRL_MUXPOS_PIN1_Val   << AC_COMPCTRL_MUXPOS_Pos)
 #define AC_COMPCTRL_MUXPOS_PIN2     (AC_COMPCTRL_MUXPOS_PIN2_Val   << AC_COMPCTRL_MUXPOS_Pos)
 #define AC_COMPCTRL_MUXPOS_PIN3     (AC_COMPCTRL_MUXPOS_PIN3_Val   << AC_COMPCTRL_MUXPOS_Pos)
 #define AC_COMPCTRL_SWAP_Pos        15           /**< \brief (AC_COMPCTRL) Swap Inputs and Invert */
-#define AC_COMPCTRL_SWAP            (0x1ul << AC_COMPCTRL_SWAP_Pos)
+#define AC_COMPCTRL_SWAP            (_U_(0x1) << AC_COMPCTRL_SWAP_Pos)
 #define AC_COMPCTRL_OUT_Pos         16           /**< \brief (AC_COMPCTRL) Output */
-#define AC_COMPCTRL_OUT_Msk         (0x3ul << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT_Msk         (_U_(0x3) << AC_COMPCTRL_OUT_Pos)
 #define AC_COMPCTRL_OUT(value)      (AC_COMPCTRL_OUT_Msk & ((value) << AC_COMPCTRL_OUT_Pos))
-#define   AC_COMPCTRL_OUT_OFF_Val         0x0ul  /**< \brief (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port */
-#define   AC_COMPCTRL_OUT_ASYNC_Val       0x1ul  /**< \brief (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port */
-#define   AC_COMPCTRL_OUT_SYNC_Val        0x2ul  /**< \brief (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_OFF_Val         _U_(0x0)   /**< \brief (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_ASYNC_Val       _U_(0x1)   /**< \brief (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_SYNC_Val        _U_(0x2)   /**< \brief (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port */
 #define AC_COMPCTRL_OUT_OFF         (AC_COMPCTRL_OUT_OFF_Val       << AC_COMPCTRL_OUT_Pos)
 #define AC_COMPCTRL_OUT_ASYNC       (AC_COMPCTRL_OUT_ASYNC_Val     << AC_COMPCTRL_OUT_Pos)
 #define AC_COMPCTRL_OUT_SYNC        (AC_COMPCTRL_OUT_SYNC_Val      << AC_COMPCTRL_OUT_Pos)
 #define AC_COMPCTRL_HYST_Pos        19           /**< \brief (AC_COMPCTRL) Hysteresis Enable */
-#define AC_COMPCTRL_HYST            (0x1ul << AC_COMPCTRL_HYST_Pos)
+#define AC_COMPCTRL_HYST            (_U_(0x1) << AC_COMPCTRL_HYST_Pos)
 #define AC_COMPCTRL_FLEN_Pos        24           /**< \brief (AC_COMPCTRL) Filter Length */
-#define AC_COMPCTRL_FLEN_Msk        (0x7ul << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN_Msk        (_U_(0x7) << AC_COMPCTRL_FLEN_Pos)
 #define AC_COMPCTRL_FLEN(value)     (AC_COMPCTRL_FLEN_Msk & ((value) << AC_COMPCTRL_FLEN_Pos))
-#define   AC_COMPCTRL_FLEN_OFF_Val        0x0ul  /**< \brief (AC_COMPCTRL) No filtering */
-#define   AC_COMPCTRL_FLEN_MAJ3_Val       0x1ul  /**< \brief (AC_COMPCTRL) 3-bit majority function (2 of 3) */
-#define   AC_COMPCTRL_FLEN_MAJ5_Val       0x2ul  /**< \brief (AC_COMPCTRL) 5-bit majority function (3 of 5) */
+#define   AC_COMPCTRL_FLEN_OFF_Val        _U_(0x0)   /**< \brief (AC_COMPCTRL) No filtering */
+#define   AC_COMPCTRL_FLEN_MAJ3_Val       _U_(0x1)   /**< \brief (AC_COMPCTRL) 3-bit majority function (2 of 3) */
+#define   AC_COMPCTRL_FLEN_MAJ5_Val       _U_(0x2)   /**< \brief (AC_COMPCTRL) 5-bit majority function (3 of 5) */
 #define AC_COMPCTRL_FLEN_OFF        (AC_COMPCTRL_FLEN_OFF_Val      << AC_COMPCTRL_FLEN_Pos)
 #define AC_COMPCTRL_FLEN_MAJ3       (AC_COMPCTRL_FLEN_MAJ3_Val     << AC_COMPCTRL_FLEN_Pos)
 #define AC_COMPCTRL_FLEN_MAJ5       (AC_COMPCTRL_FLEN_MAJ5_Val     << AC_COMPCTRL_FLEN_Pos)
-#define AC_COMPCTRL_MASK            0x070BB76Ful /**< \brief (AC_COMPCTRL) MASK Register */
+#define AC_COMPCTRL_MASK            _U_(0x070BB76F) /**< \brief (AC_COMPCTRL) MASK Register */
 
 /* -------- AC_SCALER : (AC Offset: 0x20) (R/W  8) Scaler n -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -525,12 +510,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AC_SCALER_OFFSET            0x20         /**< \brief (AC_SCALER offset) Scaler n */
-#define AC_SCALER_RESETVALUE        0x00ul       /**< \brief (AC_SCALER reset_value) Scaler n */
+#define AC_SCALER_RESETVALUE        _U_(0x00)     /**< \brief (AC_SCALER reset_value) Scaler n */
 
 #define AC_SCALER_VALUE_Pos         0            /**< \brief (AC_SCALER) Scaler Value */
-#define AC_SCALER_VALUE_Msk         (0x3Ful << AC_SCALER_VALUE_Pos)
+#define AC_SCALER_VALUE_Msk         (_U_(0x3F) << AC_SCALER_VALUE_Pos)
 #define AC_SCALER_VALUE(value)      (AC_SCALER_VALUE_Msk & ((value) << AC_SCALER_VALUE_Pos))
-#define AC_SCALER_MASK              0x3Ful       /**< \brief (AC_SCALER) MASK Register */
+#define AC_SCALER_MASK              _U_(0x3F)     /**< \brief (AC_SCALER) MASK Register */
 
 /** \brief AC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/adc.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for ADC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -67,15 +52,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_CTRLA_OFFSET            0x00         /**< \brief (ADC_CTRLA offset) Control A */
-#define ADC_CTRLA_RESETVALUE        0x00ul       /**< \brief (ADC_CTRLA reset_value) Control A */
+#define ADC_CTRLA_RESETVALUE        _U_(0x00)     /**< \brief (ADC_CTRLA reset_value) Control A */
 
 #define ADC_CTRLA_SWRST_Pos         0            /**< \brief (ADC_CTRLA) Software Reset */
-#define ADC_CTRLA_SWRST             (0x1ul << ADC_CTRLA_SWRST_Pos)
+#define ADC_CTRLA_SWRST             (_U_(0x1) << ADC_CTRLA_SWRST_Pos)
 #define ADC_CTRLA_ENABLE_Pos        1            /**< \brief (ADC_CTRLA) Enable */
-#define ADC_CTRLA_ENABLE            (0x1ul << ADC_CTRLA_ENABLE_Pos)
+#define ADC_CTRLA_ENABLE            (_U_(0x1) << ADC_CTRLA_ENABLE_Pos)
 #define ADC_CTRLA_RUNSTDBY_Pos      2            /**< \brief (ADC_CTRLA) Run in Standby */
-#define ADC_CTRLA_RUNSTDBY          (0x1ul << ADC_CTRLA_RUNSTDBY_Pos)
-#define ADC_CTRLA_MASK              0x07ul       /**< \brief (ADC_CTRLA) MASK Register */
+#define ADC_CTRLA_RUNSTDBY          (_U_(0x1) << ADC_CTRLA_RUNSTDBY_Pos)
+#define ADC_CTRLA_MASK              _U_(0x07)     /**< \brief (ADC_CTRLA) MASK Register */
 
 /* -------- ADC_REFCTRL : (ADC Offset: 0x01) (R/W  8) Reference Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -90,24 +75,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_REFCTRL_OFFSET          0x01         /**< \brief (ADC_REFCTRL offset) Reference Control */
-#define ADC_REFCTRL_RESETVALUE      0x00ul       /**< \brief (ADC_REFCTRL reset_value) Reference Control */
+#define ADC_REFCTRL_RESETVALUE      _U_(0x00)     /**< \brief (ADC_REFCTRL reset_value) Reference Control */
 
 #define ADC_REFCTRL_REFSEL_Pos      0            /**< \brief (ADC_REFCTRL) Reference Selection */
-#define ADC_REFCTRL_REFSEL_Msk      (0xFul << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_Msk      (_U_(0xF) << ADC_REFCTRL_REFSEL_Pos)
 #define ADC_REFCTRL_REFSEL(value)   (ADC_REFCTRL_REFSEL_Msk & ((value) << ADC_REFCTRL_REFSEL_Pos))
-#define   ADC_REFCTRL_REFSEL_INT1V_Val    0x0ul  /**< \brief (ADC_REFCTRL) 1.0V voltage reference */
-#define   ADC_REFCTRL_REFSEL_INTVCC0_Val  0x1ul  /**< \brief (ADC_REFCTRL) 1/1.48 VDDANA */
-#define   ADC_REFCTRL_REFSEL_INTVCC1_Val  0x2ul  /**< \brief (ADC_REFCTRL) 1/2 VDDANA (only for VDDANA > 2.0V) */
-#define   ADC_REFCTRL_REFSEL_AREFA_Val    0x3ul  /**< \brief (ADC_REFCTRL) External reference */
-#define   ADC_REFCTRL_REFSEL_AREFB_Val    0x4ul  /**< \brief (ADC_REFCTRL) External reference */
+#define   ADC_REFCTRL_REFSEL_INT1V_Val    _U_(0x0)   /**< \brief (ADC_REFCTRL) 1.0V voltage reference */
+#define   ADC_REFCTRL_REFSEL_INTVCC0_Val  _U_(0x1)   /**< \brief (ADC_REFCTRL) 1/1.48 VDDANA */
+#define   ADC_REFCTRL_REFSEL_INTVCC1_Val  _U_(0x2)   /**< \brief (ADC_REFCTRL) 1/2 VDDANA (only for VDDANA > 2.0V) */
+#define   ADC_REFCTRL_REFSEL_AREFA_Val    _U_(0x3)   /**< \brief (ADC_REFCTRL) External reference */
+#define   ADC_REFCTRL_REFSEL_AREFB_Val    _U_(0x4)   /**< \brief (ADC_REFCTRL) External reference */
 #define ADC_REFCTRL_REFSEL_INT1V    (ADC_REFCTRL_REFSEL_INT1V_Val  << ADC_REFCTRL_REFSEL_Pos)
 #define ADC_REFCTRL_REFSEL_INTVCC0  (ADC_REFCTRL_REFSEL_INTVCC0_Val << ADC_REFCTRL_REFSEL_Pos)
 #define ADC_REFCTRL_REFSEL_INTVCC1  (ADC_REFCTRL_REFSEL_INTVCC1_Val << ADC_REFCTRL_REFSEL_Pos)
 #define ADC_REFCTRL_REFSEL_AREFA    (ADC_REFCTRL_REFSEL_AREFA_Val  << ADC_REFCTRL_REFSEL_Pos)
 #define ADC_REFCTRL_REFSEL_AREFB    (ADC_REFCTRL_REFSEL_AREFB_Val  << ADC_REFCTRL_REFSEL_Pos)
 #define ADC_REFCTRL_REFCOMP_Pos     7            /**< \brief (ADC_REFCTRL) Reference Buffer Offset Compensation Enable */
-#define ADC_REFCTRL_REFCOMP         (0x1ul << ADC_REFCTRL_REFCOMP_Pos)
-#define ADC_REFCTRL_MASK            0x8Ful       /**< \brief (ADC_REFCTRL) MASK Register */
+#define ADC_REFCTRL_REFCOMP         (_U_(0x1) << ADC_REFCTRL_REFCOMP_Pos)
+#define ADC_REFCTRL_MASK            _U_(0x8F)     /**< \brief (ADC_REFCTRL) MASK Register */
 
 /* -------- ADC_AVGCTRL : (ADC Offset: 0x02) (R/W  8) Average Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -122,22 +107,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_AVGCTRL_OFFSET          0x02         /**< \brief (ADC_AVGCTRL offset) Average Control */
-#define ADC_AVGCTRL_RESETVALUE      0x00ul       /**< \brief (ADC_AVGCTRL reset_value) Average Control */
+#define ADC_AVGCTRL_RESETVALUE      _U_(0x00)     /**< \brief (ADC_AVGCTRL reset_value) Average Control */
 
 #define ADC_AVGCTRL_SAMPLENUM_Pos   0            /**< \brief (ADC_AVGCTRL) Number of Samples to be Collected */
-#define ADC_AVGCTRL_SAMPLENUM_Msk   (0xFul << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_Msk   (_U_(0xF) << ADC_AVGCTRL_SAMPLENUM_Pos)
 #define ADC_AVGCTRL_SAMPLENUM(value) (ADC_AVGCTRL_SAMPLENUM_Msk & ((value) << ADC_AVGCTRL_SAMPLENUM_Pos))
-#define   ADC_AVGCTRL_SAMPLENUM_1_Val     0x0ul  /**< \brief (ADC_AVGCTRL) 1 sample */
-#define   ADC_AVGCTRL_SAMPLENUM_2_Val     0x1ul  /**< \brief (ADC_AVGCTRL) 2 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_4_Val     0x2ul  /**< \brief (ADC_AVGCTRL) 4 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_8_Val     0x3ul  /**< \brief (ADC_AVGCTRL) 8 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_16_Val    0x4ul  /**< \brief (ADC_AVGCTRL) 16 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_32_Val    0x5ul  /**< \brief (ADC_AVGCTRL) 32 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_64_Val    0x6ul  /**< \brief (ADC_AVGCTRL) 64 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_128_Val   0x7ul  /**< \brief (ADC_AVGCTRL) 128 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_256_Val   0x8ul  /**< \brief (ADC_AVGCTRL) 256 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_512_Val   0x9ul  /**< \brief (ADC_AVGCTRL) 512 samples */
-#define   ADC_AVGCTRL_SAMPLENUM_1024_Val  0xAul  /**< \brief (ADC_AVGCTRL) 1024 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_1_Val     _U_(0x0)   /**< \brief (ADC_AVGCTRL) 1 sample */
+#define   ADC_AVGCTRL_SAMPLENUM_2_Val     _U_(0x1)   /**< \brief (ADC_AVGCTRL) 2 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_4_Val     _U_(0x2)   /**< \brief (ADC_AVGCTRL) 4 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_8_Val     _U_(0x3)   /**< \brief (ADC_AVGCTRL) 8 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_16_Val    _U_(0x4)   /**< \brief (ADC_AVGCTRL) 16 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_32_Val    _U_(0x5)   /**< \brief (ADC_AVGCTRL) 32 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_64_Val    _U_(0x6)   /**< \brief (ADC_AVGCTRL) 64 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_128_Val   _U_(0x7)   /**< \brief (ADC_AVGCTRL) 128 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_256_Val   _U_(0x8)   /**< \brief (ADC_AVGCTRL) 256 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_512_Val   _U_(0x9)   /**< \brief (ADC_AVGCTRL) 512 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_1024_Val  _U_(0xA)   /**< \brief (ADC_AVGCTRL) 1024 samples */
 #define ADC_AVGCTRL_SAMPLENUM_1     (ADC_AVGCTRL_SAMPLENUM_1_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
 #define ADC_AVGCTRL_SAMPLENUM_2     (ADC_AVGCTRL_SAMPLENUM_2_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
 #define ADC_AVGCTRL_SAMPLENUM_4     (ADC_AVGCTRL_SAMPLENUM_4_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
@@ -150,9 +135,9 @@ typedef union {
 #define ADC_AVGCTRL_SAMPLENUM_512   (ADC_AVGCTRL_SAMPLENUM_512_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
 #define ADC_AVGCTRL_SAMPLENUM_1024  (ADC_AVGCTRL_SAMPLENUM_1024_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
 #define ADC_AVGCTRL_ADJRES_Pos      4            /**< \brief (ADC_AVGCTRL) Adjusting Result / Division Coefficient */
-#define ADC_AVGCTRL_ADJRES_Msk      (0x7ul << ADC_AVGCTRL_ADJRES_Pos)
+#define ADC_AVGCTRL_ADJRES_Msk      (_U_(0x7) << ADC_AVGCTRL_ADJRES_Pos)
 #define ADC_AVGCTRL_ADJRES(value)   (ADC_AVGCTRL_ADJRES_Msk & ((value) << ADC_AVGCTRL_ADJRES_Pos))
-#define ADC_AVGCTRL_MASK            0x7Ful       /**< \brief (ADC_AVGCTRL) MASK Register */
+#define ADC_AVGCTRL_MASK            _U_(0x7F)     /**< \brief (ADC_AVGCTRL) MASK Register */
 
 /* -------- ADC_SAMPCTRL : (ADC Offset: 0x03) (R/W  8) Sampling Time Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -166,12 +151,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_SAMPCTRL_OFFSET         0x03         /**< \brief (ADC_SAMPCTRL offset) Sampling Time Control */
-#define ADC_SAMPCTRL_RESETVALUE     0x00ul       /**< \brief (ADC_SAMPCTRL reset_value) Sampling Time Control */
+#define ADC_SAMPCTRL_RESETVALUE     _U_(0x00)     /**< \brief (ADC_SAMPCTRL reset_value) Sampling Time Control */
 
 #define ADC_SAMPCTRL_SAMPLEN_Pos    0            /**< \brief (ADC_SAMPCTRL) Sampling Time Length */
-#define ADC_SAMPCTRL_SAMPLEN_Msk    (0x3Ful << ADC_SAMPCTRL_SAMPLEN_Pos)
+#define ADC_SAMPCTRL_SAMPLEN_Msk    (_U_(0x3F) << ADC_SAMPCTRL_SAMPLEN_Pos)
 #define ADC_SAMPCTRL_SAMPLEN(value) (ADC_SAMPCTRL_SAMPLEN_Msk & ((value) << ADC_SAMPCTRL_SAMPLEN_Pos))
-#define ADC_SAMPCTRL_MASK           0x3Ful       /**< \brief (ADC_SAMPCTRL) MASK Register */
+#define ADC_SAMPCTRL_MASK           _U_(0x3F)     /**< \brief (ADC_SAMPCTRL) MASK Register */
 
 /* -------- ADC_CTRLB : (ADC Offset: 0x04) (R/W 16) Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -191,38 +176,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_CTRLB_OFFSET            0x04         /**< \brief (ADC_CTRLB offset) Control B */
-#define ADC_CTRLB_RESETVALUE        0x0000ul     /**< \brief (ADC_CTRLB reset_value) Control B */
+#define ADC_CTRLB_RESETVALUE        _U_(0x0000)   /**< \brief (ADC_CTRLB reset_value) Control B */
 
 #define ADC_CTRLB_DIFFMODE_Pos      0            /**< \brief (ADC_CTRLB) Differential Mode */
-#define ADC_CTRLB_DIFFMODE          (0x1ul << ADC_CTRLB_DIFFMODE_Pos)
+#define ADC_CTRLB_DIFFMODE          (_U_(0x1) << ADC_CTRLB_DIFFMODE_Pos)
 #define ADC_CTRLB_LEFTADJ_Pos       1            /**< \brief (ADC_CTRLB) Left-Adjusted Result */
-#define ADC_CTRLB_LEFTADJ           (0x1ul << ADC_CTRLB_LEFTADJ_Pos)
+#define ADC_CTRLB_LEFTADJ           (_U_(0x1) << ADC_CTRLB_LEFTADJ_Pos)
 #define ADC_CTRLB_FREERUN_Pos       2            /**< \brief (ADC_CTRLB) Free Running Mode */
-#define ADC_CTRLB_FREERUN           (0x1ul << ADC_CTRLB_FREERUN_Pos)
+#define ADC_CTRLB_FREERUN           (_U_(0x1) << ADC_CTRLB_FREERUN_Pos)
 #define ADC_CTRLB_CORREN_Pos        3            /**< \brief (ADC_CTRLB) Digital Correction Logic Enabled */
-#define ADC_CTRLB_CORREN            (0x1ul << ADC_CTRLB_CORREN_Pos)
+#define ADC_CTRLB_CORREN            (_U_(0x1) << ADC_CTRLB_CORREN_Pos)
 #define ADC_CTRLB_RESSEL_Pos        4            /**< \brief (ADC_CTRLB) Conversion Result Resolution */
-#define ADC_CTRLB_RESSEL_Msk        (0x3ul << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL_Msk        (_U_(0x3) << ADC_CTRLB_RESSEL_Pos)
 #define ADC_CTRLB_RESSEL(value)     (ADC_CTRLB_RESSEL_Msk & ((value) << ADC_CTRLB_RESSEL_Pos))
-#define   ADC_CTRLB_RESSEL_12BIT_Val      0x0ul  /**< \brief (ADC_CTRLB) 12-bit result */
-#define   ADC_CTRLB_RESSEL_16BIT_Val      0x1ul  /**< \brief (ADC_CTRLB) For averaging mode output */
-#define   ADC_CTRLB_RESSEL_10BIT_Val      0x2ul  /**< \brief (ADC_CTRLB) 10-bit result */
-#define   ADC_CTRLB_RESSEL_8BIT_Val       0x3ul  /**< \brief (ADC_CTRLB) 8-bit result */
+#define   ADC_CTRLB_RESSEL_12BIT_Val      _U_(0x0)   /**< \brief (ADC_CTRLB) 12-bit result */
+#define   ADC_CTRLB_RESSEL_16BIT_Val      _U_(0x1)   /**< \brief (ADC_CTRLB) For averaging mode output */
+#define   ADC_CTRLB_RESSEL_10BIT_Val      _U_(0x2)   /**< \brief (ADC_CTRLB) 10-bit result */
+#define   ADC_CTRLB_RESSEL_8BIT_Val       _U_(0x3)   /**< \brief (ADC_CTRLB) 8-bit result */
 #define ADC_CTRLB_RESSEL_12BIT      (ADC_CTRLB_RESSEL_12BIT_Val    << ADC_CTRLB_RESSEL_Pos)
 #define ADC_CTRLB_RESSEL_16BIT      (ADC_CTRLB_RESSEL_16BIT_Val    << ADC_CTRLB_RESSEL_Pos)
 #define ADC_CTRLB_RESSEL_10BIT      (ADC_CTRLB_RESSEL_10BIT_Val    << ADC_CTRLB_RESSEL_Pos)
 #define ADC_CTRLB_RESSEL_8BIT       (ADC_CTRLB_RESSEL_8BIT_Val     << ADC_CTRLB_RESSEL_Pos)
 #define ADC_CTRLB_PRESCALER_Pos     8            /**< \brief (ADC_CTRLB) Prescaler Configuration */
-#define ADC_CTRLB_PRESCALER_Msk     (0x7ul << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_Msk     (_U_(0x7) << ADC_CTRLB_PRESCALER_Pos)
 #define ADC_CTRLB_PRESCALER(value)  (ADC_CTRLB_PRESCALER_Msk & ((value) << ADC_CTRLB_PRESCALER_Pos))
-#define   ADC_CTRLB_PRESCALER_DIV4_Val    0x0ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 4 */
-#define   ADC_CTRLB_PRESCALER_DIV8_Val    0x1ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 8 */
-#define   ADC_CTRLB_PRESCALER_DIV16_Val   0x2ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 16 */
-#define   ADC_CTRLB_PRESCALER_DIV32_Val   0x3ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 32 */
-#define   ADC_CTRLB_PRESCALER_DIV64_Val   0x4ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 64 */
-#define   ADC_CTRLB_PRESCALER_DIV128_Val  0x5ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 128 */
-#define   ADC_CTRLB_PRESCALER_DIV256_Val  0x6ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 256 */
-#define   ADC_CTRLB_PRESCALER_DIV512_Val  0x7ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 512 */
+#define   ADC_CTRLB_PRESCALER_DIV4_Val    _U_(0x0)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 4 */
+#define   ADC_CTRLB_PRESCALER_DIV8_Val    _U_(0x1)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 8 */
+#define   ADC_CTRLB_PRESCALER_DIV16_Val   _U_(0x2)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 16 */
+#define   ADC_CTRLB_PRESCALER_DIV32_Val   _U_(0x3)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 32 */
+#define   ADC_CTRLB_PRESCALER_DIV64_Val   _U_(0x4)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 64 */
+#define   ADC_CTRLB_PRESCALER_DIV128_Val  _U_(0x5)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 128 */
+#define   ADC_CTRLB_PRESCALER_DIV256_Val  _U_(0x6)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 256 */
+#define   ADC_CTRLB_PRESCALER_DIV512_Val  _U_(0x7)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 512 */
 #define ADC_CTRLB_PRESCALER_DIV4    (ADC_CTRLB_PRESCALER_DIV4_Val  << ADC_CTRLB_PRESCALER_Pos)
 #define ADC_CTRLB_PRESCALER_DIV8    (ADC_CTRLB_PRESCALER_DIV8_Val  << ADC_CTRLB_PRESCALER_Pos)
 #define ADC_CTRLB_PRESCALER_DIV16   (ADC_CTRLB_PRESCALER_DIV16_Val << ADC_CTRLB_PRESCALER_Pos)
@@ -231,7 +216,7 @@ typedef union {
 #define ADC_CTRLB_PRESCALER_DIV128  (ADC_CTRLB_PRESCALER_DIV128_Val << ADC_CTRLB_PRESCALER_Pos)
 #define ADC_CTRLB_PRESCALER_DIV256  (ADC_CTRLB_PRESCALER_DIV256_Val << ADC_CTRLB_PRESCALER_Pos)
 #define ADC_CTRLB_PRESCALER_DIV512  (ADC_CTRLB_PRESCALER_DIV512_Val << ADC_CTRLB_PRESCALER_Pos)
-#define ADC_CTRLB_MASK              0x073Ful     /**< \brief (ADC_CTRLB) MASK Register */
+#define ADC_CTRLB_MASK              _U_(0x073F)   /**< \brief (ADC_CTRLB) MASK Register */
 
 /* -------- ADC_WINCTRL : (ADC Offset: 0x08) (R/W  8) Window Monitor Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -245,22 +230,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_WINCTRL_OFFSET          0x08         /**< \brief (ADC_WINCTRL offset) Window Monitor Control */
-#define ADC_WINCTRL_RESETVALUE      0x00ul       /**< \brief (ADC_WINCTRL reset_value) Window Monitor Control */
+#define ADC_WINCTRL_RESETVALUE      _U_(0x00)     /**< \brief (ADC_WINCTRL reset_value) Window Monitor Control */
 
 #define ADC_WINCTRL_WINMODE_Pos     0            /**< \brief (ADC_WINCTRL) Window Monitor Mode */
-#define ADC_WINCTRL_WINMODE_Msk     (0x7ul << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_Msk     (_U_(0x7) << ADC_WINCTRL_WINMODE_Pos)
 #define ADC_WINCTRL_WINMODE(value)  (ADC_WINCTRL_WINMODE_Msk & ((value) << ADC_WINCTRL_WINMODE_Pos))
-#define   ADC_WINCTRL_WINMODE_DISABLE_Val 0x0ul  /**< \brief (ADC_WINCTRL) No window mode (default) */
-#define   ADC_WINCTRL_WINMODE_MODE1_Val   0x1ul  /**< \brief (ADC_WINCTRL) Mode 1: RESULT > WINLT */
-#define   ADC_WINCTRL_WINMODE_MODE2_Val   0x2ul  /**< \brief (ADC_WINCTRL) Mode 2: RESULT < WINUT */
-#define   ADC_WINCTRL_WINMODE_MODE3_Val   0x3ul  /**< \brief (ADC_WINCTRL) Mode 3: WINLT < RESULT < WINUT */
-#define   ADC_WINCTRL_WINMODE_MODE4_Val   0x4ul  /**< \brief (ADC_WINCTRL) Mode 4: !(WINLT < RESULT < WINUT) */
+#define   ADC_WINCTRL_WINMODE_DISABLE_Val _U_(0x0)   /**< \brief (ADC_WINCTRL) No window mode (default) */
+#define   ADC_WINCTRL_WINMODE_MODE1_Val   _U_(0x1)   /**< \brief (ADC_WINCTRL) Mode 1: RESULT > WINLT */
+#define   ADC_WINCTRL_WINMODE_MODE2_Val   _U_(0x2)   /**< \brief (ADC_WINCTRL) Mode 2: RESULT < WINUT */
+#define   ADC_WINCTRL_WINMODE_MODE3_Val   _U_(0x3)   /**< \brief (ADC_WINCTRL) Mode 3: WINLT < RESULT < WINUT */
+#define   ADC_WINCTRL_WINMODE_MODE4_Val   _U_(0x4)   /**< \brief (ADC_WINCTRL) Mode 4: !(WINLT < RESULT < WINUT) */
 #define ADC_WINCTRL_WINMODE_DISABLE (ADC_WINCTRL_WINMODE_DISABLE_Val << ADC_WINCTRL_WINMODE_Pos)
 #define ADC_WINCTRL_WINMODE_MODE1   (ADC_WINCTRL_WINMODE_MODE1_Val << ADC_WINCTRL_WINMODE_Pos)
 #define ADC_WINCTRL_WINMODE_MODE2   (ADC_WINCTRL_WINMODE_MODE2_Val << ADC_WINCTRL_WINMODE_Pos)
 #define ADC_WINCTRL_WINMODE_MODE3   (ADC_WINCTRL_WINMODE_MODE3_Val << ADC_WINCTRL_WINMODE_Pos)
 #define ADC_WINCTRL_WINMODE_MODE4   (ADC_WINCTRL_WINMODE_MODE4_Val << ADC_WINCTRL_WINMODE_Pos)
-#define ADC_WINCTRL_MASK            0x07ul       /**< \brief (ADC_WINCTRL) MASK Register */
+#define ADC_WINCTRL_MASK            _U_(0x07)     /**< \brief (ADC_WINCTRL) MASK Register */
 
 /* -------- ADC_SWTRIG : (ADC Offset: 0x0C) (R/W  8) Software Trigger -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -275,13 +260,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_SWTRIG_OFFSET           0x0C         /**< \brief (ADC_SWTRIG offset) Software Trigger */
-#define ADC_SWTRIG_RESETVALUE       0x00ul       /**< \brief (ADC_SWTRIG reset_value) Software Trigger */
+#define ADC_SWTRIG_RESETVALUE       _U_(0x00)     /**< \brief (ADC_SWTRIG reset_value) Software Trigger */
 
 #define ADC_SWTRIG_FLUSH_Pos        0            /**< \brief (ADC_SWTRIG) ADC Conversion Flush */
-#define ADC_SWTRIG_FLUSH            (0x1ul << ADC_SWTRIG_FLUSH_Pos)
+#define ADC_SWTRIG_FLUSH            (_U_(0x1) << ADC_SWTRIG_FLUSH_Pos)
 #define ADC_SWTRIG_START_Pos        1            /**< \brief (ADC_SWTRIG) ADC Start Conversion */
-#define ADC_SWTRIG_START            (0x1ul << ADC_SWTRIG_START_Pos)
-#define ADC_SWTRIG_MASK             0x03ul       /**< \brief (ADC_SWTRIG) MASK Register */
+#define ADC_SWTRIG_START            (_U_(0x1) << ADC_SWTRIG_START_Pos)
+#define ADC_SWTRIG_MASK             _U_(0x03)     /**< \brief (ADC_SWTRIG) MASK Register */
 
 /* -------- ADC_INPUTCTRL : (ADC Offset: 0x10) (R/W 32) Input Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -301,36 +286,36 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_INPUTCTRL_OFFSET        0x10         /**< \brief (ADC_INPUTCTRL offset) Input Control */
-#define ADC_INPUTCTRL_RESETVALUE    0x00000000ul /**< \brief (ADC_INPUTCTRL reset_value) Input Control */
+#define ADC_INPUTCTRL_RESETVALUE    _U_(0x00000000) /**< \brief (ADC_INPUTCTRL reset_value) Input Control */
 
 #define ADC_INPUTCTRL_MUXPOS_Pos    0            /**< \brief (ADC_INPUTCTRL) Positive Mux Input Selection */
-#define ADC_INPUTCTRL_MUXPOS_Msk    (0x1Ful << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_Msk    (_U_(0x1F) << ADC_INPUTCTRL_MUXPOS_Pos)
 #define ADC_INPUTCTRL_MUXPOS(value) (ADC_INPUTCTRL_MUXPOS_Msk & ((value) << ADC_INPUTCTRL_MUXPOS_Pos))
-#define   ADC_INPUTCTRL_MUXPOS_PIN0_Val   0x0ul  /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN1_Val   0x1ul  /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN2_Val   0x2ul  /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN3_Val   0x3ul  /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN4_Val   0x4ul  /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN5_Val   0x5ul  /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN6_Val   0x6ul  /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN7_Val   0x7ul  /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN8_Val   0x8ul  /**< \brief (ADC_INPUTCTRL) ADC AIN8 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN9_Val   0x9ul  /**< \brief (ADC_INPUTCTRL) ADC AIN9 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN10_Val  0xAul  /**< \brief (ADC_INPUTCTRL) ADC AIN10 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN11_Val  0xBul  /**< \brief (ADC_INPUTCTRL) ADC AIN11 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN12_Val  0xCul  /**< \brief (ADC_INPUTCTRL) ADC AIN12 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN13_Val  0xDul  /**< \brief (ADC_INPUTCTRL) ADC AIN13 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN14_Val  0xEul  /**< \brief (ADC_INPUTCTRL) ADC AIN14 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN15_Val  0xFul  /**< \brief (ADC_INPUTCTRL) ADC AIN15 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN16_Val  0x10ul  /**< \brief (ADC_INPUTCTRL) ADC AIN16 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN17_Val  0x11ul  /**< \brief (ADC_INPUTCTRL) ADC AIN17 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN18_Val  0x12ul  /**< \brief (ADC_INPUTCTRL) ADC AIN18 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_PIN19_Val  0x13ul  /**< \brief (ADC_INPUTCTRL) ADC AIN19 Pin */
-#define   ADC_INPUTCTRL_MUXPOS_TEMP_Val   0x18ul  /**< \brief (ADC_INPUTCTRL) Temperature Reference */
-#define   ADC_INPUTCTRL_MUXPOS_BANDGAP_Val 0x19ul  /**< \brief (ADC_INPUTCTRL) Bandgap Voltage */
-#define   ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val 0x1Aul  /**< \brief (ADC_INPUTCTRL) 1/4  Scaled Core Supply */
-#define   ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1Bul  /**< \brief (ADC_INPUTCTRL) 1/4  Scaled I/O Supply */
-#define   ADC_INPUTCTRL_MUXPOS_DAC_Val    0x1Cul  /**< \brief (ADC_INPUTCTRL) DAC Output */
+#define   ADC_INPUTCTRL_MUXPOS_PIN0_Val   _U_(0x0)   /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN1_Val   _U_(0x1)   /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN2_Val   _U_(0x2)   /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN3_Val   _U_(0x3)   /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN4_Val   _U_(0x4)   /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN5_Val   _U_(0x5)   /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN6_Val   _U_(0x6)   /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN7_Val   _U_(0x7)   /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN8_Val   _U_(0x8)   /**< \brief (ADC_INPUTCTRL) ADC AIN8 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN9_Val   _U_(0x9)   /**< \brief (ADC_INPUTCTRL) ADC AIN9 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN10_Val  _U_(0xA)   /**< \brief (ADC_INPUTCTRL) ADC AIN10 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN11_Val  _U_(0xB)   /**< \brief (ADC_INPUTCTRL) ADC AIN11 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN12_Val  _U_(0xC)   /**< \brief (ADC_INPUTCTRL) ADC AIN12 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN13_Val  _U_(0xD)   /**< \brief (ADC_INPUTCTRL) ADC AIN13 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN14_Val  _U_(0xE)   /**< \brief (ADC_INPUTCTRL) ADC AIN14 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN15_Val  _U_(0xF)   /**< \brief (ADC_INPUTCTRL) ADC AIN15 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN16_Val  _U_(0x10)   /**< \brief (ADC_INPUTCTRL) ADC AIN16 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN17_Val  _U_(0x11)   /**< \brief (ADC_INPUTCTRL) ADC AIN17 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN18_Val  _U_(0x12)   /**< \brief (ADC_INPUTCTRL) ADC AIN18 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN19_Val  _U_(0x13)   /**< \brief (ADC_INPUTCTRL) ADC AIN19 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_TEMP_Val   _U_(0x18)   /**< \brief (ADC_INPUTCTRL) Temperature Reference */
+#define   ADC_INPUTCTRL_MUXPOS_BANDGAP_Val _U_(0x19)   /**< \brief (ADC_INPUTCTRL) Bandgap Voltage */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val _U_(0x1A)   /**< \brief (ADC_INPUTCTRL) 1/4  Scaled Core Supply */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val _U_(0x1B)   /**< \brief (ADC_INPUTCTRL) 1/4  Scaled I/O Supply */
+#define   ADC_INPUTCTRL_MUXPOS_DAC_Val    _U_(0x1C)   /**< \brief (ADC_INPUTCTRL) DAC Output */
 #define ADC_INPUTCTRL_MUXPOS_PIN0   (ADC_INPUTCTRL_MUXPOS_PIN0_Val << ADC_INPUTCTRL_MUXPOS_Pos)
 #define ADC_INPUTCTRL_MUXPOS_PIN1   (ADC_INPUTCTRL_MUXPOS_PIN1_Val << ADC_INPUTCTRL_MUXPOS_Pos)
 #define ADC_INPUTCTRL_MUXPOS_PIN2   (ADC_INPUTCTRL_MUXPOS_PIN2_Val << ADC_INPUTCTRL_MUXPOS_Pos)
@@ -357,18 +342,18 @@ typedef union {
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC (ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)
 #define ADC_INPUTCTRL_MUXPOS_DAC    (ADC_INPUTCTRL_MUXPOS_DAC_Val  << ADC_INPUTCTRL_MUXPOS_Pos)
 #define ADC_INPUTCTRL_MUXNEG_Pos    8            /**< \brief (ADC_INPUTCTRL) Negative Mux Input Selection */
-#define ADC_INPUTCTRL_MUXNEG_Msk    (0x1Ful << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_Msk    (_U_(0x1F) << ADC_INPUTCTRL_MUXNEG_Pos)
 #define ADC_INPUTCTRL_MUXNEG(value) (ADC_INPUTCTRL_MUXNEG_Msk & ((value) << ADC_INPUTCTRL_MUXNEG_Pos))
-#define   ADC_INPUTCTRL_MUXNEG_PIN0_Val   0x0ul  /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
-#define   ADC_INPUTCTRL_MUXNEG_PIN1_Val   0x1ul  /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
-#define   ADC_INPUTCTRL_MUXNEG_PIN2_Val   0x2ul  /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
-#define   ADC_INPUTCTRL_MUXNEG_PIN3_Val   0x3ul  /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
-#define   ADC_INPUTCTRL_MUXNEG_PIN4_Val   0x4ul  /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
-#define   ADC_INPUTCTRL_MUXNEG_PIN5_Val   0x5ul  /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
-#define   ADC_INPUTCTRL_MUXNEG_PIN6_Val   0x6ul  /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
-#define   ADC_INPUTCTRL_MUXNEG_PIN7_Val   0x7ul  /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
-#define   ADC_INPUTCTRL_MUXNEG_GND_Val    0x18ul  /**< \brief (ADC_INPUTCTRL) Internal Ground */
-#define   ADC_INPUTCTRL_MUXNEG_IOGND_Val  0x19ul  /**< \brief (ADC_INPUTCTRL) I/O Ground */
+#define   ADC_INPUTCTRL_MUXNEG_PIN0_Val   _U_(0x0)   /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN1_Val   _U_(0x1)   /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN2_Val   _U_(0x2)   /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN3_Val   _U_(0x3)   /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN4_Val   _U_(0x4)   /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN5_Val   _U_(0x5)   /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN6_Val   _U_(0x6)   /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN7_Val   _U_(0x7)   /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_GND_Val    _U_(0x18)   /**< \brief (ADC_INPUTCTRL) Internal Ground */
+#define   ADC_INPUTCTRL_MUXNEG_IOGND_Val  _U_(0x19)   /**< \brief (ADC_INPUTCTRL) I/O Ground */
 #define ADC_INPUTCTRL_MUXNEG_PIN0   (ADC_INPUTCTRL_MUXNEG_PIN0_Val << ADC_INPUTCTRL_MUXNEG_Pos)
 #define ADC_INPUTCTRL_MUXNEG_PIN1   (ADC_INPUTCTRL_MUXNEG_PIN1_Val << ADC_INPUTCTRL_MUXNEG_Pos)
 #define ADC_INPUTCTRL_MUXNEG_PIN2   (ADC_INPUTCTRL_MUXNEG_PIN2_Val << ADC_INPUTCTRL_MUXNEG_Pos)
@@ -380,27 +365,27 @@ typedef union {
 #define ADC_INPUTCTRL_MUXNEG_GND    (ADC_INPUTCTRL_MUXNEG_GND_Val  << ADC_INPUTCTRL_MUXNEG_Pos)
 #define ADC_INPUTCTRL_MUXNEG_IOGND  (ADC_INPUTCTRL_MUXNEG_IOGND_Val << ADC_INPUTCTRL_MUXNEG_Pos)
 #define ADC_INPUTCTRL_INPUTSCAN_Pos 16           /**< \brief (ADC_INPUTCTRL) Number of Input Channels Included in Scan */
-#define ADC_INPUTCTRL_INPUTSCAN_Msk (0xFul << ADC_INPUTCTRL_INPUTSCAN_Pos)
+#define ADC_INPUTCTRL_INPUTSCAN_Msk (_U_(0xF) << ADC_INPUTCTRL_INPUTSCAN_Pos)
 #define ADC_INPUTCTRL_INPUTSCAN(value) (ADC_INPUTCTRL_INPUTSCAN_Msk & ((value) << ADC_INPUTCTRL_INPUTSCAN_Pos))
 #define ADC_INPUTCTRL_INPUTOFFSET_Pos 20           /**< \brief (ADC_INPUTCTRL) Positive Mux Setting Offset */
-#define ADC_INPUTCTRL_INPUTOFFSET_Msk (0xFul << ADC_INPUTCTRL_INPUTOFFSET_Pos)
+#define ADC_INPUTCTRL_INPUTOFFSET_Msk (_U_(0xF) << ADC_INPUTCTRL_INPUTOFFSET_Pos)
 #define ADC_INPUTCTRL_INPUTOFFSET(value) (ADC_INPUTCTRL_INPUTOFFSET_Msk & ((value) << ADC_INPUTCTRL_INPUTOFFSET_Pos))
 #define ADC_INPUTCTRL_GAIN_Pos      24           /**< \brief (ADC_INPUTCTRL) Gain Factor Selection */
-#define ADC_INPUTCTRL_GAIN_Msk      (0xFul << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_Msk      (_U_(0xF) << ADC_INPUTCTRL_GAIN_Pos)
 #define ADC_INPUTCTRL_GAIN(value)   (ADC_INPUTCTRL_GAIN_Msk & ((value) << ADC_INPUTCTRL_GAIN_Pos))
-#define   ADC_INPUTCTRL_GAIN_1X_Val       0x0ul  /**< \brief (ADC_INPUTCTRL) 1x */
-#define   ADC_INPUTCTRL_GAIN_2X_Val       0x1ul  /**< \brief (ADC_INPUTCTRL) 2x */
-#define   ADC_INPUTCTRL_GAIN_4X_Val       0x2ul  /**< \brief (ADC_INPUTCTRL) 4x */
-#define   ADC_INPUTCTRL_GAIN_8X_Val       0x3ul  /**< \brief (ADC_INPUTCTRL) 8x */
-#define   ADC_INPUTCTRL_GAIN_16X_Val      0x4ul  /**< \brief (ADC_INPUTCTRL) 16x */
-#define   ADC_INPUTCTRL_GAIN_DIV2_Val     0xFul  /**< \brief (ADC_INPUTCTRL) 1/2x */
+#define   ADC_INPUTCTRL_GAIN_1X_Val       _U_(0x0)   /**< \brief (ADC_INPUTCTRL) 1x */
+#define   ADC_INPUTCTRL_GAIN_2X_Val       _U_(0x1)   /**< \brief (ADC_INPUTCTRL) 2x */
+#define   ADC_INPUTCTRL_GAIN_4X_Val       _U_(0x2)   /**< \brief (ADC_INPUTCTRL) 4x */
+#define   ADC_INPUTCTRL_GAIN_8X_Val       _U_(0x3)   /**< \brief (ADC_INPUTCTRL) 8x */
+#define   ADC_INPUTCTRL_GAIN_16X_Val      _U_(0x4)   /**< \brief (ADC_INPUTCTRL) 16x */
+#define   ADC_INPUTCTRL_GAIN_DIV2_Val     _U_(0xF)   /**< \brief (ADC_INPUTCTRL) 1/2x */
 #define ADC_INPUTCTRL_GAIN_1X       (ADC_INPUTCTRL_GAIN_1X_Val     << ADC_INPUTCTRL_GAIN_Pos)
 #define ADC_INPUTCTRL_GAIN_2X       (ADC_INPUTCTRL_GAIN_2X_Val     << ADC_INPUTCTRL_GAIN_Pos)
 #define ADC_INPUTCTRL_GAIN_4X       (ADC_INPUTCTRL_GAIN_4X_Val     << ADC_INPUTCTRL_GAIN_Pos)
 #define ADC_INPUTCTRL_GAIN_8X       (ADC_INPUTCTRL_GAIN_8X_Val     << ADC_INPUTCTRL_GAIN_Pos)
 #define ADC_INPUTCTRL_GAIN_16X      (ADC_INPUTCTRL_GAIN_16X_Val    << ADC_INPUTCTRL_GAIN_Pos)
 #define ADC_INPUTCTRL_GAIN_DIV2     (ADC_INPUTCTRL_GAIN_DIV2_Val   << ADC_INPUTCTRL_GAIN_Pos)
-#define ADC_INPUTCTRL_MASK          0x0FFF1F1Ful /**< \brief (ADC_INPUTCTRL) MASK Register */
+#define ADC_INPUTCTRL_MASK          _U_(0x0FFF1F1F) /**< \brief (ADC_INPUTCTRL) MASK Register */
 
 /* -------- ADC_EVCTRL : (ADC Offset: 0x14) (R/W  8) Event Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -418,17 +403,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_EVCTRL_OFFSET           0x14         /**< \brief (ADC_EVCTRL offset) Event Control */
-#define ADC_EVCTRL_RESETVALUE       0x00ul       /**< \brief (ADC_EVCTRL reset_value) Event Control */
+#define ADC_EVCTRL_RESETVALUE       _U_(0x00)     /**< \brief (ADC_EVCTRL reset_value) Event Control */
 
 #define ADC_EVCTRL_STARTEI_Pos      0            /**< \brief (ADC_EVCTRL) Start Conversion Event In */
-#define ADC_EVCTRL_STARTEI          (0x1ul << ADC_EVCTRL_STARTEI_Pos)
+#define ADC_EVCTRL_STARTEI          (_U_(0x1) << ADC_EVCTRL_STARTEI_Pos)
 #define ADC_EVCTRL_SYNCEI_Pos       1            /**< \brief (ADC_EVCTRL) Synchronization Event In */
-#define ADC_EVCTRL_SYNCEI           (0x1ul << ADC_EVCTRL_SYNCEI_Pos)
+#define ADC_EVCTRL_SYNCEI           (_U_(0x1) << ADC_EVCTRL_SYNCEI_Pos)
 #define ADC_EVCTRL_RESRDYEO_Pos     4            /**< \brief (ADC_EVCTRL) Result Ready Event Out */
-#define ADC_EVCTRL_RESRDYEO         (0x1ul << ADC_EVCTRL_RESRDYEO_Pos)
+#define ADC_EVCTRL_RESRDYEO         (_U_(0x1) << ADC_EVCTRL_RESRDYEO_Pos)
 #define ADC_EVCTRL_WINMONEO_Pos     5            /**< \brief (ADC_EVCTRL) Window Monitor Event Out */
-#define ADC_EVCTRL_WINMONEO         (0x1ul << ADC_EVCTRL_WINMONEO_Pos)
-#define ADC_EVCTRL_MASK             0x33ul       /**< \brief (ADC_EVCTRL) MASK Register */
+#define ADC_EVCTRL_WINMONEO         (_U_(0x1) << ADC_EVCTRL_WINMONEO_Pos)
+#define ADC_EVCTRL_MASK             _U_(0x33)     /**< \brief (ADC_EVCTRL) MASK Register */
 
 /* -------- ADC_INTENCLR : (ADC Offset: 0x16) (R/W  8) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -445,17 +430,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_INTENCLR_OFFSET         0x16         /**< \brief (ADC_INTENCLR offset) Interrupt Enable Clear */
-#define ADC_INTENCLR_RESETVALUE     0x00ul       /**< \brief (ADC_INTENCLR reset_value) Interrupt Enable Clear */
+#define ADC_INTENCLR_RESETVALUE     _U_(0x00)     /**< \brief (ADC_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define ADC_INTENCLR_RESRDY_Pos     0            /**< \brief (ADC_INTENCLR) Result Ready Interrupt Enable */
-#define ADC_INTENCLR_RESRDY         (0x1ul << ADC_INTENCLR_RESRDY_Pos)
+#define ADC_INTENCLR_RESRDY         (_U_(0x1) << ADC_INTENCLR_RESRDY_Pos)
 #define ADC_INTENCLR_OVERRUN_Pos    1            /**< \brief (ADC_INTENCLR) Overrun Interrupt Enable */
-#define ADC_INTENCLR_OVERRUN        (0x1ul << ADC_INTENCLR_OVERRUN_Pos)
+#define ADC_INTENCLR_OVERRUN        (_U_(0x1) << ADC_INTENCLR_OVERRUN_Pos)
 #define ADC_INTENCLR_WINMON_Pos     2            /**< \brief (ADC_INTENCLR) Window Monitor Interrupt Enable */
-#define ADC_INTENCLR_WINMON         (0x1ul << ADC_INTENCLR_WINMON_Pos)
+#define ADC_INTENCLR_WINMON         (_U_(0x1) << ADC_INTENCLR_WINMON_Pos)
 #define ADC_INTENCLR_SYNCRDY_Pos    3            /**< \brief (ADC_INTENCLR) Synchronization Ready Interrupt Enable */
-#define ADC_INTENCLR_SYNCRDY        (0x1ul << ADC_INTENCLR_SYNCRDY_Pos)
-#define ADC_INTENCLR_MASK           0x0Ful       /**< \brief (ADC_INTENCLR) MASK Register */
+#define ADC_INTENCLR_SYNCRDY        (_U_(0x1) << ADC_INTENCLR_SYNCRDY_Pos)
+#define ADC_INTENCLR_MASK           _U_(0x0F)     /**< \brief (ADC_INTENCLR) MASK Register */
 
 /* -------- ADC_INTENSET : (ADC Offset: 0x17) (R/W  8) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -472,17 +457,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_INTENSET_OFFSET         0x17         /**< \brief (ADC_INTENSET offset) Interrupt Enable Set */
-#define ADC_INTENSET_RESETVALUE     0x00ul       /**< \brief (ADC_INTENSET reset_value) Interrupt Enable Set */
+#define ADC_INTENSET_RESETVALUE     _U_(0x00)     /**< \brief (ADC_INTENSET reset_value) Interrupt Enable Set */
 
 #define ADC_INTENSET_RESRDY_Pos     0            /**< \brief (ADC_INTENSET) Result Ready Interrupt Enable */
-#define ADC_INTENSET_RESRDY         (0x1ul << ADC_INTENSET_RESRDY_Pos)
+#define ADC_INTENSET_RESRDY         (_U_(0x1) << ADC_INTENSET_RESRDY_Pos)
 #define ADC_INTENSET_OVERRUN_Pos    1            /**< \brief (ADC_INTENSET) Overrun Interrupt Enable */
-#define ADC_INTENSET_OVERRUN        (0x1ul << ADC_INTENSET_OVERRUN_Pos)
+#define ADC_INTENSET_OVERRUN        (_U_(0x1) << ADC_INTENSET_OVERRUN_Pos)
 #define ADC_INTENSET_WINMON_Pos     2            /**< \brief (ADC_INTENSET) Window Monitor Interrupt Enable */
-#define ADC_INTENSET_WINMON         (0x1ul << ADC_INTENSET_WINMON_Pos)
+#define ADC_INTENSET_WINMON         (_U_(0x1) << ADC_INTENSET_WINMON_Pos)
 #define ADC_INTENSET_SYNCRDY_Pos    3            /**< \brief (ADC_INTENSET) Synchronization Ready Interrupt Enable */
-#define ADC_INTENSET_SYNCRDY        (0x1ul << ADC_INTENSET_SYNCRDY_Pos)
-#define ADC_INTENSET_MASK           0x0Ful       /**< \brief (ADC_INTENSET) MASK Register */
+#define ADC_INTENSET_SYNCRDY        (_U_(0x1) << ADC_INTENSET_SYNCRDY_Pos)
+#define ADC_INTENSET_MASK           _U_(0x0F)     /**< \brief (ADC_INTENSET) MASK Register */
 
 /* -------- ADC_INTFLAG : (ADC Offset: 0x18) (R/W  8) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -499,17 +484,17 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_INTFLAG_OFFSET          0x18         /**< \brief (ADC_INTFLAG offset) Interrupt Flag Status and Clear */
-#define ADC_INTFLAG_RESETVALUE      0x00ul       /**< \brief (ADC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define ADC_INTFLAG_RESETVALUE      _U_(0x00)     /**< \brief (ADC_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define ADC_INTFLAG_RESRDY_Pos      0            /**< \brief (ADC_INTFLAG) Result Ready */
-#define ADC_INTFLAG_RESRDY          (0x1ul << ADC_INTFLAG_RESRDY_Pos)
+#define ADC_INTFLAG_RESRDY          (_U_(0x1) << ADC_INTFLAG_RESRDY_Pos)
 #define ADC_INTFLAG_OVERRUN_Pos     1            /**< \brief (ADC_INTFLAG) Overrun */
-#define ADC_INTFLAG_OVERRUN         (0x1ul << ADC_INTFLAG_OVERRUN_Pos)
+#define ADC_INTFLAG_OVERRUN         (_U_(0x1) << ADC_INTFLAG_OVERRUN_Pos)
 #define ADC_INTFLAG_WINMON_Pos      2            /**< \brief (ADC_INTFLAG) Window Monitor */
-#define ADC_INTFLAG_WINMON          (0x1ul << ADC_INTFLAG_WINMON_Pos)
+#define ADC_INTFLAG_WINMON          (_U_(0x1) << ADC_INTFLAG_WINMON_Pos)
 #define ADC_INTFLAG_SYNCRDY_Pos     3            /**< \brief (ADC_INTFLAG) Synchronization Ready */
-#define ADC_INTFLAG_SYNCRDY         (0x1ul << ADC_INTFLAG_SYNCRDY_Pos)
-#define ADC_INTFLAG_MASK            0x0Ful       /**< \brief (ADC_INTFLAG) MASK Register */
+#define ADC_INTFLAG_SYNCRDY         (_U_(0x1) << ADC_INTFLAG_SYNCRDY_Pos)
+#define ADC_INTFLAG_MASK            _U_(0x0F)     /**< \brief (ADC_INTFLAG) MASK Register */
 
 /* -------- ADC_STATUS : (ADC Offset: 0x19) (R/   8) Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -523,11 +508,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_STATUS_OFFSET           0x19         /**< \brief (ADC_STATUS offset) Status */
-#define ADC_STATUS_RESETVALUE       0x00ul       /**< \brief (ADC_STATUS reset_value) Status */
+#define ADC_STATUS_RESETVALUE       _U_(0x00)     /**< \brief (ADC_STATUS reset_value) Status */
 
 #define ADC_STATUS_SYNCBUSY_Pos     7            /**< \brief (ADC_STATUS) Synchronization Busy */
-#define ADC_STATUS_SYNCBUSY         (0x1ul << ADC_STATUS_SYNCBUSY_Pos)
-#define ADC_STATUS_MASK             0x80ul       /**< \brief (ADC_STATUS) MASK Register */
+#define ADC_STATUS_SYNCBUSY         (_U_(0x1) << ADC_STATUS_SYNCBUSY_Pos)
+#define ADC_STATUS_MASK             _U_(0x80)     /**< \brief (ADC_STATUS) MASK Register */
 
 /* -------- ADC_RESULT : (ADC Offset: 0x1A) (R/  16) Result -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -540,12 +525,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_RESULT_OFFSET           0x1A         /**< \brief (ADC_RESULT offset) Result */
-#define ADC_RESULT_RESETVALUE       0x0000ul     /**< \brief (ADC_RESULT reset_value) Result */
+#define ADC_RESULT_RESETVALUE       _U_(0x0000)   /**< \brief (ADC_RESULT reset_value) Result */
 
 #define ADC_RESULT_RESULT_Pos       0            /**< \brief (ADC_RESULT) Result Conversion Value */
-#define ADC_RESULT_RESULT_Msk       (0xFFFFul << ADC_RESULT_RESULT_Pos)
+#define ADC_RESULT_RESULT_Msk       (_U_(0xFFFF) << ADC_RESULT_RESULT_Pos)
 #define ADC_RESULT_RESULT(value)    (ADC_RESULT_RESULT_Msk & ((value) << ADC_RESULT_RESULT_Pos))
-#define ADC_RESULT_MASK             0xFFFFul     /**< \brief (ADC_RESULT) MASK Register */
+#define ADC_RESULT_MASK             _U_(0xFFFF)   /**< \brief (ADC_RESULT) MASK Register */
 
 /* -------- ADC_WINLT : (ADC Offset: 0x1C) (R/W 16) Window Monitor Lower Threshold -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -558,12 +543,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_WINLT_OFFSET            0x1C         /**< \brief (ADC_WINLT offset) Window Monitor Lower Threshold */
-#define ADC_WINLT_RESETVALUE        0x0000ul     /**< \brief (ADC_WINLT reset_value) Window Monitor Lower Threshold */
+#define ADC_WINLT_RESETVALUE        _U_(0x0000)   /**< \brief (ADC_WINLT reset_value) Window Monitor Lower Threshold */
 
 #define ADC_WINLT_WINLT_Pos         0            /**< \brief (ADC_WINLT) Window Lower Threshold */
-#define ADC_WINLT_WINLT_Msk         (0xFFFFul << ADC_WINLT_WINLT_Pos)
+#define ADC_WINLT_WINLT_Msk         (_U_(0xFFFF) << ADC_WINLT_WINLT_Pos)
 #define ADC_WINLT_WINLT(value)      (ADC_WINLT_WINLT_Msk & ((value) << ADC_WINLT_WINLT_Pos))
-#define ADC_WINLT_MASK              0xFFFFul     /**< \brief (ADC_WINLT) MASK Register */
+#define ADC_WINLT_MASK              _U_(0xFFFF)   /**< \brief (ADC_WINLT) MASK Register */
 
 /* -------- ADC_WINUT : (ADC Offset: 0x20) (R/W 16) Window Monitor Upper Threshold -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -576,12 +561,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_WINUT_OFFSET            0x20         /**< \brief (ADC_WINUT offset) Window Monitor Upper Threshold */
-#define ADC_WINUT_RESETVALUE        0x0000ul     /**< \brief (ADC_WINUT reset_value) Window Monitor Upper Threshold */
+#define ADC_WINUT_RESETVALUE        _U_(0x0000)   /**< \brief (ADC_WINUT reset_value) Window Monitor Upper Threshold */
 
 #define ADC_WINUT_WINUT_Pos         0            /**< \brief (ADC_WINUT) Window Upper Threshold */
-#define ADC_WINUT_WINUT_Msk         (0xFFFFul << ADC_WINUT_WINUT_Pos)
+#define ADC_WINUT_WINUT_Msk         (_U_(0xFFFF) << ADC_WINUT_WINUT_Pos)
 #define ADC_WINUT_WINUT(value)      (ADC_WINUT_WINUT_Msk & ((value) << ADC_WINUT_WINUT_Pos))
-#define ADC_WINUT_MASK              0xFFFFul     /**< \brief (ADC_WINUT) MASK Register */
+#define ADC_WINUT_MASK              _U_(0xFFFF)   /**< \brief (ADC_WINUT) MASK Register */
 
 /* -------- ADC_GAINCORR : (ADC Offset: 0x24) (R/W 16) Gain Correction -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -595,12 +580,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_GAINCORR_OFFSET         0x24         /**< \brief (ADC_GAINCORR offset) Gain Correction */
-#define ADC_GAINCORR_RESETVALUE     0x0000ul     /**< \brief (ADC_GAINCORR reset_value) Gain Correction */
+#define ADC_GAINCORR_RESETVALUE     _U_(0x0000)   /**< \brief (ADC_GAINCORR reset_value) Gain Correction */
 
 #define ADC_GAINCORR_GAINCORR_Pos   0            /**< \brief (ADC_GAINCORR) Gain Correction Value */
-#define ADC_GAINCORR_GAINCORR_Msk   (0xFFFul << ADC_GAINCORR_GAINCORR_Pos)
+#define ADC_GAINCORR_GAINCORR_Msk   (_U_(0xFFF) << ADC_GAINCORR_GAINCORR_Pos)
 #define ADC_GAINCORR_GAINCORR(value) (ADC_GAINCORR_GAINCORR_Msk & ((value) << ADC_GAINCORR_GAINCORR_Pos))
-#define ADC_GAINCORR_MASK           0x0FFFul     /**< \brief (ADC_GAINCORR) MASK Register */
+#define ADC_GAINCORR_MASK           _U_(0x0FFF)   /**< \brief (ADC_GAINCORR) MASK Register */
 
 /* -------- ADC_OFFSETCORR : (ADC Offset: 0x26) (R/W 16) Offset Correction -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -614,12 +599,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_OFFSETCORR_OFFSET       0x26         /**< \brief (ADC_OFFSETCORR offset) Offset Correction */
-#define ADC_OFFSETCORR_RESETVALUE   0x0000ul     /**< \brief (ADC_OFFSETCORR reset_value) Offset Correction */
+#define ADC_OFFSETCORR_RESETVALUE   _U_(0x0000)   /**< \brief (ADC_OFFSETCORR reset_value) Offset Correction */
 
 #define ADC_OFFSETCORR_OFFSETCORR_Pos 0            /**< \brief (ADC_OFFSETCORR) Offset Correction Value */
-#define ADC_OFFSETCORR_OFFSETCORR_Msk (0xFFFul << ADC_OFFSETCORR_OFFSETCORR_Pos)
+#define ADC_OFFSETCORR_OFFSETCORR_Msk (_U_(0xFFF) << ADC_OFFSETCORR_OFFSETCORR_Pos)
 #define ADC_OFFSETCORR_OFFSETCORR(value) (ADC_OFFSETCORR_OFFSETCORR_Msk & ((value) << ADC_OFFSETCORR_OFFSETCORR_Pos))
-#define ADC_OFFSETCORR_MASK         0x0FFFul     /**< \brief (ADC_OFFSETCORR) MASK Register */
+#define ADC_OFFSETCORR_MASK         _U_(0x0FFF)   /**< \brief (ADC_OFFSETCORR) MASK Register */
 
 /* -------- ADC_CALIB : (ADC Offset: 0x28) (R/W 16) Calibration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -634,15 +619,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_CALIB_OFFSET            0x28         /**< \brief (ADC_CALIB offset) Calibration */
-#define ADC_CALIB_RESETVALUE        0x0000ul     /**< \brief (ADC_CALIB reset_value) Calibration */
+#define ADC_CALIB_RESETVALUE        _U_(0x0000)   /**< \brief (ADC_CALIB reset_value) Calibration */
 
 #define ADC_CALIB_LINEARITY_CAL_Pos 0            /**< \brief (ADC_CALIB) Linearity Calibration Value */
-#define ADC_CALIB_LINEARITY_CAL_Msk (0xFFul << ADC_CALIB_LINEARITY_CAL_Pos)
+#define ADC_CALIB_LINEARITY_CAL_Msk (_U_(0xFF) << ADC_CALIB_LINEARITY_CAL_Pos)
 #define ADC_CALIB_LINEARITY_CAL(value) (ADC_CALIB_LINEARITY_CAL_Msk & ((value) << ADC_CALIB_LINEARITY_CAL_Pos))
 #define ADC_CALIB_BIAS_CAL_Pos      8            /**< \brief (ADC_CALIB) Bias Calibration Value */
-#define ADC_CALIB_BIAS_CAL_Msk      (0x7ul << ADC_CALIB_BIAS_CAL_Pos)
+#define ADC_CALIB_BIAS_CAL_Msk      (_U_(0x7) << ADC_CALIB_BIAS_CAL_Pos)
 #define ADC_CALIB_BIAS_CAL(value)   (ADC_CALIB_BIAS_CAL_Msk & ((value) << ADC_CALIB_BIAS_CAL_Pos))
-#define ADC_CALIB_MASK              0x07FFul     /**< \brief (ADC_CALIB) MASK Register */
+#define ADC_CALIB_MASK              _U_(0x07FF)   /**< \brief (ADC_CALIB) MASK Register */
 
 /* -------- ADC_DBGCTRL : (ADC Offset: 0x2A) (R/W  8) Debug Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -656,11 +641,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADC_DBGCTRL_OFFSET          0x2A         /**< \brief (ADC_DBGCTRL offset) Debug Control */
-#define ADC_DBGCTRL_RESETVALUE      0x00ul       /**< \brief (ADC_DBGCTRL reset_value) Debug Control */
+#define ADC_DBGCTRL_RESETVALUE      _U_(0x00)     /**< \brief (ADC_DBGCTRL reset_value) Debug Control */
 
 #define ADC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (ADC_DBGCTRL) Debug Run */
-#define ADC_DBGCTRL_DBGRUN          (0x1ul << ADC_DBGCTRL_DBGRUN_Pos)
-#define ADC_DBGCTRL_MASK            0x01ul       /**< \brief (ADC_DBGCTRL) MASK Register */
+#define ADC_DBGCTRL_DBGRUN          (_U_(0x1) << ADC_DBGCTRL_DBGRUN_Pos)
+#define ADC_DBGCTRL_MASK            _U_(0x01)     /**< \brief (ADC_DBGCTRL) MASK Register */
 
 /** \brief ADC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/dac.h
@@ -1,0 +1,271 @@
+/**
+ * \file
+ *
+ * \brief Component description for DAC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMR21_DAC_COMPONENT_
+#define _SAMR21_DAC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DAC */
+/* ========================================================================== */
+/** \addtogroup SAMR21_DAC Digital Analog Converter */
+/*@{*/
+
+#define DAC_U2214
+#define REV_DAC                     0x110
+
+/* -------- DAC_CTRLA : (DAC Offset: 0x0) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      2  Run in Standby                     */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLA_OFFSET            0x0          /**< \brief (DAC_CTRLA offset) Control A */
+#define DAC_CTRLA_RESETVALUE        _U_(0x00)     /**< \brief (DAC_CTRLA reset_value) Control A */
+
+#define DAC_CTRLA_SWRST_Pos         0            /**< \brief (DAC_CTRLA) Software Reset */
+#define DAC_CTRLA_SWRST             (_U_(0x1) << DAC_CTRLA_SWRST_Pos)
+#define DAC_CTRLA_ENABLE_Pos        1            /**< \brief (DAC_CTRLA) Enable */
+#define DAC_CTRLA_ENABLE            (_U_(0x1) << DAC_CTRLA_ENABLE_Pos)
+#define DAC_CTRLA_RUNSTDBY_Pos      2            /**< \brief (DAC_CTRLA) Run in Standby */
+#define DAC_CTRLA_RUNSTDBY          (_U_(0x1) << DAC_CTRLA_RUNSTDBY_Pos)
+#define DAC_CTRLA_MASK              _U_(0x07)     /**< \brief (DAC_CTRLA) MASK Register */
+
+/* -------- DAC_CTRLB : (DAC Offset: 0x1) (R/W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EOEN:1;           /*!< bit:      0  External Output Enable             */
+    uint8_t  IOEN:1;           /*!< bit:      1  Internal Output Enable             */
+    uint8_t  LEFTADJ:1;        /*!< bit:      2  Left Adjusted Data                 */
+    uint8_t  VPD:1;            /*!< bit:      3  Voltage Pump Disable               */
+    uint8_t  BDWP:1;           /*!< bit:      4  Bypass DATABUF Write Protection    */
+    uint8_t  :1;               /*!< bit:      5  Reserved                           */
+    uint8_t  REFSEL:2;         /*!< bit:  6.. 7  Reference Selection                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLB_OFFSET            0x1          /**< \brief (DAC_CTRLB offset) Control B */
+#define DAC_CTRLB_RESETVALUE        _U_(0x00)     /**< \brief (DAC_CTRLB reset_value) Control B */
+
+#define DAC_CTRLB_EOEN_Pos          0            /**< \brief (DAC_CTRLB) External Output Enable */
+#define DAC_CTRLB_EOEN              (_U_(0x1) << DAC_CTRLB_EOEN_Pos)
+#define DAC_CTRLB_IOEN_Pos          1            /**< \brief (DAC_CTRLB) Internal Output Enable */
+#define DAC_CTRLB_IOEN              (_U_(0x1) << DAC_CTRLB_IOEN_Pos)
+#define DAC_CTRLB_LEFTADJ_Pos       2            /**< \brief (DAC_CTRLB) Left Adjusted Data */
+#define DAC_CTRLB_LEFTADJ           (_U_(0x1) << DAC_CTRLB_LEFTADJ_Pos)
+#define DAC_CTRLB_VPD_Pos           3            /**< \brief (DAC_CTRLB) Voltage Pump Disable */
+#define DAC_CTRLB_VPD               (_U_(0x1) << DAC_CTRLB_VPD_Pos)
+#define DAC_CTRLB_BDWP_Pos          4            /**< \brief (DAC_CTRLB) Bypass DATABUF Write Protection */
+#define DAC_CTRLB_BDWP              (_U_(0x1) << DAC_CTRLB_BDWP_Pos)
+#define DAC_CTRLB_REFSEL_Pos        6            /**< \brief (DAC_CTRLB) Reference Selection */
+#define DAC_CTRLB_REFSEL_Msk        (_U_(0x3) << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL(value)     (DAC_CTRLB_REFSEL_Msk & ((value) << DAC_CTRLB_REFSEL_Pos))
+#define   DAC_CTRLB_REFSEL_INT1V_Val      _U_(0x0)   /**< \brief (DAC_CTRLB) Internal 1.0V reference */
+#define   DAC_CTRLB_REFSEL_AVCC_Val       _U_(0x1)   /**< \brief (DAC_CTRLB) AVCC */
+#define   DAC_CTRLB_REFSEL_VREFP_Val      _U_(0x2)   /**< \brief (DAC_CTRLB) External reference */
+#define DAC_CTRLB_REFSEL_INT1V      (DAC_CTRLB_REFSEL_INT1V_Val    << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_AVCC       (DAC_CTRLB_REFSEL_AVCC_Val     << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_VREFP      (DAC_CTRLB_REFSEL_VREFP_Val    << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_MASK              _U_(0xDF)     /**< \brief (DAC_CTRLB) MASK Register */
+
+/* -------- DAC_EVCTRL : (DAC Offset: 0x2) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STARTEI:1;        /*!< bit:      0  Start Conversion Event Input       */
+    uint8_t  EMPTYEO:1;        /*!< bit:      1  Data Buffer Empty Event Output     */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_EVCTRL_OFFSET           0x2          /**< \brief (DAC_EVCTRL offset) Event Control */
+#define DAC_EVCTRL_RESETVALUE       _U_(0x00)     /**< \brief (DAC_EVCTRL reset_value) Event Control */
+
+#define DAC_EVCTRL_STARTEI_Pos      0            /**< \brief (DAC_EVCTRL) Start Conversion Event Input */
+#define DAC_EVCTRL_STARTEI          (_U_(0x1) << DAC_EVCTRL_STARTEI_Pos)
+#define DAC_EVCTRL_EMPTYEO_Pos      1            /**< \brief (DAC_EVCTRL) Data Buffer Empty Event Output */
+#define DAC_EVCTRL_EMPTYEO          (_U_(0x1) << DAC_EVCTRL_EMPTYEO_Pos)
+#define DAC_EVCTRL_MASK             _U_(0x03)     /**< \brief (DAC_EVCTRL) MASK Register */
+
+/* -------- DAC_INTENCLR : (DAC Offset: 0x4) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
+    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENCLR_OFFSET         0x4          /**< \brief (DAC_INTENCLR offset) Interrupt Enable Clear */
+#define DAC_INTENCLR_RESETVALUE     _U_(0x00)     /**< \brief (DAC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define DAC_INTENCLR_UNDERRUN_Pos   0            /**< \brief (DAC_INTENCLR) Underrun Interrupt Enable */
+#define DAC_INTENCLR_UNDERRUN       (_U_(0x1) << DAC_INTENCLR_UNDERRUN_Pos)
+#define DAC_INTENCLR_EMPTY_Pos      1            /**< \brief (DAC_INTENCLR) Data Buffer Empty Interrupt Enable */
+#define DAC_INTENCLR_EMPTY          (_U_(0x1) << DAC_INTENCLR_EMPTY_Pos)
+#define DAC_INTENCLR_SYNCRDY_Pos    2            /**< \brief (DAC_INTENCLR) Synchronization Ready Interrupt Enable */
+#define DAC_INTENCLR_SYNCRDY        (_U_(0x1) << DAC_INTENCLR_SYNCRDY_Pos)
+#define DAC_INTENCLR_MASK           _U_(0x07)     /**< \brief (DAC_INTENCLR) MASK Register */
+
+/* -------- DAC_INTENSET : (DAC Offset: 0x5) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
+    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENSET_OFFSET         0x5          /**< \brief (DAC_INTENSET offset) Interrupt Enable Set */
+#define DAC_INTENSET_RESETVALUE     _U_(0x00)     /**< \brief (DAC_INTENSET reset_value) Interrupt Enable Set */
+
+#define DAC_INTENSET_UNDERRUN_Pos   0            /**< \brief (DAC_INTENSET) Underrun Interrupt Enable */
+#define DAC_INTENSET_UNDERRUN       (_U_(0x1) << DAC_INTENSET_UNDERRUN_Pos)
+#define DAC_INTENSET_EMPTY_Pos      1            /**< \brief (DAC_INTENSET) Data Buffer Empty Interrupt Enable */
+#define DAC_INTENSET_EMPTY          (_U_(0x1) << DAC_INTENSET_EMPTY_Pos)
+#define DAC_INTENSET_SYNCRDY_Pos    2            /**< \brief (DAC_INTENSET) Synchronization Ready Interrupt Enable */
+#define DAC_INTENSET_SYNCRDY        (_U_(0x1) << DAC_INTENSET_SYNCRDY_Pos)
+#define DAC_INTENSET_MASK           _U_(0x07)     /**< \brief (DAC_INTENSET) MASK Register */
+
+/* -------- DAC_INTFLAG : (DAC Offset: 0x6) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
+    __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTFLAG_OFFSET          0x6          /**< \brief (DAC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define DAC_INTFLAG_RESETVALUE      _U_(0x00)     /**< \brief (DAC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define DAC_INTFLAG_UNDERRUN_Pos    0            /**< \brief (DAC_INTFLAG) Underrun */
+#define DAC_INTFLAG_UNDERRUN        (_U_(0x1) << DAC_INTFLAG_UNDERRUN_Pos)
+#define DAC_INTFLAG_EMPTY_Pos       1            /**< \brief (DAC_INTFLAG) Data Buffer Empty */
+#define DAC_INTFLAG_EMPTY           (_U_(0x1) << DAC_INTFLAG_EMPTY_Pos)
+#define DAC_INTFLAG_SYNCRDY_Pos     2            /**< \brief (DAC_INTFLAG) Synchronization Ready */
+#define DAC_INTFLAG_SYNCRDY         (_U_(0x1) << DAC_INTFLAG_SYNCRDY_Pos)
+#define DAC_INTFLAG_MASK            _U_(0x07)     /**< \brief (DAC_INTFLAG) MASK Register */
+
+/* -------- DAC_STATUS : (DAC Offset: 0x7) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy Status        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_STATUS_OFFSET           0x7          /**< \brief (DAC_STATUS offset) Status */
+#define DAC_STATUS_RESETVALUE       _U_(0x00)     /**< \brief (DAC_STATUS reset_value) Status */
+
+#define DAC_STATUS_SYNCBUSY_Pos     7            /**< \brief (DAC_STATUS) Synchronization Busy Status */
+#define DAC_STATUS_SYNCBUSY         (_U_(0x1) << DAC_STATUS_SYNCBUSY_Pos)
+#define DAC_STATUS_MASK             _U_(0x80)     /**< \brief (DAC_STATUS) MASK Register */
+
+/* -------- DAC_DATA : (DAC Offset: 0x8) (R/W 16) Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:16;          /*!< bit:  0..15  Data value to be converted         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATA_OFFSET             0x8          /**< \brief (DAC_DATA offset) Data */
+#define DAC_DATA_RESETVALUE         _U_(0x0000)   /**< \brief (DAC_DATA reset_value) Data */
+
+#define DAC_DATA_DATA_Pos           0            /**< \brief (DAC_DATA) Data value to be converted */
+#define DAC_DATA_DATA_Msk           (_U_(0xFFFF) << DAC_DATA_DATA_Pos)
+#define DAC_DATA_DATA(value)        (DAC_DATA_DATA_Msk & ((value) << DAC_DATA_DATA_Pos))
+#define DAC_DATA_MASK               _U_(0xFFFF)   /**< \brief (DAC_DATA) MASK Register */
+
+/* -------- DAC_DATABUF : (DAC Offset: 0xC) (R/W 16) Data Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATABUF:16;       /*!< bit:  0..15  Data Buffer                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DATABUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATABUF_OFFSET          0xC          /**< \brief (DAC_DATABUF offset) Data Buffer */
+#define DAC_DATABUF_RESETVALUE      _U_(0x0000)   /**< \brief (DAC_DATABUF reset_value) Data Buffer */
+
+#define DAC_DATABUF_DATABUF_Pos     0            /**< \brief (DAC_DATABUF) Data Buffer */
+#define DAC_DATABUF_DATABUF_Msk     (_U_(0xFFFF) << DAC_DATABUF_DATABUF_Pos)
+#define DAC_DATABUF_DATABUF(value)  (DAC_DATABUF_DATABUF_Msk & ((value) << DAC_DATABUF_DATABUF_Pos))
+#define DAC_DATABUF_MASK            _U_(0xFFFF)   /**< \brief (DAC_DATABUF) MASK Register */
+
+/** \brief DAC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO DAC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x0 (R/W  8) Control A */
+  __IO DAC_CTRLB_Type            CTRLB;       /**< \brief Offset: 0x1 (R/W  8) Control B */
+  __IO DAC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x2 (R/W  8) Event Control */
+       RoReg8                    Reserved1[0x1];
+  __IO DAC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x4 (R/W  8) Interrupt Enable Clear */
+  __IO DAC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x5 (R/W  8) Interrupt Enable Set */
+  __IO DAC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x6 (R/W  8) Interrupt Flag Status and Clear */
+  __I  DAC_STATUS_Type           STATUS;      /**< \brief Offset: 0x7 (R/   8) Status */
+  __IO DAC_DATA_Type             DATA;        /**< \brief Offset: 0x8 (R/W 16) Data */
+       RoReg8                    Reserved2[0x2];
+  __IO DAC_DATABUF_Type          DATABUF;     /**< \brief Offset: 0xC (R/W 16) Data Buffer */
+} Dac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMR21_DAC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/dmac.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for DMAC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -77,14 +62,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CTRL_OFFSET            0x00         /**< \brief (DMAC_CTRL offset) Control */
-#define DMAC_CTRL_RESETVALUE        0x0000ul     /**< \brief (DMAC_CTRL reset_value) Control */
+#define DMAC_CTRL_RESETVALUE        _U_(0x0000)   /**< \brief (DMAC_CTRL reset_value) Control */
 
 #define DMAC_CTRL_SWRST_Pos         0            /**< \brief (DMAC_CTRL) Software Reset */
-#define DMAC_CTRL_SWRST             (0x1ul << DMAC_CTRL_SWRST_Pos)
+#define DMAC_CTRL_SWRST             (_U_(0x1) << DMAC_CTRL_SWRST_Pos)
 #define DMAC_CTRL_DMAENABLE_Pos     1            /**< \brief (DMAC_CTRL) DMA Enable */
-#define DMAC_CTRL_DMAENABLE         (0x1ul << DMAC_CTRL_DMAENABLE_Pos)
+#define DMAC_CTRL_DMAENABLE         (_U_(0x1) << DMAC_CTRL_DMAENABLE_Pos)
 #define DMAC_CTRL_CRCENABLE_Pos     2            /**< \brief (DMAC_CTRL) CRC Enable */
-#define DMAC_CTRL_CRCENABLE         (0x1ul << DMAC_CTRL_CRCENABLE_Pos)
+#define DMAC_CTRL_CRCENABLE         (_U_(0x1) << DMAC_CTRL_CRCENABLE_Pos)
 #define DMAC_CTRL_LVLEN0_Pos        8            /**< \brief (DMAC_CTRL) Priority Level 0 Enable */
 #define DMAC_CTRL_LVLEN0            (1 << DMAC_CTRL_LVLEN0_Pos)
 #define DMAC_CTRL_LVLEN1_Pos        9            /**< \brief (DMAC_CTRL) Priority Level 1 Enable */
@@ -94,9 +79,9 @@ typedef union {
 #define DMAC_CTRL_LVLEN3_Pos        11           /**< \brief (DMAC_CTRL) Priority Level 3 Enable */
 #define DMAC_CTRL_LVLEN3            (1 << DMAC_CTRL_LVLEN3_Pos)
 #define DMAC_CTRL_LVLEN_Pos         8            /**< \brief (DMAC_CTRL) Priority Level x Enable */
-#define DMAC_CTRL_LVLEN_Msk         (0xFul << DMAC_CTRL_LVLEN_Pos)
+#define DMAC_CTRL_LVLEN_Msk         (_U_(0xF) << DMAC_CTRL_LVLEN_Pos)
 #define DMAC_CTRL_LVLEN(value)      (DMAC_CTRL_LVLEN_Msk & ((value) << DMAC_CTRL_LVLEN_Pos))
-#define DMAC_CTRL_MASK              0x0F07ul     /**< \brief (DMAC_CTRL) MASK Register */
+#define DMAC_CTRL_MASK              _U_(0x0F07)   /**< \brief (DMAC_CTRL) MASK Register */
 
 /* -------- DMAC_CRCCTRL : (DMAC Offset: 0x02) (R/W 16) CRC Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -113,32 +98,32 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CRCCTRL_OFFSET         0x02         /**< \brief (DMAC_CRCCTRL offset) CRC Control */
-#define DMAC_CRCCTRL_RESETVALUE     0x0000ul     /**< \brief (DMAC_CRCCTRL reset_value) CRC Control */
+#define DMAC_CRCCTRL_RESETVALUE     _U_(0x0000)   /**< \brief (DMAC_CRCCTRL reset_value) CRC Control */
 
 #define DMAC_CRCCTRL_CRCBEATSIZE_Pos 0            /**< \brief (DMAC_CRCCTRL) CRC Beat Size */
-#define DMAC_CRCCTRL_CRCBEATSIZE_Msk (0x3ul << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
+#define DMAC_CRCCTRL_CRCBEATSIZE_Msk (_U_(0x3) << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
 #define DMAC_CRCCTRL_CRCBEATSIZE(value) (DMAC_CRCCTRL_CRCBEATSIZE_Msk & ((value) << DMAC_CRCCTRL_CRCBEATSIZE_Pos))
-#define   DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val 0x0ul  /**< \brief (DMAC_CRCCTRL) 8-bit bus transfer */
-#define   DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val 0x1ul  /**< \brief (DMAC_CRCCTRL) 16-bit bus transfer */
-#define   DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val 0x2ul  /**< \brief (DMAC_CRCCTRL) 32-bit bus transfer */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val _U_(0x0)   /**< \brief (DMAC_CRCCTRL) 8-bit bus transfer */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val _U_(0x1)   /**< \brief (DMAC_CRCCTRL) 16-bit bus transfer */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val _U_(0x2)   /**< \brief (DMAC_CRCCTRL) 32-bit bus transfer */
 #define DMAC_CRCCTRL_CRCBEATSIZE_BYTE (DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
 #define DMAC_CRCCTRL_CRCBEATSIZE_HWORD (DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
 #define DMAC_CRCCTRL_CRCBEATSIZE_WORD (DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
 #define DMAC_CRCCTRL_CRCPOLY_Pos    2            /**< \brief (DMAC_CRCCTRL) CRC Polynomial Type */
-#define DMAC_CRCCTRL_CRCPOLY_Msk    (0x3ul << DMAC_CRCCTRL_CRCPOLY_Pos)
+#define DMAC_CRCCTRL_CRCPOLY_Msk    (_U_(0x3) << DMAC_CRCCTRL_CRCPOLY_Pos)
 #define DMAC_CRCCTRL_CRCPOLY(value) (DMAC_CRCCTRL_CRCPOLY_Msk & ((value) << DMAC_CRCCTRL_CRCPOLY_Pos))
-#define   DMAC_CRCCTRL_CRCPOLY_CRC16_Val  0x0ul  /**< \brief (DMAC_CRCCTRL) CRC-16 (CRC-CCITT) */
-#define   DMAC_CRCCTRL_CRCPOLY_CRC32_Val  0x1ul  /**< \brief (DMAC_CRCCTRL) CRC32 (IEEE 802.3) */
+#define   DMAC_CRCCTRL_CRCPOLY_CRC16_Val  _U_(0x0)   /**< \brief (DMAC_CRCCTRL) CRC-16 (CRC-CCITT) */
+#define   DMAC_CRCCTRL_CRCPOLY_CRC32_Val  _U_(0x1)   /**< \brief (DMAC_CRCCTRL) CRC32 (IEEE 802.3) */
 #define DMAC_CRCCTRL_CRCPOLY_CRC16  (DMAC_CRCCTRL_CRCPOLY_CRC16_Val << DMAC_CRCCTRL_CRCPOLY_Pos)
 #define DMAC_CRCCTRL_CRCPOLY_CRC32  (DMAC_CRCCTRL_CRCPOLY_CRC32_Val << DMAC_CRCCTRL_CRCPOLY_Pos)
 #define DMAC_CRCCTRL_CRCSRC_Pos     8            /**< \brief (DMAC_CRCCTRL) CRC Input Source */
-#define DMAC_CRCCTRL_CRCSRC_Msk     (0x3Ful << DMAC_CRCCTRL_CRCSRC_Pos)
+#define DMAC_CRCCTRL_CRCSRC_Msk     (_U_(0x3F) << DMAC_CRCCTRL_CRCSRC_Pos)
 #define DMAC_CRCCTRL_CRCSRC(value)  (DMAC_CRCCTRL_CRCSRC_Msk & ((value) << DMAC_CRCCTRL_CRCSRC_Pos))
-#define   DMAC_CRCCTRL_CRCSRC_NOACT_Val   0x0ul  /**< \brief (DMAC_CRCCTRL) No action */
-#define   DMAC_CRCCTRL_CRCSRC_IO_Val      0x1ul  /**< \brief (DMAC_CRCCTRL) I/O interface */
+#define   DMAC_CRCCTRL_CRCSRC_NOACT_Val   _U_(0x0)   /**< \brief (DMAC_CRCCTRL) No action */
+#define   DMAC_CRCCTRL_CRCSRC_IO_Val      _U_(0x1)   /**< \brief (DMAC_CRCCTRL) I/O interface */
 #define DMAC_CRCCTRL_CRCSRC_NOACT   (DMAC_CRCCTRL_CRCSRC_NOACT_Val << DMAC_CRCCTRL_CRCSRC_Pos)
 #define DMAC_CRCCTRL_CRCSRC_IO      (DMAC_CRCCTRL_CRCSRC_IO_Val    << DMAC_CRCCTRL_CRCSRC_Pos)
-#define DMAC_CRCCTRL_MASK           0x3F0Ful     /**< \brief (DMAC_CRCCTRL) MASK Register */
+#define DMAC_CRCCTRL_MASK           _U_(0x3F0F)   /**< \brief (DMAC_CRCCTRL) MASK Register */
 
 /* -------- DMAC_CRCDATAIN : (DMAC Offset: 0x04) (R/W 32) CRC Data Input -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -151,12 +136,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CRCDATAIN_OFFSET       0x04         /**< \brief (DMAC_CRCDATAIN offset) CRC Data Input */
-#define DMAC_CRCDATAIN_RESETVALUE   0x00000000ul /**< \brief (DMAC_CRCDATAIN reset_value) CRC Data Input */
+#define DMAC_CRCDATAIN_RESETVALUE   _U_(0x00000000) /**< \brief (DMAC_CRCDATAIN reset_value) CRC Data Input */
 
 #define DMAC_CRCDATAIN_CRCDATAIN_Pos 0            /**< \brief (DMAC_CRCDATAIN) CRC Data Input */
-#define DMAC_CRCDATAIN_CRCDATAIN_Msk (0xFFFFFFFFul << DMAC_CRCDATAIN_CRCDATAIN_Pos)
+#define DMAC_CRCDATAIN_CRCDATAIN_Msk (_U_(0xFFFFFFFF) << DMAC_CRCDATAIN_CRCDATAIN_Pos)
 #define DMAC_CRCDATAIN_CRCDATAIN(value) (DMAC_CRCDATAIN_CRCDATAIN_Msk & ((value) << DMAC_CRCDATAIN_CRCDATAIN_Pos))
-#define DMAC_CRCDATAIN_MASK         0xFFFFFFFFul /**< \brief (DMAC_CRCDATAIN) MASK Register */
+#define DMAC_CRCDATAIN_MASK         _U_(0xFFFFFFFF) /**< \brief (DMAC_CRCDATAIN) MASK Register */
 
 /* -------- DMAC_CRCCHKSUM : (DMAC Offset: 0x08) (R/W 32) CRC Checksum -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -169,12 +154,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CRCCHKSUM_OFFSET       0x08         /**< \brief (DMAC_CRCCHKSUM offset) CRC Checksum */
-#define DMAC_CRCCHKSUM_RESETVALUE   0x00000000ul /**< \brief (DMAC_CRCCHKSUM reset_value) CRC Checksum */
+#define DMAC_CRCCHKSUM_RESETVALUE   _U_(0x00000000) /**< \brief (DMAC_CRCCHKSUM reset_value) CRC Checksum */
 
 #define DMAC_CRCCHKSUM_CRCCHKSUM_Pos 0            /**< \brief (DMAC_CRCCHKSUM) CRC Checksum */
-#define DMAC_CRCCHKSUM_CRCCHKSUM_Msk (0xFFFFFFFFul << DMAC_CRCCHKSUM_CRCCHKSUM_Pos)
+#define DMAC_CRCCHKSUM_CRCCHKSUM_Msk (_U_(0xFFFFFFFF) << DMAC_CRCCHKSUM_CRCCHKSUM_Pos)
 #define DMAC_CRCCHKSUM_CRCCHKSUM(value) (DMAC_CRCCHKSUM_CRCCHKSUM_Msk & ((value) << DMAC_CRCCHKSUM_CRCCHKSUM_Pos))
-#define DMAC_CRCCHKSUM_MASK         0xFFFFFFFFul /**< \brief (DMAC_CRCCHKSUM) MASK Register */
+#define DMAC_CRCCHKSUM_MASK         _U_(0xFFFFFFFF) /**< \brief (DMAC_CRCCHKSUM) MASK Register */
 
 /* -------- DMAC_CRCSTATUS : (DMAC Offset: 0x0C) (R/W  8) CRC Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -189,13 +174,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CRCSTATUS_OFFSET       0x0C         /**< \brief (DMAC_CRCSTATUS offset) CRC Status */
-#define DMAC_CRCSTATUS_RESETVALUE   0x00ul       /**< \brief (DMAC_CRCSTATUS reset_value) CRC Status */
+#define DMAC_CRCSTATUS_RESETVALUE   _U_(0x00)     /**< \brief (DMAC_CRCSTATUS reset_value) CRC Status */
 
 #define DMAC_CRCSTATUS_CRCBUSY_Pos  0            /**< \brief (DMAC_CRCSTATUS) CRC Module Busy */
-#define DMAC_CRCSTATUS_CRCBUSY      (0x1ul << DMAC_CRCSTATUS_CRCBUSY_Pos)
+#define DMAC_CRCSTATUS_CRCBUSY      (_U_(0x1) << DMAC_CRCSTATUS_CRCBUSY_Pos)
 #define DMAC_CRCSTATUS_CRCZERO_Pos  1            /**< \brief (DMAC_CRCSTATUS) CRC Zero */
-#define DMAC_CRCSTATUS_CRCZERO      (0x1ul << DMAC_CRCSTATUS_CRCZERO_Pos)
-#define DMAC_CRCSTATUS_MASK         0x03ul       /**< \brief (DMAC_CRCSTATUS) MASK Register */
+#define DMAC_CRCSTATUS_CRCZERO      (_U_(0x1) << DMAC_CRCSTATUS_CRCZERO_Pos)
+#define DMAC_CRCSTATUS_MASK         _U_(0x03)     /**< \brief (DMAC_CRCSTATUS) MASK Register */
 
 /* -------- DMAC_DBGCTRL : (DMAC Offset: 0x0D) (R/W  8) Debug Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -209,11 +194,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_DBGCTRL_OFFSET         0x0D         /**< \brief (DMAC_DBGCTRL offset) Debug Control */
-#define DMAC_DBGCTRL_RESETVALUE     0x00ul       /**< \brief (DMAC_DBGCTRL reset_value) Debug Control */
+#define DMAC_DBGCTRL_RESETVALUE     _U_(0x00)     /**< \brief (DMAC_DBGCTRL reset_value) Debug Control */
 
 #define DMAC_DBGCTRL_DBGRUN_Pos     0            /**< \brief (DMAC_DBGCTRL) Debug Run */
-#define DMAC_DBGCTRL_DBGRUN         (0x1ul << DMAC_DBGCTRL_DBGRUN_Pos)
-#define DMAC_DBGCTRL_MASK           0x01ul       /**< \brief (DMAC_DBGCTRL) MASK Register */
+#define DMAC_DBGCTRL_DBGRUN         (_U_(0x1) << DMAC_DBGCTRL_DBGRUN_Pos)
+#define DMAC_DBGCTRL_MASK           _U_(0x01)     /**< \brief (DMAC_DBGCTRL) MASK Register */
 
 /* -------- DMAC_QOSCTRL : (DMAC Offset: 0x0E) (R/W  8) QOS Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -229,42 +214,42 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_QOSCTRL_OFFSET         0x0E         /**< \brief (DMAC_QOSCTRL offset) QOS Control */
-#define DMAC_QOSCTRL_RESETVALUE     0x15ul       /**< \brief (DMAC_QOSCTRL reset_value) QOS Control */
+#define DMAC_QOSCTRL_RESETVALUE     _U_(0x15)     /**< \brief (DMAC_QOSCTRL reset_value) QOS Control */
 
 #define DMAC_QOSCTRL_WRBQOS_Pos     0            /**< \brief (DMAC_QOSCTRL) Write-Back Quality of Service */
-#define DMAC_QOSCTRL_WRBQOS_Msk     (0x3ul << DMAC_QOSCTRL_WRBQOS_Pos)
+#define DMAC_QOSCTRL_WRBQOS_Msk     (_U_(0x3) << DMAC_QOSCTRL_WRBQOS_Pos)
 #define DMAC_QOSCTRL_WRBQOS(value)  (DMAC_QOSCTRL_WRBQOS_Msk & ((value) << DMAC_QOSCTRL_WRBQOS_Pos))
-#define   DMAC_QOSCTRL_WRBQOS_DISABLE_Val 0x0ul  /**< \brief (DMAC_QOSCTRL) Background (no sensitive operation) */
-#define   DMAC_QOSCTRL_WRBQOS_LOW_Val     0x1ul  /**< \brief (DMAC_QOSCTRL) Sensitive Bandwidth */
-#define   DMAC_QOSCTRL_WRBQOS_MEDIUM_Val  0x2ul  /**< \brief (DMAC_QOSCTRL) Sensitive Latency */
-#define   DMAC_QOSCTRL_WRBQOS_HIGH_Val    0x3ul  /**< \brief (DMAC_QOSCTRL) Critical Latency */
+#define   DMAC_QOSCTRL_WRBQOS_DISABLE_Val _U_(0x0)   /**< \brief (DMAC_QOSCTRL) Background (no sensitive operation) */
+#define   DMAC_QOSCTRL_WRBQOS_LOW_Val     _U_(0x1)   /**< \brief (DMAC_QOSCTRL) Sensitive Bandwidth */
+#define   DMAC_QOSCTRL_WRBQOS_MEDIUM_Val  _U_(0x2)   /**< \brief (DMAC_QOSCTRL) Sensitive Latency */
+#define   DMAC_QOSCTRL_WRBQOS_HIGH_Val    _U_(0x3)   /**< \brief (DMAC_QOSCTRL) Critical Latency */
 #define DMAC_QOSCTRL_WRBQOS_DISABLE (DMAC_QOSCTRL_WRBQOS_DISABLE_Val << DMAC_QOSCTRL_WRBQOS_Pos)
 #define DMAC_QOSCTRL_WRBQOS_LOW     (DMAC_QOSCTRL_WRBQOS_LOW_Val   << DMAC_QOSCTRL_WRBQOS_Pos)
 #define DMAC_QOSCTRL_WRBQOS_MEDIUM  (DMAC_QOSCTRL_WRBQOS_MEDIUM_Val << DMAC_QOSCTRL_WRBQOS_Pos)
 #define DMAC_QOSCTRL_WRBQOS_HIGH    (DMAC_QOSCTRL_WRBQOS_HIGH_Val  << DMAC_QOSCTRL_WRBQOS_Pos)
 #define DMAC_QOSCTRL_FQOS_Pos       2            /**< \brief (DMAC_QOSCTRL) Fetch Quality of Service */
-#define DMAC_QOSCTRL_FQOS_Msk       (0x3ul << DMAC_QOSCTRL_FQOS_Pos)
+#define DMAC_QOSCTRL_FQOS_Msk       (_U_(0x3) << DMAC_QOSCTRL_FQOS_Pos)
 #define DMAC_QOSCTRL_FQOS(value)    (DMAC_QOSCTRL_FQOS_Msk & ((value) << DMAC_QOSCTRL_FQOS_Pos))
-#define   DMAC_QOSCTRL_FQOS_DISABLE_Val   0x0ul  /**< \brief (DMAC_QOSCTRL) Background (no sensitive operation) */
-#define   DMAC_QOSCTRL_FQOS_LOW_Val       0x1ul  /**< \brief (DMAC_QOSCTRL) Sensitive Bandwidth */
-#define   DMAC_QOSCTRL_FQOS_MEDIUM_Val    0x2ul  /**< \brief (DMAC_QOSCTRL) Sensitive Latency */
-#define   DMAC_QOSCTRL_FQOS_HIGH_Val      0x3ul  /**< \brief (DMAC_QOSCTRL) Critical Latency */
+#define   DMAC_QOSCTRL_FQOS_DISABLE_Val   _U_(0x0)   /**< \brief (DMAC_QOSCTRL) Background (no sensitive operation) */
+#define   DMAC_QOSCTRL_FQOS_LOW_Val       _U_(0x1)   /**< \brief (DMAC_QOSCTRL) Sensitive Bandwidth */
+#define   DMAC_QOSCTRL_FQOS_MEDIUM_Val    _U_(0x2)   /**< \brief (DMAC_QOSCTRL) Sensitive Latency */
+#define   DMAC_QOSCTRL_FQOS_HIGH_Val      _U_(0x3)   /**< \brief (DMAC_QOSCTRL) Critical Latency */
 #define DMAC_QOSCTRL_FQOS_DISABLE   (DMAC_QOSCTRL_FQOS_DISABLE_Val << DMAC_QOSCTRL_FQOS_Pos)
 #define DMAC_QOSCTRL_FQOS_LOW       (DMAC_QOSCTRL_FQOS_LOW_Val     << DMAC_QOSCTRL_FQOS_Pos)
 #define DMAC_QOSCTRL_FQOS_MEDIUM    (DMAC_QOSCTRL_FQOS_MEDIUM_Val  << DMAC_QOSCTRL_FQOS_Pos)
 #define DMAC_QOSCTRL_FQOS_HIGH      (DMAC_QOSCTRL_FQOS_HIGH_Val    << DMAC_QOSCTRL_FQOS_Pos)
 #define DMAC_QOSCTRL_DQOS_Pos       4            /**< \brief (DMAC_QOSCTRL) Data Transfer Quality of Service */
-#define DMAC_QOSCTRL_DQOS_Msk       (0x3ul << DMAC_QOSCTRL_DQOS_Pos)
+#define DMAC_QOSCTRL_DQOS_Msk       (_U_(0x3) << DMAC_QOSCTRL_DQOS_Pos)
 #define DMAC_QOSCTRL_DQOS(value)    (DMAC_QOSCTRL_DQOS_Msk & ((value) << DMAC_QOSCTRL_DQOS_Pos))
-#define   DMAC_QOSCTRL_DQOS_DISABLE_Val   0x0ul  /**< \brief (DMAC_QOSCTRL) Background (no sensitive operation) */
-#define   DMAC_QOSCTRL_DQOS_LOW_Val       0x1ul  /**< \brief (DMAC_QOSCTRL) Sensitive Bandwidth */
-#define   DMAC_QOSCTRL_DQOS_MEDIUM_Val    0x2ul  /**< \brief (DMAC_QOSCTRL) Sensitive Latency */
-#define   DMAC_QOSCTRL_DQOS_HIGH_Val      0x3ul  /**< \brief (DMAC_QOSCTRL) Critical Latency */
+#define   DMAC_QOSCTRL_DQOS_DISABLE_Val   _U_(0x0)   /**< \brief (DMAC_QOSCTRL) Background (no sensitive operation) */
+#define   DMAC_QOSCTRL_DQOS_LOW_Val       _U_(0x1)   /**< \brief (DMAC_QOSCTRL) Sensitive Bandwidth */
+#define   DMAC_QOSCTRL_DQOS_MEDIUM_Val    _U_(0x2)   /**< \brief (DMAC_QOSCTRL) Sensitive Latency */
+#define   DMAC_QOSCTRL_DQOS_HIGH_Val      _U_(0x3)   /**< \brief (DMAC_QOSCTRL) Critical Latency */
 #define DMAC_QOSCTRL_DQOS_DISABLE   (DMAC_QOSCTRL_DQOS_DISABLE_Val << DMAC_QOSCTRL_DQOS_Pos)
 #define DMAC_QOSCTRL_DQOS_LOW       (DMAC_QOSCTRL_DQOS_LOW_Val     << DMAC_QOSCTRL_DQOS_Pos)
 #define DMAC_QOSCTRL_DQOS_MEDIUM    (DMAC_QOSCTRL_DQOS_MEDIUM_Val  << DMAC_QOSCTRL_DQOS_Pos)
 #define DMAC_QOSCTRL_DQOS_HIGH      (DMAC_QOSCTRL_DQOS_HIGH_Val    << DMAC_QOSCTRL_DQOS_Pos)
-#define DMAC_QOSCTRL_MASK           0x3Ful       /**< \brief (DMAC_QOSCTRL) MASK Register */
+#define DMAC_QOSCTRL_MASK           _U_(0x3F)     /**< \brief (DMAC_QOSCTRL) MASK Register */
 
 /* -------- DMAC_SWTRIGCTRL : (DMAC Offset: 0x10) (R/W 32) Software Trigger Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -293,7 +278,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_SWTRIGCTRL_OFFSET      0x10         /**< \brief (DMAC_SWTRIGCTRL offset) Software Trigger Control */
-#define DMAC_SWTRIGCTRL_RESETVALUE  0x00000000ul /**< \brief (DMAC_SWTRIGCTRL reset_value) Software Trigger Control */
+#define DMAC_SWTRIGCTRL_RESETVALUE  _U_(0x00000000) /**< \brief (DMAC_SWTRIGCTRL reset_value) Software Trigger Control */
 
 #define DMAC_SWTRIGCTRL_SWTRIG0_Pos 0            /**< \brief (DMAC_SWTRIGCTRL) Channel 0 Software Trigger */
 #define DMAC_SWTRIGCTRL_SWTRIG0     (1 << DMAC_SWTRIGCTRL_SWTRIG0_Pos)
@@ -320,9 +305,9 @@ typedef union {
 #define DMAC_SWTRIGCTRL_SWTRIG11_Pos 11           /**< \brief (DMAC_SWTRIGCTRL) Channel 11 Software Trigger */
 #define DMAC_SWTRIGCTRL_SWTRIG11    (1 << DMAC_SWTRIGCTRL_SWTRIG11_Pos)
 #define DMAC_SWTRIGCTRL_SWTRIG_Pos  0            /**< \brief (DMAC_SWTRIGCTRL) Channel x Software Trigger */
-#define DMAC_SWTRIGCTRL_SWTRIG_Msk  (0xFFFul << DMAC_SWTRIGCTRL_SWTRIG_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG_Msk  (_U_(0xFFF) << DMAC_SWTRIGCTRL_SWTRIG_Pos)
 #define DMAC_SWTRIGCTRL_SWTRIG(value) (DMAC_SWTRIGCTRL_SWTRIG_Msk & ((value) << DMAC_SWTRIGCTRL_SWTRIG_Pos))
-#define DMAC_SWTRIGCTRL_MASK        0x00000FFFul /**< \brief (DMAC_SWTRIGCTRL) MASK Register */
+#define DMAC_SWTRIGCTRL_MASK        _U_(0x00000FFF) /**< \brief (DMAC_SWTRIGCTRL) MASK Register */
 
 /* -------- DMAC_PRICTRL0 : (DMAC Offset: 0x14) (R/W 32) Priority Control 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -346,29 +331,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_PRICTRL0_OFFSET        0x14         /**< \brief (DMAC_PRICTRL0 offset) Priority Control 0 */
-#define DMAC_PRICTRL0_RESETVALUE    0x00000000ul /**< \brief (DMAC_PRICTRL0 reset_value) Priority Control 0 */
+#define DMAC_PRICTRL0_RESETVALUE    _U_(0x00000000) /**< \brief (DMAC_PRICTRL0 reset_value) Priority Control 0 */
 
 #define DMAC_PRICTRL0_LVLPRI0_Pos   0            /**< \brief (DMAC_PRICTRL0) Level 0 Channel Priority Number */
-#define DMAC_PRICTRL0_LVLPRI0_Msk   (0xFul << DMAC_PRICTRL0_LVLPRI0_Pos)
+#define DMAC_PRICTRL0_LVLPRI0_Msk   (_U_(0xF) << DMAC_PRICTRL0_LVLPRI0_Pos)
 #define DMAC_PRICTRL0_LVLPRI0(value) (DMAC_PRICTRL0_LVLPRI0_Msk & ((value) << DMAC_PRICTRL0_LVLPRI0_Pos))
 #define DMAC_PRICTRL0_RRLVLEN0_Pos  7            /**< \brief (DMAC_PRICTRL0) Level 0 Round-Robin Scheduling Enable */
-#define DMAC_PRICTRL0_RRLVLEN0      (0x1ul << DMAC_PRICTRL0_RRLVLEN0_Pos)
+#define DMAC_PRICTRL0_RRLVLEN0      (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN0_Pos)
 #define DMAC_PRICTRL0_LVLPRI1_Pos   8            /**< \brief (DMAC_PRICTRL0) Level 1 Channel Priority Number */
-#define DMAC_PRICTRL0_LVLPRI1_Msk   (0xFul << DMAC_PRICTRL0_LVLPRI1_Pos)
+#define DMAC_PRICTRL0_LVLPRI1_Msk   (_U_(0xF) << DMAC_PRICTRL0_LVLPRI1_Pos)
 #define DMAC_PRICTRL0_LVLPRI1(value) (DMAC_PRICTRL0_LVLPRI1_Msk & ((value) << DMAC_PRICTRL0_LVLPRI1_Pos))
 #define DMAC_PRICTRL0_RRLVLEN1_Pos  15           /**< \brief (DMAC_PRICTRL0) Level 1 Round-Robin Scheduling Enable */
-#define DMAC_PRICTRL0_RRLVLEN1      (0x1ul << DMAC_PRICTRL0_RRLVLEN1_Pos)
+#define DMAC_PRICTRL0_RRLVLEN1      (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN1_Pos)
 #define DMAC_PRICTRL0_LVLPRI2_Pos   16           /**< \brief (DMAC_PRICTRL0) Level 2 Channel Priority Number */
-#define DMAC_PRICTRL0_LVLPRI2_Msk   (0xFul << DMAC_PRICTRL0_LVLPRI2_Pos)
+#define DMAC_PRICTRL0_LVLPRI2_Msk   (_U_(0xF) << DMAC_PRICTRL0_LVLPRI2_Pos)
 #define DMAC_PRICTRL0_LVLPRI2(value) (DMAC_PRICTRL0_LVLPRI2_Msk & ((value) << DMAC_PRICTRL0_LVLPRI2_Pos))
 #define DMAC_PRICTRL0_RRLVLEN2_Pos  23           /**< \brief (DMAC_PRICTRL0) Level 2 Round-Robin Scheduling Enable */
-#define DMAC_PRICTRL0_RRLVLEN2      (0x1ul << DMAC_PRICTRL0_RRLVLEN2_Pos)
+#define DMAC_PRICTRL0_RRLVLEN2      (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN2_Pos)
 #define DMAC_PRICTRL0_LVLPRI3_Pos   24           /**< \brief (DMAC_PRICTRL0) Level 3 Channel Priority Number */
-#define DMAC_PRICTRL0_LVLPRI3_Msk   (0xFul << DMAC_PRICTRL0_LVLPRI3_Pos)
+#define DMAC_PRICTRL0_LVLPRI3_Msk   (_U_(0xF) << DMAC_PRICTRL0_LVLPRI3_Pos)
 #define DMAC_PRICTRL0_LVLPRI3(value) (DMAC_PRICTRL0_LVLPRI3_Msk & ((value) << DMAC_PRICTRL0_LVLPRI3_Pos))
 #define DMAC_PRICTRL0_RRLVLEN3_Pos  31           /**< \brief (DMAC_PRICTRL0) Level 3 Round-Robin Scheduling Enable */
-#define DMAC_PRICTRL0_RRLVLEN3      (0x1ul << DMAC_PRICTRL0_RRLVLEN3_Pos)
-#define DMAC_PRICTRL0_MASK          0x8F8F8F8Ful /**< \brief (DMAC_PRICTRL0) MASK Register */
+#define DMAC_PRICTRL0_RRLVLEN3      (_U_(0x1) << DMAC_PRICTRL0_RRLVLEN3_Pos)
+#define DMAC_PRICTRL0_MASK          _U_(0x8F8F8F8F) /**< \brief (DMAC_PRICTRL0) MASK Register */
 
 /* -------- DMAC_INTPEND : (DMAC Offset: 0x20) (R/W 16) Interrupt Pending -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -389,24 +374,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_INTPEND_OFFSET         0x20         /**< \brief (DMAC_INTPEND offset) Interrupt Pending */
-#define DMAC_INTPEND_RESETVALUE     0x0000ul     /**< \brief (DMAC_INTPEND reset_value) Interrupt Pending */
+#define DMAC_INTPEND_RESETVALUE     _U_(0x0000)   /**< \brief (DMAC_INTPEND reset_value) Interrupt Pending */
 
 #define DMAC_INTPEND_ID_Pos         0            /**< \brief (DMAC_INTPEND) Channel ID */
-#define DMAC_INTPEND_ID_Msk         (0xFul << DMAC_INTPEND_ID_Pos)
+#define DMAC_INTPEND_ID_Msk         (_U_(0xF) << DMAC_INTPEND_ID_Pos)
 #define DMAC_INTPEND_ID(value)      (DMAC_INTPEND_ID_Msk & ((value) << DMAC_INTPEND_ID_Pos))
 #define DMAC_INTPEND_TERR_Pos       8            /**< \brief (DMAC_INTPEND) Transfer Error */
-#define DMAC_INTPEND_TERR           (0x1ul << DMAC_INTPEND_TERR_Pos)
+#define DMAC_INTPEND_TERR           (_U_(0x1) << DMAC_INTPEND_TERR_Pos)
 #define DMAC_INTPEND_TCMPL_Pos      9            /**< \brief (DMAC_INTPEND) Transfer Complete */
-#define DMAC_INTPEND_TCMPL          (0x1ul << DMAC_INTPEND_TCMPL_Pos)
+#define DMAC_INTPEND_TCMPL          (_U_(0x1) << DMAC_INTPEND_TCMPL_Pos)
 #define DMAC_INTPEND_SUSP_Pos       10           /**< \brief (DMAC_INTPEND) Channel Suspend */
-#define DMAC_INTPEND_SUSP           (0x1ul << DMAC_INTPEND_SUSP_Pos)
+#define DMAC_INTPEND_SUSP           (_U_(0x1) << DMAC_INTPEND_SUSP_Pos)
 #define DMAC_INTPEND_FERR_Pos       13           /**< \brief (DMAC_INTPEND) Fetch Error */
-#define DMAC_INTPEND_FERR           (0x1ul << DMAC_INTPEND_FERR_Pos)
+#define DMAC_INTPEND_FERR           (_U_(0x1) << DMAC_INTPEND_FERR_Pos)
 #define DMAC_INTPEND_BUSY_Pos       14           /**< \brief (DMAC_INTPEND) Busy */
-#define DMAC_INTPEND_BUSY           (0x1ul << DMAC_INTPEND_BUSY_Pos)
+#define DMAC_INTPEND_BUSY           (_U_(0x1) << DMAC_INTPEND_BUSY_Pos)
 #define DMAC_INTPEND_PEND_Pos       15           /**< \brief (DMAC_INTPEND) Pending */
-#define DMAC_INTPEND_PEND           (0x1ul << DMAC_INTPEND_PEND_Pos)
-#define DMAC_INTPEND_MASK           0xE70Ful     /**< \brief (DMAC_INTPEND) MASK Register */
+#define DMAC_INTPEND_PEND           (_U_(0x1) << DMAC_INTPEND_PEND_Pos)
+#define DMAC_INTPEND_MASK           _U_(0xE70F)   /**< \brief (DMAC_INTPEND) MASK Register */
 
 /* -------- DMAC_INTSTATUS : (DMAC Offset: 0x24) (R/  32) Interrupt Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -435,7 +420,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_INTSTATUS_OFFSET       0x24         /**< \brief (DMAC_INTSTATUS offset) Interrupt Status */
-#define DMAC_INTSTATUS_RESETVALUE   0x00000000ul /**< \brief (DMAC_INTSTATUS reset_value) Interrupt Status */
+#define DMAC_INTSTATUS_RESETVALUE   _U_(0x00000000) /**< \brief (DMAC_INTSTATUS reset_value) Interrupt Status */
 
 #define DMAC_INTSTATUS_CHINT0_Pos   0            /**< \brief (DMAC_INTSTATUS) Channel 0 Pending Interrupt */
 #define DMAC_INTSTATUS_CHINT0       (1 << DMAC_INTSTATUS_CHINT0_Pos)
@@ -462,9 +447,9 @@ typedef union {
 #define DMAC_INTSTATUS_CHINT11_Pos  11           /**< \brief (DMAC_INTSTATUS) Channel 11 Pending Interrupt */
 #define DMAC_INTSTATUS_CHINT11      (1 << DMAC_INTSTATUS_CHINT11_Pos)
 #define DMAC_INTSTATUS_CHINT_Pos    0            /**< \brief (DMAC_INTSTATUS) Channel x Pending Interrupt */
-#define DMAC_INTSTATUS_CHINT_Msk    (0xFFFul << DMAC_INTSTATUS_CHINT_Pos)
+#define DMAC_INTSTATUS_CHINT_Msk    (_U_(0xFFF) << DMAC_INTSTATUS_CHINT_Pos)
 #define DMAC_INTSTATUS_CHINT(value) (DMAC_INTSTATUS_CHINT_Msk & ((value) << DMAC_INTSTATUS_CHINT_Pos))
-#define DMAC_INTSTATUS_MASK         0x00000FFFul /**< \brief (DMAC_INTSTATUS) MASK Register */
+#define DMAC_INTSTATUS_MASK         _U_(0x00000FFF) /**< \brief (DMAC_INTSTATUS) MASK Register */
 
 /* -------- DMAC_BUSYCH : (DMAC Offset: 0x28) (R/  32) Busy Channels -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -493,7 +478,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_BUSYCH_OFFSET          0x28         /**< \brief (DMAC_BUSYCH offset) Busy Channels */
-#define DMAC_BUSYCH_RESETVALUE      0x00000000ul /**< \brief (DMAC_BUSYCH reset_value) Busy Channels */
+#define DMAC_BUSYCH_RESETVALUE      _U_(0x00000000) /**< \brief (DMAC_BUSYCH reset_value) Busy Channels */
 
 #define DMAC_BUSYCH_BUSYCH0_Pos     0            /**< \brief (DMAC_BUSYCH) Busy Channel 0 */
 #define DMAC_BUSYCH_BUSYCH0         (1 << DMAC_BUSYCH_BUSYCH0_Pos)
@@ -520,9 +505,9 @@ typedef union {
 #define DMAC_BUSYCH_BUSYCH11_Pos    11           /**< \brief (DMAC_BUSYCH) Busy Channel 11 */
 #define DMAC_BUSYCH_BUSYCH11        (1 << DMAC_BUSYCH_BUSYCH11_Pos)
 #define DMAC_BUSYCH_BUSYCH_Pos      0            /**< \brief (DMAC_BUSYCH) Busy Channel x */
-#define DMAC_BUSYCH_BUSYCH_Msk      (0xFFFul << DMAC_BUSYCH_BUSYCH_Pos)
+#define DMAC_BUSYCH_BUSYCH_Msk      (_U_(0xFFF) << DMAC_BUSYCH_BUSYCH_Pos)
 #define DMAC_BUSYCH_BUSYCH(value)   (DMAC_BUSYCH_BUSYCH_Msk & ((value) << DMAC_BUSYCH_BUSYCH_Pos))
-#define DMAC_BUSYCH_MASK            0x00000FFFul /**< \brief (DMAC_BUSYCH) MASK Register */
+#define DMAC_BUSYCH_MASK            _U_(0x00000FFF) /**< \brief (DMAC_BUSYCH) MASK Register */
 
 /* -------- DMAC_PENDCH : (DMAC Offset: 0x2C) (R/  32) Pending Channels -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -551,7 +536,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_PENDCH_OFFSET          0x2C         /**< \brief (DMAC_PENDCH offset) Pending Channels */
-#define DMAC_PENDCH_RESETVALUE      0x00000000ul /**< \brief (DMAC_PENDCH reset_value) Pending Channels */
+#define DMAC_PENDCH_RESETVALUE      _U_(0x00000000) /**< \brief (DMAC_PENDCH reset_value) Pending Channels */
 
 #define DMAC_PENDCH_PENDCH0_Pos     0            /**< \brief (DMAC_PENDCH) Pending Channel 0 */
 #define DMAC_PENDCH_PENDCH0         (1 << DMAC_PENDCH_PENDCH0_Pos)
@@ -578,9 +563,9 @@ typedef union {
 #define DMAC_PENDCH_PENDCH11_Pos    11           /**< \brief (DMAC_PENDCH) Pending Channel 11 */
 #define DMAC_PENDCH_PENDCH11        (1 << DMAC_PENDCH_PENDCH11_Pos)
 #define DMAC_PENDCH_PENDCH_Pos      0            /**< \brief (DMAC_PENDCH) Pending Channel x */
-#define DMAC_PENDCH_PENDCH_Msk      (0xFFFul << DMAC_PENDCH_PENDCH_Pos)
+#define DMAC_PENDCH_PENDCH_Msk      (_U_(0xFFF) << DMAC_PENDCH_PENDCH_Pos)
 #define DMAC_PENDCH_PENDCH(value)   (DMAC_PENDCH_PENDCH_Msk & ((value) << DMAC_PENDCH_PENDCH_Pos))
-#define DMAC_PENDCH_MASK            0x00000FFFul /**< \brief (DMAC_PENDCH) MASK Register */
+#define DMAC_PENDCH_MASK            _U_(0x00000FFF) /**< \brief (DMAC_PENDCH) MASK Register */
 
 /* -------- DMAC_ACTIVE : (DMAC Offset: 0x30) (R/  32) Active Channel and Levels -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -605,7 +590,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_ACTIVE_OFFSET          0x30         /**< \brief (DMAC_ACTIVE offset) Active Channel and Levels */
-#define DMAC_ACTIVE_RESETVALUE      0x00000000ul /**< \brief (DMAC_ACTIVE reset_value) Active Channel and Levels */
+#define DMAC_ACTIVE_RESETVALUE      _U_(0x00000000) /**< \brief (DMAC_ACTIVE reset_value) Active Channel and Levels */
 
 #define DMAC_ACTIVE_LVLEX0_Pos      0            /**< \brief (DMAC_ACTIVE) Level 0 Channel Trigger Request Executing */
 #define DMAC_ACTIVE_LVLEX0          (1 << DMAC_ACTIVE_LVLEX0_Pos)
@@ -616,17 +601,17 @@ typedef union {
 #define DMAC_ACTIVE_LVLEX3_Pos      3            /**< \brief (DMAC_ACTIVE) Level 3 Channel Trigger Request Executing */
 #define DMAC_ACTIVE_LVLEX3          (1 << DMAC_ACTIVE_LVLEX3_Pos)
 #define DMAC_ACTIVE_LVLEX_Pos       0            /**< \brief (DMAC_ACTIVE) Level x Channel Trigger Request Executing */
-#define DMAC_ACTIVE_LVLEX_Msk       (0xFul << DMAC_ACTIVE_LVLEX_Pos)
+#define DMAC_ACTIVE_LVLEX_Msk       (_U_(0xF) << DMAC_ACTIVE_LVLEX_Pos)
 #define DMAC_ACTIVE_LVLEX(value)    (DMAC_ACTIVE_LVLEX_Msk & ((value) << DMAC_ACTIVE_LVLEX_Pos))
 #define DMAC_ACTIVE_ID_Pos          8            /**< \brief (DMAC_ACTIVE) Active Channel ID */
-#define DMAC_ACTIVE_ID_Msk          (0x1Ful << DMAC_ACTIVE_ID_Pos)
+#define DMAC_ACTIVE_ID_Msk          (_U_(0x1F) << DMAC_ACTIVE_ID_Pos)
 #define DMAC_ACTIVE_ID(value)       (DMAC_ACTIVE_ID_Msk & ((value) << DMAC_ACTIVE_ID_Pos))
 #define DMAC_ACTIVE_ABUSY_Pos       15           /**< \brief (DMAC_ACTIVE) Active Channel Busy */
-#define DMAC_ACTIVE_ABUSY           (0x1ul << DMAC_ACTIVE_ABUSY_Pos)
+#define DMAC_ACTIVE_ABUSY           (_U_(0x1) << DMAC_ACTIVE_ABUSY_Pos)
 #define DMAC_ACTIVE_BTCNT_Pos       16           /**< \brief (DMAC_ACTIVE) Active Channel Block Transfer Count */
-#define DMAC_ACTIVE_BTCNT_Msk       (0xFFFFul << DMAC_ACTIVE_BTCNT_Pos)
+#define DMAC_ACTIVE_BTCNT_Msk       (_U_(0xFFFF) << DMAC_ACTIVE_BTCNT_Pos)
 #define DMAC_ACTIVE_BTCNT(value)    (DMAC_ACTIVE_BTCNT_Msk & ((value) << DMAC_ACTIVE_BTCNT_Pos))
-#define DMAC_ACTIVE_MASK            0xFFFF9F0Ful /**< \brief (DMAC_ACTIVE) MASK Register */
+#define DMAC_ACTIVE_MASK            _U_(0xFFFF9F0F) /**< \brief (DMAC_ACTIVE) MASK Register */
 
 /* -------- DMAC_BASEADDR : (DMAC Offset: 0x34) (R/W 32) Descriptor Memory Section Base Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -639,12 +624,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_BASEADDR_OFFSET        0x34         /**< \brief (DMAC_BASEADDR offset) Descriptor Memory Section Base Address */
-#define DMAC_BASEADDR_RESETVALUE    0x00000000ul /**< \brief (DMAC_BASEADDR reset_value) Descriptor Memory Section Base Address */
+#define DMAC_BASEADDR_RESETVALUE    _U_(0x00000000) /**< \brief (DMAC_BASEADDR reset_value) Descriptor Memory Section Base Address */
 
 #define DMAC_BASEADDR_BASEADDR_Pos  0            /**< \brief (DMAC_BASEADDR) Descriptor Memory Base Address */
-#define DMAC_BASEADDR_BASEADDR_Msk  (0xFFFFFFFFul << DMAC_BASEADDR_BASEADDR_Pos)
+#define DMAC_BASEADDR_BASEADDR_Msk  (_U_(0xFFFFFFFF) << DMAC_BASEADDR_BASEADDR_Pos)
 #define DMAC_BASEADDR_BASEADDR(value) (DMAC_BASEADDR_BASEADDR_Msk & ((value) << DMAC_BASEADDR_BASEADDR_Pos))
-#define DMAC_BASEADDR_MASK          0xFFFFFFFFul /**< \brief (DMAC_BASEADDR) MASK Register */
+#define DMAC_BASEADDR_MASK          _U_(0xFFFFFFFF) /**< \brief (DMAC_BASEADDR) MASK Register */
 
 /* -------- DMAC_WRBADDR : (DMAC Offset: 0x38) (R/W 32) Write-Back Memory Section Base Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -657,12 +642,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_WRBADDR_OFFSET         0x38         /**< \brief (DMAC_WRBADDR offset) Write-Back Memory Section Base Address */
-#define DMAC_WRBADDR_RESETVALUE     0x00000000ul /**< \brief (DMAC_WRBADDR reset_value) Write-Back Memory Section Base Address */
+#define DMAC_WRBADDR_RESETVALUE     _U_(0x00000000) /**< \brief (DMAC_WRBADDR reset_value) Write-Back Memory Section Base Address */
 
 #define DMAC_WRBADDR_WRBADDR_Pos    0            /**< \brief (DMAC_WRBADDR) Write-Back Memory Base Address */
-#define DMAC_WRBADDR_WRBADDR_Msk    (0xFFFFFFFFul << DMAC_WRBADDR_WRBADDR_Pos)
+#define DMAC_WRBADDR_WRBADDR_Msk    (_U_(0xFFFFFFFF) << DMAC_WRBADDR_WRBADDR_Pos)
 #define DMAC_WRBADDR_WRBADDR(value) (DMAC_WRBADDR_WRBADDR_Msk & ((value) << DMAC_WRBADDR_WRBADDR_Pos))
-#define DMAC_WRBADDR_MASK           0xFFFFFFFFul /**< \brief (DMAC_WRBADDR) MASK Register */
+#define DMAC_WRBADDR_MASK           _U_(0xFFFFFFFF) /**< \brief (DMAC_WRBADDR) MASK Register */
 
 /* -------- DMAC_CHID : (DMAC Offset: 0x3F) (R/W  8) Channel ID -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -676,12 +661,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CHID_OFFSET            0x3F         /**< \brief (DMAC_CHID offset) Channel ID */
-#define DMAC_CHID_RESETVALUE        0x00ul       /**< \brief (DMAC_CHID reset_value) Channel ID */
+#define DMAC_CHID_RESETVALUE        _U_(0x00)     /**< \brief (DMAC_CHID reset_value) Channel ID */
 
 #define DMAC_CHID_ID_Pos            0            /**< \brief (DMAC_CHID) Channel ID */
-#define DMAC_CHID_ID_Msk            (0xFul << DMAC_CHID_ID_Pos)
+#define DMAC_CHID_ID_Msk            (_U_(0xF) << DMAC_CHID_ID_Pos)
 #define DMAC_CHID_ID(value)         (DMAC_CHID_ID_Msk & ((value) << DMAC_CHID_ID_Pos))
-#define DMAC_CHID_MASK              0x0Ful       /**< \brief (DMAC_CHID) MASK Register */
+#define DMAC_CHID_MASK              _U_(0x0F)     /**< \brief (DMAC_CHID) MASK Register */
 
 /* -------- DMAC_CHCTRLA : (DMAC Offset: 0x40) (R/W  8) Channel Control A -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -696,13 +681,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CHCTRLA_OFFSET         0x40         /**< \brief (DMAC_CHCTRLA offset) Channel Control A */
-#define DMAC_CHCTRLA_RESETVALUE     0x00ul       /**< \brief (DMAC_CHCTRLA reset_value) Channel Control A */
+#define DMAC_CHCTRLA_RESETVALUE     _U_(0x00)     /**< \brief (DMAC_CHCTRLA reset_value) Channel Control A */
 
 #define DMAC_CHCTRLA_SWRST_Pos      0            /**< \brief (DMAC_CHCTRLA) Channel Software Reset */
-#define DMAC_CHCTRLA_SWRST          (0x1ul << DMAC_CHCTRLA_SWRST_Pos)
+#define DMAC_CHCTRLA_SWRST          (_U_(0x1) << DMAC_CHCTRLA_SWRST_Pos)
 #define DMAC_CHCTRLA_ENABLE_Pos     1            /**< \brief (DMAC_CHCTRLA) Channel Enable */
-#define DMAC_CHCTRLA_ENABLE         (0x1ul << DMAC_CHCTRLA_ENABLE_Pos)
-#define DMAC_CHCTRLA_MASK           0x03ul       /**< \brief (DMAC_CHCTRLA) MASK Register */
+#define DMAC_CHCTRLA_ENABLE         (_U_(0x1) << DMAC_CHCTRLA_ENABLE_Pos)
+#define DMAC_CHCTRLA_MASK           _U_(0x03)     /**< \brief (DMAC_CHCTRLA) MASK Register */
 
 /* -------- DMAC_CHCTRLB : (DMAC Offset: 0x44) (R/W 32) Channel Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -724,18 +709,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CHCTRLB_OFFSET         0x44         /**< \brief (DMAC_CHCTRLB offset) Channel Control B */
-#define DMAC_CHCTRLB_RESETVALUE     0x00000000ul /**< \brief (DMAC_CHCTRLB reset_value) Channel Control B */
+#define DMAC_CHCTRLB_RESETVALUE     _U_(0x00000000) /**< \brief (DMAC_CHCTRLB reset_value) Channel Control B */
 
 #define DMAC_CHCTRLB_EVACT_Pos      0            /**< \brief (DMAC_CHCTRLB) Event Input Action */
-#define DMAC_CHCTRLB_EVACT_Msk      (0x7ul << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVACT_Msk      (_U_(0x7) << DMAC_CHCTRLB_EVACT_Pos)
 #define DMAC_CHCTRLB_EVACT(value)   (DMAC_CHCTRLB_EVACT_Msk & ((value) << DMAC_CHCTRLB_EVACT_Pos))
-#define   DMAC_CHCTRLB_EVACT_NOACT_Val    0x0ul  /**< \brief (DMAC_CHCTRLB) No action */
-#define   DMAC_CHCTRLB_EVACT_TRIG_Val     0x1ul  /**< \brief (DMAC_CHCTRLB) Transfer and periodic transfer trigger */
-#define   DMAC_CHCTRLB_EVACT_CTRIG_Val    0x2ul  /**< \brief (DMAC_CHCTRLB) Conditional transfer trigger */
-#define   DMAC_CHCTRLB_EVACT_CBLOCK_Val   0x3ul  /**< \brief (DMAC_CHCTRLB) Conditional block transfer */
-#define   DMAC_CHCTRLB_EVACT_SUSPEND_Val  0x4ul  /**< \brief (DMAC_CHCTRLB) Channel suspend operation */
-#define   DMAC_CHCTRLB_EVACT_RESUME_Val   0x5ul  /**< \brief (DMAC_CHCTRLB) Channel resume operation */
-#define   DMAC_CHCTRLB_EVACT_SSKIP_Val    0x6ul  /**< \brief (DMAC_CHCTRLB) Skip next block suspend action */
+#define   DMAC_CHCTRLB_EVACT_NOACT_Val    _U_(0x0)   /**< \brief (DMAC_CHCTRLB) No action */
+#define   DMAC_CHCTRLB_EVACT_TRIG_Val     _U_(0x1)   /**< \brief (DMAC_CHCTRLB) Transfer and periodic transfer trigger */
+#define   DMAC_CHCTRLB_EVACT_CTRIG_Val    _U_(0x2)   /**< \brief (DMAC_CHCTRLB) Conditional transfer trigger */
+#define   DMAC_CHCTRLB_EVACT_CBLOCK_Val   _U_(0x3)   /**< \brief (DMAC_CHCTRLB) Conditional block transfer */
+#define   DMAC_CHCTRLB_EVACT_SUSPEND_Val  _U_(0x4)   /**< \brief (DMAC_CHCTRLB) Channel suspend operation */
+#define   DMAC_CHCTRLB_EVACT_RESUME_Val   _U_(0x5)   /**< \brief (DMAC_CHCTRLB) Channel resume operation */
+#define   DMAC_CHCTRLB_EVACT_SSKIP_Val    _U_(0x6)   /**< \brief (DMAC_CHCTRLB) Skip next block suspend action */
 #define DMAC_CHCTRLB_EVACT_NOACT    (DMAC_CHCTRLB_EVACT_NOACT_Val  << DMAC_CHCTRLB_EVACT_Pos)
 #define DMAC_CHCTRLB_EVACT_TRIG     (DMAC_CHCTRLB_EVACT_TRIG_Val   << DMAC_CHCTRLB_EVACT_Pos)
 #define DMAC_CHCTRLB_EVACT_CTRIG    (DMAC_CHCTRLB_EVACT_CTRIG_Val  << DMAC_CHCTRLB_EVACT_Pos)
@@ -744,44 +729,44 @@ typedef union {
 #define DMAC_CHCTRLB_EVACT_RESUME   (DMAC_CHCTRLB_EVACT_RESUME_Val << DMAC_CHCTRLB_EVACT_Pos)
 #define DMAC_CHCTRLB_EVACT_SSKIP    (DMAC_CHCTRLB_EVACT_SSKIP_Val  << DMAC_CHCTRLB_EVACT_Pos)
 #define DMAC_CHCTRLB_EVIE_Pos       3            /**< \brief (DMAC_CHCTRLB) Channel Event Input Enable */
-#define DMAC_CHCTRLB_EVIE           (0x1ul << DMAC_CHCTRLB_EVIE_Pos)
+#define DMAC_CHCTRLB_EVIE           (_U_(0x1) << DMAC_CHCTRLB_EVIE_Pos)
 #define DMAC_CHCTRLB_EVOE_Pos       4            /**< \brief (DMAC_CHCTRLB) Channel Event Output Enable */
-#define DMAC_CHCTRLB_EVOE           (0x1ul << DMAC_CHCTRLB_EVOE_Pos)
+#define DMAC_CHCTRLB_EVOE           (_U_(0x1) << DMAC_CHCTRLB_EVOE_Pos)
 #define DMAC_CHCTRLB_LVL_Pos        5            /**< \brief (DMAC_CHCTRLB) Channel Arbitration Level */
-#define DMAC_CHCTRLB_LVL_Msk        (0x3ul << DMAC_CHCTRLB_LVL_Pos)
+#define DMAC_CHCTRLB_LVL_Msk        (_U_(0x3) << DMAC_CHCTRLB_LVL_Pos)
 #define DMAC_CHCTRLB_LVL(value)     (DMAC_CHCTRLB_LVL_Msk & ((value) << DMAC_CHCTRLB_LVL_Pos))
-#define   DMAC_CHCTRLB_LVL_LVL0_Val       0x0ul  /**< \brief (DMAC_CHCTRLB) Channel Priority Level 0 */
-#define   DMAC_CHCTRLB_LVL_LVL1_Val       0x1ul  /**< \brief (DMAC_CHCTRLB) Channel Priority Level 1 */
-#define   DMAC_CHCTRLB_LVL_LVL2_Val       0x2ul  /**< \brief (DMAC_CHCTRLB) Channel Priority Level 2 */
-#define   DMAC_CHCTRLB_LVL_LVL3_Val       0x3ul  /**< \brief (DMAC_CHCTRLB) Channel Priority Level 3 */
+#define   DMAC_CHCTRLB_LVL_LVL0_Val       _U_(0x0)   /**< \brief (DMAC_CHCTRLB) Channel Priority Level 0 */
+#define   DMAC_CHCTRLB_LVL_LVL1_Val       _U_(0x1)   /**< \brief (DMAC_CHCTRLB) Channel Priority Level 1 */
+#define   DMAC_CHCTRLB_LVL_LVL2_Val       _U_(0x2)   /**< \brief (DMAC_CHCTRLB) Channel Priority Level 2 */
+#define   DMAC_CHCTRLB_LVL_LVL3_Val       _U_(0x3)   /**< \brief (DMAC_CHCTRLB) Channel Priority Level 3 */
 #define DMAC_CHCTRLB_LVL_LVL0       (DMAC_CHCTRLB_LVL_LVL0_Val     << DMAC_CHCTRLB_LVL_Pos)
 #define DMAC_CHCTRLB_LVL_LVL1       (DMAC_CHCTRLB_LVL_LVL1_Val     << DMAC_CHCTRLB_LVL_Pos)
 #define DMAC_CHCTRLB_LVL_LVL2       (DMAC_CHCTRLB_LVL_LVL2_Val     << DMAC_CHCTRLB_LVL_Pos)
 #define DMAC_CHCTRLB_LVL_LVL3       (DMAC_CHCTRLB_LVL_LVL3_Val     << DMAC_CHCTRLB_LVL_Pos)
 #define DMAC_CHCTRLB_TRIGSRC_Pos    8            /**< \brief (DMAC_CHCTRLB) Trigger Source */
-#define DMAC_CHCTRLB_TRIGSRC_Msk    (0x3Ful << DMAC_CHCTRLB_TRIGSRC_Pos)
+#define DMAC_CHCTRLB_TRIGSRC_Msk    (_U_(0x3F) << DMAC_CHCTRLB_TRIGSRC_Pos)
 #define DMAC_CHCTRLB_TRIGSRC(value) (DMAC_CHCTRLB_TRIGSRC_Msk & ((value) << DMAC_CHCTRLB_TRIGSRC_Pos))
-#define   DMAC_CHCTRLB_TRIGSRC_DISABLE_Val 0x0ul  /**< \brief (DMAC_CHCTRLB) Only software/event triggers */
+#define   DMAC_CHCTRLB_TRIGSRC_DISABLE_Val _U_(0x0)   /**< \brief (DMAC_CHCTRLB) Only software/event triggers */
 #define DMAC_CHCTRLB_TRIGSRC_DISABLE (DMAC_CHCTRLB_TRIGSRC_DISABLE_Val << DMAC_CHCTRLB_TRIGSRC_Pos)
 #define DMAC_CHCTRLB_TRIGACT_Pos    22           /**< \brief (DMAC_CHCTRLB) Trigger Action */
-#define DMAC_CHCTRLB_TRIGACT_Msk    (0x3ul << DMAC_CHCTRLB_TRIGACT_Pos)
+#define DMAC_CHCTRLB_TRIGACT_Msk    (_U_(0x3) << DMAC_CHCTRLB_TRIGACT_Pos)
 #define DMAC_CHCTRLB_TRIGACT(value) (DMAC_CHCTRLB_TRIGACT_Msk & ((value) << DMAC_CHCTRLB_TRIGACT_Pos))
-#define   DMAC_CHCTRLB_TRIGACT_BLOCK_Val  0x0ul  /**< \brief (DMAC_CHCTRLB) One trigger required for each block transfer */
-#define   DMAC_CHCTRLB_TRIGACT_BEAT_Val   0x2ul  /**< \brief (DMAC_CHCTRLB) One trigger required for each beat transfer */
-#define   DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val 0x3ul  /**< \brief (DMAC_CHCTRLB) One trigger required for each transaction */
+#define   DMAC_CHCTRLB_TRIGACT_BLOCK_Val  _U_(0x0)   /**< \brief (DMAC_CHCTRLB) One trigger required for each block transfer */
+#define   DMAC_CHCTRLB_TRIGACT_BEAT_Val   _U_(0x2)   /**< \brief (DMAC_CHCTRLB) One trigger required for each beat transfer */
+#define   DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val _U_(0x3)   /**< \brief (DMAC_CHCTRLB) One trigger required for each transaction */
 #define DMAC_CHCTRLB_TRIGACT_BLOCK  (DMAC_CHCTRLB_TRIGACT_BLOCK_Val << DMAC_CHCTRLB_TRIGACT_Pos)
 #define DMAC_CHCTRLB_TRIGACT_BEAT   (DMAC_CHCTRLB_TRIGACT_BEAT_Val << DMAC_CHCTRLB_TRIGACT_Pos)
 #define DMAC_CHCTRLB_TRIGACT_TRANSACTION (DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val << DMAC_CHCTRLB_TRIGACT_Pos)
 #define DMAC_CHCTRLB_CMD_Pos        24           /**< \brief (DMAC_CHCTRLB) Software Command */
-#define DMAC_CHCTRLB_CMD_Msk        (0x3ul << DMAC_CHCTRLB_CMD_Pos)
+#define DMAC_CHCTRLB_CMD_Msk        (_U_(0x3) << DMAC_CHCTRLB_CMD_Pos)
 #define DMAC_CHCTRLB_CMD(value)     (DMAC_CHCTRLB_CMD_Msk & ((value) << DMAC_CHCTRLB_CMD_Pos))
-#define   DMAC_CHCTRLB_CMD_NOACT_Val      0x0ul  /**< \brief (DMAC_CHCTRLB) No action */
-#define   DMAC_CHCTRLB_CMD_SUSPEND_Val    0x1ul  /**< \brief (DMAC_CHCTRLB) Channel suspend operation */
-#define   DMAC_CHCTRLB_CMD_RESUME_Val     0x2ul  /**< \brief (DMAC_CHCTRLB) Channel resume operation */
+#define   DMAC_CHCTRLB_CMD_NOACT_Val      _U_(0x0)   /**< \brief (DMAC_CHCTRLB) No action */
+#define   DMAC_CHCTRLB_CMD_SUSPEND_Val    _U_(0x1)   /**< \brief (DMAC_CHCTRLB) Channel suspend operation */
+#define   DMAC_CHCTRLB_CMD_RESUME_Val     _U_(0x2)   /**< \brief (DMAC_CHCTRLB) Channel resume operation */
 #define DMAC_CHCTRLB_CMD_NOACT      (DMAC_CHCTRLB_CMD_NOACT_Val    << DMAC_CHCTRLB_CMD_Pos)
 #define DMAC_CHCTRLB_CMD_SUSPEND    (DMAC_CHCTRLB_CMD_SUSPEND_Val  << DMAC_CHCTRLB_CMD_Pos)
 #define DMAC_CHCTRLB_CMD_RESUME     (DMAC_CHCTRLB_CMD_RESUME_Val   << DMAC_CHCTRLB_CMD_Pos)
-#define DMAC_CHCTRLB_MASK           0x03C03F7Ful /**< \brief (DMAC_CHCTRLB) MASK Register */
+#define DMAC_CHCTRLB_MASK           _U_(0x03C03F7F) /**< \brief (DMAC_CHCTRLB) MASK Register */
 
 /* -------- DMAC_CHINTENCLR : (DMAC Offset: 0x4C) (R/W  8) Channel Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -797,15 +782,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CHINTENCLR_OFFSET      0x4C         /**< \brief (DMAC_CHINTENCLR offset) Channel Interrupt Enable Clear */
-#define DMAC_CHINTENCLR_RESETVALUE  0x00ul       /**< \brief (DMAC_CHINTENCLR reset_value) Channel Interrupt Enable Clear */
+#define DMAC_CHINTENCLR_RESETVALUE  _U_(0x00)     /**< \brief (DMAC_CHINTENCLR reset_value) Channel Interrupt Enable Clear */
 
 #define DMAC_CHINTENCLR_TERR_Pos    0            /**< \brief (DMAC_CHINTENCLR) Channel Transfer Error Interrupt Enable */
-#define DMAC_CHINTENCLR_TERR        (0x1ul << DMAC_CHINTENCLR_TERR_Pos)
+#define DMAC_CHINTENCLR_TERR        (_U_(0x1) << DMAC_CHINTENCLR_TERR_Pos)
 #define DMAC_CHINTENCLR_TCMPL_Pos   1            /**< \brief (DMAC_CHINTENCLR) Channel Transfer Complete Interrupt Enable */
-#define DMAC_CHINTENCLR_TCMPL       (0x1ul << DMAC_CHINTENCLR_TCMPL_Pos)
+#define DMAC_CHINTENCLR_TCMPL       (_U_(0x1) << DMAC_CHINTENCLR_TCMPL_Pos)
 #define DMAC_CHINTENCLR_SUSP_Pos    2            /**< \brief (DMAC_CHINTENCLR) Channel Suspend Interrupt Enable */
-#define DMAC_CHINTENCLR_SUSP        (0x1ul << DMAC_CHINTENCLR_SUSP_Pos)
-#define DMAC_CHINTENCLR_MASK        0x07ul       /**< \brief (DMAC_CHINTENCLR) MASK Register */
+#define DMAC_CHINTENCLR_SUSP        (_U_(0x1) << DMAC_CHINTENCLR_SUSP_Pos)
+#define DMAC_CHINTENCLR_MASK        _U_(0x07)     /**< \brief (DMAC_CHINTENCLR) MASK Register */
 
 /* -------- DMAC_CHINTENSET : (DMAC Offset: 0x4D) (R/W  8) Channel Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -821,15 +806,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CHINTENSET_OFFSET      0x4D         /**< \brief (DMAC_CHINTENSET offset) Channel Interrupt Enable Set */
-#define DMAC_CHINTENSET_RESETVALUE  0x00ul       /**< \brief (DMAC_CHINTENSET reset_value) Channel Interrupt Enable Set */
+#define DMAC_CHINTENSET_RESETVALUE  _U_(0x00)     /**< \brief (DMAC_CHINTENSET reset_value) Channel Interrupt Enable Set */
 
 #define DMAC_CHINTENSET_TERR_Pos    0            /**< \brief (DMAC_CHINTENSET) Channel Transfer Error Interrupt Enable */
-#define DMAC_CHINTENSET_TERR        (0x1ul << DMAC_CHINTENSET_TERR_Pos)
+#define DMAC_CHINTENSET_TERR        (_U_(0x1) << DMAC_CHINTENSET_TERR_Pos)
 #define DMAC_CHINTENSET_TCMPL_Pos   1            /**< \brief (DMAC_CHINTENSET) Channel Transfer Complete Interrupt Enable */
-#define DMAC_CHINTENSET_TCMPL       (0x1ul << DMAC_CHINTENSET_TCMPL_Pos)
+#define DMAC_CHINTENSET_TCMPL       (_U_(0x1) << DMAC_CHINTENSET_TCMPL_Pos)
 #define DMAC_CHINTENSET_SUSP_Pos    2            /**< \brief (DMAC_CHINTENSET) Channel Suspend Interrupt Enable */
-#define DMAC_CHINTENSET_SUSP        (0x1ul << DMAC_CHINTENSET_SUSP_Pos)
-#define DMAC_CHINTENSET_MASK        0x07ul       /**< \brief (DMAC_CHINTENSET) MASK Register */
+#define DMAC_CHINTENSET_SUSP        (_U_(0x1) << DMAC_CHINTENSET_SUSP_Pos)
+#define DMAC_CHINTENSET_MASK        _U_(0x07)     /**< \brief (DMAC_CHINTENSET) MASK Register */
 
 /* -------- DMAC_CHINTFLAG : (DMAC Offset: 0x4E) (R/W  8) Channel Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -845,15 +830,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CHINTFLAG_OFFSET       0x4E         /**< \brief (DMAC_CHINTFLAG offset) Channel Interrupt Flag Status and Clear */
-#define DMAC_CHINTFLAG_RESETVALUE   0x00ul       /**< \brief (DMAC_CHINTFLAG reset_value) Channel Interrupt Flag Status and Clear */
+#define DMAC_CHINTFLAG_RESETVALUE   _U_(0x00)     /**< \brief (DMAC_CHINTFLAG reset_value) Channel Interrupt Flag Status and Clear */
 
 #define DMAC_CHINTFLAG_TERR_Pos     0            /**< \brief (DMAC_CHINTFLAG) Channel Transfer Error */
-#define DMAC_CHINTFLAG_TERR         (0x1ul << DMAC_CHINTFLAG_TERR_Pos)
+#define DMAC_CHINTFLAG_TERR         (_U_(0x1) << DMAC_CHINTFLAG_TERR_Pos)
 #define DMAC_CHINTFLAG_TCMPL_Pos    1            /**< \brief (DMAC_CHINTFLAG) Channel Transfer Complete */
-#define DMAC_CHINTFLAG_TCMPL        (0x1ul << DMAC_CHINTFLAG_TCMPL_Pos)
+#define DMAC_CHINTFLAG_TCMPL        (_U_(0x1) << DMAC_CHINTFLAG_TCMPL_Pos)
 #define DMAC_CHINTFLAG_SUSP_Pos     2            /**< \brief (DMAC_CHINTFLAG) Channel Suspend */
-#define DMAC_CHINTFLAG_SUSP         (0x1ul << DMAC_CHINTFLAG_SUSP_Pos)
-#define DMAC_CHINTFLAG_MASK         0x07ul       /**< \brief (DMAC_CHINTFLAG) MASK Register */
+#define DMAC_CHINTFLAG_SUSP         (_U_(0x1) << DMAC_CHINTFLAG_SUSP_Pos)
+#define DMAC_CHINTFLAG_MASK         _U_(0x07)     /**< \brief (DMAC_CHINTFLAG) MASK Register */
 
 /* -------- DMAC_CHSTATUS : (DMAC Offset: 0x4F) (R/   8) Channel Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -869,15 +854,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_CHSTATUS_OFFSET        0x4F         /**< \brief (DMAC_CHSTATUS offset) Channel Status */
-#define DMAC_CHSTATUS_RESETVALUE    0x00ul       /**< \brief (DMAC_CHSTATUS reset_value) Channel Status */
+#define DMAC_CHSTATUS_RESETVALUE    _U_(0x00)     /**< \brief (DMAC_CHSTATUS reset_value) Channel Status */
 
 #define DMAC_CHSTATUS_PEND_Pos      0            /**< \brief (DMAC_CHSTATUS) Channel Pending */
-#define DMAC_CHSTATUS_PEND          (0x1ul << DMAC_CHSTATUS_PEND_Pos)
+#define DMAC_CHSTATUS_PEND          (_U_(0x1) << DMAC_CHSTATUS_PEND_Pos)
 #define DMAC_CHSTATUS_BUSY_Pos      1            /**< \brief (DMAC_CHSTATUS) Channel Busy */
-#define DMAC_CHSTATUS_BUSY          (0x1ul << DMAC_CHSTATUS_BUSY_Pos)
+#define DMAC_CHSTATUS_BUSY          (_U_(0x1) << DMAC_CHSTATUS_BUSY_Pos)
 #define DMAC_CHSTATUS_FERR_Pos      2            /**< \brief (DMAC_CHSTATUS) Channel Fetch Error */
-#define DMAC_CHSTATUS_FERR          (0x1ul << DMAC_CHSTATUS_FERR_Pos)
-#define DMAC_CHSTATUS_MASK          0x07ul       /**< \brief (DMAC_CHSTATUS) MASK Register */
+#define DMAC_CHSTATUS_FERR          (_U_(0x1) << DMAC_CHSTATUS_FERR_Pos)
+#define DMAC_CHSTATUS_MASK          _U_(0x07)     /**< \brief (DMAC_CHSTATUS) MASK Register */
 
 /* -------- DMAC_BTCTRL : (DMAC Offset: 0x00) (R/W 16) Block Transfer Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -898,60 +883,60 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DMAC_BTCTRL_OFFSET          0x00         /**< \brief (DMAC_BTCTRL offset) Block Transfer Control */
-#define DMAC_BTCTRL_RESETVALUE      0x0000ul     /**< \brief (DMAC_BTCTRL reset_value) Block Transfer Control */
+#define DMAC_BTCTRL_RESETVALUE      _U_(0x0000)   /**< \brief (DMAC_BTCTRL reset_value) Block Transfer Control */
 
 #define DMAC_BTCTRL_VALID_Pos       0            /**< \brief (DMAC_BTCTRL) Descriptor Valid */
-#define DMAC_BTCTRL_VALID           (0x1ul << DMAC_BTCTRL_VALID_Pos)
+#define DMAC_BTCTRL_VALID           (_U_(0x1) << DMAC_BTCTRL_VALID_Pos)
 #define DMAC_BTCTRL_EVOSEL_Pos      1            /**< \brief (DMAC_BTCTRL) Event Output Selection */
-#define DMAC_BTCTRL_EVOSEL_Msk      (0x3ul << DMAC_BTCTRL_EVOSEL_Pos)
+#define DMAC_BTCTRL_EVOSEL_Msk      (_U_(0x3) << DMAC_BTCTRL_EVOSEL_Pos)
 #define DMAC_BTCTRL_EVOSEL(value)   (DMAC_BTCTRL_EVOSEL_Msk & ((value) << DMAC_BTCTRL_EVOSEL_Pos))
-#define   DMAC_BTCTRL_EVOSEL_DISABLE_Val  0x0ul  /**< \brief (DMAC_BTCTRL) Event generation disabled */
-#define   DMAC_BTCTRL_EVOSEL_BLOCK_Val    0x1ul  /**< \brief (DMAC_BTCTRL) Event strobe when block transfer complete */
-#define   DMAC_BTCTRL_EVOSEL_BEAT_Val     0x3ul  /**< \brief (DMAC_BTCTRL) Event strobe when beat transfer complete */
+#define   DMAC_BTCTRL_EVOSEL_DISABLE_Val  _U_(0x0)   /**< \brief (DMAC_BTCTRL) Event generation disabled */
+#define   DMAC_BTCTRL_EVOSEL_BLOCK_Val    _U_(0x1)   /**< \brief (DMAC_BTCTRL) Event strobe when block transfer complete */
+#define   DMAC_BTCTRL_EVOSEL_BEAT_Val     _U_(0x3)   /**< \brief (DMAC_BTCTRL) Event strobe when beat transfer complete */
 #define DMAC_BTCTRL_EVOSEL_DISABLE  (DMAC_BTCTRL_EVOSEL_DISABLE_Val << DMAC_BTCTRL_EVOSEL_Pos)
 #define DMAC_BTCTRL_EVOSEL_BLOCK    (DMAC_BTCTRL_EVOSEL_BLOCK_Val  << DMAC_BTCTRL_EVOSEL_Pos)
 #define DMAC_BTCTRL_EVOSEL_BEAT     (DMAC_BTCTRL_EVOSEL_BEAT_Val   << DMAC_BTCTRL_EVOSEL_Pos)
 #define DMAC_BTCTRL_BLOCKACT_Pos    3            /**< \brief (DMAC_BTCTRL) Block Action */
-#define DMAC_BTCTRL_BLOCKACT_Msk    (0x3ul << DMAC_BTCTRL_BLOCKACT_Pos)
+#define DMAC_BTCTRL_BLOCKACT_Msk    (_U_(0x3) << DMAC_BTCTRL_BLOCKACT_Pos)
 #define DMAC_BTCTRL_BLOCKACT(value) (DMAC_BTCTRL_BLOCKACT_Msk & ((value) << DMAC_BTCTRL_BLOCKACT_Pos))
-#define   DMAC_BTCTRL_BLOCKACT_NOACT_Val  0x0ul  /**< \brief (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction */
-#define   DMAC_BTCTRL_BLOCKACT_INT_Val    0x1ul  /**< \brief (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction and block interrupt */
-#define   DMAC_BTCTRL_BLOCKACT_SUSPEND_Val 0x2ul  /**< \brief (DMAC_BTCTRL) Channel suspend operation is completed */
-#define   DMAC_BTCTRL_BLOCKACT_BOTH_Val   0x3ul  /**< \brief (DMAC_BTCTRL) Both channel suspend operation and block interrupt */
+#define   DMAC_BTCTRL_BLOCKACT_NOACT_Val  _U_(0x0)   /**< \brief (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction */
+#define   DMAC_BTCTRL_BLOCKACT_INT_Val    _U_(0x1)   /**< \brief (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction and block interrupt */
+#define   DMAC_BTCTRL_BLOCKACT_SUSPEND_Val _U_(0x2)   /**< \brief (DMAC_BTCTRL) Channel suspend operation is completed */
+#define   DMAC_BTCTRL_BLOCKACT_BOTH_Val   _U_(0x3)   /**< \brief (DMAC_BTCTRL) Both channel suspend operation and block interrupt */
 #define DMAC_BTCTRL_BLOCKACT_NOACT  (DMAC_BTCTRL_BLOCKACT_NOACT_Val << DMAC_BTCTRL_BLOCKACT_Pos)
 #define DMAC_BTCTRL_BLOCKACT_INT    (DMAC_BTCTRL_BLOCKACT_INT_Val  << DMAC_BTCTRL_BLOCKACT_Pos)
 #define DMAC_BTCTRL_BLOCKACT_SUSPEND (DMAC_BTCTRL_BLOCKACT_SUSPEND_Val << DMAC_BTCTRL_BLOCKACT_Pos)
 #define DMAC_BTCTRL_BLOCKACT_BOTH   (DMAC_BTCTRL_BLOCKACT_BOTH_Val << DMAC_BTCTRL_BLOCKACT_Pos)
 #define DMAC_BTCTRL_BEATSIZE_Pos    8            /**< \brief (DMAC_BTCTRL) Beat Size */
-#define DMAC_BTCTRL_BEATSIZE_Msk    (0x3ul << DMAC_BTCTRL_BEATSIZE_Pos)
+#define DMAC_BTCTRL_BEATSIZE_Msk    (_U_(0x3) << DMAC_BTCTRL_BEATSIZE_Pos)
 #define DMAC_BTCTRL_BEATSIZE(value) (DMAC_BTCTRL_BEATSIZE_Msk & ((value) << DMAC_BTCTRL_BEATSIZE_Pos))
-#define   DMAC_BTCTRL_BEATSIZE_BYTE_Val   0x0ul  /**< \brief (DMAC_BTCTRL) 8-bit bus transfer */
-#define   DMAC_BTCTRL_BEATSIZE_HWORD_Val  0x1ul  /**< \brief (DMAC_BTCTRL) 16-bit bus transfer */
-#define   DMAC_BTCTRL_BEATSIZE_WORD_Val   0x2ul  /**< \brief (DMAC_BTCTRL) 32-bit bus transfer */
+#define   DMAC_BTCTRL_BEATSIZE_BYTE_Val   _U_(0x0)   /**< \brief (DMAC_BTCTRL) 8-bit bus transfer */
+#define   DMAC_BTCTRL_BEATSIZE_HWORD_Val  _U_(0x1)   /**< \brief (DMAC_BTCTRL) 16-bit bus transfer */
+#define   DMAC_BTCTRL_BEATSIZE_WORD_Val   _U_(0x2)   /**< \brief (DMAC_BTCTRL) 32-bit bus transfer */
 #define DMAC_BTCTRL_BEATSIZE_BYTE   (DMAC_BTCTRL_BEATSIZE_BYTE_Val << DMAC_BTCTRL_BEATSIZE_Pos)
 #define DMAC_BTCTRL_BEATSIZE_HWORD  (DMAC_BTCTRL_BEATSIZE_HWORD_Val << DMAC_BTCTRL_BEATSIZE_Pos)
 #define DMAC_BTCTRL_BEATSIZE_WORD   (DMAC_BTCTRL_BEATSIZE_WORD_Val << DMAC_BTCTRL_BEATSIZE_Pos)
 #define DMAC_BTCTRL_SRCINC_Pos      10           /**< \brief (DMAC_BTCTRL) Source Address Increment Enable */
-#define DMAC_BTCTRL_SRCINC          (0x1ul << DMAC_BTCTRL_SRCINC_Pos)
+#define DMAC_BTCTRL_SRCINC          (_U_(0x1) << DMAC_BTCTRL_SRCINC_Pos)
 #define DMAC_BTCTRL_DSTINC_Pos      11           /**< \brief (DMAC_BTCTRL) Destination Address Increment Enable */
-#define DMAC_BTCTRL_DSTINC          (0x1ul << DMAC_BTCTRL_DSTINC_Pos)
+#define DMAC_BTCTRL_DSTINC          (_U_(0x1) << DMAC_BTCTRL_DSTINC_Pos)
 #define DMAC_BTCTRL_STEPSEL_Pos     12           /**< \brief (DMAC_BTCTRL) Step Selection */
-#define DMAC_BTCTRL_STEPSEL         (0x1ul << DMAC_BTCTRL_STEPSEL_Pos)
-#define   DMAC_BTCTRL_STEPSEL_DST_Val     0x0ul  /**< \brief (DMAC_BTCTRL) Step size settings apply to the destination address */
-#define   DMAC_BTCTRL_STEPSEL_SRC_Val     0x1ul  /**< \brief (DMAC_BTCTRL) Step size settings apply to the source address */
+#define DMAC_BTCTRL_STEPSEL         (_U_(0x1) << DMAC_BTCTRL_STEPSEL_Pos)
+#define   DMAC_BTCTRL_STEPSEL_DST_Val     _U_(0x0)   /**< \brief (DMAC_BTCTRL) Step size settings apply to the destination address */
+#define   DMAC_BTCTRL_STEPSEL_SRC_Val     _U_(0x1)   /**< \brief (DMAC_BTCTRL) Step size settings apply to the source address */
 #define DMAC_BTCTRL_STEPSEL_DST     (DMAC_BTCTRL_STEPSEL_DST_Val   << DMAC_BTCTRL_STEPSEL_Pos)
 #define DMAC_BTCTRL_STEPSEL_SRC     (DMAC_BTCTRL_STEPSEL_SRC_Val   << DMAC_BTCTRL_STEPSEL_Pos)
 #define DMAC_BTCTRL_STEPSIZE_Pos    13           /**< \brief (DMAC_BTCTRL) Address Increment Step Size */
-#define DMAC_BTCTRL_STEPSIZE_Msk    (0x7ul << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE_Msk    (_U_(0x7) << DMAC_BTCTRL_STEPSIZE_Pos)
 #define DMAC_BTCTRL_STEPSIZE(value) (DMAC_BTCTRL_STEPSIZE_Msk & ((value) << DMAC_BTCTRL_STEPSIZE_Pos))
-#define   DMAC_BTCTRL_STEPSIZE_X1_Val     0x0ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 1 */
-#define   DMAC_BTCTRL_STEPSIZE_X2_Val     0x1ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 2 */
-#define   DMAC_BTCTRL_STEPSIZE_X4_Val     0x2ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 4 */
-#define   DMAC_BTCTRL_STEPSIZE_X8_Val     0x3ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 8 */
-#define   DMAC_BTCTRL_STEPSIZE_X16_Val    0x4ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 16 */
-#define   DMAC_BTCTRL_STEPSIZE_X32_Val    0x5ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 32 */
-#define   DMAC_BTCTRL_STEPSIZE_X64_Val    0x6ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 64 */
-#define   DMAC_BTCTRL_STEPSIZE_X128_Val   0x7ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 128 */
+#define   DMAC_BTCTRL_STEPSIZE_X1_Val     _U_(0x0)   /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 1 */
+#define   DMAC_BTCTRL_STEPSIZE_X2_Val     _U_(0x1)   /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 2 */
+#define   DMAC_BTCTRL_STEPSIZE_X4_Val     _U_(0x2)   /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 4 */
+#define   DMAC_BTCTRL_STEPSIZE_X8_Val     _U_(0x3)   /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 8 */
+#define   DMAC_BTCTRL_STEPSIZE_X16_Val    _U_(0x4)   /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 16 */
+#define   DMAC_BTCTRL_STEPSIZE_X32_Val    _U_(0x5)   /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 32 */
+#define   DMAC_BTCTRL_STEPSIZE_X64_Val    _U_(0x6)   /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 64 */
+#define   DMAC_BTCTRL_STEPSIZE_X128_Val   _U_(0x7)   /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (1<<BEATSIZE) * 128 */
 #define DMAC_BTCTRL_STEPSIZE_X1     (DMAC_BTCTRL_STEPSIZE_X1_Val   << DMAC_BTCTRL_STEPSIZE_Pos)
 #define DMAC_BTCTRL_STEPSIZE_X2     (DMAC_BTCTRL_STEPSIZE_X2_Val   << DMAC_BTCTRL_STEPSIZE_Pos)
 #define DMAC_BTCTRL_STEPSIZE_X4     (DMAC_BTCTRL_STEPSIZE_X4_Val   << DMAC_BTCTRL_STEPSIZE_Pos)
@@ -960,7 +945,7 @@ typedef union {
 #define DMAC_BTCTRL_STEPSIZE_X32    (DMAC_BTCTRL_STEPSIZE_X32_Val  << DMAC_BTCTRL_STEPSIZE_Pos)
 #define DMAC_BTCTRL_STEPSIZE_X64    (DMAC_BTCTRL_STEPSIZE_X64_Val  << DMAC_BTCTRL_STEPSIZE_Pos)
 #define DMAC_BTCTRL_STEPSIZE_X128   (DMAC_BTCTRL_STEPSIZE_X128_Val << DMAC_BTCTRL_STEPSIZE_Pos)
-#define DMAC_BTCTRL_MASK            0xFF1Ful     /**< \brief (DMAC_BTCTRL) MASK Register */
+#define DMAC_BTCTRL_MASK            _U_(0xFF1F)   /**< \brief (DMAC_BTCTRL) MASK Register */
 
 /* -------- DMAC_BTCNT : (DMAC Offset: 0x02) (R/W 16) Block Transfer Count -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -975,9 +960,9 @@ typedef union {
 #define DMAC_BTCNT_OFFSET           0x02         /**< \brief (DMAC_BTCNT offset) Block Transfer Count */
 
 #define DMAC_BTCNT_BTCNT_Pos        0            /**< \brief (DMAC_BTCNT) Block Transfer Count */
-#define DMAC_BTCNT_BTCNT_Msk        (0xFFFFul << DMAC_BTCNT_BTCNT_Pos)
+#define DMAC_BTCNT_BTCNT_Msk        (_U_(0xFFFF) << DMAC_BTCNT_BTCNT_Pos)
 #define DMAC_BTCNT_BTCNT(value)     (DMAC_BTCNT_BTCNT_Msk & ((value) << DMAC_BTCNT_BTCNT_Pos))
-#define DMAC_BTCNT_MASK             0xFFFFul     /**< \brief (DMAC_BTCNT) MASK Register */
+#define DMAC_BTCNT_MASK             _U_(0xFFFF)   /**< \brief (DMAC_BTCNT) MASK Register */
 
 /* -------- DMAC_SRCADDR : (DMAC Offset: 0x04) (R/W 32) Block Transfer Source Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -992,9 +977,9 @@ typedef union {
 #define DMAC_SRCADDR_OFFSET         0x04         /**< \brief (DMAC_SRCADDR offset) Block Transfer Source Address */
 
 #define DMAC_SRCADDR_SRCADDR_Pos    0            /**< \brief (DMAC_SRCADDR) Transfer Source Address */
-#define DMAC_SRCADDR_SRCADDR_Msk    (0xFFFFFFFFul << DMAC_SRCADDR_SRCADDR_Pos)
+#define DMAC_SRCADDR_SRCADDR_Msk    (_U_(0xFFFFFFFF) << DMAC_SRCADDR_SRCADDR_Pos)
 #define DMAC_SRCADDR_SRCADDR(value) (DMAC_SRCADDR_SRCADDR_Msk & ((value) << DMAC_SRCADDR_SRCADDR_Pos))
-#define DMAC_SRCADDR_MASK           0xFFFFFFFFul /**< \brief (DMAC_SRCADDR) MASK Register */
+#define DMAC_SRCADDR_MASK           _U_(0xFFFFFFFF) /**< \brief (DMAC_SRCADDR) MASK Register */
 
 /* -------- DMAC_DSTADDR : (DMAC Offset: 0x08) (R/W 32) Block Transfer Destination Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1009,9 +994,9 @@ typedef union {
 #define DMAC_DSTADDR_OFFSET         0x08         /**< \brief (DMAC_DSTADDR offset) Block Transfer Destination Address */
 
 #define DMAC_DSTADDR_DSTADDR_Pos    0            /**< \brief (DMAC_DSTADDR) Transfer Destination Address */
-#define DMAC_DSTADDR_DSTADDR_Msk    (0xFFFFFFFFul << DMAC_DSTADDR_DSTADDR_Pos)
+#define DMAC_DSTADDR_DSTADDR_Msk    (_U_(0xFFFFFFFF) << DMAC_DSTADDR_DSTADDR_Pos)
 #define DMAC_DSTADDR_DSTADDR(value) (DMAC_DSTADDR_DSTADDR_Msk & ((value) << DMAC_DSTADDR_DSTADDR_Pos))
-#define DMAC_DSTADDR_MASK           0xFFFFFFFFul /**< \brief (DMAC_DSTADDR) MASK Register */
+#define DMAC_DSTADDR_MASK           _U_(0xFFFFFFFF) /**< \brief (DMAC_DSTADDR) MASK Register */
 
 /* -------- DMAC_DESCADDR : (DMAC Offset: 0x0C) (R/W 32) Next Descriptor Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1026,9 +1011,9 @@ typedef union {
 #define DMAC_DESCADDR_OFFSET        0x0C         /**< \brief (DMAC_DESCADDR offset) Next Descriptor Address */
 
 #define DMAC_DESCADDR_DESCADDR_Pos  0            /**< \brief (DMAC_DESCADDR) Next Descriptor Address */
-#define DMAC_DESCADDR_DESCADDR_Msk  (0xFFFFFFFFul << DMAC_DESCADDR_DESCADDR_Pos)
+#define DMAC_DESCADDR_DESCADDR_Msk  (_U_(0xFFFFFFFF) << DMAC_DESCADDR_DESCADDR_Pos)
 #define DMAC_DESCADDR_DESCADDR(value) (DMAC_DESCADDR_DESCADDR_Msk & ((value) << DMAC_DESCADDR_DESCADDR_Pos))
-#define DMAC_DESCADDR_MASK          0xFFFFFFFFul /**< \brief (DMAC_DESCADDR) MASK Register */
+#define DMAC_DESCADDR_MASK          _U_(0xFFFFFFFF) /**< \brief (DMAC_DESCADDR) MASK Register */
 
 /** \brief DMAC APB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1079,6 +1064,7 @@ typedef struct {
 #endif
 ;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
 #define SECTION_DMAC_DESCRIPTOR
 
 /*@}*/

--- a/cpu/sam0_common/include/vendor/samr21/include/component/dsu.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/dsu.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for DSU
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -69,17 +54,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_CTRL_OFFSET             0x0000       /**< \brief (DSU_CTRL offset) Control */
-#define DSU_CTRL_RESETVALUE         0x00ul       /**< \brief (DSU_CTRL reset_value) Control */
+#define DSU_CTRL_RESETVALUE         _U_(0x00)     /**< \brief (DSU_CTRL reset_value) Control */
 
 #define DSU_CTRL_SWRST_Pos          0            /**< \brief (DSU_CTRL) Software Reset */
-#define DSU_CTRL_SWRST              (0x1ul << DSU_CTRL_SWRST_Pos)
+#define DSU_CTRL_SWRST              (_U_(0x1) << DSU_CTRL_SWRST_Pos)
 #define DSU_CTRL_CRC_Pos            2            /**< \brief (DSU_CTRL) 32-bit Cyclic Redundancy Check */
-#define DSU_CTRL_CRC                (0x1ul << DSU_CTRL_CRC_Pos)
+#define DSU_CTRL_CRC                (_U_(0x1) << DSU_CTRL_CRC_Pos)
 #define DSU_CTRL_MBIST_Pos          3            /**< \brief (DSU_CTRL) Memory Built-In Self-Test */
-#define DSU_CTRL_MBIST              (0x1ul << DSU_CTRL_MBIST_Pos)
+#define DSU_CTRL_MBIST              (_U_(0x1) << DSU_CTRL_MBIST_Pos)
 #define DSU_CTRL_CE_Pos             4            /**< \brief (DSU_CTRL) Chip Erase */
-#define DSU_CTRL_CE                 (0x1ul << DSU_CTRL_CE_Pos)
-#define DSU_CTRL_MASK               0x1Dul       /**< \brief (DSU_CTRL) MASK Register */
+#define DSU_CTRL_CE                 (_U_(0x1) << DSU_CTRL_CE_Pos)
+#define DSU_CTRL_MASK               _U_(0x1D)     /**< \brief (DSU_CTRL) MASK Register */
 
 /* -------- DSU_STATUSA : (DSU Offset: 0x0001) (R/W  8) Status A -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -97,19 +82,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_STATUSA_OFFSET          0x0001       /**< \brief (DSU_STATUSA offset) Status A */
-#define DSU_STATUSA_RESETVALUE      0x00ul       /**< \brief (DSU_STATUSA reset_value) Status A */
+#define DSU_STATUSA_RESETVALUE      _U_(0x00)     /**< \brief (DSU_STATUSA reset_value) Status A */
 
 #define DSU_STATUSA_DONE_Pos        0            /**< \brief (DSU_STATUSA) Done */
-#define DSU_STATUSA_DONE            (0x1ul << DSU_STATUSA_DONE_Pos)
+#define DSU_STATUSA_DONE            (_U_(0x1) << DSU_STATUSA_DONE_Pos)
 #define DSU_STATUSA_CRSTEXT_Pos     1            /**< \brief (DSU_STATUSA) CPU Reset Phase Extension */
-#define DSU_STATUSA_CRSTEXT         (0x1ul << DSU_STATUSA_CRSTEXT_Pos)
+#define DSU_STATUSA_CRSTEXT         (_U_(0x1) << DSU_STATUSA_CRSTEXT_Pos)
 #define DSU_STATUSA_BERR_Pos        2            /**< \brief (DSU_STATUSA) Bus Error */
-#define DSU_STATUSA_BERR            (0x1ul << DSU_STATUSA_BERR_Pos)
+#define DSU_STATUSA_BERR            (_U_(0x1) << DSU_STATUSA_BERR_Pos)
 #define DSU_STATUSA_FAIL_Pos        3            /**< \brief (DSU_STATUSA) Failure */
-#define DSU_STATUSA_FAIL            (0x1ul << DSU_STATUSA_FAIL_Pos)
+#define DSU_STATUSA_FAIL            (_U_(0x1) << DSU_STATUSA_FAIL_Pos)
 #define DSU_STATUSA_PERR_Pos        4            /**< \brief (DSU_STATUSA) Protection Error */
-#define DSU_STATUSA_PERR            (0x1ul << DSU_STATUSA_PERR_Pos)
-#define DSU_STATUSA_MASK            0x1Ful       /**< \brief (DSU_STATUSA) MASK Register */
+#define DSU_STATUSA_PERR            (_U_(0x1) << DSU_STATUSA_PERR_Pos)
+#define DSU_STATUSA_MASK            _U_(0x1F)     /**< \brief (DSU_STATUSA) MASK Register */
 
 /* -------- DSU_STATUSB : (DSU Offset: 0x0002) (R/   8) Status B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -132,22 +117,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_STATUSB_OFFSET          0x0002       /**< \brief (DSU_STATUSB offset) Status B */
-#define DSU_STATUSB_RESETVALUE      0x10ul       /**< \brief (DSU_STATUSB reset_value) Status B */
+#define DSU_STATUSB_RESETVALUE      _U_(0x10)     /**< \brief (DSU_STATUSB reset_value) Status B */
 
 #define DSU_STATUSB_PROT_Pos        0            /**< \brief (DSU_STATUSB) Protected */
-#define DSU_STATUSB_PROT            (0x1ul << DSU_STATUSB_PROT_Pos)
+#define DSU_STATUSB_PROT            (_U_(0x1) << DSU_STATUSB_PROT_Pos)
 #define DSU_STATUSB_DBGPRES_Pos     1            /**< \brief (DSU_STATUSB) Debugger Present */
-#define DSU_STATUSB_DBGPRES         (0x1ul << DSU_STATUSB_DBGPRES_Pos)
+#define DSU_STATUSB_DBGPRES         (_U_(0x1) << DSU_STATUSB_DBGPRES_Pos)
 #define DSU_STATUSB_DCCD0_Pos       2            /**< \brief (DSU_STATUSB) Debug Communication Channel 0 Dirty */
 #define DSU_STATUSB_DCCD0           (1 << DSU_STATUSB_DCCD0_Pos)
 #define DSU_STATUSB_DCCD1_Pos       3            /**< \brief (DSU_STATUSB) Debug Communication Channel 1 Dirty */
 #define DSU_STATUSB_DCCD1           (1 << DSU_STATUSB_DCCD1_Pos)
 #define DSU_STATUSB_DCCD_Pos        2            /**< \brief (DSU_STATUSB) Debug Communication Channel x Dirty */
-#define DSU_STATUSB_DCCD_Msk        (0x3ul << DSU_STATUSB_DCCD_Pos)
+#define DSU_STATUSB_DCCD_Msk        (_U_(0x3) << DSU_STATUSB_DCCD_Pos)
 #define DSU_STATUSB_DCCD(value)     (DSU_STATUSB_DCCD_Msk & ((value) << DSU_STATUSB_DCCD_Pos))
 #define DSU_STATUSB_HPE_Pos         4            /**< \brief (DSU_STATUSB) Hot-Plugging Enable */
-#define DSU_STATUSB_HPE             (0x1ul << DSU_STATUSB_HPE_Pos)
-#define DSU_STATUSB_MASK            0x1Ful       /**< \brief (DSU_STATUSB) MASK Register */
+#define DSU_STATUSB_HPE             (_U_(0x1) << DSU_STATUSB_HPE_Pos)
+#define DSU_STATUSB_MASK            _U_(0x1F)     /**< \brief (DSU_STATUSB) MASK Register */
 
 /* -------- DSU_ADDR : (DSU Offset: 0x0004) (R/W 32) Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -161,12 +146,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_ADDR_OFFSET             0x0004       /**< \brief (DSU_ADDR offset) Address */
-#define DSU_ADDR_RESETVALUE         0x00000000ul /**< \brief (DSU_ADDR reset_value) Address */
+#define DSU_ADDR_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_ADDR reset_value) Address */
 
 #define DSU_ADDR_ADDR_Pos           2            /**< \brief (DSU_ADDR) Address */
-#define DSU_ADDR_ADDR_Msk           (0x3FFFFFFFul << DSU_ADDR_ADDR_Pos)
+#define DSU_ADDR_ADDR_Msk           (_U_(0x3FFFFFFF) << DSU_ADDR_ADDR_Pos)
 #define DSU_ADDR_ADDR(value)        (DSU_ADDR_ADDR_Msk & ((value) << DSU_ADDR_ADDR_Pos))
-#define DSU_ADDR_MASK               0xFFFFFFFCul /**< \brief (DSU_ADDR) MASK Register */
+#define DSU_ADDR_MASK               _U_(0xFFFFFFFC) /**< \brief (DSU_ADDR) MASK Register */
 
 /* -------- DSU_LENGTH : (DSU Offset: 0x0008) (R/W 32) Length -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -180,12 +165,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_LENGTH_OFFSET           0x0008       /**< \brief (DSU_LENGTH offset) Length */
-#define DSU_LENGTH_RESETVALUE       0x00000000ul /**< \brief (DSU_LENGTH reset_value) Length */
+#define DSU_LENGTH_RESETVALUE       _U_(0x00000000) /**< \brief (DSU_LENGTH reset_value) Length */
 
 #define DSU_LENGTH_LENGTH_Pos       2            /**< \brief (DSU_LENGTH) Length */
-#define DSU_LENGTH_LENGTH_Msk       (0x3FFFFFFFul << DSU_LENGTH_LENGTH_Pos)
+#define DSU_LENGTH_LENGTH_Msk       (_U_(0x3FFFFFFF) << DSU_LENGTH_LENGTH_Pos)
 #define DSU_LENGTH_LENGTH(value)    (DSU_LENGTH_LENGTH_Msk & ((value) << DSU_LENGTH_LENGTH_Pos))
-#define DSU_LENGTH_MASK             0xFFFFFFFCul /**< \brief (DSU_LENGTH) MASK Register */
+#define DSU_LENGTH_MASK             _U_(0xFFFFFFFC) /**< \brief (DSU_LENGTH) MASK Register */
 
 /* -------- DSU_DATA : (DSU Offset: 0x000C) (R/W 32) Data -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -198,12 +183,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_DATA_OFFSET             0x000C       /**< \brief (DSU_DATA offset) Data */
-#define DSU_DATA_RESETVALUE         0x00000000ul /**< \brief (DSU_DATA reset_value) Data */
+#define DSU_DATA_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_DATA reset_value) Data */
 
 #define DSU_DATA_DATA_Pos           0            /**< \brief (DSU_DATA) Data */
-#define DSU_DATA_DATA_Msk           (0xFFFFFFFFul << DSU_DATA_DATA_Pos)
+#define DSU_DATA_DATA_Msk           (_U_(0xFFFFFFFF) << DSU_DATA_DATA_Pos)
 #define DSU_DATA_DATA(value)        (DSU_DATA_DATA_Msk & ((value) << DSU_DATA_DATA_Pos))
-#define DSU_DATA_MASK               0xFFFFFFFFul /**< \brief (DSU_DATA) MASK Register */
+#define DSU_DATA_MASK               _U_(0xFFFFFFFF) /**< \brief (DSU_DATA) MASK Register */
 
 /* -------- DSU_DCC : (DSU Offset: 0x0010) (R/W 32) Debug Communication Channel n -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -216,12 +201,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_DCC_OFFSET              0x0010       /**< \brief (DSU_DCC offset) Debug Communication Channel n */
-#define DSU_DCC_RESETVALUE          0x00000000ul /**< \brief (DSU_DCC reset_value) Debug Communication Channel n */
+#define DSU_DCC_RESETVALUE          _U_(0x00000000) /**< \brief (DSU_DCC reset_value) Debug Communication Channel n */
 
 #define DSU_DCC_DATA_Pos            0            /**< \brief (DSU_DCC) Data */
-#define DSU_DCC_DATA_Msk            (0xFFFFFFFFul << DSU_DCC_DATA_Pos)
+#define DSU_DCC_DATA_Msk            (_U_(0xFFFFFFFF) << DSU_DCC_DATA_Pos)
 #define DSU_DCC_DATA(value)         (DSU_DCC_DATA_Msk & ((value) << DSU_DCC_DATA_Pos))
-#define DSU_DCC_MASK                0xFFFFFFFFul /**< \brief (DSU_DCC) MASK Register */
+#define DSU_DCC_MASK                _U_(0xFFFFFFFF) /**< \brief (DSU_DCC) MASK Register */
 
 /* -------- DSU_DID : (DSU Offset: 0x0018) (R/  32) Device Identification -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -242,24 +227,24 @@ typedef union {
 #define DSU_DID_OFFSET              0x0018       /**< \brief (DSU_DID offset) Device Identification */
 
 #define DSU_DID_DEVSEL_Pos          0            /**< \brief (DSU_DID) Device Select */
-#define DSU_DID_DEVSEL_Msk          (0xFFul << DSU_DID_DEVSEL_Pos)
+#define DSU_DID_DEVSEL_Msk          (_U_(0xFF) << DSU_DID_DEVSEL_Pos)
 #define DSU_DID_DEVSEL(value)       (DSU_DID_DEVSEL_Msk & ((value) << DSU_DID_DEVSEL_Pos))
 #define DSU_DID_REVISION_Pos        8            /**< \brief (DSU_DID) Revision */
-#define DSU_DID_REVISION_Msk        (0xFul << DSU_DID_REVISION_Pos)
+#define DSU_DID_REVISION_Msk        (_U_(0xF) << DSU_DID_REVISION_Pos)
 #define DSU_DID_REVISION(value)     (DSU_DID_REVISION_Msk & ((value) << DSU_DID_REVISION_Pos))
 #define DSU_DID_DIE_Pos             12           /**< \brief (DSU_DID) Die Identification */
-#define DSU_DID_DIE_Msk             (0xFul << DSU_DID_DIE_Pos)
+#define DSU_DID_DIE_Msk             (_U_(0xF) << DSU_DID_DIE_Pos)
 #define DSU_DID_DIE(value)          (DSU_DID_DIE_Msk & ((value) << DSU_DID_DIE_Pos))
 #define DSU_DID_SERIES_Pos          16           /**< \brief (DSU_DID) Product Series */
-#define DSU_DID_SERIES_Msk          (0x3Ful << DSU_DID_SERIES_Pos)
+#define DSU_DID_SERIES_Msk          (_U_(0x3F) << DSU_DID_SERIES_Pos)
 #define DSU_DID_SERIES(value)       (DSU_DID_SERIES_Msk & ((value) << DSU_DID_SERIES_Pos))
 #define DSU_DID_FAMILY_Pos          23           /**< \brief (DSU_DID) Product Family */
-#define DSU_DID_FAMILY_Msk          (0x1Ful << DSU_DID_FAMILY_Pos)
+#define DSU_DID_FAMILY_Msk          (_U_(0x1F) << DSU_DID_FAMILY_Pos)
 #define DSU_DID_FAMILY(value)       (DSU_DID_FAMILY_Msk & ((value) << DSU_DID_FAMILY_Pos))
 #define DSU_DID_PROCESSOR_Pos       28           /**< \brief (DSU_DID) Processor */
-#define DSU_DID_PROCESSOR_Msk       (0xFul << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_Msk       (_U_(0xF) << DSU_DID_PROCESSOR_Pos)
 #define DSU_DID_PROCESSOR(value)    (DSU_DID_PROCESSOR_Msk & ((value) << DSU_DID_PROCESSOR_Pos))
-#define DSU_DID_MASK                0xFFBFFFFFul /**< \brief (DSU_DID) MASK Register */
+#define DSU_DID_MASK                _U_(0xFFBFFFFF) /**< \brief (DSU_DID) MASK Register */
 
 /* -------- DSU_ENTRY : (DSU Offset: 0x1000) (R/  32) Coresight ROM Table Entry n -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -275,16 +260,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_ENTRY_OFFSET            0x1000       /**< \brief (DSU_ENTRY offset) Coresight ROM Table Entry n */
-#define DSU_ENTRY_RESETVALUE        0x00000002ul /**< \brief (DSU_ENTRY reset_value) Coresight ROM Table Entry n */
+#define DSU_ENTRY_RESETVALUE        _U_(0x00000002) /**< \brief (DSU_ENTRY reset_value) Coresight ROM Table Entry n */
 
 #define DSU_ENTRY_EPRES_Pos         0            /**< \brief (DSU_ENTRY) Entry Present */
-#define DSU_ENTRY_EPRES             (0x1ul << DSU_ENTRY_EPRES_Pos)
+#define DSU_ENTRY_EPRES             (_U_(0x1) << DSU_ENTRY_EPRES_Pos)
 #define DSU_ENTRY_FMT_Pos           1            /**< \brief (DSU_ENTRY) Format */
-#define DSU_ENTRY_FMT               (0x1ul << DSU_ENTRY_FMT_Pos)
+#define DSU_ENTRY_FMT               (_U_(0x1) << DSU_ENTRY_FMT_Pos)
 #define DSU_ENTRY_ADDOFF_Pos        12           /**< \brief (DSU_ENTRY) Address Offset */
-#define DSU_ENTRY_ADDOFF_Msk        (0xFFFFFul << DSU_ENTRY_ADDOFF_Pos)
+#define DSU_ENTRY_ADDOFF_Msk        (_U_(0xFFFFF) << DSU_ENTRY_ADDOFF_Pos)
 #define DSU_ENTRY_ADDOFF(value)     (DSU_ENTRY_ADDOFF_Msk & ((value) << DSU_ENTRY_ADDOFF_Pos))
-#define DSU_ENTRY_MASK              0xFFFFF003ul /**< \brief (DSU_ENTRY) MASK Register */
+#define DSU_ENTRY_MASK              _U_(0xFFFFF003) /**< \brief (DSU_ENTRY) MASK Register */
 
 /* -------- DSU_END : (DSU Offset: 0x1008) (R/  32) Coresight ROM Table End -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -297,12 +282,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_END_OFFSET              0x1008       /**< \brief (DSU_END offset) Coresight ROM Table End */
-#define DSU_END_RESETVALUE          0x00000000ul /**< \brief (DSU_END reset_value) Coresight ROM Table End */
+#define DSU_END_RESETVALUE          _U_(0x00000000) /**< \brief (DSU_END reset_value) Coresight ROM Table End */
 
 #define DSU_END_END_Pos             0            /**< \brief (DSU_END) End Marker */
-#define DSU_END_END_Msk             (0xFFFFFFFFul << DSU_END_END_Pos)
+#define DSU_END_END_Msk             (_U_(0xFFFFFFFF) << DSU_END_END_Pos)
 #define DSU_END_END(value)          (DSU_END_END_Msk & ((value) << DSU_END_END_Pos))
-#define DSU_END_MASK                0xFFFFFFFFul /**< \brief (DSU_END) MASK Register */
+#define DSU_END_MASK                _U_(0xFFFFFFFF) /**< \brief (DSU_END) MASK Register */
 
 /* -------- DSU_MEMTYPE : (DSU Offset: 0x1FCC) (R/  32) Coresight ROM Table Memory Type -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -316,11 +301,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_MEMTYPE_OFFSET          0x1FCC       /**< \brief (DSU_MEMTYPE offset) Coresight ROM Table Memory Type */
-#define DSU_MEMTYPE_RESETVALUE      0x00000000ul /**< \brief (DSU_MEMTYPE reset_value) Coresight ROM Table Memory Type */
+#define DSU_MEMTYPE_RESETVALUE      _U_(0x00000000) /**< \brief (DSU_MEMTYPE reset_value) Coresight ROM Table Memory Type */
 
 #define DSU_MEMTYPE_SMEMP_Pos       0            /**< \brief (DSU_MEMTYPE) System Memory Present */
-#define DSU_MEMTYPE_SMEMP           (0x1ul << DSU_MEMTYPE_SMEMP_Pos)
-#define DSU_MEMTYPE_MASK            0x00000001ul /**< \brief (DSU_MEMTYPE) MASK Register */
+#define DSU_MEMTYPE_SMEMP           (_U_(0x1) << DSU_MEMTYPE_SMEMP_Pos)
+#define DSU_MEMTYPE_MASK            _U_(0x00000001) /**< \brief (DSU_MEMTYPE) MASK Register */
 
 /* -------- DSU_PID4 : (DSU Offset: 0x1FD0) (R/  32) Peripheral Identification 4 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -335,15 +320,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_PID4_OFFSET             0x1FD0       /**< \brief (DSU_PID4 offset) Peripheral Identification 4 */
-#define DSU_PID4_RESETVALUE         0x00000000ul /**< \brief (DSU_PID4 reset_value) Peripheral Identification 4 */
+#define DSU_PID4_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID4 reset_value) Peripheral Identification 4 */
 
 #define DSU_PID4_JEPCC_Pos          0            /**< \brief (DSU_PID4) JEP-106 Continuation Code */
-#define DSU_PID4_JEPCC_Msk          (0xFul << DSU_PID4_JEPCC_Pos)
+#define DSU_PID4_JEPCC_Msk          (_U_(0xF) << DSU_PID4_JEPCC_Pos)
 #define DSU_PID4_JEPCC(value)       (DSU_PID4_JEPCC_Msk & ((value) << DSU_PID4_JEPCC_Pos))
 #define DSU_PID4_FKBC_Pos           4            /**< \brief (DSU_PID4) 4KB Count */
-#define DSU_PID4_FKBC_Msk           (0xFul << DSU_PID4_FKBC_Pos)
+#define DSU_PID4_FKBC_Msk           (_U_(0xF) << DSU_PID4_FKBC_Pos)
 #define DSU_PID4_FKBC(value)        (DSU_PID4_FKBC_Msk & ((value) << DSU_PID4_FKBC_Pos))
-#define DSU_PID4_MASK               0x000000FFul /**< \brief (DSU_PID4) MASK Register */
+#define DSU_PID4_MASK               _U_(0x000000FF) /**< \brief (DSU_PID4) MASK Register */
 
 /* -------- DSU_PID0 : (DSU Offset: 0x1FE0) (R/  32) Peripheral Identification 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -357,12 +342,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_PID0_OFFSET             0x1FE0       /**< \brief (DSU_PID0 offset) Peripheral Identification 0 */
-#define DSU_PID0_RESETVALUE         0x000000D0ul /**< \brief (DSU_PID0 reset_value) Peripheral Identification 0 */
+#define DSU_PID0_RESETVALUE         _U_(0x000000D0) /**< \brief (DSU_PID0 reset_value) Peripheral Identification 0 */
 
 #define DSU_PID0_PARTNBL_Pos        0            /**< \brief (DSU_PID0) Part Number Low */
-#define DSU_PID0_PARTNBL_Msk        (0xFFul << DSU_PID0_PARTNBL_Pos)
+#define DSU_PID0_PARTNBL_Msk        (_U_(0xFF) << DSU_PID0_PARTNBL_Pos)
 #define DSU_PID0_PARTNBL(value)     (DSU_PID0_PARTNBL_Msk & ((value) << DSU_PID0_PARTNBL_Pos))
-#define DSU_PID0_MASK               0x000000FFul /**< \brief (DSU_PID0) MASK Register */
+#define DSU_PID0_MASK               _U_(0x000000FF) /**< \brief (DSU_PID0) MASK Register */
 
 /* -------- DSU_PID1 : (DSU Offset: 0x1FE4) (R/  32) Peripheral Identification 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -377,15 +362,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_PID1_OFFSET             0x1FE4       /**< \brief (DSU_PID1 offset) Peripheral Identification 1 */
-#define DSU_PID1_RESETVALUE         0x000000FCul /**< \brief (DSU_PID1 reset_value) Peripheral Identification 1 */
+#define DSU_PID1_RESETVALUE         _U_(0x000000FC) /**< \brief (DSU_PID1 reset_value) Peripheral Identification 1 */
 
 #define DSU_PID1_PARTNBH_Pos        0            /**< \brief (DSU_PID1) Part Number High */
-#define DSU_PID1_PARTNBH_Msk        (0xFul << DSU_PID1_PARTNBH_Pos)
+#define DSU_PID1_PARTNBH_Msk        (_U_(0xF) << DSU_PID1_PARTNBH_Pos)
 #define DSU_PID1_PARTNBH(value)     (DSU_PID1_PARTNBH_Msk & ((value) << DSU_PID1_PARTNBH_Pos))
 #define DSU_PID1_JEPIDCL_Pos        4            /**< \brief (DSU_PID1) Low part of the JEP-106 Identity Code */
-#define DSU_PID1_JEPIDCL_Msk        (0xFul << DSU_PID1_JEPIDCL_Pos)
+#define DSU_PID1_JEPIDCL_Msk        (_U_(0xF) << DSU_PID1_JEPIDCL_Pos)
 #define DSU_PID1_JEPIDCL(value)     (DSU_PID1_JEPIDCL_Msk & ((value) << DSU_PID1_JEPIDCL_Pos))
-#define DSU_PID1_MASK               0x000000FFul /**< \brief (DSU_PID1) MASK Register */
+#define DSU_PID1_MASK               _U_(0x000000FF) /**< \brief (DSU_PID1) MASK Register */
 
 /* -------- DSU_PID2 : (DSU Offset: 0x1FE8) (R/  32) Peripheral Identification 2 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -401,17 +386,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_PID2_OFFSET             0x1FE8       /**< \brief (DSU_PID2 offset) Peripheral Identification 2 */
-#define DSU_PID2_RESETVALUE         0x00000009ul /**< \brief (DSU_PID2 reset_value) Peripheral Identification 2 */
+#define DSU_PID2_RESETVALUE         _U_(0x00000009) /**< \brief (DSU_PID2 reset_value) Peripheral Identification 2 */
 
 #define DSU_PID2_JEPIDCH_Pos        0            /**< \brief (DSU_PID2) JEP-106 Identity Code High */
-#define DSU_PID2_JEPIDCH_Msk        (0x7ul << DSU_PID2_JEPIDCH_Pos)
+#define DSU_PID2_JEPIDCH_Msk        (_U_(0x7) << DSU_PID2_JEPIDCH_Pos)
 #define DSU_PID2_JEPIDCH(value)     (DSU_PID2_JEPIDCH_Msk & ((value) << DSU_PID2_JEPIDCH_Pos))
 #define DSU_PID2_JEPU_Pos           3            /**< \brief (DSU_PID2) JEP-106 Identity Code is used */
-#define DSU_PID2_JEPU               (0x1ul << DSU_PID2_JEPU_Pos)
+#define DSU_PID2_JEPU               (_U_(0x1) << DSU_PID2_JEPU_Pos)
 #define DSU_PID2_REVISION_Pos       4            /**< \brief (DSU_PID2) Revision Number */
-#define DSU_PID2_REVISION_Msk       (0xFul << DSU_PID2_REVISION_Pos)
+#define DSU_PID2_REVISION_Msk       (_U_(0xF) << DSU_PID2_REVISION_Pos)
 #define DSU_PID2_REVISION(value)    (DSU_PID2_REVISION_Msk & ((value) << DSU_PID2_REVISION_Pos))
-#define DSU_PID2_MASK               0x000000FFul /**< \brief (DSU_PID2) MASK Register */
+#define DSU_PID2_MASK               _U_(0x000000FF) /**< \brief (DSU_PID2) MASK Register */
 
 /* -------- DSU_PID3 : (DSU Offset: 0x1FEC) (R/  32) Peripheral Identification 3 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -426,15 +411,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_PID3_OFFSET             0x1FEC       /**< \brief (DSU_PID3 offset) Peripheral Identification 3 */
-#define DSU_PID3_RESETVALUE         0x00000000ul /**< \brief (DSU_PID3 reset_value) Peripheral Identification 3 */
+#define DSU_PID3_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID3 reset_value) Peripheral Identification 3 */
 
 #define DSU_PID3_CUSMOD_Pos         0            /**< \brief (DSU_PID3) ARM CUSMOD */
-#define DSU_PID3_CUSMOD_Msk         (0xFul << DSU_PID3_CUSMOD_Pos)
+#define DSU_PID3_CUSMOD_Msk         (_U_(0xF) << DSU_PID3_CUSMOD_Pos)
 #define DSU_PID3_CUSMOD(value)      (DSU_PID3_CUSMOD_Msk & ((value) << DSU_PID3_CUSMOD_Pos))
 #define DSU_PID3_REVAND_Pos         4            /**< \brief (DSU_PID3) Revision Number */
-#define DSU_PID3_REVAND_Msk         (0xFul << DSU_PID3_REVAND_Pos)
+#define DSU_PID3_REVAND_Msk         (_U_(0xF) << DSU_PID3_REVAND_Pos)
 #define DSU_PID3_REVAND(value)      (DSU_PID3_REVAND_Msk & ((value) << DSU_PID3_REVAND_Pos))
-#define DSU_PID3_MASK               0x000000FFul /**< \brief (DSU_PID3) MASK Register */
+#define DSU_PID3_MASK               _U_(0x000000FF) /**< \brief (DSU_PID3) MASK Register */
 
 /* -------- DSU_CID0 : (DSU Offset: 0x1FF0) (R/  32) Component Identification 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -448,12 +433,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_CID0_OFFSET             0x1FF0       /**< \brief (DSU_CID0 offset) Component Identification 0 */
-#define DSU_CID0_RESETVALUE         0x0000000Dul /**< \brief (DSU_CID0 reset_value) Component Identification 0 */
+#define DSU_CID0_RESETVALUE         _U_(0x0000000D) /**< \brief (DSU_CID0 reset_value) Component Identification 0 */
 
 #define DSU_CID0_PREAMBLEB0_Pos     0            /**< \brief (DSU_CID0) Preamble Byte 0 */
-#define DSU_CID0_PREAMBLEB0_Msk     (0xFFul << DSU_CID0_PREAMBLEB0_Pos)
+#define DSU_CID0_PREAMBLEB0_Msk     (_U_(0xFF) << DSU_CID0_PREAMBLEB0_Pos)
 #define DSU_CID0_PREAMBLEB0(value)  (DSU_CID0_PREAMBLEB0_Msk & ((value) << DSU_CID0_PREAMBLEB0_Pos))
-#define DSU_CID0_MASK               0x000000FFul /**< \brief (DSU_CID0) MASK Register */
+#define DSU_CID0_MASK               _U_(0x000000FF) /**< \brief (DSU_CID0) MASK Register */
 
 /* -------- DSU_CID1 : (DSU Offset: 0x1FF4) (R/  32) Component Identification 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -468,15 +453,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_CID1_OFFSET             0x1FF4       /**< \brief (DSU_CID1 offset) Component Identification 1 */
-#define DSU_CID1_RESETVALUE         0x00000010ul /**< \brief (DSU_CID1 reset_value) Component Identification 1 */
+#define DSU_CID1_RESETVALUE         _U_(0x00000010) /**< \brief (DSU_CID1 reset_value) Component Identification 1 */
 
 #define DSU_CID1_PREAMBLE_Pos       0            /**< \brief (DSU_CID1) Preamble */
-#define DSU_CID1_PREAMBLE_Msk       (0xFul << DSU_CID1_PREAMBLE_Pos)
+#define DSU_CID1_PREAMBLE_Msk       (_U_(0xF) << DSU_CID1_PREAMBLE_Pos)
 #define DSU_CID1_PREAMBLE(value)    (DSU_CID1_PREAMBLE_Msk & ((value) << DSU_CID1_PREAMBLE_Pos))
 #define DSU_CID1_CCLASS_Pos         4            /**< \brief (DSU_CID1) Component Class */
-#define DSU_CID1_CCLASS_Msk         (0xFul << DSU_CID1_CCLASS_Pos)
+#define DSU_CID1_CCLASS_Msk         (_U_(0xF) << DSU_CID1_CCLASS_Pos)
 #define DSU_CID1_CCLASS(value)      (DSU_CID1_CCLASS_Msk & ((value) << DSU_CID1_CCLASS_Pos))
-#define DSU_CID1_MASK               0x000000FFul /**< \brief (DSU_CID1) MASK Register */
+#define DSU_CID1_MASK               _U_(0x000000FF) /**< \brief (DSU_CID1) MASK Register */
 
 /* -------- DSU_CID2 : (DSU Offset: 0x1FF8) (R/  32) Component Identification 2 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -490,12 +475,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_CID2_OFFSET             0x1FF8       /**< \brief (DSU_CID2 offset) Component Identification 2 */
-#define DSU_CID2_RESETVALUE         0x00000005ul /**< \brief (DSU_CID2 reset_value) Component Identification 2 */
+#define DSU_CID2_RESETVALUE         _U_(0x00000005) /**< \brief (DSU_CID2 reset_value) Component Identification 2 */
 
 #define DSU_CID2_PREAMBLEB2_Pos     0            /**< \brief (DSU_CID2) Preamble Byte 2 */
-#define DSU_CID2_PREAMBLEB2_Msk     (0xFFul << DSU_CID2_PREAMBLEB2_Pos)
+#define DSU_CID2_PREAMBLEB2_Msk     (_U_(0xFF) << DSU_CID2_PREAMBLEB2_Pos)
 #define DSU_CID2_PREAMBLEB2(value)  (DSU_CID2_PREAMBLEB2_Msk & ((value) << DSU_CID2_PREAMBLEB2_Pos))
-#define DSU_CID2_MASK               0x000000FFul /**< \brief (DSU_CID2) MASK Register */
+#define DSU_CID2_MASK               _U_(0x000000FF) /**< \brief (DSU_CID2) MASK Register */
 
 /* -------- DSU_CID3 : (DSU Offset: 0x1FFC) (R/  32) Component Identification 3 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -509,12 +494,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DSU_CID3_OFFSET             0x1FFC       /**< \brief (DSU_CID3 offset) Component Identification 3 */
-#define DSU_CID3_RESETVALUE         0x000000B1ul /**< \brief (DSU_CID3 reset_value) Component Identification 3 */
+#define DSU_CID3_RESETVALUE         _U_(0x000000B1) /**< \brief (DSU_CID3 reset_value) Component Identification 3 */
 
 #define DSU_CID3_PREAMBLEB3_Pos     0            /**< \brief (DSU_CID3) Preamble Byte 3 */
-#define DSU_CID3_PREAMBLEB3_Msk     (0xFFul << DSU_CID3_PREAMBLEB3_Pos)
+#define DSU_CID3_PREAMBLEB3_Msk     (_U_(0xFF) << DSU_CID3_PREAMBLEB3_Pos)
 #define DSU_CID3_PREAMBLEB3(value)  (DSU_CID3_PREAMBLEB3_Msk & ((value) << DSU_CID3_PREAMBLEB3_Pos))
-#define DSU_CID3_MASK               0x000000FFul /**< \brief (DSU_CID3) MASK Register */
+#define DSU_CID3_MASK               _U_(0x000000FF) /**< \brief (DSU_CID3) MASK Register */
 
 /** \brief DSU hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/eic.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for EIC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -66,13 +51,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_CTRL_OFFSET             0x00         /**< \brief (EIC_CTRL offset) Control */
-#define EIC_CTRL_RESETVALUE         0x00ul       /**< \brief (EIC_CTRL reset_value) Control */
+#define EIC_CTRL_RESETVALUE         _U_(0x00)     /**< \brief (EIC_CTRL reset_value) Control */
 
 #define EIC_CTRL_SWRST_Pos          0            /**< \brief (EIC_CTRL) Software Reset */
-#define EIC_CTRL_SWRST              (0x1ul << EIC_CTRL_SWRST_Pos)
+#define EIC_CTRL_SWRST              (_U_(0x1) << EIC_CTRL_SWRST_Pos)
 #define EIC_CTRL_ENABLE_Pos         1            /**< \brief (EIC_CTRL) Enable */
-#define EIC_CTRL_ENABLE             (0x1ul << EIC_CTRL_ENABLE_Pos)
-#define EIC_CTRL_MASK               0x03ul       /**< \brief (EIC_CTRL) MASK Register */
+#define EIC_CTRL_ENABLE             (_U_(0x1) << EIC_CTRL_ENABLE_Pos)
+#define EIC_CTRL_MASK               _U_(0x03)     /**< \brief (EIC_CTRL) MASK Register */
 
 /* -------- EIC_STATUS : (EIC Offset: 0x01) (R/   8) Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -86,11 +71,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_STATUS_OFFSET           0x01         /**< \brief (EIC_STATUS offset) Status */
-#define EIC_STATUS_RESETVALUE       0x00ul       /**< \brief (EIC_STATUS reset_value) Status */
+#define EIC_STATUS_RESETVALUE       _U_(0x00)     /**< \brief (EIC_STATUS reset_value) Status */
 
 #define EIC_STATUS_SYNCBUSY_Pos     7            /**< \brief (EIC_STATUS) Synchronization Busy */
-#define EIC_STATUS_SYNCBUSY         (0x1ul << EIC_STATUS_SYNCBUSY_Pos)
-#define EIC_STATUS_MASK             0x80ul       /**< \brief (EIC_STATUS) MASK Register */
+#define EIC_STATUS_SYNCBUSY         (_U_(0x1) << EIC_STATUS_SYNCBUSY_Pos)
+#define EIC_STATUS_MASK             _U_(0x80)     /**< \brief (EIC_STATUS) MASK Register */
 
 /* -------- EIC_NMICTRL : (EIC Offset: 0x02) (R/W  8) Non-Maskable Interrupt Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -105,17 +90,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_NMICTRL_OFFSET          0x02         /**< \brief (EIC_NMICTRL offset) Non-Maskable Interrupt Control */
-#define EIC_NMICTRL_RESETVALUE      0x00ul       /**< \brief (EIC_NMICTRL reset_value) Non-Maskable Interrupt Control */
+#define EIC_NMICTRL_RESETVALUE      _U_(0x00)     /**< \brief (EIC_NMICTRL reset_value) Non-Maskable Interrupt Control */
 
 #define EIC_NMICTRL_NMISENSE_Pos    0            /**< \brief (EIC_NMICTRL) Non-Maskable Interrupt Sense */
-#define EIC_NMICTRL_NMISENSE_Msk    (0x7ul << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_Msk    (_U_(0x7) << EIC_NMICTRL_NMISENSE_Pos)
 #define EIC_NMICTRL_NMISENSE(value) (EIC_NMICTRL_NMISENSE_Msk & ((value) << EIC_NMICTRL_NMISENSE_Pos))
-#define   EIC_NMICTRL_NMISENSE_NONE_Val   0x0ul  /**< \brief (EIC_NMICTRL) No detection */
-#define   EIC_NMICTRL_NMISENSE_RISE_Val   0x1ul  /**< \brief (EIC_NMICTRL) Rising-edge detection */
-#define   EIC_NMICTRL_NMISENSE_FALL_Val   0x2ul  /**< \brief (EIC_NMICTRL) Falling-edge detection */
-#define   EIC_NMICTRL_NMISENSE_BOTH_Val   0x3ul  /**< \brief (EIC_NMICTRL) Both-edges detection */
-#define   EIC_NMICTRL_NMISENSE_HIGH_Val   0x4ul  /**< \brief (EIC_NMICTRL) High-level detection */
-#define   EIC_NMICTRL_NMISENSE_LOW_Val    0x5ul  /**< \brief (EIC_NMICTRL) Low-level detection */
+#define   EIC_NMICTRL_NMISENSE_NONE_Val   _U_(0x0)   /**< \brief (EIC_NMICTRL) No detection */
+#define   EIC_NMICTRL_NMISENSE_RISE_Val   _U_(0x1)   /**< \brief (EIC_NMICTRL) Rising-edge detection */
+#define   EIC_NMICTRL_NMISENSE_FALL_Val   _U_(0x2)   /**< \brief (EIC_NMICTRL) Falling-edge detection */
+#define   EIC_NMICTRL_NMISENSE_BOTH_Val   _U_(0x3)   /**< \brief (EIC_NMICTRL) Both-edges detection */
+#define   EIC_NMICTRL_NMISENSE_HIGH_Val   _U_(0x4)   /**< \brief (EIC_NMICTRL) High-level detection */
+#define   EIC_NMICTRL_NMISENSE_LOW_Val    _U_(0x5)   /**< \brief (EIC_NMICTRL) Low-level detection */
 #define EIC_NMICTRL_NMISENSE_NONE   (EIC_NMICTRL_NMISENSE_NONE_Val << EIC_NMICTRL_NMISENSE_Pos)
 #define EIC_NMICTRL_NMISENSE_RISE   (EIC_NMICTRL_NMISENSE_RISE_Val << EIC_NMICTRL_NMISENSE_Pos)
 #define EIC_NMICTRL_NMISENSE_FALL   (EIC_NMICTRL_NMISENSE_FALL_Val << EIC_NMICTRL_NMISENSE_Pos)
@@ -123,8 +108,8 @@ typedef union {
 #define EIC_NMICTRL_NMISENSE_HIGH   (EIC_NMICTRL_NMISENSE_HIGH_Val << EIC_NMICTRL_NMISENSE_Pos)
 #define EIC_NMICTRL_NMISENSE_LOW    (EIC_NMICTRL_NMISENSE_LOW_Val  << EIC_NMICTRL_NMISENSE_Pos)
 #define EIC_NMICTRL_NMIFILTEN_Pos   3            /**< \brief (EIC_NMICTRL) Non-Maskable Interrupt Filter Enable */
-#define EIC_NMICTRL_NMIFILTEN       (0x1ul << EIC_NMICTRL_NMIFILTEN_Pos)
-#define EIC_NMICTRL_MASK            0x0Ful       /**< \brief (EIC_NMICTRL) MASK Register */
+#define EIC_NMICTRL_NMIFILTEN       (_U_(0x1) << EIC_NMICTRL_NMIFILTEN_Pos)
+#define EIC_NMICTRL_MASK            _U_(0x0F)     /**< \brief (EIC_NMICTRL) MASK Register */
 
 /* -------- EIC_NMIFLAG : (EIC Offset: 0x03) (R/W  8) Non-Maskable Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -138,11 +123,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_NMIFLAG_OFFSET          0x03         /**< \brief (EIC_NMIFLAG offset) Non-Maskable Interrupt Flag Status and Clear */
-#define EIC_NMIFLAG_RESETVALUE      0x00ul       /**< \brief (EIC_NMIFLAG reset_value) Non-Maskable Interrupt Flag Status and Clear */
+#define EIC_NMIFLAG_RESETVALUE      _U_(0x00)     /**< \brief (EIC_NMIFLAG reset_value) Non-Maskable Interrupt Flag Status and Clear */
 
 #define EIC_NMIFLAG_NMI_Pos         0            /**< \brief (EIC_NMIFLAG) Non-Maskable Interrupt */
-#define EIC_NMIFLAG_NMI             (0x1ul << EIC_NMIFLAG_NMI_Pos)
-#define EIC_NMIFLAG_MASK            0x01ul       /**< \brief (EIC_NMIFLAG) MASK Register */
+#define EIC_NMIFLAG_NMI             (_U_(0x1) << EIC_NMIFLAG_NMI_Pos)
+#define EIC_NMIFLAG_MASK            _U_(0x01)     /**< \brief (EIC_NMIFLAG) MASK Register */
 
 /* -------- EIC_EVCTRL : (EIC Offset: 0x04) (R/W 32) Event Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -175,7 +160,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_EVCTRL_OFFSET           0x04         /**< \brief (EIC_EVCTRL offset) Event Control */
-#define EIC_EVCTRL_RESETVALUE       0x00000000ul /**< \brief (EIC_EVCTRL reset_value) Event Control */
+#define EIC_EVCTRL_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_EVCTRL reset_value) Event Control */
 
 #define EIC_EVCTRL_EXTINTEO0_Pos    0            /**< \brief (EIC_EVCTRL) External Interrupt 0 Event Output Enable */
 #define EIC_EVCTRL_EXTINTEO0        (1 << EIC_EVCTRL_EXTINTEO0_Pos)
@@ -210,9 +195,9 @@ typedef union {
 #define EIC_EVCTRL_EXTINTEO15_Pos   15           /**< \brief (EIC_EVCTRL) External Interrupt 15 Event Output Enable */
 #define EIC_EVCTRL_EXTINTEO15       (1 << EIC_EVCTRL_EXTINTEO15_Pos)
 #define EIC_EVCTRL_EXTINTEO_Pos     0            /**< \brief (EIC_EVCTRL) External Interrupt x Event Output Enable */
-#define EIC_EVCTRL_EXTINTEO_Msk     (0xFFFFul << EIC_EVCTRL_EXTINTEO_Pos)
+#define EIC_EVCTRL_EXTINTEO_Msk     (_U_(0xFFFF) << EIC_EVCTRL_EXTINTEO_Pos)
 #define EIC_EVCTRL_EXTINTEO(value)  (EIC_EVCTRL_EXTINTEO_Msk & ((value) << EIC_EVCTRL_EXTINTEO_Pos))
-#define EIC_EVCTRL_MASK             0x0000FFFFul /**< \brief (EIC_EVCTRL) MASK Register */
+#define EIC_EVCTRL_MASK             _U_(0x0000FFFF) /**< \brief (EIC_EVCTRL) MASK Register */
 
 /* -------- EIC_INTENCLR : (EIC Offset: 0x08) (R/W 32) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -245,7 +230,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_INTENCLR_OFFSET         0x08         /**< \brief (EIC_INTENCLR offset) Interrupt Enable Clear */
-#define EIC_INTENCLR_RESETVALUE     0x00000000ul /**< \brief (EIC_INTENCLR reset_value) Interrupt Enable Clear */
+#define EIC_INTENCLR_RESETVALUE     _U_(0x00000000) /**< \brief (EIC_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define EIC_INTENCLR_EXTINT0_Pos    0            /**< \brief (EIC_INTENCLR) External Interrupt 0 Enable */
 #define EIC_INTENCLR_EXTINT0        (1 << EIC_INTENCLR_EXTINT0_Pos)
@@ -280,9 +265,9 @@ typedef union {
 #define EIC_INTENCLR_EXTINT15_Pos   15           /**< \brief (EIC_INTENCLR) External Interrupt 15 Enable */
 #define EIC_INTENCLR_EXTINT15       (1 << EIC_INTENCLR_EXTINT15_Pos)
 #define EIC_INTENCLR_EXTINT_Pos     0            /**< \brief (EIC_INTENCLR) External Interrupt x Enable */
-#define EIC_INTENCLR_EXTINT_Msk     (0xFFFFul << EIC_INTENCLR_EXTINT_Pos)
+#define EIC_INTENCLR_EXTINT_Msk     (_U_(0xFFFF) << EIC_INTENCLR_EXTINT_Pos)
 #define EIC_INTENCLR_EXTINT(value)  (EIC_INTENCLR_EXTINT_Msk & ((value) << EIC_INTENCLR_EXTINT_Pos))
-#define EIC_INTENCLR_MASK           0x0000FFFFul /**< \brief (EIC_INTENCLR) MASK Register */
+#define EIC_INTENCLR_MASK           _U_(0x0000FFFF) /**< \brief (EIC_INTENCLR) MASK Register */
 
 /* -------- EIC_INTENSET : (EIC Offset: 0x0C) (R/W 32) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -315,7 +300,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_INTENSET_OFFSET         0x0C         /**< \brief (EIC_INTENSET offset) Interrupt Enable Set */
-#define EIC_INTENSET_RESETVALUE     0x00000000ul /**< \brief (EIC_INTENSET reset_value) Interrupt Enable Set */
+#define EIC_INTENSET_RESETVALUE     _U_(0x00000000) /**< \brief (EIC_INTENSET reset_value) Interrupt Enable Set */
 
 #define EIC_INTENSET_EXTINT0_Pos    0            /**< \brief (EIC_INTENSET) External Interrupt 0 Enable */
 #define EIC_INTENSET_EXTINT0        (1 << EIC_INTENSET_EXTINT0_Pos)
@@ -350,9 +335,9 @@ typedef union {
 #define EIC_INTENSET_EXTINT15_Pos   15           /**< \brief (EIC_INTENSET) External Interrupt 15 Enable */
 #define EIC_INTENSET_EXTINT15       (1 << EIC_INTENSET_EXTINT15_Pos)
 #define EIC_INTENSET_EXTINT_Pos     0            /**< \brief (EIC_INTENSET) External Interrupt x Enable */
-#define EIC_INTENSET_EXTINT_Msk     (0xFFFFul << EIC_INTENSET_EXTINT_Pos)
+#define EIC_INTENSET_EXTINT_Msk     (_U_(0xFFFF) << EIC_INTENSET_EXTINT_Pos)
 #define EIC_INTENSET_EXTINT(value)  (EIC_INTENSET_EXTINT_Msk & ((value) << EIC_INTENSET_EXTINT_Pos))
-#define EIC_INTENSET_MASK           0x0000FFFFul /**< \brief (EIC_INTENSET) MASK Register */
+#define EIC_INTENSET_MASK           _U_(0x0000FFFF) /**< \brief (EIC_INTENSET) MASK Register */
 
 /* -------- EIC_INTFLAG : (EIC Offset: 0x10) (R/W 32) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -385,7 +370,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_INTFLAG_OFFSET          0x10         /**< \brief (EIC_INTFLAG offset) Interrupt Flag Status and Clear */
-#define EIC_INTFLAG_RESETVALUE      0x00000000ul /**< \brief (EIC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define EIC_INTFLAG_RESETVALUE      _U_(0x00000000) /**< \brief (EIC_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define EIC_INTFLAG_EXTINT0_Pos     0            /**< \brief (EIC_INTFLAG) External Interrupt 0 */
 #define EIC_INTFLAG_EXTINT0         (1 << EIC_INTFLAG_EXTINT0_Pos)
@@ -420,9 +405,9 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #define EIC_INTFLAG_EXTINT15_Pos    15           /**< \brief (EIC_INTFLAG) External Interrupt 15 */
 #define EIC_INTFLAG_EXTINT15        (1 << EIC_INTFLAG_EXTINT15_Pos)
 #define EIC_INTFLAG_EXTINT_Pos      0            /**< \brief (EIC_INTFLAG) External Interrupt x */
-#define EIC_INTFLAG_EXTINT_Msk      (0xFFFFul << EIC_INTFLAG_EXTINT_Pos)
+#define EIC_INTFLAG_EXTINT_Msk      (_U_(0xFFFF) << EIC_INTFLAG_EXTINT_Pos)
 #define EIC_INTFLAG_EXTINT(value)   (EIC_INTFLAG_EXTINT_Msk & ((value) << EIC_INTFLAG_EXTINT_Pos))
-#define EIC_INTFLAG_MASK            0x0000FFFFul /**< \brief (EIC_INTFLAG) MASK Register */
+#define EIC_INTFLAG_MASK            _U_(0x0000FFFF) /**< \brief (EIC_INTFLAG) MASK Register */
 
 /* -------- EIC_WAKEUP : (EIC Offset: 0x14) (R/W 32) Wake-Up Enable -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -455,7 +440,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_WAKEUP_OFFSET           0x14         /**< \brief (EIC_WAKEUP offset) Wake-Up Enable */
-#define EIC_WAKEUP_RESETVALUE       0x00000000ul /**< \brief (EIC_WAKEUP reset_value) Wake-Up Enable */
+#define EIC_WAKEUP_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_WAKEUP reset_value) Wake-Up Enable */
 
 #define EIC_WAKEUP_WAKEUPEN0_Pos    0            /**< \brief (EIC_WAKEUP) External Interrupt 0 Wake-up Enable */
 #define EIC_WAKEUP_WAKEUPEN0        (1 << EIC_WAKEUP_WAKEUPEN0_Pos)
@@ -490,9 +475,9 @@ typedef union {
 #define EIC_WAKEUP_WAKEUPEN15_Pos   15           /**< \brief (EIC_WAKEUP) External Interrupt 15 Wake-up Enable */
 #define EIC_WAKEUP_WAKEUPEN15       (1 << EIC_WAKEUP_WAKEUPEN15_Pos)
 #define EIC_WAKEUP_WAKEUPEN_Pos     0            /**< \brief (EIC_WAKEUP) External Interrupt x Wake-up Enable */
-#define EIC_WAKEUP_WAKEUPEN_Msk     (0xFFFFul << EIC_WAKEUP_WAKEUPEN_Pos)
+#define EIC_WAKEUP_WAKEUPEN_Msk     (_U_(0xFFFF) << EIC_WAKEUP_WAKEUPEN_Pos)
 #define EIC_WAKEUP_WAKEUPEN(value)  (EIC_WAKEUP_WAKEUPEN_Msk & ((value) << EIC_WAKEUP_WAKEUPEN_Pos))
-#define EIC_WAKEUP_MASK             0x0000FFFFul /**< \brief (EIC_WAKEUP) MASK Register */
+#define EIC_WAKEUP_MASK             _U_(0x0000FFFF) /**< \brief (EIC_WAKEUP) MASK Register */
 
 /* -------- EIC_CONFIG : (EIC Offset: 0x18) (R/W 32) Configuration n -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -520,17 +505,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_CONFIG_OFFSET           0x18         /**< \brief (EIC_CONFIG offset) Configuration n */
-#define EIC_CONFIG_RESETVALUE       0x00000000ul /**< \brief (EIC_CONFIG reset_value) Configuration n */
+#define EIC_CONFIG_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_CONFIG reset_value) Configuration n */
 
 #define EIC_CONFIG_SENSE0_Pos       0            /**< \brief (EIC_CONFIG) Input Sense 0 Configuration */
-#define EIC_CONFIG_SENSE0_Msk       (0x7ul << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_Msk       (_U_(0x7) << EIC_CONFIG_SENSE0_Pos)
 #define EIC_CONFIG_SENSE0(value)    (EIC_CONFIG_SENSE0_Msk & ((value) << EIC_CONFIG_SENSE0_Pos))
-#define   EIC_CONFIG_SENSE0_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
-#define   EIC_CONFIG_SENSE0_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising-edge detection */
-#define   EIC_CONFIG_SENSE0_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling-edge detection */
-#define   EIC_CONFIG_SENSE0_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both-edges detection */
-#define   EIC_CONFIG_SENSE0_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High-level detection */
-#define   EIC_CONFIG_SENSE0_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low-level detection */
+#define   EIC_CONFIG_SENSE0_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE0_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising-edge detection */
+#define   EIC_CONFIG_SENSE0_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling-edge detection */
+#define   EIC_CONFIG_SENSE0_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both-edges detection */
+#define   EIC_CONFIG_SENSE0_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High-level detection */
+#define   EIC_CONFIG_SENSE0_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low-level detection */
 #define EIC_CONFIG_SENSE0_NONE      (EIC_CONFIG_SENSE0_NONE_Val    << EIC_CONFIG_SENSE0_Pos)
 #define EIC_CONFIG_SENSE0_RISE      (EIC_CONFIG_SENSE0_RISE_Val    << EIC_CONFIG_SENSE0_Pos)
 #define EIC_CONFIG_SENSE0_FALL      (EIC_CONFIG_SENSE0_FALL_Val    << EIC_CONFIG_SENSE0_Pos)
@@ -538,16 +523,16 @@ typedef union {
 #define EIC_CONFIG_SENSE0_HIGH      (EIC_CONFIG_SENSE0_HIGH_Val    << EIC_CONFIG_SENSE0_Pos)
 #define EIC_CONFIG_SENSE0_LOW       (EIC_CONFIG_SENSE0_LOW_Val     << EIC_CONFIG_SENSE0_Pos)
 #define EIC_CONFIG_FILTEN0_Pos      3            /**< \brief (EIC_CONFIG) Filter 0 Enable */
-#define EIC_CONFIG_FILTEN0          (0x1ul << EIC_CONFIG_FILTEN0_Pos)
+#define EIC_CONFIG_FILTEN0          (_U_(0x1) << EIC_CONFIG_FILTEN0_Pos)
 #define EIC_CONFIG_SENSE1_Pos       4            /**< \brief (EIC_CONFIG) Input Sense 1 Configuration */
-#define EIC_CONFIG_SENSE1_Msk       (0x7ul << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_Msk       (_U_(0x7) << EIC_CONFIG_SENSE1_Pos)
 #define EIC_CONFIG_SENSE1(value)    (EIC_CONFIG_SENSE1_Msk & ((value) << EIC_CONFIG_SENSE1_Pos))
-#define   EIC_CONFIG_SENSE1_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
-#define   EIC_CONFIG_SENSE1_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
-#define   EIC_CONFIG_SENSE1_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
-#define   EIC_CONFIG_SENSE1_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
-#define   EIC_CONFIG_SENSE1_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
-#define   EIC_CONFIG_SENSE1_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define   EIC_CONFIG_SENSE1_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE1_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE1_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE1_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE1_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE1_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
 #define EIC_CONFIG_SENSE1_NONE      (EIC_CONFIG_SENSE1_NONE_Val    << EIC_CONFIG_SENSE1_Pos)
 #define EIC_CONFIG_SENSE1_RISE      (EIC_CONFIG_SENSE1_RISE_Val    << EIC_CONFIG_SENSE1_Pos)
 #define EIC_CONFIG_SENSE1_FALL      (EIC_CONFIG_SENSE1_FALL_Val    << EIC_CONFIG_SENSE1_Pos)
@@ -555,16 +540,16 @@ typedef union {
 #define EIC_CONFIG_SENSE1_HIGH      (EIC_CONFIG_SENSE1_HIGH_Val    << EIC_CONFIG_SENSE1_Pos)
 #define EIC_CONFIG_SENSE1_LOW       (EIC_CONFIG_SENSE1_LOW_Val     << EIC_CONFIG_SENSE1_Pos)
 #define EIC_CONFIG_FILTEN1_Pos      7            /**< \brief (EIC_CONFIG) Filter 1 Enable */
-#define EIC_CONFIG_FILTEN1          (0x1ul << EIC_CONFIG_FILTEN1_Pos)
+#define EIC_CONFIG_FILTEN1          (_U_(0x1) << EIC_CONFIG_FILTEN1_Pos)
 #define EIC_CONFIG_SENSE2_Pos       8            /**< \brief (EIC_CONFIG) Input Sense 2 Configuration */
-#define EIC_CONFIG_SENSE2_Msk       (0x7ul << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_Msk       (_U_(0x7) << EIC_CONFIG_SENSE2_Pos)
 #define EIC_CONFIG_SENSE2(value)    (EIC_CONFIG_SENSE2_Msk & ((value) << EIC_CONFIG_SENSE2_Pos))
-#define   EIC_CONFIG_SENSE2_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
-#define   EIC_CONFIG_SENSE2_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
-#define   EIC_CONFIG_SENSE2_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
-#define   EIC_CONFIG_SENSE2_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
-#define   EIC_CONFIG_SENSE2_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
-#define   EIC_CONFIG_SENSE2_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define   EIC_CONFIG_SENSE2_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE2_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE2_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE2_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE2_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE2_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
 #define EIC_CONFIG_SENSE2_NONE      (EIC_CONFIG_SENSE2_NONE_Val    << EIC_CONFIG_SENSE2_Pos)
 #define EIC_CONFIG_SENSE2_RISE      (EIC_CONFIG_SENSE2_RISE_Val    << EIC_CONFIG_SENSE2_Pos)
 #define EIC_CONFIG_SENSE2_FALL      (EIC_CONFIG_SENSE2_FALL_Val    << EIC_CONFIG_SENSE2_Pos)
@@ -572,16 +557,16 @@ typedef union {
 #define EIC_CONFIG_SENSE2_HIGH      (EIC_CONFIG_SENSE2_HIGH_Val    << EIC_CONFIG_SENSE2_Pos)
 #define EIC_CONFIG_SENSE2_LOW       (EIC_CONFIG_SENSE2_LOW_Val     << EIC_CONFIG_SENSE2_Pos)
 #define EIC_CONFIG_FILTEN2_Pos      11           /**< \brief (EIC_CONFIG) Filter 2 Enable */
-#define EIC_CONFIG_FILTEN2          (0x1ul << EIC_CONFIG_FILTEN2_Pos)
+#define EIC_CONFIG_FILTEN2          (_U_(0x1) << EIC_CONFIG_FILTEN2_Pos)
 #define EIC_CONFIG_SENSE3_Pos       12           /**< \brief (EIC_CONFIG) Input Sense 3 Configuration */
-#define EIC_CONFIG_SENSE3_Msk       (0x7ul << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_Msk       (_U_(0x7) << EIC_CONFIG_SENSE3_Pos)
 #define EIC_CONFIG_SENSE3(value)    (EIC_CONFIG_SENSE3_Msk & ((value) << EIC_CONFIG_SENSE3_Pos))
-#define   EIC_CONFIG_SENSE3_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
-#define   EIC_CONFIG_SENSE3_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
-#define   EIC_CONFIG_SENSE3_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
-#define   EIC_CONFIG_SENSE3_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
-#define   EIC_CONFIG_SENSE3_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
-#define   EIC_CONFIG_SENSE3_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define   EIC_CONFIG_SENSE3_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE3_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE3_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE3_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE3_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE3_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
 #define EIC_CONFIG_SENSE3_NONE      (EIC_CONFIG_SENSE3_NONE_Val    << EIC_CONFIG_SENSE3_Pos)
 #define EIC_CONFIG_SENSE3_RISE      (EIC_CONFIG_SENSE3_RISE_Val    << EIC_CONFIG_SENSE3_Pos)
 #define EIC_CONFIG_SENSE3_FALL      (EIC_CONFIG_SENSE3_FALL_Val    << EIC_CONFIG_SENSE3_Pos)
@@ -589,16 +574,16 @@ typedef union {
 #define EIC_CONFIG_SENSE3_HIGH      (EIC_CONFIG_SENSE3_HIGH_Val    << EIC_CONFIG_SENSE3_Pos)
 #define EIC_CONFIG_SENSE3_LOW       (EIC_CONFIG_SENSE3_LOW_Val     << EIC_CONFIG_SENSE3_Pos)
 #define EIC_CONFIG_FILTEN3_Pos      15           /**< \brief (EIC_CONFIG) Filter 3 Enable */
-#define EIC_CONFIG_FILTEN3          (0x1ul << EIC_CONFIG_FILTEN3_Pos)
+#define EIC_CONFIG_FILTEN3          (_U_(0x1) << EIC_CONFIG_FILTEN3_Pos)
 #define EIC_CONFIG_SENSE4_Pos       16           /**< \brief (EIC_CONFIG) Input Sense 4 Configuration */
-#define EIC_CONFIG_SENSE4_Msk       (0x7ul << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_Msk       (_U_(0x7) << EIC_CONFIG_SENSE4_Pos)
 #define EIC_CONFIG_SENSE4(value)    (EIC_CONFIG_SENSE4_Msk & ((value) << EIC_CONFIG_SENSE4_Pos))
-#define   EIC_CONFIG_SENSE4_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
-#define   EIC_CONFIG_SENSE4_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
-#define   EIC_CONFIG_SENSE4_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
-#define   EIC_CONFIG_SENSE4_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
-#define   EIC_CONFIG_SENSE4_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
-#define   EIC_CONFIG_SENSE4_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define   EIC_CONFIG_SENSE4_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE4_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE4_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE4_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE4_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE4_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
 #define EIC_CONFIG_SENSE4_NONE      (EIC_CONFIG_SENSE4_NONE_Val    << EIC_CONFIG_SENSE4_Pos)
 #define EIC_CONFIG_SENSE4_RISE      (EIC_CONFIG_SENSE4_RISE_Val    << EIC_CONFIG_SENSE4_Pos)
 #define EIC_CONFIG_SENSE4_FALL      (EIC_CONFIG_SENSE4_FALL_Val    << EIC_CONFIG_SENSE4_Pos)
@@ -606,16 +591,16 @@ typedef union {
 #define EIC_CONFIG_SENSE4_HIGH      (EIC_CONFIG_SENSE4_HIGH_Val    << EIC_CONFIG_SENSE4_Pos)
 #define EIC_CONFIG_SENSE4_LOW       (EIC_CONFIG_SENSE4_LOW_Val     << EIC_CONFIG_SENSE4_Pos)
 #define EIC_CONFIG_FILTEN4_Pos      19           /**< \brief (EIC_CONFIG) Filter 4 Enable */
-#define EIC_CONFIG_FILTEN4          (0x1ul << EIC_CONFIG_FILTEN4_Pos)
+#define EIC_CONFIG_FILTEN4          (_U_(0x1) << EIC_CONFIG_FILTEN4_Pos)
 #define EIC_CONFIG_SENSE5_Pos       20           /**< \brief (EIC_CONFIG) Input Sense 5 Configuration */
-#define EIC_CONFIG_SENSE5_Msk       (0x7ul << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_Msk       (_U_(0x7) << EIC_CONFIG_SENSE5_Pos)
 #define EIC_CONFIG_SENSE5(value)    (EIC_CONFIG_SENSE5_Msk & ((value) << EIC_CONFIG_SENSE5_Pos))
-#define   EIC_CONFIG_SENSE5_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
-#define   EIC_CONFIG_SENSE5_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
-#define   EIC_CONFIG_SENSE5_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
-#define   EIC_CONFIG_SENSE5_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
-#define   EIC_CONFIG_SENSE5_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
-#define   EIC_CONFIG_SENSE5_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define   EIC_CONFIG_SENSE5_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE5_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE5_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE5_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE5_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE5_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
 #define EIC_CONFIG_SENSE5_NONE      (EIC_CONFIG_SENSE5_NONE_Val    << EIC_CONFIG_SENSE5_Pos)
 #define EIC_CONFIG_SENSE5_RISE      (EIC_CONFIG_SENSE5_RISE_Val    << EIC_CONFIG_SENSE5_Pos)
 #define EIC_CONFIG_SENSE5_FALL      (EIC_CONFIG_SENSE5_FALL_Val    << EIC_CONFIG_SENSE5_Pos)
@@ -623,16 +608,16 @@ typedef union {
 #define EIC_CONFIG_SENSE5_HIGH      (EIC_CONFIG_SENSE5_HIGH_Val    << EIC_CONFIG_SENSE5_Pos)
 #define EIC_CONFIG_SENSE5_LOW       (EIC_CONFIG_SENSE5_LOW_Val     << EIC_CONFIG_SENSE5_Pos)
 #define EIC_CONFIG_FILTEN5_Pos      23           /**< \brief (EIC_CONFIG) Filter 5 Enable */
-#define EIC_CONFIG_FILTEN5          (0x1ul << EIC_CONFIG_FILTEN5_Pos)
+#define EIC_CONFIG_FILTEN5          (_U_(0x1) << EIC_CONFIG_FILTEN5_Pos)
 #define EIC_CONFIG_SENSE6_Pos       24           /**< \brief (EIC_CONFIG) Input Sense 6 Configuration */
-#define EIC_CONFIG_SENSE6_Msk       (0x7ul << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_Msk       (_U_(0x7) << EIC_CONFIG_SENSE6_Pos)
 #define EIC_CONFIG_SENSE6(value)    (EIC_CONFIG_SENSE6_Msk & ((value) << EIC_CONFIG_SENSE6_Pos))
-#define   EIC_CONFIG_SENSE6_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
-#define   EIC_CONFIG_SENSE6_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
-#define   EIC_CONFIG_SENSE6_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
-#define   EIC_CONFIG_SENSE6_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
-#define   EIC_CONFIG_SENSE6_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
-#define   EIC_CONFIG_SENSE6_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define   EIC_CONFIG_SENSE6_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE6_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE6_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE6_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE6_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE6_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
 #define EIC_CONFIG_SENSE6_NONE      (EIC_CONFIG_SENSE6_NONE_Val    << EIC_CONFIG_SENSE6_Pos)
 #define EIC_CONFIG_SENSE6_RISE      (EIC_CONFIG_SENSE6_RISE_Val    << EIC_CONFIG_SENSE6_Pos)
 #define EIC_CONFIG_SENSE6_FALL      (EIC_CONFIG_SENSE6_FALL_Val    << EIC_CONFIG_SENSE6_Pos)
@@ -640,16 +625,16 @@ typedef union {
 #define EIC_CONFIG_SENSE6_HIGH      (EIC_CONFIG_SENSE6_HIGH_Val    << EIC_CONFIG_SENSE6_Pos)
 #define EIC_CONFIG_SENSE6_LOW       (EIC_CONFIG_SENSE6_LOW_Val     << EIC_CONFIG_SENSE6_Pos)
 #define EIC_CONFIG_FILTEN6_Pos      27           /**< \brief (EIC_CONFIG) Filter 6 Enable */
-#define EIC_CONFIG_FILTEN6          (0x1ul << EIC_CONFIG_FILTEN6_Pos)
+#define EIC_CONFIG_FILTEN6          (_U_(0x1) << EIC_CONFIG_FILTEN6_Pos)
 #define EIC_CONFIG_SENSE7_Pos       28           /**< \brief (EIC_CONFIG) Input Sense 7 Configuration */
-#define EIC_CONFIG_SENSE7_Msk       (0x7ul << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_Msk       (_U_(0x7) << EIC_CONFIG_SENSE7_Pos)
 #define EIC_CONFIG_SENSE7(value)    (EIC_CONFIG_SENSE7_Msk & ((value) << EIC_CONFIG_SENSE7_Pos))
-#define   EIC_CONFIG_SENSE7_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
-#define   EIC_CONFIG_SENSE7_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
-#define   EIC_CONFIG_SENSE7_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
-#define   EIC_CONFIG_SENSE7_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
-#define   EIC_CONFIG_SENSE7_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
-#define   EIC_CONFIG_SENSE7_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define   EIC_CONFIG_SENSE7_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE7_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE7_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE7_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE7_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE7_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
 #define EIC_CONFIG_SENSE7_NONE      (EIC_CONFIG_SENSE7_NONE_Val    << EIC_CONFIG_SENSE7_Pos)
 #define EIC_CONFIG_SENSE7_RISE      (EIC_CONFIG_SENSE7_RISE_Val    << EIC_CONFIG_SENSE7_Pos)
 #define EIC_CONFIG_SENSE7_FALL      (EIC_CONFIG_SENSE7_FALL_Val    << EIC_CONFIG_SENSE7_Pos)
@@ -657,8 +642,8 @@ typedef union {
 #define EIC_CONFIG_SENSE7_HIGH      (EIC_CONFIG_SENSE7_HIGH_Val    << EIC_CONFIG_SENSE7_Pos)
 #define EIC_CONFIG_SENSE7_LOW       (EIC_CONFIG_SENSE7_LOW_Val     << EIC_CONFIG_SENSE7_Pos)
 #define EIC_CONFIG_FILTEN7_Pos      31           /**< \brief (EIC_CONFIG) Filter 7 Enable */
-#define EIC_CONFIG_FILTEN7          (0x1ul << EIC_CONFIG_FILTEN7_Pos)
-#define EIC_CONFIG_MASK             0xFFFFFFFFul /**< \brief (EIC_CONFIG) MASK Register */
+#define EIC_CONFIG_FILTEN7          (_U_(0x1) << EIC_CONFIG_FILTEN7_Pos)
+#define EIC_CONFIG_MASK             _U_(0xFFFFFFFF) /**< \brief (EIC_CONFIG) MASK Register */
 
 /** \brief EIC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/evsys.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for EVSYS
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -67,13 +52,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EVSYS_CTRL_OFFSET           0x00         /**< \brief (EVSYS_CTRL offset) Control */
-#define EVSYS_CTRL_RESETVALUE       0x00ul       /**< \brief (EVSYS_CTRL reset_value) Control */
+#define EVSYS_CTRL_RESETVALUE       _U_(0x00)     /**< \brief (EVSYS_CTRL reset_value) Control */
 
 #define EVSYS_CTRL_SWRST_Pos        0            /**< \brief (EVSYS_CTRL) Software Reset */
-#define EVSYS_CTRL_SWRST            (0x1ul << EVSYS_CTRL_SWRST_Pos)
+#define EVSYS_CTRL_SWRST            (_U_(0x1) << EVSYS_CTRL_SWRST_Pos)
 #define EVSYS_CTRL_GCLKREQ_Pos      4            /**< \brief (EVSYS_CTRL) Generic Clock Requests */
-#define EVSYS_CTRL_GCLKREQ          (0x1ul << EVSYS_CTRL_GCLKREQ_Pos)
-#define EVSYS_CTRL_MASK             0x11ul       /**< \brief (EVSYS_CTRL) MASK Register */
+#define EVSYS_CTRL_GCLKREQ          (_U_(0x1) << EVSYS_CTRL_GCLKREQ_Pos)
+#define EVSYS_CTRL_MASK             _U_(0x11)     /**< \brief (EVSYS_CTRL) MASK Register */
 
 /* -------- EVSYS_CHANNEL : (EVSYS Offset: 0x04) (R/W 32) Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -94,37 +79,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EVSYS_CHANNEL_OFFSET        0x04         /**< \brief (EVSYS_CHANNEL offset) Channel */
-#define EVSYS_CHANNEL_RESETVALUE    0x00000000ul /**< \brief (EVSYS_CHANNEL reset_value) Channel */
+#define EVSYS_CHANNEL_RESETVALUE    _U_(0x00000000) /**< \brief (EVSYS_CHANNEL reset_value) Channel */
 
 #define EVSYS_CHANNEL_CHANNEL_Pos   0            /**< \brief (EVSYS_CHANNEL) Channel Selection */
-#define EVSYS_CHANNEL_CHANNEL_Msk   (0xFul << EVSYS_CHANNEL_CHANNEL_Pos)
+#define EVSYS_CHANNEL_CHANNEL_Msk   (_U_(0xF) << EVSYS_CHANNEL_CHANNEL_Pos)
 #define EVSYS_CHANNEL_CHANNEL(value) (EVSYS_CHANNEL_CHANNEL_Msk & ((value) << EVSYS_CHANNEL_CHANNEL_Pos))
 #define EVSYS_CHANNEL_SWEVT_Pos     8            /**< \brief (EVSYS_CHANNEL) Software Event */
-#define EVSYS_CHANNEL_SWEVT         (0x1ul << EVSYS_CHANNEL_SWEVT_Pos)
+#define EVSYS_CHANNEL_SWEVT         (_U_(0x1) << EVSYS_CHANNEL_SWEVT_Pos)
 #define EVSYS_CHANNEL_EVGEN_Pos     16           /**< \brief (EVSYS_CHANNEL) Event Generator Selection */
-#define EVSYS_CHANNEL_EVGEN_Msk     (0x7Ful << EVSYS_CHANNEL_EVGEN_Pos)
+#define EVSYS_CHANNEL_EVGEN_Msk     (_U_(0x7F) << EVSYS_CHANNEL_EVGEN_Pos)
 #define EVSYS_CHANNEL_EVGEN(value)  (EVSYS_CHANNEL_EVGEN_Msk & ((value) << EVSYS_CHANNEL_EVGEN_Pos))
 #define EVSYS_CHANNEL_PATH_Pos      24           /**< \brief (EVSYS_CHANNEL) Path Selection */
-#define EVSYS_CHANNEL_PATH_Msk      (0x3ul << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH_Msk      (_U_(0x3) << EVSYS_CHANNEL_PATH_Pos)
 #define EVSYS_CHANNEL_PATH(value)   (EVSYS_CHANNEL_PATH_Msk & ((value) << EVSYS_CHANNEL_PATH_Pos))
-#define   EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val 0x0ul  /**< \brief (EVSYS_CHANNEL) Synchronous path */
-#define   EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val 0x1ul  /**< \brief (EVSYS_CHANNEL) Resynchronized path */
-#define   EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val 0x2ul  /**< \brief (EVSYS_CHANNEL) Asynchronous path */
+#define   EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val _U_(0x0)   /**< \brief (EVSYS_CHANNEL) Synchronous path */
+#define   EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val _U_(0x1)   /**< \brief (EVSYS_CHANNEL) Resynchronized path */
+#define   EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val _U_(0x2)   /**< \brief (EVSYS_CHANNEL) Asynchronous path */
 #define EVSYS_CHANNEL_PATH_SYNCHRONOUS (EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)
 #define EVSYS_CHANNEL_PATH_RESYNCHRONIZED (EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val << EVSYS_CHANNEL_PATH_Pos)
 #define EVSYS_CHANNEL_PATH_ASYNCHRONOUS (EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)
 #define EVSYS_CHANNEL_EDGSEL_Pos    26           /**< \brief (EVSYS_CHANNEL) Edge Detection Selection */
-#define EVSYS_CHANNEL_EDGSEL_Msk    (0x3ul << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_Msk    (_U_(0x3) << EVSYS_CHANNEL_EDGSEL_Pos)
 #define EVSYS_CHANNEL_EDGSEL(value) (EVSYS_CHANNEL_EDGSEL_Msk & ((value) << EVSYS_CHANNEL_EDGSEL_Pos))
-#define   EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val 0x0ul  /**< \brief (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path */
-#define   EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val 0x1ul  /**< \brief (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path */
-#define   EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val 0x2ul  /**< \brief (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path */
-#define   EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val 0x3ul  /**< \brief (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val _U_(0x0)   /**< \brief (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val _U_(0x1)   /**< \brief (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val _U_(0x2)   /**< \brief (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val _U_(0x3)   /**< \brief (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path */
 #define EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT (EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val << EVSYS_CHANNEL_EDGSEL_Pos)
 #define EVSYS_CHANNEL_EDGSEL_RISING_EDGE (EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)
 #define EVSYS_CHANNEL_EDGSEL_FALLING_EDGE (EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)
 #define EVSYS_CHANNEL_EDGSEL_BOTH_EDGES (EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val << EVSYS_CHANNEL_EDGSEL_Pos)
-#define EVSYS_CHANNEL_MASK          0x0F7F010Ful /**< \brief (EVSYS_CHANNEL) MASK Register */
+#define EVSYS_CHANNEL_MASK          _U_(0x0F7F010F) /**< \brief (EVSYS_CHANNEL) MASK Register */
 
 /* -------- EVSYS_USER : (EVSYS Offset: 0x08) (R/W 16) User Multiplexer -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -140,17 +125,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EVSYS_USER_OFFSET           0x08         /**< \brief (EVSYS_USER offset) User Multiplexer */
-#define EVSYS_USER_RESETVALUE       0x0000ul     /**< \brief (EVSYS_USER reset_value) User Multiplexer */
+#define EVSYS_USER_RESETVALUE       _U_(0x0000)   /**< \brief (EVSYS_USER reset_value) User Multiplexer */
 
 #define EVSYS_USER_USER_Pos         0            /**< \brief (EVSYS_USER) User Multiplexer Selection */
-#define EVSYS_USER_USER_Msk         (0x1Ful << EVSYS_USER_USER_Pos)
+#define EVSYS_USER_USER_Msk         (_U_(0x1F) << EVSYS_USER_USER_Pos)
 #define EVSYS_USER_USER(value)      (EVSYS_USER_USER_Msk & ((value) << EVSYS_USER_USER_Pos))
 #define EVSYS_USER_CHANNEL_Pos      8            /**< \brief (EVSYS_USER) Channel Event Selection */
-#define EVSYS_USER_CHANNEL_Msk      (0x1Ful << EVSYS_USER_CHANNEL_Pos)
+#define EVSYS_USER_CHANNEL_Msk      (_U_(0x1F) << EVSYS_USER_CHANNEL_Pos)
 #define EVSYS_USER_CHANNEL(value)   (EVSYS_USER_CHANNEL_Msk & ((value) << EVSYS_USER_CHANNEL_Pos))
-#define   EVSYS_USER_CHANNEL_0_Val        0x0ul  /**< \brief (EVSYS_USER) No Channel Output Selected */
+#define   EVSYS_USER_CHANNEL_0_Val        _U_(0x0)   /**< \brief (EVSYS_USER) No Channel Output Selected */
 #define EVSYS_USER_CHANNEL_0        (EVSYS_USER_CHANNEL_0_Val      << EVSYS_USER_CHANNEL_Pos)
-#define EVSYS_USER_MASK             0x1F1Ful     /**< \brief (EVSYS_USER) MASK Register */
+#define EVSYS_USER_MASK             _U_(0x1F1F)   /**< \brief (EVSYS_USER) MASK Register */
 
 /* -------- EVSYS_CHSTATUS : (EVSYS Offset: 0x0C) (R/  32) Channel Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -196,7 +181,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EVSYS_CHSTATUS_OFFSET       0x0C         /**< \brief (EVSYS_CHSTATUS offset) Channel Status */
-#define EVSYS_CHSTATUS_RESETVALUE   0x000F00FFul /**< \brief (EVSYS_CHSTATUS reset_value) Channel Status */
+#define EVSYS_CHSTATUS_RESETVALUE   _U_(0x000F00FF) /**< \brief (EVSYS_CHSTATUS reset_value) Channel Status */
 
 #define EVSYS_CHSTATUS_USRRDY0_Pos  0            /**< \brief (EVSYS_CHSTATUS) Channel 0 User Ready */
 #define EVSYS_CHSTATUS_USRRDY0      (1 << EVSYS_CHSTATUS_USRRDY0_Pos)
@@ -215,7 +200,7 @@ typedef union {
 #define EVSYS_CHSTATUS_USRRDY7_Pos  7            /**< \brief (EVSYS_CHSTATUS) Channel 7 User Ready */
 #define EVSYS_CHSTATUS_USRRDY7      (1 << EVSYS_CHSTATUS_USRRDY7_Pos)
 #define EVSYS_CHSTATUS_USRRDY_Pos   0            /**< \brief (EVSYS_CHSTATUS) Channel x User Ready */
-#define EVSYS_CHSTATUS_USRRDY_Msk   (0xFFul << EVSYS_CHSTATUS_USRRDY_Pos)
+#define EVSYS_CHSTATUS_USRRDY_Msk   (_U_(0xFF) << EVSYS_CHSTATUS_USRRDY_Pos)
 #define EVSYS_CHSTATUS_USRRDY(value) (EVSYS_CHSTATUS_USRRDY_Msk & ((value) << EVSYS_CHSTATUS_USRRDY_Pos))
 #define EVSYS_CHSTATUS_CHBUSY0_Pos  8            /**< \brief (EVSYS_CHSTATUS) Channel 0 Busy */
 #define EVSYS_CHSTATUS_CHBUSY0      (1 << EVSYS_CHSTATUS_CHBUSY0_Pos)
@@ -234,7 +219,7 @@ typedef union {
 #define EVSYS_CHSTATUS_CHBUSY7_Pos  15           /**< \brief (EVSYS_CHSTATUS) Channel 7 Busy */
 #define EVSYS_CHSTATUS_CHBUSY7      (1 << EVSYS_CHSTATUS_CHBUSY7_Pos)
 #define EVSYS_CHSTATUS_CHBUSY_Pos   8            /**< \brief (EVSYS_CHSTATUS) Channel x Busy */
-#define EVSYS_CHSTATUS_CHBUSY_Msk   (0xFFul << EVSYS_CHSTATUS_CHBUSY_Pos)
+#define EVSYS_CHSTATUS_CHBUSY_Msk   (_U_(0xFF) << EVSYS_CHSTATUS_CHBUSY_Pos)
 #define EVSYS_CHSTATUS_CHBUSY(value) (EVSYS_CHSTATUS_CHBUSY_Msk & ((value) << EVSYS_CHSTATUS_CHBUSY_Pos))
 #define EVSYS_CHSTATUS_USRRDY8_Pos  16           /**< \brief (EVSYS_CHSTATUS) Channel 8 User Ready */
 #define EVSYS_CHSTATUS_USRRDY8      (1 << EVSYS_CHSTATUS_USRRDY8_Pos)
@@ -245,7 +230,7 @@ typedef union {
 #define EVSYS_CHSTATUS_USRRDY11_Pos 19           /**< \brief (EVSYS_CHSTATUS) Channel 11 User Ready */
 #define EVSYS_CHSTATUS_USRRDY11     (1 << EVSYS_CHSTATUS_USRRDY11_Pos)
 #define EVSYS_CHSTATUS_USRRDYp8_Pos 16           /**< \brief (EVSYS_CHSTATUS) Channel x+8 User Ready */
-#define EVSYS_CHSTATUS_USRRDYp8_Msk (0xFul << EVSYS_CHSTATUS_USRRDYp8_Pos)
+#define EVSYS_CHSTATUS_USRRDYp8_Msk (_U_(0xF) << EVSYS_CHSTATUS_USRRDYp8_Pos)
 #define EVSYS_CHSTATUS_USRRDYp8(value) (EVSYS_CHSTATUS_USRRDYp8_Msk & ((value) << EVSYS_CHSTATUS_USRRDYp8_Pos))
 #define EVSYS_CHSTATUS_CHBUSY8_Pos  24           /**< \brief (EVSYS_CHSTATUS) Channel 8 Busy */
 #define EVSYS_CHSTATUS_CHBUSY8      (1 << EVSYS_CHSTATUS_CHBUSY8_Pos)
@@ -256,9 +241,9 @@ typedef union {
 #define EVSYS_CHSTATUS_CHBUSY11_Pos 27           /**< \brief (EVSYS_CHSTATUS) Channel 11 Busy */
 #define EVSYS_CHSTATUS_CHBUSY11     (1 << EVSYS_CHSTATUS_CHBUSY11_Pos)
 #define EVSYS_CHSTATUS_CHBUSYp8_Pos 24           /**< \brief (EVSYS_CHSTATUS) Channel x+8 Busy */
-#define EVSYS_CHSTATUS_CHBUSYp8_Msk (0xFul << EVSYS_CHSTATUS_CHBUSYp8_Pos)
+#define EVSYS_CHSTATUS_CHBUSYp8_Msk (_U_(0xF) << EVSYS_CHSTATUS_CHBUSYp8_Pos)
 #define EVSYS_CHSTATUS_CHBUSYp8(value) (EVSYS_CHSTATUS_CHBUSYp8_Msk & ((value) << EVSYS_CHSTATUS_CHBUSYp8_Pos))
-#define EVSYS_CHSTATUS_MASK         0x0F0FFFFFul /**< \brief (EVSYS_CHSTATUS) MASK Register */
+#define EVSYS_CHSTATUS_MASK         _U_(0x0F0FFFFF) /**< \brief (EVSYS_CHSTATUS) MASK Register */
 
 /* -------- EVSYS_INTENCLR : (EVSYS Offset: 0x10) (R/W 32) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -304,7 +289,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EVSYS_INTENCLR_OFFSET       0x10         /**< \brief (EVSYS_INTENCLR offset) Interrupt Enable Clear */
-#define EVSYS_INTENCLR_RESETVALUE   0x00000000ul /**< \brief (EVSYS_INTENCLR reset_value) Interrupt Enable Clear */
+#define EVSYS_INTENCLR_RESETVALUE   _U_(0x00000000) /**< \brief (EVSYS_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define EVSYS_INTENCLR_OVR0_Pos     0            /**< \brief (EVSYS_INTENCLR) Channel 0 Overrun Interrupt Enable */
 #define EVSYS_INTENCLR_OVR0         (1 << EVSYS_INTENCLR_OVR0_Pos)
@@ -323,7 +308,7 @@ typedef union {
 #define EVSYS_INTENCLR_OVR7_Pos     7            /**< \brief (EVSYS_INTENCLR) Channel 7 Overrun Interrupt Enable */
 #define EVSYS_INTENCLR_OVR7         (1 << EVSYS_INTENCLR_OVR7_Pos)
 #define EVSYS_INTENCLR_OVR_Pos      0            /**< \brief (EVSYS_INTENCLR) Channel x Overrun Interrupt Enable */
-#define EVSYS_INTENCLR_OVR_Msk      (0xFFul << EVSYS_INTENCLR_OVR_Pos)
+#define EVSYS_INTENCLR_OVR_Msk      (_U_(0xFF) << EVSYS_INTENCLR_OVR_Pos)
 #define EVSYS_INTENCLR_OVR(value)   (EVSYS_INTENCLR_OVR_Msk & ((value) << EVSYS_INTENCLR_OVR_Pos))
 #define EVSYS_INTENCLR_EVD0_Pos     8            /**< \brief (EVSYS_INTENCLR) Channel 0 Event Detection Interrupt Enable */
 #define EVSYS_INTENCLR_EVD0         (1 << EVSYS_INTENCLR_EVD0_Pos)
@@ -342,7 +327,7 @@ typedef union {
 #define EVSYS_INTENCLR_EVD7_Pos     15           /**< \brief (EVSYS_INTENCLR) Channel 7 Event Detection Interrupt Enable */
 #define EVSYS_INTENCLR_EVD7         (1 << EVSYS_INTENCLR_EVD7_Pos)
 #define EVSYS_INTENCLR_EVD_Pos      8            /**< \brief (EVSYS_INTENCLR) Channel x Event Detection Interrupt Enable */
-#define EVSYS_INTENCLR_EVD_Msk      (0xFFul << EVSYS_INTENCLR_EVD_Pos)
+#define EVSYS_INTENCLR_EVD_Msk      (_U_(0xFF) << EVSYS_INTENCLR_EVD_Pos)
 #define EVSYS_INTENCLR_EVD(value)   (EVSYS_INTENCLR_EVD_Msk & ((value) << EVSYS_INTENCLR_EVD_Pos))
 #define EVSYS_INTENCLR_OVR8_Pos     16           /**< \brief (EVSYS_INTENCLR) Channel 8 Overrun Interrupt Enable */
 #define EVSYS_INTENCLR_OVR8         (1 << EVSYS_INTENCLR_OVR8_Pos)
@@ -353,7 +338,7 @@ typedef union {
 #define EVSYS_INTENCLR_OVR11_Pos    19           /**< \brief (EVSYS_INTENCLR) Channel 11 Overrun Interrupt Enable */
 #define EVSYS_INTENCLR_OVR11        (1 << EVSYS_INTENCLR_OVR11_Pos)
 #define EVSYS_INTENCLR_OVRp8_Pos    16           /**< \brief (EVSYS_INTENCLR) Channel x+8 Overrun Interrupt Enable */
-#define EVSYS_INTENCLR_OVRp8_Msk    (0xFul << EVSYS_INTENCLR_OVRp8_Pos)
+#define EVSYS_INTENCLR_OVRp8_Msk    (_U_(0xF) << EVSYS_INTENCLR_OVRp8_Pos)
 #define EVSYS_INTENCLR_OVRp8(value) (EVSYS_INTENCLR_OVRp8_Msk & ((value) << EVSYS_INTENCLR_OVRp8_Pos))
 #define EVSYS_INTENCLR_EVD8_Pos     24           /**< \brief (EVSYS_INTENCLR) Channel 8 Event Detection Interrupt Enable */
 #define EVSYS_INTENCLR_EVD8         (1 << EVSYS_INTENCLR_EVD8_Pos)
@@ -364,9 +349,9 @@ typedef union {
 #define EVSYS_INTENCLR_EVD11_Pos    27           /**< \brief (EVSYS_INTENCLR) Channel 11 Event Detection Interrupt Enable */
 #define EVSYS_INTENCLR_EVD11        (1 << EVSYS_INTENCLR_EVD11_Pos)
 #define EVSYS_INTENCLR_EVDp8_Pos    24           /**< \brief (EVSYS_INTENCLR) Channel x+8 Event Detection Interrupt Enable */
-#define EVSYS_INTENCLR_EVDp8_Msk    (0xFul << EVSYS_INTENCLR_EVDp8_Pos)
+#define EVSYS_INTENCLR_EVDp8_Msk    (_U_(0xF) << EVSYS_INTENCLR_EVDp8_Pos)
 #define EVSYS_INTENCLR_EVDp8(value) (EVSYS_INTENCLR_EVDp8_Msk & ((value) << EVSYS_INTENCLR_EVDp8_Pos))
-#define EVSYS_INTENCLR_MASK         0x0F0FFFFFul /**< \brief (EVSYS_INTENCLR) MASK Register */
+#define EVSYS_INTENCLR_MASK         _U_(0x0F0FFFFF) /**< \brief (EVSYS_INTENCLR) MASK Register */
 
 /* -------- EVSYS_INTENSET : (EVSYS Offset: 0x14) (R/W 32) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -412,7 +397,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EVSYS_INTENSET_OFFSET       0x14         /**< \brief (EVSYS_INTENSET offset) Interrupt Enable Set */
-#define EVSYS_INTENSET_RESETVALUE   0x00000000ul /**< \brief (EVSYS_INTENSET reset_value) Interrupt Enable Set */
+#define EVSYS_INTENSET_RESETVALUE   _U_(0x00000000) /**< \brief (EVSYS_INTENSET reset_value) Interrupt Enable Set */
 
 #define EVSYS_INTENSET_OVR0_Pos     0            /**< \brief (EVSYS_INTENSET) Channel 0 Overrun Interrupt Enable */
 #define EVSYS_INTENSET_OVR0         (1 << EVSYS_INTENSET_OVR0_Pos)
@@ -431,7 +416,7 @@ typedef union {
 #define EVSYS_INTENSET_OVR7_Pos     7            /**< \brief (EVSYS_INTENSET) Channel 7 Overrun Interrupt Enable */
 #define EVSYS_INTENSET_OVR7         (1 << EVSYS_INTENSET_OVR7_Pos)
 #define EVSYS_INTENSET_OVR_Pos      0            /**< \brief (EVSYS_INTENSET) Channel x Overrun Interrupt Enable */
-#define EVSYS_INTENSET_OVR_Msk      (0xFFul << EVSYS_INTENSET_OVR_Pos)
+#define EVSYS_INTENSET_OVR_Msk      (_U_(0xFF) << EVSYS_INTENSET_OVR_Pos)
 #define EVSYS_INTENSET_OVR(value)   (EVSYS_INTENSET_OVR_Msk & ((value) << EVSYS_INTENSET_OVR_Pos))
 #define EVSYS_INTENSET_EVD0_Pos     8            /**< \brief (EVSYS_INTENSET) Channel 0 Event Detection Interrupt Enable */
 #define EVSYS_INTENSET_EVD0         (1 << EVSYS_INTENSET_EVD0_Pos)
@@ -450,7 +435,7 @@ typedef union {
 #define EVSYS_INTENSET_EVD7_Pos     15           /**< \brief (EVSYS_INTENSET) Channel 7 Event Detection Interrupt Enable */
 #define EVSYS_INTENSET_EVD7         (1 << EVSYS_INTENSET_EVD7_Pos)
 #define EVSYS_INTENSET_EVD_Pos      8            /**< \brief (EVSYS_INTENSET) Channel x Event Detection Interrupt Enable */
-#define EVSYS_INTENSET_EVD_Msk      (0xFFul << EVSYS_INTENSET_EVD_Pos)
+#define EVSYS_INTENSET_EVD_Msk      (_U_(0xFF) << EVSYS_INTENSET_EVD_Pos)
 #define EVSYS_INTENSET_EVD(value)   (EVSYS_INTENSET_EVD_Msk & ((value) << EVSYS_INTENSET_EVD_Pos))
 #define EVSYS_INTENSET_OVR8_Pos     16           /**< \brief (EVSYS_INTENSET) Channel 8 Overrun Interrupt Enable */
 #define EVSYS_INTENSET_OVR8         (1 << EVSYS_INTENSET_OVR8_Pos)
@@ -461,7 +446,7 @@ typedef union {
 #define EVSYS_INTENSET_OVR11_Pos    19           /**< \brief (EVSYS_INTENSET) Channel 11 Overrun Interrupt Enable */
 #define EVSYS_INTENSET_OVR11        (1 << EVSYS_INTENSET_OVR11_Pos)
 #define EVSYS_INTENSET_OVRp8_Pos    16           /**< \brief (EVSYS_INTENSET) Channel x+8 Overrun Interrupt Enable */
-#define EVSYS_INTENSET_OVRp8_Msk    (0xFul << EVSYS_INTENSET_OVRp8_Pos)
+#define EVSYS_INTENSET_OVRp8_Msk    (_U_(0xF) << EVSYS_INTENSET_OVRp8_Pos)
 #define EVSYS_INTENSET_OVRp8(value) (EVSYS_INTENSET_OVRp8_Msk & ((value) << EVSYS_INTENSET_OVRp8_Pos))
 #define EVSYS_INTENSET_EVD8_Pos     24           /**< \brief (EVSYS_INTENSET) Channel 8 Event Detection Interrupt Enable */
 #define EVSYS_INTENSET_EVD8         (1 << EVSYS_INTENSET_EVD8_Pos)
@@ -472,9 +457,9 @@ typedef union {
 #define EVSYS_INTENSET_EVD11_Pos    27           /**< \brief (EVSYS_INTENSET) Channel 11 Event Detection Interrupt Enable */
 #define EVSYS_INTENSET_EVD11        (1 << EVSYS_INTENSET_EVD11_Pos)
 #define EVSYS_INTENSET_EVDp8_Pos    24           /**< \brief (EVSYS_INTENSET) Channel x+8 Event Detection Interrupt Enable */
-#define EVSYS_INTENSET_EVDp8_Msk    (0xFul << EVSYS_INTENSET_EVDp8_Pos)
+#define EVSYS_INTENSET_EVDp8_Msk    (_U_(0xF) << EVSYS_INTENSET_EVDp8_Pos)
 #define EVSYS_INTENSET_EVDp8(value) (EVSYS_INTENSET_EVDp8_Msk & ((value) << EVSYS_INTENSET_EVDp8_Pos))
-#define EVSYS_INTENSET_MASK         0x0F0FFFFFul /**< \brief (EVSYS_INTENSET) MASK Register */
+#define EVSYS_INTENSET_MASK         _U_(0x0F0FFFFF) /**< \brief (EVSYS_INTENSET) MASK Register */
 
 /* -------- EVSYS_INTFLAG : (EVSYS Offset: 0x18) (R/W 32) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -520,7 +505,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EVSYS_INTFLAG_OFFSET        0x18         /**< \brief (EVSYS_INTFLAG offset) Interrupt Flag Status and Clear */
-#define EVSYS_INTFLAG_RESETVALUE    0x00000000ul /**< \brief (EVSYS_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define EVSYS_INTFLAG_RESETVALUE    _U_(0x00000000) /**< \brief (EVSYS_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define EVSYS_INTFLAG_OVR0_Pos      0            /**< \brief (EVSYS_INTFLAG) Channel 0 Overrun */
 #define EVSYS_INTFLAG_OVR0          (1 << EVSYS_INTFLAG_OVR0_Pos)
@@ -539,7 +524,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #define EVSYS_INTFLAG_OVR7_Pos      7            /**< \brief (EVSYS_INTFLAG) Channel 7 Overrun */
 #define EVSYS_INTFLAG_OVR7          (1 << EVSYS_INTFLAG_OVR7_Pos)
 #define EVSYS_INTFLAG_OVR_Pos       0            /**< \brief (EVSYS_INTFLAG) Channel x Overrun */
-#define EVSYS_INTFLAG_OVR_Msk       (0xFFul << EVSYS_INTFLAG_OVR_Pos)
+#define EVSYS_INTFLAG_OVR_Msk       (_U_(0xFF) << EVSYS_INTFLAG_OVR_Pos)
 #define EVSYS_INTFLAG_OVR(value)    (EVSYS_INTFLAG_OVR_Msk & ((value) << EVSYS_INTFLAG_OVR_Pos))
 #define EVSYS_INTFLAG_EVD0_Pos      8            /**< \brief (EVSYS_INTFLAG) Channel 0 Event Detection */
 #define EVSYS_INTFLAG_EVD0          (1 << EVSYS_INTFLAG_EVD0_Pos)
@@ -558,7 +543,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #define EVSYS_INTFLAG_EVD7_Pos      15           /**< \brief (EVSYS_INTFLAG) Channel 7 Event Detection */
 #define EVSYS_INTFLAG_EVD7          (1 << EVSYS_INTFLAG_EVD7_Pos)
 #define EVSYS_INTFLAG_EVD_Pos       8            /**< \brief (EVSYS_INTFLAG) Channel x Event Detection */
-#define EVSYS_INTFLAG_EVD_Msk       (0xFFul << EVSYS_INTFLAG_EVD_Pos)
+#define EVSYS_INTFLAG_EVD_Msk       (_U_(0xFF) << EVSYS_INTFLAG_EVD_Pos)
 #define EVSYS_INTFLAG_EVD(value)    (EVSYS_INTFLAG_EVD_Msk & ((value) << EVSYS_INTFLAG_EVD_Pos))
 #define EVSYS_INTFLAG_OVR8_Pos      16           /**< \brief (EVSYS_INTFLAG) Channel 8 Overrun */
 #define EVSYS_INTFLAG_OVR8          (1 << EVSYS_INTFLAG_OVR8_Pos)
@@ -569,7 +554,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #define EVSYS_INTFLAG_OVR11_Pos     19           /**< \brief (EVSYS_INTFLAG) Channel 11 Overrun */
 #define EVSYS_INTFLAG_OVR11         (1 << EVSYS_INTFLAG_OVR11_Pos)
 #define EVSYS_INTFLAG_OVRp8_Pos     16           /**< \brief (EVSYS_INTFLAG) Channel x+8 Overrun */
-#define EVSYS_INTFLAG_OVRp8_Msk     (0xFul << EVSYS_INTFLAG_OVRp8_Pos)
+#define EVSYS_INTFLAG_OVRp8_Msk     (_U_(0xF) << EVSYS_INTFLAG_OVRp8_Pos)
 #define EVSYS_INTFLAG_OVRp8(value)  (EVSYS_INTFLAG_OVRp8_Msk & ((value) << EVSYS_INTFLAG_OVRp8_Pos))
 #define EVSYS_INTFLAG_EVD8_Pos      24           /**< \brief (EVSYS_INTFLAG) Channel 8 Event Detection */
 #define EVSYS_INTFLAG_EVD8          (1 << EVSYS_INTFLAG_EVD8_Pos)
@@ -580,9 +565,9 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #define EVSYS_INTFLAG_EVD11_Pos     27           /**< \brief (EVSYS_INTFLAG) Channel 11 Event Detection */
 #define EVSYS_INTFLAG_EVD11         (1 << EVSYS_INTFLAG_EVD11_Pos)
 #define EVSYS_INTFLAG_EVDp8_Pos     24           /**< \brief (EVSYS_INTFLAG) Channel x+8 Event Detection */
-#define EVSYS_INTFLAG_EVDp8_Msk     (0xFul << EVSYS_INTFLAG_EVDp8_Pos)
+#define EVSYS_INTFLAG_EVDp8_Msk     (_U_(0xF) << EVSYS_INTFLAG_EVDp8_Pos)
 #define EVSYS_INTFLAG_EVDp8(value)  (EVSYS_INTFLAG_EVDp8_Msk & ((value) << EVSYS_INTFLAG_EVDp8_Pos))
-#define EVSYS_INTFLAG_MASK          0x0F0FFFFFul /**< \brief (EVSYS_INTFLAG) MASK Register */
+#define EVSYS_INTFLAG_MASK          _U_(0x0F0FFFFF) /**< \brief (EVSYS_INTFLAG) MASK Register */
 
 /** \brief EVSYS hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/gclk.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/gclk.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for GCLK
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -65,11 +50,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GCLK_CTRL_OFFSET            0x0          /**< \brief (GCLK_CTRL offset) Control */
-#define GCLK_CTRL_RESETVALUE        0x00ul       /**< \brief (GCLK_CTRL reset_value) Control */
+#define GCLK_CTRL_RESETVALUE        _U_(0x00)     /**< \brief (GCLK_CTRL reset_value) Control */
 
 #define GCLK_CTRL_SWRST_Pos         0            /**< \brief (GCLK_CTRL) Software Reset */
-#define GCLK_CTRL_SWRST             (0x1ul << GCLK_CTRL_SWRST_Pos)
-#define GCLK_CTRL_MASK              0x01ul       /**< \brief (GCLK_CTRL) MASK Register */
+#define GCLK_CTRL_SWRST             (_U_(0x1) << GCLK_CTRL_SWRST_Pos)
+#define GCLK_CTRL_MASK              _U_(0x01)     /**< \brief (GCLK_CTRL) MASK Register */
 
 /* -------- GCLK_STATUS : (GCLK Offset: 0x1) (R/   8) Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -83,11 +68,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GCLK_STATUS_OFFSET          0x1          /**< \brief (GCLK_STATUS offset) Status */
-#define GCLK_STATUS_RESETVALUE      0x00ul       /**< \brief (GCLK_STATUS reset_value) Status */
+#define GCLK_STATUS_RESETVALUE      _U_(0x00)     /**< \brief (GCLK_STATUS reset_value) Status */
 
 #define GCLK_STATUS_SYNCBUSY_Pos    7            /**< \brief (GCLK_STATUS) Synchronization Busy Status */
-#define GCLK_STATUS_SYNCBUSY        (0x1ul << GCLK_STATUS_SYNCBUSY_Pos)
-#define GCLK_STATUS_MASK            0x80ul       /**< \brief (GCLK_STATUS) MASK Register */
+#define GCLK_STATUS_SYNCBUSY        (_U_(0x1) << GCLK_STATUS_SYNCBUSY_Pos)
+#define GCLK_STATUS_MASK            _U_(0x80)     /**< \brief (GCLK_STATUS) MASK Register */
 
 /* -------- GCLK_CLKCTRL : (GCLK Offset: 0x2) (R/W 16) Generic Clock Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -105,48 +90,48 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GCLK_CLKCTRL_OFFSET         0x2          /**< \brief (GCLK_CLKCTRL offset) Generic Clock Control */
-#define GCLK_CLKCTRL_RESETVALUE     0x0000ul     /**< \brief (GCLK_CLKCTRL reset_value) Generic Clock Control */
+#define GCLK_CLKCTRL_RESETVALUE     _U_(0x0000)   /**< \brief (GCLK_CLKCTRL reset_value) Generic Clock Control */
 
 #define GCLK_CLKCTRL_ID_Pos         0            /**< \brief (GCLK_CLKCTRL) Generic Clock Selection ID */
-#define GCLK_CLKCTRL_ID_Msk         (0x3Ful << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_Msk         (_U_(0x3F) << GCLK_CLKCTRL_ID_Pos)
 #define GCLK_CLKCTRL_ID(value)      (GCLK_CLKCTRL_ID_Msk & ((value) << GCLK_CLKCTRL_ID_Pos))
-#define   GCLK_CLKCTRL_ID_DFLL48_Val      0x0ul  /**< \brief (GCLK_CLKCTRL) DFLL48 */
-#define   GCLK_CLKCTRL_ID_FDPLL_Val       0x1ul  /**< \brief (GCLK_CLKCTRL) FDPLL */
-#define   GCLK_CLKCTRL_ID_FDPLL32K_Val    0x2ul  /**< \brief (GCLK_CLKCTRL) FDPLL32K */
-#define   GCLK_CLKCTRL_ID_WDT_Val         0x3ul  /**< \brief (GCLK_CLKCTRL) WDT */
-#define   GCLK_CLKCTRL_ID_RTC_Val         0x4ul  /**< \brief (GCLK_CLKCTRL) RTC */
-#define   GCLK_CLKCTRL_ID_EIC_Val         0x5ul  /**< \brief (GCLK_CLKCTRL) EIC */
-#define   GCLK_CLKCTRL_ID_USB_Val         0x6ul  /**< \brief (GCLK_CLKCTRL) USB */
-#define   GCLK_CLKCTRL_ID_EVSYS_0_Val     0x7ul  /**< \brief (GCLK_CLKCTRL) EVSYS_0 */
-#define   GCLK_CLKCTRL_ID_EVSYS_1_Val     0x8ul  /**< \brief (GCLK_CLKCTRL) EVSYS_1 */
-#define   GCLK_CLKCTRL_ID_EVSYS_2_Val     0x9ul  /**< \brief (GCLK_CLKCTRL) EVSYS_2 */
-#define   GCLK_CLKCTRL_ID_EVSYS_3_Val     0xAul  /**< \brief (GCLK_CLKCTRL) EVSYS_3 */
-#define   GCLK_CLKCTRL_ID_EVSYS_4_Val     0xBul  /**< \brief (GCLK_CLKCTRL) EVSYS_4 */
-#define   GCLK_CLKCTRL_ID_EVSYS_5_Val     0xCul  /**< \brief (GCLK_CLKCTRL) EVSYS_5 */
-#define   GCLK_CLKCTRL_ID_EVSYS_6_Val     0xDul  /**< \brief (GCLK_CLKCTRL) EVSYS_6 */
-#define   GCLK_CLKCTRL_ID_EVSYS_7_Val     0xEul  /**< \brief (GCLK_CLKCTRL) EVSYS_7 */
-#define   GCLK_CLKCTRL_ID_EVSYS_8_Val     0xFul  /**< \brief (GCLK_CLKCTRL) EVSYS_8 */
-#define   GCLK_CLKCTRL_ID_EVSYS_9_Val     0x10ul  /**< \brief (GCLK_CLKCTRL) EVSYS_9 */
-#define   GCLK_CLKCTRL_ID_EVSYS_10_Val    0x11ul  /**< \brief (GCLK_CLKCTRL) EVSYS_10 */
-#define   GCLK_CLKCTRL_ID_EVSYS_11_Val    0x12ul  /**< \brief (GCLK_CLKCTRL) EVSYS_11 */
-#define   GCLK_CLKCTRL_ID_SERCOMX_SLOW_Val 0x13ul  /**< \brief (GCLK_CLKCTRL) SERCOMX_SLOW */
-#define   GCLK_CLKCTRL_ID_SERCOM0_CORE_Val 0x14ul  /**< \brief (GCLK_CLKCTRL) SERCOM0_CORE */
-#define   GCLK_CLKCTRL_ID_SERCOM1_CORE_Val 0x15ul  /**< \brief (GCLK_CLKCTRL) SERCOM1_CORE */
-#define   GCLK_CLKCTRL_ID_SERCOM2_CORE_Val 0x16ul  /**< \brief (GCLK_CLKCTRL) SERCOM2_CORE */
-#define   GCLK_CLKCTRL_ID_SERCOM3_CORE_Val 0x17ul  /**< \brief (GCLK_CLKCTRL) SERCOM3_CORE */
-#define   GCLK_CLKCTRL_ID_SERCOM4_CORE_Val 0x18ul  /**< \brief (GCLK_CLKCTRL) SERCOM4_CORE */
-#define   GCLK_CLKCTRL_ID_SERCOM5_CORE_Val 0x19ul  /**< \brief (GCLK_CLKCTRL) SERCOM5_CORE */
-#define   GCLK_CLKCTRL_ID_TCC0_TCC1_Val   0x1Aul  /**< \brief (GCLK_CLKCTRL) TCC0_TCC1 */
-#define   GCLK_CLKCTRL_ID_TCC2_TC3_Val    0x1Bul  /**< \brief (GCLK_CLKCTRL) TCC2_TC3 */
-#define   GCLK_CLKCTRL_ID_TC4_TC5_Val     0x1Cul  /**< \brief (GCLK_CLKCTRL) TC4_TC5 */
-#define   GCLK_CLKCTRL_ID_TC6_TC7_Val     0x1Dul  /**< \brief (GCLK_CLKCTRL) TC6_TC7 */
-#define   GCLK_CLKCTRL_ID_ADC_Val         0x1Eul  /**< \brief (GCLK_CLKCTRL) ADC */
-#define   GCLK_CLKCTRL_ID_AC_DIG_Val      0x1Ful  /**< \brief (GCLK_CLKCTRL) AC_DIG */
-#define   GCLK_CLKCTRL_ID_AC_ANA_Val      0x20ul  /**< \brief (GCLK_CLKCTRL) AC_ANA */
-#define   GCLK_CLKCTRL_ID_DAC_Val         0x21ul  /**< \brief (GCLK_CLKCTRL) DAC */
-#define   GCLK_CLKCTRL_ID_PTC_Val         0x22ul  /**< \brief (GCLK_CLKCTRL) PTC */
-#define   GCLK_CLKCTRL_ID_I2S_0_Val       0x23ul  /**< \brief (GCLK_CLKCTRL) I2S_0 */
-#define   GCLK_CLKCTRL_ID_I2S_1_Val       0x24ul  /**< \brief (GCLK_CLKCTRL) I2S_1 */
+#define   GCLK_CLKCTRL_ID_DFLL48_Val      _U_(0x0)   /**< \brief (GCLK_CLKCTRL) DFLL48 */
+#define   GCLK_CLKCTRL_ID_FDPLL_Val       _U_(0x1)   /**< \brief (GCLK_CLKCTRL) FDPLL */
+#define   GCLK_CLKCTRL_ID_FDPLL32K_Val    _U_(0x2)   /**< \brief (GCLK_CLKCTRL) FDPLL32K */
+#define   GCLK_CLKCTRL_ID_WDT_Val         _U_(0x3)   /**< \brief (GCLK_CLKCTRL) WDT */
+#define   GCLK_CLKCTRL_ID_RTC_Val         _U_(0x4)   /**< \brief (GCLK_CLKCTRL) RTC */
+#define   GCLK_CLKCTRL_ID_EIC_Val         _U_(0x5)   /**< \brief (GCLK_CLKCTRL) EIC */
+#define   GCLK_CLKCTRL_ID_USB_Val         _U_(0x6)   /**< \brief (GCLK_CLKCTRL) USB */
+#define   GCLK_CLKCTRL_ID_EVSYS_0_Val     _U_(0x7)   /**< \brief (GCLK_CLKCTRL) EVSYS_0 */
+#define   GCLK_CLKCTRL_ID_EVSYS_1_Val     _U_(0x8)   /**< \brief (GCLK_CLKCTRL) EVSYS_1 */
+#define   GCLK_CLKCTRL_ID_EVSYS_2_Val     _U_(0x9)   /**< \brief (GCLK_CLKCTRL) EVSYS_2 */
+#define   GCLK_CLKCTRL_ID_EVSYS_3_Val     _U_(0xA)   /**< \brief (GCLK_CLKCTRL) EVSYS_3 */
+#define   GCLK_CLKCTRL_ID_EVSYS_4_Val     _U_(0xB)   /**< \brief (GCLK_CLKCTRL) EVSYS_4 */
+#define   GCLK_CLKCTRL_ID_EVSYS_5_Val     _U_(0xC)   /**< \brief (GCLK_CLKCTRL) EVSYS_5 */
+#define   GCLK_CLKCTRL_ID_EVSYS_6_Val     _U_(0xD)   /**< \brief (GCLK_CLKCTRL) EVSYS_6 */
+#define   GCLK_CLKCTRL_ID_EVSYS_7_Val     _U_(0xE)   /**< \brief (GCLK_CLKCTRL) EVSYS_7 */
+#define   GCLK_CLKCTRL_ID_EVSYS_8_Val     _U_(0xF)   /**< \brief (GCLK_CLKCTRL) EVSYS_8 */
+#define   GCLK_CLKCTRL_ID_EVSYS_9_Val     _U_(0x10)   /**< \brief (GCLK_CLKCTRL) EVSYS_9 */
+#define   GCLK_CLKCTRL_ID_EVSYS_10_Val    _U_(0x11)   /**< \brief (GCLK_CLKCTRL) EVSYS_10 */
+#define   GCLK_CLKCTRL_ID_EVSYS_11_Val    _U_(0x12)   /**< \brief (GCLK_CLKCTRL) EVSYS_11 */
+#define   GCLK_CLKCTRL_ID_SERCOMX_SLOW_Val _U_(0x13)   /**< \brief (GCLK_CLKCTRL) SERCOMX_SLOW */
+#define   GCLK_CLKCTRL_ID_SERCOM0_CORE_Val _U_(0x14)   /**< \brief (GCLK_CLKCTRL) SERCOM0_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM1_CORE_Val _U_(0x15)   /**< \brief (GCLK_CLKCTRL) SERCOM1_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM2_CORE_Val _U_(0x16)   /**< \brief (GCLK_CLKCTRL) SERCOM2_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM3_CORE_Val _U_(0x17)   /**< \brief (GCLK_CLKCTRL) SERCOM3_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM4_CORE_Val _U_(0x18)   /**< \brief (GCLK_CLKCTRL) SERCOM4_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM5_CORE_Val _U_(0x19)   /**< \brief (GCLK_CLKCTRL) SERCOM5_CORE */
+#define   GCLK_CLKCTRL_ID_TCC0_TCC1_Val   _U_(0x1A)   /**< \brief (GCLK_CLKCTRL) TCC0_TCC1 */
+#define   GCLK_CLKCTRL_ID_TCC2_TC3_Val    _U_(0x1B)   /**< \brief (GCLK_CLKCTRL) TCC2_TC3 */
+#define   GCLK_CLKCTRL_ID_TC4_TC5_Val     _U_(0x1C)   /**< \brief (GCLK_CLKCTRL) TC4_TC5 */
+#define   GCLK_CLKCTRL_ID_TC6_TC7_Val     _U_(0x1D)   /**< \brief (GCLK_CLKCTRL) TC6_TC7 */
+#define   GCLK_CLKCTRL_ID_ADC_Val         _U_(0x1E)   /**< \brief (GCLK_CLKCTRL) ADC */
+#define   GCLK_CLKCTRL_ID_AC_DIG_Val      _U_(0x1F)   /**< \brief (GCLK_CLKCTRL) AC_DIG */
+#define   GCLK_CLKCTRL_ID_AC_ANA_Val      _U_(0x20)   /**< \brief (GCLK_CLKCTRL) AC_ANA */
+#define   GCLK_CLKCTRL_ID_DAC_Val         _U_(0x21)   /**< \brief (GCLK_CLKCTRL) DAC */
+#define   GCLK_CLKCTRL_ID_PTC_Val         _U_(0x22)   /**< \brief (GCLK_CLKCTRL) PTC */
+#define   GCLK_CLKCTRL_ID_I2S_0_Val       _U_(0x23)   /**< \brief (GCLK_CLKCTRL) I2S_0 */
+#define   GCLK_CLKCTRL_ID_I2S_1_Val       _U_(0x24)   /**< \brief (GCLK_CLKCTRL) I2S_1 */
 #define GCLK_CLKCTRL_ID_DFLL48      (GCLK_CLKCTRL_ID_DFLL48_Val    << GCLK_CLKCTRL_ID_Pos)
 #define GCLK_CLKCTRL_ID_FDPLL       (GCLK_CLKCTRL_ID_FDPLL_Val     << GCLK_CLKCTRL_ID_Pos)
 #define GCLK_CLKCTRL_ID_FDPLL32K    (GCLK_CLKCTRL_ID_FDPLL32K_Val  << GCLK_CLKCTRL_ID_Pos)
@@ -185,16 +170,16 @@ typedef union {
 #define GCLK_CLKCTRL_ID_I2S_0       (GCLK_CLKCTRL_ID_I2S_0_Val     << GCLK_CLKCTRL_ID_Pos)
 #define GCLK_CLKCTRL_ID_I2S_1       (GCLK_CLKCTRL_ID_I2S_1_Val     << GCLK_CLKCTRL_ID_Pos)
 #define GCLK_CLKCTRL_GEN_Pos        8            /**< \brief (GCLK_CLKCTRL) Generic Clock Generator */
-#define GCLK_CLKCTRL_GEN_Msk        (0xFul << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_Msk        (_U_(0xF) << GCLK_CLKCTRL_GEN_Pos)
 #define GCLK_CLKCTRL_GEN(value)     (GCLK_CLKCTRL_GEN_Msk & ((value) << GCLK_CLKCTRL_GEN_Pos))
-#define   GCLK_CLKCTRL_GEN_GCLK0_Val      0x0ul  /**< \brief (GCLK_CLKCTRL) Generic clock generator 0 */
-#define   GCLK_CLKCTRL_GEN_GCLK1_Val      0x1ul  /**< \brief (GCLK_CLKCTRL) Generic clock generator 1 */
-#define   GCLK_CLKCTRL_GEN_GCLK2_Val      0x2ul  /**< \brief (GCLK_CLKCTRL) Generic clock generator 2 */
-#define   GCLK_CLKCTRL_GEN_GCLK3_Val      0x3ul  /**< \brief (GCLK_CLKCTRL) Generic clock generator 3 */
-#define   GCLK_CLKCTRL_GEN_GCLK4_Val      0x4ul  /**< \brief (GCLK_CLKCTRL) Generic clock generator 4 */
-#define   GCLK_CLKCTRL_GEN_GCLK5_Val      0x5ul  /**< \brief (GCLK_CLKCTRL) Generic clock generator 5 */
-#define   GCLK_CLKCTRL_GEN_GCLK6_Val      0x6ul  /**< \brief (GCLK_CLKCTRL) Generic clock generator 6 */
-#define   GCLK_CLKCTRL_GEN_GCLK7_Val      0x7ul  /**< \brief (GCLK_CLKCTRL) Generic clock generator 7 */
+#define   GCLK_CLKCTRL_GEN_GCLK0_Val      _U_(0x0)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 0 */
+#define   GCLK_CLKCTRL_GEN_GCLK1_Val      _U_(0x1)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 1 */
+#define   GCLK_CLKCTRL_GEN_GCLK2_Val      _U_(0x2)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 2 */
+#define   GCLK_CLKCTRL_GEN_GCLK3_Val      _U_(0x3)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 3 */
+#define   GCLK_CLKCTRL_GEN_GCLK4_Val      _U_(0x4)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 4 */
+#define   GCLK_CLKCTRL_GEN_GCLK5_Val      _U_(0x5)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 5 */
+#define   GCLK_CLKCTRL_GEN_GCLK6_Val      _U_(0x6)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 6 */
+#define   GCLK_CLKCTRL_GEN_GCLK7_Val      _U_(0x7)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 7 */
 #define GCLK_CLKCTRL_GEN_GCLK0      (GCLK_CLKCTRL_GEN_GCLK0_Val    << GCLK_CLKCTRL_GEN_Pos)
 #define GCLK_CLKCTRL_GEN_GCLK1      (GCLK_CLKCTRL_GEN_GCLK1_Val    << GCLK_CLKCTRL_GEN_Pos)
 #define GCLK_CLKCTRL_GEN_GCLK2      (GCLK_CLKCTRL_GEN_GCLK2_Val    << GCLK_CLKCTRL_GEN_Pos)
@@ -204,10 +189,10 @@ typedef union {
 #define GCLK_CLKCTRL_GEN_GCLK6      (GCLK_CLKCTRL_GEN_GCLK6_Val    << GCLK_CLKCTRL_GEN_Pos)
 #define GCLK_CLKCTRL_GEN_GCLK7      (GCLK_CLKCTRL_GEN_GCLK7_Val    << GCLK_CLKCTRL_GEN_Pos)
 #define GCLK_CLKCTRL_CLKEN_Pos      14           /**< \brief (GCLK_CLKCTRL) Clock Enable */
-#define GCLK_CLKCTRL_CLKEN          (0x1ul << GCLK_CLKCTRL_CLKEN_Pos)
+#define GCLK_CLKCTRL_CLKEN          (_U_(0x1) << GCLK_CLKCTRL_CLKEN_Pos)
 #define GCLK_CLKCTRL_WRTLOCK_Pos    15           /**< \brief (GCLK_CLKCTRL) Write Lock */
-#define GCLK_CLKCTRL_WRTLOCK        (0x1ul << GCLK_CLKCTRL_WRTLOCK_Pos)
-#define GCLK_CLKCTRL_MASK           0xCF3Ful     /**< \brief (GCLK_CLKCTRL) MASK Register */
+#define GCLK_CLKCTRL_WRTLOCK        (_U_(0x1) << GCLK_CLKCTRL_WRTLOCK_Pos)
+#define GCLK_CLKCTRL_MASK           _U_(0xCF3F)   /**< \brief (GCLK_CLKCTRL) MASK Register */
 
 /* -------- GCLK_GENCTRL : (GCLK Offset: 0x4) (R/W 32) Generic Clock Generator Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -230,23 +215,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GCLK_GENCTRL_OFFSET         0x4          /**< \brief (GCLK_GENCTRL offset) Generic Clock Generator Control */
-#define GCLK_GENCTRL_RESETVALUE     0x00000000ul /**< \brief (GCLK_GENCTRL reset_value) Generic Clock Generator Control */
+#define GCLK_GENCTRL_RESETVALUE     _U_(0x00000000) /**< \brief (GCLK_GENCTRL reset_value) Generic Clock Generator Control */
 
 #define GCLK_GENCTRL_ID_Pos         0            /**< \brief (GCLK_GENCTRL) Generic Clock Generator Selection */
-#define GCLK_GENCTRL_ID_Msk         (0xFul << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_Msk         (_U_(0xF) << GCLK_GENCTRL_ID_Pos)
 #define GCLK_GENCTRL_ID(value)      (GCLK_GENCTRL_ID_Msk & ((value) << GCLK_GENCTRL_ID_Pos))
 #define GCLK_GENCTRL_SRC_Pos        8            /**< \brief (GCLK_GENCTRL) Source Select */
-#define GCLK_GENCTRL_SRC_Msk        (0x1Ful << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_Msk        (_U_(0x1F) << GCLK_GENCTRL_SRC_Pos)
 #define GCLK_GENCTRL_SRC(value)     (GCLK_GENCTRL_SRC_Msk & ((value) << GCLK_GENCTRL_SRC_Pos))
-#define   GCLK_GENCTRL_SRC_XOSC_Val       0x0ul  /**< \brief (GCLK_GENCTRL) XOSC oscillator output */
-#define   GCLK_GENCTRL_SRC_GCLKIN_Val     0x1ul  /**< \brief (GCLK_GENCTRL) Generator input pad */
-#define   GCLK_GENCTRL_SRC_GCLKGEN1_Val   0x2ul  /**< \brief (GCLK_GENCTRL) Generic clock generator 1 output */
-#define   GCLK_GENCTRL_SRC_OSCULP32K_Val  0x3ul  /**< \brief (GCLK_GENCTRL) OSCULP32K oscillator output */
-#define   GCLK_GENCTRL_SRC_OSC32K_Val     0x4ul  /**< \brief (GCLK_GENCTRL) OSC32K oscillator output */
-#define   GCLK_GENCTRL_SRC_XOSC32K_Val    0x5ul  /**< \brief (GCLK_GENCTRL) XOSC32K oscillator output */
-#define   GCLK_GENCTRL_SRC_OSC8M_Val      0x6ul  /**< \brief (GCLK_GENCTRL) OSC8M oscillator output */
-#define   GCLK_GENCTRL_SRC_DFLL48M_Val    0x7ul  /**< \brief (GCLK_GENCTRL) DFLL48M output */
-#define   GCLK_GENCTRL_SRC_FDPLL_Val      0x8ul  /**< \brief (GCLK_GENCTRL) FDPLL output */
+#define   GCLK_GENCTRL_SRC_XOSC_Val       _U_(0x0)   /**< \brief (GCLK_GENCTRL) XOSC oscillator output */
+#define   GCLK_GENCTRL_SRC_GCLKIN_Val     _U_(0x1)   /**< \brief (GCLK_GENCTRL) Generator input pad */
+#define   GCLK_GENCTRL_SRC_GCLKGEN1_Val   _U_(0x2)   /**< \brief (GCLK_GENCTRL) Generic clock generator 1 output */
+#define   GCLK_GENCTRL_SRC_OSCULP32K_Val  _U_(0x3)   /**< \brief (GCLK_GENCTRL) OSCULP32K oscillator output */
+#define   GCLK_GENCTRL_SRC_OSC32K_Val     _U_(0x4)   /**< \brief (GCLK_GENCTRL) OSC32K oscillator output */
+#define   GCLK_GENCTRL_SRC_XOSC32K_Val    _U_(0x5)   /**< \brief (GCLK_GENCTRL) XOSC32K oscillator output */
+#define   GCLK_GENCTRL_SRC_OSC8M_Val      _U_(0x6)   /**< \brief (GCLK_GENCTRL) OSC8M oscillator output */
+#define   GCLK_GENCTRL_SRC_DFLL48M_Val    _U_(0x7)   /**< \brief (GCLK_GENCTRL) DFLL48M output */
+#define   GCLK_GENCTRL_SRC_FDPLL_Val      _U_(0x8)   /**< \brief (GCLK_GENCTRL) FDPLL output */
 #define GCLK_GENCTRL_SRC_XOSC       (GCLK_GENCTRL_SRC_XOSC_Val     << GCLK_GENCTRL_SRC_Pos)
 #define GCLK_GENCTRL_SRC_GCLKIN     (GCLK_GENCTRL_SRC_GCLKIN_Val   << GCLK_GENCTRL_SRC_Pos)
 #define GCLK_GENCTRL_SRC_GCLKGEN1   (GCLK_GENCTRL_SRC_GCLKGEN1_Val << GCLK_GENCTRL_SRC_Pos)
@@ -257,18 +242,18 @@ typedef union {
 #define GCLK_GENCTRL_SRC_DFLL48M    (GCLK_GENCTRL_SRC_DFLL48M_Val  << GCLK_GENCTRL_SRC_Pos)
 #define GCLK_GENCTRL_SRC_FDPLL      (GCLK_GENCTRL_SRC_FDPLL_Val    << GCLK_GENCTRL_SRC_Pos)
 #define GCLK_GENCTRL_GENEN_Pos      16           /**< \brief (GCLK_GENCTRL) Generic Clock Generator Enable */
-#define GCLK_GENCTRL_GENEN          (0x1ul << GCLK_GENCTRL_GENEN_Pos)
+#define GCLK_GENCTRL_GENEN          (_U_(0x1) << GCLK_GENCTRL_GENEN_Pos)
 #define GCLK_GENCTRL_IDC_Pos        17           /**< \brief (GCLK_GENCTRL) Improve Duty Cycle */
-#define GCLK_GENCTRL_IDC            (0x1ul << GCLK_GENCTRL_IDC_Pos)
+#define GCLK_GENCTRL_IDC            (_U_(0x1) << GCLK_GENCTRL_IDC_Pos)
 #define GCLK_GENCTRL_OOV_Pos        18           /**< \brief (GCLK_GENCTRL) Output Off Value */
-#define GCLK_GENCTRL_OOV            (0x1ul << GCLK_GENCTRL_OOV_Pos)
+#define GCLK_GENCTRL_OOV            (_U_(0x1) << GCLK_GENCTRL_OOV_Pos)
 #define GCLK_GENCTRL_OE_Pos         19           /**< \brief (GCLK_GENCTRL) Output Enable */
-#define GCLK_GENCTRL_OE             (0x1ul << GCLK_GENCTRL_OE_Pos)
+#define GCLK_GENCTRL_OE             (_U_(0x1) << GCLK_GENCTRL_OE_Pos)
 #define GCLK_GENCTRL_DIVSEL_Pos     20           /**< \brief (GCLK_GENCTRL) Divide Selection */
-#define GCLK_GENCTRL_DIVSEL         (0x1ul << GCLK_GENCTRL_DIVSEL_Pos)
+#define GCLK_GENCTRL_DIVSEL         (_U_(0x1) << GCLK_GENCTRL_DIVSEL_Pos)
 #define GCLK_GENCTRL_RUNSTDBY_Pos   21           /**< \brief (GCLK_GENCTRL) Run in Standby */
-#define GCLK_GENCTRL_RUNSTDBY       (0x1ul << GCLK_GENCTRL_RUNSTDBY_Pos)
-#define GCLK_GENCTRL_MASK           0x003F1F0Ful /**< \brief (GCLK_GENCTRL) MASK Register */
+#define GCLK_GENCTRL_RUNSTDBY       (_U_(0x1) << GCLK_GENCTRL_RUNSTDBY_Pos)
+#define GCLK_GENCTRL_MASK           _U_(0x003F1F0F) /**< \brief (GCLK_GENCTRL) MASK Register */
 
 /* -------- GCLK_GENDIV : (GCLK Offset: 0x8) (R/W 32) Generic Clock Generator Division -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -284,15 +269,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GCLK_GENDIV_OFFSET          0x8          /**< \brief (GCLK_GENDIV offset) Generic Clock Generator Division */
-#define GCLK_GENDIV_RESETVALUE      0x00000000ul /**< \brief (GCLK_GENDIV reset_value) Generic Clock Generator Division */
+#define GCLK_GENDIV_RESETVALUE      _U_(0x00000000) /**< \brief (GCLK_GENDIV reset_value) Generic Clock Generator Division */
 
 #define GCLK_GENDIV_ID_Pos          0            /**< \brief (GCLK_GENDIV) Generic Clock Generator Selection */
-#define GCLK_GENDIV_ID_Msk          (0xFul << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_Msk          (_U_(0xF) << GCLK_GENDIV_ID_Pos)
 #define GCLK_GENDIV_ID(value)       (GCLK_GENDIV_ID_Msk & ((value) << GCLK_GENDIV_ID_Pos))
 #define GCLK_GENDIV_DIV_Pos         8            /**< \brief (GCLK_GENDIV) Division Factor */
-#define GCLK_GENDIV_DIV_Msk         (0xFFFFul << GCLK_GENDIV_DIV_Pos)
+#define GCLK_GENDIV_DIV_Msk         (_U_(0xFFFF) << GCLK_GENDIV_DIV_Pos)
 #define GCLK_GENDIV_DIV(value)      (GCLK_GENDIV_DIV_Msk & ((value) << GCLK_GENDIV_DIV_Pos))
-#define GCLK_GENDIV_MASK            0x00FFFF0Ful /**< \brief (GCLK_GENDIV) MASK Register */
+#define GCLK_GENDIV_MASK            _U_(0x00FFFF0F) /**< \brief (GCLK_GENDIV) MASK Register */
 
 /** \brief GCLK hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/hmatrixb.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/hmatrixb.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for HMATRIXB
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -61,9 +46,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_PRAS_OFFSET        0x080        /**< \brief (HMATRIXB_PRAS offset) Priority A for Slave */
-#define HMATRIXB_PRAS_RESETVALUE    0x00000000ul /**< \brief (HMATRIXB_PRAS reset_value) Priority A for Slave */
+#define HMATRIXB_PRAS_RESETVALUE    _U_(0x00000000) /**< \brief (HMATRIXB_PRAS reset_value) Priority A for Slave */
 
-#define HMATRIXB_PRAS_MASK          0x00000000ul /**< \brief (HMATRIXB_PRAS) MASK Register */
+#define HMATRIXB_PRAS_MASK          _U_(0x00000000) /**< \brief (HMATRIXB_PRAS) MASK Register */
 
 /* -------- HMATRIXB_PRBS : (HMATRIXB Offset: 0x084) (R/W 32) PRS Priority B for Slave -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -73,9 +58,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_PRBS_OFFSET        0x084        /**< \brief (HMATRIXB_PRBS offset) Priority B for Slave */
-#define HMATRIXB_PRBS_RESETVALUE    0x00000000ul /**< \brief (HMATRIXB_PRBS reset_value) Priority B for Slave */
+#define HMATRIXB_PRBS_RESETVALUE    _U_(0x00000000) /**< \brief (HMATRIXB_PRBS reset_value) Priority B for Slave */
 
-#define HMATRIXB_PRBS_MASK          0x00000000ul /**< \brief (HMATRIXB_PRBS) MASK Register */
+#define HMATRIXB_PRBS_MASK          _U_(0x00000000) /**< \brief (HMATRIXB_PRBS) MASK Register */
 
 /* -------- HMATRIXB_SFR : (HMATRIXB Offset: 0x110) (R/W 32) Special Function -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -88,12 +73,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_SFR_OFFSET         0x110        /**< \brief (HMATRIXB_SFR offset) Special Function */
-#define HMATRIXB_SFR_RESETVALUE     0x00000000ul /**< \brief (HMATRIXB_SFR reset_value) Special Function */
+#define HMATRIXB_SFR_RESETVALUE     _U_(0x00000000) /**< \brief (HMATRIXB_SFR reset_value) Special Function */
 
 #define HMATRIXB_SFR_SFR_Pos        0            /**< \brief (HMATRIXB_SFR) Special Function Register */
-#define HMATRIXB_SFR_SFR_Msk        (0xFFFFFFFFul << HMATRIXB_SFR_SFR_Pos)
+#define HMATRIXB_SFR_SFR_Msk        (_U_(0xFFFFFFFF) << HMATRIXB_SFR_SFR_Pos)
 #define HMATRIXB_SFR_SFR(value)     (HMATRIXB_SFR_SFR_Msk & ((value) << HMATRIXB_SFR_SFR_Pos))
-#define HMATRIXB_SFR_MASK           0xFFFFFFFFul /**< \brief (HMATRIXB_SFR) MASK Register */
+#define HMATRIXB_SFR_MASK           _U_(0xFFFFFFFF) /**< \brief (HMATRIXB_SFR) MASK Register */
 
 /** \brief HmatrixbPrs hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/mtb.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/mtb.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for MTB
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -68,11 +53,11 @@ typedef union {
 #define MTB_POSITION_OFFSET         0x000        /**< \brief (MTB_POSITION offset) MTB Position */
 
 #define MTB_POSITION_WRAP_Pos       2            /**< \brief (MTB_POSITION) Pointer Value Wraps */
-#define MTB_POSITION_WRAP           (0x1ul << MTB_POSITION_WRAP_Pos)
+#define MTB_POSITION_WRAP           (_U_(0x1) << MTB_POSITION_WRAP_Pos)
 #define MTB_POSITION_POINTER_Pos    3            /**< \brief (MTB_POSITION) Trace Packet Location Pointer */
-#define MTB_POSITION_POINTER_Msk    (0x1FFFFFFFul << MTB_POSITION_POINTER_Pos)
+#define MTB_POSITION_POINTER_Msk    (_U_(0x1FFFFFFF) << MTB_POSITION_POINTER_Pos)
 #define MTB_POSITION_POINTER(value) (MTB_POSITION_POINTER_Msk & ((value) << MTB_POSITION_POINTER_Pos))
-#define MTB_POSITION_MASK           0xFFFFFFFCul /**< \brief (MTB_POSITION) MASK Register */
+#define MTB_POSITION_MASK           _U_(0xFFFFFFFC) /**< \brief (MTB_POSITION) MASK Register */
 
 /* -------- MTB_MASTER : (MTB Offset: 0x004) (R/W 32) MTB Master -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -92,24 +77,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_MASTER_OFFSET           0x004        /**< \brief (MTB_MASTER offset) MTB Master */
-#define MTB_MASTER_RESETVALUE       0x00000000ul /**< \brief (MTB_MASTER reset_value) MTB Master */
+#define MTB_MASTER_RESETVALUE       _U_(0x00000000) /**< \brief (MTB_MASTER reset_value) MTB Master */
 
 #define MTB_MASTER_MASK_Pos         0            /**< \brief (MTB_MASTER) Maximum Value of the Trace Buffer in SRAM */
-#define MTB_MASTER_MASK_Msk         (0x1Ful << MTB_MASTER_MASK_Pos)
+#define MTB_MASTER_MASK_Msk         (_U_(0x1F) << MTB_MASTER_MASK_Pos)
 #define MTB_MASTER_MASK(value)      (MTB_MASTER_MASK_Msk & ((value) << MTB_MASTER_MASK_Pos))
 #define MTB_MASTER_TSTARTEN_Pos     5            /**< \brief (MTB_MASTER) Trace Start Input Enable */
-#define MTB_MASTER_TSTARTEN         (0x1ul << MTB_MASTER_TSTARTEN_Pos)
+#define MTB_MASTER_TSTARTEN         (_U_(0x1) << MTB_MASTER_TSTARTEN_Pos)
 #define MTB_MASTER_TSTOPEN_Pos      6            /**< \brief (MTB_MASTER) Trace Stop Input Enable */
-#define MTB_MASTER_TSTOPEN          (0x1ul << MTB_MASTER_TSTOPEN_Pos)
+#define MTB_MASTER_TSTOPEN          (_U_(0x1) << MTB_MASTER_TSTOPEN_Pos)
 #define MTB_MASTER_SFRWPRIV_Pos     7            /**< \brief (MTB_MASTER) Special Function Register Write Privilege */
-#define MTB_MASTER_SFRWPRIV         (0x1ul << MTB_MASTER_SFRWPRIV_Pos)
+#define MTB_MASTER_SFRWPRIV         (_U_(0x1) << MTB_MASTER_SFRWPRIV_Pos)
 #define MTB_MASTER_RAMPRIV_Pos      8            /**< \brief (MTB_MASTER) SRAM Privilege */
-#define MTB_MASTER_RAMPRIV          (0x1ul << MTB_MASTER_RAMPRIV_Pos)
+#define MTB_MASTER_RAMPRIV          (_U_(0x1) << MTB_MASTER_RAMPRIV_Pos)
 #define MTB_MASTER_HALTREQ_Pos      9            /**< \brief (MTB_MASTER) Halt Request */
-#define MTB_MASTER_HALTREQ          (0x1ul << MTB_MASTER_HALTREQ_Pos)
+#define MTB_MASTER_HALTREQ          (_U_(0x1) << MTB_MASTER_HALTREQ_Pos)
 #define MTB_MASTER_EN_Pos           31           /**< \brief (MTB_MASTER) Main Trace Enable */
-#define MTB_MASTER_EN               (0x1ul << MTB_MASTER_EN_Pos)
-#define MTB_MASTER_MASK_            0x800003FFul /**< \brief (MTB_MASTER) MASK Register */
+#define MTB_MASTER_EN               (_U_(0x1) << MTB_MASTER_EN_Pos)
+#define MTB_MASTER_MASK_            _U_(0x800003FF) /**< \brief (MTB_MASTER) MASK Register */
 
 /* -------- MTB_FLOW : (MTB Offset: 0x008) (R/W 32) MTB Flow -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -125,16 +110,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_FLOW_OFFSET             0x008        /**< \brief (MTB_FLOW offset) MTB Flow */
-#define MTB_FLOW_RESETVALUE         0x00000000ul /**< \brief (MTB_FLOW reset_value) MTB Flow */
+#define MTB_FLOW_RESETVALUE         _U_(0x00000000) /**< \brief (MTB_FLOW reset_value) MTB Flow */
 
 #define MTB_FLOW_AUTOSTOP_Pos       0            /**< \brief (MTB_FLOW) Auto Stop Tracing */
-#define MTB_FLOW_AUTOSTOP           (0x1ul << MTB_FLOW_AUTOSTOP_Pos)
+#define MTB_FLOW_AUTOSTOP           (_U_(0x1) << MTB_FLOW_AUTOSTOP_Pos)
 #define MTB_FLOW_AUTOHALT_Pos       1            /**< \brief (MTB_FLOW) Auto Halt Request */
-#define MTB_FLOW_AUTOHALT           (0x1ul << MTB_FLOW_AUTOHALT_Pos)
+#define MTB_FLOW_AUTOHALT           (_U_(0x1) << MTB_FLOW_AUTOHALT_Pos)
 #define MTB_FLOW_WATERMARK_Pos      3            /**< \brief (MTB_FLOW) Watermark value */
-#define MTB_FLOW_WATERMARK_Msk      (0x1FFFFFFFul << MTB_FLOW_WATERMARK_Pos)
+#define MTB_FLOW_WATERMARK_Msk      (_U_(0x1FFFFFFF) << MTB_FLOW_WATERMARK_Pos)
 #define MTB_FLOW_WATERMARK(value)   (MTB_FLOW_WATERMARK_Msk & ((value) << MTB_FLOW_WATERMARK_Pos))
-#define MTB_FLOW_MASK               0xFFFFFFFBul /**< \brief (MTB_FLOW) MASK Register */
+#define MTB_FLOW_MASK               _U_(0xFFFFFFFB) /**< \brief (MTB_FLOW) MASK Register */
 
 /* -------- MTB_BASE : (MTB Offset: 0x00C) (R/  32) MTB Base -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -144,7 +129,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_BASE_OFFSET             0x00C        /**< \brief (MTB_BASE offset) MTB Base */
-#define MTB_BASE_MASK               0xFFFFFFFFul /**< \brief (MTB_BASE) MASK Register */
+#define MTB_BASE_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_BASE) MASK Register */
 
 /* -------- MTB_ITCTRL : (MTB Offset: 0xF00) (R/W 32) MTB Integration Mode Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -154,7 +139,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_ITCTRL_OFFSET           0xF00        /**< \brief (MTB_ITCTRL offset) MTB Integration Mode Control */
-#define MTB_ITCTRL_MASK             0xFFFFFFFFul /**< \brief (MTB_ITCTRL) MASK Register */
+#define MTB_ITCTRL_MASK             _U_(0xFFFFFFFF) /**< \brief (MTB_ITCTRL) MASK Register */
 
 /* -------- MTB_CLAIMSET : (MTB Offset: 0xFA0) (R/W 32) MTB Claim Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -164,7 +149,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_CLAIMSET_OFFSET         0xFA0        /**< \brief (MTB_CLAIMSET offset) MTB Claim Set */
-#define MTB_CLAIMSET_MASK           0xFFFFFFFFul /**< \brief (MTB_CLAIMSET) MASK Register */
+#define MTB_CLAIMSET_MASK           _U_(0xFFFFFFFF) /**< \brief (MTB_CLAIMSET) MASK Register */
 
 /* -------- MTB_CLAIMCLR : (MTB Offset: 0xFA4) (R/W 32) MTB Claim Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -174,7 +159,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_CLAIMCLR_OFFSET         0xFA4        /**< \brief (MTB_CLAIMCLR offset) MTB Claim Clear */
-#define MTB_CLAIMCLR_MASK           0xFFFFFFFFul /**< \brief (MTB_CLAIMCLR) MASK Register */
+#define MTB_CLAIMCLR_MASK           _U_(0xFFFFFFFF) /**< \brief (MTB_CLAIMCLR) MASK Register */
 
 /* -------- MTB_LOCKACCESS : (MTB Offset: 0xFB0) (R/W 32) MTB Lock Access -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -184,7 +169,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_LOCKACCESS_OFFSET       0xFB0        /**< \brief (MTB_LOCKACCESS offset) MTB Lock Access */
-#define MTB_LOCKACCESS_MASK         0xFFFFFFFFul /**< \brief (MTB_LOCKACCESS) MASK Register */
+#define MTB_LOCKACCESS_MASK         _U_(0xFFFFFFFF) /**< \brief (MTB_LOCKACCESS) MASK Register */
 
 /* -------- MTB_LOCKSTATUS : (MTB Offset: 0xFB4) (R/  32) MTB Lock Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -194,7 +179,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_LOCKSTATUS_OFFSET       0xFB4        /**< \brief (MTB_LOCKSTATUS offset) MTB Lock Status */
-#define MTB_LOCKSTATUS_MASK         0xFFFFFFFFul /**< \brief (MTB_LOCKSTATUS) MASK Register */
+#define MTB_LOCKSTATUS_MASK         _U_(0xFFFFFFFF) /**< \brief (MTB_LOCKSTATUS) MASK Register */
 
 /* -------- MTB_AUTHSTATUS : (MTB Offset: 0xFB8) (R/  32) MTB Authentication Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -204,7 +189,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_AUTHSTATUS_OFFSET       0xFB8        /**< \brief (MTB_AUTHSTATUS offset) MTB Authentication Status */
-#define MTB_AUTHSTATUS_MASK         0xFFFFFFFFul /**< \brief (MTB_AUTHSTATUS) MASK Register */
+#define MTB_AUTHSTATUS_MASK         _U_(0xFFFFFFFF) /**< \brief (MTB_AUTHSTATUS) MASK Register */
 
 /* -------- MTB_DEVARCH : (MTB Offset: 0xFBC) (R/  32) MTB Device Architecture -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -214,7 +199,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_DEVARCH_OFFSET          0xFBC        /**< \brief (MTB_DEVARCH offset) MTB Device Architecture */
-#define MTB_DEVARCH_MASK            0xFFFFFFFFul /**< \brief (MTB_DEVARCH) MASK Register */
+#define MTB_DEVARCH_MASK            _U_(0xFFFFFFFF) /**< \brief (MTB_DEVARCH) MASK Register */
 
 /* -------- MTB_DEVID : (MTB Offset: 0xFC8) (R/  32) MTB Device Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -224,7 +209,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_DEVID_OFFSET            0xFC8        /**< \brief (MTB_DEVID offset) MTB Device Configuration */
-#define MTB_DEVID_MASK              0xFFFFFFFFul /**< \brief (MTB_DEVID) MASK Register */
+#define MTB_DEVID_MASK              _U_(0xFFFFFFFF) /**< \brief (MTB_DEVID) MASK Register */
 
 /* -------- MTB_DEVTYPE : (MTB Offset: 0xFCC) (R/  32) MTB Device Type -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -234,7 +219,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_DEVTYPE_OFFSET          0xFCC        /**< \brief (MTB_DEVTYPE offset) MTB Device Type */
-#define MTB_DEVTYPE_MASK            0xFFFFFFFFul /**< \brief (MTB_DEVTYPE) MASK Register */
+#define MTB_DEVTYPE_MASK            _U_(0xFFFFFFFF) /**< \brief (MTB_DEVTYPE) MASK Register */
 
 /* -------- MTB_PID4 : (MTB Offset: 0xFD0) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -244,7 +229,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_PID4_OFFSET             0xFD0        /**< \brief (MTB_PID4 offset) CoreSight */
-#define MTB_PID4_MASK               0xFFFFFFFFul /**< \brief (MTB_PID4) MASK Register */
+#define MTB_PID4_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_PID4) MASK Register */
 
 /* -------- MTB_PID5 : (MTB Offset: 0xFD4) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -254,7 +239,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_PID5_OFFSET             0xFD4        /**< \brief (MTB_PID5 offset) CoreSight */
-#define MTB_PID5_MASK               0xFFFFFFFFul /**< \brief (MTB_PID5) MASK Register */
+#define MTB_PID5_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_PID5) MASK Register */
 
 /* -------- MTB_PID6 : (MTB Offset: 0xFD8) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -264,7 +249,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_PID6_OFFSET             0xFD8        /**< \brief (MTB_PID6 offset) CoreSight */
-#define MTB_PID6_MASK               0xFFFFFFFFul /**< \brief (MTB_PID6) MASK Register */
+#define MTB_PID6_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_PID6) MASK Register */
 
 /* -------- MTB_PID7 : (MTB Offset: 0xFDC) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -274,7 +259,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_PID7_OFFSET             0xFDC        /**< \brief (MTB_PID7 offset) CoreSight */
-#define MTB_PID7_MASK               0xFFFFFFFFul /**< \brief (MTB_PID7) MASK Register */
+#define MTB_PID7_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_PID7) MASK Register */
 
 /* -------- MTB_PID0 : (MTB Offset: 0xFE0) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -284,7 +269,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_PID0_OFFSET             0xFE0        /**< \brief (MTB_PID0 offset) CoreSight */
-#define MTB_PID0_MASK               0xFFFFFFFFul /**< \brief (MTB_PID0) MASK Register */
+#define MTB_PID0_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_PID0) MASK Register */
 
 /* -------- MTB_PID1 : (MTB Offset: 0xFE4) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -294,7 +279,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_PID1_OFFSET             0xFE4        /**< \brief (MTB_PID1 offset) CoreSight */
-#define MTB_PID1_MASK               0xFFFFFFFFul /**< \brief (MTB_PID1) MASK Register */
+#define MTB_PID1_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_PID1) MASK Register */
 
 /* -------- MTB_PID2 : (MTB Offset: 0xFE8) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -304,7 +289,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_PID2_OFFSET             0xFE8        /**< \brief (MTB_PID2 offset) CoreSight */
-#define MTB_PID2_MASK               0xFFFFFFFFul /**< \brief (MTB_PID2) MASK Register */
+#define MTB_PID2_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_PID2) MASK Register */
 
 /* -------- MTB_PID3 : (MTB Offset: 0xFEC) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -314,7 +299,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_PID3_OFFSET             0xFEC        /**< \brief (MTB_PID3 offset) CoreSight */
-#define MTB_PID3_MASK               0xFFFFFFFFul /**< \brief (MTB_PID3) MASK Register */
+#define MTB_PID3_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_PID3) MASK Register */
 
 /* -------- MTB_CID0 : (MTB Offset: 0xFF0) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -324,7 +309,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_CID0_OFFSET             0xFF0        /**< \brief (MTB_CID0 offset) CoreSight */
-#define MTB_CID0_MASK               0xFFFFFFFFul /**< \brief (MTB_CID0) MASK Register */
+#define MTB_CID0_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_CID0) MASK Register */
 
 /* -------- MTB_CID1 : (MTB Offset: 0xFF4) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -334,7 +319,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_CID1_OFFSET             0xFF4        /**< \brief (MTB_CID1 offset) CoreSight */
-#define MTB_CID1_MASK               0xFFFFFFFFul /**< \brief (MTB_CID1) MASK Register */
+#define MTB_CID1_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_CID1) MASK Register */
 
 /* -------- MTB_CID2 : (MTB Offset: 0xFF8) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -344,7 +329,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_CID2_OFFSET             0xFF8        /**< \brief (MTB_CID2 offset) CoreSight */
-#define MTB_CID2_MASK               0xFFFFFFFFul /**< \brief (MTB_CID2) MASK Register */
+#define MTB_CID2_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_CID2) MASK Register */
 
 /* -------- MTB_CID3 : (MTB Offset: 0xFFC) (R/  32) CoreSight -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -354,7 +339,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MTB_CID3_OFFSET             0xFFC        /**< \brief (MTB_CID3 offset) CoreSight */
-#define MTB_CID3_MASK               0xFFFFFFFFul /**< \brief (MTB_CID3) MASK Register */
+#define MTB_CID3_MASK               _U_(0xFFFFFFFF) /**< \brief (MTB_CID3) MASK Register */
 
 /** \brief MTB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/nvmctrl.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for NVMCTRL
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -66,24 +51,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define NVMCTRL_CTRLA_OFFSET        0x00         /**< \brief (NVMCTRL_CTRLA offset) Control A */
-#define NVMCTRL_CTRLA_RESETVALUE    0x0000ul     /**< \brief (NVMCTRL_CTRLA reset_value) Control A */
+#define NVMCTRL_CTRLA_RESETVALUE    _U_(0x0000)   /**< \brief (NVMCTRL_CTRLA reset_value) Control A */
 
 #define NVMCTRL_CTRLA_CMD_Pos       0            /**< \brief (NVMCTRL_CTRLA) Command */
-#define NVMCTRL_CTRLA_CMD_Msk       (0x7Ful << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_Msk       (_U_(0x7F) << NVMCTRL_CTRLA_CMD_Pos)
 #define NVMCTRL_CTRLA_CMD(value)    (NVMCTRL_CTRLA_CMD_Msk & ((value) << NVMCTRL_CTRLA_CMD_Pos))
-#define   NVMCTRL_CTRLA_CMD_ER_Val        0x2ul  /**< \brief (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register. */
-#define   NVMCTRL_CTRLA_CMD_WP_Val        0x4ul  /**< \brief (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register. */
-#define   NVMCTRL_CTRLA_CMD_EAR_Val       0x5ul  /**< \brief (NVMCTRL_CTRLA) Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
-#define   NVMCTRL_CTRLA_CMD_WAP_Val       0x6ul  /**< \brief (NVMCTRL_CTRLA) Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
-#define   NVMCTRL_CTRLA_CMD_SF_Val        0xAul  /**< \brief (NVMCTRL_CTRLA) Security Flow Command */
-#define   NVMCTRL_CTRLA_CMD_WL_Val        0xFul  /**< \brief (NVMCTRL_CTRLA) Write lockbits */
-#define   NVMCTRL_CTRLA_CMD_LR_Val        0x40ul  /**< \brief (NVMCTRL_CTRLA) Lock Region - Locks the region containing the address location in the ADDR register. */
-#define   NVMCTRL_CTRLA_CMD_UR_Val        0x41ul  /**< \brief (NVMCTRL_CTRLA) Unlock Region - Unlocks the region containing the address location in the ADDR register. */
-#define   NVMCTRL_CTRLA_CMD_SPRM_Val      0x42ul  /**< \brief (NVMCTRL_CTRLA) Sets the power reduction mode. */
-#define   NVMCTRL_CTRLA_CMD_CPRM_Val      0x43ul  /**< \brief (NVMCTRL_CTRLA) Clears the power reduction mode. */
-#define   NVMCTRL_CTRLA_CMD_PBC_Val       0x44ul  /**< \brief (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer. */
-#define   NVMCTRL_CTRLA_CMD_SSB_Val       0x45ul  /**< \brief (NVMCTRL_CTRLA) Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row. */
-#define   NVMCTRL_CTRLA_CMD_INVALL_Val    0x46ul  /**< \brief (NVMCTRL_CTRLA) Invalidates all cache lines. */
+#define   NVMCTRL_CTRLA_CMD_ER_Val        _U_(0x2)   /**< \brief (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_WP_Val        _U_(0x4)   /**< \brief (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_EAR_Val       _U_(0x5)   /**< \brief (NVMCTRL_CTRLA) Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
+#define   NVMCTRL_CTRLA_CMD_WAP_Val       _U_(0x6)   /**< \brief (NVMCTRL_CTRLA) Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
+#define   NVMCTRL_CTRLA_CMD_SF_Val        _U_(0xA)   /**< \brief (NVMCTRL_CTRLA) Security Flow Command */
+#define   NVMCTRL_CTRLA_CMD_WL_Val        _U_(0xF)   /**< \brief (NVMCTRL_CTRLA) Write lockbits */
+#define   NVMCTRL_CTRLA_CMD_LR_Val        _U_(0x40)   /**< \brief (NVMCTRL_CTRLA) Lock Region - Locks the region containing the address location in the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_UR_Val        _U_(0x41)   /**< \brief (NVMCTRL_CTRLA) Unlock Region - Unlocks the region containing the address location in the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_SPRM_Val      _U_(0x42)   /**< \brief (NVMCTRL_CTRLA) Sets the power reduction mode. */
+#define   NVMCTRL_CTRLA_CMD_CPRM_Val      _U_(0x43)   /**< \brief (NVMCTRL_CTRLA) Clears the power reduction mode. */
+#define   NVMCTRL_CTRLA_CMD_PBC_Val       _U_(0x44)   /**< \brief (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer. */
+#define   NVMCTRL_CTRLA_CMD_SSB_Val       _U_(0x45)   /**< \brief (NVMCTRL_CTRLA) Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row. */
+#define   NVMCTRL_CTRLA_CMD_INVALL_Val    _U_(0x46)   /**< \brief (NVMCTRL_CTRLA) Invalidates all cache lines. */
 #define NVMCTRL_CTRLA_CMD_ER        (NVMCTRL_CTRLA_CMD_ER_Val      << NVMCTRL_CTRLA_CMD_Pos)
 #define NVMCTRL_CTRLA_CMD_WP        (NVMCTRL_CTRLA_CMD_WP_Val      << NVMCTRL_CTRLA_CMD_Pos)
 #define NVMCTRL_CTRLA_CMD_EAR       (NVMCTRL_CTRLA_CMD_EAR_Val     << NVMCTRL_CTRLA_CMD_Pos)
@@ -98,11 +83,11 @@ typedef union {
 #define NVMCTRL_CTRLA_CMD_SSB       (NVMCTRL_CTRLA_CMD_SSB_Val     << NVMCTRL_CTRLA_CMD_Pos)
 #define NVMCTRL_CTRLA_CMD_INVALL    (NVMCTRL_CTRLA_CMD_INVALL_Val  << NVMCTRL_CTRLA_CMD_Pos)
 #define NVMCTRL_CTRLA_CMDEX_Pos     8            /**< \brief (NVMCTRL_CTRLA) Command Execution */
-#define NVMCTRL_CTRLA_CMDEX_Msk     (0xFFul << NVMCTRL_CTRLA_CMDEX_Pos)
+#define NVMCTRL_CTRLA_CMDEX_Msk     (_U_(0xFF) << NVMCTRL_CTRLA_CMDEX_Pos)
 #define NVMCTRL_CTRLA_CMDEX(value)  (NVMCTRL_CTRLA_CMDEX_Msk & ((value) << NVMCTRL_CTRLA_CMDEX_Pos))
-#define   NVMCTRL_CTRLA_CMDEX_KEY_Val     0xA5ul  /**< \brief (NVMCTRL_CTRLA) Execution Key */
+#define   NVMCTRL_CTRLA_CMDEX_KEY_Val     _U_(0xA5)   /**< \brief (NVMCTRL_CTRLA) Execution Key */
 #define NVMCTRL_CTRLA_CMDEX_KEY     (NVMCTRL_CTRLA_CMDEX_KEY_Val   << NVMCTRL_CTRLA_CMDEX_Pos)
-#define NVMCTRL_CTRLA_MASK          0xFF7Ful     /**< \brief (NVMCTRL_CTRLA) MASK Register */
+#define NVMCTRL_CTRLA_MASK          _U_(0xFF7F)   /**< \brief (NVMCTRL_CTRLA) MASK Register */
 
 /* -------- NVMCTRL_CTRLB : (NVMCTRL Offset: 0x04) (R/W 32) Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -123,40 +108,40 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define NVMCTRL_CTRLB_OFFSET        0x04         /**< \brief (NVMCTRL_CTRLB offset) Control B */
-#define NVMCTRL_CTRLB_RESETVALUE    0x00000000ul /**< \brief (NVMCTRL_CTRLB reset_value) Control B */
+#define NVMCTRL_CTRLB_RESETVALUE    _U_(0x00000000) /**< \brief (NVMCTRL_CTRLB reset_value) Control B */
 
 #define NVMCTRL_CTRLB_RWS_Pos       1            /**< \brief (NVMCTRL_CTRLB) NVM Read Wait States */
-#define NVMCTRL_CTRLB_RWS_Msk       (0xFul << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS_Msk       (_U_(0xF) << NVMCTRL_CTRLB_RWS_Pos)
 #define NVMCTRL_CTRLB_RWS(value)    (NVMCTRL_CTRLB_RWS_Msk & ((value) << NVMCTRL_CTRLB_RWS_Pos))
-#define   NVMCTRL_CTRLB_RWS_SINGLE_Val    0x0ul  /**< \brief (NVMCTRL_CTRLB) Single Auto Wait State */
-#define   NVMCTRL_CTRLB_RWS_HALF_Val      0x1ul  /**< \brief (NVMCTRL_CTRLB) Half Auto Wait State */
-#define   NVMCTRL_CTRLB_RWS_DUAL_Val      0x2ul  /**< \brief (NVMCTRL_CTRLB) Dual Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_SINGLE_Val    _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) Single Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_HALF_Val      _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) Half Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_DUAL_Val      _U_(0x2)   /**< \brief (NVMCTRL_CTRLB) Dual Auto Wait State */
 #define NVMCTRL_CTRLB_RWS_SINGLE    (NVMCTRL_CTRLB_RWS_SINGLE_Val  << NVMCTRL_CTRLB_RWS_Pos)
 #define NVMCTRL_CTRLB_RWS_HALF      (NVMCTRL_CTRLB_RWS_HALF_Val    << NVMCTRL_CTRLB_RWS_Pos)
 #define NVMCTRL_CTRLB_RWS_DUAL      (NVMCTRL_CTRLB_RWS_DUAL_Val    << NVMCTRL_CTRLB_RWS_Pos)
 #define NVMCTRL_CTRLB_MANW_Pos      7            /**< \brief (NVMCTRL_CTRLB) Manual Write */
-#define NVMCTRL_CTRLB_MANW          (0x1ul << NVMCTRL_CTRLB_MANW_Pos)
+#define NVMCTRL_CTRLB_MANW          (_U_(0x1) << NVMCTRL_CTRLB_MANW_Pos)
 #define NVMCTRL_CTRLB_SLEEPPRM_Pos  8            /**< \brief (NVMCTRL_CTRLB) Power Reduction Mode during Sleep */
-#define NVMCTRL_CTRLB_SLEEPPRM_Msk  (0x3ul << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_Msk  (_U_(0x3) << NVMCTRL_CTRLB_SLEEPPRM_Pos)
 #define NVMCTRL_CTRLB_SLEEPPRM(value) (NVMCTRL_CTRLB_SLEEPPRM_Msk & ((value) << NVMCTRL_CTRLB_SLEEPPRM_Pos))
-#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val 0x0ul  /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access. */
-#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val 0x1ul  /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep. */
-#define   NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val 0x3ul  /**< \brief (NVMCTRL_CTRLB) Auto power reduction disabled. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val _U_(0x3)   /**< \brief (NVMCTRL_CTRLB) Auto power reduction disabled. */
 #define NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS (NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
 #define NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT (NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
 #define NVMCTRL_CTRLB_SLEEPPRM_DISABLED (NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
 #define NVMCTRL_CTRLB_READMODE_Pos  16           /**< \brief (NVMCTRL_CTRLB) NVMCTRL Read Mode */
-#define NVMCTRL_CTRLB_READMODE_Msk  (0x3ul << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE_Msk  (_U_(0x3) << NVMCTRL_CTRLB_READMODE_Pos)
 #define NVMCTRL_CTRLB_READMODE(value) (NVMCTRL_CTRLB_READMODE_Msk & ((value) << NVMCTRL_CTRLB_READMODE_Pos))
-#define   NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val 0x0ul  /**< \brief (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance. */
-#define   NVMCTRL_CTRLB_READMODE_LOW_POWER_Val 0x1ul  /**< \brief (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time. */
-#define   NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val 0x2ul  /**< \brief (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings. */
+#define   NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance. */
+#define   NVMCTRL_CTRLB_READMODE_LOW_POWER_Val _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time. */
+#define   NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val _U_(0x2)   /**< \brief (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings. */
 #define NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY (NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val << NVMCTRL_CTRLB_READMODE_Pos)
 #define NVMCTRL_CTRLB_READMODE_LOW_POWER (NVMCTRL_CTRLB_READMODE_LOW_POWER_Val << NVMCTRL_CTRLB_READMODE_Pos)
 #define NVMCTRL_CTRLB_READMODE_DETERMINISTIC (NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val << NVMCTRL_CTRLB_READMODE_Pos)
 #define NVMCTRL_CTRLB_CACHEDIS_Pos  18           /**< \brief (NVMCTRL_CTRLB) Cache Disable */
-#define NVMCTRL_CTRLB_CACHEDIS      (0x1ul << NVMCTRL_CTRLB_CACHEDIS_Pos)
-#define NVMCTRL_CTRLB_MASK          0x0007039Eul /**< \brief (NVMCTRL_CTRLB) MASK Register */
+#define NVMCTRL_CTRLB_CACHEDIS      (_U_(0x1) << NVMCTRL_CTRLB_CACHEDIS_Pos)
+#define NVMCTRL_CTRLB_MASK          _U_(0x0007039E) /**< \brief (NVMCTRL_CTRLB) MASK Register */
 
 /* -------- NVMCTRL_PARAM : (NVMCTRL Offset: 0x08) (R/W 32) NVM Parameter -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -171,22 +156,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define NVMCTRL_PARAM_OFFSET        0x08         /**< \brief (NVMCTRL_PARAM offset) NVM Parameter */
-#define NVMCTRL_PARAM_RESETVALUE    0x00000000ul /**< \brief (NVMCTRL_PARAM reset_value) NVM Parameter */
+#define NVMCTRL_PARAM_RESETVALUE    _U_(0x00000000) /**< \brief (NVMCTRL_PARAM reset_value) NVM Parameter */
 
 #define NVMCTRL_PARAM_NVMP_Pos      0            /**< \brief (NVMCTRL_PARAM) NVM Pages */
-#define NVMCTRL_PARAM_NVMP_Msk      (0xFFFFul << NVMCTRL_PARAM_NVMP_Pos)
+#define NVMCTRL_PARAM_NVMP_Msk      (_U_(0xFFFF) << NVMCTRL_PARAM_NVMP_Pos)
 #define NVMCTRL_PARAM_NVMP(value)   (NVMCTRL_PARAM_NVMP_Msk & ((value) << NVMCTRL_PARAM_NVMP_Pos))
 #define NVMCTRL_PARAM_PSZ_Pos       16           /**< \brief (NVMCTRL_PARAM) Page Size */
-#define NVMCTRL_PARAM_PSZ_Msk       (0x7ul << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_Msk       (_U_(0x7) << NVMCTRL_PARAM_PSZ_Pos)
 #define NVMCTRL_PARAM_PSZ(value)    (NVMCTRL_PARAM_PSZ_Msk & ((value) << NVMCTRL_PARAM_PSZ_Pos))
-#define   NVMCTRL_PARAM_PSZ_8_Val         0x0ul  /**< \brief (NVMCTRL_PARAM) 8 bytes */
-#define   NVMCTRL_PARAM_PSZ_16_Val        0x1ul  /**< \brief (NVMCTRL_PARAM) 16 bytes */
-#define   NVMCTRL_PARAM_PSZ_32_Val        0x2ul  /**< \brief (NVMCTRL_PARAM) 32 bytes */
-#define   NVMCTRL_PARAM_PSZ_64_Val        0x3ul  /**< \brief (NVMCTRL_PARAM) 64 bytes */
-#define   NVMCTRL_PARAM_PSZ_128_Val       0x4ul  /**< \brief (NVMCTRL_PARAM) 128 bytes */
-#define   NVMCTRL_PARAM_PSZ_256_Val       0x5ul  /**< \brief (NVMCTRL_PARAM) 256 bytes */
-#define   NVMCTRL_PARAM_PSZ_512_Val       0x6ul  /**< \brief (NVMCTRL_PARAM) 512 bytes */
-#define   NVMCTRL_PARAM_PSZ_1024_Val      0x7ul  /**< \brief (NVMCTRL_PARAM) 1024 bytes */
+#define   NVMCTRL_PARAM_PSZ_8_Val         _U_(0x0)   /**< \brief (NVMCTRL_PARAM) 8 bytes */
+#define   NVMCTRL_PARAM_PSZ_16_Val        _U_(0x1)   /**< \brief (NVMCTRL_PARAM) 16 bytes */
+#define   NVMCTRL_PARAM_PSZ_32_Val        _U_(0x2)   /**< \brief (NVMCTRL_PARAM) 32 bytes */
+#define   NVMCTRL_PARAM_PSZ_64_Val        _U_(0x3)   /**< \brief (NVMCTRL_PARAM) 64 bytes */
+#define   NVMCTRL_PARAM_PSZ_128_Val       _U_(0x4)   /**< \brief (NVMCTRL_PARAM) 128 bytes */
+#define   NVMCTRL_PARAM_PSZ_256_Val       _U_(0x5)   /**< \brief (NVMCTRL_PARAM) 256 bytes */
+#define   NVMCTRL_PARAM_PSZ_512_Val       _U_(0x6)   /**< \brief (NVMCTRL_PARAM) 512 bytes */
+#define   NVMCTRL_PARAM_PSZ_1024_Val      _U_(0x7)   /**< \brief (NVMCTRL_PARAM) 1024 bytes */
 #define NVMCTRL_PARAM_PSZ_8         (NVMCTRL_PARAM_PSZ_8_Val       << NVMCTRL_PARAM_PSZ_Pos)
 #define NVMCTRL_PARAM_PSZ_16        (NVMCTRL_PARAM_PSZ_16_Val      << NVMCTRL_PARAM_PSZ_Pos)
 #define NVMCTRL_PARAM_PSZ_32        (NVMCTRL_PARAM_PSZ_32_Val      << NVMCTRL_PARAM_PSZ_Pos)
@@ -195,7 +180,7 @@ typedef union {
 #define NVMCTRL_PARAM_PSZ_256       (NVMCTRL_PARAM_PSZ_256_Val     << NVMCTRL_PARAM_PSZ_Pos)
 #define NVMCTRL_PARAM_PSZ_512       (NVMCTRL_PARAM_PSZ_512_Val     << NVMCTRL_PARAM_PSZ_Pos)
 #define NVMCTRL_PARAM_PSZ_1024      (NVMCTRL_PARAM_PSZ_1024_Val    << NVMCTRL_PARAM_PSZ_Pos)
-#define NVMCTRL_PARAM_MASK          0x0007FFFFul /**< \brief (NVMCTRL_PARAM) MASK Register */
+#define NVMCTRL_PARAM_MASK          _U_(0x0007FFFF) /**< \brief (NVMCTRL_PARAM) MASK Register */
 
 /* -------- NVMCTRL_INTENCLR : (NVMCTRL Offset: 0x0C) (R/W  8) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -210,13 +195,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define NVMCTRL_INTENCLR_OFFSET     0x0C         /**< \brief (NVMCTRL_INTENCLR offset) Interrupt Enable Clear */
-#define NVMCTRL_INTENCLR_RESETVALUE 0x00ul       /**< \brief (NVMCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+#define NVMCTRL_INTENCLR_RESETVALUE _U_(0x00)     /**< \brief (NVMCTRL_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define NVMCTRL_INTENCLR_READY_Pos  0            /**< \brief (NVMCTRL_INTENCLR) NVM Ready Interrupt Enable */
-#define NVMCTRL_INTENCLR_READY      (0x1ul << NVMCTRL_INTENCLR_READY_Pos)
+#define NVMCTRL_INTENCLR_READY      (_U_(0x1) << NVMCTRL_INTENCLR_READY_Pos)
 #define NVMCTRL_INTENCLR_ERROR_Pos  1            /**< \brief (NVMCTRL_INTENCLR) Error Interrupt Enable */
-#define NVMCTRL_INTENCLR_ERROR      (0x1ul << NVMCTRL_INTENCLR_ERROR_Pos)
-#define NVMCTRL_INTENCLR_MASK       0x03ul       /**< \brief (NVMCTRL_INTENCLR) MASK Register */
+#define NVMCTRL_INTENCLR_ERROR      (_U_(0x1) << NVMCTRL_INTENCLR_ERROR_Pos)
+#define NVMCTRL_INTENCLR_MASK       _U_(0x03)     /**< \brief (NVMCTRL_INTENCLR) MASK Register */
 
 /* -------- NVMCTRL_INTENSET : (NVMCTRL Offset: 0x10) (R/W  8) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -231,13 +216,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define NVMCTRL_INTENSET_OFFSET     0x10         /**< \brief (NVMCTRL_INTENSET offset) Interrupt Enable Set */
-#define NVMCTRL_INTENSET_RESETVALUE 0x00ul       /**< \brief (NVMCTRL_INTENSET reset_value) Interrupt Enable Set */
+#define NVMCTRL_INTENSET_RESETVALUE _U_(0x00)     /**< \brief (NVMCTRL_INTENSET reset_value) Interrupt Enable Set */
 
 #define NVMCTRL_INTENSET_READY_Pos  0            /**< \brief (NVMCTRL_INTENSET) NVM Ready Interrupt Enable */
-#define NVMCTRL_INTENSET_READY      (0x1ul << NVMCTRL_INTENSET_READY_Pos)
+#define NVMCTRL_INTENSET_READY      (_U_(0x1) << NVMCTRL_INTENSET_READY_Pos)
 #define NVMCTRL_INTENSET_ERROR_Pos  1            /**< \brief (NVMCTRL_INTENSET) Error Interrupt Enable */
-#define NVMCTRL_INTENSET_ERROR      (0x1ul << NVMCTRL_INTENSET_ERROR_Pos)
-#define NVMCTRL_INTENSET_MASK       0x03ul       /**< \brief (NVMCTRL_INTENSET) MASK Register */
+#define NVMCTRL_INTENSET_ERROR      (_U_(0x1) << NVMCTRL_INTENSET_ERROR_Pos)
+#define NVMCTRL_INTENSET_MASK       _U_(0x03)     /**< \brief (NVMCTRL_INTENSET) MASK Register */
 
 /* -------- NVMCTRL_INTFLAG : (NVMCTRL Offset: 0x14) (R/W  8) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -252,13 +237,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define NVMCTRL_INTFLAG_OFFSET      0x14         /**< \brief (NVMCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
-#define NVMCTRL_INTFLAG_RESETVALUE  0x00ul       /**< \brief (NVMCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define NVMCTRL_INTFLAG_RESETVALUE  _U_(0x00)     /**< \brief (NVMCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define NVMCTRL_INTFLAG_READY_Pos   0            /**< \brief (NVMCTRL_INTFLAG) NVM Ready */
-#define NVMCTRL_INTFLAG_READY       (0x1ul << NVMCTRL_INTFLAG_READY_Pos)
+#define NVMCTRL_INTFLAG_READY       (_U_(0x1) << NVMCTRL_INTFLAG_READY_Pos)
 #define NVMCTRL_INTFLAG_ERROR_Pos   1            /**< \brief (NVMCTRL_INTFLAG) Error */
-#define NVMCTRL_INTFLAG_ERROR       (0x1ul << NVMCTRL_INTFLAG_ERROR_Pos)
-#define NVMCTRL_INTFLAG_MASK        0x03ul       /**< \brief (NVMCTRL_INTFLAG) MASK Register */
+#define NVMCTRL_INTFLAG_ERROR       (_U_(0x1) << NVMCTRL_INTFLAG_ERROR_Pos)
+#define NVMCTRL_INTFLAG_MASK        _U_(0x03)     /**< \brief (NVMCTRL_INTFLAG) MASK Register */
 
 /* -------- NVMCTRL_STATUS : (NVMCTRL Offset: 0x18) (R/W 16) Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -278,21 +263,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define NVMCTRL_STATUS_OFFSET       0x18         /**< \brief (NVMCTRL_STATUS offset) Status */
-#define NVMCTRL_STATUS_RESETVALUE   0x0000ul     /**< \brief (NVMCTRL_STATUS reset_value) Status */
+#define NVMCTRL_STATUS_RESETVALUE   _U_(0x0000)   /**< \brief (NVMCTRL_STATUS reset_value) Status */
 
 #define NVMCTRL_STATUS_PRM_Pos      0            /**< \brief (NVMCTRL_STATUS) Power Reduction Mode */
-#define NVMCTRL_STATUS_PRM          (0x1ul << NVMCTRL_STATUS_PRM_Pos)
+#define NVMCTRL_STATUS_PRM          (_U_(0x1) << NVMCTRL_STATUS_PRM_Pos)
 #define NVMCTRL_STATUS_LOAD_Pos     1            /**< \brief (NVMCTRL_STATUS) NVM Page Buffer Active Loading */
-#define NVMCTRL_STATUS_LOAD         (0x1ul << NVMCTRL_STATUS_LOAD_Pos)
+#define NVMCTRL_STATUS_LOAD         (_U_(0x1) << NVMCTRL_STATUS_LOAD_Pos)
 #define NVMCTRL_STATUS_PROGE_Pos    2            /**< \brief (NVMCTRL_STATUS) Programming Error Status */
-#define NVMCTRL_STATUS_PROGE        (0x1ul << NVMCTRL_STATUS_PROGE_Pos)
+#define NVMCTRL_STATUS_PROGE        (_U_(0x1) << NVMCTRL_STATUS_PROGE_Pos)
 #define NVMCTRL_STATUS_LOCKE_Pos    3            /**< \brief (NVMCTRL_STATUS) Lock Error Status */
-#define NVMCTRL_STATUS_LOCKE        (0x1ul << NVMCTRL_STATUS_LOCKE_Pos)
+#define NVMCTRL_STATUS_LOCKE        (_U_(0x1) << NVMCTRL_STATUS_LOCKE_Pos)
 #define NVMCTRL_STATUS_NVME_Pos     4            /**< \brief (NVMCTRL_STATUS) NVM Error */
-#define NVMCTRL_STATUS_NVME         (0x1ul << NVMCTRL_STATUS_NVME_Pos)
+#define NVMCTRL_STATUS_NVME         (_U_(0x1) << NVMCTRL_STATUS_NVME_Pos)
 #define NVMCTRL_STATUS_SB_Pos       8            /**< \brief (NVMCTRL_STATUS) Security Bit Status */
-#define NVMCTRL_STATUS_SB           (0x1ul << NVMCTRL_STATUS_SB_Pos)
-#define NVMCTRL_STATUS_MASK         0x011Ful     /**< \brief (NVMCTRL_STATUS) MASK Register */
+#define NVMCTRL_STATUS_SB           (_U_(0x1) << NVMCTRL_STATUS_SB_Pos)
+#define NVMCTRL_STATUS_MASK         _U_(0x011F)   /**< \brief (NVMCTRL_STATUS) MASK Register */
 
 /* -------- NVMCTRL_ADDR : (NVMCTRL Offset: 0x1C) (R/W 32) Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -306,12 +291,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define NVMCTRL_ADDR_OFFSET         0x1C         /**< \brief (NVMCTRL_ADDR offset) Address */
-#define NVMCTRL_ADDR_RESETVALUE     0x00000000ul /**< \brief (NVMCTRL_ADDR reset_value) Address */
+#define NVMCTRL_ADDR_RESETVALUE     _U_(0x00000000) /**< \brief (NVMCTRL_ADDR reset_value) Address */
 
 #define NVMCTRL_ADDR_ADDR_Pos       0            /**< \brief (NVMCTRL_ADDR) NVM Address */
-#define NVMCTRL_ADDR_ADDR_Msk       (0x3FFFFFul << NVMCTRL_ADDR_ADDR_Pos)
+#define NVMCTRL_ADDR_ADDR_Msk       (_U_(0x3FFFFF) << NVMCTRL_ADDR_ADDR_Pos)
 #define NVMCTRL_ADDR_ADDR(value)    (NVMCTRL_ADDR_ADDR_Msk & ((value) << NVMCTRL_ADDR_ADDR_Pos))
-#define NVMCTRL_ADDR_MASK           0x003FFFFFul /**< \brief (NVMCTRL_ADDR) MASK Register */
+#define NVMCTRL_ADDR_MASK           _U_(0x003FFFFF) /**< \brief (NVMCTRL_ADDR) MASK Register */
 
 /* -------- NVMCTRL_LOCK : (NVMCTRL Offset: 0x20) (R/W 16) Lock Section -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -326,9 +311,9 @@ typedef union {
 #define NVMCTRL_LOCK_OFFSET         0x20         /**< \brief (NVMCTRL_LOCK offset) Lock Section */
 
 #define NVMCTRL_LOCK_LOCK_Pos       0            /**< \brief (NVMCTRL_LOCK) Region Lock Bits */
-#define NVMCTRL_LOCK_LOCK_Msk       (0xFFFFul << NVMCTRL_LOCK_LOCK_Pos)
+#define NVMCTRL_LOCK_LOCK_Msk       (_U_(0xFFFF) << NVMCTRL_LOCK_LOCK_Pos)
 #define NVMCTRL_LOCK_LOCK(value)    (NVMCTRL_LOCK_LOCK_Msk & ((value) << NVMCTRL_LOCK_LOCK_Pos))
-#define NVMCTRL_LOCK_MASK           0xFFFFul     /**< \brief (NVMCTRL_LOCK) MASK Register */
+#define NVMCTRL_LOCK_MASK           _U_(0xFFFF)   /**< \brief (NVMCTRL_LOCK) MASK Register */
 
 /** \brief NVMCTRL APB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -349,12 +334,19 @@ typedef struct {
   __IO NVMCTRL_LOCK_Type         LOCK;        /**< \brief Offset: 0x20 (R/W 16) Lock Section */
 } Nvmctrl;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
 #define SECTION_NVMCTRL_CAL
+
 #define SECTION_NVMCTRL_LOCKBIT
+
 #define SECTION_NVMCTRL_OTP1
+
 #define SECTION_NVMCTRL_OTP2
+
 #define SECTION_NVMCTRL_OTP4
+
 #define SECTION_NVMCTRL_TEMP_LOG
+
 #define SECTION_NVMCTRL_USER
 
 /*@}*/
@@ -368,166 +360,151 @@ typedef struct {
 
 #define ADC_FUSES_BIASCAL_ADDR      (NVMCTRL_OTP4 + 4)
 #define ADC_FUSES_BIASCAL_Pos       3            /**< \brief (NVMCTRL_OTP4) ADC Bias Calibration */
-#define ADC_FUSES_BIASCAL_Msk       (0x7ul << ADC_FUSES_BIASCAL_Pos)
+#define ADC_FUSES_BIASCAL_Msk       (_U_(0x7) << ADC_FUSES_BIASCAL_Pos)
 #define ADC_FUSES_BIASCAL(value)    (ADC_FUSES_BIASCAL_Msk & ((value) << ADC_FUSES_BIASCAL_Pos))
 
 #define ADC_FUSES_LINEARITY_0_ADDR  NVMCTRL_OTP4
 #define ADC_FUSES_LINEARITY_0_Pos   27           /**< \brief (NVMCTRL_OTP4) ADC Linearity bits 4:0 */
-#define ADC_FUSES_LINEARITY_0_Msk   (0x1Ful << ADC_FUSES_LINEARITY_0_Pos)
+#define ADC_FUSES_LINEARITY_0_Msk   (_U_(0x1F) << ADC_FUSES_LINEARITY_0_Pos)
 #define ADC_FUSES_LINEARITY_0(value) (ADC_FUSES_LINEARITY_0_Msk & ((value) << ADC_FUSES_LINEARITY_0_Pos))
 
 #define ADC_FUSES_LINEARITY_1_ADDR  (NVMCTRL_OTP4 + 4)
 #define ADC_FUSES_LINEARITY_1_Pos   0            /**< \brief (NVMCTRL_OTP4) ADC Linearity bits 7:5 */
-#define ADC_FUSES_LINEARITY_1_Msk   (0x7ul << ADC_FUSES_LINEARITY_1_Pos)
+#define ADC_FUSES_LINEARITY_1_Msk   (_U_(0x7) << ADC_FUSES_LINEARITY_1_Pos)
 #define ADC_FUSES_LINEARITY_1(value) (ADC_FUSES_LINEARITY_1_Msk & ((value) << ADC_FUSES_LINEARITY_1_Pos))
 
 #define FUSES_BOD33USERLEVEL_ADDR   NVMCTRL_USER
 #define FUSES_BOD33USERLEVEL_Pos    8            /**< \brief (NVMCTRL_USER) BOD33 User Level */
-#define FUSES_BOD33USERLEVEL_Msk    (0x3Ful << FUSES_BOD33USERLEVEL_Pos)
+#define FUSES_BOD33USERLEVEL_Msk    (_U_(0x3F) << FUSES_BOD33USERLEVEL_Pos)
 #define FUSES_BOD33USERLEVEL(value) (FUSES_BOD33USERLEVEL_Msk & ((value) << FUSES_BOD33USERLEVEL_Pos))
 
 #define FUSES_BOD33_ACTION_ADDR     NVMCTRL_USER
 #define FUSES_BOD33_ACTION_Pos      15           /**< \brief (NVMCTRL_USER) BOD33 Action */
-#define FUSES_BOD33_ACTION_Msk      (0x3ul << FUSES_BOD33_ACTION_Pos)
+#define FUSES_BOD33_ACTION_Msk      (_U_(0x3) << FUSES_BOD33_ACTION_Pos)
 #define FUSES_BOD33_ACTION(value)   (FUSES_BOD33_ACTION_Msk & ((value) << FUSES_BOD33_ACTION_Pos))
 
 #define FUSES_BOD33_EN_ADDR         NVMCTRL_USER
 #define FUSES_BOD33_EN_Pos          14           /**< \brief (NVMCTRL_USER) BOD33 Enable */
-#define FUSES_BOD33_EN_Msk          (0x1ul << FUSES_BOD33_EN_Pos)
+#define FUSES_BOD33_EN_Msk          (_U_(0x1) << FUSES_BOD33_EN_Pos)
 
 #define FUSES_BOD33_HYST_ADDR       (NVMCTRL_USER + 4)
 #define FUSES_BOD33_HYST_Pos        8            /**< \brief (NVMCTRL_USER) BOD33 Hysteresis */
-#define FUSES_BOD33_HYST_Msk        (0x1ul << FUSES_BOD33_HYST_Pos)
+#define FUSES_BOD33_HYST_Msk        (_U_(0x1) << FUSES_BOD33_HYST_Pos)
 
 #define FUSES_DFLL48M_COARSE_CAL_ADDR (NVMCTRL_OTP4 + 4)
 #define FUSES_DFLL48M_COARSE_CAL_Pos 26           /**< \brief (NVMCTRL_OTP4) DFLL48M Coarse Calibration */
-#define FUSES_DFLL48M_COARSE_CAL_Msk (0x3Ful << FUSES_DFLL48M_COARSE_CAL_Pos)
+#define FUSES_DFLL48M_COARSE_CAL_Msk (_U_(0x3F) << FUSES_DFLL48M_COARSE_CAL_Pos)
 #define FUSES_DFLL48M_COARSE_CAL(value) (FUSES_DFLL48M_COARSE_CAL_Msk & ((value) << FUSES_DFLL48M_COARSE_CAL_Pos))
 
 #define FUSES_DFLL48M_FINE_CAL_ADDR (NVMCTRL_OTP4 + 8)
 #define FUSES_DFLL48M_FINE_CAL_Pos  0            /**< \brief (NVMCTRL_OTP4) DFLL48M Fine Calibration */
-#define FUSES_DFLL48M_FINE_CAL_Msk  (0x3FFul << FUSES_DFLL48M_FINE_CAL_Pos)
+#define FUSES_DFLL48M_FINE_CAL_Msk  (_U_(0x3FF) << FUSES_DFLL48M_FINE_CAL_Pos)
 #define FUSES_DFLL48M_FINE_CAL(value) (FUSES_DFLL48M_FINE_CAL_Msk & ((value) << FUSES_DFLL48M_FINE_CAL_Pos))
 
 #define FUSES_HOT_ADC_VAL_ADDR      (NVMCTRL_TEMP_LOG + 4)
 #define FUSES_HOT_ADC_VAL_Pos       20           /**< \brief (NVMCTRL_TEMP_LOG) 12-bit ADC conversion at hot temperature */
-#define FUSES_HOT_ADC_VAL_Msk       (0xFFFul << FUSES_HOT_ADC_VAL_Pos)
+#define FUSES_HOT_ADC_VAL_Msk       (_U_(0xFFF) << FUSES_HOT_ADC_VAL_Pos)
 #define FUSES_HOT_ADC_VAL(value)    (FUSES_HOT_ADC_VAL_Msk & ((value) << FUSES_HOT_ADC_VAL_Pos))
 
 #define FUSES_HOT_INT1V_VAL_ADDR    (NVMCTRL_TEMP_LOG + 4)
 #define FUSES_HOT_INT1V_VAL_Pos     0            /**< \brief (NVMCTRL_TEMP_LOG) 2's complement of the internal 1V reference drift at hot temperature (versus a 1.0 centered value) */
-#define FUSES_HOT_INT1V_VAL_Msk     (0xFFul << FUSES_HOT_INT1V_VAL_Pos)
+#define FUSES_HOT_INT1V_VAL_Msk     (_U_(0xFF) << FUSES_HOT_INT1V_VAL_Pos)
 #define FUSES_HOT_INT1V_VAL(value)  (FUSES_HOT_INT1V_VAL_Msk & ((value) << FUSES_HOT_INT1V_VAL_Pos))
 
 #define FUSES_HOT_TEMP_VAL_DEC_ADDR NVMCTRL_TEMP_LOG
 #define FUSES_HOT_TEMP_VAL_DEC_Pos  20           /**< \brief (NVMCTRL_TEMP_LOG) Decimal part of hot temperature */
-#define FUSES_HOT_TEMP_VAL_DEC_Msk  (0xFul << FUSES_HOT_TEMP_VAL_DEC_Pos)
+#define FUSES_HOT_TEMP_VAL_DEC_Msk  (_U_(0xF) << FUSES_HOT_TEMP_VAL_DEC_Pos)
 #define FUSES_HOT_TEMP_VAL_DEC(value) (FUSES_HOT_TEMP_VAL_DEC_Msk & ((value) << FUSES_HOT_TEMP_VAL_DEC_Pos))
 
 #define FUSES_HOT_TEMP_VAL_INT_ADDR NVMCTRL_TEMP_LOG
 #define FUSES_HOT_TEMP_VAL_INT_Pos  12           /**< \brief (NVMCTRL_TEMP_LOG) Integer part of hot temperature in oC */
-#define FUSES_HOT_TEMP_VAL_INT_Msk  (0xFFul << FUSES_HOT_TEMP_VAL_INT_Pos)
+#define FUSES_HOT_TEMP_VAL_INT_Msk  (_U_(0xFF) << FUSES_HOT_TEMP_VAL_INT_Pos)
 #define FUSES_HOT_TEMP_VAL_INT(value) (FUSES_HOT_TEMP_VAL_INT_Msk & ((value) << FUSES_HOT_TEMP_VAL_INT_Pos))
 
 #define FUSES_OSC32K_CAL_ADDR       (NVMCTRL_OTP4 + 4)
 #define FUSES_OSC32K_CAL_Pos        6            /**< \brief (NVMCTRL_OTP4) OSC32K Calibration */
-#define FUSES_OSC32K_CAL_Msk        (0x7Ful << FUSES_OSC32K_CAL_Pos)
+#define FUSES_OSC32K_CAL_Msk        (_U_(0x7F) << FUSES_OSC32K_CAL_Pos)
 #define FUSES_OSC32K_CAL(value)     (FUSES_OSC32K_CAL_Msk & ((value) << FUSES_OSC32K_CAL_Pos))
 
 #define FUSES_ROOM_ADC_VAL_ADDR     (NVMCTRL_TEMP_LOG + 4)
 #define FUSES_ROOM_ADC_VAL_Pos      8            /**< \brief (NVMCTRL_TEMP_LOG) 12-bit ADC conversion at room temperature */
-#define FUSES_ROOM_ADC_VAL_Msk      (0xFFFul << FUSES_ROOM_ADC_VAL_Pos)
+#define FUSES_ROOM_ADC_VAL_Msk      (_U_(0xFFF) << FUSES_ROOM_ADC_VAL_Pos)
 #define FUSES_ROOM_ADC_VAL(value)   (FUSES_ROOM_ADC_VAL_Msk & ((value) << FUSES_ROOM_ADC_VAL_Pos))
 
 #define FUSES_ROOM_INT1V_VAL_ADDR   NVMCTRL_TEMP_LOG
 #define FUSES_ROOM_INT1V_VAL_Pos    24           /**< \brief (NVMCTRL_TEMP_LOG) 2's complement of the internal 1V reference drift at room temperature (versus a 1.0 centered value) */
-#define FUSES_ROOM_INT1V_VAL_Msk    (0xFFul << FUSES_ROOM_INT1V_VAL_Pos)
+#define FUSES_ROOM_INT1V_VAL_Msk    (_U_(0xFF) << FUSES_ROOM_INT1V_VAL_Pos)
 #define FUSES_ROOM_INT1V_VAL(value) (FUSES_ROOM_INT1V_VAL_Msk & ((value) << FUSES_ROOM_INT1V_VAL_Pos))
 
 #define FUSES_ROOM_TEMP_VAL_DEC_ADDR NVMCTRL_TEMP_LOG
 #define FUSES_ROOM_TEMP_VAL_DEC_Pos 8            /**< \brief (NVMCTRL_TEMP_LOG) Decimal part of room temperature */
-#define FUSES_ROOM_TEMP_VAL_DEC_Msk (0xFul << FUSES_ROOM_TEMP_VAL_DEC_Pos)
+#define FUSES_ROOM_TEMP_VAL_DEC_Msk (_U_(0xF) << FUSES_ROOM_TEMP_VAL_DEC_Pos)
 #define FUSES_ROOM_TEMP_VAL_DEC(value) (FUSES_ROOM_TEMP_VAL_DEC_Msk & ((value) << FUSES_ROOM_TEMP_VAL_DEC_Pos))
 
 #define FUSES_ROOM_TEMP_VAL_INT_ADDR NVMCTRL_TEMP_LOG
 #define FUSES_ROOM_TEMP_VAL_INT_Pos 0            /**< \brief (NVMCTRL_TEMP_LOG) Integer part of room temperature in oC */
-#define FUSES_ROOM_TEMP_VAL_INT_Msk (0xFFul << FUSES_ROOM_TEMP_VAL_INT_Pos)
+#define FUSES_ROOM_TEMP_VAL_INT_Msk (_U_(0xFF) << FUSES_ROOM_TEMP_VAL_INT_Pos)
 #define FUSES_ROOM_TEMP_VAL_INT(value) (FUSES_ROOM_TEMP_VAL_INT_Msk & ((value) << FUSES_ROOM_TEMP_VAL_INT_Pos))
 
 #define NVMCTRL_FUSES_BOOTPROT_ADDR NVMCTRL_USER
 #define NVMCTRL_FUSES_BOOTPROT_Pos  0            /**< \brief (NVMCTRL_USER) Bootloader Size */
-#define NVMCTRL_FUSES_BOOTPROT_Msk  (0x7ul << NVMCTRL_FUSES_BOOTPROT_Pos)
+#define NVMCTRL_FUSES_BOOTPROT_Msk  (_U_(0x7) << NVMCTRL_FUSES_BOOTPROT_Pos)
 #define NVMCTRL_FUSES_BOOTPROT(value) (NVMCTRL_FUSES_BOOTPROT_Msk & ((value) << NVMCTRL_FUSES_BOOTPROT_Pos))
 
 #define NVMCTRL_FUSES_EEPROM_SIZE_ADDR NVMCTRL_USER
 #define NVMCTRL_FUSES_EEPROM_SIZE_Pos 4            /**< \brief (NVMCTRL_USER) EEPROM Size */
-#define NVMCTRL_FUSES_EEPROM_SIZE_Msk (0x7ul << NVMCTRL_FUSES_EEPROM_SIZE_Pos)
+#define NVMCTRL_FUSES_EEPROM_SIZE_Msk (_U_(0x7) << NVMCTRL_FUSES_EEPROM_SIZE_Pos)
 #define NVMCTRL_FUSES_EEPROM_SIZE(value) (NVMCTRL_FUSES_EEPROM_SIZE_Msk & ((value) << NVMCTRL_FUSES_EEPROM_SIZE_Pos))
-
-#define NVMCTRL_FUSES_NVMP_ADDR     NVMCTRL_OTP1
-#define NVMCTRL_FUSES_NVMP_Pos      16           /**< \brief (NVMCTRL_OTP1) Number of NVM Pages */
-#define NVMCTRL_FUSES_NVMP_Msk      (0xFFFFul << NVMCTRL_FUSES_NVMP_Pos)
-#define NVMCTRL_FUSES_NVMP(value)   (NVMCTRL_FUSES_NVMP_Msk & ((value) << NVMCTRL_FUSES_NVMP_Pos))
-
-#define NVMCTRL_FUSES_NVM_LOCK_ADDR NVMCTRL_OTP1
-#define NVMCTRL_FUSES_NVM_LOCK_Pos  0            /**< \brief (NVMCTRL_OTP1) NVM Lock */
-#define NVMCTRL_FUSES_NVM_LOCK_Msk  (0xFFul << NVMCTRL_FUSES_NVM_LOCK_Pos)
-#define NVMCTRL_FUSES_NVM_LOCK(value) (NVMCTRL_FUSES_NVM_LOCK_Msk & ((value) << NVMCTRL_FUSES_NVM_LOCK_Pos))
-
-#define NVMCTRL_FUSES_PSZ_ADDR      NVMCTRL_OTP1
-#define NVMCTRL_FUSES_PSZ_Pos       8            /**< \brief (NVMCTRL_OTP1) NVM Page Size */
-#define NVMCTRL_FUSES_PSZ_Msk       (0xFul << NVMCTRL_FUSES_PSZ_Pos)
-#define NVMCTRL_FUSES_PSZ(value)    (NVMCTRL_FUSES_PSZ_Msk & ((value) << NVMCTRL_FUSES_PSZ_Pos))
 
 #define NVMCTRL_FUSES_REGION_LOCKS_ADDR (NVMCTRL_USER + 4)
 #define NVMCTRL_FUSES_REGION_LOCKS_Pos 16           /**< \brief (NVMCTRL_USER) NVM Region Locks */
-#define NVMCTRL_FUSES_REGION_LOCKS_Msk (0xFFFFul << NVMCTRL_FUSES_REGION_LOCKS_Pos)
+#define NVMCTRL_FUSES_REGION_LOCKS_Msk (_U_(0xFFFF) << NVMCTRL_FUSES_REGION_LOCKS_Pos)
 #define NVMCTRL_FUSES_REGION_LOCKS(value) (NVMCTRL_FUSES_REGION_LOCKS_Msk & ((value) << NVMCTRL_FUSES_REGION_LOCKS_Pos))
 
 #define USB_FUSES_TRANSN_ADDR       (NVMCTRL_OTP4 + 4)
 #define USB_FUSES_TRANSN_Pos        13           /**< \brief (NVMCTRL_OTP4) USB pad Transn calibration */
-#define USB_FUSES_TRANSN_Msk        (0x1Ful << USB_FUSES_TRANSN_Pos)
+#define USB_FUSES_TRANSN_Msk        (_U_(0x1F) << USB_FUSES_TRANSN_Pos)
 #define USB_FUSES_TRANSN(value)     (USB_FUSES_TRANSN_Msk & ((value) << USB_FUSES_TRANSN_Pos))
 
 #define USB_FUSES_TRANSP_ADDR       (NVMCTRL_OTP4 + 4)
 #define USB_FUSES_TRANSP_Pos        18           /**< \brief (NVMCTRL_OTP4) USB pad Transp calibration */
-#define USB_FUSES_TRANSP_Msk        (0x1Ful << USB_FUSES_TRANSP_Pos)
+#define USB_FUSES_TRANSP_Msk        (_U_(0x1F) << USB_FUSES_TRANSP_Pos)
 #define USB_FUSES_TRANSP(value)     (USB_FUSES_TRANSP_Msk & ((value) << USB_FUSES_TRANSP_Pos))
 
 #define USB_FUSES_TRIM_ADDR         (NVMCTRL_OTP4 + 4)
 #define USB_FUSES_TRIM_Pos          23           /**< \brief (NVMCTRL_OTP4) USB pad Trim calibration */
-#define USB_FUSES_TRIM_Msk          (0x7ul << USB_FUSES_TRIM_Pos)
+#define USB_FUSES_TRIM_Msk          (_U_(0x7) << USB_FUSES_TRIM_Pos)
 #define USB_FUSES_TRIM(value)       (USB_FUSES_TRIM_Msk & ((value) << USB_FUSES_TRIM_Pos))
 
 #define WDT_FUSES_ALWAYSON_ADDR     NVMCTRL_USER
 #define WDT_FUSES_ALWAYSON_Pos      26           /**< \brief (NVMCTRL_USER) WDT Always On */
-#define WDT_FUSES_ALWAYSON_Msk      (0x1ul << WDT_FUSES_ALWAYSON_Pos)
+#define WDT_FUSES_ALWAYSON_Msk      (_U_(0x1) << WDT_FUSES_ALWAYSON_Pos)
 
 #define WDT_FUSES_ENABLE_ADDR       NVMCTRL_USER
 #define WDT_FUSES_ENABLE_Pos        25           /**< \brief (NVMCTRL_USER) WDT Enable */
-#define WDT_FUSES_ENABLE_Msk        (0x1ul << WDT_FUSES_ENABLE_Pos)
+#define WDT_FUSES_ENABLE_Msk        (_U_(0x1) << WDT_FUSES_ENABLE_Pos)
 
 #define WDT_FUSES_EWOFFSET_ADDR     (NVMCTRL_USER + 4)
 #define WDT_FUSES_EWOFFSET_Pos      3            /**< \brief (NVMCTRL_USER) WDT Early Warning Offset */
-#define WDT_FUSES_EWOFFSET_Msk      (0xFul << WDT_FUSES_EWOFFSET_Pos)
+#define WDT_FUSES_EWOFFSET_Msk      (_U_(0xF) << WDT_FUSES_EWOFFSET_Pos)
 #define WDT_FUSES_EWOFFSET(value)   (WDT_FUSES_EWOFFSET_Msk & ((value) << WDT_FUSES_EWOFFSET_Pos))
 
 #define WDT_FUSES_PER_ADDR          NVMCTRL_USER
 #define WDT_FUSES_PER_Pos           27           /**< \brief (NVMCTRL_USER) WDT Period */
-#define WDT_FUSES_PER_Msk           (0xFul << WDT_FUSES_PER_Pos)
+#define WDT_FUSES_PER_Msk           (_U_(0xF) << WDT_FUSES_PER_Pos)
 #define WDT_FUSES_PER(value)        (WDT_FUSES_PER_Msk & ((value) << WDT_FUSES_PER_Pos))
 
 #define WDT_FUSES_WEN_ADDR          (NVMCTRL_USER + 4)
 #define WDT_FUSES_WEN_Pos           7            /**< \brief (NVMCTRL_USER) WDT Window Mode Enable */
-#define WDT_FUSES_WEN_Msk           (0x1ul << WDT_FUSES_WEN_Pos)
+#define WDT_FUSES_WEN_Msk           (_U_(0x1) << WDT_FUSES_WEN_Pos)
 
 #define WDT_FUSES_WINDOW_0_ADDR     NVMCTRL_USER
 #define WDT_FUSES_WINDOW_0_Pos      31           /**< \brief (NVMCTRL_USER) WDT Window bit 0 */
-#define WDT_FUSES_WINDOW_0_Msk      (0x1ul << WDT_FUSES_WINDOW_0_Pos)
+#define WDT_FUSES_WINDOW_0_Msk      (_U_(0x1) << WDT_FUSES_WINDOW_0_Pos)
 
 #define WDT_FUSES_WINDOW_1_ADDR     (NVMCTRL_USER + 4)
 #define WDT_FUSES_WINDOW_1_Pos      0            /**< \brief (NVMCTRL_USER) WDT Window bits 3:1 */
-#define WDT_FUSES_WINDOW_1_Msk      (0x7ul << WDT_FUSES_WINDOW_1_Pos)
+#define WDT_FUSES_WINDOW_1_Msk      (_U_(0x7) << WDT_FUSES_WINDOW_1_Pos)
 #define WDT_FUSES_WINDOW_1(value)   (WDT_FUSES_WINDOW_1_Msk & ((value) << WDT_FUSES_WINDOW_1_Pos))
 
 /*@}*/

--- a/cpu/sam0_common/include/vendor/samr21/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/pac.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for PAC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -65,12 +50,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PAC_WPCLR_OFFSET            0x0          /**< \brief (PAC_WPCLR offset) Write Protection Clear */
-#define PAC_WPCLR_RESETVALUE        0x00000000ul /**< \brief (PAC_WPCLR reset_value) Write Protection Clear */
+#define PAC_WPCLR_RESETVALUE        _U_(0x00000000) /**< \brief (PAC_WPCLR reset_value) Write Protection Clear */
 
 #define PAC_WPCLR_WP_Pos            1            /**< \brief (PAC_WPCLR) Write Protection Clear */
-#define PAC_WPCLR_WP_Msk            (0x7FFFFFFFul << PAC_WPCLR_WP_Pos)
+#define PAC_WPCLR_WP_Msk            (_U_(0x7FFFFFFF) << PAC_WPCLR_WP_Pos)
 #define PAC_WPCLR_WP(value)         (PAC_WPCLR_WP_Msk & ((value) << PAC_WPCLR_WP_Pos))
-#define PAC_WPCLR_MASK              0xFFFFFFFEul /**< \brief (PAC_WPCLR) MASK Register */
+#define PAC_WPCLR_MASK              _U_(0xFFFFFFFE) /**< \brief (PAC_WPCLR) MASK Register */
 
 /* -------- PAC_WPSET : (PAC Offset: 0x4) (R/W 32) Write Protection Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -84,12 +69,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PAC_WPSET_OFFSET            0x4          /**< \brief (PAC_WPSET offset) Write Protection Set */
-#define PAC_WPSET_RESETVALUE        0x00000000ul /**< \brief (PAC_WPSET reset_value) Write Protection Set */
+#define PAC_WPSET_RESETVALUE        _U_(0x00000000) /**< \brief (PAC_WPSET reset_value) Write Protection Set */
 
 #define PAC_WPSET_WP_Pos            1            /**< \brief (PAC_WPSET) Write Protection Set */
-#define PAC_WPSET_WP_Msk            (0x7FFFFFFFul << PAC_WPSET_WP_Pos)
+#define PAC_WPSET_WP_Msk            (_U_(0x7FFFFFFF) << PAC_WPSET_WP_Pos)
 #define PAC_WPSET_WP(value)         (PAC_WPSET_WP_Msk & ((value) << PAC_WPSET_WP_Pos))
-#define PAC_WPSET_MASK              0xFFFFFFFEul /**< \brief (PAC_WPSET) MASK Register */
+#define PAC_WPSET_MASK              _U_(0xFFFFFFFE) /**< \brief (PAC_WPSET) MASK Register */
 
 /** \brief PAC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/pm.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for PM
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -61,9 +46,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_CTRL_OFFSET              0x00         /**< \brief (PM_CTRL offset) Control */
-#define PM_CTRL_RESETVALUE          0x00ul       /**< \brief (PM_CTRL reset_value) Control */
+#define PM_CTRL_RESETVALUE          _U_(0x00)     /**< \brief (PM_CTRL reset_value) Control */
 
-#define PM_CTRL_MASK                0x00ul       /**< \brief (PM_CTRL) MASK Register */
+#define PM_CTRL_MASK                _U_(0x00)     /**< \brief (PM_CTRL) MASK Register */
 
 /* -------- PM_SLEEP : (PM Offset: 0x01) (R/W  8) Sleep Mode -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -77,18 +62,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_SLEEP_OFFSET             0x01         /**< \brief (PM_SLEEP offset) Sleep Mode */
-#define PM_SLEEP_RESETVALUE         0x00ul       /**< \brief (PM_SLEEP reset_value) Sleep Mode */
+#define PM_SLEEP_RESETVALUE         _U_(0x00)     /**< \brief (PM_SLEEP reset_value) Sleep Mode */
 
 #define PM_SLEEP_IDLE_Pos           0            /**< \brief (PM_SLEEP) Idle Mode Configuration */
-#define PM_SLEEP_IDLE_Msk           (0x3ul << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_IDLE_Msk           (_U_(0x3) << PM_SLEEP_IDLE_Pos)
 #define PM_SLEEP_IDLE(value)        (PM_SLEEP_IDLE_Msk & ((value) << PM_SLEEP_IDLE_Pos))
-#define   PM_SLEEP_IDLE_CPU_Val           0x0ul  /**< \brief (PM_SLEEP) The CPU clock domain is stopped */
-#define   PM_SLEEP_IDLE_AHB_Val           0x1ul  /**< \brief (PM_SLEEP) The CPU and AHB clock domains are stopped */
-#define   PM_SLEEP_IDLE_APB_Val           0x2ul  /**< \brief (PM_SLEEP) The CPU, AHB and APB clock domains are stopped */
+#define   PM_SLEEP_IDLE_CPU_Val           _U_(0x0)   /**< \brief (PM_SLEEP) The CPU clock domain is stopped */
+#define   PM_SLEEP_IDLE_AHB_Val           _U_(0x1)   /**< \brief (PM_SLEEP) The CPU and AHB clock domains are stopped */
+#define   PM_SLEEP_IDLE_APB_Val           _U_(0x2)   /**< \brief (PM_SLEEP) The CPU, AHB and APB clock domains are stopped */
 #define PM_SLEEP_IDLE_CPU           (PM_SLEEP_IDLE_CPU_Val         << PM_SLEEP_IDLE_Pos)
 #define PM_SLEEP_IDLE_AHB           (PM_SLEEP_IDLE_AHB_Val         << PM_SLEEP_IDLE_Pos)
 #define PM_SLEEP_IDLE_APB           (PM_SLEEP_IDLE_APB_Val         << PM_SLEEP_IDLE_Pos)
-#define PM_SLEEP_MASK               0x03ul       /**< \brief (PM_SLEEP) MASK Register */
+#define PM_SLEEP_MASK               _U_(0x03)     /**< \brief (PM_SLEEP) MASK Register */
 
 /* -------- PM_CPUSEL : (PM Offset: 0x08) (R/W  8) CPU Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -102,19 +87,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_CPUSEL_OFFSET            0x08         /**< \brief (PM_CPUSEL offset) CPU Clock Select */
-#define PM_CPUSEL_RESETVALUE        0x00ul       /**< \brief (PM_CPUSEL reset_value) CPU Clock Select */
+#define PM_CPUSEL_RESETVALUE        _U_(0x00)     /**< \brief (PM_CPUSEL reset_value) CPU Clock Select */
 
 #define PM_CPUSEL_CPUDIV_Pos        0            /**< \brief (PM_CPUSEL) CPU Prescaler Selection */
-#define PM_CPUSEL_CPUDIV_Msk        (0x7ul << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_Msk        (_U_(0x7) << PM_CPUSEL_CPUDIV_Pos)
 #define PM_CPUSEL_CPUDIV(value)     (PM_CPUSEL_CPUDIV_Msk & ((value) << PM_CPUSEL_CPUDIV_Pos))
-#define   PM_CPUSEL_CPUDIV_DIV1_Val       0x0ul  /**< \brief (PM_CPUSEL) Divide by 1 */
-#define   PM_CPUSEL_CPUDIV_DIV2_Val       0x1ul  /**< \brief (PM_CPUSEL) Divide by 2 */
-#define   PM_CPUSEL_CPUDIV_DIV4_Val       0x2ul  /**< \brief (PM_CPUSEL) Divide by 4 */
-#define   PM_CPUSEL_CPUDIV_DIV8_Val       0x3ul  /**< \brief (PM_CPUSEL) Divide by 8 */
-#define   PM_CPUSEL_CPUDIV_DIV16_Val      0x4ul  /**< \brief (PM_CPUSEL) Divide by 16 */
-#define   PM_CPUSEL_CPUDIV_DIV32_Val      0x5ul  /**< \brief (PM_CPUSEL) Divide by 32 */
-#define   PM_CPUSEL_CPUDIV_DIV64_Val      0x6ul  /**< \brief (PM_CPUSEL) Divide by 64 */
-#define   PM_CPUSEL_CPUDIV_DIV128_Val     0x7ul  /**< \brief (PM_CPUSEL) Divide by 128 */
+#define   PM_CPUSEL_CPUDIV_DIV1_Val       _U_(0x0)   /**< \brief (PM_CPUSEL) Divide by 1 */
+#define   PM_CPUSEL_CPUDIV_DIV2_Val       _U_(0x1)   /**< \brief (PM_CPUSEL) Divide by 2 */
+#define   PM_CPUSEL_CPUDIV_DIV4_Val       _U_(0x2)   /**< \brief (PM_CPUSEL) Divide by 4 */
+#define   PM_CPUSEL_CPUDIV_DIV8_Val       _U_(0x3)   /**< \brief (PM_CPUSEL) Divide by 8 */
+#define   PM_CPUSEL_CPUDIV_DIV16_Val      _U_(0x4)   /**< \brief (PM_CPUSEL) Divide by 16 */
+#define   PM_CPUSEL_CPUDIV_DIV32_Val      _U_(0x5)   /**< \brief (PM_CPUSEL) Divide by 32 */
+#define   PM_CPUSEL_CPUDIV_DIV64_Val      _U_(0x6)   /**< \brief (PM_CPUSEL) Divide by 64 */
+#define   PM_CPUSEL_CPUDIV_DIV128_Val     _U_(0x7)   /**< \brief (PM_CPUSEL) Divide by 128 */
 #define PM_CPUSEL_CPUDIV_DIV1       (PM_CPUSEL_CPUDIV_DIV1_Val     << PM_CPUSEL_CPUDIV_Pos)
 #define PM_CPUSEL_CPUDIV_DIV2       (PM_CPUSEL_CPUDIV_DIV2_Val     << PM_CPUSEL_CPUDIV_Pos)
 #define PM_CPUSEL_CPUDIV_DIV4       (PM_CPUSEL_CPUDIV_DIV4_Val     << PM_CPUSEL_CPUDIV_Pos)
@@ -123,7 +108,7 @@ typedef union {
 #define PM_CPUSEL_CPUDIV_DIV32      (PM_CPUSEL_CPUDIV_DIV32_Val    << PM_CPUSEL_CPUDIV_Pos)
 #define PM_CPUSEL_CPUDIV_DIV64      (PM_CPUSEL_CPUDIV_DIV64_Val    << PM_CPUSEL_CPUDIV_Pos)
 #define PM_CPUSEL_CPUDIV_DIV128     (PM_CPUSEL_CPUDIV_DIV128_Val   << PM_CPUSEL_CPUDIV_Pos)
-#define PM_CPUSEL_MASK              0x07ul       /**< \brief (PM_CPUSEL) MASK Register */
+#define PM_CPUSEL_MASK              _U_(0x07)     /**< \brief (PM_CPUSEL) MASK Register */
 
 /* -------- PM_APBASEL : (PM Offset: 0x09) (R/W  8) APBA Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -137,19 +122,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_APBASEL_OFFSET           0x09         /**< \brief (PM_APBASEL offset) APBA Clock Select */
-#define PM_APBASEL_RESETVALUE       0x00ul       /**< \brief (PM_APBASEL reset_value) APBA Clock Select */
+#define PM_APBASEL_RESETVALUE       _U_(0x00)     /**< \brief (PM_APBASEL reset_value) APBA Clock Select */
 
 #define PM_APBASEL_APBADIV_Pos      0            /**< \brief (PM_APBASEL) APBA Prescaler Selection */
-#define PM_APBASEL_APBADIV_Msk      (0x7ul << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_Msk      (_U_(0x7) << PM_APBASEL_APBADIV_Pos)
 #define PM_APBASEL_APBADIV(value)   (PM_APBASEL_APBADIV_Msk & ((value) << PM_APBASEL_APBADIV_Pos))
-#define   PM_APBASEL_APBADIV_DIV1_Val     0x0ul  /**< \brief (PM_APBASEL) Divide by 1 */
-#define   PM_APBASEL_APBADIV_DIV2_Val     0x1ul  /**< \brief (PM_APBASEL) Divide by 2 */
-#define   PM_APBASEL_APBADIV_DIV4_Val     0x2ul  /**< \brief (PM_APBASEL) Divide by 4 */
-#define   PM_APBASEL_APBADIV_DIV8_Val     0x3ul  /**< \brief (PM_APBASEL) Divide by 8 */
-#define   PM_APBASEL_APBADIV_DIV16_Val    0x4ul  /**< \brief (PM_APBASEL) Divide by 16 */
-#define   PM_APBASEL_APBADIV_DIV32_Val    0x5ul  /**< \brief (PM_APBASEL) Divide by 32 */
-#define   PM_APBASEL_APBADIV_DIV64_Val    0x6ul  /**< \brief (PM_APBASEL) Divide by 64 */
-#define   PM_APBASEL_APBADIV_DIV128_Val   0x7ul  /**< \brief (PM_APBASEL) Divide by 128 */
+#define   PM_APBASEL_APBADIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBASEL) Divide by 1 */
+#define   PM_APBASEL_APBADIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBASEL) Divide by 2 */
+#define   PM_APBASEL_APBADIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBASEL) Divide by 4 */
+#define   PM_APBASEL_APBADIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBASEL) Divide by 8 */
+#define   PM_APBASEL_APBADIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBASEL) Divide by 16 */
+#define   PM_APBASEL_APBADIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBASEL) Divide by 32 */
+#define   PM_APBASEL_APBADIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBASEL) Divide by 64 */
+#define   PM_APBASEL_APBADIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBASEL) Divide by 128 */
 #define PM_APBASEL_APBADIV_DIV1     (PM_APBASEL_APBADIV_DIV1_Val   << PM_APBASEL_APBADIV_Pos)
 #define PM_APBASEL_APBADIV_DIV2     (PM_APBASEL_APBADIV_DIV2_Val   << PM_APBASEL_APBADIV_Pos)
 #define PM_APBASEL_APBADIV_DIV4     (PM_APBASEL_APBADIV_DIV4_Val   << PM_APBASEL_APBADIV_Pos)
@@ -158,7 +143,7 @@ typedef union {
 #define PM_APBASEL_APBADIV_DIV32    (PM_APBASEL_APBADIV_DIV32_Val  << PM_APBASEL_APBADIV_Pos)
 #define PM_APBASEL_APBADIV_DIV64    (PM_APBASEL_APBADIV_DIV64_Val  << PM_APBASEL_APBADIV_Pos)
 #define PM_APBASEL_APBADIV_DIV128   (PM_APBASEL_APBADIV_DIV128_Val << PM_APBASEL_APBADIV_Pos)
-#define PM_APBASEL_MASK             0x07ul       /**< \brief (PM_APBASEL) MASK Register */
+#define PM_APBASEL_MASK             _U_(0x07)     /**< \brief (PM_APBASEL) MASK Register */
 
 /* -------- PM_APBBSEL : (PM Offset: 0x0A) (R/W  8) APBB Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -172,19 +157,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_APBBSEL_OFFSET           0x0A         /**< \brief (PM_APBBSEL offset) APBB Clock Select */
-#define PM_APBBSEL_RESETVALUE       0x00ul       /**< \brief (PM_APBBSEL reset_value) APBB Clock Select */
+#define PM_APBBSEL_RESETVALUE       _U_(0x00)     /**< \brief (PM_APBBSEL reset_value) APBB Clock Select */
 
 #define PM_APBBSEL_APBBDIV_Pos      0            /**< \brief (PM_APBBSEL) APBB Prescaler Selection */
-#define PM_APBBSEL_APBBDIV_Msk      (0x7ul << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_Msk      (_U_(0x7) << PM_APBBSEL_APBBDIV_Pos)
 #define PM_APBBSEL_APBBDIV(value)   (PM_APBBSEL_APBBDIV_Msk & ((value) << PM_APBBSEL_APBBDIV_Pos))
-#define   PM_APBBSEL_APBBDIV_DIV1_Val     0x0ul  /**< \brief (PM_APBBSEL) Divide by 1 */
-#define   PM_APBBSEL_APBBDIV_DIV2_Val     0x1ul  /**< \brief (PM_APBBSEL) Divide by 2 */
-#define   PM_APBBSEL_APBBDIV_DIV4_Val     0x2ul  /**< \brief (PM_APBBSEL) Divide by 4 */
-#define   PM_APBBSEL_APBBDIV_DIV8_Val     0x3ul  /**< \brief (PM_APBBSEL) Divide by 8 */
-#define   PM_APBBSEL_APBBDIV_DIV16_Val    0x4ul  /**< \brief (PM_APBBSEL) Divide by 16 */
-#define   PM_APBBSEL_APBBDIV_DIV32_Val    0x5ul  /**< \brief (PM_APBBSEL) Divide by 32 */
-#define   PM_APBBSEL_APBBDIV_DIV64_Val    0x6ul  /**< \brief (PM_APBBSEL) Divide by 64 */
-#define   PM_APBBSEL_APBBDIV_DIV128_Val   0x7ul  /**< \brief (PM_APBBSEL) Divide by 128 */
+#define   PM_APBBSEL_APBBDIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBBSEL) Divide by 1 */
+#define   PM_APBBSEL_APBBDIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBBSEL) Divide by 2 */
+#define   PM_APBBSEL_APBBDIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBBSEL) Divide by 4 */
+#define   PM_APBBSEL_APBBDIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBBSEL) Divide by 8 */
+#define   PM_APBBSEL_APBBDIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBBSEL) Divide by 16 */
+#define   PM_APBBSEL_APBBDIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBBSEL) Divide by 32 */
+#define   PM_APBBSEL_APBBDIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBBSEL) Divide by 64 */
+#define   PM_APBBSEL_APBBDIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBBSEL) Divide by 128 */
 #define PM_APBBSEL_APBBDIV_DIV1     (PM_APBBSEL_APBBDIV_DIV1_Val   << PM_APBBSEL_APBBDIV_Pos)
 #define PM_APBBSEL_APBBDIV_DIV2     (PM_APBBSEL_APBBDIV_DIV2_Val   << PM_APBBSEL_APBBDIV_Pos)
 #define PM_APBBSEL_APBBDIV_DIV4     (PM_APBBSEL_APBBDIV_DIV4_Val   << PM_APBBSEL_APBBDIV_Pos)
@@ -193,7 +178,7 @@ typedef union {
 #define PM_APBBSEL_APBBDIV_DIV32    (PM_APBBSEL_APBBDIV_DIV32_Val  << PM_APBBSEL_APBBDIV_Pos)
 #define PM_APBBSEL_APBBDIV_DIV64    (PM_APBBSEL_APBBDIV_DIV64_Val  << PM_APBBSEL_APBBDIV_Pos)
 #define PM_APBBSEL_APBBDIV_DIV128   (PM_APBBSEL_APBBDIV_DIV128_Val << PM_APBBSEL_APBBDIV_Pos)
-#define PM_APBBSEL_MASK             0x07ul       /**< \brief (PM_APBBSEL) MASK Register */
+#define PM_APBBSEL_MASK             _U_(0x07)     /**< \brief (PM_APBBSEL) MASK Register */
 
 /* -------- PM_APBCSEL : (PM Offset: 0x0B) (R/W  8) APBC Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -207,19 +192,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_APBCSEL_OFFSET           0x0B         /**< \brief (PM_APBCSEL offset) APBC Clock Select */
-#define PM_APBCSEL_RESETVALUE       0x00ul       /**< \brief (PM_APBCSEL reset_value) APBC Clock Select */
+#define PM_APBCSEL_RESETVALUE       _U_(0x00)     /**< \brief (PM_APBCSEL reset_value) APBC Clock Select */
 
 #define PM_APBCSEL_APBCDIV_Pos      0            /**< \brief (PM_APBCSEL) APBC Prescaler Selection */
-#define PM_APBCSEL_APBCDIV_Msk      (0x7ul << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_Msk      (_U_(0x7) << PM_APBCSEL_APBCDIV_Pos)
 #define PM_APBCSEL_APBCDIV(value)   (PM_APBCSEL_APBCDIV_Msk & ((value) << PM_APBCSEL_APBCDIV_Pos))
-#define   PM_APBCSEL_APBCDIV_DIV1_Val     0x0ul  /**< \brief (PM_APBCSEL) Divide by 1 */
-#define   PM_APBCSEL_APBCDIV_DIV2_Val     0x1ul  /**< \brief (PM_APBCSEL) Divide by 2 */
-#define   PM_APBCSEL_APBCDIV_DIV4_Val     0x2ul  /**< \brief (PM_APBCSEL) Divide by 4 */
-#define   PM_APBCSEL_APBCDIV_DIV8_Val     0x3ul  /**< \brief (PM_APBCSEL) Divide by 8 */
-#define   PM_APBCSEL_APBCDIV_DIV16_Val    0x4ul  /**< \brief (PM_APBCSEL) Divide by 16 */
-#define   PM_APBCSEL_APBCDIV_DIV32_Val    0x5ul  /**< \brief (PM_APBCSEL) Divide by 32 */
-#define   PM_APBCSEL_APBCDIV_DIV64_Val    0x6ul  /**< \brief (PM_APBCSEL) Divide by 64 */
-#define   PM_APBCSEL_APBCDIV_DIV128_Val   0x7ul  /**< \brief (PM_APBCSEL) Divide by 128 */
+#define   PM_APBCSEL_APBCDIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBCSEL) Divide by 1 */
+#define   PM_APBCSEL_APBCDIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBCSEL) Divide by 2 */
+#define   PM_APBCSEL_APBCDIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBCSEL) Divide by 4 */
+#define   PM_APBCSEL_APBCDIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBCSEL) Divide by 8 */
+#define   PM_APBCSEL_APBCDIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBCSEL) Divide by 16 */
+#define   PM_APBCSEL_APBCDIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBCSEL) Divide by 32 */
+#define   PM_APBCSEL_APBCDIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBCSEL) Divide by 64 */
+#define   PM_APBCSEL_APBCDIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBCSEL) Divide by 128 */
 #define PM_APBCSEL_APBCDIV_DIV1     (PM_APBCSEL_APBCDIV_DIV1_Val   << PM_APBCSEL_APBCDIV_Pos)
 #define PM_APBCSEL_APBCDIV_DIV2     (PM_APBCSEL_APBCDIV_DIV2_Val   << PM_APBCSEL_APBCDIV_Pos)
 #define PM_APBCSEL_APBCDIV_DIV4     (PM_APBCSEL_APBCDIV_DIV4_Val   << PM_APBCSEL_APBCDIV_Pos)
@@ -228,7 +213,7 @@ typedef union {
 #define PM_APBCSEL_APBCDIV_DIV32    (PM_APBCSEL_APBCDIV_DIV32_Val  << PM_APBCSEL_APBCDIV_Pos)
 #define PM_APBCSEL_APBCDIV_DIV64    (PM_APBCSEL_APBCDIV_DIV64_Val  << PM_APBCSEL_APBCDIV_Pos)
 #define PM_APBCSEL_APBCDIV_DIV128   (PM_APBCSEL_APBCDIV_DIV128_Val << PM_APBCSEL_APBCDIV_Pos)
-#define PM_APBCSEL_MASK             0x07ul       /**< \brief (PM_APBCSEL) MASK Register */
+#define PM_APBCSEL_MASK             _U_(0x07)     /**< \brief (PM_APBCSEL) MASK Register */
 
 /* -------- PM_AHBMASK : (PM Offset: 0x14) (R/W 32) AHB Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -248,23 +233,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_AHBMASK_OFFSET           0x14         /**< \brief (PM_AHBMASK offset) AHB Mask */
-#define PM_AHBMASK_RESETVALUE       0x0000007Ful /**< \brief (PM_AHBMASK reset_value) AHB Mask */
+#define PM_AHBMASK_RESETVALUE       _U_(0x0000007F) /**< \brief (PM_AHBMASK reset_value) AHB Mask */
 
 #define PM_AHBMASK_HPB0_Pos         0            /**< \brief (PM_AHBMASK) HPB0 AHB Clock Mask */
-#define PM_AHBMASK_HPB0             (0x1ul << PM_AHBMASK_HPB0_Pos)
+#define PM_AHBMASK_HPB0             (_U_(0x1) << PM_AHBMASK_HPB0_Pos)
 #define PM_AHBMASK_HPB1_Pos         1            /**< \brief (PM_AHBMASK) HPB1 AHB Clock Mask */
-#define PM_AHBMASK_HPB1             (0x1ul << PM_AHBMASK_HPB1_Pos)
+#define PM_AHBMASK_HPB1             (_U_(0x1) << PM_AHBMASK_HPB1_Pos)
 #define PM_AHBMASK_HPB2_Pos         2            /**< \brief (PM_AHBMASK) HPB2 AHB Clock Mask */
-#define PM_AHBMASK_HPB2             (0x1ul << PM_AHBMASK_HPB2_Pos)
+#define PM_AHBMASK_HPB2             (_U_(0x1) << PM_AHBMASK_HPB2_Pos)
 #define PM_AHBMASK_DSU_Pos          3            /**< \brief (PM_AHBMASK) DSU AHB Clock Mask */
-#define PM_AHBMASK_DSU              (0x1ul << PM_AHBMASK_DSU_Pos)
+#define PM_AHBMASK_DSU              (_U_(0x1) << PM_AHBMASK_DSU_Pos)
 #define PM_AHBMASK_NVMCTRL_Pos      4            /**< \brief (PM_AHBMASK) NVMCTRL AHB Clock Mask */
-#define PM_AHBMASK_NVMCTRL          (0x1ul << PM_AHBMASK_NVMCTRL_Pos)
+#define PM_AHBMASK_NVMCTRL          (_U_(0x1) << PM_AHBMASK_NVMCTRL_Pos)
 #define PM_AHBMASK_DMAC_Pos         5            /**< \brief (PM_AHBMASK) DMAC AHB Clock Mask */
-#define PM_AHBMASK_DMAC             (0x1ul << PM_AHBMASK_DMAC_Pos)
+#define PM_AHBMASK_DMAC             (_U_(0x1) << PM_AHBMASK_DMAC_Pos)
 #define PM_AHBMASK_USB_Pos          6            /**< \brief (PM_AHBMASK) USB AHB Clock Mask */
-#define PM_AHBMASK_USB              (0x1ul << PM_AHBMASK_USB_Pos)
-#define PM_AHBMASK_MASK             0x0000007Ful /**< \brief (PM_AHBMASK) MASK Register */
+#define PM_AHBMASK_USB              (_U_(0x1) << PM_AHBMASK_USB_Pos)
+#define PM_AHBMASK_MASK             _U_(0x0000007F) /**< \brief (PM_AHBMASK) MASK Register */
 
 /* -------- PM_APBAMASK : (PM Offset: 0x18) (R/W 32) APBA Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -284,23 +269,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_APBAMASK_OFFSET          0x18         /**< \brief (PM_APBAMASK offset) APBA Mask */
-#define PM_APBAMASK_RESETVALUE      0x0000007Ful /**< \brief (PM_APBAMASK reset_value) APBA Mask */
+#define PM_APBAMASK_RESETVALUE      _U_(0x0000007F) /**< \brief (PM_APBAMASK reset_value) APBA Mask */
 
 #define PM_APBAMASK_PAC0_Pos        0            /**< \brief (PM_APBAMASK) PAC0 APB Clock Enable */
-#define PM_APBAMASK_PAC0            (0x1ul << PM_APBAMASK_PAC0_Pos)
+#define PM_APBAMASK_PAC0            (_U_(0x1) << PM_APBAMASK_PAC0_Pos)
 #define PM_APBAMASK_PM_Pos          1            /**< \brief (PM_APBAMASK) PM APB Clock Enable */
-#define PM_APBAMASK_PM              (0x1ul << PM_APBAMASK_PM_Pos)
+#define PM_APBAMASK_PM              (_U_(0x1) << PM_APBAMASK_PM_Pos)
 #define PM_APBAMASK_SYSCTRL_Pos     2            /**< \brief (PM_APBAMASK) SYSCTRL APB Clock Enable */
-#define PM_APBAMASK_SYSCTRL         (0x1ul << PM_APBAMASK_SYSCTRL_Pos)
+#define PM_APBAMASK_SYSCTRL         (_U_(0x1) << PM_APBAMASK_SYSCTRL_Pos)
 #define PM_APBAMASK_GCLK_Pos        3            /**< \brief (PM_APBAMASK) GCLK APB Clock Enable */
-#define PM_APBAMASK_GCLK            (0x1ul << PM_APBAMASK_GCLK_Pos)
+#define PM_APBAMASK_GCLK            (_U_(0x1) << PM_APBAMASK_GCLK_Pos)
 #define PM_APBAMASK_WDT_Pos         4            /**< \brief (PM_APBAMASK) WDT APB Clock Enable */
-#define PM_APBAMASK_WDT             (0x1ul << PM_APBAMASK_WDT_Pos)
+#define PM_APBAMASK_WDT             (_U_(0x1) << PM_APBAMASK_WDT_Pos)
 #define PM_APBAMASK_RTC_Pos         5            /**< \brief (PM_APBAMASK) RTC APB Clock Enable */
-#define PM_APBAMASK_RTC             (0x1ul << PM_APBAMASK_RTC_Pos)
+#define PM_APBAMASK_RTC             (_U_(0x1) << PM_APBAMASK_RTC_Pos)
 #define PM_APBAMASK_EIC_Pos         6            /**< \brief (PM_APBAMASK) EIC APB Clock Enable */
-#define PM_APBAMASK_EIC             (0x1ul << PM_APBAMASK_EIC_Pos)
-#define PM_APBAMASK_MASK            0x0000007Ful /**< \brief (PM_APBAMASK) MASK Register */
+#define PM_APBAMASK_EIC             (_U_(0x1) << PM_APBAMASK_EIC_Pos)
+#define PM_APBAMASK_MASK            _U_(0x0000007F) /**< \brief (PM_APBAMASK) MASK Register */
 
 /* -------- PM_APBBMASK : (PM Offset: 0x1C) (R/W 32) APBB Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -320,23 +305,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_APBBMASK_OFFSET          0x1C         /**< \brief (PM_APBBMASK offset) APBB Mask */
-#define PM_APBBMASK_RESETVALUE      0x0000007Ful /**< \brief (PM_APBBMASK reset_value) APBB Mask */
+#define PM_APBBMASK_RESETVALUE      _U_(0x0000007F) /**< \brief (PM_APBBMASK reset_value) APBB Mask */
 
 #define PM_APBBMASK_PAC1_Pos        0            /**< \brief (PM_APBBMASK) PAC1 APB Clock Enable */
-#define PM_APBBMASK_PAC1            (0x1ul << PM_APBBMASK_PAC1_Pos)
+#define PM_APBBMASK_PAC1            (_U_(0x1) << PM_APBBMASK_PAC1_Pos)
 #define PM_APBBMASK_DSU_Pos         1            /**< \brief (PM_APBBMASK) DSU APB Clock Enable */
-#define PM_APBBMASK_DSU             (0x1ul << PM_APBBMASK_DSU_Pos)
+#define PM_APBBMASK_DSU             (_U_(0x1) << PM_APBBMASK_DSU_Pos)
 #define PM_APBBMASK_NVMCTRL_Pos     2            /**< \brief (PM_APBBMASK) NVMCTRL APB Clock Enable */
-#define PM_APBBMASK_NVMCTRL         (0x1ul << PM_APBBMASK_NVMCTRL_Pos)
+#define PM_APBBMASK_NVMCTRL         (_U_(0x1) << PM_APBBMASK_NVMCTRL_Pos)
 #define PM_APBBMASK_PORT_Pos        3            /**< \brief (PM_APBBMASK) PORT APB Clock Enable */
-#define PM_APBBMASK_PORT            (0x1ul << PM_APBBMASK_PORT_Pos)
+#define PM_APBBMASK_PORT            (_U_(0x1) << PM_APBBMASK_PORT_Pos)
 #define PM_APBBMASK_DMAC_Pos        4            /**< \brief (PM_APBBMASK) DMAC APB Clock Enable */
-#define PM_APBBMASK_DMAC            (0x1ul << PM_APBBMASK_DMAC_Pos)
+#define PM_APBBMASK_DMAC            (_U_(0x1) << PM_APBBMASK_DMAC_Pos)
 #define PM_APBBMASK_USB_Pos         5            /**< \brief (PM_APBBMASK) USB APB Clock Enable */
-#define PM_APBBMASK_USB             (0x1ul << PM_APBBMASK_USB_Pos)
+#define PM_APBBMASK_USB             (_U_(0x1) << PM_APBBMASK_USB_Pos)
 #define PM_APBBMASK_HMATRIX_Pos     6            /**< \brief (PM_APBBMASK) HMATRIX APB Clock Enable */
-#define PM_APBBMASK_HMATRIX         (0x1ul << PM_APBBMASK_HMATRIX_Pos)
-#define PM_APBBMASK_MASK            0x0000007Ful /**< \brief (PM_APBBMASK) MASK Register */
+#define PM_APBBMASK_HMATRIX         (_U_(0x1) << PM_APBBMASK_HMATRIX_Pos)
+#define PM_APBBMASK_MASK            _U_(0x0000007F) /**< \brief (PM_APBBMASK) MASK Register */
 
 /* -------- PM_APBCMASK : (PM Offset: 0x20) (R/W 32) APBC Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -356,10 +341,11 @@ typedef union {
     uint32_t TC3_:1;           /*!< bit:     11  TC3 APB Clock Enable               */
     uint32_t TC4_:1;           /*!< bit:     12  TC4 APB Clock Enable               */
     uint32_t TC5_:1;           /*!< bit:     13  TC5 APB Clock Enable               */
-    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t TC6_:1;           /*!< bit:     14  TC6 APB Clock Enable               */
+    uint32_t TC7_:1;           /*!< bit:     15  TC7 APB Clock Enable               */
     uint32_t ADC_:1;           /*!< bit:     16  ADC APB Clock Enable               */
     uint32_t AC_:1;            /*!< bit:     17  AC APB Clock Enable                */
-    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t DAC_:1;           /*!< bit:     18  DAC APB Clock Enable               */
     uint32_t PTC_:1;           /*!< bit:     19  PTC APB Clock Enable               */
     uint32_t :1;               /*!< bit:     20  Reserved                           */
     uint32_t RFCTRL_:1;        /*!< bit:     21  RFCTRL APB Clock Enable            */
@@ -370,45 +356,51 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_APBCMASK_OFFSET          0x20         /**< \brief (PM_APBCMASK offset) APBC Mask */
-#define PM_APBCMASK_RESETVALUE      0x00010000ul /**< \brief (PM_APBCMASK reset_value) APBC Mask */
+#define PM_APBCMASK_RESETVALUE      _U_(0x00010000) /**< \brief (PM_APBCMASK reset_value) APBC Mask */
 
 #define PM_APBCMASK_PAC2_Pos        0            /**< \brief (PM_APBCMASK) PAC2 APB Clock Enable */
-#define PM_APBCMASK_PAC2            (0x1ul << PM_APBCMASK_PAC2_Pos)
+#define PM_APBCMASK_PAC2            (_U_(0x1) << PM_APBCMASK_PAC2_Pos)
 #define PM_APBCMASK_EVSYS_Pos       1            /**< \brief (PM_APBCMASK) EVSYS APB Clock Enable */
-#define PM_APBCMASK_EVSYS           (0x1ul << PM_APBCMASK_EVSYS_Pos)
+#define PM_APBCMASK_EVSYS           (_U_(0x1) << PM_APBCMASK_EVSYS_Pos)
 #define PM_APBCMASK_SERCOM0_Pos     2            /**< \brief (PM_APBCMASK) SERCOM0 APB Clock Enable */
-#define PM_APBCMASK_SERCOM0         (0x1ul << PM_APBCMASK_SERCOM0_Pos)
+#define PM_APBCMASK_SERCOM0         (_U_(0x1) << PM_APBCMASK_SERCOM0_Pos)
 #define PM_APBCMASK_SERCOM1_Pos     3            /**< \brief (PM_APBCMASK) SERCOM1 APB Clock Enable */
-#define PM_APBCMASK_SERCOM1         (0x1ul << PM_APBCMASK_SERCOM1_Pos)
+#define PM_APBCMASK_SERCOM1         (_U_(0x1) << PM_APBCMASK_SERCOM1_Pos)
 #define PM_APBCMASK_SERCOM2_Pos     4            /**< \brief (PM_APBCMASK) SERCOM2 APB Clock Enable */
-#define PM_APBCMASK_SERCOM2         (0x1ul << PM_APBCMASK_SERCOM2_Pos)
+#define PM_APBCMASK_SERCOM2         (_U_(0x1) << PM_APBCMASK_SERCOM2_Pos)
 #define PM_APBCMASK_SERCOM3_Pos     5            /**< \brief (PM_APBCMASK) SERCOM3 APB Clock Enable */
-#define PM_APBCMASK_SERCOM3         (0x1ul << PM_APBCMASK_SERCOM3_Pos)
+#define PM_APBCMASK_SERCOM3         (_U_(0x1) << PM_APBCMASK_SERCOM3_Pos)
 #define PM_APBCMASK_SERCOM4_Pos     6            /**< \brief (PM_APBCMASK) SERCOM4 APB Clock Enable */
-#define PM_APBCMASK_SERCOM4         (0x1ul << PM_APBCMASK_SERCOM4_Pos)
+#define PM_APBCMASK_SERCOM4         (_U_(0x1) << PM_APBCMASK_SERCOM4_Pos)
 #define PM_APBCMASK_SERCOM5_Pos     7            /**< \brief (PM_APBCMASK) SERCOM5 APB Clock Enable */
-#define PM_APBCMASK_SERCOM5         (0x1ul << PM_APBCMASK_SERCOM5_Pos)
+#define PM_APBCMASK_SERCOM5         (_U_(0x1) << PM_APBCMASK_SERCOM5_Pos)
 #define PM_APBCMASK_TCC0_Pos        8            /**< \brief (PM_APBCMASK) TCC0 APB Clock Enable */
-#define PM_APBCMASK_TCC0            (0x1ul << PM_APBCMASK_TCC0_Pos)
+#define PM_APBCMASK_TCC0            (_U_(0x1) << PM_APBCMASK_TCC0_Pos)
 #define PM_APBCMASK_TCC1_Pos        9            /**< \brief (PM_APBCMASK) TCC1 APB Clock Enable */
-#define PM_APBCMASK_TCC1            (0x1ul << PM_APBCMASK_TCC1_Pos)
+#define PM_APBCMASK_TCC1            (_U_(0x1) << PM_APBCMASK_TCC1_Pos)
 #define PM_APBCMASK_TCC2_Pos        10           /**< \brief (PM_APBCMASK) TCC2 APB Clock Enable */
-#define PM_APBCMASK_TCC2            (0x1ul << PM_APBCMASK_TCC2_Pos)
+#define PM_APBCMASK_TCC2            (_U_(0x1) << PM_APBCMASK_TCC2_Pos)
 #define PM_APBCMASK_TC3_Pos         11           /**< \brief (PM_APBCMASK) TC3 APB Clock Enable */
-#define PM_APBCMASK_TC3             (0x1ul << PM_APBCMASK_TC3_Pos)
+#define PM_APBCMASK_TC3             (_U_(0x1) << PM_APBCMASK_TC3_Pos)
 #define PM_APBCMASK_TC4_Pos         12           /**< \brief (PM_APBCMASK) TC4 APB Clock Enable */
-#define PM_APBCMASK_TC4             (0x1ul << PM_APBCMASK_TC4_Pos)
+#define PM_APBCMASK_TC4             (_U_(0x1) << PM_APBCMASK_TC4_Pos)
 #define PM_APBCMASK_TC5_Pos         13           /**< \brief (PM_APBCMASK) TC5 APB Clock Enable */
-#define PM_APBCMASK_TC5             (0x1ul << PM_APBCMASK_TC5_Pos)
+#define PM_APBCMASK_TC5             (_U_(0x1) << PM_APBCMASK_TC5_Pos)
+#define PM_APBCMASK_TC6_Pos         14           /**< \brief (PM_APBCMASK) TC6 APB Clock Enable */
+#define PM_APBCMASK_TC6             (_U_(0x1) << PM_APBCMASK_TC6_Pos)
+#define PM_APBCMASK_TC7_Pos         15           /**< \brief (PM_APBCMASK) TC7 APB Clock Enable */
+#define PM_APBCMASK_TC7             (_U_(0x1) << PM_APBCMASK_TC7_Pos)
 #define PM_APBCMASK_ADC_Pos         16           /**< \brief (PM_APBCMASK) ADC APB Clock Enable */
-#define PM_APBCMASK_ADC             (0x1ul << PM_APBCMASK_ADC_Pos)
+#define PM_APBCMASK_ADC             (_U_(0x1) << PM_APBCMASK_ADC_Pos)
 #define PM_APBCMASK_AC_Pos          17           /**< \brief (PM_APBCMASK) AC APB Clock Enable */
-#define PM_APBCMASK_AC              (0x1ul << PM_APBCMASK_AC_Pos)
+#define PM_APBCMASK_AC              (_U_(0x1) << PM_APBCMASK_AC_Pos)
+#define PM_APBCMASK_DAC_Pos         18           /**< \brief (PM_APBCMASK) DAC APB Clock Enable */
+#define PM_APBCMASK_DAC             (_U_(0x1) << PM_APBCMASK_DAC_Pos)
 #define PM_APBCMASK_PTC_Pos         19           /**< \brief (PM_APBCMASK) PTC APB Clock Enable */
-#define PM_APBCMASK_PTC             (0x1ul << PM_APBCMASK_PTC_Pos)
+#define PM_APBCMASK_PTC             (_U_(0x1) << PM_APBCMASK_PTC_Pos)
 #define PM_APBCMASK_RFCTRL_Pos      21           /**< \brief (PM_APBCMASK) RFCTRL APB Clock Enable */
-#define PM_APBCMASK_RFCTRL          (0x1ul << PM_APBCMASK_RFCTRL_Pos)
-#define PM_APBCMASK_MASK            0x002B3FFFul /**< \brief (PM_APBCMASK) MASK Register */
+#define PM_APBCMASK_RFCTRL          (_U_(0x1) << PM_APBCMASK_RFCTRL_Pos)
+#define PM_APBCMASK_MASK            _U_(0x002FFFFF) /**< \brief (PM_APBCMASK) MASK Register */
 
 /* -------- PM_INTENCLR : (PM Offset: 0x34) (R/W  8) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -422,11 +414,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_INTENCLR_OFFSET          0x34         /**< \brief (PM_INTENCLR offset) Interrupt Enable Clear */
-#define PM_INTENCLR_RESETVALUE      0x00ul       /**< \brief (PM_INTENCLR reset_value) Interrupt Enable Clear */
+#define PM_INTENCLR_RESETVALUE      _U_(0x00)     /**< \brief (PM_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define PM_INTENCLR_CKRDY_Pos       0            /**< \brief (PM_INTENCLR) Clock Ready Interrupt Enable */
-#define PM_INTENCLR_CKRDY           (0x1ul << PM_INTENCLR_CKRDY_Pos)
-#define PM_INTENCLR_MASK            0x01ul       /**< \brief (PM_INTENCLR) MASK Register */
+#define PM_INTENCLR_CKRDY           (_U_(0x1) << PM_INTENCLR_CKRDY_Pos)
+#define PM_INTENCLR_MASK            _U_(0x01)     /**< \brief (PM_INTENCLR) MASK Register */
 
 /* -------- PM_INTENSET : (PM Offset: 0x35) (R/W  8) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -440,11 +432,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_INTENSET_OFFSET          0x35         /**< \brief (PM_INTENSET offset) Interrupt Enable Set */
-#define PM_INTENSET_RESETVALUE      0x00ul       /**< \brief (PM_INTENSET reset_value) Interrupt Enable Set */
+#define PM_INTENSET_RESETVALUE      _U_(0x00)     /**< \brief (PM_INTENSET reset_value) Interrupt Enable Set */
 
 #define PM_INTENSET_CKRDY_Pos       0            /**< \brief (PM_INTENSET) Clock Ready Interrupt Enable */
-#define PM_INTENSET_CKRDY           (0x1ul << PM_INTENSET_CKRDY_Pos)
-#define PM_INTENSET_MASK            0x01ul       /**< \brief (PM_INTENSET) MASK Register */
+#define PM_INTENSET_CKRDY           (_U_(0x1) << PM_INTENSET_CKRDY_Pos)
+#define PM_INTENSET_MASK            _U_(0x01)     /**< \brief (PM_INTENSET) MASK Register */
 
 /* -------- PM_INTFLAG : (PM Offset: 0x36) (R/W  8) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -458,11 +450,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_INTFLAG_OFFSET           0x36         /**< \brief (PM_INTFLAG offset) Interrupt Flag Status and Clear */
-#define PM_INTFLAG_RESETVALUE       0x00ul       /**< \brief (PM_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define PM_INTFLAG_RESETVALUE       _U_(0x00)     /**< \brief (PM_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define PM_INTFLAG_CKRDY_Pos        0            /**< \brief (PM_INTFLAG) Clock Ready */
-#define PM_INTFLAG_CKRDY            (0x1ul << PM_INTFLAG_CKRDY_Pos)
-#define PM_INTFLAG_MASK             0x01ul       /**< \brief (PM_INTFLAG) MASK Register */
+#define PM_INTFLAG_CKRDY            (_U_(0x1) << PM_INTFLAG_CKRDY_Pos)
+#define PM_INTFLAG_MASK             _U_(0x01)     /**< \brief (PM_INTFLAG) MASK Register */
 
 /* -------- PM_RCAUSE : (PM Offset: 0x38) (R/   8) Reset Cause -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -482,21 +474,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_RCAUSE_OFFSET            0x38         /**< \brief (PM_RCAUSE offset) Reset Cause */
-#define PM_RCAUSE_RESETVALUE        0x01ul       /**< \brief (PM_RCAUSE reset_value) Reset Cause */
+#define PM_RCAUSE_RESETVALUE        _U_(0x01)     /**< \brief (PM_RCAUSE reset_value) Reset Cause */
 
 #define PM_RCAUSE_POR_Pos           0            /**< \brief (PM_RCAUSE) Power On Reset */
-#define PM_RCAUSE_POR               (0x1ul << PM_RCAUSE_POR_Pos)
+#define PM_RCAUSE_POR               (_U_(0x1) << PM_RCAUSE_POR_Pos)
 #define PM_RCAUSE_BOD12_Pos         1            /**< \brief (PM_RCAUSE) Brown Out 12 Detector Reset */
-#define PM_RCAUSE_BOD12             (0x1ul << PM_RCAUSE_BOD12_Pos)
+#define PM_RCAUSE_BOD12             (_U_(0x1) << PM_RCAUSE_BOD12_Pos)
 #define PM_RCAUSE_BOD33_Pos         2            /**< \brief (PM_RCAUSE) Brown Out 33 Detector Reset */
-#define PM_RCAUSE_BOD33             (0x1ul << PM_RCAUSE_BOD33_Pos)
+#define PM_RCAUSE_BOD33             (_U_(0x1) << PM_RCAUSE_BOD33_Pos)
 #define PM_RCAUSE_EXT_Pos           4            /**< \brief (PM_RCAUSE) External Reset */
-#define PM_RCAUSE_EXT               (0x1ul << PM_RCAUSE_EXT_Pos)
+#define PM_RCAUSE_EXT               (_U_(0x1) << PM_RCAUSE_EXT_Pos)
 #define PM_RCAUSE_WDT_Pos           5            /**< \brief (PM_RCAUSE) Watchdog Reset */
-#define PM_RCAUSE_WDT               (0x1ul << PM_RCAUSE_WDT_Pos)
+#define PM_RCAUSE_WDT               (_U_(0x1) << PM_RCAUSE_WDT_Pos)
 #define PM_RCAUSE_SYST_Pos          6            /**< \brief (PM_RCAUSE) System Reset Request */
-#define PM_RCAUSE_SYST              (0x1ul << PM_RCAUSE_SYST_Pos)
-#define PM_RCAUSE_MASK              0x77ul       /**< \brief (PM_RCAUSE) MASK Register */
+#define PM_RCAUSE_SYST              (_U_(0x1) << PM_RCAUSE_SYST_Pos)
+#define PM_RCAUSE_MASK              _U_(0x77)     /**< \brief (PM_RCAUSE) MASK Register */
 
 /** \brief PM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/port.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/port.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for PORT
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -64,12 +49,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_DIR_OFFSET             0x00         /**< \brief (PORT_DIR offset) Data Direction */
-#define PORT_DIR_RESETVALUE         0x00000000ul /**< \brief (PORT_DIR reset_value) Data Direction */
+#define PORT_DIR_RESETVALUE         _U_(0x00000000) /**< \brief (PORT_DIR reset_value) Data Direction */
 
 #define PORT_DIR_DIR_Pos            0            /**< \brief (PORT_DIR) Port Data Direction */
-#define PORT_DIR_DIR_Msk            (0xFFFFFFFFul << PORT_DIR_DIR_Pos)
+#define PORT_DIR_DIR_Msk            (_U_(0xFFFFFFFF) << PORT_DIR_DIR_Pos)
 #define PORT_DIR_DIR(value)         (PORT_DIR_DIR_Msk & ((value) << PORT_DIR_DIR_Pos))
-#define PORT_DIR_MASK               0xFFFFFFFFul /**< \brief (PORT_DIR) MASK Register */
+#define PORT_DIR_MASK               _U_(0xFFFFFFFF) /**< \brief (PORT_DIR) MASK Register */
 
 /* -------- PORT_DIRCLR : (PORT Offset: 0x04) (R/W 32) GROUP Data Direction Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -82,12 +67,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_DIRCLR_OFFSET          0x04         /**< \brief (PORT_DIRCLR offset) Data Direction Clear */
-#define PORT_DIRCLR_RESETVALUE      0x00000000ul /**< \brief (PORT_DIRCLR reset_value) Data Direction Clear */
+#define PORT_DIRCLR_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRCLR reset_value) Data Direction Clear */
 
 #define PORT_DIRCLR_DIRCLR_Pos      0            /**< \brief (PORT_DIRCLR) Port Data Direction Clear */
-#define PORT_DIRCLR_DIRCLR_Msk      (0xFFFFFFFFul << PORT_DIRCLR_DIRCLR_Pos)
+#define PORT_DIRCLR_DIRCLR_Msk      (_U_(0xFFFFFFFF) << PORT_DIRCLR_DIRCLR_Pos)
 #define PORT_DIRCLR_DIRCLR(value)   (PORT_DIRCLR_DIRCLR_Msk & ((value) << PORT_DIRCLR_DIRCLR_Pos))
-#define PORT_DIRCLR_MASK            0xFFFFFFFFul /**< \brief (PORT_DIRCLR) MASK Register */
+#define PORT_DIRCLR_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRCLR) MASK Register */
 
 /* -------- PORT_DIRSET : (PORT Offset: 0x08) (R/W 32) GROUP Data Direction Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -100,12 +85,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_DIRSET_OFFSET          0x08         /**< \brief (PORT_DIRSET offset) Data Direction Set */
-#define PORT_DIRSET_RESETVALUE      0x00000000ul /**< \brief (PORT_DIRSET reset_value) Data Direction Set */
+#define PORT_DIRSET_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRSET reset_value) Data Direction Set */
 
 #define PORT_DIRSET_DIRSET_Pos      0            /**< \brief (PORT_DIRSET) Port Data Direction Set */
-#define PORT_DIRSET_DIRSET_Msk      (0xFFFFFFFFul << PORT_DIRSET_DIRSET_Pos)
+#define PORT_DIRSET_DIRSET_Msk      (_U_(0xFFFFFFFF) << PORT_DIRSET_DIRSET_Pos)
 #define PORT_DIRSET_DIRSET(value)   (PORT_DIRSET_DIRSET_Msk & ((value) << PORT_DIRSET_DIRSET_Pos))
-#define PORT_DIRSET_MASK            0xFFFFFFFFul /**< \brief (PORT_DIRSET) MASK Register */
+#define PORT_DIRSET_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRSET) MASK Register */
 
 /* -------- PORT_DIRTGL : (PORT Offset: 0x0C) (R/W 32) GROUP Data Direction Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -118,12 +103,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_DIRTGL_OFFSET          0x0C         /**< \brief (PORT_DIRTGL offset) Data Direction Toggle */
-#define PORT_DIRTGL_RESETVALUE      0x00000000ul /**< \brief (PORT_DIRTGL reset_value) Data Direction Toggle */
+#define PORT_DIRTGL_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRTGL reset_value) Data Direction Toggle */
 
 #define PORT_DIRTGL_DIRTGL_Pos      0            /**< \brief (PORT_DIRTGL) Port Data Direction Toggle */
-#define PORT_DIRTGL_DIRTGL_Msk      (0xFFFFFFFFul << PORT_DIRTGL_DIRTGL_Pos)
+#define PORT_DIRTGL_DIRTGL_Msk      (_U_(0xFFFFFFFF) << PORT_DIRTGL_DIRTGL_Pos)
 #define PORT_DIRTGL_DIRTGL(value)   (PORT_DIRTGL_DIRTGL_Msk & ((value) << PORT_DIRTGL_DIRTGL_Pos))
-#define PORT_DIRTGL_MASK            0xFFFFFFFFul /**< \brief (PORT_DIRTGL) MASK Register */
+#define PORT_DIRTGL_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRTGL) MASK Register */
 
 /* -------- PORT_OUT : (PORT Offset: 0x10) (R/W 32) GROUP Data Output Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -136,12 +121,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_OUT_OFFSET             0x10         /**< \brief (PORT_OUT offset) Data Output Value */
-#define PORT_OUT_RESETVALUE         0x00000000ul /**< \brief (PORT_OUT reset_value) Data Output Value */
+#define PORT_OUT_RESETVALUE         _U_(0x00000000) /**< \brief (PORT_OUT reset_value) Data Output Value */
 
 #define PORT_OUT_OUT_Pos            0            /**< \brief (PORT_OUT) Port Data Output Value */
-#define PORT_OUT_OUT_Msk            (0xFFFFFFFFul << PORT_OUT_OUT_Pos)
+#define PORT_OUT_OUT_Msk            (_U_(0xFFFFFFFF) << PORT_OUT_OUT_Pos)
 #define PORT_OUT_OUT(value)         (PORT_OUT_OUT_Msk & ((value) << PORT_OUT_OUT_Pos))
-#define PORT_OUT_MASK               0xFFFFFFFFul /**< \brief (PORT_OUT) MASK Register */
+#define PORT_OUT_MASK               _U_(0xFFFFFFFF) /**< \brief (PORT_OUT) MASK Register */
 
 /* -------- PORT_OUTCLR : (PORT Offset: 0x14) (R/W 32) GROUP Data Output Value Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -154,12 +139,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_OUTCLR_OFFSET          0x14         /**< \brief (PORT_OUTCLR offset) Data Output Value Clear */
-#define PORT_OUTCLR_RESETVALUE      0x00000000ul /**< \brief (PORT_OUTCLR reset_value) Data Output Value Clear */
+#define PORT_OUTCLR_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTCLR reset_value) Data Output Value Clear */
 
 #define PORT_OUTCLR_OUTCLR_Pos      0            /**< \brief (PORT_OUTCLR) Port Data Output Value Clear */
-#define PORT_OUTCLR_OUTCLR_Msk      (0xFFFFFFFFul << PORT_OUTCLR_OUTCLR_Pos)
+#define PORT_OUTCLR_OUTCLR_Msk      (_U_(0xFFFFFFFF) << PORT_OUTCLR_OUTCLR_Pos)
 #define PORT_OUTCLR_OUTCLR(value)   (PORT_OUTCLR_OUTCLR_Msk & ((value) << PORT_OUTCLR_OUTCLR_Pos))
-#define PORT_OUTCLR_MASK            0xFFFFFFFFul /**< \brief (PORT_OUTCLR) MASK Register */
+#define PORT_OUTCLR_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTCLR) MASK Register */
 
 /* -------- PORT_OUTSET : (PORT Offset: 0x18) (R/W 32) GROUP Data Output Value Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -172,12 +157,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_OUTSET_OFFSET          0x18         /**< \brief (PORT_OUTSET offset) Data Output Value Set */
-#define PORT_OUTSET_RESETVALUE      0x00000000ul /**< \brief (PORT_OUTSET reset_value) Data Output Value Set */
+#define PORT_OUTSET_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTSET reset_value) Data Output Value Set */
 
 #define PORT_OUTSET_OUTSET_Pos      0            /**< \brief (PORT_OUTSET) Port Data Output Value Set */
-#define PORT_OUTSET_OUTSET_Msk      (0xFFFFFFFFul << PORT_OUTSET_OUTSET_Pos)
+#define PORT_OUTSET_OUTSET_Msk      (_U_(0xFFFFFFFF) << PORT_OUTSET_OUTSET_Pos)
 #define PORT_OUTSET_OUTSET(value)   (PORT_OUTSET_OUTSET_Msk & ((value) << PORT_OUTSET_OUTSET_Pos))
-#define PORT_OUTSET_MASK            0xFFFFFFFFul /**< \brief (PORT_OUTSET) MASK Register */
+#define PORT_OUTSET_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTSET) MASK Register */
 
 /* -------- PORT_OUTTGL : (PORT Offset: 0x1C) (R/W 32) GROUP Data Output Value Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -190,12 +175,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_OUTTGL_OFFSET          0x1C         /**< \brief (PORT_OUTTGL offset) Data Output Value Toggle */
-#define PORT_OUTTGL_RESETVALUE      0x00000000ul /**< \brief (PORT_OUTTGL reset_value) Data Output Value Toggle */
+#define PORT_OUTTGL_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTTGL reset_value) Data Output Value Toggle */
 
 #define PORT_OUTTGL_OUTTGL_Pos      0            /**< \brief (PORT_OUTTGL) Port Data Output Value Toggle */
-#define PORT_OUTTGL_OUTTGL_Msk      (0xFFFFFFFFul << PORT_OUTTGL_OUTTGL_Pos)
+#define PORT_OUTTGL_OUTTGL_Msk      (_U_(0xFFFFFFFF) << PORT_OUTTGL_OUTTGL_Pos)
 #define PORT_OUTTGL_OUTTGL(value)   (PORT_OUTTGL_OUTTGL_Msk & ((value) << PORT_OUTTGL_OUTTGL_Pos))
-#define PORT_OUTTGL_MASK            0xFFFFFFFFul /**< \brief (PORT_OUTTGL) MASK Register */
+#define PORT_OUTTGL_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTTGL) MASK Register */
 
 /* -------- PORT_IN : (PORT Offset: 0x20) (R/  32) GROUP Data Input Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -208,12 +193,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_IN_OFFSET              0x20         /**< \brief (PORT_IN offset) Data Input Value */
-#define PORT_IN_RESETVALUE          0x00000000ul /**< \brief (PORT_IN reset_value) Data Input Value */
+#define PORT_IN_RESETVALUE          _U_(0x00000000) /**< \brief (PORT_IN reset_value) Data Input Value */
 
 #define PORT_IN_IN_Pos              0            /**< \brief (PORT_IN) Port Data Input Value */
-#define PORT_IN_IN_Msk              (0xFFFFFFFFul << PORT_IN_IN_Pos)
+#define PORT_IN_IN_Msk              (_U_(0xFFFFFFFF) << PORT_IN_IN_Pos)
 #define PORT_IN_IN(value)           (PORT_IN_IN_Msk & ((value) << PORT_IN_IN_Pos))
-#define PORT_IN_MASK                0xFFFFFFFFul /**< \brief (PORT_IN) MASK Register */
+#define PORT_IN_MASK                _U_(0xFFFFFFFF) /**< \brief (PORT_IN) MASK Register */
 
 /* -------- PORT_CTRL : (PORT Offset: 0x24) (R/W 32) GROUP Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -226,12 +211,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_CTRL_OFFSET            0x24         /**< \brief (PORT_CTRL offset) Control */
-#define PORT_CTRL_RESETVALUE        0x00000000ul /**< \brief (PORT_CTRL reset_value) Control */
+#define PORT_CTRL_RESETVALUE        _U_(0x00000000) /**< \brief (PORT_CTRL reset_value) Control */
 
 #define PORT_CTRL_SAMPLING_Pos      0            /**< \brief (PORT_CTRL) Input Sampling Mode */
-#define PORT_CTRL_SAMPLING_Msk      (0xFFFFFFFFul << PORT_CTRL_SAMPLING_Pos)
+#define PORT_CTRL_SAMPLING_Msk      (_U_(0xFFFFFFFF) << PORT_CTRL_SAMPLING_Pos)
 #define PORT_CTRL_SAMPLING(value)   (PORT_CTRL_SAMPLING_Msk & ((value) << PORT_CTRL_SAMPLING_Pos))
-#define PORT_CTRL_MASK              0xFFFFFFFFul /**< \brief (PORT_CTRL) MASK Register */
+#define PORT_CTRL_MASK              _U_(0xFFFFFFFF) /**< \brief (PORT_CTRL) MASK Register */
 
 /* -------- PORT_WRCONFIG : (PORT Offset: 0x28) ( /W 32) GROUP Write Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -255,29 +240,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_WRCONFIG_OFFSET        0x28         /**< \brief (PORT_WRCONFIG offset) Write Configuration */
-#define PORT_WRCONFIG_RESETVALUE    0x00000000ul /**< \brief (PORT_WRCONFIG reset_value) Write Configuration */
+#define PORT_WRCONFIG_RESETVALUE    _U_(0x00000000) /**< \brief (PORT_WRCONFIG reset_value) Write Configuration */
 
 #define PORT_WRCONFIG_PINMASK_Pos   0            /**< \brief (PORT_WRCONFIG) Pin Mask for Multiple Pin Configuration */
-#define PORT_WRCONFIG_PINMASK_Msk   (0xFFFFul << PORT_WRCONFIG_PINMASK_Pos)
+#define PORT_WRCONFIG_PINMASK_Msk   (_U_(0xFFFF) << PORT_WRCONFIG_PINMASK_Pos)
 #define PORT_WRCONFIG_PINMASK(value) (PORT_WRCONFIG_PINMASK_Msk & ((value) << PORT_WRCONFIG_PINMASK_Pos))
 #define PORT_WRCONFIG_PMUXEN_Pos    16           /**< \brief (PORT_WRCONFIG) Peripheral Multiplexer Enable */
-#define PORT_WRCONFIG_PMUXEN        (0x1ul << PORT_WRCONFIG_PMUXEN_Pos)
+#define PORT_WRCONFIG_PMUXEN        (_U_(0x1) << PORT_WRCONFIG_PMUXEN_Pos)
 #define PORT_WRCONFIG_INEN_Pos      17           /**< \brief (PORT_WRCONFIG) Input Enable */
-#define PORT_WRCONFIG_INEN          (0x1ul << PORT_WRCONFIG_INEN_Pos)
+#define PORT_WRCONFIG_INEN          (_U_(0x1) << PORT_WRCONFIG_INEN_Pos)
 #define PORT_WRCONFIG_PULLEN_Pos    18           /**< \brief (PORT_WRCONFIG) Pull Enable */
-#define PORT_WRCONFIG_PULLEN        (0x1ul << PORT_WRCONFIG_PULLEN_Pos)
+#define PORT_WRCONFIG_PULLEN        (_U_(0x1) << PORT_WRCONFIG_PULLEN_Pos)
 #define PORT_WRCONFIG_DRVSTR_Pos    22           /**< \brief (PORT_WRCONFIG) Output Driver Strength Selection */
-#define PORT_WRCONFIG_DRVSTR        (0x1ul << PORT_WRCONFIG_DRVSTR_Pos)
+#define PORT_WRCONFIG_DRVSTR        (_U_(0x1) << PORT_WRCONFIG_DRVSTR_Pos)
 #define PORT_WRCONFIG_PMUX_Pos      24           /**< \brief (PORT_WRCONFIG) Peripheral Multiplexing */
-#define PORT_WRCONFIG_PMUX_Msk      (0xFul << PORT_WRCONFIG_PMUX_Pos)
+#define PORT_WRCONFIG_PMUX_Msk      (_U_(0xF) << PORT_WRCONFIG_PMUX_Pos)
 #define PORT_WRCONFIG_PMUX(value)   (PORT_WRCONFIG_PMUX_Msk & ((value) << PORT_WRCONFIG_PMUX_Pos))
 #define PORT_WRCONFIG_WRPMUX_Pos    28           /**< \brief (PORT_WRCONFIG) Write PMUX */
-#define PORT_WRCONFIG_WRPMUX        (0x1ul << PORT_WRCONFIG_WRPMUX_Pos)
+#define PORT_WRCONFIG_WRPMUX        (_U_(0x1) << PORT_WRCONFIG_WRPMUX_Pos)
 #define PORT_WRCONFIG_WRPINCFG_Pos  30           /**< \brief (PORT_WRCONFIG) Write PINCFG */
-#define PORT_WRCONFIG_WRPINCFG      (0x1ul << PORT_WRCONFIG_WRPINCFG_Pos)
+#define PORT_WRCONFIG_WRPINCFG      (_U_(0x1) << PORT_WRCONFIG_WRPINCFG_Pos)
 #define PORT_WRCONFIG_HWSEL_Pos     31           /**< \brief (PORT_WRCONFIG) Half-Word Select */
-#define PORT_WRCONFIG_HWSEL         (0x1ul << PORT_WRCONFIG_HWSEL_Pos)
-#define PORT_WRCONFIG_MASK          0xDF47FFFFul /**< \brief (PORT_WRCONFIG) MASK Register */
+#define PORT_WRCONFIG_HWSEL         (_U_(0x1) << PORT_WRCONFIG_HWSEL_Pos)
+#define PORT_WRCONFIG_MASK          _U_(0xDF47FFFF) /**< \brief (PORT_WRCONFIG) MASK Register */
 
 /* -------- PORT_PMUX : (PORT Offset: 0x30) (R/W  8) GROUP Peripheral Multiplexing n -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -291,19 +276,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_PMUX_OFFSET            0x30         /**< \brief (PORT_PMUX offset) Peripheral Multiplexing n */
-#define PORT_PMUX_RESETVALUE        0x00ul       /**< \brief (PORT_PMUX reset_value) Peripheral Multiplexing n */
+#define PORT_PMUX_RESETVALUE        _U_(0x00)     /**< \brief (PORT_PMUX reset_value) Peripheral Multiplexing n */
 
 #define PORT_PMUX_PMUXE_Pos         0            /**< \brief (PORT_PMUX) Peripheral Multiplexing Even */
-#define PORT_PMUX_PMUXE_Msk         (0xFul << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_Msk         (_U_(0xF) << PORT_PMUX_PMUXE_Pos)
 #define PORT_PMUX_PMUXE(value)      (PORT_PMUX_PMUXE_Msk & ((value) << PORT_PMUX_PMUXE_Pos))
-#define   PORT_PMUX_PMUXE_A_Val           0x0ul  /**< \brief (PORT_PMUX) Peripheral function A selected */
-#define   PORT_PMUX_PMUXE_B_Val           0x1ul  /**< \brief (PORT_PMUX) Peripheral function B selected */
-#define   PORT_PMUX_PMUXE_C_Val           0x2ul  /**< \brief (PORT_PMUX) Peripheral function C selected */
-#define   PORT_PMUX_PMUXE_D_Val           0x3ul  /**< \brief (PORT_PMUX) Peripheral function D selected */
-#define   PORT_PMUX_PMUXE_E_Val           0x4ul  /**< \brief (PORT_PMUX) Peripheral function E selected */
-#define   PORT_PMUX_PMUXE_F_Val           0x5ul  /**< \brief (PORT_PMUX) Peripheral function F selected */
-#define   PORT_PMUX_PMUXE_G_Val           0x6ul  /**< \brief (PORT_PMUX) Peripheral function G selected */
-#define   PORT_PMUX_PMUXE_H_Val           0x7ul  /**< \brief (PORT_PMUX) Peripheral function H selected */
+#define   PORT_PMUX_PMUXE_A_Val           _U_(0x0)   /**< \brief (PORT_PMUX) Peripheral function A selected */
+#define   PORT_PMUX_PMUXE_B_Val           _U_(0x1)   /**< \brief (PORT_PMUX) Peripheral function B selected */
+#define   PORT_PMUX_PMUXE_C_Val           _U_(0x2)   /**< \brief (PORT_PMUX) Peripheral function C selected */
+#define   PORT_PMUX_PMUXE_D_Val           _U_(0x3)   /**< \brief (PORT_PMUX) Peripheral function D selected */
+#define   PORT_PMUX_PMUXE_E_Val           _U_(0x4)   /**< \brief (PORT_PMUX) Peripheral function E selected */
+#define   PORT_PMUX_PMUXE_F_Val           _U_(0x5)   /**< \brief (PORT_PMUX) Peripheral function F selected */
+#define   PORT_PMUX_PMUXE_G_Val           _U_(0x6)   /**< \brief (PORT_PMUX) Peripheral function G selected */
+#define   PORT_PMUX_PMUXE_H_Val           _U_(0x7)   /**< \brief (PORT_PMUX) Peripheral function H selected */
 #define PORT_PMUX_PMUXE_A           (PORT_PMUX_PMUXE_A_Val         << PORT_PMUX_PMUXE_Pos)
 #define PORT_PMUX_PMUXE_B           (PORT_PMUX_PMUXE_B_Val         << PORT_PMUX_PMUXE_Pos)
 #define PORT_PMUX_PMUXE_C           (PORT_PMUX_PMUXE_C_Val         << PORT_PMUX_PMUXE_Pos)
@@ -313,16 +298,16 @@ typedef union {
 #define PORT_PMUX_PMUXE_G           (PORT_PMUX_PMUXE_G_Val         << PORT_PMUX_PMUXE_Pos)
 #define PORT_PMUX_PMUXE_H           (PORT_PMUX_PMUXE_H_Val         << PORT_PMUX_PMUXE_Pos)
 #define PORT_PMUX_PMUXO_Pos         4            /**< \brief (PORT_PMUX) Peripheral Multiplexing Odd */
-#define PORT_PMUX_PMUXO_Msk         (0xFul << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_Msk         (_U_(0xF) << PORT_PMUX_PMUXO_Pos)
 #define PORT_PMUX_PMUXO(value)      (PORT_PMUX_PMUXO_Msk & ((value) << PORT_PMUX_PMUXO_Pos))
-#define   PORT_PMUX_PMUXO_A_Val           0x0ul  /**< \brief (PORT_PMUX) Peripheral function A selected */
-#define   PORT_PMUX_PMUXO_B_Val           0x1ul  /**< \brief (PORT_PMUX) Peripheral function B selected */
-#define   PORT_PMUX_PMUXO_C_Val           0x2ul  /**< \brief (PORT_PMUX) Peripheral function C selected */
-#define   PORT_PMUX_PMUXO_D_Val           0x3ul  /**< \brief (PORT_PMUX) Peripheral function D selected */
-#define   PORT_PMUX_PMUXO_E_Val           0x4ul  /**< \brief (PORT_PMUX) Peripheral function E selected */
-#define   PORT_PMUX_PMUXO_F_Val           0x5ul  /**< \brief (PORT_PMUX) Peripheral function F selected */
-#define   PORT_PMUX_PMUXO_G_Val           0x6ul  /**< \brief (PORT_PMUX) Peripheral function G selected */
-#define   PORT_PMUX_PMUXO_H_Val           0x7ul  /**< \brief (PORT_PMUX) Peripheral function H selected */
+#define   PORT_PMUX_PMUXO_A_Val           _U_(0x0)   /**< \brief (PORT_PMUX) Peripheral function A selected */
+#define   PORT_PMUX_PMUXO_B_Val           _U_(0x1)   /**< \brief (PORT_PMUX) Peripheral function B selected */
+#define   PORT_PMUX_PMUXO_C_Val           _U_(0x2)   /**< \brief (PORT_PMUX) Peripheral function C selected */
+#define   PORT_PMUX_PMUXO_D_Val           _U_(0x3)   /**< \brief (PORT_PMUX) Peripheral function D selected */
+#define   PORT_PMUX_PMUXO_E_Val           _U_(0x4)   /**< \brief (PORT_PMUX) Peripheral function E selected */
+#define   PORT_PMUX_PMUXO_F_Val           _U_(0x5)   /**< \brief (PORT_PMUX) Peripheral function F selected */
+#define   PORT_PMUX_PMUXO_G_Val           _U_(0x6)   /**< \brief (PORT_PMUX) Peripheral function G selected */
+#define   PORT_PMUX_PMUXO_H_Val           _U_(0x7)   /**< \brief (PORT_PMUX) Peripheral function H selected */
 #define PORT_PMUX_PMUXO_A           (PORT_PMUX_PMUXO_A_Val         << PORT_PMUX_PMUXO_Pos)
 #define PORT_PMUX_PMUXO_B           (PORT_PMUX_PMUXO_B_Val         << PORT_PMUX_PMUXO_Pos)
 #define PORT_PMUX_PMUXO_C           (PORT_PMUX_PMUXO_C_Val         << PORT_PMUX_PMUXO_Pos)
@@ -331,7 +316,7 @@ typedef union {
 #define PORT_PMUX_PMUXO_F           (PORT_PMUX_PMUXO_F_Val         << PORT_PMUX_PMUXO_Pos)
 #define PORT_PMUX_PMUXO_G           (PORT_PMUX_PMUXO_G_Val         << PORT_PMUX_PMUXO_Pos)
 #define PORT_PMUX_PMUXO_H           (PORT_PMUX_PMUXO_H_Val         << PORT_PMUX_PMUXO_Pos)
-#define PORT_PMUX_MASK              0xFFul       /**< \brief (PORT_PMUX) MASK Register */
+#define PORT_PMUX_MASK              _U_(0xFF)     /**< \brief (PORT_PMUX) MASK Register */
 
 /* -------- PORT_PINCFG : (PORT Offset: 0x40) (R/W  8) GROUP Pin Configuration n -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -349,17 +334,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PORT_PINCFG_OFFSET          0x40         /**< \brief (PORT_PINCFG offset) Pin Configuration n */
-#define PORT_PINCFG_RESETVALUE      0x00ul       /**< \brief (PORT_PINCFG reset_value) Pin Configuration n */
+#define PORT_PINCFG_RESETVALUE      _U_(0x00)     /**< \brief (PORT_PINCFG reset_value) Pin Configuration n */
 
 #define PORT_PINCFG_PMUXEN_Pos      0            /**< \brief (PORT_PINCFG) Peripheral Multiplexer Enable */
-#define PORT_PINCFG_PMUXEN          (0x1ul << PORT_PINCFG_PMUXEN_Pos)
+#define PORT_PINCFG_PMUXEN          (_U_(0x1) << PORT_PINCFG_PMUXEN_Pos)
 #define PORT_PINCFG_INEN_Pos        1            /**< \brief (PORT_PINCFG) Input Enable */
-#define PORT_PINCFG_INEN            (0x1ul << PORT_PINCFG_INEN_Pos)
+#define PORT_PINCFG_INEN            (_U_(0x1) << PORT_PINCFG_INEN_Pos)
 #define PORT_PINCFG_PULLEN_Pos      2            /**< \brief (PORT_PINCFG) Pull Enable */
-#define PORT_PINCFG_PULLEN          (0x1ul << PORT_PINCFG_PULLEN_Pos)
+#define PORT_PINCFG_PULLEN          (_U_(0x1) << PORT_PINCFG_PULLEN_Pos)
 #define PORT_PINCFG_DRVSTR_Pos      6            /**< \brief (PORT_PINCFG) Output Driver Strength Selection */
-#define PORT_PINCFG_DRVSTR          (0x1ul << PORT_PINCFG_DRVSTR_Pos)
-#define PORT_PINCFG_MASK            0x47ul       /**< \brief (PORT_PINCFG) MASK Register */
+#define PORT_PINCFG_DRVSTR          (_U_(0x1) << PORT_PINCFG_DRVSTR_Pos)
+#define PORT_PINCFG_MASK            _U_(0x47)     /**< \brief (PORT_PINCFG) MASK Register */
 
 /** \brief PortGroup hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -388,7 +373,6 @@ typedef struct {
        PortGroup                 Group[3];    /**< \brief Offset: 0x00 PortGroup groups [GROUPS] */
 } Port;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
-#define SECTION_PORT_IOBUS
 
 /*@}*/
 

--- a/cpu/sam0_common/include/vendor/samr21/include/component/rfctrl.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/rfctrl.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for RFCTRL
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -70,27 +55,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RFCTRL_FECFG_OFFSET         0x0          /**< \brief (RFCTRL_FECFG offset) Front-end control bus configuration */
-#define RFCTRL_FECFG_RESETVALUE     0x0000ul     /**< \brief (RFCTRL_FECFG reset_value) Front-end control bus configuration */
+#define RFCTRL_FECFG_RESETVALUE     _U_(0x0000)   /**< \brief (RFCTRL_FECFG reset_value) Front-end control bus configuration */
 
 #define RFCTRL_FECFG_F0CFG_Pos      0            /**< \brief (RFCTRL_FECFG) Front-end control signal 0 configuration */
-#define RFCTRL_FECFG_F0CFG_Msk      (0x3ul << RFCTRL_FECFG_F0CFG_Pos)
+#define RFCTRL_FECFG_F0CFG_Msk      (_U_(0x3) << RFCTRL_FECFG_F0CFG_Pos)
 #define RFCTRL_FECFG_F0CFG(value)   (RFCTRL_FECFG_F0CFG_Msk & ((value) << RFCTRL_FECFG_F0CFG_Pos))
 #define RFCTRL_FECFG_F1CFG_Pos      2            /**< \brief (RFCTRL_FECFG) Front-end control signal 1 configuration */
-#define RFCTRL_FECFG_F1CFG_Msk      (0x3ul << RFCTRL_FECFG_F1CFG_Pos)
+#define RFCTRL_FECFG_F1CFG_Msk      (_U_(0x3) << RFCTRL_FECFG_F1CFG_Pos)
 #define RFCTRL_FECFG_F1CFG(value)   (RFCTRL_FECFG_F1CFG_Msk & ((value) << RFCTRL_FECFG_F1CFG_Pos))
 #define RFCTRL_FECFG_F2CFG_Pos      4            /**< \brief (RFCTRL_FECFG) Front-end control signal 2 configuration */
-#define RFCTRL_FECFG_F2CFG_Msk      (0x3ul << RFCTRL_FECFG_F2CFG_Pos)
+#define RFCTRL_FECFG_F2CFG_Msk      (_U_(0x3) << RFCTRL_FECFG_F2CFG_Pos)
 #define RFCTRL_FECFG_F2CFG(value)   (RFCTRL_FECFG_F2CFG_Msk & ((value) << RFCTRL_FECFG_F2CFG_Pos))
 #define RFCTRL_FECFG_F3CFG_Pos      6            /**< \brief (RFCTRL_FECFG) Front-end control signal 3 configuration */
-#define RFCTRL_FECFG_F3CFG_Msk      (0x3ul << RFCTRL_FECFG_F3CFG_Pos)
+#define RFCTRL_FECFG_F3CFG_Msk      (_U_(0x3) << RFCTRL_FECFG_F3CFG_Pos)
 #define RFCTRL_FECFG_F3CFG(value)   (RFCTRL_FECFG_F3CFG_Msk & ((value) << RFCTRL_FECFG_F3CFG_Pos))
 #define RFCTRL_FECFG_F4CFG_Pos      8            /**< \brief (RFCTRL_FECFG) Front-end control signal 4 configuration */
-#define RFCTRL_FECFG_F4CFG_Msk      (0x3ul << RFCTRL_FECFG_F4CFG_Pos)
+#define RFCTRL_FECFG_F4CFG_Msk      (_U_(0x3) << RFCTRL_FECFG_F4CFG_Pos)
 #define RFCTRL_FECFG_F4CFG(value)   (RFCTRL_FECFG_F4CFG_Msk & ((value) << RFCTRL_FECFG_F4CFG_Pos))
 #define RFCTRL_FECFG_F5CFG_Pos      10           /**< \brief (RFCTRL_FECFG) Front-end control signal 5 configuration */
-#define RFCTRL_FECFG_F5CFG_Msk      (0x3ul << RFCTRL_FECFG_F5CFG_Pos)
+#define RFCTRL_FECFG_F5CFG_Msk      (_U_(0x3) << RFCTRL_FECFG_F5CFG_Pos)
 #define RFCTRL_FECFG_F5CFG(value)   (RFCTRL_FECFG_F5CFG_Msk & ((value) << RFCTRL_FECFG_F5CFG_Pos))
-#define RFCTRL_FECFG_MASK           0x0FFFul     /**< \brief (RFCTRL_FECFG) MASK Register */
+#define RFCTRL_FECFG_MASK           _U_(0x0FFF)   /**< \brief (RFCTRL_FECFG) MASK Register */
 
 /** \brief RFCTRL hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/rtc.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for RTC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -70,37 +55,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE0_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE0_CTRL offset) MODE0 Control */
-#define RTC_MODE0_CTRL_RESETVALUE   0x0000ul     /**< \brief (RTC_MODE0_CTRL reset_value) MODE0 Control */
+#define RTC_MODE0_CTRL_RESETVALUE   _U_(0x0000)   /**< \brief (RTC_MODE0_CTRL reset_value) MODE0 Control */
 
 #define RTC_MODE0_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE0_CTRL) Software Reset */
-#define RTC_MODE0_CTRL_SWRST        (0x1ul << RTC_MODE0_CTRL_SWRST_Pos)
+#define RTC_MODE0_CTRL_SWRST        (_U_(0x1) << RTC_MODE0_CTRL_SWRST_Pos)
 #define RTC_MODE0_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE0_CTRL) Enable */
-#define RTC_MODE0_CTRL_ENABLE       (0x1ul << RTC_MODE0_CTRL_ENABLE_Pos)
+#define RTC_MODE0_CTRL_ENABLE       (_U_(0x1) << RTC_MODE0_CTRL_ENABLE_Pos)
 #define RTC_MODE0_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE0_CTRL) Operating Mode */
-#define RTC_MODE0_CTRL_MODE_Msk     (0x3ul << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE0_CTRL_MODE_Pos)
 #define RTC_MODE0_CTRL_MODE(value)  (RTC_MODE0_CTRL_MODE_Msk & ((value) << RTC_MODE0_CTRL_MODE_Pos))
-#define   RTC_MODE0_CTRL_MODE_COUNT32_Val 0x0ul  /**< \brief (RTC_MODE0_CTRL) Mode 0: 32-bit Counter */
-#define   RTC_MODE0_CTRL_MODE_COUNT16_Val 0x1ul  /**< \brief (RTC_MODE0_CTRL) Mode 1: 16-bit Counter */
-#define   RTC_MODE0_CTRL_MODE_CLOCK_Val   0x2ul  /**< \brief (RTC_MODE0_CTRL) Mode 2: Clock/Calendar */
+#define   RTC_MODE0_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE0_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE0_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE0_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE0_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE0_CTRL) Mode 2: Clock/Calendar */
 #define RTC_MODE0_CTRL_MODE_COUNT32 (RTC_MODE0_CTRL_MODE_COUNT32_Val << RTC_MODE0_CTRL_MODE_Pos)
 #define RTC_MODE0_CTRL_MODE_COUNT16 (RTC_MODE0_CTRL_MODE_COUNT16_Val << RTC_MODE0_CTRL_MODE_Pos)
 #define RTC_MODE0_CTRL_MODE_CLOCK   (RTC_MODE0_CTRL_MODE_CLOCK_Val << RTC_MODE0_CTRL_MODE_Pos)
 #define RTC_MODE0_CTRL_MATCHCLR_Pos 7            /**< \brief (RTC_MODE0_CTRL) Clear on Match */
-#define RTC_MODE0_CTRL_MATCHCLR     (0x1ul << RTC_MODE0_CTRL_MATCHCLR_Pos)
+#define RTC_MODE0_CTRL_MATCHCLR     (_U_(0x1) << RTC_MODE0_CTRL_MATCHCLR_Pos)
 #define RTC_MODE0_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE0_CTRL) Prescaler */
-#define RTC_MODE0_CTRL_PRESCALER_Msk (0xFul << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE0_CTRL_PRESCALER_Pos)
 #define RTC_MODE0_CTRL_PRESCALER(value) (RTC_MODE0_CTRL_PRESCALER_Msk & ((value) << RTC_MODE0_CTRL_PRESCALER_Pos))
-#define   RTC_MODE0_CTRL_PRESCALER_DIV1_Val 0x0ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV2_Val 0x1ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV4_Val 0x2ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV8_Val 0x3ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV16_Val 0x4ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV32_Val 0x5ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV64_Val 0x6ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV128_Val 0x7ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV256_Val 0x8ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV512_Val 0x9ul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
-#define   RTC_MODE0_CTRL_PRESCALER_DIV1024_Val 0xAul  /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
 #define RTC_MODE0_CTRL_PRESCALER_DIV1 (RTC_MODE0_CTRL_PRESCALER_DIV1_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
 #define RTC_MODE0_CTRL_PRESCALER_DIV2 (RTC_MODE0_CTRL_PRESCALER_DIV2_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
 #define RTC_MODE0_CTRL_PRESCALER_DIV4 (RTC_MODE0_CTRL_PRESCALER_DIV4_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
@@ -112,7 +97,7 @@ typedef union {
 #define RTC_MODE0_CTRL_PRESCALER_DIV256 (RTC_MODE0_CTRL_PRESCALER_DIV256_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
 #define RTC_MODE0_CTRL_PRESCALER_DIV512 (RTC_MODE0_CTRL_PRESCALER_DIV512_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
 #define RTC_MODE0_CTRL_PRESCALER_DIV1024 (RTC_MODE0_CTRL_PRESCALER_DIV1024_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
-#define RTC_MODE0_CTRL_MASK         0x0F8Ful     /**< \brief (RTC_MODE0_CTRL) MASK Register */
+#define RTC_MODE0_CTRL_MASK         _U_(0x0F8F)   /**< \brief (RTC_MODE0_CTRL) MASK Register */
 
 /* -------- RTC_MODE1_CTRL : (RTC Offset: 0x00) (R/W 16) MODE1 MODE1 Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -130,35 +115,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE1_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE1_CTRL offset) MODE1 Control */
-#define RTC_MODE1_CTRL_RESETVALUE   0x0000ul     /**< \brief (RTC_MODE1_CTRL reset_value) MODE1 Control */
+#define RTC_MODE1_CTRL_RESETVALUE   _U_(0x0000)   /**< \brief (RTC_MODE1_CTRL reset_value) MODE1 Control */
 
 #define RTC_MODE1_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE1_CTRL) Software Reset */
-#define RTC_MODE1_CTRL_SWRST        (0x1ul << RTC_MODE1_CTRL_SWRST_Pos)
+#define RTC_MODE1_CTRL_SWRST        (_U_(0x1) << RTC_MODE1_CTRL_SWRST_Pos)
 #define RTC_MODE1_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE1_CTRL) Enable */
-#define RTC_MODE1_CTRL_ENABLE       (0x1ul << RTC_MODE1_CTRL_ENABLE_Pos)
+#define RTC_MODE1_CTRL_ENABLE       (_U_(0x1) << RTC_MODE1_CTRL_ENABLE_Pos)
 #define RTC_MODE1_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE1_CTRL) Operating Mode */
-#define RTC_MODE1_CTRL_MODE_Msk     (0x3ul << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE1_CTRL_MODE_Pos)
 #define RTC_MODE1_CTRL_MODE(value)  (RTC_MODE1_CTRL_MODE_Msk & ((value) << RTC_MODE1_CTRL_MODE_Pos))
-#define   RTC_MODE1_CTRL_MODE_COUNT32_Val 0x0ul  /**< \brief (RTC_MODE1_CTRL) Mode 0: 32-bit Counter */
-#define   RTC_MODE1_CTRL_MODE_COUNT16_Val 0x1ul  /**< \brief (RTC_MODE1_CTRL) Mode 1: 16-bit Counter */
-#define   RTC_MODE1_CTRL_MODE_CLOCK_Val   0x2ul  /**< \brief (RTC_MODE1_CTRL) Mode 2: Clock/Calendar */
+#define   RTC_MODE1_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE1_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE1_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE1_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE1_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE1_CTRL) Mode 2: Clock/Calendar */
 #define RTC_MODE1_CTRL_MODE_COUNT32 (RTC_MODE1_CTRL_MODE_COUNT32_Val << RTC_MODE1_CTRL_MODE_Pos)
 #define RTC_MODE1_CTRL_MODE_COUNT16 (RTC_MODE1_CTRL_MODE_COUNT16_Val << RTC_MODE1_CTRL_MODE_Pos)
 #define RTC_MODE1_CTRL_MODE_CLOCK   (RTC_MODE1_CTRL_MODE_CLOCK_Val << RTC_MODE1_CTRL_MODE_Pos)
 #define RTC_MODE1_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE1_CTRL) Prescaler */
-#define RTC_MODE1_CTRL_PRESCALER_Msk (0xFul << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE1_CTRL_PRESCALER_Pos)
 #define RTC_MODE1_CTRL_PRESCALER(value) (RTC_MODE1_CTRL_PRESCALER_Msk & ((value) << RTC_MODE1_CTRL_PRESCALER_Pos))
-#define   RTC_MODE1_CTRL_PRESCALER_DIV1_Val 0x0ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV2_Val 0x1ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV4_Val 0x2ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV8_Val 0x3ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV16_Val 0x4ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV32_Val 0x5ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV64_Val 0x6ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV128_Val 0x7ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV256_Val 0x8ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV512_Val 0x9ul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
-#define   RTC_MODE1_CTRL_PRESCALER_DIV1024_Val 0xAul  /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
 #define RTC_MODE1_CTRL_PRESCALER_DIV1 (RTC_MODE1_CTRL_PRESCALER_DIV1_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
 #define RTC_MODE1_CTRL_PRESCALER_DIV2 (RTC_MODE1_CTRL_PRESCALER_DIV2_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
 #define RTC_MODE1_CTRL_PRESCALER_DIV4 (RTC_MODE1_CTRL_PRESCALER_DIV4_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
@@ -170,7 +155,7 @@ typedef union {
 #define RTC_MODE1_CTRL_PRESCALER_DIV256 (RTC_MODE1_CTRL_PRESCALER_DIV256_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
 #define RTC_MODE1_CTRL_PRESCALER_DIV512 (RTC_MODE1_CTRL_PRESCALER_DIV512_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
 #define RTC_MODE1_CTRL_PRESCALER_DIV1024 (RTC_MODE1_CTRL_PRESCALER_DIV1024_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
-#define RTC_MODE1_CTRL_MASK         0x0F0Ful     /**< \brief (RTC_MODE1_CTRL) MASK Register */
+#define RTC_MODE1_CTRL_MASK         _U_(0x0F0F)   /**< \brief (RTC_MODE1_CTRL) MASK Register */
 
 /* -------- RTC_MODE2_CTRL : (RTC Offset: 0x00) (R/W 16) MODE2 MODE2 Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -190,39 +175,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE2_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE2_CTRL offset) MODE2 Control */
-#define RTC_MODE2_CTRL_RESETVALUE   0x0000ul     /**< \brief (RTC_MODE2_CTRL reset_value) MODE2 Control */
+#define RTC_MODE2_CTRL_RESETVALUE   _U_(0x0000)   /**< \brief (RTC_MODE2_CTRL reset_value) MODE2 Control */
 
 #define RTC_MODE2_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE2_CTRL) Software Reset */
-#define RTC_MODE2_CTRL_SWRST        (0x1ul << RTC_MODE2_CTRL_SWRST_Pos)
+#define RTC_MODE2_CTRL_SWRST        (_U_(0x1) << RTC_MODE2_CTRL_SWRST_Pos)
 #define RTC_MODE2_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE2_CTRL) Enable */
-#define RTC_MODE2_CTRL_ENABLE       (0x1ul << RTC_MODE2_CTRL_ENABLE_Pos)
+#define RTC_MODE2_CTRL_ENABLE       (_U_(0x1) << RTC_MODE2_CTRL_ENABLE_Pos)
 #define RTC_MODE2_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE2_CTRL) Operating Mode */
-#define RTC_MODE2_CTRL_MODE_Msk     (0x3ul << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE2_CTRL_MODE_Pos)
 #define RTC_MODE2_CTRL_MODE(value)  (RTC_MODE2_CTRL_MODE_Msk & ((value) << RTC_MODE2_CTRL_MODE_Pos))
-#define   RTC_MODE2_CTRL_MODE_COUNT32_Val 0x0ul  /**< \brief (RTC_MODE2_CTRL) Mode 0: 32-bit Counter */
-#define   RTC_MODE2_CTRL_MODE_COUNT16_Val 0x1ul  /**< \brief (RTC_MODE2_CTRL) Mode 1: 16-bit Counter */
-#define   RTC_MODE2_CTRL_MODE_CLOCK_Val   0x2ul  /**< \brief (RTC_MODE2_CTRL) Mode 2: Clock/Calendar */
+#define   RTC_MODE2_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE2_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE2_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE2_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE2_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE2_CTRL) Mode 2: Clock/Calendar */
 #define RTC_MODE2_CTRL_MODE_COUNT32 (RTC_MODE2_CTRL_MODE_COUNT32_Val << RTC_MODE2_CTRL_MODE_Pos)
 #define RTC_MODE2_CTRL_MODE_COUNT16 (RTC_MODE2_CTRL_MODE_COUNT16_Val << RTC_MODE2_CTRL_MODE_Pos)
 #define RTC_MODE2_CTRL_MODE_CLOCK   (RTC_MODE2_CTRL_MODE_CLOCK_Val << RTC_MODE2_CTRL_MODE_Pos)
 #define RTC_MODE2_CTRL_CLKREP_Pos   6            /**< \brief (RTC_MODE2_CTRL) Clock Representation */
-#define RTC_MODE2_CTRL_CLKREP       (0x1ul << RTC_MODE2_CTRL_CLKREP_Pos)
+#define RTC_MODE2_CTRL_CLKREP       (_U_(0x1) << RTC_MODE2_CTRL_CLKREP_Pos)
 #define RTC_MODE2_CTRL_MATCHCLR_Pos 7            /**< \brief (RTC_MODE2_CTRL) Clear on Match */
-#define RTC_MODE2_CTRL_MATCHCLR     (0x1ul << RTC_MODE2_CTRL_MATCHCLR_Pos)
+#define RTC_MODE2_CTRL_MATCHCLR     (_U_(0x1) << RTC_MODE2_CTRL_MATCHCLR_Pos)
 #define RTC_MODE2_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE2_CTRL) Prescaler */
-#define RTC_MODE2_CTRL_PRESCALER_Msk (0xFul << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE2_CTRL_PRESCALER_Pos)
 #define RTC_MODE2_CTRL_PRESCALER(value) (RTC_MODE2_CTRL_PRESCALER_Msk & ((value) << RTC_MODE2_CTRL_PRESCALER_Pos))
-#define   RTC_MODE2_CTRL_PRESCALER_DIV1_Val 0x0ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV2_Val 0x1ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV4_Val 0x2ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV8_Val 0x3ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV16_Val 0x4ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV32_Val 0x5ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV64_Val 0x6ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV128_Val 0x7ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV256_Val 0x8ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV512_Val 0x9ul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
-#define   RTC_MODE2_CTRL_PRESCALER_DIV1024_Val 0xAul  /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
 #define RTC_MODE2_CTRL_PRESCALER_DIV1 (RTC_MODE2_CTRL_PRESCALER_DIV1_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
 #define RTC_MODE2_CTRL_PRESCALER_DIV2 (RTC_MODE2_CTRL_PRESCALER_DIV2_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
 #define RTC_MODE2_CTRL_PRESCALER_DIV4 (RTC_MODE2_CTRL_PRESCALER_DIV4_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
@@ -234,7 +219,7 @@ typedef union {
 #define RTC_MODE2_CTRL_PRESCALER_DIV256 (RTC_MODE2_CTRL_PRESCALER_DIV256_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
 #define RTC_MODE2_CTRL_PRESCALER_DIV512 (RTC_MODE2_CTRL_PRESCALER_DIV512_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
 #define RTC_MODE2_CTRL_PRESCALER_DIV1024 (RTC_MODE2_CTRL_PRESCALER_DIV1024_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
-#define RTC_MODE2_CTRL_MASK         0x0FCFul     /**< \brief (RTC_MODE2_CTRL) MASK Register */
+#define RTC_MODE2_CTRL_MASK         _U_(0x0FCF)   /**< \brief (RTC_MODE2_CTRL) MASK Register */
 
 /* -------- RTC_READREQ : (RTC Offset: 0x02) (R/W 16) Read Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -250,16 +235,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_READREQ_OFFSET          0x02         /**< \brief (RTC_READREQ offset) Read Request */
-#define RTC_READREQ_RESETVALUE      0x0010ul     /**< \brief (RTC_READREQ reset_value) Read Request */
+#define RTC_READREQ_RESETVALUE      _U_(0x0010)   /**< \brief (RTC_READREQ reset_value) Read Request */
 
 #define RTC_READREQ_ADDR_Pos        0            /**< \brief (RTC_READREQ) Address */
-#define RTC_READREQ_ADDR_Msk        (0x3Ful << RTC_READREQ_ADDR_Pos)
+#define RTC_READREQ_ADDR_Msk        (_U_(0x3F) << RTC_READREQ_ADDR_Pos)
 #define RTC_READREQ_ADDR(value)     (RTC_READREQ_ADDR_Msk & ((value) << RTC_READREQ_ADDR_Pos))
 #define RTC_READREQ_RCONT_Pos       14           /**< \brief (RTC_READREQ) Read Continuously */
-#define RTC_READREQ_RCONT           (0x1ul << RTC_READREQ_RCONT_Pos)
+#define RTC_READREQ_RCONT           (_U_(0x1) << RTC_READREQ_RCONT_Pos)
 #define RTC_READREQ_RREQ_Pos        15           /**< \brief (RTC_READREQ) Read Request */
-#define RTC_READREQ_RREQ            (0x1ul << RTC_READREQ_RREQ_Pos)
-#define RTC_READREQ_MASK            0xC03Ful     /**< \brief (RTC_READREQ) MASK Register */
+#define RTC_READREQ_RREQ            (_U_(0x1) << RTC_READREQ_RREQ_Pos)
+#define RTC_READREQ_MASK            _U_(0xC03F)   /**< \brief (RTC_READREQ) MASK Register */
 
 /* -------- RTC_MODE0_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE0 MODE0 Event Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -287,7 +272,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE0_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE0_EVCTRL offset) MODE0 Event Control */
-#define RTC_MODE0_EVCTRL_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE0_EVCTRL reset_value) MODE0 Event Control */
+#define RTC_MODE0_EVCTRL_RESETVALUE _U_(0x0000)   /**< \brief (RTC_MODE0_EVCTRL reset_value) MODE0 Event Control */
 
 #define RTC_MODE0_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 0 Event Output Enable */
 #define RTC_MODE0_EVCTRL_PEREO0     (1 << RTC_MODE0_EVCTRL_PEREO0_Pos)
@@ -306,16 +291,16 @@ typedef union {
 #define RTC_MODE0_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 7 Event Output Enable */
 #define RTC_MODE0_EVCTRL_PEREO7     (1 << RTC_MODE0_EVCTRL_PEREO7_Pos)
 #define RTC_MODE0_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval x Event Output Enable */
-#define RTC_MODE0_EVCTRL_PEREO_Msk  (0xFFul << RTC_MODE0_EVCTRL_PEREO_Pos)
+#define RTC_MODE0_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE0_EVCTRL_PEREO_Pos)
 #define RTC_MODE0_EVCTRL_PEREO(value) (RTC_MODE0_EVCTRL_PEREO_Msk & ((value) << RTC_MODE0_EVCTRL_PEREO_Pos))
 #define RTC_MODE0_EVCTRL_CMPEO0_Pos 8            /**< \brief (RTC_MODE0_EVCTRL) Compare 0 Event Output Enable */
 #define RTC_MODE0_EVCTRL_CMPEO0     (1 << RTC_MODE0_EVCTRL_CMPEO0_Pos)
 #define RTC_MODE0_EVCTRL_CMPEO_Pos  8            /**< \brief (RTC_MODE0_EVCTRL) Compare x Event Output Enable */
-#define RTC_MODE0_EVCTRL_CMPEO_Msk  (0x1ul << RTC_MODE0_EVCTRL_CMPEO_Pos)
+#define RTC_MODE0_EVCTRL_CMPEO_Msk  (_U_(0x1) << RTC_MODE0_EVCTRL_CMPEO_Pos)
 #define RTC_MODE0_EVCTRL_CMPEO(value) (RTC_MODE0_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE0_EVCTRL_CMPEO_Pos))
 #define RTC_MODE0_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE0_EVCTRL) Overflow Event Output Enable */
-#define RTC_MODE0_EVCTRL_OVFEO      (0x1ul << RTC_MODE0_EVCTRL_OVFEO_Pos)
-#define RTC_MODE0_EVCTRL_MASK       0x81FFul     /**< \brief (RTC_MODE0_EVCTRL) MASK Register */
+#define RTC_MODE0_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE0_EVCTRL_OVFEO_Pos)
+#define RTC_MODE0_EVCTRL_MASK       _U_(0x81FF)   /**< \brief (RTC_MODE0_EVCTRL) MASK Register */
 
 /* -------- RTC_MODE1_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE1 MODE1 Event Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -344,7 +329,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE1_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE1_EVCTRL offset) MODE1 Event Control */
-#define RTC_MODE1_EVCTRL_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE1_EVCTRL reset_value) MODE1 Event Control */
+#define RTC_MODE1_EVCTRL_RESETVALUE _U_(0x0000)   /**< \brief (RTC_MODE1_EVCTRL reset_value) MODE1 Event Control */
 
 #define RTC_MODE1_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 0 Event Output Enable */
 #define RTC_MODE1_EVCTRL_PEREO0     (1 << RTC_MODE1_EVCTRL_PEREO0_Pos)
@@ -363,18 +348,18 @@ typedef union {
 #define RTC_MODE1_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 7 Event Output Enable */
 #define RTC_MODE1_EVCTRL_PEREO7     (1 << RTC_MODE1_EVCTRL_PEREO7_Pos)
 #define RTC_MODE1_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval x Event Output Enable */
-#define RTC_MODE1_EVCTRL_PEREO_Msk  (0xFFul << RTC_MODE1_EVCTRL_PEREO_Pos)
+#define RTC_MODE1_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE1_EVCTRL_PEREO_Pos)
 #define RTC_MODE1_EVCTRL_PEREO(value) (RTC_MODE1_EVCTRL_PEREO_Msk & ((value) << RTC_MODE1_EVCTRL_PEREO_Pos))
 #define RTC_MODE1_EVCTRL_CMPEO0_Pos 8            /**< \brief (RTC_MODE1_EVCTRL) Compare 0 Event Output Enable */
 #define RTC_MODE1_EVCTRL_CMPEO0     (1 << RTC_MODE1_EVCTRL_CMPEO0_Pos)
 #define RTC_MODE1_EVCTRL_CMPEO1_Pos 9            /**< \brief (RTC_MODE1_EVCTRL) Compare 1 Event Output Enable */
 #define RTC_MODE1_EVCTRL_CMPEO1     (1 << RTC_MODE1_EVCTRL_CMPEO1_Pos)
 #define RTC_MODE1_EVCTRL_CMPEO_Pos  8            /**< \brief (RTC_MODE1_EVCTRL) Compare x Event Output Enable */
-#define RTC_MODE1_EVCTRL_CMPEO_Msk  (0x3ul << RTC_MODE1_EVCTRL_CMPEO_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO_Msk  (_U_(0x3) << RTC_MODE1_EVCTRL_CMPEO_Pos)
 #define RTC_MODE1_EVCTRL_CMPEO(value) (RTC_MODE1_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE1_EVCTRL_CMPEO_Pos))
 #define RTC_MODE1_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE1_EVCTRL) Overflow Event Output Enable */
-#define RTC_MODE1_EVCTRL_OVFEO      (0x1ul << RTC_MODE1_EVCTRL_OVFEO_Pos)
-#define RTC_MODE1_EVCTRL_MASK       0x83FFul     /**< \brief (RTC_MODE1_EVCTRL) MASK Register */
+#define RTC_MODE1_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE1_EVCTRL_OVFEO_Pos)
+#define RTC_MODE1_EVCTRL_MASK       _U_(0x83FF)   /**< \brief (RTC_MODE1_EVCTRL) MASK Register */
 
 /* -------- RTC_MODE2_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE2 MODE2 Event Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -402,7 +387,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE2_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE2_EVCTRL offset) MODE2 Event Control */
-#define RTC_MODE2_EVCTRL_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE2_EVCTRL reset_value) MODE2 Event Control */
+#define RTC_MODE2_EVCTRL_RESETVALUE _U_(0x0000)   /**< \brief (RTC_MODE2_EVCTRL reset_value) MODE2 Event Control */
 
 #define RTC_MODE2_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 0 Event Output Enable */
 #define RTC_MODE2_EVCTRL_PEREO0     (1 << RTC_MODE2_EVCTRL_PEREO0_Pos)
@@ -421,16 +406,16 @@ typedef union {
 #define RTC_MODE2_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 7 Event Output Enable */
 #define RTC_MODE2_EVCTRL_PEREO7     (1 << RTC_MODE2_EVCTRL_PEREO7_Pos)
 #define RTC_MODE2_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval x Event Output Enable */
-#define RTC_MODE2_EVCTRL_PEREO_Msk  (0xFFul << RTC_MODE2_EVCTRL_PEREO_Pos)
+#define RTC_MODE2_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE2_EVCTRL_PEREO_Pos)
 #define RTC_MODE2_EVCTRL_PEREO(value) (RTC_MODE2_EVCTRL_PEREO_Msk & ((value) << RTC_MODE2_EVCTRL_PEREO_Pos))
 #define RTC_MODE2_EVCTRL_ALARMEO0_Pos 8            /**< \brief (RTC_MODE2_EVCTRL) Alarm 0 Event Output Enable */
 #define RTC_MODE2_EVCTRL_ALARMEO0   (1 << RTC_MODE2_EVCTRL_ALARMEO0_Pos)
 #define RTC_MODE2_EVCTRL_ALARMEO_Pos 8            /**< \brief (RTC_MODE2_EVCTRL) Alarm x Event Output Enable */
-#define RTC_MODE2_EVCTRL_ALARMEO_Msk (0x1ul << RTC_MODE2_EVCTRL_ALARMEO_Pos)
+#define RTC_MODE2_EVCTRL_ALARMEO_Msk (_U_(0x1) << RTC_MODE2_EVCTRL_ALARMEO_Pos)
 #define RTC_MODE2_EVCTRL_ALARMEO(value) (RTC_MODE2_EVCTRL_ALARMEO_Msk & ((value) << RTC_MODE2_EVCTRL_ALARMEO_Pos))
 #define RTC_MODE2_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE2_EVCTRL) Overflow Event Output Enable */
-#define RTC_MODE2_EVCTRL_OVFEO      (0x1ul << RTC_MODE2_EVCTRL_OVFEO_Pos)
-#define RTC_MODE2_EVCTRL_MASK       0x81FFul     /**< \brief (RTC_MODE2_EVCTRL) MASK Register */
+#define RTC_MODE2_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE2_EVCTRL_OVFEO_Pos)
+#define RTC_MODE2_EVCTRL_MASK       _U_(0x81FF)   /**< \brief (RTC_MODE2_EVCTRL) MASK Register */
 
 /* -------- RTC_MODE0_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE0 MODE0 Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -450,18 +435,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE0_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE0_INTENCLR offset) MODE0 Interrupt Enable Clear */
-#define RTC_MODE0_INTENCLR_RESETVALUE 0x00ul       /**< \brief (RTC_MODE0_INTENCLR reset_value) MODE0 Interrupt Enable Clear */
+#define RTC_MODE0_INTENCLR_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE0_INTENCLR reset_value) MODE0 Interrupt Enable Clear */
 
 #define RTC_MODE0_INTENCLR_CMP0_Pos 0            /**< \brief (RTC_MODE0_INTENCLR) Compare 0 Interrupt Enable */
 #define RTC_MODE0_INTENCLR_CMP0     (1 << RTC_MODE0_INTENCLR_CMP0_Pos)
 #define RTC_MODE0_INTENCLR_CMP_Pos  0            /**< \brief (RTC_MODE0_INTENCLR) Compare x Interrupt Enable */
-#define RTC_MODE0_INTENCLR_CMP_Msk  (0x1ul << RTC_MODE0_INTENCLR_CMP_Pos)
+#define RTC_MODE0_INTENCLR_CMP_Msk  (_U_(0x1) << RTC_MODE0_INTENCLR_CMP_Pos)
 #define RTC_MODE0_INTENCLR_CMP(value) (RTC_MODE0_INTENCLR_CMP_Msk & ((value) << RTC_MODE0_INTENCLR_CMP_Pos))
 #define RTC_MODE0_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTENCLR) Synchronization Ready Interrupt Enable */
-#define RTC_MODE0_INTENCLR_SYNCRDY  (0x1ul << RTC_MODE0_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE0_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE0_INTENCLR_SYNCRDY_Pos)
 #define RTC_MODE0_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE0_INTENCLR) Overflow Interrupt Enable */
-#define RTC_MODE0_INTENCLR_OVF      (0x1ul << RTC_MODE0_INTENCLR_OVF_Pos)
-#define RTC_MODE0_INTENCLR_MASK     0xC1ul       /**< \brief (RTC_MODE0_INTENCLR) MASK Register */
+#define RTC_MODE0_INTENCLR_OVF      (_U_(0x1) << RTC_MODE0_INTENCLR_OVF_Pos)
+#define RTC_MODE0_INTENCLR_MASK     _U_(0xC1)     /**< \brief (RTC_MODE0_INTENCLR) MASK Register */
 
 /* -------- RTC_MODE1_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE1 MODE1 Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -482,20 +467,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE1_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE1_INTENCLR offset) MODE1 Interrupt Enable Clear */
-#define RTC_MODE1_INTENCLR_RESETVALUE 0x00ul       /**< \brief (RTC_MODE1_INTENCLR reset_value) MODE1 Interrupt Enable Clear */
+#define RTC_MODE1_INTENCLR_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE1_INTENCLR reset_value) MODE1 Interrupt Enable Clear */
 
 #define RTC_MODE1_INTENCLR_CMP0_Pos 0            /**< \brief (RTC_MODE1_INTENCLR) Compare 0 Interrupt Enable */
 #define RTC_MODE1_INTENCLR_CMP0     (1 << RTC_MODE1_INTENCLR_CMP0_Pos)
 #define RTC_MODE1_INTENCLR_CMP1_Pos 1            /**< \brief (RTC_MODE1_INTENCLR) Compare 1 Interrupt Enable */
 #define RTC_MODE1_INTENCLR_CMP1     (1 << RTC_MODE1_INTENCLR_CMP1_Pos)
 #define RTC_MODE1_INTENCLR_CMP_Pos  0            /**< \brief (RTC_MODE1_INTENCLR) Compare x Interrupt Enable */
-#define RTC_MODE1_INTENCLR_CMP_Msk  (0x3ul << RTC_MODE1_INTENCLR_CMP_Pos)
+#define RTC_MODE1_INTENCLR_CMP_Msk  (_U_(0x3) << RTC_MODE1_INTENCLR_CMP_Pos)
 #define RTC_MODE1_INTENCLR_CMP(value) (RTC_MODE1_INTENCLR_CMP_Msk & ((value) << RTC_MODE1_INTENCLR_CMP_Pos))
 #define RTC_MODE1_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTENCLR) Synchronization Ready Interrupt Enable */
-#define RTC_MODE1_INTENCLR_SYNCRDY  (0x1ul << RTC_MODE1_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE1_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE1_INTENCLR_SYNCRDY_Pos)
 #define RTC_MODE1_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE1_INTENCLR) Overflow Interrupt Enable */
-#define RTC_MODE1_INTENCLR_OVF      (0x1ul << RTC_MODE1_INTENCLR_OVF_Pos)
-#define RTC_MODE1_INTENCLR_MASK     0xC3ul       /**< \brief (RTC_MODE1_INTENCLR) MASK Register */
+#define RTC_MODE1_INTENCLR_OVF      (_U_(0x1) << RTC_MODE1_INTENCLR_OVF_Pos)
+#define RTC_MODE1_INTENCLR_MASK     _U_(0xC3)     /**< \brief (RTC_MODE1_INTENCLR) MASK Register */
 
 /* -------- RTC_MODE2_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE2 MODE2 Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -515,18 +500,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE2_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE2_INTENCLR offset) MODE2 Interrupt Enable Clear */
-#define RTC_MODE2_INTENCLR_RESETVALUE 0x00ul       /**< \brief (RTC_MODE2_INTENCLR reset_value) MODE2 Interrupt Enable Clear */
+#define RTC_MODE2_INTENCLR_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE2_INTENCLR reset_value) MODE2 Interrupt Enable Clear */
 
 #define RTC_MODE2_INTENCLR_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTENCLR) Alarm 0 Interrupt Enable */
 #define RTC_MODE2_INTENCLR_ALARM0   (1 << RTC_MODE2_INTENCLR_ALARM0_Pos)
 #define RTC_MODE2_INTENCLR_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTENCLR) Alarm x Interrupt Enable */
-#define RTC_MODE2_INTENCLR_ALARM_Msk (0x1ul << RTC_MODE2_INTENCLR_ALARM_Pos)
+#define RTC_MODE2_INTENCLR_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTENCLR_ALARM_Pos)
 #define RTC_MODE2_INTENCLR_ALARM(value) (RTC_MODE2_INTENCLR_ALARM_Msk & ((value) << RTC_MODE2_INTENCLR_ALARM_Pos))
 #define RTC_MODE2_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTENCLR) Synchronization Ready Interrupt Enable */
-#define RTC_MODE2_INTENCLR_SYNCRDY  (0x1ul << RTC_MODE2_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE2_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE2_INTENCLR_SYNCRDY_Pos)
 #define RTC_MODE2_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE2_INTENCLR) Overflow Interrupt Enable */
-#define RTC_MODE2_INTENCLR_OVF      (0x1ul << RTC_MODE2_INTENCLR_OVF_Pos)
-#define RTC_MODE2_INTENCLR_MASK     0xC1ul       /**< \brief (RTC_MODE2_INTENCLR) MASK Register */
+#define RTC_MODE2_INTENCLR_OVF      (_U_(0x1) << RTC_MODE2_INTENCLR_OVF_Pos)
+#define RTC_MODE2_INTENCLR_MASK     _U_(0xC1)     /**< \brief (RTC_MODE2_INTENCLR) MASK Register */
 
 /* -------- RTC_MODE0_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE0 MODE0 Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -546,18 +531,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE0_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE0_INTENSET offset) MODE0 Interrupt Enable Set */
-#define RTC_MODE0_INTENSET_RESETVALUE 0x00ul       /**< \brief (RTC_MODE0_INTENSET reset_value) MODE0 Interrupt Enable Set */
+#define RTC_MODE0_INTENSET_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE0_INTENSET reset_value) MODE0 Interrupt Enable Set */
 
 #define RTC_MODE0_INTENSET_CMP0_Pos 0            /**< \brief (RTC_MODE0_INTENSET) Compare 0 Interrupt Enable */
 #define RTC_MODE0_INTENSET_CMP0     (1 << RTC_MODE0_INTENSET_CMP0_Pos)
 #define RTC_MODE0_INTENSET_CMP_Pos  0            /**< \brief (RTC_MODE0_INTENSET) Compare x Interrupt Enable */
-#define RTC_MODE0_INTENSET_CMP_Msk  (0x1ul << RTC_MODE0_INTENSET_CMP_Pos)
+#define RTC_MODE0_INTENSET_CMP_Msk  (_U_(0x1) << RTC_MODE0_INTENSET_CMP_Pos)
 #define RTC_MODE0_INTENSET_CMP(value) (RTC_MODE0_INTENSET_CMP_Msk & ((value) << RTC_MODE0_INTENSET_CMP_Pos))
 #define RTC_MODE0_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTENSET) Synchronization Ready Interrupt Enable */
-#define RTC_MODE0_INTENSET_SYNCRDY  (0x1ul << RTC_MODE0_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE0_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE0_INTENSET_SYNCRDY_Pos)
 #define RTC_MODE0_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE0_INTENSET) Overflow Interrupt Enable */
-#define RTC_MODE0_INTENSET_OVF      (0x1ul << RTC_MODE0_INTENSET_OVF_Pos)
-#define RTC_MODE0_INTENSET_MASK     0xC1ul       /**< \brief (RTC_MODE0_INTENSET) MASK Register */
+#define RTC_MODE0_INTENSET_OVF      (_U_(0x1) << RTC_MODE0_INTENSET_OVF_Pos)
+#define RTC_MODE0_INTENSET_MASK     _U_(0xC1)     /**< \brief (RTC_MODE0_INTENSET) MASK Register */
 
 /* -------- RTC_MODE1_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE1 MODE1 Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -578,20 +563,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE1_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE1_INTENSET offset) MODE1 Interrupt Enable Set */
-#define RTC_MODE1_INTENSET_RESETVALUE 0x00ul       /**< \brief (RTC_MODE1_INTENSET reset_value) MODE1 Interrupt Enable Set */
+#define RTC_MODE1_INTENSET_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE1_INTENSET reset_value) MODE1 Interrupt Enable Set */
 
 #define RTC_MODE1_INTENSET_CMP0_Pos 0            /**< \brief (RTC_MODE1_INTENSET) Compare 0 Interrupt Enable */
 #define RTC_MODE1_INTENSET_CMP0     (1 << RTC_MODE1_INTENSET_CMP0_Pos)
 #define RTC_MODE1_INTENSET_CMP1_Pos 1            /**< \brief (RTC_MODE1_INTENSET) Compare 1 Interrupt Enable */
 #define RTC_MODE1_INTENSET_CMP1     (1 << RTC_MODE1_INTENSET_CMP1_Pos)
 #define RTC_MODE1_INTENSET_CMP_Pos  0            /**< \brief (RTC_MODE1_INTENSET) Compare x Interrupt Enable */
-#define RTC_MODE1_INTENSET_CMP_Msk  (0x3ul << RTC_MODE1_INTENSET_CMP_Pos)
+#define RTC_MODE1_INTENSET_CMP_Msk  (_U_(0x3) << RTC_MODE1_INTENSET_CMP_Pos)
 #define RTC_MODE1_INTENSET_CMP(value) (RTC_MODE1_INTENSET_CMP_Msk & ((value) << RTC_MODE1_INTENSET_CMP_Pos))
 #define RTC_MODE1_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTENSET) Synchronization Ready Interrupt Enable */
-#define RTC_MODE1_INTENSET_SYNCRDY  (0x1ul << RTC_MODE1_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE1_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE1_INTENSET_SYNCRDY_Pos)
 #define RTC_MODE1_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE1_INTENSET) Overflow Interrupt Enable */
-#define RTC_MODE1_INTENSET_OVF      (0x1ul << RTC_MODE1_INTENSET_OVF_Pos)
-#define RTC_MODE1_INTENSET_MASK     0xC3ul       /**< \brief (RTC_MODE1_INTENSET) MASK Register */
+#define RTC_MODE1_INTENSET_OVF      (_U_(0x1) << RTC_MODE1_INTENSET_OVF_Pos)
+#define RTC_MODE1_INTENSET_MASK     _U_(0xC3)     /**< \brief (RTC_MODE1_INTENSET) MASK Register */
 
 /* -------- RTC_MODE2_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE2 MODE2 Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -611,18 +596,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE2_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE2_INTENSET offset) MODE2 Interrupt Enable Set */
-#define RTC_MODE2_INTENSET_RESETVALUE 0x00ul       /**< \brief (RTC_MODE2_INTENSET reset_value) MODE2 Interrupt Enable Set */
+#define RTC_MODE2_INTENSET_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE2_INTENSET reset_value) MODE2 Interrupt Enable Set */
 
 #define RTC_MODE2_INTENSET_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTENSET) Alarm 0 Interrupt Enable */
 #define RTC_MODE2_INTENSET_ALARM0   (1 << RTC_MODE2_INTENSET_ALARM0_Pos)
 #define RTC_MODE2_INTENSET_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTENSET) Alarm x Interrupt Enable */
-#define RTC_MODE2_INTENSET_ALARM_Msk (0x1ul << RTC_MODE2_INTENSET_ALARM_Pos)
+#define RTC_MODE2_INTENSET_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTENSET_ALARM_Pos)
 #define RTC_MODE2_INTENSET_ALARM(value) (RTC_MODE2_INTENSET_ALARM_Msk & ((value) << RTC_MODE2_INTENSET_ALARM_Pos))
 #define RTC_MODE2_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTENSET) Synchronization Ready Interrupt Enable */
-#define RTC_MODE2_INTENSET_SYNCRDY  (0x1ul << RTC_MODE2_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE2_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE2_INTENSET_SYNCRDY_Pos)
 #define RTC_MODE2_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE2_INTENSET) Overflow Interrupt Enable */
-#define RTC_MODE2_INTENSET_OVF      (0x1ul << RTC_MODE2_INTENSET_OVF_Pos)
-#define RTC_MODE2_INTENSET_MASK     0xC1ul       /**< \brief (RTC_MODE2_INTENSET) MASK Register */
+#define RTC_MODE2_INTENSET_OVF      (_U_(0x1) << RTC_MODE2_INTENSET_OVF_Pos)
+#define RTC_MODE2_INTENSET_MASK     _U_(0xC1)     /**< \brief (RTC_MODE2_INTENSET) MASK Register */
 
 /* -------- RTC_MODE0_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE0 MODE0 Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -642,18 +627,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE0_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE0_INTFLAG offset) MODE0 Interrupt Flag Status and Clear */
-#define RTC_MODE0_INTFLAG_RESETVALUE 0x00ul       /**< \brief (RTC_MODE0_INTFLAG reset_value) MODE0 Interrupt Flag Status and Clear */
+#define RTC_MODE0_INTFLAG_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE0_INTFLAG reset_value) MODE0 Interrupt Flag Status and Clear */
 
 #define RTC_MODE0_INTFLAG_CMP0_Pos  0            /**< \brief (RTC_MODE0_INTFLAG) Compare 0 */
 #define RTC_MODE0_INTFLAG_CMP0      (1 << RTC_MODE0_INTFLAG_CMP0_Pos)
 #define RTC_MODE0_INTFLAG_CMP_Pos   0            /**< \brief (RTC_MODE0_INTFLAG) Compare x */
-#define RTC_MODE0_INTFLAG_CMP_Msk   (0x1ul << RTC_MODE0_INTFLAG_CMP_Pos)
+#define RTC_MODE0_INTFLAG_CMP_Msk   (_U_(0x1) << RTC_MODE0_INTFLAG_CMP_Pos)
 #define RTC_MODE0_INTFLAG_CMP(value) (RTC_MODE0_INTFLAG_CMP_Msk & ((value) << RTC_MODE0_INTFLAG_CMP_Pos))
 #define RTC_MODE0_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTFLAG) Synchronization Ready */
-#define RTC_MODE0_INTFLAG_SYNCRDY   (0x1ul << RTC_MODE0_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE0_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE0_INTFLAG_SYNCRDY_Pos)
 #define RTC_MODE0_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE0_INTFLAG) Overflow */
-#define RTC_MODE0_INTFLAG_OVF       (0x1ul << RTC_MODE0_INTFLAG_OVF_Pos)
-#define RTC_MODE0_INTFLAG_MASK      0xC1ul       /**< \brief (RTC_MODE0_INTFLAG) MASK Register */
+#define RTC_MODE0_INTFLAG_OVF       (_U_(0x1) << RTC_MODE0_INTFLAG_OVF_Pos)
+#define RTC_MODE0_INTFLAG_MASK      _U_(0xC1)     /**< \brief (RTC_MODE0_INTFLAG) MASK Register */
 
 /* -------- RTC_MODE1_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE1 MODE1 Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -674,20 +659,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE1_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE1_INTFLAG offset) MODE1 Interrupt Flag Status and Clear */
-#define RTC_MODE1_INTFLAG_RESETVALUE 0x00ul       /**< \brief (RTC_MODE1_INTFLAG reset_value) MODE1 Interrupt Flag Status and Clear */
+#define RTC_MODE1_INTFLAG_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE1_INTFLAG reset_value) MODE1 Interrupt Flag Status and Clear */
 
 #define RTC_MODE1_INTFLAG_CMP0_Pos  0            /**< \brief (RTC_MODE1_INTFLAG) Compare 0 */
 #define RTC_MODE1_INTFLAG_CMP0      (1 << RTC_MODE1_INTFLAG_CMP0_Pos)
 #define RTC_MODE1_INTFLAG_CMP1_Pos  1            /**< \brief (RTC_MODE1_INTFLAG) Compare 1 */
 #define RTC_MODE1_INTFLAG_CMP1      (1 << RTC_MODE1_INTFLAG_CMP1_Pos)
 #define RTC_MODE1_INTFLAG_CMP_Pos   0            /**< \brief (RTC_MODE1_INTFLAG) Compare x */
-#define RTC_MODE1_INTFLAG_CMP_Msk   (0x3ul << RTC_MODE1_INTFLAG_CMP_Pos)
+#define RTC_MODE1_INTFLAG_CMP_Msk   (_U_(0x3) << RTC_MODE1_INTFLAG_CMP_Pos)
 #define RTC_MODE1_INTFLAG_CMP(value) (RTC_MODE1_INTFLAG_CMP_Msk & ((value) << RTC_MODE1_INTFLAG_CMP_Pos))
 #define RTC_MODE1_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTFLAG) Synchronization Ready */
-#define RTC_MODE1_INTFLAG_SYNCRDY   (0x1ul << RTC_MODE1_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE1_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE1_INTFLAG_SYNCRDY_Pos)
 #define RTC_MODE1_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE1_INTFLAG) Overflow */
-#define RTC_MODE1_INTFLAG_OVF       (0x1ul << RTC_MODE1_INTFLAG_OVF_Pos)
-#define RTC_MODE1_INTFLAG_MASK      0xC3ul       /**< \brief (RTC_MODE1_INTFLAG) MASK Register */
+#define RTC_MODE1_INTFLAG_OVF       (_U_(0x1) << RTC_MODE1_INTFLAG_OVF_Pos)
+#define RTC_MODE1_INTFLAG_MASK      _U_(0xC3)     /**< \brief (RTC_MODE1_INTFLAG) MASK Register */
 
 /* -------- RTC_MODE2_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE2 MODE2 Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -707,18 +692,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE2_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE2_INTFLAG offset) MODE2 Interrupt Flag Status and Clear */
-#define RTC_MODE2_INTFLAG_RESETVALUE 0x00ul       /**< \brief (RTC_MODE2_INTFLAG reset_value) MODE2 Interrupt Flag Status and Clear */
+#define RTC_MODE2_INTFLAG_RESETVALUE _U_(0x00)     /**< \brief (RTC_MODE2_INTFLAG reset_value) MODE2 Interrupt Flag Status and Clear */
 
 #define RTC_MODE2_INTFLAG_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTFLAG) Alarm 0 */
 #define RTC_MODE2_INTFLAG_ALARM0    (1 << RTC_MODE2_INTFLAG_ALARM0_Pos)
 #define RTC_MODE2_INTFLAG_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTFLAG) Alarm x */
-#define RTC_MODE2_INTFLAG_ALARM_Msk (0x1ul << RTC_MODE2_INTFLAG_ALARM_Pos)
+#define RTC_MODE2_INTFLAG_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTFLAG_ALARM_Pos)
 #define RTC_MODE2_INTFLAG_ALARM(value) (RTC_MODE2_INTFLAG_ALARM_Msk & ((value) << RTC_MODE2_INTFLAG_ALARM_Pos))
 #define RTC_MODE2_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTFLAG) Synchronization Ready */
-#define RTC_MODE2_INTFLAG_SYNCRDY   (0x1ul << RTC_MODE2_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE2_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE2_INTFLAG_SYNCRDY_Pos)
 #define RTC_MODE2_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE2_INTFLAG) Overflow */
-#define RTC_MODE2_INTFLAG_OVF       (0x1ul << RTC_MODE2_INTFLAG_OVF_Pos)
-#define RTC_MODE2_INTFLAG_MASK      0xC1ul       /**< \brief (RTC_MODE2_INTFLAG) MASK Register */
+#define RTC_MODE2_INTFLAG_OVF       (_U_(0x1) << RTC_MODE2_INTFLAG_OVF_Pos)
+#define RTC_MODE2_INTFLAG_MASK      _U_(0xC1)     /**< \brief (RTC_MODE2_INTFLAG) MASK Register */
 
 /* -------- RTC_STATUS : (RTC Offset: 0x0A) (R/W  8) Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -732,11 +717,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_STATUS_OFFSET           0x0A         /**< \brief (RTC_STATUS offset) Status */
-#define RTC_STATUS_RESETVALUE       0x00ul       /**< \brief (RTC_STATUS reset_value) Status */
+#define RTC_STATUS_RESETVALUE       _U_(0x00)     /**< \brief (RTC_STATUS reset_value) Status */
 
 #define RTC_STATUS_SYNCBUSY_Pos     7            /**< \brief (RTC_STATUS) Synchronization Busy */
-#define RTC_STATUS_SYNCBUSY         (0x1ul << RTC_STATUS_SYNCBUSY_Pos)
-#define RTC_STATUS_MASK             0x80ul       /**< \brief (RTC_STATUS) MASK Register */
+#define RTC_STATUS_SYNCBUSY         (_U_(0x1) << RTC_STATUS_SYNCBUSY_Pos)
+#define RTC_STATUS_MASK             _U_(0x80)     /**< \brief (RTC_STATUS) MASK Register */
 
 /* -------- RTC_DBGCTRL : (RTC Offset: 0x0B) (R/W  8) Debug Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -750,11 +735,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_DBGCTRL_OFFSET          0x0B         /**< \brief (RTC_DBGCTRL offset) Debug Control */
-#define RTC_DBGCTRL_RESETVALUE      0x00ul       /**< \brief (RTC_DBGCTRL reset_value) Debug Control */
+#define RTC_DBGCTRL_RESETVALUE      _U_(0x00)     /**< \brief (RTC_DBGCTRL reset_value) Debug Control */
 
 #define RTC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (RTC_DBGCTRL) Run During Debug */
-#define RTC_DBGCTRL_DBGRUN          (0x1ul << RTC_DBGCTRL_DBGRUN_Pos)
-#define RTC_DBGCTRL_MASK            0x01ul       /**< \brief (RTC_DBGCTRL) MASK Register */
+#define RTC_DBGCTRL_DBGRUN          (_U_(0x1) << RTC_DBGCTRL_DBGRUN_Pos)
+#define RTC_DBGCTRL_MASK            _U_(0x01)     /**< \brief (RTC_DBGCTRL) MASK Register */
 
 /* -------- RTC_FREQCORR : (RTC Offset: 0x0C) (R/W  8) Frequency Correction -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -768,14 +753,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_FREQCORR_OFFSET         0x0C         /**< \brief (RTC_FREQCORR offset) Frequency Correction */
-#define RTC_FREQCORR_RESETVALUE     0x00ul       /**< \brief (RTC_FREQCORR reset_value) Frequency Correction */
+#define RTC_FREQCORR_RESETVALUE     _U_(0x00)     /**< \brief (RTC_FREQCORR reset_value) Frequency Correction */
 
 #define RTC_FREQCORR_VALUE_Pos      0            /**< \brief (RTC_FREQCORR) Correction Value */
-#define RTC_FREQCORR_VALUE_Msk      (0x7Ful << RTC_FREQCORR_VALUE_Pos)
+#define RTC_FREQCORR_VALUE_Msk      (_U_(0x7F) << RTC_FREQCORR_VALUE_Pos)
 #define RTC_FREQCORR_VALUE(value)   (RTC_FREQCORR_VALUE_Msk & ((value) << RTC_FREQCORR_VALUE_Pos))
 #define RTC_FREQCORR_SIGN_Pos       7            /**< \brief (RTC_FREQCORR) Correction Sign */
-#define RTC_FREQCORR_SIGN           (0x1ul << RTC_FREQCORR_SIGN_Pos)
-#define RTC_FREQCORR_MASK           0xFFul       /**< \brief (RTC_FREQCORR) MASK Register */
+#define RTC_FREQCORR_SIGN           (_U_(0x1) << RTC_FREQCORR_SIGN_Pos)
+#define RTC_FREQCORR_MASK           _U_(0xFF)     /**< \brief (RTC_FREQCORR) MASK Register */
 
 /* -------- RTC_MODE0_COUNT : (RTC Offset: 0x10) (R/W 32) MODE0 MODE0 Counter Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -788,12 +773,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE0_COUNT_OFFSET      0x10         /**< \brief (RTC_MODE0_COUNT offset) MODE0 Counter Value */
-#define RTC_MODE0_COUNT_RESETVALUE  0x00000000ul /**< \brief (RTC_MODE0_COUNT reset_value) MODE0 Counter Value */
+#define RTC_MODE0_COUNT_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE0_COUNT reset_value) MODE0 Counter Value */
 
 #define RTC_MODE0_COUNT_COUNT_Pos   0            /**< \brief (RTC_MODE0_COUNT) Counter Value */
-#define RTC_MODE0_COUNT_COUNT_Msk   (0xFFFFFFFFul << RTC_MODE0_COUNT_COUNT_Pos)
+#define RTC_MODE0_COUNT_COUNT_Msk   (_U_(0xFFFFFFFF) << RTC_MODE0_COUNT_COUNT_Pos)
 #define RTC_MODE0_COUNT_COUNT(value) (RTC_MODE0_COUNT_COUNT_Msk & ((value) << RTC_MODE0_COUNT_COUNT_Pos))
-#define RTC_MODE0_COUNT_MASK        0xFFFFFFFFul /**< \brief (RTC_MODE0_COUNT) MASK Register */
+#define RTC_MODE0_COUNT_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE0_COUNT) MASK Register */
 
 /* -------- RTC_MODE1_COUNT : (RTC Offset: 0x10) (R/W 16) MODE1 MODE1 Counter Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -806,12 +791,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE1_COUNT_OFFSET      0x10         /**< \brief (RTC_MODE1_COUNT offset) MODE1 Counter Value */
-#define RTC_MODE1_COUNT_RESETVALUE  0x0000ul     /**< \brief (RTC_MODE1_COUNT reset_value) MODE1 Counter Value */
+#define RTC_MODE1_COUNT_RESETVALUE  _U_(0x0000)   /**< \brief (RTC_MODE1_COUNT reset_value) MODE1 Counter Value */
 
 #define RTC_MODE1_COUNT_COUNT_Pos   0            /**< \brief (RTC_MODE1_COUNT) Counter Value */
-#define RTC_MODE1_COUNT_COUNT_Msk   (0xFFFFul << RTC_MODE1_COUNT_COUNT_Pos)
+#define RTC_MODE1_COUNT_COUNT_Msk   (_U_(0xFFFF) << RTC_MODE1_COUNT_COUNT_Pos)
 #define RTC_MODE1_COUNT_COUNT(value) (RTC_MODE1_COUNT_COUNT_Msk & ((value) << RTC_MODE1_COUNT_COUNT_Pos))
-#define RTC_MODE1_COUNT_MASK        0xFFFFul     /**< \brief (RTC_MODE1_COUNT) MASK Register */
+#define RTC_MODE1_COUNT_MASK        _U_(0xFFFF)   /**< \brief (RTC_MODE1_COUNT) MASK Register */
 
 /* -------- RTC_MODE2_CLOCK : (RTC Offset: 0x10) (R/W 32) MODE2 MODE2 Clock Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -829,29 +814,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE2_CLOCK_OFFSET      0x10         /**< \brief (RTC_MODE2_CLOCK offset) MODE2 Clock Value */
-#define RTC_MODE2_CLOCK_RESETVALUE  0x00000000ul /**< \brief (RTC_MODE2_CLOCK reset_value) MODE2 Clock Value */
+#define RTC_MODE2_CLOCK_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE2_CLOCK reset_value) MODE2 Clock Value */
 
 #define RTC_MODE2_CLOCK_SECOND_Pos  0            /**< \brief (RTC_MODE2_CLOCK) Second */
-#define RTC_MODE2_CLOCK_SECOND_Msk  (0x3Ful << RTC_MODE2_CLOCK_SECOND_Pos)
+#define RTC_MODE2_CLOCK_SECOND_Msk  (_U_(0x3F) << RTC_MODE2_CLOCK_SECOND_Pos)
 #define RTC_MODE2_CLOCK_SECOND(value) (RTC_MODE2_CLOCK_SECOND_Msk & ((value) << RTC_MODE2_CLOCK_SECOND_Pos))
 #define RTC_MODE2_CLOCK_MINUTE_Pos  6            /**< \brief (RTC_MODE2_CLOCK) Minute */
-#define RTC_MODE2_CLOCK_MINUTE_Msk  (0x3Ful << RTC_MODE2_CLOCK_MINUTE_Pos)
+#define RTC_MODE2_CLOCK_MINUTE_Msk  (_U_(0x3F) << RTC_MODE2_CLOCK_MINUTE_Pos)
 #define RTC_MODE2_CLOCK_MINUTE(value) (RTC_MODE2_CLOCK_MINUTE_Msk & ((value) << RTC_MODE2_CLOCK_MINUTE_Pos))
 #define RTC_MODE2_CLOCK_HOUR_Pos    12           /**< \brief (RTC_MODE2_CLOCK) Hour */
-#define RTC_MODE2_CLOCK_HOUR_Msk    (0x1Ful << RTC_MODE2_CLOCK_HOUR_Pos)
+#define RTC_MODE2_CLOCK_HOUR_Msk    (_U_(0x1F) << RTC_MODE2_CLOCK_HOUR_Pos)
 #define RTC_MODE2_CLOCK_HOUR(value) (RTC_MODE2_CLOCK_HOUR_Msk & ((value) << RTC_MODE2_CLOCK_HOUR_Pos))
-#define   RTC_MODE2_CLOCK_HOUR_PM_Val     0x10ul  /**< \brief (RTC_MODE2_CLOCK) Afternoon Hour */
+#define   RTC_MODE2_CLOCK_HOUR_AM_Val     _U_(0x0)   /**< \brief (RTC_MODE2_CLOCK) AM when CLKREP in 12-hour */
+#define   RTC_MODE2_CLOCK_HOUR_PM_Val     _U_(0x10)   /**< \brief (RTC_MODE2_CLOCK) PM when CLKREP in 12-hour */
+#define RTC_MODE2_CLOCK_HOUR_AM     (RTC_MODE2_CLOCK_HOUR_AM_Val   << RTC_MODE2_CLOCK_HOUR_Pos)
 #define RTC_MODE2_CLOCK_HOUR_PM     (RTC_MODE2_CLOCK_HOUR_PM_Val   << RTC_MODE2_CLOCK_HOUR_Pos)
 #define RTC_MODE2_CLOCK_DAY_Pos     17           /**< \brief (RTC_MODE2_CLOCK) Day */
-#define RTC_MODE2_CLOCK_DAY_Msk     (0x1Ful << RTC_MODE2_CLOCK_DAY_Pos)
+#define RTC_MODE2_CLOCK_DAY_Msk     (_U_(0x1F) << RTC_MODE2_CLOCK_DAY_Pos)
 #define RTC_MODE2_CLOCK_DAY(value)  (RTC_MODE2_CLOCK_DAY_Msk & ((value) << RTC_MODE2_CLOCK_DAY_Pos))
 #define RTC_MODE2_CLOCK_MONTH_Pos   22           /**< \brief (RTC_MODE2_CLOCK) Month */
-#define RTC_MODE2_CLOCK_MONTH_Msk   (0xFul << RTC_MODE2_CLOCK_MONTH_Pos)
+#define RTC_MODE2_CLOCK_MONTH_Msk   (_U_(0xF) << RTC_MODE2_CLOCK_MONTH_Pos)
 #define RTC_MODE2_CLOCK_MONTH(value) (RTC_MODE2_CLOCK_MONTH_Msk & ((value) << RTC_MODE2_CLOCK_MONTH_Pos))
 #define RTC_MODE2_CLOCK_YEAR_Pos    26           /**< \brief (RTC_MODE2_CLOCK) Year */
-#define RTC_MODE2_CLOCK_YEAR_Msk    (0x3Ful << RTC_MODE2_CLOCK_YEAR_Pos)
+#define RTC_MODE2_CLOCK_YEAR_Msk    (_U_(0x3F) << RTC_MODE2_CLOCK_YEAR_Pos)
 #define RTC_MODE2_CLOCK_YEAR(value) (RTC_MODE2_CLOCK_YEAR_Msk & ((value) << RTC_MODE2_CLOCK_YEAR_Pos))
-#define RTC_MODE2_CLOCK_MASK        0xFFFFFFFFul /**< \brief (RTC_MODE2_CLOCK) MASK Register */
+#define RTC_MODE2_CLOCK_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE2_CLOCK) MASK Register */
 
 /* -------- RTC_MODE1_PER : (RTC Offset: 0x14) (R/W 16) MODE1 MODE1 Counter Period -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -864,12 +851,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE1_PER_OFFSET        0x14         /**< \brief (RTC_MODE1_PER offset) MODE1 Counter Period */
-#define RTC_MODE1_PER_RESETVALUE    0x0000ul     /**< \brief (RTC_MODE1_PER reset_value) MODE1 Counter Period */
+#define RTC_MODE1_PER_RESETVALUE    _U_(0x0000)   /**< \brief (RTC_MODE1_PER reset_value) MODE1 Counter Period */
 
 #define RTC_MODE1_PER_PER_Pos       0            /**< \brief (RTC_MODE1_PER) Counter Period */
-#define RTC_MODE1_PER_PER_Msk       (0xFFFFul << RTC_MODE1_PER_PER_Pos)
+#define RTC_MODE1_PER_PER_Msk       (_U_(0xFFFF) << RTC_MODE1_PER_PER_Pos)
 #define RTC_MODE1_PER_PER(value)    (RTC_MODE1_PER_PER_Msk & ((value) << RTC_MODE1_PER_PER_Pos))
-#define RTC_MODE1_PER_MASK          0xFFFFul     /**< \brief (RTC_MODE1_PER) MASK Register */
+#define RTC_MODE1_PER_MASK          _U_(0xFFFF)   /**< \brief (RTC_MODE1_PER) MASK Register */
 
 /* -------- RTC_MODE0_COMP : (RTC Offset: 0x18) (R/W 32) MODE0 MODE0 Compare n Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -882,12 +869,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE0_COMP_OFFSET       0x18         /**< \brief (RTC_MODE0_COMP offset) MODE0 Compare n Value */
-#define RTC_MODE0_COMP_RESETVALUE   0x00000000ul /**< \brief (RTC_MODE0_COMP reset_value) MODE0 Compare n Value */
+#define RTC_MODE0_COMP_RESETVALUE   _U_(0x00000000) /**< \brief (RTC_MODE0_COMP reset_value) MODE0 Compare n Value */
 
 #define RTC_MODE0_COMP_COMP_Pos     0            /**< \brief (RTC_MODE0_COMP) Compare Value */
-#define RTC_MODE0_COMP_COMP_Msk     (0xFFFFFFFFul << RTC_MODE0_COMP_COMP_Pos)
+#define RTC_MODE0_COMP_COMP_Msk     (_U_(0xFFFFFFFF) << RTC_MODE0_COMP_COMP_Pos)
 #define RTC_MODE0_COMP_COMP(value)  (RTC_MODE0_COMP_COMP_Msk & ((value) << RTC_MODE0_COMP_COMP_Pos))
-#define RTC_MODE0_COMP_MASK         0xFFFFFFFFul /**< \brief (RTC_MODE0_COMP) MASK Register */
+#define RTC_MODE0_COMP_MASK         _U_(0xFFFFFFFF) /**< \brief (RTC_MODE0_COMP) MASK Register */
 
 /* -------- RTC_MODE1_COMP : (RTC Offset: 0x18) (R/W 16) MODE1 MODE1 Compare n Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -900,12 +887,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE1_COMP_OFFSET       0x18         /**< \brief (RTC_MODE1_COMP offset) MODE1 Compare n Value */
-#define RTC_MODE1_COMP_RESETVALUE   0x0000ul     /**< \brief (RTC_MODE1_COMP reset_value) MODE1 Compare n Value */
+#define RTC_MODE1_COMP_RESETVALUE   _U_(0x0000)   /**< \brief (RTC_MODE1_COMP reset_value) MODE1 Compare n Value */
 
 #define RTC_MODE1_COMP_COMP_Pos     0            /**< \brief (RTC_MODE1_COMP) Compare Value */
-#define RTC_MODE1_COMP_COMP_Msk     (0xFFFFul << RTC_MODE1_COMP_COMP_Pos)
+#define RTC_MODE1_COMP_COMP_Msk     (_U_(0xFFFF) << RTC_MODE1_COMP_COMP_Pos)
 #define RTC_MODE1_COMP_COMP(value)  (RTC_MODE1_COMP_COMP_Msk & ((value) << RTC_MODE1_COMP_COMP_Pos))
-#define RTC_MODE1_COMP_MASK         0xFFFFul     /**< \brief (RTC_MODE1_COMP) MASK Register */
+#define RTC_MODE1_COMP_MASK         _U_(0xFFFF)   /**< \brief (RTC_MODE1_COMP) MASK Register */
 
 /* -------- RTC_MODE2_ALARM : (RTC Offset: 0x18) (R/W 32) MODE2 MODE2_ALARM Alarm n Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -923,27 +910,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE2_ALARM_OFFSET      0x18         /**< \brief (RTC_MODE2_ALARM offset) MODE2_ALARM Alarm n Value */
-#define RTC_MODE2_ALARM_RESETVALUE  0x00000000ul /**< \brief (RTC_MODE2_ALARM reset_value) MODE2_ALARM Alarm n Value */
+#define RTC_MODE2_ALARM_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE2_ALARM reset_value) MODE2_ALARM Alarm n Value */
 
 #define RTC_MODE2_ALARM_SECOND_Pos  0            /**< \brief (RTC_MODE2_ALARM) Second */
-#define RTC_MODE2_ALARM_SECOND_Msk  (0x3Ful << RTC_MODE2_ALARM_SECOND_Pos)
+#define RTC_MODE2_ALARM_SECOND_Msk  (_U_(0x3F) << RTC_MODE2_ALARM_SECOND_Pos)
 #define RTC_MODE2_ALARM_SECOND(value) (RTC_MODE2_ALARM_SECOND_Msk & ((value) << RTC_MODE2_ALARM_SECOND_Pos))
 #define RTC_MODE2_ALARM_MINUTE_Pos  6            /**< \brief (RTC_MODE2_ALARM) Minute */
-#define RTC_MODE2_ALARM_MINUTE_Msk  (0x3Ful << RTC_MODE2_ALARM_MINUTE_Pos)
+#define RTC_MODE2_ALARM_MINUTE_Msk  (_U_(0x3F) << RTC_MODE2_ALARM_MINUTE_Pos)
 #define RTC_MODE2_ALARM_MINUTE(value) (RTC_MODE2_ALARM_MINUTE_Msk & ((value) << RTC_MODE2_ALARM_MINUTE_Pos))
 #define RTC_MODE2_ALARM_HOUR_Pos    12           /**< \brief (RTC_MODE2_ALARM) Hour */
-#define RTC_MODE2_ALARM_HOUR_Msk    (0x1Ful << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_HOUR_Msk    (_U_(0x1F) << RTC_MODE2_ALARM_HOUR_Pos)
 #define RTC_MODE2_ALARM_HOUR(value) (RTC_MODE2_ALARM_HOUR_Msk & ((value) << RTC_MODE2_ALARM_HOUR_Pos))
+#define   RTC_MODE2_ALARM_HOUR_AM_Val     _U_(0x0)   /**< \brief (RTC_MODE2_ALARM) Morning hour */
+#define   RTC_MODE2_ALARM_HOUR_PM_Val     _U_(0x10)   /**< \brief (RTC_MODE2_ALARM) Afternoon hour */
+#define RTC_MODE2_ALARM_HOUR_AM     (RTC_MODE2_ALARM_HOUR_AM_Val   << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_HOUR_PM     (RTC_MODE2_ALARM_HOUR_PM_Val   << RTC_MODE2_ALARM_HOUR_Pos)
 #define RTC_MODE2_ALARM_DAY_Pos     17           /**< \brief (RTC_MODE2_ALARM) Day */
-#define RTC_MODE2_ALARM_DAY_Msk     (0x1Ful << RTC_MODE2_ALARM_DAY_Pos)
+#define RTC_MODE2_ALARM_DAY_Msk     (_U_(0x1F) << RTC_MODE2_ALARM_DAY_Pos)
 #define RTC_MODE2_ALARM_DAY(value)  (RTC_MODE2_ALARM_DAY_Msk & ((value) << RTC_MODE2_ALARM_DAY_Pos))
 #define RTC_MODE2_ALARM_MONTH_Pos   22           /**< \brief (RTC_MODE2_ALARM) Month */
-#define RTC_MODE2_ALARM_MONTH_Msk   (0xFul << RTC_MODE2_ALARM_MONTH_Pos)
+#define RTC_MODE2_ALARM_MONTH_Msk   (_U_(0xF) << RTC_MODE2_ALARM_MONTH_Pos)
 #define RTC_MODE2_ALARM_MONTH(value) (RTC_MODE2_ALARM_MONTH_Msk & ((value) << RTC_MODE2_ALARM_MONTH_Pos))
 #define RTC_MODE2_ALARM_YEAR_Pos    26           /**< \brief (RTC_MODE2_ALARM) Year */
-#define RTC_MODE2_ALARM_YEAR_Msk    (0x3Ful << RTC_MODE2_ALARM_YEAR_Pos)
+#define RTC_MODE2_ALARM_YEAR_Msk    (_U_(0x3F) << RTC_MODE2_ALARM_YEAR_Pos)
 #define RTC_MODE2_ALARM_YEAR(value) (RTC_MODE2_ALARM_YEAR_Msk & ((value) << RTC_MODE2_ALARM_YEAR_Pos))
-#define RTC_MODE2_ALARM_MASK        0xFFFFFFFFul /**< \brief (RTC_MODE2_ALARM) MASK Register */
+#define RTC_MODE2_ALARM_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE2_ALARM) MASK Register */
 
 /* -------- RTC_MODE2_MASK : (RTC Offset: 0x1C) (R/W  8) MODE2 MODE2_ALARM Alarm n Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -957,18 +948,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MODE2_MASK_OFFSET       0x1C         /**< \brief (RTC_MODE2_MASK offset) MODE2_ALARM Alarm n Mask */
-#define RTC_MODE2_MASK_RESETVALUE   0x00ul       /**< \brief (RTC_MODE2_MASK reset_value) MODE2_ALARM Alarm n Mask */
+#define RTC_MODE2_MASK_RESETVALUE   _U_(0x00)     /**< \brief (RTC_MODE2_MASK reset_value) MODE2_ALARM Alarm n Mask */
 
 #define RTC_MODE2_MASK_SEL_Pos      0            /**< \brief (RTC_MODE2_MASK) Alarm Mask Selection */
-#define RTC_MODE2_MASK_SEL_Msk      (0x7ul << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_Msk      (_U_(0x7) << RTC_MODE2_MASK_SEL_Pos)
 #define RTC_MODE2_MASK_SEL(value)   (RTC_MODE2_MASK_SEL_Msk & ((value) << RTC_MODE2_MASK_SEL_Pos))
-#define   RTC_MODE2_MASK_SEL_OFF_Val      0x0ul  /**< \brief (RTC_MODE2_MASK) Alarm Disabled */
-#define   RTC_MODE2_MASK_SEL_SS_Val       0x1ul  /**< \brief (RTC_MODE2_MASK) Match seconds only */
-#define   RTC_MODE2_MASK_SEL_MMSS_Val     0x2ul  /**< \brief (RTC_MODE2_MASK) Match seconds and minutes only */
-#define   RTC_MODE2_MASK_SEL_HHMMSS_Val   0x3ul  /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, and hours only */
-#define   RTC_MODE2_MASK_SEL_DDHHMMSS_Val 0x4ul  /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only */
-#define   RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val 0x5ul  /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only */
-#define   RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val 0x6ul  /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years */
+#define   RTC_MODE2_MASK_SEL_OFF_Val      _U_(0x0)   /**< \brief (RTC_MODE2_MASK) Alarm Disabled */
+#define   RTC_MODE2_MASK_SEL_SS_Val       _U_(0x1)   /**< \brief (RTC_MODE2_MASK) Match seconds only */
+#define   RTC_MODE2_MASK_SEL_MMSS_Val     _U_(0x2)   /**< \brief (RTC_MODE2_MASK) Match seconds and minutes only */
+#define   RTC_MODE2_MASK_SEL_HHMMSS_Val   _U_(0x3)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, and hours only */
+#define   RTC_MODE2_MASK_SEL_DDHHMMSS_Val _U_(0x4)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only */
+#define   RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val _U_(0x5)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only */
+#define   RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val _U_(0x6)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years */
 #define RTC_MODE2_MASK_SEL_OFF      (RTC_MODE2_MASK_SEL_OFF_Val    << RTC_MODE2_MASK_SEL_Pos)
 #define RTC_MODE2_MASK_SEL_SS       (RTC_MODE2_MASK_SEL_SS_Val     << RTC_MODE2_MASK_SEL_Pos)
 #define RTC_MODE2_MASK_SEL_MMSS     (RTC_MODE2_MASK_SEL_MMSS_Val   << RTC_MODE2_MASK_SEL_Pos)
@@ -976,7 +967,7 @@ typedef union {
 #define RTC_MODE2_MASK_SEL_DDHHMMSS (RTC_MODE2_MASK_SEL_DDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
 #define RTC_MODE2_MASK_SEL_MMDDHHMMSS (RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
 #define RTC_MODE2_MASK_SEL_YYMMDDHHMMSS (RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
-#define RTC_MODE2_MASK_MASK         0x07ul       /**< \brief (RTC_MODE2_MASK) MASK Register */
+#define RTC_MODE2_MASK_MASK         _U_(0x07)     /**< \brief (RTC_MODE2_MASK) MASK Register */
 
 /** \brief RtcMode2Alarm hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/sercom.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for SERCOM
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -80,21 +65,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_CTRLA_OFFSET    0x00         /**< \brief (SERCOM_I2CM_CTRLA offset) I2CM Control A */
-#define SERCOM_I2CM_CTRLA_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_CTRLA reset_value) I2CM Control A */
+#define SERCOM_I2CM_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_CTRLA reset_value) I2CM Control A */
 
 #define SERCOM_I2CM_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_I2CM_CTRLA) Software Reset */
-#define SERCOM_I2CM_CTRLA_SWRST     (0x1ul << SERCOM_I2CM_CTRLA_SWRST_Pos)
+#define SERCOM_I2CM_CTRLA_SWRST     (_U_(0x1) << SERCOM_I2CM_CTRLA_SWRST_Pos)
 #define SERCOM_I2CM_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_I2CM_CTRLA) Enable */
-#define SERCOM_I2CM_CTRLA_ENABLE    (0x1ul << SERCOM_I2CM_CTRLA_ENABLE_Pos)
+#define SERCOM_I2CM_CTRLA_ENABLE    (_U_(0x1) << SERCOM_I2CM_CTRLA_ENABLE_Pos)
 #define SERCOM_I2CM_CTRLA_MODE_Pos  2            /**< \brief (SERCOM_I2CM_CTRLA) Operating Mode */
-#define SERCOM_I2CM_CTRLA_MODE_Msk  (0x7ul << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_Msk  (_U_(0x7) << SERCOM_I2CM_CTRLA_MODE_Pos)
 #define SERCOM_I2CM_CTRLA_MODE(value) (SERCOM_I2CM_CTRLA_MODE_Msk & ((value) << SERCOM_I2CM_CTRLA_MODE_Pos))
-#define   SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK_Val 0x0ul  /**< \brief (SERCOM_I2CM_CTRLA) USART mode with external clock */
-#define   SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK_Val 0x1ul  /**< \brief (SERCOM_I2CM_CTRLA) USART mode with internal clock */
-#define   SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE_Val 0x2ul  /**< \brief (SERCOM_I2CM_CTRLA) SPI mode with external clock */
-#define   SERCOM_I2CM_CTRLA_MODE_SPI_MASTER_Val 0x3ul  /**< \brief (SERCOM_I2CM_CTRLA) SPI mode with internal clock */
-#define   SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE_Val 0x4ul  /**< \brief (SERCOM_I2CM_CTRLA) I2C mode with external clock */
-#define   SERCOM_I2CM_CTRLA_MODE_I2C_MASTER_Val 0x5ul  /**< \brief (SERCOM_I2CM_CTRLA) I2C mode with internal clock */
+#define   SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_I2CM_CTRLA) USART mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_I2CM_CTRLA) USART mode with internal clock */
+#define   SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_I2CM_CTRLA) SPI mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_I2CM_CTRLA) SPI mode with internal clock */
+#define   SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_I2CM_CTRLA) I2C mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_I2CM_CTRLA) I2C mode with internal clock */
 #define SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK (SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
 #define SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK (SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
 #define SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE (SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
@@ -102,27 +87,27 @@ typedef union {
 #define SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE (SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
 #define SERCOM_I2CM_CTRLA_MODE_I2C_MASTER (SERCOM_I2CM_CTRLA_MODE_I2C_MASTER_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
 #define SERCOM_I2CM_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_I2CM_CTRLA) Run in Standby */
-#define SERCOM_I2CM_CTRLA_RUNSTDBY  (0x1ul << SERCOM_I2CM_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_I2CM_CTRLA_RUNSTDBY  (_U_(0x1) << SERCOM_I2CM_CTRLA_RUNSTDBY_Pos)
 #define SERCOM_I2CM_CTRLA_PINOUT_Pos 16           /**< \brief (SERCOM_I2CM_CTRLA) Pin Usage */
-#define SERCOM_I2CM_CTRLA_PINOUT    (0x1ul << SERCOM_I2CM_CTRLA_PINOUT_Pos)
+#define SERCOM_I2CM_CTRLA_PINOUT    (_U_(0x1) << SERCOM_I2CM_CTRLA_PINOUT_Pos)
 #define SERCOM_I2CM_CTRLA_SDAHOLD_Pos 20           /**< \brief (SERCOM_I2CM_CTRLA) SDA Hold Time */
-#define SERCOM_I2CM_CTRLA_SDAHOLD_Msk (0x3ul << SERCOM_I2CM_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Msk (_U_(0x3) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos)
 #define SERCOM_I2CM_CTRLA_SDAHOLD(value) (SERCOM_I2CM_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos))
 #define SERCOM_I2CM_CTRLA_MEXTTOEN_Pos 22           /**< \brief (SERCOM_I2CM_CTRLA) Master SCL Low Extend Timeout */
-#define SERCOM_I2CM_CTRLA_MEXTTOEN  (0x1ul << SERCOM_I2CM_CTRLA_MEXTTOEN_Pos)
+#define SERCOM_I2CM_CTRLA_MEXTTOEN  (_U_(0x1) << SERCOM_I2CM_CTRLA_MEXTTOEN_Pos)
 #define SERCOM_I2CM_CTRLA_SEXTTOEN_Pos 23           /**< \brief (SERCOM_I2CM_CTRLA) Slave SCL Low Extend Timeout */
-#define SERCOM_I2CM_CTRLA_SEXTTOEN  (0x1ul << SERCOM_I2CM_CTRLA_SEXTTOEN_Pos)
+#define SERCOM_I2CM_CTRLA_SEXTTOEN  (_U_(0x1) << SERCOM_I2CM_CTRLA_SEXTTOEN_Pos)
 #define SERCOM_I2CM_CTRLA_SPEED_Pos 24           /**< \brief (SERCOM_I2CM_CTRLA) Transfer Speed */
-#define SERCOM_I2CM_CTRLA_SPEED_Msk (0x3ul << SERCOM_I2CM_CTRLA_SPEED_Pos)
+#define SERCOM_I2CM_CTRLA_SPEED_Msk (_U_(0x3) << SERCOM_I2CM_CTRLA_SPEED_Pos)
 #define SERCOM_I2CM_CTRLA_SPEED(value) (SERCOM_I2CM_CTRLA_SPEED_Msk & ((value) << SERCOM_I2CM_CTRLA_SPEED_Pos))
 #define SERCOM_I2CM_CTRLA_SCLSM_Pos 27           /**< \brief (SERCOM_I2CM_CTRLA) SCL Clock Stretch Mode */
-#define SERCOM_I2CM_CTRLA_SCLSM     (0x1ul << SERCOM_I2CM_CTRLA_SCLSM_Pos)
+#define SERCOM_I2CM_CTRLA_SCLSM     (_U_(0x1) << SERCOM_I2CM_CTRLA_SCLSM_Pos)
 #define SERCOM_I2CM_CTRLA_INACTOUT_Pos 28           /**< \brief (SERCOM_I2CM_CTRLA) Inactive Time-Out */
-#define SERCOM_I2CM_CTRLA_INACTOUT_Msk (0x3ul << SERCOM_I2CM_CTRLA_INACTOUT_Pos)
+#define SERCOM_I2CM_CTRLA_INACTOUT_Msk (_U_(0x3) << SERCOM_I2CM_CTRLA_INACTOUT_Pos)
 #define SERCOM_I2CM_CTRLA_INACTOUT(value) (SERCOM_I2CM_CTRLA_INACTOUT_Msk & ((value) << SERCOM_I2CM_CTRLA_INACTOUT_Pos))
 #define SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos 30           /**< \brief (SERCOM_I2CM_CTRLA) SCL Low Timeout Enable */
-#define SERCOM_I2CM_CTRLA_LOWTOUTEN (0x1ul << SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos)
-#define SERCOM_I2CM_CTRLA_MASK      0x7BF1009Ful /**< \brief (SERCOM_I2CM_CTRLA) MASK Register */
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN (_U_(0x1) << SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos)
+#define SERCOM_I2CM_CTRLA_MASK      _U_(0x7BF1009F) /**< \brief (SERCOM_I2CM_CTRLA) MASK Register */
 
 /* -------- SERCOM_I2CS_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CS I2CS Control A -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -151,21 +136,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_CTRLA_OFFSET    0x00         /**< \brief (SERCOM_I2CS_CTRLA offset) I2CS Control A */
-#define SERCOM_I2CS_CTRLA_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CS_CTRLA reset_value) I2CS Control A */
+#define SERCOM_I2CS_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_CTRLA reset_value) I2CS Control A */
 
 #define SERCOM_I2CS_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_I2CS_CTRLA) Software Reset */
-#define SERCOM_I2CS_CTRLA_SWRST     (0x1ul << SERCOM_I2CS_CTRLA_SWRST_Pos)
+#define SERCOM_I2CS_CTRLA_SWRST     (_U_(0x1) << SERCOM_I2CS_CTRLA_SWRST_Pos)
 #define SERCOM_I2CS_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_I2CS_CTRLA) Enable */
-#define SERCOM_I2CS_CTRLA_ENABLE    (0x1ul << SERCOM_I2CS_CTRLA_ENABLE_Pos)
+#define SERCOM_I2CS_CTRLA_ENABLE    (_U_(0x1) << SERCOM_I2CS_CTRLA_ENABLE_Pos)
 #define SERCOM_I2CS_CTRLA_MODE_Pos  2            /**< \brief (SERCOM_I2CS_CTRLA) Operating Mode */
-#define SERCOM_I2CS_CTRLA_MODE_Msk  (0x7ul << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_Msk  (_U_(0x7) << SERCOM_I2CS_CTRLA_MODE_Pos)
 #define SERCOM_I2CS_CTRLA_MODE(value) (SERCOM_I2CS_CTRLA_MODE_Msk & ((value) << SERCOM_I2CS_CTRLA_MODE_Pos))
-#define   SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK_Val 0x0ul  /**< \brief (SERCOM_I2CS_CTRLA) USART mode with external clock */
-#define   SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK_Val 0x1ul  /**< \brief (SERCOM_I2CS_CTRLA) USART mode with internal clock */
-#define   SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE_Val 0x2ul  /**< \brief (SERCOM_I2CS_CTRLA) SPI mode with external clock */
-#define   SERCOM_I2CS_CTRLA_MODE_SPI_MASTER_Val 0x3ul  /**< \brief (SERCOM_I2CS_CTRLA) SPI mode with internal clock */
-#define   SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE_Val 0x4ul  /**< \brief (SERCOM_I2CS_CTRLA) I2C mode with external clock */
-#define   SERCOM_I2CS_CTRLA_MODE_I2C_MASTER_Val 0x5ul  /**< \brief (SERCOM_I2CS_CTRLA) I2C mode with internal clock */
+#define   SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_I2CS_CTRLA) USART mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_I2CS_CTRLA) USART mode with internal clock */
+#define   SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_I2CS_CTRLA) SPI mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_I2CS_CTRLA) SPI mode with internal clock */
+#define   SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_I2CS_CTRLA) I2C mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_I2CS_CTRLA) I2C mode with internal clock */
 #define SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK (SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
 #define SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK (SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
 #define SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE (SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
@@ -173,22 +158,22 @@ typedef union {
 #define SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE (SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
 #define SERCOM_I2CS_CTRLA_MODE_I2C_MASTER (SERCOM_I2CS_CTRLA_MODE_I2C_MASTER_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
 #define SERCOM_I2CS_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_I2CS_CTRLA) Run during Standby */
-#define SERCOM_I2CS_CTRLA_RUNSTDBY  (0x1ul << SERCOM_I2CS_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_I2CS_CTRLA_RUNSTDBY  (_U_(0x1) << SERCOM_I2CS_CTRLA_RUNSTDBY_Pos)
 #define SERCOM_I2CS_CTRLA_PINOUT_Pos 16           /**< \brief (SERCOM_I2CS_CTRLA) Pin Usage */
-#define SERCOM_I2CS_CTRLA_PINOUT    (0x1ul << SERCOM_I2CS_CTRLA_PINOUT_Pos)
+#define SERCOM_I2CS_CTRLA_PINOUT    (_U_(0x1) << SERCOM_I2CS_CTRLA_PINOUT_Pos)
 #define SERCOM_I2CS_CTRLA_SDAHOLD_Pos 20           /**< \brief (SERCOM_I2CS_CTRLA) SDA Hold Time */
-#define SERCOM_I2CS_CTRLA_SDAHOLD_Msk (0x3ul << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Msk (_U_(0x3) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
 #define SERCOM_I2CS_CTRLA_SDAHOLD(value) (SERCOM_I2CS_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos))
 #define SERCOM_I2CS_CTRLA_SEXTTOEN_Pos 23           /**< \brief (SERCOM_I2CS_CTRLA) Slave SCL Low Extend Timeout */
-#define SERCOM_I2CS_CTRLA_SEXTTOEN  (0x1ul << SERCOM_I2CS_CTRLA_SEXTTOEN_Pos)
+#define SERCOM_I2CS_CTRLA_SEXTTOEN  (_U_(0x1) << SERCOM_I2CS_CTRLA_SEXTTOEN_Pos)
 #define SERCOM_I2CS_CTRLA_SPEED_Pos 24           /**< \brief (SERCOM_I2CS_CTRLA) Transfer Speed */
-#define SERCOM_I2CS_CTRLA_SPEED_Msk (0x3ul << SERCOM_I2CS_CTRLA_SPEED_Pos)
+#define SERCOM_I2CS_CTRLA_SPEED_Msk (_U_(0x3) << SERCOM_I2CS_CTRLA_SPEED_Pos)
 #define SERCOM_I2CS_CTRLA_SPEED(value) (SERCOM_I2CS_CTRLA_SPEED_Msk & ((value) << SERCOM_I2CS_CTRLA_SPEED_Pos))
 #define SERCOM_I2CS_CTRLA_SCLSM_Pos 27           /**< \brief (SERCOM_I2CS_CTRLA) SCL Clock Stretch Mode */
-#define SERCOM_I2CS_CTRLA_SCLSM     (0x1ul << SERCOM_I2CS_CTRLA_SCLSM_Pos)
+#define SERCOM_I2CS_CTRLA_SCLSM     (_U_(0x1) << SERCOM_I2CS_CTRLA_SCLSM_Pos)
 #define SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos 30           /**< \brief (SERCOM_I2CS_CTRLA) SCL Low Timeout Enable */
-#define SERCOM_I2CS_CTRLA_LOWTOUTEN (0x1ul << SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos)
-#define SERCOM_I2CS_CTRLA_MASK      0x4BB1009Ful /**< \brief (SERCOM_I2CS_CTRLA) MASK Register */
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN (_U_(0x1) << SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos)
+#define SERCOM_I2CS_CTRLA_MASK      _U_(0x4BB1009F) /**< \brief (SERCOM_I2CS_CTRLA) MASK Register */
 
 /* -------- SERCOM_SPI_CTRLA : (SERCOM Offset: 0x00) (R/W 32) SPI SPI Control A -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -216,21 +201,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_CTRLA_OFFSET     0x00         /**< \brief (SERCOM_SPI_CTRLA offset) SPI Control A */
-#define SERCOM_SPI_CTRLA_RESETVALUE 0x00000000ul /**< \brief (SERCOM_SPI_CTRLA reset_value) SPI Control A */
+#define SERCOM_SPI_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_SPI_CTRLA reset_value) SPI Control A */
 
 #define SERCOM_SPI_CTRLA_SWRST_Pos  0            /**< \brief (SERCOM_SPI_CTRLA) Software Reset */
-#define SERCOM_SPI_CTRLA_SWRST      (0x1ul << SERCOM_SPI_CTRLA_SWRST_Pos)
+#define SERCOM_SPI_CTRLA_SWRST      (_U_(0x1) << SERCOM_SPI_CTRLA_SWRST_Pos)
 #define SERCOM_SPI_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_SPI_CTRLA) Enable */
-#define SERCOM_SPI_CTRLA_ENABLE     (0x1ul << SERCOM_SPI_CTRLA_ENABLE_Pos)
+#define SERCOM_SPI_CTRLA_ENABLE     (_U_(0x1) << SERCOM_SPI_CTRLA_ENABLE_Pos)
 #define SERCOM_SPI_CTRLA_MODE_Pos   2            /**< \brief (SERCOM_SPI_CTRLA) Operating Mode */
-#define SERCOM_SPI_CTRLA_MODE_Msk   (0x7ul << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_Msk   (_U_(0x7) << SERCOM_SPI_CTRLA_MODE_Pos)
 #define SERCOM_SPI_CTRLA_MODE(value) (SERCOM_SPI_CTRLA_MODE_Msk & ((value) << SERCOM_SPI_CTRLA_MODE_Pos))
-#define   SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK_Val 0x0ul  /**< \brief (SERCOM_SPI_CTRLA) USART mode with external clock */
-#define   SERCOM_SPI_CTRLA_MODE_USART_INT_CLK_Val 0x1ul  /**< \brief (SERCOM_SPI_CTRLA) USART mode with internal clock */
-#define   SERCOM_SPI_CTRLA_MODE_SPI_SLAVE_Val 0x2ul  /**< \brief (SERCOM_SPI_CTRLA) SPI mode with external clock */
-#define   SERCOM_SPI_CTRLA_MODE_SPI_MASTER_Val 0x3ul  /**< \brief (SERCOM_SPI_CTRLA) SPI mode with internal clock */
-#define   SERCOM_SPI_CTRLA_MODE_I2C_SLAVE_Val 0x4ul  /**< \brief (SERCOM_SPI_CTRLA) I2C mode with external clock */
-#define   SERCOM_SPI_CTRLA_MODE_I2C_MASTER_Val 0x5ul  /**< \brief (SERCOM_SPI_CTRLA) I2C mode with internal clock */
+#define   SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_SPI_CTRLA) USART mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_SPI_CTRLA) USART mode with internal clock */
+#define   SERCOM_SPI_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_SPI_CTRLA) SPI mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_SPI_CTRLA) SPI mode with internal clock */
+#define   SERCOM_SPI_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_SPI_CTRLA) I2C mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_SPI_CTRLA) I2C mode with internal clock */
 #define SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK (SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_SPI_CTRLA_MODE_Pos)
 #define SERCOM_SPI_CTRLA_MODE_USART_INT_CLK (SERCOM_SPI_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_SPI_CTRLA_MODE_Pos)
 #define SERCOM_SPI_CTRLA_MODE_SPI_SLAVE (SERCOM_SPI_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_SPI_CTRLA_MODE_Pos)
@@ -238,25 +223,25 @@ typedef union {
 #define SERCOM_SPI_CTRLA_MODE_I2C_SLAVE (SERCOM_SPI_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_SPI_CTRLA_MODE_Pos)
 #define SERCOM_SPI_CTRLA_MODE_I2C_MASTER (SERCOM_SPI_CTRLA_MODE_I2C_MASTER_Val << SERCOM_SPI_CTRLA_MODE_Pos)
 #define SERCOM_SPI_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_SPI_CTRLA) Run during Standby */
-#define SERCOM_SPI_CTRLA_RUNSTDBY   (0x1ul << SERCOM_SPI_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_SPI_CTRLA_RUNSTDBY   (_U_(0x1) << SERCOM_SPI_CTRLA_RUNSTDBY_Pos)
 #define SERCOM_SPI_CTRLA_IBON_Pos   8            /**< \brief (SERCOM_SPI_CTRLA) Immediate Buffer Overflow Notification */
-#define SERCOM_SPI_CTRLA_IBON       (0x1ul << SERCOM_SPI_CTRLA_IBON_Pos)
+#define SERCOM_SPI_CTRLA_IBON       (_U_(0x1) << SERCOM_SPI_CTRLA_IBON_Pos)
 #define SERCOM_SPI_CTRLA_DOPO_Pos   16           /**< \brief (SERCOM_SPI_CTRLA) Data Out Pinout */
-#define SERCOM_SPI_CTRLA_DOPO_Msk   (0x3ul << SERCOM_SPI_CTRLA_DOPO_Pos)
+#define SERCOM_SPI_CTRLA_DOPO_Msk   (_U_(0x3) << SERCOM_SPI_CTRLA_DOPO_Pos)
 #define SERCOM_SPI_CTRLA_DOPO(value) (SERCOM_SPI_CTRLA_DOPO_Msk & ((value) << SERCOM_SPI_CTRLA_DOPO_Pos))
 #define SERCOM_SPI_CTRLA_DIPO_Pos   20           /**< \brief (SERCOM_SPI_CTRLA) Data In Pinout */
-#define SERCOM_SPI_CTRLA_DIPO_Msk   (0x3ul << SERCOM_SPI_CTRLA_DIPO_Pos)
+#define SERCOM_SPI_CTRLA_DIPO_Msk   (_U_(0x3) << SERCOM_SPI_CTRLA_DIPO_Pos)
 #define SERCOM_SPI_CTRLA_DIPO(value) (SERCOM_SPI_CTRLA_DIPO_Msk & ((value) << SERCOM_SPI_CTRLA_DIPO_Pos))
 #define SERCOM_SPI_CTRLA_FORM_Pos   24           /**< \brief (SERCOM_SPI_CTRLA) Frame Format */
-#define SERCOM_SPI_CTRLA_FORM_Msk   (0xFul << SERCOM_SPI_CTRLA_FORM_Pos)
+#define SERCOM_SPI_CTRLA_FORM_Msk   (_U_(0xF) << SERCOM_SPI_CTRLA_FORM_Pos)
 #define SERCOM_SPI_CTRLA_FORM(value) (SERCOM_SPI_CTRLA_FORM_Msk & ((value) << SERCOM_SPI_CTRLA_FORM_Pos))
 #define SERCOM_SPI_CTRLA_CPHA_Pos   28           /**< \brief (SERCOM_SPI_CTRLA) Clock Phase */
-#define SERCOM_SPI_CTRLA_CPHA       (0x1ul << SERCOM_SPI_CTRLA_CPHA_Pos)
+#define SERCOM_SPI_CTRLA_CPHA       (_U_(0x1) << SERCOM_SPI_CTRLA_CPHA_Pos)
 #define SERCOM_SPI_CTRLA_CPOL_Pos   29           /**< \brief (SERCOM_SPI_CTRLA) Clock Polarity */
-#define SERCOM_SPI_CTRLA_CPOL       (0x1ul << SERCOM_SPI_CTRLA_CPOL_Pos)
+#define SERCOM_SPI_CTRLA_CPOL       (_U_(0x1) << SERCOM_SPI_CTRLA_CPOL_Pos)
 #define SERCOM_SPI_CTRLA_DORD_Pos   30           /**< \brief (SERCOM_SPI_CTRLA) Data Order */
-#define SERCOM_SPI_CTRLA_DORD       (0x1ul << SERCOM_SPI_CTRLA_DORD_Pos)
-#define SERCOM_SPI_CTRLA_MASK       0x7F33019Ful /**< \brief (SERCOM_SPI_CTRLA) MASK Register */
+#define SERCOM_SPI_CTRLA_DORD       (_U_(0x1) << SERCOM_SPI_CTRLA_DORD_Pos)
+#define SERCOM_SPI_CTRLA_MASK       _U_(0x7F33019F) /**< \brief (SERCOM_SPI_CTRLA) MASK Register */
 
 /* -------- SERCOM_USART_CTRLA : (SERCOM Offset: 0x00) (R/W 32) USART USART Control A -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -285,21 +270,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_CTRLA_OFFSET   0x00         /**< \brief (SERCOM_USART_CTRLA offset) USART Control A */
-#define SERCOM_USART_CTRLA_RESETVALUE 0x00000000ul /**< \brief (SERCOM_USART_CTRLA reset_value) USART Control A */
+#define SERCOM_USART_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_USART_CTRLA reset_value) USART Control A */
 
 #define SERCOM_USART_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_USART_CTRLA) Software Reset */
-#define SERCOM_USART_CTRLA_SWRST    (0x1ul << SERCOM_USART_CTRLA_SWRST_Pos)
+#define SERCOM_USART_CTRLA_SWRST    (_U_(0x1) << SERCOM_USART_CTRLA_SWRST_Pos)
 #define SERCOM_USART_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_USART_CTRLA) Enable */
-#define SERCOM_USART_CTRLA_ENABLE   (0x1ul << SERCOM_USART_CTRLA_ENABLE_Pos)
+#define SERCOM_USART_CTRLA_ENABLE   (_U_(0x1) << SERCOM_USART_CTRLA_ENABLE_Pos)
 #define SERCOM_USART_CTRLA_MODE_Pos 2            /**< \brief (SERCOM_USART_CTRLA) Operating Mode */
-#define SERCOM_USART_CTRLA_MODE_Msk (0x7ul << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_Msk (_U_(0x7) << SERCOM_USART_CTRLA_MODE_Pos)
 #define SERCOM_USART_CTRLA_MODE(value) (SERCOM_USART_CTRLA_MODE_Msk & ((value) << SERCOM_USART_CTRLA_MODE_Pos))
-#define   SERCOM_USART_CTRLA_MODE_USART_EXT_CLK_Val 0x0ul  /**< \brief (SERCOM_USART_CTRLA) USART mode with external clock */
-#define   SERCOM_USART_CTRLA_MODE_USART_INT_CLK_Val 0x1ul  /**< \brief (SERCOM_USART_CTRLA) USART mode with internal clock */
-#define   SERCOM_USART_CTRLA_MODE_SPI_SLAVE_Val 0x2ul  /**< \brief (SERCOM_USART_CTRLA) SPI mode with external clock */
-#define   SERCOM_USART_CTRLA_MODE_SPI_MASTER_Val 0x3ul  /**< \brief (SERCOM_USART_CTRLA) SPI mode with internal clock */
-#define   SERCOM_USART_CTRLA_MODE_I2C_SLAVE_Val 0x4ul  /**< \brief (SERCOM_USART_CTRLA) I2C mode with external clock */
-#define   SERCOM_USART_CTRLA_MODE_I2C_MASTER_Val 0x5ul  /**< \brief (SERCOM_USART_CTRLA) I2C mode with internal clock */
+#define   SERCOM_USART_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) USART mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) USART mode with internal clock */
+#define   SERCOM_USART_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_USART_CTRLA) SPI mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_USART_CTRLA) SPI mode with internal clock */
+#define   SERCOM_USART_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_USART_CTRLA) I2C mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_USART_CTRLA) I2C mode with internal clock */
 #define SERCOM_USART_CTRLA_MODE_USART_EXT_CLK (SERCOM_USART_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_USART_CTRLA_MODE_Pos)
 #define SERCOM_USART_CTRLA_MODE_USART_INT_CLK (SERCOM_USART_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_USART_CTRLA_MODE_Pos)
 #define SERCOM_USART_CTRLA_MODE_SPI_SLAVE (SERCOM_USART_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_USART_CTRLA_MODE_Pos)
@@ -307,31 +292,31 @@ typedef union {
 #define SERCOM_USART_CTRLA_MODE_I2C_SLAVE (SERCOM_USART_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_USART_CTRLA_MODE_Pos)
 #define SERCOM_USART_CTRLA_MODE_I2C_MASTER (SERCOM_USART_CTRLA_MODE_I2C_MASTER_Val << SERCOM_USART_CTRLA_MODE_Pos)
 #define SERCOM_USART_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_USART_CTRLA) Run during Standby */
-#define SERCOM_USART_CTRLA_RUNSTDBY (0x1ul << SERCOM_USART_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_USART_CTRLA_RUNSTDBY (_U_(0x1) << SERCOM_USART_CTRLA_RUNSTDBY_Pos)
 #define SERCOM_USART_CTRLA_IBON_Pos 8            /**< \brief (SERCOM_USART_CTRLA) Immediate Buffer Overflow Notification */
-#define SERCOM_USART_CTRLA_IBON     (0x1ul << SERCOM_USART_CTRLA_IBON_Pos)
+#define SERCOM_USART_CTRLA_IBON     (_U_(0x1) << SERCOM_USART_CTRLA_IBON_Pos)
 #define SERCOM_USART_CTRLA_SAMPR_Pos 13           /**< \brief (SERCOM_USART_CTRLA) Sample */
-#define SERCOM_USART_CTRLA_SAMPR_Msk (0x7ul << SERCOM_USART_CTRLA_SAMPR_Pos)
+#define SERCOM_USART_CTRLA_SAMPR_Msk (_U_(0x7) << SERCOM_USART_CTRLA_SAMPR_Pos)
 #define SERCOM_USART_CTRLA_SAMPR(value) (SERCOM_USART_CTRLA_SAMPR_Msk & ((value) << SERCOM_USART_CTRLA_SAMPR_Pos))
 #define SERCOM_USART_CTRLA_TXPO_Pos 16           /**< \brief (SERCOM_USART_CTRLA) Transmit Data Pinout */
-#define SERCOM_USART_CTRLA_TXPO_Msk (0x3ul << SERCOM_USART_CTRLA_TXPO_Pos)
+#define SERCOM_USART_CTRLA_TXPO_Msk (_U_(0x3) << SERCOM_USART_CTRLA_TXPO_Pos)
 #define SERCOM_USART_CTRLA_TXPO(value) (SERCOM_USART_CTRLA_TXPO_Msk & ((value) << SERCOM_USART_CTRLA_TXPO_Pos))
 #define SERCOM_USART_CTRLA_RXPO_Pos 20           /**< \brief (SERCOM_USART_CTRLA) Receive Data Pinout */
-#define SERCOM_USART_CTRLA_RXPO_Msk (0x3ul << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_Msk (_U_(0x3) << SERCOM_USART_CTRLA_RXPO_Pos)
 #define SERCOM_USART_CTRLA_RXPO(value) (SERCOM_USART_CTRLA_RXPO_Msk & ((value) << SERCOM_USART_CTRLA_RXPO_Pos))
 #define SERCOM_USART_CTRLA_SAMPA_Pos 22           /**< \brief (SERCOM_USART_CTRLA) Sample Adjustment */
-#define SERCOM_USART_CTRLA_SAMPA_Msk (0x3ul << SERCOM_USART_CTRLA_SAMPA_Pos)
+#define SERCOM_USART_CTRLA_SAMPA_Msk (_U_(0x3) << SERCOM_USART_CTRLA_SAMPA_Pos)
 #define SERCOM_USART_CTRLA_SAMPA(value) (SERCOM_USART_CTRLA_SAMPA_Msk & ((value) << SERCOM_USART_CTRLA_SAMPA_Pos))
 #define SERCOM_USART_CTRLA_FORM_Pos 24           /**< \brief (SERCOM_USART_CTRLA) Frame Format */
-#define SERCOM_USART_CTRLA_FORM_Msk (0xFul << SERCOM_USART_CTRLA_FORM_Pos)
+#define SERCOM_USART_CTRLA_FORM_Msk (_U_(0xF) << SERCOM_USART_CTRLA_FORM_Pos)
 #define SERCOM_USART_CTRLA_FORM(value) (SERCOM_USART_CTRLA_FORM_Msk & ((value) << SERCOM_USART_CTRLA_FORM_Pos))
 #define SERCOM_USART_CTRLA_CMODE_Pos 28           /**< \brief (SERCOM_USART_CTRLA) Communication Mode */
-#define SERCOM_USART_CTRLA_CMODE    (0x1ul << SERCOM_USART_CTRLA_CMODE_Pos)
+#define SERCOM_USART_CTRLA_CMODE    (_U_(0x1) << SERCOM_USART_CTRLA_CMODE_Pos)
 #define SERCOM_USART_CTRLA_CPOL_Pos 29           /**< \brief (SERCOM_USART_CTRLA) Clock Polarity */
-#define SERCOM_USART_CTRLA_CPOL     (0x1ul << SERCOM_USART_CTRLA_CPOL_Pos)
+#define SERCOM_USART_CTRLA_CPOL     (_U_(0x1) << SERCOM_USART_CTRLA_CPOL_Pos)
 #define SERCOM_USART_CTRLA_DORD_Pos 30           /**< \brief (SERCOM_USART_CTRLA) Data Order */
-#define SERCOM_USART_CTRLA_DORD     (0x1ul << SERCOM_USART_CTRLA_DORD_Pos)
-#define SERCOM_USART_CTRLA_MASK     0x7FF3E19Ful /**< \brief (SERCOM_USART_CTRLA) MASK Register */
+#define SERCOM_USART_CTRLA_DORD     (_U_(0x1) << SERCOM_USART_CTRLA_DORD_Pos)
+#define SERCOM_USART_CTRLA_MASK     _U_(0x7FF3E19F) /**< \brief (SERCOM_USART_CTRLA) MASK Register */
 
 /* -------- SERCOM_I2CM_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CM I2CM Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -350,18 +335,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_CTRLB_OFFSET    0x04         /**< \brief (SERCOM_I2CM_CTRLB offset) I2CM Control B */
-#define SERCOM_I2CM_CTRLB_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_CTRLB reset_value) I2CM Control B */
+#define SERCOM_I2CM_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_CTRLB reset_value) I2CM Control B */
 
 #define SERCOM_I2CM_CTRLB_SMEN_Pos  8            /**< \brief (SERCOM_I2CM_CTRLB) Smart Mode Enable */
-#define SERCOM_I2CM_CTRLB_SMEN      (0x1ul << SERCOM_I2CM_CTRLB_SMEN_Pos)
+#define SERCOM_I2CM_CTRLB_SMEN      (_U_(0x1) << SERCOM_I2CM_CTRLB_SMEN_Pos)
 #define SERCOM_I2CM_CTRLB_QCEN_Pos  9            /**< \brief (SERCOM_I2CM_CTRLB) Quick Command Enable */
-#define SERCOM_I2CM_CTRLB_QCEN      (0x1ul << SERCOM_I2CM_CTRLB_QCEN_Pos)
+#define SERCOM_I2CM_CTRLB_QCEN      (_U_(0x1) << SERCOM_I2CM_CTRLB_QCEN_Pos)
 #define SERCOM_I2CM_CTRLB_CMD_Pos   16           /**< \brief (SERCOM_I2CM_CTRLB) Command */
-#define SERCOM_I2CM_CTRLB_CMD_Msk   (0x3ul << SERCOM_I2CM_CTRLB_CMD_Pos)
+#define SERCOM_I2CM_CTRLB_CMD_Msk   (_U_(0x3) << SERCOM_I2CM_CTRLB_CMD_Pos)
 #define SERCOM_I2CM_CTRLB_CMD(value) (SERCOM_I2CM_CTRLB_CMD_Msk & ((value) << SERCOM_I2CM_CTRLB_CMD_Pos))
 #define SERCOM_I2CM_CTRLB_ACKACT_Pos 18           /**< \brief (SERCOM_I2CM_CTRLB) Acknowledge Action */
-#define SERCOM_I2CM_CTRLB_ACKACT    (0x1ul << SERCOM_I2CM_CTRLB_ACKACT_Pos)
-#define SERCOM_I2CM_CTRLB_MASK      0x00070300ul /**< \brief (SERCOM_I2CM_CTRLB) MASK Register */
+#define SERCOM_I2CM_CTRLB_ACKACT    (_U_(0x1) << SERCOM_I2CM_CTRLB_ACKACT_Pos)
+#define SERCOM_I2CM_CTRLB_MASK      _U_(0x00070300) /**< \brief (SERCOM_I2CM_CTRLB) MASK Register */
 
 /* -------- SERCOM_I2CS_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CS I2CS Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -382,23 +367,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_CTRLB_OFFSET    0x04         /**< \brief (SERCOM_I2CS_CTRLB offset) I2CS Control B */
-#define SERCOM_I2CS_CTRLB_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CS_CTRLB reset_value) I2CS Control B */
+#define SERCOM_I2CS_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_CTRLB reset_value) I2CS Control B */
 
 #define SERCOM_I2CS_CTRLB_SMEN_Pos  8            /**< \brief (SERCOM_I2CS_CTRLB) Smart Mode Enable */
-#define SERCOM_I2CS_CTRLB_SMEN      (0x1ul << SERCOM_I2CS_CTRLB_SMEN_Pos)
+#define SERCOM_I2CS_CTRLB_SMEN      (_U_(0x1) << SERCOM_I2CS_CTRLB_SMEN_Pos)
 #define SERCOM_I2CS_CTRLB_GCMD_Pos  9            /**< \brief (SERCOM_I2CS_CTRLB) PMBus Group Command */
-#define SERCOM_I2CS_CTRLB_GCMD      (0x1ul << SERCOM_I2CS_CTRLB_GCMD_Pos)
+#define SERCOM_I2CS_CTRLB_GCMD      (_U_(0x1) << SERCOM_I2CS_CTRLB_GCMD_Pos)
 #define SERCOM_I2CS_CTRLB_AACKEN_Pos 10           /**< \brief (SERCOM_I2CS_CTRLB) Automatic Address Acknowledge */
-#define SERCOM_I2CS_CTRLB_AACKEN    (0x1ul << SERCOM_I2CS_CTRLB_AACKEN_Pos)
+#define SERCOM_I2CS_CTRLB_AACKEN    (_U_(0x1) << SERCOM_I2CS_CTRLB_AACKEN_Pos)
 #define SERCOM_I2CS_CTRLB_AMODE_Pos 14           /**< \brief (SERCOM_I2CS_CTRLB) Address Mode */
-#define SERCOM_I2CS_CTRLB_AMODE_Msk (0x3ul << SERCOM_I2CS_CTRLB_AMODE_Pos)
+#define SERCOM_I2CS_CTRLB_AMODE_Msk (_U_(0x3) << SERCOM_I2CS_CTRLB_AMODE_Pos)
 #define SERCOM_I2CS_CTRLB_AMODE(value) (SERCOM_I2CS_CTRLB_AMODE_Msk & ((value) << SERCOM_I2CS_CTRLB_AMODE_Pos))
 #define SERCOM_I2CS_CTRLB_CMD_Pos   16           /**< \brief (SERCOM_I2CS_CTRLB) Command */
-#define SERCOM_I2CS_CTRLB_CMD_Msk   (0x3ul << SERCOM_I2CS_CTRLB_CMD_Pos)
+#define SERCOM_I2CS_CTRLB_CMD_Msk   (_U_(0x3) << SERCOM_I2CS_CTRLB_CMD_Pos)
 #define SERCOM_I2CS_CTRLB_CMD(value) (SERCOM_I2CS_CTRLB_CMD_Msk & ((value) << SERCOM_I2CS_CTRLB_CMD_Pos))
 #define SERCOM_I2CS_CTRLB_ACKACT_Pos 18           /**< \brief (SERCOM_I2CS_CTRLB) Acknowledge Action */
-#define SERCOM_I2CS_CTRLB_ACKACT    (0x1ul << SERCOM_I2CS_CTRLB_ACKACT_Pos)
-#define SERCOM_I2CS_CTRLB_MASK      0x0007C700ul /**< \brief (SERCOM_I2CS_CTRLB) MASK Register */
+#define SERCOM_I2CS_CTRLB_ACKACT    (_U_(0x1) << SERCOM_I2CS_CTRLB_ACKACT_Pos)
+#define SERCOM_I2CS_CTRLB_MASK      _U_(0x0007C700) /**< \brief (SERCOM_I2CS_CTRLB) MASK Register */
 
 /* -------- SERCOM_SPI_CTRLB : (SERCOM Offset: 0x04) (R/W 32) SPI SPI Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -421,23 +406,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_CTRLB_OFFSET     0x04         /**< \brief (SERCOM_SPI_CTRLB offset) SPI Control B */
-#define SERCOM_SPI_CTRLB_RESETVALUE 0x00000000ul /**< \brief (SERCOM_SPI_CTRLB reset_value) SPI Control B */
+#define SERCOM_SPI_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_SPI_CTRLB reset_value) SPI Control B */
 
 #define SERCOM_SPI_CTRLB_CHSIZE_Pos 0            /**< \brief (SERCOM_SPI_CTRLB) Character Size */
-#define SERCOM_SPI_CTRLB_CHSIZE_Msk (0x7ul << SERCOM_SPI_CTRLB_CHSIZE_Pos)
+#define SERCOM_SPI_CTRLB_CHSIZE_Msk (_U_(0x7) << SERCOM_SPI_CTRLB_CHSIZE_Pos)
 #define SERCOM_SPI_CTRLB_CHSIZE(value) (SERCOM_SPI_CTRLB_CHSIZE_Msk & ((value) << SERCOM_SPI_CTRLB_CHSIZE_Pos))
 #define SERCOM_SPI_CTRLB_PLOADEN_Pos 6            /**< \brief (SERCOM_SPI_CTRLB) Data Preload Enable */
-#define SERCOM_SPI_CTRLB_PLOADEN    (0x1ul << SERCOM_SPI_CTRLB_PLOADEN_Pos)
+#define SERCOM_SPI_CTRLB_PLOADEN    (_U_(0x1) << SERCOM_SPI_CTRLB_PLOADEN_Pos)
 #define SERCOM_SPI_CTRLB_SSDE_Pos   9            /**< \brief (SERCOM_SPI_CTRLB) Slave Select Low Detect Enable */
-#define SERCOM_SPI_CTRLB_SSDE       (0x1ul << SERCOM_SPI_CTRLB_SSDE_Pos)
+#define SERCOM_SPI_CTRLB_SSDE       (_U_(0x1) << SERCOM_SPI_CTRLB_SSDE_Pos)
 #define SERCOM_SPI_CTRLB_MSSEN_Pos  13           /**< \brief (SERCOM_SPI_CTRLB) Master Slave Select Enable */
-#define SERCOM_SPI_CTRLB_MSSEN      (0x1ul << SERCOM_SPI_CTRLB_MSSEN_Pos)
+#define SERCOM_SPI_CTRLB_MSSEN      (_U_(0x1) << SERCOM_SPI_CTRLB_MSSEN_Pos)
 #define SERCOM_SPI_CTRLB_AMODE_Pos  14           /**< \brief (SERCOM_SPI_CTRLB) Address Mode */
-#define SERCOM_SPI_CTRLB_AMODE_Msk  (0x3ul << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_AMODE_Msk  (_U_(0x3) << SERCOM_SPI_CTRLB_AMODE_Pos)
 #define SERCOM_SPI_CTRLB_AMODE(value) (SERCOM_SPI_CTRLB_AMODE_Msk & ((value) << SERCOM_SPI_CTRLB_AMODE_Pos))
 #define SERCOM_SPI_CTRLB_RXEN_Pos   17           /**< \brief (SERCOM_SPI_CTRLB) Receiver Enable */
-#define SERCOM_SPI_CTRLB_RXEN       (0x1ul << SERCOM_SPI_CTRLB_RXEN_Pos)
-#define SERCOM_SPI_CTRLB_MASK       0x0002E247ul /**< \brief (SERCOM_SPI_CTRLB) MASK Register */
+#define SERCOM_SPI_CTRLB_RXEN       (_U_(0x1) << SERCOM_SPI_CTRLB_RXEN_Pos)
+#define SERCOM_SPI_CTRLB_MASK       _U_(0x0002E247) /**< \brief (SERCOM_SPI_CTRLB) MASK Register */
 
 /* -------- SERCOM_USART_CTRLB : (SERCOM Offset: 0x04) (R/W 32) USART USART Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -462,26 +447,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_CTRLB_OFFSET   0x04         /**< \brief (SERCOM_USART_CTRLB offset) USART Control B */
-#define SERCOM_USART_CTRLB_RESETVALUE 0x00000000ul /**< \brief (SERCOM_USART_CTRLB reset_value) USART Control B */
+#define SERCOM_USART_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_USART_CTRLB reset_value) USART Control B */
 
 #define SERCOM_USART_CTRLB_CHSIZE_Pos 0            /**< \brief (SERCOM_USART_CTRLB) Character Size */
-#define SERCOM_USART_CTRLB_CHSIZE_Msk (0x7ul << SERCOM_USART_CTRLB_CHSIZE_Pos)
+#define SERCOM_USART_CTRLB_CHSIZE_Msk (_U_(0x7) << SERCOM_USART_CTRLB_CHSIZE_Pos)
 #define SERCOM_USART_CTRLB_CHSIZE(value) (SERCOM_USART_CTRLB_CHSIZE_Msk & ((value) << SERCOM_USART_CTRLB_CHSIZE_Pos))
 #define SERCOM_USART_CTRLB_SBMODE_Pos 6            /**< \brief (SERCOM_USART_CTRLB) Stop Bit Mode */
-#define SERCOM_USART_CTRLB_SBMODE   (0x1ul << SERCOM_USART_CTRLB_SBMODE_Pos)
+#define SERCOM_USART_CTRLB_SBMODE   (_U_(0x1) << SERCOM_USART_CTRLB_SBMODE_Pos)
 #define SERCOM_USART_CTRLB_COLDEN_Pos 8            /**< \brief (SERCOM_USART_CTRLB) Collision Detection Enable */
-#define SERCOM_USART_CTRLB_COLDEN   (0x1ul << SERCOM_USART_CTRLB_COLDEN_Pos)
+#define SERCOM_USART_CTRLB_COLDEN   (_U_(0x1) << SERCOM_USART_CTRLB_COLDEN_Pos)
 #define SERCOM_USART_CTRLB_SFDE_Pos 9            /**< \brief (SERCOM_USART_CTRLB) Start of Frame Detection Enable */
-#define SERCOM_USART_CTRLB_SFDE     (0x1ul << SERCOM_USART_CTRLB_SFDE_Pos)
+#define SERCOM_USART_CTRLB_SFDE     (_U_(0x1) << SERCOM_USART_CTRLB_SFDE_Pos)
 #define SERCOM_USART_CTRLB_ENC_Pos  10           /**< \brief (SERCOM_USART_CTRLB) Encoding Format */
-#define SERCOM_USART_CTRLB_ENC      (0x1ul << SERCOM_USART_CTRLB_ENC_Pos)
+#define SERCOM_USART_CTRLB_ENC      (_U_(0x1) << SERCOM_USART_CTRLB_ENC_Pos)
 #define SERCOM_USART_CTRLB_PMODE_Pos 13           /**< \brief (SERCOM_USART_CTRLB) Parity Mode */
-#define SERCOM_USART_CTRLB_PMODE    (0x1ul << SERCOM_USART_CTRLB_PMODE_Pos)
+#define SERCOM_USART_CTRLB_PMODE    (_U_(0x1) << SERCOM_USART_CTRLB_PMODE_Pos)
 #define SERCOM_USART_CTRLB_TXEN_Pos 16           /**< \brief (SERCOM_USART_CTRLB) Transmitter Enable */
-#define SERCOM_USART_CTRLB_TXEN     (0x1ul << SERCOM_USART_CTRLB_TXEN_Pos)
+#define SERCOM_USART_CTRLB_TXEN     (_U_(0x1) << SERCOM_USART_CTRLB_TXEN_Pos)
 #define SERCOM_USART_CTRLB_RXEN_Pos 17           /**< \brief (SERCOM_USART_CTRLB) Receiver Enable */
-#define SERCOM_USART_CTRLB_RXEN     (0x1ul << SERCOM_USART_CTRLB_RXEN_Pos)
-#define SERCOM_USART_CTRLB_MASK     0x00032747ul /**< \brief (SERCOM_USART_CTRLB) MASK Register */
+#define SERCOM_USART_CTRLB_RXEN     (_U_(0x1) << SERCOM_USART_CTRLB_RXEN_Pos)
+#define SERCOM_USART_CTRLB_MASK     _U_(0x00032747) /**< \brief (SERCOM_USART_CTRLB) MASK Register */
 
 /* -------- SERCOM_I2CM_BAUD : (SERCOM Offset: 0x0C) (R/W 32) I2CM I2CM Baud Rate -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -497,21 +482,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_BAUD_OFFSET     0x0C         /**< \brief (SERCOM_I2CM_BAUD offset) I2CM Baud Rate */
-#define SERCOM_I2CM_BAUD_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_BAUD reset_value) I2CM Baud Rate */
+#define SERCOM_I2CM_BAUD_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_BAUD reset_value) I2CM Baud Rate */
 
 #define SERCOM_I2CM_BAUD_BAUD_Pos   0            /**< \brief (SERCOM_I2CM_BAUD) Baud Rate Value */
-#define SERCOM_I2CM_BAUD_BAUD_Msk   (0xFFul << SERCOM_I2CM_BAUD_BAUD_Pos)
+#define SERCOM_I2CM_BAUD_BAUD_Msk   (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUD_Pos)
 #define SERCOM_I2CM_BAUD_BAUD(value) (SERCOM_I2CM_BAUD_BAUD_Msk & ((value) << SERCOM_I2CM_BAUD_BAUD_Pos))
 #define SERCOM_I2CM_BAUD_BAUDLOW_Pos 8            /**< \brief (SERCOM_I2CM_BAUD) Baud Rate Value Low */
-#define SERCOM_I2CM_BAUD_BAUDLOW_Msk (0xFFul << SERCOM_I2CM_BAUD_BAUDLOW_Pos)
+#define SERCOM_I2CM_BAUD_BAUDLOW_Msk (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUDLOW_Pos)
 #define SERCOM_I2CM_BAUD_BAUDLOW(value) (SERCOM_I2CM_BAUD_BAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_BAUDLOW_Pos))
 #define SERCOM_I2CM_BAUD_HSBAUD_Pos 16           /**< \brief (SERCOM_I2CM_BAUD) High Speed Baud Rate Value */
-#define SERCOM_I2CM_BAUD_HSBAUD_Msk (0xFFul << SERCOM_I2CM_BAUD_HSBAUD_Pos)
+#define SERCOM_I2CM_BAUD_HSBAUD_Msk (_U_(0xFF) << SERCOM_I2CM_BAUD_HSBAUD_Pos)
 #define SERCOM_I2CM_BAUD_HSBAUD(value) (SERCOM_I2CM_BAUD_HSBAUD_Msk & ((value) << SERCOM_I2CM_BAUD_HSBAUD_Pos))
 #define SERCOM_I2CM_BAUD_HSBAUDLOW_Pos 24           /**< \brief (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Low */
-#define SERCOM_I2CM_BAUD_HSBAUDLOW_Msk (0xFFul << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos)
+#define SERCOM_I2CM_BAUD_HSBAUDLOW_Msk (_U_(0xFF) << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos)
 #define SERCOM_I2CM_BAUD_HSBAUDLOW(value) (SERCOM_I2CM_BAUD_HSBAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos))
-#define SERCOM_I2CM_BAUD_MASK       0xFFFFFFFFul /**< \brief (SERCOM_I2CM_BAUD) MASK Register */
+#define SERCOM_I2CM_BAUD_MASK       _U_(0xFFFFFFFF) /**< \brief (SERCOM_I2CM_BAUD) MASK Register */
 
 /* -------- SERCOM_SPI_BAUD : (SERCOM Offset: 0x0C) (R/W  8) SPI SPI Baud Rate -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -524,12 +509,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_BAUD_OFFSET      0x0C         /**< \brief (SERCOM_SPI_BAUD offset) SPI Baud Rate */
-#define SERCOM_SPI_BAUD_RESETVALUE  0x00ul       /**< \brief (SERCOM_SPI_BAUD reset_value) SPI Baud Rate */
+#define SERCOM_SPI_BAUD_RESETVALUE  _U_(0x00)     /**< \brief (SERCOM_SPI_BAUD reset_value) SPI Baud Rate */
 
 #define SERCOM_SPI_BAUD_BAUD_Pos    0            /**< \brief (SERCOM_SPI_BAUD) Baud Rate Value */
-#define SERCOM_SPI_BAUD_BAUD_Msk    (0xFFul << SERCOM_SPI_BAUD_BAUD_Pos)
+#define SERCOM_SPI_BAUD_BAUD_Msk    (_U_(0xFF) << SERCOM_SPI_BAUD_BAUD_Pos)
 #define SERCOM_SPI_BAUD_BAUD(value) (SERCOM_SPI_BAUD_BAUD_Msk & ((value) << SERCOM_SPI_BAUD_BAUD_Pos))
-#define SERCOM_SPI_BAUD_MASK        0xFFul       /**< \brief (SERCOM_SPI_BAUD) MASK Register */
+#define SERCOM_SPI_BAUD_MASK        _U_(0xFF)     /**< \brief (SERCOM_SPI_BAUD) MASK Register */
 
 /* -------- SERCOM_USART_BAUD : (SERCOM Offset: 0x0C) (R/W 16) USART USART Baud Rate -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -553,36 +538,36 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_BAUD_OFFSET    0x0C         /**< \brief (SERCOM_USART_BAUD offset) USART Baud Rate */
-#define SERCOM_USART_BAUD_RESETVALUE 0x0000ul     /**< \brief (SERCOM_USART_BAUD reset_value) USART Baud Rate */
+#define SERCOM_USART_BAUD_RESETVALUE _U_(0x0000)   /**< \brief (SERCOM_USART_BAUD reset_value) USART Baud Rate */
 
 #define SERCOM_USART_BAUD_BAUD_Pos  0            /**< \brief (SERCOM_USART_BAUD) Baud Rate Value */
-#define SERCOM_USART_BAUD_BAUD_Msk  (0xFFFFul << SERCOM_USART_BAUD_BAUD_Pos)
+#define SERCOM_USART_BAUD_BAUD_Msk  (_U_(0xFFFF) << SERCOM_USART_BAUD_BAUD_Pos)
 #define SERCOM_USART_BAUD_BAUD(value) (SERCOM_USART_BAUD_BAUD_Msk & ((value) << SERCOM_USART_BAUD_BAUD_Pos))
-#define SERCOM_USART_BAUD_MASK      0xFFFFul     /**< \brief (SERCOM_USART_BAUD) MASK Register */
+#define SERCOM_USART_BAUD_MASK      _U_(0xFFFF)   /**< \brief (SERCOM_USART_BAUD) MASK Register */
 
 // FRAC mode
 #define SERCOM_USART_BAUD_FRAC_BAUD_Pos 0            /**< \brief (SERCOM_USART_BAUD_FRAC) Baud Rate Value */
-#define SERCOM_USART_BAUD_FRAC_BAUD_Msk (0x1FFFul << SERCOM_USART_BAUD_FRAC_BAUD_Pos)
+#define SERCOM_USART_BAUD_FRAC_BAUD_Msk (_U_(0x1FFF) << SERCOM_USART_BAUD_FRAC_BAUD_Pos)
 #define SERCOM_USART_BAUD_FRAC_BAUD(value) (SERCOM_USART_BAUD_FRAC_BAUD_Msk & ((value) << SERCOM_USART_BAUD_FRAC_BAUD_Pos))
 #define SERCOM_USART_BAUD_FRAC_FP_Pos 13           /**< \brief (SERCOM_USART_BAUD_FRAC) Fractional Part */
-#define SERCOM_USART_BAUD_FRAC_FP_Msk (0x7ul << SERCOM_USART_BAUD_FRAC_FP_Pos)
+#define SERCOM_USART_BAUD_FRAC_FP_Msk (_U_(0x7) << SERCOM_USART_BAUD_FRAC_FP_Pos)
 #define SERCOM_USART_BAUD_FRAC_FP(value) (SERCOM_USART_BAUD_FRAC_FP_Msk & ((value) << SERCOM_USART_BAUD_FRAC_FP_Pos))
-#define SERCOM_USART_BAUD_FRAC_MASK 0xFFFFul     /**< \brief (SERCOM_USART_BAUD_FRAC) MASK Register */
+#define SERCOM_USART_BAUD_FRAC_MASK _U_(0xFFFF)   /**< \brief (SERCOM_USART_BAUD_FRAC) MASK Register */
 
 // FRACFP mode
 #define SERCOM_USART_BAUD_FRACFP_BAUD_Pos 0            /**< \brief (SERCOM_USART_BAUD_FRACFP) Baud Rate Value */
-#define SERCOM_USART_BAUD_FRACFP_BAUD_Msk (0x1FFFul << SERCOM_USART_BAUD_FRACFP_BAUD_Pos)
+#define SERCOM_USART_BAUD_FRACFP_BAUD_Msk (_U_(0x1FFF) << SERCOM_USART_BAUD_FRACFP_BAUD_Pos)
 #define SERCOM_USART_BAUD_FRACFP_BAUD(value) (SERCOM_USART_BAUD_FRACFP_BAUD_Msk & ((value) << SERCOM_USART_BAUD_FRACFP_BAUD_Pos))
 #define SERCOM_USART_BAUD_FRACFP_FP_Pos 13           /**< \brief (SERCOM_USART_BAUD_FRACFP) Fractional Part */
-#define SERCOM_USART_BAUD_FRACFP_FP_Msk (0x7ul << SERCOM_USART_BAUD_FRACFP_FP_Pos)
+#define SERCOM_USART_BAUD_FRACFP_FP_Msk (_U_(0x7) << SERCOM_USART_BAUD_FRACFP_FP_Pos)
 #define SERCOM_USART_BAUD_FRACFP_FP(value) (SERCOM_USART_BAUD_FRACFP_FP_Msk & ((value) << SERCOM_USART_BAUD_FRACFP_FP_Pos))
-#define SERCOM_USART_BAUD_FRACFP_MASK 0xFFFFul     /**< \brief (SERCOM_USART_BAUD_FRACFP) MASK Register */
+#define SERCOM_USART_BAUD_FRACFP_MASK _U_(0xFFFF)   /**< \brief (SERCOM_USART_BAUD_FRACFP) MASK Register */
 
 // USARTFP mode
 #define SERCOM_USART_BAUD_USARTFP_BAUD_Pos 0            /**< \brief (SERCOM_USART_BAUD_USARTFP) Baud Rate Value */
-#define SERCOM_USART_BAUD_USARTFP_BAUD_Msk (0xFFFFul << SERCOM_USART_BAUD_USARTFP_BAUD_Pos)
+#define SERCOM_USART_BAUD_USARTFP_BAUD_Msk (_U_(0xFFFF) << SERCOM_USART_BAUD_USARTFP_BAUD_Pos)
 #define SERCOM_USART_BAUD_USARTFP_BAUD(value) (SERCOM_USART_BAUD_USARTFP_BAUD_Msk & ((value) << SERCOM_USART_BAUD_USARTFP_BAUD_Pos))
-#define SERCOM_USART_BAUD_USARTFP_MASK 0xFFFFul     /**< \brief (SERCOM_USART_BAUD_USARTFP) MASK Register */
+#define SERCOM_USART_BAUD_USARTFP_MASK _U_(0xFFFF)   /**< \brief (SERCOM_USART_BAUD_USARTFP) MASK Register */
 
 /* -------- SERCOM_USART_RXPL : (SERCOM Offset: 0x0E) (R/W  8) USART USART Receive Pulse Length -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -595,12 +580,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_RXPL_OFFSET    0x0E         /**< \brief (SERCOM_USART_RXPL offset) USART Receive Pulse Length */
-#define SERCOM_USART_RXPL_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_RXPL reset_value) USART Receive Pulse Length */
+#define SERCOM_USART_RXPL_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_USART_RXPL reset_value) USART Receive Pulse Length */
 
 #define SERCOM_USART_RXPL_RXPL_Pos  0            /**< \brief (SERCOM_USART_RXPL) Receive Pulse Length */
-#define SERCOM_USART_RXPL_RXPL_Msk  (0xFFul << SERCOM_USART_RXPL_RXPL_Pos)
+#define SERCOM_USART_RXPL_RXPL_Msk  (_U_(0xFF) << SERCOM_USART_RXPL_RXPL_Pos)
 #define SERCOM_USART_RXPL_RXPL(value) (SERCOM_USART_RXPL_RXPL_Msk & ((value) << SERCOM_USART_RXPL_RXPL_Pos))
-#define SERCOM_USART_RXPL_MASK      0xFFul       /**< \brief (SERCOM_USART_RXPL) MASK Register */
+#define SERCOM_USART_RXPL_MASK      _U_(0xFF)     /**< \brief (SERCOM_USART_RXPL) MASK Register */
 
 /* -------- SERCOM_I2CM_INTENCLR : (SERCOM Offset: 0x14) (R/W  8) I2CM I2CM Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -616,15 +601,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_INTENCLR_OFFSET 0x14         /**< \brief (SERCOM_I2CM_INTENCLR offset) I2CM Interrupt Enable Clear */
-#define SERCOM_I2CM_INTENCLR_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_INTENCLR reset_value) I2CM Interrupt Enable Clear */
+#define SERCOM_I2CM_INTENCLR_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CM_INTENCLR reset_value) I2CM Interrupt Enable Clear */
 
 #define SERCOM_I2CM_INTENCLR_MB_Pos 0            /**< \brief (SERCOM_I2CM_INTENCLR) Master On Bus Interrupt Disable */
-#define SERCOM_I2CM_INTENCLR_MB     (0x1ul << SERCOM_I2CM_INTENCLR_MB_Pos)
+#define SERCOM_I2CM_INTENCLR_MB     (_U_(0x1) << SERCOM_I2CM_INTENCLR_MB_Pos)
 #define SERCOM_I2CM_INTENCLR_SB_Pos 1            /**< \brief (SERCOM_I2CM_INTENCLR) Slave On Bus Interrupt Disable */
-#define SERCOM_I2CM_INTENCLR_SB     (0x1ul << SERCOM_I2CM_INTENCLR_SB_Pos)
+#define SERCOM_I2CM_INTENCLR_SB     (_U_(0x1) << SERCOM_I2CM_INTENCLR_SB_Pos)
 #define SERCOM_I2CM_INTENCLR_ERROR_Pos 7            /**< \brief (SERCOM_I2CM_INTENCLR) Combined Error Interrupt Disable */
-#define SERCOM_I2CM_INTENCLR_ERROR  (0x1ul << SERCOM_I2CM_INTENCLR_ERROR_Pos)
-#define SERCOM_I2CM_INTENCLR_MASK   0x83ul       /**< \brief (SERCOM_I2CM_INTENCLR) MASK Register */
+#define SERCOM_I2CM_INTENCLR_ERROR  (_U_(0x1) << SERCOM_I2CM_INTENCLR_ERROR_Pos)
+#define SERCOM_I2CM_INTENCLR_MASK   _U_(0x83)     /**< \brief (SERCOM_I2CM_INTENCLR) MASK Register */
 
 /* -------- SERCOM_I2CS_INTENCLR : (SERCOM Offset: 0x14) (R/W  8) I2CS I2CS Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -641,17 +626,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_INTENCLR_OFFSET 0x14         /**< \brief (SERCOM_I2CS_INTENCLR offset) I2CS Interrupt Enable Clear */
-#define SERCOM_I2CS_INTENCLR_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CS_INTENCLR reset_value) I2CS Interrupt Enable Clear */
+#define SERCOM_I2CS_INTENCLR_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CS_INTENCLR reset_value) I2CS Interrupt Enable Clear */
 
 #define SERCOM_I2CS_INTENCLR_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTENCLR) Stop Received Interrupt Disable */
-#define SERCOM_I2CS_INTENCLR_PREC   (0x1ul << SERCOM_I2CS_INTENCLR_PREC_Pos)
+#define SERCOM_I2CS_INTENCLR_PREC   (_U_(0x1) << SERCOM_I2CS_INTENCLR_PREC_Pos)
 #define SERCOM_I2CS_INTENCLR_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTENCLR) Address Match Interrupt Disable */
-#define SERCOM_I2CS_INTENCLR_AMATCH (0x1ul << SERCOM_I2CS_INTENCLR_AMATCH_Pos)
+#define SERCOM_I2CS_INTENCLR_AMATCH (_U_(0x1) << SERCOM_I2CS_INTENCLR_AMATCH_Pos)
 #define SERCOM_I2CS_INTENCLR_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTENCLR) Data Interrupt Disable */
-#define SERCOM_I2CS_INTENCLR_DRDY   (0x1ul << SERCOM_I2CS_INTENCLR_DRDY_Pos)
+#define SERCOM_I2CS_INTENCLR_DRDY   (_U_(0x1) << SERCOM_I2CS_INTENCLR_DRDY_Pos)
 #define SERCOM_I2CS_INTENCLR_ERROR_Pos 7            /**< \brief (SERCOM_I2CS_INTENCLR) Combined Error Interrupt Disable */
-#define SERCOM_I2CS_INTENCLR_ERROR  (0x1ul << SERCOM_I2CS_INTENCLR_ERROR_Pos)
-#define SERCOM_I2CS_INTENCLR_MASK   0x87ul       /**< \brief (SERCOM_I2CS_INTENCLR) MASK Register */
+#define SERCOM_I2CS_INTENCLR_ERROR  (_U_(0x1) << SERCOM_I2CS_INTENCLR_ERROR_Pos)
+#define SERCOM_I2CS_INTENCLR_MASK   _U_(0x87)     /**< \brief (SERCOM_I2CS_INTENCLR) MASK Register */
 
 /* -------- SERCOM_SPI_INTENCLR : (SERCOM Offset: 0x14) (R/W  8) SPI SPI Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -669,19 +654,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_INTENCLR_OFFSET  0x14         /**< \brief (SERCOM_SPI_INTENCLR offset) SPI Interrupt Enable Clear */
-#define SERCOM_SPI_INTENCLR_RESETVALUE 0x00ul       /**< \brief (SERCOM_SPI_INTENCLR reset_value) SPI Interrupt Enable Clear */
+#define SERCOM_SPI_INTENCLR_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_SPI_INTENCLR reset_value) SPI Interrupt Enable Clear */
 
 #define SERCOM_SPI_INTENCLR_DRE_Pos 0            /**< \brief (SERCOM_SPI_INTENCLR) Data Register Empty Interrupt Disable */
-#define SERCOM_SPI_INTENCLR_DRE     (0x1ul << SERCOM_SPI_INTENCLR_DRE_Pos)
+#define SERCOM_SPI_INTENCLR_DRE     (_U_(0x1) << SERCOM_SPI_INTENCLR_DRE_Pos)
 #define SERCOM_SPI_INTENCLR_TXC_Pos 1            /**< \brief (SERCOM_SPI_INTENCLR) Transmit Complete Interrupt Disable */
-#define SERCOM_SPI_INTENCLR_TXC     (0x1ul << SERCOM_SPI_INTENCLR_TXC_Pos)
+#define SERCOM_SPI_INTENCLR_TXC     (_U_(0x1) << SERCOM_SPI_INTENCLR_TXC_Pos)
 #define SERCOM_SPI_INTENCLR_RXC_Pos 2            /**< \brief (SERCOM_SPI_INTENCLR) Receive Complete Interrupt Disable */
-#define SERCOM_SPI_INTENCLR_RXC     (0x1ul << SERCOM_SPI_INTENCLR_RXC_Pos)
+#define SERCOM_SPI_INTENCLR_RXC     (_U_(0x1) << SERCOM_SPI_INTENCLR_RXC_Pos)
 #define SERCOM_SPI_INTENCLR_SSL_Pos 3            /**< \brief (SERCOM_SPI_INTENCLR) Slave Select Low Interrupt Disable */
-#define SERCOM_SPI_INTENCLR_SSL     (0x1ul << SERCOM_SPI_INTENCLR_SSL_Pos)
+#define SERCOM_SPI_INTENCLR_SSL     (_U_(0x1) << SERCOM_SPI_INTENCLR_SSL_Pos)
 #define SERCOM_SPI_INTENCLR_ERROR_Pos 7            /**< \brief (SERCOM_SPI_INTENCLR) Combined Error Interrupt Disable */
-#define SERCOM_SPI_INTENCLR_ERROR   (0x1ul << SERCOM_SPI_INTENCLR_ERROR_Pos)
-#define SERCOM_SPI_INTENCLR_MASK    0x8Ful       /**< \brief (SERCOM_SPI_INTENCLR) MASK Register */
+#define SERCOM_SPI_INTENCLR_ERROR   (_U_(0x1) << SERCOM_SPI_INTENCLR_ERROR_Pos)
+#define SERCOM_SPI_INTENCLR_MASK    _U_(0x8F)     /**< \brief (SERCOM_SPI_INTENCLR) MASK Register */
 
 /* -------- SERCOM_USART_INTENCLR : (SERCOM Offset: 0x14) (R/W  8) USART USART Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -701,23 +686,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_INTENCLR_OFFSET 0x14         /**< \brief (SERCOM_USART_INTENCLR offset) USART Interrupt Enable Clear */
-#define SERCOM_USART_INTENCLR_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_INTENCLR reset_value) USART Interrupt Enable Clear */
+#define SERCOM_USART_INTENCLR_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_USART_INTENCLR reset_value) USART Interrupt Enable Clear */
 
 #define SERCOM_USART_INTENCLR_DRE_Pos 0            /**< \brief (SERCOM_USART_INTENCLR) Data Register Empty Interrupt Disable */
-#define SERCOM_USART_INTENCLR_DRE   (0x1ul << SERCOM_USART_INTENCLR_DRE_Pos)
+#define SERCOM_USART_INTENCLR_DRE   (_U_(0x1) << SERCOM_USART_INTENCLR_DRE_Pos)
 #define SERCOM_USART_INTENCLR_TXC_Pos 1            /**< \brief (SERCOM_USART_INTENCLR) Transmit Complete Interrupt Disable */
-#define SERCOM_USART_INTENCLR_TXC   (0x1ul << SERCOM_USART_INTENCLR_TXC_Pos)
+#define SERCOM_USART_INTENCLR_TXC   (_U_(0x1) << SERCOM_USART_INTENCLR_TXC_Pos)
 #define SERCOM_USART_INTENCLR_RXC_Pos 2            /**< \brief (SERCOM_USART_INTENCLR) Receive Complete Interrupt Disable */
-#define SERCOM_USART_INTENCLR_RXC   (0x1ul << SERCOM_USART_INTENCLR_RXC_Pos)
+#define SERCOM_USART_INTENCLR_RXC   (_U_(0x1) << SERCOM_USART_INTENCLR_RXC_Pos)
 #define SERCOM_USART_INTENCLR_RXS_Pos 3            /**< \brief (SERCOM_USART_INTENCLR) Receive Start Interrupt Disable */
-#define SERCOM_USART_INTENCLR_RXS   (0x1ul << SERCOM_USART_INTENCLR_RXS_Pos)
+#define SERCOM_USART_INTENCLR_RXS   (_U_(0x1) << SERCOM_USART_INTENCLR_RXS_Pos)
 #define SERCOM_USART_INTENCLR_CTSIC_Pos 4            /**< \brief (SERCOM_USART_INTENCLR) Clear To Send Input Change Interrupt Disable */
-#define SERCOM_USART_INTENCLR_CTSIC (0x1ul << SERCOM_USART_INTENCLR_CTSIC_Pos)
+#define SERCOM_USART_INTENCLR_CTSIC (_U_(0x1) << SERCOM_USART_INTENCLR_CTSIC_Pos)
 #define SERCOM_USART_INTENCLR_RXBRK_Pos 5            /**< \brief (SERCOM_USART_INTENCLR) Break Received Interrupt Disable */
-#define SERCOM_USART_INTENCLR_RXBRK (0x1ul << SERCOM_USART_INTENCLR_RXBRK_Pos)
+#define SERCOM_USART_INTENCLR_RXBRK (_U_(0x1) << SERCOM_USART_INTENCLR_RXBRK_Pos)
 #define SERCOM_USART_INTENCLR_ERROR_Pos 7            /**< \brief (SERCOM_USART_INTENCLR) Combined Error Interrupt Disable */
-#define SERCOM_USART_INTENCLR_ERROR (0x1ul << SERCOM_USART_INTENCLR_ERROR_Pos)
-#define SERCOM_USART_INTENCLR_MASK  0xBFul       /**< \brief (SERCOM_USART_INTENCLR) MASK Register */
+#define SERCOM_USART_INTENCLR_ERROR (_U_(0x1) << SERCOM_USART_INTENCLR_ERROR_Pos)
+#define SERCOM_USART_INTENCLR_MASK  _U_(0xBF)     /**< \brief (SERCOM_USART_INTENCLR) MASK Register */
 
 /* -------- SERCOM_I2CM_INTENSET : (SERCOM Offset: 0x16) (R/W  8) I2CM I2CM Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -733,15 +718,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_INTENSET_OFFSET 0x16         /**< \brief (SERCOM_I2CM_INTENSET offset) I2CM Interrupt Enable Set */
-#define SERCOM_I2CM_INTENSET_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_INTENSET reset_value) I2CM Interrupt Enable Set */
+#define SERCOM_I2CM_INTENSET_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CM_INTENSET reset_value) I2CM Interrupt Enable Set */
 
 #define SERCOM_I2CM_INTENSET_MB_Pos 0            /**< \brief (SERCOM_I2CM_INTENSET) Master On Bus Interrupt Enable */
-#define SERCOM_I2CM_INTENSET_MB     (0x1ul << SERCOM_I2CM_INTENSET_MB_Pos)
+#define SERCOM_I2CM_INTENSET_MB     (_U_(0x1) << SERCOM_I2CM_INTENSET_MB_Pos)
 #define SERCOM_I2CM_INTENSET_SB_Pos 1            /**< \brief (SERCOM_I2CM_INTENSET) Slave On Bus Interrupt Enable */
-#define SERCOM_I2CM_INTENSET_SB     (0x1ul << SERCOM_I2CM_INTENSET_SB_Pos)
+#define SERCOM_I2CM_INTENSET_SB     (_U_(0x1) << SERCOM_I2CM_INTENSET_SB_Pos)
 #define SERCOM_I2CM_INTENSET_ERROR_Pos 7            /**< \brief (SERCOM_I2CM_INTENSET) Combined Error Interrupt Enable */
-#define SERCOM_I2CM_INTENSET_ERROR  (0x1ul << SERCOM_I2CM_INTENSET_ERROR_Pos)
-#define SERCOM_I2CM_INTENSET_MASK   0x83ul       /**< \brief (SERCOM_I2CM_INTENSET) MASK Register */
+#define SERCOM_I2CM_INTENSET_ERROR  (_U_(0x1) << SERCOM_I2CM_INTENSET_ERROR_Pos)
+#define SERCOM_I2CM_INTENSET_MASK   _U_(0x83)     /**< \brief (SERCOM_I2CM_INTENSET) MASK Register */
 
 /* -------- SERCOM_I2CS_INTENSET : (SERCOM Offset: 0x16) (R/W  8) I2CS I2CS Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -758,17 +743,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_INTENSET_OFFSET 0x16         /**< \brief (SERCOM_I2CS_INTENSET offset) I2CS Interrupt Enable Set */
-#define SERCOM_I2CS_INTENSET_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CS_INTENSET reset_value) I2CS Interrupt Enable Set */
+#define SERCOM_I2CS_INTENSET_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CS_INTENSET reset_value) I2CS Interrupt Enable Set */
 
 #define SERCOM_I2CS_INTENSET_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTENSET) Stop Received Interrupt Enable */
-#define SERCOM_I2CS_INTENSET_PREC   (0x1ul << SERCOM_I2CS_INTENSET_PREC_Pos)
+#define SERCOM_I2CS_INTENSET_PREC   (_U_(0x1) << SERCOM_I2CS_INTENSET_PREC_Pos)
 #define SERCOM_I2CS_INTENSET_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTENSET) Address Match Interrupt Enable */
-#define SERCOM_I2CS_INTENSET_AMATCH (0x1ul << SERCOM_I2CS_INTENSET_AMATCH_Pos)
+#define SERCOM_I2CS_INTENSET_AMATCH (_U_(0x1) << SERCOM_I2CS_INTENSET_AMATCH_Pos)
 #define SERCOM_I2CS_INTENSET_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTENSET) Data Interrupt Enable */
-#define SERCOM_I2CS_INTENSET_DRDY   (0x1ul << SERCOM_I2CS_INTENSET_DRDY_Pos)
+#define SERCOM_I2CS_INTENSET_DRDY   (_U_(0x1) << SERCOM_I2CS_INTENSET_DRDY_Pos)
 #define SERCOM_I2CS_INTENSET_ERROR_Pos 7            /**< \brief (SERCOM_I2CS_INTENSET) Combined Error Interrupt Enable */
-#define SERCOM_I2CS_INTENSET_ERROR  (0x1ul << SERCOM_I2CS_INTENSET_ERROR_Pos)
-#define SERCOM_I2CS_INTENSET_MASK   0x87ul       /**< \brief (SERCOM_I2CS_INTENSET) MASK Register */
+#define SERCOM_I2CS_INTENSET_ERROR  (_U_(0x1) << SERCOM_I2CS_INTENSET_ERROR_Pos)
+#define SERCOM_I2CS_INTENSET_MASK   _U_(0x87)     /**< \brief (SERCOM_I2CS_INTENSET) MASK Register */
 
 /* -------- SERCOM_SPI_INTENSET : (SERCOM Offset: 0x16) (R/W  8) SPI SPI Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -786,19 +771,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_INTENSET_OFFSET  0x16         /**< \brief (SERCOM_SPI_INTENSET offset) SPI Interrupt Enable Set */
-#define SERCOM_SPI_INTENSET_RESETVALUE 0x00ul       /**< \brief (SERCOM_SPI_INTENSET reset_value) SPI Interrupt Enable Set */
+#define SERCOM_SPI_INTENSET_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_SPI_INTENSET reset_value) SPI Interrupt Enable Set */
 
 #define SERCOM_SPI_INTENSET_DRE_Pos 0            /**< \brief (SERCOM_SPI_INTENSET) Data Register Empty Interrupt Enable */
-#define SERCOM_SPI_INTENSET_DRE     (0x1ul << SERCOM_SPI_INTENSET_DRE_Pos)
+#define SERCOM_SPI_INTENSET_DRE     (_U_(0x1) << SERCOM_SPI_INTENSET_DRE_Pos)
 #define SERCOM_SPI_INTENSET_TXC_Pos 1            /**< \brief (SERCOM_SPI_INTENSET) Transmit Complete Interrupt Enable */
-#define SERCOM_SPI_INTENSET_TXC     (0x1ul << SERCOM_SPI_INTENSET_TXC_Pos)
+#define SERCOM_SPI_INTENSET_TXC     (_U_(0x1) << SERCOM_SPI_INTENSET_TXC_Pos)
 #define SERCOM_SPI_INTENSET_RXC_Pos 2            /**< \brief (SERCOM_SPI_INTENSET) Receive Complete Interrupt Enable */
-#define SERCOM_SPI_INTENSET_RXC     (0x1ul << SERCOM_SPI_INTENSET_RXC_Pos)
+#define SERCOM_SPI_INTENSET_RXC     (_U_(0x1) << SERCOM_SPI_INTENSET_RXC_Pos)
 #define SERCOM_SPI_INTENSET_SSL_Pos 3            /**< \brief (SERCOM_SPI_INTENSET) Slave Select Low Interrupt Enable */
-#define SERCOM_SPI_INTENSET_SSL     (0x1ul << SERCOM_SPI_INTENSET_SSL_Pos)
+#define SERCOM_SPI_INTENSET_SSL     (_U_(0x1) << SERCOM_SPI_INTENSET_SSL_Pos)
 #define SERCOM_SPI_INTENSET_ERROR_Pos 7            /**< \brief (SERCOM_SPI_INTENSET) Combined Error Interrupt Enable */
-#define SERCOM_SPI_INTENSET_ERROR   (0x1ul << SERCOM_SPI_INTENSET_ERROR_Pos)
-#define SERCOM_SPI_INTENSET_MASK    0x8Ful       /**< \brief (SERCOM_SPI_INTENSET) MASK Register */
+#define SERCOM_SPI_INTENSET_ERROR   (_U_(0x1) << SERCOM_SPI_INTENSET_ERROR_Pos)
+#define SERCOM_SPI_INTENSET_MASK    _U_(0x8F)     /**< \brief (SERCOM_SPI_INTENSET) MASK Register */
 
 /* -------- SERCOM_USART_INTENSET : (SERCOM Offset: 0x16) (R/W  8) USART USART Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -818,23 +803,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_INTENSET_OFFSET 0x16         /**< \brief (SERCOM_USART_INTENSET offset) USART Interrupt Enable Set */
-#define SERCOM_USART_INTENSET_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_INTENSET reset_value) USART Interrupt Enable Set */
+#define SERCOM_USART_INTENSET_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_USART_INTENSET reset_value) USART Interrupt Enable Set */
 
 #define SERCOM_USART_INTENSET_DRE_Pos 0            /**< \brief (SERCOM_USART_INTENSET) Data Register Empty Interrupt Enable */
-#define SERCOM_USART_INTENSET_DRE   (0x1ul << SERCOM_USART_INTENSET_DRE_Pos)
+#define SERCOM_USART_INTENSET_DRE   (_U_(0x1) << SERCOM_USART_INTENSET_DRE_Pos)
 #define SERCOM_USART_INTENSET_TXC_Pos 1            /**< \brief (SERCOM_USART_INTENSET) Transmit Complete Interrupt Enable */
-#define SERCOM_USART_INTENSET_TXC   (0x1ul << SERCOM_USART_INTENSET_TXC_Pos)
+#define SERCOM_USART_INTENSET_TXC   (_U_(0x1) << SERCOM_USART_INTENSET_TXC_Pos)
 #define SERCOM_USART_INTENSET_RXC_Pos 2            /**< \brief (SERCOM_USART_INTENSET) Receive Complete Interrupt Enable */
-#define SERCOM_USART_INTENSET_RXC   (0x1ul << SERCOM_USART_INTENSET_RXC_Pos)
+#define SERCOM_USART_INTENSET_RXC   (_U_(0x1) << SERCOM_USART_INTENSET_RXC_Pos)
 #define SERCOM_USART_INTENSET_RXS_Pos 3            /**< \brief (SERCOM_USART_INTENSET) Receive Start Interrupt Enable */
-#define SERCOM_USART_INTENSET_RXS   (0x1ul << SERCOM_USART_INTENSET_RXS_Pos)
+#define SERCOM_USART_INTENSET_RXS   (_U_(0x1) << SERCOM_USART_INTENSET_RXS_Pos)
 #define SERCOM_USART_INTENSET_CTSIC_Pos 4            /**< \brief (SERCOM_USART_INTENSET) Clear To Send Input Change Interrupt Enable */
-#define SERCOM_USART_INTENSET_CTSIC (0x1ul << SERCOM_USART_INTENSET_CTSIC_Pos)
+#define SERCOM_USART_INTENSET_CTSIC (_U_(0x1) << SERCOM_USART_INTENSET_CTSIC_Pos)
 #define SERCOM_USART_INTENSET_RXBRK_Pos 5            /**< \brief (SERCOM_USART_INTENSET) Break Received Interrupt Enable */
-#define SERCOM_USART_INTENSET_RXBRK (0x1ul << SERCOM_USART_INTENSET_RXBRK_Pos)
+#define SERCOM_USART_INTENSET_RXBRK (_U_(0x1) << SERCOM_USART_INTENSET_RXBRK_Pos)
 #define SERCOM_USART_INTENSET_ERROR_Pos 7            /**< \brief (SERCOM_USART_INTENSET) Combined Error Interrupt Enable */
-#define SERCOM_USART_INTENSET_ERROR (0x1ul << SERCOM_USART_INTENSET_ERROR_Pos)
-#define SERCOM_USART_INTENSET_MASK  0xBFul       /**< \brief (SERCOM_USART_INTENSET) MASK Register */
+#define SERCOM_USART_INTENSET_ERROR (_U_(0x1) << SERCOM_USART_INTENSET_ERROR_Pos)
+#define SERCOM_USART_INTENSET_MASK  _U_(0xBF)     /**< \brief (SERCOM_USART_INTENSET) MASK Register */
 
 /* -------- SERCOM_I2CM_INTFLAG : (SERCOM Offset: 0x18) (R/W  8) I2CM I2CM Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -850,15 +835,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_INTFLAG_OFFSET  0x18         /**< \brief (SERCOM_I2CM_INTFLAG offset) I2CM Interrupt Flag Status and Clear */
-#define SERCOM_I2CM_INTFLAG_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_INTFLAG reset_value) I2CM Interrupt Flag Status and Clear */
+#define SERCOM_I2CM_INTFLAG_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CM_INTFLAG reset_value) I2CM Interrupt Flag Status and Clear */
 
 #define SERCOM_I2CM_INTFLAG_MB_Pos  0            /**< \brief (SERCOM_I2CM_INTFLAG) Master On Bus Interrupt */
-#define SERCOM_I2CM_INTFLAG_MB      (0x1ul << SERCOM_I2CM_INTFLAG_MB_Pos)
+#define SERCOM_I2CM_INTFLAG_MB      (_U_(0x1) << SERCOM_I2CM_INTFLAG_MB_Pos)
 #define SERCOM_I2CM_INTFLAG_SB_Pos  1            /**< \brief (SERCOM_I2CM_INTFLAG) Slave On Bus Interrupt */
-#define SERCOM_I2CM_INTFLAG_SB      (0x1ul << SERCOM_I2CM_INTFLAG_SB_Pos)
+#define SERCOM_I2CM_INTFLAG_SB      (_U_(0x1) << SERCOM_I2CM_INTFLAG_SB_Pos)
 #define SERCOM_I2CM_INTFLAG_ERROR_Pos 7            /**< \brief (SERCOM_I2CM_INTFLAG) Combined Error Interrupt */
-#define SERCOM_I2CM_INTFLAG_ERROR   (0x1ul << SERCOM_I2CM_INTFLAG_ERROR_Pos)
-#define SERCOM_I2CM_INTFLAG_MASK    0x83ul       /**< \brief (SERCOM_I2CM_INTFLAG) MASK Register */
+#define SERCOM_I2CM_INTFLAG_ERROR   (_U_(0x1) << SERCOM_I2CM_INTFLAG_ERROR_Pos)
+#define SERCOM_I2CM_INTFLAG_MASK    _U_(0x83)     /**< \brief (SERCOM_I2CM_INTFLAG) MASK Register */
 
 /* -------- SERCOM_I2CS_INTFLAG : (SERCOM Offset: 0x18) (R/W  8) I2CS I2CS Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -875,17 +860,17 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_INTFLAG_OFFSET  0x18         /**< \brief (SERCOM_I2CS_INTFLAG offset) I2CS Interrupt Flag Status and Clear */
-#define SERCOM_I2CS_INTFLAG_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CS_INTFLAG reset_value) I2CS Interrupt Flag Status and Clear */
+#define SERCOM_I2CS_INTFLAG_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CS_INTFLAG reset_value) I2CS Interrupt Flag Status and Clear */
 
 #define SERCOM_I2CS_INTFLAG_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTFLAG) Stop Received Interrupt */
-#define SERCOM_I2CS_INTFLAG_PREC    (0x1ul << SERCOM_I2CS_INTFLAG_PREC_Pos)
+#define SERCOM_I2CS_INTFLAG_PREC    (_U_(0x1) << SERCOM_I2CS_INTFLAG_PREC_Pos)
 #define SERCOM_I2CS_INTFLAG_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTFLAG) Address Match Interrupt */
-#define SERCOM_I2CS_INTFLAG_AMATCH  (0x1ul << SERCOM_I2CS_INTFLAG_AMATCH_Pos)
+#define SERCOM_I2CS_INTFLAG_AMATCH  (_U_(0x1) << SERCOM_I2CS_INTFLAG_AMATCH_Pos)
 #define SERCOM_I2CS_INTFLAG_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTFLAG) Data Interrupt */
-#define SERCOM_I2CS_INTFLAG_DRDY    (0x1ul << SERCOM_I2CS_INTFLAG_DRDY_Pos)
+#define SERCOM_I2CS_INTFLAG_DRDY    (_U_(0x1) << SERCOM_I2CS_INTFLAG_DRDY_Pos)
 #define SERCOM_I2CS_INTFLAG_ERROR_Pos 7            /**< \brief (SERCOM_I2CS_INTFLAG) Combined Error Interrupt */
-#define SERCOM_I2CS_INTFLAG_ERROR   (0x1ul << SERCOM_I2CS_INTFLAG_ERROR_Pos)
-#define SERCOM_I2CS_INTFLAG_MASK    0x87ul       /**< \brief (SERCOM_I2CS_INTFLAG) MASK Register */
+#define SERCOM_I2CS_INTFLAG_ERROR   (_U_(0x1) << SERCOM_I2CS_INTFLAG_ERROR_Pos)
+#define SERCOM_I2CS_INTFLAG_MASK    _U_(0x87)     /**< \brief (SERCOM_I2CS_INTFLAG) MASK Register */
 
 /* -------- SERCOM_SPI_INTFLAG : (SERCOM Offset: 0x18) (R/W  8) SPI SPI Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -903,19 +888,19 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_INTFLAG_OFFSET   0x18         /**< \brief (SERCOM_SPI_INTFLAG offset) SPI Interrupt Flag Status and Clear */
-#define SERCOM_SPI_INTFLAG_RESETVALUE 0x00ul       /**< \brief (SERCOM_SPI_INTFLAG reset_value) SPI Interrupt Flag Status and Clear */
+#define SERCOM_SPI_INTFLAG_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_SPI_INTFLAG reset_value) SPI Interrupt Flag Status and Clear */
 
 #define SERCOM_SPI_INTFLAG_DRE_Pos  0            /**< \brief (SERCOM_SPI_INTFLAG) Data Register Empty Interrupt */
-#define SERCOM_SPI_INTFLAG_DRE      (0x1ul << SERCOM_SPI_INTFLAG_DRE_Pos)
+#define SERCOM_SPI_INTFLAG_DRE      (_U_(0x1) << SERCOM_SPI_INTFLAG_DRE_Pos)
 #define SERCOM_SPI_INTFLAG_TXC_Pos  1            /**< \brief (SERCOM_SPI_INTFLAG) Transmit Complete Interrupt */
-#define SERCOM_SPI_INTFLAG_TXC      (0x1ul << SERCOM_SPI_INTFLAG_TXC_Pos)
+#define SERCOM_SPI_INTFLAG_TXC      (_U_(0x1) << SERCOM_SPI_INTFLAG_TXC_Pos)
 #define SERCOM_SPI_INTFLAG_RXC_Pos  2            /**< \brief (SERCOM_SPI_INTFLAG) Receive Complete Interrupt */
-#define SERCOM_SPI_INTFLAG_RXC      (0x1ul << SERCOM_SPI_INTFLAG_RXC_Pos)
+#define SERCOM_SPI_INTFLAG_RXC      (_U_(0x1) << SERCOM_SPI_INTFLAG_RXC_Pos)
 #define SERCOM_SPI_INTFLAG_SSL_Pos  3            /**< \brief (SERCOM_SPI_INTFLAG) Slave Select Low Interrupt Flag */
-#define SERCOM_SPI_INTFLAG_SSL      (0x1ul << SERCOM_SPI_INTFLAG_SSL_Pos)
+#define SERCOM_SPI_INTFLAG_SSL      (_U_(0x1) << SERCOM_SPI_INTFLAG_SSL_Pos)
 #define SERCOM_SPI_INTFLAG_ERROR_Pos 7            /**< \brief (SERCOM_SPI_INTFLAG) Combined Error Interrupt */
-#define SERCOM_SPI_INTFLAG_ERROR    (0x1ul << SERCOM_SPI_INTFLAG_ERROR_Pos)
-#define SERCOM_SPI_INTFLAG_MASK     0x8Ful       /**< \brief (SERCOM_SPI_INTFLAG) MASK Register */
+#define SERCOM_SPI_INTFLAG_ERROR    (_U_(0x1) << SERCOM_SPI_INTFLAG_ERROR_Pos)
+#define SERCOM_SPI_INTFLAG_MASK     _U_(0x8F)     /**< \brief (SERCOM_SPI_INTFLAG) MASK Register */
 
 /* -------- SERCOM_USART_INTFLAG : (SERCOM Offset: 0x18) (R/W  8) USART USART Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -935,23 +920,23 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_INTFLAG_OFFSET 0x18         /**< \brief (SERCOM_USART_INTFLAG offset) USART Interrupt Flag Status and Clear */
-#define SERCOM_USART_INTFLAG_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_INTFLAG reset_value) USART Interrupt Flag Status and Clear */
+#define SERCOM_USART_INTFLAG_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_USART_INTFLAG reset_value) USART Interrupt Flag Status and Clear */
 
 #define SERCOM_USART_INTFLAG_DRE_Pos 0            /**< \brief (SERCOM_USART_INTFLAG) Data Register Empty Interrupt */
-#define SERCOM_USART_INTFLAG_DRE    (0x1ul << SERCOM_USART_INTFLAG_DRE_Pos)
+#define SERCOM_USART_INTFLAG_DRE    (_U_(0x1) << SERCOM_USART_INTFLAG_DRE_Pos)
 #define SERCOM_USART_INTFLAG_TXC_Pos 1            /**< \brief (SERCOM_USART_INTFLAG) Transmit Complete Interrupt */
-#define SERCOM_USART_INTFLAG_TXC    (0x1ul << SERCOM_USART_INTFLAG_TXC_Pos)
+#define SERCOM_USART_INTFLAG_TXC    (_U_(0x1) << SERCOM_USART_INTFLAG_TXC_Pos)
 #define SERCOM_USART_INTFLAG_RXC_Pos 2            /**< \brief (SERCOM_USART_INTFLAG) Receive Complete Interrupt */
-#define SERCOM_USART_INTFLAG_RXC    (0x1ul << SERCOM_USART_INTFLAG_RXC_Pos)
+#define SERCOM_USART_INTFLAG_RXC    (_U_(0x1) << SERCOM_USART_INTFLAG_RXC_Pos)
 #define SERCOM_USART_INTFLAG_RXS_Pos 3            /**< \brief (SERCOM_USART_INTFLAG) Receive Start Interrupt */
-#define SERCOM_USART_INTFLAG_RXS    (0x1ul << SERCOM_USART_INTFLAG_RXS_Pos)
+#define SERCOM_USART_INTFLAG_RXS    (_U_(0x1) << SERCOM_USART_INTFLAG_RXS_Pos)
 #define SERCOM_USART_INTFLAG_CTSIC_Pos 4            /**< \brief (SERCOM_USART_INTFLAG) Clear To Send Input Change Interrupt */
-#define SERCOM_USART_INTFLAG_CTSIC  (0x1ul << SERCOM_USART_INTFLAG_CTSIC_Pos)
+#define SERCOM_USART_INTFLAG_CTSIC  (_U_(0x1) << SERCOM_USART_INTFLAG_CTSIC_Pos)
 #define SERCOM_USART_INTFLAG_RXBRK_Pos 5            /**< \brief (SERCOM_USART_INTFLAG) Break Received Interrupt */
-#define SERCOM_USART_INTFLAG_RXBRK  (0x1ul << SERCOM_USART_INTFLAG_RXBRK_Pos)
+#define SERCOM_USART_INTFLAG_RXBRK  (_U_(0x1) << SERCOM_USART_INTFLAG_RXBRK_Pos)
 #define SERCOM_USART_INTFLAG_ERROR_Pos 7            /**< \brief (SERCOM_USART_INTFLAG) Combined Error Interrupt */
-#define SERCOM_USART_INTFLAG_ERROR  (0x1ul << SERCOM_USART_INTFLAG_ERROR_Pos)
-#define SERCOM_USART_INTFLAG_MASK   0xBFul       /**< \brief (SERCOM_USART_INTFLAG) MASK Register */
+#define SERCOM_USART_INTFLAG_ERROR  (_U_(0x1) << SERCOM_USART_INTFLAG_ERROR_Pos)
+#define SERCOM_USART_INTFLAG_MASK   _U_(0xBF)     /**< \brief (SERCOM_USART_INTFLAG) MASK Register */
 
 /* -------- SERCOM_I2CM_STATUS : (SERCOM Offset: 0x1A) (R/W 16) I2CM I2CM Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -974,28 +959,28 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_STATUS_OFFSET   0x1A         /**< \brief (SERCOM_I2CM_STATUS offset) I2CM Status */
-#define SERCOM_I2CM_STATUS_RESETVALUE 0x0000ul     /**< \brief (SERCOM_I2CM_STATUS reset_value) I2CM Status */
+#define SERCOM_I2CM_STATUS_RESETVALUE _U_(0x0000)   /**< \brief (SERCOM_I2CM_STATUS reset_value) I2CM Status */
 
 #define SERCOM_I2CM_STATUS_BUSERR_Pos 0            /**< \brief (SERCOM_I2CM_STATUS) Bus Error */
-#define SERCOM_I2CM_STATUS_BUSERR   (0x1ul << SERCOM_I2CM_STATUS_BUSERR_Pos)
+#define SERCOM_I2CM_STATUS_BUSERR   (_U_(0x1) << SERCOM_I2CM_STATUS_BUSERR_Pos)
 #define SERCOM_I2CM_STATUS_ARBLOST_Pos 1            /**< \brief (SERCOM_I2CM_STATUS) Arbitration Lost */
-#define SERCOM_I2CM_STATUS_ARBLOST  (0x1ul << SERCOM_I2CM_STATUS_ARBLOST_Pos)
+#define SERCOM_I2CM_STATUS_ARBLOST  (_U_(0x1) << SERCOM_I2CM_STATUS_ARBLOST_Pos)
 #define SERCOM_I2CM_STATUS_RXNACK_Pos 2            /**< \brief (SERCOM_I2CM_STATUS) Received Not Acknowledge */
-#define SERCOM_I2CM_STATUS_RXNACK   (0x1ul << SERCOM_I2CM_STATUS_RXNACK_Pos)
+#define SERCOM_I2CM_STATUS_RXNACK   (_U_(0x1) << SERCOM_I2CM_STATUS_RXNACK_Pos)
 #define SERCOM_I2CM_STATUS_BUSSTATE_Pos 4            /**< \brief (SERCOM_I2CM_STATUS) Bus State */
-#define SERCOM_I2CM_STATUS_BUSSTATE_Msk (0x3ul << SERCOM_I2CM_STATUS_BUSSTATE_Pos)
+#define SERCOM_I2CM_STATUS_BUSSTATE_Msk (_U_(0x3) << SERCOM_I2CM_STATUS_BUSSTATE_Pos)
 #define SERCOM_I2CM_STATUS_BUSSTATE(value) (SERCOM_I2CM_STATUS_BUSSTATE_Msk & ((value) << SERCOM_I2CM_STATUS_BUSSTATE_Pos))
 #define SERCOM_I2CM_STATUS_LOWTOUT_Pos 6            /**< \brief (SERCOM_I2CM_STATUS) SCL Low Timeout */
-#define SERCOM_I2CM_STATUS_LOWTOUT  (0x1ul << SERCOM_I2CM_STATUS_LOWTOUT_Pos)
+#define SERCOM_I2CM_STATUS_LOWTOUT  (_U_(0x1) << SERCOM_I2CM_STATUS_LOWTOUT_Pos)
 #define SERCOM_I2CM_STATUS_CLKHOLD_Pos 7            /**< \brief (SERCOM_I2CM_STATUS) Clock Hold */
-#define SERCOM_I2CM_STATUS_CLKHOLD  (0x1ul << SERCOM_I2CM_STATUS_CLKHOLD_Pos)
+#define SERCOM_I2CM_STATUS_CLKHOLD  (_U_(0x1) << SERCOM_I2CM_STATUS_CLKHOLD_Pos)
 #define SERCOM_I2CM_STATUS_MEXTTOUT_Pos 8            /**< \brief (SERCOM_I2CM_STATUS) Master SCL Low Extend Timeout */
-#define SERCOM_I2CM_STATUS_MEXTTOUT (0x1ul << SERCOM_I2CM_STATUS_MEXTTOUT_Pos)
+#define SERCOM_I2CM_STATUS_MEXTTOUT (_U_(0x1) << SERCOM_I2CM_STATUS_MEXTTOUT_Pos)
 #define SERCOM_I2CM_STATUS_SEXTTOUT_Pos 9            /**< \brief (SERCOM_I2CM_STATUS) Slave SCL Low Extend Timeout */
-#define SERCOM_I2CM_STATUS_SEXTTOUT (0x1ul << SERCOM_I2CM_STATUS_SEXTTOUT_Pos)
+#define SERCOM_I2CM_STATUS_SEXTTOUT (_U_(0x1) << SERCOM_I2CM_STATUS_SEXTTOUT_Pos)
 #define SERCOM_I2CM_STATUS_LENERR_Pos 10           /**< \brief (SERCOM_I2CM_STATUS) Length Error */
-#define SERCOM_I2CM_STATUS_LENERR   (0x1ul << SERCOM_I2CM_STATUS_LENERR_Pos)
-#define SERCOM_I2CM_STATUS_MASK     0x07F7ul     /**< \brief (SERCOM_I2CM_STATUS) MASK Register */
+#define SERCOM_I2CM_STATUS_LENERR   (_U_(0x1) << SERCOM_I2CM_STATUS_LENERR_Pos)
+#define SERCOM_I2CM_STATUS_MASK     _U_(0x07F7)   /**< \brief (SERCOM_I2CM_STATUS) MASK Register */
 
 /* -------- SERCOM_I2CS_STATUS : (SERCOM Offset: 0x1A) (R/W 16) I2CS I2CS Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1019,27 +1004,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_STATUS_OFFSET   0x1A         /**< \brief (SERCOM_I2CS_STATUS offset) I2CS Status */
-#define SERCOM_I2CS_STATUS_RESETVALUE 0x0000ul     /**< \brief (SERCOM_I2CS_STATUS reset_value) I2CS Status */
+#define SERCOM_I2CS_STATUS_RESETVALUE _U_(0x0000)   /**< \brief (SERCOM_I2CS_STATUS reset_value) I2CS Status */
 
 #define SERCOM_I2CS_STATUS_BUSERR_Pos 0            /**< \brief (SERCOM_I2CS_STATUS) Bus Error */
-#define SERCOM_I2CS_STATUS_BUSERR   (0x1ul << SERCOM_I2CS_STATUS_BUSERR_Pos)
+#define SERCOM_I2CS_STATUS_BUSERR   (_U_(0x1) << SERCOM_I2CS_STATUS_BUSERR_Pos)
 #define SERCOM_I2CS_STATUS_COLL_Pos 1            /**< \brief (SERCOM_I2CS_STATUS) Transmit Collision */
-#define SERCOM_I2CS_STATUS_COLL     (0x1ul << SERCOM_I2CS_STATUS_COLL_Pos)
+#define SERCOM_I2CS_STATUS_COLL     (_U_(0x1) << SERCOM_I2CS_STATUS_COLL_Pos)
 #define SERCOM_I2CS_STATUS_RXNACK_Pos 2            /**< \brief (SERCOM_I2CS_STATUS) Received Not Acknowledge */
-#define SERCOM_I2CS_STATUS_RXNACK   (0x1ul << SERCOM_I2CS_STATUS_RXNACK_Pos)
+#define SERCOM_I2CS_STATUS_RXNACK   (_U_(0x1) << SERCOM_I2CS_STATUS_RXNACK_Pos)
 #define SERCOM_I2CS_STATUS_DIR_Pos  3            /**< \brief (SERCOM_I2CS_STATUS) Read/Write Direction */
-#define SERCOM_I2CS_STATUS_DIR      (0x1ul << SERCOM_I2CS_STATUS_DIR_Pos)
+#define SERCOM_I2CS_STATUS_DIR      (_U_(0x1) << SERCOM_I2CS_STATUS_DIR_Pos)
 #define SERCOM_I2CS_STATUS_SR_Pos   4            /**< \brief (SERCOM_I2CS_STATUS) Repeated Start */
-#define SERCOM_I2CS_STATUS_SR       (0x1ul << SERCOM_I2CS_STATUS_SR_Pos)
+#define SERCOM_I2CS_STATUS_SR       (_U_(0x1) << SERCOM_I2CS_STATUS_SR_Pos)
 #define SERCOM_I2CS_STATUS_LOWTOUT_Pos 6            /**< \brief (SERCOM_I2CS_STATUS) SCL Low Timeout */
-#define SERCOM_I2CS_STATUS_LOWTOUT  (0x1ul << SERCOM_I2CS_STATUS_LOWTOUT_Pos)
+#define SERCOM_I2CS_STATUS_LOWTOUT  (_U_(0x1) << SERCOM_I2CS_STATUS_LOWTOUT_Pos)
 #define SERCOM_I2CS_STATUS_CLKHOLD_Pos 7            /**< \brief (SERCOM_I2CS_STATUS) Clock Hold */
-#define SERCOM_I2CS_STATUS_CLKHOLD  (0x1ul << SERCOM_I2CS_STATUS_CLKHOLD_Pos)
+#define SERCOM_I2CS_STATUS_CLKHOLD  (_U_(0x1) << SERCOM_I2CS_STATUS_CLKHOLD_Pos)
 #define SERCOM_I2CS_STATUS_SEXTTOUT_Pos 9            /**< \brief (SERCOM_I2CS_STATUS) Slave SCL Low Extend Timeout */
-#define SERCOM_I2CS_STATUS_SEXTTOUT (0x1ul << SERCOM_I2CS_STATUS_SEXTTOUT_Pos)
+#define SERCOM_I2CS_STATUS_SEXTTOUT (_U_(0x1) << SERCOM_I2CS_STATUS_SEXTTOUT_Pos)
 #define SERCOM_I2CS_STATUS_HS_Pos   10           /**< \brief (SERCOM_I2CS_STATUS) High Speed */
-#define SERCOM_I2CS_STATUS_HS       (0x1ul << SERCOM_I2CS_STATUS_HS_Pos)
-#define SERCOM_I2CS_STATUS_MASK     0x06DFul     /**< \brief (SERCOM_I2CS_STATUS) MASK Register */
+#define SERCOM_I2CS_STATUS_HS       (_U_(0x1) << SERCOM_I2CS_STATUS_HS_Pos)
+#define SERCOM_I2CS_STATUS_MASK     _U_(0x06DF)   /**< \brief (SERCOM_I2CS_STATUS) MASK Register */
 
 /* -------- SERCOM_SPI_STATUS : (SERCOM Offset: 0x1A) (R/W 16) SPI SPI Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1054,11 +1039,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_STATUS_OFFSET    0x1A         /**< \brief (SERCOM_SPI_STATUS offset) SPI Status */
-#define SERCOM_SPI_STATUS_RESETVALUE 0x0000ul     /**< \brief (SERCOM_SPI_STATUS reset_value) SPI Status */
+#define SERCOM_SPI_STATUS_RESETVALUE _U_(0x0000)   /**< \brief (SERCOM_SPI_STATUS reset_value) SPI Status */
 
 #define SERCOM_SPI_STATUS_BUFOVF_Pos 2            /**< \brief (SERCOM_SPI_STATUS) Buffer Overflow */
-#define SERCOM_SPI_STATUS_BUFOVF    (0x1ul << SERCOM_SPI_STATUS_BUFOVF_Pos)
-#define SERCOM_SPI_STATUS_MASK      0x0004ul     /**< \brief (SERCOM_SPI_STATUS) MASK Register */
+#define SERCOM_SPI_STATUS_BUFOVF    (_U_(0x1) << SERCOM_SPI_STATUS_BUFOVF_Pos)
+#define SERCOM_SPI_STATUS_MASK      _U_(0x0004)   /**< \brief (SERCOM_SPI_STATUS) MASK Register */
 
 /* -------- SERCOM_USART_STATUS : (SERCOM Offset: 0x1A) (R/W 16) USART USART Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1077,21 +1062,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_STATUS_OFFSET  0x1A         /**< \brief (SERCOM_USART_STATUS offset) USART Status */
-#define SERCOM_USART_STATUS_RESETVALUE 0x0000ul     /**< \brief (SERCOM_USART_STATUS reset_value) USART Status */
+#define SERCOM_USART_STATUS_RESETVALUE _U_(0x0000)   /**< \brief (SERCOM_USART_STATUS reset_value) USART Status */
 
 #define SERCOM_USART_STATUS_PERR_Pos 0            /**< \brief (SERCOM_USART_STATUS) Parity Error */
-#define SERCOM_USART_STATUS_PERR    (0x1ul << SERCOM_USART_STATUS_PERR_Pos)
+#define SERCOM_USART_STATUS_PERR    (_U_(0x1) << SERCOM_USART_STATUS_PERR_Pos)
 #define SERCOM_USART_STATUS_FERR_Pos 1            /**< \brief (SERCOM_USART_STATUS) Frame Error */
-#define SERCOM_USART_STATUS_FERR    (0x1ul << SERCOM_USART_STATUS_FERR_Pos)
+#define SERCOM_USART_STATUS_FERR    (_U_(0x1) << SERCOM_USART_STATUS_FERR_Pos)
 #define SERCOM_USART_STATUS_BUFOVF_Pos 2            /**< \brief (SERCOM_USART_STATUS) Buffer Overflow */
-#define SERCOM_USART_STATUS_BUFOVF  (0x1ul << SERCOM_USART_STATUS_BUFOVF_Pos)
+#define SERCOM_USART_STATUS_BUFOVF  (_U_(0x1) << SERCOM_USART_STATUS_BUFOVF_Pos)
 #define SERCOM_USART_STATUS_CTS_Pos 3            /**< \brief (SERCOM_USART_STATUS) Clear To Send */
-#define SERCOM_USART_STATUS_CTS     (0x1ul << SERCOM_USART_STATUS_CTS_Pos)
+#define SERCOM_USART_STATUS_CTS     (_U_(0x1) << SERCOM_USART_STATUS_CTS_Pos)
 #define SERCOM_USART_STATUS_ISF_Pos 4            /**< \brief (SERCOM_USART_STATUS) Inconsistent Sync Field */
-#define SERCOM_USART_STATUS_ISF     (0x1ul << SERCOM_USART_STATUS_ISF_Pos)
+#define SERCOM_USART_STATUS_ISF     (_U_(0x1) << SERCOM_USART_STATUS_ISF_Pos)
 #define SERCOM_USART_STATUS_COLL_Pos 5            /**< \brief (SERCOM_USART_STATUS) Collision Detected */
-#define SERCOM_USART_STATUS_COLL    (0x1ul << SERCOM_USART_STATUS_COLL_Pos)
-#define SERCOM_USART_STATUS_MASK    0x003Ful     /**< \brief (SERCOM_USART_STATUS) MASK Register */
+#define SERCOM_USART_STATUS_COLL    (_U_(0x1) << SERCOM_USART_STATUS_COLL_Pos)
+#define SERCOM_USART_STATUS_MASK    _U_(0x003F)   /**< \brief (SERCOM_USART_STATUS) MASK Register */
 
 /* -------- SERCOM_I2CM_SYNCBUSY : (SERCOM Offset: 0x1C) (R/  32) I2CM I2CM Syncbusy -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1107,15 +1092,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_SYNCBUSY_OFFSET 0x1C         /**< \brief (SERCOM_I2CM_SYNCBUSY offset) I2CM Syncbusy */
-#define SERCOM_I2CM_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_SYNCBUSY reset_value) I2CM Syncbusy */
+#define SERCOM_I2CM_SYNCBUSY_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_SYNCBUSY reset_value) I2CM Syncbusy */
 
 #define SERCOM_I2CM_SYNCBUSY_SWRST_Pos 0            /**< \brief (SERCOM_I2CM_SYNCBUSY) Software Reset Synchronization Busy */
-#define SERCOM_I2CM_SYNCBUSY_SWRST  (0x1ul << SERCOM_I2CM_SYNCBUSY_SWRST_Pos)
+#define SERCOM_I2CM_SYNCBUSY_SWRST  (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_SWRST_Pos)
 #define SERCOM_I2CM_SYNCBUSY_ENABLE_Pos 1            /**< \brief (SERCOM_I2CM_SYNCBUSY) SERCOM Enable Synchronization Busy */
-#define SERCOM_I2CM_SYNCBUSY_ENABLE (0x1ul << SERCOM_I2CM_SYNCBUSY_ENABLE_Pos)
+#define SERCOM_I2CM_SYNCBUSY_ENABLE (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_ENABLE_Pos)
 #define SERCOM_I2CM_SYNCBUSY_SYSOP_Pos 2            /**< \brief (SERCOM_I2CM_SYNCBUSY) System Operation Synchronization Busy */
-#define SERCOM_I2CM_SYNCBUSY_SYSOP  (0x1ul << SERCOM_I2CM_SYNCBUSY_SYSOP_Pos)
-#define SERCOM_I2CM_SYNCBUSY_MASK   0x00000007ul /**< \brief (SERCOM_I2CM_SYNCBUSY) MASK Register */
+#define SERCOM_I2CM_SYNCBUSY_SYSOP  (_U_(0x1) << SERCOM_I2CM_SYNCBUSY_SYSOP_Pos)
+#define SERCOM_I2CM_SYNCBUSY_MASK   _U_(0x00000007) /**< \brief (SERCOM_I2CM_SYNCBUSY) MASK Register */
 
 /* -------- SERCOM_I2CS_SYNCBUSY : (SERCOM Offset: 0x1C) (R/  32) I2CS I2CS Syncbusy -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1130,13 +1115,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_SYNCBUSY_OFFSET 0x1C         /**< \brief (SERCOM_I2CS_SYNCBUSY offset) I2CS Syncbusy */
-#define SERCOM_I2CS_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CS_SYNCBUSY reset_value) I2CS Syncbusy */
+#define SERCOM_I2CS_SYNCBUSY_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_SYNCBUSY reset_value) I2CS Syncbusy */
 
 #define SERCOM_I2CS_SYNCBUSY_SWRST_Pos 0            /**< \brief (SERCOM_I2CS_SYNCBUSY) Software Reset Synchronization Busy */
-#define SERCOM_I2CS_SYNCBUSY_SWRST  (0x1ul << SERCOM_I2CS_SYNCBUSY_SWRST_Pos)
+#define SERCOM_I2CS_SYNCBUSY_SWRST  (_U_(0x1) << SERCOM_I2CS_SYNCBUSY_SWRST_Pos)
 #define SERCOM_I2CS_SYNCBUSY_ENABLE_Pos 1            /**< \brief (SERCOM_I2CS_SYNCBUSY) SERCOM Enable Synchronization Busy */
-#define SERCOM_I2CS_SYNCBUSY_ENABLE (0x1ul << SERCOM_I2CS_SYNCBUSY_ENABLE_Pos)
-#define SERCOM_I2CS_SYNCBUSY_MASK   0x00000003ul /**< \brief (SERCOM_I2CS_SYNCBUSY) MASK Register */
+#define SERCOM_I2CS_SYNCBUSY_ENABLE (_U_(0x1) << SERCOM_I2CS_SYNCBUSY_ENABLE_Pos)
+#define SERCOM_I2CS_SYNCBUSY_MASK   _U_(0x00000003) /**< \brief (SERCOM_I2CS_SYNCBUSY) MASK Register */
 
 /* -------- SERCOM_SPI_SYNCBUSY : (SERCOM Offset: 0x1C) (R/  32) SPI SPI Syncbusy -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1152,15 +1137,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_SYNCBUSY_OFFSET  0x1C         /**< \brief (SERCOM_SPI_SYNCBUSY offset) SPI Syncbusy */
-#define SERCOM_SPI_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (SERCOM_SPI_SYNCBUSY reset_value) SPI Syncbusy */
+#define SERCOM_SPI_SYNCBUSY_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_SPI_SYNCBUSY reset_value) SPI Syncbusy */
 
 #define SERCOM_SPI_SYNCBUSY_SWRST_Pos 0            /**< \brief (SERCOM_SPI_SYNCBUSY) Software Reset Synchronization Busy */
-#define SERCOM_SPI_SYNCBUSY_SWRST   (0x1ul << SERCOM_SPI_SYNCBUSY_SWRST_Pos)
+#define SERCOM_SPI_SYNCBUSY_SWRST   (_U_(0x1) << SERCOM_SPI_SYNCBUSY_SWRST_Pos)
 #define SERCOM_SPI_SYNCBUSY_ENABLE_Pos 1            /**< \brief (SERCOM_SPI_SYNCBUSY) SERCOM Enable Synchronization Busy */
-#define SERCOM_SPI_SYNCBUSY_ENABLE  (0x1ul << SERCOM_SPI_SYNCBUSY_ENABLE_Pos)
+#define SERCOM_SPI_SYNCBUSY_ENABLE  (_U_(0x1) << SERCOM_SPI_SYNCBUSY_ENABLE_Pos)
 #define SERCOM_SPI_SYNCBUSY_CTRLB_Pos 2            /**< \brief (SERCOM_SPI_SYNCBUSY) CTRLB Synchronization Busy */
-#define SERCOM_SPI_SYNCBUSY_CTRLB   (0x1ul << SERCOM_SPI_SYNCBUSY_CTRLB_Pos)
-#define SERCOM_SPI_SYNCBUSY_MASK    0x00000007ul /**< \brief (SERCOM_SPI_SYNCBUSY) MASK Register */
+#define SERCOM_SPI_SYNCBUSY_CTRLB   (_U_(0x1) << SERCOM_SPI_SYNCBUSY_CTRLB_Pos)
+#define SERCOM_SPI_SYNCBUSY_MASK    _U_(0x00000007) /**< \brief (SERCOM_SPI_SYNCBUSY) MASK Register */
 
 /* -------- SERCOM_USART_SYNCBUSY : (SERCOM Offset: 0x1C) (R/  32) USART USART Syncbusy -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1176,15 +1161,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_SYNCBUSY_OFFSET 0x1C         /**< \brief (SERCOM_USART_SYNCBUSY offset) USART Syncbusy */
-#define SERCOM_USART_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (SERCOM_USART_SYNCBUSY reset_value) USART Syncbusy */
+#define SERCOM_USART_SYNCBUSY_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_USART_SYNCBUSY reset_value) USART Syncbusy */
 
 #define SERCOM_USART_SYNCBUSY_SWRST_Pos 0            /**< \brief (SERCOM_USART_SYNCBUSY) Software Reset Synchronization Busy */
-#define SERCOM_USART_SYNCBUSY_SWRST (0x1ul << SERCOM_USART_SYNCBUSY_SWRST_Pos)
+#define SERCOM_USART_SYNCBUSY_SWRST (_U_(0x1) << SERCOM_USART_SYNCBUSY_SWRST_Pos)
 #define SERCOM_USART_SYNCBUSY_ENABLE_Pos 1            /**< \brief (SERCOM_USART_SYNCBUSY) SERCOM Enable Synchronization Busy */
-#define SERCOM_USART_SYNCBUSY_ENABLE (0x1ul << SERCOM_USART_SYNCBUSY_ENABLE_Pos)
+#define SERCOM_USART_SYNCBUSY_ENABLE (_U_(0x1) << SERCOM_USART_SYNCBUSY_ENABLE_Pos)
 #define SERCOM_USART_SYNCBUSY_CTRLB_Pos 2            /**< \brief (SERCOM_USART_SYNCBUSY) CTRLB Synchronization Busy */
-#define SERCOM_USART_SYNCBUSY_CTRLB (0x1ul << SERCOM_USART_SYNCBUSY_CTRLB_Pos)
-#define SERCOM_USART_SYNCBUSY_MASK  0x00000007ul /**< \brief (SERCOM_USART_SYNCBUSY) MASK Register */
+#define SERCOM_USART_SYNCBUSY_CTRLB (_U_(0x1) << SERCOM_USART_SYNCBUSY_CTRLB_Pos)
+#define SERCOM_USART_SYNCBUSY_MASK  _U_(0x00000007) /**< \brief (SERCOM_USART_SYNCBUSY) MASK Register */
 
 /* -------- SERCOM_I2CM_ADDR : (SERCOM Offset: 0x24) (R/W 32) I2CM I2CM Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1203,21 +1188,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_ADDR_OFFSET     0x24         /**< \brief (SERCOM_I2CM_ADDR offset) I2CM Address */
-#define SERCOM_I2CM_ADDR_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_ADDR reset_value) I2CM Address */
+#define SERCOM_I2CM_ADDR_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_ADDR reset_value) I2CM Address */
 
 #define SERCOM_I2CM_ADDR_ADDR_Pos   0            /**< \brief (SERCOM_I2CM_ADDR) Address Value */
-#define SERCOM_I2CM_ADDR_ADDR_Msk   (0x7FFul << SERCOM_I2CM_ADDR_ADDR_Pos)
+#define SERCOM_I2CM_ADDR_ADDR_Msk   (_U_(0x7FF) << SERCOM_I2CM_ADDR_ADDR_Pos)
 #define SERCOM_I2CM_ADDR_ADDR(value) (SERCOM_I2CM_ADDR_ADDR_Msk & ((value) << SERCOM_I2CM_ADDR_ADDR_Pos))
 #define SERCOM_I2CM_ADDR_LENEN_Pos  13           /**< \brief (SERCOM_I2CM_ADDR) Length Enable */
-#define SERCOM_I2CM_ADDR_LENEN      (0x1ul << SERCOM_I2CM_ADDR_LENEN_Pos)
+#define SERCOM_I2CM_ADDR_LENEN      (_U_(0x1) << SERCOM_I2CM_ADDR_LENEN_Pos)
 #define SERCOM_I2CM_ADDR_HS_Pos     14           /**< \brief (SERCOM_I2CM_ADDR) High Speed Mode */
-#define SERCOM_I2CM_ADDR_HS         (0x1ul << SERCOM_I2CM_ADDR_HS_Pos)
+#define SERCOM_I2CM_ADDR_HS         (_U_(0x1) << SERCOM_I2CM_ADDR_HS_Pos)
 #define SERCOM_I2CM_ADDR_TENBITEN_Pos 15           /**< \brief (SERCOM_I2CM_ADDR) Ten Bit Addressing Enable */
-#define SERCOM_I2CM_ADDR_TENBITEN   (0x1ul << SERCOM_I2CM_ADDR_TENBITEN_Pos)
+#define SERCOM_I2CM_ADDR_TENBITEN   (_U_(0x1) << SERCOM_I2CM_ADDR_TENBITEN_Pos)
 #define SERCOM_I2CM_ADDR_LEN_Pos    16           /**< \brief (SERCOM_I2CM_ADDR) Length */
-#define SERCOM_I2CM_ADDR_LEN_Msk    (0xFFul << SERCOM_I2CM_ADDR_LEN_Pos)
+#define SERCOM_I2CM_ADDR_LEN_Msk    (_U_(0xFF) << SERCOM_I2CM_ADDR_LEN_Pos)
 #define SERCOM_I2CM_ADDR_LEN(value) (SERCOM_I2CM_ADDR_LEN_Msk & ((value) << SERCOM_I2CM_ADDR_LEN_Pos))
-#define SERCOM_I2CM_ADDR_MASK       0x00FFE7FFul /**< \brief (SERCOM_I2CM_ADDR) MASK Register */
+#define SERCOM_I2CM_ADDR_MASK       _U_(0x00FFE7FF) /**< \brief (SERCOM_I2CM_ADDR) MASK Register */
 
 /* -------- SERCOM_I2CS_ADDR : (SERCOM Offset: 0x24) (R/W 32) I2CS I2CS Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1236,19 +1221,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_ADDR_OFFSET     0x24         /**< \brief (SERCOM_I2CS_ADDR offset) I2CS Address */
-#define SERCOM_I2CS_ADDR_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CS_ADDR reset_value) I2CS Address */
+#define SERCOM_I2CS_ADDR_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_ADDR reset_value) I2CS Address */
 
 #define SERCOM_I2CS_ADDR_GENCEN_Pos 0            /**< \brief (SERCOM_I2CS_ADDR) General Call Address Enable */
-#define SERCOM_I2CS_ADDR_GENCEN     (0x1ul << SERCOM_I2CS_ADDR_GENCEN_Pos)
+#define SERCOM_I2CS_ADDR_GENCEN     (_U_(0x1) << SERCOM_I2CS_ADDR_GENCEN_Pos)
 #define SERCOM_I2CS_ADDR_ADDR_Pos   1            /**< \brief (SERCOM_I2CS_ADDR) Address Value */
-#define SERCOM_I2CS_ADDR_ADDR_Msk   (0x3FFul << SERCOM_I2CS_ADDR_ADDR_Pos)
+#define SERCOM_I2CS_ADDR_ADDR_Msk   (_U_(0x3FF) << SERCOM_I2CS_ADDR_ADDR_Pos)
 #define SERCOM_I2CS_ADDR_ADDR(value) (SERCOM_I2CS_ADDR_ADDR_Msk & ((value) << SERCOM_I2CS_ADDR_ADDR_Pos))
 #define SERCOM_I2CS_ADDR_TENBITEN_Pos 15           /**< \brief (SERCOM_I2CS_ADDR) Ten Bit Addressing Enable */
-#define SERCOM_I2CS_ADDR_TENBITEN   (0x1ul << SERCOM_I2CS_ADDR_TENBITEN_Pos)
+#define SERCOM_I2CS_ADDR_TENBITEN   (_U_(0x1) << SERCOM_I2CS_ADDR_TENBITEN_Pos)
 #define SERCOM_I2CS_ADDR_ADDRMASK_Pos 17           /**< \brief (SERCOM_I2CS_ADDR) Address Mask */
-#define SERCOM_I2CS_ADDR_ADDRMASK_Msk (0x3FFul << SERCOM_I2CS_ADDR_ADDRMASK_Pos)
+#define SERCOM_I2CS_ADDR_ADDRMASK_Msk (_U_(0x3FF) << SERCOM_I2CS_ADDR_ADDRMASK_Pos)
 #define SERCOM_I2CS_ADDR_ADDRMASK(value) (SERCOM_I2CS_ADDR_ADDRMASK_Msk & ((value) << SERCOM_I2CS_ADDR_ADDRMASK_Pos))
-#define SERCOM_I2CS_ADDR_MASK       0x07FE87FFul /**< \brief (SERCOM_I2CS_ADDR) MASK Register */
+#define SERCOM_I2CS_ADDR_MASK       _U_(0x07FE87FF) /**< \brief (SERCOM_I2CS_ADDR) MASK Register */
 
 /* -------- SERCOM_SPI_ADDR : (SERCOM Offset: 0x24) (R/W 32) SPI SPI Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1264,15 +1249,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_ADDR_OFFSET      0x24         /**< \brief (SERCOM_SPI_ADDR offset) SPI Address */
-#define SERCOM_SPI_ADDR_RESETVALUE  0x00000000ul /**< \brief (SERCOM_SPI_ADDR reset_value) SPI Address */
+#define SERCOM_SPI_ADDR_RESETVALUE  _U_(0x00000000) /**< \brief (SERCOM_SPI_ADDR reset_value) SPI Address */
 
 #define SERCOM_SPI_ADDR_ADDR_Pos    0            /**< \brief (SERCOM_SPI_ADDR) Address Value */
-#define SERCOM_SPI_ADDR_ADDR_Msk    (0xFFul << SERCOM_SPI_ADDR_ADDR_Pos)
+#define SERCOM_SPI_ADDR_ADDR_Msk    (_U_(0xFF) << SERCOM_SPI_ADDR_ADDR_Pos)
 #define SERCOM_SPI_ADDR_ADDR(value) (SERCOM_SPI_ADDR_ADDR_Msk & ((value) << SERCOM_SPI_ADDR_ADDR_Pos))
 #define SERCOM_SPI_ADDR_ADDRMASK_Pos 16           /**< \brief (SERCOM_SPI_ADDR) Address Mask */
-#define SERCOM_SPI_ADDR_ADDRMASK_Msk (0xFFul << SERCOM_SPI_ADDR_ADDRMASK_Pos)
+#define SERCOM_SPI_ADDR_ADDRMASK_Msk (_U_(0xFF) << SERCOM_SPI_ADDR_ADDRMASK_Pos)
 #define SERCOM_SPI_ADDR_ADDRMASK(value) (SERCOM_SPI_ADDR_ADDRMASK_Msk & ((value) << SERCOM_SPI_ADDR_ADDRMASK_Pos))
-#define SERCOM_SPI_ADDR_MASK        0x00FF00FFul /**< \brief (SERCOM_SPI_ADDR) MASK Register */
+#define SERCOM_SPI_ADDR_MASK        _U_(0x00FF00FF) /**< \brief (SERCOM_SPI_ADDR) MASK Register */
 
 /* -------- SERCOM_I2CM_DATA : (SERCOM Offset: 0x28) (R/W  8) I2CM I2CM Data -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1285,12 +1270,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_DATA_OFFSET     0x28         /**< \brief (SERCOM_I2CM_DATA offset) I2CM Data */
-#define SERCOM_I2CM_DATA_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_DATA reset_value) I2CM Data */
+#define SERCOM_I2CM_DATA_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CM_DATA reset_value) I2CM Data */
 
 #define SERCOM_I2CM_DATA_DATA_Pos   0            /**< \brief (SERCOM_I2CM_DATA) Data Value */
-#define SERCOM_I2CM_DATA_DATA_Msk   (0xFFul << SERCOM_I2CM_DATA_DATA_Pos)
+#define SERCOM_I2CM_DATA_DATA_Msk   (_U_(0xFF) << SERCOM_I2CM_DATA_DATA_Pos)
 #define SERCOM_I2CM_DATA_DATA(value) (SERCOM_I2CM_DATA_DATA_Msk & ((value) << SERCOM_I2CM_DATA_DATA_Pos))
-#define SERCOM_I2CM_DATA_MASK       0xFFul       /**< \brief (SERCOM_I2CM_DATA) MASK Register */
+#define SERCOM_I2CM_DATA_MASK       _U_(0xFF)     /**< \brief (SERCOM_I2CM_DATA) MASK Register */
 
 /* -------- SERCOM_I2CS_DATA : (SERCOM Offset: 0x28) (R/W  8) I2CS I2CS Data -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1303,12 +1288,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CS_DATA_OFFSET     0x28         /**< \brief (SERCOM_I2CS_DATA offset) I2CS Data */
-#define SERCOM_I2CS_DATA_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CS_DATA reset_value) I2CS Data */
+#define SERCOM_I2CS_DATA_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CS_DATA reset_value) I2CS Data */
 
 #define SERCOM_I2CS_DATA_DATA_Pos   0            /**< \brief (SERCOM_I2CS_DATA) Data Value */
-#define SERCOM_I2CS_DATA_DATA_Msk   (0xFFul << SERCOM_I2CS_DATA_DATA_Pos)
+#define SERCOM_I2CS_DATA_DATA_Msk   (_U_(0xFF) << SERCOM_I2CS_DATA_DATA_Pos)
 #define SERCOM_I2CS_DATA_DATA(value) (SERCOM_I2CS_DATA_DATA_Msk & ((value) << SERCOM_I2CS_DATA_DATA_Pos))
-#define SERCOM_I2CS_DATA_MASK       0xFFul       /**< \brief (SERCOM_I2CS_DATA) MASK Register */
+#define SERCOM_I2CS_DATA_MASK       _U_(0xFF)     /**< \brief (SERCOM_I2CS_DATA) MASK Register */
 
 /* -------- SERCOM_SPI_DATA : (SERCOM Offset: 0x28) (R/W 32) SPI SPI Data -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1322,12 +1307,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_DATA_OFFSET      0x28         /**< \brief (SERCOM_SPI_DATA offset) SPI Data */
-#define SERCOM_SPI_DATA_RESETVALUE  0x00000000ul /**< \brief (SERCOM_SPI_DATA reset_value) SPI Data */
+#define SERCOM_SPI_DATA_RESETVALUE  _U_(0x00000000) /**< \brief (SERCOM_SPI_DATA reset_value) SPI Data */
 
 #define SERCOM_SPI_DATA_DATA_Pos    0            /**< \brief (SERCOM_SPI_DATA) Data Value */
-#define SERCOM_SPI_DATA_DATA_Msk    (0x1FFul << SERCOM_SPI_DATA_DATA_Pos)
+#define SERCOM_SPI_DATA_DATA_Msk    (_U_(0x1FF) << SERCOM_SPI_DATA_DATA_Pos)
 #define SERCOM_SPI_DATA_DATA(value) (SERCOM_SPI_DATA_DATA_Msk & ((value) << SERCOM_SPI_DATA_DATA_Pos))
-#define SERCOM_SPI_DATA_MASK        0x000001FFul /**< \brief (SERCOM_SPI_DATA) MASK Register */
+#define SERCOM_SPI_DATA_MASK        _U_(0x000001FF) /**< \brief (SERCOM_SPI_DATA) MASK Register */
 
 /* -------- SERCOM_USART_DATA : (SERCOM Offset: 0x28) (R/W 16) USART USART Data -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1341,12 +1326,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_DATA_OFFSET    0x28         /**< \brief (SERCOM_USART_DATA offset) USART Data */
-#define SERCOM_USART_DATA_RESETVALUE 0x0000ul     /**< \brief (SERCOM_USART_DATA reset_value) USART Data */
+#define SERCOM_USART_DATA_RESETVALUE _U_(0x0000)   /**< \brief (SERCOM_USART_DATA reset_value) USART Data */
 
 #define SERCOM_USART_DATA_DATA_Pos  0            /**< \brief (SERCOM_USART_DATA) Data Value */
-#define SERCOM_USART_DATA_DATA_Msk  (0x1FFul << SERCOM_USART_DATA_DATA_Pos)
+#define SERCOM_USART_DATA_DATA_Msk  (_U_(0x1FF) << SERCOM_USART_DATA_DATA_Pos)
 #define SERCOM_USART_DATA_DATA(value) (SERCOM_USART_DATA_DATA_Msk & ((value) << SERCOM_USART_DATA_DATA_Pos))
-#define SERCOM_USART_DATA_MASK      0x01FFul     /**< \brief (SERCOM_USART_DATA) MASK Register */
+#define SERCOM_USART_DATA_MASK      _U_(0x01FF)   /**< \brief (SERCOM_USART_DATA) MASK Register */
 
 /* -------- SERCOM_I2CM_DBGCTRL : (SERCOM Offset: 0x30) (R/W  8) I2CM I2CM Debug Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1360,11 +1345,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_I2CM_DBGCTRL_OFFSET  0x30         /**< \brief (SERCOM_I2CM_DBGCTRL offset) I2CM Debug Control */
-#define SERCOM_I2CM_DBGCTRL_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_DBGCTRL reset_value) I2CM Debug Control */
+#define SERCOM_I2CM_DBGCTRL_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_I2CM_DBGCTRL reset_value) I2CM Debug Control */
 
 #define SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_I2CM_DBGCTRL) Debug Mode */
-#define SERCOM_I2CM_DBGCTRL_DBGSTOP (0x1ul << SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos)
-#define SERCOM_I2CM_DBGCTRL_MASK    0x01ul       /**< \brief (SERCOM_I2CM_DBGCTRL) MASK Register */
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP (_U_(0x1) << SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_I2CM_DBGCTRL_MASK    _U_(0x01)     /**< \brief (SERCOM_I2CM_DBGCTRL) MASK Register */
 
 /* -------- SERCOM_SPI_DBGCTRL : (SERCOM Offset: 0x30) (R/W  8) SPI SPI Debug Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1378,11 +1363,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_SPI_DBGCTRL_OFFSET   0x30         /**< \brief (SERCOM_SPI_DBGCTRL offset) SPI Debug Control */
-#define SERCOM_SPI_DBGCTRL_RESETVALUE 0x00ul       /**< \brief (SERCOM_SPI_DBGCTRL reset_value) SPI Debug Control */
+#define SERCOM_SPI_DBGCTRL_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_SPI_DBGCTRL reset_value) SPI Debug Control */
 
 #define SERCOM_SPI_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_SPI_DBGCTRL) Debug Mode */
-#define SERCOM_SPI_DBGCTRL_DBGSTOP  (0x1ul << SERCOM_SPI_DBGCTRL_DBGSTOP_Pos)
-#define SERCOM_SPI_DBGCTRL_MASK     0x01ul       /**< \brief (SERCOM_SPI_DBGCTRL) MASK Register */
+#define SERCOM_SPI_DBGCTRL_DBGSTOP  (_U_(0x1) << SERCOM_SPI_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_SPI_DBGCTRL_MASK     _U_(0x01)     /**< \brief (SERCOM_SPI_DBGCTRL) MASK Register */
 
 /* -------- SERCOM_USART_DBGCTRL : (SERCOM Offset: 0x30) (R/W  8) USART USART Debug Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1396,11 +1381,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SERCOM_USART_DBGCTRL_OFFSET 0x30         /**< \brief (SERCOM_USART_DBGCTRL offset) USART Debug Control */
-#define SERCOM_USART_DBGCTRL_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_DBGCTRL reset_value) USART Debug Control */
+#define SERCOM_USART_DBGCTRL_RESETVALUE _U_(0x00)     /**< \brief (SERCOM_USART_DBGCTRL reset_value) USART Debug Control */
 
 #define SERCOM_USART_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_USART_DBGCTRL) Debug Mode */
-#define SERCOM_USART_DBGCTRL_DBGSTOP (0x1ul << SERCOM_USART_DBGCTRL_DBGSTOP_Pos)
-#define SERCOM_USART_DBGCTRL_MASK   0x01ul       /**< \brief (SERCOM_USART_DBGCTRL) MASK Register */
+#define SERCOM_USART_DBGCTRL_DBGSTOP (_U_(0x1) << SERCOM_USART_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_USART_DBGCTRL_MASK   _U_(0x01)     /**< \brief (SERCOM_USART_DBGCTRL) MASK Register */
 
 /** \brief SERCOM_I2CM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/sysctrl.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for SYSCTRL
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -80,39 +65,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_INTENCLR_OFFSET     0x00         /**< \brief (SYSCTRL_INTENCLR offset) Interrupt Enable Clear */
-#define SYSCTRL_INTENCLR_RESETVALUE 0x00000000ul /**< \brief (SYSCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+#define SYSCTRL_INTENCLR_RESETVALUE _U_(0x00000000) /**< \brief (SYSCTRL_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define SYSCTRL_INTENCLR_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTENCLR) XOSC Ready Interrupt Enable */
-#define SYSCTRL_INTENCLR_XOSCRDY    (0x1ul << SYSCTRL_INTENCLR_XOSCRDY_Pos)
+#define SYSCTRL_INTENCLR_XOSCRDY    (_U_(0x1) << SYSCTRL_INTENCLR_XOSCRDY_Pos)
 #define SYSCTRL_INTENCLR_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTENCLR) XOSC32K Ready Interrupt Enable */
-#define SYSCTRL_INTENCLR_XOSC32KRDY (0x1ul << SYSCTRL_INTENCLR_XOSC32KRDY_Pos)
+#define SYSCTRL_INTENCLR_XOSC32KRDY (_U_(0x1) << SYSCTRL_INTENCLR_XOSC32KRDY_Pos)
 #define SYSCTRL_INTENCLR_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTENCLR) OSC32K Ready Interrupt Enable */
-#define SYSCTRL_INTENCLR_OSC32KRDY  (0x1ul << SYSCTRL_INTENCLR_OSC32KRDY_Pos)
+#define SYSCTRL_INTENCLR_OSC32KRDY  (_U_(0x1) << SYSCTRL_INTENCLR_OSC32KRDY_Pos)
 #define SYSCTRL_INTENCLR_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTENCLR) OSC8M Ready Interrupt Enable */
-#define SYSCTRL_INTENCLR_OSC8MRDY   (0x1ul << SYSCTRL_INTENCLR_OSC8MRDY_Pos)
+#define SYSCTRL_INTENCLR_OSC8MRDY   (_U_(0x1) << SYSCTRL_INTENCLR_OSC8MRDY_Pos)
 #define SYSCTRL_INTENCLR_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTENCLR) DFLL Ready Interrupt Enable */
-#define SYSCTRL_INTENCLR_DFLLRDY    (0x1ul << SYSCTRL_INTENCLR_DFLLRDY_Pos)
+#define SYSCTRL_INTENCLR_DFLLRDY    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLRDY_Pos)
 #define SYSCTRL_INTENCLR_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTENCLR) DFLL Out Of Bounds Interrupt Enable */
-#define SYSCTRL_INTENCLR_DFLLOOB    (0x1ul << SYSCTRL_INTENCLR_DFLLOOB_Pos)
+#define SYSCTRL_INTENCLR_DFLLOOB    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLOOB_Pos)
 #define SYSCTRL_INTENCLR_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTENCLR) DFLL Lock Fine Interrupt Enable */
-#define SYSCTRL_INTENCLR_DFLLLCKF   (0x1ul << SYSCTRL_INTENCLR_DFLLLCKF_Pos)
+#define SYSCTRL_INTENCLR_DFLLLCKF   (_U_(0x1) << SYSCTRL_INTENCLR_DFLLLCKF_Pos)
 #define SYSCTRL_INTENCLR_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTENCLR) DFLL Lock Coarse Interrupt Enable */
-#define SYSCTRL_INTENCLR_DFLLLCKC   (0x1ul << SYSCTRL_INTENCLR_DFLLLCKC_Pos)
+#define SYSCTRL_INTENCLR_DFLLLCKC   (_U_(0x1) << SYSCTRL_INTENCLR_DFLLLCKC_Pos)
 #define SYSCTRL_INTENCLR_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTENCLR) DFLL Reference Clock Stopped Interrupt Enable */
-#define SYSCTRL_INTENCLR_DFLLRCS    (0x1ul << SYSCTRL_INTENCLR_DFLLRCS_Pos)
+#define SYSCTRL_INTENCLR_DFLLRCS    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLRCS_Pos)
 #define SYSCTRL_INTENCLR_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTENCLR) BOD33 Ready Interrupt Enable */
-#define SYSCTRL_INTENCLR_BOD33RDY   (0x1ul << SYSCTRL_INTENCLR_BOD33RDY_Pos)
+#define SYSCTRL_INTENCLR_BOD33RDY   (_U_(0x1) << SYSCTRL_INTENCLR_BOD33RDY_Pos)
 #define SYSCTRL_INTENCLR_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTENCLR) BOD33 Detection Interrupt Enable */
-#define SYSCTRL_INTENCLR_BOD33DET   (0x1ul << SYSCTRL_INTENCLR_BOD33DET_Pos)
+#define SYSCTRL_INTENCLR_BOD33DET   (_U_(0x1) << SYSCTRL_INTENCLR_BOD33DET_Pos)
 #define SYSCTRL_INTENCLR_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTENCLR) BOD33 Synchronization Ready Interrupt Enable */
-#define SYSCTRL_INTENCLR_B33SRDY    (0x1ul << SYSCTRL_INTENCLR_B33SRDY_Pos)
+#define SYSCTRL_INTENCLR_B33SRDY    (_U_(0x1) << SYSCTRL_INTENCLR_B33SRDY_Pos)
 #define SYSCTRL_INTENCLR_DPLLLCKR_Pos 15           /**< \brief (SYSCTRL_INTENCLR) DPLL Lock Rise Interrupt Enable */
-#define SYSCTRL_INTENCLR_DPLLLCKR   (0x1ul << SYSCTRL_INTENCLR_DPLLLCKR_Pos)
+#define SYSCTRL_INTENCLR_DPLLLCKR   (_U_(0x1) << SYSCTRL_INTENCLR_DPLLLCKR_Pos)
 #define SYSCTRL_INTENCLR_DPLLLCKF_Pos 16           /**< \brief (SYSCTRL_INTENCLR) DPLL Lock Fall Interrupt Enable */
-#define SYSCTRL_INTENCLR_DPLLLCKF   (0x1ul << SYSCTRL_INTENCLR_DPLLLCKF_Pos)
+#define SYSCTRL_INTENCLR_DPLLLCKF   (_U_(0x1) << SYSCTRL_INTENCLR_DPLLLCKF_Pos)
 #define SYSCTRL_INTENCLR_DPLLLTO_Pos 17           /**< \brief (SYSCTRL_INTENCLR) DPLL Lock Timeout Interrupt Enable */
-#define SYSCTRL_INTENCLR_DPLLLTO    (0x1ul << SYSCTRL_INTENCLR_DPLLLTO_Pos)
-#define SYSCTRL_INTENCLR_MASK       0x00038FFFul /**< \brief (SYSCTRL_INTENCLR) MASK Register */
+#define SYSCTRL_INTENCLR_DPLLLTO    (_U_(0x1) << SYSCTRL_INTENCLR_DPLLLTO_Pos)
+#define SYSCTRL_INTENCLR_MASK       _U_(0x00038FFF) /**< \brief (SYSCTRL_INTENCLR) MASK Register */
 
 /* -------- SYSCTRL_INTENSET : (SYSCTRL Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -141,39 +126,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_INTENSET_OFFSET     0x04         /**< \brief (SYSCTRL_INTENSET offset) Interrupt Enable Set */
-#define SYSCTRL_INTENSET_RESETVALUE 0x00000000ul /**< \brief (SYSCTRL_INTENSET reset_value) Interrupt Enable Set */
+#define SYSCTRL_INTENSET_RESETVALUE _U_(0x00000000) /**< \brief (SYSCTRL_INTENSET reset_value) Interrupt Enable Set */
 
 #define SYSCTRL_INTENSET_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTENSET) XOSC Ready Interrupt Enable */
-#define SYSCTRL_INTENSET_XOSCRDY    (0x1ul << SYSCTRL_INTENSET_XOSCRDY_Pos)
+#define SYSCTRL_INTENSET_XOSCRDY    (_U_(0x1) << SYSCTRL_INTENSET_XOSCRDY_Pos)
 #define SYSCTRL_INTENSET_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTENSET) XOSC32K Ready Interrupt Enable */
-#define SYSCTRL_INTENSET_XOSC32KRDY (0x1ul << SYSCTRL_INTENSET_XOSC32KRDY_Pos)
+#define SYSCTRL_INTENSET_XOSC32KRDY (_U_(0x1) << SYSCTRL_INTENSET_XOSC32KRDY_Pos)
 #define SYSCTRL_INTENSET_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTENSET) OSC32K Ready Interrupt Enable */
-#define SYSCTRL_INTENSET_OSC32KRDY  (0x1ul << SYSCTRL_INTENSET_OSC32KRDY_Pos)
+#define SYSCTRL_INTENSET_OSC32KRDY  (_U_(0x1) << SYSCTRL_INTENSET_OSC32KRDY_Pos)
 #define SYSCTRL_INTENSET_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTENSET) OSC8M Ready Interrupt Enable */
-#define SYSCTRL_INTENSET_OSC8MRDY   (0x1ul << SYSCTRL_INTENSET_OSC8MRDY_Pos)
+#define SYSCTRL_INTENSET_OSC8MRDY   (_U_(0x1) << SYSCTRL_INTENSET_OSC8MRDY_Pos)
 #define SYSCTRL_INTENSET_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTENSET) DFLL Ready Interrupt Enable */
-#define SYSCTRL_INTENSET_DFLLRDY    (0x1ul << SYSCTRL_INTENSET_DFLLRDY_Pos)
+#define SYSCTRL_INTENSET_DFLLRDY    (_U_(0x1) << SYSCTRL_INTENSET_DFLLRDY_Pos)
 #define SYSCTRL_INTENSET_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTENSET) DFLL Out Of Bounds Interrupt Enable */
-#define SYSCTRL_INTENSET_DFLLOOB    (0x1ul << SYSCTRL_INTENSET_DFLLOOB_Pos)
+#define SYSCTRL_INTENSET_DFLLOOB    (_U_(0x1) << SYSCTRL_INTENSET_DFLLOOB_Pos)
 #define SYSCTRL_INTENSET_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTENSET) DFLL Lock Fine Interrupt Enable */
-#define SYSCTRL_INTENSET_DFLLLCKF   (0x1ul << SYSCTRL_INTENSET_DFLLLCKF_Pos)
+#define SYSCTRL_INTENSET_DFLLLCKF   (_U_(0x1) << SYSCTRL_INTENSET_DFLLLCKF_Pos)
 #define SYSCTRL_INTENSET_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTENSET) DFLL Lock Coarse Interrupt Enable */
-#define SYSCTRL_INTENSET_DFLLLCKC   (0x1ul << SYSCTRL_INTENSET_DFLLLCKC_Pos)
+#define SYSCTRL_INTENSET_DFLLLCKC   (_U_(0x1) << SYSCTRL_INTENSET_DFLLLCKC_Pos)
 #define SYSCTRL_INTENSET_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTENSET) DFLL Reference Clock Stopped Interrupt Enable */
-#define SYSCTRL_INTENSET_DFLLRCS    (0x1ul << SYSCTRL_INTENSET_DFLLRCS_Pos)
+#define SYSCTRL_INTENSET_DFLLRCS    (_U_(0x1) << SYSCTRL_INTENSET_DFLLRCS_Pos)
 #define SYSCTRL_INTENSET_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTENSET) BOD33 Ready Interrupt Enable */
-#define SYSCTRL_INTENSET_BOD33RDY   (0x1ul << SYSCTRL_INTENSET_BOD33RDY_Pos)
+#define SYSCTRL_INTENSET_BOD33RDY   (_U_(0x1) << SYSCTRL_INTENSET_BOD33RDY_Pos)
 #define SYSCTRL_INTENSET_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTENSET) BOD33 Detection Interrupt Enable */
-#define SYSCTRL_INTENSET_BOD33DET   (0x1ul << SYSCTRL_INTENSET_BOD33DET_Pos)
+#define SYSCTRL_INTENSET_BOD33DET   (_U_(0x1) << SYSCTRL_INTENSET_BOD33DET_Pos)
 #define SYSCTRL_INTENSET_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTENSET) BOD33 Synchronization Ready Interrupt Enable */
-#define SYSCTRL_INTENSET_B33SRDY    (0x1ul << SYSCTRL_INTENSET_B33SRDY_Pos)
+#define SYSCTRL_INTENSET_B33SRDY    (_U_(0x1) << SYSCTRL_INTENSET_B33SRDY_Pos)
 #define SYSCTRL_INTENSET_DPLLLCKR_Pos 15           /**< \brief (SYSCTRL_INTENSET) DPLL Lock Rise Interrupt Enable */
-#define SYSCTRL_INTENSET_DPLLLCKR   (0x1ul << SYSCTRL_INTENSET_DPLLLCKR_Pos)
+#define SYSCTRL_INTENSET_DPLLLCKR   (_U_(0x1) << SYSCTRL_INTENSET_DPLLLCKR_Pos)
 #define SYSCTRL_INTENSET_DPLLLCKF_Pos 16           /**< \brief (SYSCTRL_INTENSET) DPLL Lock Fall Interrupt Enable */
-#define SYSCTRL_INTENSET_DPLLLCKF   (0x1ul << SYSCTRL_INTENSET_DPLLLCKF_Pos)
+#define SYSCTRL_INTENSET_DPLLLCKF   (_U_(0x1) << SYSCTRL_INTENSET_DPLLLCKF_Pos)
 #define SYSCTRL_INTENSET_DPLLLTO_Pos 17           /**< \brief (SYSCTRL_INTENSET) DPLL Lock Timeout Interrupt Enable */
-#define SYSCTRL_INTENSET_DPLLLTO    (0x1ul << SYSCTRL_INTENSET_DPLLLTO_Pos)
-#define SYSCTRL_INTENSET_MASK       0x00038FFFul /**< \brief (SYSCTRL_INTENSET) MASK Register */
+#define SYSCTRL_INTENSET_DPLLLTO    (_U_(0x1) << SYSCTRL_INTENSET_DPLLLTO_Pos)
+#define SYSCTRL_INTENSET_MASK       _U_(0x00038FFF) /**< \brief (SYSCTRL_INTENSET) MASK Register */
 
 /* -------- SYSCTRL_INTFLAG : (SYSCTRL Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -202,39 +187,39 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_INTFLAG_OFFSET      0x08         /**< \brief (SYSCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
-#define SYSCTRL_INTFLAG_RESETVALUE  0x00000000ul /**< \brief (SYSCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define SYSCTRL_INTFLAG_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define SYSCTRL_INTFLAG_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTFLAG) XOSC Ready */
-#define SYSCTRL_INTFLAG_XOSCRDY     (0x1ul << SYSCTRL_INTFLAG_XOSCRDY_Pos)
+#define SYSCTRL_INTFLAG_XOSCRDY     (_U_(0x1) << SYSCTRL_INTFLAG_XOSCRDY_Pos)
 #define SYSCTRL_INTFLAG_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTFLAG) XOSC32K Ready */
-#define SYSCTRL_INTFLAG_XOSC32KRDY  (0x1ul << SYSCTRL_INTFLAG_XOSC32KRDY_Pos)
+#define SYSCTRL_INTFLAG_XOSC32KRDY  (_U_(0x1) << SYSCTRL_INTFLAG_XOSC32KRDY_Pos)
 #define SYSCTRL_INTFLAG_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTFLAG) OSC32K Ready */
-#define SYSCTRL_INTFLAG_OSC32KRDY   (0x1ul << SYSCTRL_INTFLAG_OSC32KRDY_Pos)
+#define SYSCTRL_INTFLAG_OSC32KRDY   (_U_(0x1) << SYSCTRL_INTFLAG_OSC32KRDY_Pos)
 #define SYSCTRL_INTFLAG_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTFLAG) OSC8M Ready */
-#define SYSCTRL_INTFLAG_OSC8MRDY    (0x1ul << SYSCTRL_INTFLAG_OSC8MRDY_Pos)
+#define SYSCTRL_INTFLAG_OSC8MRDY    (_U_(0x1) << SYSCTRL_INTFLAG_OSC8MRDY_Pos)
 #define SYSCTRL_INTFLAG_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTFLAG) DFLL Ready */
-#define SYSCTRL_INTFLAG_DFLLRDY     (0x1ul << SYSCTRL_INTFLAG_DFLLRDY_Pos)
+#define SYSCTRL_INTFLAG_DFLLRDY     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLRDY_Pos)
 #define SYSCTRL_INTFLAG_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTFLAG) DFLL Out Of Bounds */
-#define SYSCTRL_INTFLAG_DFLLOOB     (0x1ul << SYSCTRL_INTFLAG_DFLLOOB_Pos)
+#define SYSCTRL_INTFLAG_DFLLOOB     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLOOB_Pos)
 #define SYSCTRL_INTFLAG_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTFLAG) DFLL Lock Fine */
-#define SYSCTRL_INTFLAG_DFLLLCKF    (0x1ul << SYSCTRL_INTFLAG_DFLLLCKF_Pos)
+#define SYSCTRL_INTFLAG_DFLLLCKF    (_U_(0x1) << SYSCTRL_INTFLAG_DFLLLCKF_Pos)
 #define SYSCTRL_INTFLAG_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTFLAG) DFLL Lock Coarse */
-#define SYSCTRL_INTFLAG_DFLLLCKC    (0x1ul << SYSCTRL_INTFLAG_DFLLLCKC_Pos)
+#define SYSCTRL_INTFLAG_DFLLLCKC    (_U_(0x1) << SYSCTRL_INTFLAG_DFLLLCKC_Pos)
 #define SYSCTRL_INTFLAG_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTFLAG) DFLL Reference Clock Stopped */
-#define SYSCTRL_INTFLAG_DFLLRCS     (0x1ul << SYSCTRL_INTFLAG_DFLLRCS_Pos)
+#define SYSCTRL_INTFLAG_DFLLRCS     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLRCS_Pos)
 #define SYSCTRL_INTFLAG_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTFLAG) BOD33 Ready */
-#define SYSCTRL_INTFLAG_BOD33RDY    (0x1ul << SYSCTRL_INTFLAG_BOD33RDY_Pos)
+#define SYSCTRL_INTFLAG_BOD33RDY    (_U_(0x1) << SYSCTRL_INTFLAG_BOD33RDY_Pos)
 #define SYSCTRL_INTFLAG_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTFLAG) BOD33 Detection */
-#define SYSCTRL_INTFLAG_BOD33DET    (0x1ul << SYSCTRL_INTFLAG_BOD33DET_Pos)
+#define SYSCTRL_INTFLAG_BOD33DET    (_U_(0x1) << SYSCTRL_INTFLAG_BOD33DET_Pos)
 #define SYSCTRL_INTFLAG_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTFLAG) BOD33 Synchronization Ready */
-#define SYSCTRL_INTFLAG_B33SRDY     (0x1ul << SYSCTRL_INTFLAG_B33SRDY_Pos)
+#define SYSCTRL_INTFLAG_B33SRDY     (_U_(0x1) << SYSCTRL_INTFLAG_B33SRDY_Pos)
 #define SYSCTRL_INTFLAG_DPLLLCKR_Pos 15           /**< \brief (SYSCTRL_INTFLAG) DPLL Lock Rise */
-#define SYSCTRL_INTFLAG_DPLLLCKR    (0x1ul << SYSCTRL_INTFLAG_DPLLLCKR_Pos)
+#define SYSCTRL_INTFLAG_DPLLLCKR    (_U_(0x1) << SYSCTRL_INTFLAG_DPLLLCKR_Pos)
 #define SYSCTRL_INTFLAG_DPLLLCKF_Pos 16           /**< \brief (SYSCTRL_INTFLAG) DPLL Lock Fall */
-#define SYSCTRL_INTFLAG_DPLLLCKF    (0x1ul << SYSCTRL_INTFLAG_DPLLLCKF_Pos)
+#define SYSCTRL_INTFLAG_DPLLLCKF    (_U_(0x1) << SYSCTRL_INTFLAG_DPLLLCKF_Pos)
 #define SYSCTRL_INTFLAG_DPLLLTO_Pos 17           /**< \brief (SYSCTRL_INTFLAG) DPLL Lock Timeout */
-#define SYSCTRL_INTFLAG_DPLLLTO     (0x1ul << SYSCTRL_INTFLAG_DPLLLTO_Pos)
-#define SYSCTRL_INTFLAG_MASK        0x00038FFFul /**< \brief (SYSCTRL_INTFLAG) MASK Register */
+#define SYSCTRL_INTFLAG_DPLLLTO     (_U_(0x1) << SYSCTRL_INTFLAG_DPLLLTO_Pos)
+#define SYSCTRL_INTFLAG_MASK        _U_(0x00038FFF) /**< \brief (SYSCTRL_INTFLAG) MASK Register */
 
 /* -------- SYSCTRL_PCLKSR : (SYSCTRL Offset: 0x0C) (R/  32) Power and Clocks Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -263,39 +248,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_PCLKSR_OFFSET       0x0C         /**< \brief (SYSCTRL_PCLKSR offset) Power and Clocks Status */
-#define SYSCTRL_PCLKSR_RESETVALUE   0x00000000ul /**< \brief (SYSCTRL_PCLKSR reset_value) Power and Clocks Status */
+#define SYSCTRL_PCLKSR_RESETVALUE   _U_(0x00000000) /**< \brief (SYSCTRL_PCLKSR reset_value) Power and Clocks Status */
 
 #define SYSCTRL_PCLKSR_XOSCRDY_Pos  0            /**< \brief (SYSCTRL_PCLKSR) XOSC Ready */
-#define SYSCTRL_PCLKSR_XOSCRDY      (0x1ul << SYSCTRL_PCLKSR_XOSCRDY_Pos)
+#define SYSCTRL_PCLKSR_XOSCRDY      (_U_(0x1) << SYSCTRL_PCLKSR_XOSCRDY_Pos)
 #define SYSCTRL_PCLKSR_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_PCLKSR) XOSC32K Ready */
-#define SYSCTRL_PCLKSR_XOSC32KRDY   (0x1ul << SYSCTRL_PCLKSR_XOSC32KRDY_Pos)
+#define SYSCTRL_PCLKSR_XOSC32KRDY   (_U_(0x1) << SYSCTRL_PCLKSR_XOSC32KRDY_Pos)
 #define SYSCTRL_PCLKSR_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_PCLKSR) OSC32K Ready */
-#define SYSCTRL_PCLKSR_OSC32KRDY    (0x1ul << SYSCTRL_PCLKSR_OSC32KRDY_Pos)
+#define SYSCTRL_PCLKSR_OSC32KRDY    (_U_(0x1) << SYSCTRL_PCLKSR_OSC32KRDY_Pos)
 #define SYSCTRL_PCLKSR_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_PCLKSR) OSC8M Ready */
-#define SYSCTRL_PCLKSR_OSC8MRDY     (0x1ul << SYSCTRL_PCLKSR_OSC8MRDY_Pos)
+#define SYSCTRL_PCLKSR_OSC8MRDY     (_U_(0x1) << SYSCTRL_PCLKSR_OSC8MRDY_Pos)
 #define SYSCTRL_PCLKSR_DFLLRDY_Pos  4            /**< \brief (SYSCTRL_PCLKSR) DFLL Ready */
-#define SYSCTRL_PCLKSR_DFLLRDY      (0x1ul << SYSCTRL_PCLKSR_DFLLRDY_Pos)
+#define SYSCTRL_PCLKSR_DFLLRDY      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLRDY_Pos)
 #define SYSCTRL_PCLKSR_DFLLOOB_Pos  5            /**< \brief (SYSCTRL_PCLKSR) DFLL Out Of Bounds */
-#define SYSCTRL_PCLKSR_DFLLOOB      (0x1ul << SYSCTRL_PCLKSR_DFLLOOB_Pos)
+#define SYSCTRL_PCLKSR_DFLLOOB      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLOOB_Pos)
 #define SYSCTRL_PCLKSR_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_PCLKSR) DFLL Lock Fine */
-#define SYSCTRL_PCLKSR_DFLLLCKF     (0x1ul << SYSCTRL_PCLKSR_DFLLLCKF_Pos)
+#define SYSCTRL_PCLKSR_DFLLLCKF     (_U_(0x1) << SYSCTRL_PCLKSR_DFLLLCKF_Pos)
 #define SYSCTRL_PCLKSR_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_PCLKSR) DFLL Lock Coarse */
-#define SYSCTRL_PCLKSR_DFLLLCKC     (0x1ul << SYSCTRL_PCLKSR_DFLLLCKC_Pos)
+#define SYSCTRL_PCLKSR_DFLLLCKC     (_U_(0x1) << SYSCTRL_PCLKSR_DFLLLCKC_Pos)
 #define SYSCTRL_PCLKSR_DFLLRCS_Pos  8            /**< \brief (SYSCTRL_PCLKSR) DFLL Reference Clock Stopped */
-#define SYSCTRL_PCLKSR_DFLLRCS      (0x1ul << SYSCTRL_PCLKSR_DFLLRCS_Pos)
+#define SYSCTRL_PCLKSR_DFLLRCS      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLRCS_Pos)
 #define SYSCTRL_PCLKSR_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_PCLKSR) BOD33 Ready */
-#define SYSCTRL_PCLKSR_BOD33RDY     (0x1ul << SYSCTRL_PCLKSR_BOD33RDY_Pos)
+#define SYSCTRL_PCLKSR_BOD33RDY     (_U_(0x1) << SYSCTRL_PCLKSR_BOD33RDY_Pos)
 #define SYSCTRL_PCLKSR_BOD33DET_Pos 10           /**< \brief (SYSCTRL_PCLKSR) BOD33 Detection */
-#define SYSCTRL_PCLKSR_BOD33DET     (0x1ul << SYSCTRL_PCLKSR_BOD33DET_Pos)
+#define SYSCTRL_PCLKSR_BOD33DET     (_U_(0x1) << SYSCTRL_PCLKSR_BOD33DET_Pos)
 #define SYSCTRL_PCLKSR_B33SRDY_Pos  11           /**< \brief (SYSCTRL_PCLKSR) BOD33 Synchronization Ready */
-#define SYSCTRL_PCLKSR_B33SRDY      (0x1ul << SYSCTRL_PCLKSR_B33SRDY_Pos)
+#define SYSCTRL_PCLKSR_B33SRDY      (_U_(0x1) << SYSCTRL_PCLKSR_B33SRDY_Pos)
 #define SYSCTRL_PCLKSR_DPLLLCKR_Pos 15           /**< \brief (SYSCTRL_PCLKSR) DPLL Lock Rise */
-#define SYSCTRL_PCLKSR_DPLLLCKR     (0x1ul << SYSCTRL_PCLKSR_DPLLLCKR_Pos)
+#define SYSCTRL_PCLKSR_DPLLLCKR     (_U_(0x1) << SYSCTRL_PCLKSR_DPLLLCKR_Pos)
 #define SYSCTRL_PCLKSR_DPLLLCKF_Pos 16           /**< \brief (SYSCTRL_PCLKSR) DPLL Lock Fall */
-#define SYSCTRL_PCLKSR_DPLLLCKF     (0x1ul << SYSCTRL_PCLKSR_DPLLLCKF_Pos)
+#define SYSCTRL_PCLKSR_DPLLLCKF     (_U_(0x1) << SYSCTRL_PCLKSR_DPLLLCKF_Pos)
 #define SYSCTRL_PCLKSR_DPLLLTO_Pos  17           /**< \brief (SYSCTRL_PCLKSR) DPLL Lock Timeout */
-#define SYSCTRL_PCLKSR_DPLLLTO      (0x1ul << SYSCTRL_PCLKSR_DPLLLTO_Pos)
-#define SYSCTRL_PCLKSR_MASK         0x00038FFFul /**< \brief (SYSCTRL_PCLKSR) MASK Register */
+#define SYSCTRL_PCLKSR_DPLLLTO      (_U_(0x1) << SYSCTRL_PCLKSR_DPLLLTO_Pos)
+#define SYSCTRL_PCLKSR_MASK         _U_(0x00038FFF) /**< \brief (SYSCTRL_PCLKSR) MASK Register */
 
 /* -------- SYSCTRL_XOSC : (SYSCTRL Offset: 0x10) (R/W 16) External Multipurpose Crystal Oscillator (XOSC) Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -316,35 +301,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_XOSC_OFFSET         0x10         /**< \brief (SYSCTRL_XOSC offset) External Multipurpose Crystal Oscillator (XOSC) Control */
-#define SYSCTRL_XOSC_RESETVALUE     0x0080ul     /**< \brief (SYSCTRL_XOSC reset_value) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define SYSCTRL_XOSC_RESETVALUE     _U_(0x0080)   /**< \brief (SYSCTRL_XOSC reset_value) External Multipurpose Crystal Oscillator (XOSC) Control */
 
 #define SYSCTRL_XOSC_ENABLE_Pos     1            /**< \brief (SYSCTRL_XOSC) Oscillator Enable */
-#define SYSCTRL_XOSC_ENABLE         (0x1ul << SYSCTRL_XOSC_ENABLE_Pos)
+#define SYSCTRL_XOSC_ENABLE         (_U_(0x1) << SYSCTRL_XOSC_ENABLE_Pos)
 #define SYSCTRL_XOSC_XTALEN_Pos     2            /**< \brief (SYSCTRL_XOSC) Crystal Oscillator Enable */
-#define SYSCTRL_XOSC_XTALEN         (0x1ul << SYSCTRL_XOSC_XTALEN_Pos)
+#define SYSCTRL_XOSC_XTALEN         (_U_(0x1) << SYSCTRL_XOSC_XTALEN_Pos)
 #define SYSCTRL_XOSC_RUNSTDBY_Pos   6            /**< \brief (SYSCTRL_XOSC) Run in Standby */
-#define SYSCTRL_XOSC_RUNSTDBY       (0x1ul << SYSCTRL_XOSC_RUNSTDBY_Pos)
+#define SYSCTRL_XOSC_RUNSTDBY       (_U_(0x1) << SYSCTRL_XOSC_RUNSTDBY_Pos)
 #define SYSCTRL_XOSC_ONDEMAND_Pos   7            /**< \brief (SYSCTRL_XOSC) On Demand Control */
-#define SYSCTRL_XOSC_ONDEMAND       (0x1ul << SYSCTRL_XOSC_ONDEMAND_Pos)
+#define SYSCTRL_XOSC_ONDEMAND       (_U_(0x1) << SYSCTRL_XOSC_ONDEMAND_Pos)
 #define SYSCTRL_XOSC_GAIN_Pos       8            /**< \brief (SYSCTRL_XOSC) Oscillator Gain */
-#define SYSCTRL_XOSC_GAIN_Msk       (0x7ul << SYSCTRL_XOSC_GAIN_Pos)
+#define SYSCTRL_XOSC_GAIN_Msk       (_U_(0x7) << SYSCTRL_XOSC_GAIN_Pos)
 #define SYSCTRL_XOSC_GAIN(value)    (SYSCTRL_XOSC_GAIN_Msk & ((value) << SYSCTRL_XOSC_GAIN_Pos))
-#define   SYSCTRL_XOSC_GAIN_0_Val         0x0ul  /**< \brief (SYSCTRL_XOSC) 2MHz */
-#define   SYSCTRL_XOSC_GAIN_1_Val         0x1ul  /**< \brief (SYSCTRL_XOSC) 4MHz */
-#define   SYSCTRL_XOSC_GAIN_2_Val         0x2ul  /**< \brief (SYSCTRL_XOSC) 8MHz */
-#define   SYSCTRL_XOSC_GAIN_3_Val         0x3ul  /**< \brief (SYSCTRL_XOSC) 16MHz */
-#define   SYSCTRL_XOSC_GAIN_4_Val         0x4ul  /**< \brief (SYSCTRL_XOSC) 30MHz */
+#define   SYSCTRL_XOSC_GAIN_0_Val         _U_(0x0)   /**< \brief (SYSCTRL_XOSC) 2MHz */
+#define   SYSCTRL_XOSC_GAIN_1_Val         _U_(0x1)   /**< \brief (SYSCTRL_XOSC) 4MHz */
+#define   SYSCTRL_XOSC_GAIN_2_Val         _U_(0x2)   /**< \brief (SYSCTRL_XOSC) 8MHz */
+#define   SYSCTRL_XOSC_GAIN_3_Val         _U_(0x3)   /**< \brief (SYSCTRL_XOSC) 16MHz */
+#define   SYSCTRL_XOSC_GAIN_4_Val         _U_(0x4)   /**< \brief (SYSCTRL_XOSC) 30MHz */
 #define SYSCTRL_XOSC_GAIN_0         (SYSCTRL_XOSC_GAIN_0_Val       << SYSCTRL_XOSC_GAIN_Pos)
 #define SYSCTRL_XOSC_GAIN_1         (SYSCTRL_XOSC_GAIN_1_Val       << SYSCTRL_XOSC_GAIN_Pos)
 #define SYSCTRL_XOSC_GAIN_2         (SYSCTRL_XOSC_GAIN_2_Val       << SYSCTRL_XOSC_GAIN_Pos)
 #define SYSCTRL_XOSC_GAIN_3         (SYSCTRL_XOSC_GAIN_3_Val       << SYSCTRL_XOSC_GAIN_Pos)
 #define SYSCTRL_XOSC_GAIN_4         (SYSCTRL_XOSC_GAIN_4_Val       << SYSCTRL_XOSC_GAIN_Pos)
 #define SYSCTRL_XOSC_AMPGC_Pos      11           /**< \brief (SYSCTRL_XOSC) Automatic Amplitude Gain Control */
-#define SYSCTRL_XOSC_AMPGC          (0x1ul << SYSCTRL_XOSC_AMPGC_Pos)
+#define SYSCTRL_XOSC_AMPGC          (_U_(0x1) << SYSCTRL_XOSC_AMPGC_Pos)
 #define SYSCTRL_XOSC_STARTUP_Pos    12           /**< \brief (SYSCTRL_XOSC) Start-Up Time */
-#define SYSCTRL_XOSC_STARTUP_Msk    (0xFul << SYSCTRL_XOSC_STARTUP_Pos)
+#define SYSCTRL_XOSC_STARTUP_Msk    (_U_(0xF) << SYSCTRL_XOSC_STARTUP_Pos)
 #define SYSCTRL_XOSC_STARTUP(value) (SYSCTRL_XOSC_STARTUP_Msk & ((value) << SYSCTRL_XOSC_STARTUP_Pos))
-#define SYSCTRL_XOSC_MASK           0xFFC6ul     /**< \brief (SYSCTRL_XOSC) MASK Register */
+#define SYSCTRL_XOSC_MASK           _U_(0xFFC6)   /**< \brief (SYSCTRL_XOSC) MASK Register */
 
 /* -------- SYSCTRL_XOSC32K : (SYSCTRL Offset: 0x14) (R/W 16) 32kHz External Crystal Oscillator (XOSC32K) Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -368,28 +353,28 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_XOSC32K_OFFSET      0x14         /**< \brief (SYSCTRL_XOSC32K offset) 32kHz External Crystal Oscillator (XOSC32K) Control */
-#define SYSCTRL_XOSC32K_RESETVALUE  0x0080ul     /**< \brief (SYSCTRL_XOSC32K reset_value) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define SYSCTRL_XOSC32K_RESETVALUE  _U_(0x0080)   /**< \brief (SYSCTRL_XOSC32K reset_value) 32kHz External Crystal Oscillator (XOSC32K) Control */
 
 #define SYSCTRL_XOSC32K_ENABLE_Pos  1            /**< \brief (SYSCTRL_XOSC32K) Oscillator Enable */
-#define SYSCTRL_XOSC32K_ENABLE      (0x1ul << SYSCTRL_XOSC32K_ENABLE_Pos)
+#define SYSCTRL_XOSC32K_ENABLE      (_U_(0x1) << SYSCTRL_XOSC32K_ENABLE_Pos)
 #define SYSCTRL_XOSC32K_XTALEN_Pos  2            /**< \brief (SYSCTRL_XOSC32K) Crystal Oscillator Enable */
-#define SYSCTRL_XOSC32K_XTALEN      (0x1ul << SYSCTRL_XOSC32K_XTALEN_Pos)
+#define SYSCTRL_XOSC32K_XTALEN      (_U_(0x1) << SYSCTRL_XOSC32K_XTALEN_Pos)
 #define SYSCTRL_XOSC32K_EN32K_Pos   3            /**< \brief (SYSCTRL_XOSC32K) 32kHz Output Enable */
-#define SYSCTRL_XOSC32K_EN32K       (0x1ul << SYSCTRL_XOSC32K_EN32K_Pos)
+#define SYSCTRL_XOSC32K_EN32K       (_U_(0x1) << SYSCTRL_XOSC32K_EN32K_Pos)
 #define SYSCTRL_XOSC32K_EN1K_Pos    4            /**< \brief (SYSCTRL_XOSC32K) 1kHz Output Enable */
-#define SYSCTRL_XOSC32K_EN1K        (0x1ul << SYSCTRL_XOSC32K_EN1K_Pos)
+#define SYSCTRL_XOSC32K_EN1K        (_U_(0x1) << SYSCTRL_XOSC32K_EN1K_Pos)
 #define SYSCTRL_XOSC32K_AAMPEN_Pos  5            /**< \brief (SYSCTRL_XOSC32K) Automatic Amplitude Control Enable */
-#define SYSCTRL_XOSC32K_AAMPEN      (0x1ul << SYSCTRL_XOSC32K_AAMPEN_Pos)
+#define SYSCTRL_XOSC32K_AAMPEN      (_U_(0x1) << SYSCTRL_XOSC32K_AAMPEN_Pos)
 #define SYSCTRL_XOSC32K_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_XOSC32K) Run in Standby */
-#define SYSCTRL_XOSC32K_RUNSTDBY    (0x1ul << SYSCTRL_XOSC32K_RUNSTDBY_Pos)
+#define SYSCTRL_XOSC32K_RUNSTDBY    (_U_(0x1) << SYSCTRL_XOSC32K_RUNSTDBY_Pos)
 #define SYSCTRL_XOSC32K_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_XOSC32K) On Demand Control */
-#define SYSCTRL_XOSC32K_ONDEMAND    (0x1ul << SYSCTRL_XOSC32K_ONDEMAND_Pos)
+#define SYSCTRL_XOSC32K_ONDEMAND    (_U_(0x1) << SYSCTRL_XOSC32K_ONDEMAND_Pos)
 #define SYSCTRL_XOSC32K_STARTUP_Pos 8            /**< \brief (SYSCTRL_XOSC32K) Oscillator Start-Up Time */
-#define SYSCTRL_XOSC32K_STARTUP_Msk (0x7ul << SYSCTRL_XOSC32K_STARTUP_Pos)
+#define SYSCTRL_XOSC32K_STARTUP_Msk (_U_(0x7) << SYSCTRL_XOSC32K_STARTUP_Pos)
 #define SYSCTRL_XOSC32K_STARTUP(value) (SYSCTRL_XOSC32K_STARTUP_Msk & ((value) << SYSCTRL_XOSC32K_STARTUP_Pos))
 #define SYSCTRL_XOSC32K_WRTLOCK_Pos 12           /**< \brief (SYSCTRL_XOSC32K) Write Lock */
-#define SYSCTRL_XOSC32K_WRTLOCK     (0x1ul << SYSCTRL_XOSC32K_WRTLOCK_Pos)
-#define SYSCTRL_XOSC32K_MASK        0x17FEul     /**< \brief (SYSCTRL_XOSC32K) MASK Register */
+#define SYSCTRL_XOSC32K_WRTLOCK     (_U_(0x1) << SYSCTRL_XOSC32K_WRTLOCK_Pos)
+#define SYSCTRL_XOSC32K_MASK        _U_(0x17FE)   /**< \brief (SYSCTRL_XOSC32K) MASK Register */
 
 /* -------- SYSCTRL_OSC32K : (SYSCTRL Offset: 0x18) (R/W 32) 32kHz Internal Oscillator (OSC32K) Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -414,27 +399,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_OSC32K_OFFSET       0x18         /**< \brief (SYSCTRL_OSC32K offset) 32kHz Internal Oscillator (OSC32K) Control */
-#define SYSCTRL_OSC32K_RESETVALUE   0x003F0080ul /**< \brief (SYSCTRL_OSC32K reset_value) 32kHz Internal Oscillator (OSC32K) Control */
+#define SYSCTRL_OSC32K_RESETVALUE   _U_(0x003F0080) /**< \brief (SYSCTRL_OSC32K reset_value) 32kHz Internal Oscillator (OSC32K) Control */
 
 #define SYSCTRL_OSC32K_ENABLE_Pos   1            /**< \brief (SYSCTRL_OSC32K) Oscillator Enable */
-#define SYSCTRL_OSC32K_ENABLE       (0x1ul << SYSCTRL_OSC32K_ENABLE_Pos)
+#define SYSCTRL_OSC32K_ENABLE       (_U_(0x1) << SYSCTRL_OSC32K_ENABLE_Pos)
 #define SYSCTRL_OSC32K_EN32K_Pos    2            /**< \brief (SYSCTRL_OSC32K) 32kHz Output Enable */
-#define SYSCTRL_OSC32K_EN32K        (0x1ul << SYSCTRL_OSC32K_EN32K_Pos)
+#define SYSCTRL_OSC32K_EN32K        (_U_(0x1) << SYSCTRL_OSC32K_EN32K_Pos)
 #define SYSCTRL_OSC32K_EN1K_Pos     3            /**< \brief (SYSCTRL_OSC32K) 1kHz Output Enable */
-#define SYSCTRL_OSC32K_EN1K         (0x1ul << SYSCTRL_OSC32K_EN1K_Pos)
+#define SYSCTRL_OSC32K_EN1K         (_U_(0x1) << SYSCTRL_OSC32K_EN1K_Pos)
 #define SYSCTRL_OSC32K_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_OSC32K) Run in Standby */
-#define SYSCTRL_OSC32K_RUNSTDBY     (0x1ul << SYSCTRL_OSC32K_RUNSTDBY_Pos)
+#define SYSCTRL_OSC32K_RUNSTDBY     (_U_(0x1) << SYSCTRL_OSC32K_RUNSTDBY_Pos)
 #define SYSCTRL_OSC32K_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_OSC32K) On Demand Control */
-#define SYSCTRL_OSC32K_ONDEMAND     (0x1ul << SYSCTRL_OSC32K_ONDEMAND_Pos)
+#define SYSCTRL_OSC32K_ONDEMAND     (_U_(0x1) << SYSCTRL_OSC32K_ONDEMAND_Pos)
 #define SYSCTRL_OSC32K_STARTUP_Pos  8            /**< \brief (SYSCTRL_OSC32K) Oscillator Start-Up Time */
-#define SYSCTRL_OSC32K_STARTUP_Msk  (0x7ul << SYSCTRL_OSC32K_STARTUP_Pos)
+#define SYSCTRL_OSC32K_STARTUP_Msk  (_U_(0x7) << SYSCTRL_OSC32K_STARTUP_Pos)
 #define SYSCTRL_OSC32K_STARTUP(value) (SYSCTRL_OSC32K_STARTUP_Msk & ((value) << SYSCTRL_OSC32K_STARTUP_Pos))
 #define SYSCTRL_OSC32K_WRTLOCK_Pos  12           /**< \brief (SYSCTRL_OSC32K) Write Lock */
-#define SYSCTRL_OSC32K_WRTLOCK      (0x1ul << SYSCTRL_OSC32K_WRTLOCK_Pos)
+#define SYSCTRL_OSC32K_WRTLOCK      (_U_(0x1) << SYSCTRL_OSC32K_WRTLOCK_Pos)
 #define SYSCTRL_OSC32K_CALIB_Pos    16           /**< \brief (SYSCTRL_OSC32K) Oscillator Calibration */
-#define SYSCTRL_OSC32K_CALIB_Msk    (0x7Ful << SYSCTRL_OSC32K_CALIB_Pos)
+#define SYSCTRL_OSC32K_CALIB_Msk    (_U_(0x7F) << SYSCTRL_OSC32K_CALIB_Pos)
 #define SYSCTRL_OSC32K_CALIB(value) (SYSCTRL_OSC32K_CALIB_Msk & ((value) << SYSCTRL_OSC32K_CALIB_Pos))
-#define SYSCTRL_OSC32K_MASK         0x007F17CEul /**< \brief (SYSCTRL_OSC32K) MASK Register */
+#define SYSCTRL_OSC32K_MASK         _U_(0x007F17CE) /**< \brief (SYSCTRL_OSC32K) MASK Register */
 
 /* -------- SYSCTRL_OSCULP32K : (SYSCTRL Offset: 0x1C) (R/W  8) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -449,14 +434,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_OSCULP32K_OFFSET    0x1C         /**< \brief (SYSCTRL_OSCULP32K offset) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
-#define SYSCTRL_OSCULP32K_RESETVALUE 0x1Ful       /**< \brief (SYSCTRL_OSCULP32K reset_value) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+#define SYSCTRL_OSCULP32K_RESETVALUE _U_(0x1F)     /**< \brief (SYSCTRL_OSCULP32K reset_value) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
 
 #define SYSCTRL_OSCULP32K_CALIB_Pos 0            /**< \brief (SYSCTRL_OSCULP32K) Oscillator Calibration */
-#define SYSCTRL_OSCULP32K_CALIB_Msk (0x1Ful << SYSCTRL_OSCULP32K_CALIB_Pos)
+#define SYSCTRL_OSCULP32K_CALIB_Msk (_U_(0x1F) << SYSCTRL_OSCULP32K_CALIB_Pos)
 #define SYSCTRL_OSCULP32K_CALIB(value) (SYSCTRL_OSCULP32K_CALIB_Msk & ((value) << SYSCTRL_OSCULP32K_CALIB_Pos))
 #define SYSCTRL_OSCULP32K_WRTLOCK_Pos 7            /**< \brief (SYSCTRL_OSCULP32K) Write Lock */
-#define SYSCTRL_OSCULP32K_WRTLOCK   (0x1ul << SYSCTRL_OSCULP32K_WRTLOCK_Pos)
-#define SYSCTRL_OSCULP32K_MASK      0x9Ful       /**< \brief (SYSCTRL_OSCULP32K) MASK Register */
+#define SYSCTRL_OSCULP32K_WRTLOCK   (_U_(0x1) << SYSCTRL_OSCULP32K_WRTLOCK_Pos)
+#define SYSCTRL_OSCULP32K_MASK      _U_(0x9F)     /**< \brief (SYSCTRL_OSCULP32K) MASK Register */
 
 /* -------- SYSCTRL_OSC8M : (SYSCTRL Offset: 0x20) (R/W 32) 8MHz Internal Oscillator (OSC8M) Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -478,40 +463,40 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_OSC8M_OFFSET        0x20         /**< \brief (SYSCTRL_OSC8M offset) 8MHz Internal Oscillator (OSC8M) Control */
-#define SYSCTRL_OSC8M_RESETVALUE    0x87070382ul /**< \brief (SYSCTRL_OSC8M reset_value) 8MHz Internal Oscillator (OSC8M) Control */
+#define SYSCTRL_OSC8M_RESETVALUE    _U_(0x87070382) /**< \brief (SYSCTRL_OSC8M reset_value) 8MHz Internal Oscillator (OSC8M) Control */
 
 #define SYSCTRL_OSC8M_ENABLE_Pos    1            /**< \brief (SYSCTRL_OSC8M) Oscillator Enable */
-#define SYSCTRL_OSC8M_ENABLE        (0x1ul << SYSCTRL_OSC8M_ENABLE_Pos)
+#define SYSCTRL_OSC8M_ENABLE        (_U_(0x1) << SYSCTRL_OSC8M_ENABLE_Pos)
 #define SYSCTRL_OSC8M_RUNSTDBY_Pos  6            /**< \brief (SYSCTRL_OSC8M) Run in Standby */
-#define SYSCTRL_OSC8M_RUNSTDBY      (0x1ul << SYSCTRL_OSC8M_RUNSTDBY_Pos)
+#define SYSCTRL_OSC8M_RUNSTDBY      (_U_(0x1) << SYSCTRL_OSC8M_RUNSTDBY_Pos)
 #define SYSCTRL_OSC8M_ONDEMAND_Pos  7            /**< \brief (SYSCTRL_OSC8M) On Demand Control */
-#define SYSCTRL_OSC8M_ONDEMAND      (0x1ul << SYSCTRL_OSC8M_ONDEMAND_Pos)
+#define SYSCTRL_OSC8M_ONDEMAND      (_U_(0x1) << SYSCTRL_OSC8M_ONDEMAND_Pos)
 #define SYSCTRL_OSC8M_PRESC_Pos     8            /**< \brief (SYSCTRL_OSC8M) Oscillator Prescaler */
-#define SYSCTRL_OSC8M_PRESC_Msk     (0x3ul << SYSCTRL_OSC8M_PRESC_Pos)
+#define SYSCTRL_OSC8M_PRESC_Msk     (_U_(0x3) << SYSCTRL_OSC8M_PRESC_Pos)
 #define SYSCTRL_OSC8M_PRESC(value)  (SYSCTRL_OSC8M_PRESC_Msk & ((value) << SYSCTRL_OSC8M_PRESC_Pos))
-#define   SYSCTRL_OSC8M_PRESC_0_Val       0x0ul  /**< \brief (SYSCTRL_OSC8M) 1 */
-#define   SYSCTRL_OSC8M_PRESC_1_Val       0x1ul  /**< \brief (SYSCTRL_OSC8M) 2 */
-#define   SYSCTRL_OSC8M_PRESC_2_Val       0x2ul  /**< \brief (SYSCTRL_OSC8M) 4 */
-#define   SYSCTRL_OSC8M_PRESC_3_Val       0x3ul  /**< \brief (SYSCTRL_OSC8M) 8 */
+#define   SYSCTRL_OSC8M_PRESC_0_Val       _U_(0x0)   /**< \brief (SYSCTRL_OSC8M) 1 */
+#define   SYSCTRL_OSC8M_PRESC_1_Val       _U_(0x1)   /**< \brief (SYSCTRL_OSC8M) 2 */
+#define   SYSCTRL_OSC8M_PRESC_2_Val       _U_(0x2)   /**< \brief (SYSCTRL_OSC8M) 4 */
+#define   SYSCTRL_OSC8M_PRESC_3_Val       _U_(0x3)   /**< \brief (SYSCTRL_OSC8M) 8 */
 #define SYSCTRL_OSC8M_PRESC_0       (SYSCTRL_OSC8M_PRESC_0_Val     << SYSCTRL_OSC8M_PRESC_Pos)
 #define SYSCTRL_OSC8M_PRESC_1       (SYSCTRL_OSC8M_PRESC_1_Val     << SYSCTRL_OSC8M_PRESC_Pos)
 #define SYSCTRL_OSC8M_PRESC_2       (SYSCTRL_OSC8M_PRESC_2_Val     << SYSCTRL_OSC8M_PRESC_Pos)
 #define SYSCTRL_OSC8M_PRESC_3       (SYSCTRL_OSC8M_PRESC_3_Val     << SYSCTRL_OSC8M_PRESC_Pos)
 #define SYSCTRL_OSC8M_CALIB_Pos     16           /**< \brief (SYSCTRL_OSC8M) Oscillator Calibration */
-#define SYSCTRL_OSC8M_CALIB_Msk     (0xFFFul << SYSCTRL_OSC8M_CALIB_Pos)
+#define SYSCTRL_OSC8M_CALIB_Msk     (_U_(0xFFF) << SYSCTRL_OSC8M_CALIB_Pos)
 #define SYSCTRL_OSC8M_CALIB(value)  (SYSCTRL_OSC8M_CALIB_Msk & ((value) << SYSCTRL_OSC8M_CALIB_Pos))
 #define SYSCTRL_OSC8M_FRANGE_Pos    30           /**< \brief (SYSCTRL_OSC8M) Oscillator Frequency Range */
-#define SYSCTRL_OSC8M_FRANGE_Msk    (0x3ul << SYSCTRL_OSC8M_FRANGE_Pos)
+#define SYSCTRL_OSC8M_FRANGE_Msk    (_U_(0x3) << SYSCTRL_OSC8M_FRANGE_Pos)
 #define SYSCTRL_OSC8M_FRANGE(value) (SYSCTRL_OSC8M_FRANGE_Msk & ((value) << SYSCTRL_OSC8M_FRANGE_Pos))
-#define   SYSCTRL_OSC8M_FRANGE_0_Val      0x0ul  /**< \brief (SYSCTRL_OSC8M) 4 to 6MHz */
-#define   SYSCTRL_OSC8M_FRANGE_1_Val      0x1ul  /**< \brief (SYSCTRL_OSC8M) 6 to 8MHz */
-#define   SYSCTRL_OSC8M_FRANGE_2_Val      0x2ul  /**< \brief (SYSCTRL_OSC8M) 8 to 11MHz */
-#define   SYSCTRL_OSC8M_FRANGE_3_Val      0x3ul  /**< \brief (SYSCTRL_OSC8M) 11 to 15MHz */
+#define   SYSCTRL_OSC8M_FRANGE_0_Val      _U_(0x0)   /**< \brief (SYSCTRL_OSC8M) 4 to 6MHz */
+#define   SYSCTRL_OSC8M_FRANGE_1_Val      _U_(0x1)   /**< \brief (SYSCTRL_OSC8M) 6 to 8MHz */
+#define   SYSCTRL_OSC8M_FRANGE_2_Val      _U_(0x2)   /**< \brief (SYSCTRL_OSC8M) 8 to 11MHz */
+#define   SYSCTRL_OSC8M_FRANGE_3_Val      _U_(0x3)   /**< \brief (SYSCTRL_OSC8M) 11 to 15MHz */
 #define SYSCTRL_OSC8M_FRANGE_0      (SYSCTRL_OSC8M_FRANGE_0_Val    << SYSCTRL_OSC8M_FRANGE_Pos)
 #define SYSCTRL_OSC8M_FRANGE_1      (SYSCTRL_OSC8M_FRANGE_1_Val    << SYSCTRL_OSC8M_FRANGE_Pos)
 #define SYSCTRL_OSC8M_FRANGE_2      (SYSCTRL_OSC8M_FRANGE_2_Val    << SYSCTRL_OSC8M_FRANGE_Pos)
 #define SYSCTRL_OSC8M_FRANGE_3      (SYSCTRL_OSC8M_FRANGE_3_Val    << SYSCTRL_OSC8M_FRANGE_Pos)
-#define SYSCTRL_OSC8M_MASK          0xCFFF03C2ul /**< \brief (SYSCTRL_OSC8M) MASK Register */
+#define SYSCTRL_OSC8M_MASK          _U_(0xCFFF03C2) /**< \brief (SYSCTRL_OSC8M) MASK Register */
 
 /* -------- SYSCTRL_DFLLCTRL : (SYSCTRL Offset: 0x24) (R/W 16) DFLL48M Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -536,31 +521,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_DFLLCTRL_OFFSET     0x24         /**< \brief (SYSCTRL_DFLLCTRL offset) DFLL48M Control */
-#define SYSCTRL_DFLLCTRL_RESETVALUE 0x0080ul     /**< \brief (SYSCTRL_DFLLCTRL reset_value) DFLL48M Control */
+#define SYSCTRL_DFLLCTRL_RESETVALUE _U_(0x0080)   /**< \brief (SYSCTRL_DFLLCTRL reset_value) DFLL48M Control */
 
 #define SYSCTRL_DFLLCTRL_ENABLE_Pos 1            /**< \brief (SYSCTRL_DFLLCTRL) DFLL Enable */
-#define SYSCTRL_DFLLCTRL_ENABLE     (0x1ul << SYSCTRL_DFLLCTRL_ENABLE_Pos)
+#define SYSCTRL_DFLLCTRL_ENABLE     (_U_(0x1) << SYSCTRL_DFLLCTRL_ENABLE_Pos)
 #define SYSCTRL_DFLLCTRL_MODE_Pos   2            /**< \brief (SYSCTRL_DFLLCTRL) Operating Mode Selection */
-#define SYSCTRL_DFLLCTRL_MODE       (0x1ul << SYSCTRL_DFLLCTRL_MODE_Pos)
+#define SYSCTRL_DFLLCTRL_MODE       (_U_(0x1) << SYSCTRL_DFLLCTRL_MODE_Pos)
 #define SYSCTRL_DFLLCTRL_STABLE_Pos 3            /**< \brief (SYSCTRL_DFLLCTRL) Stable DFLL Frequency */
-#define SYSCTRL_DFLLCTRL_STABLE     (0x1ul << SYSCTRL_DFLLCTRL_STABLE_Pos)
+#define SYSCTRL_DFLLCTRL_STABLE     (_U_(0x1) << SYSCTRL_DFLLCTRL_STABLE_Pos)
 #define SYSCTRL_DFLLCTRL_LLAW_Pos   4            /**< \brief (SYSCTRL_DFLLCTRL) Lose Lock After Wake */
-#define SYSCTRL_DFLLCTRL_LLAW       (0x1ul << SYSCTRL_DFLLCTRL_LLAW_Pos)
+#define SYSCTRL_DFLLCTRL_LLAW       (_U_(0x1) << SYSCTRL_DFLLCTRL_LLAW_Pos)
 #define SYSCTRL_DFLLCTRL_USBCRM_Pos 5            /**< \brief (SYSCTRL_DFLLCTRL) USB Clock Recovery Mode */
-#define SYSCTRL_DFLLCTRL_USBCRM     (0x1ul << SYSCTRL_DFLLCTRL_USBCRM_Pos)
+#define SYSCTRL_DFLLCTRL_USBCRM     (_U_(0x1) << SYSCTRL_DFLLCTRL_USBCRM_Pos)
 #define SYSCTRL_DFLLCTRL_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_DFLLCTRL) Run in Standby */
-#define SYSCTRL_DFLLCTRL_RUNSTDBY   (0x1ul << SYSCTRL_DFLLCTRL_RUNSTDBY_Pos)
+#define SYSCTRL_DFLLCTRL_RUNSTDBY   (_U_(0x1) << SYSCTRL_DFLLCTRL_RUNSTDBY_Pos)
 #define SYSCTRL_DFLLCTRL_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_DFLLCTRL) On Demand Control */
-#define SYSCTRL_DFLLCTRL_ONDEMAND   (0x1ul << SYSCTRL_DFLLCTRL_ONDEMAND_Pos)
+#define SYSCTRL_DFLLCTRL_ONDEMAND   (_U_(0x1) << SYSCTRL_DFLLCTRL_ONDEMAND_Pos)
 #define SYSCTRL_DFLLCTRL_CCDIS_Pos  8            /**< \brief (SYSCTRL_DFLLCTRL) Chill Cycle Disable */
-#define SYSCTRL_DFLLCTRL_CCDIS      (0x1ul << SYSCTRL_DFLLCTRL_CCDIS_Pos)
+#define SYSCTRL_DFLLCTRL_CCDIS      (_U_(0x1) << SYSCTRL_DFLLCTRL_CCDIS_Pos)
 #define SYSCTRL_DFLLCTRL_QLDIS_Pos  9            /**< \brief (SYSCTRL_DFLLCTRL) Quick Lock Disable */
-#define SYSCTRL_DFLLCTRL_QLDIS      (0x1ul << SYSCTRL_DFLLCTRL_QLDIS_Pos)
+#define SYSCTRL_DFLLCTRL_QLDIS      (_U_(0x1) << SYSCTRL_DFLLCTRL_QLDIS_Pos)
 #define SYSCTRL_DFLLCTRL_BPLCKC_Pos 10           /**< \brief (SYSCTRL_DFLLCTRL) Bypass Coarse Lock */
-#define SYSCTRL_DFLLCTRL_BPLCKC     (0x1ul << SYSCTRL_DFLLCTRL_BPLCKC_Pos)
+#define SYSCTRL_DFLLCTRL_BPLCKC     (_U_(0x1) << SYSCTRL_DFLLCTRL_BPLCKC_Pos)
 #define SYSCTRL_DFLLCTRL_WAITLOCK_Pos 11           /**< \brief (SYSCTRL_DFLLCTRL) Wait Lock */
-#define SYSCTRL_DFLLCTRL_WAITLOCK   (0x1ul << SYSCTRL_DFLLCTRL_WAITLOCK_Pos)
-#define SYSCTRL_DFLLCTRL_MASK       0x0FFEul     /**< \brief (SYSCTRL_DFLLCTRL) MASK Register */
+#define SYSCTRL_DFLLCTRL_WAITLOCK   (_U_(0x1) << SYSCTRL_DFLLCTRL_WAITLOCK_Pos)
+#define SYSCTRL_DFLLCTRL_MASK       _U_(0x0FFE)   /**< \brief (SYSCTRL_DFLLCTRL) MASK Register */
 
 /* -------- SYSCTRL_DFLLVAL : (SYSCTRL Offset: 0x28) (R/W 32) DFLL48M Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -575,18 +560,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_DFLLVAL_OFFSET      0x28         /**< \brief (SYSCTRL_DFLLVAL offset) DFLL48M Value */
-#define SYSCTRL_DFLLVAL_RESETVALUE  0x00000000ul /**< \brief (SYSCTRL_DFLLVAL reset_value) DFLL48M Value */
+#define SYSCTRL_DFLLVAL_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_DFLLVAL reset_value) DFLL48M Value */
 
 #define SYSCTRL_DFLLVAL_FINE_Pos    0            /**< \brief (SYSCTRL_DFLLVAL) Fine Value */
-#define SYSCTRL_DFLLVAL_FINE_Msk    (0x3FFul << SYSCTRL_DFLLVAL_FINE_Pos)
+#define SYSCTRL_DFLLVAL_FINE_Msk    (_U_(0x3FF) << SYSCTRL_DFLLVAL_FINE_Pos)
 #define SYSCTRL_DFLLVAL_FINE(value) (SYSCTRL_DFLLVAL_FINE_Msk & ((value) << SYSCTRL_DFLLVAL_FINE_Pos))
 #define SYSCTRL_DFLLVAL_COARSE_Pos  10           /**< \brief (SYSCTRL_DFLLVAL) Coarse Value */
-#define SYSCTRL_DFLLVAL_COARSE_Msk  (0x3Ful << SYSCTRL_DFLLVAL_COARSE_Pos)
+#define SYSCTRL_DFLLVAL_COARSE_Msk  (_U_(0x3F) << SYSCTRL_DFLLVAL_COARSE_Pos)
 #define SYSCTRL_DFLLVAL_COARSE(value) (SYSCTRL_DFLLVAL_COARSE_Msk & ((value) << SYSCTRL_DFLLVAL_COARSE_Pos))
 #define SYSCTRL_DFLLVAL_DIFF_Pos    16           /**< \brief (SYSCTRL_DFLLVAL) Multiplication Ratio Difference */
-#define SYSCTRL_DFLLVAL_DIFF_Msk    (0xFFFFul << SYSCTRL_DFLLVAL_DIFF_Pos)
+#define SYSCTRL_DFLLVAL_DIFF_Msk    (_U_(0xFFFF) << SYSCTRL_DFLLVAL_DIFF_Pos)
 #define SYSCTRL_DFLLVAL_DIFF(value) (SYSCTRL_DFLLVAL_DIFF_Msk & ((value) << SYSCTRL_DFLLVAL_DIFF_Pos))
-#define SYSCTRL_DFLLVAL_MASK        0xFFFFFFFFul /**< \brief (SYSCTRL_DFLLVAL) MASK Register */
+#define SYSCTRL_DFLLVAL_MASK        _U_(0xFFFFFFFF) /**< \brief (SYSCTRL_DFLLVAL) MASK Register */
 
 /* -------- SYSCTRL_DFLLMUL : (SYSCTRL Offset: 0x2C) (R/W 32) DFLL48M Multiplier -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -601,18 +586,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_DFLLMUL_OFFSET      0x2C         /**< \brief (SYSCTRL_DFLLMUL offset) DFLL48M Multiplier */
-#define SYSCTRL_DFLLMUL_RESETVALUE  0x00000000ul /**< \brief (SYSCTRL_DFLLMUL reset_value) DFLL48M Multiplier */
+#define SYSCTRL_DFLLMUL_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_DFLLMUL reset_value) DFLL48M Multiplier */
 
 #define SYSCTRL_DFLLMUL_MUL_Pos     0            /**< \brief (SYSCTRL_DFLLMUL) DFLL Multiply Factor */
-#define SYSCTRL_DFLLMUL_MUL_Msk     (0xFFFFul << SYSCTRL_DFLLMUL_MUL_Pos)
+#define SYSCTRL_DFLLMUL_MUL_Msk     (_U_(0xFFFF) << SYSCTRL_DFLLMUL_MUL_Pos)
 #define SYSCTRL_DFLLMUL_MUL(value)  (SYSCTRL_DFLLMUL_MUL_Msk & ((value) << SYSCTRL_DFLLMUL_MUL_Pos))
 #define SYSCTRL_DFLLMUL_FSTEP_Pos   16           /**< \brief (SYSCTRL_DFLLMUL) Fine Maximum Step */
-#define SYSCTRL_DFLLMUL_FSTEP_Msk   (0x3FFul << SYSCTRL_DFLLMUL_FSTEP_Pos)
+#define SYSCTRL_DFLLMUL_FSTEP_Msk   (_U_(0x3FF) << SYSCTRL_DFLLMUL_FSTEP_Pos)
 #define SYSCTRL_DFLLMUL_FSTEP(value) (SYSCTRL_DFLLMUL_FSTEP_Msk & ((value) << SYSCTRL_DFLLMUL_FSTEP_Pos))
 #define SYSCTRL_DFLLMUL_CSTEP_Pos   26           /**< \brief (SYSCTRL_DFLLMUL) Coarse Maximum Step */
-#define SYSCTRL_DFLLMUL_CSTEP_Msk   (0x3Ful << SYSCTRL_DFLLMUL_CSTEP_Pos)
+#define SYSCTRL_DFLLMUL_CSTEP_Msk   (_U_(0x3F) << SYSCTRL_DFLLMUL_CSTEP_Pos)
 #define SYSCTRL_DFLLMUL_CSTEP(value) (SYSCTRL_DFLLMUL_CSTEP_Msk & ((value) << SYSCTRL_DFLLMUL_CSTEP_Pos))
-#define SYSCTRL_DFLLMUL_MASK        0xFFFFFFFFul /**< \brief (SYSCTRL_DFLLMUL) MASK Register */
+#define SYSCTRL_DFLLMUL_MASK        _U_(0xFFFFFFFF) /**< \brief (SYSCTRL_DFLLMUL) MASK Register */
 
 /* -------- SYSCTRL_DFLLSYNC : (SYSCTRL Offset: 0x30) (R/W  8) DFLL48M Synchronization -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -626,11 +611,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_DFLLSYNC_OFFSET     0x30         /**< \brief (SYSCTRL_DFLLSYNC offset) DFLL48M Synchronization */
-#define SYSCTRL_DFLLSYNC_RESETVALUE 0x00ul       /**< \brief (SYSCTRL_DFLLSYNC reset_value) DFLL48M Synchronization */
+#define SYSCTRL_DFLLSYNC_RESETVALUE _U_(0x00)     /**< \brief (SYSCTRL_DFLLSYNC reset_value) DFLL48M Synchronization */
 
 #define SYSCTRL_DFLLSYNC_READREQ_Pos 7            /**< \brief (SYSCTRL_DFLLSYNC) Read Request */
-#define SYSCTRL_DFLLSYNC_READREQ    (0x1ul << SYSCTRL_DFLLSYNC_READREQ_Pos)
-#define SYSCTRL_DFLLSYNC_MASK       0x80ul       /**< \brief (SYSCTRL_DFLLSYNC) MASK Register */
+#define SYSCTRL_DFLLSYNC_READREQ    (_U_(0x1) << SYSCTRL_DFLLSYNC_READREQ_Pos)
+#define SYSCTRL_DFLLSYNC_MASK       _U_(0x80)     /**< \brief (SYSCTRL_DFLLSYNC) MASK Register */
 
 /* -------- SYSCTRL_BOD33 : (SYSCTRL Offset: 0x34) (R/W 32) 3.3V Brown-Out Detector (BOD33) Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -655,46 +640,46 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_BOD33_OFFSET        0x34         /**< \brief (SYSCTRL_BOD33 offset) 3.3V Brown-Out Detector (BOD33) Control */
-#define SYSCTRL_BOD33_RESETVALUE    0x00000000ul /**< \brief (SYSCTRL_BOD33 reset_value) 3.3V Brown-Out Detector (BOD33) Control */
+#define SYSCTRL_BOD33_RESETVALUE    _U_(0x00000000) /**< \brief (SYSCTRL_BOD33 reset_value) 3.3V Brown-Out Detector (BOD33) Control */
 
 #define SYSCTRL_BOD33_ENABLE_Pos    1            /**< \brief (SYSCTRL_BOD33) Enable */
-#define SYSCTRL_BOD33_ENABLE        (0x1ul << SYSCTRL_BOD33_ENABLE_Pos)
+#define SYSCTRL_BOD33_ENABLE        (_U_(0x1) << SYSCTRL_BOD33_ENABLE_Pos)
 #define SYSCTRL_BOD33_HYST_Pos      2            /**< \brief (SYSCTRL_BOD33) Hysteresis */
-#define SYSCTRL_BOD33_HYST          (0x1ul << SYSCTRL_BOD33_HYST_Pos)
+#define SYSCTRL_BOD33_HYST          (_U_(0x1) << SYSCTRL_BOD33_HYST_Pos)
 #define SYSCTRL_BOD33_ACTION_Pos    3            /**< \brief (SYSCTRL_BOD33) BOD33 Action */
-#define SYSCTRL_BOD33_ACTION_Msk    (0x3ul << SYSCTRL_BOD33_ACTION_Pos)
+#define SYSCTRL_BOD33_ACTION_Msk    (_U_(0x3) << SYSCTRL_BOD33_ACTION_Pos)
 #define SYSCTRL_BOD33_ACTION(value) (SYSCTRL_BOD33_ACTION_Msk & ((value) << SYSCTRL_BOD33_ACTION_Pos))
-#define   SYSCTRL_BOD33_ACTION_NONE_Val   0x0ul  /**< \brief (SYSCTRL_BOD33) No action */
-#define   SYSCTRL_BOD33_ACTION_RESET_Val  0x1ul  /**< \brief (SYSCTRL_BOD33) The BOD33 generates a reset */
-#define   SYSCTRL_BOD33_ACTION_INTERRUPT_Val 0x2ul  /**< \brief (SYSCTRL_BOD33) The BOD33 generates an interrupt */
+#define   SYSCTRL_BOD33_ACTION_NONE_Val   _U_(0x0)   /**< \brief (SYSCTRL_BOD33) No action */
+#define   SYSCTRL_BOD33_ACTION_RESET_Val  _U_(0x1)   /**< \brief (SYSCTRL_BOD33) The BOD33 generates a reset */
+#define   SYSCTRL_BOD33_ACTION_INTERRUPT_Val _U_(0x2)   /**< \brief (SYSCTRL_BOD33) The BOD33 generates an interrupt */
 #define SYSCTRL_BOD33_ACTION_NONE   (SYSCTRL_BOD33_ACTION_NONE_Val << SYSCTRL_BOD33_ACTION_Pos)
 #define SYSCTRL_BOD33_ACTION_RESET  (SYSCTRL_BOD33_ACTION_RESET_Val << SYSCTRL_BOD33_ACTION_Pos)
 #define SYSCTRL_BOD33_ACTION_INTERRUPT (SYSCTRL_BOD33_ACTION_INTERRUPT_Val << SYSCTRL_BOD33_ACTION_Pos)
 #define SYSCTRL_BOD33_RUNSTDBY_Pos  6            /**< \brief (SYSCTRL_BOD33) Run in Standby */
-#define SYSCTRL_BOD33_RUNSTDBY      (0x1ul << SYSCTRL_BOD33_RUNSTDBY_Pos)
+#define SYSCTRL_BOD33_RUNSTDBY      (_U_(0x1) << SYSCTRL_BOD33_RUNSTDBY_Pos)
 #define SYSCTRL_BOD33_MODE_Pos      8            /**< \brief (SYSCTRL_BOD33) Operation Mode */
-#define SYSCTRL_BOD33_MODE          (0x1ul << SYSCTRL_BOD33_MODE_Pos)
+#define SYSCTRL_BOD33_MODE          (_U_(0x1) << SYSCTRL_BOD33_MODE_Pos)
 #define SYSCTRL_BOD33_CEN_Pos       9            /**< \brief (SYSCTRL_BOD33) Clock Enable */
-#define SYSCTRL_BOD33_CEN           (0x1ul << SYSCTRL_BOD33_CEN_Pos)
+#define SYSCTRL_BOD33_CEN           (_U_(0x1) << SYSCTRL_BOD33_CEN_Pos)
 #define SYSCTRL_BOD33_PSEL_Pos      12           /**< \brief (SYSCTRL_BOD33) Prescaler Select */
-#define SYSCTRL_BOD33_PSEL_Msk      (0xFul << SYSCTRL_BOD33_PSEL_Pos)
+#define SYSCTRL_BOD33_PSEL_Msk      (_U_(0xF) << SYSCTRL_BOD33_PSEL_Pos)
 #define SYSCTRL_BOD33_PSEL(value)   (SYSCTRL_BOD33_PSEL_Msk & ((value) << SYSCTRL_BOD33_PSEL_Pos))
-#define   SYSCTRL_BOD33_PSEL_DIV2_Val     0x0ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 2 */
-#define   SYSCTRL_BOD33_PSEL_DIV4_Val     0x1ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 4 */
-#define   SYSCTRL_BOD33_PSEL_DIV8_Val     0x2ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 8 */
-#define   SYSCTRL_BOD33_PSEL_DIV16_Val    0x3ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 16 */
-#define   SYSCTRL_BOD33_PSEL_DIV32_Val    0x4ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 32 */
-#define   SYSCTRL_BOD33_PSEL_DIV64_Val    0x5ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 64 */
-#define   SYSCTRL_BOD33_PSEL_DIV128_Val   0x6ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 128 */
-#define   SYSCTRL_BOD33_PSEL_DIV256_Val   0x7ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 256 */
-#define   SYSCTRL_BOD33_PSEL_DIV512_Val   0x8ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 512 */
-#define   SYSCTRL_BOD33_PSEL_DIV1K_Val    0x9ul  /**< \brief (SYSCTRL_BOD33) Divide clock by 1024 */
-#define   SYSCTRL_BOD33_PSEL_DIV2K_Val    0xAul  /**< \brief (SYSCTRL_BOD33) Divide clock by 2048 */
-#define   SYSCTRL_BOD33_PSEL_DIV4K_Val    0xBul  /**< \brief (SYSCTRL_BOD33) Divide clock by 4096 */
-#define   SYSCTRL_BOD33_PSEL_DIV8K_Val    0xCul  /**< \brief (SYSCTRL_BOD33) Divide clock by 8192 */
-#define   SYSCTRL_BOD33_PSEL_DIV16K_Val   0xDul  /**< \brief (SYSCTRL_BOD33) Divide clock by 16384 */
-#define   SYSCTRL_BOD33_PSEL_DIV32K_Val   0xEul  /**< \brief (SYSCTRL_BOD33) Divide clock by 32768 */
-#define   SYSCTRL_BOD33_PSEL_DIV64K_Val   0xFul  /**< \brief (SYSCTRL_BOD33) Divide clock by 65536 */
+#define   SYSCTRL_BOD33_PSEL_DIV2_Val     _U_(0x0)   /**< \brief (SYSCTRL_BOD33) Divide clock by 2 */
+#define   SYSCTRL_BOD33_PSEL_DIV4_Val     _U_(0x1)   /**< \brief (SYSCTRL_BOD33) Divide clock by 4 */
+#define   SYSCTRL_BOD33_PSEL_DIV8_Val     _U_(0x2)   /**< \brief (SYSCTRL_BOD33) Divide clock by 8 */
+#define   SYSCTRL_BOD33_PSEL_DIV16_Val    _U_(0x3)   /**< \brief (SYSCTRL_BOD33) Divide clock by 16 */
+#define   SYSCTRL_BOD33_PSEL_DIV32_Val    _U_(0x4)   /**< \brief (SYSCTRL_BOD33) Divide clock by 32 */
+#define   SYSCTRL_BOD33_PSEL_DIV64_Val    _U_(0x5)   /**< \brief (SYSCTRL_BOD33) Divide clock by 64 */
+#define   SYSCTRL_BOD33_PSEL_DIV128_Val   _U_(0x6)   /**< \brief (SYSCTRL_BOD33) Divide clock by 128 */
+#define   SYSCTRL_BOD33_PSEL_DIV256_Val   _U_(0x7)   /**< \brief (SYSCTRL_BOD33) Divide clock by 256 */
+#define   SYSCTRL_BOD33_PSEL_DIV512_Val   _U_(0x8)   /**< \brief (SYSCTRL_BOD33) Divide clock by 512 */
+#define   SYSCTRL_BOD33_PSEL_DIV1K_Val    _U_(0x9)   /**< \brief (SYSCTRL_BOD33) Divide clock by 1024 */
+#define   SYSCTRL_BOD33_PSEL_DIV2K_Val    _U_(0xA)   /**< \brief (SYSCTRL_BOD33) Divide clock by 2048 */
+#define   SYSCTRL_BOD33_PSEL_DIV4K_Val    _U_(0xB)   /**< \brief (SYSCTRL_BOD33) Divide clock by 4096 */
+#define   SYSCTRL_BOD33_PSEL_DIV8K_Val    _U_(0xC)   /**< \brief (SYSCTRL_BOD33) Divide clock by 8192 */
+#define   SYSCTRL_BOD33_PSEL_DIV16K_Val   _U_(0xD)   /**< \brief (SYSCTRL_BOD33) Divide clock by 16384 */
+#define   SYSCTRL_BOD33_PSEL_DIV32K_Val   _U_(0xE)   /**< \brief (SYSCTRL_BOD33) Divide clock by 32768 */
+#define   SYSCTRL_BOD33_PSEL_DIV64K_Val   _U_(0xF)   /**< \brief (SYSCTRL_BOD33) Divide clock by 65536 */
 #define SYSCTRL_BOD33_PSEL_DIV2     (SYSCTRL_BOD33_PSEL_DIV2_Val   << SYSCTRL_BOD33_PSEL_Pos)
 #define SYSCTRL_BOD33_PSEL_DIV4     (SYSCTRL_BOD33_PSEL_DIV4_Val   << SYSCTRL_BOD33_PSEL_Pos)
 #define SYSCTRL_BOD33_PSEL_DIV8     (SYSCTRL_BOD33_PSEL_DIV8_Val   << SYSCTRL_BOD33_PSEL_Pos)
@@ -712,9 +697,9 @@ typedef union {
 #define SYSCTRL_BOD33_PSEL_DIV32K   (SYSCTRL_BOD33_PSEL_DIV32K_Val << SYSCTRL_BOD33_PSEL_Pos)
 #define SYSCTRL_BOD33_PSEL_DIV64K   (SYSCTRL_BOD33_PSEL_DIV64K_Val << SYSCTRL_BOD33_PSEL_Pos)
 #define SYSCTRL_BOD33_LEVEL_Pos     16           /**< \brief (SYSCTRL_BOD33) BOD33 Threshold Level */
-#define SYSCTRL_BOD33_LEVEL_Msk     (0x3Ful << SYSCTRL_BOD33_LEVEL_Pos)
+#define SYSCTRL_BOD33_LEVEL_Msk     (_U_(0x3F) << SYSCTRL_BOD33_LEVEL_Pos)
 #define SYSCTRL_BOD33_LEVEL(value)  (SYSCTRL_BOD33_LEVEL_Msk & ((value) << SYSCTRL_BOD33_LEVEL_Pos))
-#define SYSCTRL_BOD33_MASK          0x003FF35Eul /**< \brief (SYSCTRL_BOD33) MASK Register */
+#define SYSCTRL_BOD33_MASK          _U_(0x003FF35E) /**< \brief (SYSCTRL_BOD33) MASK Register */
 
 /* -------- SYSCTRL_VREG : (SYSCTRL Offset: 0x3C) (R/W 16) Voltage Regulator System (VREG) Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -731,13 +716,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_VREG_OFFSET         0x3C         /**< \brief (SYSCTRL_VREG offset) Voltage Regulator System (VREG) Control */
-#define SYSCTRL_VREG_RESETVALUE     0x0000ul     /**< \brief (SYSCTRL_VREG reset_value) Voltage Regulator System (VREG) Control */
+#define SYSCTRL_VREG_RESETVALUE     _U_(0x0000)   /**< \brief (SYSCTRL_VREG reset_value) Voltage Regulator System (VREG) Control */
 
 #define SYSCTRL_VREG_RUNSTDBY_Pos   6            /**< \brief (SYSCTRL_VREG) Run in Standby */
-#define SYSCTRL_VREG_RUNSTDBY       (0x1ul << SYSCTRL_VREG_RUNSTDBY_Pos)
+#define SYSCTRL_VREG_RUNSTDBY       (_U_(0x1) << SYSCTRL_VREG_RUNSTDBY_Pos)
 #define SYSCTRL_VREG_FORCELDO_Pos   13           /**< \brief (SYSCTRL_VREG) Force LDO Voltage Regulator */
-#define SYSCTRL_VREG_FORCELDO       (0x1ul << SYSCTRL_VREG_FORCELDO_Pos)
-#define SYSCTRL_VREG_MASK           0x2040ul     /**< \brief (SYSCTRL_VREG) MASK Register */
+#define SYSCTRL_VREG_FORCELDO       (_U_(0x1) << SYSCTRL_VREG_FORCELDO_Pos)
+#define SYSCTRL_VREG_MASK           _U_(0x2040)   /**< \brief (SYSCTRL_VREG) MASK Register */
 
 /* -------- SYSCTRL_VREF : (SYSCTRL Offset: 0x40) (R/W 32) Voltage References System (VREF) Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -755,16 +740,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_VREF_OFFSET         0x40         /**< \brief (SYSCTRL_VREF offset) Voltage References System (VREF) Control */
-#define SYSCTRL_VREF_RESETVALUE     0x00000000ul /**< \brief (SYSCTRL_VREF reset_value) Voltage References System (VREF) Control */
+#define SYSCTRL_VREF_RESETVALUE     _U_(0x00000000) /**< \brief (SYSCTRL_VREF reset_value) Voltage References System (VREF) Control */
 
 #define SYSCTRL_VREF_TSEN_Pos       1            /**< \brief (SYSCTRL_VREF) Temperature Sensor Enable */
-#define SYSCTRL_VREF_TSEN           (0x1ul << SYSCTRL_VREF_TSEN_Pos)
+#define SYSCTRL_VREF_TSEN           (_U_(0x1) << SYSCTRL_VREF_TSEN_Pos)
 #define SYSCTRL_VREF_BGOUTEN_Pos    2            /**< \brief (SYSCTRL_VREF) Bandgap Output Enable */
-#define SYSCTRL_VREF_BGOUTEN        (0x1ul << SYSCTRL_VREF_BGOUTEN_Pos)
+#define SYSCTRL_VREF_BGOUTEN        (_U_(0x1) << SYSCTRL_VREF_BGOUTEN_Pos)
 #define SYSCTRL_VREF_CALIB_Pos      16           /**< \brief (SYSCTRL_VREF) Bandgap Voltage Generator Calibration */
-#define SYSCTRL_VREF_CALIB_Msk      (0x7FFul << SYSCTRL_VREF_CALIB_Pos)
+#define SYSCTRL_VREF_CALIB_Msk      (_U_(0x7FF) << SYSCTRL_VREF_CALIB_Pos)
 #define SYSCTRL_VREF_CALIB(value)   (SYSCTRL_VREF_CALIB_Msk & ((value) << SYSCTRL_VREF_CALIB_Pos))
-#define SYSCTRL_VREF_MASK           0x07FF0006ul /**< \brief (SYSCTRL_VREF) MASK Register */
+#define SYSCTRL_VREF_MASK           _U_(0x07FF0006) /**< \brief (SYSCTRL_VREF) MASK Register */
 
 /* -------- SYSCTRL_DPLLCTRLA : (SYSCTRL Offset: 0x44) (R/W  8) DPLL Control A -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -781,15 +766,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_DPLLCTRLA_OFFSET    0x44         /**< \brief (SYSCTRL_DPLLCTRLA offset) DPLL Control A */
-#define SYSCTRL_DPLLCTRLA_RESETVALUE 0x80ul       /**< \brief (SYSCTRL_DPLLCTRLA reset_value) DPLL Control A */
+#define SYSCTRL_DPLLCTRLA_RESETVALUE _U_(0x80)     /**< \brief (SYSCTRL_DPLLCTRLA reset_value) DPLL Control A */
 
 #define SYSCTRL_DPLLCTRLA_ENABLE_Pos 1            /**< \brief (SYSCTRL_DPLLCTRLA) DPLL Enable */
-#define SYSCTRL_DPLLCTRLA_ENABLE    (0x1ul << SYSCTRL_DPLLCTRLA_ENABLE_Pos)
+#define SYSCTRL_DPLLCTRLA_ENABLE    (_U_(0x1) << SYSCTRL_DPLLCTRLA_ENABLE_Pos)
 #define SYSCTRL_DPLLCTRLA_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_DPLLCTRLA) Run in Standby */
-#define SYSCTRL_DPLLCTRLA_RUNSTDBY  (0x1ul << SYSCTRL_DPLLCTRLA_RUNSTDBY_Pos)
+#define SYSCTRL_DPLLCTRLA_RUNSTDBY  (_U_(0x1) << SYSCTRL_DPLLCTRLA_RUNSTDBY_Pos)
 #define SYSCTRL_DPLLCTRLA_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_DPLLCTRLA) On Demand Clock Activation */
-#define SYSCTRL_DPLLCTRLA_ONDEMAND  (0x1ul << SYSCTRL_DPLLCTRLA_ONDEMAND_Pos)
-#define SYSCTRL_DPLLCTRLA_MASK      0xC2ul       /**< \brief (SYSCTRL_DPLLCTRLA) MASK Register */
+#define SYSCTRL_DPLLCTRLA_ONDEMAND  (_U_(0x1) << SYSCTRL_DPLLCTRLA_ONDEMAND_Pos)
+#define SYSCTRL_DPLLCTRLA_MASK      _U_(0xC2)     /**< \brief (SYSCTRL_DPLLCTRLA) MASK Register */
 
 /* -------- SYSCTRL_DPLLRATIO : (SYSCTRL Offset: 0x48) (R/W 32) DPLL Ratio Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -805,15 +790,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_DPLLRATIO_OFFSET    0x48         /**< \brief (SYSCTRL_DPLLRATIO offset) DPLL Ratio Control */
-#define SYSCTRL_DPLLRATIO_RESETVALUE 0x00000000ul /**< \brief (SYSCTRL_DPLLRATIO reset_value) DPLL Ratio Control */
+#define SYSCTRL_DPLLRATIO_RESETVALUE _U_(0x00000000) /**< \brief (SYSCTRL_DPLLRATIO reset_value) DPLL Ratio Control */
 
 #define SYSCTRL_DPLLRATIO_LDR_Pos   0            /**< \brief (SYSCTRL_DPLLRATIO) Loop Divider Ratio */
-#define SYSCTRL_DPLLRATIO_LDR_Msk   (0xFFFul << SYSCTRL_DPLLRATIO_LDR_Pos)
+#define SYSCTRL_DPLLRATIO_LDR_Msk   (_U_(0xFFF) << SYSCTRL_DPLLRATIO_LDR_Pos)
 #define SYSCTRL_DPLLRATIO_LDR(value) (SYSCTRL_DPLLRATIO_LDR_Msk & ((value) << SYSCTRL_DPLLRATIO_LDR_Pos))
 #define SYSCTRL_DPLLRATIO_LDRFRAC_Pos 16           /**< \brief (SYSCTRL_DPLLRATIO) Loop Divider Ratio Fractional Part */
-#define SYSCTRL_DPLLRATIO_LDRFRAC_Msk (0xFul << SYSCTRL_DPLLRATIO_LDRFRAC_Pos)
+#define SYSCTRL_DPLLRATIO_LDRFRAC_Msk (_U_(0xF) << SYSCTRL_DPLLRATIO_LDRFRAC_Pos)
 #define SYSCTRL_DPLLRATIO_LDRFRAC(value) (SYSCTRL_DPLLRATIO_LDRFRAC_Msk & ((value) << SYSCTRL_DPLLRATIO_LDRFRAC_Pos))
-#define SYSCTRL_DPLLRATIO_MASK      0x000F0FFFul /**< \brief (SYSCTRL_DPLLRATIO) MASK Register */
+#define SYSCTRL_DPLLRATIO_MASK      _U_(0x000F0FFF) /**< \brief (SYSCTRL_DPLLRATIO) MASK Register */
 
 /* -------- SYSCTRL_DPLLCTRLB : (SYSCTRL Offset: 0x4C) (R/W 32) DPLL Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -836,51 +821,51 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_DPLLCTRLB_OFFSET    0x4C         /**< \brief (SYSCTRL_DPLLCTRLB offset) DPLL Control B */
-#define SYSCTRL_DPLLCTRLB_RESETVALUE 0x00000000ul /**< \brief (SYSCTRL_DPLLCTRLB reset_value) DPLL Control B */
+#define SYSCTRL_DPLLCTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SYSCTRL_DPLLCTRLB reset_value) DPLL Control B */
 
 #define SYSCTRL_DPLLCTRLB_FILTER_Pos 0            /**< \brief (SYSCTRL_DPLLCTRLB) Proportional Integral Filter Selection */
-#define SYSCTRL_DPLLCTRLB_FILTER_Msk (0x3ul << SYSCTRL_DPLLCTRLB_FILTER_Pos)
+#define SYSCTRL_DPLLCTRLB_FILTER_Msk (_U_(0x3) << SYSCTRL_DPLLCTRLB_FILTER_Pos)
 #define SYSCTRL_DPLLCTRLB_FILTER(value) (SYSCTRL_DPLLCTRLB_FILTER_Msk & ((value) << SYSCTRL_DPLLCTRLB_FILTER_Pos))
-#define   SYSCTRL_DPLLCTRLB_FILTER_DEFAULT_Val 0x0ul  /**< \brief (SYSCTRL_DPLLCTRLB) Default filter mode */
-#define   SYSCTRL_DPLLCTRLB_FILTER_LBFILT_Val 0x1ul  /**< \brief (SYSCTRL_DPLLCTRLB) Low bandwidth filter */
-#define   SYSCTRL_DPLLCTRLB_FILTER_HBFILT_Val 0x2ul  /**< \brief (SYSCTRL_DPLLCTRLB) High bandwidth filter */
-#define   SYSCTRL_DPLLCTRLB_FILTER_HDFILT_Val 0x3ul  /**< \brief (SYSCTRL_DPLLCTRLB) High damping filter */
+#define   SYSCTRL_DPLLCTRLB_FILTER_DEFAULT_Val _U_(0x0)   /**< \brief (SYSCTRL_DPLLCTRLB) Default filter mode */
+#define   SYSCTRL_DPLLCTRLB_FILTER_LBFILT_Val _U_(0x1)   /**< \brief (SYSCTRL_DPLLCTRLB) Low bandwidth filter */
+#define   SYSCTRL_DPLLCTRLB_FILTER_HBFILT_Val _U_(0x2)   /**< \brief (SYSCTRL_DPLLCTRLB) High bandwidth filter */
+#define   SYSCTRL_DPLLCTRLB_FILTER_HDFILT_Val _U_(0x3)   /**< \brief (SYSCTRL_DPLLCTRLB) High damping filter */
 #define SYSCTRL_DPLLCTRLB_FILTER_DEFAULT (SYSCTRL_DPLLCTRLB_FILTER_DEFAULT_Val << SYSCTRL_DPLLCTRLB_FILTER_Pos)
 #define SYSCTRL_DPLLCTRLB_FILTER_LBFILT (SYSCTRL_DPLLCTRLB_FILTER_LBFILT_Val << SYSCTRL_DPLLCTRLB_FILTER_Pos)
 #define SYSCTRL_DPLLCTRLB_FILTER_HBFILT (SYSCTRL_DPLLCTRLB_FILTER_HBFILT_Val << SYSCTRL_DPLLCTRLB_FILTER_Pos)
 #define SYSCTRL_DPLLCTRLB_FILTER_HDFILT (SYSCTRL_DPLLCTRLB_FILTER_HDFILT_Val << SYSCTRL_DPLLCTRLB_FILTER_Pos)
 #define SYSCTRL_DPLLCTRLB_LPEN_Pos  2            /**< \brief (SYSCTRL_DPLLCTRLB) Low-Power Enable */
-#define SYSCTRL_DPLLCTRLB_LPEN      (0x1ul << SYSCTRL_DPLLCTRLB_LPEN_Pos)
+#define SYSCTRL_DPLLCTRLB_LPEN      (_U_(0x1) << SYSCTRL_DPLLCTRLB_LPEN_Pos)
 #define SYSCTRL_DPLLCTRLB_WUF_Pos   3            /**< \brief (SYSCTRL_DPLLCTRLB) Wake Up Fast */
-#define SYSCTRL_DPLLCTRLB_WUF       (0x1ul << SYSCTRL_DPLLCTRLB_WUF_Pos)
+#define SYSCTRL_DPLLCTRLB_WUF       (_U_(0x1) << SYSCTRL_DPLLCTRLB_WUF_Pos)
 #define SYSCTRL_DPLLCTRLB_REFCLK_Pos 4            /**< \brief (SYSCTRL_DPLLCTRLB) Reference Clock Selection */
-#define SYSCTRL_DPLLCTRLB_REFCLK_Msk (0x3ul << SYSCTRL_DPLLCTRLB_REFCLK_Pos)
+#define SYSCTRL_DPLLCTRLB_REFCLK_Msk (_U_(0x3) << SYSCTRL_DPLLCTRLB_REFCLK_Pos)
 #define SYSCTRL_DPLLCTRLB_REFCLK(value) (SYSCTRL_DPLLCTRLB_REFCLK_Msk & ((value) << SYSCTRL_DPLLCTRLB_REFCLK_Pos))
-#define   SYSCTRL_DPLLCTRLB_REFCLK_REF0_Val 0x0ul  /**< \brief (SYSCTRL_DPLLCTRLB) CLK_DPLL_REF0 clock reference */
-#define   SYSCTRL_DPLLCTRLB_REFCLK_REF1_Val 0x1ul  /**< \brief (SYSCTRL_DPLLCTRLB) CLK_DPLL_REF1 clock reference */
-#define   SYSCTRL_DPLLCTRLB_REFCLK_GCLK_Val 0x2ul  /**< \brief (SYSCTRL_DPLLCTRLB) GCLK_DPLL clock reference */
+#define   SYSCTRL_DPLLCTRLB_REFCLK_REF0_Val _U_(0x0)   /**< \brief (SYSCTRL_DPLLCTRLB) CLK_DPLL_REF0 clock reference */
+#define   SYSCTRL_DPLLCTRLB_REFCLK_REF1_Val _U_(0x1)   /**< \brief (SYSCTRL_DPLLCTRLB) CLK_DPLL_REF1 clock reference */
+#define   SYSCTRL_DPLLCTRLB_REFCLK_GCLK_Val _U_(0x2)   /**< \brief (SYSCTRL_DPLLCTRLB) GCLK_DPLL clock reference */
 #define SYSCTRL_DPLLCTRLB_REFCLK_REF0 (SYSCTRL_DPLLCTRLB_REFCLK_REF0_Val << SYSCTRL_DPLLCTRLB_REFCLK_Pos)
 #define SYSCTRL_DPLLCTRLB_REFCLK_REF1 (SYSCTRL_DPLLCTRLB_REFCLK_REF1_Val << SYSCTRL_DPLLCTRLB_REFCLK_Pos)
 #define SYSCTRL_DPLLCTRLB_REFCLK_GCLK (SYSCTRL_DPLLCTRLB_REFCLK_GCLK_Val << SYSCTRL_DPLLCTRLB_REFCLK_Pos)
 #define SYSCTRL_DPLLCTRLB_LTIME_Pos 8            /**< \brief (SYSCTRL_DPLLCTRLB) Lock Time */
-#define SYSCTRL_DPLLCTRLB_LTIME_Msk (0x7ul << SYSCTRL_DPLLCTRLB_LTIME_Pos)
+#define SYSCTRL_DPLLCTRLB_LTIME_Msk (_U_(0x7) << SYSCTRL_DPLLCTRLB_LTIME_Pos)
 #define SYSCTRL_DPLLCTRLB_LTIME(value) (SYSCTRL_DPLLCTRLB_LTIME_Msk & ((value) << SYSCTRL_DPLLCTRLB_LTIME_Pos))
-#define   SYSCTRL_DPLLCTRLB_LTIME_DEFAULT_Val 0x0ul  /**< \brief (SYSCTRL_DPLLCTRLB) No time-out */
-#define   SYSCTRL_DPLLCTRLB_LTIME_8MS_Val 0x4ul  /**< \brief (SYSCTRL_DPLLCTRLB) Time-out if no lock within 8 ms */
-#define   SYSCTRL_DPLLCTRLB_LTIME_9MS_Val 0x5ul  /**< \brief (SYSCTRL_DPLLCTRLB) Time-out if no lock within 9 ms */
-#define   SYSCTRL_DPLLCTRLB_LTIME_10MS_Val 0x6ul  /**< \brief (SYSCTRL_DPLLCTRLB) Time-out if no lock within 10 ms */
-#define   SYSCTRL_DPLLCTRLB_LTIME_11MS_Val 0x7ul  /**< \brief (SYSCTRL_DPLLCTRLB) Time-out if no lock within 11 ms */
+#define   SYSCTRL_DPLLCTRLB_LTIME_DEFAULT_Val _U_(0x0)   /**< \brief (SYSCTRL_DPLLCTRLB) No time-out */
+#define   SYSCTRL_DPLLCTRLB_LTIME_8MS_Val _U_(0x4)   /**< \brief (SYSCTRL_DPLLCTRLB) Time-out if no lock within 8 ms */
+#define   SYSCTRL_DPLLCTRLB_LTIME_9MS_Val _U_(0x5)   /**< \brief (SYSCTRL_DPLLCTRLB) Time-out if no lock within 9 ms */
+#define   SYSCTRL_DPLLCTRLB_LTIME_10MS_Val _U_(0x6)   /**< \brief (SYSCTRL_DPLLCTRLB) Time-out if no lock within 10 ms */
+#define   SYSCTRL_DPLLCTRLB_LTIME_11MS_Val _U_(0x7)   /**< \brief (SYSCTRL_DPLLCTRLB) Time-out if no lock within 11 ms */
 #define SYSCTRL_DPLLCTRLB_LTIME_DEFAULT (SYSCTRL_DPLLCTRLB_LTIME_DEFAULT_Val << SYSCTRL_DPLLCTRLB_LTIME_Pos)
 #define SYSCTRL_DPLLCTRLB_LTIME_8MS (SYSCTRL_DPLLCTRLB_LTIME_8MS_Val << SYSCTRL_DPLLCTRLB_LTIME_Pos)
 #define SYSCTRL_DPLLCTRLB_LTIME_9MS (SYSCTRL_DPLLCTRLB_LTIME_9MS_Val << SYSCTRL_DPLLCTRLB_LTIME_Pos)
 #define SYSCTRL_DPLLCTRLB_LTIME_10MS (SYSCTRL_DPLLCTRLB_LTIME_10MS_Val << SYSCTRL_DPLLCTRLB_LTIME_Pos)
 #define SYSCTRL_DPLLCTRLB_LTIME_11MS (SYSCTRL_DPLLCTRLB_LTIME_11MS_Val << SYSCTRL_DPLLCTRLB_LTIME_Pos)
 #define SYSCTRL_DPLLCTRLB_LBYPASS_Pos 12           /**< \brief (SYSCTRL_DPLLCTRLB) Lock Bypass */
-#define SYSCTRL_DPLLCTRLB_LBYPASS   (0x1ul << SYSCTRL_DPLLCTRLB_LBYPASS_Pos)
+#define SYSCTRL_DPLLCTRLB_LBYPASS   (_U_(0x1) << SYSCTRL_DPLLCTRLB_LBYPASS_Pos)
 #define SYSCTRL_DPLLCTRLB_DIV_Pos   16           /**< \brief (SYSCTRL_DPLLCTRLB) Clock Divider */
-#define SYSCTRL_DPLLCTRLB_DIV_Msk   (0x7FFul << SYSCTRL_DPLLCTRLB_DIV_Pos)
+#define SYSCTRL_DPLLCTRLB_DIV_Msk   (_U_(0x7FF) << SYSCTRL_DPLLCTRLB_DIV_Pos)
 #define SYSCTRL_DPLLCTRLB_DIV(value) (SYSCTRL_DPLLCTRLB_DIV_Msk & ((value) << SYSCTRL_DPLLCTRLB_DIV_Pos))
-#define SYSCTRL_DPLLCTRLB_MASK      0x07FF173Ful /**< \brief (SYSCTRL_DPLLCTRLB) MASK Register */
+#define SYSCTRL_DPLLCTRLB_MASK      _U_(0x07FF173F) /**< \brief (SYSCTRL_DPLLCTRLB) MASK Register */
 
 /* -------- SYSCTRL_DPLLSTATUS : (SYSCTRL Offset: 0x50) (R/   8) DPLL Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -897,17 +882,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SYSCTRL_DPLLSTATUS_OFFSET   0x50         /**< \brief (SYSCTRL_DPLLSTATUS offset) DPLL Status */
-#define SYSCTRL_DPLLSTATUS_RESETVALUE 0x00ul       /**< \brief (SYSCTRL_DPLLSTATUS reset_value) DPLL Status */
+#define SYSCTRL_DPLLSTATUS_RESETVALUE _U_(0x00)     /**< \brief (SYSCTRL_DPLLSTATUS reset_value) DPLL Status */
 
 #define SYSCTRL_DPLLSTATUS_LOCK_Pos 0            /**< \brief (SYSCTRL_DPLLSTATUS) DPLL Lock Status */
-#define SYSCTRL_DPLLSTATUS_LOCK     (0x1ul << SYSCTRL_DPLLSTATUS_LOCK_Pos)
+#define SYSCTRL_DPLLSTATUS_LOCK     (_U_(0x1) << SYSCTRL_DPLLSTATUS_LOCK_Pos)
 #define SYSCTRL_DPLLSTATUS_CLKRDY_Pos 1            /**< \brief (SYSCTRL_DPLLSTATUS) Output Clock Ready */
-#define SYSCTRL_DPLLSTATUS_CLKRDY   (0x1ul << SYSCTRL_DPLLSTATUS_CLKRDY_Pos)
+#define SYSCTRL_DPLLSTATUS_CLKRDY   (_U_(0x1) << SYSCTRL_DPLLSTATUS_CLKRDY_Pos)
 #define SYSCTRL_DPLLSTATUS_ENABLE_Pos 2            /**< \brief (SYSCTRL_DPLLSTATUS) DPLL Enable */
-#define SYSCTRL_DPLLSTATUS_ENABLE   (0x1ul << SYSCTRL_DPLLSTATUS_ENABLE_Pos)
+#define SYSCTRL_DPLLSTATUS_ENABLE   (_U_(0x1) << SYSCTRL_DPLLSTATUS_ENABLE_Pos)
 #define SYSCTRL_DPLLSTATUS_DIV_Pos  3            /**< \brief (SYSCTRL_DPLLSTATUS) Divider Enable */
-#define SYSCTRL_DPLLSTATUS_DIV      (0x1ul << SYSCTRL_DPLLSTATUS_DIV_Pos)
-#define SYSCTRL_DPLLSTATUS_MASK     0x0Ful       /**< \brief (SYSCTRL_DPLLSTATUS) MASK Register */
+#define SYSCTRL_DPLLSTATUS_DIV      (_U_(0x1) << SYSCTRL_DPLLSTATUS_DIV_Pos)
+#define SYSCTRL_DPLLSTATUS_MASK     _U_(0x0F)     /**< \brief (SYSCTRL_DPLLSTATUS) MASK Register */
 
 /** \brief SYSCTRL hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/tc.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for TC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -73,43 +58,43 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CTRLA_OFFSET             0x00         /**< \brief (TC_CTRLA offset) Control A */
-#define TC_CTRLA_RESETVALUE         0x0000ul     /**< \brief (TC_CTRLA reset_value) Control A */
+#define TC_CTRLA_RESETVALUE         _U_(0x0000)   /**< \brief (TC_CTRLA reset_value) Control A */
 
 #define TC_CTRLA_SWRST_Pos          0            /**< \brief (TC_CTRLA) Software Reset */
-#define TC_CTRLA_SWRST              (0x1ul << TC_CTRLA_SWRST_Pos)
+#define TC_CTRLA_SWRST              (_U_(0x1) << TC_CTRLA_SWRST_Pos)
 #define TC_CTRLA_ENABLE_Pos         1            /**< \brief (TC_CTRLA) Enable */
-#define TC_CTRLA_ENABLE             (0x1ul << TC_CTRLA_ENABLE_Pos)
+#define TC_CTRLA_ENABLE             (_U_(0x1) << TC_CTRLA_ENABLE_Pos)
 #define TC_CTRLA_MODE_Pos           2            /**< \brief (TC_CTRLA) TC Mode */
-#define TC_CTRLA_MODE_Msk           (0x3ul << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE_Msk           (_U_(0x3) << TC_CTRLA_MODE_Pos)
 #define TC_CTRLA_MODE(value)        (TC_CTRLA_MODE_Msk & ((value) << TC_CTRLA_MODE_Pos))
-#define   TC_CTRLA_MODE_COUNT16_Val       0x0ul  /**< \brief (TC_CTRLA) Counter in 16-bit mode */
-#define   TC_CTRLA_MODE_COUNT8_Val        0x1ul  /**< \brief (TC_CTRLA) Counter in 8-bit mode */
-#define   TC_CTRLA_MODE_COUNT32_Val       0x2ul  /**< \brief (TC_CTRLA) Counter in 32-bit mode */
+#define   TC_CTRLA_MODE_COUNT16_Val       _U_(0x0)   /**< \brief (TC_CTRLA) Counter in 16-bit mode */
+#define   TC_CTRLA_MODE_COUNT8_Val        _U_(0x1)   /**< \brief (TC_CTRLA) Counter in 8-bit mode */
+#define   TC_CTRLA_MODE_COUNT32_Val       _U_(0x2)   /**< \brief (TC_CTRLA) Counter in 32-bit mode */
 #define TC_CTRLA_MODE_COUNT16       (TC_CTRLA_MODE_COUNT16_Val     << TC_CTRLA_MODE_Pos)
 #define TC_CTRLA_MODE_COUNT8        (TC_CTRLA_MODE_COUNT8_Val      << TC_CTRLA_MODE_Pos)
 #define TC_CTRLA_MODE_COUNT32       (TC_CTRLA_MODE_COUNT32_Val     << TC_CTRLA_MODE_Pos)
 #define TC_CTRLA_WAVEGEN_Pos        5            /**< \brief (TC_CTRLA) Waveform Generation Operation */
-#define TC_CTRLA_WAVEGEN_Msk        (0x3ul << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN_Msk        (_U_(0x3) << TC_CTRLA_WAVEGEN_Pos)
 #define TC_CTRLA_WAVEGEN(value)     (TC_CTRLA_WAVEGEN_Msk & ((value) << TC_CTRLA_WAVEGEN_Pos))
-#define   TC_CTRLA_WAVEGEN_NFRQ_Val       0x0ul  /**< \brief (TC_CTRLA)  */
-#define   TC_CTRLA_WAVEGEN_MFRQ_Val       0x1ul  /**< \brief (TC_CTRLA)  */
-#define   TC_CTRLA_WAVEGEN_NPWM_Val       0x2ul  /**< \brief (TC_CTRLA)  */
-#define   TC_CTRLA_WAVEGEN_MPWM_Val       0x3ul  /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_NFRQ_Val       _U_(0x0)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_MFRQ_Val       _U_(0x1)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_NPWM_Val       _U_(0x2)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_MPWM_Val       _U_(0x3)   /**< \brief (TC_CTRLA)  */
 #define TC_CTRLA_WAVEGEN_NFRQ       (TC_CTRLA_WAVEGEN_NFRQ_Val     << TC_CTRLA_WAVEGEN_Pos)
 #define TC_CTRLA_WAVEGEN_MFRQ       (TC_CTRLA_WAVEGEN_MFRQ_Val     << TC_CTRLA_WAVEGEN_Pos)
 #define TC_CTRLA_WAVEGEN_NPWM       (TC_CTRLA_WAVEGEN_NPWM_Val     << TC_CTRLA_WAVEGEN_Pos)
 #define TC_CTRLA_WAVEGEN_MPWM       (TC_CTRLA_WAVEGEN_MPWM_Val     << TC_CTRLA_WAVEGEN_Pos)
 #define TC_CTRLA_PRESCALER_Pos      8            /**< \brief (TC_CTRLA) Prescaler */
-#define TC_CTRLA_PRESCALER_Msk      (0x7ul << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_Msk      (_U_(0x7) << TC_CTRLA_PRESCALER_Pos)
 #define TC_CTRLA_PRESCALER(value)   (TC_CTRLA_PRESCALER_Msk & ((value) << TC_CTRLA_PRESCALER_Pos))
-#define   TC_CTRLA_PRESCALER_DIV1_Val     0x0ul  /**< \brief (TC_CTRLA) Prescaler: GCLK_TC */
-#define   TC_CTRLA_PRESCALER_DIV2_Val     0x1ul  /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/2 */
-#define   TC_CTRLA_PRESCALER_DIV4_Val     0x2ul  /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/4 */
-#define   TC_CTRLA_PRESCALER_DIV8_Val     0x3ul  /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/8 */
-#define   TC_CTRLA_PRESCALER_DIV16_Val    0x4ul  /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/16 */
-#define   TC_CTRLA_PRESCALER_DIV64_Val    0x5ul  /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/64 */
-#define   TC_CTRLA_PRESCALER_DIV256_Val   0x6ul  /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/256 */
-#define   TC_CTRLA_PRESCALER_DIV1024_Val  0x7ul  /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/1024 */
+#define   TC_CTRLA_PRESCALER_DIV1_Val     _U_(0x0)   /**< \brief (TC_CTRLA) Prescaler: GCLK_TC */
+#define   TC_CTRLA_PRESCALER_DIV2_Val     _U_(0x1)   /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/2 */
+#define   TC_CTRLA_PRESCALER_DIV4_Val     _U_(0x2)   /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/4 */
+#define   TC_CTRLA_PRESCALER_DIV8_Val     _U_(0x3)   /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/8 */
+#define   TC_CTRLA_PRESCALER_DIV16_Val    _U_(0x4)   /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/16 */
+#define   TC_CTRLA_PRESCALER_DIV64_Val    _U_(0x5)   /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/64 */
+#define   TC_CTRLA_PRESCALER_DIV256_Val   _U_(0x6)   /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/256 */
+#define   TC_CTRLA_PRESCALER_DIV1024_Val  _U_(0x7)   /**< \brief (TC_CTRLA) Prescaler: GCLK_TC/1024 */
 #define TC_CTRLA_PRESCALER_DIV1     (TC_CTRLA_PRESCALER_DIV1_Val   << TC_CTRLA_PRESCALER_Pos)
 #define TC_CTRLA_PRESCALER_DIV2     (TC_CTRLA_PRESCALER_DIV2_Val   << TC_CTRLA_PRESCALER_Pos)
 #define TC_CTRLA_PRESCALER_DIV4     (TC_CTRLA_PRESCALER_DIV4_Val   << TC_CTRLA_PRESCALER_Pos)
@@ -119,17 +104,17 @@ typedef union {
 #define TC_CTRLA_PRESCALER_DIV256   (TC_CTRLA_PRESCALER_DIV256_Val << TC_CTRLA_PRESCALER_Pos)
 #define TC_CTRLA_PRESCALER_DIV1024  (TC_CTRLA_PRESCALER_DIV1024_Val << TC_CTRLA_PRESCALER_Pos)
 #define TC_CTRLA_RUNSTDBY_Pos       11           /**< \brief (TC_CTRLA) Run in Standby */
-#define TC_CTRLA_RUNSTDBY           (0x1ul << TC_CTRLA_RUNSTDBY_Pos)
+#define TC_CTRLA_RUNSTDBY           (_U_(0x1) << TC_CTRLA_RUNSTDBY_Pos)
 #define TC_CTRLA_PRESCSYNC_Pos      12           /**< \brief (TC_CTRLA) Prescaler and Counter Synchronization */
-#define TC_CTRLA_PRESCSYNC_Msk      (0x3ul << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC_Msk      (_U_(0x3) << TC_CTRLA_PRESCSYNC_Pos)
 #define TC_CTRLA_PRESCSYNC(value)   (TC_CTRLA_PRESCSYNC_Msk & ((value) << TC_CTRLA_PRESCSYNC_Pos))
-#define   TC_CTRLA_PRESCSYNC_GCLK_Val     0x0ul  /**< \brief (TC_CTRLA) Reload or reset the counter on next generic clock */
-#define   TC_CTRLA_PRESCSYNC_PRESC_Val    0x1ul  /**< \brief (TC_CTRLA) Reload or reset the counter on next prescaler clock */
-#define   TC_CTRLA_PRESCSYNC_RESYNC_Val   0x2ul  /**< \brief (TC_CTRLA) Reload or reset the counter on next generic clock. Reset the prescaler counter */
+#define   TC_CTRLA_PRESCSYNC_GCLK_Val     _U_(0x0)   /**< \brief (TC_CTRLA) Reload or reset the counter on next generic clock */
+#define   TC_CTRLA_PRESCSYNC_PRESC_Val    _U_(0x1)   /**< \brief (TC_CTRLA) Reload or reset the counter on next prescaler clock */
+#define   TC_CTRLA_PRESCSYNC_RESYNC_Val   _U_(0x2)   /**< \brief (TC_CTRLA) Reload or reset the counter on next generic clock. Reset the prescaler counter */
 #define TC_CTRLA_PRESCSYNC_GCLK     (TC_CTRLA_PRESCSYNC_GCLK_Val   << TC_CTRLA_PRESCSYNC_Pos)
 #define TC_CTRLA_PRESCSYNC_PRESC    (TC_CTRLA_PRESCSYNC_PRESC_Val  << TC_CTRLA_PRESCSYNC_Pos)
 #define TC_CTRLA_PRESCSYNC_RESYNC   (TC_CTRLA_PRESCSYNC_RESYNC_Val << TC_CTRLA_PRESCSYNC_Pos)
-#define TC_CTRLA_MASK               0x3F6Ful     /**< \brief (TC_CTRLA) MASK Register */
+#define TC_CTRLA_MASK               _U_(0x3F6F)   /**< \brief (TC_CTRLA) MASK Register */
 
 /* -------- TC_READREQ : (TC Offset: 0x02) (R/W 16) Read Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -145,16 +130,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_READREQ_OFFSET           0x02         /**< \brief (TC_READREQ offset) Read Request */
-#define TC_READREQ_RESETVALUE       0x0000ul     /**< \brief (TC_READREQ reset_value) Read Request */
+#define TC_READREQ_RESETVALUE       _U_(0x0000)   /**< \brief (TC_READREQ reset_value) Read Request */
 
 #define TC_READREQ_ADDR_Pos         0            /**< \brief (TC_READREQ) Address */
-#define TC_READREQ_ADDR_Msk         (0x1Ful << TC_READREQ_ADDR_Pos)
+#define TC_READREQ_ADDR_Msk         (_U_(0x1F) << TC_READREQ_ADDR_Pos)
 #define TC_READREQ_ADDR(value)      (TC_READREQ_ADDR_Msk & ((value) << TC_READREQ_ADDR_Pos))
 #define TC_READREQ_RCONT_Pos        14           /**< \brief (TC_READREQ) Read Continuously */
-#define TC_READREQ_RCONT            (0x1ul << TC_READREQ_RCONT_Pos)
+#define TC_READREQ_RCONT            (_U_(0x1) << TC_READREQ_RCONT_Pos)
 #define TC_READREQ_RREQ_Pos         15           /**< \brief (TC_READREQ) Read Request */
-#define TC_READREQ_RREQ             (0x1ul << TC_READREQ_RREQ_Pos)
-#define TC_READREQ_MASK             0xC01Ful     /**< \brief (TC_READREQ) MASK Register */
+#define TC_READREQ_RREQ             (_U_(0x1) << TC_READREQ_RREQ_Pos)
+#define TC_READREQ_MASK             _U_(0xC01F)   /**< \brief (TC_READREQ) MASK Register */
 
 /* -------- TC_CTRLBCLR : (TC Offset: 0x04) (R/W  8) Control B Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -171,22 +156,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CTRLBCLR_OFFSET          0x04         /**< \brief (TC_CTRLBCLR offset) Control B Clear */
-#define TC_CTRLBCLR_RESETVALUE      0x02ul       /**< \brief (TC_CTRLBCLR reset_value) Control B Clear */
+#define TC_CTRLBCLR_RESETVALUE      _U_(0x02)     /**< \brief (TC_CTRLBCLR reset_value) Control B Clear */
 
 #define TC_CTRLBCLR_DIR_Pos         0            /**< \brief (TC_CTRLBCLR) Counter Direction */
-#define TC_CTRLBCLR_DIR             (0x1ul << TC_CTRLBCLR_DIR_Pos)
+#define TC_CTRLBCLR_DIR             (_U_(0x1) << TC_CTRLBCLR_DIR_Pos)
 #define TC_CTRLBCLR_ONESHOT_Pos     2            /**< \brief (TC_CTRLBCLR) One-Shot */
-#define TC_CTRLBCLR_ONESHOT         (0x1ul << TC_CTRLBCLR_ONESHOT_Pos)
+#define TC_CTRLBCLR_ONESHOT         (_U_(0x1) << TC_CTRLBCLR_ONESHOT_Pos)
 #define TC_CTRLBCLR_CMD_Pos         6            /**< \brief (TC_CTRLBCLR) Command */
-#define TC_CTRLBCLR_CMD_Msk         (0x3ul << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_Msk         (_U_(0x3) << TC_CTRLBCLR_CMD_Pos)
 #define TC_CTRLBCLR_CMD(value)      (TC_CTRLBCLR_CMD_Msk & ((value) << TC_CTRLBCLR_CMD_Pos))
-#define   TC_CTRLBCLR_CMD_NONE_Val        0x0ul  /**< \brief (TC_CTRLBCLR) No action */
-#define   TC_CTRLBCLR_CMD_RETRIGGER_Val   0x1ul  /**< \brief (TC_CTRLBCLR) Force a start, restart or retrigger */
-#define   TC_CTRLBCLR_CMD_STOP_Val        0x2ul  /**< \brief (TC_CTRLBCLR) Force a stop */
+#define   TC_CTRLBCLR_CMD_NONE_Val        _U_(0x0)   /**< \brief (TC_CTRLBCLR) No action */
+#define   TC_CTRLBCLR_CMD_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_CTRLBCLR) Force a start, restart or retrigger */
+#define   TC_CTRLBCLR_CMD_STOP_Val        _U_(0x2)   /**< \brief (TC_CTRLBCLR) Force a stop */
 #define TC_CTRLBCLR_CMD_NONE        (TC_CTRLBCLR_CMD_NONE_Val      << TC_CTRLBCLR_CMD_Pos)
 #define TC_CTRLBCLR_CMD_RETRIGGER   (TC_CTRLBCLR_CMD_RETRIGGER_Val << TC_CTRLBCLR_CMD_Pos)
 #define TC_CTRLBCLR_CMD_STOP        (TC_CTRLBCLR_CMD_STOP_Val      << TC_CTRLBCLR_CMD_Pos)
-#define TC_CTRLBCLR_MASK            0xC5ul       /**< \brief (TC_CTRLBCLR) MASK Register */
+#define TC_CTRLBCLR_MASK            _U_(0xC5)     /**< \brief (TC_CTRLBCLR) MASK Register */
 
 /* -------- TC_CTRLBSET : (TC Offset: 0x05) (R/W  8) Control B Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -203,22 +188,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CTRLBSET_OFFSET          0x05         /**< \brief (TC_CTRLBSET offset) Control B Set */
-#define TC_CTRLBSET_RESETVALUE      0x00ul       /**< \brief (TC_CTRLBSET reset_value) Control B Set */
+#define TC_CTRLBSET_RESETVALUE      _U_(0x00)     /**< \brief (TC_CTRLBSET reset_value) Control B Set */
 
 #define TC_CTRLBSET_DIR_Pos         0            /**< \brief (TC_CTRLBSET) Counter Direction */
-#define TC_CTRLBSET_DIR             (0x1ul << TC_CTRLBSET_DIR_Pos)
+#define TC_CTRLBSET_DIR             (_U_(0x1) << TC_CTRLBSET_DIR_Pos)
 #define TC_CTRLBSET_ONESHOT_Pos     2            /**< \brief (TC_CTRLBSET) One-Shot */
-#define TC_CTRLBSET_ONESHOT         (0x1ul << TC_CTRLBSET_ONESHOT_Pos)
+#define TC_CTRLBSET_ONESHOT         (_U_(0x1) << TC_CTRLBSET_ONESHOT_Pos)
 #define TC_CTRLBSET_CMD_Pos         6            /**< \brief (TC_CTRLBSET) Command */
-#define TC_CTRLBSET_CMD_Msk         (0x3ul << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_Msk         (_U_(0x3) << TC_CTRLBSET_CMD_Pos)
 #define TC_CTRLBSET_CMD(value)      (TC_CTRLBSET_CMD_Msk & ((value) << TC_CTRLBSET_CMD_Pos))
-#define   TC_CTRLBSET_CMD_NONE_Val        0x0ul  /**< \brief (TC_CTRLBSET) No action */
-#define   TC_CTRLBSET_CMD_RETRIGGER_Val   0x1ul  /**< \brief (TC_CTRLBSET) Force a start, restart or retrigger */
-#define   TC_CTRLBSET_CMD_STOP_Val        0x2ul  /**< \brief (TC_CTRLBSET) Force a stop */
+#define   TC_CTRLBSET_CMD_NONE_Val        _U_(0x0)   /**< \brief (TC_CTRLBSET) No action */
+#define   TC_CTRLBSET_CMD_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_CTRLBSET) Force a start, restart or retrigger */
+#define   TC_CTRLBSET_CMD_STOP_Val        _U_(0x2)   /**< \brief (TC_CTRLBSET) Force a stop */
 #define TC_CTRLBSET_CMD_NONE        (TC_CTRLBSET_CMD_NONE_Val      << TC_CTRLBSET_CMD_Pos)
 #define TC_CTRLBSET_CMD_RETRIGGER   (TC_CTRLBSET_CMD_RETRIGGER_Val << TC_CTRLBSET_CMD_Pos)
 #define TC_CTRLBSET_CMD_STOP        (TC_CTRLBSET_CMD_STOP_Val      << TC_CTRLBSET_CMD_Pos)
-#define TC_CTRLBSET_MASK            0xC5ul       /**< \brief (TC_CTRLBSET) MASK Register */
+#define TC_CTRLBSET_MASK            _U_(0xC5)     /**< \brief (TC_CTRLBSET) MASK Register */
 
 /* -------- TC_CTRLC : (TC Offset: 0x06) (R/W  8) Control C -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -242,23 +227,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CTRLC_OFFSET             0x06         /**< \brief (TC_CTRLC offset) Control C */
-#define TC_CTRLC_RESETVALUE         0x00ul       /**< \brief (TC_CTRLC reset_value) Control C */
+#define TC_CTRLC_RESETVALUE         _U_(0x00)     /**< \brief (TC_CTRLC reset_value) Control C */
 
 #define TC_CTRLC_INVEN0_Pos         0            /**< \brief (TC_CTRLC) Output Waveform 0 Invert Enable */
 #define TC_CTRLC_INVEN0             (1 << TC_CTRLC_INVEN0_Pos)
 #define TC_CTRLC_INVEN1_Pos         1            /**< \brief (TC_CTRLC) Output Waveform 1 Invert Enable */
 #define TC_CTRLC_INVEN1             (1 << TC_CTRLC_INVEN1_Pos)
 #define TC_CTRLC_INVEN_Pos          0            /**< \brief (TC_CTRLC) Output Waveform x Invert Enable */
-#define TC_CTRLC_INVEN_Msk          (0x3ul << TC_CTRLC_INVEN_Pos)
+#define TC_CTRLC_INVEN_Msk          (_U_(0x3) << TC_CTRLC_INVEN_Pos)
 #define TC_CTRLC_INVEN(value)       (TC_CTRLC_INVEN_Msk & ((value) << TC_CTRLC_INVEN_Pos))
 #define TC_CTRLC_CPTEN0_Pos         4            /**< \brief (TC_CTRLC) Capture Channel 0 Enable */
 #define TC_CTRLC_CPTEN0             (1 << TC_CTRLC_CPTEN0_Pos)
 #define TC_CTRLC_CPTEN1_Pos         5            /**< \brief (TC_CTRLC) Capture Channel 1 Enable */
 #define TC_CTRLC_CPTEN1             (1 << TC_CTRLC_CPTEN1_Pos)
 #define TC_CTRLC_CPTEN_Pos          4            /**< \brief (TC_CTRLC) Capture Channel x Enable */
-#define TC_CTRLC_CPTEN_Msk          (0x3ul << TC_CTRLC_CPTEN_Pos)
+#define TC_CTRLC_CPTEN_Msk          (_U_(0x3) << TC_CTRLC_CPTEN_Pos)
 #define TC_CTRLC_CPTEN(value)       (TC_CTRLC_CPTEN_Msk & ((value) << TC_CTRLC_CPTEN_Pos))
-#define TC_CTRLC_MASK               0x33ul       /**< \brief (TC_CTRLC) MASK Register */
+#define TC_CTRLC_MASK               _U_(0x33)     /**< \brief (TC_CTRLC) MASK Register */
 
 /* -------- TC_DBGCTRL : (TC Offset: 0x08) (R/W  8) Debug Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -272,11 +257,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_DBGCTRL_OFFSET           0x08         /**< \brief (TC_DBGCTRL offset) Debug Control */
-#define TC_DBGCTRL_RESETVALUE       0x00ul       /**< \brief (TC_DBGCTRL reset_value) Debug Control */
+#define TC_DBGCTRL_RESETVALUE       _U_(0x00)     /**< \brief (TC_DBGCTRL reset_value) Debug Control */
 
 #define TC_DBGCTRL_DBGRUN_Pos       0            /**< \brief (TC_DBGCTRL) Debug Run Mode */
-#define TC_DBGCTRL_DBGRUN           (0x1ul << TC_DBGCTRL_DBGRUN_Pos)
-#define TC_DBGCTRL_MASK             0x01ul       /**< \brief (TC_DBGCTRL) MASK Register */
+#define TC_DBGCTRL_DBGRUN           (_U_(0x1) << TC_DBGCTRL_DBGRUN_Pos)
+#define TC_DBGCTRL_MASK             _U_(0x01)     /**< \brief (TC_DBGCTRL) MASK Register */
 
 /* -------- TC_EVCTRL : (TC Offset: 0x0A) (R/W 16) Event Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -303,17 +288,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_EVCTRL_OFFSET            0x0A         /**< \brief (TC_EVCTRL offset) Event Control */
-#define TC_EVCTRL_RESETVALUE        0x0000ul     /**< \brief (TC_EVCTRL reset_value) Event Control */
+#define TC_EVCTRL_RESETVALUE        _U_(0x0000)   /**< \brief (TC_EVCTRL reset_value) Event Control */
 
 #define TC_EVCTRL_EVACT_Pos         0            /**< \brief (TC_EVCTRL) Event Action */
-#define TC_EVCTRL_EVACT_Msk         (0x7ul << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_Msk         (_U_(0x7) << TC_EVCTRL_EVACT_Pos)
 #define TC_EVCTRL_EVACT(value)      (TC_EVCTRL_EVACT_Msk & ((value) << TC_EVCTRL_EVACT_Pos))
-#define   TC_EVCTRL_EVACT_OFF_Val         0x0ul  /**< \brief (TC_EVCTRL) Event action disabled */
-#define   TC_EVCTRL_EVACT_RETRIGGER_Val   0x1ul  /**< \brief (TC_EVCTRL) Start, restart or retrigger TC on event */
-#define   TC_EVCTRL_EVACT_COUNT_Val       0x2ul  /**< \brief (TC_EVCTRL) Count on event */
-#define   TC_EVCTRL_EVACT_START_Val       0x3ul  /**< \brief (TC_EVCTRL) Start TC on event */
-#define   TC_EVCTRL_EVACT_PPW_Val         0x5ul  /**< \brief (TC_EVCTRL) Period captured in CC0, pulse width in CC1 */
-#define   TC_EVCTRL_EVACT_PWP_Val         0x6ul  /**< \brief (TC_EVCTRL) Period captured in CC1, pulse width in CC0 */
+#define   TC_EVCTRL_EVACT_OFF_Val         _U_(0x0)   /**< \brief (TC_EVCTRL) Event action disabled */
+#define   TC_EVCTRL_EVACT_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_EVCTRL) Start, restart or retrigger TC on event */
+#define   TC_EVCTRL_EVACT_COUNT_Val       _U_(0x2)   /**< \brief (TC_EVCTRL) Count on event */
+#define   TC_EVCTRL_EVACT_START_Val       _U_(0x3)   /**< \brief (TC_EVCTRL) Start TC on event */
+#define   TC_EVCTRL_EVACT_PPW_Val         _U_(0x5)   /**< \brief (TC_EVCTRL) Period captured in CC0, pulse width in CC1 */
+#define   TC_EVCTRL_EVACT_PWP_Val         _U_(0x6)   /**< \brief (TC_EVCTRL) Period captured in CC1, pulse width in CC0 */
 #define TC_EVCTRL_EVACT_OFF         (TC_EVCTRL_EVACT_OFF_Val       << TC_EVCTRL_EVACT_Pos)
 #define TC_EVCTRL_EVACT_RETRIGGER   (TC_EVCTRL_EVACT_RETRIGGER_Val << TC_EVCTRL_EVACT_Pos)
 #define TC_EVCTRL_EVACT_COUNT       (TC_EVCTRL_EVACT_COUNT_Val     << TC_EVCTRL_EVACT_Pos)
@@ -321,19 +306,19 @@ typedef union {
 #define TC_EVCTRL_EVACT_PPW         (TC_EVCTRL_EVACT_PPW_Val       << TC_EVCTRL_EVACT_Pos)
 #define TC_EVCTRL_EVACT_PWP         (TC_EVCTRL_EVACT_PWP_Val       << TC_EVCTRL_EVACT_Pos)
 #define TC_EVCTRL_TCINV_Pos         4            /**< \brief (TC_EVCTRL) TC Inverted Event Input */
-#define TC_EVCTRL_TCINV             (0x1ul << TC_EVCTRL_TCINV_Pos)
+#define TC_EVCTRL_TCINV             (_U_(0x1) << TC_EVCTRL_TCINV_Pos)
 #define TC_EVCTRL_TCEI_Pos          5            /**< \brief (TC_EVCTRL) TC Event Input */
-#define TC_EVCTRL_TCEI              (0x1ul << TC_EVCTRL_TCEI_Pos)
+#define TC_EVCTRL_TCEI              (_U_(0x1) << TC_EVCTRL_TCEI_Pos)
 #define TC_EVCTRL_OVFEO_Pos         8            /**< \brief (TC_EVCTRL) Overflow/Underflow Event Output Enable */
-#define TC_EVCTRL_OVFEO             (0x1ul << TC_EVCTRL_OVFEO_Pos)
+#define TC_EVCTRL_OVFEO             (_U_(0x1) << TC_EVCTRL_OVFEO_Pos)
 #define TC_EVCTRL_MCEO0_Pos         12           /**< \brief (TC_EVCTRL) Match or Capture Channel 0 Event Output Enable */
 #define TC_EVCTRL_MCEO0             (1 << TC_EVCTRL_MCEO0_Pos)
 #define TC_EVCTRL_MCEO1_Pos         13           /**< \brief (TC_EVCTRL) Match or Capture Channel 1 Event Output Enable */
 #define TC_EVCTRL_MCEO1             (1 << TC_EVCTRL_MCEO1_Pos)
 #define TC_EVCTRL_MCEO_Pos          12           /**< \brief (TC_EVCTRL) Match or Capture Channel x Event Output Enable */
-#define TC_EVCTRL_MCEO_Msk          (0x3ul << TC_EVCTRL_MCEO_Pos)
+#define TC_EVCTRL_MCEO_Msk          (_U_(0x3) << TC_EVCTRL_MCEO_Pos)
 #define TC_EVCTRL_MCEO(value)       (TC_EVCTRL_MCEO_Msk & ((value) << TC_EVCTRL_MCEO_Pos))
-#define TC_EVCTRL_MASK              0x3137ul     /**< \brief (TC_EVCTRL) MASK Register */
+#define TC_EVCTRL_MASK              _U_(0x3137)   /**< \brief (TC_EVCTRL) MASK Register */
 
 /* -------- TC_INTENCLR : (TC Offset: 0x0C) (R/W  8) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -357,22 +342,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_INTENCLR_OFFSET          0x0C         /**< \brief (TC_INTENCLR offset) Interrupt Enable Clear */
-#define TC_INTENCLR_RESETVALUE      0x00ul       /**< \brief (TC_INTENCLR reset_value) Interrupt Enable Clear */
+#define TC_INTENCLR_RESETVALUE      _U_(0x00)     /**< \brief (TC_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define TC_INTENCLR_OVF_Pos         0            /**< \brief (TC_INTENCLR) Overflow Interrupt Enable */
-#define TC_INTENCLR_OVF             (0x1ul << TC_INTENCLR_OVF_Pos)
+#define TC_INTENCLR_OVF             (_U_(0x1) << TC_INTENCLR_OVF_Pos)
 #define TC_INTENCLR_ERR_Pos         1            /**< \brief (TC_INTENCLR) Error Interrupt Enable */
-#define TC_INTENCLR_ERR             (0x1ul << TC_INTENCLR_ERR_Pos)
+#define TC_INTENCLR_ERR             (_U_(0x1) << TC_INTENCLR_ERR_Pos)
 #define TC_INTENCLR_SYNCRDY_Pos     3            /**< \brief (TC_INTENCLR) Synchronization Ready Interrupt Enable */
-#define TC_INTENCLR_SYNCRDY         (0x1ul << TC_INTENCLR_SYNCRDY_Pos)
+#define TC_INTENCLR_SYNCRDY         (_U_(0x1) << TC_INTENCLR_SYNCRDY_Pos)
 #define TC_INTENCLR_MC0_Pos         4            /**< \brief (TC_INTENCLR) Match or Capture Channel 0 Interrupt Enable */
 #define TC_INTENCLR_MC0             (1 << TC_INTENCLR_MC0_Pos)
 #define TC_INTENCLR_MC1_Pos         5            /**< \brief (TC_INTENCLR) Match or Capture Channel 1 Interrupt Enable */
 #define TC_INTENCLR_MC1             (1 << TC_INTENCLR_MC1_Pos)
 #define TC_INTENCLR_MC_Pos          4            /**< \brief (TC_INTENCLR) Match or Capture Channel x Interrupt Enable */
-#define TC_INTENCLR_MC_Msk          (0x3ul << TC_INTENCLR_MC_Pos)
+#define TC_INTENCLR_MC_Msk          (_U_(0x3) << TC_INTENCLR_MC_Pos)
 #define TC_INTENCLR_MC(value)       (TC_INTENCLR_MC_Msk & ((value) << TC_INTENCLR_MC_Pos))
-#define TC_INTENCLR_MASK            0x3Bul       /**< \brief (TC_INTENCLR) MASK Register */
+#define TC_INTENCLR_MASK            _U_(0x3B)     /**< \brief (TC_INTENCLR) MASK Register */
 
 /* -------- TC_INTENSET : (TC Offset: 0x0D) (R/W  8) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -396,22 +381,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_INTENSET_OFFSET          0x0D         /**< \brief (TC_INTENSET offset) Interrupt Enable Set */
-#define TC_INTENSET_RESETVALUE      0x00ul       /**< \brief (TC_INTENSET reset_value) Interrupt Enable Set */
+#define TC_INTENSET_RESETVALUE      _U_(0x00)     /**< \brief (TC_INTENSET reset_value) Interrupt Enable Set */
 
 #define TC_INTENSET_OVF_Pos         0            /**< \brief (TC_INTENSET) Overflow Interrupt Enable */
-#define TC_INTENSET_OVF             (0x1ul << TC_INTENSET_OVF_Pos)
+#define TC_INTENSET_OVF             (_U_(0x1) << TC_INTENSET_OVF_Pos)
 #define TC_INTENSET_ERR_Pos         1            /**< \brief (TC_INTENSET) Error Interrupt Enable */
-#define TC_INTENSET_ERR             (0x1ul << TC_INTENSET_ERR_Pos)
+#define TC_INTENSET_ERR             (_U_(0x1) << TC_INTENSET_ERR_Pos)
 #define TC_INTENSET_SYNCRDY_Pos     3            /**< \brief (TC_INTENSET) Synchronization Ready Interrupt Enable */
-#define TC_INTENSET_SYNCRDY         (0x1ul << TC_INTENSET_SYNCRDY_Pos)
+#define TC_INTENSET_SYNCRDY         (_U_(0x1) << TC_INTENSET_SYNCRDY_Pos)
 #define TC_INTENSET_MC0_Pos         4            /**< \brief (TC_INTENSET) Match or Capture Channel 0 Interrupt Enable */
 #define TC_INTENSET_MC0             (1 << TC_INTENSET_MC0_Pos)
 #define TC_INTENSET_MC1_Pos         5            /**< \brief (TC_INTENSET) Match or Capture Channel 1 Interrupt Enable */
 #define TC_INTENSET_MC1             (1 << TC_INTENSET_MC1_Pos)
 #define TC_INTENSET_MC_Pos          4            /**< \brief (TC_INTENSET) Match or Capture Channel x Interrupt Enable */
-#define TC_INTENSET_MC_Msk          (0x3ul << TC_INTENSET_MC_Pos)
+#define TC_INTENSET_MC_Msk          (_U_(0x3) << TC_INTENSET_MC_Pos)
 #define TC_INTENSET_MC(value)       (TC_INTENSET_MC_Msk & ((value) << TC_INTENSET_MC_Pos))
-#define TC_INTENSET_MASK            0x3Bul       /**< \brief (TC_INTENSET) MASK Register */
+#define TC_INTENSET_MASK            _U_(0x3B)     /**< \brief (TC_INTENSET) MASK Register */
 
 /* -------- TC_INTFLAG : (TC Offset: 0x0E) (R/W  8) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -435,22 +420,22 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_INTFLAG_OFFSET           0x0E         /**< \brief (TC_INTFLAG offset) Interrupt Flag Status and Clear */
-#define TC_INTFLAG_RESETVALUE       0x00ul       /**< \brief (TC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define TC_INTFLAG_RESETVALUE       _U_(0x00)     /**< \brief (TC_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define TC_INTFLAG_OVF_Pos          0            /**< \brief (TC_INTFLAG) Overflow */
-#define TC_INTFLAG_OVF              (0x1ul << TC_INTFLAG_OVF_Pos)
+#define TC_INTFLAG_OVF              (_U_(0x1) << TC_INTFLAG_OVF_Pos)
 #define TC_INTFLAG_ERR_Pos          1            /**< \brief (TC_INTFLAG) Error */
-#define TC_INTFLAG_ERR              (0x1ul << TC_INTFLAG_ERR_Pos)
+#define TC_INTFLAG_ERR              (_U_(0x1) << TC_INTFLAG_ERR_Pos)
 #define TC_INTFLAG_SYNCRDY_Pos      3            /**< \brief (TC_INTFLAG) Synchronization Ready */
-#define TC_INTFLAG_SYNCRDY          (0x1ul << TC_INTFLAG_SYNCRDY_Pos)
+#define TC_INTFLAG_SYNCRDY          (_U_(0x1) << TC_INTFLAG_SYNCRDY_Pos)
 #define TC_INTFLAG_MC0_Pos          4            /**< \brief (TC_INTFLAG) Match or Capture Channel 0 */
 #define TC_INTFLAG_MC0              (1 << TC_INTFLAG_MC0_Pos)
 #define TC_INTFLAG_MC1_Pos          5            /**< \brief (TC_INTFLAG) Match or Capture Channel 1 */
 #define TC_INTFLAG_MC1              (1 << TC_INTFLAG_MC1_Pos)
 #define TC_INTFLAG_MC_Pos           4            /**< \brief (TC_INTFLAG) Match or Capture Channel x */
-#define TC_INTFLAG_MC_Msk           (0x3ul << TC_INTFLAG_MC_Pos)
+#define TC_INTFLAG_MC_Msk           (_U_(0x3) << TC_INTFLAG_MC_Pos)
 #define TC_INTFLAG_MC(value)        (TC_INTFLAG_MC_Msk & ((value) << TC_INTFLAG_MC_Pos))
-#define TC_INTFLAG_MASK             0x3Bul       /**< \brief (TC_INTFLAG) MASK Register */
+#define TC_INTFLAG_MASK             _U_(0x3B)     /**< \brief (TC_INTFLAG) MASK Register */
 
 /* -------- TC_STATUS : (TC Offset: 0x0F) (R/   8) Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -467,15 +452,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_STATUS_OFFSET            0x0F         /**< \brief (TC_STATUS offset) Status */
-#define TC_STATUS_RESETVALUE        0x08ul       /**< \brief (TC_STATUS reset_value) Status */
+#define TC_STATUS_RESETVALUE        _U_(0x08)     /**< \brief (TC_STATUS reset_value) Status */
 
 #define TC_STATUS_STOP_Pos          3            /**< \brief (TC_STATUS) Stop */
-#define TC_STATUS_STOP              (0x1ul << TC_STATUS_STOP_Pos)
+#define TC_STATUS_STOP              (_U_(0x1) << TC_STATUS_STOP_Pos)
 #define TC_STATUS_SLAVE_Pos         4            /**< \brief (TC_STATUS) Slave */
-#define TC_STATUS_SLAVE             (0x1ul << TC_STATUS_SLAVE_Pos)
+#define TC_STATUS_SLAVE             (_U_(0x1) << TC_STATUS_SLAVE_Pos)
 #define TC_STATUS_SYNCBUSY_Pos      7            /**< \brief (TC_STATUS) Synchronization Busy */
-#define TC_STATUS_SYNCBUSY          (0x1ul << TC_STATUS_SYNCBUSY_Pos)
-#define TC_STATUS_MASK              0x98ul       /**< \brief (TC_STATUS) MASK Register */
+#define TC_STATUS_SYNCBUSY          (_U_(0x1) << TC_STATUS_SYNCBUSY_Pos)
+#define TC_STATUS_MASK              _U_(0x98)     /**< \brief (TC_STATUS) MASK Register */
 
 /* -------- TC_COUNT16_COUNT : (TC Offset: 0x10) (R/W 16) COUNT16 COUNT16 Counter Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -488,12 +473,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_COUNT16_COUNT_OFFSET     0x10         /**< \brief (TC_COUNT16_COUNT offset) COUNT16 Counter Value */
-#define TC_COUNT16_COUNT_RESETVALUE 0x0000ul     /**< \brief (TC_COUNT16_COUNT reset_value) COUNT16 Counter Value */
+#define TC_COUNT16_COUNT_RESETVALUE _U_(0x0000)   /**< \brief (TC_COUNT16_COUNT reset_value) COUNT16 Counter Value */
 
 #define TC_COUNT16_COUNT_COUNT_Pos  0            /**< \brief (TC_COUNT16_COUNT) Count Value */
-#define TC_COUNT16_COUNT_COUNT_Msk  (0xFFFFul << TC_COUNT16_COUNT_COUNT_Pos)
+#define TC_COUNT16_COUNT_COUNT_Msk  (_U_(0xFFFF) << TC_COUNT16_COUNT_COUNT_Pos)
 #define TC_COUNT16_COUNT_COUNT(value) (TC_COUNT16_COUNT_COUNT_Msk & ((value) << TC_COUNT16_COUNT_COUNT_Pos))
-#define TC_COUNT16_COUNT_MASK       0xFFFFul     /**< \brief (TC_COUNT16_COUNT) MASK Register */
+#define TC_COUNT16_COUNT_MASK       _U_(0xFFFF)   /**< \brief (TC_COUNT16_COUNT) MASK Register */
 
 /* -------- TC_COUNT32_COUNT : (TC Offset: 0x10) (R/W 32) COUNT32 COUNT32 Counter Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -506,12 +491,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_COUNT32_COUNT_OFFSET     0x10         /**< \brief (TC_COUNT32_COUNT offset) COUNT32 Counter Value */
-#define TC_COUNT32_COUNT_RESETVALUE 0x00000000ul /**< \brief (TC_COUNT32_COUNT reset_value) COUNT32 Counter Value */
+#define TC_COUNT32_COUNT_RESETVALUE _U_(0x00000000) /**< \brief (TC_COUNT32_COUNT reset_value) COUNT32 Counter Value */
 
 #define TC_COUNT32_COUNT_COUNT_Pos  0            /**< \brief (TC_COUNT32_COUNT) Count Value */
-#define TC_COUNT32_COUNT_COUNT_Msk  (0xFFFFFFFFul << TC_COUNT32_COUNT_COUNT_Pos)
+#define TC_COUNT32_COUNT_COUNT_Msk  (_U_(0xFFFFFFFF) << TC_COUNT32_COUNT_COUNT_Pos)
 #define TC_COUNT32_COUNT_COUNT(value) (TC_COUNT32_COUNT_COUNT_Msk & ((value) << TC_COUNT32_COUNT_COUNT_Pos))
-#define TC_COUNT32_COUNT_MASK       0xFFFFFFFFul /**< \brief (TC_COUNT32_COUNT) MASK Register */
+#define TC_COUNT32_COUNT_MASK       _U_(0xFFFFFFFF) /**< \brief (TC_COUNT32_COUNT) MASK Register */
 
 /* -------- TC_COUNT8_COUNT : (TC Offset: 0x10) (R/W  8) COUNT8 COUNT8 Counter Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -524,12 +509,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_COUNT8_COUNT_OFFSET      0x10         /**< \brief (TC_COUNT8_COUNT offset) COUNT8 Counter Value */
-#define TC_COUNT8_COUNT_RESETVALUE  0x00ul       /**< \brief (TC_COUNT8_COUNT reset_value) COUNT8 Counter Value */
+#define TC_COUNT8_COUNT_RESETVALUE  _U_(0x00)     /**< \brief (TC_COUNT8_COUNT reset_value) COUNT8 Counter Value */
 
 #define TC_COUNT8_COUNT_COUNT_Pos   0            /**< \brief (TC_COUNT8_COUNT) Counter Value */
-#define TC_COUNT8_COUNT_COUNT_Msk   (0xFFul << TC_COUNT8_COUNT_COUNT_Pos)
+#define TC_COUNT8_COUNT_COUNT_Msk   (_U_(0xFF) << TC_COUNT8_COUNT_COUNT_Pos)
 #define TC_COUNT8_COUNT_COUNT(value) (TC_COUNT8_COUNT_COUNT_Msk & ((value) << TC_COUNT8_COUNT_COUNT_Pos))
-#define TC_COUNT8_COUNT_MASK        0xFFul       /**< \brief (TC_COUNT8_COUNT) MASK Register */
+#define TC_COUNT8_COUNT_MASK        _U_(0xFF)     /**< \brief (TC_COUNT8_COUNT) MASK Register */
 
 /* -------- TC_COUNT8_PER : (TC Offset: 0x14) (R/W  8) COUNT8 COUNT8 Period Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -542,12 +527,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_COUNT8_PER_OFFSET        0x14         /**< \brief (TC_COUNT8_PER offset) COUNT8 Period Value */
-#define TC_COUNT8_PER_RESETVALUE    0xFFul       /**< \brief (TC_COUNT8_PER reset_value) COUNT8 Period Value */
+#define TC_COUNT8_PER_RESETVALUE    _U_(0xFF)     /**< \brief (TC_COUNT8_PER reset_value) COUNT8 Period Value */
 
 #define TC_COUNT8_PER_PER_Pos       0            /**< \brief (TC_COUNT8_PER) Period Value */
-#define TC_COUNT8_PER_PER_Msk       (0xFFul << TC_COUNT8_PER_PER_Pos)
+#define TC_COUNT8_PER_PER_Msk       (_U_(0xFF) << TC_COUNT8_PER_PER_Pos)
 #define TC_COUNT8_PER_PER(value)    (TC_COUNT8_PER_PER_Msk & ((value) << TC_COUNT8_PER_PER_Pos))
-#define TC_COUNT8_PER_MASK          0xFFul       /**< \brief (TC_COUNT8_PER) MASK Register */
+#define TC_COUNT8_PER_MASK          _U_(0xFF)     /**< \brief (TC_COUNT8_PER) MASK Register */
 
 /* -------- TC_COUNT16_CC : (TC Offset: 0x18) (R/W 16) COUNT16 COUNT16 Compare/Capture -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -560,12 +545,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_COUNT16_CC_OFFSET        0x18         /**< \brief (TC_COUNT16_CC offset) COUNT16 Compare/Capture */
-#define TC_COUNT16_CC_RESETVALUE    0x0000ul     /**< \brief (TC_COUNT16_CC reset_value) COUNT16 Compare/Capture */
+#define TC_COUNT16_CC_RESETVALUE    _U_(0x0000)   /**< \brief (TC_COUNT16_CC reset_value) COUNT16 Compare/Capture */
 
 #define TC_COUNT16_CC_CC_Pos        0            /**< \brief (TC_COUNT16_CC) Compare/Capture Value */
-#define TC_COUNT16_CC_CC_Msk        (0xFFFFul << TC_COUNT16_CC_CC_Pos)
+#define TC_COUNT16_CC_CC_Msk        (_U_(0xFFFF) << TC_COUNT16_CC_CC_Pos)
 #define TC_COUNT16_CC_CC(value)     (TC_COUNT16_CC_CC_Msk & ((value) << TC_COUNT16_CC_CC_Pos))
-#define TC_COUNT16_CC_MASK          0xFFFFul     /**< \brief (TC_COUNT16_CC) MASK Register */
+#define TC_COUNT16_CC_MASK          _U_(0xFFFF)   /**< \brief (TC_COUNT16_CC) MASK Register */
 
 /* -------- TC_COUNT32_CC : (TC Offset: 0x18) (R/W 32) COUNT32 COUNT32 Compare/Capture -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -578,12 +563,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_COUNT32_CC_OFFSET        0x18         /**< \brief (TC_COUNT32_CC offset) COUNT32 Compare/Capture */
-#define TC_COUNT32_CC_RESETVALUE    0x00000000ul /**< \brief (TC_COUNT32_CC reset_value) COUNT32 Compare/Capture */
+#define TC_COUNT32_CC_RESETVALUE    _U_(0x00000000) /**< \brief (TC_COUNT32_CC reset_value) COUNT32 Compare/Capture */
 
 #define TC_COUNT32_CC_CC_Pos        0            /**< \brief (TC_COUNT32_CC) Compare/Capture Value */
-#define TC_COUNT32_CC_CC_Msk        (0xFFFFFFFFul << TC_COUNT32_CC_CC_Pos)
+#define TC_COUNT32_CC_CC_Msk        (_U_(0xFFFFFFFF) << TC_COUNT32_CC_CC_Pos)
 #define TC_COUNT32_CC_CC(value)     (TC_COUNT32_CC_CC_Msk & ((value) << TC_COUNT32_CC_CC_Pos))
-#define TC_COUNT32_CC_MASK          0xFFFFFFFFul /**< \brief (TC_COUNT32_CC) MASK Register */
+#define TC_COUNT32_CC_MASK          _U_(0xFFFFFFFF) /**< \brief (TC_COUNT32_CC) MASK Register */
 
 /* -------- TC_COUNT8_CC : (TC Offset: 0x18) (R/W  8) COUNT8 COUNT8 Compare/Capture -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -596,12 +581,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_COUNT8_CC_OFFSET         0x18         /**< \brief (TC_COUNT8_CC offset) COUNT8 Compare/Capture */
-#define TC_COUNT8_CC_RESETVALUE     0x00ul       /**< \brief (TC_COUNT8_CC reset_value) COUNT8 Compare/Capture */
+#define TC_COUNT8_CC_RESETVALUE     _U_(0x00)     /**< \brief (TC_COUNT8_CC reset_value) COUNT8 Compare/Capture */
 
 #define TC_COUNT8_CC_CC_Pos         0            /**< \brief (TC_COUNT8_CC) Compare/Capture Value */
-#define TC_COUNT8_CC_CC_Msk         (0xFFul << TC_COUNT8_CC_CC_Pos)
+#define TC_COUNT8_CC_CC_Msk         (_U_(0xFF) << TC_COUNT8_CC_CC_Pos)
 #define TC_COUNT8_CC_CC(value)      (TC_COUNT8_CC_CC_Msk & ((value) << TC_COUNT8_CC_CC_Pos))
-#define TC_COUNT8_CC_MASK           0xFFul       /**< \brief (TC_COUNT8_CC) MASK Register */
+#define TC_COUNT8_CC_MASK           _U_(0xFF)     /**< \brief (TC_COUNT8_CC) MASK Register */
 
 /** \brief TC_COUNT8 hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/tcc.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for TCC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -83,34 +68,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_CTRLA_OFFSET            0x00         /**< \brief (TCC_CTRLA offset) Control A */
-#define TCC_CTRLA_RESETVALUE        0x00000000ul /**< \brief (TCC_CTRLA reset_value) Control A */
+#define TCC_CTRLA_RESETVALUE        _U_(0x00000000) /**< \brief (TCC_CTRLA reset_value) Control A */
 
 #define TCC_CTRLA_SWRST_Pos         0            /**< \brief (TCC_CTRLA) Software Reset */
-#define TCC_CTRLA_SWRST             (0x1ul << TCC_CTRLA_SWRST_Pos)
+#define TCC_CTRLA_SWRST             (_U_(0x1) << TCC_CTRLA_SWRST_Pos)
 #define TCC_CTRLA_ENABLE_Pos        1            /**< \brief (TCC_CTRLA) Enable */
-#define TCC_CTRLA_ENABLE            (0x1ul << TCC_CTRLA_ENABLE_Pos)
+#define TCC_CTRLA_ENABLE            (_U_(0x1) << TCC_CTRLA_ENABLE_Pos)
 #define TCC_CTRLA_RESOLUTION_Pos    5            /**< \brief (TCC_CTRLA) Enhanced Resolution */
-#define TCC_CTRLA_RESOLUTION_Msk    (0x3ul << TCC_CTRLA_RESOLUTION_Pos)
+#define TCC_CTRLA_RESOLUTION_Msk    (_U_(0x3) << TCC_CTRLA_RESOLUTION_Pos)
 #define TCC_CTRLA_RESOLUTION(value) (TCC_CTRLA_RESOLUTION_Msk & ((value) << TCC_CTRLA_RESOLUTION_Pos))
-#define   TCC_CTRLA_RESOLUTION_NONE_Val   0x0ul  /**< \brief (TCC_CTRLA) Dithering is disabled */
-#define   TCC_CTRLA_RESOLUTION_DITH4_Val  0x1ul  /**< \brief (TCC_CTRLA) Dithering is done every 16 PWM frames */
-#define   TCC_CTRLA_RESOLUTION_DITH5_Val  0x2ul  /**< \brief (TCC_CTRLA) Dithering is done every 32 PWM frames */
-#define   TCC_CTRLA_RESOLUTION_DITH6_Val  0x3ul  /**< \brief (TCC_CTRLA) Dithering is done every 64 PWM frames */
+#define   TCC_CTRLA_RESOLUTION_NONE_Val   _U_(0x0)   /**< \brief (TCC_CTRLA) Dithering is disabled */
+#define   TCC_CTRLA_RESOLUTION_DITH4_Val  _U_(0x1)   /**< \brief (TCC_CTRLA) Dithering is done every 16 PWM frames */
+#define   TCC_CTRLA_RESOLUTION_DITH5_Val  _U_(0x2)   /**< \brief (TCC_CTRLA) Dithering is done every 32 PWM frames */
+#define   TCC_CTRLA_RESOLUTION_DITH6_Val  _U_(0x3)   /**< \brief (TCC_CTRLA) Dithering is done every 64 PWM frames */
 #define TCC_CTRLA_RESOLUTION_NONE   (TCC_CTRLA_RESOLUTION_NONE_Val << TCC_CTRLA_RESOLUTION_Pos)
 #define TCC_CTRLA_RESOLUTION_DITH4  (TCC_CTRLA_RESOLUTION_DITH4_Val << TCC_CTRLA_RESOLUTION_Pos)
 #define TCC_CTRLA_RESOLUTION_DITH5  (TCC_CTRLA_RESOLUTION_DITH5_Val << TCC_CTRLA_RESOLUTION_Pos)
 #define TCC_CTRLA_RESOLUTION_DITH6  (TCC_CTRLA_RESOLUTION_DITH6_Val << TCC_CTRLA_RESOLUTION_Pos)
 #define TCC_CTRLA_PRESCALER_Pos     8            /**< \brief (TCC_CTRLA) Prescaler */
-#define TCC_CTRLA_PRESCALER_Msk     (0x7ul << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER_Msk     (_U_(0x7) << TCC_CTRLA_PRESCALER_Pos)
 #define TCC_CTRLA_PRESCALER(value)  (TCC_CTRLA_PRESCALER_Msk & ((value) << TCC_CTRLA_PRESCALER_Pos))
-#define   TCC_CTRLA_PRESCALER_DIV1_Val    0x0ul  /**< \brief (TCC_CTRLA) No division */
-#define   TCC_CTRLA_PRESCALER_DIV2_Val    0x1ul  /**< \brief (TCC_CTRLA) Divide by 2 */
-#define   TCC_CTRLA_PRESCALER_DIV4_Val    0x2ul  /**< \brief (TCC_CTRLA) Divide by 4 */
-#define   TCC_CTRLA_PRESCALER_DIV8_Val    0x3ul  /**< \brief (TCC_CTRLA) Divide by 8 */
-#define   TCC_CTRLA_PRESCALER_DIV16_Val   0x4ul  /**< \brief (TCC_CTRLA) Divide by 16 */
-#define   TCC_CTRLA_PRESCALER_DIV64_Val   0x5ul  /**< \brief (TCC_CTRLA) Divide by 64 */
-#define   TCC_CTRLA_PRESCALER_DIV256_Val  0x6ul  /**< \brief (TCC_CTRLA) Divide by 256 */
-#define   TCC_CTRLA_PRESCALER_DIV1024_Val 0x7ul  /**< \brief (TCC_CTRLA) Divide by 1024 */
+#define   TCC_CTRLA_PRESCALER_DIV1_Val    _U_(0x0)   /**< \brief (TCC_CTRLA) No division */
+#define   TCC_CTRLA_PRESCALER_DIV2_Val    _U_(0x1)   /**< \brief (TCC_CTRLA) Divide by 2 */
+#define   TCC_CTRLA_PRESCALER_DIV4_Val    _U_(0x2)   /**< \brief (TCC_CTRLA) Divide by 4 */
+#define   TCC_CTRLA_PRESCALER_DIV8_Val    _U_(0x3)   /**< \brief (TCC_CTRLA) Divide by 8 */
+#define   TCC_CTRLA_PRESCALER_DIV16_Val   _U_(0x4)   /**< \brief (TCC_CTRLA) Divide by 16 */
+#define   TCC_CTRLA_PRESCALER_DIV64_Val   _U_(0x5)   /**< \brief (TCC_CTRLA) Divide by 64 */
+#define   TCC_CTRLA_PRESCALER_DIV256_Val  _U_(0x6)   /**< \brief (TCC_CTRLA) Divide by 256 */
+#define   TCC_CTRLA_PRESCALER_DIV1024_Val _U_(0x7)   /**< \brief (TCC_CTRLA) Divide by 1024 */
 #define TCC_CTRLA_PRESCALER_DIV1    (TCC_CTRLA_PRESCALER_DIV1_Val  << TCC_CTRLA_PRESCALER_Pos)
 #define TCC_CTRLA_PRESCALER_DIV2    (TCC_CTRLA_PRESCALER_DIV2_Val  << TCC_CTRLA_PRESCALER_Pos)
 #define TCC_CTRLA_PRESCALER_DIV4    (TCC_CTRLA_PRESCALER_DIV4_Val  << TCC_CTRLA_PRESCALER_Pos)
@@ -120,18 +105,18 @@ typedef union {
 #define TCC_CTRLA_PRESCALER_DIV256  (TCC_CTRLA_PRESCALER_DIV256_Val << TCC_CTRLA_PRESCALER_Pos)
 #define TCC_CTRLA_PRESCALER_DIV1024 (TCC_CTRLA_PRESCALER_DIV1024_Val << TCC_CTRLA_PRESCALER_Pos)
 #define TCC_CTRLA_RUNSTDBY_Pos      11           /**< \brief (TCC_CTRLA) Run in Standby */
-#define TCC_CTRLA_RUNSTDBY          (0x1ul << TCC_CTRLA_RUNSTDBY_Pos)
+#define TCC_CTRLA_RUNSTDBY          (_U_(0x1) << TCC_CTRLA_RUNSTDBY_Pos)
 #define TCC_CTRLA_PRESCSYNC_Pos     12           /**< \brief (TCC_CTRLA) Prescaler and Counter Synchronization Selection */
-#define TCC_CTRLA_PRESCSYNC_Msk     (0x3ul << TCC_CTRLA_PRESCSYNC_Pos)
+#define TCC_CTRLA_PRESCSYNC_Msk     (_U_(0x3) << TCC_CTRLA_PRESCSYNC_Pos)
 #define TCC_CTRLA_PRESCSYNC(value)  (TCC_CTRLA_PRESCSYNC_Msk & ((value) << TCC_CTRLA_PRESCSYNC_Pos))
-#define   TCC_CTRLA_PRESCSYNC_GCLK_Val    0x0ul  /**< \brief (TCC_CTRLA) Reload or reset counter on next GCLK */
-#define   TCC_CTRLA_PRESCSYNC_PRESC_Val   0x1ul  /**< \brief (TCC_CTRLA) Reload or reset counter on next prescaler clock */
-#define   TCC_CTRLA_PRESCSYNC_RESYNC_Val  0x2ul  /**< \brief (TCC_CTRLA) Reload or reset counter on next GCLK and reset prescaler counter */
+#define   TCC_CTRLA_PRESCSYNC_GCLK_Val    _U_(0x0)   /**< \brief (TCC_CTRLA) Reload or reset counter on next GCLK */
+#define   TCC_CTRLA_PRESCSYNC_PRESC_Val   _U_(0x1)   /**< \brief (TCC_CTRLA) Reload or reset counter on next prescaler clock */
+#define   TCC_CTRLA_PRESCSYNC_RESYNC_Val  _U_(0x2)   /**< \brief (TCC_CTRLA) Reload or reset counter on next GCLK and reset prescaler counter */
 #define TCC_CTRLA_PRESCSYNC_GCLK    (TCC_CTRLA_PRESCSYNC_GCLK_Val  << TCC_CTRLA_PRESCSYNC_Pos)
 #define TCC_CTRLA_PRESCSYNC_PRESC   (TCC_CTRLA_PRESCSYNC_PRESC_Val << TCC_CTRLA_PRESCSYNC_Pos)
 #define TCC_CTRLA_PRESCSYNC_RESYNC  (TCC_CTRLA_PRESCSYNC_RESYNC_Val << TCC_CTRLA_PRESCSYNC_Pos)
 #define TCC_CTRLA_ALOCK_Pos         14           /**< \brief (TCC_CTRLA) Auto Lock */
-#define TCC_CTRLA_ALOCK             (0x1ul << TCC_CTRLA_ALOCK_Pos)
+#define TCC_CTRLA_ALOCK             (_U_(0x1) << TCC_CTRLA_ALOCK_Pos)
 #define TCC_CTRLA_CPTEN0_Pos        24           /**< \brief (TCC_CTRLA) Capture Channel 0 Enable */
 #define TCC_CTRLA_CPTEN0            (1 << TCC_CTRLA_CPTEN0_Pos)
 #define TCC_CTRLA_CPTEN1_Pos        25           /**< \brief (TCC_CTRLA) Capture Channel 1 Enable */
@@ -141,9 +126,9 @@ typedef union {
 #define TCC_CTRLA_CPTEN3_Pos        27           /**< \brief (TCC_CTRLA) Capture Channel 3 Enable */
 #define TCC_CTRLA_CPTEN3            (1 << TCC_CTRLA_CPTEN3_Pos)
 #define TCC_CTRLA_CPTEN_Pos         24           /**< \brief (TCC_CTRLA) Capture Channel x Enable */
-#define TCC_CTRLA_CPTEN_Msk         (0xFul << TCC_CTRLA_CPTEN_Pos)
+#define TCC_CTRLA_CPTEN_Msk         (_U_(0xF) << TCC_CTRLA_CPTEN_Pos)
 #define TCC_CTRLA_CPTEN(value)      (TCC_CTRLA_CPTEN_Msk & ((value) << TCC_CTRLA_CPTEN_Pos))
-#define TCC_CTRLA_MASK              0x0F007F63ul /**< \brief (TCC_CTRLA) MASK Register */
+#define TCC_CTRLA_MASK              _U_(0x0F007F63) /**< \brief (TCC_CTRLA) MASK Register */
 
 /* -------- TCC_CTRLBCLR : (TCC Offset: 0x04) (R/W  8) Control B Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -160,39 +145,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_CTRLBCLR_OFFSET         0x04         /**< \brief (TCC_CTRLBCLR offset) Control B Clear */
-#define TCC_CTRLBCLR_RESETVALUE     0x00ul       /**< \brief (TCC_CTRLBCLR reset_value) Control B Clear */
+#define TCC_CTRLBCLR_RESETVALUE     _U_(0x00)     /**< \brief (TCC_CTRLBCLR reset_value) Control B Clear */
 
 #define TCC_CTRLBCLR_DIR_Pos        0            /**< \brief (TCC_CTRLBCLR) Counter Direction */
-#define TCC_CTRLBCLR_DIR            (0x1ul << TCC_CTRLBCLR_DIR_Pos)
+#define TCC_CTRLBCLR_DIR            (_U_(0x1) << TCC_CTRLBCLR_DIR_Pos)
 #define TCC_CTRLBCLR_LUPD_Pos       1            /**< \brief (TCC_CTRLBCLR) Lock Update */
-#define TCC_CTRLBCLR_LUPD           (0x1ul << TCC_CTRLBCLR_LUPD_Pos)
+#define TCC_CTRLBCLR_LUPD           (_U_(0x1) << TCC_CTRLBCLR_LUPD_Pos)
 #define TCC_CTRLBCLR_ONESHOT_Pos    2            /**< \brief (TCC_CTRLBCLR) One-Shot */
-#define TCC_CTRLBCLR_ONESHOT        (0x1ul << TCC_CTRLBCLR_ONESHOT_Pos)
+#define TCC_CTRLBCLR_ONESHOT        (_U_(0x1) << TCC_CTRLBCLR_ONESHOT_Pos)
 #define TCC_CTRLBCLR_IDXCMD_Pos     3            /**< \brief (TCC_CTRLBCLR) Ramp Index Command */
-#define TCC_CTRLBCLR_IDXCMD_Msk     (0x3ul << TCC_CTRLBCLR_IDXCMD_Pos)
+#define TCC_CTRLBCLR_IDXCMD_Msk     (_U_(0x3) << TCC_CTRLBCLR_IDXCMD_Pos)
 #define TCC_CTRLBCLR_IDXCMD(value)  (TCC_CTRLBCLR_IDXCMD_Msk & ((value) << TCC_CTRLBCLR_IDXCMD_Pos))
-#define   TCC_CTRLBCLR_IDXCMD_DISABLE_Val 0x0ul  /**< \brief (TCC_CTRLBCLR) Command disabled: Index toggles between cycles A and B */
-#define   TCC_CTRLBCLR_IDXCMD_SET_Val     0x1ul  /**< \brief (TCC_CTRLBCLR) Set index: cycle B will be forced in the next cycle */
-#define   TCC_CTRLBCLR_IDXCMD_CLEAR_Val   0x2ul  /**< \brief (TCC_CTRLBCLR) Clear index: cycle A will be forced in the next cycle */
-#define   TCC_CTRLBCLR_IDXCMD_HOLD_Val    0x3ul  /**< \brief (TCC_CTRLBCLR) Hold index: the next cycle will be the same as the current cycle */
+#define   TCC_CTRLBCLR_IDXCMD_DISABLE_Val _U_(0x0)   /**< \brief (TCC_CTRLBCLR) Command disabled: Index toggles between cycles A and B */
+#define   TCC_CTRLBCLR_IDXCMD_SET_Val     _U_(0x1)   /**< \brief (TCC_CTRLBCLR) Set index: cycle B will be forced in the next cycle */
+#define   TCC_CTRLBCLR_IDXCMD_CLEAR_Val   _U_(0x2)   /**< \brief (TCC_CTRLBCLR) Clear index: cycle A will be forced in the next cycle */
+#define   TCC_CTRLBCLR_IDXCMD_HOLD_Val    _U_(0x3)   /**< \brief (TCC_CTRLBCLR) Hold index: the next cycle will be the same as the current cycle */
 #define TCC_CTRLBCLR_IDXCMD_DISABLE (TCC_CTRLBCLR_IDXCMD_DISABLE_Val << TCC_CTRLBCLR_IDXCMD_Pos)
 #define TCC_CTRLBCLR_IDXCMD_SET     (TCC_CTRLBCLR_IDXCMD_SET_Val   << TCC_CTRLBCLR_IDXCMD_Pos)
 #define TCC_CTRLBCLR_IDXCMD_CLEAR   (TCC_CTRLBCLR_IDXCMD_CLEAR_Val << TCC_CTRLBCLR_IDXCMD_Pos)
 #define TCC_CTRLBCLR_IDXCMD_HOLD    (TCC_CTRLBCLR_IDXCMD_HOLD_Val  << TCC_CTRLBCLR_IDXCMD_Pos)
 #define TCC_CTRLBCLR_CMD_Pos        5            /**< \brief (TCC_CTRLBCLR) TCC Command */
-#define TCC_CTRLBCLR_CMD_Msk        (0x7ul << TCC_CTRLBCLR_CMD_Pos)
+#define TCC_CTRLBCLR_CMD_Msk        (_U_(0x7) << TCC_CTRLBCLR_CMD_Pos)
 #define TCC_CTRLBCLR_CMD(value)     (TCC_CTRLBCLR_CMD_Msk & ((value) << TCC_CTRLBCLR_CMD_Pos))
-#define   TCC_CTRLBCLR_CMD_NONE_Val       0x0ul  /**< \brief (TCC_CTRLBCLR) No action */
-#define   TCC_CTRLBCLR_CMD_RETRIGGER_Val  0x1ul  /**< \brief (TCC_CTRLBCLR) Clear start, restart or retrigger */
-#define   TCC_CTRLBCLR_CMD_STOP_Val       0x2ul  /**< \brief (TCC_CTRLBCLR) Force stop */
-#define   TCC_CTRLBCLR_CMD_UPDATE_Val     0x3ul  /**< \brief (TCC_CTRLBCLR) Force update of double buffered registers */
-#define   TCC_CTRLBCLR_CMD_READSYNC_Val   0x4ul  /**< \brief (TCC_CTRLBCLR) Force COUNT read synchronization */
+#define   TCC_CTRLBCLR_CMD_NONE_Val       _U_(0x0)   /**< \brief (TCC_CTRLBCLR) No action */
+#define   TCC_CTRLBCLR_CMD_RETRIGGER_Val  _U_(0x1)   /**< \brief (TCC_CTRLBCLR) Clear start, restart or retrigger */
+#define   TCC_CTRLBCLR_CMD_STOP_Val       _U_(0x2)   /**< \brief (TCC_CTRLBCLR) Force stop */
+#define   TCC_CTRLBCLR_CMD_UPDATE_Val     _U_(0x3)   /**< \brief (TCC_CTRLBCLR) Force update of double buffered registers */
+#define   TCC_CTRLBCLR_CMD_READSYNC_Val   _U_(0x4)   /**< \brief (TCC_CTRLBCLR) Force COUNT read synchronization */
 #define TCC_CTRLBCLR_CMD_NONE       (TCC_CTRLBCLR_CMD_NONE_Val     << TCC_CTRLBCLR_CMD_Pos)
 #define TCC_CTRLBCLR_CMD_RETRIGGER  (TCC_CTRLBCLR_CMD_RETRIGGER_Val << TCC_CTRLBCLR_CMD_Pos)
 #define TCC_CTRLBCLR_CMD_STOP       (TCC_CTRLBCLR_CMD_STOP_Val     << TCC_CTRLBCLR_CMD_Pos)
 #define TCC_CTRLBCLR_CMD_UPDATE     (TCC_CTRLBCLR_CMD_UPDATE_Val   << TCC_CTRLBCLR_CMD_Pos)
 #define TCC_CTRLBCLR_CMD_READSYNC   (TCC_CTRLBCLR_CMD_READSYNC_Val << TCC_CTRLBCLR_CMD_Pos)
-#define TCC_CTRLBCLR_MASK           0xFFul       /**< \brief (TCC_CTRLBCLR) MASK Register */
+#define TCC_CTRLBCLR_MASK           _U_(0xFF)     /**< \brief (TCC_CTRLBCLR) MASK Register */
 
 /* -------- TCC_CTRLBSET : (TCC Offset: 0x05) (R/W  8) Control B Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -209,39 +194,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_CTRLBSET_OFFSET         0x05         /**< \brief (TCC_CTRLBSET offset) Control B Set */
-#define TCC_CTRLBSET_RESETVALUE     0x00ul       /**< \brief (TCC_CTRLBSET reset_value) Control B Set */
+#define TCC_CTRLBSET_RESETVALUE     _U_(0x00)     /**< \brief (TCC_CTRLBSET reset_value) Control B Set */
 
 #define TCC_CTRLBSET_DIR_Pos        0            /**< \brief (TCC_CTRLBSET) Counter Direction */
-#define TCC_CTRLBSET_DIR            (0x1ul << TCC_CTRLBSET_DIR_Pos)
+#define TCC_CTRLBSET_DIR            (_U_(0x1) << TCC_CTRLBSET_DIR_Pos)
 #define TCC_CTRLBSET_LUPD_Pos       1            /**< \brief (TCC_CTRLBSET) Lock Update */
-#define TCC_CTRLBSET_LUPD           (0x1ul << TCC_CTRLBSET_LUPD_Pos)
+#define TCC_CTRLBSET_LUPD           (_U_(0x1) << TCC_CTRLBSET_LUPD_Pos)
 #define TCC_CTRLBSET_ONESHOT_Pos    2            /**< \brief (TCC_CTRLBSET) One-Shot */
-#define TCC_CTRLBSET_ONESHOT        (0x1ul << TCC_CTRLBSET_ONESHOT_Pos)
+#define TCC_CTRLBSET_ONESHOT        (_U_(0x1) << TCC_CTRLBSET_ONESHOT_Pos)
 #define TCC_CTRLBSET_IDXCMD_Pos     3            /**< \brief (TCC_CTRLBSET) Ramp Index Command */
-#define TCC_CTRLBSET_IDXCMD_Msk     (0x3ul << TCC_CTRLBSET_IDXCMD_Pos)
+#define TCC_CTRLBSET_IDXCMD_Msk     (_U_(0x3) << TCC_CTRLBSET_IDXCMD_Pos)
 #define TCC_CTRLBSET_IDXCMD(value)  (TCC_CTRLBSET_IDXCMD_Msk & ((value) << TCC_CTRLBSET_IDXCMD_Pos))
-#define   TCC_CTRLBSET_IDXCMD_DISABLE_Val 0x0ul  /**< \brief (TCC_CTRLBSET) Command disabled: Index toggles between cycles A and B */
-#define   TCC_CTRLBSET_IDXCMD_SET_Val     0x1ul  /**< \brief (TCC_CTRLBSET) Set index: cycle B will be forced in the next cycle */
-#define   TCC_CTRLBSET_IDXCMD_CLEAR_Val   0x2ul  /**< \brief (TCC_CTRLBSET) Clear index: cycle A will be forced in the next cycle */
-#define   TCC_CTRLBSET_IDXCMD_HOLD_Val    0x3ul  /**< \brief (TCC_CTRLBSET) Hold index: the next cycle will be the same as the current cycle */
+#define   TCC_CTRLBSET_IDXCMD_DISABLE_Val _U_(0x0)   /**< \brief (TCC_CTRLBSET) Command disabled: Index toggles between cycles A and B */
+#define   TCC_CTRLBSET_IDXCMD_SET_Val     _U_(0x1)   /**< \brief (TCC_CTRLBSET) Set index: cycle B will be forced in the next cycle */
+#define   TCC_CTRLBSET_IDXCMD_CLEAR_Val   _U_(0x2)   /**< \brief (TCC_CTRLBSET) Clear index: cycle A will be forced in the next cycle */
+#define   TCC_CTRLBSET_IDXCMD_HOLD_Val    _U_(0x3)   /**< \brief (TCC_CTRLBSET) Hold index: the next cycle will be the same as the current cycle */
 #define TCC_CTRLBSET_IDXCMD_DISABLE (TCC_CTRLBSET_IDXCMD_DISABLE_Val << TCC_CTRLBSET_IDXCMD_Pos)
 #define TCC_CTRLBSET_IDXCMD_SET     (TCC_CTRLBSET_IDXCMD_SET_Val   << TCC_CTRLBSET_IDXCMD_Pos)
 #define TCC_CTRLBSET_IDXCMD_CLEAR   (TCC_CTRLBSET_IDXCMD_CLEAR_Val << TCC_CTRLBSET_IDXCMD_Pos)
 #define TCC_CTRLBSET_IDXCMD_HOLD    (TCC_CTRLBSET_IDXCMD_HOLD_Val  << TCC_CTRLBSET_IDXCMD_Pos)
 #define TCC_CTRLBSET_CMD_Pos        5            /**< \brief (TCC_CTRLBSET) TCC Command */
-#define TCC_CTRLBSET_CMD_Msk        (0x7ul << TCC_CTRLBSET_CMD_Pos)
+#define TCC_CTRLBSET_CMD_Msk        (_U_(0x7) << TCC_CTRLBSET_CMD_Pos)
 #define TCC_CTRLBSET_CMD(value)     (TCC_CTRLBSET_CMD_Msk & ((value) << TCC_CTRLBSET_CMD_Pos))
-#define   TCC_CTRLBSET_CMD_NONE_Val       0x0ul  /**< \brief (TCC_CTRLBSET) No action */
-#define   TCC_CTRLBSET_CMD_RETRIGGER_Val  0x1ul  /**< \brief (TCC_CTRLBSET) Clear start, restart or retrigger */
-#define   TCC_CTRLBSET_CMD_STOP_Val       0x2ul  /**< \brief (TCC_CTRLBSET) Force stop */
-#define   TCC_CTRLBSET_CMD_UPDATE_Val     0x3ul  /**< \brief (TCC_CTRLBSET) Force update of double buffered registers */
-#define   TCC_CTRLBSET_CMD_READSYNC_Val   0x4ul  /**< \brief (TCC_CTRLBSET) Force COUNT read synchronization */
+#define   TCC_CTRLBSET_CMD_NONE_Val       _U_(0x0)   /**< \brief (TCC_CTRLBSET) No action */
+#define   TCC_CTRLBSET_CMD_RETRIGGER_Val  _U_(0x1)   /**< \brief (TCC_CTRLBSET) Clear start, restart or retrigger */
+#define   TCC_CTRLBSET_CMD_STOP_Val       _U_(0x2)   /**< \brief (TCC_CTRLBSET) Force stop */
+#define   TCC_CTRLBSET_CMD_UPDATE_Val     _U_(0x3)   /**< \brief (TCC_CTRLBSET) Force update of double buffered registers */
+#define   TCC_CTRLBSET_CMD_READSYNC_Val   _U_(0x4)   /**< \brief (TCC_CTRLBSET) Force COUNT read synchronization */
 #define TCC_CTRLBSET_CMD_NONE       (TCC_CTRLBSET_CMD_NONE_Val     << TCC_CTRLBSET_CMD_Pos)
 #define TCC_CTRLBSET_CMD_RETRIGGER  (TCC_CTRLBSET_CMD_RETRIGGER_Val << TCC_CTRLBSET_CMD_Pos)
 #define TCC_CTRLBSET_CMD_STOP       (TCC_CTRLBSET_CMD_STOP_Val     << TCC_CTRLBSET_CMD_Pos)
 #define TCC_CTRLBSET_CMD_UPDATE     (TCC_CTRLBSET_CMD_UPDATE_Val   << TCC_CTRLBSET_CMD_Pos)
 #define TCC_CTRLBSET_CMD_READSYNC   (TCC_CTRLBSET_CMD_READSYNC_Val << TCC_CTRLBSET_CMD_Pos)
-#define TCC_CTRLBSET_MASK           0xFFul       /**< \brief (TCC_CTRLBSET) MASK Register */
+#define TCC_CTRLBSET_MASK           _U_(0xFF)     /**< \brief (TCC_CTRLBSET) MASK Register */
 
 /* -------- TCC_SYNCBUSY : (TCC Offset: 0x08) (R/  32) Synchronization Busy -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -281,24 +266,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_SYNCBUSY_OFFSET         0x08         /**< \brief (TCC_SYNCBUSY offset) Synchronization Busy */
-#define TCC_SYNCBUSY_RESETVALUE     0x00000000ul /**< \brief (TCC_SYNCBUSY reset_value) Synchronization Busy */
+#define TCC_SYNCBUSY_RESETVALUE     _U_(0x00000000) /**< \brief (TCC_SYNCBUSY reset_value) Synchronization Busy */
 
 #define TCC_SYNCBUSY_SWRST_Pos      0            /**< \brief (TCC_SYNCBUSY) Swrst Busy */
-#define TCC_SYNCBUSY_SWRST          (0x1ul << TCC_SYNCBUSY_SWRST_Pos)
+#define TCC_SYNCBUSY_SWRST          (_U_(0x1) << TCC_SYNCBUSY_SWRST_Pos)
 #define TCC_SYNCBUSY_ENABLE_Pos     1            /**< \brief (TCC_SYNCBUSY) Enable Busy */
-#define TCC_SYNCBUSY_ENABLE         (0x1ul << TCC_SYNCBUSY_ENABLE_Pos)
+#define TCC_SYNCBUSY_ENABLE         (_U_(0x1) << TCC_SYNCBUSY_ENABLE_Pos)
 #define TCC_SYNCBUSY_CTRLB_Pos      2            /**< \brief (TCC_SYNCBUSY) Ctrlb Busy */
-#define TCC_SYNCBUSY_CTRLB          (0x1ul << TCC_SYNCBUSY_CTRLB_Pos)
+#define TCC_SYNCBUSY_CTRLB          (_U_(0x1) << TCC_SYNCBUSY_CTRLB_Pos)
 #define TCC_SYNCBUSY_STATUS_Pos     3            /**< \brief (TCC_SYNCBUSY) Status Busy */
-#define TCC_SYNCBUSY_STATUS         (0x1ul << TCC_SYNCBUSY_STATUS_Pos)
+#define TCC_SYNCBUSY_STATUS         (_U_(0x1) << TCC_SYNCBUSY_STATUS_Pos)
 #define TCC_SYNCBUSY_COUNT_Pos      4            /**< \brief (TCC_SYNCBUSY) Count Busy */
-#define TCC_SYNCBUSY_COUNT          (0x1ul << TCC_SYNCBUSY_COUNT_Pos)
+#define TCC_SYNCBUSY_COUNT          (_U_(0x1) << TCC_SYNCBUSY_COUNT_Pos)
 #define TCC_SYNCBUSY_PATT_Pos       5            /**< \brief (TCC_SYNCBUSY) Pattern Busy */
-#define TCC_SYNCBUSY_PATT           (0x1ul << TCC_SYNCBUSY_PATT_Pos)
+#define TCC_SYNCBUSY_PATT           (_U_(0x1) << TCC_SYNCBUSY_PATT_Pos)
 #define TCC_SYNCBUSY_WAVE_Pos       6            /**< \brief (TCC_SYNCBUSY) Wave Busy */
-#define TCC_SYNCBUSY_WAVE           (0x1ul << TCC_SYNCBUSY_WAVE_Pos)
+#define TCC_SYNCBUSY_WAVE           (_U_(0x1) << TCC_SYNCBUSY_WAVE_Pos)
 #define TCC_SYNCBUSY_PER_Pos        7            /**< \brief (TCC_SYNCBUSY) Period busy */
-#define TCC_SYNCBUSY_PER            (0x1ul << TCC_SYNCBUSY_PER_Pos)
+#define TCC_SYNCBUSY_PER            (_U_(0x1) << TCC_SYNCBUSY_PER_Pos)
 #define TCC_SYNCBUSY_CC0_Pos        8            /**< \brief (TCC_SYNCBUSY) Compare Channel 0 Busy */
 #define TCC_SYNCBUSY_CC0            (1 << TCC_SYNCBUSY_CC0_Pos)
 #define TCC_SYNCBUSY_CC1_Pos        9            /**< \brief (TCC_SYNCBUSY) Compare Channel 1 Busy */
@@ -308,14 +293,14 @@ typedef union {
 #define TCC_SYNCBUSY_CC3_Pos        11           /**< \brief (TCC_SYNCBUSY) Compare Channel 3 Busy */
 #define TCC_SYNCBUSY_CC3            (1 << TCC_SYNCBUSY_CC3_Pos)
 #define TCC_SYNCBUSY_CC_Pos         8            /**< \brief (TCC_SYNCBUSY) Compare Channel x Busy */
-#define TCC_SYNCBUSY_CC_Msk         (0xFul << TCC_SYNCBUSY_CC_Pos)
+#define TCC_SYNCBUSY_CC_Msk         (_U_(0xF) << TCC_SYNCBUSY_CC_Pos)
 #define TCC_SYNCBUSY_CC(value)      (TCC_SYNCBUSY_CC_Msk & ((value) << TCC_SYNCBUSY_CC_Pos))
 #define TCC_SYNCBUSY_PATTB_Pos      16           /**< \brief (TCC_SYNCBUSY) Pattern Buffer Busy */
-#define TCC_SYNCBUSY_PATTB          (0x1ul << TCC_SYNCBUSY_PATTB_Pos)
+#define TCC_SYNCBUSY_PATTB          (_U_(0x1) << TCC_SYNCBUSY_PATTB_Pos)
 #define TCC_SYNCBUSY_WAVEB_Pos      17           /**< \brief (TCC_SYNCBUSY) Wave Buffer Busy */
-#define TCC_SYNCBUSY_WAVEB          (0x1ul << TCC_SYNCBUSY_WAVEB_Pos)
+#define TCC_SYNCBUSY_WAVEB          (_U_(0x1) << TCC_SYNCBUSY_WAVEB_Pos)
 #define TCC_SYNCBUSY_PERB_Pos       18           /**< \brief (TCC_SYNCBUSY) Period Buffer Busy */
-#define TCC_SYNCBUSY_PERB           (0x1ul << TCC_SYNCBUSY_PERB_Pos)
+#define TCC_SYNCBUSY_PERB           (_U_(0x1) << TCC_SYNCBUSY_PERB_Pos)
 #define TCC_SYNCBUSY_CCB0_Pos       19           /**< \brief (TCC_SYNCBUSY) Compare Channel Buffer 0 Busy */
 #define TCC_SYNCBUSY_CCB0           (1 << TCC_SYNCBUSY_CCB0_Pos)
 #define TCC_SYNCBUSY_CCB1_Pos       20           /**< \brief (TCC_SYNCBUSY) Compare Channel Buffer 1 Busy */
@@ -325,9 +310,9 @@ typedef union {
 #define TCC_SYNCBUSY_CCB3_Pos       22           /**< \brief (TCC_SYNCBUSY) Compare Channel Buffer 3 Busy */
 #define TCC_SYNCBUSY_CCB3           (1 << TCC_SYNCBUSY_CCB3_Pos)
 #define TCC_SYNCBUSY_CCB_Pos        19           /**< \brief (TCC_SYNCBUSY) Compare Channel Buffer x Busy */
-#define TCC_SYNCBUSY_CCB_Msk        (0xFul << TCC_SYNCBUSY_CCB_Pos)
+#define TCC_SYNCBUSY_CCB_Msk        (_U_(0xF) << TCC_SYNCBUSY_CCB_Pos)
 #define TCC_SYNCBUSY_CCB(value)     (TCC_SYNCBUSY_CCB_Msk & ((value) << TCC_SYNCBUSY_CCB_Pos))
-#define TCC_SYNCBUSY_MASK           0x007F0FFFul /**< \brief (TCC_SYNCBUSY) MASK Register */
+#define TCC_SYNCBUSY_MASK           _U_(0x007F0FFF) /**< \brief (TCC_SYNCBUSY) MASK Register */
 
 /* -------- TCC_FCTRLA : (TCC Offset: 0x0C) (R/W 32) Recoverable Fault A Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -352,68 +337,68 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_FCTRLA_OFFSET           0x0C         /**< \brief (TCC_FCTRLA offset) Recoverable Fault A Configuration */
-#define TCC_FCTRLA_RESETVALUE       0x00000000ul /**< \brief (TCC_FCTRLA reset_value) Recoverable Fault A Configuration */
+#define TCC_FCTRLA_RESETVALUE       _U_(0x00000000) /**< \brief (TCC_FCTRLA reset_value) Recoverable Fault A Configuration */
 
 #define TCC_FCTRLA_SRC_Pos          0            /**< \brief (TCC_FCTRLA) Fault A Source */
-#define TCC_FCTRLA_SRC_Msk          (0x3ul << TCC_FCTRLA_SRC_Pos)
+#define TCC_FCTRLA_SRC_Msk          (_U_(0x3) << TCC_FCTRLA_SRC_Pos)
 #define TCC_FCTRLA_SRC(value)       (TCC_FCTRLA_SRC_Msk & ((value) << TCC_FCTRLA_SRC_Pos))
-#define   TCC_FCTRLA_SRC_DISABLE_Val      0x0ul  /**< \brief (TCC_FCTRLA) Fault input disabled */
-#define   TCC_FCTRLA_SRC_ENABLE_Val       0x1ul  /**< \brief (TCC_FCTRLA) MCEx (x=0,1) event input */
-#define   TCC_FCTRLA_SRC_INVERT_Val       0x2ul  /**< \brief (TCC_FCTRLA) Inverted MCEx (x=0,1) event input */
-#define   TCC_FCTRLA_SRC_ALTFAULT_Val     0x3ul  /**< \brief (TCC_FCTRLA) Alternate fault (A or B) state at the end of the previous period */
+#define   TCC_FCTRLA_SRC_DISABLE_Val      _U_(0x0)   /**< \brief (TCC_FCTRLA) Fault input disabled */
+#define   TCC_FCTRLA_SRC_ENABLE_Val       _U_(0x1)   /**< \brief (TCC_FCTRLA) MCEx (x=0,1) event input */
+#define   TCC_FCTRLA_SRC_INVERT_Val       _U_(0x2)   /**< \brief (TCC_FCTRLA) Inverted MCEx (x=0,1) event input */
+#define   TCC_FCTRLA_SRC_ALTFAULT_Val     _U_(0x3)   /**< \brief (TCC_FCTRLA) Alternate fault (A or B) state at the end of the previous period */
 #define TCC_FCTRLA_SRC_DISABLE      (TCC_FCTRLA_SRC_DISABLE_Val    << TCC_FCTRLA_SRC_Pos)
 #define TCC_FCTRLA_SRC_ENABLE       (TCC_FCTRLA_SRC_ENABLE_Val     << TCC_FCTRLA_SRC_Pos)
 #define TCC_FCTRLA_SRC_INVERT       (TCC_FCTRLA_SRC_INVERT_Val     << TCC_FCTRLA_SRC_Pos)
 #define TCC_FCTRLA_SRC_ALTFAULT     (TCC_FCTRLA_SRC_ALTFAULT_Val   << TCC_FCTRLA_SRC_Pos)
 #define TCC_FCTRLA_KEEP_Pos         3            /**< \brief (TCC_FCTRLA) Fault A Keeper */
-#define TCC_FCTRLA_KEEP             (0x1ul << TCC_FCTRLA_KEEP_Pos)
+#define TCC_FCTRLA_KEEP             (_U_(0x1) << TCC_FCTRLA_KEEP_Pos)
 #define TCC_FCTRLA_QUAL_Pos         4            /**< \brief (TCC_FCTRLA) Fault A Qualification */
-#define TCC_FCTRLA_QUAL             (0x1ul << TCC_FCTRLA_QUAL_Pos)
+#define TCC_FCTRLA_QUAL             (_U_(0x1) << TCC_FCTRLA_QUAL_Pos)
 #define TCC_FCTRLA_BLANK_Pos        5            /**< \brief (TCC_FCTRLA) Fault A Blanking Mode */
-#define TCC_FCTRLA_BLANK_Msk        (0x3ul << TCC_FCTRLA_BLANK_Pos)
+#define TCC_FCTRLA_BLANK_Msk        (_U_(0x3) << TCC_FCTRLA_BLANK_Pos)
 #define TCC_FCTRLA_BLANK(value)     (TCC_FCTRLA_BLANK_Msk & ((value) << TCC_FCTRLA_BLANK_Pos))
-#define   TCC_FCTRLA_BLANK_NONE_Val       0x0ul  /**< \brief (TCC_FCTRLA) No blanking applied */
-#define   TCC_FCTRLA_BLANK_RISE_Val       0x1ul  /**< \brief (TCC_FCTRLA) Blanking applied from rising edge of the output waveform */
-#define   TCC_FCTRLA_BLANK_FALL_Val       0x2ul  /**< \brief (TCC_FCTRLA) Blanking applied from falling edge of the output waveform */
-#define   TCC_FCTRLA_BLANK_BOTH_Val       0x3ul  /**< \brief (TCC_FCTRLA) Blanking applied from each toggle of the output waveform */
+#define   TCC_FCTRLA_BLANK_NONE_Val       _U_(0x0)   /**< \brief (TCC_FCTRLA) No blanking applied */
+#define   TCC_FCTRLA_BLANK_RISE_Val       _U_(0x1)   /**< \brief (TCC_FCTRLA) Blanking applied from rising edge of the output waveform */
+#define   TCC_FCTRLA_BLANK_FALL_Val       _U_(0x2)   /**< \brief (TCC_FCTRLA) Blanking applied from falling edge of the output waveform */
+#define   TCC_FCTRLA_BLANK_BOTH_Val       _U_(0x3)   /**< \brief (TCC_FCTRLA) Blanking applied from each toggle of the output waveform */
 #define TCC_FCTRLA_BLANK_NONE       (TCC_FCTRLA_BLANK_NONE_Val     << TCC_FCTRLA_BLANK_Pos)
 #define TCC_FCTRLA_BLANK_RISE       (TCC_FCTRLA_BLANK_RISE_Val     << TCC_FCTRLA_BLANK_Pos)
 #define TCC_FCTRLA_BLANK_FALL       (TCC_FCTRLA_BLANK_FALL_Val     << TCC_FCTRLA_BLANK_Pos)
 #define TCC_FCTRLA_BLANK_BOTH       (TCC_FCTRLA_BLANK_BOTH_Val     << TCC_FCTRLA_BLANK_Pos)
 #define TCC_FCTRLA_RESTART_Pos      7            /**< \brief (TCC_FCTRLA) Fault A Restart */
-#define TCC_FCTRLA_RESTART          (0x1ul << TCC_FCTRLA_RESTART_Pos)
+#define TCC_FCTRLA_RESTART          (_U_(0x1) << TCC_FCTRLA_RESTART_Pos)
 #define TCC_FCTRLA_HALT_Pos         8            /**< \brief (TCC_FCTRLA) Fault A Halt Mode */
-#define TCC_FCTRLA_HALT_Msk         (0x3ul << TCC_FCTRLA_HALT_Pos)
+#define TCC_FCTRLA_HALT_Msk         (_U_(0x3) << TCC_FCTRLA_HALT_Pos)
 #define TCC_FCTRLA_HALT(value)      (TCC_FCTRLA_HALT_Msk & ((value) << TCC_FCTRLA_HALT_Pos))
-#define   TCC_FCTRLA_HALT_DISABLE_Val     0x0ul  /**< \brief (TCC_FCTRLA) Halt action disabled */
-#define   TCC_FCTRLA_HALT_HW_Val          0x1ul  /**< \brief (TCC_FCTRLA) Hardware halt action */
-#define   TCC_FCTRLA_HALT_SW_Val          0x2ul  /**< \brief (TCC_FCTRLA) Software halt action */
-#define   TCC_FCTRLA_HALT_NR_Val          0x3ul  /**< \brief (TCC_FCTRLA) Non-recoverable fault */
+#define   TCC_FCTRLA_HALT_DISABLE_Val     _U_(0x0)   /**< \brief (TCC_FCTRLA) Halt action disabled */
+#define   TCC_FCTRLA_HALT_HW_Val          _U_(0x1)   /**< \brief (TCC_FCTRLA) Hardware halt action */
+#define   TCC_FCTRLA_HALT_SW_Val          _U_(0x2)   /**< \brief (TCC_FCTRLA) Software halt action */
+#define   TCC_FCTRLA_HALT_NR_Val          _U_(0x3)   /**< \brief (TCC_FCTRLA) Non-recoverable fault */
 #define TCC_FCTRLA_HALT_DISABLE     (TCC_FCTRLA_HALT_DISABLE_Val   << TCC_FCTRLA_HALT_Pos)
 #define TCC_FCTRLA_HALT_HW          (TCC_FCTRLA_HALT_HW_Val        << TCC_FCTRLA_HALT_Pos)
 #define TCC_FCTRLA_HALT_SW          (TCC_FCTRLA_HALT_SW_Val        << TCC_FCTRLA_HALT_Pos)
 #define TCC_FCTRLA_HALT_NR          (TCC_FCTRLA_HALT_NR_Val        << TCC_FCTRLA_HALT_Pos)
 #define TCC_FCTRLA_CHSEL_Pos        10           /**< \brief (TCC_FCTRLA) Fault A Capture Channel */
-#define TCC_FCTRLA_CHSEL_Msk        (0x3ul << TCC_FCTRLA_CHSEL_Pos)
+#define TCC_FCTRLA_CHSEL_Msk        (_U_(0x3) << TCC_FCTRLA_CHSEL_Pos)
 #define TCC_FCTRLA_CHSEL(value)     (TCC_FCTRLA_CHSEL_Msk & ((value) << TCC_FCTRLA_CHSEL_Pos))
-#define   TCC_FCTRLA_CHSEL_CC0_Val        0x0ul  /**< \brief (TCC_FCTRLA) Capture value stored in channel 0 */
-#define   TCC_FCTRLA_CHSEL_CC1_Val        0x1ul  /**< \brief (TCC_FCTRLA) Capture value stored in channel 1 */
-#define   TCC_FCTRLA_CHSEL_CC2_Val        0x2ul  /**< \brief (TCC_FCTRLA) Capture value stored in channel 2 */
-#define   TCC_FCTRLA_CHSEL_CC3_Val        0x3ul  /**< \brief (TCC_FCTRLA) Capture value stored in channel 3 */
+#define   TCC_FCTRLA_CHSEL_CC0_Val        _U_(0x0)   /**< \brief (TCC_FCTRLA) Capture value stored in channel 0 */
+#define   TCC_FCTRLA_CHSEL_CC1_Val        _U_(0x1)   /**< \brief (TCC_FCTRLA) Capture value stored in channel 1 */
+#define   TCC_FCTRLA_CHSEL_CC2_Val        _U_(0x2)   /**< \brief (TCC_FCTRLA) Capture value stored in channel 2 */
+#define   TCC_FCTRLA_CHSEL_CC3_Val        _U_(0x3)   /**< \brief (TCC_FCTRLA) Capture value stored in channel 3 */
 #define TCC_FCTRLA_CHSEL_CC0        (TCC_FCTRLA_CHSEL_CC0_Val      << TCC_FCTRLA_CHSEL_Pos)
 #define TCC_FCTRLA_CHSEL_CC1        (TCC_FCTRLA_CHSEL_CC1_Val      << TCC_FCTRLA_CHSEL_Pos)
 #define TCC_FCTRLA_CHSEL_CC2        (TCC_FCTRLA_CHSEL_CC2_Val      << TCC_FCTRLA_CHSEL_Pos)
 #define TCC_FCTRLA_CHSEL_CC3        (TCC_FCTRLA_CHSEL_CC3_Val      << TCC_FCTRLA_CHSEL_Pos)
 #define TCC_FCTRLA_CAPTURE_Pos      12           /**< \brief (TCC_FCTRLA) Fault A Capture Action */
-#define TCC_FCTRLA_CAPTURE_Msk      (0x7ul << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE_Msk      (_U_(0x7) << TCC_FCTRLA_CAPTURE_Pos)
 #define TCC_FCTRLA_CAPTURE(value)   (TCC_FCTRLA_CAPTURE_Msk & ((value) << TCC_FCTRLA_CAPTURE_Pos))
-#define   TCC_FCTRLA_CAPTURE_DISABLE_Val  0x0ul  /**< \brief (TCC_FCTRLA) No capture */
-#define   TCC_FCTRLA_CAPTURE_CAPT_Val     0x1ul  /**< \brief (TCC_FCTRLA) Capture on fault */
-#define   TCC_FCTRLA_CAPTURE_CAPTMIN_Val  0x2ul  /**< \brief (TCC_FCTRLA) Minimum capture */
-#define   TCC_FCTRLA_CAPTURE_CAPTMAX_Val  0x3ul  /**< \brief (TCC_FCTRLA) Maximum capture */
-#define   TCC_FCTRLA_CAPTURE_LOCMIN_Val   0x4ul  /**< \brief (TCC_FCTRLA) Minimum local detection */
-#define   TCC_FCTRLA_CAPTURE_LOCMAX_Val   0x5ul  /**< \brief (TCC_FCTRLA) Maximum local detection */
-#define   TCC_FCTRLA_CAPTURE_DERIV0_Val   0x6ul  /**< \brief (TCC_FCTRLA) Minimum and maximum local detection */
+#define   TCC_FCTRLA_CAPTURE_DISABLE_Val  _U_(0x0)   /**< \brief (TCC_FCTRLA) No capture */
+#define   TCC_FCTRLA_CAPTURE_CAPT_Val     _U_(0x1)   /**< \brief (TCC_FCTRLA) Capture on fault */
+#define   TCC_FCTRLA_CAPTURE_CAPTMIN_Val  _U_(0x2)   /**< \brief (TCC_FCTRLA) Minimum capture */
+#define   TCC_FCTRLA_CAPTURE_CAPTMAX_Val  _U_(0x3)   /**< \brief (TCC_FCTRLA) Maximum capture */
+#define   TCC_FCTRLA_CAPTURE_LOCMIN_Val   _U_(0x4)   /**< \brief (TCC_FCTRLA) Minimum local detection */
+#define   TCC_FCTRLA_CAPTURE_LOCMAX_Val   _U_(0x5)   /**< \brief (TCC_FCTRLA) Maximum local detection */
+#define   TCC_FCTRLA_CAPTURE_DERIV0_Val   _U_(0x6)   /**< \brief (TCC_FCTRLA) Minimum and maximum local detection */
 #define TCC_FCTRLA_CAPTURE_DISABLE  (TCC_FCTRLA_CAPTURE_DISABLE_Val << TCC_FCTRLA_CAPTURE_Pos)
 #define TCC_FCTRLA_CAPTURE_CAPT     (TCC_FCTRLA_CAPTURE_CAPT_Val   << TCC_FCTRLA_CAPTURE_Pos)
 #define TCC_FCTRLA_CAPTURE_CAPTMIN  (TCC_FCTRLA_CAPTURE_CAPTMIN_Val << TCC_FCTRLA_CAPTURE_Pos)
@@ -422,12 +407,12 @@ typedef union {
 #define TCC_FCTRLA_CAPTURE_LOCMAX   (TCC_FCTRLA_CAPTURE_LOCMAX_Val << TCC_FCTRLA_CAPTURE_Pos)
 #define TCC_FCTRLA_CAPTURE_DERIV0   (TCC_FCTRLA_CAPTURE_DERIV0_Val << TCC_FCTRLA_CAPTURE_Pos)
 #define TCC_FCTRLA_BLANKVAL_Pos     16           /**< \brief (TCC_FCTRLA) Fault A Blanking Time */
-#define TCC_FCTRLA_BLANKVAL_Msk     (0xFFul << TCC_FCTRLA_BLANKVAL_Pos)
+#define TCC_FCTRLA_BLANKVAL_Msk     (_U_(0xFF) << TCC_FCTRLA_BLANKVAL_Pos)
 #define TCC_FCTRLA_BLANKVAL(value)  (TCC_FCTRLA_BLANKVAL_Msk & ((value) << TCC_FCTRLA_BLANKVAL_Pos))
 #define TCC_FCTRLA_FILTERVAL_Pos    24           /**< \brief (TCC_FCTRLA) Fault A Filter Value */
-#define TCC_FCTRLA_FILTERVAL_Msk    (0xFul << TCC_FCTRLA_FILTERVAL_Pos)
+#define TCC_FCTRLA_FILTERVAL_Msk    (_U_(0xF) << TCC_FCTRLA_FILTERVAL_Pos)
 #define TCC_FCTRLA_FILTERVAL(value) (TCC_FCTRLA_FILTERVAL_Msk & ((value) << TCC_FCTRLA_FILTERVAL_Pos))
-#define TCC_FCTRLA_MASK             0x0FFF7FFBul /**< \brief (TCC_FCTRLA) MASK Register */
+#define TCC_FCTRLA_MASK             _U_(0x0FFF7FFB) /**< \brief (TCC_FCTRLA) MASK Register */
 
 /* -------- TCC_FCTRLB : (TCC Offset: 0x10) (R/W 32) Recoverable Fault B Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -452,68 +437,68 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_FCTRLB_OFFSET           0x10         /**< \brief (TCC_FCTRLB offset) Recoverable Fault B Configuration */
-#define TCC_FCTRLB_RESETVALUE       0x00000000ul /**< \brief (TCC_FCTRLB reset_value) Recoverable Fault B Configuration */
+#define TCC_FCTRLB_RESETVALUE       _U_(0x00000000) /**< \brief (TCC_FCTRLB reset_value) Recoverable Fault B Configuration */
 
 #define TCC_FCTRLB_SRC_Pos          0            /**< \brief (TCC_FCTRLB) Fault B Source */
-#define TCC_FCTRLB_SRC_Msk          (0x3ul << TCC_FCTRLB_SRC_Pos)
+#define TCC_FCTRLB_SRC_Msk          (_U_(0x3) << TCC_FCTRLB_SRC_Pos)
 #define TCC_FCTRLB_SRC(value)       (TCC_FCTRLB_SRC_Msk & ((value) << TCC_FCTRLB_SRC_Pos))
-#define   TCC_FCTRLB_SRC_DISABLE_Val      0x0ul  /**< \brief (TCC_FCTRLB) Fault input disabled */
-#define   TCC_FCTRLB_SRC_ENABLE_Val       0x1ul  /**< \brief (TCC_FCTRLB) MCEx (x=0,1) event input */
-#define   TCC_FCTRLB_SRC_INVERT_Val       0x2ul  /**< \brief (TCC_FCTRLB) Inverted MCEx (x=0,1) event input */
-#define   TCC_FCTRLB_SRC_ALTFAULT_Val     0x3ul  /**< \brief (TCC_FCTRLB) Alternate fault (A or B) state at the end of the previous period */
+#define   TCC_FCTRLB_SRC_DISABLE_Val      _U_(0x0)   /**< \brief (TCC_FCTRLB) Fault input disabled */
+#define   TCC_FCTRLB_SRC_ENABLE_Val       _U_(0x1)   /**< \brief (TCC_FCTRLB) MCEx (x=0,1) event input */
+#define   TCC_FCTRLB_SRC_INVERT_Val       _U_(0x2)   /**< \brief (TCC_FCTRLB) Inverted MCEx (x=0,1) event input */
+#define   TCC_FCTRLB_SRC_ALTFAULT_Val     _U_(0x3)   /**< \brief (TCC_FCTRLB) Alternate fault (A or B) state at the end of the previous period */
 #define TCC_FCTRLB_SRC_DISABLE      (TCC_FCTRLB_SRC_DISABLE_Val    << TCC_FCTRLB_SRC_Pos)
 #define TCC_FCTRLB_SRC_ENABLE       (TCC_FCTRLB_SRC_ENABLE_Val     << TCC_FCTRLB_SRC_Pos)
 #define TCC_FCTRLB_SRC_INVERT       (TCC_FCTRLB_SRC_INVERT_Val     << TCC_FCTRLB_SRC_Pos)
 #define TCC_FCTRLB_SRC_ALTFAULT     (TCC_FCTRLB_SRC_ALTFAULT_Val   << TCC_FCTRLB_SRC_Pos)
 #define TCC_FCTRLB_KEEP_Pos         3            /**< \brief (TCC_FCTRLB) Fault B Keeper */
-#define TCC_FCTRLB_KEEP             (0x1ul << TCC_FCTRLB_KEEP_Pos)
+#define TCC_FCTRLB_KEEP             (_U_(0x1) << TCC_FCTRLB_KEEP_Pos)
 #define TCC_FCTRLB_QUAL_Pos         4            /**< \brief (TCC_FCTRLB) Fault B Qualification */
-#define TCC_FCTRLB_QUAL             (0x1ul << TCC_FCTRLB_QUAL_Pos)
+#define TCC_FCTRLB_QUAL             (_U_(0x1) << TCC_FCTRLB_QUAL_Pos)
 #define TCC_FCTRLB_BLANK_Pos        5            /**< \brief (TCC_FCTRLB) Fault B Blanking Mode */
-#define TCC_FCTRLB_BLANK_Msk        (0x3ul << TCC_FCTRLB_BLANK_Pos)
+#define TCC_FCTRLB_BLANK_Msk        (_U_(0x3) << TCC_FCTRLB_BLANK_Pos)
 #define TCC_FCTRLB_BLANK(value)     (TCC_FCTRLB_BLANK_Msk & ((value) << TCC_FCTRLB_BLANK_Pos))
-#define   TCC_FCTRLB_BLANK_NONE_Val       0x0ul  /**< \brief (TCC_FCTRLB) No blanking applied */
-#define   TCC_FCTRLB_BLANK_RISE_Val       0x1ul  /**< \brief (TCC_FCTRLB) Blanking applied from rising edge of the output waveform */
-#define   TCC_FCTRLB_BLANK_FALL_Val       0x2ul  /**< \brief (TCC_FCTRLB) Blanking applied from falling edge of the output waveform */
-#define   TCC_FCTRLB_BLANK_BOTH_Val       0x3ul  /**< \brief (TCC_FCTRLB) Blanking applied from each toggle of the output waveform */
+#define   TCC_FCTRLB_BLANK_NONE_Val       _U_(0x0)   /**< \brief (TCC_FCTRLB) No blanking applied */
+#define   TCC_FCTRLB_BLANK_RISE_Val       _U_(0x1)   /**< \brief (TCC_FCTRLB) Blanking applied from rising edge of the output waveform */
+#define   TCC_FCTRLB_BLANK_FALL_Val       _U_(0x2)   /**< \brief (TCC_FCTRLB) Blanking applied from falling edge of the output waveform */
+#define   TCC_FCTRLB_BLANK_BOTH_Val       _U_(0x3)   /**< \brief (TCC_FCTRLB) Blanking applied from each toggle of the output waveform */
 #define TCC_FCTRLB_BLANK_NONE       (TCC_FCTRLB_BLANK_NONE_Val     << TCC_FCTRLB_BLANK_Pos)
 #define TCC_FCTRLB_BLANK_RISE       (TCC_FCTRLB_BLANK_RISE_Val     << TCC_FCTRLB_BLANK_Pos)
 #define TCC_FCTRLB_BLANK_FALL       (TCC_FCTRLB_BLANK_FALL_Val     << TCC_FCTRLB_BLANK_Pos)
 #define TCC_FCTRLB_BLANK_BOTH       (TCC_FCTRLB_BLANK_BOTH_Val     << TCC_FCTRLB_BLANK_Pos)
 #define TCC_FCTRLB_RESTART_Pos      7            /**< \brief (TCC_FCTRLB) Fault B Restart */
-#define TCC_FCTRLB_RESTART          (0x1ul << TCC_FCTRLB_RESTART_Pos)
+#define TCC_FCTRLB_RESTART          (_U_(0x1) << TCC_FCTRLB_RESTART_Pos)
 #define TCC_FCTRLB_HALT_Pos         8            /**< \brief (TCC_FCTRLB) Fault B Halt Mode */
-#define TCC_FCTRLB_HALT_Msk         (0x3ul << TCC_FCTRLB_HALT_Pos)
+#define TCC_FCTRLB_HALT_Msk         (_U_(0x3) << TCC_FCTRLB_HALT_Pos)
 #define TCC_FCTRLB_HALT(value)      (TCC_FCTRLB_HALT_Msk & ((value) << TCC_FCTRLB_HALT_Pos))
-#define   TCC_FCTRLB_HALT_DISABLE_Val     0x0ul  /**< \brief (TCC_FCTRLB) Halt action disabled */
-#define   TCC_FCTRLB_HALT_HW_Val          0x1ul  /**< \brief (TCC_FCTRLB) Hardware halt action */
-#define   TCC_FCTRLB_HALT_SW_Val          0x2ul  /**< \brief (TCC_FCTRLB) Software halt action */
-#define   TCC_FCTRLB_HALT_NR_Val          0x3ul  /**< \brief (TCC_FCTRLB) Non-recoverable fault */
+#define   TCC_FCTRLB_HALT_DISABLE_Val     _U_(0x0)   /**< \brief (TCC_FCTRLB) Halt action disabled */
+#define   TCC_FCTRLB_HALT_HW_Val          _U_(0x1)   /**< \brief (TCC_FCTRLB) Hardware halt action */
+#define   TCC_FCTRLB_HALT_SW_Val          _U_(0x2)   /**< \brief (TCC_FCTRLB) Software halt action */
+#define   TCC_FCTRLB_HALT_NR_Val          _U_(0x3)   /**< \brief (TCC_FCTRLB) Non-recoverable fault */
 #define TCC_FCTRLB_HALT_DISABLE     (TCC_FCTRLB_HALT_DISABLE_Val   << TCC_FCTRLB_HALT_Pos)
 #define TCC_FCTRLB_HALT_HW          (TCC_FCTRLB_HALT_HW_Val        << TCC_FCTRLB_HALT_Pos)
 #define TCC_FCTRLB_HALT_SW          (TCC_FCTRLB_HALT_SW_Val        << TCC_FCTRLB_HALT_Pos)
 #define TCC_FCTRLB_HALT_NR          (TCC_FCTRLB_HALT_NR_Val        << TCC_FCTRLB_HALT_Pos)
 #define TCC_FCTRLB_CHSEL_Pos        10           /**< \brief (TCC_FCTRLB) Fault B Capture Channel */
-#define TCC_FCTRLB_CHSEL_Msk        (0x3ul << TCC_FCTRLB_CHSEL_Pos)
+#define TCC_FCTRLB_CHSEL_Msk        (_U_(0x3) << TCC_FCTRLB_CHSEL_Pos)
 #define TCC_FCTRLB_CHSEL(value)     (TCC_FCTRLB_CHSEL_Msk & ((value) << TCC_FCTRLB_CHSEL_Pos))
-#define   TCC_FCTRLB_CHSEL_CC0_Val        0x0ul  /**< \brief (TCC_FCTRLB) Capture value stored in channel 0 */
-#define   TCC_FCTRLB_CHSEL_CC1_Val        0x1ul  /**< \brief (TCC_FCTRLB) Capture value stored in channel 1 */
-#define   TCC_FCTRLB_CHSEL_CC2_Val        0x2ul  /**< \brief (TCC_FCTRLB) Capture value stored in channel 2 */
-#define   TCC_FCTRLB_CHSEL_CC3_Val        0x3ul  /**< \brief (TCC_FCTRLB) Capture value stored in channel 3 */
+#define   TCC_FCTRLB_CHSEL_CC0_Val        _U_(0x0)   /**< \brief (TCC_FCTRLB) Capture value stored in channel 0 */
+#define   TCC_FCTRLB_CHSEL_CC1_Val        _U_(0x1)   /**< \brief (TCC_FCTRLB) Capture value stored in channel 1 */
+#define   TCC_FCTRLB_CHSEL_CC2_Val        _U_(0x2)   /**< \brief (TCC_FCTRLB) Capture value stored in channel 2 */
+#define   TCC_FCTRLB_CHSEL_CC3_Val        _U_(0x3)   /**< \brief (TCC_FCTRLB) Capture value stored in channel 3 */
 #define TCC_FCTRLB_CHSEL_CC0        (TCC_FCTRLB_CHSEL_CC0_Val      << TCC_FCTRLB_CHSEL_Pos)
 #define TCC_FCTRLB_CHSEL_CC1        (TCC_FCTRLB_CHSEL_CC1_Val      << TCC_FCTRLB_CHSEL_Pos)
 #define TCC_FCTRLB_CHSEL_CC2        (TCC_FCTRLB_CHSEL_CC2_Val      << TCC_FCTRLB_CHSEL_Pos)
 #define TCC_FCTRLB_CHSEL_CC3        (TCC_FCTRLB_CHSEL_CC3_Val      << TCC_FCTRLB_CHSEL_Pos)
 #define TCC_FCTRLB_CAPTURE_Pos      12           /**< \brief (TCC_FCTRLB) Fault B Capture Action */
-#define TCC_FCTRLB_CAPTURE_Msk      (0x7ul << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE_Msk      (_U_(0x7) << TCC_FCTRLB_CAPTURE_Pos)
 #define TCC_FCTRLB_CAPTURE(value)   (TCC_FCTRLB_CAPTURE_Msk & ((value) << TCC_FCTRLB_CAPTURE_Pos))
-#define   TCC_FCTRLB_CAPTURE_DISABLE_Val  0x0ul  /**< \brief (TCC_FCTRLB) No capture */
-#define   TCC_FCTRLB_CAPTURE_CAPT_Val     0x1ul  /**< \brief (TCC_FCTRLB) Capture on fault */
-#define   TCC_FCTRLB_CAPTURE_CAPTMIN_Val  0x2ul  /**< \brief (TCC_FCTRLB) Minimum capture */
-#define   TCC_FCTRLB_CAPTURE_CAPTMAX_Val  0x3ul  /**< \brief (TCC_FCTRLB) Maximum capture */
-#define   TCC_FCTRLB_CAPTURE_LOCMIN_Val   0x4ul  /**< \brief (TCC_FCTRLB) Minimum local detection */
-#define   TCC_FCTRLB_CAPTURE_LOCMAX_Val   0x5ul  /**< \brief (TCC_FCTRLB) Maximum local detection */
-#define   TCC_FCTRLB_CAPTURE_DERIV0_Val   0x6ul  /**< \brief (TCC_FCTRLB) Minimum and maximum local detection */
+#define   TCC_FCTRLB_CAPTURE_DISABLE_Val  _U_(0x0)   /**< \brief (TCC_FCTRLB) No capture */
+#define   TCC_FCTRLB_CAPTURE_CAPT_Val     _U_(0x1)   /**< \brief (TCC_FCTRLB) Capture on fault */
+#define   TCC_FCTRLB_CAPTURE_CAPTMIN_Val  _U_(0x2)   /**< \brief (TCC_FCTRLB) Minimum capture */
+#define   TCC_FCTRLB_CAPTURE_CAPTMAX_Val  _U_(0x3)   /**< \brief (TCC_FCTRLB) Maximum capture */
+#define   TCC_FCTRLB_CAPTURE_LOCMIN_Val   _U_(0x4)   /**< \brief (TCC_FCTRLB) Minimum local detection */
+#define   TCC_FCTRLB_CAPTURE_LOCMAX_Val   _U_(0x5)   /**< \brief (TCC_FCTRLB) Maximum local detection */
+#define   TCC_FCTRLB_CAPTURE_DERIV0_Val   _U_(0x6)   /**< \brief (TCC_FCTRLB) Minimum and maximum local detection */
 #define TCC_FCTRLB_CAPTURE_DISABLE  (TCC_FCTRLB_CAPTURE_DISABLE_Val << TCC_FCTRLB_CAPTURE_Pos)
 #define TCC_FCTRLB_CAPTURE_CAPT     (TCC_FCTRLB_CAPTURE_CAPT_Val   << TCC_FCTRLB_CAPTURE_Pos)
 #define TCC_FCTRLB_CAPTURE_CAPTMIN  (TCC_FCTRLB_CAPTURE_CAPTMIN_Val << TCC_FCTRLB_CAPTURE_Pos)
@@ -522,12 +507,12 @@ typedef union {
 #define TCC_FCTRLB_CAPTURE_LOCMAX   (TCC_FCTRLB_CAPTURE_LOCMAX_Val << TCC_FCTRLB_CAPTURE_Pos)
 #define TCC_FCTRLB_CAPTURE_DERIV0   (TCC_FCTRLB_CAPTURE_DERIV0_Val << TCC_FCTRLB_CAPTURE_Pos)
 #define TCC_FCTRLB_BLANKVAL_Pos     16           /**< \brief (TCC_FCTRLB) Fault B Blanking Time */
-#define TCC_FCTRLB_BLANKVAL_Msk     (0xFFul << TCC_FCTRLB_BLANKVAL_Pos)
+#define TCC_FCTRLB_BLANKVAL_Msk     (_U_(0xFF) << TCC_FCTRLB_BLANKVAL_Pos)
 #define TCC_FCTRLB_BLANKVAL(value)  (TCC_FCTRLB_BLANKVAL_Msk & ((value) << TCC_FCTRLB_BLANKVAL_Pos))
 #define TCC_FCTRLB_FILTERVAL_Pos    24           /**< \brief (TCC_FCTRLB) Fault B Filter Value */
-#define TCC_FCTRLB_FILTERVAL_Msk    (0xFul << TCC_FCTRLB_FILTERVAL_Pos)
+#define TCC_FCTRLB_FILTERVAL_Msk    (_U_(0xF) << TCC_FCTRLB_FILTERVAL_Pos)
 #define TCC_FCTRLB_FILTERVAL(value) (TCC_FCTRLB_FILTERVAL_Msk & ((value) << TCC_FCTRLB_FILTERVAL_Pos))
-#define TCC_FCTRLB_MASK             0x0FFF7FFBul /**< \brief (TCC_FCTRLB) MASK Register */
+#define TCC_FCTRLB_MASK             _U_(0x0FFF7FFB) /**< \brief (TCC_FCTRLB) MASK Register */
 
 /* -------- TCC_WEXCTRL : (TCC Offset: 0x14) (R/W 32) Waveform Extension Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -553,10 +538,10 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_WEXCTRL_OFFSET          0x14         /**< \brief (TCC_WEXCTRL offset) Waveform Extension Configuration */
-#define TCC_WEXCTRL_RESETVALUE      0x00000000ul /**< \brief (TCC_WEXCTRL reset_value) Waveform Extension Configuration */
+#define TCC_WEXCTRL_RESETVALUE      _U_(0x00000000) /**< \brief (TCC_WEXCTRL reset_value) Waveform Extension Configuration */
 
 #define TCC_WEXCTRL_OTMX_Pos        0            /**< \brief (TCC_WEXCTRL) Output Matrix */
-#define TCC_WEXCTRL_OTMX_Msk        (0x3ul << TCC_WEXCTRL_OTMX_Pos)
+#define TCC_WEXCTRL_OTMX_Msk        (_U_(0x3) << TCC_WEXCTRL_OTMX_Pos)
 #define TCC_WEXCTRL_OTMX(value)     (TCC_WEXCTRL_OTMX_Msk & ((value) << TCC_WEXCTRL_OTMX_Pos))
 #define TCC_WEXCTRL_DTIEN0_Pos      8            /**< \brief (TCC_WEXCTRL) Dead-time Insertion Generator 0 Enable */
 #define TCC_WEXCTRL_DTIEN0          (1 << TCC_WEXCTRL_DTIEN0_Pos)
@@ -567,15 +552,15 @@ typedef union {
 #define TCC_WEXCTRL_DTIEN3_Pos      11           /**< \brief (TCC_WEXCTRL) Dead-time Insertion Generator 3 Enable */
 #define TCC_WEXCTRL_DTIEN3          (1 << TCC_WEXCTRL_DTIEN3_Pos)
 #define TCC_WEXCTRL_DTIEN_Pos       8            /**< \brief (TCC_WEXCTRL) Dead-time Insertion Generator x Enable */
-#define TCC_WEXCTRL_DTIEN_Msk       (0xFul << TCC_WEXCTRL_DTIEN_Pos)
+#define TCC_WEXCTRL_DTIEN_Msk       (_U_(0xF) << TCC_WEXCTRL_DTIEN_Pos)
 #define TCC_WEXCTRL_DTIEN(value)    (TCC_WEXCTRL_DTIEN_Msk & ((value) << TCC_WEXCTRL_DTIEN_Pos))
 #define TCC_WEXCTRL_DTLS_Pos        16           /**< \brief (TCC_WEXCTRL) Dead-time Low Side Outputs Value */
-#define TCC_WEXCTRL_DTLS_Msk        (0xFFul << TCC_WEXCTRL_DTLS_Pos)
+#define TCC_WEXCTRL_DTLS_Msk        (_U_(0xFF) << TCC_WEXCTRL_DTLS_Pos)
 #define TCC_WEXCTRL_DTLS(value)     (TCC_WEXCTRL_DTLS_Msk & ((value) << TCC_WEXCTRL_DTLS_Pos))
 #define TCC_WEXCTRL_DTHS_Pos        24           /**< \brief (TCC_WEXCTRL) Dead-time High Side Outputs Value */
-#define TCC_WEXCTRL_DTHS_Msk        (0xFFul << TCC_WEXCTRL_DTHS_Pos)
+#define TCC_WEXCTRL_DTHS_Msk        (_U_(0xFF) << TCC_WEXCTRL_DTHS_Pos)
 #define TCC_WEXCTRL_DTHS(value)     (TCC_WEXCTRL_DTHS_Msk & ((value) << TCC_WEXCTRL_DTHS_Pos))
-#define TCC_WEXCTRL_MASK            0xFFFF0F03ul /**< \brief (TCC_WEXCTRL) MASK Register */
+#define TCC_WEXCTRL_MASK            _U_(0xFFFF0F03) /**< \brief (TCC_WEXCTRL) MASK Register */
 
 /* -------- TCC_DRVCTRL : (TCC Offset: 0x18) (R/W 32) Driver Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -619,7 +604,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_DRVCTRL_OFFSET          0x18         /**< \brief (TCC_DRVCTRL offset) Driver Control */
-#define TCC_DRVCTRL_RESETVALUE      0x00000000ul /**< \brief (TCC_DRVCTRL reset_value) Driver Control */
+#define TCC_DRVCTRL_RESETVALUE      _U_(0x00000000) /**< \brief (TCC_DRVCTRL reset_value) Driver Control */
 
 #define TCC_DRVCTRL_NRE0_Pos        0            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 0 Output Enable */
 #define TCC_DRVCTRL_NRE0            (1 << TCC_DRVCTRL_NRE0_Pos)
@@ -638,7 +623,7 @@ typedef union {
 #define TCC_DRVCTRL_NRE7_Pos        7            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 7 Output Enable */
 #define TCC_DRVCTRL_NRE7            (1 << TCC_DRVCTRL_NRE7_Pos)
 #define TCC_DRVCTRL_NRE_Pos         0            /**< \brief (TCC_DRVCTRL) Non-Recoverable State x Output Enable */
-#define TCC_DRVCTRL_NRE_Msk         (0xFFul << TCC_DRVCTRL_NRE_Pos)
+#define TCC_DRVCTRL_NRE_Msk         (_U_(0xFF) << TCC_DRVCTRL_NRE_Pos)
 #define TCC_DRVCTRL_NRE(value)      (TCC_DRVCTRL_NRE_Msk & ((value) << TCC_DRVCTRL_NRE_Pos))
 #define TCC_DRVCTRL_NRV0_Pos        8            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 0 Output Value */
 #define TCC_DRVCTRL_NRV0            (1 << TCC_DRVCTRL_NRV0_Pos)
@@ -657,7 +642,7 @@ typedef union {
 #define TCC_DRVCTRL_NRV7_Pos        15           /**< \brief (TCC_DRVCTRL) Non-Recoverable State 7 Output Value */
 #define TCC_DRVCTRL_NRV7            (1 << TCC_DRVCTRL_NRV7_Pos)
 #define TCC_DRVCTRL_NRV_Pos         8            /**< \brief (TCC_DRVCTRL) Non-Recoverable State x Output Value */
-#define TCC_DRVCTRL_NRV_Msk         (0xFFul << TCC_DRVCTRL_NRV_Pos)
+#define TCC_DRVCTRL_NRV_Msk         (_U_(0xFF) << TCC_DRVCTRL_NRV_Pos)
 #define TCC_DRVCTRL_NRV(value)      (TCC_DRVCTRL_NRV_Msk & ((value) << TCC_DRVCTRL_NRV_Pos))
 #define TCC_DRVCTRL_INVEN0_Pos      16           /**< \brief (TCC_DRVCTRL) Output Waveform 0 Inversion */
 #define TCC_DRVCTRL_INVEN0          (1 << TCC_DRVCTRL_INVEN0_Pos)
@@ -676,15 +661,15 @@ typedef union {
 #define TCC_DRVCTRL_INVEN7_Pos      23           /**< \brief (TCC_DRVCTRL) Output Waveform 7 Inversion */
 #define TCC_DRVCTRL_INVEN7          (1 << TCC_DRVCTRL_INVEN7_Pos)
 #define TCC_DRVCTRL_INVEN_Pos       16           /**< \brief (TCC_DRVCTRL) Output Waveform x Inversion */
-#define TCC_DRVCTRL_INVEN_Msk       (0xFFul << TCC_DRVCTRL_INVEN_Pos)
+#define TCC_DRVCTRL_INVEN_Msk       (_U_(0xFF) << TCC_DRVCTRL_INVEN_Pos)
 #define TCC_DRVCTRL_INVEN(value)    (TCC_DRVCTRL_INVEN_Msk & ((value) << TCC_DRVCTRL_INVEN_Pos))
 #define TCC_DRVCTRL_FILTERVAL0_Pos  24           /**< \brief (TCC_DRVCTRL) Non-Recoverable Fault Input 0 Filter Value */
-#define TCC_DRVCTRL_FILTERVAL0_Msk  (0xFul << TCC_DRVCTRL_FILTERVAL0_Pos)
+#define TCC_DRVCTRL_FILTERVAL0_Msk  (_U_(0xF) << TCC_DRVCTRL_FILTERVAL0_Pos)
 #define TCC_DRVCTRL_FILTERVAL0(value) (TCC_DRVCTRL_FILTERVAL0_Msk & ((value) << TCC_DRVCTRL_FILTERVAL0_Pos))
 #define TCC_DRVCTRL_FILTERVAL1_Pos  28           /**< \brief (TCC_DRVCTRL) Non-Recoverable Fault Input 1 Filter Value */
-#define TCC_DRVCTRL_FILTERVAL1_Msk  (0xFul << TCC_DRVCTRL_FILTERVAL1_Pos)
+#define TCC_DRVCTRL_FILTERVAL1_Msk  (_U_(0xF) << TCC_DRVCTRL_FILTERVAL1_Pos)
 #define TCC_DRVCTRL_FILTERVAL1(value) (TCC_DRVCTRL_FILTERVAL1_Msk & ((value) << TCC_DRVCTRL_FILTERVAL1_Pos))
-#define TCC_DRVCTRL_MASK            0xFFFFFFFFul /**< \brief (TCC_DRVCTRL) MASK Register */
+#define TCC_DRVCTRL_MASK            _U_(0xFFFFFFFF) /**< \brief (TCC_DRVCTRL) MASK Register */
 
 /* -------- TCC_DBGCTRL : (TCC Offset: 0x1E) (R/W  8) Debug Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -700,13 +685,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_DBGCTRL_OFFSET          0x1E         /**< \brief (TCC_DBGCTRL offset) Debug Control */
-#define TCC_DBGCTRL_RESETVALUE      0x00ul       /**< \brief (TCC_DBGCTRL reset_value) Debug Control */
+#define TCC_DBGCTRL_RESETVALUE      _U_(0x00)     /**< \brief (TCC_DBGCTRL reset_value) Debug Control */
 
 #define TCC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (TCC_DBGCTRL) Debug Running Mode */
-#define TCC_DBGCTRL_DBGRUN          (0x1ul << TCC_DBGCTRL_DBGRUN_Pos)
+#define TCC_DBGCTRL_DBGRUN          (_U_(0x1) << TCC_DBGCTRL_DBGRUN_Pos)
 #define TCC_DBGCTRL_FDDBD_Pos       2            /**< \brief (TCC_DBGCTRL) Fault Detection on Debug Break Detection */
-#define TCC_DBGCTRL_FDDBD           (0x1ul << TCC_DBGCTRL_FDDBD_Pos)
-#define TCC_DBGCTRL_MASK            0x05ul       /**< \brief (TCC_DBGCTRL) MASK Register */
+#define TCC_DBGCTRL_FDDBD           (_U_(0x1) << TCC_DBGCTRL_FDDBD_Pos)
+#define TCC_DBGCTRL_MASK            _U_(0x05)     /**< \brief (TCC_DBGCTRL) MASK Register */
 
 /* -------- TCC_EVCTRL : (TCC Offset: 0x20) (R/W 32) Event Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -748,18 +733,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_EVCTRL_OFFSET           0x20         /**< \brief (TCC_EVCTRL offset) Event Control */
-#define TCC_EVCTRL_RESETVALUE       0x00000000ul /**< \brief (TCC_EVCTRL reset_value) Event Control */
+#define TCC_EVCTRL_RESETVALUE       _U_(0x00000000) /**< \brief (TCC_EVCTRL reset_value) Event Control */
 
 #define TCC_EVCTRL_EVACT0_Pos       0            /**< \brief (TCC_EVCTRL) Timer/counter Input Event0 Action */
-#define TCC_EVCTRL_EVACT0_Msk       (0x7ul << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0_Msk       (_U_(0x7) << TCC_EVCTRL_EVACT0_Pos)
 #define TCC_EVCTRL_EVACT0(value)    (TCC_EVCTRL_EVACT0_Msk & ((value) << TCC_EVCTRL_EVACT0_Pos))
-#define   TCC_EVCTRL_EVACT0_OFF_Val       0x0ul  /**< \brief (TCC_EVCTRL) Event action disabled */
-#define   TCC_EVCTRL_EVACT0_RETRIGGER_Val 0x1ul  /**< \brief (TCC_EVCTRL) Start, restart or re-trigger counter on event */
-#define   TCC_EVCTRL_EVACT0_COUNTEV_Val   0x2ul  /**< \brief (TCC_EVCTRL) Count on event */
-#define   TCC_EVCTRL_EVACT0_START_Val     0x3ul  /**< \brief (TCC_EVCTRL) Start counter on event */
-#define   TCC_EVCTRL_EVACT0_INC_Val       0x4ul  /**< \brief (TCC_EVCTRL) Increment counter on event */
-#define   TCC_EVCTRL_EVACT0_COUNT_Val     0x5ul  /**< \brief (TCC_EVCTRL) Count on active state of asynchronous event */
-#define   TCC_EVCTRL_EVACT0_FAULT_Val     0x7ul  /**< \brief (TCC_EVCTRL) Non-recoverable fault */
+#define   TCC_EVCTRL_EVACT0_OFF_Val       _U_(0x0)   /**< \brief (TCC_EVCTRL) Event action disabled */
+#define   TCC_EVCTRL_EVACT0_RETRIGGER_Val _U_(0x1)   /**< \brief (TCC_EVCTRL) Start, restart or re-trigger counter on event */
+#define   TCC_EVCTRL_EVACT0_COUNTEV_Val   _U_(0x2)   /**< \brief (TCC_EVCTRL) Count on event */
+#define   TCC_EVCTRL_EVACT0_START_Val     _U_(0x3)   /**< \brief (TCC_EVCTRL) Start counter on event */
+#define   TCC_EVCTRL_EVACT0_INC_Val       _U_(0x4)   /**< \brief (TCC_EVCTRL) Increment counter on event */
+#define   TCC_EVCTRL_EVACT0_COUNT_Val     _U_(0x5)   /**< \brief (TCC_EVCTRL) Count on active state of asynchronous event */
+#define   TCC_EVCTRL_EVACT0_FAULT_Val     _U_(0x7)   /**< \brief (TCC_EVCTRL) Non-recoverable fault */
 #define TCC_EVCTRL_EVACT0_OFF       (TCC_EVCTRL_EVACT0_OFF_Val     << TCC_EVCTRL_EVACT0_Pos)
 #define TCC_EVCTRL_EVACT0_RETRIGGER (TCC_EVCTRL_EVACT0_RETRIGGER_Val << TCC_EVCTRL_EVACT0_Pos)
 #define TCC_EVCTRL_EVACT0_COUNTEV   (TCC_EVCTRL_EVACT0_COUNTEV_Val << TCC_EVCTRL_EVACT0_Pos)
@@ -768,16 +753,16 @@ typedef union {
 #define TCC_EVCTRL_EVACT0_COUNT     (TCC_EVCTRL_EVACT0_COUNT_Val   << TCC_EVCTRL_EVACT0_Pos)
 #define TCC_EVCTRL_EVACT0_FAULT     (TCC_EVCTRL_EVACT0_FAULT_Val   << TCC_EVCTRL_EVACT0_Pos)
 #define TCC_EVCTRL_EVACT1_Pos       3            /**< \brief (TCC_EVCTRL) Timer/counter Input Event1 Action */
-#define TCC_EVCTRL_EVACT1_Msk       (0x7ul << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1_Msk       (_U_(0x7) << TCC_EVCTRL_EVACT1_Pos)
 #define TCC_EVCTRL_EVACT1(value)    (TCC_EVCTRL_EVACT1_Msk & ((value) << TCC_EVCTRL_EVACT1_Pos))
-#define   TCC_EVCTRL_EVACT1_OFF_Val       0x0ul  /**< \brief (TCC_EVCTRL) Event action disabled */
-#define   TCC_EVCTRL_EVACT1_RETRIGGER_Val 0x1ul  /**< \brief (TCC_EVCTRL) Re-trigger counter on event */
-#define   TCC_EVCTRL_EVACT1_DIR_Val       0x2ul  /**< \brief (TCC_EVCTRL) Direction control */
-#define   TCC_EVCTRL_EVACT1_STOP_Val      0x3ul  /**< \brief (TCC_EVCTRL) Stop counter on event */
-#define   TCC_EVCTRL_EVACT1_DEC_Val       0x4ul  /**< \brief (TCC_EVCTRL) Decrement counter on event */
-#define   TCC_EVCTRL_EVACT1_PPW_Val       0x5ul  /**< \brief (TCC_EVCTRL) Period capture value in CC0 register, pulse width capture value in CC1 register */
-#define   TCC_EVCTRL_EVACT1_PWP_Val       0x6ul  /**< \brief (TCC_EVCTRL) Period capture value in CC1 register, pulse width capture value in CC0 register */
-#define   TCC_EVCTRL_EVACT1_FAULT_Val     0x7ul  /**< \brief (TCC_EVCTRL) Non-recoverable fault */
+#define   TCC_EVCTRL_EVACT1_OFF_Val       _U_(0x0)   /**< \brief (TCC_EVCTRL) Event action disabled */
+#define   TCC_EVCTRL_EVACT1_RETRIGGER_Val _U_(0x1)   /**< \brief (TCC_EVCTRL) Re-trigger counter on event */
+#define   TCC_EVCTRL_EVACT1_DIR_Val       _U_(0x2)   /**< \brief (TCC_EVCTRL) Direction control */
+#define   TCC_EVCTRL_EVACT1_STOP_Val      _U_(0x3)   /**< \brief (TCC_EVCTRL) Stop counter on event */
+#define   TCC_EVCTRL_EVACT1_DEC_Val       _U_(0x4)   /**< \brief (TCC_EVCTRL) Decrement counter on event */
+#define   TCC_EVCTRL_EVACT1_PPW_Val       _U_(0x5)   /**< \brief (TCC_EVCTRL) Period capture value in CC0 register, pulse width capture value in CC1 register */
+#define   TCC_EVCTRL_EVACT1_PWP_Val       _U_(0x6)   /**< \brief (TCC_EVCTRL) Period capture value in CC1 register, pulse width capture value in CC0 register */
+#define   TCC_EVCTRL_EVACT1_FAULT_Val     _U_(0x7)   /**< \brief (TCC_EVCTRL) Non-recoverable fault */
 #define TCC_EVCTRL_EVACT1_OFF       (TCC_EVCTRL_EVACT1_OFF_Val     << TCC_EVCTRL_EVACT1_Pos)
 #define TCC_EVCTRL_EVACT1_RETRIGGER (TCC_EVCTRL_EVACT1_RETRIGGER_Val << TCC_EVCTRL_EVACT1_Pos)
 #define TCC_EVCTRL_EVACT1_DIR       (TCC_EVCTRL_EVACT1_DIR_Val     << TCC_EVCTRL_EVACT1_Pos)
@@ -787,35 +772,35 @@ typedef union {
 #define TCC_EVCTRL_EVACT1_PWP       (TCC_EVCTRL_EVACT1_PWP_Val     << TCC_EVCTRL_EVACT1_Pos)
 #define TCC_EVCTRL_EVACT1_FAULT     (TCC_EVCTRL_EVACT1_FAULT_Val   << TCC_EVCTRL_EVACT1_Pos)
 #define TCC_EVCTRL_CNTSEL_Pos       6            /**< \brief (TCC_EVCTRL) Timer/counter Output Event Mode */
-#define TCC_EVCTRL_CNTSEL_Msk       (0x3ul << TCC_EVCTRL_CNTSEL_Pos)
+#define TCC_EVCTRL_CNTSEL_Msk       (_U_(0x3) << TCC_EVCTRL_CNTSEL_Pos)
 #define TCC_EVCTRL_CNTSEL(value)    (TCC_EVCTRL_CNTSEL_Msk & ((value) << TCC_EVCTRL_CNTSEL_Pos))
-#define   TCC_EVCTRL_CNTSEL_START_Val     0x0ul  /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a new counter cycle starts */
-#define   TCC_EVCTRL_CNTSEL_END_Val       0x1ul  /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a counter cycle ends */
-#define   TCC_EVCTRL_CNTSEL_BETWEEN_Val   0x2ul  /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a counter cycle ends, except for the first and last cycles */
-#define   TCC_EVCTRL_CNTSEL_BOUNDARY_Val  0x3ul  /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a new counter cycle starts or a counter cycle ends */
+#define   TCC_EVCTRL_CNTSEL_START_Val     _U_(0x0)   /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a new counter cycle starts */
+#define   TCC_EVCTRL_CNTSEL_END_Val       _U_(0x1)   /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a counter cycle ends */
+#define   TCC_EVCTRL_CNTSEL_BETWEEN_Val   _U_(0x2)   /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a counter cycle ends, except for the first and last cycles */
+#define   TCC_EVCTRL_CNTSEL_BOUNDARY_Val  _U_(0x3)   /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a new counter cycle starts or a counter cycle ends */
 #define TCC_EVCTRL_CNTSEL_START     (TCC_EVCTRL_CNTSEL_START_Val   << TCC_EVCTRL_CNTSEL_Pos)
 #define TCC_EVCTRL_CNTSEL_END       (TCC_EVCTRL_CNTSEL_END_Val     << TCC_EVCTRL_CNTSEL_Pos)
 #define TCC_EVCTRL_CNTSEL_BETWEEN   (TCC_EVCTRL_CNTSEL_BETWEEN_Val << TCC_EVCTRL_CNTSEL_Pos)
 #define TCC_EVCTRL_CNTSEL_BOUNDARY  (TCC_EVCTRL_CNTSEL_BOUNDARY_Val << TCC_EVCTRL_CNTSEL_Pos)
 #define TCC_EVCTRL_OVFEO_Pos        8            /**< \brief (TCC_EVCTRL) Overflow/Underflow Output Event Enable */
-#define TCC_EVCTRL_OVFEO            (0x1ul << TCC_EVCTRL_OVFEO_Pos)
+#define TCC_EVCTRL_OVFEO            (_U_(0x1) << TCC_EVCTRL_OVFEO_Pos)
 #define TCC_EVCTRL_TRGEO_Pos        9            /**< \brief (TCC_EVCTRL) Retrigger Output Event Enable */
-#define TCC_EVCTRL_TRGEO            (0x1ul << TCC_EVCTRL_TRGEO_Pos)
+#define TCC_EVCTRL_TRGEO            (_U_(0x1) << TCC_EVCTRL_TRGEO_Pos)
 #define TCC_EVCTRL_CNTEO_Pos        10           /**< \brief (TCC_EVCTRL) Timer/counter Output Event Enable */
-#define TCC_EVCTRL_CNTEO            (0x1ul << TCC_EVCTRL_CNTEO_Pos)
+#define TCC_EVCTRL_CNTEO            (_U_(0x1) << TCC_EVCTRL_CNTEO_Pos)
 #define TCC_EVCTRL_TCINV0_Pos       12           /**< \brief (TCC_EVCTRL) Inverted Event 0 Input Enable */
 #define TCC_EVCTRL_TCINV0           (1 << TCC_EVCTRL_TCINV0_Pos)
 #define TCC_EVCTRL_TCINV1_Pos       13           /**< \brief (TCC_EVCTRL) Inverted Event 1 Input Enable */
 #define TCC_EVCTRL_TCINV1           (1 << TCC_EVCTRL_TCINV1_Pos)
 #define TCC_EVCTRL_TCINV_Pos        12           /**< \brief (TCC_EVCTRL) Inverted Event x Input Enable */
-#define TCC_EVCTRL_TCINV_Msk        (0x3ul << TCC_EVCTRL_TCINV_Pos)
+#define TCC_EVCTRL_TCINV_Msk        (_U_(0x3) << TCC_EVCTRL_TCINV_Pos)
 #define TCC_EVCTRL_TCINV(value)     (TCC_EVCTRL_TCINV_Msk & ((value) << TCC_EVCTRL_TCINV_Pos))
 #define TCC_EVCTRL_TCEI0_Pos        14           /**< \brief (TCC_EVCTRL) Timer/counter Event 0 Input Enable */
 #define TCC_EVCTRL_TCEI0            (1 << TCC_EVCTRL_TCEI0_Pos)
 #define TCC_EVCTRL_TCEI1_Pos        15           /**< \brief (TCC_EVCTRL) Timer/counter Event 1 Input Enable */
 #define TCC_EVCTRL_TCEI1            (1 << TCC_EVCTRL_TCEI1_Pos)
 #define TCC_EVCTRL_TCEI_Pos         14           /**< \brief (TCC_EVCTRL) Timer/counter Event x Input Enable */
-#define TCC_EVCTRL_TCEI_Msk         (0x3ul << TCC_EVCTRL_TCEI_Pos)
+#define TCC_EVCTRL_TCEI_Msk         (_U_(0x3) << TCC_EVCTRL_TCEI_Pos)
 #define TCC_EVCTRL_TCEI(value)      (TCC_EVCTRL_TCEI_Msk & ((value) << TCC_EVCTRL_TCEI_Pos))
 #define TCC_EVCTRL_MCEI0_Pos        16           /**< \brief (TCC_EVCTRL) Match or Capture Channel 0 Event Input Enable */
 #define TCC_EVCTRL_MCEI0            (1 << TCC_EVCTRL_MCEI0_Pos)
@@ -826,7 +811,7 @@ typedef union {
 #define TCC_EVCTRL_MCEI3_Pos        19           /**< \brief (TCC_EVCTRL) Match or Capture Channel 3 Event Input Enable */
 #define TCC_EVCTRL_MCEI3            (1 << TCC_EVCTRL_MCEI3_Pos)
 #define TCC_EVCTRL_MCEI_Pos         16           /**< \brief (TCC_EVCTRL) Match or Capture Channel x Event Input Enable */
-#define TCC_EVCTRL_MCEI_Msk         (0xFul << TCC_EVCTRL_MCEI_Pos)
+#define TCC_EVCTRL_MCEI_Msk         (_U_(0xF) << TCC_EVCTRL_MCEI_Pos)
 #define TCC_EVCTRL_MCEI(value)      (TCC_EVCTRL_MCEI_Msk & ((value) << TCC_EVCTRL_MCEI_Pos))
 #define TCC_EVCTRL_MCEO0_Pos        24           /**< \brief (TCC_EVCTRL) Match or Capture Channel 0 Event Output Enable */
 #define TCC_EVCTRL_MCEO0            (1 << TCC_EVCTRL_MCEO0_Pos)
@@ -837,9 +822,9 @@ typedef union {
 #define TCC_EVCTRL_MCEO3_Pos        27           /**< \brief (TCC_EVCTRL) Match or Capture Channel 3 Event Output Enable */
 #define TCC_EVCTRL_MCEO3            (1 << TCC_EVCTRL_MCEO3_Pos)
 #define TCC_EVCTRL_MCEO_Pos         24           /**< \brief (TCC_EVCTRL) Match or Capture Channel x Event Output Enable */
-#define TCC_EVCTRL_MCEO_Msk         (0xFul << TCC_EVCTRL_MCEO_Pos)
+#define TCC_EVCTRL_MCEO_Msk         (_U_(0xF) << TCC_EVCTRL_MCEO_Pos)
 #define TCC_EVCTRL_MCEO(value)      (TCC_EVCTRL_MCEO_Msk & ((value) << TCC_EVCTRL_MCEO_Pos))
-#define TCC_EVCTRL_MASK             0x0F0FF7FFul /**< \brief (TCC_EVCTRL) MASK Register */
+#define TCC_EVCTRL_MASK             _U_(0x0F0FF7FF) /**< \brief (TCC_EVCTRL) MASK Register */
 
 /* -------- TCC_INTENCLR : (TCC Offset: 0x24) (R/W 32) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -871,26 +856,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_INTENCLR_OFFSET         0x24         /**< \brief (TCC_INTENCLR offset) Interrupt Enable Clear */
-#define TCC_INTENCLR_RESETVALUE     0x00000000ul /**< \brief (TCC_INTENCLR reset_value) Interrupt Enable Clear */
+#define TCC_INTENCLR_RESETVALUE     _U_(0x00000000) /**< \brief (TCC_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define TCC_INTENCLR_OVF_Pos        0            /**< \brief (TCC_INTENCLR) Overflow Interrupt Enable */
-#define TCC_INTENCLR_OVF            (0x1ul << TCC_INTENCLR_OVF_Pos)
+#define TCC_INTENCLR_OVF            (_U_(0x1) << TCC_INTENCLR_OVF_Pos)
 #define TCC_INTENCLR_TRG_Pos        1            /**< \brief (TCC_INTENCLR) Retrigger Interrupt Enable */
-#define TCC_INTENCLR_TRG            (0x1ul << TCC_INTENCLR_TRG_Pos)
+#define TCC_INTENCLR_TRG            (_U_(0x1) << TCC_INTENCLR_TRG_Pos)
 #define TCC_INTENCLR_CNT_Pos        2            /**< \brief (TCC_INTENCLR) Counter Interrupt Enable */
-#define TCC_INTENCLR_CNT            (0x1ul << TCC_INTENCLR_CNT_Pos)
+#define TCC_INTENCLR_CNT            (_U_(0x1) << TCC_INTENCLR_CNT_Pos)
 #define TCC_INTENCLR_ERR_Pos        3            /**< \brief (TCC_INTENCLR) Error Interrupt Enable */
-#define TCC_INTENCLR_ERR            (0x1ul << TCC_INTENCLR_ERR_Pos)
+#define TCC_INTENCLR_ERR            (_U_(0x1) << TCC_INTENCLR_ERR_Pos)
 #define TCC_INTENCLR_DFS_Pos        11           /**< \brief (TCC_INTENCLR) Non-Recoverable Debug Fault Interrupt Enable */
-#define TCC_INTENCLR_DFS            (0x1ul << TCC_INTENCLR_DFS_Pos)
+#define TCC_INTENCLR_DFS            (_U_(0x1) << TCC_INTENCLR_DFS_Pos)
 #define TCC_INTENCLR_FAULTA_Pos     12           /**< \brief (TCC_INTENCLR) Recoverable Fault A Interrupt Enable */
-#define TCC_INTENCLR_FAULTA         (0x1ul << TCC_INTENCLR_FAULTA_Pos)
+#define TCC_INTENCLR_FAULTA         (_U_(0x1) << TCC_INTENCLR_FAULTA_Pos)
 #define TCC_INTENCLR_FAULTB_Pos     13           /**< \brief (TCC_INTENCLR) Recoverable Fault B Interrupt Enable */
-#define TCC_INTENCLR_FAULTB         (0x1ul << TCC_INTENCLR_FAULTB_Pos)
+#define TCC_INTENCLR_FAULTB         (_U_(0x1) << TCC_INTENCLR_FAULTB_Pos)
 #define TCC_INTENCLR_FAULT0_Pos     14           /**< \brief (TCC_INTENCLR) Non-Recoverable Fault 0 Interrupt Enable */
-#define TCC_INTENCLR_FAULT0         (0x1ul << TCC_INTENCLR_FAULT0_Pos)
+#define TCC_INTENCLR_FAULT0         (_U_(0x1) << TCC_INTENCLR_FAULT0_Pos)
 #define TCC_INTENCLR_FAULT1_Pos     15           /**< \brief (TCC_INTENCLR) Non-Recoverable Fault 1 Interrupt Enable */
-#define TCC_INTENCLR_FAULT1         (0x1ul << TCC_INTENCLR_FAULT1_Pos)
+#define TCC_INTENCLR_FAULT1         (_U_(0x1) << TCC_INTENCLR_FAULT1_Pos)
 #define TCC_INTENCLR_MC0_Pos        16           /**< \brief (TCC_INTENCLR) Match or Capture Channel 0 Interrupt Enable */
 #define TCC_INTENCLR_MC0            (1 << TCC_INTENCLR_MC0_Pos)
 #define TCC_INTENCLR_MC1_Pos        17           /**< \brief (TCC_INTENCLR) Match or Capture Channel 1 Interrupt Enable */
@@ -900,9 +885,9 @@ typedef union {
 #define TCC_INTENCLR_MC3_Pos        19           /**< \brief (TCC_INTENCLR) Match or Capture Channel 3 Interrupt Enable */
 #define TCC_INTENCLR_MC3            (1 << TCC_INTENCLR_MC3_Pos)
 #define TCC_INTENCLR_MC_Pos         16           /**< \brief (TCC_INTENCLR) Match or Capture Channel x Interrupt Enable */
-#define TCC_INTENCLR_MC_Msk         (0xFul << TCC_INTENCLR_MC_Pos)
+#define TCC_INTENCLR_MC_Msk         (_U_(0xF) << TCC_INTENCLR_MC_Pos)
 #define TCC_INTENCLR_MC(value)      (TCC_INTENCLR_MC_Msk & ((value) << TCC_INTENCLR_MC_Pos))
-#define TCC_INTENCLR_MASK           0x000FF80Ful /**< \brief (TCC_INTENCLR) MASK Register */
+#define TCC_INTENCLR_MASK           _U_(0x000FF80F) /**< \brief (TCC_INTENCLR) MASK Register */
 
 /* -------- TCC_INTENSET : (TCC Offset: 0x28) (R/W 32) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -934,26 +919,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_INTENSET_OFFSET         0x28         /**< \brief (TCC_INTENSET offset) Interrupt Enable Set */
-#define TCC_INTENSET_RESETVALUE     0x00000000ul /**< \brief (TCC_INTENSET reset_value) Interrupt Enable Set */
+#define TCC_INTENSET_RESETVALUE     _U_(0x00000000) /**< \brief (TCC_INTENSET reset_value) Interrupt Enable Set */
 
 #define TCC_INTENSET_OVF_Pos        0            /**< \brief (TCC_INTENSET) Overflow Interrupt Enable */
-#define TCC_INTENSET_OVF            (0x1ul << TCC_INTENSET_OVF_Pos)
+#define TCC_INTENSET_OVF            (_U_(0x1) << TCC_INTENSET_OVF_Pos)
 #define TCC_INTENSET_TRG_Pos        1            /**< \brief (TCC_INTENSET) Retrigger Interrupt Enable */
-#define TCC_INTENSET_TRG            (0x1ul << TCC_INTENSET_TRG_Pos)
+#define TCC_INTENSET_TRG            (_U_(0x1) << TCC_INTENSET_TRG_Pos)
 #define TCC_INTENSET_CNT_Pos        2            /**< \brief (TCC_INTENSET) Counter Interrupt Enable */
-#define TCC_INTENSET_CNT            (0x1ul << TCC_INTENSET_CNT_Pos)
+#define TCC_INTENSET_CNT            (_U_(0x1) << TCC_INTENSET_CNT_Pos)
 #define TCC_INTENSET_ERR_Pos        3            /**< \brief (TCC_INTENSET) Error Interrupt Enable */
-#define TCC_INTENSET_ERR            (0x1ul << TCC_INTENSET_ERR_Pos)
+#define TCC_INTENSET_ERR            (_U_(0x1) << TCC_INTENSET_ERR_Pos)
 #define TCC_INTENSET_DFS_Pos        11           /**< \brief (TCC_INTENSET) Non-Recoverable Debug Fault Interrupt Enable */
-#define TCC_INTENSET_DFS            (0x1ul << TCC_INTENSET_DFS_Pos)
+#define TCC_INTENSET_DFS            (_U_(0x1) << TCC_INTENSET_DFS_Pos)
 #define TCC_INTENSET_FAULTA_Pos     12           /**< \brief (TCC_INTENSET) Recoverable Fault A Interrupt Enable */
-#define TCC_INTENSET_FAULTA         (0x1ul << TCC_INTENSET_FAULTA_Pos)
+#define TCC_INTENSET_FAULTA         (_U_(0x1) << TCC_INTENSET_FAULTA_Pos)
 #define TCC_INTENSET_FAULTB_Pos     13           /**< \brief (TCC_INTENSET) Recoverable Fault B Interrupt Enable */
-#define TCC_INTENSET_FAULTB         (0x1ul << TCC_INTENSET_FAULTB_Pos)
+#define TCC_INTENSET_FAULTB         (_U_(0x1) << TCC_INTENSET_FAULTB_Pos)
 #define TCC_INTENSET_FAULT0_Pos     14           /**< \brief (TCC_INTENSET) Non-Recoverable Fault 0 Interrupt Enable */
-#define TCC_INTENSET_FAULT0         (0x1ul << TCC_INTENSET_FAULT0_Pos)
+#define TCC_INTENSET_FAULT0         (_U_(0x1) << TCC_INTENSET_FAULT0_Pos)
 #define TCC_INTENSET_FAULT1_Pos     15           /**< \brief (TCC_INTENSET) Non-Recoverable Fault 1 Interrupt Enable */
-#define TCC_INTENSET_FAULT1         (0x1ul << TCC_INTENSET_FAULT1_Pos)
+#define TCC_INTENSET_FAULT1         (_U_(0x1) << TCC_INTENSET_FAULT1_Pos)
 #define TCC_INTENSET_MC0_Pos        16           /**< \brief (TCC_INTENSET) Match or Capture Channel 0 Interrupt Enable */
 #define TCC_INTENSET_MC0            (1 << TCC_INTENSET_MC0_Pos)
 #define TCC_INTENSET_MC1_Pos        17           /**< \brief (TCC_INTENSET) Match or Capture Channel 1 Interrupt Enable */
@@ -963,9 +948,9 @@ typedef union {
 #define TCC_INTENSET_MC3_Pos        19           /**< \brief (TCC_INTENSET) Match or Capture Channel 3 Interrupt Enable */
 #define TCC_INTENSET_MC3            (1 << TCC_INTENSET_MC3_Pos)
 #define TCC_INTENSET_MC_Pos         16           /**< \brief (TCC_INTENSET) Match or Capture Channel x Interrupt Enable */
-#define TCC_INTENSET_MC_Msk         (0xFul << TCC_INTENSET_MC_Pos)
+#define TCC_INTENSET_MC_Msk         (_U_(0xF) << TCC_INTENSET_MC_Pos)
 #define TCC_INTENSET_MC(value)      (TCC_INTENSET_MC_Msk & ((value) << TCC_INTENSET_MC_Pos))
-#define TCC_INTENSET_MASK           0x000FF80Ful /**< \brief (TCC_INTENSET) MASK Register */
+#define TCC_INTENSET_MASK           _U_(0x000FF80F) /**< \brief (TCC_INTENSET) MASK Register */
 
 /* -------- TCC_INTFLAG : (TCC Offset: 0x2C) (R/W 32) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -997,26 +982,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_INTFLAG_OFFSET          0x2C         /**< \brief (TCC_INTFLAG offset) Interrupt Flag Status and Clear */
-#define TCC_INTFLAG_RESETVALUE      0x00000000ul /**< \brief (TCC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define TCC_INTFLAG_RESETVALUE      _U_(0x00000000) /**< \brief (TCC_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define TCC_INTFLAG_OVF_Pos         0            /**< \brief (TCC_INTFLAG) Overflow */
-#define TCC_INTFLAG_OVF             (0x1ul << TCC_INTFLAG_OVF_Pos)
+#define TCC_INTFLAG_OVF             (_U_(0x1) << TCC_INTFLAG_OVF_Pos)
 #define TCC_INTFLAG_TRG_Pos         1            /**< \brief (TCC_INTFLAG) Retrigger */
-#define TCC_INTFLAG_TRG             (0x1ul << TCC_INTFLAG_TRG_Pos)
+#define TCC_INTFLAG_TRG             (_U_(0x1) << TCC_INTFLAG_TRG_Pos)
 #define TCC_INTFLAG_CNT_Pos         2            /**< \brief (TCC_INTFLAG) Counter */
-#define TCC_INTFLAG_CNT             (0x1ul << TCC_INTFLAG_CNT_Pos)
+#define TCC_INTFLAG_CNT             (_U_(0x1) << TCC_INTFLAG_CNT_Pos)
 #define TCC_INTFLAG_ERR_Pos         3            /**< \brief (TCC_INTFLAG) Error */
-#define TCC_INTFLAG_ERR             (0x1ul << TCC_INTFLAG_ERR_Pos)
+#define TCC_INTFLAG_ERR             (_U_(0x1) << TCC_INTFLAG_ERR_Pos)
 #define TCC_INTFLAG_DFS_Pos         11           /**< \brief (TCC_INTFLAG) Non-Recoverable Debug Fault */
-#define TCC_INTFLAG_DFS             (0x1ul << TCC_INTFLAG_DFS_Pos)
+#define TCC_INTFLAG_DFS             (_U_(0x1) << TCC_INTFLAG_DFS_Pos)
 #define TCC_INTFLAG_FAULTA_Pos      12           /**< \brief (TCC_INTFLAG) Recoverable Fault A */
-#define TCC_INTFLAG_FAULTA          (0x1ul << TCC_INTFLAG_FAULTA_Pos)
+#define TCC_INTFLAG_FAULTA          (_U_(0x1) << TCC_INTFLAG_FAULTA_Pos)
 #define TCC_INTFLAG_FAULTB_Pos      13           /**< \brief (TCC_INTFLAG) Recoverable Fault B */
-#define TCC_INTFLAG_FAULTB          (0x1ul << TCC_INTFLAG_FAULTB_Pos)
+#define TCC_INTFLAG_FAULTB          (_U_(0x1) << TCC_INTFLAG_FAULTB_Pos)
 #define TCC_INTFLAG_FAULT0_Pos      14           /**< \brief (TCC_INTFLAG) Non-Recoverable Fault 0 */
-#define TCC_INTFLAG_FAULT0          (0x1ul << TCC_INTFLAG_FAULT0_Pos)
+#define TCC_INTFLAG_FAULT0          (_U_(0x1) << TCC_INTFLAG_FAULT0_Pos)
 #define TCC_INTFLAG_FAULT1_Pos      15           /**< \brief (TCC_INTFLAG) Non-Recoverable Fault 1 */
-#define TCC_INTFLAG_FAULT1          (0x1ul << TCC_INTFLAG_FAULT1_Pos)
+#define TCC_INTFLAG_FAULT1          (_U_(0x1) << TCC_INTFLAG_FAULT1_Pos)
 #define TCC_INTFLAG_MC0_Pos         16           /**< \brief (TCC_INTFLAG) Match or Capture 0 */
 #define TCC_INTFLAG_MC0             (1 << TCC_INTFLAG_MC0_Pos)
 #define TCC_INTFLAG_MC1_Pos         17           /**< \brief (TCC_INTFLAG) Match or Capture 1 */
@@ -1026,9 +1011,9 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #define TCC_INTFLAG_MC3_Pos         19           /**< \brief (TCC_INTFLAG) Match or Capture 3 */
 #define TCC_INTFLAG_MC3             (1 << TCC_INTFLAG_MC3_Pos)
 #define TCC_INTFLAG_MC_Pos          16           /**< \brief (TCC_INTFLAG) Match or Capture x */
-#define TCC_INTFLAG_MC_Msk          (0xFul << TCC_INTFLAG_MC_Pos)
+#define TCC_INTFLAG_MC_Msk          (_U_(0xF) << TCC_INTFLAG_MC_Pos)
 #define TCC_INTFLAG_MC(value)       (TCC_INTFLAG_MC_Msk & ((value) << TCC_INTFLAG_MC_Pos))
-#define TCC_INTFLAG_MASK            0x000FF80Ful /**< \brief (TCC_INTFLAG) MASK Register */
+#define TCC_INTFLAG_MASK            _U_(0x000FF80F) /**< \brief (TCC_INTFLAG) MASK Register */
 
 /* -------- TCC_STATUS : (TCC Offset: 0x30) (R/W 32) Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1073,38 +1058,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_STATUS_OFFSET           0x30         /**< \brief (TCC_STATUS offset) Status */
-#define TCC_STATUS_RESETVALUE       0x00000001ul /**< \brief (TCC_STATUS reset_value) Status */
+#define TCC_STATUS_RESETVALUE       _U_(0x00000001) /**< \brief (TCC_STATUS reset_value) Status */
 
 #define TCC_STATUS_STOP_Pos         0            /**< \brief (TCC_STATUS) Stop */
-#define TCC_STATUS_STOP             (0x1ul << TCC_STATUS_STOP_Pos)
+#define TCC_STATUS_STOP             (_U_(0x1) << TCC_STATUS_STOP_Pos)
 #define TCC_STATUS_IDX_Pos          1            /**< \brief (TCC_STATUS) Ramp */
-#define TCC_STATUS_IDX              (0x1ul << TCC_STATUS_IDX_Pos)
+#define TCC_STATUS_IDX              (_U_(0x1) << TCC_STATUS_IDX_Pos)
 #define TCC_STATUS_DFS_Pos          3            /**< \brief (TCC_STATUS) Non-Recoverable Debug Fault State */
-#define TCC_STATUS_DFS              (0x1ul << TCC_STATUS_DFS_Pos)
+#define TCC_STATUS_DFS              (_U_(0x1) << TCC_STATUS_DFS_Pos)
 #define TCC_STATUS_SLAVE_Pos        4            /**< \brief (TCC_STATUS) Slave */
-#define TCC_STATUS_SLAVE            (0x1ul << TCC_STATUS_SLAVE_Pos)
+#define TCC_STATUS_SLAVE            (_U_(0x1) << TCC_STATUS_SLAVE_Pos)
 #define TCC_STATUS_PATTBV_Pos       5            /**< \brief (TCC_STATUS) Pattern Buffer Valid */
-#define TCC_STATUS_PATTBV           (0x1ul << TCC_STATUS_PATTBV_Pos)
+#define TCC_STATUS_PATTBV           (_U_(0x1) << TCC_STATUS_PATTBV_Pos)
 #define TCC_STATUS_WAVEBV_Pos       6            /**< \brief (TCC_STATUS) Wave Buffer Valid */
-#define TCC_STATUS_WAVEBV           (0x1ul << TCC_STATUS_WAVEBV_Pos)
+#define TCC_STATUS_WAVEBV           (_U_(0x1) << TCC_STATUS_WAVEBV_Pos)
 #define TCC_STATUS_PERBV_Pos        7            /**< \brief (TCC_STATUS) Period Buffer Valid */
-#define TCC_STATUS_PERBV            (0x1ul << TCC_STATUS_PERBV_Pos)
+#define TCC_STATUS_PERBV            (_U_(0x1) << TCC_STATUS_PERBV_Pos)
 #define TCC_STATUS_FAULTAIN_Pos     8            /**< \brief (TCC_STATUS) Recoverable Fault A Input */
-#define TCC_STATUS_FAULTAIN         (0x1ul << TCC_STATUS_FAULTAIN_Pos)
+#define TCC_STATUS_FAULTAIN         (_U_(0x1) << TCC_STATUS_FAULTAIN_Pos)
 #define TCC_STATUS_FAULTBIN_Pos     9            /**< \brief (TCC_STATUS) Recoverable Fault B Input */
-#define TCC_STATUS_FAULTBIN         (0x1ul << TCC_STATUS_FAULTBIN_Pos)
+#define TCC_STATUS_FAULTBIN         (_U_(0x1) << TCC_STATUS_FAULTBIN_Pos)
 #define TCC_STATUS_FAULT0IN_Pos     10           /**< \brief (TCC_STATUS) Non-Recoverable Fault0 Input */
-#define TCC_STATUS_FAULT0IN         (0x1ul << TCC_STATUS_FAULT0IN_Pos)
+#define TCC_STATUS_FAULT0IN         (_U_(0x1) << TCC_STATUS_FAULT0IN_Pos)
 #define TCC_STATUS_FAULT1IN_Pos     11           /**< \brief (TCC_STATUS) Non-Recoverable Fault1 Input */
-#define TCC_STATUS_FAULT1IN         (0x1ul << TCC_STATUS_FAULT1IN_Pos)
+#define TCC_STATUS_FAULT1IN         (_U_(0x1) << TCC_STATUS_FAULT1IN_Pos)
 #define TCC_STATUS_FAULTA_Pos       12           /**< \brief (TCC_STATUS) Recoverable Fault A State */
-#define TCC_STATUS_FAULTA           (0x1ul << TCC_STATUS_FAULTA_Pos)
+#define TCC_STATUS_FAULTA           (_U_(0x1) << TCC_STATUS_FAULTA_Pos)
 #define TCC_STATUS_FAULTB_Pos       13           /**< \brief (TCC_STATUS) Recoverable Fault B State */
-#define TCC_STATUS_FAULTB           (0x1ul << TCC_STATUS_FAULTB_Pos)
+#define TCC_STATUS_FAULTB           (_U_(0x1) << TCC_STATUS_FAULTB_Pos)
 #define TCC_STATUS_FAULT0_Pos       14           /**< \brief (TCC_STATUS) Non-Recoverable Fault 0 State */
-#define TCC_STATUS_FAULT0           (0x1ul << TCC_STATUS_FAULT0_Pos)
+#define TCC_STATUS_FAULT0           (_U_(0x1) << TCC_STATUS_FAULT0_Pos)
 #define TCC_STATUS_FAULT1_Pos       15           /**< \brief (TCC_STATUS) Non-Recoverable Fault 1 State */
-#define TCC_STATUS_FAULT1           (0x1ul << TCC_STATUS_FAULT1_Pos)
+#define TCC_STATUS_FAULT1           (_U_(0x1) << TCC_STATUS_FAULT1_Pos)
 #define TCC_STATUS_CCBV0_Pos        16           /**< \brief (TCC_STATUS) Compare Channel 0 Buffer Valid */
 #define TCC_STATUS_CCBV0            (1 << TCC_STATUS_CCBV0_Pos)
 #define TCC_STATUS_CCBV1_Pos        17           /**< \brief (TCC_STATUS) Compare Channel 1 Buffer Valid */
@@ -1114,7 +1099,7 @@ typedef union {
 #define TCC_STATUS_CCBV3_Pos        19           /**< \brief (TCC_STATUS) Compare Channel 3 Buffer Valid */
 #define TCC_STATUS_CCBV3            (1 << TCC_STATUS_CCBV3_Pos)
 #define TCC_STATUS_CCBV_Pos         16           /**< \brief (TCC_STATUS) Compare Channel x Buffer Valid */
-#define TCC_STATUS_CCBV_Msk         (0xFul << TCC_STATUS_CCBV_Pos)
+#define TCC_STATUS_CCBV_Msk         (_U_(0xF) << TCC_STATUS_CCBV_Pos)
 #define TCC_STATUS_CCBV(value)      (TCC_STATUS_CCBV_Msk & ((value) << TCC_STATUS_CCBV_Pos))
 #define TCC_STATUS_CMP0_Pos         24           /**< \brief (TCC_STATUS) Compare Channel 0 Value */
 #define TCC_STATUS_CMP0             (1 << TCC_STATUS_CMP0_Pos)
@@ -1125,9 +1110,9 @@ typedef union {
 #define TCC_STATUS_CMP3_Pos         27           /**< \brief (TCC_STATUS) Compare Channel 3 Value */
 #define TCC_STATUS_CMP3             (1 << TCC_STATUS_CMP3_Pos)
 #define TCC_STATUS_CMP_Pos          24           /**< \brief (TCC_STATUS) Compare Channel x Value */
-#define TCC_STATUS_CMP_Msk          (0xFul << TCC_STATUS_CMP_Pos)
+#define TCC_STATUS_CMP_Msk          (_U_(0xF) << TCC_STATUS_CMP_Pos)
 #define TCC_STATUS_CMP(value)       (TCC_STATUS_CMP_Msk & ((value) << TCC_STATUS_CMP_Pos))
-#define TCC_STATUS_MASK             0x0F0FFFFBul /**< \brief (TCC_STATUS) MASK Register */
+#define TCC_STATUS_MASK             _U_(0x0F0FFFFB) /**< \brief (TCC_STATUS) MASK Register */
 
 /* -------- TCC_COUNT : (TCC Offset: 0x34) (R/W 32) Count -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1156,30 +1141,30 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_COUNT_OFFSET            0x34         /**< \brief (TCC_COUNT offset) Count */
-#define TCC_COUNT_RESETVALUE        0x00000000ul /**< \brief (TCC_COUNT reset_value) Count */
+#define TCC_COUNT_RESETVALUE        _U_(0x00000000) /**< \brief (TCC_COUNT reset_value) Count */
 
 // DITH4 mode
 #define TCC_COUNT_DITH4_COUNT_Pos   4            /**< \brief (TCC_COUNT_DITH4) Counter Value */
-#define TCC_COUNT_DITH4_COUNT_Msk   (0xFFFFFul << TCC_COUNT_DITH4_COUNT_Pos)
+#define TCC_COUNT_DITH4_COUNT_Msk   (_U_(0xFFFFF) << TCC_COUNT_DITH4_COUNT_Pos)
 #define TCC_COUNT_DITH4_COUNT(value) (TCC_COUNT_DITH4_COUNT_Msk & ((value) << TCC_COUNT_DITH4_COUNT_Pos))
-#define TCC_COUNT_DITH4_MASK        0x00FFFFF0ul /**< \brief (TCC_COUNT_DITH4) MASK Register */
+#define TCC_COUNT_DITH4_MASK        _U_(0x00FFFFF0) /**< \brief (TCC_COUNT_DITH4) MASK Register */
 
 // DITH5 mode
 #define TCC_COUNT_DITH5_COUNT_Pos   5            /**< \brief (TCC_COUNT_DITH5) Counter Value */
-#define TCC_COUNT_DITH5_COUNT_Msk   (0x7FFFFul << TCC_COUNT_DITH5_COUNT_Pos)
+#define TCC_COUNT_DITH5_COUNT_Msk   (_U_(0x7FFFF) << TCC_COUNT_DITH5_COUNT_Pos)
 #define TCC_COUNT_DITH5_COUNT(value) (TCC_COUNT_DITH5_COUNT_Msk & ((value) << TCC_COUNT_DITH5_COUNT_Pos))
-#define TCC_COUNT_DITH5_MASK        0x00FFFFE0ul /**< \brief (TCC_COUNT_DITH5) MASK Register */
+#define TCC_COUNT_DITH5_MASK        _U_(0x00FFFFE0) /**< \brief (TCC_COUNT_DITH5) MASK Register */
 
 // DITH6 mode
 #define TCC_COUNT_DITH6_COUNT_Pos   6            /**< \brief (TCC_COUNT_DITH6) Counter Value */
-#define TCC_COUNT_DITH6_COUNT_Msk   (0x3FFFFul << TCC_COUNT_DITH6_COUNT_Pos)
+#define TCC_COUNT_DITH6_COUNT_Msk   (_U_(0x3FFFF) << TCC_COUNT_DITH6_COUNT_Pos)
 #define TCC_COUNT_DITH6_COUNT(value) (TCC_COUNT_DITH6_COUNT_Msk & ((value) << TCC_COUNT_DITH6_COUNT_Pos))
-#define TCC_COUNT_DITH6_MASK        0x00FFFFC0ul /**< \brief (TCC_COUNT_DITH6) MASK Register */
+#define TCC_COUNT_DITH6_MASK        _U_(0x00FFFFC0) /**< \brief (TCC_COUNT_DITH6) MASK Register */
 
 #define TCC_COUNT_COUNT_Pos         0            /**< \brief (TCC_COUNT) Counter Value */
-#define TCC_COUNT_COUNT_Msk         (0xFFFFFFul << TCC_COUNT_COUNT_Pos)
+#define TCC_COUNT_COUNT_Msk         (_U_(0xFFFFFF) << TCC_COUNT_COUNT_Pos)
 #define TCC_COUNT_COUNT(value)      (TCC_COUNT_COUNT_Msk & ((value) << TCC_COUNT_COUNT_Pos))
-#define TCC_COUNT_MASK              0x00FFFFFFul /**< \brief (TCC_COUNT) MASK Register */
+#define TCC_COUNT_MASK              _U_(0x00FFFFFF) /**< \brief (TCC_COUNT) MASK Register */
 
 /* -------- TCC_PATT : (TCC Offset: 0x38) (R/W 16) Pattern -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1211,7 +1196,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_PATT_OFFSET             0x38         /**< \brief (TCC_PATT offset) Pattern */
-#define TCC_PATT_RESETVALUE         0x0000ul     /**< \brief (TCC_PATT reset_value) Pattern */
+#define TCC_PATT_RESETVALUE         _U_(0x0000)   /**< \brief (TCC_PATT reset_value) Pattern */
 
 #define TCC_PATT_PGE0_Pos           0            /**< \brief (TCC_PATT) Pattern Generator 0 Output Enable */
 #define TCC_PATT_PGE0               (1 << TCC_PATT_PGE0_Pos)
@@ -1230,7 +1215,7 @@ typedef union {
 #define TCC_PATT_PGE7_Pos           7            /**< \brief (TCC_PATT) Pattern Generator 7 Output Enable */
 #define TCC_PATT_PGE7               (1 << TCC_PATT_PGE7_Pos)
 #define TCC_PATT_PGE_Pos            0            /**< \brief (TCC_PATT) Pattern Generator x Output Enable */
-#define TCC_PATT_PGE_Msk            (0xFFul << TCC_PATT_PGE_Pos)
+#define TCC_PATT_PGE_Msk            (_U_(0xFF) << TCC_PATT_PGE_Pos)
 #define TCC_PATT_PGE(value)         (TCC_PATT_PGE_Msk & ((value) << TCC_PATT_PGE_Pos))
 #define TCC_PATT_PGV0_Pos           8            /**< \brief (TCC_PATT) Pattern Generator 0 Output Value */
 #define TCC_PATT_PGV0               (1 << TCC_PATT_PGV0_Pos)
@@ -1249,9 +1234,9 @@ typedef union {
 #define TCC_PATT_PGV7_Pos           15           /**< \brief (TCC_PATT) Pattern Generator 7 Output Value */
 #define TCC_PATT_PGV7               (1 << TCC_PATT_PGV7_Pos)
 #define TCC_PATT_PGV_Pos            8            /**< \brief (TCC_PATT) Pattern Generator x Output Value */
-#define TCC_PATT_PGV_Msk            (0xFFul << TCC_PATT_PGV_Pos)
+#define TCC_PATT_PGV_Msk            (_U_(0xFF) << TCC_PATT_PGV_Pos)
 #define TCC_PATT_PGV(value)         (TCC_PATT_PGV_Msk & ((value) << TCC_PATT_PGV_Pos))
-#define TCC_PATT_MASK               0xFFFFul     /**< \brief (TCC_PATT) MASK Register */
+#define TCC_PATT_MASK               _U_(0xFFFF)   /**< \brief (TCC_PATT) MASK Register */
 
 /* -------- TCC_WAVE : (TCC Offset: 0x3C) (R/W 32) Waveform Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1292,18 +1277,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_WAVE_OFFSET             0x3C         /**< \brief (TCC_WAVE offset) Waveform Control */
-#define TCC_WAVE_RESETVALUE         0x00000000ul /**< \brief (TCC_WAVE reset_value) Waveform Control */
+#define TCC_WAVE_RESETVALUE         _U_(0x00000000) /**< \brief (TCC_WAVE reset_value) Waveform Control */
 
 #define TCC_WAVE_WAVEGEN_Pos        0            /**< \brief (TCC_WAVE) Waveform Generation */
-#define TCC_WAVE_WAVEGEN_Msk        (0x7ul << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_WAVEGEN_Msk        (_U_(0x7) << TCC_WAVE_WAVEGEN_Pos)
 #define TCC_WAVE_WAVEGEN(value)     (TCC_WAVE_WAVEGEN_Msk & ((value) << TCC_WAVE_WAVEGEN_Pos))
-#define   TCC_WAVE_WAVEGEN_NFRQ_Val       0x0ul  /**< \brief (TCC_WAVE) Normal frequency */
-#define   TCC_WAVE_WAVEGEN_MFRQ_Val       0x1ul  /**< \brief (TCC_WAVE) Match frequency */
-#define   TCC_WAVE_WAVEGEN_NPWM_Val       0x2ul  /**< \brief (TCC_WAVE) Normal PWM */
-#define   TCC_WAVE_WAVEGEN_DSCRITICAL_Val 0x4ul  /**< \brief (TCC_WAVE) Dual-slope critical */
-#define   TCC_WAVE_WAVEGEN_DSBOTTOM_Val   0x5ul  /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches ZERO */
-#define   TCC_WAVE_WAVEGEN_DSBOTH_Val     0x6ul  /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP */
-#define   TCC_WAVE_WAVEGEN_DSTOP_Val      0x7ul  /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches TOP */
+#define   TCC_WAVE_WAVEGEN_NFRQ_Val       _U_(0x0)   /**< \brief (TCC_WAVE) Normal frequency */
+#define   TCC_WAVE_WAVEGEN_MFRQ_Val       _U_(0x1)   /**< \brief (TCC_WAVE) Match frequency */
+#define   TCC_WAVE_WAVEGEN_NPWM_Val       _U_(0x2)   /**< \brief (TCC_WAVE) Normal PWM */
+#define   TCC_WAVE_WAVEGEN_DSCRITICAL_Val _U_(0x4)   /**< \brief (TCC_WAVE) Dual-slope critical */
+#define   TCC_WAVE_WAVEGEN_DSBOTTOM_Val   _U_(0x5)   /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches ZERO */
+#define   TCC_WAVE_WAVEGEN_DSBOTH_Val     _U_(0x6)   /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP */
+#define   TCC_WAVE_WAVEGEN_DSTOP_Val      _U_(0x7)   /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches TOP */
 #define TCC_WAVE_WAVEGEN_NFRQ       (TCC_WAVE_WAVEGEN_NFRQ_Val     << TCC_WAVE_WAVEGEN_Pos)
 #define TCC_WAVE_WAVEGEN_MFRQ       (TCC_WAVE_WAVEGEN_MFRQ_Val     << TCC_WAVE_WAVEGEN_Pos)
 #define TCC_WAVE_WAVEGEN_NPWM       (TCC_WAVE_WAVEGEN_NPWM_Val     << TCC_WAVE_WAVEGEN_Pos)
@@ -1312,16 +1297,16 @@ typedef union {
 #define TCC_WAVE_WAVEGEN_DSBOTH     (TCC_WAVE_WAVEGEN_DSBOTH_Val   << TCC_WAVE_WAVEGEN_Pos)
 #define TCC_WAVE_WAVEGEN_DSTOP      (TCC_WAVE_WAVEGEN_DSTOP_Val    << TCC_WAVE_WAVEGEN_Pos)
 #define TCC_WAVE_RAMP_Pos           4            /**< \brief (TCC_WAVE) Ramp Mode */
-#define TCC_WAVE_RAMP_Msk           (0x3ul << TCC_WAVE_RAMP_Pos)
+#define TCC_WAVE_RAMP_Msk           (_U_(0x3) << TCC_WAVE_RAMP_Pos)
 #define TCC_WAVE_RAMP(value)        (TCC_WAVE_RAMP_Msk & ((value) << TCC_WAVE_RAMP_Pos))
-#define   TCC_WAVE_RAMP_RAMP1_Val         0x0ul  /**< \brief (TCC_WAVE) RAMP1 operation */
-#define   TCC_WAVE_RAMP_RAMP2A_Val        0x1ul  /**< \brief (TCC_WAVE) Alternative RAMP2 operation */
-#define   TCC_WAVE_RAMP_RAMP2_Val         0x2ul  /**< \brief (TCC_WAVE) RAMP2 operation */
+#define   TCC_WAVE_RAMP_RAMP1_Val         _U_(0x0)   /**< \brief (TCC_WAVE) RAMP1 operation */
+#define   TCC_WAVE_RAMP_RAMP2A_Val        _U_(0x1)   /**< \brief (TCC_WAVE) Alternative RAMP2 operation */
+#define   TCC_WAVE_RAMP_RAMP2_Val         _U_(0x2)   /**< \brief (TCC_WAVE) RAMP2 operation */
 #define TCC_WAVE_RAMP_RAMP1         (TCC_WAVE_RAMP_RAMP1_Val       << TCC_WAVE_RAMP_Pos)
 #define TCC_WAVE_RAMP_RAMP2A        (TCC_WAVE_RAMP_RAMP2A_Val      << TCC_WAVE_RAMP_Pos)
 #define TCC_WAVE_RAMP_RAMP2         (TCC_WAVE_RAMP_RAMP2_Val       << TCC_WAVE_RAMP_Pos)
 #define TCC_WAVE_CIPEREN_Pos        7            /**< \brief (TCC_WAVE) Circular period Enable */
-#define TCC_WAVE_CIPEREN            (0x1ul << TCC_WAVE_CIPEREN_Pos)
+#define TCC_WAVE_CIPEREN            (_U_(0x1) << TCC_WAVE_CIPEREN_Pos)
 #define TCC_WAVE_CICCEN0_Pos        8            /**< \brief (TCC_WAVE) Circular Channel 0 Enable */
 #define TCC_WAVE_CICCEN0            (1 << TCC_WAVE_CICCEN0_Pos)
 #define TCC_WAVE_CICCEN1_Pos        9            /**< \brief (TCC_WAVE) Circular Channel 1 Enable */
@@ -1331,7 +1316,7 @@ typedef union {
 #define TCC_WAVE_CICCEN3_Pos        11           /**< \brief (TCC_WAVE) Circular Channel 3 Enable */
 #define TCC_WAVE_CICCEN3            (1 << TCC_WAVE_CICCEN3_Pos)
 #define TCC_WAVE_CICCEN_Pos         8            /**< \brief (TCC_WAVE) Circular Channel x Enable */
-#define TCC_WAVE_CICCEN_Msk         (0xFul << TCC_WAVE_CICCEN_Pos)
+#define TCC_WAVE_CICCEN_Msk         (_U_(0xF) << TCC_WAVE_CICCEN_Pos)
 #define TCC_WAVE_CICCEN(value)      (TCC_WAVE_CICCEN_Msk & ((value) << TCC_WAVE_CICCEN_Pos))
 #define TCC_WAVE_POL0_Pos           16           /**< \brief (TCC_WAVE) Channel 0 Polarity */
 #define TCC_WAVE_POL0               (1 << TCC_WAVE_POL0_Pos)
@@ -1342,7 +1327,7 @@ typedef union {
 #define TCC_WAVE_POL3_Pos           19           /**< \brief (TCC_WAVE) Channel 3 Polarity */
 #define TCC_WAVE_POL3               (1 << TCC_WAVE_POL3_Pos)
 #define TCC_WAVE_POL_Pos            16           /**< \brief (TCC_WAVE) Channel x Polarity */
-#define TCC_WAVE_POL_Msk            (0xFul << TCC_WAVE_POL_Pos)
+#define TCC_WAVE_POL_Msk            (_U_(0xF) << TCC_WAVE_POL_Pos)
 #define TCC_WAVE_POL(value)         (TCC_WAVE_POL_Msk & ((value) << TCC_WAVE_POL_Pos))
 #define TCC_WAVE_SWAP0_Pos          24           /**< \brief (TCC_WAVE) Swap DTI Output Pair 0 */
 #define TCC_WAVE_SWAP0              (1 << TCC_WAVE_SWAP0_Pos)
@@ -1353,9 +1338,9 @@ typedef union {
 #define TCC_WAVE_SWAP3_Pos          27           /**< \brief (TCC_WAVE) Swap DTI Output Pair 3 */
 #define TCC_WAVE_SWAP3              (1 << TCC_WAVE_SWAP3_Pos)
 #define TCC_WAVE_SWAP_Pos           24           /**< \brief (TCC_WAVE) Swap DTI Output Pair x */
-#define TCC_WAVE_SWAP_Msk           (0xFul << TCC_WAVE_SWAP_Pos)
+#define TCC_WAVE_SWAP_Msk           (_U_(0xF) << TCC_WAVE_SWAP_Pos)
 #define TCC_WAVE_SWAP(value)        (TCC_WAVE_SWAP_Msk & ((value) << TCC_WAVE_SWAP_Pos))
-#define TCC_WAVE_MASK               0x0F0F0FB7ul /**< \brief (TCC_WAVE) MASK Register */
+#define TCC_WAVE_MASK               _U_(0x0F0F0FB7) /**< \brief (TCC_WAVE) MASK Register */
 
 /* -------- TCC_PER : (TCC Offset: 0x40) (R/W 32) Period -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1384,39 +1369,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_PER_OFFSET              0x40         /**< \brief (TCC_PER offset) Period */
-#define TCC_PER_RESETVALUE          0xFFFFFFFFul /**< \brief (TCC_PER reset_value) Period */
+#define TCC_PER_RESETVALUE          _U_(0xFFFFFFFF) /**< \brief (TCC_PER reset_value) Period */
 
 // DITH4 mode
 #define TCC_PER_DITH4_DITHERCY_Pos  0            /**< \brief (TCC_PER_DITH4) Dithering Cycle Number */
-#define TCC_PER_DITH4_DITHERCY_Msk  (0xFul << TCC_PER_DITH4_DITHERCY_Pos)
+#define TCC_PER_DITH4_DITHERCY_Msk  (_U_(0xF) << TCC_PER_DITH4_DITHERCY_Pos)
 #define TCC_PER_DITH4_DITHERCY(value) (TCC_PER_DITH4_DITHERCY_Msk & ((value) << TCC_PER_DITH4_DITHERCY_Pos))
 #define TCC_PER_DITH4_PER_Pos       4            /**< \brief (TCC_PER_DITH4) Period Value */
-#define TCC_PER_DITH4_PER_Msk       (0xFFFFFul << TCC_PER_DITH4_PER_Pos)
+#define TCC_PER_DITH4_PER_Msk       (_U_(0xFFFFF) << TCC_PER_DITH4_PER_Pos)
 #define TCC_PER_DITH4_PER(value)    (TCC_PER_DITH4_PER_Msk & ((value) << TCC_PER_DITH4_PER_Pos))
-#define TCC_PER_DITH4_MASK          0x00FFFFFFul /**< \brief (TCC_PER_DITH4) MASK Register */
+#define TCC_PER_DITH4_MASK          _U_(0x00FFFFFF) /**< \brief (TCC_PER_DITH4) MASK Register */
 
 // DITH5 mode
 #define TCC_PER_DITH5_DITHERCY_Pos  0            /**< \brief (TCC_PER_DITH5) Dithering Cycle Number */
-#define TCC_PER_DITH5_DITHERCY_Msk  (0x1Ful << TCC_PER_DITH5_DITHERCY_Pos)
+#define TCC_PER_DITH5_DITHERCY_Msk  (_U_(0x1F) << TCC_PER_DITH5_DITHERCY_Pos)
 #define TCC_PER_DITH5_DITHERCY(value) (TCC_PER_DITH5_DITHERCY_Msk & ((value) << TCC_PER_DITH5_DITHERCY_Pos))
 #define TCC_PER_DITH5_PER_Pos       5            /**< \brief (TCC_PER_DITH5) Period Value */
-#define TCC_PER_DITH5_PER_Msk       (0x7FFFFul << TCC_PER_DITH5_PER_Pos)
+#define TCC_PER_DITH5_PER_Msk       (_U_(0x7FFFF) << TCC_PER_DITH5_PER_Pos)
 #define TCC_PER_DITH5_PER(value)    (TCC_PER_DITH5_PER_Msk & ((value) << TCC_PER_DITH5_PER_Pos))
-#define TCC_PER_DITH5_MASK          0x00FFFFFFul /**< \brief (TCC_PER_DITH5) MASK Register */
+#define TCC_PER_DITH5_MASK          _U_(0x00FFFFFF) /**< \brief (TCC_PER_DITH5) MASK Register */
 
 // DITH6 mode
 #define TCC_PER_DITH6_DITHERCY_Pos  0            /**< \brief (TCC_PER_DITH6) Dithering Cycle Number */
-#define TCC_PER_DITH6_DITHERCY_Msk  (0x3Ful << TCC_PER_DITH6_DITHERCY_Pos)
+#define TCC_PER_DITH6_DITHERCY_Msk  (_U_(0x3F) << TCC_PER_DITH6_DITHERCY_Pos)
 #define TCC_PER_DITH6_DITHERCY(value) (TCC_PER_DITH6_DITHERCY_Msk & ((value) << TCC_PER_DITH6_DITHERCY_Pos))
 #define TCC_PER_DITH6_PER_Pos       6            /**< \brief (TCC_PER_DITH6) Period Value */
-#define TCC_PER_DITH6_PER_Msk       (0x3FFFFul << TCC_PER_DITH6_PER_Pos)
+#define TCC_PER_DITH6_PER_Msk       (_U_(0x3FFFF) << TCC_PER_DITH6_PER_Pos)
 #define TCC_PER_DITH6_PER(value)    (TCC_PER_DITH6_PER_Msk & ((value) << TCC_PER_DITH6_PER_Pos))
-#define TCC_PER_DITH6_MASK          0x00FFFFFFul /**< \brief (TCC_PER_DITH6) MASK Register */
+#define TCC_PER_DITH6_MASK          _U_(0x00FFFFFF) /**< \brief (TCC_PER_DITH6) MASK Register */
 
 #define TCC_PER_PER_Pos             0            /**< \brief (TCC_PER) Period Value */
-#define TCC_PER_PER_Msk             (0xFFFFFFul << TCC_PER_PER_Pos)
+#define TCC_PER_PER_Msk             (_U_(0xFFFFFF) << TCC_PER_PER_Pos)
 #define TCC_PER_PER(value)          (TCC_PER_PER_Msk & ((value) << TCC_PER_PER_Pos))
-#define TCC_PER_MASK                0x00FFFFFFul /**< \brief (TCC_PER) MASK Register */
+#define TCC_PER_MASK                _U_(0x00FFFFFF) /**< \brief (TCC_PER) MASK Register */
 
 /* -------- TCC_CC : (TCC Offset: 0x44) (R/W 32) Compare and Capture -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1445,39 +1430,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_CC_OFFSET               0x44         /**< \brief (TCC_CC offset) Compare and Capture */
-#define TCC_CC_RESETVALUE           0x00000000ul /**< \brief (TCC_CC reset_value) Compare and Capture */
+#define TCC_CC_RESETVALUE           _U_(0x00000000) /**< \brief (TCC_CC reset_value) Compare and Capture */
 
 // DITH4 mode
 #define TCC_CC_DITH4_DITHERCY_Pos   0            /**< \brief (TCC_CC_DITH4) Dithering Cycle Number */
-#define TCC_CC_DITH4_DITHERCY_Msk   (0xFul << TCC_CC_DITH4_DITHERCY_Pos)
+#define TCC_CC_DITH4_DITHERCY_Msk   (_U_(0xF) << TCC_CC_DITH4_DITHERCY_Pos)
 #define TCC_CC_DITH4_DITHERCY(value) (TCC_CC_DITH4_DITHERCY_Msk & ((value) << TCC_CC_DITH4_DITHERCY_Pos))
 #define TCC_CC_DITH4_CC_Pos         4            /**< \brief (TCC_CC_DITH4) Channel Compare/Capture Value */
-#define TCC_CC_DITH4_CC_Msk         (0xFFFFFul << TCC_CC_DITH4_CC_Pos)
+#define TCC_CC_DITH4_CC_Msk         (_U_(0xFFFFF) << TCC_CC_DITH4_CC_Pos)
 #define TCC_CC_DITH4_CC(value)      (TCC_CC_DITH4_CC_Msk & ((value) << TCC_CC_DITH4_CC_Pos))
-#define TCC_CC_DITH4_MASK           0x00FFFFFFul /**< \brief (TCC_CC_DITH4) MASK Register */
+#define TCC_CC_DITH4_MASK           _U_(0x00FFFFFF) /**< \brief (TCC_CC_DITH4) MASK Register */
 
 // DITH5 mode
 #define TCC_CC_DITH5_DITHERCY_Pos   0            /**< \brief (TCC_CC_DITH5) Dithering Cycle Number */
-#define TCC_CC_DITH5_DITHERCY_Msk   (0x1Ful << TCC_CC_DITH5_DITHERCY_Pos)
+#define TCC_CC_DITH5_DITHERCY_Msk   (_U_(0x1F) << TCC_CC_DITH5_DITHERCY_Pos)
 #define TCC_CC_DITH5_DITHERCY(value) (TCC_CC_DITH5_DITHERCY_Msk & ((value) << TCC_CC_DITH5_DITHERCY_Pos))
 #define TCC_CC_DITH5_CC_Pos         5            /**< \brief (TCC_CC_DITH5) Channel Compare/Capture Value */
-#define TCC_CC_DITH5_CC_Msk         (0x7FFFFul << TCC_CC_DITH5_CC_Pos)
+#define TCC_CC_DITH5_CC_Msk         (_U_(0x7FFFF) << TCC_CC_DITH5_CC_Pos)
 #define TCC_CC_DITH5_CC(value)      (TCC_CC_DITH5_CC_Msk & ((value) << TCC_CC_DITH5_CC_Pos))
-#define TCC_CC_DITH5_MASK           0x00FFFFFFul /**< \brief (TCC_CC_DITH5) MASK Register */
+#define TCC_CC_DITH5_MASK           _U_(0x00FFFFFF) /**< \brief (TCC_CC_DITH5) MASK Register */
 
 // DITH6 mode
 #define TCC_CC_DITH6_DITHERCY_Pos   0            /**< \brief (TCC_CC_DITH6) Dithering Cycle Number */
-#define TCC_CC_DITH6_DITHERCY_Msk   (0x3Ful << TCC_CC_DITH6_DITHERCY_Pos)
+#define TCC_CC_DITH6_DITHERCY_Msk   (_U_(0x3F) << TCC_CC_DITH6_DITHERCY_Pos)
 #define TCC_CC_DITH6_DITHERCY(value) (TCC_CC_DITH6_DITHERCY_Msk & ((value) << TCC_CC_DITH6_DITHERCY_Pos))
 #define TCC_CC_DITH6_CC_Pos         6            /**< \brief (TCC_CC_DITH6) Channel Compare/Capture Value */
-#define TCC_CC_DITH6_CC_Msk         (0x3FFFFul << TCC_CC_DITH6_CC_Pos)
+#define TCC_CC_DITH6_CC_Msk         (_U_(0x3FFFF) << TCC_CC_DITH6_CC_Pos)
 #define TCC_CC_DITH6_CC(value)      (TCC_CC_DITH6_CC_Msk & ((value) << TCC_CC_DITH6_CC_Pos))
-#define TCC_CC_DITH6_MASK           0x00FFFFFFul /**< \brief (TCC_CC_DITH6) MASK Register */
+#define TCC_CC_DITH6_MASK           _U_(0x00FFFFFF) /**< \brief (TCC_CC_DITH6) MASK Register */
 
 #define TCC_CC_CC_Pos               0            /**< \brief (TCC_CC) Channel Compare/Capture Value */
-#define TCC_CC_CC_Msk               (0xFFFFFFul << TCC_CC_CC_Pos)
+#define TCC_CC_CC_Msk               (_U_(0xFFFFFF) << TCC_CC_CC_Pos)
 #define TCC_CC_CC(value)            (TCC_CC_CC_Msk & ((value) << TCC_CC_CC_Pos))
-#define TCC_CC_MASK                 0x00FFFFFFul /**< \brief (TCC_CC) MASK Register */
+#define TCC_CC_MASK                 _U_(0x00FFFFFF) /**< \brief (TCC_CC) MASK Register */
 
 /* -------- TCC_PATTB : (TCC Offset: 0x64) (R/W 16) Pattern Buffer -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1509,7 +1494,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_PATTB_OFFSET            0x64         /**< \brief (TCC_PATTB offset) Pattern Buffer */
-#define TCC_PATTB_RESETVALUE        0x0000ul     /**< \brief (TCC_PATTB reset_value) Pattern Buffer */
+#define TCC_PATTB_RESETVALUE        _U_(0x0000)   /**< \brief (TCC_PATTB reset_value) Pattern Buffer */
 
 #define TCC_PATTB_PGEB0_Pos         0            /**< \brief (TCC_PATTB) Pattern Generator 0 Output Enable Buffer */
 #define TCC_PATTB_PGEB0             (1 << TCC_PATTB_PGEB0_Pos)
@@ -1528,7 +1513,7 @@ typedef union {
 #define TCC_PATTB_PGEB7_Pos         7            /**< \brief (TCC_PATTB) Pattern Generator 7 Output Enable Buffer */
 #define TCC_PATTB_PGEB7             (1 << TCC_PATTB_PGEB7_Pos)
 #define TCC_PATTB_PGEB_Pos          0            /**< \brief (TCC_PATTB) Pattern Generator x Output Enable Buffer */
-#define TCC_PATTB_PGEB_Msk          (0xFFul << TCC_PATTB_PGEB_Pos)
+#define TCC_PATTB_PGEB_Msk          (_U_(0xFF) << TCC_PATTB_PGEB_Pos)
 #define TCC_PATTB_PGEB(value)       (TCC_PATTB_PGEB_Msk & ((value) << TCC_PATTB_PGEB_Pos))
 #define TCC_PATTB_PGVB0_Pos         8            /**< \brief (TCC_PATTB) Pattern Generator 0 Output Enable */
 #define TCC_PATTB_PGVB0             (1 << TCC_PATTB_PGVB0_Pos)
@@ -1547,9 +1532,9 @@ typedef union {
 #define TCC_PATTB_PGVB7_Pos         15           /**< \brief (TCC_PATTB) Pattern Generator 7 Output Enable */
 #define TCC_PATTB_PGVB7             (1 << TCC_PATTB_PGVB7_Pos)
 #define TCC_PATTB_PGVB_Pos          8            /**< \brief (TCC_PATTB) Pattern Generator x Output Enable */
-#define TCC_PATTB_PGVB_Msk          (0xFFul << TCC_PATTB_PGVB_Pos)
+#define TCC_PATTB_PGVB_Msk          (_U_(0xFF) << TCC_PATTB_PGVB_Pos)
 #define TCC_PATTB_PGVB(value)       (TCC_PATTB_PGVB_Msk & ((value) << TCC_PATTB_PGVB_Pos))
-#define TCC_PATTB_MASK              0xFFFFul     /**< \brief (TCC_PATTB) MASK Register */
+#define TCC_PATTB_MASK              _U_(0xFFFF)   /**< \brief (TCC_PATTB) MASK Register */
 
 /* -------- TCC_WAVEB : (TCC Offset: 0x68) (R/W 32) Waveform Control Buffer -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1590,18 +1575,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_WAVEB_OFFSET            0x68         /**< \brief (TCC_WAVEB offset) Waveform Control Buffer */
-#define TCC_WAVEB_RESETVALUE        0x00000000ul /**< \brief (TCC_WAVEB reset_value) Waveform Control Buffer */
+#define TCC_WAVEB_RESETVALUE        _U_(0x00000000) /**< \brief (TCC_WAVEB reset_value) Waveform Control Buffer */
 
 #define TCC_WAVEB_WAVEGENB_Pos      0            /**< \brief (TCC_WAVEB) Waveform Generation Buffer */
-#define TCC_WAVEB_WAVEGENB_Msk      (0x7ul << TCC_WAVEB_WAVEGENB_Pos)
+#define TCC_WAVEB_WAVEGENB_Msk      (_U_(0x7) << TCC_WAVEB_WAVEGENB_Pos)
 #define TCC_WAVEB_WAVEGENB(value)   (TCC_WAVEB_WAVEGENB_Msk & ((value) << TCC_WAVEB_WAVEGENB_Pos))
-#define   TCC_WAVEB_WAVEGENB_NFRQ_Val     0x0ul  /**< \brief (TCC_WAVEB) Normal frequency */
-#define   TCC_WAVEB_WAVEGENB_MFRQ_Val     0x1ul  /**< \brief (TCC_WAVEB) Match frequency */
-#define   TCC_WAVEB_WAVEGENB_NPWM_Val     0x2ul  /**< \brief (TCC_WAVEB) Normal PWM */
-#define   TCC_WAVEB_WAVEGENB_DSCRITICAL_Val 0x4ul  /**< \brief (TCC_WAVEB) Dual-slope critical */
-#define   TCC_WAVEB_WAVEGENB_DSBOTTOM_Val 0x5ul  /**< \brief (TCC_WAVEB) Dual-slope with interrupt/event condition when COUNT reaches ZERO */
-#define   TCC_WAVEB_WAVEGENB_DSBOTH_Val   0x6ul  /**< \brief (TCC_WAVEB) Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP */
-#define   TCC_WAVEB_WAVEGENB_DSTOP_Val    0x7ul  /**< \brief (TCC_WAVEB) Dual-slope with interrupt/event condition when COUNT reaches TOP */
+#define   TCC_WAVEB_WAVEGENB_NFRQ_Val     _U_(0x0)   /**< \brief (TCC_WAVEB) Normal frequency */
+#define   TCC_WAVEB_WAVEGENB_MFRQ_Val     _U_(0x1)   /**< \brief (TCC_WAVEB) Match frequency */
+#define   TCC_WAVEB_WAVEGENB_NPWM_Val     _U_(0x2)   /**< \brief (TCC_WAVEB) Normal PWM */
+#define   TCC_WAVEB_WAVEGENB_DSCRITICAL_Val _U_(0x4)   /**< \brief (TCC_WAVEB) Dual-slope critical */
+#define   TCC_WAVEB_WAVEGENB_DSBOTTOM_Val _U_(0x5)   /**< \brief (TCC_WAVEB) Dual-slope with interrupt/event condition when COUNT reaches ZERO */
+#define   TCC_WAVEB_WAVEGENB_DSBOTH_Val   _U_(0x6)   /**< \brief (TCC_WAVEB) Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP */
+#define   TCC_WAVEB_WAVEGENB_DSTOP_Val    _U_(0x7)   /**< \brief (TCC_WAVEB) Dual-slope with interrupt/event condition when COUNT reaches TOP */
 #define TCC_WAVEB_WAVEGENB_NFRQ     (TCC_WAVEB_WAVEGENB_NFRQ_Val   << TCC_WAVEB_WAVEGENB_Pos)
 #define TCC_WAVEB_WAVEGENB_MFRQ     (TCC_WAVEB_WAVEGENB_MFRQ_Val   << TCC_WAVEB_WAVEGENB_Pos)
 #define TCC_WAVEB_WAVEGENB_NPWM     (TCC_WAVEB_WAVEGENB_NPWM_Val   << TCC_WAVEB_WAVEGENB_Pos)
@@ -1610,16 +1595,16 @@ typedef union {
 #define TCC_WAVEB_WAVEGENB_DSBOTH   (TCC_WAVEB_WAVEGENB_DSBOTH_Val << TCC_WAVEB_WAVEGENB_Pos)
 #define TCC_WAVEB_WAVEGENB_DSTOP    (TCC_WAVEB_WAVEGENB_DSTOP_Val  << TCC_WAVEB_WAVEGENB_Pos)
 #define TCC_WAVEB_RAMPB_Pos         4            /**< \brief (TCC_WAVEB) Ramp Mode Buffer */
-#define TCC_WAVEB_RAMPB_Msk         (0x3ul << TCC_WAVEB_RAMPB_Pos)
+#define TCC_WAVEB_RAMPB_Msk         (_U_(0x3) << TCC_WAVEB_RAMPB_Pos)
 #define TCC_WAVEB_RAMPB(value)      (TCC_WAVEB_RAMPB_Msk & ((value) << TCC_WAVEB_RAMPB_Pos))
-#define   TCC_WAVEB_RAMPB_RAMP1_Val       0x0ul  /**< \brief (TCC_WAVEB) RAMP1 operation */
-#define   TCC_WAVEB_RAMPB_RAMP2A_Val      0x1ul  /**< \brief (TCC_WAVEB) Alternative RAMP2 operation */
-#define   TCC_WAVEB_RAMPB_RAMP2_Val       0x2ul  /**< \brief (TCC_WAVEB) RAMP2 operation */
+#define   TCC_WAVEB_RAMPB_RAMP1_Val       _U_(0x0)   /**< \brief (TCC_WAVEB) RAMP1 operation */
+#define   TCC_WAVEB_RAMPB_RAMP2A_Val      _U_(0x1)   /**< \brief (TCC_WAVEB) Alternative RAMP2 operation */
+#define   TCC_WAVEB_RAMPB_RAMP2_Val       _U_(0x2)   /**< \brief (TCC_WAVEB) RAMP2 operation */
 #define TCC_WAVEB_RAMPB_RAMP1       (TCC_WAVEB_RAMPB_RAMP1_Val     << TCC_WAVEB_RAMPB_Pos)
 #define TCC_WAVEB_RAMPB_RAMP2A      (TCC_WAVEB_RAMPB_RAMP2A_Val    << TCC_WAVEB_RAMPB_Pos)
 #define TCC_WAVEB_RAMPB_RAMP2       (TCC_WAVEB_RAMPB_RAMP2_Val     << TCC_WAVEB_RAMPB_Pos)
 #define TCC_WAVEB_CIPERENB_Pos      7            /**< \brief (TCC_WAVEB) Circular Period Enable Buffer */
-#define TCC_WAVEB_CIPERENB          (0x1ul << TCC_WAVEB_CIPERENB_Pos)
+#define TCC_WAVEB_CIPERENB          (_U_(0x1) << TCC_WAVEB_CIPERENB_Pos)
 #define TCC_WAVEB_CICCENB0_Pos      8            /**< \brief (TCC_WAVEB) Circular Channel 0 Enable Buffer */
 #define TCC_WAVEB_CICCENB0          (1 << TCC_WAVEB_CICCENB0_Pos)
 #define TCC_WAVEB_CICCENB1_Pos      9            /**< \brief (TCC_WAVEB) Circular Channel 1 Enable Buffer */
@@ -1629,7 +1614,7 @@ typedef union {
 #define TCC_WAVEB_CICCENB3_Pos      11           /**< \brief (TCC_WAVEB) Circular Channel 3 Enable Buffer */
 #define TCC_WAVEB_CICCENB3          (1 << TCC_WAVEB_CICCENB3_Pos)
 #define TCC_WAVEB_CICCENB_Pos       8            /**< \brief (TCC_WAVEB) Circular Channel x Enable Buffer */
-#define TCC_WAVEB_CICCENB_Msk       (0xFul << TCC_WAVEB_CICCENB_Pos)
+#define TCC_WAVEB_CICCENB_Msk       (_U_(0xF) << TCC_WAVEB_CICCENB_Pos)
 #define TCC_WAVEB_CICCENB(value)    (TCC_WAVEB_CICCENB_Msk & ((value) << TCC_WAVEB_CICCENB_Pos))
 #define TCC_WAVEB_POLB0_Pos         16           /**< \brief (TCC_WAVEB) Channel 0 Polarity Buffer */
 #define TCC_WAVEB_POLB0             (1 << TCC_WAVEB_POLB0_Pos)
@@ -1640,7 +1625,7 @@ typedef union {
 #define TCC_WAVEB_POLB3_Pos         19           /**< \brief (TCC_WAVEB) Channel 3 Polarity Buffer */
 #define TCC_WAVEB_POLB3             (1 << TCC_WAVEB_POLB3_Pos)
 #define TCC_WAVEB_POLB_Pos          16           /**< \brief (TCC_WAVEB) Channel x Polarity Buffer */
-#define TCC_WAVEB_POLB_Msk          (0xFul << TCC_WAVEB_POLB_Pos)
+#define TCC_WAVEB_POLB_Msk          (_U_(0xF) << TCC_WAVEB_POLB_Pos)
 #define TCC_WAVEB_POLB(value)       (TCC_WAVEB_POLB_Msk & ((value) << TCC_WAVEB_POLB_Pos))
 #define TCC_WAVEB_SWAPB0_Pos        24           /**< \brief (TCC_WAVEB) Swap DTI Output Pair 0 Buffer */
 #define TCC_WAVEB_SWAPB0            (1 << TCC_WAVEB_SWAPB0_Pos)
@@ -1651,9 +1636,9 @@ typedef union {
 #define TCC_WAVEB_SWAPB3_Pos        27           /**< \brief (TCC_WAVEB) Swap DTI Output Pair 3 Buffer */
 #define TCC_WAVEB_SWAPB3            (1 << TCC_WAVEB_SWAPB3_Pos)
 #define TCC_WAVEB_SWAPB_Pos         24           /**< \brief (TCC_WAVEB) Swap DTI Output Pair x Buffer */
-#define TCC_WAVEB_SWAPB_Msk         (0xFul << TCC_WAVEB_SWAPB_Pos)
+#define TCC_WAVEB_SWAPB_Msk         (_U_(0xF) << TCC_WAVEB_SWAPB_Pos)
 #define TCC_WAVEB_SWAPB(value)      (TCC_WAVEB_SWAPB_Msk & ((value) << TCC_WAVEB_SWAPB_Pos))
-#define TCC_WAVEB_MASK              0x0F0F0FB7ul /**< \brief (TCC_WAVEB) MASK Register */
+#define TCC_WAVEB_MASK              _U_(0x0F0F0FB7) /**< \brief (TCC_WAVEB) MASK Register */
 
 /* -------- TCC_PERB : (TCC Offset: 0x6C) (R/W 32) Period Buffer -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1682,39 +1667,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_PERB_OFFSET             0x6C         /**< \brief (TCC_PERB offset) Period Buffer */
-#define TCC_PERB_RESETVALUE         0xFFFFFFFFul /**< \brief (TCC_PERB reset_value) Period Buffer */
+#define TCC_PERB_RESETVALUE         _U_(0xFFFFFFFF) /**< \brief (TCC_PERB reset_value) Period Buffer */
 
 // DITH4 mode
 #define TCC_PERB_DITH4_DITHERCYB_Pos 0            /**< \brief (TCC_PERB_DITH4) Dithering Buffer Cycle Number */
-#define TCC_PERB_DITH4_DITHERCYB_Msk (0xFul << TCC_PERB_DITH4_DITHERCYB_Pos)
+#define TCC_PERB_DITH4_DITHERCYB_Msk (_U_(0xF) << TCC_PERB_DITH4_DITHERCYB_Pos)
 #define TCC_PERB_DITH4_DITHERCYB(value) (TCC_PERB_DITH4_DITHERCYB_Msk & ((value) << TCC_PERB_DITH4_DITHERCYB_Pos))
 #define TCC_PERB_DITH4_PERB_Pos     4            /**< \brief (TCC_PERB_DITH4) Period Buffer Value */
-#define TCC_PERB_DITH4_PERB_Msk     (0xFFFFFul << TCC_PERB_DITH4_PERB_Pos)
+#define TCC_PERB_DITH4_PERB_Msk     (_U_(0xFFFFF) << TCC_PERB_DITH4_PERB_Pos)
 #define TCC_PERB_DITH4_PERB(value)  (TCC_PERB_DITH4_PERB_Msk & ((value) << TCC_PERB_DITH4_PERB_Pos))
-#define TCC_PERB_DITH4_MASK         0x00FFFFFFul /**< \brief (TCC_PERB_DITH4) MASK Register */
+#define TCC_PERB_DITH4_MASK         _U_(0x00FFFFFF) /**< \brief (TCC_PERB_DITH4) MASK Register */
 
 // DITH5 mode
 #define TCC_PERB_DITH5_DITHERCYB_Pos 0            /**< \brief (TCC_PERB_DITH5) Dithering Buffer Cycle Number */
-#define TCC_PERB_DITH5_DITHERCYB_Msk (0x1Ful << TCC_PERB_DITH5_DITHERCYB_Pos)
+#define TCC_PERB_DITH5_DITHERCYB_Msk (_U_(0x1F) << TCC_PERB_DITH5_DITHERCYB_Pos)
 #define TCC_PERB_DITH5_DITHERCYB(value) (TCC_PERB_DITH5_DITHERCYB_Msk & ((value) << TCC_PERB_DITH5_DITHERCYB_Pos))
 #define TCC_PERB_DITH5_PERB_Pos     5            /**< \brief (TCC_PERB_DITH5) Period Buffer Value */
-#define TCC_PERB_DITH5_PERB_Msk     (0x7FFFFul << TCC_PERB_DITH5_PERB_Pos)
+#define TCC_PERB_DITH5_PERB_Msk     (_U_(0x7FFFF) << TCC_PERB_DITH5_PERB_Pos)
 #define TCC_PERB_DITH5_PERB(value)  (TCC_PERB_DITH5_PERB_Msk & ((value) << TCC_PERB_DITH5_PERB_Pos))
-#define TCC_PERB_DITH5_MASK         0x00FFFFFFul /**< \brief (TCC_PERB_DITH5) MASK Register */
+#define TCC_PERB_DITH5_MASK         _U_(0x00FFFFFF) /**< \brief (TCC_PERB_DITH5) MASK Register */
 
 // DITH6 mode
 #define TCC_PERB_DITH6_DITHERCYB_Pos 0            /**< \brief (TCC_PERB_DITH6) Dithering Buffer Cycle Number */
-#define TCC_PERB_DITH6_DITHERCYB_Msk (0x3Ful << TCC_PERB_DITH6_DITHERCYB_Pos)
+#define TCC_PERB_DITH6_DITHERCYB_Msk (_U_(0x3F) << TCC_PERB_DITH6_DITHERCYB_Pos)
 #define TCC_PERB_DITH6_DITHERCYB(value) (TCC_PERB_DITH6_DITHERCYB_Msk & ((value) << TCC_PERB_DITH6_DITHERCYB_Pos))
 #define TCC_PERB_DITH6_PERB_Pos     6            /**< \brief (TCC_PERB_DITH6) Period Buffer Value */
-#define TCC_PERB_DITH6_PERB_Msk     (0x3FFFFul << TCC_PERB_DITH6_PERB_Pos)
+#define TCC_PERB_DITH6_PERB_Msk     (_U_(0x3FFFF) << TCC_PERB_DITH6_PERB_Pos)
 #define TCC_PERB_DITH6_PERB(value)  (TCC_PERB_DITH6_PERB_Msk & ((value) << TCC_PERB_DITH6_PERB_Pos))
-#define TCC_PERB_DITH6_MASK         0x00FFFFFFul /**< \brief (TCC_PERB_DITH6) MASK Register */
+#define TCC_PERB_DITH6_MASK         _U_(0x00FFFFFF) /**< \brief (TCC_PERB_DITH6) MASK Register */
 
 #define TCC_PERB_PERB_Pos           0            /**< \brief (TCC_PERB) Period Buffer Value */
-#define TCC_PERB_PERB_Msk           (0xFFFFFFul << TCC_PERB_PERB_Pos)
+#define TCC_PERB_PERB_Msk           (_U_(0xFFFFFF) << TCC_PERB_PERB_Pos)
 #define TCC_PERB_PERB(value)        (TCC_PERB_PERB_Msk & ((value) << TCC_PERB_PERB_Pos))
-#define TCC_PERB_MASK               0x00FFFFFFul /**< \brief (TCC_PERB) MASK Register */
+#define TCC_PERB_MASK               _U_(0x00FFFFFF) /**< \brief (TCC_PERB) MASK Register */
 
 /* -------- TCC_CCB : (TCC Offset: 0x70) (R/W 32) Compare and Capture Buffer -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1743,39 +1728,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TCC_CCB_OFFSET              0x70         /**< \brief (TCC_CCB offset) Compare and Capture Buffer */
-#define TCC_CCB_RESETVALUE          0x00000000ul /**< \brief (TCC_CCB reset_value) Compare and Capture Buffer */
+#define TCC_CCB_RESETVALUE          _U_(0x00000000) /**< \brief (TCC_CCB reset_value) Compare and Capture Buffer */
 
 // DITH4 mode
 #define TCC_CCB_DITH4_DITHERCYB_Pos 0            /**< \brief (TCC_CCB_DITH4) Dithering Buffer Cycle Number */
-#define TCC_CCB_DITH4_DITHERCYB_Msk (0xFul << TCC_CCB_DITH4_DITHERCYB_Pos)
+#define TCC_CCB_DITH4_DITHERCYB_Msk (_U_(0xF) << TCC_CCB_DITH4_DITHERCYB_Pos)
 #define TCC_CCB_DITH4_DITHERCYB(value) (TCC_CCB_DITH4_DITHERCYB_Msk & ((value) << TCC_CCB_DITH4_DITHERCYB_Pos))
 #define TCC_CCB_DITH4_CCB_Pos       4            /**< \brief (TCC_CCB_DITH4) Channel Compare/Capture Buffer Value */
-#define TCC_CCB_DITH4_CCB_Msk       (0xFFFFFul << TCC_CCB_DITH4_CCB_Pos)
+#define TCC_CCB_DITH4_CCB_Msk       (_U_(0xFFFFF) << TCC_CCB_DITH4_CCB_Pos)
 #define TCC_CCB_DITH4_CCB(value)    (TCC_CCB_DITH4_CCB_Msk & ((value) << TCC_CCB_DITH4_CCB_Pos))
-#define TCC_CCB_DITH4_MASK          0x00FFFFFFul /**< \brief (TCC_CCB_DITH4) MASK Register */
+#define TCC_CCB_DITH4_MASK          _U_(0x00FFFFFF) /**< \brief (TCC_CCB_DITH4) MASK Register */
 
 // DITH5 mode
 #define TCC_CCB_DITH5_DITHERCYB_Pos 0            /**< \brief (TCC_CCB_DITH5) Dithering Buffer Cycle Number */
-#define TCC_CCB_DITH5_DITHERCYB_Msk (0x1Ful << TCC_CCB_DITH5_DITHERCYB_Pos)
+#define TCC_CCB_DITH5_DITHERCYB_Msk (_U_(0x1F) << TCC_CCB_DITH5_DITHERCYB_Pos)
 #define TCC_CCB_DITH5_DITHERCYB(value) (TCC_CCB_DITH5_DITHERCYB_Msk & ((value) << TCC_CCB_DITH5_DITHERCYB_Pos))
 #define TCC_CCB_DITH5_CCB_Pos       5            /**< \brief (TCC_CCB_DITH5) Channel Compare/Capture Buffer Value */
-#define TCC_CCB_DITH5_CCB_Msk       (0x7FFFFul << TCC_CCB_DITH5_CCB_Pos)
+#define TCC_CCB_DITH5_CCB_Msk       (_U_(0x7FFFF) << TCC_CCB_DITH5_CCB_Pos)
 #define TCC_CCB_DITH5_CCB(value)    (TCC_CCB_DITH5_CCB_Msk & ((value) << TCC_CCB_DITH5_CCB_Pos))
-#define TCC_CCB_DITH5_MASK          0x00FFFFFFul /**< \brief (TCC_CCB_DITH5) MASK Register */
+#define TCC_CCB_DITH5_MASK          _U_(0x00FFFFFF) /**< \brief (TCC_CCB_DITH5) MASK Register */
 
 // DITH6 mode
 #define TCC_CCB_DITH6_DITHERCYB_Pos 0            /**< \brief (TCC_CCB_DITH6) Dithering Buffer Cycle Number */
-#define TCC_CCB_DITH6_DITHERCYB_Msk (0x3Ful << TCC_CCB_DITH6_DITHERCYB_Pos)
+#define TCC_CCB_DITH6_DITHERCYB_Msk (_U_(0x3F) << TCC_CCB_DITH6_DITHERCYB_Pos)
 #define TCC_CCB_DITH6_DITHERCYB(value) (TCC_CCB_DITH6_DITHERCYB_Msk & ((value) << TCC_CCB_DITH6_DITHERCYB_Pos))
 #define TCC_CCB_DITH6_CCB_Pos       6            /**< \brief (TCC_CCB_DITH6) Channel Compare/Capture Buffer Value */
-#define TCC_CCB_DITH6_CCB_Msk       (0x3FFFFul << TCC_CCB_DITH6_CCB_Pos)
+#define TCC_CCB_DITH6_CCB_Msk       (_U_(0x3FFFF) << TCC_CCB_DITH6_CCB_Pos)
 #define TCC_CCB_DITH6_CCB(value)    (TCC_CCB_DITH6_CCB_Msk & ((value) << TCC_CCB_DITH6_CCB_Pos))
-#define TCC_CCB_DITH6_MASK          0x00FFFFFFul /**< \brief (TCC_CCB_DITH6) MASK Register */
+#define TCC_CCB_DITH6_MASK          _U_(0x00FFFFFF) /**< \brief (TCC_CCB_DITH6) MASK Register */
 
 #define TCC_CCB_CCB_Pos             0            /**< \brief (TCC_CCB) Channel Compare/Capture Buffer Value */
-#define TCC_CCB_CCB_Msk             (0xFFFFFFul << TCC_CCB_CCB_Pos)
+#define TCC_CCB_CCB_Msk             (_U_(0xFFFFFF) << TCC_CCB_CCB_Pos)
 #define TCC_CCB_CCB(value)          (TCC_CCB_CCB_Msk & ((value) << TCC_CCB_CCB_Pos))
-#define TCC_CCB_MASK                0x00FFFFFFul /**< \brief (TCC_CCB) MASK Register */
+#define TCC_CCB_MASK                _U_(0x00FFFFFF) /**< \brief (TCC_CCB) MASK Register */
 
 /** \brief TCC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/usb.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for USB
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -68,21 +53,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_CTRLA_OFFSET            0x000        /**< \brief (USB_CTRLA offset) Control A */
-#define USB_CTRLA_RESETVALUE        0x00ul       /**< \brief (USB_CTRLA reset_value) Control A */
+#define USB_CTRLA_RESETVALUE        _U_(0x00)     /**< \brief (USB_CTRLA reset_value) Control A */
 
 #define USB_CTRLA_SWRST_Pos         0            /**< \brief (USB_CTRLA) Software Reset */
-#define USB_CTRLA_SWRST             (0x1ul << USB_CTRLA_SWRST_Pos)
+#define USB_CTRLA_SWRST             (_U_(0x1) << USB_CTRLA_SWRST_Pos)
 #define USB_CTRLA_ENABLE_Pos        1            /**< \brief (USB_CTRLA) Enable */
-#define USB_CTRLA_ENABLE            (0x1ul << USB_CTRLA_ENABLE_Pos)
+#define USB_CTRLA_ENABLE            (_U_(0x1) << USB_CTRLA_ENABLE_Pos)
 #define USB_CTRLA_RUNSTDBY_Pos      2            /**< \brief (USB_CTRLA) Run in Standby Mode */
-#define USB_CTRLA_RUNSTDBY          (0x1ul << USB_CTRLA_RUNSTDBY_Pos)
+#define USB_CTRLA_RUNSTDBY          (_U_(0x1) << USB_CTRLA_RUNSTDBY_Pos)
 #define USB_CTRLA_MODE_Pos          7            /**< \brief (USB_CTRLA) Operating Mode */
-#define USB_CTRLA_MODE              (0x1ul << USB_CTRLA_MODE_Pos)
-#define   USB_CTRLA_MODE_DEVICE_Val       0x0ul  /**< \brief (USB_CTRLA) Device Mode */
-#define   USB_CTRLA_MODE_HOST_Val         0x1ul  /**< \brief (USB_CTRLA) Host Mode */
+#define USB_CTRLA_MODE              (_U_(0x1) << USB_CTRLA_MODE_Pos)
+#define   USB_CTRLA_MODE_DEVICE_Val       _U_(0x0)   /**< \brief (USB_CTRLA) Device Mode */
+#define   USB_CTRLA_MODE_HOST_Val         _U_(0x1)   /**< \brief (USB_CTRLA) Host Mode */
 #define USB_CTRLA_MODE_DEVICE       (USB_CTRLA_MODE_DEVICE_Val     << USB_CTRLA_MODE_Pos)
 #define USB_CTRLA_MODE_HOST         (USB_CTRLA_MODE_HOST_Val       << USB_CTRLA_MODE_Pos)
-#define USB_CTRLA_MASK              0x87ul       /**< \brief (USB_CTRLA) MASK Register */
+#define USB_CTRLA_MASK              _U_(0x87)     /**< \brief (USB_CTRLA) MASK Register */
 
 /* -------- USB_SYNCBUSY : (USB Offset: 0x002) (R/   8) Synchronization Busy -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -97,13 +82,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_SYNCBUSY_OFFSET         0x002        /**< \brief (USB_SYNCBUSY offset) Synchronization Busy */
-#define USB_SYNCBUSY_RESETVALUE     0x00ul       /**< \brief (USB_SYNCBUSY reset_value) Synchronization Busy */
+#define USB_SYNCBUSY_RESETVALUE     _U_(0x00)     /**< \brief (USB_SYNCBUSY reset_value) Synchronization Busy */
 
 #define USB_SYNCBUSY_SWRST_Pos      0            /**< \brief (USB_SYNCBUSY) Software Reset Synchronization Busy */
-#define USB_SYNCBUSY_SWRST          (0x1ul << USB_SYNCBUSY_SWRST_Pos)
+#define USB_SYNCBUSY_SWRST          (_U_(0x1) << USB_SYNCBUSY_SWRST_Pos)
 #define USB_SYNCBUSY_ENABLE_Pos     1            /**< \brief (USB_SYNCBUSY) Enable Synchronization Busy */
-#define USB_SYNCBUSY_ENABLE         (0x1ul << USB_SYNCBUSY_ENABLE_Pos)
-#define USB_SYNCBUSY_MASK           0x03ul       /**< \brief (USB_SYNCBUSY) MASK Register */
+#define USB_SYNCBUSY_ENABLE         (_U_(0x1) << USB_SYNCBUSY_ENABLE_Pos)
+#define USB_SYNCBUSY_MASK           _U_(0x03)     /**< \brief (USB_SYNCBUSY) MASK Register */
 
 /* -------- USB_QOSCTRL : (USB Offset: 0x003) (R/W  8) USB Quality Of Service -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -118,31 +103,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_QOSCTRL_OFFSET          0x003        /**< \brief (USB_QOSCTRL offset) USB Quality Of Service */
-#define USB_QOSCTRL_RESETVALUE      0x05ul       /**< \brief (USB_QOSCTRL reset_value) USB Quality Of Service */
+#define USB_QOSCTRL_RESETVALUE      _U_(0x05)     /**< \brief (USB_QOSCTRL reset_value) USB Quality Of Service */
 
 #define USB_QOSCTRL_CQOS_Pos        0            /**< \brief (USB_QOSCTRL) Configuration Quality of Service */
-#define USB_QOSCTRL_CQOS_Msk        (0x3ul << USB_QOSCTRL_CQOS_Pos)
+#define USB_QOSCTRL_CQOS_Msk        (_U_(0x3) << USB_QOSCTRL_CQOS_Pos)
 #define USB_QOSCTRL_CQOS(value)     (USB_QOSCTRL_CQOS_Msk & ((value) << USB_QOSCTRL_CQOS_Pos))
-#define   USB_QOSCTRL_CQOS_DISABLE_Val    0x0ul  /**< \brief (USB_QOSCTRL) Background (no sensitive operation) */
-#define   USB_QOSCTRL_CQOS_LOW_Val        0x1ul  /**< \brief (USB_QOSCTRL) Sensitive Bandwidth */
-#define   USB_QOSCTRL_CQOS_MEDIUM_Val     0x2ul  /**< \brief (USB_QOSCTRL) Sensitive Latency */
-#define   USB_QOSCTRL_CQOS_HIGH_Val       0x3ul  /**< \brief (USB_QOSCTRL) Critical Latency */
+#define   USB_QOSCTRL_CQOS_DISABLE_Val    _U_(0x0)   /**< \brief (USB_QOSCTRL) Background (no sensitive operation) */
+#define   USB_QOSCTRL_CQOS_LOW_Val        _U_(0x1)   /**< \brief (USB_QOSCTRL) Sensitive Bandwidth */
+#define   USB_QOSCTRL_CQOS_MEDIUM_Val     _U_(0x2)   /**< \brief (USB_QOSCTRL) Sensitive Latency */
+#define   USB_QOSCTRL_CQOS_HIGH_Val       _U_(0x3)   /**< \brief (USB_QOSCTRL) Critical Latency */
 #define USB_QOSCTRL_CQOS_DISABLE    (USB_QOSCTRL_CQOS_DISABLE_Val  << USB_QOSCTRL_CQOS_Pos)
 #define USB_QOSCTRL_CQOS_LOW        (USB_QOSCTRL_CQOS_LOW_Val      << USB_QOSCTRL_CQOS_Pos)
 #define USB_QOSCTRL_CQOS_MEDIUM     (USB_QOSCTRL_CQOS_MEDIUM_Val   << USB_QOSCTRL_CQOS_Pos)
 #define USB_QOSCTRL_CQOS_HIGH       (USB_QOSCTRL_CQOS_HIGH_Val     << USB_QOSCTRL_CQOS_Pos)
 #define USB_QOSCTRL_DQOS_Pos        2            /**< \brief (USB_QOSCTRL) Data Quality of Service */
-#define USB_QOSCTRL_DQOS_Msk        (0x3ul << USB_QOSCTRL_DQOS_Pos)
+#define USB_QOSCTRL_DQOS_Msk        (_U_(0x3) << USB_QOSCTRL_DQOS_Pos)
 #define USB_QOSCTRL_DQOS(value)     (USB_QOSCTRL_DQOS_Msk & ((value) << USB_QOSCTRL_DQOS_Pos))
-#define   USB_QOSCTRL_DQOS_DISABLE_Val    0x0ul  /**< \brief (USB_QOSCTRL) Background (no sensitive operation) */
-#define   USB_QOSCTRL_DQOS_LOW_Val        0x1ul  /**< \brief (USB_QOSCTRL) Sensitive Bandwidth */
-#define   USB_QOSCTRL_DQOS_MEDIUM_Val     0x2ul  /**< \brief (USB_QOSCTRL) Sensitive Latency */
-#define   USB_QOSCTRL_DQOS_HIGH_Val       0x3ul  /**< \brief (USB_QOSCTRL) Critical Latency */
+#define   USB_QOSCTRL_DQOS_DISABLE_Val    _U_(0x0)   /**< \brief (USB_QOSCTRL) Background (no sensitive operation) */
+#define   USB_QOSCTRL_DQOS_LOW_Val        _U_(0x1)   /**< \brief (USB_QOSCTRL) Sensitive Bandwidth */
+#define   USB_QOSCTRL_DQOS_MEDIUM_Val     _U_(0x2)   /**< \brief (USB_QOSCTRL) Sensitive Latency */
+#define   USB_QOSCTRL_DQOS_HIGH_Val       _U_(0x3)   /**< \brief (USB_QOSCTRL) Critical Latency */
 #define USB_QOSCTRL_DQOS_DISABLE    (USB_QOSCTRL_DQOS_DISABLE_Val  << USB_QOSCTRL_DQOS_Pos)
 #define USB_QOSCTRL_DQOS_LOW        (USB_QOSCTRL_DQOS_LOW_Val      << USB_QOSCTRL_DQOS_Pos)
 #define USB_QOSCTRL_DQOS_MEDIUM     (USB_QOSCTRL_DQOS_MEDIUM_Val   << USB_QOSCTRL_DQOS_Pos)
 #define USB_QOSCTRL_DQOS_HIGH       (USB_QOSCTRL_DQOS_HIGH_Val     << USB_QOSCTRL_DQOS_Pos)
-#define USB_QOSCTRL_MASK            0x0Ful       /**< \brief (USB_QOSCTRL) MASK Register */
+#define USB_QOSCTRL_MASK            _U_(0x0F)     /**< \brief (USB_QOSCTRL) MASK Register */
 
 /* -------- USB_DEVICE_CTRLB : (USB Offset: 0x008) (R/W 16) DEVICE DEVICE Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -165,47 +150,47 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_CTRLB_OFFSET     0x008        /**< \brief (USB_DEVICE_CTRLB offset) DEVICE Control B */
-#define USB_DEVICE_CTRLB_RESETVALUE 0x0001ul     /**< \brief (USB_DEVICE_CTRLB reset_value) DEVICE Control B */
+#define USB_DEVICE_CTRLB_RESETVALUE _U_(0x0001)   /**< \brief (USB_DEVICE_CTRLB reset_value) DEVICE Control B */
 
 #define USB_DEVICE_CTRLB_DETACH_Pos 0            /**< \brief (USB_DEVICE_CTRLB) Detach */
-#define USB_DEVICE_CTRLB_DETACH     (0x1ul << USB_DEVICE_CTRLB_DETACH_Pos)
+#define USB_DEVICE_CTRLB_DETACH     (_U_(0x1) << USB_DEVICE_CTRLB_DETACH_Pos)
 #define USB_DEVICE_CTRLB_UPRSM_Pos  1            /**< \brief (USB_DEVICE_CTRLB) Upstream Resume */
-#define USB_DEVICE_CTRLB_UPRSM      (0x1ul << USB_DEVICE_CTRLB_UPRSM_Pos)
+#define USB_DEVICE_CTRLB_UPRSM      (_U_(0x1) << USB_DEVICE_CTRLB_UPRSM_Pos)
 #define USB_DEVICE_CTRLB_SPDCONF_Pos 2            /**< \brief (USB_DEVICE_CTRLB) Speed Configuration */
-#define USB_DEVICE_CTRLB_SPDCONF_Msk (0x3ul << USB_DEVICE_CTRLB_SPDCONF_Pos)
+#define USB_DEVICE_CTRLB_SPDCONF_Msk (_U_(0x3) << USB_DEVICE_CTRLB_SPDCONF_Pos)
 #define USB_DEVICE_CTRLB_SPDCONF(value) (USB_DEVICE_CTRLB_SPDCONF_Msk & ((value) << USB_DEVICE_CTRLB_SPDCONF_Pos))
-#define   USB_DEVICE_CTRLB_SPDCONF_FS_Val 0x0ul  /**< \brief (USB_DEVICE_CTRLB) FS : Full Speed */
-#define   USB_DEVICE_CTRLB_SPDCONF_LS_Val 0x1ul  /**< \brief (USB_DEVICE_CTRLB) LS : Low Speed */
-#define   USB_DEVICE_CTRLB_SPDCONF_HS_Val 0x2ul  /**< \brief (USB_DEVICE_CTRLB) HS : High Speed capable */
-#define   USB_DEVICE_CTRLB_SPDCONF_HSTM_Val 0x3ul  /**< \brief (USB_DEVICE_CTRLB) HSTM: High Speed Test Mode (force high-speed mode for test mode) */
+#define   USB_DEVICE_CTRLB_SPDCONF_FS_Val _U_(0x0)   /**< \brief (USB_DEVICE_CTRLB) FS : Full Speed */
+#define   USB_DEVICE_CTRLB_SPDCONF_LS_Val _U_(0x1)   /**< \brief (USB_DEVICE_CTRLB) LS : Low Speed */
+#define   USB_DEVICE_CTRLB_SPDCONF_HS_Val _U_(0x2)   /**< \brief (USB_DEVICE_CTRLB) HS : High Speed capable */
+#define   USB_DEVICE_CTRLB_SPDCONF_HSTM_Val _U_(0x3)   /**< \brief (USB_DEVICE_CTRLB) HSTM: High Speed Test Mode (force high-speed mode for test mode) */
 #define USB_DEVICE_CTRLB_SPDCONF_FS (USB_DEVICE_CTRLB_SPDCONF_FS_Val << USB_DEVICE_CTRLB_SPDCONF_Pos)
 #define USB_DEVICE_CTRLB_SPDCONF_LS (USB_DEVICE_CTRLB_SPDCONF_LS_Val << USB_DEVICE_CTRLB_SPDCONF_Pos)
 #define USB_DEVICE_CTRLB_SPDCONF_HS (USB_DEVICE_CTRLB_SPDCONF_HS_Val << USB_DEVICE_CTRLB_SPDCONF_Pos)
 #define USB_DEVICE_CTRLB_SPDCONF_HSTM (USB_DEVICE_CTRLB_SPDCONF_HSTM_Val << USB_DEVICE_CTRLB_SPDCONF_Pos)
 #define USB_DEVICE_CTRLB_NREPLY_Pos 4            /**< \brief (USB_DEVICE_CTRLB) No Reply */
-#define USB_DEVICE_CTRLB_NREPLY     (0x1ul << USB_DEVICE_CTRLB_NREPLY_Pos)
+#define USB_DEVICE_CTRLB_NREPLY     (_U_(0x1) << USB_DEVICE_CTRLB_NREPLY_Pos)
 #define USB_DEVICE_CTRLB_TSTJ_Pos   5            /**< \brief (USB_DEVICE_CTRLB) Test mode J */
-#define USB_DEVICE_CTRLB_TSTJ       (0x1ul << USB_DEVICE_CTRLB_TSTJ_Pos)
+#define USB_DEVICE_CTRLB_TSTJ       (_U_(0x1) << USB_DEVICE_CTRLB_TSTJ_Pos)
 #define USB_DEVICE_CTRLB_TSTK_Pos   6            /**< \brief (USB_DEVICE_CTRLB) Test mode K */
-#define USB_DEVICE_CTRLB_TSTK       (0x1ul << USB_DEVICE_CTRLB_TSTK_Pos)
+#define USB_DEVICE_CTRLB_TSTK       (_U_(0x1) << USB_DEVICE_CTRLB_TSTK_Pos)
 #define USB_DEVICE_CTRLB_TSTPCKT_Pos 7            /**< \brief (USB_DEVICE_CTRLB) Test packet mode */
-#define USB_DEVICE_CTRLB_TSTPCKT    (0x1ul << USB_DEVICE_CTRLB_TSTPCKT_Pos)
+#define USB_DEVICE_CTRLB_TSTPCKT    (_U_(0x1) << USB_DEVICE_CTRLB_TSTPCKT_Pos)
 #define USB_DEVICE_CTRLB_OPMODE2_Pos 8            /**< \brief (USB_DEVICE_CTRLB) Specific Operational Mode */
-#define USB_DEVICE_CTRLB_OPMODE2    (0x1ul << USB_DEVICE_CTRLB_OPMODE2_Pos)
+#define USB_DEVICE_CTRLB_OPMODE2    (_U_(0x1) << USB_DEVICE_CTRLB_OPMODE2_Pos)
 #define USB_DEVICE_CTRLB_GNAK_Pos   9            /**< \brief (USB_DEVICE_CTRLB) Global NAK */
-#define USB_DEVICE_CTRLB_GNAK       (0x1ul << USB_DEVICE_CTRLB_GNAK_Pos)
+#define USB_DEVICE_CTRLB_GNAK       (_U_(0x1) << USB_DEVICE_CTRLB_GNAK_Pos)
 #define USB_DEVICE_CTRLB_LPMHDSK_Pos 10           /**< \brief (USB_DEVICE_CTRLB) Link Power Management Handshake */
-#define USB_DEVICE_CTRLB_LPMHDSK_Msk (0x3ul << USB_DEVICE_CTRLB_LPMHDSK_Pos)
+#define USB_DEVICE_CTRLB_LPMHDSK_Msk (_U_(0x3) << USB_DEVICE_CTRLB_LPMHDSK_Pos)
 #define USB_DEVICE_CTRLB_LPMHDSK(value) (USB_DEVICE_CTRLB_LPMHDSK_Msk & ((value) << USB_DEVICE_CTRLB_LPMHDSK_Pos))
-#define   USB_DEVICE_CTRLB_LPMHDSK_NO_Val 0x0ul  /**< \brief (USB_DEVICE_CTRLB) No handshake. LPM is not supported */
-#define   USB_DEVICE_CTRLB_LPMHDSK_ACK_Val 0x1ul  /**< \brief (USB_DEVICE_CTRLB) ACK */
-#define   USB_DEVICE_CTRLB_LPMHDSK_NYET_Val 0x2ul  /**< \brief (USB_DEVICE_CTRLB) NYET */
-#define   USB_DEVICE_CTRLB_LPMHDSK_STALL_Val 0x3ul  /**< \brief (USB_DEVICE_CTRLB) STALL */
+#define   USB_DEVICE_CTRLB_LPMHDSK_NO_Val _U_(0x0)   /**< \brief (USB_DEVICE_CTRLB) No handshake. LPM is not supported */
+#define   USB_DEVICE_CTRLB_LPMHDSK_ACK_Val _U_(0x1)   /**< \brief (USB_DEVICE_CTRLB) ACK */
+#define   USB_DEVICE_CTRLB_LPMHDSK_NYET_Val _U_(0x2)   /**< \brief (USB_DEVICE_CTRLB) NYET */
+#define   USB_DEVICE_CTRLB_LPMHDSK_STALL_Val _U_(0x3)   /**< \brief (USB_DEVICE_CTRLB) STALL */
 #define USB_DEVICE_CTRLB_LPMHDSK_NO (USB_DEVICE_CTRLB_LPMHDSK_NO_Val << USB_DEVICE_CTRLB_LPMHDSK_Pos)
 #define USB_DEVICE_CTRLB_LPMHDSK_ACK (USB_DEVICE_CTRLB_LPMHDSK_ACK_Val << USB_DEVICE_CTRLB_LPMHDSK_Pos)
 #define USB_DEVICE_CTRLB_LPMHDSK_NYET (USB_DEVICE_CTRLB_LPMHDSK_NYET_Val << USB_DEVICE_CTRLB_LPMHDSK_Pos)
 #define USB_DEVICE_CTRLB_LPMHDSK_STALL (USB_DEVICE_CTRLB_LPMHDSK_STALL_Val << USB_DEVICE_CTRLB_LPMHDSK_Pos)
-#define USB_DEVICE_CTRLB_MASK       0x0FFFul     /**< \brief (USB_DEVICE_CTRLB) MASK Register */
+#define USB_DEVICE_CTRLB_MASK       _U_(0x0FFF)   /**< \brief (USB_DEVICE_CTRLB) MASK Register */
 
 /* -------- USB_HOST_CTRLB : (USB Offset: 0x008) (R/W 16) HOST HOST Control B -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -229,30 +214,30 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_CTRLB_OFFSET       0x008        /**< \brief (USB_HOST_CTRLB offset) HOST Control B */
-#define USB_HOST_CTRLB_RESETVALUE   0x0000ul     /**< \brief (USB_HOST_CTRLB reset_value) HOST Control B */
+#define USB_HOST_CTRLB_RESETVALUE   _U_(0x0000)   /**< \brief (USB_HOST_CTRLB reset_value) HOST Control B */
 
 #define USB_HOST_CTRLB_RESUME_Pos   1            /**< \brief (USB_HOST_CTRLB) Send USB Resume */
-#define USB_HOST_CTRLB_RESUME       (0x1ul << USB_HOST_CTRLB_RESUME_Pos)
+#define USB_HOST_CTRLB_RESUME       (_U_(0x1) << USB_HOST_CTRLB_RESUME_Pos)
 #define USB_HOST_CTRLB_SPDCONF_Pos  2            /**< \brief (USB_HOST_CTRLB) Speed Configuration for Host */
-#define USB_HOST_CTRLB_SPDCONF_Msk  (0x3ul << USB_HOST_CTRLB_SPDCONF_Pos)
+#define USB_HOST_CTRLB_SPDCONF_Msk  (_U_(0x3) << USB_HOST_CTRLB_SPDCONF_Pos)
 #define USB_HOST_CTRLB_SPDCONF(value) (USB_HOST_CTRLB_SPDCONF_Msk & ((value) << USB_HOST_CTRLB_SPDCONF_Pos))
-#define   USB_HOST_CTRLB_SPDCONF_NORMAL_Val 0x0ul  /**< \brief (USB_HOST_CTRLB) Normal mode:the host starts in full-speed mode and performs a high-speed reset to switch to the high speed mode if the downstream peripheral is high-speed capable. */
-#define   USB_HOST_CTRLB_SPDCONF_FS_Val   0x3ul  /**< \brief (USB_HOST_CTRLB) Full-speed:the host remains in full-speed mode whatever is the peripheral speed capability. Relevant in UTMI mode only. */
+#define   USB_HOST_CTRLB_SPDCONF_NORMAL_Val _U_(0x0)   /**< \brief (USB_HOST_CTRLB) Normal mode:the host starts in full-speed mode and performs a high-speed reset to switch to the high speed mode if the downstream peripheral is high-speed capable. */
+#define   USB_HOST_CTRLB_SPDCONF_FS_Val   _U_(0x3)   /**< \brief (USB_HOST_CTRLB) Full-speed:the host remains in full-speed mode whatever is the peripheral speed capability. Relevant in UTMI mode only. */
 #define USB_HOST_CTRLB_SPDCONF_NORMAL (USB_HOST_CTRLB_SPDCONF_NORMAL_Val << USB_HOST_CTRLB_SPDCONF_Pos)
 #define USB_HOST_CTRLB_SPDCONF_FS   (USB_HOST_CTRLB_SPDCONF_FS_Val << USB_HOST_CTRLB_SPDCONF_Pos)
 #define USB_HOST_CTRLB_TSTJ_Pos     5            /**< \brief (USB_HOST_CTRLB) Test mode J */
-#define USB_HOST_CTRLB_TSTJ         (0x1ul << USB_HOST_CTRLB_TSTJ_Pos)
+#define USB_HOST_CTRLB_TSTJ         (_U_(0x1) << USB_HOST_CTRLB_TSTJ_Pos)
 #define USB_HOST_CTRLB_TSTK_Pos     6            /**< \brief (USB_HOST_CTRLB) Test mode K */
-#define USB_HOST_CTRLB_TSTK         (0x1ul << USB_HOST_CTRLB_TSTK_Pos)
+#define USB_HOST_CTRLB_TSTK         (_U_(0x1) << USB_HOST_CTRLB_TSTK_Pos)
 #define USB_HOST_CTRLB_SOFE_Pos     8            /**< \brief (USB_HOST_CTRLB) Start of Frame Generation Enable */
-#define USB_HOST_CTRLB_SOFE         (0x1ul << USB_HOST_CTRLB_SOFE_Pos)
+#define USB_HOST_CTRLB_SOFE         (_U_(0x1) << USB_HOST_CTRLB_SOFE_Pos)
 #define USB_HOST_CTRLB_BUSRESET_Pos 9            /**< \brief (USB_HOST_CTRLB) Send USB Reset */
-#define USB_HOST_CTRLB_BUSRESET     (0x1ul << USB_HOST_CTRLB_BUSRESET_Pos)
+#define USB_HOST_CTRLB_BUSRESET     (_U_(0x1) << USB_HOST_CTRLB_BUSRESET_Pos)
 #define USB_HOST_CTRLB_VBUSOK_Pos   10           /**< \brief (USB_HOST_CTRLB) VBUS is OK */
-#define USB_HOST_CTRLB_VBUSOK       (0x1ul << USB_HOST_CTRLB_VBUSOK_Pos)
+#define USB_HOST_CTRLB_VBUSOK       (_U_(0x1) << USB_HOST_CTRLB_VBUSOK_Pos)
 #define USB_HOST_CTRLB_L1RESUME_Pos 11           /**< \brief (USB_HOST_CTRLB) Send L1 Resume */
-#define USB_HOST_CTRLB_L1RESUME     (0x1ul << USB_HOST_CTRLB_L1RESUME_Pos)
-#define USB_HOST_CTRLB_MASK         0x0F6Eul     /**< \brief (USB_HOST_CTRLB) MASK Register */
+#define USB_HOST_CTRLB_L1RESUME     (_U_(0x1) << USB_HOST_CTRLB_L1RESUME_Pos)
+#define USB_HOST_CTRLB_MASK         _U_(0x0F6E)   /**< \brief (USB_HOST_CTRLB) MASK Register */
 
 /* -------- USB_DEVICE_DADD : (USB Offset: 0x00A) (R/W  8) DEVICE DEVICE Device Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -266,14 +251,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_DADD_OFFSET      0x00A        /**< \brief (USB_DEVICE_DADD offset) DEVICE Device Address */
-#define USB_DEVICE_DADD_RESETVALUE  0x00ul       /**< \brief (USB_DEVICE_DADD reset_value) DEVICE Device Address */
+#define USB_DEVICE_DADD_RESETVALUE  _U_(0x00)     /**< \brief (USB_DEVICE_DADD reset_value) DEVICE Device Address */
 
 #define USB_DEVICE_DADD_DADD_Pos    0            /**< \brief (USB_DEVICE_DADD) Device Address */
-#define USB_DEVICE_DADD_DADD_Msk    (0x7Ful << USB_DEVICE_DADD_DADD_Pos)
+#define USB_DEVICE_DADD_DADD_Msk    (_U_(0x7F) << USB_DEVICE_DADD_DADD_Pos)
 #define USB_DEVICE_DADD_DADD(value) (USB_DEVICE_DADD_DADD_Msk & ((value) << USB_DEVICE_DADD_DADD_Pos))
 #define USB_DEVICE_DADD_ADDEN_Pos   7            /**< \brief (USB_DEVICE_DADD) Device Address Enable */
-#define USB_DEVICE_DADD_ADDEN       (0x1ul << USB_DEVICE_DADD_ADDEN_Pos)
-#define USB_DEVICE_DADD_MASK        0xFFul       /**< \brief (USB_DEVICE_DADD) MASK Register */
+#define USB_DEVICE_DADD_ADDEN       (_U_(0x1) << USB_DEVICE_DADD_ADDEN_Pos)
+#define USB_DEVICE_DADD_MASK        _U_(0xFF)     /**< \brief (USB_DEVICE_DADD) MASK Register */
 
 /* -------- USB_HOST_HSOFC : (USB Offset: 0x00A) (R/W  8) HOST HOST Host Start Of Frame Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -288,14 +273,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_HSOFC_OFFSET       0x00A        /**< \brief (USB_HOST_HSOFC offset) HOST Host Start Of Frame Control */
-#define USB_HOST_HSOFC_RESETVALUE   0x00ul       /**< \brief (USB_HOST_HSOFC reset_value) HOST Host Start Of Frame Control */
+#define USB_HOST_HSOFC_RESETVALUE   _U_(0x00)     /**< \brief (USB_HOST_HSOFC reset_value) HOST Host Start Of Frame Control */
 
 #define USB_HOST_HSOFC_FLENC_Pos    0            /**< \brief (USB_HOST_HSOFC) Frame Length Control */
-#define USB_HOST_HSOFC_FLENC_Msk    (0xFul << USB_HOST_HSOFC_FLENC_Pos)
+#define USB_HOST_HSOFC_FLENC_Msk    (_U_(0xF) << USB_HOST_HSOFC_FLENC_Pos)
 #define USB_HOST_HSOFC_FLENC(value) (USB_HOST_HSOFC_FLENC_Msk & ((value) << USB_HOST_HSOFC_FLENC_Pos))
 #define USB_HOST_HSOFC_FLENCE_Pos   7            /**< \brief (USB_HOST_HSOFC) Frame Length Control Enable */
-#define USB_HOST_HSOFC_FLENCE       (0x1ul << USB_HOST_HSOFC_FLENCE_Pos)
-#define USB_HOST_HSOFC_MASK         0x8Ful       /**< \brief (USB_HOST_HSOFC) MASK Register */
+#define USB_HOST_HSOFC_FLENCE       (_U_(0x1) << USB_HOST_HSOFC_FLENCE_Pos)
+#define USB_HOST_HSOFC_MASK         _U_(0x8F)     /**< \brief (USB_HOST_HSOFC) MASK Register */
 
 /* -------- USB_DEVICE_STATUS : (USB Offset: 0x00C) (R/   8) DEVICE DEVICE Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -311,27 +296,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_STATUS_OFFSET    0x00C        /**< \brief (USB_DEVICE_STATUS offset) DEVICE Status */
-#define USB_DEVICE_STATUS_RESETVALUE 0x40ul       /**< \brief (USB_DEVICE_STATUS reset_value) DEVICE Status */
+#define USB_DEVICE_STATUS_RESETVALUE _U_(0x40)     /**< \brief (USB_DEVICE_STATUS reset_value) DEVICE Status */
 
 #define USB_DEVICE_STATUS_SPEED_Pos 2            /**< \brief (USB_DEVICE_STATUS) Speed Status */
-#define USB_DEVICE_STATUS_SPEED_Msk (0x3ul << USB_DEVICE_STATUS_SPEED_Pos)
+#define USB_DEVICE_STATUS_SPEED_Msk (_U_(0x3) << USB_DEVICE_STATUS_SPEED_Pos)
 #define USB_DEVICE_STATUS_SPEED(value) (USB_DEVICE_STATUS_SPEED_Msk & ((value) << USB_DEVICE_STATUS_SPEED_Pos))
-#define   USB_DEVICE_STATUS_SPEED_FS_Val  0x0ul  /**< \brief (USB_DEVICE_STATUS) Full-speed mode */
-#define   USB_DEVICE_STATUS_SPEED_HS_Val  0x1ul  /**< \brief (USB_DEVICE_STATUS) High-speed mode */
-#define   USB_DEVICE_STATUS_SPEED_LS_Val  0x2ul  /**< \brief (USB_DEVICE_STATUS) Low-speed mode */
+#define   USB_DEVICE_STATUS_SPEED_FS_Val  _U_(0x0)   /**< \brief (USB_DEVICE_STATUS) Full-speed mode */
+#define   USB_DEVICE_STATUS_SPEED_HS_Val  _U_(0x1)   /**< \brief (USB_DEVICE_STATUS) High-speed mode */
+#define   USB_DEVICE_STATUS_SPEED_LS_Val  _U_(0x2)   /**< \brief (USB_DEVICE_STATUS) Low-speed mode */
 #define USB_DEVICE_STATUS_SPEED_FS  (USB_DEVICE_STATUS_SPEED_FS_Val << USB_DEVICE_STATUS_SPEED_Pos)
 #define USB_DEVICE_STATUS_SPEED_HS  (USB_DEVICE_STATUS_SPEED_HS_Val << USB_DEVICE_STATUS_SPEED_Pos)
 #define USB_DEVICE_STATUS_SPEED_LS  (USB_DEVICE_STATUS_SPEED_LS_Val << USB_DEVICE_STATUS_SPEED_Pos)
 #define USB_DEVICE_STATUS_LINESTATE_Pos 6            /**< \brief (USB_DEVICE_STATUS) USB Line State Status */
-#define USB_DEVICE_STATUS_LINESTATE_Msk (0x3ul << USB_DEVICE_STATUS_LINESTATE_Pos)
+#define USB_DEVICE_STATUS_LINESTATE_Msk (_U_(0x3) << USB_DEVICE_STATUS_LINESTATE_Pos)
 #define USB_DEVICE_STATUS_LINESTATE(value) (USB_DEVICE_STATUS_LINESTATE_Msk & ((value) << USB_DEVICE_STATUS_LINESTATE_Pos))
-#define   USB_DEVICE_STATUS_LINESTATE_0_Val 0x0ul  /**< \brief (USB_DEVICE_STATUS) SE0/RESET */
-#define   USB_DEVICE_STATUS_LINESTATE_1_Val 0x1ul  /**< \brief (USB_DEVICE_STATUS) FS-J or LS-K State */
-#define   USB_DEVICE_STATUS_LINESTATE_2_Val 0x2ul  /**< \brief (USB_DEVICE_STATUS) FS-K or LS-J State */
+#define   USB_DEVICE_STATUS_LINESTATE_0_Val _U_(0x0)   /**< \brief (USB_DEVICE_STATUS) SE0/RESET */
+#define   USB_DEVICE_STATUS_LINESTATE_1_Val _U_(0x1)   /**< \brief (USB_DEVICE_STATUS) FS-J or LS-K State */
+#define   USB_DEVICE_STATUS_LINESTATE_2_Val _U_(0x2)   /**< \brief (USB_DEVICE_STATUS) FS-K or LS-J State */
 #define USB_DEVICE_STATUS_LINESTATE_0 (USB_DEVICE_STATUS_LINESTATE_0_Val << USB_DEVICE_STATUS_LINESTATE_Pos)
 #define USB_DEVICE_STATUS_LINESTATE_1 (USB_DEVICE_STATUS_LINESTATE_1_Val << USB_DEVICE_STATUS_LINESTATE_Pos)
 #define USB_DEVICE_STATUS_LINESTATE_2 (USB_DEVICE_STATUS_LINESTATE_2_Val << USB_DEVICE_STATUS_LINESTATE_Pos)
-#define USB_DEVICE_STATUS_MASK      0xCCul       /**< \brief (USB_DEVICE_STATUS) MASK Register */
+#define USB_DEVICE_STATUS_MASK      _U_(0xCC)     /**< \brief (USB_DEVICE_STATUS) MASK Register */
 
 /* -------- USB_HOST_STATUS : (USB Offset: 0x00C) (R/W  8) HOST HOST Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -347,40 +332,40 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_STATUS_OFFSET      0x00C        /**< \brief (USB_HOST_STATUS offset) HOST Status */
-#define USB_HOST_STATUS_RESETVALUE  0x00ul       /**< \brief (USB_HOST_STATUS reset_value) HOST Status */
+#define USB_HOST_STATUS_RESETVALUE  _U_(0x00)     /**< \brief (USB_HOST_STATUS reset_value) HOST Status */
 
 #define USB_HOST_STATUS_SPEED_Pos   2            /**< \brief (USB_HOST_STATUS) Speed Status */
-#define USB_HOST_STATUS_SPEED_Msk   (0x3ul << USB_HOST_STATUS_SPEED_Pos)
+#define USB_HOST_STATUS_SPEED_Msk   (_U_(0x3) << USB_HOST_STATUS_SPEED_Pos)
 #define USB_HOST_STATUS_SPEED(value) (USB_HOST_STATUS_SPEED_Msk & ((value) << USB_HOST_STATUS_SPEED_Pos))
 #define USB_HOST_STATUS_LINESTATE_Pos 6            /**< \brief (USB_HOST_STATUS) USB Line State Status */
-#define USB_HOST_STATUS_LINESTATE_Msk (0x3ul << USB_HOST_STATUS_LINESTATE_Pos)
+#define USB_HOST_STATUS_LINESTATE_Msk (_U_(0x3) << USB_HOST_STATUS_LINESTATE_Pos)
 #define USB_HOST_STATUS_LINESTATE(value) (USB_HOST_STATUS_LINESTATE_Msk & ((value) << USB_HOST_STATUS_LINESTATE_Pos))
-#define USB_HOST_STATUS_MASK        0xCCul       /**< \brief (USB_HOST_STATUS) MASK Register */
+#define USB_HOST_STATUS_MASK        _U_(0xCC)     /**< \brief (USB_HOST_STATUS) MASK Register */
 
 /* -------- USB_FSMSTATUS : (USB Offset: 0x00D) (R/   8) Finite State Machine Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union {
   struct {
-    uint8_t  FSMSTATE:6;       /*!< bit:  0.. 5  Fine State Machine Status          */
-    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  FSMSTATE:7;       /*!< bit:  0.. 6  Fine State Machine Status          */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_FSMSTATUS_Type;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_FSMSTATUS_OFFSET        0x00D        /**< \brief (USB_FSMSTATUS offset) Finite State Machine Status */
-#define USB_FSMSTATUS_RESETVALUE    0x01ul       /**< \brief (USB_FSMSTATUS reset_value) Finite State Machine Status */
+#define USB_FSMSTATUS_RESETVALUE    _U_(0x01)     /**< \brief (USB_FSMSTATUS reset_value) Finite State Machine Status */
 
 #define USB_FSMSTATUS_FSMSTATE_Pos  0            /**< \brief (USB_FSMSTATUS) Fine State Machine Status */
-#define USB_FSMSTATUS_FSMSTATE_Msk  (0x3Ful << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_FSMSTATE_Msk  (_U_(0x7F) << USB_FSMSTATUS_FSMSTATE_Pos)
 #define USB_FSMSTATUS_FSMSTATE(value) (USB_FSMSTATUS_FSMSTATE_Msk & ((value) << USB_FSMSTATUS_FSMSTATE_Pos))
-#define   USB_FSMSTATUS_FSMSTATE_OFF_Val  0x1ul  /**< \brief (USB_FSMSTATUS) OFF (L3). It corresponds to the powered-off, disconnected, and disabled state */
-#define   USB_FSMSTATUS_FSMSTATE_ON_Val   0x2ul  /**< \brief (USB_FSMSTATUS) ON (L0). It corresponds to the Idle and Active states */
-#define   USB_FSMSTATUS_FSMSTATE_SUSPEND_Val 0x4ul  /**< \brief (USB_FSMSTATUS) SUSPEND (L2) */
-#define   USB_FSMSTATUS_FSMSTATE_SLEEP_Val 0x8ul  /**< \brief (USB_FSMSTATUS) SLEEP (L1) */
-#define   USB_FSMSTATUS_FSMSTATE_DNRESUME_Val 0x10ul  /**< \brief (USB_FSMSTATUS) DNRESUME. Down Stream Resume. */
-#define   USB_FSMSTATUS_FSMSTATE_UPRESUME_Val 0x20ul  /**< \brief (USB_FSMSTATUS) UPRESUME. Up Stream Resume. */
-#define   USB_FSMSTATUS_FSMSTATE_RESET_Val 0x40ul  /**< \brief (USB_FSMSTATUS) RESET. USB lines Reset. */
+#define   USB_FSMSTATUS_FSMSTATE_OFF_Val  _U_(0x1)   /**< \brief (USB_FSMSTATUS) OFF (L3). It corresponds to the powered-off, disconnected, and disabled state */
+#define   USB_FSMSTATUS_FSMSTATE_ON_Val   _U_(0x2)   /**< \brief (USB_FSMSTATUS) ON (L0). It corresponds to the Idle and Active states */
+#define   USB_FSMSTATUS_FSMSTATE_SUSPEND_Val _U_(0x4)   /**< \brief (USB_FSMSTATUS) SUSPEND (L2) */
+#define   USB_FSMSTATUS_FSMSTATE_SLEEP_Val _U_(0x8)   /**< \brief (USB_FSMSTATUS) SLEEP (L1) */
+#define   USB_FSMSTATUS_FSMSTATE_DNRESUME_Val _U_(0x10)   /**< \brief (USB_FSMSTATUS) DNRESUME. Down Stream Resume. */
+#define   USB_FSMSTATUS_FSMSTATE_UPRESUME_Val _U_(0x20)   /**< \brief (USB_FSMSTATUS) UPRESUME. Up Stream Resume. */
+#define   USB_FSMSTATUS_FSMSTATE_RESET_Val _U_(0x40)   /**< \brief (USB_FSMSTATUS) RESET. USB lines Reset. */
 #define USB_FSMSTATUS_FSMSTATE_OFF  (USB_FSMSTATUS_FSMSTATE_OFF_Val << USB_FSMSTATUS_FSMSTATE_Pos)
 #define USB_FSMSTATUS_FSMSTATE_ON   (USB_FSMSTATUS_FSMSTATE_ON_Val << USB_FSMSTATUS_FSMSTATE_Pos)
 #define USB_FSMSTATUS_FSMSTATE_SUSPEND (USB_FSMSTATUS_FSMSTATE_SUSPEND_Val << USB_FSMSTATUS_FSMSTATE_Pos)
@@ -388,7 +373,7 @@ typedef union {
 #define USB_FSMSTATUS_FSMSTATE_DNRESUME (USB_FSMSTATUS_FSMSTATE_DNRESUME_Val << USB_FSMSTATUS_FSMSTATE_Pos)
 #define USB_FSMSTATUS_FSMSTATE_UPRESUME (USB_FSMSTATUS_FSMSTATE_UPRESUME_Val << USB_FSMSTATUS_FSMSTATE_Pos)
 #define USB_FSMSTATUS_FSMSTATE_RESET (USB_FSMSTATUS_FSMSTATE_RESET_Val << USB_FSMSTATUS_FSMSTATE_Pos)
-#define USB_FSMSTATUS_MASK          0x3Ful       /**< \brief (USB_FSMSTATUS) MASK Register */
+#define USB_FSMSTATUS_MASK          _U_(0x7F)     /**< \brief (USB_FSMSTATUS) MASK Register */
 
 /* -------- USB_DEVICE_FNUM : (USB Offset: 0x010) (R/  16) DEVICE DEVICE Device Frame Number -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -404,17 +389,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_FNUM_OFFSET      0x010        /**< \brief (USB_DEVICE_FNUM offset) DEVICE Device Frame Number */
-#define USB_DEVICE_FNUM_RESETVALUE  0x0000ul     /**< \brief (USB_DEVICE_FNUM reset_value) DEVICE Device Frame Number */
+#define USB_DEVICE_FNUM_RESETVALUE  _U_(0x0000)   /**< \brief (USB_DEVICE_FNUM reset_value) DEVICE Device Frame Number */
 
 #define USB_DEVICE_FNUM_MFNUM_Pos   0            /**< \brief (USB_DEVICE_FNUM) Micro Frame Number */
-#define USB_DEVICE_FNUM_MFNUM_Msk   (0x7ul << USB_DEVICE_FNUM_MFNUM_Pos)
+#define USB_DEVICE_FNUM_MFNUM_Msk   (_U_(0x7) << USB_DEVICE_FNUM_MFNUM_Pos)
 #define USB_DEVICE_FNUM_MFNUM(value) (USB_DEVICE_FNUM_MFNUM_Msk & ((value) << USB_DEVICE_FNUM_MFNUM_Pos))
 #define USB_DEVICE_FNUM_FNUM_Pos    3            /**< \brief (USB_DEVICE_FNUM) Frame Number */
-#define USB_DEVICE_FNUM_FNUM_Msk    (0x7FFul << USB_DEVICE_FNUM_FNUM_Pos)
+#define USB_DEVICE_FNUM_FNUM_Msk    (_U_(0x7FF) << USB_DEVICE_FNUM_FNUM_Pos)
 #define USB_DEVICE_FNUM_FNUM(value) (USB_DEVICE_FNUM_FNUM_Msk & ((value) << USB_DEVICE_FNUM_FNUM_Pos))
 #define USB_DEVICE_FNUM_FNCERR_Pos  15           /**< \brief (USB_DEVICE_FNUM) Frame Number CRC Error */
-#define USB_DEVICE_FNUM_FNCERR      (0x1ul << USB_DEVICE_FNUM_FNCERR_Pos)
-#define USB_DEVICE_FNUM_MASK        0xBFFFul     /**< \brief (USB_DEVICE_FNUM) MASK Register */
+#define USB_DEVICE_FNUM_FNCERR      (_U_(0x1) << USB_DEVICE_FNUM_FNCERR_Pos)
+#define USB_DEVICE_FNUM_MASK        _U_(0xBFFF)   /**< \brief (USB_DEVICE_FNUM) MASK Register */
 
 /* -------- USB_HOST_FNUM : (USB Offset: 0x010) (R/W 16) HOST HOST Host Frame Number -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -429,15 +414,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_FNUM_OFFSET        0x010        /**< \brief (USB_HOST_FNUM offset) HOST Host Frame Number */
-#define USB_HOST_FNUM_RESETVALUE    0x0000ul     /**< \brief (USB_HOST_FNUM reset_value) HOST Host Frame Number */
+#define USB_HOST_FNUM_RESETVALUE    _U_(0x0000)   /**< \brief (USB_HOST_FNUM reset_value) HOST Host Frame Number */
 
 #define USB_HOST_FNUM_MFNUM_Pos     0            /**< \brief (USB_HOST_FNUM) Micro Frame Number */
-#define USB_HOST_FNUM_MFNUM_Msk     (0x7ul << USB_HOST_FNUM_MFNUM_Pos)
+#define USB_HOST_FNUM_MFNUM_Msk     (_U_(0x7) << USB_HOST_FNUM_MFNUM_Pos)
 #define USB_HOST_FNUM_MFNUM(value)  (USB_HOST_FNUM_MFNUM_Msk & ((value) << USB_HOST_FNUM_MFNUM_Pos))
 #define USB_HOST_FNUM_FNUM_Pos      3            /**< \brief (USB_HOST_FNUM) Frame Number */
-#define USB_HOST_FNUM_FNUM_Msk      (0x7FFul << USB_HOST_FNUM_FNUM_Pos)
+#define USB_HOST_FNUM_FNUM_Msk      (_U_(0x7FF) << USB_HOST_FNUM_FNUM_Pos)
 #define USB_HOST_FNUM_FNUM(value)   (USB_HOST_FNUM_FNUM_Msk & ((value) << USB_HOST_FNUM_FNUM_Pos))
-#define USB_HOST_FNUM_MASK          0x3FFFul     /**< \brief (USB_HOST_FNUM) MASK Register */
+#define USB_HOST_FNUM_MASK          _U_(0x3FFF)   /**< \brief (USB_HOST_FNUM) MASK Register */
 
 /* -------- USB_HOST_FLENHIGH : (USB Offset: 0x012) (R/   8) HOST HOST Host Frame Length -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -450,12 +435,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_FLENHIGH_OFFSET    0x012        /**< \brief (USB_HOST_FLENHIGH offset) HOST Host Frame Length */
-#define USB_HOST_FLENHIGH_RESETVALUE 0x00ul       /**< \brief (USB_HOST_FLENHIGH reset_value) HOST Host Frame Length */
+#define USB_HOST_FLENHIGH_RESETVALUE _U_(0x00)     /**< \brief (USB_HOST_FLENHIGH reset_value) HOST Host Frame Length */
 
 #define USB_HOST_FLENHIGH_FLENHIGH_Pos 0            /**< \brief (USB_HOST_FLENHIGH) Frame Length */
-#define USB_HOST_FLENHIGH_FLENHIGH_Msk (0xFFul << USB_HOST_FLENHIGH_FLENHIGH_Pos)
+#define USB_HOST_FLENHIGH_FLENHIGH_Msk (_U_(0xFF) << USB_HOST_FLENHIGH_FLENHIGH_Pos)
 #define USB_HOST_FLENHIGH_FLENHIGH(value) (USB_HOST_FLENHIGH_FLENHIGH_Msk & ((value) << USB_HOST_FLENHIGH_FLENHIGH_Pos))
-#define USB_HOST_FLENHIGH_MASK      0xFFul       /**< \brief (USB_HOST_FLENHIGH) MASK Register */
+#define USB_HOST_FLENHIGH_MASK      _U_(0xFF)     /**< \brief (USB_HOST_FLENHIGH) MASK Register */
 
 /* -------- USB_DEVICE_INTENCLR : (USB Offset: 0x014) (R/W 16) DEVICE DEVICE Device Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -478,29 +463,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_INTENCLR_OFFSET  0x014        /**< \brief (USB_DEVICE_INTENCLR offset) DEVICE Device Interrupt Enable Clear */
-#define USB_DEVICE_INTENCLR_RESETVALUE 0x0000ul     /**< \brief (USB_DEVICE_INTENCLR reset_value) DEVICE Device Interrupt Enable Clear */
+#define USB_DEVICE_INTENCLR_RESETVALUE _U_(0x0000)   /**< \brief (USB_DEVICE_INTENCLR reset_value) DEVICE Device Interrupt Enable Clear */
 
 #define USB_DEVICE_INTENCLR_SUSPEND_Pos 0            /**< \brief (USB_DEVICE_INTENCLR) Suspend Interrupt Enable */
-#define USB_DEVICE_INTENCLR_SUSPEND (0x1ul << USB_DEVICE_INTENCLR_SUSPEND_Pos)
+#define USB_DEVICE_INTENCLR_SUSPEND (_U_(0x1) << USB_DEVICE_INTENCLR_SUSPEND_Pos)
 #define USB_DEVICE_INTENCLR_MSOF_Pos 1            /**< \brief (USB_DEVICE_INTENCLR) Micro Start of Frame Interrupt Enable in High Speed Mode */
-#define USB_DEVICE_INTENCLR_MSOF    (0x1ul << USB_DEVICE_INTENCLR_MSOF_Pos)
+#define USB_DEVICE_INTENCLR_MSOF    (_U_(0x1) << USB_DEVICE_INTENCLR_MSOF_Pos)
 #define USB_DEVICE_INTENCLR_SOF_Pos 2            /**< \brief (USB_DEVICE_INTENCLR) Start Of Frame Interrupt Enable */
-#define USB_DEVICE_INTENCLR_SOF     (0x1ul << USB_DEVICE_INTENCLR_SOF_Pos)
+#define USB_DEVICE_INTENCLR_SOF     (_U_(0x1) << USB_DEVICE_INTENCLR_SOF_Pos)
 #define USB_DEVICE_INTENCLR_EORST_Pos 3            /**< \brief (USB_DEVICE_INTENCLR) End of Reset Interrupt Enable */
-#define USB_DEVICE_INTENCLR_EORST   (0x1ul << USB_DEVICE_INTENCLR_EORST_Pos)
+#define USB_DEVICE_INTENCLR_EORST   (_U_(0x1) << USB_DEVICE_INTENCLR_EORST_Pos)
 #define USB_DEVICE_INTENCLR_WAKEUP_Pos 4            /**< \brief (USB_DEVICE_INTENCLR) Wake Up Interrupt Enable */
-#define USB_DEVICE_INTENCLR_WAKEUP  (0x1ul << USB_DEVICE_INTENCLR_WAKEUP_Pos)
+#define USB_DEVICE_INTENCLR_WAKEUP  (_U_(0x1) << USB_DEVICE_INTENCLR_WAKEUP_Pos)
 #define USB_DEVICE_INTENCLR_EORSM_Pos 5            /**< \brief (USB_DEVICE_INTENCLR) End Of Resume Interrupt Enable */
-#define USB_DEVICE_INTENCLR_EORSM   (0x1ul << USB_DEVICE_INTENCLR_EORSM_Pos)
+#define USB_DEVICE_INTENCLR_EORSM   (_U_(0x1) << USB_DEVICE_INTENCLR_EORSM_Pos)
 #define USB_DEVICE_INTENCLR_UPRSM_Pos 6            /**< \brief (USB_DEVICE_INTENCLR) Upstream Resume Interrupt Enable */
-#define USB_DEVICE_INTENCLR_UPRSM   (0x1ul << USB_DEVICE_INTENCLR_UPRSM_Pos)
+#define USB_DEVICE_INTENCLR_UPRSM   (_U_(0x1) << USB_DEVICE_INTENCLR_UPRSM_Pos)
 #define USB_DEVICE_INTENCLR_RAMACER_Pos 7            /**< \brief (USB_DEVICE_INTENCLR) Ram Access Interrupt Enable */
-#define USB_DEVICE_INTENCLR_RAMACER (0x1ul << USB_DEVICE_INTENCLR_RAMACER_Pos)
+#define USB_DEVICE_INTENCLR_RAMACER (_U_(0x1) << USB_DEVICE_INTENCLR_RAMACER_Pos)
 #define USB_DEVICE_INTENCLR_LPMNYET_Pos 8            /**< \brief (USB_DEVICE_INTENCLR) Link Power Management Not Yet Interrupt Enable */
-#define USB_DEVICE_INTENCLR_LPMNYET (0x1ul << USB_DEVICE_INTENCLR_LPMNYET_Pos)
+#define USB_DEVICE_INTENCLR_LPMNYET (_U_(0x1) << USB_DEVICE_INTENCLR_LPMNYET_Pos)
 #define USB_DEVICE_INTENCLR_LPMSUSP_Pos 9            /**< \brief (USB_DEVICE_INTENCLR) Link Power Management Suspend Interrupt Enable */
-#define USB_DEVICE_INTENCLR_LPMSUSP (0x1ul << USB_DEVICE_INTENCLR_LPMSUSP_Pos)
-#define USB_DEVICE_INTENCLR_MASK    0x03FFul     /**< \brief (USB_DEVICE_INTENCLR) MASK Register */
+#define USB_DEVICE_INTENCLR_LPMSUSP (_U_(0x1) << USB_DEVICE_INTENCLR_LPMSUSP_Pos)
+#define USB_DEVICE_INTENCLR_MASK    _U_(0x03FF)   /**< \brief (USB_DEVICE_INTENCLR) MASK Register */
 
 /* -------- USB_HOST_INTENCLR : (USB Offset: 0x014) (R/W 16) HOST HOST Host Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -522,25 +507,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_INTENCLR_OFFSET    0x014        /**< \brief (USB_HOST_INTENCLR offset) HOST Host Interrupt Enable Clear */
-#define USB_HOST_INTENCLR_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_INTENCLR reset_value) HOST Host Interrupt Enable Clear */
+#define USB_HOST_INTENCLR_RESETVALUE _U_(0x0000)   /**< \brief (USB_HOST_INTENCLR reset_value) HOST Host Interrupt Enable Clear */
 
 #define USB_HOST_INTENCLR_HSOF_Pos  2            /**< \brief (USB_HOST_INTENCLR) Host Start Of Frame Interrupt Disable */
-#define USB_HOST_INTENCLR_HSOF      (0x1ul << USB_HOST_INTENCLR_HSOF_Pos)
+#define USB_HOST_INTENCLR_HSOF      (_U_(0x1) << USB_HOST_INTENCLR_HSOF_Pos)
 #define USB_HOST_INTENCLR_RST_Pos   3            /**< \brief (USB_HOST_INTENCLR) BUS Reset Interrupt Disable */
-#define USB_HOST_INTENCLR_RST       (0x1ul << USB_HOST_INTENCLR_RST_Pos)
+#define USB_HOST_INTENCLR_RST       (_U_(0x1) << USB_HOST_INTENCLR_RST_Pos)
 #define USB_HOST_INTENCLR_WAKEUP_Pos 4            /**< \brief (USB_HOST_INTENCLR) Wake Up Interrupt Disable */
-#define USB_HOST_INTENCLR_WAKEUP    (0x1ul << USB_HOST_INTENCLR_WAKEUP_Pos)
+#define USB_HOST_INTENCLR_WAKEUP    (_U_(0x1) << USB_HOST_INTENCLR_WAKEUP_Pos)
 #define USB_HOST_INTENCLR_DNRSM_Pos 5            /**< \brief (USB_HOST_INTENCLR) DownStream to Device Interrupt Disable */
-#define USB_HOST_INTENCLR_DNRSM     (0x1ul << USB_HOST_INTENCLR_DNRSM_Pos)
+#define USB_HOST_INTENCLR_DNRSM     (_U_(0x1) << USB_HOST_INTENCLR_DNRSM_Pos)
 #define USB_HOST_INTENCLR_UPRSM_Pos 6            /**< \brief (USB_HOST_INTENCLR) Upstream Resume from Device Interrupt Disable */
-#define USB_HOST_INTENCLR_UPRSM     (0x1ul << USB_HOST_INTENCLR_UPRSM_Pos)
+#define USB_HOST_INTENCLR_UPRSM     (_U_(0x1) << USB_HOST_INTENCLR_UPRSM_Pos)
 #define USB_HOST_INTENCLR_RAMACER_Pos 7            /**< \brief (USB_HOST_INTENCLR) Ram Access Interrupt Disable */
-#define USB_HOST_INTENCLR_RAMACER   (0x1ul << USB_HOST_INTENCLR_RAMACER_Pos)
+#define USB_HOST_INTENCLR_RAMACER   (_U_(0x1) << USB_HOST_INTENCLR_RAMACER_Pos)
 #define USB_HOST_INTENCLR_DCONN_Pos 8            /**< \brief (USB_HOST_INTENCLR) Device Connection Interrupt Disable */
-#define USB_HOST_INTENCLR_DCONN     (0x1ul << USB_HOST_INTENCLR_DCONN_Pos)
+#define USB_HOST_INTENCLR_DCONN     (_U_(0x1) << USB_HOST_INTENCLR_DCONN_Pos)
 #define USB_HOST_INTENCLR_DDISC_Pos 9            /**< \brief (USB_HOST_INTENCLR) Device Disconnection Interrupt Disable */
-#define USB_HOST_INTENCLR_DDISC     (0x1ul << USB_HOST_INTENCLR_DDISC_Pos)
-#define USB_HOST_INTENCLR_MASK      0x03FCul     /**< \brief (USB_HOST_INTENCLR) MASK Register */
+#define USB_HOST_INTENCLR_DDISC     (_U_(0x1) << USB_HOST_INTENCLR_DDISC_Pos)
+#define USB_HOST_INTENCLR_MASK      _U_(0x03FC)   /**< \brief (USB_HOST_INTENCLR) MASK Register */
 
 /* -------- USB_DEVICE_INTENSET : (USB Offset: 0x018) (R/W 16) DEVICE DEVICE Device Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -563,29 +548,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_INTENSET_OFFSET  0x018        /**< \brief (USB_DEVICE_INTENSET offset) DEVICE Device Interrupt Enable Set */
-#define USB_DEVICE_INTENSET_RESETVALUE 0x0000ul     /**< \brief (USB_DEVICE_INTENSET reset_value) DEVICE Device Interrupt Enable Set */
+#define USB_DEVICE_INTENSET_RESETVALUE _U_(0x0000)   /**< \brief (USB_DEVICE_INTENSET reset_value) DEVICE Device Interrupt Enable Set */
 
 #define USB_DEVICE_INTENSET_SUSPEND_Pos 0            /**< \brief (USB_DEVICE_INTENSET) Suspend Interrupt Enable */
-#define USB_DEVICE_INTENSET_SUSPEND (0x1ul << USB_DEVICE_INTENSET_SUSPEND_Pos)
+#define USB_DEVICE_INTENSET_SUSPEND (_U_(0x1) << USB_DEVICE_INTENSET_SUSPEND_Pos)
 #define USB_DEVICE_INTENSET_MSOF_Pos 1            /**< \brief (USB_DEVICE_INTENSET) Micro Start of Frame Interrupt Enable in High Speed Mode */
-#define USB_DEVICE_INTENSET_MSOF    (0x1ul << USB_DEVICE_INTENSET_MSOF_Pos)
+#define USB_DEVICE_INTENSET_MSOF    (_U_(0x1) << USB_DEVICE_INTENSET_MSOF_Pos)
 #define USB_DEVICE_INTENSET_SOF_Pos 2            /**< \brief (USB_DEVICE_INTENSET) Start Of Frame Interrupt Enable */
-#define USB_DEVICE_INTENSET_SOF     (0x1ul << USB_DEVICE_INTENSET_SOF_Pos)
+#define USB_DEVICE_INTENSET_SOF     (_U_(0x1) << USB_DEVICE_INTENSET_SOF_Pos)
 #define USB_DEVICE_INTENSET_EORST_Pos 3            /**< \brief (USB_DEVICE_INTENSET) End of Reset Interrupt Enable */
-#define USB_DEVICE_INTENSET_EORST   (0x1ul << USB_DEVICE_INTENSET_EORST_Pos)
+#define USB_DEVICE_INTENSET_EORST   (_U_(0x1) << USB_DEVICE_INTENSET_EORST_Pos)
 #define USB_DEVICE_INTENSET_WAKEUP_Pos 4            /**< \brief (USB_DEVICE_INTENSET) Wake Up Interrupt Enable */
-#define USB_DEVICE_INTENSET_WAKEUP  (0x1ul << USB_DEVICE_INTENSET_WAKEUP_Pos)
+#define USB_DEVICE_INTENSET_WAKEUP  (_U_(0x1) << USB_DEVICE_INTENSET_WAKEUP_Pos)
 #define USB_DEVICE_INTENSET_EORSM_Pos 5            /**< \brief (USB_DEVICE_INTENSET) End Of Resume Interrupt Enable */
-#define USB_DEVICE_INTENSET_EORSM   (0x1ul << USB_DEVICE_INTENSET_EORSM_Pos)
+#define USB_DEVICE_INTENSET_EORSM   (_U_(0x1) << USB_DEVICE_INTENSET_EORSM_Pos)
 #define USB_DEVICE_INTENSET_UPRSM_Pos 6            /**< \brief (USB_DEVICE_INTENSET) Upstream Resume Interrupt Enable */
-#define USB_DEVICE_INTENSET_UPRSM   (0x1ul << USB_DEVICE_INTENSET_UPRSM_Pos)
+#define USB_DEVICE_INTENSET_UPRSM   (_U_(0x1) << USB_DEVICE_INTENSET_UPRSM_Pos)
 #define USB_DEVICE_INTENSET_RAMACER_Pos 7            /**< \brief (USB_DEVICE_INTENSET) Ram Access Interrupt Enable */
-#define USB_DEVICE_INTENSET_RAMACER (0x1ul << USB_DEVICE_INTENSET_RAMACER_Pos)
+#define USB_DEVICE_INTENSET_RAMACER (_U_(0x1) << USB_DEVICE_INTENSET_RAMACER_Pos)
 #define USB_DEVICE_INTENSET_LPMNYET_Pos 8            /**< \brief (USB_DEVICE_INTENSET) Link Power Management Not Yet Interrupt Enable */
-#define USB_DEVICE_INTENSET_LPMNYET (0x1ul << USB_DEVICE_INTENSET_LPMNYET_Pos)
+#define USB_DEVICE_INTENSET_LPMNYET (_U_(0x1) << USB_DEVICE_INTENSET_LPMNYET_Pos)
 #define USB_DEVICE_INTENSET_LPMSUSP_Pos 9            /**< \brief (USB_DEVICE_INTENSET) Link Power Management Suspend Interrupt Enable */
-#define USB_DEVICE_INTENSET_LPMSUSP (0x1ul << USB_DEVICE_INTENSET_LPMSUSP_Pos)
-#define USB_DEVICE_INTENSET_MASK    0x03FFul     /**< \brief (USB_DEVICE_INTENSET) MASK Register */
+#define USB_DEVICE_INTENSET_LPMSUSP (_U_(0x1) << USB_DEVICE_INTENSET_LPMSUSP_Pos)
+#define USB_DEVICE_INTENSET_MASK    _U_(0x03FF)   /**< \brief (USB_DEVICE_INTENSET) MASK Register */
 
 /* -------- USB_HOST_INTENSET : (USB Offset: 0x018) (R/W 16) HOST HOST Host Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -607,25 +592,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_INTENSET_OFFSET    0x018        /**< \brief (USB_HOST_INTENSET offset) HOST Host Interrupt Enable Set */
-#define USB_HOST_INTENSET_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_INTENSET reset_value) HOST Host Interrupt Enable Set */
+#define USB_HOST_INTENSET_RESETVALUE _U_(0x0000)   /**< \brief (USB_HOST_INTENSET reset_value) HOST Host Interrupt Enable Set */
 
 #define USB_HOST_INTENSET_HSOF_Pos  2            /**< \brief (USB_HOST_INTENSET) Host Start Of Frame Interrupt Enable */
-#define USB_HOST_INTENSET_HSOF      (0x1ul << USB_HOST_INTENSET_HSOF_Pos)
+#define USB_HOST_INTENSET_HSOF      (_U_(0x1) << USB_HOST_INTENSET_HSOF_Pos)
 #define USB_HOST_INTENSET_RST_Pos   3            /**< \brief (USB_HOST_INTENSET) Bus Reset Interrupt Enable */
-#define USB_HOST_INTENSET_RST       (0x1ul << USB_HOST_INTENSET_RST_Pos)
+#define USB_HOST_INTENSET_RST       (_U_(0x1) << USB_HOST_INTENSET_RST_Pos)
 #define USB_HOST_INTENSET_WAKEUP_Pos 4            /**< \brief (USB_HOST_INTENSET) Wake Up Interrupt Enable */
-#define USB_HOST_INTENSET_WAKEUP    (0x1ul << USB_HOST_INTENSET_WAKEUP_Pos)
+#define USB_HOST_INTENSET_WAKEUP    (_U_(0x1) << USB_HOST_INTENSET_WAKEUP_Pos)
 #define USB_HOST_INTENSET_DNRSM_Pos 5            /**< \brief (USB_HOST_INTENSET) DownStream to the Device Interrupt Enable */
-#define USB_HOST_INTENSET_DNRSM     (0x1ul << USB_HOST_INTENSET_DNRSM_Pos)
+#define USB_HOST_INTENSET_DNRSM     (_U_(0x1) << USB_HOST_INTENSET_DNRSM_Pos)
 #define USB_HOST_INTENSET_UPRSM_Pos 6            /**< \brief (USB_HOST_INTENSET) Upstream Resume fromthe device Interrupt Enable */
-#define USB_HOST_INTENSET_UPRSM     (0x1ul << USB_HOST_INTENSET_UPRSM_Pos)
+#define USB_HOST_INTENSET_UPRSM     (_U_(0x1) << USB_HOST_INTENSET_UPRSM_Pos)
 #define USB_HOST_INTENSET_RAMACER_Pos 7            /**< \brief (USB_HOST_INTENSET) Ram Access Interrupt Enable */
-#define USB_HOST_INTENSET_RAMACER   (0x1ul << USB_HOST_INTENSET_RAMACER_Pos)
+#define USB_HOST_INTENSET_RAMACER   (_U_(0x1) << USB_HOST_INTENSET_RAMACER_Pos)
 #define USB_HOST_INTENSET_DCONN_Pos 8            /**< \brief (USB_HOST_INTENSET) Link Power Management Interrupt Enable */
-#define USB_HOST_INTENSET_DCONN     (0x1ul << USB_HOST_INTENSET_DCONN_Pos)
+#define USB_HOST_INTENSET_DCONN     (_U_(0x1) << USB_HOST_INTENSET_DCONN_Pos)
 #define USB_HOST_INTENSET_DDISC_Pos 9            /**< \brief (USB_HOST_INTENSET) Device Disconnection Interrupt Enable */
-#define USB_HOST_INTENSET_DDISC     (0x1ul << USB_HOST_INTENSET_DDISC_Pos)
-#define USB_HOST_INTENSET_MASK      0x03FCul     /**< \brief (USB_HOST_INTENSET) MASK Register */
+#define USB_HOST_INTENSET_DDISC     (_U_(0x1) << USB_HOST_INTENSET_DDISC_Pos)
+#define USB_HOST_INTENSET_MASK      _U_(0x03FC)   /**< \brief (USB_HOST_INTENSET) MASK Register */
 
 /* -------- USB_DEVICE_INTFLAG : (USB Offset: 0x01C) (R/W 16) DEVICE DEVICE Device Interrupt Flag -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -648,29 +633,29 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_INTFLAG_OFFSET   0x01C        /**< \brief (USB_DEVICE_INTFLAG offset) DEVICE Device Interrupt Flag */
-#define USB_DEVICE_INTFLAG_RESETVALUE 0x0000ul     /**< \brief (USB_DEVICE_INTFLAG reset_value) DEVICE Device Interrupt Flag */
+#define USB_DEVICE_INTFLAG_RESETVALUE _U_(0x0000)   /**< \brief (USB_DEVICE_INTFLAG reset_value) DEVICE Device Interrupt Flag */
 
 #define USB_DEVICE_INTFLAG_SUSPEND_Pos 0            /**< \brief (USB_DEVICE_INTFLAG) Suspend */
-#define USB_DEVICE_INTFLAG_SUSPEND  (0x1ul << USB_DEVICE_INTFLAG_SUSPEND_Pos)
+#define USB_DEVICE_INTFLAG_SUSPEND  (_U_(0x1) << USB_DEVICE_INTFLAG_SUSPEND_Pos)
 #define USB_DEVICE_INTFLAG_MSOF_Pos 1            /**< \brief (USB_DEVICE_INTFLAG) Micro Start of Frame in High Speed Mode */
-#define USB_DEVICE_INTFLAG_MSOF     (0x1ul << USB_DEVICE_INTFLAG_MSOF_Pos)
+#define USB_DEVICE_INTFLAG_MSOF     (_U_(0x1) << USB_DEVICE_INTFLAG_MSOF_Pos)
 #define USB_DEVICE_INTFLAG_SOF_Pos  2            /**< \brief (USB_DEVICE_INTFLAG) Start Of Frame */
-#define USB_DEVICE_INTFLAG_SOF      (0x1ul << USB_DEVICE_INTFLAG_SOF_Pos)
+#define USB_DEVICE_INTFLAG_SOF      (_U_(0x1) << USB_DEVICE_INTFLAG_SOF_Pos)
 #define USB_DEVICE_INTFLAG_EORST_Pos 3            /**< \brief (USB_DEVICE_INTFLAG) End of Reset */
-#define USB_DEVICE_INTFLAG_EORST    (0x1ul << USB_DEVICE_INTFLAG_EORST_Pos)
+#define USB_DEVICE_INTFLAG_EORST    (_U_(0x1) << USB_DEVICE_INTFLAG_EORST_Pos)
 #define USB_DEVICE_INTFLAG_WAKEUP_Pos 4            /**< \brief (USB_DEVICE_INTFLAG) Wake Up */
-#define USB_DEVICE_INTFLAG_WAKEUP   (0x1ul << USB_DEVICE_INTFLAG_WAKEUP_Pos)
+#define USB_DEVICE_INTFLAG_WAKEUP   (_U_(0x1) << USB_DEVICE_INTFLAG_WAKEUP_Pos)
 #define USB_DEVICE_INTFLAG_EORSM_Pos 5            /**< \brief (USB_DEVICE_INTFLAG) End Of Resume */
-#define USB_DEVICE_INTFLAG_EORSM    (0x1ul << USB_DEVICE_INTFLAG_EORSM_Pos)
+#define USB_DEVICE_INTFLAG_EORSM    (_U_(0x1) << USB_DEVICE_INTFLAG_EORSM_Pos)
 #define USB_DEVICE_INTFLAG_UPRSM_Pos 6            /**< \brief (USB_DEVICE_INTFLAG) Upstream Resume */
-#define USB_DEVICE_INTFLAG_UPRSM    (0x1ul << USB_DEVICE_INTFLAG_UPRSM_Pos)
+#define USB_DEVICE_INTFLAG_UPRSM    (_U_(0x1) << USB_DEVICE_INTFLAG_UPRSM_Pos)
 #define USB_DEVICE_INTFLAG_RAMACER_Pos 7            /**< \brief (USB_DEVICE_INTFLAG) Ram Access */
-#define USB_DEVICE_INTFLAG_RAMACER  (0x1ul << USB_DEVICE_INTFLAG_RAMACER_Pos)
+#define USB_DEVICE_INTFLAG_RAMACER  (_U_(0x1) << USB_DEVICE_INTFLAG_RAMACER_Pos)
 #define USB_DEVICE_INTFLAG_LPMNYET_Pos 8            /**< \brief (USB_DEVICE_INTFLAG) Link Power Management Not Yet */
-#define USB_DEVICE_INTFLAG_LPMNYET  (0x1ul << USB_DEVICE_INTFLAG_LPMNYET_Pos)
+#define USB_DEVICE_INTFLAG_LPMNYET  (_U_(0x1) << USB_DEVICE_INTFLAG_LPMNYET_Pos)
 #define USB_DEVICE_INTFLAG_LPMSUSP_Pos 9            /**< \brief (USB_DEVICE_INTFLAG) Link Power Management Suspend */
-#define USB_DEVICE_INTFLAG_LPMSUSP  (0x1ul << USB_DEVICE_INTFLAG_LPMSUSP_Pos)
-#define USB_DEVICE_INTFLAG_MASK     0x03FFul     /**< \brief (USB_DEVICE_INTFLAG) MASK Register */
+#define USB_DEVICE_INTFLAG_LPMSUSP  (_U_(0x1) << USB_DEVICE_INTFLAG_LPMSUSP_Pos)
+#define USB_DEVICE_INTFLAG_MASK     _U_(0x03FF)   /**< \brief (USB_DEVICE_INTFLAG) MASK Register */
 
 /* -------- USB_HOST_INTFLAG : (USB Offset: 0x01C) (R/W 16) HOST HOST Host Interrupt Flag -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -692,25 +677,25 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_INTFLAG_OFFSET     0x01C        /**< \brief (USB_HOST_INTFLAG offset) HOST Host Interrupt Flag */
-#define USB_HOST_INTFLAG_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_INTFLAG reset_value) HOST Host Interrupt Flag */
+#define USB_HOST_INTFLAG_RESETVALUE _U_(0x0000)   /**< \brief (USB_HOST_INTFLAG reset_value) HOST Host Interrupt Flag */
 
 #define USB_HOST_INTFLAG_HSOF_Pos   2            /**< \brief (USB_HOST_INTFLAG) Host Start Of Frame */
-#define USB_HOST_INTFLAG_HSOF       (0x1ul << USB_HOST_INTFLAG_HSOF_Pos)
+#define USB_HOST_INTFLAG_HSOF       (_U_(0x1) << USB_HOST_INTFLAG_HSOF_Pos)
 #define USB_HOST_INTFLAG_RST_Pos    3            /**< \brief (USB_HOST_INTFLAG) Bus Reset */
-#define USB_HOST_INTFLAG_RST        (0x1ul << USB_HOST_INTFLAG_RST_Pos)
+#define USB_HOST_INTFLAG_RST        (_U_(0x1) << USB_HOST_INTFLAG_RST_Pos)
 #define USB_HOST_INTFLAG_WAKEUP_Pos 4            /**< \brief (USB_HOST_INTFLAG) Wake Up */
-#define USB_HOST_INTFLAG_WAKEUP     (0x1ul << USB_HOST_INTFLAG_WAKEUP_Pos)
+#define USB_HOST_INTFLAG_WAKEUP     (_U_(0x1) << USB_HOST_INTFLAG_WAKEUP_Pos)
 #define USB_HOST_INTFLAG_DNRSM_Pos  5            /**< \brief (USB_HOST_INTFLAG) Downstream */
-#define USB_HOST_INTFLAG_DNRSM      (0x1ul << USB_HOST_INTFLAG_DNRSM_Pos)
+#define USB_HOST_INTFLAG_DNRSM      (_U_(0x1) << USB_HOST_INTFLAG_DNRSM_Pos)
 #define USB_HOST_INTFLAG_UPRSM_Pos  6            /**< \brief (USB_HOST_INTFLAG) Upstream Resume from the Device */
-#define USB_HOST_INTFLAG_UPRSM      (0x1ul << USB_HOST_INTFLAG_UPRSM_Pos)
+#define USB_HOST_INTFLAG_UPRSM      (_U_(0x1) << USB_HOST_INTFLAG_UPRSM_Pos)
 #define USB_HOST_INTFLAG_RAMACER_Pos 7            /**< \brief (USB_HOST_INTFLAG) Ram Access */
-#define USB_HOST_INTFLAG_RAMACER    (0x1ul << USB_HOST_INTFLAG_RAMACER_Pos)
+#define USB_HOST_INTFLAG_RAMACER    (_U_(0x1) << USB_HOST_INTFLAG_RAMACER_Pos)
 #define USB_HOST_INTFLAG_DCONN_Pos  8            /**< \brief (USB_HOST_INTFLAG) Device Connection */
-#define USB_HOST_INTFLAG_DCONN      (0x1ul << USB_HOST_INTFLAG_DCONN_Pos)
+#define USB_HOST_INTFLAG_DCONN      (_U_(0x1) << USB_HOST_INTFLAG_DCONN_Pos)
 #define USB_HOST_INTFLAG_DDISC_Pos  9            /**< \brief (USB_HOST_INTFLAG) Device Disconnection */
-#define USB_HOST_INTFLAG_DDISC      (0x1ul << USB_HOST_INTFLAG_DDISC_Pos)
-#define USB_HOST_INTFLAG_MASK       0x03FCul     /**< \brief (USB_HOST_INTFLAG) MASK Register */
+#define USB_HOST_INTFLAG_DDISC      (_U_(0x1) << USB_HOST_INTFLAG_DDISC_Pos)
+#define USB_HOST_INTFLAG_MASK       _U_(0x03FC)   /**< \brief (USB_HOST_INTFLAG) MASK Register */
 
 /* -------- USB_DEVICE_EPINTSMRY : (USB Offset: 0x020) (R/  16) DEVICE DEVICE End Point Interrupt Summary -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -735,7 +720,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_EPINTSMRY_OFFSET 0x020        /**< \brief (USB_DEVICE_EPINTSMRY offset) DEVICE End Point Interrupt Summary */
-#define USB_DEVICE_EPINTSMRY_RESETVALUE 0x0000ul     /**< \brief (USB_DEVICE_EPINTSMRY reset_value) DEVICE End Point Interrupt Summary */
+#define USB_DEVICE_EPINTSMRY_RESETVALUE _U_(0x0000)   /**< \brief (USB_DEVICE_EPINTSMRY reset_value) DEVICE End Point Interrupt Summary */
 
 #define USB_DEVICE_EPINTSMRY_EPINT0_Pos 0            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 0 Interrupt */
 #define USB_DEVICE_EPINTSMRY_EPINT0 (1 << USB_DEVICE_EPINTSMRY_EPINT0_Pos)
@@ -754,9 +739,9 @@ typedef union {
 #define USB_DEVICE_EPINTSMRY_EPINT7_Pos 7            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 7 Interrupt */
 #define USB_DEVICE_EPINTSMRY_EPINT7 (1 << USB_DEVICE_EPINTSMRY_EPINT7_Pos)
 #define USB_DEVICE_EPINTSMRY_EPINT_Pos 0            /**< \brief (USB_DEVICE_EPINTSMRY) End Point x Interrupt */
-#define USB_DEVICE_EPINTSMRY_EPINT_Msk (0xFFul << USB_DEVICE_EPINTSMRY_EPINT_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT_Msk (_U_(0xFF) << USB_DEVICE_EPINTSMRY_EPINT_Pos)
 #define USB_DEVICE_EPINTSMRY_EPINT(value) (USB_DEVICE_EPINTSMRY_EPINT_Msk & ((value) << USB_DEVICE_EPINTSMRY_EPINT_Pos))
-#define USB_DEVICE_EPINTSMRY_MASK   0x00FFul     /**< \brief (USB_DEVICE_EPINTSMRY) MASK Register */
+#define USB_DEVICE_EPINTSMRY_MASK   _U_(0x00FF)   /**< \brief (USB_DEVICE_EPINTSMRY) MASK Register */
 
 /* -------- USB_HOST_PINTSMRY : (USB Offset: 0x020) (R/  16) HOST HOST Pipe Interrupt Summary -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -781,7 +766,7 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_PINTSMRY_OFFSET    0x020        /**< \brief (USB_HOST_PINTSMRY offset) HOST Pipe Interrupt Summary */
-#define USB_HOST_PINTSMRY_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_PINTSMRY reset_value) HOST Pipe Interrupt Summary */
+#define USB_HOST_PINTSMRY_RESETVALUE _U_(0x0000)   /**< \brief (USB_HOST_PINTSMRY reset_value) HOST Pipe Interrupt Summary */
 
 #define USB_HOST_PINTSMRY_EPINT0_Pos 0            /**< \brief (USB_HOST_PINTSMRY) Pipe 0 Interrupt */
 #define USB_HOST_PINTSMRY_EPINT0    (1 << USB_HOST_PINTSMRY_EPINT0_Pos)
@@ -800,9 +785,9 @@ typedef union {
 #define USB_HOST_PINTSMRY_EPINT7_Pos 7            /**< \brief (USB_HOST_PINTSMRY) Pipe 7 Interrupt */
 #define USB_HOST_PINTSMRY_EPINT7    (1 << USB_HOST_PINTSMRY_EPINT7_Pos)
 #define USB_HOST_PINTSMRY_EPINT_Pos 0            /**< \brief (USB_HOST_PINTSMRY) Pipe x Interrupt */
-#define USB_HOST_PINTSMRY_EPINT_Msk (0xFFul << USB_HOST_PINTSMRY_EPINT_Pos)
+#define USB_HOST_PINTSMRY_EPINT_Msk (_U_(0xFF) << USB_HOST_PINTSMRY_EPINT_Pos)
 #define USB_HOST_PINTSMRY_EPINT(value) (USB_HOST_PINTSMRY_EPINT_Msk & ((value) << USB_HOST_PINTSMRY_EPINT_Pos))
-#define USB_HOST_PINTSMRY_MASK      0x00FFul     /**< \brief (USB_HOST_PINTSMRY) MASK Register */
+#define USB_HOST_PINTSMRY_MASK      _U_(0x00FF)   /**< \brief (USB_HOST_PINTSMRY) MASK Register */
 
 /* -------- USB_DESCADD : (USB Offset: 0x024) (R/W 32) Descriptor Address -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -815,12 +800,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DESCADD_OFFSET          0x024        /**< \brief (USB_DESCADD offset) Descriptor Address */
-#define USB_DESCADD_RESETVALUE      0x00000000ul /**< \brief (USB_DESCADD reset_value) Descriptor Address */
+#define USB_DESCADD_RESETVALUE      _U_(0x00000000) /**< \brief (USB_DESCADD reset_value) Descriptor Address */
 
 #define USB_DESCADD_DESCADD_Pos     0            /**< \brief (USB_DESCADD) Descriptor Address Value */
-#define USB_DESCADD_DESCADD_Msk     (0xFFFFFFFFul << USB_DESCADD_DESCADD_Pos)
+#define USB_DESCADD_DESCADD_Msk     (_U_(0xFFFFFFFF) << USB_DESCADD_DESCADD_Pos)
 #define USB_DESCADD_DESCADD(value)  (USB_DESCADD_DESCADD_Msk & ((value) << USB_DESCADD_DESCADD_Pos))
-#define USB_DESCADD_MASK            0xFFFFFFFFul /**< \brief (USB_DESCADD) MASK Register */
+#define USB_DESCADD_MASK            _U_(0xFFFFFFFF) /**< \brief (USB_DESCADD) MASK Register */
 
 /* -------- USB_PADCAL : (USB Offset: 0x028) (R/W 16) USB PAD Calibration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -838,18 +823,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_PADCAL_OFFSET           0x028        /**< \brief (USB_PADCAL offset) USB PAD Calibration */
-#define USB_PADCAL_RESETVALUE       0x0000ul     /**< \brief (USB_PADCAL reset_value) USB PAD Calibration */
+#define USB_PADCAL_RESETVALUE       _U_(0x0000)   /**< \brief (USB_PADCAL reset_value) USB PAD Calibration */
 
 #define USB_PADCAL_TRANSP_Pos       0            /**< \brief (USB_PADCAL) USB Pad Transp calibration */
-#define USB_PADCAL_TRANSP_Msk       (0x1Ful << USB_PADCAL_TRANSP_Pos)
+#define USB_PADCAL_TRANSP_Msk       (_U_(0x1F) << USB_PADCAL_TRANSP_Pos)
 #define USB_PADCAL_TRANSP(value)    (USB_PADCAL_TRANSP_Msk & ((value) << USB_PADCAL_TRANSP_Pos))
 #define USB_PADCAL_TRANSN_Pos       6            /**< \brief (USB_PADCAL) USB Pad Transn calibration */
-#define USB_PADCAL_TRANSN_Msk       (0x1Ful << USB_PADCAL_TRANSN_Pos)
+#define USB_PADCAL_TRANSN_Msk       (_U_(0x1F) << USB_PADCAL_TRANSN_Pos)
 #define USB_PADCAL_TRANSN(value)    (USB_PADCAL_TRANSN_Msk & ((value) << USB_PADCAL_TRANSN_Pos))
 #define USB_PADCAL_TRIM_Pos         12           /**< \brief (USB_PADCAL) USB Pad Trim calibration */
-#define USB_PADCAL_TRIM_Msk         (0x7ul << USB_PADCAL_TRIM_Pos)
+#define USB_PADCAL_TRIM_Msk         (_U_(0x7) << USB_PADCAL_TRIM_Pos)
 #define USB_PADCAL_TRIM(value)      (USB_PADCAL_TRIM_Msk & ((value) << USB_PADCAL_TRIM_Pos))
-#define USB_PADCAL_MASK             0x77DFul     /**< \brief (USB_PADCAL) MASK Register */
+#define USB_PADCAL_MASK             _U_(0x77DF)   /**< \brief (USB_PADCAL) MASK Register */
 
 /* -------- USB_DEVICE_EPCFG : (USB Offset: 0x100) (R/W  8) DEVICE DEVICE_ENDPOINT End Point Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -865,17 +850,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_EPCFG_OFFSET     0x100        /**< \brief (USB_DEVICE_EPCFG offset) DEVICE_ENDPOINT End Point Configuration */
-#define USB_DEVICE_EPCFG_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPCFG reset_value) DEVICE_ENDPOINT End Point Configuration */
+#define USB_DEVICE_EPCFG_RESETVALUE _U_(0x00)     /**< \brief (USB_DEVICE_EPCFG reset_value) DEVICE_ENDPOINT End Point Configuration */
 
 #define USB_DEVICE_EPCFG_EPTYPE0_Pos 0            /**< \brief (USB_DEVICE_EPCFG) End Point Type0 */
-#define USB_DEVICE_EPCFG_EPTYPE0_Msk (0x7ul << USB_DEVICE_EPCFG_EPTYPE0_Pos)
+#define USB_DEVICE_EPCFG_EPTYPE0_Msk (_U_(0x7) << USB_DEVICE_EPCFG_EPTYPE0_Pos)
 #define USB_DEVICE_EPCFG_EPTYPE0(value) (USB_DEVICE_EPCFG_EPTYPE0_Msk & ((value) << USB_DEVICE_EPCFG_EPTYPE0_Pos))
 #define USB_DEVICE_EPCFG_EPTYPE1_Pos 4            /**< \brief (USB_DEVICE_EPCFG) End Point Type1 */
-#define USB_DEVICE_EPCFG_EPTYPE1_Msk (0x7ul << USB_DEVICE_EPCFG_EPTYPE1_Pos)
+#define USB_DEVICE_EPCFG_EPTYPE1_Msk (_U_(0x7) << USB_DEVICE_EPCFG_EPTYPE1_Pos)
 #define USB_DEVICE_EPCFG_EPTYPE1(value) (USB_DEVICE_EPCFG_EPTYPE1_Msk & ((value) << USB_DEVICE_EPCFG_EPTYPE1_Pos))
 #define USB_DEVICE_EPCFG_NYETDIS_Pos 7            /**< \brief (USB_DEVICE_EPCFG) NYET Token Disable */
-#define USB_DEVICE_EPCFG_NYETDIS    (0x1ul << USB_DEVICE_EPCFG_NYETDIS_Pos)
-#define USB_DEVICE_EPCFG_MASK       0xF7ul       /**< \brief (USB_DEVICE_EPCFG) MASK Register */
+#define USB_DEVICE_EPCFG_NYETDIS    (_U_(0x1) << USB_DEVICE_EPCFG_NYETDIS_Pos)
+#define USB_DEVICE_EPCFG_MASK       _U_(0xF7)     /**< \brief (USB_DEVICE_EPCFG) MASK Register */
 
 /* -------- USB_HOST_PCFG : (USB Offset: 0x100) (R/W  8) HOST HOST_PIPE End Point Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -891,17 +876,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_PCFG_OFFSET        0x100        /**< \brief (USB_HOST_PCFG offset) HOST_PIPE End Point Configuration */
-#define USB_HOST_PCFG_RESETVALUE    0x00ul       /**< \brief (USB_HOST_PCFG reset_value) HOST_PIPE End Point Configuration */
+#define USB_HOST_PCFG_RESETVALUE    _U_(0x00)     /**< \brief (USB_HOST_PCFG reset_value) HOST_PIPE End Point Configuration */
 
 #define USB_HOST_PCFG_PTOKEN_Pos    0            /**< \brief (USB_HOST_PCFG) Pipe Token */
-#define USB_HOST_PCFG_PTOKEN_Msk    (0x3ul << USB_HOST_PCFG_PTOKEN_Pos)
+#define USB_HOST_PCFG_PTOKEN_Msk    (_U_(0x3) << USB_HOST_PCFG_PTOKEN_Pos)
 #define USB_HOST_PCFG_PTOKEN(value) (USB_HOST_PCFG_PTOKEN_Msk & ((value) << USB_HOST_PCFG_PTOKEN_Pos))
 #define USB_HOST_PCFG_BK_Pos        2            /**< \brief (USB_HOST_PCFG) Pipe Bank */
-#define USB_HOST_PCFG_BK            (0x1ul << USB_HOST_PCFG_BK_Pos)
+#define USB_HOST_PCFG_BK            (_U_(0x1) << USB_HOST_PCFG_BK_Pos)
 #define USB_HOST_PCFG_PTYPE_Pos     3            /**< \brief (USB_HOST_PCFG) Pipe Type */
-#define USB_HOST_PCFG_PTYPE_Msk     (0x7ul << USB_HOST_PCFG_PTYPE_Pos)
+#define USB_HOST_PCFG_PTYPE_Msk     (_U_(0x7) << USB_HOST_PCFG_PTYPE_Pos)
 #define USB_HOST_PCFG_PTYPE(value)  (USB_HOST_PCFG_PTYPE_Msk & ((value) << USB_HOST_PCFG_PTYPE_Pos))
-#define USB_HOST_PCFG_MASK          0x3Ful       /**< \brief (USB_HOST_PCFG) MASK Register */
+#define USB_HOST_PCFG_MASK          _U_(0x3F)     /**< \brief (USB_HOST_PCFG) MASK Register */
 
 /* -------- USB_HOST_BINTERVAL : (USB Offset: 0x103) (R/W  8) HOST HOST_PIPE Bus Access Period of Pipe -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -914,12 +899,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_BINTERVAL_OFFSET   0x103        /**< \brief (USB_HOST_BINTERVAL offset) HOST_PIPE Bus Access Period of Pipe */
-#define USB_HOST_BINTERVAL_RESETVALUE 0x00ul       /**< \brief (USB_HOST_BINTERVAL reset_value) HOST_PIPE Bus Access Period of Pipe */
+#define USB_HOST_BINTERVAL_RESETVALUE _U_(0x00)     /**< \brief (USB_HOST_BINTERVAL reset_value) HOST_PIPE Bus Access Period of Pipe */
 
 #define USB_HOST_BINTERVAL_BITINTERVAL_Pos 0            /**< \brief (USB_HOST_BINTERVAL) Bit Interval */
-#define USB_HOST_BINTERVAL_BITINTERVAL_Msk (0xFFul << USB_HOST_BINTERVAL_BITINTERVAL_Pos)
+#define USB_HOST_BINTERVAL_BITINTERVAL_Msk (_U_(0xFF) << USB_HOST_BINTERVAL_BITINTERVAL_Pos)
 #define USB_HOST_BINTERVAL_BITINTERVAL(value) (USB_HOST_BINTERVAL_BITINTERVAL_Msk & ((value) << USB_HOST_BINTERVAL_BITINTERVAL_Pos))
-#define USB_HOST_BINTERVAL_MASK     0xFFul       /**< \brief (USB_HOST_BINTERVAL) MASK Register */
+#define USB_HOST_BINTERVAL_MASK     _U_(0xFF)     /**< \brief (USB_HOST_BINTERVAL) MASK Register */
 
 /* -------- USB_DEVICE_EPSTATUSCLR : (USB Offset: 0x104) ( /W  8) DEVICE DEVICE_ENDPOINT End Point Pipe Status Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -944,26 +929,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_EPSTATUSCLR_OFFSET 0x104        /**< \brief (USB_DEVICE_EPSTATUSCLR offset) DEVICE_ENDPOINT End Point Pipe Status Clear */
-#define USB_DEVICE_EPSTATUSCLR_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPSTATUSCLR reset_value) DEVICE_ENDPOINT End Point Pipe Status Clear */
+#define USB_DEVICE_EPSTATUSCLR_RESETVALUE _U_(0x00)     /**< \brief (USB_DEVICE_EPSTATUSCLR reset_value) DEVICE_ENDPOINT End Point Pipe Status Clear */
 
 #define USB_DEVICE_EPSTATUSCLR_DTGLOUT_Pos 0            /**< \brief (USB_DEVICE_EPSTATUSCLR) Data Toggle OUT Clear */
-#define USB_DEVICE_EPSTATUSCLR_DTGLOUT (0x1ul << USB_DEVICE_EPSTATUSCLR_DTGLOUT_Pos)
+#define USB_DEVICE_EPSTATUSCLR_DTGLOUT (_U_(0x1) << USB_DEVICE_EPSTATUSCLR_DTGLOUT_Pos)
 #define USB_DEVICE_EPSTATUSCLR_DTGLIN_Pos 1            /**< \brief (USB_DEVICE_EPSTATUSCLR) Data Toggle IN Clear */
-#define USB_DEVICE_EPSTATUSCLR_DTGLIN (0x1ul << USB_DEVICE_EPSTATUSCLR_DTGLIN_Pos)
+#define USB_DEVICE_EPSTATUSCLR_DTGLIN (_U_(0x1) << USB_DEVICE_EPSTATUSCLR_DTGLIN_Pos)
 #define USB_DEVICE_EPSTATUSCLR_CURBK_Pos 2            /**< \brief (USB_DEVICE_EPSTATUSCLR) Curren Bank Clear */
-#define USB_DEVICE_EPSTATUSCLR_CURBK (0x1ul << USB_DEVICE_EPSTATUSCLR_CURBK_Pos)
+#define USB_DEVICE_EPSTATUSCLR_CURBK (_U_(0x1) << USB_DEVICE_EPSTATUSCLR_CURBK_Pos)
 #define USB_DEVICE_EPSTATUSCLR_STALLRQ0_Pos 4            /**< \brief (USB_DEVICE_EPSTATUSCLR) Stall 0 Request Clear */
 #define USB_DEVICE_EPSTATUSCLR_STALLRQ0 (1 << USB_DEVICE_EPSTATUSCLR_STALLRQ0_Pos)
 #define USB_DEVICE_EPSTATUSCLR_STALLRQ1_Pos 5            /**< \brief (USB_DEVICE_EPSTATUSCLR) Stall 1 Request Clear */
 #define USB_DEVICE_EPSTATUSCLR_STALLRQ1 (1 << USB_DEVICE_EPSTATUSCLR_STALLRQ1_Pos)
 #define USB_DEVICE_EPSTATUSCLR_STALLRQ_Pos 4            /**< \brief (USB_DEVICE_EPSTATUSCLR) Stall x Request Clear */
-#define USB_DEVICE_EPSTATUSCLR_STALLRQ_Msk (0x3ul << USB_DEVICE_EPSTATUSCLR_STALLRQ_Pos)
+#define USB_DEVICE_EPSTATUSCLR_STALLRQ_Msk (_U_(0x3) << USB_DEVICE_EPSTATUSCLR_STALLRQ_Pos)
 #define USB_DEVICE_EPSTATUSCLR_STALLRQ(value) (USB_DEVICE_EPSTATUSCLR_STALLRQ_Msk & ((value) << USB_DEVICE_EPSTATUSCLR_STALLRQ_Pos))
 #define USB_DEVICE_EPSTATUSCLR_BK0RDY_Pos 6            /**< \brief (USB_DEVICE_EPSTATUSCLR) Bank 0 Ready Clear */
-#define USB_DEVICE_EPSTATUSCLR_BK0RDY (0x1ul << USB_DEVICE_EPSTATUSCLR_BK0RDY_Pos)
+#define USB_DEVICE_EPSTATUSCLR_BK0RDY (_U_(0x1) << USB_DEVICE_EPSTATUSCLR_BK0RDY_Pos)
 #define USB_DEVICE_EPSTATUSCLR_BK1RDY_Pos 7            /**< \brief (USB_DEVICE_EPSTATUSCLR) Bank 1 Ready Clear */
-#define USB_DEVICE_EPSTATUSCLR_BK1RDY (0x1ul << USB_DEVICE_EPSTATUSCLR_BK1RDY_Pos)
-#define USB_DEVICE_EPSTATUSCLR_MASK 0xF7ul       /**< \brief (USB_DEVICE_EPSTATUSCLR) MASK Register */
+#define USB_DEVICE_EPSTATUSCLR_BK1RDY (_U_(0x1) << USB_DEVICE_EPSTATUSCLR_BK1RDY_Pos)
+#define USB_DEVICE_EPSTATUSCLR_MASK _U_(0xF7)     /**< \brief (USB_DEVICE_EPSTATUSCLR) MASK Register */
 
 /* -------- USB_HOST_PSTATUSCLR : (USB Offset: 0x104) ( /W  8) HOST HOST_PIPE End Point Pipe Status Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -983,19 +968,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_PSTATUSCLR_OFFSET  0x104        /**< \brief (USB_HOST_PSTATUSCLR offset) HOST_PIPE End Point Pipe Status Clear */
-#define USB_HOST_PSTATUSCLR_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PSTATUSCLR reset_value) HOST_PIPE End Point Pipe Status Clear */
+#define USB_HOST_PSTATUSCLR_RESETVALUE _U_(0x00)     /**< \brief (USB_HOST_PSTATUSCLR reset_value) HOST_PIPE End Point Pipe Status Clear */
 
 #define USB_HOST_PSTATUSCLR_DTGL_Pos 0            /**< \brief (USB_HOST_PSTATUSCLR) Data Toggle clear */
-#define USB_HOST_PSTATUSCLR_DTGL    (0x1ul << USB_HOST_PSTATUSCLR_DTGL_Pos)
+#define USB_HOST_PSTATUSCLR_DTGL    (_U_(0x1) << USB_HOST_PSTATUSCLR_DTGL_Pos)
 #define USB_HOST_PSTATUSCLR_CURBK_Pos 2            /**< \brief (USB_HOST_PSTATUSCLR) Curren Bank clear */
-#define USB_HOST_PSTATUSCLR_CURBK   (0x1ul << USB_HOST_PSTATUSCLR_CURBK_Pos)
+#define USB_HOST_PSTATUSCLR_CURBK   (_U_(0x1) << USB_HOST_PSTATUSCLR_CURBK_Pos)
 #define USB_HOST_PSTATUSCLR_PFREEZE_Pos 4            /**< \brief (USB_HOST_PSTATUSCLR) Pipe Freeze Clear */
-#define USB_HOST_PSTATUSCLR_PFREEZE (0x1ul << USB_HOST_PSTATUSCLR_PFREEZE_Pos)
+#define USB_HOST_PSTATUSCLR_PFREEZE (_U_(0x1) << USB_HOST_PSTATUSCLR_PFREEZE_Pos)
 #define USB_HOST_PSTATUSCLR_BK0RDY_Pos 6            /**< \brief (USB_HOST_PSTATUSCLR) Bank 0 Ready Clear */
-#define USB_HOST_PSTATUSCLR_BK0RDY  (0x1ul << USB_HOST_PSTATUSCLR_BK0RDY_Pos)
+#define USB_HOST_PSTATUSCLR_BK0RDY  (_U_(0x1) << USB_HOST_PSTATUSCLR_BK0RDY_Pos)
 #define USB_HOST_PSTATUSCLR_BK1RDY_Pos 7            /**< \brief (USB_HOST_PSTATUSCLR) Bank 1 Ready Clear */
-#define USB_HOST_PSTATUSCLR_BK1RDY  (0x1ul << USB_HOST_PSTATUSCLR_BK1RDY_Pos)
-#define USB_HOST_PSTATUSCLR_MASK    0xD5ul       /**< \brief (USB_HOST_PSTATUSCLR) MASK Register */
+#define USB_HOST_PSTATUSCLR_BK1RDY  (_U_(0x1) << USB_HOST_PSTATUSCLR_BK1RDY_Pos)
+#define USB_HOST_PSTATUSCLR_MASK    _U_(0xD5)     /**< \brief (USB_HOST_PSTATUSCLR) MASK Register */
 
 /* -------- USB_DEVICE_EPSTATUSSET : (USB Offset: 0x105) ( /W  8) DEVICE DEVICE_ENDPOINT End Point Pipe Status Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1020,26 +1005,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_EPSTATUSSET_OFFSET 0x105        /**< \brief (USB_DEVICE_EPSTATUSSET offset) DEVICE_ENDPOINT End Point Pipe Status Set */
-#define USB_DEVICE_EPSTATUSSET_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPSTATUSSET reset_value) DEVICE_ENDPOINT End Point Pipe Status Set */
+#define USB_DEVICE_EPSTATUSSET_RESETVALUE _U_(0x00)     /**< \brief (USB_DEVICE_EPSTATUSSET reset_value) DEVICE_ENDPOINT End Point Pipe Status Set */
 
 #define USB_DEVICE_EPSTATUSSET_DTGLOUT_Pos 0            /**< \brief (USB_DEVICE_EPSTATUSSET) Data Toggle OUT Set */
-#define USB_DEVICE_EPSTATUSSET_DTGLOUT (0x1ul << USB_DEVICE_EPSTATUSSET_DTGLOUT_Pos)
+#define USB_DEVICE_EPSTATUSSET_DTGLOUT (_U_(0x1) << USB_DEVICE_EPSTATUSSET_DTGLOUT_Pos)
 #define USB_DEVICE_EPSTATUSSET_DTGLIN_Pos 1            /**< \brief (USB_DEVICE_EPSTATUSSET) Data Toggle IN Set */
-#define USB_DEVICE_EPSTATUSSET_DTGLIN (0x1ul << USB_DEVICE_EPSTATUSSET_DTGLIN_Pos)
+#define USB_DEVICE_EPSTATUSSET_DTGLIN (_U_(0x1) << USB_DEVICE_EPSTATUSSET_DTGLIN_Pos)
 #define USB_DEVICE_EPSTATUSSET_CURBK_Pos 2            /**< \brief (USB_DEVICE_EPSTATUSSET) Current Bank Set */
-#define USB_DEVICE_EPSTATUSSET_CURBK (0x1ul << USB_DEVICE_EPSTATUSSET_CURBK_Pos)
+#define USB_DEVICE_EPSTATUSSET_CURBK (_U_(0x1) << USB_DEVICE_EPSTATUSSET_CURBK_Pos)
 #define USB_DEVICE_EPSTATUSSET_STALLRQ0_Pos 4            /**< \brief (USB_DEVICE_EPSTATUSSET) Stall 0 Request Set */
 #define USB_DEVICE_EPSTATUSSET_STALLRQ0 (1 << USB_DEVICE_EPSTATUSSET_STALLRQ0_Pos)
 #define USB_DEVICE_EPSTATUSSET_STALLRQ1_Pos 5            /**< \brief (USB_DEVICE_EPSTATUSSET) Stall 1 Request Set */
 #define USB_DEVICE_EPSTATUSSET_STALLRQ1 (1 << USB_DEVICE_EPSTATUSSET_STALLRQ1_Pos)
 #define USB_DEVICE_EPSTATUSSET_STALLRQ_Pos 4            /**< \brief (USB_DEVICE_EPSTATUSSET) Stall x Request Set */
-#define USB_DEVICE_EPSTATUSSET_STALLRQ_Msk (0x3ul << USB_DEVICE_EPSTATUSSET_STALLRQ_Pos)
+#define USB_DEVICE_EPSTATUSSET_STALLRQ_Msk (_U_(0x3) << USB_DEVICE_EPSTATUSSET_STALLRQ_Pos)
 #define USB_DEVICE_EPSTATUSSET_STALLRQ(value) (USB_DEVICE_EPSTATUSSET_STALLRQ_Msk & ((value) << USB_DEVICE_EPSTATUSSET_STALLRQ_Pos))
 #define USB_DEVICE_EPSTATUSSET_BK0RDY_Pos 6            /**< \brief (USB_DEVICE_EPSTATUSSET) Bank 0 Ready Set */
-#define USB_DEVICE_EPSTATUSSET_BK0RDY (0x1ul << USB_DEVICE_EPSTATUSSET_BK0RDY_Pos)
+#define USB_DEVICE_EPSTATUSSET_BK0RDY (_U_(0x1) << USB_DEVICE_EPSTATUSSET_BK0RDY_Pos)
 #define USB_DEVICE_EPSTATUSSET_BK1RDY_Pos 7            /**< \brief (USB_DEVICE_EPSTATUSSET) Bank 1 Ready Set */
-#define USB_DEVICE_EPSTATUSSET_BK1RDY (0x1ul << USB_DEVICE_EPSTATUSSET_BK1RDY_Pos)
-#define USB_DEVICE_EPSTATUSSET_MASK 0xF7ul       /**< \brief (USB_DEVICE_EPSTATUSSET) MASK Register */
+#define USB_DEVICE_EPSTATUSSET_BK1RDY (_U_(0x1) << USB_DEVICE_EPSTATUSSET_BK1RDY_Pos)
+#define USB_DEVICE_EPSTATUSSET_MASK _U_(0xF7)     /**< \brief (USB_DEVICE_EPSTATUSSET) MASK Register */
 
 /* -------- USB_HOST_PSTATUSSET : (USB Offset: 0x105) ( /W  8) HOST HOST_PIPE End Point Pipe Status Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1059,19 +1044,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_PSTATUSSET_OFFSET  0x105        /**< \brief (USB_HOST_PSTATUSSET offset) HOST_PIPE End Point Pipe Status Set */
-#define USB_HOST_PSTATUSSET_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PSTATUSSET reset_value) HOST_PIPE End Point Pipe Status Set */
+#define USB_HOST_PSTATUSSET_RESETVALUE _U_(0x00)     /**< \brief (USB_HOST_PSTATUSSET reset_value) HOST_PIPE End Point Pipe Status Set */
 
 #define USB_HOST_PSTATUSSET_DTGL_Pos 0            /**< \brief (USB_HOST_PSTATUSSET) Data Toggle Set */
-#define USB_HOST_PSTATUSSET_DTGL    (0x1ul << USB_HOST_PSTATUSSET_DTGL_Pos)
+#define USB_HOST_PSTATUSSET_DTGL    (_U_(0x1) << USB_HOST_PSTATUSSET_DTGL_Pos)
 #define USB_HOST_PSTATUSSET_CURBK_Pos 2            /**< \brief (USB_HOST_PSTATUSSET) Current Bank Set */
-#define USB_HOST_PSTATUSSET_CURBK   (0x1ul << USB_HOST_PSTATUSSET_CURBK_Pos)
+#define USB_HOST_PSTATUSSET_CURBK   (_U_(0x1) << USB_HOST_PSTATUSSET_CURBK_Pos)
 #define USB_HOST_PSTATUSSET_PFREEZE_Pos 4            /**< \brief (USB_HOST_PSTATUSSET) Pipe Freeze Set */
-#define USB_HOST_PSTATUSSET_PFREEZE (0x1ul << USB_HOST_PSTATUSSET_PFREEZE_Pos)
+#define USB_HOST_PSTATUSSET_PFREEZE (_U_(0x1) << USB_HOST_PSTATUSSET_PFREEZE_Pos)
 #define USB_HOST_PSTATUSSET_BK0RDY_Pos 6            /**< \brief (USB_HOST_PSTATUSSET) Bank 0 Ready Set */
-#define USB_HOST_PSTATUSSET_BK0RDY  (0x1ul << USB_HOST_PSTATUSSET_BK0RDY_Pos)
+#define USB_HOST_PSTATUSSET_BK0RDY  (_U_(0x1) << USB_HOST_PSTATUSSET_BK0RDY_Pos)
 #define USB_HOST_PSTATUSSET_BK1RDY_Pos 7            /**< \brief (USB_HOST_PSTATUSSET) Bank 1 Ready Set */
-#define USB_HOST_PSTATUSSET_BK1RDY  (0x1ul << USB_HOST_PSTATUSSET_BK1RDY_Pos)
-#define USB_HOST_PSTATUSSET_MASK    0xD5ul       /**< \brief (USB_HOST_PSTATUSSET) MASK Register */
+#define USB_HOST_PSTATUSSET_BK1RDY  (_U_(0x1) << USB_HOST_PSTATUSSET_BK1RDY_Pos)
+#define USB_HOST_PSTATUSSET_MASK    _U_(0xD5)     /**< \brief (USB_HOST_PSTATUSSET) MASK Register */
 
 /* -------- USB_DEVICE_EPSTATUS : (USB Offset: 0x106) (R/   8) DEVICE DEVICE_ENDPOINT End Point Pipe Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1096,26 +1081,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_EPSTATUS_OFFSET  0x106        /**< \brief (USB_DEVICE_EPSTATUS offset) DEVICE_ENDPOINT End Point Pipe Status */
-#define USB_DEVICE_EPSTATUS_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPSTATUS reset_value) DEVICE_ENDPOINT End Point Pipe Status */
+#define USB_DEVICE_EPSTATUS_RESETVALUE _U_(0x00)     /**< \brief (USB_DEVICE_EPSTATUS reset_value) DEVICE_ENDPOINT End Point Pipe Status */
 
 #define USB_DEVICE_EPSTATUS_DTGLOUT_Pos 0            /**< \brief (USB_DEVICE_EPSTATUS) Data Toggle Out */
-#define USB_DEVICE_EPSTATUS_DTGLOUT (0x1ul << USB_DEVICE_EPSTATUS_DTGLOUT_Pos)
+#define USB_DEVICE_EPSTATUS_DTGLOUT (_U_(0x1) << USB_DEVICE_EPSTATUS_DTGLOUT_Pos)
 #define USB_DEVICE_EPSTATUS_DTGLIN_Pos 1            /**< \brief (USB_DEVICE_EPSTATUS) Data Toggle In */
-#define USB_DEVICE_EPSTATUS_DTGLIN  (0x1ul << USB_DEVICE_EPSTATUS_DTGLIN_Pos)
+#define USB_DEVICE_EPSTATUS_DTGLIN  (_U_(0x1) << USB_DEVICE_EPSTATUS_DTGLIN_Pos)
 #define USB_DEVICE_EPSTATUS_CURBK_Pos 2            /**< \brief (USB_DEVICE_EPSTATUS) Current Bank */
-#define USB_DEVICE_EPSTATUS_CURBK   (0x1ul << USB_DEVICE_EPSTATUS_CURBK_Pos)
+#define USB_DEVICE_EPSTATUS_CURBK   (_U_(0x1) << USB_DEVICE_EPSTATUS_CURBK_Pos)
 #define USB_DEVICE_EPSTATUS_STALLRQ0_Pos 4            /**< \brief (USB_DEVICE_EPSTATUS) Stall 0 Request */
 #define USB_DEVICE_EPSTATUS_STALLRQ0 (1 << USB_DEVICE_EPSTATUS_STALLRQ0_Pos)
 #define USB_DEVICE_EPSTATUS_STALLRQ1_Pos 5            /**< \brief (USB_DEVICE_EPSTATUS) Stall 1 Request */
 #define USB_DEVICE_EPSTATUS_STALLRQ1 (1 << USB_DEVICE_EPSTATUS_STALLRQ1_Pos)
 #define USB_DEVICE_EPSTATUS_STALLRQ_Pos 4            /**< \brief (USB_DEVICE_EPSTATUS) Stall x Request */
-#define USB_DEVICE_EPSTATUS_STALLRQ_Msk (0x3ul << USB_DEVICE_EPSTATUS_STALLRQ_Pos)
+#define USB_DEVICE_EPSTATUS_STALLRQ_Msk (_U_(0x3) << USB_DEVICE_EPSTATUS_STALLRQ_Pos)
 #define USB_DEVICE_EPSTATUS_STALLRQ(value) (USB_DEVICE_EPSTATUS_STALLRQ_Msk & ((value) << USB_DEVICE_EPSTATUS_STALLRQ_Pos))
 #define USB_DEVICE_EPSTATUS_BK0RDY_Pos 6            /**< \brief (USB_DEVICE_EPSTATUS) Bank 0 ready */
-#define USB_DEVICE_EPSTATUS_BK0RDY  (0x1ul << USB_DEVICE_EPSTATUS_BK0RDY_Pos)
+#define USB_DEVICE_EPSTATUS_BK0RDY  (_U_(0x1) << USB_DEVICE_EPSTATUS_BK0RDY_Pos)
 #define USB_DEVICE_EPSTATUS_BK1RDY_Pos 7            /**< \brief (USB_DEVICE_EPSTATUS) Bank 1 ready */
-#define USB_DEVICE_EPSTATUS_BK1RDY  (0x1ul << USB_DEVICE_EPSTATUS_BK1RDY_Pos)
-#define USB_DEVICE_EPSTATUS_MASK    0xF7ul       /**< \brief (USB_DEVICE_EPSTATUS) MASK Register */
+#define USB_DEVICE_EPSTATUS_BK1RDY  (_U_(0x1) << USB_DEVICE_EPSTATUS_BK1RDY_Pos)
+#define USB_DEVICE_EPSTATUS_MASK    _U_(0xF7)     /**< \brief (USB_DEVICE_EPSTATUS) MASK Register */
 
 /* -------- USB_HOST_PSTATUS : (USB Offset: 0x106) (R/   8) HOST HOST_PIPE End Point Pipe Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1135,19 +1120,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_PSTATUS_OFFSET     0x106        /**< \brief (USB_HOST_PSTATUS offset) HOST_PIPE End Point Pipe Status */
-#define USB_HOST_PSTATUS_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PSTATUS reset_value) HOST_PIPE End Point Pipe Status */
+#define USB_HOST_PSTATUS_RESETVALUE _U_(0x00)     /**< \brief (USB_HOST_PSTATUS reset_value) HOST_PIPE End Point Pipe Status */
 
 #define USB_HOST_PSTATUS_DTGL_Pos   0            /**< \brief (USB_HOST_PSTATUS) Data Toggle */
-#define USB_HOST_PSTATUS_DTGL       (0x1ul << USB_HOST_PSTATUS_DTGL_Pos)
+#define USB_HOST_PSTATUS_DTGL       (_U_(0x1) << USB_HOST_PSTATUS_DTGL_Pos)
 #define USB_HOST_PSTATUS_CURBK_Pos  2            /**< \brief (USB_HOST_PSTATUS) Current Bank */
-#define USB_HOST_PSTATUS_CURBK      (0x1ul << USB_HOST_PSTATUS_CURBK_Pos)
+#define USB_HOST_PSTATUS_CURBK      (_U_(0x1) << USB_HOST_PSTATUS_CURBK_Pos)
 #define USB_HOST_PSTATUS_PFREEZE_Pos 4            /**< \brief (USB_HOST_PSTATUS) Pipe Freeze */
-#define USB_HOST_PSTATUS_PFREEZE    (0x1ul << USB_HOST_PSTATUS_PFREEZE_Pos)
+#define USB_HOST_PSTATUS_PFREEZE    (_U_(0x1) << USB_HOST_PSTATUS_PFREEZE_Pos)
 #define USB_HOST_PSTATUS_BK0RDY_Pos 6            /**< \brief (USB_HOST_PSTATUS) Bank 0 ready */
-#define USB_HOST_PSTATUS_BK0RDY     (0x1ul << USB_HOST_PSTATUS_BK0RDY_Pos)
+#define USB_HOST_PSTATUS_BK0RDY     (_U_(0x1) << USB_HOST_PSTATUS_BK0RDY_Pos)
 #define USB_HOST_PSTATUS_BK1RDY_Pos 7            /**< \brief (USB_HOST_PSTATUS) Bank 1 ready */
-#define USB_HOST_PSTATUS_BK1RDY     (0x1ul << USB_HOST_PSTATUS_BK1RDY_Pos)
-#define USB_HOST_PSTATUS_MASK       0xD5ul       /**< \brief (USB_HOST_PSTATUS) MASK Register */
+#define USB_HOST_PSTATUS_BK1RDY     (_U_(0x1) << USB_HOST_PSTATUS_BK1RDY_Pos)
+#define USB_HOST_PSTATUS_MASK       _U_(0xD5)     /**< \brief (USB_HOST_PSTATUS) MASK Register */
 
 /* -------- USB_DEVICE_EPINTFLAG : (USB Offset: 0x107) (R/W  8) DEVICE DEVICE_ENDPOINT End Point Interrupt Flag -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1174,32 +1159,32 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_EPINTFLAG_OFFSET 0x107        /**< \brief (USB_DEVICE_EPINTFLAG offset) DEVICE_ENDPOINT End Point Interrupt Flag */
-#define USB_DEVICE_EPINTFLAG_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPINTFLAG reset_value) DEVICE_ENDPOINT End Point Interrupt Flag */
+#define USB_DEVICE_EPINTFLAG_RESETVALUE _U_(0x00)     /**< \brief (USB_DEVICE_EPINTFLAG reset_value) DEVICE_ENDPOINT End Point Interrupt Flag */
 
 #define USB_DEVICE_EPINTFLAG_TRCPT0_Pos 0            /**< \brief (USB_DEVICE_EPINTFLAG) Transfer Complete 0 */
 #define USB_DEVICE_EPINTFLAG_TRCPT0 (1 << USB_DEVICE_EPINTFLAG_TRCPT0_Pos)
 #define USB_DEVICE_EPINTFLAG_TRCPT1_Pos 1            /**< \brief (USB_DEVICE_EPINTFLAG) Transfer Complete 1 */
 #define USB_DEVICE_EPINTFLAG_TRCPT1 (1 << USB_DEVICE_EPINTFLAG_TRCPT1_Pos)
 #define USB_DEVICE_EPINTFLAG_TRCPT_Pos 0            /**< \brief (USB_DEVICE_EPINTFLAG) Transfer Complete x */
-#define USB_DEVICE_EPINTFLAG_TRCPT_Msk (0x3ul << USB_DEVICE_EPINTFLAG_TRCPT_Pos)
+#define USB_DEVICE_EPINTFLAG_TRCPT_Msk (_U_(0x3) << USB_DEVICE_EPINTFLAG_TRCPT_Pos)
 #define USB_DEVICE_EPINTFLAG_TRCPT(value) (USB_DEVICE_EPINTFLAG_TRCPT_Msk & ((value) << USB_DEVICE_EPINTFLAG_TRCPT_Pos))
 #define USB_DEVICE_EPINTFLAG_TRFAIL0_Pos 2            /**< \brief (USB_DEVICE_EPINTFLAG) Error Flow 0 */
 #define USB_DEVICE_EPINTFLAG_TRFAIL0 (1 << USB_DEVICE_EPINTFLAG_TRFAIL0_Pos)
 #define USB_DEVICE_EPINTFLAG_TRFAIL1_Pos 3            /**< \brief (USB_DEVICE_EPINTFLAG) Error Flow 1 */
 #define USB_DEVICE_EPINTFLAG_TRFAIL1 (1 << USB_DEVICE_EPINTFLAG_TRFAIL1_Pos)
 #define USB_DEVICE_EPINTFLAG_TRFAIL_Pos 2            /**< \brief (USB_DEVICE_EPINTFLAG) Error Flow x */
-#define USB_DEVICE_EPINTFLAG_TRFAIL_Msk (0x3ul << USB_DEVICE_EPINTFLAG_TRFAIL_Pos)
+#define USB_DEVICE_EPINTFLAG_TRFAIL_Msk (_U_(0x3) << USB_DEVICE_EPINTFLAG_TRFAIL_Pos)
 #define USB_DEVICE_EPINTFLAG_TRFAIL(value) (USB_DEVICE_EPINTFLAG_TRFAIL_Msk & ((value) << USB_DEVICE_EPINTFLAG_TRFAIL_Pos))
 #define USB_DEVICE_EPINTFLAG_RXSTP_Pos 4            /**< \brief (USB_DEVICE_EPINTFLAG) Received Setup */
-#define USB_DEVICE_EPINTFLAG_RXSTP  (0x1ul << USB_DEVICE_EPINTFLAG_RXSTP_Pos)
+#define USB_DEVICE_EPINTFLAG_RXSTP  (_U_(0x1) << USB_DEVICE_EPINTFLAG_RXSTP_Pos)
 #define USB_DEVICE_EPINTFLAG_STALL0_Pos 5            /**< \brief (USB_DEVICE_EPINTFLAG) Stall 0 In/out */
 #define USB_DEVICE_EPINTFLAG_STALL0 (1 << USB_DEVICE_EPINTFLAG_STALL0_Pos)
 #define USB_DEVICE_EPINTFLAG_STALL1_Pos 6            /**< \brief (USB_DEVICE_EPINTFLAG) Stall 1 In/out */
 #define USB_DEVICE_EPINTFLAG_STALL1 (1 << USB_DEVICE_EPINTFLAG_STALL1_Pos)
 #define USB_DEVICE_EPINTFLAG_STALL_Pos 5            /**< \brief (USB_DEVICE_EPINTFLAG) Stall x In/out */
-#define USB_DEVICE_EPINTFLAG_STALL_Msk (0x3ul << USB_DEVICE_EPINTFLAG_STALL_Pos)
+#define USB_DEVICE_EPINTFLAG_STALL_Msk (_U_(0x3) << USB_DEVICE_EPINTFLAG_STALL_Pos)
 #define USB_DEVICE_EPINTFLAG_STALL(value) (USB_DEVICE_EPINTFLAG_STALL_Msk & ((value) << USB_DEVICE_EPINTFLAG_STALL_Pos))
-#define USB_DEVICE_EPINTFLAG_MASK   0x7Ful       /**< \brief (USB_DEVICE_EPINTFLAG) MASK Register */
+#define USB_DEVICE_EPINTFLAG_MASK   _U_(0x7F)     /**< \brief (USB_DEVICE_EPINTFLAG) MASK Register */
 
 /* -------- USB_HOST_PINTFLAG : (USB Offset: 0x107) (R/W  8) HOST HOST_PIPE Pipe Interrupt Flag -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1222,24 +1207,24 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_PINTFLAG_OFFSET    0x107        /**< \brief (USB_HOST_PINTFLAG offset) HOST_PIPE Pipe Interrupt Flag */
-#define USB_HOST_PINTFLAG_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PINTFLAG reset_value) HOST_PIPE Pipe Interrupt Flag */
+#define USB_HOST_PINTFLAG_RESETVALUE _U_(0x00)     /**< \brief (USB_HOST_PINTFLAG reset_value) HOST_PIPE Pipe Interrupt Flag */
 
 #define USB_HOST_PINTFLAG_TRCPT0_Pos 0            /**< \brief (USB_HOST_PINTFLAG) Transfer Complete 0 Interrupt Flag */
 #define USB_HOST_PINTFLAG_TRCPT0    (1 << USB_HOST_PINTFLAG_TRCPT0_Pos)
 #define USB_HOST_PINTFLAG_TRCPT1_Pos 1            /**< \brief (USB_HOST_PINTFLAG) Transfer Complete 1 Interrupt Flag */
 #define USB_HOST_PINTFLAG_TRCPT1    (1 << USB_HOST_PINTFLAG_TRCPT1_Pos)
 #define USB_HOST_PINTFLAG_TRCPT_Pos 0            /**< \brief (USB_HOST_PINTFLAG) Transfer Complete x Interrupt Flag */
-#define USB_HOST_PINTFLAG_TRCPT_Msk (0x3ul << USB_HOST_PINTFLAG_TRCPT_Pos)
+#define USB_HOST_PINTFLAG_TRCPT_Msk (_U_(0x3) << USB_HOST_PINTFLAG_TRCPT_Pos)
 #define USB_HOST_PINTFLAG_TRCPT(value) (USB_HOST_PINTFLAG_TRCPT_Msk & ((value) << USB_HOST_PINTFLAG_TRCPT_Pos))
 #define USB_HOST_PINTFLAG_TRFAIL_Pos 2            /**< \brief (USB_HOST_PINTFLAG) Error Flow Interrupt Flag */
-#define USB_HOST_PINTFLAG_TRFAIL    (0x1ul << USB_HOST_PINTFLAG_TRFAIL_Pos)
+#define USB_HOST_PINTFLAG_TRFAIL    (_U_(0x1) << USB_HOST_PINTFLAG_TRFAIL_Pos)
 #define USB_HOST_PINTFLAG_PERR_Pos  3            /**< \brief (USB_HOST_PINTFLAG) Pipe Error Interrupt Flag */
-#define USB_HOST_PINTFLAG_PERR      (0x1ul << USB_HOST_PINTFLAG_PERR_Pos)
+#define USB_HOST_PINTFLAG_PERR      (_U_(0x1) << USB_HOST_PINTFLAG_PERR_Pos)
 #define USB_HOST_PINTFLAG_TXSTP_Pos 4            /**< \brief (USB_HOST_PINTFLAG) Transmit  Setup Interrupt Flag */
-#define USB_HOST_PINTFLAG_TXSTP     (0x1ul << USB_HOST_PINTFLAG_TXSTP_Pos)
+#define USB_HOST_PINTFLAG_TXSTP     (_U_(0x1) << USB_HOST_PINTFLAG_TXSTP_Pos)
 #define USB_HOST_PINTFLAG_STALL_Pos 5            /**< \brief (USB_HOST_PINTFLAG) Stall Interrupt Flag */
-#define USB_HOST_PINTFLAG_STALL     (0x1ul << USB_HOST_PINTFLAG_STALL_Pos)
-#define USB_HOST_PINTFLAG_MASK      0x3Ful       /**< \brief (USB_HOST_PINTFLAG) MASK Register */
+#define USB_HOST_PINTFLAG_STALL     (_U_(0x1) << USB_HOST_PINTFLAG_STALL_Pos)
+#define USB_HOST_PINTFLAG_MASK      _U_(0x3F)     /**< \brief (USB_HOST_PINTFLAG) MASK Register */
 
 /* -------- USB_DEVICE_EPINTENCLR : (USB Offset: 0x108) (R/W  8) DEVICE DEVICE_ENDPOINT End Point Interrupt Clear Flag -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1266,32 +1251,32 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_EPINTENCLR_OFFSET 0x108        /**< \brief (USB_DEVICE_EPINTENCLR offset) DEVICE_ENDPOINT End Point Interrupt Clear Flag */
-#define USB_DEVICE_EPINTENCLR_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPINTENCLR reset_value) DEVICE_ENDPOINT End Point Interrupt Clear Flag */
+#define USB_DEVICE_EPINTENCLR_RESETVALUE _U_(0x00)     /**< \brief (USB_DEVICE_EPINTENCLR reset_value) DEVICE_ENDPOINT End Point Interrupt Clear Flag */
 
 #define USB_DEVICE_EPINTENCLR_TRCPT0_Pos 0            /**< \brief (USB_DEVICE_EPINTENCLR) Transfer Complete 0 Interrupt Disable */
 #define USB_DEVICE_EPINTENCLR_TRCPT0 (1 << USB_DEVICE_EPINTENCLR_TRCPT0_Pos)
 #define USB_DEVICE_EPINTENCLR_TRCPT1_Pos 1            /**< \brief (USB_DEVICE_EPINTENCLR) Transfer Complete 1 Interrupt Disable */
 #define USB_DEVICE_EPINTENCLR_TRCPT1 (1 << USB_DEVICE_EPINTENCLR_TRCPT1_Pos)
 #define USB_DEVICE_EPINTENCLR_TRCPT_Pos 0            /**< \brief (USB_DEVICE_EPINTENCLR) Transfer Complete x Interrupt Disable */
-#define USB_DEVICE_EPINTENCLR_TRCPT_Msk (0x3ul << USB_DEVICE_EPINTENCLR_TRCPT_Pos)
+#define USB_DEVICE_EPINTENCLR_TRCPT_Msk (_U_(0x3) << USB_DEVICE_EPINTENCLR_TRCPT_Pos)
 #define USB_DEVICE_EPINTENCLR_TRCPT(value) (USB_DEVICE_EPINTENCLR_TRCPT_Msk & ((value) << USB_DEVICE_EPINTENCLR_TRCPT_Pos))
 #define USB_DEVICE_EPINTENCLR_TRFAIL0_Pos 2            /**< \brief (USB_DEVICE_EPINTENCLR) Error Flow 0 Interrupt Disable */
 #define USB_DEVICE_EPINTENCLR_TRFAIL0 (1 << USB_DEVICE_EPINTENCLR_TRFAIL0_Pos)
 #define USB_DEVICE_EPINTENCLR_TRFAIL1_Pos 3            /**< \brief (USB_DEVICE_EPINTENCLR) Error Flow 1 Interrupt Disable */
 #define USB_DEVICE_EPINTENCLR_TRFAIL1 (1 << USB_DEVICE_EPINTENCLR_TRFAIL1_Pos)
 #define USB_DEVICE_EPINTENCLR_TRFAIL_Pos 2            /**< \brief (USB_DEVICE_EPINTENCLR) Error Flow x Interrupt Disable */
-#define USB_DEVICE_EPINTENCLR_TRFAIL_Msk (0x3ul << USB_DEVICE_EPINTENCLR_TRFAIL_Pos)
+#define USB_DEVICE_EPINTENCLR_TRFAIL_Msk (_U_(0x3) << USB_DEVICE_EPINTENCLR_TRFAIL_Pos)
 #define USB_DEVICE_EPINTENCLR_TRFAIL(value) (USB_DEVICE_EPINTENCLR_TRFAIL_Msk & ((value) << USB_DEVICE_EPINTENCLR_TRFAIL_Pos))
 #define USB_DEVICE_EPINTENCLR_RXSTP_Pos 4            /**< \brief (USB_DEVICE_EPINTENCLR) Received Setup Interrupt Disable */
-#define USB_DEVICE_EPINTENCLR_RXSTP (0x1ul << USB_DEVICE_EPINTENCLR_RXSTP_Pos)
+#define USB_DEVICE_EPINTENCLR_RXSTP (_U_(0x1) << USB_DEVICE_EPINTENCLR_RXSTP_Pos)
 #define USB_DEVICE_EPINTENCLR_STALL0_Pos 5            /**< \brief (USB_DEVICE_EPINTENCLR) Stall 0 In/Out Interrupt Disable */
 #define USB_DEVICE_EPINTENCLR_STALL0 (1 << USB_DEVICE_EPINTENCLR_STALL0_Pos)
 #define USB_DEVICE_EPINTENCLR_STALL1_Pos 6            /**< \brief (USB_DEVICE_EPINTENCLR) Stall 1 In/Out Interrupt Disable */
 #define USB_DEVICE_EPINTENCLR_STALL1 (1 << USB_DEVICE_EPINTENCLR_STALL1_Pos)
 #define USB_DEVICE_EPINTENCLR_STALL_Pos 5            /**< \brief (USB_DEVICE_EPINTENCLR) Stall x In/Out Interrupt Disable */
-#define USB_DEVICE_EPINTENCLR_STALL_Msk (0x3ul << USB_DEVICE_EPINTENCLR_STALL_Pos)
+#define USB_DEVICE_EPINTENCLR_STALL_Msk (_U_(0x3) << USB_DEVICE_EPINTENCLR_STALL_Pos)
 #define USB_DEVICE_EPINTENCLR_STALL(value) (USB_DEVICE_EPINTENCLR_STALL_Msk & ((value) << USB_DEVICE_EPINTENCLR_STALL_Pos))
-#define USB_DEVICE_EPINTENCLR_MASK  0x7Ful       /**< \brief (USB_DEVICE_EPINTENCLR) MASK Register */
+#define USB_DEVICE_EPINTENCLR_MASK  _U_(0x7F)     /**< \brief (USB_DEVICE_EPINTENCLR) MASK Register */
 
 /* -------- USB_HOST_PINTENCLR : (USB Offset: 0x108) (R/W  8) HOST HOST_PIPE Pipe Interrupt Flag Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1314,24 +1299,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_PINTENCLR_OFFSET   0x108        /**< \brief (USB_HOST_PINTENCLR offset) HOST_PIPE Pipe Interrupt Flag Clear */
-#define USB_HOST_PINTENCLR_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PINTENCLR reset_value) HOST_PIPE Pipe Interrupt Flag Clear */
+#define USB_HOST_PINTENCLR_RESETVALUE _U_(0x00)     /**< \brief (USB_HOST_PINTENCLR reset_value) HOST_PIPE Pipe Interrupt Flag Clear */
 
 #define USB_HOST_PINTENCLR_TRCPT0_Pos 0            /**< \brief (USB_HOST_PINTENCLR) Transfer Complete 0 Disable */
 #define USB_HOST_PINTENCLR_TRCPT0   (1 << USB_HOST_PINTENCLR_TRCPT0_Pos)
 #define USB_HOST_PINTENCLR_TRCPT1_Pos 1            /**< \brief (USB_HOST_PINTENCLR) Transfer Complete 1 Disable */
 #define USB_HOST_PINTENCLR_TRCPT1   (1 << USB_HOST_PINTENCLR_TRCPT1_Pos)
 #define USB_HOST_PINTENCLR_TRCPT_Pos 0            /**< \brief (USB_HOST_PINTENCLR) Transfer Complete x Disable */
-#define USB_HOST_PINTENCLR_TRCPT_Msk (0x3ul << USB_HOST_PINTENCLR_TRCPT_Pos)
+#define USB_HOST_PINTENCLR_TRCPT_Msk (_U_(0x3) << USB_HOST_PINTENCLR_TRCPT_Pos)
 #define USB_HOST_PINTENCLR_TRCPT(value) (USB_HOST_PINTENCLR_TRCPT_Msk & ((value) << USB_HOST_PINTENCLR_TRCPT_Pos))
 #define USB_HOST_PINTENCLR_TRFAIL_Pos 2            /**< \brief (USB_HOST_PINTENCLR) Error Flow Interrupt Disable */
-#define USB_HOST_PINTENCLR_TRFAIL   (0x1ul << USB_HOST_PINTENCLR_TRFAIL_Pos)
+#define USB_HOST_PINTENCLR_TRFAIL   (_U_(0x1) << USB_HOST_PINTENCLR_TRFAIL_Pos)
 #define USB_HOST_PINTENCLR_PERR_Pos 3            /**< \brief (USB_HOST_PINTENCLR) Pipe Error Interrupt Disable */
-#define USB_HOST_PINTENCLR_PERR     (0x1ul << USB_HOST_PINTENCLR_PERR_Pos)
+#define USB_HOST_PINTENCLR_PERR     (_U_(0x1) << USB_HOST_PINTENCLR_PERR_Pos)
 #define USB_HOST_PINTENCLR_TXSTP_Pos 4            /**< \brief (USB_HOST_PINTENCLR) Transmit  Setup Interrupt Disable */
-#define USB_HOST_PINTENCLR_TXSTP    (0x1ul << USB_HOST_PINTENCLR_TXSTP_Pos)
+#define USB_HOST_PINTENCLR_TXSTP    (_U_(0x1) << USB_HOST_PINTENCLR_TXSTP_Pos)
 #define USB_HOST_PINTENCLR_STALL_Pos 5            /**< \brief (USB_HOST_PINTENCLR) Stall Inetrrupt Disable */
-#define USB_HOST_PINTENCLR_STALL    (0x1ul << USB_HOST_PINTENCLR_STALL_Pos)
-#define USB_HOST_PINTENCLR_MASK     0x3Ful       /**< \brief (USB_HOST_PINTENCLR) MASK Register */
+#define USB_HOST_PINTENCLR_STALL    (_U_(0x1) << USB_HOST_PINTENCLR_STALL_Pos)
+#define USB_HOST_PINTENCLR_MASK     _U_(0x3F)     /**< \brief (USB_HOST_PINTENCLR) MASK Register */
 
 /* -------- USB_DEVICE_EPINTENSET : (USB Offset: 0x109) (R/W  8) DEVICE DEVICE_ENDPOINT End Point Interrupt Set Flag -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1358,32 +1343,32 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_DEVICE_EPINTENSET_OFFSET 0x109        /**< \brief (USB_DEVICE_EPINTENSET offset) DEVICE_ENDPOINT End Point Interrupt Set Flag */
-#define USB_DEVICE_EPINTENSET_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPINTENSET reset_value) DEVICE_ENDPOINT End Point Interrupt Set Flag */
+#define USB_DEVICE_EPINTENSET_RESETVALUE _U_(0x00)     /**< \brief (USB_DEVICE_EPINTENSET reset_value) DEVICE_ENDPOINT End Point Interrupt Set Flag */
 
 #define USB_DEVICE_EPINTENSET_TRCPT0_Pos 0            /**< \brief (USB_DEVICE_EPINTENSET) Transfer Complete 0 Interrupt Enable */
 #define USB_DEVICE_EPINTENSET_TRCPT0 (1 << USB_DEVICE_EPINTENSET_TRCPT0_Pos)
 #define USB_DEVICE_EPINTENSET_TRCPT1_Pos 1            /**< \brief (USB_DEVICE_EPINTENSET) Transfer Complete 1 Interrupt Enable */
 #define USB_DEVICE_EPINTENSET_TRCPT1 (1 << USB_DEVICE_EPINTENSET_TRCPT1_Pos)
 #define USB_DEVICE_EPINTENSET_TRCPT_Pos 0            /**< \brief (USB_DEVICE_EPINTENSET) Transfer Complete x Interrupt Enable */
-#define USB_DEVICE_EPINTENSET_TRCPT_Msk (0x3ul << USB_DEVICE_EPINTENSET_TRCPT_Pos)
+#define USB_DEVICE_EPINTENSET_TRCPT_Msk (_U_(0x3) << USB_DEVICE_EPINTENSET_TRCPT_Pos)
 #define USB_DEVICE_EPINTENSET_TRCPT(value) (USB_DEVICE_EPINTENSET_TRCPT_Msk & ((value) << USB_DEVICE_EPINTENSET_TRCPT_Pos))
 #define USB_DEVICE_EPINTENSET_TRFAIL0_Pos 2            /**< \brief (USB_DEVICE_EPINTENSET) Error Flow 0 Interrupt Enable */
 #define USB_DEVICE_EPINTENSET_TRFAIL0 (1 << USB_DEVICE_EPINTENSET_TRFAIL0_Pos)
 #define USB_DEVICE_EPINTENSET_TRFAIL1_Pos 3            /**< \brief (USB_DEVICE_EPINTENSET) Error Flow 1 Interrupt Enable */
 #define USB_DEVICE_EPINTENSET_TRFAIL1 (1 << USB_DEVICE_EPINTENSET_TRFAIL1_Pos)
 #define USB_DEVICE_EPINTENSET_TRFAIL_Pos 2            /**< \brief (USB_DEVICE_EPINTENSET) Error Flow x Interrupt Enable */
-#define USB_DEVICE_EPINTENSET_TRFAIL_Msk (0x3ul << USB_DEVICE_EPINTENSET_TRFAIL_Pos)
+#define USB_DEVICE_EPINTENSET_TRFAIL_Msk (_U_(0x3) << USB_DEVICE_EPINTENSET_TRFAIL_Pos)
 #define USB_DEVICE_EPINTENSET_TRFAIL(value) (USB_DEVICE_EPINTENSET_TRFAIL_Msk & ((value) << USB_DEVICE_EPINTENSET_TRFAIL_Pos))
 #define USB_DEVICE_EPINTENSET_RXSTP_Pos 4            /**< \brief (USB_DEVICE_EPINTENSET) Received Setup Interrupt Enable */
-#define USB_DEVICE_EPINTENSET_RXSTP (0x1ul << USB_DEVICE_EPINTENSET_RXSTP_Pos)
+#define USB_DEVICE_EPINTENSET_RXSTP (_U_(0x1) << USB_DEVICE_EPINTENSET_RXSTP_Pos)
 #define USB_DEVICE_EPINTENSET_STALL0_Pos 5            /**< \brief (USB_DEVICE_EPINTENSET) Stall 0 In/out Interrupt enable */
 #define USB_DEVICE_EPINTENSET_STALL0 (1 << USB_DEVICE_EPINTENSET_STALL0_Pos)
 #define USB_DEVICE_EPINTENSET_STALL1_Pos 6            /**< \brief (USB_DEVICE_EPINTENSET) Stall 1 In/out Interrupt enable */
 #define USB_DEVICE_EPINTENSET_STALL1 (1 << USB_DEVICE_EPINTENSET_STALL1_Pos)
 #define USB_DEVICE_EPINTENSET_STALL_Pos 5            /**< \brief (USB_DEVICE_EPINTENSET) Stall x In/out Interrupt enable */
-#define USB_DEVICE_EPINTENSET_STALL_Msk (0x3ul << USB_DEVICE_EPINTENSET_STALL_Pos)
+#define USB_DEVICE_EPINTENSET_STALL_Msk (_U_(0x3) << USB_DEVICE_EPINTENSET_STALL_Pos)
 #define USB_DEVICE_EPINTENSET_STALL(value) (USB_DEVICE_EPINTENSET_STALL_Msk & ((value) << USB_DEVICE_EPINTENSET_STALL_Pos))
-#define USB_DEVICE_EPINTENSET_MASK  0x7Ful       /**< \brief (USB_DEVICE_EPINTENSET) MASK Register */
+#define USB_DEVICE_EPINTENSET_MASK  _U_(0x7F)     /**< \brief (USB_DEVICE_EPINTENSET) MASK Register */
 
 /* -------- USB_HOST_PINTENSET : (USB Offset: 0x109) (R/W  8) HOST HOST_PIPE Pipe Interrupt Flag Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1406,24 +1391,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_PINTENSET_OFFSET   0x109        /**< \brief (USB_HOST_PINTENSET offset) HOST_PIPE Pipe Interrupt Flag Set */
-#define USB_HOST_PINTENSET_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PINTENSET reset_value) HOST_PIPE Pipe Interrupt Flag Set */
+#define USB_HOST_PINTENSET_RESETVALUE _U_(0x00)     /**< \brief (USB_HOST_PINTENSET reset_value) HOST_PIPE Pipe Interrupt Flag Set */
 
 #define USB_HOST_PINTENSET_TRCPT0_Pos 0            /**< \brief (USB_HOST_PINTENSET) Transfer Complete 0 Interrupt Enable */
 #define USB_HOST_PINTENSET_TRCPT0   (1 << USB_HOST_PINTENSET_TRCPT0_Pos)
 #define USB_HOST_PINTENSET_TRCPT1_Pos 1            /**< \brief (USB_HOST_PINTENSET) Transfer Complete 1 Interrupt Enable */
 #define USB_HOST_PINTENSET_TRCPT1   (1 << USB_HOST_PINTENSET_TRCPT1_Pos)
 #define USB_HOST_PINTENSET_TRCPT_Pos 0            /**< \brief (USB_HOST_PINTENSET) Transfer Complete x Interrupt Enable */
-#define USB_HOST_PINTENSET_TRCPT_Msk (0x3ul << USB_HOST_PINTENSET_TRCPT_Pos)
+#define USB_HOST_PINTENSET_TRCPT_Msk (_U_(0x3) << USB_HOST_PINTENSET_TRCPT_Pos)
 #define USB_HOST_PINTENSET_TRCPT(value) (USB_HOST_PINTENSET_TRCPT_Msk & ((value) << USB_HOST_PINTENSET_TRCPT_Pos))
 #define USB_HOST_PINTENSET_TRFAIL_Pos 2            /**< \brief (USB_HOST_PINTENSET) Error Flow Interrupt Enable */
-#define USB_HOST_PINTENSET_TRFAIL   (0x1ul << USB_HOST_PINTENSET_TRFAIL_Pos)
+#define USB_HOST_PINTENSET_TRFAIL   (_U_(0x1) << USB_HOST_PINTENSET_TRFAIL_Pos)
 #define USB_HOST_PINTENSET_PERR_Pos 3            /**< \brief (USB_HOST_PINTENSET) Pipe Error Interrupt Enable */
-#define USB_HOST_PINTENSET_PERR     (0x1ul << USB_HOST_PINTENSET_PERR_Pos)
+#define USB_HOST_PINTENSET_PERR     (_U_(0x1) << USB_HOST_PINTENSET_PERR_Pos)
 #define USB_HOST_PINTENSET_TXSTP_Pos 4            /**< \brief (USB_HOST_PINTENSET) Transmit  Setup Interrupt Enable */
-#define USB_HOST_PINTENSET_TXSTP    (0x1ul << USB_HOST_PINTENSET_TXSTP_Pos)
+#define USB_HOST_PINTENSET_TXSTP    (_U_(0x1) << USB_HOST_PINTENSET_TXSTP_Pos)
 #define USB_HOST_PINTENSET_STALL_Pos 5            /**< \brief (USB_HOST_PINTENSET) Stall Interrupt Enable */
-#define USB_HOST_PINTENSET_STALL    (0x1ul << USB_HOST_PINTENSET_STALL_Pos)
-#define USB_HOST_PINTENSET_MASK     0x3Ful       /**< \brief (USB_HOST_PINTENSET) MASK Register */
+#define USB_HOST_PINTENSET_STALL    (_U_(0x1) << USB_HOST_PINTENSET_STALL_Pos)
+#define USB_HOST_PINTENSET_MASK     _U_(0x3F)     /**< \brief (USB_HOST_PINTENSET) MASK Register */
 
 /* -------- USB_DEVICE_ADDR : (USB Offset: 0x000) (R/W 32) DEVICE DEVICE_DESC_BANK Endpoint Bank, Adress of Data Buffer -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1438,9 +1423,9 @@ typedef union {
 #define USB_DEVICE_ADDR_OFFSET      0x000        /**< \brief (USB_DEVICE_ADDR offset) DEVICE_DESC_BANK Endpoint Bank, Adress of Data Buffer */
 
 #define USB_DEVICE_ADDR_ADDR_Pos    0            /**< \brief (USB_DEVICE_ADDR) Adress of data buffer */
-#define USB_DEVICE_ADDR_ADDR_Msk    (0xFFFFFFFFul << USB_DEVICE_ADDR_ADDR_Pos)
+#define USB_DEVICE_ADDR_ADDR_Msk    (_U_(0xFFFFFFFF) << USB_DEVICE_ADDR_ADDR_Pos)
 #define USB_DEVICE_ADDR_ADDR(value) (USB_DEVICE_ADDR_ADDR_Msk & ((value) << USB_DEVICE_ADDR_ADDR_Pos))
-#define USB_DEVICE_ADDR_MASK        0xFFFFFFFFul /**< \brief (USB_DEVICE_ADDR) MASK Register */
+#define USB_DEVICE_ADDR_MASK        _U_(0xFFFFFFFF) /**< \brief (USB_DEVICE_ADDR) MASK Register */
 
 /* -------- USB_HOST_ADDR : (USB Offset: 0x000) (R/W 32) HOST HOST_DESC_BANK Host Bank, Adress of Data Buffer -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1455,9 +1440,9 @@ typedef union {
 #define USB_HOST_ADDR_OFFSET        0x000        /**< \brief (USB_HOST_ADDR offset) HOST_DESC_BANK Host Bank, Adress of Data Buffer */
 
 #define USB_HOST_ADDR_ADDR_Pos      0            /**< \brief (USB_HOST_ADDR) Adress of data buffer */
-#define USB_HOST_ADDR_ADDR_Msk      (0xFFFFFFFFul << USB_HOST_ADDR_ADDR_Pos)
+#define USB_HOST_ADDR_ADDR_Msk      (_U_(0xFFFFFFFF) << USB_HOST_ADDR_ADDR_Pos)
 #define USB_HOST_ADDR_ADDR(value)   (USB_HOST_ADDR_ADDR_Msk & ((value) << USB_HOST_ADDR_ADDR_Pos))
-#define USB_HOST_ADDR_MASK          0xFFFFFFFFul /**< \brief (USB_HOST_ADDR) MASK Register */
+#define USB_HOST_ADDR_MASK          _U_(0xFFFFFFFF) /**< \brief (USB_HOST_ADDR) MASK Register */
 
 /* -------- USB_DEVICE_PCKSIZE : (USB Offset: 0x004) (R/W 32) DEVICE DEVICE_DESC_BANK Endpoint Bank, Packet Size -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1475,17 +1460,17 @@ typedef union {
 #define USB_DEVICE_PCKSIZE_OFFSET   0x004        /**< \brief (USB_DEVICE_PCKSIZE offset) DEVICE_DESC_BANK Endpoint Bank, Packet Size */
 
 #define USB_DEVICE_PCKSIZE_BYTE_COUNT_Pos 0            /**< \brief (USB_DEVICE_PCKSIZE) Byte Count */
-#define USB_DEVICE_PCKSIZE_BYTE_COUNT_Msk (0x3FFFul << USB_DEVICE_PCKSIZE_BYTE_COUNT_Pos)
+#define USB_DEVICE_PCKSIZE_BYTE_COUNT_Msk (_U_(0x3FFF) << USB_DEVICE_PCKSIZE_BYTE_COUNT_Pos)
 #define USB_DEVICE_PCKSIZE_BYTE_COUNT(value) (USB_DEVICE_PCKSIZE_BYTE_COUNT_Msk & ((value) << USB_DEVICE_PCKSIZE_BYTE_COUNT_Pos))
 #define USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Pos 14           /**< \brief (USB_DEVICE_PCKSIZE) Multi Packet In or Out size */
-#define USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Msk (0x3FFFul << USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Pos)
+#define USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Msk (_U_(0x3FFF) << USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Pos)
 #define USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE(value) (USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Msk & ((value) << USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Pos))
 #define USB_DEVICE_PCKSIZE_SIZE_Pos 28           /**< \brief (USB_DEVICE_PCKSIZE) Enpoint size */
-#define USB_DEVICE_PCKSIZE_SIZE_Msk (0x7ul << USB_DEVICE_PCKSIZE_SIZE_Pos)
+#define USB_DEVICE_PCKSIZE_SIZE_Msk (_U_(0x7) << USB_DEVICE_PCKSIZE_SIZE_Pos)
 #define USB_DEVICE_PCKSIZE_SIZE(value) (USB_DEVICE_PCKSIZE_SIZE_Msk & ((value) << USB_DEVICE_PCKSIZE_SIZE_Pos))
 #define USB_DEVICE_PCKSIZE_AUTO_ZLP_Pos 31           /**< \brief (USB_DEVICE_PCKSIZE) Automatic Zero Length Packet */
-#define USB_DEVICE_PCKSIZE_AUTO_ZLP (0x1ul << USB_DEVICE_PCKSIZE_AUTO_ZLP_Pos)
-#define USB_DEVICE_PCKSIZE_MASK     0xFFFFFFFFul /**< \brief (USB_DEVICE_PCKSIZE) MASK Register */
+#define USB_DEVICE_PCKSIZE_AUTO_ZLP (_U_(0x1) << USB_DEVICE_PCKSIZE_AUTO_ZLP_Pos)
+#define USB_DEVICE_PCKSIZE_MASK     _U_(0xFFFFFFFF) /**< \brief (USB_DEVICE_PCKSIZE) MASK Register */
 
 /* -------- USB_HOST_PCKSIZE : (USB Offset: 0x004) (R/W 32) HOST HOST_DESC_BANK Host Bank, Packet Size -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1503,17 +1488,17 @@ typedef union {
 #define USB_HOST_PCKSIZE_OFFSET     0x004        /**< \brief (USB_HOST_PCKSIZE offset) HOST_DESC_BANK Host Bank, Packet Size */
 
 #define USB_HOST_PCKSIZE_BYTE_COUNT_Pos 0            /**< \brief (USB_HOST_PCKSIZE) Byte Count */
-#define USB_HOST_PCKSIZE_BYTE_COUNT_Msk (0x3FFFul << USB_HOST_PCKSIZE_BYTE_COUNT_Pos)
+#define USB_HOST_PCKSIZE_BYTE_COUNT_Msk (_U_(0x3FFF) << USB_HOST_PCKSIZE_BYTE_COUNT_Pos)
 #define USB_HOST_PCKSIZE_BYTE_COUNT(value) (USB_HOST_PCKSIZE_BYTE_COUNT_Msk & ((value) << USB_HOST_PCKSIZE_BYTE_COUNT_Pos))
 #define USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Pos 14           /**< \brief (USB_HOST_PCKSIZE) Multi Packet In or Out size */
-#define USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Msk (0x3FFFul << USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Pos)
+#define USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Msk (_U_(0x3FFF) << USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Pos)
 #define USB_HOST_PCKSIZE_MULTI_PACKET_SIZE(value) (USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Msk & ((value) << USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Pos))
 #define USB_HOST_PCKSIZE_SIZE_Pos   28           /**< \brief (USB_HOST_PCKSIZE) Pipe size */
-#define USB_HOST_PCKSIZE_SIZE_Msk   (0x7ul << USB_HOST_PCKSIZE_SIZE_Pos)
+#define USB_HOST_PCKSIZE_SIZE_Msk   (_U_(0x7) << USB_HOST_PCKSIZE_SIZE_Pos)
 #define USB_HOST_PCKSIZE_SIZE(value) (USB_HOST_PCKSIZE_SIZE_Msk & ((value) << USB_HOST_PCKSIZE_SIZE_Pos))
 #define USB_HOST_PCKSIZE_AUTO_ZLP_Pos 31           /**< \brief (USB_HOST_PCKSIZE) Automatic Zero Length Packet */
-#define USB_HOST_PCKSIZE_AUTO_ZLP   (0x1ul << USB_HOST_PCKSIZE_AUTO_ZLP_Pos)
-#define USB_HOST_PCKSIZE_MASK       0xFFFFFFFFul /**< \brief (USB_HOST_PCKSIZE) MASK Register */
+#define USB_HOST_PCKSIZE_AUTO_ZLP   (_U_(0x1) << USB_HOST_PCKSIZE_AUTO_ZLP_Pos)
+#define USB_HOST_PCKSIZE_MASK       _U_(0xFFFFFFFF) /**< \brief (USB_HOST_PCKSIZE) MASK Register */
 
 /* -------- USB_DEVICE_EXTREG : (USB Offset: 0x008) (R/W 16) DEVICE DEVICE_DESC_BANK Endpoint Bank, Extended -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1530,12 +1515,12 @@ typedef union {
 #define USB_DEVICE_EXTREG_OFFSET    0x008        /**< \brief (USB_DEVICE_EXTREG offset) DEVICE_DESC_BANK Endpoint Bank, Extended */
 
 #define USB_DEVICE_EXTREG_SUBPID_Pos 0            /**< \brief (USB_DEVICE_EXTREG) SUBPID field send with extended token */
-#define USB_DEVICE_EXTREG_SUBPID_Msk (0xFul << USB_DEVICE_EXTREG_SUBPID_Pos)
+#define USB_DEVICE_EXTREG_SUBPID_Msk (_U_(0xF) << USB_DEVICE_EXTREG_SUBPID_Pos)
 #define USB_DEVICE_EXTREG_SUBPID(value) (USB_DEVICE_EXTREG_SUBPID_Msk & ((value) << USB_DEVICE_EXTREG_SUBPID_Pos))
 #define USB_DEVICE_EXTREG_VARIABLE_Pos 4            /**< \brief (USB_DEVICE_EXTREG) Variable field send with extended token */
-#define USB_DEVICE_EXTREG_VARIABLE_Msk (0x7FFul << USB_DEVICE_EXTREG_VARIABLE_Pos)
+#define USB_DEVICE_EXTREG_VARIABLE_Msk (_U_(0x7FF) << USB_DEVICE_EXTREG_VARIABLE_Pos)
 #define USB_DEVICE_EXTREG_VARIABLE(value) (USB_DEVICE_EXTREG_VARIABLE_Msk & ((value) << USB_DEVICE_EXTREG_VARIABLE_Pos))
-#define USB_DEVICE_EXTREG_MASK      0x7FFFul     /**< \brief (USB_DEVICE_EXTREG) MASK Register */
+#define USB_DEVICE_EXTREG_MASK      _U_(0x7FFF)   /**< \brief (USB_DEVICE_EXTREG) MASK Register */
 
 /* -------- USB_HOST_EXTREG : (USB Offset: 0x008) (R/W 16) HOST HOST_DESC_BANK Host Bank, Extended -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1552,12 +1537,12 @@ typedef union {
 #define USB_HOST_EXTREG_OFFSET      0x008        /**< \brief (USB_HOST_EXTREG offset) HOST_DESC_BANK Host Bank, Extended */
 
 #define USB_HOST_EXTREG_SUBPID_Pos  0            /**< \brief (USB_HOST_EXTREG) SUBPID field send with extended token */
-#define USB_HOST_EXTREG_SUBPID_Msk  (0xFul << USB_HOST_EXTREG_SUBPID_Pos)
+#define USB_HOST_EXTREG_SUBPID_Msk  (_U_(0xF) << USB_HOST_EXTREG_SUBPID_Pos)
 #define USB_HOST_EXTREG_SUBPID(value) (USB_HOST_EXTREG_SUBPID_Msk & ((value) << USB_HOST_EXTREG_SUBPID_Pos))
 #define USB_HOST_EXTREG_VARIABLE_Pos 4            /**< \brief (USB_HOST_EXTREG) Variable field send with extended token */
-#define USB_HOST_EXTREG_VARIABLE_Msk (0x7FFul << USB_HOST_EXTREG_VARIABLE_Pos)
+#define USB_HOST_EXTREG_VARIABLE_Msk (_U_(0x7FF) << USB_HOST_EXTREG_VARIABLE_Pos)
 #define USB_HOST_EXTREG_VARIABLE(value) (USB_HOST_EXTREG_VARIABLE_Msk & ((value) << USB_HOST_EXTREG_VARIABLE_Pos))
-#define USB_HOST_EXTREG_MASK        0x7FFFul     /**< \brief (USB_HOST_EXTREG) MASK Register */
+#define USB_HOST_EXTREG_MASK        _U_(0x7FFF)   /**< \brief (USB_HOST_EXTREG) MASK Register */
 
 /* -------- USB_DEVICE_STATUS_BK : (USB Offset: 0x00A) (R/W  8) DEVICE DEVICE_DESC_BANK Enpoint Bank, Status of Bank -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1574,10 +1559,10 @@ typedef union {
 #define USB_DEVICE_STATUS_BK_OFFSET 0x00A        /**< \brief (USB_DEVICE_STATUS_BK offset) DEVICE_DESC_BANK Enpoint Bank, Status of Bank */
 
 #define USB_DEVICE_STATUS_BK_CRCERR_Pos 0            /**< \brief (USB_DEVICE_STATUS_BK) CRC Error Status */
-#define USB_DEVICE_STATUS_BK_CRCERR (0x1ul << USB_DEVICE_STATUS_BK_CRCERR_Pos)
+#define USB_DEVICE_STATUS_BK_CRCERR (_U_(0x1) << USB_DEVICE_STATUS_BK_CRCERR_Pos)
 #define USB_DEVICE_STATUS_BK_ERRORFLOW_Pos 1            /**< \brief (USB_DEVICE_STATUS_BK) Error Flow Status */
-#define USB_DEVICE_STATUS_BK_ERRORFLOW (0x1ul << USB_DEVICE_STATUS_BK_ERRORFLOW_Pos)
-#define USB_DEVICE_STATUS_BK_MASK   0x03ul       /**< \brief (USB_DEVICE_STATUS_BK) MASK Register */
+#define USB_DEVICE_STATUS_BK_ERRORFLOW (_U_(0x1) << USB_DEVICE_STATUS_BK_ERRORFLOW_Pos)
+#define USB_DEVICE_STATUS_BK_MASK   _U_(0x03)     /**< \brief (USB_DEVICE_STATUS_BK) MASK Register */
 
 /* -------- USB_HOST_STATUS_BK : (USB Offset: 0x00A) (R/W  8) HOST HOST_DESC_BANK Host Bank, Status of Bank -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1594,10 +1579,10 @@ typedef union {
 #define USB_HOST_STATUS_BK_OFFSET   0x00A        /**< \brief (USB_HOST_STATUS_BK offset) HOST_DESC_BANK Host Bank, Status of Bank */
 
 #define USB_HOST_STATUS_BK_CRCERR_Pos 0            /**< \brief (USB_HOST_STATUS_BK) CRC Error Status */
-#define USB_HOST_STATUS_BK_CRCERR   (0x1ul << USB_HOST_STATUS_BK_CRCERR_Pos)
+#define USB_HOST_STATUS_BK_CRCERR   (_U_(0x1) << USB_HOST_STATUS_BK_CRCERR_Pos)
 #define USB_HOST_STATUS_BK_ERRORFLOW_Pos 1            /**< \brief (USB_HOST_STATUS_BK) Error Flow Status */
-#define USB_HOST_STATUS_BK_ERRORFLOW (0x1ul << USB_HOST_STATUS_BK_ERRORFLOW_Pos)
-#define USB_HOST_STATUS_BK_MASK     0x03ul       /**< \brief (USB_HOST_STATUS_BK) MASK Register */
+#define USB_HOST_STATUS_BK_ERRORFLOW (_U_(0x1) << USB_HOST_STATUS_BK_ERRORFLOW_Pos)
+#define USB_HOST_STATUS_BK_MASK     _U_(0x03)     /**< \brief (USB_HOST_STATUS_BK) MASK Register */
 
 /* -------- USB_HOST_CTRL_PIPE : (USB Offset: 0x00C) (R/W 16) HOST HOST_DESC_BANK Host Bank, Host Control Pipe -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1613,18 +1598,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USB_HOST_CTRL_PIPE_OFFSET   0x00C        /**< \brief (USB_HOST_CTRL_PIPE offset) HOST_DESC_BANK Host Bank, Host Control Pipe */
-#define USB_HOST_CTRL_PIPE_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_CTRL_PIPE reset_value) HOST_DESC_BANK Host Bank, Host Control Pipe */
+#define USB_HOST_CTRL_PIPE_RESETVALUE _U_(0x0000)   /**< \brief (USB_HOST_CTRL_PIPE reset_value) HOST_DESC_BANK Host Bank, Host Control Pipe */
 
 #define USB_HOST_CTRL_PIPE_PDADDR_Pos 0            /**< \brief (USB_HOST_CTRL_PIPE) Pipe Device Adress */
-#define USB_HOST_CTRL_PIPE_PDADDR_Msk (0x7Ful << USB_HOST_CTRL_PIPE_PDADDR_Pos)
+#define USB_HOST_CTRL_PIPE_PDADDR_Msk (_U_(0x7F) << USB_HOST_CTRL_PIPE_PDADDR_Pos)
 #define USB_HOST_CTRL_PIPE_PDADDR(value) (USB_HOST_CTRL_PIPE_PDADDR_Msk & ((value) << USB_HOST_CTRL_PIPE_PDADDR_Pos))
 #define USB_HOST_CTRL_PIPE_PEPNUM_Pos 8            /**< \brief (USB_HOST_CTRL_PIPE) Pipe Endpoint Number */
-#define USB_HOST_CTRL_PIPE_PEPNUM_Msk (0xFul << USB_HOST_CTRL_PIPE_PEPNUM_Pos)
+#define USB_HOST_CTRL_PIPE_PEPNUM_Msk (_U_(0xF) << USB_HOST_CTRL_PIPE_PEPNUM_Pos)
 #define USB_HOST_CTRL_PIPE_PEPNUM(value) (USB_HOST_CTRL_PIPE_PEPNUM_Msk & ((value) << USB_HOST_CTRL_PIPE_PEPNUM_Pos))
 #define USB_HOST_CTRL_PIPE_PERMAX_Pos 12           /**< \brief (USB_HOST_CTRL_PIPE) Pipe Error Max Number */
-#define USB_HOST_CTRL_PIPE_PERMAX_Msk (0xFul << USB_HOST_CTRL_PIPE_PERMAX_Pos)
+#define USB_HOST_CTRL_PIPE_PERMAX_Msk (_U_(0xF) << USB_HOST_CTRL_PIPE_PERMAX_Pos)
 #define USB_HOST_CTRL_PIPE_PERMAX(value) (USB_HOST_CTRL_PIPE_PERMAX_Msk & ((value) << USB_HOST_CTRL_PIPE_PERMAX_Pos))
-#define USB_HOST_CTRL_PIPE_MASK     0xFF7Ful     /**< \brief (USB_HOST_CTRL_PIPE) MASK Register */
+#define USB_HOST_CTRL_PIPE_MASK     _U_(0xFF7F)   /**< \brief (USB_HOST_CTRL_PIPE) MASK Register */
 
 /* -------- USB_HOST_STATUS_PIPE : (USB Offset: 0x00E) (R/W 16) HOST HOST_DESC_BANK Host Bank, Host Status Pipe -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1645,19 +1630,19 @@ typedef union {
 #define USB_HOST_STATUS_PIPE_OFFSET 0x00E        /**< \brief (USB_HOST_STATUS_PIPE offset) HOST_DESC_BANK Host Bank, Host Status Pipe */
 
 #define USB_HOST_STATUS_PIPE_DTGLER_Pos 0            /**< \brief (USB_HOST_STATUS_PIPE) Data Toggle Error */
-#define USB_HOST_STATUS_PIPE_DTGLER (0x1ul << USB_HOST_STATUS_PIPE_DTGLER_Pos)
+#define USB_HOST_STATUS_PIPE_DTGLER (_U_(0x1) << USB_HOST_STATUS_PIPE_DTGLER_Pos)
 #define USB_HOST_STATUS_PIPE_DAPIDER_Pos 1            /**< \brief (USB_HOST_STATUS_PIPE) Data PID Error */
-#define USB_HOST_STATUS_PIPE_DAPIDER (0x1ul << USB_HOST_STATUS_PIPE_DAPIDER_Pos)
+#define USB_HOST_STATUS_PIPE_DAPIDER (_U_(0x1) << USB_HOST_STATUS_PIPE_DAPIDER_Pos)
 #define USB_HOST_STATUS_PIPE_PIDER_Pos 2            /**< \brief (USB_HOST_STATUS_PIPE) PID Error */
-#define USB_HOST_STATUS_PIPE_PIDER  (0x1ul << USB_HOST_STATUS_PIPE_PIDER_Pos)
+#define USB_HOST_STATUS_PIPE_PIDER  (_U_(0x1) << USB_HOST_STATUS_PIPE_PIDER_Pos)
 #define USB_HOST_STATUS_PIPE_TOUTER_Pos 3            /**< \brief (USB_HOST_STATUS_PIPE) Time Out Error */
-#define USB_HOST_STATUS_PIPE_TOUTER (0x1ul << USB_HOST_STATUS_PIPE_TOUTER_Pos)
+#define USB_HOST_STATUS_PIPE_TOUTER (_U_(0x1) << USB_HOST_STATUS_PIPE_TOUTER_Pos)
 #define USB_HOST_STATUS_PIPE_CRC16ER_Pos 4            /**< \brief (USB_HOST_STATUS_PIPE) CRC16 Error */
-#define USB_HOST_STATUS_PIPE_CRC16ER (0x1ul << USB_HOST_STATUS_PIPE_CRC16ER_Pos)
+#define USB_HOST_STATUS_PIPE_CRC16ER (_U_(0x1) << USB_HOST_STATUS_PIPE_CRC16ER_Pos)
 #define USB_HOST_STATUS_PIPE_ERCNT_Pos 5            /**< \brief (USB_HOST_STATUS_PIPE) Pipe Error Count */
-#define USB_HOST_STATUS_PIPE_ERCNT_Msk (0x7ul << USB_HOST_STATUS_PIPE_ERCNT_Pos)
+#define USB_HOST_STATUS_PIPE_ERCNT_Msk (_U_(0x7) << USB_HOST_STATUS_PIPE_ERCNT_Pos)
 #define USB_HOST_STATUS_PIPE_ERCNT(value) (USB_HOST_STATUS_PIPE_ERCNT_Msk & ((value) << USB_HOST_STATUS_PIPE_ERCNT_Pos))
-#define USB_HOST_STATUS_PIPE_MASK   0x00FFul     /**< \brief (USB_HOST_STATUS_PIPE) MASK Register */
+#define USB_HOST_STATUS_PIPE_MASK   _U_(0x00FF)   /**< \brief (USB_HOST_STATUS_PIPE) MASK Register */
 
 /** \brief UsbDeviceDescBank SRAM registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1790,6 +1775,7 @@ typedef struct { /* USB is Host */
        UsbHostDescBank           HostDescBank[2]; /**< \brief Offset: 0x000 UsbHostDescBank groups [2*HOST_IMPLEMENTED] */
 } UsbHostDescriptor;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
 #define SECTION_USB_DESCRIPTOR
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/wdt.h
@@ -3,39 +3,24 @@
  *
  * \brief Component description for WDT
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -68,15 +53,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_CTRL_OFFSET             0x0          /**< \brief (WDT_CTRL offset) Control */
-#define WDT_CTRL_RESETVALUE         0x00ul       /**< \brief (WDT_CTRL reset_value) Control */
+#define WDT_CTRL_RESETVALUE         _U_(0x00)     /**< \brief (WDT_CTRL reset_value) Control */
 
 #define WDT_CTRL_ENABLE_Pos         1            /**< \brief (WDT_CTRL) Enable */
-#define WDT_CTRL_ENABLE             (0x1ul << WDT_CTRL_ENABLE_Pos)
+#define WDT_CTRL_ENABLE             (_U_(0x1) << WDT_CTRL_ENABLE_Pos)
 #define WDT_CTRL_WEN_Pos            2            /**< \brief (WDT_CTRL) Watchdog Timer Window Mode Enable */
-#define WDT_CTRL_WEN                (0x1ul << WDT_CTRL_WEN_Pos)
+#define WDT_CTRL_WEN                (_U_(0x1) << WDT_CTRL_WEN_Pos)
 #define WDT_CTRL_ALWAYSON_Pos       7            /**< \brief (WDT_CTRL) Always-On */
-#define WDT_CTRL_ALWAYSON           (0x1ul << WDT_CTRL_ALWAYSON_Pos)
-#define WDT_CTRL_MASK               0x86ul       /**< \brief (WDT_CTRL) MASK Register */
+#define WDT_CTRL_ALWAYSON           (_U_(0x1) << WDT_CTRL_ALWAYSON_Pos)
+#define WDT_CTRL_MASK               _U_(0x86)     /**< \brief (WDT_CTRL) MASK Register */
 
 /* -------- WDT_CONFIG : (WDT Offset: 0x1) (R/W  8) Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -90,23 +75,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_CONFIG_OFFSET           0x1          /**< \brief (WDT_CONFIG offset) Configuration */
-#define WDT_CONFIG_RESETVALUE       0xBBul       /**< \brief (WDT_CONFIG reset_value) Configuration */
+#define WDT_CONFIG_RESETVALUE       _U_(0xBB)     /**< \brief (WDT_CONFIG reset_value) Configuration */
 
 #define WDT_CONFIG_PER_Pos          0            /**< \brief (WDT_CONFIG) Time-Out Period */
-#define WDT_CONFIG_PER_Msk          (0xFul << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_Msk          (_U_(0xF) << WDT_CONFIG_PER_Pos)
 #define WDT_CONFIG_PER(value)       (WDT_CONFIG_PER_Msk & ((value) << WDT_CONFIG_PER_Pos))
-#define   WDT_CONFIG_PER_8_Val            0x0ul  /**< \brief (WDT_CONFIG) 8 clock cycles */
-#define   WDT_CONFIG_PER_16_Val           0x1ul  /**< \brief (WDT_CONFIG) 16 clock cycles */
-#define   WDT_CONFIG_PER_32_Val           0x2ul  /**< \brief (WDT_CONFIG) 32 clock cycles */
-#define   WDT_CONFIG_PER_64_Val           0x3ul  /**< \brief (WDT_CONFIG) 64 clock cycles */
-#define   WDT_CONFIG_PER_128_Val          0x4ul  /**< \brief (WDT_CONFIG) 128 clock cycles */
-#define   WDT_CONFIG_PER_256_Val          0x5ul  /**< \brief (WDT_CONFIG) 256 clock cycles */
-#define   WDT_CONFIG_PER_512_Val          0x6ul  /**< \brief (WDT_CONFIG) 512 clock cycles */
-#define   WDT_CONFIG_PER_1K_Val           0x7ul  /**< \brief (WDT_CONFIG) 1024 clock cycles */
-#define   WDT_CONFIG_PER_2K_Val           0x8ul  /**< \brief (WDT_CONFIG) 2048 clock cycles */
-#define   WDT_CONFIG_PER_4K_Val           0x9ul  /**< \brief (WDT_CONFIG) 4096 clock cycles */
-#define   WDT_CONFIG_PER_8K_Val           0xAul  /**< \brief (WDT_CONFIG) 8192 clock cycles */
-#define   WDT_CONFIG_PER_16K_Val          0xBul  /**< \brief (WDT_CONFIG) 16384 clock cycles */
+#define   WDT_CONFIG_PER_8_Val            _U_(0x0)   /**< \brief (WDT_CONFIG) 8 clock cycles */
+#define   WDT_CONFIG_PER_16_Val           _U_(0x1)   /**< \brief (WDT_CONFIG) 16 clock cycles */
+#define   WDT_CONFIG_PER_32_Val           _U_(0x2)   /**< \brief (WDT_CONFIG) 32 clock cycles */
+#define   WDT_CONFIG_PER_64_Val           _U_(0x3)   /**< \brief (WDT_CONFIG) 64 clock cycles */
+#define   WDT_CONFIG_PER_128_Val          _U_(0x4)   /**< \brief (WDT_CONFIG) 128 clock cycles */
+#define   WDT_CONFIG_PER_256_Val          _U_(0x5)   /**< \brief (WDT_CONFIG) 256 clock cycles */
+#define   WDT_CONFIG_PER_512_Val          _U_(0x6)   /**< \brief (WDT_CONFIG) 512 clock cycles */
+#define   WDT_CONFIG_PER_1K_Val           _U_(0x7)   /**< \brief (WDT_CONFIG) 1024 clock cycles */
+#define   WDT_CONFIG_PER_2K_Val           _U_(0x8)   /**< \brief (WDT_CONFIG) 2048 clock cycles */
+#define   WDT_CONFIG_PER_4K_Val           _U_(0x9)   /**< \brief (WDT_CONFIG) 4096 clock cycles */
+#define   WDT_CONFIG_PER_8K_Val           _U_(0xA)   /**< \brief (WDT_CONFIG) 8192 clock cycles */
+#define   WDT_CONFIG_PER_16K_Val          _U_(0xB)   /**< \brief (WDT_CONFIG) 16384 clock cycles */
 #define WDT_CONFIG_PER_8            (WDT_CONFIG_PER_8_Val          << WDT_CONFIG_PER_Pos)
 #define WDT_CONFIG_PER_16           (WDT_CONFIG_PER_16_Val         << WDT_CONFIG_PER_Pos)
 #define WDT_CONFIG_PER_32           (WDT_CONFIG_PER_32_Val         << WDT_CONFIG_PER_Pos)
@@ -120,20 +105,20 @@ typedef union {
 #define WDT_CONFIG_PER_8K           (WDT_CONFIG_PER_8K_Val         << WDT_CONFIG_PER_Pos)
 #define WDT_CONFIG_PER_16K          (WDT_CONFIG_PER_16K_Val        << WDT_CONFIG_PER_Pos)
 #define WDT_CONFIG_WINDOW_Pos       4            /**< \brief (WDT_CONFIG) Window Mode Time-Out Period */
-#define WDT_CONFIG_WINDOW_Msk       (0xFul << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_Msk       (_U_(0xF) << WDT_CONFIG_WINDOW_Pos)
 #define WDT_CONFIG_WINDOW(value)    (WDT_CONFIG_WINDOW_Msk & ((value) << WDT_CONFIG_WINDOW_Pos))
-#define   WDT_CONFIG_WINDOW_8_Val         0x0ul  /**< \brief (WDT_CONFIG) 8 clock cycles */
-#define   WDT_CONFIG_WINDOW_16_Val        0x1ul  /**< \brief (WDT_CONFIG) 16 clock cycles */
-#define   WDT_CONFIG_WINDOW_32_Val        0x2ul  /**< \brief (WDT_CONFIG) 32 clock cycles */
-#define   WDT_CONFIG_WINDOW_64_Val        0x3ul  /**< \brief (WDT_CONFIG) 64 clock cycles */
-#define   WDT_CONFIG_WINDOW_128_Val       0x4ul  /**< \brief (WDT_CONFIG) 128 clock cycles */
-#define   WDT_CONFIG_WINDOW_256_Val       0x5ul  /**< \brief (WDT_CONFIG) 256 clock cycles */
-#define   WDT_CONFIG_WINDOW_512_Val       0x6ul  /**< \brief (WDT_CONFIG) 512 clock cycles */
-#define   WDT_CONFIG_WINDOW_1K_Val        0x7ul  /**< \brief (WDT_CONFIG) 1024 clock cycles */
-#define   WDT_CONFIG_WINDOW_2K_Val        0x8ul  /**< \brief (WDT_CONFIG) 2048 clock cycles */
-#define   WDT_CONFIG_WINDOW_4K_Val        0x9ul  /**< \brief (WDT_CONFIG) 4096 clock cycles */
-#define   WDT_CONFIG_WINDOW_8K_Val        0xAul  /**< \brief (WDT_CONFIG) 8192 clock cycles */
-#define   WDT_CONFIG_WINDOW_16K_Val       0xBul  /**< \brief (WDT_CONFIG) 16384 clock cycles */
+#define   WDT_CONFIG_WINDOW_8_Val         _U_(0x0)   /**< \brief (WDT_CONFIG) 8 clock cycles */
+#define   WDT_CONFIG_WINDOW_16_Val        _U_(0x1)   /**< \brief (WDT_CONFIG) 16 clock cycles */
+#define   WDT_CONFIG_WINDOW_32_Val        _U_(0x2)   /**< \brief (WDT_CONFIG) 32 clock cycles */
+#define   WDT_CONFIG_WINDOW_64_Val        _U_(0x3)   /**< \brief (WDT_CONFIG) 64 clock cycles */
+#define   WDT_CONFIG_WINDOW_128_Val       _U_(0x4)   /**< \brief (WDT_CONFIG) 128 clock cycles */
+#define   WDT_CONFIG_WINDOW_256_Val       _U_(0x5)   /**< \brief (WDT_CONFIG) 256 clock cycles */
+#define   WDT_CONFIG_WINDOW_512_Val       _U_(0x6)   /**< \brief (WDT_CONFIG) 512 clock cycles */
+#define   WDT_CONFIG_WINDOW_1K_Val        _U_(0x7)   /**< \brief (WDT_CONFIG) 1024 clock cycles */
+#define   WDT_CONFIG_WINDOW_2K_Val        _U_(0x8)   /**< \brief (WDT_CONFIG) 2048 clock cycles */
+#define   WDT_CONFIG_WINDOW_4K_Val        _U_(0x9)   /**< \brief (WDT_CONFIG) 4096 clock cycles */
+#define   WDT_CONFIG_WINDOW_8K_Val        _U_(0xA)   /**< \brief (WDT_CONFIG) 8192 clock cycles */
+#define   WDT_CONFIG_WINDOW_16K_Val       _U_(0xB)   /**< \brief (WDT_CONFIG) 16384 clock cycles */
 #define WDT_CONFIG_WINDOW_8         (WDT_CONFIG_WINDOW_8_Val       << WDT_CONFIG_WINDOW_Pos)
 #define WDT_CONFIG_WINDOW_16        (WDT_CONFIG_WINDOW_16_Val      << WDT_CONFIG_WINDOW_Pos)
 #define WDT_CONFIG_WINDOW_32        (WDT_CONFIG_WINDOW_32_Val      << WDT_CONFIG_WINDOW_Pos)
@@ -146,7 +131,7 @@ typedef union {
 #define WDT_CONFIG_WINDOW_4K        (WDT_CONFIG_WINDOW_4K_Val      << WDT_CONFIG_WINDOW_Pos)
 #define WDT_CONFIG_WINDOW_8K        (WDT_CONFIG_WINDOW_8K_Val      << WDT_CONFIG_WINDOW_Pos)
 #define WDT_CONFIG_WINDOW_16K       (WDT_CONFIG_WINDOW_16K_Val     << WDT_CONFIG_WINDOW_Pos)
-#define WDT_CONFIG_MASK             0xFFul       /**< \brief (WDT_CONFIG) MASK Register */
+#define WDT_CONFIG_MASK             _U_(0xFF)     /**< \brief (WDT_CONFIG) MASK Register */
 
 /* -------- WDT_EWCTRL : (WDT Offset: 0x2) (R/W  8) Early Warning Interrupt Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -160,23 +145,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_EWCTRL_OFFSET           0x2          /**< \brief (WDT_EWCTRL offset) Early Warning Interrupt Control */
-#define WDT_EWCTRL_RESETVALUE       0x0Bul       /**< \brief (WDT_EWCTRL reset_value) Early Warning Interrupt Control */
+#define WDT_EWCTRL_RESETVALUE       _U_(0x0B)     /**< \brief (WDT_EWCTRL reset_value) Early Warning Interrupt Control */
 
 #define WDT_EWCTRL_EWOFFSET_Pos     0            /**< \brief (WDT_EWCTRL) Early Warning Interrupt Time Offset */
-#define WDT_EWCTRL_EWOFFSET_Msk     (0xFul << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_Msk     (_U_(0xF) << WDT_EWCTRL_EWOFFSET_Pos)
 #define WDT_EWCTRL_EWOFFSET(value)  (WDT_EWCTRL_EWOFFSET_Msk & ((value) << WDT_EWCTRL_EWOFFSET_Pos))
-#define   WDT_EWCTRL_EWOFFSET_8_Val       0x0ul  /**< \brief (WDT_EWCTRL) 8 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_16_Val      0x1ul  /**< \brief (WDT_EWCTRL) 16 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_32_Val      0x2ul  /**< \brief (WDT_EWCTRL) 32 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_64_Val      0x3ul  /**< \brief (WDT_EWCTRL) 64 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_128_Val     0x4ul  /**< \brief (WDT_EWCTRL) 128 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_256_Val     0x5ul  /**< \brief (WDT_EWCTRL) 256 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_512_Val     0x6ul  /**< \brief (WDT_EWCTRL) 512 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_1K_Val      0x7ul  /**< \brief (WDT_EWCTRL) 1024 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_2K_Val      0x8ul  /**< \brief (WDT_EWCTRL) 2048 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_4K_Val      0x9ul  /**< \brief (WDT_EWCTRL) 4096 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_8K_Val      0xAul  /**< \brief (WDT_EWCTRL) 8192 clock cycles */
-#define   WDT_EWCTRL_EWOFFSET_16K_Val     0xBul  /**< \brief (WDT_EWCTRL) 16384 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_8_Val       _U_(0x0)   /**< \brief (WDT_EWCTRL) 8 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_16_Val      _U_(0x1)   /**< \brief (WDT_EWCTRL) 16 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_32_Val      _U_(0x2)   /**< \brief (WDT_EWCTRL) 32 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_64_Val      _U_(0x3)   /**< \brief (WDT_EWCTRL) 64 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_128_Val     _U_(0x4)   /**< \brief (WDT_EWCTRL) 128 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_256_Val     _U_(0x5)   /**< \brief (WDT_EWCTRL) 256 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_512_Val     _U_(0x6)   /**< \brief (WDT_EWCTRL) 512 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_1K_Val      _U_(0x7)   /**< \brief (WDT_EWCTRL) 1024 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_2K_Val      _U_(0x8)   /**< \brief (WDT_EWCTRL) 2048 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_4K_Val      _U_(0x9)   /**< \brief (WDT_EWCTRL) 4096 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_8K_Val      _U_(0xA)   /**< \brief (WDT_EWCTRL) 8192 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_16K_Val     _U_(0xB)   /**< \brief (WDT_EWCTRL) 16384 clock cycles */
 #define WDT_EWCTRL_EWOFFSET_8       (WDT_EWCTRL_EWOFFSET_8_Val     << WDT_EWCTRL_EWOFFSET_Pos)
 #define WDT_EWCTRL_EWOFFSET_16      (WDT_EWCTRL_EWOFFSET_16_Val    << WDT_EWCTRL_EWOFFSET_Pos)
 #define WDT_EWCTRL_EWOFFSET_32      (WDT_EWCTRL_EWOFFSET_32_Val    << WDT_EWCTRL_EWOFFSET_Pos)
@@ -189,7 +174,7 @@ typedef union {
 #define WDT_EWCTRL_EWOFFSET_4K      (WDT_EWCTRL_EWOFFSET_4K_Val    << WDT_EWCTRL_EWOFFSET_Pos)
 #define WDT_EWCTRL_EWOFFSET_8K      (WDT_EWCTRL_EWOFFSET_8K_Val    << WDT_EWCTRL_EWOFFSET_Pos)
 #define WDT_EWCTRL_EWOFFSET_16K     (WDT_EWCTRL_EWOFFSET_16K_Val   << WDT_EWCTRL_EWOFFSET_Pos)
-#define WDT_EWCTRL_MASK             0x0Ful       /**< \brief (WDT_EWCTRL) MASK Register */
+#define WDT_EWCTRL_MASK             _U_(0x0F)     /**< \brief (WDT_EWCTRL) MASK Register */
 
 /* -------- WDT_INTENCLR : (WDT Offset: 0x4) (R/W  8) Interrupt Enable Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -203,11 +188,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_INTENCLR_OFFSET         0x4          /**< \brief (WDT_INTENCLR offset) Interrupt Enable Clear */
-#define WDT_INTENCLR_RESETVALUE     0x00ul       /**< \brief (WDT_INTENCLR reset_value) Interrupt Enable Clear */
+#define WDT_INTENCLR_RESETVALUE     _U_(0x00)     /**< \brief (WDT_INTENCLR reset_value) Interrupt Enable Clear */
 
 #define WDT_INTENCLR_EW_Pos         0            /**< \brief (WDT_INTENCLR) Early Warning Interrupt Enable */
-#define WDT_INTENCLR_EW             (0x1ul << WDT_INTENCLR_EW_Pos)
-#define WDT_INTENCLR_MASK           0x01ul       /**< \brief (WDT_INTENCLR) MASK Register */
+#define WDT_INTENCLR_EW             (_U_(0x1) << WDT_INTENCLR_EW_Pos)
+#define WDT_INTENCLR_MASK           _U_(0x01)     /**< \brief (WDT_INTENCLR) MASK Register */
 
 /* -------- WDT_INTENSET : (WDT Offset: 0x5) (R/W  8) Interrupt Enable Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -221,11 +206,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_INTENSET_OFFSET         0x5          /**< \brief (WDT_INTENSET offset) Interrupt Enable Set */
-#define WDT_INTENSET_RESETVALUE     0x00ul       /**< \brief (WDT_INTENSET reset_value) Interrupt Enable Set */
+#define WDT_INTENSET_RESETVALUE     _U_(0x00)     /**< \brief (WDT_INTENSET reset_value) Interrupt Enable Set */
 
 #define WDT_INTENSET_EW_Pos         0            /**< \brief (WDT_INTENSET) Early Warning Interrupt Enable */
-#define WDT_INTENSET_EW             (0x1ul << WDT_INTENSET_EW_Pos)
-#define WDT_INTENSET_MASK           0x01ul       /**< \brief (WDT_INTENSET) MASK Register */
+#define WDT_INTENSET_EW             (_U_(0x1) << WDT_INTENSET_EW_Pos)
+#define WDT_INTENSET_MASK           _U_(0x01)     /**< \brief (WDT_INTENSET) MASK Register */
 
 /* -------- WDT_INTFLAG : (WDT Offset: 0x6) (R/W  8) Interrupt Flag Status and Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -239,11 +224,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_INTFLAG_OFFSET          0x6          /**< \brief (WDT_INTFLAG offset) Interrupt Flag Status and Clear */
-#define WDT_INTFLAG_RESETVALUE      0x00ul       /**< \brief (WDT_INTFLAG reset_value) Interrupt Flag Status and Clear */
+#define WDT_INTFLAG_RESETVALUE      _U_(0x00)     /**< \brief (WDT_INTFLAG reset_value) Interrupt Flag Status and Clear */
 
 #define WDT_INTFLAG_EW_Pos          0            /**< \brief (WDT_INTFLAG) Early Warning */
-#define WDT_INTFLAG_EW              (0x1ul << WDT_INTFLAG_EW_Pos)
-#define WDT_INTFLAG_MASK            0x01ul       /**< \brief (WDT_INTFLAG) MASK Register */
+#define WDT_INTFLAG_EW              (_U_(0x1) << WDT_INTFLAG_EW_Pos)
+#define WDT_INTFLAG_MASK            _U_(0x01)     /**< \brief (WDT_INTFLAG) MASK Register */
 
 /* -------- WDT_STATUS : (WDT Offset: 0x7) (R/   8) Status -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -257,11 +242,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_STATUS_OFFSET           0x7          /**< \brief (WDT_STATUS offset) Status */
-#define WDT_STATUS_RESETVALUE       0x00ul       /**< \brief (WDT_STATUS reset_value) Status */
+#define WDT_STATUS_RESETVALUE       _U_(0x00)     /**< \brief (WDT_STATUS reset_value) Status */
 
 #define WDT_STATUS_SYNCBUSY_Pos     7            /**< \brief (WDT_STATUS) Synchronization Busy */
-#define WDT_STATUS_SYNCBUSY         (0x1ul << WDT_STATUS_SYNCBUSY_Pos)
-#define WDT_STATUS_MASK             0x80ul       /**< \brief (WDT_STATUS) MASK Register */
+#define WDT_STATUS_SYNCBUSY         (_U_(0x1) << WDT_STATUS_SYNCBUSY_Pos)
+#define WDT_STATUS_MASK             _U_(0x80)     /**< \brief (WDT_STATUS) MASK Register */
 
 /* -------- WDT_CLEAR : (WDT Offset: 0x8) ( /W  8) Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -274,14 +259,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_CLEAR_OFFSET            0x8          /**< \brief (WDT_CLEAR offset) Clear */
-#define WDT_CLEAR_RESETVALUE        0x00ul       /**< \brief (WDT_CLEAR reset_value) Clear */
+#define WDT_CLEAR_RESETVALUE        _U_(0x00)     /**< \brief (WDT_CLEAR reset_value) Clear */
 
 #define WDT_CLEAR_CLEAR_Pos         0            /**< \brief (WDT_CLEAR) Watchdog Clear */
-#define WDT_CLEAR_CLEAR_Msk         (0xFFul << WDT_CLEAR_CLEAR_Pos)
+#define WDT_CLEAR_CLEAR_Msk         (_U_(0xFF) << WDT_CLEAR_CLEAR_Pos)
 #define WDT_CLEAR_CLEAR(value)      (WDT_CLEAR_CLEAR_Msk & ((value) << WDT_CLEAR_CLEAR_Pos))
-#define   WDT_CLEAR_CLEAR_KEY_Val         0xA5ul  /**< \brief (WDT_CLEAR) Clear Key */
+#define   WDT_CLEAR_CLEAR_KEY_Val         _U_(0xA5)   /**< \brief (WDT_CLEAR) Clear Key */
 #define WDT_CLEAR_CLEAR_KEY         (WDT_CLEAR_CLEAR_KEY_Val       << WDT_CLEAR_CLEAR_Pos)
-#define WDT_CLEAR_MASK              0xFFul       /**< \brief (WDT_CLEAR) MASK Register */
+#define WDT_CLEAR_MASK              _U_(0xFF)     /**< \brief (WDT_CLEAR) MASK Register */
 
 /** \brief WDT hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/ac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/ac.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for AC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,35 +31,35 @@
 
 /* ========== Register definition for AC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_AC_CTRLA               (0x42004400U) /**< \brief (AC) Control A */
-#define REG_AC_CTRLB               (0x42004401U) /**< \brief (AC) Control B */
-#define REG_AC_EVCTRL              (0x42004402U) /**< \brief (AC) Event Control */
-#define REG_AC_INTENCLR            (0x42004404U) /**< \brief (AC) Interrupt Enable Clear */
-#define REG_AC_INTENSET            (0x42004405U) /**< \brief (AC) Interrupt Enable Set */
-#define REG_AC_INTFLAG             (0x42004406U) /**< \brief (AC) Interrupt Flag Status and Clear */
-#define REG_AC_STATUSA             (0x42004408U) /**< \brief (AC) Status A */
-#define REG_AC_STATUSB             (0x42004409U) /**< \brief (AC) Status B */
-#define REG_AC_STATUSC             (0x4200440AU) /**< \brief (AC) Status C */
-#define REG_AC_WINCTRL             (0x4200440CU) /**< \brief (AC) Window Control */
-#define REG_AC_COMPCTRL0           (0x42004410U) /**< \brief (AC) Comparator Control 0 */
-#define REG_AC_COMPCTRL1           (0x42004414U) /**< \brief (AC) Comparator Control 1 */
-#define REG_AC_SCALER0             (0x42004420U) /**< \brief (AC) Scaler 0 */
-#define REG_AC_SCALER1             (0x42004421U) /**< \brief (AC) Scaler 1 */
+#define REG_AC_CTRLA               (0x42004400) /**< \brief (AC) Control A */
+#define REG_AC_CTRLB               (0x42004401) /**< \brief (AC) Control B */
+#define REG_AC_EVCTRL              (0x42004402) /**< \brief (AC) Event Control */
+#define REG_AC_INTENCLR            (0x42004404) /**< \brief (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET            (0x42004405) /**< \brief (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG             (0x42004406) /**< \brief (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA             (0x42004408) /**< \brief (AC) Status A */
+#define REG_AC_STATUSB             (0x42004409) /**< \brief (AC) Status B */
+#define REG_AC_STATUSC             (0x4200440A) /**< \brief (AC) Status C */
+#define REG_AC_WINCTRL             (0x4200440C) /**< \brief (AC) Window Control */
+#define REG_AC_COMPCTRL0           (0x42004410) /**< \brief (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1           (0x42004414) /**< \brief (AC) Comparator Control 1 */
+#define REG_AC_SCALER0             (0x42004420) /**< \brief (AC) Scaler 0 */
+#define REG_AC_SCALER1             (0x42004421) /**< \brief (AC) Scaler 1 */
 #else
-#define REG_AC_CTRLA               (*(RwReg8 *)0x42004400U) /**< \brief (AC) Control A */
-#define REG_AC_CTRLB               (*(WoReg8 *)0x42004401U) /**< \brief (AC) Control B */
-#define REG_AC_EVCTRL              (*(RwReg16*)0x42004402U) /**< \brief (AC) Event Control */
-#define REG_AC_INTENCLR            (*(RwReg8 *)0x42004404U) /**< \brief (AC) Interrupt Enable Clear */
-#define REG_AC_INTENSET            (*(RwReg8 *)0x42004405U) /**< \brief (AC) Interrupt Enable Set */
-#define REG_AC_INTFLAG             (*(RwReg8 *)0x42004406U) /**< \brief (AC) Interrupt Flag Status and Clear */
-#define REG_AC_STATUSA             (*(RoReg8 *)0x42004408U) /**< \brief (AC) Status A */
-#define REG_AC_STATUSB             (*(RoReg8 *)0x42004409U) /**< \brief (AC) Status B */
-#define REG_AC_STATUSC             (*(RoReg8 *)0x4200440AU) /**< \brief (AC) Status C */
-#define REG_AC_WINCTRL             (*(RwReg8 *)0x4200440CU) /**< \brief (AC) Window Control */
-#define REG_AC_COMPCTRL0           (*(RwReg  *)0x42004410U) /**< \brief (AC) Comparator Control 0 */
-#define REG_AC_COMPCTRL1           (*(RwReg  *)0x42004414U) /**< \brief (AC) Comparator Control 1 */
-#define REG_AC_SCALER0             (*(RwReg8 *)0x42004420U) /**< \brief (AC) Scaler 0 */
-#define REG_AC_SCALER1             (*(RwReg8 *)0x42004421U) /**< \brief (AC) Scaler 1 */
+#define REG_AC_CTRLA               (*(RwReg8 *)0x42004400UL) /**< \brief (AC) Control A */
+#define REG_AC_CTRLB               (*(WoReg8 *)0x42004401UL) /**< \brief (AC) Control B */
+#define REG_AC_EVCTRL              (*(RwReg16*)0x42004402UL) /**< \brief (AC) Event Control */
+#define REG_AC_INTENCLR            (*(RwReg8 *)0x42004404UL) /**< \brief (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET            (*(RwReg8 *)0x42004405UL) /**< \brief (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG             (*(RwReg8 *)0x42004406UL) /**< \brief (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA             (*(RoReg8 *)0x42004408UL) /**< \brief (AC) Status A */
+#define REG_AC_STATUSB             (*(RoReg8 *)0x42004409UL) /**< \brief (AC) Status B */
+#define REG_AC_STATUSC             (*(RoReg8 *)0x4200440AUL) /**< \brief (AC) Status C */
+#define REG_AC_WINCTRL             (*(RwReg8 *)0x4200440CUL) /**< \brief (AC) Window Control */
+#define REG_AC_COMPCTRL0           (*(RwReg  *)0x42004410UL) /**< \brief (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1           (*(RwReg  *)0x42004414UL) /**< \brief (AC) Comparator Control 1 */
+#define REG_AC_SCALER0             (*(RwReg8 *)0x42004420UL) /**< \brief (AC) Scaler 0 */
+#define REG_AC_SCALER1             (*(RwReg8 *)0x42004421UL) /**< \brief (AC) Scaler 1 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for AC peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/adc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/adc.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for ADC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,47 +31,47 @@
 
 /* ========== Register definition for ADC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_ADC_CTRLA              (0x42004000U) /**< \brief (ADC) Control A */
-#define REG_ADC_REFCTRL            (0x42004001U) /**< \brief (ADC) Reference Control */
-#define REG_ADC_AVGCTRL            (0x42004002U) /**< \brief (ADC) Average Control */
-#define REG_ADC_SAMPCTRL           (0x42004003U) /**< \brief (ADC) Sampling Time Control */
-#define REG_ADC_CTRLB              (0x42004004U) /**< \brief (ADC) Control B */
-#define REG_ADC_WINCTRL            (0x42004008U) /**< \brief (ADC) Window Monitor Control */
-#define REG_ADC_SWTRIG             (0x4200400CU) /**< \brief (ADC) Software Trigger */
-#define REG_ADC_INPUTCTRL          (0x42004010U) /**< \brief (ADC) Input Control */
-#define REG_ADC_EVCTRL             (0x42004014U) /**< \brief (ADC) Event Control */
-#define REG_ADC_INTENCLR           (0x42004016U) /**< \brief (ADC) Interrupt Enable Clear */
-#define REG_ADC_INTENSET           (0x42004017U) /**< \brief (ADC) Interrupt Enable Set */
-#define REG_ADC_INTFLAG            (0x42004018U) /**< \brief (ADC) Interrupt Flag Status and Clear */
-#define REG_ADC_STATUS             (0x42004019U) /**< \brief (ADC) Status */
-#define REG_ADC_RESULT             (0x4200401AU) /**< \brief (ADC) Result */
-#define REG_ADC_WINLT              (0x4200401CU) /**< \brief (ADC) Window Monitor Lower Threshold */
-#define REG_ADC_WINUT              (0x42004020U) /**< \brief (ADC) Window Monitor Upper Threshold */
-#define REG_ADC_GAINCORR           (0x42004024U) /**< \brief (ADC) Gain Correction */
-#define REG_ADC_OFFSETCORR         (0x42004026U) /**< \brief (ADC) Offset Correction */
-#define REG_ADC_CALIB              (0x42004028U) /**< \brief (ADC) Calibration */
-#define REG_ADC_DBGCTRL            (0x4200402AU) /**< \brief (ADC) Debug Control */
+#define REG_ADC_CTRLA              (0x42004000) /**< \brief (ADC) Control A */
+#define REG_ADC_REFCTRL            (0x42004001) /**< \brief (ADC) Reference Control */
+#define REG_ADC_AVGCTRL            (0x42004002) /**< \brief (ADC) Average Control */
+#define REG_ADC_SAMPCTRL           (0x42004003) /**< \brief (ADC) Sampling Time Control */
+#define REG_ADC_CTRLB              (0x42004004) /**< \brief (ADC) Control B */
+#define REG_ADC_WINCTRL            (0x42004008) /**< \brief (ADC) Window Monitor Control */
+#define REG_ADC_SWTRIG             (0x4200400C) /**< \brief (ADC) Software Trigger */
+#define REG_ADC_INPUTCTRL          (0x42004010) /**< \brief (ADC) Input Control */
+#define REG_ADC_EVCTRL             (0x42004014) /**< \brief (ADC) Event Control */
+#define REG_ADC_INTENCLR           (0x42004016) /**< \brief (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET           (0x42004017) /**< \brief (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG            (0x42004018) /**< \brief (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_STATUS             (0x42004019) /**< \brief (ADC) Status */
+#define REG_ADC_RESULT             (0x4200401A) /**< \brief (ADC) Result */
+#define REG_ADC_WINLT              (0x4200401C) /**< \brief (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT              (0x42004020) /**< \brief (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR           (0x42004024) /**< \brief (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR         (0x42004026) /**< \brief (ADC) Offset Correction */
+#define REG_ADC_CALIB              (0x42004028) /**< \brief (ADC) Calibration */
+#define REG_ADC_DBGCTRL            (0x4200402A) /**< \brief (ADC) Debug Control */
 #else
-#define REG_ADC_CTRLA              (*(RwReg8 *)0x42004000U) /**< \brief (ADC) Control A */
-#define REG_ADC_REFCTRL            (*(RwReg8 *)0x42004001U) /**< \brief (ADC) Reference Control */
-#define REG_ADC_AVGCTRL            (*(RwReg8 *)0x42004002U) /**< \brief (ADC) Average Control */
-#define REG_ADC_SAMPCTRL           (*(RwReg8 *)0x42004003U) /**< \brief (ADC) Sampling Time Control */
-#define REG_ADC_CTRLB              (*(RwReg16*)0x42004004U) /**< \brief (ADC) Control B */
-#define REG_ADC_WINCTRL            (*(RwReg8 *)0x42004008U) /**< \brief (ADC) Window Monitor Control */
-#define REG_ADC_SWTRIG             (*(RwReg8 *)0x4200400CU) /**< \brief (ADC) Software Trigger */
-#define REG_ADC_INPUTCTRL          (*(RwReg  *)0x42004010U) /**< \brief (ADC) Input Control */
-#define REG_ADC_EVCTRL             (*(RwReg8 *)0x42004014U) /**< \brief (ADC) Event Control */
-#define REG_ADC_INTENCLR           (*(RwReg8 *)0x42004016U) /**< \brief (ADC) Interrupt Enable Clear */
-#define REG_ADC_INTENSET           (*(RwReg8 *)0x42004017U) /**< \brief (ADC) Interrupt Enable Set */
-#define REG_ADC_INTFLAG            (*(RwReg8 *)0x42004018U) /**< \brief (ADC) Interrupt Flag Status and Clear */
-#define REG_ADC_STATUS             (*(RoReg8 *)0x42004019U) /**< \brief (ADC) Status */
-#define REG_ADC_RESULT             (*(RoReg16*)0x4200401AU) /**< \brief (ADC) Result */
-#define REG_ADC_WINLT              (*(RwReg16*)0x4200401CU) /**< \brief (ADC) Window Monitor Lower Threshold */
-#define REG_ADC_WINUT              (*(RwReg16*)0x42004020U) /**< \brief (ADC) Window Monitor Upper Threshold */
-#define REG_ADC_GAINCORR           (*(RwReg16*)0x42004024U) /**< \brief (ADC) Gain Correction */
-#define REG_ADC_OFFSETCORR         (*(RwReg16*)0x42004026U) /**< \brief (ADC) Offset Correction */
-#define REG_ADC_CALIB              (*(RwReg16*)0x42004028U) /**< \brief (ADC) Calibration */
-#define REG_ADC_DBGCTRL            (*(RwReg8 *)0x4200402AU) /**< \brief (ADC) Debug Control */
+#define REG_ADC_CTRLA              (*(RwReg8 *)0x42004000UL) /**< \brief (ADC) Control A */
+#define REG_ADC_REFCTRL            (*(RwReg8 *)0x42004001UL) /**< \brief (ADC) Reference Control */
+#define REG_ADC_AVGCTRL            (*(RwReg8 *)0x42004002UL) /**< \brief (ADC) Average Control */
+#define REG_ADC_SAMPCTRL           (*(RwReg8 *)0x42004003UL) /**< \brief (ADC) Sampling Time Control */
+#define REG_ADC_CTRLB              (*(RwReg16*)0x42004004UL) /**< \brief (ADC) Control B */
+#define REG_ADC_WINCTRL            (*(RwReg8 *)0x42004008UL) /**< \brief (ADC) Window Monitor Control */
+#define REG_ADC_SWTRIG             (*(RwReg8 *)0x4200400CUL) /**< \brief (ADC) Software Trigger */
+#define REG_ADC_INPUTCTRL          (*(RwReg  *)0x42004010UL) /**< \brief (ADC) Input Control */
+#define REG_ADC_EVCTRL             (*(RwReg8 *)0x42004014UL) /**< \brief (ADC) Event Control */
+#define REG_ADC_INTENCLR           (*(RwReg8 *)0x42004016UL) /**< \brief (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET           (*(RwReg8 *)0x42004017UL) /**< \brief (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG            (*(RwReg8 *)0x42004018UL) /**< \brief (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_STATUS             (*(RoReg8 *)0x42004019UL) /**< \brief (ADC) Status */
+#define REG_ADC_RESULT             (*(RoReg16*)0x4200401AUL) /**< \brief (ADC) Result */
+#define REG_ADC_WINLT              (*(RwReg16*)0x4200401CUL) /**< \brief (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT              (*(RwReg16*)0x42004020UL) /**< \brief (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR           (*(RwReg16*)0x42004024UL) /**< \brief (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR         (*(RwReg16*)0x42004026UL) /**< \brief (ADC) Offset Correction */
+#define REG_ADC_CALIB              (*(RwReg16*)0x42004028UL) /**< \brief (ADC) Calibration */
+#define REG_ADC_DBGCTRL            (*(RwReg8 *)0x4200402AUL) /**< \brief (ADC) Debug Control */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for ADC peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/dac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/dac.h
@@ -1,0 +1,59 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DAC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMR21_DAC_INSTANCE_
+#define _SAMR21_DAC_INSTANCE_
+
+/* ========== Register definition for DAC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DAC_CTRLA              (0x42004800) /**< \brief (DAC) Control A */
+#define REG_DAC_CTRLB              (0x42004801) /**< \brief (DAC) Control B */
+#define REG_DAC_EVCTRL             (0x42004802) /**< \brief (DAC) Event Control */
+#define REG_DAC_INTENCLR           (0x42004804) /**< \brief (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET           (0x42004805) /**< \brief (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG            (0x42004806) /**< \brief (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS             (0x42004807) /**< \brief (DAC) Status */
+#define REG_DAC_DATA               (0x42004808) /**< \brief (DAC) Data */
+#define REG_DAC_DATABUF            (0x4200480C) /**< \brief (DAC) Data Buffer */
+#else
+#define REG_DAC_CTRLA              (*(RwReg8 *)0x42004800UL) /**< \brief (DAC) Control A */
+#define REG_DAC_CTRLB              (*(RwReg8 *)0x42004801UL) /**< \brief (DAC) Control B */
+#define REG_DAC_EVCTRL             (*(RwReg8 *)0x42004802UL) /**< \brief (DAC) Event Control */
+#define REG_DAC_INTENCLR           (*(RwReg8 *)0x42004804UL) /**< \brief (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET           (*(RwReg8 *)0x42004805UL) /**< \brief (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG            (*(RwReg8 *)0x42004806UL) /**< \brief (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS             (*(RoReg8 *)0x42004807UL) /**< \brief (DAC) Status */
+#define REG_DAC_DATA               (*(RwReg16*)0x42004808UL) /**< \brief (DAC) Data */
+#define REG_DAC_DATABUF            (*(RwReg16*)0x4200480CUL) /**< \brief (DAC) Data Buffer */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DAC peripheral ========== */
+#define DAC_DMAC_ID_EMPTY           40       // Index of DMAC EMPTY trigger
+#define DAC_GCLK_ID                 33       // Index of Generic Clock
+
+#endif /* _SAMR21_DAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/dmac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/dmac.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for DMAC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,53 +31,53 @@
 
 /* ========== Register definition for DMAC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_DMAC_CTRL              (0x41004800U) /**< \brief (DMAC) Control */
-#define REG_DMAC_CRCCTRL           (0x41004802U) /**< \brief (DMAC) CRC Control */
-#define REG_DMAC_CRCDATAIN         (0x41004804U) /**< \brief (DMAC) CRC Data Input */
-#define REG_DMAC_CRCCHKSUM         (0x41004808U) /**< \brief (DMAC) CRC Checksum */
-#define REG_DMAC_CRCSTATUS         (0x4100480CU) /**< \brief (DMAC) CRC Status */
-#define REG_DMAC_DBGCTRL           (0x4100480DU) /**< \brief (DMAC) Debug Control */
-#define REG_DMAC_QOSCTRL           (0x4100480EU) /**< \brief (DMAC) QOS Control */
-#define REG_DMAC_SWTRIGCTRL        (0x41004810U) /**< \brief (DMAC) Software Trigger Control */
-#define REG_DMAC_PRICTRL0          (0x41004814U) /**< \brief (DMAC) Priority Control 0 */
-#define REG_DMAC_INTPEND           (0x41004820U) /**< \brief (DMAC) Interrupt Pending */
-#define REG_DMAC_INTSTATUS         (0x41004824U) /**< \brief (DMAC) Interrupt Status */
-#define REG_DMAC_BUSYCH            (0x41004828U) /**< \brief (DMAC) Busy Channels */
-#define REG_DMAC_PENDCH            (0x4100482CU) /**< \brief (DMAC) Pending Channels */
-#define REG_DMAC_ACTIVE            (0x41004830U) /**< \brief (DMAC) Active Channel and Levels */
-#define REG_DMAC_BASEADDR          (0x41004834U) /**< \brief (DMAC) Descriptor Memory Section Base Address */
-#define REG_DMAC_WRBADDR           (0x41004838U) /**< \brief (DMAC) Write-Back Memory Section Base Address */
-#define REG_DMAC_CHID              (0x4100483FU) /**< \brief (DMAC) Channel ID */
-#define REG_DMAC_CHCTRLA           (0x41004840U) /**< \brief (DMAC) Channel Control A */
-#define REG_DMAC_CHCTRLB           (0x41004844U) /**< \brief (DMAC) Channel Control B */
-#define REG_DMAC_CHINTENCLR        (0x4100484CU) /**< \brief (DMAC) Channel Interrupt Enable Clear */
-#define REG_DMAC_CHINTENSET        (0x4100484DU) /**< \brief (DMAC) Channel Interrupt Enable Set */
-#define REG_DMAC_CHINTFLAG         (0x4100484EU) /**< \brief (DMAC) Channel Interrupt Flag Status and Clear */
-#define REG_DMAC_CHSTATUS          (0x4100484FU) /**< \brief (DMAC) Channel Status */
+#define REG_DMAC_CTRL              (0x41004800) /**< \brief (DMAC) Control */
+#define REG_DMAC_CRCCTRL           (0x41004802) /**< \brief (DMAC) CRC Control */
+#define REG_DMAC_CRCDATAIN         (0x41004804) /**< \brief (DMAC) CRC Data Input */
+#define REG_DMAC_CRCCHKSUM         (0x41004808) /**< \brief (DMAC) CRC Checksum */
+#define REG_DMAC_CRCSTATUS         (0x4100480C) /**< \brief (DMAC) CRC Status */
+#define REG_DMAC_DBGCTRL           (0x4100480D) /**< \brief (DMAC) Debug Control */
+#define REG_DMAC_QOSCTRL           (0x4100480E) /**< \brief (DMAC) QOS Control */
+#define REG_DMAC_SWTRIGCTRL        (0x41004810) /**< \brief (DMAC) Software Trigger Control */
+#define REG_DMAC_PRICTRL0          (0x41004814) /**< \brief (DMAC) Priority Control 0 */
+#define REG_DMAC_INTPEND           (0x41004820) /**< \brief (DMAC) Interrupt Pending */
+#define REG_DMAC_INTSTATUS         (0x41004824) /**< \brief (DMAC) Interrupt Status */
+#define REG_DMAC_BUSYCH            (0x41004828) /**< \brief (DMAC) Busy Channels */
+#define REG_DMAC_PENDCH            (0x4100482C) /**< \brief (DMAC) Pending Channels */
+#define REG_DMAC_ACTIVE            (0x41004830) /**< \brief (DMAC) Active Channel and Levels */
+#define REG_DMAC_BASEADDR          (0x41004834) /**< \brief (DMAC) Descriptor Memory Section Base Address */
+#define REG_DMAC_WRBADDR           (0x41004838) /**< \brief (DMAC) Write-Back Memory Section Base Address */
+#define REG_DMAC_CHID              (0x4100483F) /**< \brief (DMAC) Channel ID */
+#define REG_DMAC_CHCTRLA           (0x41004840) /**< \brief (DMAC) Channel Control A */
+#define REG_DMAC_CHCTRLB           (0x41004844) /**< \brief (DMAC) Channel Control B */
+#define REG_DMAC_CHINTENCLR        (0x4100484C) /**< \brief (DMAC) Channel Interrupt Enable Clear */
+#define REG_DMAC_CHINTENSET        (0x4100484D) /**< \brief (DMAC) Channel Interrupt Enable Set */
+#define REG_DMAC_CHINTFLAG         (0x4100484E) /**< \brief (DMAC) Channel Interrupt Flag Status and Clear */
+#define REG_DMAC_CHSTATUS          (0x4100484F) /**< \brief (DMAC) Channel Status */
 #else
-#define REG_DMAC_CTRL              (*(RwReg16*)0x41004800U) /**< \brief (DMAC) Control */
-#define REG_DMAC_CRCCTRL           (*(RwReg16*)0x41004802U) /**< \brief (DMAC) CRC Control */
-#define REG_DMAC_CRCDATAIN         (*(RwReg  *)0x41004804U) /**< \brief (DMAC) CRC Data Input */
-#define REG_DMAC_CRCCHKSUM         (*(RwReg  *)0x41004808U) /**< \brief (DMAC) CRC Checksum */
-#define REG_DMAC_CRCSTATUS         (*(RwReg8 *)0x4100480CU) /**< \brief (DMAC) CRC Status */
-#define REG_DMAC_DBGCTRL           (*(RwReg8 *)0x4100480DU) /**< \brief (DMAC) Debug Control */
-#define REG_DMAC_QOSCTRL           (*(RwReg8 *)0x4100480EU) /**< \brief (DMAC) QOS Control */
-#define REG_DMAC_SWTRIGCTRL        (*(RwReg  *)0x41004810U) /**< \brief (DMAC) Software Trigger Control */
-#define REG_DMAC_PRICTRL0          (*(RwReg  *)0x41004814U) /**< \brief (DMAC) Priority Control 0 */
-#define REG_DMAC_INTPEND           (*(RwReg16*)0x41004820U) /**< \brief (DMAC) Interrupt Pending */
-#define REG_DMAC_INTSTATUS         (*(RoReg  *)0x41004824U) /**< \brief (DMAC) Interrupt Status */
-#define REG_DMAC_BUSYCH            (*(RoReg  *)0x41004828U) /**< \brief (DMAC) Busy Channels */
-#define REG_DMAC_PENDCH            (*(RoReg  *)0x4100482CU) /**< \brief (DMAC) Pending Channels */
-#define REG_DMAC_ACTIVE            (*(RoReg  *)0x41004830U) /**< \brief (DMAC) Active Channel and Levels */
-#define REG_DMAC_BASEADDR          (*(RwReg  *)0x41004834U) /**< \brief (DMAC) Descriptor Memory Section Base Address */
-#define REG_DMAC_WRBADDR           (*(RwReg  *)0x41004838U) /**< \brief (DMAC) Write-Back Memory Section Base Address */
-#define REG_DMAC_CHID              (*(RwReg8 *)0x4100483FU) /**< \brief (DMAC) Channel ID */
-#define REG_DMAC_CHCTRLA           (*(RwReg8 *)0x41004840U) /**< \brief (DMAC) Channel Control A */
-#define REG_DMAC_CHCTRLB           (*(RwReg  *)0x41004844U) /**< \brief (DMAC) Channel Control B */
-#define REG_DMAC_CHINTENCLR        (*(RwReg8 *)0x4100484CU) /**< \brief (DMAC) Channel Interrupt Enable Clear */
-#define REG_DMAC_CHINTENSET        (*(RwReg8 *)0x4100484DU) /**< \brief (DMAC) Channel Interrupt Enable Set */
-#define REG_DMAC_CHINTFLAG         (*(RwReg8 *)0x4100484EU) /**< \brief (DMAC) Channel Interrupt Flag Status and Clear */
-#define REG_DMAC_CHSTATUS          (*(RoReg8 *)0x4100484FU) /**< \brief (DMAC) Channel Status */
+#define REG_DMAC_CTRL              (*(RwReg16*)0x41004800UL) /**< \brief (DMAC) Control */
+#define REG_DMAC_CRCCTRL           (*(RwReg16*)0x41004802UL) /**< \brief (DMAC) CRC Control */
+#define REG_DMAC_CRCDATAIN         (*(RwReg  *)0x41004804UL) /**< \brief (DMAC) CRC Data Input */
+#define REG_DMAC_CRCCHKSUM         (*(RwReg  *)0x41004808UL) /**< \brief (DMAC) CRC Checksum */
+#define REG_DMAC_CRCSTATUS         (*(RwReg8 *)0x4100480CUL) /**< \brief (DMAC) CRC Status */
+#define REG_DMAC_DBGCTRL           (*(RwReg8 *)0x4100480DUL) /**< \brief (DMAC) Debug Control */
+#define REG_DMAC_QOSCTRL           (*(RwReg8 *)0x4100480EUL) /**< \brief (DMAC) QOS Control */
+#define REG_DMAC_SWTRIGCTRL        (*(RwReg  *)0x41004810UL) /**< \brief (DMAC) Software Trigger Control */
+#define REG_DMAC_PRICTRL0          (*(RwReg  *)0x41004814UL) /**< \brief (DMAC) Priority Control 0 */
+#define REG_DMAC_INTPEND           (*(RwReg16*)0x41004820UL) /**< \brief (DMAC) Interrupt Pending */
+#define REG_DMAC_INTSTATUS         (*(RoReg  *)0x41004824UL) /**< \brief (DMAC) Interrupt Status */
+#define REG_DMAC_BUSYCH            (*(RoReg  *)0x41004828UL) /**< \brief (DMAC) Busy Channels */
+#define REG_DMAC_PENDCH            (*(RoReg  *)0x4100482CUL) /**< \brief (DMAC) Pending Channels */
+#define REG_DMAC_ACTIVE            (*(RoReg  *)0x41004830UL) /**< \brief (DMAC) Active Channel and Levels */
+#define REG_DMAC_BASEADDR          (*(RwReg  *)0x41004834UL) /**< \brief (DMAC) Descriptor Memory Section Base Address */
+#define REG_DMAC_WRBADDR           (*(RwReg  *)0x41004838UL) /**< \brief (DMAC) Write-Back Memory Section Base Address */
+#define REG_DMAC_CHID              (*(RwReg8 *)0x4100483FUL) /**< \brief (DMAC) Channel ID */
+#define REG_DMAC_CHCTRLA           (*(RwReg8 *)0x41004840UL) /**< \brief (DMAC) Channel Control A */
+#define REG_DMAC_CHCTRLB           (*(RwReg  *)0x41004844UL) /**< \brief (DMAC) Channel Control B */
+#define REG_DMAC_CHINTENCLR        (*(RwReg8 *)0x4100484CUL) /**< \brief (DMAC) Channel Interrupt Enable Clear */
+#define REG_DMAC_CHINTENSET        (*(RwReg8 *)0x4100484DUL) /**< \brief (DMAC) Channel Interrupt Enable Set */
+#define REG_DMAC_CHINTFLAG         (*(RwReg8 *)0x4100484EUL) /**< \brief (DMAC) Channel Interrupt Flag Status and Clear */
+#define REG_DMAC_CHSTATUS          (*(RoReg8 *)0x4100484FUL) /**< \brief (DMAC) Channel Status */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for DMAC peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/dsu.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/dsu.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for DSU
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,51 +31,51 @@
 
 /* ========== Register definition for DSU peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_DSU_CTRL               (0x41002000U) /**< \brief (DSU) Control */
-#define REG_DSU_STATUSA            (0x41002001U) /**< \brief (DSU) Status A */
-#define REG_DSU_STATUSB            (0x41002002U) /**< \brief (DSU) Status B */
-#define REG_DSU_ADDR               (0x41002004U) /**< \brief (DSU) Address */
-#define REG_DSU_LENGTH             (0x41002008U) /**< \brief (DSU) Length */
-#define REG_DSU_DATA               (0x4100200CU) /**< \brief (DSU) Data */
-#define REG_DSU_DCC0               (0x41002010U) /**< \brief (DSU) Debug Communication Channel 0 */
-#define REG_DSU_DCC1               (0x41002014U) /**< \brief (DSU) Debug Communication Channel 1 */
-#define REG_DSU_DID                (0x41002018U) /**< \brief (DSU) Device Identification */
-#define REG_DSU_ENTRY0             (0x41003000U) /**< \brief (DSU) Coresight ROM Table Entry 0 */
-#define REG_DSU_ENTRY1             (0x41003004U) /**< \brief (DSU) Coresight ROM Table Entry 1 */
-#define REG_DSU_END                (0x41003008U) /**< \brief (DSU) Coresight ROM Table End */
-#define REG_DSU_MEMTYPE            (0x41003FCCU) /**< \brief (DSU) Coresight ROM Table Memory Type */
-#define REG_DSU_PID4               (0x41003FD0U) /**< \brief (DSU) Peripheral Identification 4 */
-#define REG_DSU_PID0               (0x41003FE0U) /**< \brief (DSU) Peripheral Identification 0 */
-#define REG_DSU_PID1               (0x41003FE4U) /**< \brief (DSU) Peripheral Identification 1 */
-#define REG_DSU_PID2               (0x41003FE8U) /**< \brief (DSU) Peripheral Identification 2 */
-#define REG_DSU_PID3               (0x41003FECU) /**< \brief (DSU) Peripheral Identification 3 */
-#define REG_DSU_CID0               (0x41003FF0U) /**< \brief (DSU) Component Identification 0 */
-#define REG_DSU_CID1               (0x41003FF4U) /**< \brief (DSU) Component Identification 1 */
-#define REG_DSU_CID2               (0x41003FF8U) /**< \brief (DSU) Component Identification 2 */
-#define REG_DSU_CID3               (0x41003FFCU) /**< \brief (DSU) Component Identification 3 */
+#define REG_DSU_CTRL               (0x41002000) /**< \brief (DSU) Control */
+#define REG_DSU_STATUSA            (0x41002001) /**< \brief (DSU) Status A */
+#define REG_DSU_STATUSB            (0x41002002) /**< \brief (DSU) Status B */
+#define REG_DSU_ADDR               (0x41002004) /**< \brief (DSU) Address */
+#define REG_DSU_LENGTH             (0x41002008) /**< \brief (DSU) Length */
+#define REG_DSU_DATA               (0x4100200C) /**< \brief (DSU) Data */
+#define REG_DSU_DCC0               (0x41002010) /**< \brief (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1               (0x41002014) /**< \brief (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID                (0x41002018) /**< \brief (DSU) Device Identification */
+#define REG_DSU_ENTRY0             (0x41003000) /**< \brief (DSU) Coresight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1             (0x41003004) /**< \brief (DSU) Coresight ROM Table Entry 1 */
+#define REG_DSU_END                (0x41003008) /**< \brief (DSU) Coresight ROM Table End */
+#define REG_DSU_MEMTYPE            (0x41003FCC) /**< \brief (DSU) Coresight ROM Table Memory Type */
+#define REG_DSU_PID4               (0x41003FD0) /**< \brief (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID0               (0x41003FE0) /**< \brief (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1               (0x41003FE4) /**< \brief (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2               (0x41003FE8) /**< \brief (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3               (0x41003FEC) /**< \brief (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0               (0x41003FF0) /**< \brief (DSU) Component Identification 0 */
+#define REG_DSU_CID1               (0x41003FF4) /**< \brief (DSU) Component Identification 1 */
+#define REG_DSU_CID2               (0x41003FF8) /**< \brief (DSU) Component Identification 2 */
+#define REG_DSU_CID3               (0x41003FFC) /**< \brief (DSU) Component Identification 3 */
 #else
-#define REG_DSU_CTRL               (*(WoReg8 *)0x41002000U) /**< \brief (DSU) Control */
-#define REG_DSU_STATUSA            (*(RwReg8 *)0x41002001U) /**< \brief (DSU) Status A */
-#define REG_DSU_STATUSB            (*(RoReg8 *)0x41002002U) /**< \brief (DSU) Status B */
-#define REG_DSU_ADDR               (*(RwReg  *)0x41002004U) /**< \brief (DSU) Address */
-#define REG_DSU_LENGTH             (*(RwReg  *)0x41002008U) /**< \brief (DSU) Length */
-#define REG_DSU_DATA               (*(RwReg  *)0x4100200CU) /**< \brief (DSU) Data */
-#define REG_DSU_DCC0               (*(RwReg  *)0x41002010U) /**< \brief (DSU) Debug Communication Channel 0 */
-#define REG_DSU_DCC1               (*(RwReg  *)0x41002014U) /**< \brief (DSU) Debug Communication Channel 1 */
-#define REG_DSU_DID                (*(RoReg  *)0x41002018U) /**< \brief (DSU) Device Identification */
-#define REG_DSU_ENTRY0             (*(RoReg  *)0x41003000U) /**< \brief (DSU) Coresight ROM Table Entry 0 */
-#define REG_DSU_ENTRY1             (*(RoReg  *)0x41003004U) /**< \brief (DSU) Coresight ROM Table Entry 1 */
-#define REG_DSU_END                (*(RoReg  *)0x41003008U) /**< \brief (DSU) Coresight ROM Table End */
-#define REG_DSU_MEMTYPE            (*(RoReg  *)0x41003FCCU) /**< \brief (DSU) Coresight ROM Table Memory Type */
-#define REG_DSU_PID4               (*(RoReg  *)0x41003FD0U) /**< \brief (DSU) Peripheral Identification 4 */
-#define REG_DSU_PID0               (*(RoReg  *)0x41003FE0U) /**< \brief (DSU) Peripheral Identification 0 */
-#define REG_DSU_PID1               (*(RoReg  *)0x41003FE4U) /**< \brief (DSU) Peripheral Identification 1 */
-#define REG_DSU_PID2               (*(RoReg  *)0x41003FE8U) /**< \brief (DSU) Peripheral Identification 2 */
-#define REG_DSU_PID3               (*(RoReg  *)0x41003FECU) /**< \brief (DSU) Peripheral Identification 3 */
-#define REG_DSU_CID0               (*(RoReg  *)0x41003FF0U) /**< \brief (DSU) Component Identification 0 */
-#define REG_DSU_CID1               (*(RoReg  *)0x41003FF4U) /**< \brief (DSU) Component Identification 1 */
-#define REG_DSU_CID2               (*(RoReg  *)0x41003FF8U) /**< \brief (DSU) Component Identification 2 */
-#define REG_DSU_CID3               (*(RoReg  *)0x41003FFCU) /**< \brief (DSU) Component Identification 3 */
+#define REG_DSU_CTRL               (*(WoReg8 *)0x41002000UL) /**< \brief (DSU) Control */
+#define REG_DSU_STATUSA            (*(RwReg8 *)0x41002001UL) /**< \brief (DSU) Status A */
+#define REG_DSU_STATUSB            (*(RoReg8 *)0x41002002UL) /**< \brief (DSU) Status B */
+#define REG_DSU_ADDR               (*(RwReg  *)0x41002004UL) /**< \brief (DSU) Address */
+#define REG_DSU_LENGTH             (*(RwReg  *)0x41002008UL) /**< \brief (DSU) Length */
+#define REG_DSU_DATA               (*(RwReg  *)0x4100200CUL) /**< \brief (DSU) Data */
+#define REG_DSU_DCC0               (*(RwReg  *)0x41002010UL) /**< \brief (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1               (*(RwReg  *)0x41002014UL) /**< \brief (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID                (*(RoReg  *)0x41002018UL) /**< \brief (DSU) Device Identification */
+#define REG_DSU_ENTRY0             (*(RoReg  *)0x41003000UL) /**< \brief (DSU) Coresight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1             (*(RoReg  *)0x41003004UL) /**< \brief (DSU) Coresight ROM Table Entry 1 */
+#define REG_DSU_END                (*(RoReg  *)0x41003008UL) /**< \brief (DSU) Coresight ROM Table End */
+#define REG_DSU_MEMTYPE            (*(RoReg  *)0x41003FCCUL) /**< \brief (DSU) Coresight ROM Table Memory Type */
+#define REG_DSU_PID4               (*(RoReg  *)0x41003FD0UL) /**< \brief (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID0               (*(RoReg  *)0x41003FE0UL) /**< \brief (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1               (*(RoReg  *)0x41003FE4UL) /**< \brief (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2               (*(RoReg  *)0x41003FE8UL) /**< \brief (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3               (*(RoReg  *)0x41003FECUL) /**< \brief (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0               (*(RoReg  *)0x41003FF0UL) /**< \brief (DSU) Component Identification 0 */
+#define REG_DSU_CID1               (*(RoReg  *)0x41003FF4UL) /**< \brief (DSU) Component Identification 1 */
+#define REG_DSU_CID2               (*(RoReg  *)0x41003FF8UL) /**< \brief (DSU) Component Identification 2 */
+#define REG_DSU_CID3               (*(RoReg  *)0x41003FFCUL) /**< \brief (DSU) Component Identification 3 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for DSU peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/eic.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/eic.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for EIC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,29 +31,29 @@
 
 /* ========== Register definition for EIC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_EIC_CTRL               (0x40001800U) /**< \brief (EIC) Control */
-#define REG_EIC_STATUS             (0x40001801U) /**< \brief (EIC) Status */
-#define REG_EIC_NMICTRL            (0x40001802U) /**< \brief (EIC) Non-Maskable Interrupt Control */
-#define REG_EIC_NMIFLAG            (0x40001803U) /**< \brief (EIC) Non-Maskable Interrupt Flag Status and Clear */
-#define REG_EIC_EVCTRL             (0x40001804U) /**< \brief (EIC) Event Control */
-#define REG_EIC_INTENCLR           (0x40001808U) /**< \brief (EIC) Interrupt Enable Clear */
-#define REG_EIC_INTENSET           (0x4000180CU) /**< \brief (EIC) Interrupt Enable Set */
-#define REG_EIC_INTFLAG            (0x40001810U) /**< \brief (EIC) Interrupt Flag Status and Clear */
-#define REG_EIC_WAKEUP             (0x40001814U) /**< \brief (EIC) Wake-Up Enable */
-#define REG_EIC_CONFIG0            (0x40001818U) /**< \brief (EIC) Configuration 0 */
-#define REG_EIC_CONFIG1            (0x4000181CU) /**< \brief (EIC) Configuration 1 */
+#define REG_EIC_CTRL               (0x40001800) /**< \brief (EIC) Control */
+#define REG_EIC_STATUS             (0x40001801) /**< \brief (EIC) Status */
+#define REG_EIC_NMICTRL            (0x40001802) /**< \brief (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG            (0x40001803) /**< \brief (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_EVCTRL             (0x40001804) /**< \brief (EIC) Event Control */
+#define REG_EIC_INTENCLR           (0x40001808) /**< \brief (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET           (0x4000180C) /**< \brief (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG            (0x40001810) /**< \brief (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_WAKEUP             (0x40001814) /**< \brief (EIC) Wake-Up Enable */
+#define REG_EIC_CONFIG0            (0x40001818) /**< \brief (EIC) Configuration 0 */
+#define REG_EIC_CONFIG1            (0x4000181C) /**< \brief (EIC) Configuration 1 */
 #else
-#define REG_EIC_CTRL               (*(RwReg8 *)0x40001800U) /**< \brief (EIC) Control */
-#define REG_EIC_STATUS             (*(RoReg8 *)0x40001801U) /**< \brief (EIC) Status */
-#define REG_EIC_NMICTRL            (*(RwReg8 *)0x40001802U) /**< \brief (EIC) Non-Maskable Interrupt Control */
-#define REG_EIC_NMIFLAG            (*(RwReg8 *)0x40001803U) /**< \brief (EIC) Non-Maskable Interrupt Flag Status and Clear */
-#define REG_EIC_EVCTRL             (*(RwReg  *)0x40001804U) /**< \brief (EIC) Event Control */
-#define REG_EIC_INTENCLR           (*(RwReg  *)0x40001808U) /**< \brief (EIC) Interrupt Enable Clear */
-#define REG_EIC_INTENSET           (*(RwReg  *)0x4000180CU) /**< \brief (EIC) Interrupt Enable Set */
-#define REG_EIC_INTFLAG            (*(RwReg  *)0x40001810U) /**< \brief (EIC) Interrupt Flag Status and Clear */
-#define REG_EIC_WAKEUP             (*(RwReg  *)0x40001814U) /**< \brief (EIC) Wake-Up Enable */
-#define REG_EIC_CONFIG0            (*(RwReg  *)0x40001818U) /**< \brief (EIC) Configuration 0 */
-#define REG_EIC_CONFIG1            (*(RwReg  *)0x4000181CU) /**< \brief (EIC) Configuration 1 */
+#define REG_EIC_CTRL               (*(RwReg8 *)0x40001800UL) /**< \brief (EIC) Control */
+#define REG_EIC_STATUS             (*(RoReg8 *)0x40001801UL) /**< \brief (EIC) Status */
+#define REG_EIC_NMICTRL            (*(RwReg8 *)0x40001802UL) /**< \brief (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG            (*(RwReg8 *)0x40001803UL) /**< \brief (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_EVCTRL             (*(RwReg  *)0x40001804UL) /**< \brief (EIC) Event Control */
+#define REG_EIC_INTENCLR           (*(RwReg  *)0x40001808UL) /**< \brief (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET           (*(RwReg  *)0x4000180CUL) /**< \brief (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG            (*(RwReg  *)0x40001810UL) /**< \brief (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_WAKEUP             (*(RwReg  *)0x40001814UL) /**< \brief (EIC) Wake-Up Enable */
+#define REG_EIC_CONFIG0            (*(RwReg  *)0x40001818UL) /**< \brief (EIC) Configuration 0 */
+#define REG_EIC_CONFIG1            (*(RwReg  *)0x4000181CUL) /**< \brief (EIC) Configuration 1 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for EIC peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/evsys.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/evsys.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for EVSYS
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,21 +31,21 @@
 
 /* ========== Register definition for EVSYS peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_EVSYS_CTRL             (0x42000400U) /**< \brief (EVSYS) Control */
-#define REG_EVSYS_CHANNEL          (0x42000404U) /**< \brief (EVSYS) Channel */
-#define REG_EVSYS_USER             (0x42000408U) /**< \brief (EVSYS) User Multiplexer */
-#define REG_EVSYS_CHSTATUS         (0x4200040CU) /**< \brief (EVSYS) Channel Status */
-#define REG_EVSYS_INTENCLR         (0x42000410U) /**< \brief (EVSYS) Interrupt Enable Clear */
-#define REG_EVSYS_INTENSET         (0x42000414U) /**< \brief (EVSYS) Interrupt Enable Set */
-#define REG_EVSYS_INTFLAG          (0x42000418U) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
+#define REG_EVSYS_CTRL             (0x42000400) /**< \brief (EVSYS) Control */
+#define REG_EVSYS_CHANNEL          (0x42000404) /**< \brief (EVSYS) Channel */
+#define REG_EVSYS_USER             (0x42000408) /**< \brief (EVSYS) User Multiplexer */
+#define REG_EVSYS_CHSTATUS         (0x4200040C) /**< \brief (EVSYS) Channel Status */
+#define REG_EVSYS_INTENCLR         (0x42000410) /**< \brief (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET         (0x42000414) /**< \brief (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG          (0x42000418) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
 #else
-#define REG_EVSYS_CTRL             (*(WoReg8 *)0x42000400U) /**< \brief (EVSYS) Control */
-#define REG_EVSYS_CHANNEL          (*(RwReg  *)0x42000404U) /**< \brief (EVSYS) Channel */
-#define REG_EVSYS_USER             (*(RwReg16*)0x42000408U) /**< \brief (EVSYS) User Multiplexer */
-#define REG_EVSYS_CHSTATUS         (*(RoReg  *)0x4200040CU) /**< \brief (EVSYS) Channel Status */
-#define REG_EVSYS_INTENCLR         (*(RwReg  *)0x42000410U) /**< \brief (EVSYS) Interrupt Enable Clear */
-#define REG_EVSYS_INTENSET         (*(RwReg  *)0x42000414U) /**< \brief (EVSYS) Interrupt Enable Set */
-#define REG_EVSYS_INTFLAG          (*(RwReg  *)0x42000418U) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
+#define REG_EVSYS_CTRL             (*(WoReg8 *)0x42000400UL) /**< \brief (EVSYS) Control */
+#define REG_EVSYS_CHANNEL          (*(RwReg  *)0x42000404UL) /**< \brief (EVSYS) Channel */
+#define REG_EVSYS_USER             (*(RwReg16*)0x42000408UL) /**< \brief (EVSYS) User Multiplexer */
+#define REG_EVSYS_CHSTATUS         (*(RoReg  *)0x4200040CUL) /**< \brief (EVSYS) Channel Status */
+#define REG_EVSYS_INTENCLR         (*(RwReg  *)0x42000410UL) /**< \brief (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET         (*(RwReg  *)0x42000414UL) /**< \brief (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG          (*(RwReg  *)0x42000418UL) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for EVSYS peripheral ========== */
@@ -160,8 +145,6 @@
 #define EVSYS_ID_GEN_AC_COMP_1      69
 #define EVSYS_ID_GEN_AC_WIN_0       70
 #define EVSYS_ID_GEN_DAC_EMPTY      71
-#define EVSYS_ID_GEN_PTC_EOC        72
-#define EVSYS_ID_GEN_PTC_WCOMP      73
 
 // USERS
 #define EVSYS_ID_USER_DMAC_CH_0     0
@@ -192,6 +175,5 @@
 #define EVSYS_ID_USER_AC_SOC_0      25
 #define EVSYS_ID_USER_AC_SOC_1      26
 #define EVSYS_ID_USER_DAC_START     27
-#define EVSYS_ID_USER_PTC_STCONV    28
 
 #endif /* _SAMR21_EVSYS_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/gclk.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/gclk.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for GCLK
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,17 +31,17 @@
 
 /* ========== Register definition for GCLK peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_GCLK_CTRL              (0x40000C00U) /**< \brief (GCLK) Control */
-#define REG_GCLK_STATUS            (0x40000C01U) /**< \brief (GCLK) Status */
-#define REG_GCLK_CLKCTRL           (0x40000C02U) /**< \brief (GCLK) Generic Clock Control */
-#define REG_GCLK_GENCTRL           (0x40000C04U) /**< \brief (GCLK) Generic Clock Generator Control */
-#define REG_GCLK_GENDIV            (0x40000C08U) /**< \brief (GCLK) Generic Clock Generator Division */
+#define REG_GCLK_CTRL              (0x40000C00) /**< \brief (GCLK) Control */
+#define REG_GCLK_STATUS            (0x40000C01) /**< \brief (GCLK) Status */
+#define REG_GCLK_CLKCTRL           (0x40000C02) /**< \brief (GCLK) Generic Clock Control */
+#define REG_GCLK_GENCTRL           (0x40000C04) /**< \brief (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENDIV            (0x40000C08) /**< \brief (GCLK) Generic Clock Generator Division */
 #else
-#define REG_GCLK_CTRL              (*(RwReg8 *)0x40000C00U) /**< \brief (GCLK) Control */
-#define REG_GCLK_STATUS            (*(RoReg8 *)0x40000C01U) /**< \brief (GCLK) Status */
-#define REG_GCLK_CLKCTRL           (*(RwReg16*)0x40000C02U) /**< \brief (GCLK) Generic Clock Control */
-#define REG_GCLK_GENCTRL           (*(RwReg  *)0x40000C04U) /**< \brief (GCLK) Generic Clock Generator Control */
-#define REG_GCLK_GENDIV            (*(RwReg  *)0x40000C08U) /**< \brief (GCLK) Generic Clock Generator Division */
+#define REG_GCLK_CTRL              (*(RwReg8 *)0x40000C00UL) /**< \brief (GCLK) Control */
+#define REG_GCLK_STATUS            (*(RoReg8 *)0x40000C01UL) /**< \brief (GCLK) Status */
+#define REG_GCLK_CLKCTRL           (*(RwReg16*)0x40000C02UL) /**< \brief (GCLK) Generic Clock Control */
+#define REG_GCLK_GENCTRL           (*(RwReg  *)0x40000C04UL) /**< \brief (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENDIV            (*(RwReg  *)0x40000C08UL) /**< \brief (GCLK) Generic Clock Generator Division */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for GCLK peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/mtb.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/mtb.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for MTB
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,57 +31,57 @@
 
 /* ========== Register definition for MTB peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_MTB_POSITION           (0x41006000U) /**< \brief (MTB) MTB Position */
-#define REG_MTB_MASTER             (0x41006004U) /**< \brief (MTB) MTB Master */
-#define REG_MTB_FLOW               (0x41006008U) /**< \brief (MTB) MTB Flow */
-#define REG_MTB_BASE               (0x4100600CU) /**< \brief (MTB) MTB Base */
-#define REG_MTB_ITCTRL             (0x41006F00U) /**< \brief (MTB) MTB Integration Mode Control */
-#define REG_MTB_CLAIMSET           (0x41006FA0U) /**< \brief (MTB) MTB Claim Set */
-#define REG_MTB_CLAIMCLR           (0x41006FA4U) /**< \brief (MTB) MTB Claim Clear */
-#define REG_MTB_LOCKACCESS         (0x41006FB0U) /**< \brief (MTB) MTB Lock Access */
-#define REG_MTB_LOCKSTATUS         (0x41006FB4U) /**< \brief (MTB) MTB Lock Status */
-#define REG_MTB_AUTHSTATUS         (0x41006FB8U) /**< \brief (MTB) MTB Authentication Status */
-#define REG_MTB_DEVARCH            (0x41006FBCU) /**< \brief (MTB) MTB Device Architecture */
-#define REG_MTB_DEVID              (0x41006FC8U) /**< \brief (MTB) MTB Device Configuration */
-#define REG_MTB_DEVTYPE            (0x41006FCCU) /**< \brief (MTB) MTB Device Type */
-#define REG_MTB_PID4               (0x41006FD0U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID5               (0x41006FD4U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID6               (0x41006FD8U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID7               (0x41006FDCU) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID0               (0x41006FE0U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID1               (0x41006FE4U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID2               (0x41006FE8U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID3               (0x41006FECU) /**< \brief (MTB) CoreSight */
-#define REG_MTB_CID0               (0x41006FF0U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_CID1               (0x41006FF4U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_CID2               (0x41006FF8U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_CID3               (0x41006FFCU) /**< \brief (MTB) CoreSight */
+#define REG_MTB_POSITION           (0x41006000) /**< \brief (MTB) MTB Position */
+#define REG_MTB_MASTER             (0x41006004) /**< \brief (MTB) MTB Master */
+#define REG_MTB_FLOW               (0x41006008) /**< \brief (MTB) MTB Flow */
+#define REG_MTB_BASE               (0x4100600C) /**< \brief (MTB) MTB Base */
+#define REG_MTB_ITCTRL             (0x41006F00) /**< \brief (MTB) MTB Integration Mode Control */
+#define REG_MTB_CLAIMSET           (0x41006FA0) /**< \brief (MTB) MTB Claim Set */
+#define REG_MTB_CLAIMCLR           (0x41006FA4) /**< \brief (MTB) MTB Claim Clear */
+#define REG_MTB_LOCKACCESS         (0x41006FB0) /**< \brief (MTB) MTB Lock Access */
+#define REG_MTB_LOCKSTATUS         (0x41006FB4) /**< \brief (MTB) MTB Lock Status */
+#define REG_MTB_AUTHSTATUS         (0x41006FB8) /**< \brief (MTB) MTB Authentication Status */
+#define REG_MTB_DEVARCH            (0x41006FBC) /**< \brief (MTB) MTB Device Architecture */
+#define REG_MTB_DEVID              (0x41006FC8) /**< \brief (MTB) MTB Device Configuration */
+#define REG_MTB_DEVTYPE            (0x41006FCC) /**< \brief (MTB) MTB Device Type */
+#define REG_MTB_PID4               (0x41006FD0) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID5               (0x41006FD4) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID6               (0x41006FD8) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID7               (0x41006FDC) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID0               (0x41006FE0) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID1               (0x41006FE4) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID2               (0x41006FE8) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID3               (0x41006FEC) /**< \brief (MTB) CoreSight */
+#define REG_MTB_CID0               (0x41006FF0) /**< \brief (MTB) CoreSight */
+#define REG_MTB_CID1               (0x41006FF4) /**< \brief (MTB) CoreSight */
+#define REG_MTB_CID2               (0x41006FF8) /**< \brief (MTB) CoreSight */
+#define REG_MTB_CID3               (0x41006FFC) /**< \brief (MTB) CoreSight */
 #else
-#define REG_MTB_POSITION           (*(RwReg  *)0x41006000U) /**< \brief (MTB) MTB Position */
-#define REG_MTB_MASTER             (*(RwReg  *)0x41006004U) /**< \brief (MTB) MTB Master */
-#define REG_MTB_FLOW               (*(RwReg  *)0x41006008U) /**< \brief (MTB) MTB Flow */
-#define REG_MTB_BASE               (*(RoReg  *)0x4100600CU) /**< \brief (MTB) MTB Base */
-#define REG_MTB_ITCTRL             (*(RwReg  *)0x41006F00U) /**< \brief (MTB) MTB Integration Mode Control */
-#define REG_MTB_CLAIMSET           (*(RwReg  *)0x41006FA0U) /**< \brief (MTB) MTB Claim Set */
-#define REG_MTB_CLAIMCLR           (*(RwReg  *)0x41006FA4U) /**< \brief (MTB) MTB Claim Clear */
-#define REG_MTB_LOCKACCESS         (*(RwReg  *)0x41006FB0U) /**< \brief (MTB) MTB Lock Access */
-#define REG_MTB_LOCKSTATUS         (*(RoReg  *)0x41006FB4U) /**< \brief (MTB) MTB Lock Status */
-#define REG_MTB_AUTHSTATUS         (*(RoReg  *)0x41006FB8U) /**< \brief (MTB) MTB Authentication Status */
-#define REG_MTB_DEVARCH            (*(RoReg  *)0x41006FBCU) /**< \brief (MTB) MTB Device Architecture */
-#define REG_MTB_DEVID              (*(RoReg  *)0x41006FC8U) /**< \brief (MTB) MTB Device Configuration */
-#define REG_MTB_DEVTYPE            (*(RoReg  *)0x41006FCCU) /**< \brief (MTB) MTB Device Type */
-#define REG_MTB_PID4               (*(RoReg  *)0x41006FD0U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID5               (*(RoReg  *)0x41006FD4U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID6               (*(RoReg  *)0x41006FD8U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID7               (*(RoReg  *)0x41006FDCU) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID0               (*(RoReg  *)0x41006FE0U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID1               (*(RoReg  *)0x41006FE4U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID2               (*(RoReg  *)0x41006FE8U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_PID3               (*(RoReg  *)0x41006FECU) /**< \brief (MTB) CoreSight */
-#define REG_MTB_CID0               (*(RoReg  *)0x41006FF0U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_CID1               (*(RoReg  *)0x41006FF4U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_CID2               (*(RoReg  *)0x41006FF8U) /**< \brief (MTB) CoreSight */
-#define REG_MTB_CID3               (*(RoReg  *)0x41006FFCU) /**< \brief (MTB) CoreSight */
+#define REG_MTB_POSITION           (*(RwReg  *)0x41006000UL) /**< \brief (MTB) MTB Position */
+#define REG_MTB_MASTER             (*(RwReg  *)0x41006004UL) /**< \brief (MTB) MTB Master */
+#define REG_MTB_FLOW               (*(RwReg  *)0x41006008UL) /**< \brief (MTB) MTB Flow */
+#define REG_MTB_BASE               (*(RoReg  *)0x4100600CUL) /**< \brief (MTB) MTB Base */
+#define REG_MTB_ITCTRL             (*(RwReg  *)0x41006F00UL) /**< \brief (MTB) MTB Integration Mode Control */
+#define REG_MTB_CLAIMSET           (*(RwReg  *)0x41006FA0UL) /**< \brief (MTB) MTB Claim Set */
+#define REG_MTB_CLAIMCLR           (*(RwReg  *)0x41006FA4UL) /**< \brief (MTB) MTB Claim Clear */
+#define REG_MTB_LOCKACCESS         (*(RwReg  *)0x41006FB0UL) /**< \brief (MTB) MTB Lock Access */
+#define REG_MTB_LOCKSTATUS         (*(RoReg  *)0x41006FB4UL) /**< \brief (MTB) MTB Lock Status */
+#define REG_MTB_AUTHSTATUS         (*(RoReg  *)0x41006FB8UL) /**< \brief (MTB) MTB Authentication Status */
+#define REG_MTB_DEVARCH            (*(RoReg  *)0x41006FBCUL) /**< \brief (MTB) MTB Device Architecture */
+#define REG_MTB_DEVID              (*(RoReg  *)0x41006FC8UL) /**< \brief (MTB) MTB Device Configuration */
+#define REG_MTB_DEVTYPE            (*(RoReg  *)0x41006FCCUL) /**< \brief (MTB) MTB Device Type */
+#define REG_MTB_PID4               (*(RoReg  *)0x41006FD0UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID5               (*(RoReg  *)0x41006FD4UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID6               (*(RoReg  *)0x41006FD8UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID7               (*(RoReg  *)0x41006FDCUL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID0               (*(RoReg  *)0x41006FE0UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID1               (*(RoReg  *)0x41006FE4UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID2               (*(RoReg  *)0x41006FE8UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_PID3               (*(RoReg  *)0x41006FECUL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_CID0               (*(RoReg  *)0x41006FF0UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_CID1               (*(RoReg  *)0x41006FF4UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_CID2               (*(RoReg  *)0x41006FF8UL) /**< \brief (MTB) CoreSight */
+#define REG_MTB_CID3               (*(RoReg  *)0x41006FFCUL) /**< \brief (MTB) CoreSight */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/nvmctrl.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for NVMCTRL
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,25 +31,25 @@
 
 /* ========== Register definition for NVMCTRL peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_NVMCTRL_CTRLA          (0x41004000U) /**< \brief (NVMCTRL) Control A */
-#define REG_NVMCTRL_CTRLB          (0x41004004U) /**< \brief (NVMCTRL) Control B */
-#define REG_NVMCTRL_PARAM          (0x41004008U) /**< \brief (NVMCTRL) NVM Parameter */
-#define REG_NVMCTRL_INTENCLR       (0x4100400CU) /**< \brief (NVMCTRL) Interrupt Enable Clear */
-#define REG_NVMCTRL_INTENSET       (0x41004010U) /**< \brief (NVMCTRL) Interrupt Enable Set */
-#define REG_NVMCTRL_INTFLAG        (0x41004014U) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
-#define REG_NVMCTRL_STATUS         (0x41004018U) /**< \brief (NVMCTRL) Status */
-#define REG_NVMCTRL_ADDR           (0x4100401CU) /**< \brief (NVMCTRL) Address */
-#define REG_NVMCTRL_LOCK           (0x41004020U) /**< \brief (NVMCTRL) Lock Section */
+#define REG_NVMCTRL_CTRLA          (0x41004000) /**< \brief (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB          (0x41004004) /**< \brief (NVMCTRL) Control B */
+#define REG_NVMCTRL_PARAM          (0x41004008) /**< \brief (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_INTENCLR       (0x4100400C) /**< \brief (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET       (0x41004010) /**< \brief (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG        (0x41004014) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS         (0x41004018) /**< \brief (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR           (0x4100401C) /**< \brief (NVMCTRL) Address */
+#define REG_NVMCTRL_LOCK           (0x41004020) /**< \brief (NVMCTRL) Lock Section */
 #else
-#define REG_NVMCTRL_CTRLA          (*(RwReg16*)0x41004000U) /**< \brief (NVMCTRL) Control A */
-#define REG_NVMCTRL_CTRLB          (*(RwReg  *)0x41004004U) /**< \brief (NVMCTRL) Control B */
-#define REG_NVMCTRL_PARAM          (*(RwReg  *)0x41004008U) /**< \brief (NVMCTRL) NVM Parameter */
-#define REG_NVMCTRL_INTENCLR       (*(RwReg8 *)0x4100400CU) /**< \brief (NVMCTRL) Interrupt Enable Clear */
-#define REG_NVMCTRL_INTENSET       (*(RwReg8 *)0x41004010U) /**< \brief (NVMCTRL) Interrupt Enable Set */
-#define REG_NVMCTRL_INTFLAG        (*(RwReg8 *)0x41004014U) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
-#define REG_NVMCTRL_STATUS         (*(RwReg16*)0x41004018U) /**< \brief (NVMCTRL) Status */
-#define REG_NVMCTRL_ADDR           (*(RwReg  *)0x4100401CU) /**< \brief (NVMCTRL) Address */
-#define REG_NVMCTRL_LOCK           (*(RwReg16*)0x41004020U) /**< \brief (NVMCTRL) Lock Section */
+#define REG_NVMCTRL_CTRLA          (*(RwReg16*)0x41004000UL) /**< \brief (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB          (*(RwReg  *)0x41004004UL) /**< \brief (NVMCTRL) Control B */
+#define REG_NVMCTRL_PARAM          (*(RwReg  *)0x41004008UL) /**< \brief (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_INTENCLR       (*(RwReg8 *)0x4100400CUL) /**< \brief (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET       (*(RwReg8 *)0x41004010UL) /**< \brief (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG        (*(RwReg8 *)0x41004014UL) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS         (*(RwReg16*)0x41004018UL) /**< \brief (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR           (*(RwReg  *)0x4100401CUL) /**< \brief (NVMCTRL) Address */
+#define REG_NVMCTRL_LOCK           (*(RwReg16*)0x41004020UL) /**< \brief (NVMCTRL) Lock Section */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for NVMCTRL peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/pac0.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/pac0.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for PAC0
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,11 +31,11 @@
 
 /* ========== Register definition for PAC0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_PAC0_WPCLR             (0x40000000U) /**< \brief (PAC0) Write Protection Clear */
-#define REG_PAC0_WPSET             (0x40000004U) /**< \brief (PAC0) Write Protection Set */
+#define REG_PAC0_WPCLR             (0x40000000) /**< \brief (PAC0) Write Protection Clear */
+#define REG_PAC0_WPSET             (0x40000004) /**< \brief (PAC0) Write Protection Set */
 #else
-#define REG_PAC0_WPCLR             (*(RwReg  *)0x40000000U) /**< \brief (PAC0) Write Protection Clear */
-#define REG_PAC0_WPSET             (*(RwReg  *)0x40000004U) /**< \brief (PAC0) Write Protection Set */
+#define REG_PAC0_WPCLR             (*(RwReg  *)0x40000000UL) /**< \brief (PAC0) Write Protection Clear */
+#define REG_PAC0_WPSET             (*(RwReg  *)0x40000004UL) /**< \brief (PAC0) Write Protection Set */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for PAC0 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/pac1.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/pac1.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for PAC1
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,11 +31,11 @@
 
 /* ========== Register definition for PAC1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_PAC1_WPCLR             (0x41000000U) /**< \brief (PAC1) Write Protection Clear */
-#define REG_PAC1_WPSET             (0x41000004U) /**< \brief (PAC1) Write Protection Set */
+#define REG_PAC1_WPCLR             (0x41000000) /**< \brief (PAC1) Write Protection Clear */
+#define REG_PAC1_WPSET             (0x41000004) /**< \brief (PAC1) Write Protection Set */
 #else
-#define REG_PAC1_WPCLR             (*(RwReg  *)0x41000000U) /**< \brief (PAC1) Write Protection Clear */
-#define REG_PAC1_WPSET             (*(RwReg  *)0x41000004U) /**< \brief (PAC1) Write Protection Set */
+#define REG_PAC1_WPCLR             (*(RwReg  *)0x41000000UL) /**< \brief (PAC1) Write Protection Clear */
+#define REG_PAC1_WPSET             (*(RwReg  *)0x41000004UL) /**< \brief (PAC1) Write Protection Set */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for PAC1 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/pac2.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/pac2.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for PAC2
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,11 +31,11 @@
 
 /* ========== Register definition for PAC2 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_PAC2_WPCLR             (0x42000000U) /**< \brief (PAC2) Write Protection Clear */
-#define REG_PAC2_WPSET             (0x42000004U) /**< \brief (PAC2) Write Protection Set */
+#define REG_PAC2_WPCLR             (0x42000000) /**< \brief (PAC2) Write Protection Clear */
+#define REG_PAC2_WPSET             (0x42000004) /**< \brief (PAC2) Write Protection Set */
 #else
-#define REG_PAC2_WPCLR             (*(RwReg  *)0x42000000U) /**< \brief (PAC2) Write Protection Clear */
-#define REG_PAC2_WPSET             (*(RwReg  *)0x42000004U) /**< \brief (PAC2) Write Protection Set */
+#define REG_PAC2_WPCLR             (*(RwReg  *)0x42000000UL) /**< \brief (PAC2) Write Protection Clear */
+#define REG_PAC2_WPSET             (*(RwReg  *)0x42000004UL) /**< \brief (PAC2) Write Protection Set */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for PAC2 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/pm.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/pm.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for PM
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,35 +31,35 @@
 
 /* ========== Register definition for PM peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_PM_CTRL                (0x40000400U) /**< \brief (PM) Control */
-#define REG_PM_SLEEP               (0x40000401U) /**< \brief (PM) Sleep Mode */
-#define REG_PM_CPUSEL              (0x40000408U) /**< \brief (PM) CPU Clock Select */
-#define REG_PM_APBASEL             (0x40000409U) /**< \brief (PM) APBA Clock Select */
-#define REG_PM_APBBSEL             (0x4000040AU) /**< \brief (PM) APBB Clock Select */
-#define REG_PM_APBCSEL             (0x4000040BU) /**< \brief (PM) APBC Clock Select */
-#define REG_PM_AHBMASK             (0x40000414U) /**< \brief (PM) AHB Mask */
-#define REG_PM_APBAMASK            (0x40000418U) /**< \brief (PM) APBA Mask */
-#define REG_PM_APBBMASK            (0x4000041CU) /**< \brief (PM) APBB Mask */
-#define REG_PM_APBCMASK            (0x40000420U) /**< \brief (PM) APBC Mask */
-#define REG_PM_INTENCLR            (0x40000434U) /**< \brief (PM) Interrupt Enable Clear */
-#define REG_PM_INTENSET            (0x40000435U) /**< \brief (PM) Interrupt Enable Set */
-#define REG_PM_INTFLAG             (0x40000436U) /**< \brief (PM) Interrupt Flag Status and Clear */
-#define REG_PM_RCAUSE              (0x40000438U) /**< \brief (PM) Reset Cause */
+#define REG_PM_CTRL                (0x40000400) /**< \brief (PM) Control */
+#define REG_PM_SLEEP               (0x40000401) /**< \brief (PM) Sleep Mode */
+#define REG_PM_CPUSEL              (0x40000408) /**< \brief (PM) CPU Clock Select */
+#define REG_PM_APBASEL             (0x40000409) /**< \brief (PM) APBA Clock Select */
+#define REG_PM_APBBSEL             (0x4000040A) /**< \brief (PM) APBB Clock Select */
+#define REG_PM_APBCSEL             (0x4000040B) /**< \brief (PM) APBC Clock Select */
+#define REG_PM_AHBMASK             (0x40000414) /**< \brief (PM) AHB Mask */
+#define REG_PM_APBAMASK            (0x40000418) /**< \brief (PM) APBA Mask */
+#define REG_PM_APBBMASK            (0x4000041C) /**< \brief (PM) APBB Mask */
+#define REG_PM_APBCMASK            (0x40000420) /**< \brief (PM) APBC Mask */
+#define REG_PM_INTENCLR            (0x40000434) /**< \brief (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET            (0x40000435) /**< \brief (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG             (0x40000436) /**< \brief (PM) Interrupt Flag Status and Clear */
+#define REG_PM_RCAUSE              (0x40000438) /**< \brief (PM) Reset Cause */
 #else
-#define REG_PM_CTRL                (*(RwReg8 *)0x40000400U) /**< \brief (PM) Control */
-#define REG_PM_SLEEP               (*(RwReg8 *)0x40000401U) /**< \brief (PM) Sleep Mode */
-#define REG_PM_CPUSEL              (*(RwReg8 *)0x40000408U) /**< \brief (PM) CPU Clock Select */
-#define REG_PM_APBASEL             (*(RwReg8 *)0x40000409U) /**< \brief (PM) APBA Clock Select */
-#define REG_PM_APBBSEL             (*(RwReg8 *)0x4000040AU) /**< \brief (PM) APBB Clock Select */
-#define REG_PM_APBCSEL             (*(RwReg8 *)0x4000040BU) /**< \brief (PM) APBC Clock Select */
-#define REG_PM_AHBMASK             (*(RwReg  *)0x40000414U) /**< \brief (PM) AHB Mask */
-#define REG_PM_APBAMASK            (*(RwReg  *)0x40000418U) /**< \brief (PM) APBA Mask */
-#define REG_PM_APBBMASK            (*(RwReg  *)0x4000041CU) /**< \brief (PM) APBB Mask */
-#define REG_PM_APBCMASK            (*(RwReg  *)0x40000420U) /**< \brief (PM) APBC Mask */
-#define REG_PM_INTENCLR            (*(RwReg8 *)0x40000434U) /**< \brief (PM) Interrupt Enable Clear */
-#define REG_PM_INTENSET            (*(RwReg8 *)0x40000435U) /**< \brief (PM) Interrupt Enable Set */
-#define REG_PM_INTFLAG             (*(RwReg8 *)0x40000436U) /**< \brief (PM) Interrupt Flag Status and Clear */
-#define REG_PM_RCAUSE              (*(RoReg8 *)0x40000438U) /**< \brief (PM) Reset Cause */
+#define REG_PM_CTRL                (*(RwReg8 *)0x40000400UL) /**< \brief (PM) Control */
+#define REG_PM_SLEEP               (*(RwReg8 *)0x40000401UL) /**< \brief (PM) Sleep Mode */
+#define REG_PM_CPUSEL              (*(RwReg8 *)0x40000408UL) /**< \brief (PM) CPU Clock Select */
+#define REG_PM_APBASEL             (*(RwReg8 *)0x40000409UL) /**< \brief (PM) APBA Clock Select */
+#define REG_PM_APBBSEL             (*(RwReg8 *)0x4000040AUL) /**< \brief (PM) APBB Clock Select */
+#define REG_PM_APBCSEL             (*(RwReg8 *)0x4000040BUL) /**< \brief (PM) APBC Clock Select */
+#define REG_PM_AHBMASK             (*(RwReg  *)0x40000414UL) /**< \brief (PM) AHB Mask */
+#define REG_PM_APBAMASK            (*(RwReg  *)0x40000418UL) /**< \brief (PM) APBA Mask */
+#define REG_PM_APBBMASK            (*(RwReg  *)0x4000041CUL) /**< \brief (PM) APBB Mask */
+#define REG_PM_APBCMASK            (*(RwReg  *)0x40000420UL) /**< \brief (PM) APBC Mask */
+#define REG_PM_INTENCLR            (*(RwReg8 *)0x40000434UL) /**< \brief (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET            (*(RwReg8 *)0x40000435UL) /**< \brief (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG             (*(RwReg8 *)0x40000436UL) /**< \brief (PM) Interrupt Flag Status and Clear */
+#define REG_PM_RCAUSE              (*(RoReg8 *)0x40000438UL) /**< \brief (PM) Reset Cause */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for PM peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/port.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/port.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for PORT
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,85 +31,85 @@
 
 /* ========== Register definition for PORT peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_PORT_DIR0              (0x41004400U) /**< \brief (PORT) Data Direction 0 */
-#define REG_PORT_DIRCLR0           (0x41004404U) /**< \brief (PORT) Data Direction Clear 0 */
-#define REG_PORT_DIRSET0           (0x41004408U) /**< \brief (PORT) Data Direction Set 0 */
-#define REG_PORT_DIRTGL0           (0x4100440CU) /**< \brief (PORT) Data Direction Toggle 0 */
-#define REG_PORT_OUT0              (0x41004410U) /**< \brief (PORT) Data Output Value 0 */
-#define REG_PORT_OUTCLR0           (0x41004414U) /**< \brief (PORT) Data Output Value Clear 0 */
-#define REG_PORT_OUTSET0           (0x41004418U) /**< \brief (PORT) Data Output Value Set 0 */
-#define REG_PORT_OUTTGL0           (0x4100441CU) /**< \brief (PORT) Data Output Value Toggle 0 */
-#define REG_PORT_IN0               (0x41004420U) /**< \brief (PORT) Data Input Value 0 */
-#define REG_PORT_CTRL0             (0x41004424U) /**< \brief (PORT) Control 0 */
-#define REG_PORT_WRCONFIG0         (0x41004428U) /**< \brief (PORT) Write Configuration 0 */
-#define REG_PORT_PMUX0             (0x41004430U) /**< \brief (PORT) Peripheral Multiplexing 0 */
-#define REG_PORT_PINCFG0           (0x41004440U) /**< \brief (PORT) Pin Configuration 0 */
-#define REG_PORT_DIR1              (0x41004480U) /**< \brief (PORT) Data Direction 1 */
-#define REG_PORT_DIRCLR1           (0x41004484U) /**< \brief (PORT) Data Direction Clear 1 */
-#define REG_PORT_DIRSET1           (0x41004488U) /**< \brief (PORT) Data Direction Set 1 */
-#define REG_PORT_DIRTGL1           (0x4100448CU) /**< \brief (PORT) Data Direction Toggle 1 */
-#define REG_PORT_OUT1              (0x41004490U) /**< \brief (PORT) Data Output Value 1 */
-#define REG_PORT_OUTCLR1           (0x41004494U) /**< \brief (PORT) Data Output Value Clear 1 */
-#define REG_PORT_OUTSET1           (0x41004498U) /**< \brief (PORT) Data Output Value Set 1 */
-#define REG_PORT_OUTTGL1           (0x4100449CU) /**< \brief (PORT) Data Output Value Toggle 1 */
-#define REG_PORT_IN1               (0x410044A0U) /**< \brief (PORT) Data Input Value 1 */
-#define REG_PORT_CTRL1             (0x410044A4U) /**< \brief (PORT) Control 1 */
-#define REG_PORT_WRCONFIG1         (0x410044A8U) /**< \brief (PORT) Write Configuration 1 */
-#define REG_PORT_PMUX1             (0x410044B0U) /**< \brief (PORT) Peripheral Multiplexing 1 */
-#define REG_PORT_PINCFG1           (0x410044C0U) /**< \brief (PORT) Pin Configuration 1 */
-#define REG_PORT_DIR2              (0x41004500U) /**< \brief (PORT) Data Direction 2 */
-#define REG_PORT_DIRCLR2           (0x41004504U) /**< \brief (PORT) Data Direction Clear 2 */
-#define REG_PORT_DIRSET2           (0x41004508U) /**< \brief (PORT) Data Direction Set 2 */
-#define REG_PORT_DIRTGL2           (0x4100450CU) /**< \brief (PORT) Data Direction Toggle 2 */
-#define REG_PORT_OUT2              (0x41004510U) /**< \brief (PORT) Data Output Value 2 */
-#define REG_PORT_OUTCLR2           (0x41004514U) /**< \brief (PORT) Data Output Value Clear 2 */
-#define REG_PORT_OUTSET2           (0x41004518U) /**< \brief (PORT) Data Output Value Set 2 */
-#define REG_PORT_OUTTGL2           (0x4100451CU) /**< \brief (PORT) Data Output Value Toggle 2 */
-#define REG_PORT_IN2               (0x41004520U) /**< \brief (PORT) Data Input Value 2 */
-#define REG_PORT_CTRL2             (0x41004524U) /**< \brief (PORT) Control 2 */
-#define REG_PORT_WRCONFIG2         (0x41004528U) /**< \brief (PORT) Write Configuration 2 */
-#define REG_PORT_PMUX2             (0x41004530U) /**< \brief (PORT) Peripheral Multiplexing 2 */
-#define REG_PORT_PINCFG2           (0x41004540U) /**< \brief (PORT) Pin Configuration 2 */
+#define REG_PORT_DIR0              (0x41004400) /**< \brief (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0           (0x41004404) /**< \brief (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0           (0x41004408) /**< \brief (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0           (0x4100440C) /**< \brief (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0              (0x41004410) /**< \brief (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0           (0x41004414) /**< \brief (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0           (0x41004418) /**< \brief (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0           (0x4100441C) /**< \brief (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0               (0x41004420) /**< \brief (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0             (0x41004424) /**< \brief (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0         (0x41004428) /**< \brief (PORT) Write Configuration 0 */
+#define REG_PORT_PMUX0             (0x41004430) /**< \brief (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0           (0x41004440) /**< \brief (PORT) Pin Configuration 0 */
+#define REG_PORT_DIR1              (0x41004480) /**< \brief (PORT) Data Direction 1 */
+#define REG_PORT_DIRCLR1           (0x41004484) /**< \brief (PORT) Data Direction Clear 1 */
+#define REG_PORT_DIRSET1           (0x41004488) /**< \brief (PORT) Data Direction Set 1 */
+#define REG_PORT_DIRTGL1           (0x4100448C) /**< \brief (PORT) Data Direction Toggle 1 */
+#define REG_PORT_OUT1              (0x41004490) /**< \brief (PORT) Data Output Value 1 */
+#define REG_PORT_OUTCLR1           (0x41004494) /**< \brief (PORT) Data Output Value Clear 1 */
+#define REG_PORT_OUTSET1           (0x41004498) /**< \brief (PORT) Data Output Value Set 1 */
+#define REG_PORT_OUTTGL1           (0x4100449C) /**< \brief (PORT) Data Output Value Toggle 1 */
+#define REG_PORT_IN1               (0x410044A0) /**< \brief (PORT) Data Input Value 1 */
+#define REG_PORT_CTRL1             (0x410044A4) /**< \brief (PORT) Control 1 */
+#define REG_PORT_WRCONFIG1         (0x410044A8) /**< \brief (PORT) Write Configuration 1 */
+#define REG_PORT_PMUX1             (0x410044B0) /**< \brief (PORT) Peripheral Multiplexing 1 */
+#define REG_PORT_PINCFG1           (0x410044C0) /**< \brief (PORT) Pin Configuration 1 */
+#define REG_PORT_DIR2              (0x41004500) /**< \brief (PORT) Data Direction 2 */
+#define REG_PORT_DIRCLR2           (0x41004504) /**< \brief (PORT) Data Direction Clear 2 */
+#define REG_PORT_DIRSET2           (0x41004508) /**< \brief (PORT) Data Direction Set 2 */
+#define REG_PORT_DIRTGL2           (0x4100450C) /**< \brief (PORT) Data Direction Toggle 2 */
+#define REG_PORT_OUT2              (0x41004510) /**< \brief (PORT) Data Output Value 2 */
+#define REG_PORT_OUTCLR2           (0x41004514) /**< \brief (PORT) Data Output Value Clear 2 */
+#define REG_PORT_OUTSET2           (0x41004518) /**< \brief (PORT) Data Output Value Set 2 */
+#define REG_PORT_OUTTGL2           (0x4100451C) /**< \brief (PORT) Data Output Value Toggle 2 */
+#define REG_PORT_IN2               (0x41004520) /**< \brief (PORT) Data Input Value 2 */
+#define REG_PORT_CTRL2             (0x41004524) /**< \brief (PORT) Control 2 */
+#define REG_PORT_WRCONFIG2         (0x41004528) /**< \brief (PORT) Write Configuration 2 */
+#define REG_PORT_PMUX2             (0x41004530) /**< \brief (PORT) Peripheral Multiplexing 2 */
+#define REG_PORT_PINCFG2           (0x41004540) /**< \brief (PORT) Pin Configuration 2 */
 #else
-#define REG_PORT_DIR0              (*(RwReg  *)0x41004400U) /**< \brief (PORT) Data Direction 0 */
-#define REG_PORT_DIRCLR0           (*(RwReg  *)0x41004404U) /**< \brief (PORT) Data Direction Clear 0 */
-#define REG_PORT_DIRSET0           (*(RwReg  *)0x41004408U) /**< \brief (PORT) Data Direction Set 0 */
-#define REG_PORT_DIRTGL0           (*(RwReg  *)0x4100440CU) /**< \brief (PORT) Data Direction Toggle 0 */
-#define REG_PORT_OUT0              (*(RwReg  *)0x41004410U) /**< \brief (PORT) Data Output Value 0 */
-#define REG_PORT_OUTCLR0           (*(RwReg  *)0x41004414U) /**< \brief (PORT) Data Output Value Clear 0 */
-#define REG_PORT_OUTSET0           (*(RwReg  *)0x41004418U) /**< \brief (PORT) Data Output Value Set 0 */
-#define REG_PORT_OUTTGL0           (*(RwReg  *)0x4100441CU) /**< \brief (PORT) Data Output Value Toggle 0 */
-#define REG_PORT_IN0               (*(RoReg  *)0x41004420U) /**< \brief (PORT) Data Input Value 0 */
-#define REG_PORT_CTRL0             (*(RwReg  *)0x41004424U) /**< \brief (PORT) Control 0 */
-#define REG_PORT_WRCONFIG0         (*(WoReg  *)0x41004428U) /**< \brief (PORT) Write Configuration 0 */
-#define REG_PORT_PMUX0             (*(RwReg  *)0x41004430U) /**< \brief (PORT) Peripheral Multiplexing 0 */
-#define REG_PORT_PINCFG0           (*(RwReg  *)0x41004440U) /**< \brief (PORT) Pin Configuration 0 */
-#define REG_PORT_DIR1              (*(RwReg  *)0x41004480U) /**< \brief (PORT) Data Direction 1 */
-#define REG_PORT_DIRCLR1           (*(RwReg  *)0x41004484U) /**< \brief (PORT) Data Direction Clear 1 */
-#define REG_PORT_DIRSET1           (*(RwReg  *)0x41004488U) /**< \brief (PORT) Data Direction Set 1 */
-#define REG_PORT_DIRTGL1           (*(RwReg  *)0x4100448CU) /**< \brief (PORT) Data Direction Toggle 1 */
-#define REG_PORT_OUT1              (*(RwReg  *)0x41004490U) /**< \brief (PORT) Data Output Value 1 */
-#define REG_PORT_OUTCLR1           (*(RwReg  *)0x41004494U) /**< \brief (PORT) Data Output Value Clear 1 */
-#define REG_PORT_OUTSET1           (*(RwReg  *)0x41004498U) /**< \brief (PORT) Data Output Value Set 1 */
-#define REG_PORT_OUTTGL1           (*(RwReg  *)0x4100449CU) /**< \brief (PORT) Data Output Value Toggle 1 */
-#define REG_PORT_IN1               (*(RoReg  *)0x410044A0U) /**< \brief (PORT) Data Input Value 1 */
-#define REG_PORT_CTRL1             (*(RwReg  *)0x410044A4U) /**< \brief (PORT) Control 1 */
-#define REG_PORT_WRCONFIG1         (*(WoReg  *)0x410044A8U) /**< \brief (PORT) Write Configuration 1 */
-#define REG_PORT_PMUX1             (*(RwReg  *)0x410044B0U) /**< \brief (PORT) Peripheral Multiplexing 1 */
-#define REG_PORT_PINCFG1           (*(RwReg  *)0x410044C0U) /**< \brief (PORT) Pin Configuration 1 */
-#define REG_PORT_DIR2              (*(RwReg  *)0x41004500U) /**< \brief (PORT) Data Direction 2 */
-#define REG_PORT_DIRCLR2           (*(RwReg  *)0x41004504U) /**< \brief (PORT) Data Direction Clear 2 */
-#define REG_PORT_DIRSET2           (*(RwReg  *)0x41004508U) /**< \brief (PORT) Data Direction Set 2 */
-#define REG_PORT_DIRTGL2           (*(RwReg  *)0x4100450CU) /**< \brief (PORT) Data Direction Toggle 2 */
-#define REG_PORT_OUT2              (*(RwReg  *)0x41004510U) /**< \brief (PORT) Data Output Value 2 */
-#define REG_PORT_OUTCLR2           (*(RwReg  *)0x41004514U) /**< \brief (PORT) Data Output Value Clear 2 */
-#define REG_PORT_OUTSET2           (*(RwReg  *)0x41004518U) /**< \brief (PORT) Data Output Value Set 2 */
-#define REG_PORT_OUTTGL2           (*(RwReg  *)0x4100451CU) /**< \brief (PORT) Data Output Value Toggle 2 */
-#define REG_PORT_IN2               (*(RoReg  *)0x41004520U) /**< \brief (PORT) Data Input Value 2 */
-#define REG_PORT_CTRL2             (*(RwReg  *)0x41004524U) /**< \brief (PORT) Control 2 */
-#define REG_PORT_WRCONFIG2         (*(WoReg  *)0x41004528U) /**< \brief (PORT) Write Configuration 2 */
-#define REG_PORT_PMUX2             (*(RwReg  *)0x41004530U) /**< \brief (PORT) Peripheral Multiplexing 2 */
-#define REG_PORT_PINCFG2           (*(RwReg  *)0x41004540U) /**< \brief (PORT) Pin Configuration 2 */
+#define REG_PORT_DIR0              (*(RwReg  *)0x41004400UL) /**< \brief (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0           (*(RwReg  *)0x41004404UL) /**< \brief (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0           (*(RwReg  *)0x41004408UL) /**< \brief (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0           (*(RwReg  *)0x4100440CUL) /**< \brief (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0              (*(RwReg  *)0x41004410UL) /**< \brief (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0           (*(RwReg  *)0x41004414UL) /**< \brief (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0           (*(RwReg  *)0x41004418UL) /**< \brief (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0           (*(RwReg  *)0x4100441CUL) /**< \brief (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0               (*(RoReg  *)0x41004420UL) /**< \brief (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0             (*(RwReg  *)0x41004424UL) /**< \brief (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0         (*(WoReg  *)0x41004428UL) /**< \brief (PORT) Write Configuration 0 */
+#define REG_PORT_PMUX0             (*(RwReg  *)0x41004430UL) /**< \brief (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0           (*(RwReg  *)0x41004440UL) /**< \brief (PORT) Pin Configuration 0 */
+#define REG_PORT_DIR1              (*(RwReg  *)0x41004480UL) /**< \brief (PORT) Data Direction 1 */
+#define REG_PORT_DIRCLR1           (*(RwReg  *)0x41004484UL) /**< \brief (PORT) Data Direction Clear 1 */
+#define REG_PORT_DIRSET1           (*(RwReg  *)0x41004488UL) /**< \brief (PORT) Data Direction Set 1 */
+#define REG_PORT_DIRTGL1           (*(RwReg  *)0x4100448CUL) /**< \brief (PORT) Data Direction Toggle 1 */
+#define REG_PORT_OUT1              (*(RwReg  *)0x41004490UL) /**< \brief (PORT) Data Output Value 1 */
+#define REG_PORT_OUTCLR1           (*(RwReg  *)0x41004494UL) /**< \brief (PORT) Data Output Value Clear 1 */
+#define REG_PORT_OUTSET1           (*(RwReg  *)0x41004498UL) /**< \brief (PORT) Data Output Value Set 1 */
+#define REG_PORT_OUTTGL1           (*(RwReg  *)0x4100449CUL) /**< \brief (PORT) Data Output Value Toggle 1 */
+#define REG_PORT_IN1               (*(RoReg  *)0x410044A0UL) /**< \brief (PORT) Data Input Value 1 */
+#define REG_PORT_CTRL1             (*(RwReg  *)0x410044A4UL) /**< \brief (PORT) Control 1 */
+#define REG_PORT_WRCONFIG1         (*(WoReg  *)0x410044A8UL) /**< \brief (PORT) Write Configuration 1 */
+#define REG_PORT_PMUX1             (*(RwReg  *)0x410044B0UL) /**< \brief (PORT) Peripheral Multiplexing 1 */
+#define REG_PORT_PINCFG1           (*(RwReg  *)0x410044C0UL) /**< \brief (PORT) Pin Configuration 1 */
+#define REG_PORT_DIR2              (*(RwReg  *)0x41004500UL) /**< \brief (PORT) Data Direction 2 */
+#define REG_PORT_DIRCLR2           (*(RwReg  *)0x41004504UL) /**< \brief (PORT) Data Direction Clear 2 */
+#define REG_PORT_DIRSET2           (*(RwReg  *)0x41004508UL) /**< \brief (PORT) Data Direction Set 2 */
+#define REG_PORT_DIRTGL2           (*(RwReg  *)0x4100450CUL) /**< \brief (PORT) Data Direction Toggle 2 */
+#define REG_PORT_OUT2              (*(RwReg  *)0x41004510UL) /**< \brief (PORT) Data Output Value 2 */
+#define REG_PORT_OUTCLR2           (*(RwReg  *)0x41004514UL) /**< \brief (PORT) Data Output Value Clear 2 */
+#define REG_PORT_OUTSET2           (*(RwReg  *)0x41004518UL) /**< \brief (PORT) Data Output Value Set 2 */
+#define REG_PORT_OUTTGL2           (*(RwReg  *)0x4100451CUL) /**< \brief (PORT) Data Output Value Toggle 2 */
+#define REG_PORT_IN2               (*(RoReg  *)0x41004520UL) /**< \brief (PORT) Data Input Value 2 */
+#define REG_PORT_CTRL2             (*(RwReg  *)0x41004524UL) /**< \brief (PORT) Control 2 */
+#define REG_PORT_WRCONFIG2         (*(WoReg  *)0x41004528UL) /**< \brief (PORT) Write Configuration 2 */
+#define REG_PORT_PMUX2             (*(RwReg  *)0x41004530UL) /**< \brief (PORT) Peripheral Multiplexing 2 */
+#define REG_PORT_PINCFG2           (*(RwReg  *)0x41004540UL) /**< \brief (PORT) Pin Configuration 2 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for PORT peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/rfctrl.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/rfctrl.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for RFCTRL
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,9 +31,9 @@
 
 /* ========== Register definition for RFCTRL peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_RFCTRL_FECFG           (0x42005400U) /**< \brief (RFCTRL) Front-end control bus configuration */
+#define REG_RFCTRL_FECFG           (0x42005400) /**< \brief (RFCTRL) Front-end control bus configuration */
 #else
-#define REG_RFCTRL_FECFG           (*(RwReg16*)0x42005400U) /**< \brief (RFCTRL) Front-end control bus configuration */
+#define REG_RFCTRL_FECFG           (*(RwReg16*)0x42005400UL) /**< \brief (RFCTRL) Front-end control bus configuration */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for RFCTRL peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/rtc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/rtc.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for RTC
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,63 +31,63 @@
 
 /* ========== Register definition for RTC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_RTC_READREQ            (0x40001402U) /**< \brief (RTC) Read Request */
-#define REG_RTC_STATUS             (0x4000140AU) /**< \brief (RTC) Status */
-#define REG_RTC_DBGCTRL            (0x4000140BU) /**< \brief (RTC) Debug Control */
-#define REG_RTC_FREQCORR           (0x4000140CU) /**< \brief (RTC) Frequency Correction */
-#define REG_RTC_MODE0_CTRL         (0x40001400U) /**< \brief (RTC) MODE0 Control */
-#define REG_RTC_MODE0_EVCTRL       (0x40001404U) /**< \brief (RTC) MODE0 Event Control */
-#define REG_RTC_MODE0_INTENCLR     (0x40001406U) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
-#define REG_RTC_MODE0_INTENSET     (0x40001407U) /**< \brief (RTC) MODE0 Interrupt Enable Set */
-#define REG_RTC_MODE0_INTFLAG      (0x40001408U) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
-#define REG_RTC_MODE0_COUNT        (0x40001410U) /**< \brief (RTC) MODE0 Counter Value */
-#define REG_RTC_MODE0_COMP0        (0x40001418U) /**< \brief (RTC) MODE0 Compare 0 Value */
-#define REG_RTC_MODE1_CTRL         (0x40001400U) /**< \brief (RTC) MODE1 Control */
-#define REG_RTC_MODE1_EVCTRL       (0x40001404U) /**< \brief (RTC) MODE1 Event Control */
-#define REG_RTC_MODE1_INTENCLR     (0x40001406U) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
-#define REG_RTC_MODE1_INTENSET     (0x40001407U) /**< \brief (RTC) MODE1 Interrupt Enable Set */
-#define REG_RTC_MODE1_INTFLAG      (0x40001408U) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
-#define REG_RTC_MODE1_COUNT        (0x40001410U) /**< \brief (RTC) MODE1 Counter Value */
-#define REG_RTC_MODE1_PER          (0x40001414U) /**< \brief (RTC) MODE1 Counter Period */
-#define REG_RTC_MODE1_COMP0        (0x40001418U) /**< \brief (RTC) MODE1 Compare 0 Value */
-#define REG_RTC_MODE1_COMP1        (0x4000141AU) /**< \brief (RTC) MODE1 Compare 1 Value */
-#define REG_RTC_MODE2_CTRL         (0x40001400U) /**< \brief (RTC) MODE2 Control */
-#define REG_RTC_MODE2_EVCTRL       (0x40001404U) /**< \brief (RTC) MODE2 Event Control */
-#define REG_RTC_MODE2_INTENCLR     (0x40001406U) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
-#define REG_RTC_MODE2_INTENSET     (0x40001407U) /**< \brief (RTC) MODE2 Interrupt Enable Set */
-#define REG_RTC_MODE2_INTFLAG      (0x40001408U) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
-#define REG_RTC_MODE2_CLOCK        (0x40001410U) /**< \brief (RTC) MODE2 Clock Value */
-#define REG_RTC_MODE2_ALARM_ALARM0 (0x40001418U) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
-#define REG_RTC_MODE2_ALARM_MASK0  (0x4000141CU) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
+#define REG_RTC_READREQ            (0x40001402) /**< \brief (RTC) Read Request */
+#define REG_RTC_STATUS             (0x4000140A) /**< \brief (RTC) Status */
+#define REG_RTC_DBGCTRL            (0x4000140B) /**< \brief (RTC) Debug Control */
+#define REG_RTC_FREQCORR           (0x4000140C) /**< \brief (RTC) Frequency Correction */
+#define REG_RTC_MODE0_CTRL         (0x40001400) /**< \brief (RTC) MODE0 Control */
+#define REG_RTC_MODE0_EVCTRL       (0x40001404) /**< \brief (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR     (0x40001406) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET     (0x40001407) /**< \brief (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG      (0x40001408) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_COUNT        (0x40001410) /**< \brief (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP0        (0x40001418) /**< \brief (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE1_CTRL         (0x40001400) /**< \brief (RTC) MODE1 Control */
+#define REG_RTC_MODE1_EVCTRL       (0x40001404) /**< \brief (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR     (0x40001406) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET     (0x40001407) /**< \brief (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG      (0x40001408) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_COUNT        (0x40001410) /**< \brief (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER          (0x40001414) /**< \brief (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP0        (0x40001418) /**< \brief (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1        (0x4000141A) /**< \brief (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE2_CTRL         (0x40001400) /**< \brief (RTC) MODE2 Control */
+#define REG_RTC_MODE2_EVCTRL       (0x40001404) /**< \brief (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR     (0x40001406) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET     (0x40001407) /**< \brief (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG      (0x40001408) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_CLOCK        (0x40001410) /**< \brief (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_ALARM_ALARM0 (0x40001418) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_ALARM_MASK0  (0x4000141C) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
 #else
-#define REG_RTC_READREQ            (*(RwReg16*)0x40001402U) /**< \brief (RTC) Read Request */
-#define REG_RTC_STATUS             (*(RwReg8 *)0x4000140AU) /**< \brief (RTC) Status */
-#define REG_RTC_DBGCTRL            (*(RwReg8 *)0x4000140BU) /**< \brief (RTC) Debug Control */
-#define REG_RTC_FREQCORR           (*(RwReg8 *)0x4000140CU) /**< \brief (RTC) Frequency Correction */
-#define REG_RTC_MODE0_CTRL         (*(RwReg16*)0x40001400U) /**< \brief (RTC) MODE0 Control */
-#define REG_RTC_MODE0_EVCTRL       (*(RwReg16*)0x40001404U) /**< \brief (RTC) MODE0 Event Control */
-#define REG_RTC_MODE0_INTENCLR     (*(RwReg8 *)0x40001406U) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
-#define REG_RTC_MODE0_INTENSET     (*(RwReg8 *)0x40001407U) /**< \brief (RTC) MODE0 Interrupt Enable Set */
-#define REG_RTC_MODE0_INTFLAG      (*(RwReg8 *)0x40001408U) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
-#define REG_RTC_MODE0_COUNT        (*(RwReg  *)0x40001410U) /**< \brief (RTC) MODE0 Counter Value */
-#define REG_RTC_MODE0_COMP0        (*(RwReg  *)0x40001418U) /**< \brief (RTC) MODE0 Compare 0 Value */
-#define REG_RTC_MODE1_CTRL         (*(RwReg16*)0x40001400U) /**< \brief (RTC) MODE1 Control */
-#define REG_RTC_MODE1_EVCTRL       (*(RwReg16*)0x40001404U) /**< \brief (RTC) MODE1 Event Control */
-#define REG_RTC_MODE1_INTENCLR     (*(RwReg8 *)0x40001406U) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
-#define REG_RTC_MODE1_INTENSET     (*(RwReg8 *)0x40001407U) /**< \brief (RTC) MODE1 Interrupt Enable Set */
-#define REG_RTC_MODE1_INTFLAG      (*(RwReg8 *)0x40001408U) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
-#define REG_RTC_MODE1_COUNT        (*(RwReg16*)0x40001410U) /**< \brief (RTC) MODE1 Counter Value */
-#define REG_RTC_MODE1_PER          (*(RwReg16*)0x40001414U) /**< \brief (RTC) MODE1 Counter Period */
-#define REG_RTC_MODE1_COMP0        (*(RwReg16*)0x40001418U) /**< \brief (RTC) MODE1 Compare 0 Value */
-#define REG_RTC_MODE1_COMP1        (*(RwReg16*)0x4000141AU) /**< \brief (RTC) MODE1 Compare 1 Value */
-#define REG_RTC_MODE2_CTRL         (*(RwReg16*)0x40001400U) /**< \brief (RTC) MODE2 Control */
-#define REG_RTC_MODE2_EVCTRL       (*(RwReg16*)0x40001404U) /**< \brief (RTC) MODE2 Event Control */
-#define REG_RTC_MODE2_INTENCLR     (*(RwReg8 *)0x40001406U) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
-#define REG_RTC_MODE2_INTENSET     (*(RwReg8 *)0x40001407U) /**< \brief (RTC) MODE2 Interrupt Enable Set */
-#define REG_RTC_MODE2_INTFLAG      (*(RwReg8 *)0x40001408U) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
-#define REG_RTC_MODE2_CLOCK        (*(RwReg  *)0x40001410U) /**< \brief (RTC) MODE2 Clock Value */
-#define REG_RTC_MODE2_ALARM_ALARM0 (*(RwReg  *)0x40001418U) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
-#define REG_RTC_MODE2_ALARM_MASK0  (*(RwReg  *)0x4000141CU) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
+#define REG_RTC_READREQ            (*(RwReg16*)0x40001402UL) /**< \brief (RTC) Read Request */
+#define REG_RTC_STATUS             (*(RwReg8 *)0x4000140AUL) /**< \brief (RTC) Status */
+#define REG_RTC_DBGCTRL            (*(RwReg8 *)0x4000140BUL) /**< \brief (RTC) Debug Control */
+#define REG_RTC_FREQCORR           (*(RwReg8 *)0x4000140CUL) /**< \brief (RTC) Frequency Correction */
+#define REG_RTC_MODE0_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE0 Control */
+#define REG_RTC_MODE0_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_COUNT        (*(RwReg  *)0x40001410UL) /**< \brief (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP0        (*(RwReg  *)0x40001418UL) /**< \brief (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE1_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE1 Control */
+#define REG_RTC_MODE1_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_COUNT        (*(RwReg16*)0x40001410UL) /**< \brief (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER          (*(RwReg16*)0x40001414UL) /**< \brief (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP0        (*(RwReg16*)0x40001418UL) /**< \brief (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1        (*(RwReg16*)0x4000141AUL) /**< \brief (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE2_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE2 Control */
+#define REG_RTC_MODE2_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_CLOCK        (*(RwReg  *)0x40001410UL) /**< \brief (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_ALARM_ALARM0 (*(RwReg  *)0x40001418UL) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_ALARM_MASK0  (*(RwReg  *)0x4000141CUL) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for RTC peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/sbmatrix.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/sbmatrix.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for SBMATRIX
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,103 +31,103 @@
 
 /* ========== Register definition for SBMATRIX peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_SBMATRIX_PRAS0         (0x41007080U) /**< \brief (SBMATRIX) Priority A for Slave 0 */
-#define REG_SBMATRIX_PRBS0         (0x41007084U) /**< \brief (SBMATRIX) Priority B for Slave 0 */
-#define REG_SBMATRIX_PRAS1         (0x41007088U) /**< \brief (SBMATRIX) Priority A for Slave 1 */
-#define REG_SBMATRIX_PRBS1         (0x4100708CU) /**< \brief (SBMATRIX) Priority B for Slave 1 */
-#define REG_SBMATRIX_PRAS2         (0x41007090U) /**< \brief (SBMATRIX) Priority A for Slave 2 */
-#define REG_SBMATRIX_PRBS2         (0x41007094U) /**< \brief (SBMATRIX) Priority B for Slave 2 */
-#define REG_SBMATRIX_PRAS3         (0x41007098U) /**< \brief (SBMATRIX) Priority A for Slave 3 */
-#define REG_SBMATRIX_PRBS3         (0x4100709CU) /**< \brief (SBMATRIX) Priority B for Slave 3 */
-#define REG_SBMATRIX_PRAS4         (0x410070A0U) /**< \brief (SBMATRIX) Priority A for Slave 4 */
-#define REG_SBMATRIX_PRBS4         (0x410070A4U) /**< \brief (SBMATRIX) Priority B for Slave 4 */
-#define REG_SBMATRIX_PRAS5         (0x410070A8U) /**< \brief (SBMATRIX) Priority A for Slave 5 */
-#define REG_SBMATRIX_PRBS5         (0x410070ACU) /**< \brief (SBMATRIX) Priority B for Slave 5 */
-#define REG_SBMATRIX_PRAS6         (0x410070B0U) /**< \brief (SBMATRIX) Priority A for Slave 6 */
-#define REG_SBMATRIX_PRBS6         (0x410070B4U) /**< \brief (SBMATRIX) Priority B for Slave 6 */
-#define REG_SBMATRIX_PRAS7         (0x410070B8U) /**< \brief (SBMATRIX) Priority A for Slave 7 */
-#define REG_SBMATRIX_PRBS7         (0x410070BCU) /**< \brief (SBMATRIX) Priority B for Slave 7 */
-#define REG_SBMATRIX_PRAS8         (0x410070C0U) /**< \brief (SBMATRIX) Priority A for Slave 8 */
-#define REG_SBMATRIX_PRBS8         (0x410070C4U) /**< \brief (SBMATRIX) Priority B for Slave 8 */
-#define REG_SBMATRIX_PRAS9         (0x410070C8U) /**< \brief (SBMATRIX) Priority A for Slave 9 */
-#define REG_SBMATRIX_PRBS9         (0x410070CCU) /**< \brief (SBMATRIX) Priority B for Slave 9 */
-#define REG_SBMATRIX_PRAS10        (0x410070D0U) /**< \brief (SBMATRIX) Priority A for Slave 10 */
-#define REG_SBMATRIX_PRBS10        (0x410070D4U) /**< \brief (SBMATRIX) Priority B for Slave 10 */
-#define REG_SBMATRIX_PRAS11        (0x410070D8U) /**< \brief (SBMATRIX) Priority A for Slave 11 */
-#define REG_SBMATRIX_PRBS11        (0x410070DCU) /**< \brief (SBMATRIX) Priority B for Slave 11 */
-#define REG_SBMATRIX_PRAS12        (0x410070E0U) /**< \brief (SBMATRIX) Priority A for Slave 12 */
-#define REG_SBMATRIX_PRBS12        (0x410070E4U) /**< \brief (SBMATRIX) Priority B for Slave 12 */
-#define REG_SBMATRIX_PRAS13        (0x410070E8U) /**< \brief (SBMATRIX) Priority A for Slave 13 */
-#define REG_SBMATRIX_PRBS13        (0x410070ECU) /**< \brief (SBMATRIX) Priority B for Slave 13 */
-#define REG_SBMATRIX_PRAS14        (0x410070F0U) /**< \brief (SBMATRIX) Priority A for Slave 14 */
-#define REG_SBMATRIX_PRBS14        (0x410070F4U) /**< \brief (SBMATRIX) Priority B for Slave 14 */
-#define REG_SBMATRIX_PRAS15        (0x410070F8U) /**< \brief (SBMATRIX) Priority A for Slave 15 */
-#define REG_SBMATRIX_PRBS15        (0x410070FCU) /**< \brief (SBMATRIX) Priority B for Slave 15 */
-#define REG_SBMATRIX_SFR0          (0x41007110U) /**< \brief (SBMATRIX) Special Function 0 */
-#define REG_SBMATRIX_SFR1          (0x41007114U) /**< \brief (SBMATRIX) Special Function 1 */
-#define REG_SBMATRIX_SFR2          (0x41007118U) /**< \brief (SBMATRIX) Special Function 2 */
-#define REG_SBMATRIX_SFR3          (0x4100711CU) /**< \brief (SBMATRIX) Special Function 3 */
-#define REG_SBMATRIX_SFR4          (0x41007120U) /**< \brief (SBMATRIX) Special Function 4 */
-#define REG_SBMATRIX_SFR5          (0x41007124U) /**< \brief (SBMATRIX) Special Function 5 */
-#define REG_SBMATRIX_SFR6          (0x41007128U) /**< \brief (SBMATRIX) Special Function 6 */
-#define REG_SBMATRIX_SFR7          (0x4100712CU) /**< \brief (SBMATRIX) Special Function 7 */
-#define REG_SBMATRIX_SFR8          (0x41007130U) /**< \brief (SBMATRIX) Special Function 8 */
-#define REG_SBMATRIX_SFR9          (0x41007134U) /**< \brief (SBMATRIX) Special Function 9 */
-#define REG_SBMATRIX_SFR10         (0x41007138U) /**< \brief (SBMATRIX) Special Function 10 */
-#define REG_SBMATRIX_SFR11         (0x4100713CU) /**< \brief (SBMATRIX) Special Function 11 */
-#define REG_SBMATRIX_SFR12         (0x41007140U) /**< \brief (SBMATRIX) Special Function 12 */
-#define REG_SBMATRIX_SFR13         (0x41007144U) /**< \brief (SBMATRIX) Special Function 13 */
-#define REG_SBMATRIX_SFR14         (0x41007148U) /**< \brief (SBMATRIX) Special Function 14 */
-#define REG_SBMATRIX_SFR15         (0x4100714CU) /**< \brief (SBMATRIX) Special Function 15 */
+#define REG_SBMATRIX_PRAS0         (0x41007080) /**< \brief (SBMATRIX) Priority A for Slave 0 */
+#define REG_SBMATRIX_PRBS0         (0x41007084) /**< \brief (SBMATRIX) Priority B for Slave 0 */
+#define REG_SBMATRIX_PRAS1         (0x41007088) /**< \brief (SBMATRIX) Priority A for Slave 1 */
+#define REG_SBMATRIX_PRBS1         (0x4100708C) /**< \brief (SBMATRIX) Priority B for Slave 1 */
+#define REG_SBMATRIX_PRAS2         (0x41007090) /**< \brief (SBMATRIX) Priority A for Slave 2 */
+#define REG_SBMATRIX_PRBS2         (0x41007094) /**< \brief (SBMATRIX) Priority B for Slave 2 */
+#define REG_SBMATRIX_PRAS3         (0x41007098) /**< \brief (SBMATRIX) Priority A for Slave 3 */
+#define REG_SBMATRIX_PRBS3         (0x4100709C) /**< \brief (SBMATRIX) Priority B for Slave 3 */
+#define REG_SBMATRIX_PRAS4         (0x410070A0) /**< \brief (SBMATRIX) Priority A for Slave 4 */
+#define REG_SBMATRIX_PRBS4         (0x410070A4) /**< \brief (SBMATRIX) Priority B for Slave 4 */
+#define REG_SBMATRIX_PRAS5         (0x410070A8) /**< \brief (SBMATRIX) Priority A for Slave 5 */
+#define REG_SBMATRIX_PRBS5         (0x410070AC) /**< \brief (SBMATRIX) Priority B for Slave 5 */
+#define REG_SBMATRIX_PRAS6         (0x410070B0) /**< \brief (SBMATRIX) Priority A for Slave 6 */
+#define REG_SBMATRIX_PRBS6         (0x410070B4) /**< \brief (SBMATRIX) Priority B for Slave 6 */
+#define REG_SBMATRIX_PRAS7         (0x410070B8) /**< \brief (SBMATRIX) Priority A for Slave 7 */
+#define REG_SBMATRIX_PRBS7         (0x410070BC) /**< \brief (SBMATRIX) Priority B for Slave 7 */
+#define REG_SBMATRIX_PRAS8         (0x410070C0) /**< \brief (SBMATRIX) Priority A for Slave 8 */
+#define REG_SBMATRIX_PRBS8         (0x410070C4) /**< \brief (SBMATRIX) Priority B for Slave 8 */
+#define REG_SBMATRIX_PRAS9         (0x410070C8) /**< \brief (SBMATRIX) Priority A for Slave 9 */
+#define REG_SBMATRIX_PRBS9         (0x410070CC) /**< \brief (SBMATRIX) Priority B for Slave 9 */
+#define REG_SBMATRIX_PRAS10        (0x410070D0) /**< \brief (SBMATRIX) Priority A for Slave 10 */
+#define REG_SBMATRIX_PRBS10        (0x410070D4) /**< \brief (SBMATRIX) Priority B for Slave 10 */
+#define REG_SBMATRIX_PRAS11        (0x410070D8) /**< \brief (SBMATRIX) Priority A for Slave 11 */
+#define REG_SBMATRIX_PRBS11        (0x410070DC) /**< \brief (SBMATRIX) Priority B for Slave 11 */
+#define REG_SBMATRIX_PRAS12        (0x410070E0) /**< \brief (SBMATRIX) Priority A for Slave 12 */
+#define REG_SBMATRIX_PRBS12        (0x410070E4) /**< \brief (SBMATRIX) Priority B for Slave 12 */
+#define REG_SBMATRIX_PRAS13        (0x410070E8) /**< \brief (SBMATRIX) Priority A for Slave 13 */
+#define REG_SBMATRIX_PRBS13        (0x410070EC) /**< \brief (SBMATRIX) Priority B for Slave 13 */
+#define REG_SBMATRIX_PRAS14        (0x410070F0) /**< \brief (SBMATRIX) Priority A for Slave 14 */
+#define REG_SBMATRIX_PRBS14        (0x410070F4) /**< \brief (SBMATRIX) Priority B for Slave 14 */
+#define REG_SBMATRIX_PRAS15        (0x410070F8) /**< \brief (SBMATRIX) Priority A for Slave 15 */
+#define REG_SBMATRIX_PRBS15        (0x410070FC) /**< \brief (SBMATRIX) Priority B for Slave 15 */
+#define REG_SBMATRIX_SFR0          (0x41007110) /**< \brief (SBMATRIX) Special Function 0 */
+#define REG_SBMATRIX_SFR1          (0x41007114) /**< \brief (SBMATRIX) Special Function 1 */
+#define REG_SBMATRIX_SFR2          (0x41007118) /**< \brief (SBMATRIX) Special Function 2 */
+#define REG_SBMATRIX_SFR3          (0x4100711C) /**< \brief (SBMATRIX) Special Function 3 */
+#define REG_SBMATRIX_SFR4          (0x41007120) /**< \brief (SBMATRIX) Special Function 4 */
+#define REG_SBMATRIX_SFR5          (0x41007124) /**< \brief (SBMATRIX) Special Function 5 */
+#define REG_SBMATRIX_SFR6          (0x41007128) /**< \brief (SBMATRIX) Special Function 6 */
+#define REG_SBMATRIX_SFR7          (0x4100712C) /**< \brief (SBMATRIX) Special Function 7 */
+#define REG_SBMATRIX_SFR8          (0x41007130) /**< \brief (SBMATRIX) Special Function 8 */
+#define REG_SBMATRIX_SFR9          (0x41007134) /**< \brief (SBMATRIX) Special Function 9 */
+#define REG_SBMATRIX_SFR10         (0x41007138) /**< \brief (SBMATRIX) Special Function 10 */
+#define REG_SBMATRIX_SFR11         (0x4100713C) /**< \brief (SBMATRIX) Special Function 11 */
+#define REG_SBMATRIX_SFR12         (0x41007140) /**< \brief (SBMATRIX) Special Function 12 */
+#define REG_SBMATRIX_SFR13         (0x41007144) /**< \brief (SBMATRIX) Special Function 13 */
+#define REG_SBMATRIX_SFR14         (0x41007148) /**< \brief (SBMATRIX) Special Function 14 */
+#define REG_SBMATRIX_SFR15         (0x4100714C) /**< \brief (SBMATRIX) Special Function 15 */
 #else
-#define REG_SBMATRIX_PRAS0         (*(RwReg  *)0x41007080U) /**< \brief (SBMATRIX) Priority A for Slave 0 */
-#define REG_SBMATRIX_PRBS0         (*(RwReg  *)0x41007084U) /**< \brief (SBMATRIX) Priority B for Slave 0 */
-#define REG_SBMATRIX_PRAS1         (*(RwReg  *)0x41007088U) /**< \brief (SBMATRIX) Priority A for Slave 1 */
-#define REG_SBMATRIX_PRBS1         (*(RwReg  *)0x4100708CU) /**< \brief (SBMATRIX) Priority B for Slave 1 */
-#define REG_SBMATRIX_PRAS2         (*(RwReg  *)0x41007090U) /**< \brief (SBMATRIX) Priority A for Slave 2 */
-#define REG_SBMATRIX_PRBS2         (*(RwReg  *)0x41007094U) /**< \brief (SBMATRIX) Priority B for Slave 2 */
-#define REG_SBMATRIX_PRAS3         (*(RwReg  *)0x41007098U) /**< \brief (SBMATRIX) Priority A for Slave 3 */
-#define REG_SBMATRIX_PRBS3         (*(RwReg  *)0x4100709CU) /**< \brief (SBMATRIX) Priority B for Slave 3 */
-#define REG_SBMATRIX_PRAS4         (*(RwReg  *)0x410070A0U) /**< \brief (SBMATRIX) Priority A for Slave 4 */
-#define REG_SBMATRIX_PRBS4         (*(RwReg  *)0x410070A4U) /**< \brief (SBMATRIX) Priority B for Slave 4 */
-#define REG_SBMATRIX_PRAS5         (*(RwReg  *)0x410070A8U) /**< \brief (SBMATRIX) Priority A for Slave 5 */
-#define REG_SBMATRIX_PRBS5         (*(RwReg  *)0x410070ACU) /**< \brief (SBMATRIX) Priority B for Slave 5 */
-#define REG_SBMATRIX_PRAS6         (*(RwReg  *)0x410070B0U) /**< \brief (SBMATRIX) Priority A for Slave 6 */
-#define REG_SBMATRIX_PRBS6         (*(RwReg  *)0x410070B4U) /**< \brief (SBMATRIX) Priority B for Slave 6 */
-#define REG_SBMATRIX_PRAS7         (*(RwReg  *)0x410070B8U) /**< \brief (SBMATRIX) Priority A for Slave 7 */
-#define REG_SBMATRIX_PRBS7         (*(RwReg  *)0x410070BCU) /**< \brief (SBMATRIX) Priority B for Slave 7 */
-#define REG_SBMATRIX_PRAS8         (*(RwReg  *)0x410070C0U) /**< \brief (SBMATRIX) Priority A for Slave 8 */
-#define REG_SBMATRIX_PRBS8         (*(RwReg  *)0x410070C4U) /**< \brief (SBMATRIX) Priority B for Slave 8 */
-#define REG_SBMATRIX_PRAS9         (*(RwReg  *)0x410070C8U) /**< \brief (SBMATRIX) Priority A for Slave 9 */
-#define REG_SBMATRIX_PRBS9         (*(RwReg  *)0x410070CCU) /**< \brief (SBMATRIX) Priority B for Slave 9 */
-#define REG_SBMATRIX_PRAS10        (*(RwReg  *)0x410070D0U) /**< \brief (SBMATRIX) Priority A for Slave 10 */
-#define REG_SBMATRIX_PRBS10        (*(RwReg  *)0x410070D4U) /**< \brief (SBMATRIX) Priority B for Slave 10 */
-#define REG_SBMATRIX_PRAS11        (*(RwReg  *)0x410070D8U) /**< \brief (SBMATRIX) Priority A for Slave 11 */
-#define REG_SBMATRIX_PRBS11        (*(RwReg  *)0x410070DCU) /**< \brief (SBMATRIX) Priority B for Slave 11 */
-#define REG_SBMATRIX_PRAS12        (*(RwReg  *)0x410070E0U) /**< \brief (SBMATRIX) Priority A for Slave 12 */
-#define REG_SBMATRIX_PRBS12        (*(RwReg  *)0x410070E4U) /**< \brief (SBMATRIX) Priority B for Slave 12 */
-#define REG_SBMATRIX_PRAS13        (*(RwReg  *)0x410070E8U) /**< \brief (SBMATRIX) Priority A for Slave 13 */
-#define REG_SBMATRIX_PRBS13        (*(RwReg  *)0x410070ECU) /**< \brief (SBMATRIX) Priority B for Slave 13 */
-#define REG_SBMATRIX_PRAS14        (*(RwReg  *)0x410070F0U) /**< \brief (SBMATRIX) Priority A for Slave 14 */
-#define REG_SBMATRIX_PRBS14        (*(RwReg  *)0x410070F4U) /**< \brief (SBMATRIX) Priority B for Slave 14 */
-#define REG_SBMATRIX_PRAS15        (*(RwReg  *)0x410070F8U) /**< \brief (SBMATRIX) Priority A for Slave 15 */
-#define REG_SBMATRIX_PRBS15        (*(RwReg  *)0x410070FCU) /**< \brief (SBMATRIX) Priority B for Slave 15 */
-#define REG_SBMATRIX_SFR0          (*(RwReg  *)0x41007110U) /**< \brief (SBMATRIX) Special Function 0 */
-#define REG_SBMATRIX_SFR1          (*(RwReg  *)0x41007114U) /**< \brief (SBMATRIX) Special Function 1 */
-#define REG_SBMATRIX_SFR2          (*(RwReg  *)0x41007118U) /**< \brief (SBMATRIX) Special Function 2 */
-#define REG_SBMATRIX_SFR3          (*(RwReg  *)0x4100711CU) /**< \brief (SBMATRIX) Special Function 3 */
-#define REG_SBMATRIX_SFR4          (*(RwReg  *)0x41007120U) /**< \brief (SBMATRIX) Special Function 4 */
-#define REG_SBMATRIX_SFR5          (*(RwReg  *)0x41007124U) /**< \brief (SBMATRIX) Special Function 5 */
-#define REG_SBMATRIX_SFR6          (*(RwReg  *)0x41007128U) /**< \brief (SBMATRIX) Special Function 6 */
-#define REG_SBMATRIX_SFR7          (*(RwReg  *)0x4100712CU) /**< \brief (SBMATRIX) Special Function 7 */
-#define REG_SBMATRIX_SFR8          (*(RwReg  *)0x41007130U) /**< \brief (SBMATRIX) Special Function 8 */
-#define REG_SBMATRIX_SFR9          (*(RwReg  *)0x41007134U) /**< \brief (SBMATRIX) Special Function 9 */
-#define REG_SBMATRIX_SFR10         (*(RwReg  *)0x41007138U) /**< \brief (SBMATRIX) Special Function 10 */
-#define REG_SBMATRIX_SFR11         (*(RwReg  *)0x4100713CU) /**< \brief (SBMATRIX) Special Function 11 */
-#define REG_SBMATRIX_SFR12         (*(RwReg  *)0x41007140U) /**< \brief (SBMATRIX) Special Function 12 */
-#define REG_SBMATRIX_SFR13         (*(RwReg  *)0x41007144U) /**< \brief (SBMATRIX) Special Function 13 */
-#define REG_SBMATRIX_SFR14         (*(RwReg  *)0x41007148U) /**< \brief (SBMATRIX) Special Function 14 */
-#define REG_SBMATRIX_SFR15         (*(RwReg  *)0x4100714CU) /**< \brief (SBMATRIX) Special Function 15 */
+#define REG_SBMATRIX_PRAS0         (*(RwReg  *)0x41007080UL) /**< \brief (SBMATRIX) Priority A for Slave 0 */
+#define REG_SBMATRIX_PRBS0         (*(RwReg  *)0x41007084UL) /**< \brief (SBMATRIX) Priority B for Slave 0 */
+#define REG_SBMATRIX_PRAS1         (*(RwReg  *)0x41007088UL) /**< \brief (SBMATRIX) Priority A for Slave 1 */
+#define REG_SBMATRIX_PRBS1         (*(RwReg  *)0x4100708CUL) /**< \brief (SBMATRIX) Priority B for Slave 1 */
+#define REG_SBMATRIX_PRAS2         (*(RwReg  *)0x41007090UL) /**< \brief (SBMATRIX) Priority A for Slave 2 */
+#define REG_SBMATRIX_PRBS2         (*(RwReg  *)0x41007094UL) /**< \brief (SBMATRIX) Priority B for Slave 2 */
+#define REG_SBMATRIX_PRAS3         (*(RwReg  *)0x41007098UL) /**< \brief (SBMATRIX) Priority A for Slave 3 */
+#define REG_SBMATRIX_PRBS3         (*(RwReg  *)0x4100709CUL) /**< \brief (SBMATRIX) Priority B for Slave 3 */
+#define REG_SBMATRIX_PRAS4         (*(RwReg  *)0x410070A0UL) /**< \brief (SBMATRIX) Priority A for Slave 4 */
+#define REG_SBMATRIX_PRBS4         (*(RwReg  *)0x410070A4UL) /**< \brief (SBMATRIX) Priority B for Slave 4 */
+#define REG_SBMATRIX_PRAS5         (*(RwReg  *)0x410070A8UL) /**< \brief (SBMATRIX) Priority A for Slave 5 */
+#define REG_SBMATRIX_PRBS5         (*(RwReg  *)0x410070ACUL) /**< \brief (SBMATRIX) Priority B for Slave 5 */
+#define REG_SBMATRIX_PRAS6         (*(RwReg  *)0x410070B0UL) /**< \brief (SBMATRIX) Priority A for Slave 6 */
+#define REG_SBMATRIX_PRBS6         (*(RwReg  *)0x410070B4UL) /**< \brief (SBMATRIX) Priority B for Slave 6 */
+#define REG_SBMATRIX_PRAS7         (*(RwReg  *)0x410070B8UL) /**< \brief (SBMATRIX) Priority A for Slave 7 */
+#define REG_SBMATRIX_PRBS7         (*(RwReg  *)0x410070BCUL) /**< \brief (SBMATRIX) Priority B for Slave 7 */
+#define REG_SBMATRIX_PRAS8         (*(RwReg  *)0x410070C0UL) /**< \brief (SBMATRIX) Priority A for Slave 8 */
+#define REG_SBMATRIX_PRBS8         (*(RwReg  *)0x410070C4UL) /**< \brief (SBMATRIX) Priority B for Slave 8 */
+#define REG_SBMATRIX_PRAS9         (*(RwReg  *)0x410070C8UL) /**< \brief (SBMATRIX) Priority A for Slave 9 */
+#define REG_SBMATRIX_PRBS9         (*(RwReg  *)0x410070CCUL) /**< \brief (SBMATRIX) Priority B for Slave 9 */
+#define REG_SBMATRIX_PRAS10        (*(RwReg  *)0x410070D0UL) /**< \brief (SBMATRIX) Priority A for Slave 10 */
+#define REG_SBMATRIX_PRBS10        (*(RwReg  *)0x410070D4UL) /**< \brief (SBMATRIX) Priority B for Slave 10 */
+#define REG_SBMATRIX_PRAS11        (*(RwReg  *)0x410070D8UL) /**< \brief (SBMATRIX) Priority A for Slave 11 */
+#define REG_SBMATRIX_PRBS11        (*(RwReg  *)0x410070DCUL) /**< \brief (SBMATRIX) Priority B for Slave 11 */
+#define REG_SBMATRIX_PRAS12        (*(RwReg  *)0x410070E0UL) /**< \brief (SBMATRIX) Priority A for Slave 12 */
+#define REG_SBMATRIX_PRBS12        (*(RwReg  *)0x410070E4UL) /**< \brief (SBMATRIX) Priority B for Slave 12 */
+#define REG_SBMATRIX_PRAS13        (*(RwReg  *)0x410070E8UL) /**< \brief (SBMATRIX) Priority A for Slave 13 */
+#define REG_SBMATRIX_PRBS13        (*(RwReg  *)0x410070ECUL) /**< \brief (SBMATRIX) Priority B for Slave 13 */
+#define REG_SBMATRIX_PRAS14        (*(RwReg  *)0x410070F0UL) /**< \brief (SBMATRIX) Priority A for Slave 14 */
+#define REG_SBMATRIX_PRBS14        (*(RwReg  *)0x410070F4UL) /**< \brief (SBMATRIX) Priority B for Slave 14 */
+#define REG_SBMATRIX_PRAS15        (*(RwReg  *)0x410070F8UL) /**< \brief (SBMATRIX) Priority A for Slave 15 */
+#define REG_SBMATRIX_PRBS15        (*(RwReg  *)0x410070FCUL) /**< \brief (SBMATRIX) Priority B for Slave 15 */
+#define REG_SBMATRIX_SFR0          (*(RwReg  *)0x41007110UL) /**< \brief (SBMATRIX) Special Function 0 */
+#define REG_SBMATRIX_SFR1          (*(RwReg  *)0x41007114UL) /**< \brief (SBMATRIX) Special Function 1 */
+#define REG_SBMATRIX_SFR2          (*(RwReg  *)0x41007118UL) /**< \brief (SBMATRIX) Special Function 2 */
+#define REG_SBMATRIX_SFR3          (*(RwReg  *)0x4100711CUL) /**< \brief (SBMATRIX) Special Function 3 */
+#define REG_SBMATRIX_SFR4          (*(RwReg  *)0x41007120UL) /**< \brief (SBMATRIX) Special Function 4 */
+#define REG_SBMATRIX_SFR5          (*(RwReg  *)0x41007124UL) /**< \brief (SBMATRIX) Special Function 5 */
+#define REG_SBMATRIX_SFR6          (*(RwReg  *)0x41007128UL) /**< \brief (SBMATRIX) Special Function 6 */
+#define REG_SBMATRIX_SFR7          (*(RwReg  *)0x4100712CUL) /**< \brief (SBMATRIX) Special Function 7 */
+#define REG_SBMATRIX_SFR8          (*(RwReg  *)0x41007130UL) /**< \brief (SBMATRIX) Special Function 8 */
+#define REG_SBMATRIX_SFR9          (*(RwReg  *)0x41007134UL) /**< \brief (SBMATRIX) Special Function 9 */
+#define REG_SBMATRIX_SFR10         (*(RwReg  *)0x41007138UL) /**< \brief (SBMATRIX) Special Function 10 */
+#define REG_SBMATRIX_SFR11         (*(RwReg  *)0x4100713CUL) /**< \brief (SBMATRIX) Special Function 11 */
+#define REG_SBMATRIX_SFR12         (*(RwReg  *)0x41007140UL) /**< \brief (SBMATRIX) Special Function 12 */
+#define REG_SBMATRIX_SFR13         (*(RwReg  *)0x41007144UL) /**< \brief (SBMATRIX) Special Function 13 */
+#define REG_SBMATRIX_SFR14         (*(RwReg  *)0x41007148UL) /**< \brief (SBMATRIX) Special Function 14 */
+#define REG_SBMATRIX_SFR15         (*(RwReg  *)0x4100714CUL) /**< \brief (SBMATRIX) Special Function 15 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for SBMATRIX peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/sercom0.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/sercom0.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for SERCOM0
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,91 +31,91 @@
 
 /* ========== Register definition for SERCOM0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_SERCOM0_I2CM_CTRLA     (0x42000800U) /**< \brief (SERCOM0) I2CM Control A */
-#define REG_SERCOM0_I2CM_CTRLB     (0x42000804U) /**< \brief (SERCOM0) I2CM Control B */
-#define REG_SERCOM0_I2CM_BAUD      (0x4200080CU) /**< \brief (SERCOM0) I2CM Baud Rate */
-#define REG_SERCOM0_I2CM_INTENCLR  (0x42000814U) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
-#define REG_SERCOM0_I2CM_INTENSET  (0x42000816U) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
-#define REG_SERCOM0_I2CM_INTFLAG   (0x42000818U) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM0_I2CM_STATUS    (0x4200081AU) /**< \brief (SERCOM0) I2CM Status */
-#define REG_SERCOM0_I2CM_SYNCBUSY  (0x4200081CU) /**< \brief (SERCOM0) I2CM Syncbusy */
-#define REG_SERCOM0_I2CM_ADDR      (0x42000824U) /**< \brief (SERCOM0) I2CM Address */
-#define REG_SERCOM0_I2CM_DATA      (0x42000828U) /**< \brief (SERCOM0) I2CM Data */
-#define REG_SERCOM0_I2CM_DBGCTRL   (0x42000830U) /**< \brief (SERCOM0) I2CM Debug Control */
-#define REG_SERCOM0_I2CS_CTRLA     (0x42000800U) /**< \brief (SERCOM0) I2CS Control A */
-#define REG_SERCOM0_I2CS_CTRLB     (0x42000804U) /**< \brief (SERCOM0) I2CS Control B */
-#define REG_SERCOM0_I2CS_INTENCLR  (0x42000814U) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
-#define REG_SERCOM0_I2CS_INTENSET  (0x42000816U) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
-#define REG_SERCOM0_I2CS_INTFLAG   (0x42000818U) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM0_I2CS_STATUS    (0x4200081AU) /**< \brief (SERCOM0) I2CS Status */
-#define REG_SERCOM0_I2CS_SYNCBUSY  (0x4200081CU) /**< \brief (SERCOM0) I2CS Syncbusy */
-#define REG_SERCOM0_I2CS_ADDR      (0x42000824U) /**< \brief (SERCOM0) I2CS Address */
-#define REG_SERCOM0_I2CS_DATA      (0x42000828U) /**< \brief (SERCOM0) I2CS Data */
-#define REG_SERCOM0_SPI_CTRLA      (0x42000800U) /**< \brief (SERCOM0) SPI Control A */
-#define REG_SERCOM0_SPI_CTRLB      (0x42000804U) /**< \brief (SERCOM0) SPI Control B */
-#define REG_SERCOM0_SPI_BAUD       (0x4200080CU) /**< \brief (SERCOM0) SPI Baud Rate */
-#define REG_SERCOM0_SPI_INTENCLR   (0x42000814U) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
-#define REG_SERCOM0_SPI_INTENSET   (0x42000816U) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
-#define REG_SERCOM0_SPI_INTFLAG    (0x42000818U) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM0_SPI_STATUS     (0x4200081AU) /**< \brief (SERCOM0) SPI Status */
-#define REG_SERCOM0_SPI_SYNCBUSY   (0x4200081CU) /**< \brief (SERCOM0) SPI Syncbusy */
-#define REG_SERCOM0_SPI_ADDR       (0x42000824U) /**< \brief (SERCOM0) SPI Address */
-#define REG_SERCOM0_SPI_DATA       (0x42000828U) /**< \brief (SERCOM0) SPI Data */
-#define REG_SERCOM0_SPI_DBGCTRL    (0x42000830U) /**< \brief (SERCOM0) SPI Debug Control */
-#define REG_SERCOM0_USART_CTRLA    (0x42000800U) /**< \brief (SERCOM0) USART Control A */
-#define REG_SERCOM0_USART_CTRLB    (0x42000804U) /**< \brief (SERCOM0) USART Control B */
-#define REG_SERCOM0_USART_BAUD     (0x4200080CU) /**< \brief (SERCOM0) USART Baud Rate */
-#define REG_SERCOM0_USART_RXPL     (0x4200080EU) /**< \brief (SERCOM0) USART Receive Pulse Length */
-#define REG_SERCOM0_USART_INTENCLR (0x42000814U) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
-#define REG_SERCOM0_USART_INTENSET (0x42000816U) /**< \brief (SERCOM0) USART Interrupt Enable Set */
-#define REG_SERCOM0_USART_INTFLAG  (0x42000818U) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM0_USART_STATUS   (0x4200081AU) /**< \brief (SERCOM0) USART Status */
-#define REG_SERCOM0_USART_SYNCBUSY (0x4200081CU) /**< \brief (SERCOM0) USART Syncbusy */
-#define REG_SERCOM0_USART_DATA     (0x42000828U) /**< \brief (SERCOM0) USART Data */
-#define REG_SERCOM0_USART_DBGCTRL  (0x42000830U) /**< \brief (SERCOM0) USART Debug Control */
+#define REG_SERCOM0_I2CM_CTRLA     (0x42000800) /**< \brief (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB     (0x42000804) /**< \brief (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_BAUD      (0x4200080C) /**< \brief (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR  (0x42000814) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET  (0x42000816) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG   (0x42000818) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS    (0x4200081A) /**< \brief (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_SYNCBUSY  (0x4200081C) /**< \brief (SERCOM0) I2CM Syncbusy */
+#define REG_SERCOM0_I2CM_ADDR      (0x42000824) /**< \brief (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA      (0x42000828) /**< \brief (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CM_DBGCTRL   (0x42000830) /**< \brief (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CS_CTRLA     (0x42000800) /**< \brief (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB     (0x42000804) /**< \brief (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR  (0x42000814) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET  (0x42000816) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG   (0x42000818) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS    (0x4200081A) /**< \brief (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_SYNCBUSY  (0x4200081C) /**< \brief (SERCOM0) I2CS Syncbusy */
+#define REG_SERCOM0_I2CS_ADDR      (0x42000824) /**< \brief (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA      (0x42000828) /**< \brief (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA      (0x42000800) /**< \brief (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB      (0x42000804) /**< \brief (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_BAUD       (0x4200080C) /**< \brief (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR   (0x42000814) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET   (0x42000816) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG    (0x42000818) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS     (0x4200081A) /**< \brief (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_SYNCBUSY   (0x4200081C) /**< \brief (SERCOM0) SPI Syncbusy */
+#define REG_SERCOM0_SPI_ADDR       (0x42000824) /**< \brief (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA       (0x42000828) /**< \brief (SERCOM0) SPI Data */
+#define REG_SERCOM0_SPI_DBGCTRL    (0x42000830) /**< \brief (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_USART_CTRLA    (0x42000800) /**< \brief (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB    (0x42000804) /**< \brief (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_BAUD     (0x4200080C) /**< \brief (SERCOM0) USART Baud Rate */
+#define REG_SERCOM0_USART_RXPL     (0x4200080E) /**< \brief (SERCOM0) USART Receive Pulse Length */
+#define REG_SERCOM0_USART_INTENCLR (0x42000814) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (0x42000816) /**< \brief (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG  (0x42000818) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS   (0x4200081A) /**< \brief (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_SYNCBUSY (0x4200081C) /**< \brief (SERCOM0) USART Syncbusy */
+#define REG_SERCOM0_USART_DATA     (0x42000828) /**< \brief (SERCOM0) USART Data */
+#define REG_SERCOM0_USART_DBGCTRL  (0x42000830) /**< \brief (SERCOM0) USART Debug Control */
 #else
-#define REG_SERCOM0_I2CM_CTRLA     (*(RwReg  *)0x42000800U) /**< \brief (SERCOM0) I2CM Control A */
-#define REG_SERCOM0_I2CM_CTRLB     (*(RwReg  *)0x42000804U) /**< \brief (SERCOM0) I2CM Control B */
-#define REG_SERCOM0_I2CM_BAUD      (*(RwReg  *)0x4200080CU) /**< \brief (SERCOM0) I2CM Baud Rate */
-#define REG_SERCOM0_I2CM_INTENCLR  (*(RwReg8 *)0x42000814U) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
-#define REG_SERCOM0_I2CM_INTENSET  (*(RwReg8 *)0x42000816U) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
-#define REG_SERCOM0_I2CM_INTFLAG   (*(RwReg8 *)0x42000818U) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM0_I2CM_STATUS    (*(RwReg16*)0x4200081AU) /**< \brief (SERCOM0) I2CM Status */
-#define REG_SERCOM0_I2CM_SYNCBUSY  (*(RoReg  *)0x4200081CU) /**< \brief (SERCOM0) I2CM Syncbusy */
-#define REG_SERCOM0_I2CM_ADDR      (*(RwReg  *)0x42000824U) /**< \brief (SERCOM0) I2CM Address */
-#define REG_SERCOM0_I2CM_DATA      (*(RwReg8 *)0x42000828U) /**< \brief (SERCOM0) I2CM Data */
-#define REG_SERCOM0_I2CM_DBGCTRL   (*(RwReg8 *)0x42000830U) /**< \brief (SERCOM0) I2CM Debug Control */
-#define REG_SERCOM0_I2CS_CTRLA     (*(RwReg  *)0x42000800U) /**< \brief (SERCOM0) I2CS Control A */
-#define REG_SERCOM0_I2CS_CTRLB     (*(RwReg  *)0x42000804U) /**< \brief (SERCOM0) I2CS Control B */
-#define REG_SERCOM0_I2CS_INTENCLR  (*(RwReg8 *)0x42000814U) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
-#define REG_SERCOM0_I2CS_INTENSET  (*(RwReg8 *)0x42000816U) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
-#define REG_SERCOM0_I2CS_INTFLAG   (*(RwReg8 *)0x42000818U) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM0_I2CS_STATUS    (*(RwReg16*)0x4200081AU) /**< \brief (SERCOM0) I2CS Status */
-#define REG_SERCOM0_I2CS_SYNCBUSY  (*(RoReg  *)0x4200081CU) /**< \brief (SERCOM0) I2CS Syncbusy */
-#define REG_SERCOM0_I2CS_ADDR      (*(RwReg  *)0x42000824U) /**< \brief (SERCOM0) I2CS Address */
-#define REG_SERCOM0_I2CS_DATA      (*(RwReg8 *)0x42000828U) /**< \brief (SERCOM0) I2CS Data */
-#define REG_SERCOM0_SPI_CTRLA      (*(RwReg  *)0x42000800U) /**< \brief (SERCOM0) SPI Control A */
-#define REG_SERCOM0_SPI_CTRLB      (*(RwReg  *)0x42000804U) /**< \brief (SERCOM0) SPI Control B */
-#define REG_SERCOM0_SPI_BAUD       (*(RwReg8 *)0x4200080CU) /**< \brief (SERCOM0) SPI Baud Rate */
-#define REG_SERCOM0_SPI_INTENCLR   (*(RwReg8 *)0x42000814U) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
-#define REG_SERCOM0_SPI_INTENSET   (*(RwReg8 *)0x42000816U) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
-#define REG_SERCOM0_SPI_INTFLAG    (*(RwReg8 *)0x42000818U) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM0_SPI_STATUS     (*(RwReg16*)0x4200081AU) /**< \brief (SERCOM0) SPI Status */
-#define REG_SERCOM0_SPI_SYNCBUSY   (*(RoReg  *)0x4200081CU) /**< \brief (SERCOM0) SPI Syncbusy */
-#define REG_SERCOM0_SPI_ADDR       (*(RwReg  *)0x42000824U) /**< \brief (SERCOM0) SPI Address */
-#define REG_SERCOM0_SPI_DATA       (*(RwReg  *)0x42000828U) /**< \brief (SERCOM0) SPI Data */
-#define REG_SERCOM0_SPI_DBGCTRL    (*(RwReg8 *)0x42000830U) /**< \brief (SERCOM0) SPI Debug Control */
-#define REG_SERCOM0_USART_CTRLA    (*(RwReg  *)0x42000800U) /**< \brief (SERCOM0) USART Control A */
-#define REG_SERCOM0_USART_CTRLB    (*(RwReg  *)0x42000804U) /**< \brief (SERCOM0) USART Control B */
-#define REG_SERCOM0_USART_BAUD     (*(RwReg16*)0x4200080CU) /**< \brief (SERCOM0) USART Baud Rate */
-#define REG_SERCOM0_USART_RXPL     (*(RwReg8 *)0x4200080EU) /**< \brief (SERCOM0) USART Receive Pulse Length */
-#define REG_SERCOM0_USART_INTENCLR (*(RwReg8 *)0x42000814U) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
-#define REG_SERCOM0_USART_INTENSET (*(RwReg8 *)0x42000816U) /**< \brief (SERCOM0) USART Interrupt Enable Set */
-#define REG_SERCOM0_USART_INTFLAG  (*(RwReg8 *)0x42000818U) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM0_USART_STATUS   (*(RwReg16*)0x4200081AU) /**< \brief (SERCOM0) USART Status */
-#define REG_SERCOM0_USART_SYNCBUSY (*(RoReg  *)0x4200081CU) /**< \brief (SERCOM0) USART Syncbusy */
-#define REG_SERCOM0_USART_DATA     (*(RwReg16*)0x42000828U) /**< \brief (SERCOM0) USART Data */
-#define REG_SERCOM0_USART_DBGCTRL  (*(RwReg8 *)0x42000830U) /**< \brief (SERCOM0) USART Debug Control */
+#define REG_SERCOM0_I2CM_CTRLA     (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB     (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_BAUD      (*(RwReg  *)0x4200080CUL) /**< \brief (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR  (*(RwReg8 *)0x42000814UL) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET  (*(RwReg8 *)0x42000816UL) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG   (*(RwReg8 *)0x42000818UL) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS    (*(RwReg16*)0x4200081AUL) /**< \brief (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_SYNCBUSY  (*(RoReg  *)0x4200081CUL) /**< \brief (SERCOM0) I2CM Syncbusy */
+#define REG_SERCOM0_I2CM_ADDR      (*(RwReg  *)0x42000824UL) /**< \brief (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA      (*(RwReg8 *)0x42000828UL) /**< \brief (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CM_DBGCTRL   (*(RwReg8 *)0x42000830UL) /**< \brief (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CS_CTRLA     (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB     (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR  (*(RwReg8 *)0x42000814UL) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET  (*(RwReg8 *)0x42000816UL) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG   (*(RwReg8 *)0x42000818UL) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS    (*(RwReg16*)0x4200081AUL) /**< \brief (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_SYNCBUSY  (*(RoReg  *)0x4200081CUL) /**< \brief (SERCOM0) I2CS Syncbusy */
+#define REG_SERCOM0_I2CS_ADDR      (*(RwReg  *)0x42000824UL) /**< \brief (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA      (*(RwReg8 *)0x42000828UL) /**< \brief (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA      (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB      (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_BAUD       (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR   (*(RwReg8 *)0x42000814UL) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET   (*(RwReg8 *)0x42000816UL) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG    (*(RwReg8 *)0x42000818UL) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS     (*(RwReg16*)0x4200081AUL) /**< \brief (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_SYNCBUSY   (*(RoReg  *)0x4200081CUL) /**< \brief (SERCOM0) SPI Syncbusy */
+#define REG_SERCOM0_SPI_ADDR       (*(RwReg  *)0x42000824UL) /**< \brief (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA       (*(RwReg  *)0x42000828UL) /**< \brief (SERCOM0) SPI Data */
+#define REG_SERCOM0_SPI_DBGCTRL    (*(RwReg8 *)0x42000830UL) /**< \brief (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_USART_CTRLA    (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB    (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_BAUD     (*(RwReg16*)0x4200080CUL) /**< \brief (SERCOM0) USART Baud Rate */
+#define REG_SERCOM0_USART_RXPL     (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) USART Receive Pulse Length */
+#define REG_SERCOM0_USART_INTENCLR (*(RwReg8 *)0x42000814UL) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (*(RwReg8 *)0x42000816UL) /**< \brief (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG  (*(RwReg8 *)0x42000818UL) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS   (*(RwReg16*)0x4200081AUL) /**< \brief (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_SYNCBUSY (*(RoReg  *)0x4200081CUL) /**< \brief (SERCOM0) USART Syncbusy */
+#define REG_SERCOM0_USART_DATA     (*(RwReg16*)0x42000828UL) /**< \brief (SERCOM0) USART Data */
+#define REG_SERCOM0_USART_DBGCTRL  (*(RwReg8 *)0x42000830UL) /**< \brief (SERCOM0) USART Debug Control */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for SERCOM0 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/sercom1.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/sercom1.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for SERCOM1
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,91 +31,91 @@
 
 /* ========== Register definition for SERCOM1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_SERCOM1_I2CM_CTRLA     (0x42000C00U) /**< \brief (SERCOM1) I2CM Control A */
-#define REG_SERCOM1_I2CM_CTRLB     (0x42000C04U) /**< \brief (SERCOM1) I2CM Control B */
-#define REG_SERCOM1_I2CM_BAUD      (0x42000C0CU) /**< \brief (SERCOM1) I2CM Baud Rate */
-#define REG_SERCOM1_I2CM_INTENCLR  (0x42000C14U) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
-#define REG_SERCOM1_I2CM_INTENSET  (0x42000C16U) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
-#define REG_SERCOM1_I2CM_INTFLAG   (0x42000C18U) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM1_I2CM_STATUS    (0x42000C1AU) /**< \brief (SERCOM1) I2CM Status */
-#define REG_SERCOM1_I2CM_SYNCBUSY  (0x42000C1CU) /**< \brief (SERCOM1) I2CM Syncbusy */
-#define REG_SERCOM1_I2CM_ADDR      (0x42000C24U) /**< \brief (SERCOM1) I2CM Address */
-#define REG_SERCOM1_I2CM_DATA      (0x42000C28U) /**< \brief (SERCOM1) I2CM Data */
-#define REG_SERCOM1_I2CM_DBGCTRL   (0x42000C30U) /**< \brief (SERCOM1) I2CM Debug Control */
-#define REG_SERCOM1_I2CS_CTRLA     (0x42000C00U) /**< \brief (SERCOM1) I2CS Control A */
-#define REG_SERCOM1_I2CS_CTRLB     (0x42000C04U) /**< \brief (SERCOM1) I2CS Control B */
-#define REG_SERCOM1_I2CS_INTENCLR  (0x42000C14U) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
-#define REG_SERCOM1_I2CS_INTENSET  (0x42000C16U) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
-#define REG_SERCOM1_I2CS_INTFLAG   (0x42000C18U) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM1_I2CS_STATUS    (0x42000C1AU) /**< \brief (SERCOM1) I2CS Status */
-#define REG_SERCOM1_I2CS_SYNCBUSY  (0x42000C1CU) /**< \brief (SERCOM1) I2CS Syncbusy */
-#define REG_SERCOM1_I2CS_ADDR      (0x42000C24U) /**< \brief (SERCOM1) I2CS Address */
-#define REG_SERCOM1_I2CS_DATA      (0x42000C28U) /**< \brief (SERCOM1) I2CS Data */
-#define REG_SERCOM1_SPI_CTRLA      (0x42000C00U) /**< \brief (SERCOM1) SPI Control A */
-#define REG_SERCOM1_SPI_CTRLB      (0x42000C04U) /**< \brief (SERCOM1) SPI Control B */
-#define REG_SERCOM1_SPI_BAUD       (0x42000C0CU) /**< \brief (SERCOM1) SPI Baud Rate */
-#define REG_SERCOM1_SPI_INTENCLR   (0x42000C14U) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
-#define REG_SERCOM1_SPI_INTENSET   (0x42000C16U) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
-#define REG_SERCOM1_SPI_INTFLAG    (0x42000C18U) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM1_SPI_STATUS     (0x42000C1AU) /**< \brief (SERCOM1) SPI Status */
-#define REG_SERCOM1_SPI_SYNCBUSY   (0x42000C1CU) /**< \brief (SERCOM1) SPI Syncbusy */
-#define REG_SERCOM1_SPI_ADDR       (0x42000C24U) /**< \brief (SERCOM1) SPI Address */
-#define REG_SERCOM1_SPI_DATA       (0x42000C28U) /**< \brief (SERCOM1) SPI Data */
-#define REG_SERCOM1_SPI_DBGCTRL    (0x42000C30U) /**< \brief (SERCOM1) SPI Debug Control */
-#define REG_SERCOM1_USART_CTRLA    (0x42000C00U) /**< \brief (SERCOM1) USART Control A */
-#define REG_SERCOM1_USART_CTRLB    (0x42000C04U) /**< \brief (SERCOM1) USART Control B */
-#define REG_SERCOM1_USART_BAUD     (0x42000C0CU) /**< \brief (SERCOM1) USART Baud Rate */
-#define REG_SERCOM1_USART_RXPL     (0x42000C0EU) /**< \brief (SERCOM1) USART Receive Pulse Length */
-#define REG_SERCOM1_USART_INTENCLR (0x42000C14U) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
-#define REG_SERCOM1_USART_INTENSET (0x42000C16U) /**< \brief (SERCOM1) USART Interrupt Enable Set */
-#define REG_SERCOM1_USART_INTFLAG  (0x42000C18U) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM1_USART_STATUS   (0x42000C1AU) /**< \brief (SERCOM1) USART Status */
-#define REG_SERCOM1_USART_SYNCBUSY (0x42000C1CU) /**< \brief (SERCOM1) USART Syncbusy */
-#define REG_SERCOM1_USART_DATA     (0x42000C28U) /**< \brief (SERCOM1) USART Data */
-#define REG_SERCOM1_USART_DBGCTRL  (0x42000C30U) /**< \brief (SERCOM1) USART Debug Control */
+#define REG_SERCOM1_I2CM_CTRLA     (0x42000C00) /**< \brief (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB     (0x42000C04) /**< \brief (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_BAUD      (0x42000C0C) /**< \brief (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR  (0x42000C14) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET  (0x42000C16) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG   (0x42000C18) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS    (0x42000C1A) /**< \brief (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_SYNCBUSY  (0x42000C1C) /**< \brief (SERCOM1) I2CM Syncbusy */
+#define REG_SERCOM1_I2CM_ADDR      (0x42000C24) /**< \brief (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA      (0x42000C28) /**< \brief (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CM_DBGCTRL   (0x42000C30) /**< \brief (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CS_CTRLA     (0x42000C00) /**< \brief (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB     (0x42000C04) /**< \brief (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR  (0x42000C14) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET  (0x42000C16) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG   (0x42000C18) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS    (0x42000C1A) /**< \brief (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_SYNCBUSY  (0x42000C1C) /**< \brief (SERCOM1) I2CS Syncbusy */
+#define REG_SERCOM1_I2CS_ADDR      (0x42000C24) /**< \brief (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA      (0x42000C28) /**< \brief (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA      (0x42000C00) /**< \brief (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB      (0x42000C04) /**< \brief (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_BAUD       (0x42000C0C) /**< \brief (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR   (0x42000C14) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET   (0x42000C16) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG    (0x42000C18) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS     (0x42000C1A) /**< \brief (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_SYNCBUSY   (0x42000C1C) /**< \brief (SERCOM1) SPI Syncbusy */
+#define REG_SERCOM1_SPI_ADDR       (0x42000C24) /**< \brief (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA       (0x42000C28) /**< \brief (SERCOM1) SPI Data */
+#define REG_SERCOM1_SPI_DBGCTRL    (0x42000C30) /**< \brief (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_USART_CTRLA    (0x42000C00) /**< \brief (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB    (0x42000C04) /**< \brief (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_BAUD     (0x42000C0C) /**< \brief (SERCOM1) USART Baud Rate */
+#define REG_SERCOM1_USART_RXPL     (0x42000C0E) /**< \brief (SERCOM1) USART Receive Pulse Length */
+#define REG_SERCOM1_USART_INTENCLR (0x42000C14) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (0x42000C16) /**< \brief (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG  (0x42000C18) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS   (0x42000C1A) /**< \brief (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_SYNCBUSY (0x42000C1C) /**< \brief (SERCOM1) USART Syncbusy */
+#define REG_SERCOM1_USART_DATA     (0x42000C28) /**< \brief (SERCOM1) USART Data */
+#define REG_SERCOM1_USART_DBGCTRL  (0x42000C30) /**< \brief (SERCOM1) USART Debug Control */
 #else
-#define REG_SERCOM1_I2CM_CTRLA     (*(RwReg  *)0x42000C00U) /**< \brief (SERCOM1) I2CM Control A */
-#define REG_SERCOM1_I2CM_CTRLB     (*(RwReg  *)0x42000C04U) /**< \brief (SERCOM1) I2CM Control B */
-#define REG_SERCOM1_I2CM_BAUD      (*(RwReg  *)0x42000C0CU) /**< \brief (SERCOM1) I2CM Baud Rate */
-#define REG_SERCOM1_I2CM_INTENCLR  (*(RwReg8 *)0x42000C14U) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
-#define REG_SERCOM1_I2CM_INTENSET  (*(RwReg8 *)0x42000C16U) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
-#define REG_SERCOM1_I2CM_INTFLAG   (*(RwReg8 *)0x42000C18U) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM1_I2CM_STATUS    (*(RwReg16*)0x42000C1AU) /**< \brief (SERCOM1) I2CM Status */
-#define REG_SERCOM1_I2CM_SYNCBUSY  (*(RoReg  *)0x42000C1CU) /**< \brief (SERCOM1) I2CM Syncbusy */
-#define REG_SERCOM1_I2CM_ADDR      (*(RwReg  *)0x42000C24U) /**< \brief (SERCOM1) I2CM Address */
-#define REG_SERCOM1_I2CM_DATA      (*(RwReg8 *)0x42000C28U) /**< \brief (SERCOM1) I2CM Data */
-#define REG_SERCOM1_I2CM_DBGCTRL   (*(RwReg8 *)0x42000C30U) /**< \brief (SERCOM1) I2CM Debug Control */
-#define REG_SERCOM1_I2CS_CTRLA     (*(RwReg  *)0x42000C00U) /**< \brief (SERCOM1) I2CS Control A */
-#define REG_SERCOM1_I2CS_CTRLB     (*(RwReg  *)0x42000C04U) /**< \brief (SERCOM1) I2CS Control B */
-#define REG_SERCOM1_I2CS_INTENCLR  (*(RwReg8 *)0x42000C14U) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
-#define REG_SERCOM1_I2CS_INTENSET  (*(RwReg8 *)0x42000C16U) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
-#define REG_SERCOM1_I2CS_INTFLAG   (*(RwReg8 *)0x42000C18U) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM1_I2CS_STATUS    (*(RwReg16*)0x42000C1AU) /**< \brief (SERCOM1) I2CS Status */
-#define REG_SERCOM1_I2CS_SYNCBUSY  (*(RoReg  *)0x42000C1CU) /**< \brief (SERCOM1) I2CS Syncbusy */
-#define REG_SERCOM1_I2CS_ADDR      (*(RwReg  *)0x42000C24U) /**< \brief (SERCOM1) I2CS Address */
-#define REG_SERCOM1_I2CS_DATA      (*(RwReg8 *)0x42000C28U) /**< \brief (SERCOM1) I2CS Data */
-#define REG_SERCOM1_SPI_CTRLA      (*(RwReg  *)0x42000C00U) /**< \brief (SERCOM1) SPI Control A */
-#define REG_SERCOM1_SPI_CTRLB      (*(RwReg  *)0x42000C04U) /**< \brief (SERCOM1) SPI Control B */
-#define REG_SERCOM1_SPI_BAUD       (*(RwReg8 *)0x42000C0CU) /**< \brief (SERCOM1) SPI Baud Rate */
-#define REG_SERCOM1_SPI_INTENCLR   (*(RwReg8 *)0x42000C14U) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
-#define REG_SERCOM1_SPI_INTENSET   (*(RwReg8 *)0x42000C16U) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
-#define REG_SERCOM1_SPI_INTFLAG    (*(RwReg8 *)0x42000C18U) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM1_SPI_STATUS     (*(RwReg16*)0x42000C1AU) /**< \brief (SERCOM1) SPI Status */
-#define REG_SERCOM1_SPI_SYNCBUSY   (*(RoReg  *)0x42000C1CU) /**< \brief (SERCOM1) SPI Syncbusy */
-#define REG_SERCOM1_SPI_ADDR       (*(RwReg  *)0x42000C24U) /**< \brief (SERCOM1) SPI Address */
-#define REG_SERCOM1_SPI_DATA       (*(RwReg  *)0x42000C28U) /**< \brief (SERCOM1) SPI Data */
-#define REG_SERCOM1_SPI_DBGCTRL    (*(RwReg8 *)0x42000C30U) /**< \brief (SERCOM1) SPI Debug Control */
-#define REG_SERCOM1_USART_CTRLA    (*(RwReg  *)0x42000C00U) /**< \brief (SERCOM1) USART Control A */
-#define REG_SERCOM1_USART_CTRLB    (*(RwReg  *)0x42000C04U) /**< \brief (SERCOM1) USART Control B */
-#define REG_SERCOM1_USART_BAUD     (*(RwReg16*)0x42000C0CU) /**< \brief (SERCOM1) USART Baud Rate */
-#define REG_SERCOM1_USART_RXPL     (*(RwReg8 *)0x42000C0EU) /**< \brief (SERCOM1) USART Receive Pulse Length */
-#define REG_SERCOM1_USART_INTENCLR (*(RwReg8 *)0x42000C14U) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
-#define REG_SERCOM1_USART_INTENSET (*(RwReg8 *)0x42000C16U) /**< \brief (SERCOM1) USART Interrupt Enable Set */
-#define REG_SERCOM1_USART_INTFLAG  (*(RwReg8 *)0x42000C18U) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM1_USART_STATUS   (*(RwReg16*)0x42000C1AU) /**< \brief (SERCOM1) USART Status */
-#define REG_SERCOM1_USART_SYNCBUSY (*(RoReg  *)0x42000C1CU) /**< \brief (SERCOM1) USART Syncbusy */
-#define REG_SERCOM1_USART_DATA     (*(RwReg16*)0x42000C28U) /**< \brief (SERCOM1) USART Data */
-#define REG_SERCOM1_USART_DBGCTRL  (*(RwReg8 *)0x42000C30U) /**< \brief (SERCOM1) USART Debug Control */
+#define REG_SERCOM1_I2CM_CTRLA     (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB     (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_BAUD      (*(RwReg  *)0x42000C0CUL) /**< \brief (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR  (*(RwReg8 *)0x42000C14UL) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET  (*(RwReg8 *)0x42000C16UL) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG   (*(RwReg8 *)0x42000C18UL) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS    (*(RwReg16*)0x42000C1AUL) /**< \brief (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_SYNCBUSY  (*(RoReg  *)0x42000C1CUL) /**< \brief (SERCOM1) I2CM Syncbusy */
+#define REG_SERCOM1_I2CM_ADDR      (*(RwReg  *)0x42000C24UL) /**< \brief (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA      (*(RwReg8 *)0x42000C28UL) /**< \brief (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CM_DBGCTRL   (*(RwReg8 *)0x42000C30UL) /**< \brief (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CS_CTRLA     (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB     (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR  (*(RwReg8 *)0x42000C14UL) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET  (*(RwReg8 *)0x42000C16UL) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG   (*(RwReg8 *)0x42000C18UL) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS    (*(RwReg16*)0x42000C1AUL) /**< \brief (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_SYNCBUSY  (*(RoReg  *)0x42000C1CUL) /**< \brief (SERCOM1) I2CS Syncbusy */
+#define REG_SERCOM1_I2CS_ADDR      (*(RwReg  *)0x42000C24UL) /**< \brief (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA      (*(RwReg8 *)0x42000C28UL) /**< \brief (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA      (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB      (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_BAUD       (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR   (*(RwReg8 *)0x42000C14UL) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET   (*(RwReg8 *)0x42000C16UL) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG    (*(RwReg8 *)0x42000C18UL) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS     (*(RwReg16*)0x42000C1AUL) /**< \brief (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_SYNCBUSY   (*(RoReg  *)0x42000C1CUL) /**< \brief (SERCOM1) SPI Syncbusy */
+#define REG_SERCOM1_SPI_ADDR       (*(RwReg  *)0x42000C24UL) /**< \brief (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA       (*(RwReg  *)0x42000C28UL) /**< \brief (SERCOM1) SPI Data */
+#define REG_SERCOM1_SPI_DBGCTRL    (*(RwReg8 *)0x42000C30UL) /**< \brief (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_USART_CTRLA    (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB    (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_BAUD     (*(RwReg16*)0x42000C0CUL) /**< \brief (SERCOM1) USART Baud Rate */
+#define REG_SERCOM1_USART_RXPL     (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) USART Receive Pulse Length */
+#define REG_SERCOM1_USART_INTENCLR (*(RwReg8 *)0x42000C14UL) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (*(RwReg8 *)0x42000C16UL) /**< \brief (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG  (*(RwReg8 *)0x42000C18UL) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS   (*(RwReg16*)0x42000C1AUL) /**< \brief (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_SYNCBUSY (*(RoReg  *)0x42000C1CUL) /**< \brief (SERCOM1) USART Syncbusy */
+#define REG_SERCOM1_USART_DATA     (*(RwReg16*)0x42000C28UL) /**< \brief (SERCOM1) USART Data */
+#define REG_SERCOM1_USART_DBGCTRL  (*(RwReg8 *)0x42000C30UL) /**< \brief (SERCOM1) USART Debug Control */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for SERCOM1 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/sercom2.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/sercom2.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for SERCOM2
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,91 +31,91 @@
 
 /* ========== Register definition for SERCOM2 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_SERCOM2_I2CM_CTRLA     (0x42001000U) /**< \brief (SERCOM2) I2CM Control A */
-#define REG_SERCOM2_I2CM_CTRLB     (0x42001004U) /**< \brief (SERCOM2) I2CM Control B */
-#define REG_SERCOM2_I2CM_BAUD      (0x4200100CU) /**< \brief (SERCOM2) I2CM Baud Rate */
-#define REG_SERCOM2_I2CM_INTENCLR  (0x42001014U) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
-#define REG_SERCOM2_I2CM_INTENSET  (0x42001016U) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
-#define REG_SERCOM2_I2CM_INTFLAG   (0x42001018U) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM2_I2CM_STATUS    (0x4200101AU) /**< \brief (SERCOM2) I2CM Status */
-#define REG_SERCOM2_I2CM_SYNCBUSY  (0x4200101CU) /**< \brief (SERCOM2) I2CM Syncbusy */
-#define REG_SERCOM2_I2CM_ADDR      (0x42001024U) /**< \brief (SERCOM2) I2CM Address */
-#define REG_SERCOM2_I2CM_DATA      (0x42001028U) /**< \brief (SERCOM2) I2CM Data */
-#define REG_SERCOM2_I2CM_DBGCTRL   (0x42001030U) /**< \brief (SERCOM2) I2CM Debug Control */
-#define REG_SERCOM2_I2CS_CTRLA     (0x42001000U) /**< \brief (SERCOM2) I2CS Control A */
-#define REG_SERCOM2_I2CS_CTRLB     (0x42001004U) /**< \brief (SERCOM2) I2CS Control B */
-#define REG_SERCOM2_I2CS_INTENCLR  (0x42001014U) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
-#define REG_SERCOM2_I2CS_INTENSET  (0x42001016U) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
-#define REG_SERCOM2_I2CS_INTFLAG   (0x42001018U) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM2_I2CS_STATUS    (0x4200101AU) /**< \brief (SERCOM2) I2CS Status */
-#define REG_SERCOM2_I2CS_SYNCBUSY  (0x4200101CU) /**< \brief (SERCOM2) I2CS Syncbusy */
-#define REG_SERCOM2_I2CS_ADDR      (0x42001024U) /**< \brief (SERCOM2) I2CS Address */
-#define REG_SERCOM2_I2CS_DATA      (0x42001028U) /**< \brief (SERCOM2) I2CS Data */
-#define REG_SERCOM2_SPI_CTRLA      (0x42001000U) /**< \brief (SERCOM2) SPI Control A */
-#define REG_SERCOM2_SPI_CTRLB      (0x42001004U) /**< \brief (SERCOM2) SPI Control B */
-#define REG_SERCOM2_SPI_BAUD       (0x4200100CU) /**< \brief (SERCOM2) SPI Baud Rate */
-#define REG_SERCOM2_SPI_INTENCLR   (0x42001014U) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
-#define REG_SERCOM2_SPI_INTENSET   (0x42001016U) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
-#define REG_SERCOM2_SPI_INTFLAG    (0x42001018U) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM2_SPI_STATUS     (0x4200101AU) /**< \brief (SERCOM2) SPI Status */
-#define REG_SERCOM2_SPI_SYNCBUSY   (0x4200101CU) /**< \brief (SERCOM2) SPI Syncbusy */
-#define REG_SERCOM2_SPI_ADDR       (0x42001024U) /**< \brief (SERCOM2) SPI Address */
-#define REG_SERCOM2_SPI_DATA       (0x42001028U) /**< \brief (SERCOM2) SPI Data */
-#define REG_SERCOM2_SPI_DBGCTRL    (0x42001030U) /**< \brief (SERCOM2) SPI Debug Control */
-#define REG_SERCOM2_USART_CTRLA    (0x42001000U) /**< \brief (SERCOM2) USART Control A */
-#define REG_SERCOM2_USART_CTRLB    (0x42001004U) /**< \brief (SERCOM2) USART Control B */
-#define REG_SERCOM2_USART_BAUD     (0x4200100CU) /**< \brief (SERCOM2) USART Baud Rate */
-#define REG_SERCOM2_USART_RXPL     (0x4200100EU) /**< \brief (SERCOM2) USART Receive Pulse Length */
-#define REG_SERCOM2_USART_INTENCLR (0x42001014U) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
-#define REG_SERCOM2_USART_INTENSET (0x42001016U) /**< \brief (SERCOM2) USART Interrupt Enable Set */
-#define REG_SERCOM2_USART_INTFLAG  (0x42001018U) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM2_USART_STATUS   (0x4200101AU) /**< \brief (SERCOM2) USART Status */
-#define REG_SERCOM2_USART_SYNCBUSY (0x4200101CU) /**< \brief (SERCOM2) USART Syncbusy */
-#define REG_SERCOM2_USART_DATA     (0x42001028U) /**< \brief (SERCOM2) USART Data */
-#define REG_SERCOM2_USART_DBGCTRL  (0x42001030U) /**< \brief (SERCOM2) USART Debug Control */
+#define REG_SERCOM2_I2CM_CTRLA     (0x42001000) /**< \brief (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB     (0x42001004) /**< \brief (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_BAUD      (0x4200100C) /**< \brief (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR  (0x42001014) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET  (0x42001016) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG   (0x42001018) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS    (0x4200101A) /**< \brief (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_SYNCBUSY  (0x4200101C) /**< \brief (SERCOM2) I2CM Syncbusy */
+#define REG_SERCOM2_I2CM_ADDR      (0x42001024) /**< \brief (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA      (0x42001028) /**< \brief (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CM_DBGCTRL   (0x42001030) /**< \brief (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CS_CTRLA     (0x42001000) /**< \brief (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB     (0x42001004) /**< \brief (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR  (0x42001014) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET  (0x42001016) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG   (0x42001018) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS    (0x4200101A) /**< \brief (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_SYNCBUSY  (0x4200101C) /**< \brief (SERCOM2) I2CS Syncbusy */
+#define REG_SERCOM2_I2CS_ADDR      (0x42001024) /**< \brief (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA      (0x42001028) /**< \brief (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA      (0x42001000) /**< \brief (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB      (0x42001004) /**< \brief (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_BAUD       (0x4200100C) /**< \brief (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR   (0x42001014) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET   (0x42001016) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG    (0x42001018) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS     (0x4200101A) /**< \brief (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_SYNCBUSY   (0x4200101C) /**< \brief (SERCOM2) SPI Syncbusy */
+#define REG_SERCOM2_SPI_ADDR       (0x42001024) /**< \brief (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA       (0x42001028) /**< \brief (SERCOM2) SPI Data */
+#define REG_SERCOM2_SPI_DBGCTRL    (0x42001030) /**< \brief (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_USART_CTRLA    (0x42001000) /**< \brief (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB    (0x42001004) /**< \brief (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_BAUD     (0x4200100C) /**< \brief (SERCOM2) USART Baud Rate */
+#define REG_SERCOM2_USART_RXPL     (0x4200100E) /**< \brief (SERCOM2) USART Receive Pulse Length */
+#define REG_SERCOM2_USART_INTENCLR (0x42001014) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (0x42001016) /**< \brief (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG  (0x42001018) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS   (0x4200101A) /**< \brief (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_SYNCBUSY (0x4200101C) /**< \brief (SERCOM2) USART Syncbusy */
+#define REG_SERCOM2_USART_DATA     (0x42001028) /**< \brief (SERCOM2) USART Data */
+#define REG_SERCOM2_USART_DBGCTRL  (0x42001030) /**< \brief (SERCOM2) USART Debug Control */
 #else
-#define REG_SERCOM2_I2CM_CTRLA     (*(RwReg  *)0x42001000U) /**< \brief (SERCOM2) I2CM Control A */
-#define REG_SERCOM2_I2CM_CTRLB     (*(RwReg  *)0x42001004U) /**< \brief (SERCOM2) I2CM Control B */
-#define REG_SERCOM2_I2CM_BAUD      (*(RwReg  *)0x4200100CU) /**< \brief (SERCOM2) I2CM Baud Rate */
-#define REG_SERCOM2_I2CM_INTENCLR  (*(RwReg8 *)0x42001014U) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
-#define REG_SERCOM2_I2CM_INTENSET  (*(RwReg8 *)0x42001016U) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
-#define REG_SERCOM2_I2CM_INTFLAG   (*(RwReg8 *)0x42001018U) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM2_I2CM_STATUS    (*(RwReg16*)0x4200101AU) /**< \brief (SERCOM2) I2CM Status */
-#define REG_SERCOM2_I2CM_SYNCBUSY  (*(RoReg  *)0x4200101CU) /**< \brief (SERCOM2) I2CM Syncbusy */
-#define REG_SERCOM2_I2CM_ADDR      (*(RwReg  *)0x42001024U) /**< \brief (SERCOM2) I2CM Address */
-#define REG_SERCOM2_I2CM_DATA      (*(RwReg8 *)0x42001028U) /**< \brief (SERCOM2) I2CM Data */
-#define REG_SERCOM2_I2CM_DBGCTRL   (*(RwReg8 *)0x42001030U) /**< \brief (SERCOM2) I2CM Debug Control */
-#define REG_SERCOM2_I2CS_CTRLA     (*(RwReg  *)0x42001000U) /**< \brief (SERCOM2) I2CS Control A */
-#define REG_SERCOM2_I2CS_CTRLB     (*(RwReg  *)0x42001004U) /**< \brief (SERCOM2) I2CS Control B */
-#define REG_SERCOM2_I2CS_INTENCLR  (*(RwReg8 *)0x42001014U) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
-#define REG_SERCOM2_I2CS_INTENSET  (*(RwReg8 *)0x42001016U) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
-#define REG_SERCOM2_I2CS_INTFLAG   (*(RwReg8 *)0x42001018U) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM2_I2CS_STATUS    (*(RwReg16*)0x4200101AU) /**< \brief (SERCOM2) I2CS Status */
-#define REG_SERCOM2_I2CS_SYNCBUSY  (*(RoReg  *)0x4200101CU) /**< \brief (SERCOM2) I2CS Syncbusy */
-#define REG_SERCOM2_I2CS_ADDR      (*(RwReg  *)0x42001024U) /**< \brief (SERCOM2) I2CS Address */
-#define REG_SERCOM2_I2CS_DATA      (*(RwReg8 *)0x42001028U) /**< \brief (SERCOM2) I2CS Data */
-#define REG_SERCOM2_SPI_CTRLA      (*(RwReg  *)0x42001000U) /**< \brief (SERCOM2) SPI Control A */
-#define REG_SERCOM2_SPI_CTRLB      (*(RwReg  *)0x42001004U) /**< \brief (SERCOM2) SPI Control B */
-#define REG_SERCOM2_SPI_BAUD       (*(RwReg8 *)0x4200100CU) /**< \brief (SERCOM2) SPI Baud Rate */
-#define REG_SERCOM2_SPI_INTENCLR   (*(RwReg8 *)0x42001014U) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
-#define REG_SERCOM2_SPI_INTENSET   (*(RwReg8 *)0x42001016U) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
-#define REG_SERCOM2_SPI_INTFLAG    (*(RwReg8 *)0x42001018U) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM2_SPI_STATUS     (*(RwReg16*)0x4200101AU) /**< \brief (SERCOM2) SPI Status */
-#define REG_SERCOM2_SPI_SYNCBUSY   (*(RoReg  *)0x4200101CU) /**< \brief (SERCOM2) SPI Syncbusy */
-#define REG_SERCOM2_SPI_ADDR       (*(RwReg  *)0x42001024U) /**< \brief (SERCOM2) SPI Address */
-#define REG_SERCOM2_SPI_DATA       (*(RwReg  *)0x42001028U) /**< \brief (SERCOM2) SPI Data */
-#define REG_SERCOM2_SPI_DBGCTRL    (*(RwReg8 *)0x42001030U) /**< \brief (SERCOM2) SPI Debug Control */
-#define REG_SERCOM2_USART_CTRLA    (*(RwReg  *)0x42001000U) /**< \brief (SERCOM2) USART Control A */
-#define REG_SERCOM2_USART_CTRLB    (*(RwReg  *)0x42001004U) /**< \brief (SERCOM2) USART Control B */
-#define REG_SERCOM2_USART_BAUD     (*(RwReg16*)0x4200100CU) /**< \brief (SERCOM2) USART Baud Rate */
-#define REG_SERCOM2_USART_RXPL     (*(RwReg8 *)0x4200100EU) /**< \brief (SERCOM2) USART Receive Pulse Length */
-#define REG_SERCOM2_USART_INTENCLR (*(RwReg8 *)0x42001014U) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
-#define REG_SERCOM2_USART_INTENSET (*(RwReg8 *)0x42001016U) /**< \brief (SERCOM2) USART Interrupt Enable Set */
-#define REG_SERCOM2_USART_INTFLAG  (*(RwReg8 *)0x42001018U) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM2_USART_STATUS   (*(RwReg16*)0x4200101AU) /**< \brief (SERCOM2) USART Status */
-#define REG_SERCOM2_USART_SYNCBUSY (*(RoReg  *)0x4200101CU) /**< \brief (SERCOM2) USART Syncbusy */
-#define REG_SERCOM2_USART_DATA     (*(RwReg16*)0x42001028U) /**< \brief (SERCOM2) USART Data */
-#define REG_SERCOM2_USART_DBGCTRL  (*(RwReg8 *)0x42001030U) /**< \brief (SERCOM2) USART Debug Control */
+#define REG_SERCOM2_I2CM_CTRLA     (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB     (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_BAUD      (*(RwReg  *)0x4200100CUL) /**< \brief (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR  (*(RwReg8 *)0x42001014UL) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET  (*(RwReg8 *)0x42001016UL) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG   (*(RwReg8 *)0x42001018UL) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS    (*(RwReg16*)0x4200101AUL) /**< \brief (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_SYNCBUSY  (*(RoReg  *)0x4200101CUL) /**< \brief (SERCOM2) I2CM Syncbusy */
+#define REG_SERCOM2_I2CM_ADDR      (*(RwReg  *)0x42001024UL) /**< \brief (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA      (*(RwReg8 *)0x42001028UL) /**< \brief (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CM_DBGCTRL   (*(RwReg8 *)0x42001030UL) /**< \brief (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CS_CTRLA     (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB     (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR  (*(RwReg8 *)0x42001014UL) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET  (*(RwReg8 *)0x42001016UL) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG   (*(RwReg8 *)0x42001018UL) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS    (*(RwReg16*)0x4200101AUL) /**< \brief (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_SYNCBUSY  (*(RoReg  *)0x4200101CUL) /**< \brief (SERCOM2) I2CS Syncbusy */
+#define REG_SERCOM2_I2CS_ADDR      (*(RwReg  *)0x42001024UL) /**< \brief (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA      (*(RwReg8 *)0x42001028UL) /**< \brief (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA      (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB      (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_BAUD       (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR   (*(RwReg8 *)0x42001014UL) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET   (*(RwReg8 *)0x42001016UL) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG    (*(RwReg8 *)0x42001018UL) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS     (*(RwReg16*)0x4200101AUL) /**< \brief (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_SYNCBUSY   (*(RoReg  *)0x4200101CUL) /**< \brief (SERCOM2) SPI Syncbusy */
+#define REG_SERCOM2_SPI_ADDR       (*(RwReg  *)0x42001024UL) /**< \brief (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA       (*(RwReg  *)0x42001028UL) /**< \brief (SERCOM2) SPI Data */
+#define REG_SERCOM2_SPI_DBGCTRL    (*(RwReg8 *)0x42001030UL) /**< \brief (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_USART_CTRLA    (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB    (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_BAUD     (*(RwReg16*)0x4200100CUL) /**< \brief (SERCOM2) USART Baud Rate */
+#define REG_SERCOM2_USART_RXPL     (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) USART Receive Pulse Length */
+#define REG_SERCOM2_USART_INTENCLR (*(RwReg8 *)0x42001014UL) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (*(RwReg8 *)0x42001016UL) /**< \brief (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG  (*(RwReg8 *)0x42001018UL) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS   (*(RwReg16*)0x4200101AUL) /**< \brief (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_SYNCBUSY (*(RoReg  *)0x4200101CUL) /**< \brief (SERCOM2) USART Syncbusy */
+#define REG_SERCOM2_USART_DATA     (*(RwReg16*)0x42001028UL) /**< \brief (SERCOM2) USART Data */
+#define REG_SERCOM2_USART_DBGCTRL  (*(RwReg8 *)0x42001030UL) /**< \brief (SERCOM2) USART Debug Control */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for SERCOM2 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/sercom3.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/sercom3.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for SERCOM3
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,91 +31,91 @@
 
 /* ========== Register definition for SERCOM3 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_SERCOM3_I2CM_CTRLA     (0x42001400U) /**< \brief (SERCOM3) I2CM Control A */
-#define REG_SERCOM3_I2CM_CTRLB     (0x42001404U) /**< \brief (SERCOM3) I2CM Control B */
-#define REG_SERCOM3_I2CM_BAUD      (0x4200140CU) /**< \brief (SERCOM3) I2CM Baud Rate */
-#define REG_SERCOM3_I2CM_INTENCLR  (0x42001414U) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
-#define REG_SERCOM3_I2CM_INTENSET  (0x42001416U) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
-#define REG_SERCOM3_I2CM_INTFLAG   (0x42001418U) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM3_I2CM_STATUS    (0x4200141AU) /**< \brief (SERCOM3) I2CM Status */
-#define REG_SERCOM3_I2CM_SYNCBUSY  (0x4200141CU) /**< \brief (SERCOM3) I2CM Syncbusy */
-#define REG_SERCOM3_I2CM_ADDR      (0x42001424U) /**< \brief (SERCOM3) I2CM Address */
-#define REG_SERCOM3_I2CM_DATA      (0x42001428U) /**< \brief (SERCOM3) I2CM Data */
-#define REG_SERCOM3_I2CM_DBGCTRL   (0x42001430U) /**< \brief (SERCOM3) I2CM Debug Control */
-#define REG_SERCOM3_I2CS_CTRLA     (0x42001400U) /**< \brief (SERCOM3) I2CS Control A */
-#define REG_SERCOM3_I2CS_CTRLB     (0x42001404U) /**< \brief (SERCOM3) I2CS Control B */
-#define REG_SERCOM3_I2CS_INTENCLR  (0x42001414U) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
-#define REG_SERCOM3_I2CS_INTENSET  (0x42001416U) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
-#define REG_SERCOM3_I2CS_INTFLAG   (0x42001418U) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM3_I2CS_STATUS    (0x4200141AU) /**< \brief (SERCOM3) I2CS Status */
-#define REG_SERCOM3_I2CS_SYNCBUSY  (0x4200141CU) /**< \brief (SERCOM3) I2CS Syncbusy */
-#define REG_SERCOM3_I2CS_ADDR      (0x42001424U) /**< \brief (SERCOM3) I2CS Address */
-#define REG_SERCOM3_I2CS_DATA      (0x42001428U) /**< \brief (SERCOM3) I2CS Data */
-#define REG_SERCOM3_SPI_CTRLA      (0x42001400U) /**< \brief (SERCOM3) SPI Control A */
-#define REG_SERCOM3_SPI_CTRLB      (0x42001404U) /**< \brief (SERCOM3) SPI Control B */
-#define REG_SERCOM3_SPI_BAUD       (0x4200140CU) /**< \brief (SERCOM3) SPI Baud Rate */
-#define REG_SERCOM3_SPI_INTENCLR   (0x42001414U) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
-#define REG_SERCOM3_SPI_INTENSET   (0x42001416U) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
-#define REG_SERCOM3_SPI_INTFLAG    (0x42001418U) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM3_SPI_STATUS     (0x4200141AU) /**< \brief (SERCOM3) SPI Status */
-#define REG_SERCOM3_SPI_SYNCBUSY   (0x4200141CU) /**< \brief (SERCOM3) SPI Syncbusy */
-#define REG_SERCOM3_SPI_ADDR       (0x42001424U) /**< \brief (SERCOM3) SPI Address */
-#define REG_SERCOM3_SPI_DATA       (0x42001428U) /**< \brief (SERCOM3) SPI Data */
-#define REG_SERCOM3_SPI_DBGCTRL    (0x42001430U) /**< \brief (SERCOM3) SPI Debug Control */
-#define REG_SERCOM3_USART_CTRLA    (0x42001400U) /**< \brief (SERCOM3) USART Control A */
-#define REG_SERCOM3_USART_CTRLB    (0x42001404U) /**< \brief (SERCOM3) USART Control B */
-#define REG_SERCOM3_USART_BAUD     (0x4200140CU) /**< \brief (SERCOM3) USART Baud Rate */
-#define REG_SERCOM3_USART_RXPL     (0x4200140EU) /**< \brief (SERCOM3) USART Receive Pulse Length */
-#define REG_SERCOM3_USART_INTENCLR (0x42001414U) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
-#define REG_SERCOM3_USART_INTENSET (0x42001416U) /**< \brief (SERCOM3) USART Interrupt Enable Set */
-#define REG_SERCOM3_USART_INTFLAG  (0x42001418U) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM3_USART_STATUS   (0x4200141AU) /**< \brief (SERCOM3) USART Status */
-#define REG_SERCOM3_USART_SYNCBUSY (0x4200141CU) /**< \brief (SERCOM3) USART Syncbusy */
-#define REG_SERCOM3_USART_DATA     (0x42001428U) /**< \brief (SERCOM3) USART Data */
-#define REG_SERCOM3_USART_DBGCTRL  (0x42001430U) /**< \brief (SERCOM3) USART Debug Control */
+#define REG_SERCOM3_I2CM_CTRLA     (0x42001400) /**< \brief (SERCOM3) I2CM Control A */
+#define REG_SERCOM3_I2CM_CTRLB     (0x42001404) /**< \brief (SERCOM3) I2CM Control B */
+#define REG_SERCOM3_I2CM_BAUD      (0x4200140C) /**< \brief (SERCOM3) I2CM Baud Rate */
+#define REG_SERCOM3_I2CM_INTENCLR  (0x42001414) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
+#define REG_SERCOM3_I2CM_INTENSET  (0x42001416) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
+#define REG_SERCOM3_I2CM_INTFLAG   (0x42001418) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CM_STATUS    (0x4200141A) /**< \brief (SERCOM3) I2CM Status */
+#define REG_SERCOM3_I2CM_SYNCBUSY  (0x4200141C) /**< \brief (SERCOM3) I2CM Syncbusy */
+#define REG_SERCOM3_I2CM_ADDR      (0x42001424) /**< \brief (SERCOM3) I2CM Address */
+#define REG_SERCOM3_I2CM_DATA      (0x42001428) /**< \brief (SERCOM3) I2CM Data */
+#define REG_SERCOM3_I2CM_DBGCTRL   (0x42001430) /**< \brief (SERCOM3) I2CM Debug Control */
+#define REG_SERCOM3_I2CS_CTRLA     (0x42001400) /**< \brief (SERCOM3) I2CS Control A */
+#define REG_SERCOM3_I2CS_CTRLB     (0x42001404) /**< \brief (SERCOM3) I2CS Control B */
+#define REG_SERCOM3_I2CS_INTENCLR  (0x42001414) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
+#define REG_SERCOM3_I2CS_INTENSET  (0x42001416) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
+#define REG_SERCOM3_I2CS_INTFLAG   (0x42001418) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CS_STATUS    (0x4200141A) /**< \brief (SERCOM3) I2CS Status */
+#define REG_SERCOM3_I2CS_SYNCBUSY  (0x4200141C) /**< \brief (SERCOM3) I2CS Syncbusy */
+#define REG_SERCOM3_I2CS_ADDR      (0x42001424) /**< \brief (SERCOM3) I2CS Address */
+#define REG_SERCOM3_I2CS_DATA      (0x42001428) /**< \brief (SERCOM3) I2CS Data */
+#define REG_SERCOM3_SPI_CTRLA      (0x42001400) /**< \brief (SERCOM3) SPI Control A */
+#define REG_SERCOM3_SPI_CTRLB      (0x42001404) /**< \brief (SERCOM3) SPI Control B */
+#define REG_SERCOM3_SPI_BAUD       (0x4200140C) /**< \brief (SERCOM3) SPI Baud Rate */
+#define REG_SERCOM3_SPI_INTENCLR   (0x42001414) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
+#define REG_SERCOM3_SPI_INTENSET   (0x42001416) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
+#define REG_SERCOM3_SPI_INTFLAG    (0x42001418) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM3_SPI_STATUS     (0x4200141A) /**< \brief (SERCOM3) SPI Status */
+#define REG_SERCOM3_SPI_SYNCBUSY   (0x4200141C) /**< \brief (SERCOM3) SPI Syncbusy */
+#define REG_SERCOM3_SPI_ADDR       (0x42001424) /**< \brief (SERCOM3) SPI Address */
+#define REG_SERCOM3_SPI_DATA       (0x42001428) /**< \brief (SERCOM3) SPI Data */
+#define REG_SERCOM3_SPI_DBGCTRL    (0x42001430) /**< \brief (SERCOM3) SPI Debug Control */
+#define REG_SERCOM3_USART_CTRLA    (0x42001400) /**< \brief (SERCOM3) USART Control A */
+#define REG_SERCOM3_USART_CTRLB    (0x42001404) /**< \brief (SERCOM3) USART Control B */
+#define REG_SERCOM3_USART_BAUD     (0x4200140C) /**< \brief (SERCOM3) USART Baud Rate */
+#define REG_SERCOM3_USART_RXPL     (0x4200140E) /**< \brief (SERCOM3) USART Receive Pulse Length */
+#define REG_SERCOM3_USART_INTENCLR (0x42001414) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
+#define REG_SERCOM3_USART_INTENSET (0x42001416) /**< \brief (SERCOM3) USART Interrupt Enable Set */
+#define REG_SERCOM3_USART_INTFLAG  (0x42001418) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM3_USART_STATUS   (0x4200141A) /**< \brief (SERCOM3) USART Status */
+#define REG_SERCOM3_USART_SYNCBUSY (0x4200141C) /**< \brief (SERCOM3) USART Syncbusy */
+#define REG_SERCOM3_USART_DATA     (0x42001428) /**< \brief (SERCOM3) USART Data */
+#define REG_SERCOM3_USART_DBGCTRL  (0x42001430) /**< \brief (SERCOM3) USART Debug Control */
 #else
-#define REG_SERCOM3_I2CM_CTRLA     (*(RwReg  *)0x42001400U) /**< \brief (SERCOM3) I2CM Control A */
-#define REG_SERCOM3_I2CM_CTRLB     (*(RwReg  *)0x42001404U) /**< \brief (SERCOM3) I2CM Control B */
-#define REG_SERCOM3_I2CM_BAUD      (*(RwReg  *)0x4200140CU) /**< \brief (SERCOM3) I2CM Baud Rate */
-#define REG_SERCOM3_I2CM_INTENCLR  (*(RwReg8 *)0x42001414U) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
-#define REG_SERCOM3_I2CM_INTENSET  (*(RwReg8 *)0x42001416U) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
-#define REG_SERCOM3_I2CM_INTFLAG   (*(RwReg8 *)0x42001418U) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM3_I2CM_STATUS    (*(RwReg16*)0x4200141AU) /**< \brief (SERCOM3) I2CM Status */
-#define REG_SERCOM3_I2CM_SYNCBUSY  (*(RoReg  *)0x4200141CU) /**< \brief (SERCOM3) I2CM Syncbusy */
-#define REG_SERCOM3_I2CM_ADDR      (*(RwReg  *)0x42001424U) /**< \brief (SERCOM3) I2CM Address */
-#define REG_SERCOM3_I2CM_DATA      (*(RwReg8 *)0x42001428U) /**< \brief (SERCOM3) I2CM Data */
-#define REG_SERCOM3_I2CM_DBGCTRL   (*(RwReg8 *)0x42001430U) /**< \brief (SERCOM3) I2CM Debug Control */
-#define REG_SERCOM3_I2CS_CTRLA     (*(RwReg  *)0x42001400U) /**< \brief (SERCOM3) I2CS Control A */
-#define REG_SERCOM3_I2CS_CTRLB     (*(RwReg  *)0x42001404U) /**< \brief (SERCOM3) I2CS Control B */
-#define REG_SERCOM3_I2CS_INTENCLR  (*(RwReg8 *)0x42001414U) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
-#define REG_SERCOM3_I2CS_INTENSET  (*(RwReg8 *)0x42001416U) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
-#define REG_SERCOM3_I2CS_INTFLAG   (*(RwReg8 *)0x42001418U) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM3_I2CS_STATUS    (*(RwReg16*)0x4200141AU) /**< \brief (SERCOM3) I2CS Status */
-#define REG_SERCOM3_I2CS_SYNCBUSY  (*(RoReg  *)0x4200141CU) /**< \brief (SERCOM3) I2CS Syncbusy */
-#define REG_SERCOM3_I2CS_ADDR      (*(RwReg  *)0x42001424U) /**< \brief (SERCOM3) I2CS Address */
-#define REG_SERCOM3_I2CS_DATA      (*(RwReg8 *)0x42001428U) /**< \brief (SERCOM3) I2CS Data */
-#define REG_SERCOM3_SPI_CTRLA      (*(RwReg  *)0x42001400U) /**< \brief (SERCOM3) SPI Control A */
-#define REG_SERCOM3_SPI_CTRLB      (*(RwReg  *)0x42001404U) /**< \brief (SERCOM3) SPI Control B */
-#define REG_SERCOM3_SPI_BAUD       (*(RwReg8 *)0x4200140CU) /**< \brief (SERCOM3) SPI Baud Rate */
-#define REG_SERCOM3_SPI_INTENCLR   (*(RwReg8 *)0x42001414U) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
-#define REG_SERCOM3_SPI_INTENSET   (*(RwReg8 *)0x42001416U) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
-#define REG_SERCOM3_SPI_INTFLAG    (*(RwReg8 *)0x42001418U) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM3_SPI_STATUS     (*(RwReg16*)0x4200141AU) /**< \brief (SERCOM3) SPI Status */
-#define REG_SERCOM3_SPI_SYNCBUSY   (*(RoReg  *)0x4200141CU) /**< \brief (SERCOM3) SPI Syncbusy */
-#define REG_SERCOM3_SPI_ADDR       (*(RwReg  *)0x42001424U) /**< \brief (SERCOM3) SPI Address */
-#define REG_SERCOM3_SPI_DATA       (*(RwReg  *)0x42001428U) /**< \brief (SERCOM3) SPI Data */
-#define REG_SERCOM3_SPI_DBGCTRL    (*(RwReg8 *)0x42001430U) /**< \brief (SERCOM3) SPI Debug Control */
-#define REG_SERCOM3_USART_CTRLA    (*(RwReg  *)0x42001400U) /**< \brief (SERCOM3) USART Control A */
-#define REG_SERCOM3_USART_CTRLB    (*(RwReg  *)0x42001404U) /**< \brief (SERCOM3) USART Control B */
-#define REG_SERCOM3_USART_BAUD     (*(RwReg16*)0x4200140CU) /**< \brief (SERCOM3) USART Baud Rate */
-#define REG_SERCOM3_USART_RXPL     (*(RwReg8 *)0x4200140EU) /**< \brief (SERCOM3) USART Receive Pulse Length */
-#define REG_SERCOM3_USART_INTENCLR (*(RwReg8 *)0x42001414U) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
-#define REG_SERCOM3_USART_INTENSET (*(RwReg8 *)0x42001416U) /**< \brief (SERCOM3) USART Interrupt Enable Set */
-#define REG_SERCOM3_USART_INTFLAG  (*(RwReg8 *)0x42001418U) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM3_USART_STATUS   (*(RwReg16*)0x4200141AU) /**< \brief (SERCOM3) USART Status */
-#define REG_SERCOM3_USART_SYNCBUSY (*(RoReg  *)0x4200141CU) /**< \brief (SERCOM3) USART Syncbusy */
-#define REG_SERCOM3_USART_DATA     (*(RwReg16*)0x42001428U) /**< \brief (SERCOM3) USART Data */
-#define REG_SERCOM3_USART_DBGCTRL  (*(RwReg8 *)0x42001430U) /**< \brief (SERCOM3) USART Debug Control */
+#define REG_SERCOM3_I2CM_CTRLA     (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) I2CM Control A */
+#define REG_SERCOM3_I2CM_CTRLB     (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) I2CM Control B */
+#define REG_SERCOM3_I2CM_BAUD      (*(RwReg  *)0x4200140CUL) /**< \brief (SERCOM3) I2CM Baud Rate */
+#define REG_SERCOM3_I2CM_INTENCLR  (*(RwReg8 *)0x42001414UL) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
+#define REG_SERCOM3_I2CM_INTENSET  (*(RwReg8 *)0x42001416UL) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
+#define REG_SERCOM3_I2CM_INTFLAG   (*(RwReg8 *)0x42001418UL) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CM_STATUS    (*(RwReg16*)0x4200141AUL) /**< \brief (SERCOM3) I2CM Status */
+#define REG_SERCOM3_I2CM_SYNCBUSY  (*(RoReg  *)0x4200141CUL) /**< \brief (SERCOM3) I2CM Syncbusy */
+#define REG_SERCOM3_I2CM_ADDR      (*(RwReg  *)0x42001424UL) /**< \brief (SERCOM3) I2CM Address */
+#define REG_SERCOM3_I2CM_DATA      (*(RwReg8 *)0x42001428UL) /**< \brief (SERCOM3) I2CM Data */
+#define REG_SERCOM3_I2CM_DBGCTRL   (*(RwReg8 *)0x42001430UL) /**< \brief (SERCOM3) I2CM Debug Control */
+#define REG_SERCOM3_I2CS_CTRLA     (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) I2CS Control A */
+#define REG_SERCOM3_I2CS_CTRLB     (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) I2CS Control B */
+#define REG_SERCOM3_I2CS_INTENCLR  (*(RwReg8 *)0x42001414UL) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
+#define REG_SERCOM3_I2CS_INTENSET  (*(RwReg8 *)0x42001416UL) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
+#define REG_SERCOM3_I2CS_INTFLAG   (*(RwReg8 *)0x42001418UL) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CS_STATUS    (*(RwReg16*)0x4200141AUL) /**< \brief (SERCOM3) I2CS Status */
+#define REG_SERCOM3_I2CS_SYNCBUSY  (*(RoReg  *)0x4200141CUL) /**< \brief (SERCOM3) I2CS Syncbusy */
+#define REG_SERCOM3_I2CS_ADDR      (*(RwReg  *)0x42001424UL) /**< \brief (SERCOM3) I2CS Address */
+#define REG_SERCOM3_I2CS_DATA      (*(RwReg8 *)0x42001428UL) /**< \brief (SERCOM3) I2CS Data */
+#define REG_SERCOM3_SPI_CTRLA      (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) SPI Control A */
+#define REG_SERCOM3_SPI_CTRLB      (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) SPI Control B */
+#define REG_SERCOM3_SPI_BAUD       (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) SPI Baud Rate */
+#define REG_SERCOM3_SPI_INTENCLR   (*(RwReg8 *)0x42001414UL) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
+#define REG_SERCOM3_SPI_INTENSET   (*(RwReg8 *)0x42001416UL) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
+#define REG_SERCOM3_SPI_INTFLAG    (*(RwReg8 *)0x42001418UL) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM3_SPI_STATUS     (*(RwReg16*)0x4200141AUL) /**< \brief (SERCOM3) SPI Status */
+#define REG_SERCOM3_SPI_SYNCBUSY   (*(RoReg  *)0x4200141CUL) /**< \brief (SERCOM3) SPI Syncbusy */
+#define REG_SERCOM3_SPI_ADDR       (*(RwReg  *)0x42001424UL) /**< \brief (SERCOM3) SPI Address */
+#define REG_SERCOM3_SPI_DATA       (*(RwReg  *)0x42001428UL) /**< \brief (SERCOM3) SPI Data */
+#define REG_SERCOM3_SPI_DBGCTRL    (*(RwReg8 *)0x42001430UL) /**< \brief (SERCOM3) SPI Debug Control */
+#define REG_SERCOM3_USART_CTRLA    (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) USART Control A */
+#define REG_SERCOM3_USART_CTRLB    (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) USART Control B */
+#define REG_SERCOM3_USART_BAUD     (*(RwReg16*)0x4200140CUL) /**< \brief (SERCOM3) USART Baud Rate */
+#define REG_SERCOM3_USART_RXPL     (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) USART Receive Pulse Length */
+#define REG_SERCOM3_USART_INTENCLR (*(RwReg8 *)0x42001414UL) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
+#define REG_SERCOM3_USART_INTENSET (*(RwReg8 *)0x42001416UL) /**< \brief (SERCOM3) USART Interrupt Enable Set */
+#define REG_SERCOM3_USART_INTFLAG  (*(RwReg8 *)0x42001418UL) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM3_USART_STATUS   (*(RwReg16*)0x4200141AUL) /**< \brief (SERCOM3) USART Status */
+#define REG_SERCOM3_USART_SYNCBUSY (*(RoReg  *)0x4200141CUL) /**< \brief (SERCOM3) USART Syncbusy */
+#define REG_SERCOM3_USART_DATA     (*(RwReg16*)0x42001428UL) /**< \brief (SERCOM3) USART Data */
+#define REG_SERCOM3_USART_DBGCTRL  (*(RwReg8 *)0x42001430UL) /**< \brief (SERCOM3) USART Debug Control */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for SERCOM3 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/sercom4.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/sercom4.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for SERCOM4
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,91 +31,91 @@
 
 /* ========== Register definition for SERCOM4 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_SERCOM4_I2CM_CTRLA     (0x42001800U) /**< \brief (SERCOM4) I2CM Control A */
-#define REG_SERCOM4_I2CM_CTRLB     (0x42001804U) /**< \brief (SERCOM4) I2CM Control B */
-#define REG_SERCOM4_I2CM_BAUD      (0x4200180CU) /**< \brief (SERCOM4) I2CM Baud Rate */
-#define REG_SERCOM4_I2CM_INTENCLR  (0x42001814U) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
-#define REG_SERCOM4_I2CM_INTENSET  (0x42001816U) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
-#define REG_SERCOM4_I2CM_INTFLAG   (0x42001818U) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM4_I2CM_STATUS    (0x4200181AU) /**< \brief (SERCOM4) I2CM Status */
-#define REG_SERCOM4_I2CM_SYNCBUSY  (0x4200181CU) /**< \brief (SERCOM4) I2CM Syncbusy */
-#define REG_SERCOM4_I2CM_ADDR      (0x42001824U) /**< \brief (SERCOM4) I2CM Address */
-#define REG_SERCOM4_I2CM_DATA      (0x42001828U) /**< \brief (SERCOM4) I2CM Data */
-#define REG_SERCOM4_I2CM_DBGCTRL   (0x42001830U) /**< \brief (SERCOM4) I2CM Debug Control */
-#define REG_SERCOM4_I2CS_CTRLA     (0x42001800U) /**< \brief (SERCOM4) I2CS Control A */
-#define REG_SERCOM4_I2CS_CTRLB     (0x42001804U) /**< \brief (SERCOM4) I2CS Control B */
-#define REG_SERCOM4_I2CS_INTENCLR  (0x42001814U) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
-#define REG_SERCOM4_I2CS_INTENSET  (0x42001816U) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
-#define REG_SERCOM4_I2CS_INTFLAG   (0x42001818U) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM4_I2CS_STATUS    (0x4200181AU) /**< \brief (SERCOM4) I2CS Status */
-#define REG_SERCOM4_I2CS_SYNCBUSY  (0x4200181CU) /**< \brief (SERCOM4) I2CS Syncbusy */
-#define REG_SERCOM4_I2CS_ADDR      (0x42001824U) /**< \brief (SERCOM4) I2CS Address */
-#define REG_SERCOM4_I2CS_DATA      (0x42001828U) /**< \brief (SERCOM4) I2CS Data */
-#define REG_SERCOM4_SPI_CTRLA      (0x42001800U) /**< \brief (SERCOM4) SPI Control A */
-#define REG_SERCOM4_SPI_CTRLB      (0x42001804U) /**< \brief (SERCOM4) SPI Control B */
-#define REG_SERCOM4_SPI_BAUD       (0x4200180CU) /**< \brief (SERCOM4) SPI Baud Rate */
-#define REG_SERCOM4_SPI_INTENCLR   (0x42001814U) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
-#define REG_SERCOM4_SPI_INTENSET   (0x42001816U) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
-#define REG_SERCOM4_SPI_INTFLAG    (0x42001818U) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM4_SPI_STATUS     (0x4200181AU) /**< \brief (SERCOM4) SPI Status */
-#define REG_SERCOM4_SPI_SYNCBUSY   (0x4200181CU) /**< \brief (SERCOM4) SPI Syncbusy */
-#define REG_SERCOM4_SPI_ADDR       (0x42001824U) /**< \brief (SERCOM4) SPI Address */
-#define REG_SERCOM4_SPI_DATA       (0x42001828U) /**< \brief (SERCOM4) SPI Data */
-#define REG_SERCOM4_SPI_DBGCTRL    (0x42001830U) /**< \brief (SERCOM4) SPI Debug Control */
-#define REG_SERCOM4_USART_CTRLA    (0x42001800U) /**< \brief (SERCOM4) USART Control A */
-#define REG_SERCOM4_USART_CTRLB    (0x42001804U) /**< \brief (SERCOM4) USART Control B */
-#define REG_SERCOM4_USART_BAUD     (0x4200180CU) /**< \brief (SERCOM4) USART Baud Rate */
-#define REG_SERCOM4_USART_RXPL     (0x4200180EU) /**< \brief (SERCOM4) USART Receive Pulse Length */
-#define REG_SERCOM4_USART_INTENCLR (0x42001814U) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
-#define REG_SERCOM4_USART_INTENSET (0x42001816U) /**< \brief (SERCOM4) USART Interrupt Enable Set */
-#define REG_SERCOM4_USART_INTFLAG  (0x42001818U) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM4_USART_STATUS   (0x4200181AU) /**< \brief (SERCOM4) USART Status */
-#define REG_SERCOM4_USART_SYNCBUSY (0x4200181CU) /**< \brief (SERCOM4) USART Syncbusy */
-#define REG_SERCOM4_USART_DATA     (0x42001828U) /**< \brief (SERCOM4) USART Data */
-#define REG_SERCOM4_USART_DBGCTRL  (0x42001830U) /**< \brief (SERCOM4) USART Debug Control */
+#define REG_SERCOM4_I2CM_CTRLA     (0x42001800) /**< \brief (SERCOM4) I2CM Control A */
+#define REG_SERCOM4_I2CM_CTRLB     (0x42001804) /**< \brief (SERCOM4) I2CM Control B */
+#define REG_SERCOM4_I2CM_BAUD      (0x4200180C) /**< \brief (SERCOM4) I2CM Baud Rate */
+#define REG_SERCOM4_I2CM_INTENCLR  (0x42001814) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
+#define REG_SERCOM4_I2CM_INTENSET  (0x42001816) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
+#define REG_SERCOM4_I2CM_INTFLAG   (0x42001818) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CM_STATUS    (0x4200181A) /**< \brief (SERCOM4) I2CM Status */
+#define REG_SERCOM4_I2CM_SYNCBUSY  (0x4200181C) /**< \brief (SERCOM4) I2CM Syncbusy */
+#define REG_SERCOM4_I2CM_ADDR      (0x42001824) /**< \brief (SERCOM4) I2CM Address */
+#define REG_SERCOM4_I2CM_DATA      (0x42001828) /**< \brief (SERCOM4) I2CM Data */
+#define REG_SERCOM4_I2CM_DBGCTRL   (0x42001830) /**< \brief (SERCOM4) I2CM Debug Control */
+#define REG_SERCOM4_I2CS_CTRLA     (0x42001800) /**< \brief (SERCOM4) I2CS Control A */
+#define REG_SERCOM4_I2CS_CTRLB     (0x42001804) /**< \brief (SERCOM4) I2CS Control B */
+#define REG_SERCOM4_I2CS_INTENCLR  (0x42001814) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
+#define REG_SERCOM4_I2CS_INTENSET  (0x42001816) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
+#define REG_SERCOM4_I2CS_INTFLAG   (0x42001818) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CS_STATUS    (0x4200181A) /**< \brief (SERCOM4) I2CS Status */
+#define REG_SERCOM4_I2CS_SYNCBUSY  (0x4200181C) /**< \brief (SERCOM4) I2CS Syncbusy */
+#define REG_SERCOM4_I2CS_ADDR      (0x42001824) /**< \brief (SERCOM4) I2CS Address */
+#define REG_SERCOM4_I2CS_DATA      (0x42001828) /**< \brief (SERCOM4) I2CS Data */
+#define REG_SERCOM4_SPI_CTRLA      (0x42001800) /**< \brief (SERCOM4) SPI Control A */
+#define REG_SERCOM4_SPI_CTRLB      (0x42001804) /**< \brief (SERCOM4) SPI Control B */
+#define REG_SERCOM4_SPI_BAUD       (0x4200180C) /**< \brief (SERCOM4) SPI Baud Rate */
+#define REG_SERCOM4_SPI_INTENCLR   (0x42001814) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
+#define REG_SERCOM4_SPI_INTENSET   (0x42001816) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
+#define REG_SERCOM4_SPI_INTFLAG    (0x42001818) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM4_SPI_STATUS     (0x4200181A) /**< \brief (SERCOM4) SPI Status */
+#define REG_SERCOM4_SPI_SYNCBUSY   (0x4200181C) /**< \brief (SERCOM4) SPI Syncbusy */
+#define REG_SERCOM4_SPI_ADDR       (0x42001824) /**< \brief (SERCOM4) SPI Address */
+#define REG_SERCOM4_SPI_DATA       (0x42001828) /**< \brief (SERCOM4) SPI Data */
+#define REG_SERCOM4_SPI_DBGCTRL    (0x42001830) /**< \brief (SERCOM4) SPI Debug Control */
+#define REG_SERCOM4_USART_CTRLA    (0x42001800) /**< \brief (SERCOM4) USART Control A */
+#define REG_SERCOM4_USART_CTRLB    (0x42001804) /**< \brief (SERCOM4) USART Control B */
+#define REG_SERCOM4_USART_BAUD     (0x4200180C) /**< \brief (SERCOM4) USART Baud Rate */
+#define REG_SERCOM4_USART_RXPL     (0x4200180E) /**< \brief (SERCOM4) USART Receive Pulse Length */
+#define REG_SERCOM4_USART_INTENCLR (0x42001814) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
+#define REG_SERCOM4_USART_INTENSET (0x42001816) /**< \brief (SERCOM4) USART Interrupt Enable Set */
+#define REG_SERCOM4_USART_INTFLAG  (0x42001818) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM4_USART_STATUS   (0x4200181A) /**< \brief (SERCOM4) USART Status */
+#define REG_SERCOM4_USART_SYNCBUSY (0x4200181C) /**< \brief (SERCOM4) USART Syncbusy */
+#define REG_SERCOM4_USART_DATA     (0x42001828) /**< \brief (SERCOM4) USART Data */
+#define REG_SERCOM4_USART_DBGCTRL  (0x42001830) /**< \brief (SERCOM4) USART Debug Control */
 #else
-#define REG_SERCOM4_I2CM_CTRLA     (*(RwReg  *)0x42001800U) /**< \brief (SERCOM4) I2CM Control A */
-#define REG_SERCOM4_I2CM_CTRLB     (*(RwReg  *)0x42001804U) /**< \brief (SERCOM4) I2CM Control B */
-#define REG_SERCOM4_I2CM_BAUD      (*(RwReg  *)0x4200180CU) /**< \brief (SERCOM4) I2CM Baud Rate */
-#define REG_SERCOM4_I2CM_INTENCLR  (*(RwReg8 *)0x42001814U) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
-#define REG_SERCOM4_I2CM_INTENSET  (*(RwReg8 *)0x42001816U) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
-#define REG_SERCOM4_I2CM_INTFLAG   (*(RwReg8 *)0x42001818U) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM4_I2CM_STATUS    (*(RwReg16*)0x4200181AU) /**< \brief (SERCOM4) I2CM Status */
-#define REG_SERCOM4_I2CM_SYNCBUSY  (*(RoReg  *)0x4200181CU) /**< \brief (SERCOM4) I2CM Syncbusy */
-#define REG_SERCOM4_I2CM_ADDR      (*(RwReg  *)0x42001824U) /**< \brief (SERCOM4) I2CM Address */
-#define REG_SERCOM4_I2CM_DATA      (*(RwReg8 *)0x42001828U) /**< \brief (SERCOM4) I2CM Data */
-#define REG_SERCOM4_I2CM_DBGCTRL   (*(RwReg8 *)0x42001830U) /**< \brief (SERCOM4) I2CM Debug Control */
-#define REG_SERCOM4_I2CS_CTRLA     (*(RwReg  *)0x42001800U) /**< \brief (SERCOM4) I2CS Control A */
-#define REG_SERCOM4_I2CS_CTRLB     (*(RwReg  *)0x42001804U) /**< \brief (SERCOM4) I2CS Control B */
-#define REG_SERCOM4_I2CS_INTENCLR  (*(RwReg8 *)0x42001814U) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
-#define REG_SERCOM4_I2CS_INTENSET  (*(RwReg8 *)0x42001816U) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
-#define REG_SERCOM4_I2CS_INTFLAG   (*(RwReg8 *)0x42001818U) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM4_I2CS_STATUS    (*(RwReg16*)0x4200181AU) /**< \brief (SERCOM4) I2CS Status */
-#define REG_SERCOM4_I2CS_SYNCBUSY  (*(RoReg  *)0x4200181CU) /**< \brief (SERCOM4) I2CS Syncbusy */
-#define REG_SERCOM4_I2CS_ADDR      (*(RwReg  *)0x42001824U) /**< \brief (SERCOM4) I2CS Address */
-#define REG_SERCOM4_I2CS_DATA      (*(RwReg8 *)0x42001828U) /**< \brief (SERCOM4) I2CS Data */
-#define REG_SERCOM4_SPI_CTRLA      (*(RwReg  *)0x42001800U) /**< \brief (SERCOM4) SPI Control A */
-#define REG_SERCOM4_SPI_CTRLB      (*(RwReg  *)0x42001804U) /**< \brief (SERCOM4) SPI Control B */
-#define REG_SERCOM4_SPI_BAUD       (*(RwReg8 *)0x4200180CU) /**< \brief (SERCOM4) SPI Baud Rate */
-#define REG_SERCOM4_SPI_INTENCLR   (*(RwReg8 *)0x42001814U) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
-#define REG_SERCOM4_SPI_INTENSET   (*(RwReg8 *)0x42001816U) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
-#define REG_SERCOM4_SPI_INTFLAG    (*(RwReg8 *)0x42001818U) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM4_SPI_STATUS     (*(RwReg16*)0x4200181AU) /**< \brief (SERCOM4) SPI Status */
-#define REG_SERCOM4_SPI_SYNCBUSY   (*(RoReg  *)0x4200181CU) /**< \brief (SERCOM4) SPI Syncbusy */
-#define REG_SERCOM4_SPI_ADDR       (*(RwReg  *)0x42001824U) /**< \brief (SERCOM4) SPI Address */
-#define REG_SERCOM4_SPI_DATA       (*(RwReg  *)0x42001828U) /**< \brief (SERCOM4) SPI Data */
-#define REG_SERCOM4_SPI_DBGCTRL    (*(RwReg8 *)0x42001830U) /**< \brief (SERCOM4) SPI Debug Control */
-#define REG_SERCOM4_USART_CTRLA    (*(RwReg  *)0x42001800U) /**< \brief (SERCOM4) USART Control A */
-#define REG_SERCOM4_USART_CTRLB    (*(RwReg  *)0x42001804U) /**< \brief (SERCOM4) USART Control B */
-#define REG_SERCOM4_USART_BAUD     (*(RwReg16*)0x4200180CU) /**< \brief (SERCOM4) USART Baud Rate */
-#define REG_SERCOM4_USART_RXPL     (*(RwReg8 *)0x4200180EU) /**< \brief (SERCOM4) USART Receive Pulse Length */
-#define REG_SERCOM4_USART_INTENCLR (*(RwReg8 *)0x42001814U) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
-#define REG_SERCOM4_USART_INTENSET (*(RwReg8 *)0x42001816U) /**< \brief (SERCOM4) USART Interrupt Enable Set */
-#define REG_SERCOM4_USART_INTFLAG  (*(RwReg8 *)0x42001818U) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM4_USART_STATUS   (*(RwReg16*)0x4200181AU) /**< \brief (SERCOM4) USART Status */
-#define REG_SERCOM4_USART_SYNCBUSY (*(RoReg  *)0x4200181CU) /**< \brief (SERCOM4) USART Syncbusy */
-#define REG_SERCOM4_USART_DATA     (*(RwReg16*)0x42001828U) /**< \brief (SERCOM4) USART Data */
-#define REG_SERCOM4_USART_DBGCTRL  (*(RwReg8 *)0x42001830U) /**< \brief (SERCOM4) USART Debug Control */
+#define REG_SERCOM4_I2CM_CTRLA     (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) I2CM Control A */
+#define REG_SERCOM4_I2CM_CTRLB     (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) I2CM Control B */
+#define REG_SERCOM4_I2CM_BAUD      (*(RwReg  *)0x4200180CUL) /**< \brief (SERCOM4) I2CM Baud Rate */
+#define REG_SERCOM4_I2CM_INTENCLR  (*(RwReg8 *)0x42001814UL) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
+#define REG_SERCOM4_I2CM_INTENSET  (*(RwReg8 *)0x42001816UL) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
+#define REG_SERCOM4_I2CM_INTFLAG   (*(RwReg8 *)0x42001818UL) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CM_STATUS    (*(RwReg16*)0x4200181AUL) /**< \brief (SERCOM4) I2CM Status */
+#define REG_SERCOM4_I2CM_SYNCBUSY  (*(RoReg  *)0x4200181CUL) /**< \brief (SERCOM4) I2CM Syncbusy */
+#define REG_SERCOM4_I2CM_ADDR      (*(RwReg  *)0x42001824UL) /**< \brief (SERCOM4) I2CM Address */
+#define REG_SERCOM4_I2CM_DATA      (*(RwReg8 *)0x42001828UL) /**< \brief (SERCOM4) I2CM Data */
+#define REG_SERCOM4_I2CM_DBGCTRL   (*(RwReg8 *)0x42001830UL) /**< \brief (SERCOM4) I2CM Debug Control */
+#define REG_SERCOM4_I2CS_CTRLA     (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) I2CS Control A */
+#define REG_SERCOM4_I2CS_CTRLB     (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) I2CS Control B */
+#define REG_SERCOM4_I2CS_INTENCLR  (*(RwReg8 *)0x42001814UL) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
+#define REG_SERCOM4_I2CS_INTENSET  (*(RwReg8 *)0x42001816UL) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
+#define REG_SERCOM4_I2CS_INTFLAG   (*(RwReg8 *)0x42001818UL) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CS_STATUS    (*(RwReg16*)0x4200181AUL) /**< \brief (SERCOM4) I2CS Status */
+#define REG_SERCOM4_I2CS_SYNCBUSY  (*(RoReg  *)0x4200181CUL) /**< \brief (SERCOM4) I2CS Syncbusy */
+#define REG_SERCOM4_I2CS_ADDR      (*(RwReg  *)0x42001824UL) /**< \brief (SERCOM4) I2CS Address */
+#define REG_SERCOM4_I2CS_DATA      (*(RwReg8 *)0x42001828UL) /**< \brief (SERCOM4) I2CS Data */
+#define REG_SERCOM4_SPI_CTRLA      (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) SPI Control A */
+#define REG_SERCOM4_SPI_CTRLB      (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) SPI Control B */
+#define REG_SERCOM4_SPI_BAUD       (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) SPI Baud Rate */
+#define REG_SERCOM4_SPI_INTENCLR   (*(RwReg8 *)0x42001814UL) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
+#define REG_SERCOM4_SPI_INTENSET   (*(RwReg8 *)0x42001816UL) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
+#define REG_SERCOM4_SPI_INTFLAG    (*(RwReg8 *)0x42001818UL) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM4_SPI_STATUS     (*(RwReg16*)0x4200181AUL) /**< \brief (SERCOM4) SPI Status */
+#define REG_SERCOM4_SPI_SYNCBUSY   (*(RoReg  *)0x4200181CUL) /**< \brief (SERCOM4) SPI Syncbusy */
+#define REG_SERCOM4_SPI_ADDR       (*(RwReg  *)0x42001824UL) /**< \brief (SERCOM4) SPI Address */
+#define REG_SERCOM4_SPI_DATA       (*(RwReg  *)0x42001828UL) /**< \brief (SERCOM4) SPI Data */
+#define REG_SERCOM4_SPI_DBGCTRL    (*(RwReg8 *)0x42001830UL) /**< \brief (SERCOM4) SPI Debug Control */
+#define REG_SERCOM4_USART_CTRLA    (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) USART Control A */
+#define REG_SERCOM4_USART_CTRLB    (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) USART Control B */
+#define REG_SERCOM4_USART_BAUD     (*(RwReg16*)0x4200180CUL) /**< \brief (SERCOM4) USART Baud Rate */
+#define REG_SERCOM4_USART_RXPL     (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) USART Receive Pulse Length */
+#define REG_SERCOM4_USART_INTENCLR (*(RwReg8 *)0x42001814UL) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
+#define REG_SERCOM4_USART_INTENSET (*(RwReg8 *)0x42001816UL) /**< \brief (SERCOM4) USART Interrupt Enable Set */
+#define REG_SERCOM4_USART_INTFLAG  (*(RwReg8 *)0x42001818UL) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM4_USART_STATUS   (*(RwReg16*)0x4200181AUL) /**< \brief (SERCOM4) USART Status */
+#define REG_SERCOM4_USART_SYNCBUSY (*(RoReg  *)0x4200181CUL) /**< \brief (SERCOM4) USART Syncbusy */
+#define REG_SERCOM4_USART_DATA     (*(RwReg16*)0x42001828UL) /**< \brief (SERCOM4) USART Data */
+#define REG_SERCOM4_USART_DBGCTRL  (*(RwReg8 *)0x42001830UL) /**< \brief (SERCOM4) USART Debug Control */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for SERCOM4 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/sercom5.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/sercom5.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for SERCOM5
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,91 +31,91 @@
 
 /* ========== Register definition for SERCOM5 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_SERCOM5_I2CM_CTRLA     (0x42001C00U) /**< \brief (SERCOM5) I2CM Control A */
-#define REG_SERCOM5_I2CM_CTRLB     (0x42001C04U) /**< \brief (SERCOM5) I2CM Control B */
-#define REG_SERCOM5_I2CM_BAUD      (0x42001C0CU) /**< \brief (SERCOM5) I2CM Baud Rate */
-#define REG_SERCOM5_I2CM_INTENCLR  (0x42001C14U) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
-#define REG_SERCOM5_I2CM_INTENSET  (0x42001C16U) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
-#define REG_SERCOM5_I2CM_INTFLAG   (0x42001C18U) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM5_I2CM_STATUS    (0x42001C1AU) /**< \brief (SERCOM5) I2CM Status */
-#define REG_SERCOM5_I2CM_SYNCBUSY  (0x42001C1CU) /**< \brief (SERCOM5) I2CM Syncbusy */
-#define REG_SERCOM5_I2CM_ADDR      (0x42001C24U) /**< \brief (SERCOM5) I2CM Address */
-#define REG_SERCOM5_I2CM_DATA      (0x42001C28U) /**< \brief (SERCOM5) I2CM Data */
-#define REG_SERCOM5_I2CM_DBGCTRL   (0x42001C30U) /**< \brief (SERCOM5) I2CM Debug Control */
-#define REG_SERCOM5_I2CS_CTRLA     (0x42001C00U) /**< \brief (SERCOM5) I2CS Control A */
-#define REG_SERCOM5_I2CS_CTRLB     (0x42001C04U) /**< \brief (SERCOM5) I2CS Control B */
-#define REG_SERCOM5_I2CS_INTENCLR  (0x42001C14U) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
-#define REG_SERCOM5_I2CS_INTENSET  (0x42001C16U) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
-#define REG_SERCOM5_I2CS_INTFLAG   (0x42001C18U) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM5_I2CS_STATUS    (0x42001C1AU) /**< \brief (SERCOM5) I2CS Status */
-#define REG_SERCOM5_I2CS_SYNCBUSY  (0x42001C1CU) /**< \brief (SERCOM5) I2CS Syncbusy */
-#define REG_SERCOM5_I2CS_ADDR      (0x42001C24U) /**< \brief (SERCOM5) I2CS Address */
-#define REG_SERCOM5_I2CS_DATA      (0x42001C28U) /**< \brief (SERCOM5) I2CS Data */
-#define REG_SERCOM5_SPI_CTRLA      (0x42001C00U) /**< \brief (SERCOM5) SPI Control A */
-#define REG_SERCOM5_SPI_CTRLB      (0x42001C04U) /**< \brief (SERCOM5) SPI Control B */
-#define REG_SERCOM5_SPI_BAUD       (0x42001C0CU) /**< \brief (SERCOM5) SPI Baud Rate */
-#define REG_SERCOM5_SPI_INTENCLR   (0x42001C14U) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
-#define REG_SERCOM5_SPI_INTENSET   (0x42001C16U) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
-#define REG_SERCOM5_SPI_INTFLAG    (0x42001C18U) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM5_SPI_STATUS     (0x42001C1AU) /**< \brief (SERCOM5) SPI Status */
-#define REG_SERCOM5_SPI_SYNCBUSY   (0x42001C1CU) /**< \brief (SERCOM5) SPI Syncbusy */
-#define REG_SERCOM5_SPI_ADDR       (0x42001C24U) /**< \brief (SERCOM5) SPI Address */
-#define REG_SERCOM5_SPI_DATA       (0x42001C28U) /**< \brief (SERCOM5) SPI Data */
-#define REG_SERCOM5_SPI_DBGCTRL    (0x42001C30U) /**< \brief (SERCOM5) SPI Debug Control */
-#define REG_SERCOM5_USART_CTRLA    (0x42001C00U) /**< \brief (SERCOM5) USART Control A */
-#define REG_SERCOM5_USART_CTRLB    (0x42001C04U) /**< \brief (SERCOM5) USART Control B */
-#define REG_SERCOM5_USART_BAUD     (0x42001C0CU) /**< \brief (SERCOM5) USART Baud Rate */
-#define REG_SERCOM5_USART_RXPL     (0x42001C0EU) /**< \brief (SERCOM5) USART Receive Pulse Length */
-#define REG_SERCOM5_USART_INTENCLR (0x42001C14U) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
-#define REG_SERCOM5_USART_INTENSET (0x42001C16U) /**< \brief (SERCOM5) USART Interrupt Enable Set */
-#define REG_SERCOM5_USART_INTFLAG  (0x42001C18U) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM5_USART_STATUS   (0x42001C1AU) /**< \brief (SERCOM5) USART Status */
-#define REG_SERCOM5_USART_SYNCBUSY (0x42001C1CU) /**< \brief (SERCOM5) USART Syncbusy */
-#define REG_SERCOM5_USART_DATA     (0x42001C28U) /**< \brief (SERCOM5) USART Data */
-#define REG_SERCOM5_USART_DBGCTRL  (0x42001C30U) /**< \brief (SERCOM5) USART Debug Control */
+#define REG_SERCOM5_I2CM_CTRLA     (0x42001C00) /**< \brief (SERCOM5) I2CM Control A */
+#define REG_SERCOM5_I2CM_CTRLB     (0x42001C04) /**< \brief (SERCOM5) I2CM Control B */
+#define REG_SERCOM5_I2CM_BAUD      (0x42001C0C) /**< \brief (SERCOM5) I2CM Baud Rate */
+#define REG_SERCOM5_I2CM_INTENCLR  (0x42001C14) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
+#define REG_SERCOM5_I2CM_INTENSET  (0x42001C16) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
+#define REG_SERCOM5_I2CM_INTFLAG   (0x42001C18) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CM_STATUS    (0x42001C1A) /**< \brief (SERCOM5) I2CM Status */
+#define REG_SERCOM5_I2CM_SYNCBUSY  (0x42001C1C) /**< \brief (SERCOM5) I2CM Syncbusy */
+#define REG_SERCOM5_I2CM_ADDR      (0x42001C24) /**< \brief (SERCOM5) I2CM Address */
+#define REG_SERCOM5_I2CM_DATA      (0x42001C28) /**< \brief (SERCOM5) I2CM Data */
+#define REG_SERCOM5_I2CM_DBGCTRL   (0x42001C30) /**< \brief (SERCOM5) I2CM Debug Control */
+#define REG_SERCOM5_I2CS_CTRLA     (0x42001C00) /**< \brief (SERCOM5) I2CS Control A */
+#define REG_SERCOM5_I2CS_CTRLB     (0x42001C04) /**< \brief (SERCOM5) I2CS Control B */
+#define REG_SERCOM5_I2CS_INTENCLR  (0x42001C14) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
+#define REG_SERCOM5_I2CS_INTENSET  (0x42001C16) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
+#define REG_SERCOM5_I2CS_INTFLAG   (0x42001C18) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CS_STATUS    (0x42001C1A) /**< \brief (SERCOM5) I2CS Status */
+#define REG_SERCOM5_I2CS_SYNCBUSY  (0x42001C1C) /**< \brief (SERCOM5) I2CS Syncbusy */
+#define REG_SERCOM5_I2CS_ADDR      (0x42001C24) /**< \brief (SERCOM5) I2CS Address */
+#define REG_SERCOM5_I2CS_DATA      (0x42001C28) /**< \brief (SERCOM5) I2CS Data */
+#define REG_SERCOM5_SPI_CTRLA      (0x42001C00) /**< \brief (SERCOM5) SPI Control A */
+#define REG_SERCOM5_SPI_CTRLB      (0x42001C04) /**< \brief (SERCOM5) SPI Control B */
+#define REG_SERCOM5_SPI_BAUD       (0x42001C0C) /**< \brief (SERCOM5) SPI Baud Rate */
+#define REG_SERCOM5_SPI_INTENCLR   (0x42001C14) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
+#define REG_SERCOM5_SPI_INTENSET   (0x42001C16) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
+#define REG_SERCOM5_SPI_INTFLAG    (0x42001C18) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM5_SPI_STATUS     (0x42001C1A) /**< \brief (SERCOM5) SPI Status */
+#define REG_SERCOM5_SPI_SYNCBUSY   (0x42001C1C) /**< \brief (SERCOM5) SPI Syncbusy */
+#define REG_SERCOM5_SPI_ADDR       (0x42001C24) /**< \brief (SERCOM5) SPI Address */
+#define REG_SERCOM5_SPI_DATA       (0x42001C28) /**< \brief (SERCOM5) SPI Data */
+#define REG_SERCOM5_SPI_DBGCTRL    (0x42001C30) /**< \brief (SERCOM5) SPI Debug Control */
+#define REG_SERCOM5_USART_CTRLA    (0x42001C00) /**< \brief (SERCOM5) USART Control A */
+#define REG_SERCOM5_USART_CTRLB    (0x42001C04) /**< \brief (SERCOM5) USART Control B */
+#define REG_SERCOM5_USART_BAUD     (0x42001C0C) /**< \brief (SERCOM5) USART Baud Rate */
+#define REG_SERCOM5_USART_RXPL     (0x42001C0E) /**< \brief (SERCOM5) USART Receive Pulse Length */
+#define REG_SERCOM5_USART_INTENCLR (0x42001C14) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
+#define REG_SERCOM5_USART_INTENSET (0x42001C16) /**< \brief (SERCOM5) USART Interrupt Enable Set */
+#define REG_SERCOM5_USART_INTFLAG  (0x42001C18) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM5_USART_STATUS   (0x42001C1A) /**< \brief (SERCOM5) USART Status */
+#define REG_SERCOM5_USART_SYNCBUSY (0x42001C1C) /**< \brief (SERCOM5) USART Syncbusy */
+#define REG_SERCOM5_USART_DATA     (0x42001C28) /**< \brief (SERCOM5) USART Data */
+#define REG_SERCOM5_USART_DBGCTRL  (0x42001C30) /**< \brief (SERCOM5) USART Debug Control */
 #else
-#define REG_SERCOM5_I2CM_CTRLA     (*(RwReg  *)0x42001C00U) /**< \brief (SERCOM5) I2CM Control A */
-#define REG_SERCOM5_I2CM_CTRLB     (*(RwReg  *)0x42001C04U) /**< \brief (SERCOM5) I2CM Control B */
-#define REG_SERCOM5_I2CM_BAUD      (*(RwReg  *)0x42001C0CU) /**< \brief (SERCOM5) I2CM Baud Rate */
-#define REG_SERCOM5_I2CM_INTENCLR  (*(RwReg8 *)0x42001C14U) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
-#define REG_SERCOM5_I2CM_INTENSET  (*(RwReg8 *)0x42001C16U) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
-#define REG_SERCOM5_I2CM_INTFLAG   (*(RwReg8 *)0x42001C18U) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
-#define REG_SERCOM5_I2CM_STATUS    (*(RwReg16*)0x42001C1AU) /**< \brief (SERCOM5) I2CM Status */
-#define REG_SERCOM5_I2CM_SYNCBUSY  (*(RoReg  *)0x42001C1CU) /**< \brief (SERCOM5) I2CM Syncbusy */
-#define REG_SERCOM5_I2CM_ADDR      (*(RwReg  *)0x42001C24U) /**< \brief (SERCOM5) I2CM Address */
-#define REG_SERCOM5_I2CM_DATA      (*(RwReg8 *)0x42001C28U) /**< \brief (SERCOM5) I2CM Data */
-#define REG_SERCOM5_I2CM_DBGCTRL   (*(RwReg8 *)0x42001C30U) /**< \brief (SERCOM5) I2CM Debug Control */
-#define REG_SERCOM5_I2CS_CTRLA     (*(RwReg  *)0x42001C00U) /**< \brief (SERCOM5) I2CS Control A */
-#define REG_SERCOM5_I2CS_CTRLB     (*(RwReg  *)0x42001C04U) /**< \brief (SERCOM5) I2CS Control B */
-#define REG_SERCOM5_I2CS_INTENCLR  (*(RwReg8 *)0x42001C14U) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
-#define REG_SERCOM5_I2CS_INTENSET  (*(RwReg8 *)0x42001C16U) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
-#define REG_SERCOM5_I2CS_INTFLAG   (*(RwReg8 *)0x42001C18U) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
-#define REG_SERCOM5_I2CS_STATUS    (*(RwReg16*)0x42001C1AU) /**< \brief (SERCOM5) I2CS Status */
-#define REG_SERCOM5_I2CS_SYNCBUSY  (*(RoReg  *)0x42001C1CU) /**< \brief (SERCOM5) I2CS Syncbusy */
-#define REG_SERCOM5_I2CS_ADDR      (*(RwReg  *)0x42001C24U) /**< \brief (SERCOM5) I2CS Address */
-#define REG_SERCOM5_I2CS_DATA      (*(RwReg8 *)0x42001C28U) /**< \brief (SERCOM5) I2CS Data */
-#define REG_SERCOM5_SPI_CTRLA      (*(RwReg  *)0x42001C00U) /**< \brief (SERCOM5) SPI Control A */
-#define REG_SERCOM5_SPI_CTRLB      (*(RwReg  *)0x42001C04U) /**< \brief (SERCOM5) SPI Control B */
-#define REG_SERCOM5_SPI_BAUD       (*(RwReg8 *)0x42001C0CU) /**< \brief (SERCOM5) SPI Baud Rate */
-#define REG_SERCOM5_SPI_INTENCLR   (*(RwReg8 *)0x42001C14U) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
-#define REG_SERCOM5_SPI_INTENSET   (*(RwReg8 *)0x42001C16U) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
-#define REG_SERCOM5_SPI_INTFLAG    (*(RwReg8 *)0x42001C18U) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
-#define REG_SERCOM5_SPI_STATUS     (*(RwReg16*)0x42001C1AU) /**< \brief (SERCOM5) SPI Status */
-#define REG_SERCOM5_SPI_SYNCBUSY   (*(RoReg  *)0x42001C1CU) /**< \brief (SERCOM5) SPI Syncbusy */
-#define REG_SERCOM5_SPI_ADDR       (*(RwReg  *)0x42001C24U) /**< \brief (SERCOM5) SPI Address */
-#define REG_SERCOM5_SPI_DATA       (*(RwReg  *)0x42001C28U) /**< \brief (SERCOM5) SPI Data */
-#define REG_SERCOM5_SPI_DBGCTRL    (*(RwReg8 *)0x42001C30U) /**< \brief (SERCOM5) SPI Debug Control */
-#define REG_SERCOM5_USART_CTRLA    (*(RwReg  *)0x42001C00U) /**< \brief (SERCOM5) USART Control A */
-#define REG_SERCOM5_USART_CTRLB    (*(RwReg  *)0x42001C04U) /**< \brief (SERCOM5) USART Control B */
-#define REG_SERCOM5_USART_BAUD     (*(RwReg16*)0x42001C0CU) /**< \brief (SERCOM5) USART Baud Rate */
-#define REG_SERCOM5_USART_RXPL     (*(RwReg8 *)0x42001C0EU) /**< \brief (SERCOM5) USART Receive Pulse Length */
-#define REG_SERCOM5_USART_INTENCLR (*(RwReg8 *)0x42001C14U) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
-#define REG_SERCOM5_USART_INTENSET (*(RwReg8 *)0x42001C16U) /**< \brief (SERCOM5) USART Interrupt Enable Set */
-#define REG_SERCOM5_USART_INTFLAG  (*(RwReg8 *)0x42001C18U) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
-#define REG_SERCOM5_USART_STATUS   (*(RwReg16*)0x42001C1AU) /**< \brief (SERCOM5) USART Status */
-#define REG_SERCOM5_USART_SYNCBUSY (*(RoReg  *)0x42001C1CU) /**< \brief (SERCOM5) USART Syncbusy */
-#define REG_SERCOM5_USART_DATA     (*(RwReg16*)0x42001C28U) /**< \brief (SERCOM5) USART Data */
-#define REG_SERCOM5_USART_DBGCTRL  (*(RwReg8 *)0x42001C30U) /**< \brief (SERCOM5) USART Debug Control */
+#define REG_SERCOM5_I2CM_CTRLA     (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) I2CM Control A */
+#define REG_SERCOM5_I2CM_CTRLB     (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) I2CM Control B */
+#define REG_SERCOM5_I2CM_BAUD      (*(RwReg  *)0x42001C0CUL) /**< \brief (SERCOM5) I2CM Baud Rate */
+#define REG_SERCOM5_I2CM_INTENCLR  (*(RwReg8 *)0x42001C14UL) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
+#define REG_SERCOM5_I2CM_INTENSET  (*(RwReg8 *)0x42001C16UL) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
+#define REG_SERCOM5_I2CM_INTFLAG   (*(RwReg8 *)0x42001C18UL) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CM_STATUS    (*(RwReg16*)0x42001C1AUL) /**< \brief (SERCOM5) I2CM Status */
+#define REG_SERCOM5_I2CM_SYNCBUSY  (*(RoReg  *)0x42001C1CUL) /**< \brief (SERCOM5) I2CM Syncbusy */
+#define REG_SERCOM5_I2CM_ADDR      (*(RwReg  *)0x42001C24UL) /**< \brief (SERCOM5) I2CM Address */
+#define REG_SERCOM5_I2CM_DATA      (*(RwReg8 *)0x42001C28UL) /**< \brief (SERCOM5) I2CM Data */
+#define REG_SERCOM5_I2CM_DBGCTRL   (*(RwReg8 *)0x42001C30UL) /**< \brief (SERCOM5) I2CM Debug Control */
+#define REG_SERCOM5_I2CS_CTRLA     (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) I2CS Control A */
+#define REG_SERCOM5_I2CS_CTRLB     (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) I2CS Control B */
+#define REG_SERCOM5_I2CS_INTENCLR  (*(RwReg8 *)0x42001C14UL) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
+#define REG_SERCOM5_I2CS_INTENSET  (*(RwReg8 *)0x42001C16UL) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
+#define REG_SERCOM5_I2CS_INTFLAG   (*(RwReg8 *)0x42001C18UL) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CS_STATUS    (*(RwReg16*)0x42001C1AUL) /**< \brief (SERCOM5) I2CS Status */
+#define REG_SERCOM5_I2CS_SYNCBUSY  (*(RoReg  *)0x42001C1CUL) /**< \brief (SERCOM5) I2CS Syncbusy */
+#define REG_SERCOM5_I2CS_ADDR      (*(RwReg  *)0x42001C24UL) /**< \brief (SERCOM5) I2CS Address */
+#define REG_SERCOM5_I2CS_DATA      (*(RwReg8 *)0x42001C28UL) /**< \brief (SERCOM5) I2CS Data */
+#define REG_SERCOM5_SPI_CTRLA      (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) SPI Control A */
+#define REG_SERCOM5_SPI_CTRLB      (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) SPI Control B */
+#define REG_SERCOM5_SPI_BAUD       (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) SPI Baud Rate */
+#define REG_SERCOM5_SPI_INTENCLR   (*(RwReg8 *)0x42001C14UL) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
+#define REG_SERCOM5_SPI_INTENSET   (*(RwReg8 *)0x42001C16UL) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
+#define REG_SERCOM5_SPI_INTFLAG    (*(RwReg8 *)0x42001C18UL) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM5_SPI_STATUS     (*(RwReg16*)0x42001C1AUL) /**< \brief (SERCOM5) SPI Status */
+#define REG_SERCOM5_SPI_SYNCBUSY   (*(RoReg  *)0x42001C1CUL) /**< \brief (SERCOM5) SPI Syncbusy */
+#define REG_SERCOM5_SPI_ADDR       (*(RwReg  *)0x42001C24UL) /**< \brief (SERCOM5) SPI Address */
+#define REG_SERCOM5_SPI_DATA       (*(RwReg  *)0x42001C28UL) /**< \brief (SERCOM5) SPI Data */
+#define REG_SERCOM5_SPI_DBGCTRL    (*(RwReg8 *)0x42001C30UL) /**< \brief (SERCOM5) SPI Debug Control */
+#define REG_SERCOM5_USART_CTRLA    (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) USART Control A */
+#define REG_SERCOM5_USART_CTRLB    (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) USART Control B */
+#define REG_SERCOM5_USART_BAUD     (*(RwReg16*)0x42001C0CUL) /**< \brief (SERCOM5) USART Baud Rate */
+#define REG_SERCOM5_USART_RXPL     (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) USART Receive Pulse Length */
+#define REG_SERCOM5_USART_INTENCLR (*(RwReg8 *)0x42001C14UL) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
+#define REG_SERCOM5_USART_INTENSET (*(RwReg8 *)0x42001C16UL) /**< \brief (SERCOM5) USART Interrupt Enable Set */
+#define REG_SERCOM5_USART_INTFLAG  (*(RwReg8 *)0x42001C18UL) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM5_USART_STATUS   (*(RwReg16*)0x42001C1AUL) /**< \brief (SERCOM5) USART Status */
+#define REG_SERCOM5_USART_SYNCBUSY (*(RoReg  *)0x42001C1CUL) /**< \brief (SERCOM5) USART Syncbusy */
+#define REG_SERCOM5_USART_DATA     (*(RwReg16*)0x42001C28UL) /**< \brief (SERCOM5) USART Data */
+#define REG_SERCOM5_USART_DBGCTRL  (*(RwReg8 *)0x42001C30UL) /**< \brief (SERCOM5) USART Debug Control */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for SERCOM5 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/sysctrl.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for SYSCTRL
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,47 +31,47 @@
 
 /* ========== Register definition for SYSCTRL peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_SYSCTRL_INTENCLR       (0x40000800U) /**< \brief (SYSCTRL) Interrupt Enable Clear */
-#define REG_SYSCTRL_INTENSET       (0x40000804U) /**< \brief (SYSCTRL) Interrupt Enable Set */
-#define REG_SYSCTRL_INTFLAG        (0x40000808U) /**< \brief (SYSCTRL) Interrupt Flag Status and Clear */
-#define REG_SYSCTRL_PCLKSR         (0x4000080CU) /**< \brief (SYSCTRL) Power and Clocks Status */
-#define REG_SYSCTRL_XOSC           (0x40000810U) /**< \brief (SYSCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
-#define REG_SYSCTRL_XOSC32K        (0x40000814U) /**< \brief (SYSCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
-#define REG_SYSCTRL_OSC32K         (0x40000818U) /**< \brief (SYSCTRL) 32kHz Internal Oscillator (OSC32K) Control */
-#define REG_SYSCTRL_OSCULP32K      (0x4000081CU) /**< \brief (SYSCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
-#define REG_SYSCTRL_OSC8M          (0x40000820U) /**< \brief (SYSCTRL) 8MHz Internal Oscillator (OSC8M) Control */
-#define REG_SYSCTRL_DFLLCTRL       (0x40000824U) /**< \brief (SYSCTRL) DFLL48M Control */
-#define REG_SYSCTRL_DFLLVAL        (0x40000828U) /**< \brief (SYSCTRL) DFLL48M Value */
-#define REG_SYSCTRL_DFLLMUL        (0x4000082CU) /**< \brief (SYSCTRL) DFLL48M Multiplier */
-#define REG_SYSCTRL_DFLLSYNC       (0x40000830U) /**< \brief (SYSCTRL) DFLL48M Synchronization */
-#define REG_SYSCTRL_BOD33          (0x40000834U) /**< \brief (SYSCTRL) 3.3V Brown-Out Detector (BOD33) Control */
-#define REG_SYSCTRL_VREG           (0x4000083CU) /**< \brief (SYSCTRL) Voltage Regulator System (VREG) Control */
-#define REG_SYSCTRL_VREF           (0x40000840U) /**< \brief (SYSCTRL) Voltage References System (VREF) Control */
-#define REG_SYSCTRL_DPLLCTRLA      (0x40000844U) /**< \brief (SYSCTRL) DPLL Control A */
-#define REG_SYSCTRL_DPLLRATIO      (0x40000848U) /**< \brief (SYSCTRL) DPLL Ratio Control */
-#define REG_SYSCTRL_DPLLCTRLB      (0x4000084CU) /**< \brief (SYSCTRL) DPLL Control B */
-#define REG_SYSCTRL_DPLLSTATUS     (0x40000850U) /**< \brief (SYSCTRL) DPLL Status */
+#define REG_SYSCTRL_INTENCLR       (0x40000800) /**< \brief (SYSCTRL) Interrupt Enable Clear */
+#define REG_SYSCTRL_INTENSET       (0x40000804) /**< \brief (SYSCTRL) Interrupt Enable Set */
+#define REG_SYSCTRL_INTFLAG        (0x40000808) /**< \brief (SYSCTRL) Interrupt Flag Status and Clear */
+#define REG_SYSCTRL_PCLKSR         (0x4000080C) /**< \brief (SYSCTRL) Power and Clocks Status */
+#define REG_SYSCTRL_XOSC           (0x40000810) /**< \brief (SYSCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define REG_SYSCTRL_XOSC32K        (0x40000814) /**< \brief (SYSCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define REG_SYSCTRL_OSC32K         (0x40000818) /**< \brief (SYSCTRL) 32kHz Internal Oscillator (OSC32K) Control */
+#define REG_SYSCTRL_OSCULP32K      (0x4000081C) /**< \brief (SYSCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+#define REG_SYSCTRL_OSC8M          (0x40000820) /**< \brief (SYSCTRL) 8MHz Internal Oscillator (OSC8M) Control */
+#define REG_SYSCTRL_DFLLCTRL       (0x40000824) /**< \brief (SYSCTRL) DFLL48M Control */
+#define REG_SYSCTRL_DFLLVAL        (0x40000828) /**< \brief (SYSCTRL) DFLL48M Value */
+#define REG_SYSCTRL_DFLLMUL        (0x4000082C) /**< \brief (SYSCTRL) DFLL48M Multiplier */
+#define REG_SYSCTRL_DFLLSYNC       (0x40000830) /**< \brief (SYSCTRL) DFLL48M Synchronization */
+#define REG_SYSCTRL_BOD33          (0x40000834) /**< \brief (SYSCTRL) 3.3V Brown-Out Detector (BOD33) Control */
+#define REG_SYSCTRL_VREG           (0x4000083C) /**< \brief (SYSCTRL) Voltage Regulator System (VREG) Control */
+#define REG_SYSCTRL_VREF           (0x40000840) /**< \brief (SYSCTRL) Voltage References System (VREF) Control */
+#define REG_SYSCTRL_DPLLCTRLA      (0x40000844) /**< \brief (SYSCTRL) DPLL Control A */
+#define REG_SYSCTRL_DPLLRATIO      (0x40000848) /**< \brief (SYSCTRL) DPLL Ratio Control */
+#define REG_SYSCTRL_DPLLCTRLB      (0x4000084C) /**< \brief (SYSCTRL) DPLL Control B */
+#define REG_SYSCTRL_DPLLSTATUS     (0x40000850) /**< \brief (SYSCTRL) DPLL Status */
 #else
-#define REG_SYSCTRL_INTENCLR       (*(RwReg  *)0x40000800U) /**< \brief (SYSCTRL) Interrupt Enable Clear */
-#define REG_SYSCTRL_INTENSET       (*(RwReg  *)0x40000804U) /**< \brief (SYSCTRL) Interrupt Enable Set */
-#define REG_SYSCTRL_INTFLAG        (*(RwReg  *)0x40000808U) /**< \brief (SYSCTRL) Interrupt Flag Status and Clear */
-#define REG_SYSCTRL_PCLKSR         (*(RoReg  *)0x4000080CU) /**< \brief (SYSCTRL) Power and Clocks Status */
-#define REG_SYSCTRL_XOSC           (*(RwReg16*)0x40000810U) /**< \brief (SYSCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
-#define REG_SYSCTRL_XOSC32K        (*(RwReg16*)0x40000814U) /**< \brief (SYSCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
-#define REG_SYSCTRL_OSC32K         (*(RwReg  *)0x40000818U) /**< \brief (SYSCTRL) 32kHz Internal Oscillator (OSC32K) Control */
-#define REG_SYSCTRL_OSCULP32K      (*(RwReg8 *)0x4000081CU) /**< \brief (SYSCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
-#define REG_SYSCTRL_OSC8M          (*(RwReg  *)0x40000820U) /**< \brief (SYSCTRL) 8MHz Internal Oscillator (OSC8M) Control */
-#define REG_SYSCTRL_DFLLCTRL       (*(RwReg16*)0x40000824U) /**< \brief (SYSCTRL) DFLL48M Control */
-#define REG_SYSCTRL_DFLLVAL        (*(RwReg  *)0x40000828U) /**< \brief (SYSCTRL) DFLL48M Value */
-#define REG_SYSCTRL_DFLLMUL        (*(RwReg  *)0x4000082CU) /**< \brief (SYSCTRL) DFLL48M Multiplier */
-#define REG_SYSCTRL_DFLLSYNC       (*(RwReg8 *)0x40000830U) /**< \brief (SYSCTRL) DFLL48M Synchronization */
-#define REG_SYSCTRL_BOD33          (*(RwReg  *)0x40000834U) /**< \brief (SYSCTRL) 3.3V Brown-Out Detector (BOD33) Control */
-#define REG_SYSCTRL_VREG           (*(RwReg16*)0x4000083CU) /**< \brief (SYSCTRL) Voltage Regulator System (VREG) Control */
-#define REG_SYSCTRL_VREF           (*(RwReg  *)0x40000840U) /**< \brief (SYSCTRL) Voltage References System (VREF) Control */
-#define REG_SYSCTRL_DPLLCTRLA      (*(RwReg8 *)0x40000844U) /**< \brief (SYSCTRL) DPLL Control A */
-#define REG_SYSCTRL_DPLLRATIO      (*(RwReg  *)0x40000848U) /**< \brief (SYSCTRL) DPLL Ratio Control */
-#define REG_SYSCTRL_DPLLCTRLB      (*(RwReg  *)0x4000084CU) /**< \brief (SYSCTRL) DPLL Control B */
-#define REG_SYSCTRL_DPLLSTATUS     (*(RoReg8 *)0x40000850U) /**< \brief (SYSCTRL) DPLL Status */
+#define REG_SYSCTRL_INTENCLR       (*(RwReg  *)0x40000800UL) /**< \brief (SYSCTRL) Interrupt Enable Clear */
+#define REG_SYSCTRL_INTENSET       (*(RwReg  *)0x40000804UL) /**< \brief (SYSCTRL) Interrupt Enable Set */
+#define REG_SYSCTRL_INTFLAG        (*(RwReg  *)0x40000808UL) /**< \brief (SYSCTRL) Interrupt Flag Status and Clear */
+#define REG_SYSCTRL_PCLKSR         (*(RoReg  *)0x4000080CUL) /**< \brief (SYSCTRL) Power and Clocks Status */
+#define REG_SYSCTRL_XOSC           (*(RwReg16*)0x40000810UL) /**< \brief (SYSCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define REG_SYSCTRL_XOSC32K        (*(RwReg16*)0x40000814UL) /**< \brief (SYSCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define REG_SYSCTRL_OSC32K         (*(RwReg  *)0x40000818UL) /**< \brief (SYSCTRL) 32kHz Internal Oscillator (OSC32K) Control */
+#define REG_SYSCTRL_OSCULP32K      (*(RwReg8 *)0x4000081CUL) /**< \brief (SYSCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+#define REG_SYSCTRL_OSC8M          (*(RwReg  *)0x40000820UL) /**< \brief (SYSCTRL) 8MHz Internal Oscillator (OSC8M) Control */
+#define REG_SYSCTRL_DFLLCTRL       (*(RwReg16*)0x40000824UL) /**< \brief (SYSCTRL) DFLL48M Control */
+#define REG_SYSCTRL_DFLLVAL        (*(RwReg  *)0x40000828UL) /**< \brief (SYSCTRL) DFLL48M Value */
+#define REG_SYSCTRL_DFLLMUL        (*(RwReg  *)0x4000082CUL) /**< \brief (SYSCTRL) DFLL48M Multiplier */
+#define REG_SYSCTRL_DFLLSYNC       (*(RwReg8 *)0x40000830UL) /**< \brief (SYSCTRL) DFLL48M Synchronization */
+#define REG_SYSCTRL_BOD33          (*(RwReg  *)0x40000834UL) /**< \brief (SYSCTRL) 3.3V Brown-Out Detector (BOD33) Control */
+#define REG_SYSCTRL_VREG           (*(RwReg16*)0x4000083CUL) /**< \brief (SYSCTRL) Voltage Regulator System (VREG) Control */
+#define REG_SYSCTRL_VREF           (*(RwReg  *)0x40000840UL) /**< \brief (SYSCTRL) Voltage References System (VREF) Control */
+#define REG_SYSCTRL_DPLLCTRLA      (*(RwReg8 *)0x40000844UL) /**< \brief (SYSCTRL) DPLL Control A */
+#define REG_SYSCTRL_DPLLRATIO      (*(RwReg  *)0x40000848UL) /**< \brief (SYSCTRL) DPLL Ratio Control */
+#define REG_SYSCTRL_DPLLCTRLB      (*(RwReg  *)0x4000084CUL) /**< \brief (SYSCTRL) DPLL Control B */
+#define REG_SYSCTRL_DPLLSTATUS     (*(RoReg8 *)0x40000850UL) /**< \brief (SYSCTRL) DPLL Status */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for SYSCTRL peripheral ========== */
@@ -99,6 +84,7 @@
 #define SYSCTRL_GCLK_ID_FDPLL32K    2        // Index of Generic Clock for DPLL 32K
 #define SYSCTRL_OSC32K_COARSE_CALIB_MSB 6       
 #define SYSCTRL_POR33_ENTEST_MSB    1       
+#define SYSCTRL_SYSTEM_CLOCK        1000000  // Initial system clock frequency
 #define SYSCTRL_ULPVREF_DIVLEV_MSB  3       
 #define SYSCTRL_ULPVREG_FORCEGAIN_MSB 1       
 #define SYSCTRL_ULPVREG_RAMREFSEL_MSB 2       

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/tc3.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/tc3.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for TC3
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,49 +31,49 @@
 
 /* ========== Register definition for TC3 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_TC3_CTRLA              (0x42002C00U) /**< \brief (TC3) Control A */
-#define REG_TC3_READREQ            (0x42002C02U) /**< \brief (TC3) Read Request */
-#define REG_TC3_CTRLBCLR           (0x42002C04U) /**< \brief (TC3) Control B Clear */
-#define REG_TC3_CTRLBSET           (0x42002C05U) /**< \brief (TC3) Control B Set */
-#define REG_TC3_CTRLC              (0x42002C06U) /**< \brief (TC3) Control C */
-#define REG_TC3_DBGCTRL            (0x42002C08U) /**< \brief (TC3) Debug Control */
-#define REG_TC3_EVCTRL             (0x42002C0AU) /**< \brief (TC3) Event Control */
-#define REG_TC3_INTENCLR           (0x42002C0CU) /**< \brief (TC3) Interrupt Enable Clear */
-#define REG_TC3_INTENSET           (0x42002C0DU) /**< \brief (TC3) Interrupt Enable Set */
-#define REG_TC3_INTFLAG            (0x42002C0EU) /**< \brief (TC3) Interrupt Flag Status and Clear */
-#define REG_TC3_STATUS             (0x42002C0FU) /**< \brief (TC3) Status */
-#define REG_TC3_COUNT16_COUNT      (0x42002C10U) /**< \brief (TC3) COUNT16 Counter Value */
-#define REG_TC3_COUNT16_CC0        (0x42002C18U) /**< \brief (TC3) COUNT16 Compare/Capture 0 */
-#define REG_TC3_COUNT16_CC1        (0x42002C1AU) /**< \brief (TC3) COUNT16 Compare/Capture 1 */
-#define REG_TC3_COUNT32_COUNT      (0x42002C10U) /**< \brief (TC3) COUNT32 Counter Value */
-#define REG_TC3_COUNT32_CC0        (0x42002C18U) /**< \brief (TC3) COUNT32 Compare/Capture 0 */
-#define REG_TC3_COUNT32_CC1        (0x42002C1CU) /**< \brief (TC3) COUNT32 Compare/Capture 1 */
-#define REG_TC3_COUNT8_COUNT       (0x42002C10U) /**< \brief (TC3) COUNT8 Counter Value */
-#define REG_TC3_COUNT8_PER         (0x42002C14U) /**< \brief (TC3) COUNT8 Period Value */
-#define REG_TC3_COUNT8_CC0         (0x42002C18U) /**< \brief (TC3) COUNT8 Compare/Capture 0 */
-#define REG_TC3_COUNT8_CC1         (0x42002C19U) /**< \brief (TC3) COUNT8 Compare/Capture 1 */
+#define REG_TC3_CTRLA              (0x42002C00) /**< \brief (TC3) Control A */
+#define REG_TC3_READREQ            (0x42002C02) /**< \brief (TC3) Read Request */
+#define REG_TC3_CTRLBCLR           (0x42002C04) /**< \brief (TC3) Control B Clear */
+#define REG_TC3_CTRLBSET           (0x42002C05) /**< \brief (TC3) Control B Set */
+#define REG_TC3_CTRLC              (0x42002C06) /**< \brief (TC3) Control C */
+#define REG_TC3_DBGCTRL            (0x42002C08) /**< \brief (TC3) Debug Control */
+#define REG_TC3_EVCTRL             (0x42002C0A) /**< \brief (TC3) Event Control */
+#define REG_TC3_INTENCLR           (0x42002C0C) /**< \brief (TC3) Interrupt Enable Clear */
+#define REG_TC3_INTENSET           (0x42002C0D) /**< \brief (TC3) Interrupt Enable Set */
+#define REG_TC3_INTFLAG            (0x42002C0E) /**< \brief (TC3) Interrupt Flag Status and Clear */
+#define REG_TC3_STATUS             (0x42002C0F) /**< \brief (TC3) Status */
+#define REG_TC3_COUNT16_COUNT      (0x42002C10) /**< \brief (TC3) COUNT16 Counter Value */
+#define REG_TC3_COUNT16_CC0        (0x42002C18) /**< \brief (TC3) COUNT16 Compare/Capture 0 */
+#define REG_TC3_COUNT16_CC1        (0x42002C1A) /**< \brief (TC3) COUNT16 Compare/Capture 1 */
+#define REG_TC3_COUNT32_COUNT      (0x42002C10) /**< \brief (TC3) COUNT32 Counter Value */
+#define REG_TC3_COUNT32_CC0        (0x42002C18) /**< \brief (TC3) COUNT32 Compare/Capture 0 */
+#define REG_TC3_COUNT32_CC1        (0x42002C1C) /**< \brief (TC3) COUNT32 Compare/Capture 1 */
+#define REG_TC3_COUNT8_COUNT       (0x42002C10) /**< \brief (TC3) COUNT8 Counter Value */
+#define REG_TC3_COUNT8_PER         (0x42002C14) /**< \brief (TC3) COUNT8 Period Value */
+#define REG_TC3_COUNT8_CC0         (0x42002C18) /**< \brief (TC3) COUNT8 Compare/Capture 0 */
+#define REG_TC3_COUNT8_CC1         (0x42002C19) /**< \brief (TC3) COUNT8 Compare/Capture 1 */
 #else
-#define REG_TC3_CTRLA              (*(RwReg16*)0x42002C00U) /**< \brief (TC3) Control A */
-#define REG_TC3_READREQ            (*(RwReg16*)0x42002C02U) /**< \brief (TC3) Read Request */
-#define REG_TC3_CTRLBCLR           (*(RwReg8 *)0x42002C04U) /**< \brief (TC3) Control B Clear */
-#define REG_TC3_CTRLBSET           (*(RwReg8 *)0x42002C05U) /**< \brief (TC3) Control B Set */
-#define REG_TC3_CTRLC              (*(RwReg8 *)0x42002C06U) /**< \brief (TC3) Control C */
-#define REG_TC3_DBGCTRL            (*(RwReg8 *)0x42002C08U) /**< \brief (TC3) Debug Control */
-#define REG_TC3_EVCTRL             (*(RwReg16*)0x42002C0AU) /**< \brief (TC3) Event Control */
-#define REG_TC3_INTENCLR           (*(RwReg8 *)0x42002C0CU) /**< \brief (TC3) Interrupt Enable Clear */
-#define REG_TC3_INTENSET           (*(RwReg8 *)0x42002C0DU) /**< \brief (TC3) Interrupt Enable Set */
-#define REG_TC3_INTFLAG            (*(RwReg8 *)0x42002C0EU) /**< \brief (TC3) Interrupt Flag Status and Clear */
-#define REG_TC3_STATUS             (*(RoReg8 *)0x42002C0FU) /**< \brief (TC3) Status */
-#define REG_TC3_COUNT16_COUNT      (*(RwReg16*)0x42002C10U) /**< \brief (TC3) COUNT16 Counter Value */
-#define REG_TC3_COUNT16_CC0        (*(RwReg16*)0x42002C18U) /**< \brief (TC3) COUNT16 Compare/Capture 0 */
-#define REG_TC3_COUNT16_CC1        (*(RwReg16*)0x42002C1AU) /**< \brief (TC3) COUNT16 Compare/Capture 1 */
-#define REG_TC3_COUNT32_COUNT      (*(RwReg  *)0x42002C10U) /**< \brief (TC3) COUNT32 Counter Value */
-#define REG_TC3_COUNT32_CC0        (*(RwReg  *)0x42002C18U) /**< \brief (TC3) COUNT32 Compare/Capture 0 */
-#define REG_TC3_COUNT32_CC1        (*(RwReg  *)0x42002C1CU) /**< \brief (TC3) COUNT32 Compare/Capture 1 */
-#define REG_TC3_COUNT8_COUNT       (*(RwReg8 *)0x42002C10U) /**< \brief (TC3) COUNT8 Counter Value */
-#define REG_TC3_COUNT8_PER         (*(RwReg8 *)0x42002C14U) /**< \brief (TC3) COUNT8 Period Value */
-#define REG_TC3_COUNT8_CC0         (*(RwReg8 *)0x42002C18U) /**< \brief (TC3) COUNT8 Compare/Capture 0 */
-#define REG_TC3_COUNT8_CC1         (*(RwReg8 *)0x42002C19U) /**< \brief (TC3) COUNT8 Compare/Capture 1 */
+#define REG_TC3_CTRLA              (*(RwReg16*)0x42002C00UL) /**< \brief (TC3) Control A */
+#define REG_TC3_READREQ            (*(RwReg16*)0x42002C02UL) /**< \brief (TC3) Read Request */
+#define REG_TC3_CTRLBCLR           (*(RwReg8 *)0x42002C04UL) /**< \brief (TC3) Control B Clear */
+#define REG_TC3_CTRLBSET           (*(RwReg8 *)0x42002C05UL) /**< \brief (TC3) Control B Set */
+#define REG_TC3_CTRLC              (*(RwReg8 *)0x42002C06UL) /**< \brief (TC3) Control C */
+#define REG_TC3_DBGCTRL            (*(RwReg8 *)0x42002C08UL) /**< \brief (TC3) Debug Control */
+#define REG_TC3_EVCTRL             (*(RwReg16*)0x42002C0AUL) /**< \brief (TC3) Event Control */
+#define REG_TC3_INTENCLR           (*(RwReg8 *)0x42002C0CUL) /**< \brief (TC3) Interrupt Enable Clear */
+#define REG_TC3_INTENSET           (*(RwReg8 *)0x42002C0DUL) /**< \brief (TC3) Interrupt Enable Set */
+#define REG_TC3_INTFLAG            (*(RwReg8 *)0x42002C0EUL) /**< \brief (TC3) Interrupt Flag Status and Clear */
+#define REG_TC3_STATUS             (*(RoReg8 *)0x42002C0FUL) /**< \brief (TC3) Status */
+#define REG_TC3_COUNT16_COUNT      (*(RwReg16*)0x42002C10UL) /**< \brief (TC3) COUNT16 Counter Value */
+#define REG_TC3_COUNT16_CC0        (*(RwReg16*)0x42002C18UL) /**< \brief (TC3) COUNT16 Compare/Capture 0 */
+#define REG_TC3_COUNT16_CC1        (*(RwReg16*)0x42002C1AUL) /**< \brief (TC3) COUNT16 Compare/Capture 1 */
+#define REG_TC3_COUNT32_COUNT      (*(RwReg  *)0x42002C10UL) /**< \brief (TC3) COUNT32 Counter Value */
+#define REG_TC3_COUNT32_CC0        (*(RwReg  *)0x42002C18UL) /**< \brief (TC3) COUNT32 Compare/Capture 0 */
+#define REG_TC3_COUNT32_CC1        (*(RwReg  *)0x42002C1CUL) /**< \brief (TC3) COUNT32 Compare/Capture 1 */
+#define REG_TC3_COUNT8_COUNT       (*(RwReg8 *)0x42002C10UL) /**< \brief (TC3) COUNT8 Counter Value */
+#define REG_TC3_COUNT8_PER         (*(RwReg8 *)0x42002C14UL) /**< \brief (TC3) COUNT8 Period Value */
+#define REG_TC3_COUNT8_CC0         (*(RwReg8 *)0x42002C18UL) /**< \brief (TC3) COUNT8 Compare/Capture 0 */
+#define REG_TC3_COUNT8_CC1         (*(RwReg8 *)0x42002C19UL) /**< \brief (TC3) COUNT8 Compare/Capture 1 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for TC3 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/tc4.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/tc4.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for TC4
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,49 +31,49 @@
 
 /* ========== Register definition for TC4 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_TC4_CTRLA              (0x42003000U) /**< \brief (TC4) Control A */
-#define REG_TC4_READREQ            (0x42003002U) /**< \brief (TC4) Read Request */
-#define REG_TC4_CTRLBCLR           (0x42003004U) /**< \brief (TC4) Control B Clear */
-#define REG_TC4_CTRLBSET           (0x42003005U) /**< \brief (TC4) Control B Set */
-#define REG_TC4_CTRLC              (0x42003006U) /**< \brief (TC4) Control C */
-#define REG_TC4_DBGCTRL            (0x42003008U) /**< \brief (TC4) Debug Control */
-#define REG_TC4_EVCTRL             (0x4200300AU) /**< \brief (TC4) Event Control */
-#define REG_TC4_INTENCLR           (0x4200300CU) /**< \brief (TC4) Interrupt Enable Clear */
-#define REG_TC4_INTENSET           (0x4200300DU) /**< \brief (TC4) Interrupt Enable Set */
-#define REG_TC4_INTFLAG            (0x4200300EU) /**< \brief (TC4) Interrupt Flag Status and Clear */
-#define REG_TC4_STATUS             (0x4200300FU) /**< \brief (TC4) Status */
-#define REG_TC4_COUNT16_COUNT      (0x42003010U) /**< \brief (TC4) COUNT16 Counter Value */
-#define REG_TC4_COUNT16_CC0        (0x42003018U) /**< \brief (TC4) COUNT16 Compare/Capture 0 */
-#define REG_TC4_COUNT16_CC1        (0x4200301AU) /**< \brief (TC4) COUNT16 Compare/Capture 1 */
-#define REG_TC4_COUNT32_COUNT      (0x42003010U) /**< \brief (TC4) COUNT32 Counter Value */
-#define REG_TC4_COUNT32_CC0        (0x42003018U) /**< \brief (TC4) COUNT32 Compare/Capture 0 */
-#define REG_TC4_COUNT32_CC1        (0x4200301CU) /**< \brief (TC4) COUNT32 Compare/Capture 1 */
-#define REG_TC4_COUNT8_COUNT       (0x42003010U) /**< \brief (TC4) COUNT8 Counter Value */
-#define REG_TC4_COUNT8_PER         (0x42003014U) /**< \brief (TC4) COUNT8 Period Value */
-#define REG_TC4_COUNT8_CC0         (0x42003018U) /**< \brief (TC4) COUNT8 Compare/Capture 0 */
-#define REG_TC4_COUNT8_CC1         (0x42003019U) /**< \brief (TC4) COUNT8 Compare/Capture 1 */
+#define REG_TC4_CTRLA              (0x42003000) /**< \brief (TC4) Control A */
+#define REG_TC4_READREQ            (0x42003002) /**< \brief (TC4) Read Request */
+#define REG_TC4_CTRLBCLR           (0x42003004) /**< \brief (TC4) Control B Clear */
+#define REG_TC4_CTRLBSET           (0x42003005) /**< \brief (TC4) Control B Set */
+#define REG_TC4_CTRLC              (0x42003006) /**< \brief (TC4) Control C */
+#define REG_TC4_DBGCTRL            (0x42003008) /**< \brief (TC4) Debug Control */
+#define REG_TC4_EVCTRL             (0x4200300A) /**< \brief (TC4) Event Control */
+#define REG_TC4_INTENCLR           (0x4200300C) /**< \brief (TC4) Interrupt Enable Clear */
+#define REG_TC4_INTENSET           (0x4200300D) /**< \brief (TC4) Interrupt Enable Set */
+#define REG_TC4_INTFLAG            (0x4200300E) /**< \brief (TC4) Interrupt Flag Status and Clear */
+#define REG_TC4_STATUS             (0x4200300F) /**< \brief (TC4) Status */
+#define REG_TC4_COUNT16_COUNT      (0x42003010) /**< \brief (TC4) COUNT16 Counter Value */
+#define REG_TC4_COUNT16_CC0        (0x42003018) /**< \brief (TC4) COUNT16 Compare/Capture 0 */
+#define REG_TC4_COUNT16_CC1        (0x4200301A) /**< \brief (TC4) COUNT16 Compare/Capture 1 */
+#define REG_TC4_COUNT32_COUNT      (0x42003010) /**< \brief (TC4) COUNT32 Counter Value */
+#define REG_TC4_COUNT32_CC0        (0x42003018) /**< \brief (TC4) COUNT32 Compare/Capture 0 */
+#define REG_TC4_COUNT32_CC1        (0x4200301C) /**< \brief (TC4) COUNT32 Compare/Capture 1 */
+#define REG_TC4_COUNT8_COUNT       (0x42003010) /**< \brief (TC4) COUNT8 Counter Value */
+#define REG_TC4_COUNT8_PER         (0x42003014) /**< \brief (TC4) COUNT8 Period Value */
+#define REG_TC4_COUNT8_CC0         (0x42003018) /**< \brief (TC4) COUNT8 Compare/Capture 0 */
+#define REG_TC4_COUNT8_CC1         (0x42003019) /**< \brief (TC4) COUNT8 Compare/Capture 1 */
 #else
-#define REG_TC4_CTRLA              (*(RwReg16*)0x42003000U) /**< \brief (TC4) Control A */
-#define REG_TC4_READREQ            (*(RwReg16*)0x42003002U) /**< \brief (TC4) Read Request */
-#define REG_TC4_CTRLBCLR           (*(RwReg8 *)0x42003004U) /**< \brief (TC4) Control B Clear */
-#define REG_TC4_CTRLBSET           (*(RwReg8 *)0x42003005U) /**< \brief (TC4) Control B Set */
-#define REG_TC4_CTRLC              (*(RwReg8 *)0x42003006U) /**< \brief (TC4) Control C */
-#define REG_TC4_DBGCTRL            (*(RwReg8 *)0x42003008U) /**< \brief (TC4) Debug Control */
-#define REG_TC4_EVCTRL             (*(RwReg16*)0x4200300AU) /**< \brief (TC4) Event Control */
-#define REG_TC4_INTENCLR           (*(RwReg8 *)0x4200300CU) /**< \brief (TC4) Interrupt Enable Clear */
-#define REG_TC4_INTENSET           (*(RwReg8 *)0x4200300DU) /**< \brief (TC4) Interrupt Enable Set */
-#define REG_TC4_INTFLAG            (*(RwReg8 *)0x4200300EU) /**< \brief (TC4) Interrupt Flag Status and Clear */
-#define REG_TC4_STATUS             (*(RoReg8 *)0x4200300FU) /**< \brief (TC4) Status */
-#define REG_TC4_COUNT16_COUNT      (*(RwReg16*)0x42003010U) /**< \brief (TC4) COUNT16 Counter Value */
-#define REG_TC4_COUNT16_CC0        (*(RwReg16*)0x42003018U) /**< \brief (TC4) COUNT16 Compare/Capture 0 */
-#define REG_TC4_COUNT16_CC1        (*(RwReg16*)0x4200301AU) /**< \brief (TC4) COUNT16 Compare/Capture 1 */
-#define REG_TC4_COUNT32_COUNT      (*(RwReg  *)0x42003010U) /**< \brief (TC4) COUNT32 Counter Value */
-#define REG_TC4_COUNT32_CC0        (*(RwReg  *)0x42003018U) /**< \brief (TC4) COUNT32 Compare/Capture 0 */
-#define REG_TC4_COUNT32_CC1        (*(RwReg  *)0x4200301CU) /**< \brief (TC4) COUNT32 Compare/Capture 1 */
-#define REG_TC4_COUNT8_COUNT       (*(RwReg8 *)0x42003010U) /**< \brief (TC4) COUNT8 Counter Value */
-#define REG_TC4_COUNT8_PER         (*(RwReg8 *)0x42003014U) /**< \brief (TC4) COUNT8 Period Value */
-#define REG_TC4_COUNT8_CC0         (*(RwReg8 *)0x42003018U) /**< \brief (TC4) COUNT8 Compare/Capture 0 */
-#define REG_TC4_COUNT8_CC1         (*(RwReg8 *)0x42003019U) /**< \brief (TC4) COUNT8 Compare/Capture 1 */
+#define REG_TC4_CTRLA              (*(RwReg16*)0x42003000UL) /**< \brief (TC4) Control A */
+#define REG_TC4_READREQ            (*(RwReg16*)0x42003002UL) /**< \brief (TC4) Read Request */
+#define REG_TC4_CTRLBCLR           (*(RwReg8 *)0x42003004UL) /**< \brief (TC4) Control B Clear */
+#define REG_TC4_CTRLBSET           (*(RwReg8 *)0x42003005UL) /**< \brief (TC4) Control B Set */
+#define REG_TC4_CTRLC              (*(RwReg8 *)0x42003006UL) /**< \brief (TC4) Control C */
+#define REG_TC4_DBGCTRL            (*(RwReg8 *)0x42003008UL) /**< \brief (TC4) Debug Control */
+#define REG_TC4_EVCTRL             (*(RwReg16*)0x4200300AUL) /**< \brief (TC4) Event Control */
+#define REG_TC4_INTENCLR           (*(RwReg8 *)0x4200300CUL) /**< \brief (TC4) Interrupt Enable Clear */
+#define REG_TC4_INTENSET           (*(RwReg8 *)0x4200300DUL) /**< \brief (TC4) Interrupt Enable Set */
+#define REG_TC4_INTFLAG            (*(RwReg8 *)0x4200300EUL) /**< \brief (TC4) Interrupt Flag Status and Clear */
+#define REG_TC4_STATUS             (*(RoReg8 *)0x4200300FUL) /**< \brief (TC4) Status */
+#define REG_TC4_COUNT16_COUNT      (*(RwReg16*)0x42003010UL) /**< \brief (TC4) COUNT16 Counter Value */
+#define REG_TC4_COUNT16_CC0        (*(RwReg16*)0x42003018UL) /**< \brief (TC4) COUNT16 Compare/Capture 0 */
+#define REG_TC4_COUNT16_CC1        (*(RwReg16*)0x4200301AUL) /**< \brief (TC4) COUNT16 Compare/Capture 1 */
+#define REG_TC4_COUNT32_COUNT      (*(RwReg  *)0x42003010UL) /**< \brief (TC4) COUNT32 Counter Value */
+#define REG_TC4_COUNT32_CC0        (*(RwReg  *)0x42003018UL) /**< \brief (TC4) COUNT32 Compare/Capture 0 */
+#define REG_TC4_COUNT32_CC1        (*(RwReg  *)0x4200301CUL) /**< \brief (TC4) COUNT32 Compare/Capture 1 */
+#define REG_TC4_COUNT8_COUNT       (*(RwReg8 *)0x42003010UL) /**< \brief (TC4) COUNT8 Counter Value */
+#define REG_TC4_COUNT8_PER         (*(RwReg8 *)0x42003014UL) /**< \brief (TC4) COUNT8 Period Value */
+#define REG_TC4_COUNT8_CC0         (*(RwReg8 *)0x42003018UL) /**< \brief (TC4) COUNT8 Compare/Capture 0 */
+#define REG_TC4_COUNT8_CC1         (*(RwReg8 *)0x42003019UL) /**< \brief (TC4) COUNT8 Compare/Capture 1 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for TC4 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/tc5.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/tc5.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for TC5
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,49 +31,49 @@
 
 /* ========== Register definition for TC5 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_TC5_CTRLA              (0x42003400U) /**< \brief (TC5) Control A */
-#define REG_TC5_READREQ            (0x42003402U) /**< \brief (TC5) Read Request */
-#define REG_TC5_CTRLBCLR           (0x42003404U) /**< \brief (TC5) Control B Clear */
-#define REG_TC5_CTRLBSET           (0x42003405U) /**< \brief (TC5) Control B Set */
-#define REG_TC5_CTRLC              (0x42003406U) /**< \brief (TC5) Control C */
-#define REG_TC5_DBGCTRL            (0x42003408U) /**< \brief (TC5) Debug Control */
-#define REG_TC5_EVCTRL             (0x4200340AU) /**< \brief (TC5) Event Control */
-#define REG_TC5_INTENCLR           (0x4200340CU) /**< \brief (TC5) Interrupt Enable Clear */
-#define REG_TC5_INTENSET           (0x4200340DU) /**< \brief (TC5) Interrupt Enable Set */
-#define REG_TC5_INTFLAG            (0x4200340EU) /**< \brief (TC5) Interrupt Flag Status and Clear */
-#define REG_TC5_STATUS             (0x4200340FU) /**< \brief (TC5) Status */
-#define REG_TC5_COUNT16_COUNT      (0x42003410U) /**< \brief (TC5) COUNT16 Counter Value */
-#define REG_TC5_COUNT16_CC0        (0x42003418U) /**< \brief (TC5) COUNT16 Compare/Capture 0 */
-#define REG_TC5_COUNT16_CC1        (0x4200341AU) /**< \brief (TC5) COUNT16 Compare/Capture 1 */
-#define REG_TC5_COUNT32_COUNT      (0x42003410U) /**< \brief (TC5) COUNT32 Counter Value */
-#define REG_TC5_COUNT32_CC0        (0x42003418U) /**< \brief (TC5) COUNT32 Compare/Capture 0 */
-#define REG_TC5_COUNT32_CC1        (0x4200341CU) /**< \brief (TC5) COUNT32 Compare/Capture 1 */
-#define REG_TC5_COUNT8_COUNT       (0x42003410U) /**< \brief (TC5) COUNT8 Counter Value */
-#define REG_TC5_COUNT8_PER         (0x42003414U) /**< \brief (TC5) COUNT8 Period Value */
-#define REG_TC5_COUNT8_CC0         (0x42003418U) /**< \brief (TC5) COUNT8 Compare/Capture 0 */
-#define REG_TC5_COUNT8_CC1         (0x42003419U) /**< \brief (TC5) COUNT8 Compare/Capture 1 */
+#define REG_TC5_CTRLA              (0x42003400) /**< \brief (TC5) Control A */
+#define REG_TC5_READREQ            (0x42003402) /**< \brief (TC5) Read Request */
+#define REG_TC5_CTRLBCLR           (0x42003404) /**< \brief (TC5) Control B Clear */
+#define REG_TC5_CTRLBSET           (0x42003405) /**< \brief (TC5) Control B Set */
+#define REG_TC5_CTRLC              (0x42003406) /**< \brief (TC5) Control C */
+#define REG_TC5_DBGCTRL            (0x42003408) /**< \brief (TC5) Debug Control */
+#define REG_TC5_EVCTRL             (0x4200340A) /**< \brief (TC5) Event Control */
+#define REG_TC5_INTENCLR           (0x4200340C) /**< \brief (TC5) Interrupt Enable Clear */
+#define REG_TC5_INTENSET           (0x4200340D) /**< \brief (TC5) Interrupt Enable Set */
+#define REG_TC5_INTFLAG            (0x4200340E) /**< \brief (TC5) Interrupt Flag Status and Clear */
+#define REG_TC5_STATUS             (0x4200340F) /**< \brief (TC5) Status */
+#define REG_TC5_COUNT16_COUNT      (0x42003410) /**< \brief (TC5) COUNT16 Counter Value */
+#define REG_TC5_COUNT16_CC0        (0x42003418) /**< \brief (TC5) COUNT16 Compare/Capture 0 */
+#define REG_TC5_COUNT16_CC1        (0x4200341A) /**< \brief (TC5) COUNT16 Compare/Capture 1 */
+#define REG_TC5_COUNT32_COUNT      (0x42003410) /**< \brief (TC5) COUNT32 Counter Value */
+#define REG_TC5_COUNT32_CC0        (0x42003418) /**< \brief (TC5) COUNT32 Compare/Capture 0 */
+#define REG_TC5_COUNT32_CC1        (0x4200341C) /**< \brief (TC5) COUNT32 Compare/Capture 1 */
+#define REG_TC5_COUNT8_COUNT       (0x42003410) /**< \brief (TC5) COUNT8 Counter Value */
+#define REG_TC5_COUNT8_PER         (0x42003414) /**< \brief (TC5) COUNT8 Period Value */
+#define REG_TC5_COUNT8_CC0         (0x42003418) /**< \brief (TC5) COUNT8 Compare/Capture 0 */
+#define REG_TC5_COUNT8_CC1         (0x42003419) /**< \brief (TC5) COUNT8 Compare/Capture 1 */
 #else
-#define REG_TC5_CTRLA              (*(RwReg16*)0x42003400U) /**< \brief (TC5) Control A */
-#define REG_TC5_READREQ            (*(RwReg16*)0x42003402U) /**< \brief (TC5) Read Request */
-#define REG_TC5_CTRLBCLR           (*(RwReg8 *)0x42003404U) /**< \brief (TC5) Control B Clear */
-#define REG_TC5_CTRLBSET           (*(RwReg8 *)0x42003405U) /**< \brief (TC5) Control B Set */
-#define REG_TC5_CTRLC              (*(RwReg8 *)0x42003406U) /**< \brief (TC5) Control C */
-#define REG_TC5_DBGCTRL            (*(RwReg8 *)0x42003408U) /**< \brief (TC5) Debug Control */
-#define REG_TC5_EVCTRL             (*(RwReg16*)0x4200340AU) /**< \brief (TC5) Event Control */
-#define REG_TC5_INTENCLR           (*(RwReg8 *)0x4200340CU) /**< \brief (TC5) Interrupt Enable Clear */
-#define REG_TC5_INTENSET           (*(RwReg8 *)0x4200340DU) /**< \brief (TC5) Interrupt Enable Set */
-#define REG_TC5_INTFLAG            (*(RwReg8 *)0x4200340EU) /**< \brief (TC5) Interrupt Flag Status and Clear */
-#define REG_TC5_STATUS             (*(RoReg8 *)0x4200340FU) /**< \brief (TC5) Status */
-#define REG_TC5_COUNT16_COUNT      (*(RwReg16*)0x42003410U) /**< \brief (TC5) COUNT16 Counter Value */
-#define REG_TC5_COUNT16_CC0        (*(RwReg16*)0x42003418U) /**< \brief (TC5) COUNT16 Compare/Capture 0 */
-#define REG_TC5_COUNT16_CC1        (*(RwReg16*)0x4200341AU) /**< \brief (TC5) COUNT16 Compare/Capture 1 */
-#define REG_TC5_COUNT32_COUNT      (*(RwReg  *)0x42003410U) /**< \brief (TC5) COUNT32 Counter Value */
-#define REG_TC5_COUNT32_CC0        (*(RwReg  *)0x42003418U) /**< \brief (TC5) COUNT32 Compare/Capture 0 */
-#define REG_TC5_COUNT32_CC1        (*(RwReg  *)0x4200341CU) /**< \brief (TC5) COUNT32 Compare/Capture 1 */
-#define REG_TC5_COUNT8_COUNT       (*(RwReg8 *)0x42003410U) /**< \brief (TC5) COUNT8 Counter Value */
-#define REG_TC5_COUNT8_PER         (*(RwReg8 *)0x42003414U) /**< \brief (TC5) COUNT8 Period Value */
-#define REG_TC5_COUNT8_CC0         (*(RwReg8 *)0x42003418U) /**< \brief (TC5) COUNT8 Compare/Capture 0 */
-#define REG_TC5_COUNT8_CC1         (*(RwReg8 *)0x42003419U) /**< \brief (TC5) COUNT8 Compare/Capture 1 */
+#define REG_TC5_CTRLA              (*(RwReg16*)0x42003400UL) /**< \brief (TC5) Control A */
+#define REG_TC5_READREQ            (*(RwReg16*)0x42003402UL) /**< \brief (TC5) Read Request */
+#define REG_TC5_CTRLBCLR           (*(RwReg8 *)0x42003404UL) /**< \brief (TC5) Control B Clear */
+#define REG_TC5_CTRLBSET           (*(RwReg8 *)0x42003405UL) /**< \brief (TC5) Control B Set */
+#define REG_TC5_CTRLC              (*(RwReg8 *)0x42003406UL) /**< \brief (TC5) Control C */
+#define REG_TC5_DBGCTRL            (*(RwReg8 *)0x42003408UL) /**< \brief (TC5) Debug Control */
+#define REG_TC5_EVCTRL             (*(RwReg16*)0x4200340AUL) /**< \brief (TC5) Event Control */
+#define REG_TC5_INTENCLR           (*(RwReg8 *)0x4200340CUL) /**< \brief (TC5) Interrupt Enable Clear */
+#define REG_TC5_INTENSET           (*(RwReg8 *)0x4200340DUL) /**< \brief (TC5) Interrupt Enable Set */
+#define REG_TC5_INTFLAG            (*(RwReg8 *)0x4200340EUL) /**< \brief (TC5) Interrupt Flag Status and Clear */
+#define REG_TC5_STATUS             (*(RoReg8 *)0x4200340FUL) /**< \brief (TC5) Status */
+#define REG_TC5_COUNT16_COUNT      (*(RwReg16*)0x42003410UL) /**< \brief (TC5) COUNT16 Counter Value */
+#define REG_TC5_COUNT16_CC0        (*(RwReg16*)0x42003418UL) /**< \brief (TC5) COUNT16 Compare/Capture 0 */
+#define REG_TC5_COUNT16_CC1        (*(RwReg16*)0x4200341AUL) /**< \brief (TC5) COUNT16 Compare/Capture 1 */
+#define REG_TC5_COUNT32_COUNT      (*(RwReg  *)0x42003410UL) /**< \brief (TC5) COUNT32 Counter Value */
+#define REG_TC5_COUNT32_CC0        (*(RwReg  *)0x42003418UL) /**< \brief (TC5) COUNT32 Compare/Capture 0 */
+#define REG_TC5_COUNT32_CC1        (*(RwReg  *)0x4200341CUL) /**< \brief (TC5) COUNT32 Compare/Capture 1 */
+#define REG_TC5_COUNT8_COUNT       (*(RwReg8 *)0x42003410UL) /**< \brief (TC5) COUNT8 Counter Value */
+#define REG_TC5_COUNT8_PER         (*(RwReg8 *)0x42003414UL) /**< \brief (TC5) COUNT8 Period Value */
+#define REG_TC5_COUNT8_CC0         (*(RwReg8 *)0x42003418UL) /**< \brief (TC5) COUNT8 Compare/Capture 0 */
+#define REG_TC5_COUNT8_CC1         (*(RwReg8 *)0x42003419UL) /**< \brief (TC5) COUNT8 Compare/Capture 1 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for TC5 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/tc6.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/tc6.h
@@ -1,0 +1,96 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC6
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMR21_TC6_INSTANCE_
+#define _SAMR21_TC6_INSTANCE_
+
+/* ========== Register definition for TC6 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC6_CTRLA              (0x42003800) /**< \brief (TC6) Control A */
+#define REG_TC6_READREQ            (0x42003802) /**< \brief (TC6) Read Request */
+#define REG_TC6_CTRLBCLR           (0x42003804) /**< \brief (TC6) Control B Clear */
+#define REG_TC6_CTRLBSET           (0x42003805) /**< \brief (TC6) Control B Set */
+#define REG_TC6_CTRLC              (0x42003806) /**< \brief (TC6) Control C */
+#define REG_TC6_DBGCTRL            (0x42003808) /**< \brief (TC6) Debug Control */
+#define REG_TC6_EVCTRL             (0x4200380A) /**< \brief (TC6) Event Control */
+#define REG_TC6_INTENCLR           (0x4200380C) /**< \brief (TC6) Interrupt Enable Clear */
+#define REG_TC6_INTENSET           (0x4200380D) /**< \brief (TC6) Interrupt Enable Set */
+#define REG_TC6_INTFLAG            (0x4200380E) /**< \brief (TC6) Interrupt Flag Status and Clear */
+#define REG_TC6_STATUS             (0x4200380F) /**< \brief (TC6) Status */
+#define REG_TC6_COUNT16_COUNT      (0x42003810) /**< \brief (TC6) COUNT16 Counter Value */
+#define REG_TC6_COUNT16_CC0        (0x42003818) /**< \brief (TC6) COUNT16 Compare/Capture 0 */
+#define REG_TC6_COUNT16_CC1        (0x4200381A) /**< \brief (TC6) COUNT16 Compare/Capture 1 */
+#define REG_TC6_COUNT32_COUNT      (0x42003810) /**< \brief (TC6) COUNT32 Counter Value */
+#define REG_TC6_COUNT32_CC0        (0x42003818) /**< \brief (TC6) COUNT32 Compare/Capture 0 */
+#define REG_TC6_COUNT32_CC1        (0x4200381C) /**< \brief (TC6) COUNT32 Compare/Capture 1 */
+#define REG_TC6_COUNT8_COUNT       (0x42003810) /**< \brief (TC6) COUNT8 Counter Value */
+#define REG_TC6_COUNT8_PER         (0x42003814) /**< \brief (TC6) COUNT8 Period Value */
+#define REG_TC6_COUNT8_CC0         (0x42003818) /**< \brief (TC6) COUNT8 Compare/Capture 0 */
+#define REG_TC6_COUNT8_CC1         (0x42003819) /**< \brief (TC6) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC6_CTRLA              (*(RwReg16*)0x42003800UL) /**< \brief (TC6) Control A */
+#define REG_TC6_READREQ            (*(RwReg16*)0x42003802UL) /**< \brief (TC6) Read Request */
+#define REG_TC6_CTRLBCLR           (*(RwReg8 *)0x42003804UL) /**< \brief (TC6) Control B Clear */
+#define REG_TC6_CTRLBSET           (*(RwReg8 *)0x42003805UL) /**< \brief (TC6) Control B Set */
+#define REG_TC6_CTRLC              (*(RwReg8 *)0x42003806UL) /**< \brief (TC6) Control C */
+#define REG_TC6_DBGCTRL            (*(RwReg8 *)0x42003808UL) /**< \brief (TC6) Debug Control */
+#define REG_TC6_EVCTRL             (*(RwReg16*)0x4200380AUL) /**< \brief (TC6) Event Control */
+#define REG_TC6_INTENCLR           (*(RwReg8 *)0x4200380CUL) /**< \brief (TC6) Interrupt Enable Clear */
+#define REG_TC6_INTENSET           (*(RwReg8 *)0x4200380DUL) /**< \brief (TC6) Interrupt Enable Set */
+#define REG_TC6_INTFLAG            (*(RwReg8 *)0x4200380EUL) /**< \brief (TC6) Interrupt Flag Status and Clear */
+#define REG_TC6_STATUS             (*(RoReg8 *)0x4200380FUL) /**< \brief (TC6) Status */
+#define REG_TC6_COUNT16_COUNT      (*(RwReg16*)0x42003810UL) /**< \brief (TC6) COUNT16 Counter Value */
+#define REG_TC6_COUNT16_CC0        (*(RwReg16*)0x42003818UL) /**< \brief (TC6) COUNT16 Compare/Capture 0 */
+#define REG_TC6_COUNT16_CC1        (*(RwReg16*)0x4200381AUL) /**< \brief (TC6) COUNT16 Compare/Capture 1 */
+#define REG_TC6_COUNT32_COUNT      (*(RwReg  *)0x42003810UL) /**< \brief (TC6) COUNT32 Counter Value */
+#define REG_TC6_COUNT32_CC0        (*(RwReg  *)0x42003818UL) /**< \brief (TC6) COUNT32 Compare/Capture 0 */
+#define REG_TC6_COUNT32_CC1        (*(RwReg  *)0x4200381CUL) /**< \brief (TC6) COUNT32 Compare/Capture 1 */
+#define REG_TC6_COUNT8_COUNT       (*(RwReg8 *)0x42003810UL) /**< \brief (TC6) COUNT8 Counter Value */
+#define REG_TC6_COUNT8_PER         (*(RwReg8 *)0x42003814UL) /**< \brief (TC6) COUNT8 Period Value */
+#define REG_TC6_COUNT8_CC0         (*(RwReg8 *)0x42003818UL) /**< \brief (TC6) COUNT8 Compare/Capture 0 */
+#define REG_TC6_COUNT8_CC1         (*(RwReg8 *)0x42003819UL) /**< \brief (TC6) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC6 peripheral ========== */
+#define TC6_CC8_NUM                 2        // Number of 8-bit Counters
+#define TC6_CC16_NUM                2        // Number of 16-bit Counters
+#define TC6_CC32_NUM                2        // Number of 32-bit Counters
+#define TC6_DITHERING_EXT           0        // Dithering feature implemented
+#define TC6_DMAC_ID_MC_0            34
+#define TC6_DMAC_ID_MC_1            35
+#define TC6_DMAC_ID_MC_LSB          34
+#define TC6_DMAC_ID_MC_MSB          35
+#define TC6_DMAC_ID_MC_SIZE         2
+#define TC6_DMAC_ID_OVF             33       // Indexes of DMA Overflow trigger
+#define TC6_GCLK_ID                 29       // Index of Generic Clock
+#define TC6_MASTER                  1       
+#define TC6_OW_NUM                  2        // Number of Output Waveforms
+#define TC6_PERIOD_EXT              0        // Period feature implemented
+#define TC6_SHADOW_EXT              0        // Shadow feature implemented
+
+#endif /* _SAMR21_TC6_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/tc7.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/tc7.h
@@ -1,0 +1,96 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC7
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMR21_TC7_INSTANCE_
+#define _SAMR21_TC7_INSTANCE_
+
+/* ========== Register definition for TC7 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC7_CTRLA              (0x42003C00) /**< \brief (TC7) Control A */
+#define REG_TC7_READREQ            (0x42003C02) /**< \brief (TC7) Read Request */
+#define REG_TC7_CTRLBCLR           (0x42003C04) /**< \brief (TC7) Control B Clear */
+#define REG_TC7_CTRLBSET           (0x42003C05) /**< \brief (TC7) Control B Set */
+#define REG_TC7_CTRLC              (0x42003C06) /**< \brief (TC7) Control C */
+#define REG_TC7_DBGCTRL            (0x42003C08) /**< \brief (TC7) Debug Control */
+#define REG_TC7_EVCTRL             (0x42003C0A) /**< \brief (TC7) Event Control */
+#define REG_TC7_INTENCLR           (0x42003C0C) /**< \brief (TC7) Interrupt Enable Clear */
+#define REG_TC7_INTENSET           (0x42003C0D) /**< \brief (TC7) Interrupt Enable Set */
+#define REG_TC7_INTFLAG            (0x42003C0E) /**< \brief (TC7) Interrupt Flag Status and Clear */
+#define REG_TC7_STATUS             (0x42003C0F) /**< \brief (TC7) Status */
+#define REG_TC7_COUNT16_COUNT      (0x42003C10) /**< \brief (TC7) COUNT16 Counter Value */
+#define REG_TC7_COUNT16_CC0        (0x42003C18) /**< \brief (TC7) COUNT16 Compare/Capture 0 */
+#define REG_TC7_COUNT16_CC1        (0x42003C1A) /**< \brief (TC7) COUNT16 Compare/Capture 1 */
+#define REG_TC7_COUNT32_COUNT      (0x42003C10) /**< \brief (TC7) COUNT32 Counter Value */
+#define REG_TC7_COUNT32_CC0        (0x42003C18) /**< \brief (TC7) COUNT32 Compare/Capture 0 */
+#define REG_TC7_COUNT32_CC1        (0x42003C1C) /**< \brief (TC7) COUNT32 Compare/Capture 1 */
+#define REG_TC7_COUNT8_COUNT       (0x42003C10) /**< \brief (TC7) COUNT8 Counter Value */
+#define REG_TC7_COUNT8_PER         (0x42003C14) /**< \brief (TC7) COUNT8 Period Value */
+#define REG_TC7_COUNT8_CC0         (0x42003C18) /**< \brief (TC7) COUNT8 Compare/Capture 0 */
+#define REG_TC7_COUNT8_CC1         (0x42003C19) /**< \brief (TC7) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC7_CTRLA              (*(RwReg16*)0x42003C00UL) /**< \brief (TC7) Control A */
+#define REG_TC7_READREQ            (*(RwReg16*)0x42003C02UL) /**< \brief (TC7) Read Request */
+#define REG_TC7_CTRLBCLR           (*(RwReg8 *)0x42003C04UL) /**< \brief (TC7) Control B Clear */
+#define REG_TC7_CTRLBSET           (*(RwReg8 *)0x42003C05UL) /**< \brief (TC7) Control B Set */
+#define REG_TC7_CTRLC              (*(RwReg8 *)0x42003C06UL) /**< \brief (TC7) Control C */
+#define REG_TC7_DBGCTRL            (*(RwReg8 *)0x42003C08UL) /**< \brief (TC7) Debug Control */
+#define REG_TC7_EVCTRL             (*(RwReg16*)0x42003C0AUL) /**< \brief (TC7) Event Control */
+#define REG_TC7_INTENCLR           (*(RwReg8 *)0x42003C0CUL) /**< \brief (TC7) Interrupt Enable Clear */
+#define REG_TC7_INTENSET           (*(RwReg8 *)0x42003C0DUL) /**< \brief (TC7) Interrupt Enable Set */
+#define REG_TC7_INTFLAG            (*(RwReg8 *)0x42003C0EUL) /**< \brief (TC7) Interrupt Flag Status and Clear */
+#define REG_TC7_STATUS             (*(RoReg8 *)0x42003C0FUL) /**< \brief (TC7) Status */
+#define REG_TC7_COUNT16_COUNT      (*(RwReg16*)0x42003C10UL) /**< \brief (TC7) COUNT16 Counter Value */
+#define REG_TC7_COUNT16_CC0        (*(RwReg16*)0x42003C18UL) /**< \brief (TC7) COUNT16 Compare/Capture 0 */
+#define REG_TC7_COUNT16_CC1        (*(RwReg16*)0x42003C1AUL) /**< \brief (TC7) COUNT16 Compare/Capture 1 */
+#define REG_TC7_COUNT32_COUNT      (*(RwReg  *)0x42003C10UL) /**< \brief (TC7) COUNT32 Counter Value */
+#define REG_TC7_COUNT32_CC0        (*(RwReg  *)0x42003C18UL) /**< \brief (TC7) COUNT32 Compare/Capture 0 */
+#define REG_TC7_COUNT32_CC1        (*(RwReg  *)0x42003C1CUL) /**< \brief (TC7) COUNT32 Compare/Capture 1 */
+#define REG_TC7_COUNT8_COUNT       (*(RwReg8 *)0x42003C10UL) /**< \brief (TC7) COUNT8 Counter Value */
+#define REG_TC7_COUNT8_PER         (*(RwReg8 *)0x42003C14UL) /**< \brief (TC7) COUNT8 Period Value */
+#define REG_TC7_COUNT8_CC0         (*(RwReg8 *)0x42003C18UL) /**< \brief (TC7) COUNT8 Compare/Capture 0 */
+#define REG_TC7_COUNT8_CC1         (*(RwReg8 *)0x42003C19UL) /**< \brief (TC7) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC7 peripheral ========== */
+#define TC7_CC8_NUM                 2        // Number of 8-bit Counters
+#define TC7_CC16_NUM                2        // Number of 16-bit Counters
+#define TC7_CC32_NUM                2        // Number of 32-bit Counters
+#define TC7_DITHERING_EXT           0        // Dithering feature implemented
+#define TC7_DMAC_ID_MC_0            37
+#define TC7_DMAC_ID_MC_1            38
+#define TC7_DMAC_ID_MC_LSB          37
+#define TC7_DMAC_ID_MC_MSB          38
+#define TC7_DMAC_ID_MC_SIZE         2
+#define TC7_DMAC_ID_OVF             36       // Indexes of DMA Overflow trigger
+#define TC7_GCLK_ID                 29       // Index of Generic Clock
+#define TC7_MASTER                  0       
+#define TC7_OW_NUM                  2        // Number of Output Waveforms
+#define TC7_PERIOD_EXT              0        // Period feature implemented
+#define TC7_SHADOW_EXT              0        // Shadow feature implemented
+
+#endif /* _SAMR21_TC7_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/tcc0.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/tcc0.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for TCC0
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,65 +31,65 @@
 
 /* ========== Register definition for TCC0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_TCC0_CTRLA             (0x42002000U) /**< \brief (TCC0) Control A */
-#define REG_TCC0_CTRLBCLR          (0x42002004U) /**< \brief (TCC0) Control B Clear */
-#define REG_TCC0_CTRLBSET          (0x42002005U) /**< \brief (TCC0) Control B Set */
-#define REG_TCC0_SYNCBUSY          (0x42002008U) /**< \brief (TCC0) Synchronization Busy */
-#define REG_TCC0_FCTRLA            (0x4200200CU) /**< \brief (TCC0) Recoverable Fault A Configuration */
-#define REG_TCC0_FCTRLB            (0x42002010U) /**< \brief (TCC0) Recoverable Fault B Configuration */
-#define REG_TCC0_WEXCTRL           (0x42002014U) /**< \brief (TCC0) Waveform Extension Configuration */
-#define REG_TCC0_DRVCTRL           (0x42002018U) /**< \brief (TCC0) Driver Control */
-#define REG_TCC0_DBGCTRL           (0x4200201EU) /**< \brief (TCC0) Debug Control */
-#define REG_TCC0_EVCTRL            (0x42002020U) /**< \brief (TCC0) Event Control */
-#define REG_TCC0_INTENCLR          (0x42002024U) /**< \brief (TCC0) Interrupt Enable Clear */
-#define REG_TCC0_INTENSET          (0x42002028U) /**< \brief (TCC0) Interrupt Enable Set */
-#define REG_TCC0_INTFLAG           (0x4200202CU) /**< \brief (TCC0) Interrupt Flag Status and Clear */
-#define REG_TCC0_STATUS            (0x42002030U) /**< \brief (TCC0) Status */
-#define REG_TCC0_COUNT             (0x42002034U) /**< \brief (TCC0) Count */
-#define REG_TCC0_PATT              (0x42002038U) /**< \brief (TCC0) Pattern */
-#define REG_TCC0_WAVE              (0x4200203CU) /**< \brief (TCC0) Waveform Control */
-#define REG_TCC0_PER               (0x42002040U) /**< \brief (TCC0) Period */
-#define REG_TCC0_CC0               (0x42002044U) /**< \brief (TCC0) Compare and Capture 0 */
-#define REG_TCC0_CC1               (0x42002048U) /**< \brief (TCC0) Compare and Capture 1 */
-#define REG_TCC0_CC2               (0x4200204CU) /**< \brief (TCC0) Compare and Capture 2 */
-#define REG_TCC0_CC3               (0x42002050U) /**< \brief (TCC0) Compare and Capture 3 */
-#define REG_TCC0_PATTB             (0x42002064U) /**< \brief (TCC0) Pattern Buffer */
-#define REG_TCC0_WAVEB             (0x42002068U) /**< \brief (TCC0) Waveform Control Buffer */
-#define REG_TCC0_PERB              (0x4200206CU) /**< \brief (TCC0) Period Buffer */
-#define REG_TCC0_CCB0              (0x42002070U) /**< \brief (TCC0) Compare and Capture Buffer 0 */
-#define REG_TCC0_CCB1              (0x42002074U) /**< \brief (TCC0) Compare and Capture Buffer 1 */
-#define REG_TCC0_CCB2              (0x42002078U) /**< \brief (TCC0) Compare and Capture Buffer 2 */
-#define REG_TCC0_CCB3              (0x4200207CU) /**< \brief (TCC0) Compare and Capture Buffer 3 */
+#define REG_TCC0_CTRLA             (0x42002000) /**< \brief (TCC0) Control A */
+#define REG_TCC0_CTRLBCLR          (0x42002004) /**< \brief (TCC0) Control B Clear */
+#define REG_TCC0_CTRLBSET          (0x42002005) /**< \brief (TCC0) Control B Set */
+#define REG_TCC0_SYNCBUSY          (0x42002008) /**< \brief (TCC0) Synchronization Busy */
+#define REG_TCC0_FCTRLA            (0x4200200C) /**< \brief (TCC0) Recoverable Fault A Configuration */
+#define REG_TCC0_FCTRLB            (0x42002010) /**< \brief (TCC0) Recoverable Fault B Configuration */
+#define REG_TCC0_WEXCTRL           (0x42002014) /**< \brief (TCC0) Waveform Extension Configuration */
+#define REG_TCC0_DRVCTRL           (0x42002018) /**< \brief (TCC0) Driver Control */
+#define REG_TCC0_DBGCTRL           (0x4200201E) /**< \brief (TCC0) Debug Control */
+#define REG_TCC0_EVCTRL            (0x42002020) /**< \brief (TCC0) Event Control */
+#define REG_TCC0_INTENCLR          (0x42002024) /**< \brief (TCC0) Interrupt Enable Clear */
+#define REG_TCC0_INTENSET          (0x42002028) /**< \brief (TCC0) Interrupt Enable Set */
+#define REG_TCC0_INTFLAG           (0x4200202C) /**< \brief (TCC0) Interrupt Flag Status and Clear */
+#define REG_TCC0_STATUS            (0x42002030) /**< \brief (TCC0) Status */
+#define REG_TCC0_COUNT             (0x42002034) /**< \brief (TCC0) Count */
+#define REG_TCC0_PATT              (0x42002038) /**< \brief (TCC0) Pattern */
+#define REG_TCC0_WAVE              (0x4200203C) /**< \brief (TCC0) Waveform Control */
+#define REG_TCC0_PER               (0x42002040) /**< \brief (TCC0) Period */
+#define REG_TCC0_CC0               (0x42002044) /**< \brief (TCC0) Compare and Capture 0 */
+#define REG_TCC0_CC1               (0x42002048) /**< \brief (TCC0) Compare and Capture 1 */
+#define REG_TCC0_CC2               (0x4200204C) /**< \brief (TCC0) Compare and Capture 2 */
+#define REG_TCC0_CC3               (0x42002050) /**< \brief (TCC0) Compare and Capture 3 */
+#define REG_TCC0_PATTB             (0x42002064) /**< \brief (TCC0) Pattern Buffer */
+#define REG_TCC0_WAVEB             (0x42002068) /**< \brief (TCC0) Waveform Control Buffer */
+#define REG_TCC0_PERB              (0x4200206C) /**< \brief (TCC0) Period Buffer */
+#define REG_TCC0_CCB0              (0x42002070) /**< \brief (TCC0) Compare and Capture Buffer 0 */
+#define REG_TCC0_CCB1              (0x42002074) /**< \brief (TCC0) Compare and Capture Buffer 1 */
+#define REG_TCC0_CCB2              (0x42002078) /**< \brief (TCC0) Compare and Capture Buffer 2 */
+#define REG_TCC0_CCB3              (0x4200207C) /**< \brief (TCC0) Compare and Capture Buffer 3 */
 #else
-#define REG_TCC0_CTRLA             (*(RwReg  *)0x42002000U) /**< \brief (TCC0) Control A */
-#define REG_TCC0_CTRLBCLR          (*(RwReg8 *)0x42002004U) /**< \brief (TCC0) Control B Clear */
-#define REG_TCC0_CTRLBSET          (*(RwReg8 *)0x42002005U) /**< \brief (TCC0) Control B Set */
-#define REG_TCC0_SYNCBUSY          (*(RoReg  *)0x42002008U) /**< \brief (TCC0) Synchronization Busy */
-#define REG_TCC0_FCTRLA            (*(RwReg  *)0x4200200CU) /**< \brief (TCC0) Recoverable Fault A Configuration */
-#define REG_TCC0_FCTRLB            (*(RwReg  *)0x42002010U) /**< \brief (TCC0) Recoverable Fault B Configuration */
-#define REG_TCC0_WEXCTRL           (*(RwReg  *)0x42002014U) /**< \brief (TCC0) Waveform Extension Configuration */
-#define REG_TCC0_DRVCTRL           (*(RwReg  *)0x42002018U) /**< \brief (TCC0) Driver Control */
-#define REG_TCC0_DBGCTRL           (*(RwReg8 *)0x4200201EU) /**< \brief (TCC0) Debug Control */
-#define REG_TCC0_EVCTRL            (*(RwReg  *)0x42002020U) /**< \brief (TCC0) Event Control */
-#define REG_TCC0_INTENCLR          (*(RwReg  *)0x42002024U) /**< \brief (TCC0) Interrupt Enable Clear */
-#define REG_TCC0_INTENSET          (*(RwReg  *)0x42002028U) /**< \brief (TCC0) Interrupt Enable Set */
-#define REG_TCC0_INTFLAG           (*(RwReg  *)0x4200202CU) /**< \brief (TCC0) Interrupt Flag Status and Clear */
-#define REG_TCC0_STATUS            (*(RwReg  *)0x42002030U) /**< \brief (TCC0) Status */
-#define REG_TCC0_COUNT             (*(RwReg  *)0x42002034U) /**< \brief (TCC0) Count */
-#define REG_TCC0_PATT              (*(RwReg16*)0x42002038U) /**< \brief (TCC0) Pattern */
-#define REG_TCC0_WAVE              (*(RwReg  *)0x4200203CU) /**< \brief (TCC0) Waveform Control */
-#define REG_TCC0_PER               (*(RwReg  *)0x42002040U) /**< \brief (TCC0) Period */
-#define REG_TCC0_CC0               (*(RwReg  *)0x42002044U) /**< \brief (TCC0) Compare and Capture 0 */
-#define REG_TCC0_CC1               (*(RwReg  *)0x42002048U) /**< \brief (TCC0) Compare and Capture 1 */
-#define REG_TCC0_CC2               (*(RwReg  *)0x4200204CU) /**< \brief (TCC0) Compare and Capture 2 */
-#define REG_TCC0_CC3               (*(RwReg  *)0x42002050U) /**< \brief (TCC0) Compare and Capture 3 */
-#define REG_TCC0_PATTB             (*(RwReg16*)0x42002064U) /**< \brief (TCC0) Pattern Buffer */
-#define REG_TCC0_WAVEB             (*(RwReg  *)0x42002068U) /**< \brief (TCC0) Waveform Control Buffer */
-#define REG_TCC0_PERB              (*(RwReg  *)0x4200206CU) /**< \brief (TCC0) Period Buffer */
-#define REG_TCC0_CCB0              (*(RwReg  *)0x42002070U) /**< \brief (TCC0) Compare and Capture Buffer 0 */
-#define REG_TCC0_CCB1              (*(RwReg  *)0x42002074U) /**< \brief (TCC0) Compare and Capture Buffer 1 */
-#define REG_TCC0_CCB2              (*(RwReg  *)0x42002078U) /**< \brief (TCC0) Compare and Capture Buffer 2 */
-#define REG_TCC0_CCB3              (*(RwReg  *)0x4200207CU) /**< \brief (TCC0) Compare and Capture Buffer 3 */
+#define REG_TCC0_CTRLA             (*(RwReg  *)0x42002000UL) /**< \brief (TCC0) Control A */
+#define REG_TCC0_CTRLBCLR          (*(RwReg8 *)0x42002004UL) /**< \brief (TCC0) Control B Clear */
+#define REG_TCC0_CTRLBSET          (*(RwReg8 *)0x42002005UL) /**< \brief (TCC0) Control B Set */
+#define REG_TCC0_SYNCBUSY          (*(RoReg  *)0x42002008UL) /**< \brief (TCC0) Synchronization Busy */
+#define REG_TCC0_FCTRLA            (*(RwReg  *)0x4200200CUL) /**< \brief (TCC0) Recoverable Fault A Configuration */
+#define REG_TCC0_FCTRLB            (*(RwReg  *)0x42002010UL) /**< \brief (TCC0) Recoverable Fault B Configuration */
+#define REG_TCC0_WEXCTRL           (*(RwReg  *)0x42002014UL) /**< \brief (TCC0) Waveform Extension Configuration */
+#define REG_TCC0_DRVCTRL           (*(RwReg  *)0x42002018UL) /**< \brief (TCC0) Driver Control */
+#define REG_TCC0_DBGCTRL           (*(RwReg8 *)0x4200201EUL) /**< \brief (TCC0) Debug Control */
+#define REG_TCC0_EVCTRL            (*(RwReg  *)0x42002020UL) /**< \brief (TCC0) Event Control */
+#define REG_TCC0_INTENCLR          (*(RwReg  *)0x42002024UL) /**< \brief (TCC0) Interrupt Enable Clear */
+#define REG_TCC0_INTENSET          (*(RwReg  *)0x42002028UL) /**< \brief (TCC0) Interrupt Enable Set */
+#define REG_TCC0_INTFLAG           (*(RwReg  *)0x4200202CUL) /**< \brief (TCC0) Interrupt Flag Status and Clear */
+#define REG_TCC0_STATUS            (*(RwReg  *)0x42002030UL) /**< \brief (TCC0) Status */
+#define REG_TCC0_COUNT             (*(RwReg  *)0x42002034UL) /**< \brief (TCC0) Count */
+#define REG_TCC0_PATT              (*(RwReg16*)0x42002038UL) /**< \brief (TCC0) Pattern */
+#define REG_TCC0_WAVE              (*(RwReg  *)0x4200203CUL) /**< \brief (TCC0) Waveform Control */
+#define REG_TCC0_PER               (*(RwReg  *)0x42002040UL) /**< \brief (TCC0) Period */
+#define REG_TCC0_CC0               (*(RwReg  *)0x42002044UL) /**< \brief (TCC0) Compare and Capture 0 */
+#define REG_TCC0_CC1               (*(RwReg  *)0x42002048UL) /**< \brief (TCC0) Compare and Capture 1 */
+#define REG_TCC0_CC2               (*(RwReg  *)0x4200204CUL) /**< \brief (TCC0) Compare and Capture 2 */
+#define REG_TCC0_CC3               (*(RwReg  *)0x42002050UL) /**< \brief (TCC0) Compare and Capture 3 */
+#define REG_TCC0_PATTB             (*(RwReg16*)0x42002064UL) /**< \brief (TCC0) Pattern Buffer */
+#define REG_TCC0_WAVEB             (*(RwReg  *)0x42002068UL) /**< \brief (TCC0) Waveform Control Buffer */
+#define REG_TCC0_PERB              (*(RwReg  *)0x4200206CUL) /**< \brief (TCC0) Period Buffer */
+#define REG_TCC0_CCB0              (*(RwReg  *)0x42002070UL) /**< \brief (TCC0) Compare and Capture Buffer 0 */
+#define REG_TCC0_CCB1              (*(RwReg  *)0x42002074UL) /**< \brief (TCC0) Compare and Capture Buffer 1 */
+#define REG_TCC0_CCB2              (*(RwReg  *)0x42002078UL) /**< \brief (TCC0) Compare and Capture Buffer 2 */
+#define REG_TCC0_CCB3              (*(RwReg  *)0x4200207CUL) /**< \brief (TCC0) Compare and Capture Buffer 3 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for TCC0 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/tcc1.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/tcc1.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for TCC1
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,55 +31,55 @@
 
 /* ========== Register definition for TCC1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_TCC1_CTRLA             (0x42002400U) /**< \brief (TCC1) Control A */
-#define REG_TCC1_CTRLBCLR          (0x42002404U) /**< \brief (TCC1) Control B Clear */
-#define REG_TCC1_CTRLBSET          (0x42002405U) /**< \brief (TCC1) Control B Set */
-#define REG_TCC1_SYNCBUSY          (0x42002408U) /**< \brief (TCC1) Synchronization Busy */
-#define REG_TCC1_FCTRLA            (0x4200240CU) /**< \brief (TCC1) Recoverable Fault A Configuration */
-#define REG_TCC1_FCTRLB            (0x42002410U) /**< \brief (TCC1) Recoverable Fault B Configuration */
-#define REG_TCC1_DRVCTRL           (0x42002418U) /**< \brief (TCC1) Driver Control */
-#define REG_TCC1_DBGCTRL           (0x4200241EU) /**< \brief (TCC1) Debug Control */
-#define REG_TCC1_EVCTRL            (0x42002420U) /**< \brief (TCC1) Event Control */
-#define REG_TCC1_INTENCLR          (0x42002424U) /**< \brief (TCC1) Interrupt Enable Clear */
-#define REG_TCC1_INTENSET          (0x42002428U) /**< \brief (TCC1) Interrupt Enable Set */
-#define REG_TCC1_INTFLAG           (0x4200242CU) /**< \brief (TCC1) Interrupt Flag Status and Clear */
-#define REG_TCC1_STATUS            (0x42002430U) /**< \brief (TCC1) Status */
-#define REG_TCC1_COUNT             (0x42002434U) /**< \brief (TCC1) Count */
-#define REG_TCC1_PATT              (0x42002438U) /**< \brief (TCC1) Pattern */
-#define REG_TCC1_WAVE              (0x4200243CU) /**< \brief (TCC1) Waveform Control */
-#define REG_TCC1_PER               (0x42002440U) /**< \brief (TCC1) Period */
-#define REG_TCC1_CC0               (0x42002444U) /**< \brief (TCC1) Compare and Capture 0 */
-#define REG_TCC1_CC1               (0x42002448U) /**< \brief (TCC1) Compare and Capture 1 */
-#define REG_TCC1_PATTB             (0x42002464U) /**< \brief (TCC1) Pattern Buffer */
-#define REG_TCC1_WAVEB             (0x42002468U) /**< \brief (TCC1) Waveform Control Buffer */
-#define REG_TCC1_PERB              (0x4200246CU) /**< \brief (TCC1) Period Buffer */
-#define REG_TCC1_CCB0              (0x42002470U) /**< \brief (TCC1) Compare and Capture Buffer 0 */
-#define REG_TCC1_CCB1              (0x42002474U) /**< \brief (TCC1) Compare and Capture Buffer 1 */
+#define REG_TCC1_CTRLA             (0x42002400) /**< \brief (TCC1) Control A */
+#define REG_TCC1_CTRLBCLR          (0x42002404) /**< \brief (TCC1) Control B Clear */
+#define REG_TCC1_CTRLBSET          (0x42002405) /**< \brief (TCC1) Control B Set */
+#define REG_TCC1_SYNCBUSY          (0x42002408) /**< \brief (TCC1) Synchronization Busy */
+#define REG_TCC1_FCTRLA            (0x4200240C) /**< \brief (TCC1) Recoverable Fault A Configuration */
+#define REG_TCC1_FCTRLB            (0x42002410) /**< \brief (TCC1) Recoverable Fault B Configuration */
+#define REG_TCC1_DRVCTRL           (0x42002418) /**< \brief (TCC1) Driver Control */
+#define REG_TCC1_DBGCTRL           (0x4200241E) /**< \brief (TCC1) Debug Control */
+#define REG_TCC1_EVCTRL            (0x42002420) /**< \brief (TCC1) Event Control */
+#define REG_TCC1_INTENCLR          (0x42002424) /**< \brief (TCC1) Interrupt Enable Clear */
+#define REG_TCC1_INTENSET          (0x42002428) /**< \brief (TCC1) Interrupt Enable Set */
+#define REG_TCC1_INTFLAG           (0x4200242C) /**< \brief (TCC1) Interrupt Flag Status and Clear */
+#define REG_TCC1_STATUS            (0x42002430) /**< \brief (TCC1) Status */
+#define REG_TCC1_COUNT             (0x42002434) /**< \brief (TCC1) Count */
+#define REG_TCC1_PATT              (0x42002438) /**< \brief (TCC1) Pattern */
+#define REG_TCC1_WAVE              (0x4200243C) /**< \brief (TCC1) Waveform Control */
+#define REG_TCC1_PER               (0x42002440) /**< \brief (TCC1) Period */
+#define REG_TCC1_CC0               (0x42002444) /**< \brief (TCC1) Compare and Capture 0 */
+#define REG_TCC1_CC1               (0x42002448) /**< \brief (TCC1) Compare and Capture 1 */
+#define REG_TCC1_PATTB             (0x42002464) /**< \brief (TCC1) Pattern Buffer */
+#define REG_TCC1_WAVEB             (0x42002468) /**< \brief (TCC1) Waveform Control Buffer */
+#define REG_TCC1_PERB              (0x4200246C) /**< \brief (TCC1) Period Buffer */
+#define REG_TCC1_CCB0              (0x42002470) /**< \brief (TCC1) Compare and Capture Buffer 0 */
+#define REG_TCC1_CCB1              (0x42002474) /**< \brief (TCC1) Compare and Capture Buffer 1 */
 #else
-#define REG_TCC1_CTRLA             (*(RwReg  *)0x42002400U) /**< \brief (TCC1) Control A */
-#define REG_TCC1_CTRLBCLR          (*(RwReg8 *)0x42002404U) /**< \brief (TCC1) Control B Clear */
-#define REG_TCC1_CTRLBSET          (*(RwReg8 *)0x42002405U) /**< \brief (TCC1) Control B Set */
-#define REG_TCC1_SYNCBUSY          (*(RoReg  *)0x42002408U) /**< \brief (TCC1) Synchronization Busy */
-#define REG_TCC1_FCTRLA            (*(RwReg  *)0x4200240CU) /**< \brief (TCC1) Recoverable Fault A Configuration */
-#define REG_TCC1_FCTRLB            (*(RwReg  *)0x42002410U) /**< \brief (TCC1) Recoverable Fault B Configuration */
-#define REG_TCC1_DRVCTRL           (*(RwReg  *)0x42002418U) /**< \brief (TCC1) Driver Control */
-#define REG_TCC1_DBGCTRL           (*(RwReg8 *)0x4200241EU) /**< \brief (TCC1) Debug Control */
-#define REG_TCC1_EVCTRL            (*(RwReg  *)0x42002420U) /**< \brief (TCC1) Event Control */
-#define REG_TCC1_INTENCLR          (*(RwReg  *)0x42002424U) /**< \brief (TCC1) Interrupt Enable Clear */
-#define REG_TCC1_INTENSET          (*(RwReg  *)0x42002428U) /**< \brief (TCC1) Interrupt Enable Set */
-#define REG_TCC1_INTFLAG           (*(RwReg  *)0x4200242CU) /**< \brief (TCC1) Interrupt Flag Status and Clear */
-#define REG_TCC1_STATUS            (*(RwReg  *)0x42002430U) /**< \brief (TCC1) Status */
-#define REG_TCC1_COUNT             (*(RwReg  *)0x42002434U) /**< \brief (TCC1) Count */
-#define REG_TCC1_PATT              (*(RwReg16*)0x42002438U) /**< \brief (TCC1) Pattern */
-#define REG_TCC1_WAVE              (*(RwReg  *)0x4200243CU) /**< \brief (TCC1) Waveform Control */
-#define REG_TCC1_PER               (*(RwReg  *)0x42002440U) /**< \brief (TCC1) Period */
-#define REG_TCC1_CC0               (*(RwReg  *)0x42002444U) /**< \brief (TCC1) Compare and Capture 0 */
-#define REG_TCC1_CC1               (*(RwReg  *)0x42002448U) /**< \brief (TCC1) Compare and Capture 1 */
-#define REG_TCC1_PATTB             (*(RwReg16*)0x42002464U) /**< \brief (TCC1) Pattern Buffer */
-#define REG_TCC1_WAVEB             (*(RwReg  *)0x42002468U) /**< \brief (TCC1) Waveform Control Buffer */
-#define REG_TCC1_PERB              (*(RwReg  *)0x4200246CU) /**< \brief (TCC1) Period Buffer */
-#define REG_TCC1_CCB0              (*(RwReg  *)0x42002470U) /**< \brief (TCC1) Compare and Capture Buffer 0 */
-#define REG_TCC1_CCB1              (*(RwReg  *)0x42002474U) /**< \brief (TCC1) Compare and Capture Buffer 1 */
+#define REG_TCC1_CTRLA             (*(RwReg  *)0x42002400UL) /**< \brief (TCC1) Control A */
+#define REG_TCC1_CTRLBCLR          (*(RwReg8 *)0x42002404UL) /**< \brief (TCC1) Control B Clear */
+#define REG_TCC1_CTRLBSET          (*(RwReg8 *)0x42002405UL) /**< \brief (TCC1) Control B Set */
+#define REG_TCC1_SYNCBUSY          (*(RoReg  *)0x42002408UL) /**< \brief (TCC1) Synchronization Busy */
+#define REG_TCC1_FCTRLA            (*(RwReg  *)0x4200240CUL) /**< \brief (TCC1) Recoverable Fault A Configuration */
+#define REG_TCC1_FCTRLB            (*(RwReg  *)0x42002410UL) /**< \brief (TCC1) Recoverable Fault B Configuration */
+#define REG_TCC1_DRVCTRL           (*(RwReg  *)0x42002418UL) /**< \brief (TCC1) Driver Control */
+#define REG_TCC1_DBGCTRL           (*(RwReg8 *)0x4200241EUL) /**< \brief (TCC1) Debug Control */
+#define REG_TCC1_EVCTRL            (*(RwReg  *)0x42002420UL) /**< \brief (TCC1) Event Control */
+#define REG_TCC1_INTENCLR          (*(RwReg  *)0x42002424UL) /**< \brief (TCC1) Interrupt Enable Clear */
+#define REG_TCC1_INTENSET          (*(RwReg  *)0x42002428UL) /**< \brief (TCC1) Interrupt Enable Set */
+#define REG_TCC1_INTFLAG           (*(RwReg  *)0x4200242CUL) /**< \brief (TCC1) Interrupt Flag Status and Clear */
+#define REG_TCC1_STATUS            (*(RwReg  *)0x42002430UL) /**< \brief (TCC1) Status */
+#define REG_TCC1_COUNT             (*(RwReg  *)0x42002434UL) /**< \brief (TCC1) Count */
+#define REG_TCC1_PATT              (*(RwReg16*)0x42002438UL) /**< \brief (TCC1) Pattern */
+#define REG_TCC1_WAVE              (*(RwReg  *)0x4200243CUL) /**< \brief (TCC1) Waveform Control */
+#define REG_TCC1_PER               (*(RwReg  *)0x42002440UL) /**< \brief (TCC1) Period */
+#define REG_TCC1_CC0               (*(RwReg  *)0x42002444UL) /**< \brief (TCC1) Compare and Capture 0 */
+#define REG_TCC1_CC1               (*(RwReg  *)0x42002448UL) /**< \brief (TCC1) Compare and Capture 1 */
+#define REG_TCC1_PATTB             (*(RwReg16*)0x42002464UL) /**< \brief (TCC1) Pattern Buffer */
+#define REG_TCC1_WAVEB             (*(RwReg  *)0x42002468UL) /**< \brief (TCC1) Waveform Control Buffer */
+#define REG_TCC1_PERB              (*(RwReg  *)0x4200246CUL) /**< \brief (TCC1) Period Buffer */
+#define REG_TCC1_CCB0              (*(RwReg  *)0x42002470UL) /**< \brief (TCC1) Compare and Capture Buffer 0 */
+#define REG_TCC1_CCB1              (*(RwReg  *)0x42002474UL) /**< \brief (TCC1) Compare and Capture Buffer 1 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for TCC1 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/tcc2.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/tcc2.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for TCC2
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,51 +31,51 @@
 
 /* ========== Register definition for TCC2 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_TCC2_CTRLA             (0x42002800U) /**< \brief (TCC2) Control A */
-#define REG_TCC2_CTRLBCLR          (0x42002804U) /**< \brief (TCC2) Control B Clear */
-#define REG_TCC2_CTRLBSET          (0x42002805U) /**< \brief (TCC2) Control B Set */
-#define REG_TCC2_SYNCBUSY          (0x42002808U) /**< \brief (TCC2) Synchronization Busy */
-#define REG_TCC2_FCTRLA            (0x4200280CU) /**< \brief (TCC2) Recoverable Fault A Configuration */
-#define REG_TCC2_FCTRLB            (0x42002810U) /**< \brief (TCC2) Recoverable Fault B Configuration */
-#define REG_TCC2_DRVCTRL           (0x42002818U) /**< \brief (TCC2) Driver Control */
-#define REG_TCC2_DBGCTRL           (0x4200281EU) /**< \brief (TCC2) Debug Control */
-#define REG_TCC2_EVCTRL            (0x42002820U) /**< \brief (TCC2) Event Control */
-#define REG_TCC2_INTENCLR          (0x42002824U) /**< \brief (TCC2) Interrupt Enable Clear */
-#define REG_TCC2_INTENSET          (0x42002828U) /**< \brief (TCC2) Interrupt Enable Set */
-#define REG_TCC2_INTFLAG           (0x4200282CU) /**< \brief (TCC2) Interrupt Flag Status and Clear */
-#define REG_TCC2_STATUS            (0x42002830U) /**< \brief (TCC2) Status */
-#define REG_TCC2_COUNT             (0x42002834U) /**< \brief (TCC2) Count */
-#define REG_TCC2_WAVE              (0x4200283CU) /**< \brief (TCC2) Waveform Control */
-#define REG_TCC2_PER               (0x42002840U) /**< \brief (TCC2) Period */
-#define REG_TCC2_CC0               (0x42002844U) /**< \brief (TCC2) Compare and Capture 0 */
-#define REG_TCC2_CC1               (0x42002848U) /**< \brief (TCC2) Compare and Capture 1 */
-#define REG_TCC2_WAVEB             (0x42002868U) /**< \brief (TCC2) Waveform Control Buffer */
-#define REG_TCC2_PERB              (0x4200286CU) /**< \brief (TCC2) Period Buffer */
-#define REG_TCC2_CCB0              (0x42002870U) /**< \brief (TCC2) Compare and Capture Buffer 0 */
-#define REG_TCC2_CCB1              (0x42002874U) /**< \brief (TCC2) Compare and Capture Buffer 1 */
+#define REG_TCC2_CTRLA             (0x42002800) /**< \brief (TCC2) Control A */
+#define REG_TCC2_CTRLBCLR          (0x42002804) /**< \brief (TCC2) Control B Clear */
+#define REG_TCC2_CTRLBSET          (0x42002805) /**< \brief (TCC2) Control B Set */
+#define REG_TCC2_SYNCBUSY          (0x42002808) /**< \brief (TCC2) Synchronization Busy */
+#define REG_TCC2_FCTRLA            (0x4200280C) /**< \brief (TCC2) Recoverable Fault A Configuration */
+#define REG_TCC2_FCTRLB            (0x42002810) /**< \brief (TCC2) Recoverable Fault B Configuration */
+#define REG_TCC2_DRVCTRL           (0x42002818) /**< \brief (TCC2) Driver Control */
+#define REG_TCC2_DBGCTRL           (0x4200281E) /**< \brief (TCC2) Debug Control */
+#define REG_TCC2_EVCTRL            (0x42002820) /**< \brief (TCC2) Event Control */
+#define REG_TCC2_INTENCLR          (0x42002824) /**< \brief (TCC2) Interrupt Enable Clear */
+#define REG_TCC2_INTENSET          (0x42002828) /**< \brief (TCC2) Interrupt Enable Set */
+#define REG_TCC2_INTFLAG           (0x4200282C) /**< \brief (TCC2) Interrupt Flag Status and Clear */
+#define REG_TCC2_STATUS            (0x42002830) /**< \brief (TCC2) Status */
+#define REG_TCC2_COUNT             (0x42002834) /**< \brief (TCC2) Count */
+#define REG_TCC2_WAVE              (0x4200283C) /**< \brief (TCC2) Waveform Control */
+#define REG_TCC2_PER               (0x42002840) /**< \brief (TCC2) Period */
+#define REG_TCC2_CC0               (0x42002844) /**< \brief (TCC2) Compare and Capture 0 */
+#define REG_TCC2_CC1               (0x42002848) /**< \brief (TCC2) Compare and Capture 1 */
+#define REG_TCC2_WAVEB             (0x42002868) /**< \brief (TCC2) Waveform Control Buffer */
+#define REG_TCC2_PERB              (0x4200286C) /**< \brief (TCC2) Period Buffer */
+#define REG_TCC2_CCB0              (0x42002870) /**< \brief (TCC2) Compare and Capture Buffer 0 */
+#define REG_TCC2_CCB1              (0x42002874) /**< \brief (TCC2) Compare and Capture Buffer 1 */
 #else
-#define REG_TCC2_CTRLA             (*(RwReg  *)0x42002800U) /**< \brief (TCC2) Control A */
-#define REG_TCC2_CTRLBCLR          (*(RwReg8 *)0x42002804U) /**< \brief (TCC2) Control B Clear */
-#define REG_TCC2_CTRLBSET          (*(RwReg8 *)0x42002805U) /**< \brief (TCC2) Control B Set */
-#define REG_TCC2_SYNCBUSY          (*(RoReg  *)0x42002808U) /**< \brief (TCC2) Synchronization Busy */
-#define REG_TCC2_FCTRLA            (*(RwReg  *)0x4200280CU) /**< \brief (TCC2) Recoverable Fault A Configuration */
-#define REG_TCC2_FCTRLB            (*(RwReg  *)0x42002810U) /**< \brief (TCC2) Recoverable Fault B Configuration */
-#define REG_TCC2_DRVCTRL           (*(RwReg  *)0x42002818U) /**< \brief (TCC2) Driver Control */
-#define REG_TCC2_DBGCTRL           (*(RwReg8 *)0x4200281EU) /**< \brief (TCC2) Debug Control */
-#define REG_TCC2_EVCTRL            (*(RwReg  *)0x42002820U) /**< \brief (TCC2) Event Control */
-#define REG_TCC2_INTENCLR          (*(RwReg  *)0x42002824U) /**< \brief (TCC2) Interrupt Enable Clear */
-#define REG_TCC2_INTENSET          (*(RwReg  *)0x42002828U) /**< \brief (TCC2) Interrupt Enable Set */
-#define REG_TCC2_INTFLAG           (*(RwReg  *)0x4200282CU) /**< \brief (TCC2) Interrupt Flag Status and Clear */
-#define REG_TCC2_STATUS            (*(RwReg  *)0x42002830U) /**< \brief (TCC2) Status */
-#define REG_TCC2_COUNT             (*(RwReg  *)0x42002834U) /**< \brief (TCC2) Count */
-#define REG_TCC2_WAVE              (*(RwReg  *)0x4200283CU) /**< \brief (TCC2) Waveform Control */
-#define REG_TCC2_PER               (*(RwReg  *)0x42002840U) /**< \brief (TCC2) Period */
-#define REG_TCC2_CC0               (*(RwReg  *)0x42002844U) /**< \brief (TCC2) Compare and Capture 0 */
-#define REG_TCC2_CC1               (*(RwReg  *)0x42002848U) /**< \brief (TCC2) Compare and Capture 1 */
-#define REG_TCC2_WAVEB             (*(RwReg  *)0x42002868U) /**< \brief (TCC2) Waveform Control Buffer */
-#define REG_TCC2_PERB              (*(RwReg  *)0x4200286CU) /**< \brief (TCC2) Period Buffer */
-#define REG_TCC2_CCB0              (*(RwReg  *)0x42002870U) /**< \brief (TCC2) Compare and Capture Buffer 0 */
-#define REG_TCC2_CCB1              (*(RwReg  *)0x42002874U) /**< \brief (TCC2) Compare and Capture Buffer 1 */
+#define REG_TCC2_CTRLA             (*(RwReg  *)0x42002800UL) /**< \brief (TCC2) Control A */
+#define REG_TCC2_CTRLBCLR          (*(RwReg8 *)0x42002804UL) /**< \brief (TCC2) Control B Clear */
+#define REG_TCC2_CTRLBSET          (*(RwReg8 *)0x42002805UL) /**< \brief (TCC2) Control B Set */
+#define REG_TCC2_SYNCBUSY          (*(RoReg  *)0x42002808UL) /**< \brief (TCC2) Synchronization Busy */
+#define REG_TCC2_FCTRLA            (*(RwReg  *)0x4200280CUL) /**< \brief (TCC2) Recoverable Fault A Configuration */
+#define REG_TCC2_FCTRLB            (*(RwReg  *)0x42002810UL) /**< \brief (TCC2) Recoverable Fault B Configuration */
+#define REG_TCC2_DRVCTRL           (*(RwReg  *)0x42002818UL) /**< \brief (TCC2) Driver Control */
+#define REG_TCC2_DBGCTRL           (*(RwReg8 *)0x4200281EUL) /**< \brief (TCC2) Debug Control */
+#define REG_TCC2_EVCTRL            (*(RwReg  *)0x42002820UL) /**< \brief (TCC2) Event Control */
+#define REG_TCC2_INTENCLR          (*(RwReg  *)0x42002824UL) /**< \brief (TCC2) Interrupt Enable Clear */
+#define REG_TCC2_INTENSET          (*(RwReg  *)0x42002828UL) /**< \brief (TCC2) Interrupt Enable Set */
+#define REG_TCC2_INTFLAG           (*(RwReg  *)0x4200282CUL) /**< \brief (TCC2) Interrupt Flag Status and Clear */
+#define REG_TCC2_STATUS            (*(RwReg  *)0x42002830UL) /**< \brief (TCC2) Status */
+#define REG_TCC2_COUNT             (*(RwReg  *)0x42002834UL) /**< \brief (TCC2) Count */
+#define REG_TCC2_WAVE              (*(RwReg  *)0x4200283CUL) /**< \brief (TCC2) Waveform Control */
+#define REG_TCC2_PER               (*(RwReg  *)0x42002840UL) /**< \brief (TCC2) Period */
+#define REG_TCC2_CC0               (*(RwReg  *)0x42002844UL) /**< \brief (TCC2) Compare and Capture 0 */
+#define REG_TCC2_CC1               (*(RwReg  *)0x42002848UL) /**< \brief (TCC2) Compare and Capture 1 */
+#define REG_TCC2_WAVEB             (*(RwReg  *)0x42002868UL) /**< \brief (TCC2) Waveform Control Buffer */
+#define REG_TCC2_PERB              (*(RwReg  *)0x4200286CUL) /**< \brief (TCC2) Period Buffer */
+#define REG_TCC2_CCB0              (*(RwReg  *)0x42002870UL) /**< \brief (TCC2) Compare and Capture Buffer 0 */
+#define REG_TCC2_CCB1              (*(RwReg  *)0x42002874UL) /**< \brief (TCC2) Compare and Capture Buffer 1 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for TCC2 peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/usb.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/usb.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for USB
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,293 +31,293 @@
 
 /* ========== Register definition for USB peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_USB_CTRLA              (0x41005000U) /**< \brief (USB) Control A */
-#define REG_USB_SYNCBUSY           (0x41005002U) /**< \brief (USB) Synchronization Busy */
-#define REG_USB_QOSCTRL            (0x41005003U) /**< \brief (USB) USB Quality Of Service */
-#define REG_USB_FSMSTATUS          (0x4100500DU) /**< \brief (USB) Finite State Machine Status */
-#define REG_USB_DESCADD            (0x41005024U) /**< \brief (USB) Descriptor Address */
-#define REG_USB_PADCAL             (0x41005028U) /**< \brief (USB) USB PAD Calibration */
-#define REG_USB_DEVICE_CTRLB       (0x41005008U) /**< \brief (USB) DEVICE Control B */
-#define REG_USB_DEVICE_DADD        (0x4100500AU) /**< \brief (USB) DEVICE Device Address */
-#define REG_USB_DEVICE_STATUS      (0x4100500CU) /**< \brief (USB) DEVICE Status */
-#define REG_USB_DEVICE_FNUM        (0x41005010U) /**< \brief (USB) DEVICE Device Frame Number */
-#define REG_USB_DEVICE_INTENCLR    (0x41005014U) /**< \brief (USB) DEVICE Device Interrupt Enable Clear */
-#define REG_USB_DEVICE_INTENSET    (0x41005018U) /**< \brief (USB) DEVICE Device Interrupt Enable Set */
-#define REG_USB_DEVICE_INTFLAG     (0x4100501CU) /**< \brief (USB) DEVICE Device Interrupt Flag */
-#define REG_USB_DEVICE_EPINTSMRY   (0x41005020U) /**< \brief (USB) DEVICE End Point Interrupt Summary */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG0 (0x41005100U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR0 (0x41005104U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET0 (0x41005105U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS0 (0x41005106U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG0 (0x41005107U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR0 (0x41005108U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET0 (0x41005109U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG1 (0x41005120U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR1 (0x41005124U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET1 (0x41005125U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS1 (0x41005126U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG1 (0x41005127U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR1 (0x41005128U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET1 (0x41005129U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG2 (0x41005140U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR2 (0x41005144U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET2 (0x41005145U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS2 (0x41005146U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG2 (0x41005147U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR2 (0x41005148U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET2 (0x41005149U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG3 (0x41005160U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR3 (0x41005164U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET3 (0x41005165U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS3 (0x41005166U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG3 (0x41005167U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR3 (0x41005168U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET3 (0x41005169U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG4 (0x41005180U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR4 (0x41005184U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET4 (0x41005185U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS4 (0x41005186U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG4 (0x41005187U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR4 (0x41005188U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET4 (0x41005189U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG5 (0x410051A0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR5 (0x410051A4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET5 (0x410051A5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS5 (0x410051A6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG5 (0x410051A7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR5 (0x410051A8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET5 (0x410051A9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG6 (0x410051C0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR6 (0x410051C4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET6 (0x410051C5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS6 (0x410051C6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG6 (0x410051C7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR6 (0x410051C8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET6 (0x410051C9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG7 (0x410051E0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR7 (0x410051E4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET7 (0x410051E5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS7 (0x410051E6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG7 (0x410051E7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR7 (0x410051E8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET7 (0x410051E9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 7 */
-#define REG_USB_HOST_CTRLB         (0x41005008U) /**< \brief (USB) HOST Control B */
-#define REG_USB_HOST_HSOFC         (0x4100500AU) /**< \brief (USB) HOST Host Start Of Frame Control */
-#define REG_USB_HOST_STATUS        (0x4100500CU) /**< \brief (USB) HOST Status */
-#define REG_USB_HOST_FNUM          (0x41005010U) /**< \brief (USB) HOST Host Frame Number */
-#define REG_USB_HOST_FLENHIGH      (0x41005012U) /**< \brief (USB) HOST Host Frame Length */
-#define REG_USB_HOST_INTENCLR      (0x41005014U) /**< \brief (USB) HOST Host Interrupt Enable Clear */
-#define REG_USB_HOST_INTENSET      (0x41005018U) /**< \brief (USB) HOST Host Interrupt Enable Set */
-#define REG_USB_HOST_INTFLAG       (0x4100501CU) /**< \brief (USB) HOST Host Interrupt Flag */
-#define REG_USB_HOST_PINTSMRY      (0x41005020U) /**< \brief (USB) HOST Pipe Interrupt Summary */
-#define REG_USB_HOST_PIPE_PCFG0    (0x41005100U) /**< \brief (USB) HOST_PIPE End Point Configuration 0 */
-#define REG_USB_HOST_PIPE_BINTERVAL0 (0x41005103U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 0 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR0 (0x41005104U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 0 */
-#define REG_USB_HOST_PIPE_PSTATUSSET0 (0x41005105U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 0 */
-#define REG_USB_HOST_PIPE_PSTATUS0 (0x41005106U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 0 */
-#define REG_USB_HOST_PIPE_PINTFLAG0 (0x41005107U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 0 */
-#define REG_USB_HOST_PIPE_PINTENCLR0 (0x41005108U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 0 */
-#define REG_USB_HOST_PIPE_PINTENSET0 (0x41005109U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 0 */
-#define REG_USB_HOST_PIPE_PCFG1    (0x41005120U) /**< \brief (USB) HOST_PIPE End Point Configuration 1 */
-#define REG_USB_HOST_PIPE_BINTERVAL1 (0x41005123U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 1 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR1 (0x41005124U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 1 */
-#define REG_USB_HOST_PIPE_PSTATUSSET1 (0x41005125U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 1 */
-#define REG_USB_HOST_PIPE_PSTATUS1 (0x41005126U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 1 */
-#define REG_USB_HOST_PIPE_PINTFLAG1 (0x41005127U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 1 */
-#define REG_USB_HOST_PIPE_PINTENCLR1 (0x41005128U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 1 */
-#define REG_USB_HOST_PIPE_PINTENSET1 (0x41005129U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 1 */
-#define REG_USB_HOST_PIPE_PCFG2    (0x41005140U) /**< \brief (USB) HOST_PIPE End Point Configuration 2 */
-#define REG_USB_HOST_PIPE_BINTERVAL2 (0x41005143U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 2 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR2 (0x41005144U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 2 */
-#define REG_USB_HOST_PIPE_PSTATUSSET2 (0x41005145U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 2 */
-#define REG_USB_HOST_PIPE_PSTATUS2 (0x41005146U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 2 */
-#define REG_USB_HOST_PIPE_PINTFLAG2 (0x41005147U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 2 */
-#define REG_USB_HOST_PIPE_PINTENCLR2 (0x41005148U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 2 */
-#define REG_USB_HOST_PIPE_PINTENSET2 (0x41005149U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 2 */
-#define REG_USB_HOST_PIPE_PCFG3    (0x41005160U) /**< \brief (USB) HOST_PIPE End Point Configuration 3 */
-#define REG_USB_HOST_PIPE_BINTERVAL3 (0x41005163U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 3 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR3 (0x41005164U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 3 */
-#define REG_USB_HOST_PIPE_PSTATUSSET3 (0x41005165U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 3 */
-#define REG_USB_HOST_PIPE_PSTATUS3 (0x41005166U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 3 */
-#define REG_USB_HOST_PIPE_PINTFLAG3 (0x41005167U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 3 */
-#define REG_USB_HOST_PIPE_PINTENCLR3 (0x41005168U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 3 */
-#define REG_USB_HOST_PIPE_PINTENSET3 (0x41005169U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 3 */
-#define REG_USB_HOST_PIPE_PCFG4    (0x41005180U) /**< \brief (USB) HOST_PIPE End Point Configuration 4 */
-#define REG_USB_HOST_PIPE_BINTERVAL4 (0x41005183U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 4 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR4 (0x41005184U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 4 */
-#define REG_USB_HOST_PIPE_PSTATUSSET4 (0x41005185U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 4 */
-#define REG_USB_HOST_PIPE_PSTATUS4 (0x41005186U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 4 */
-#define REG_USB_HOST_PIPE_PINTFLAG4 (0x41005187U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 4 */
-#define REG_USB_HOST_PIPE_PINTENCLR4 (0x41005188U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 4 */
-#define REG_USB_HOST_PIPE_PINTENSET4 (0x41005189U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 4 */
-#define REG_USB_HOST_PIPE_PCFG5    (0x410051A0U) /**< \brief (USB) HOST_PIPE End Point Configuration 5 */
-#define REG_USB_HOST_PIPE_BINTERVAL5 (0x410051A3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 5 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR5 (0x410051A4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 5 */
-#define REG_USB_HOST_PIPE_PSTATUSSET5 (0x410051A5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 5 */
-#define REG_USB_HOST_PIPE_PSTATUS5 (0x410051A6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 5 */
-#define REG_USB_HOST_PIPE_PINTFLAG5 (0x410051A7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 5 */
-#define REG_USB_HOST_PIPE_PINTENCLR5 (0x410051A8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 5 */
-#define REG_USB_HOST_PIPE_PINTENSET5 (0x410051A9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 5 */
-#define REG_USB_HOST_PIPE_PCFG6    (0x410051C0U) /**< \brief (USB) HOST_PIPE End Point Configuration 6 */
-#define REG_USB_HOST_PIPE_BINTERVAL6 (0x410051C3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 6 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR6 (0x410051C4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 6 */
-#define REG_USB_HOST_PIPE_PSTATUSSET6 (0x410051C5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 6 */
-#define REG_USB_HOST_PIPE_PSTATUS6 (0x410051C6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 6 */
-#define REG_USB_HOST_PIPE_PINTFLAG6 (0x410051C7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 6 */
-#define REG_USB_HOST_PIPE_PINTENCLR6 (0x410051C8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 6 */
-#define REG_USB_HOST_PIPE_PINTENSET6 (0x410051C9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 6 */
-#define REG_USB_HOST_PIPE_PCFG7    (0x410051E0U) /**< \brief (USB) HOST_PIPE End Point Configuration 7 */
-#define REG_USB_HOST_PIPE_BINTERVAL7 (0x410051E3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 7 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR7 (0x410051E4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 7 */
-#define REG_USB_HOST_PIPE_PSTATUSSET7 (0x410051E5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 7 */
-#define REG_USB_HOST_PIPE_PSTATUS7 (0x410051E6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 7 */
-#define REG_USB_HOST_PIPE_PINTFLAG7 (0x410051E7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 7 */
-#define REG_USB_HOST_PIPE_PINTENCLR7 (0x410051E8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 7 */
-#define REG_USB_HOST_PIPE_PINTENSET7 (0x410051E9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 7 */
+#define REG_USB_CTRLA              (0x41005000) /**< \brief (USB) Control A */
+#define REG_USB_SYNCBUSY           (0x41005002) /**< \brief (USB) Synchronization Busy */
+#define REG_USB_QOSCTRL            (0x41005003) /**< \brief (USB) USB Quality Of Service */
+#define REG_USB_FSMSTATUS          (0x4100500D) /**< \brief (USB) Finite State Machine Status */
+#define REG_USB_DESCADD            (0x41005024) /**< \brief (USB) Descriptor Address */
+#define REG_USB_PADCAL             (0x41005028) /**< \brief (USB) USB PAD Calibration */
+#define REG_USB_DEVICE_CTRLB       (0x41005008) /**< \brief (USB) DEVICE Control B */
+#define REG_USB_DEVICE_DADD        (0x4100500A) /**< \brief (USB) DEVICE Device Address */
+#define REG_USB_DEVICE_STATUS      (0x4100500C) /**< \brief (USB) DEVICE Status */
+#define REG_USB_DEVICE_FNUM        (0x41005010) /**< \brief (USB) DEVICE Device Frame Number */
+#define REG_USB_DEVICE_INTENCLR    (0x41005014) /**< \brief (USB) DEVICE Device Interrupt Enable Clear */
+#define REG_USB_DEVICE_INTENSET    (0x41005018) /**< \brief (USB) DEVICE Device Interrupt Enable Set */
+#define REG_USB_DEVICE_INTFLAG     (0x4100501C) /**< \brief (USB) DEVICE Device Interrupt Flag */
+#define REG_USB_DEVICE_EPINTSMRY   (0x41005020) /**< \brief (USB) DEVICE End Point Interrupt Summary */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG0 (0x41005100) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR0 (0x41005104) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET0 (0x41005105) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS0 (0x41005106) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG0 (0x41005107) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR0 (0x41005108) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET0 (0x41005109) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG1 (0x41005120) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR1 (0x41005124) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET1 (0x41005125) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS1 (0x41005126) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG1 (0x41005127) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR1 (0x41005128) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET1 (0x41005129) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG2 (0x41005140) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR2 (0x41005144) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET2 (0x41005145) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS2 (0x41005146) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG2 (0x41005147) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR2 (0x41005148) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET2 (0x41005149) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG3 (0x41005160) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR3 (0x41005164) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET3 (0x41005165) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS3 (0x41005166) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG3 (0x41005167) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR3 (0x41005168) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET3 (0x41005169) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG4 (0x41005180) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR4 (0x41005184) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET4 (0x41005185) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS4 (0x41005186) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG4 (0x41005187) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR4 (0x41005188) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET4 (0x41005189) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG5 (0x410051A0) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR5 (0x410051A4) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET5 (0x410051A5) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS5 (0x410051A6) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG5 (0x410051A7) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR5 (0x410051A8) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET5 (0x410051A9) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG6 (0x410051C0) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR6 (0x410051C4) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET6 (0x410051C5) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS6 (0x410051C6) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG6 (0x410051C7) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR6 (0x410051C8) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET6 (0x410051C9) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG7 (0x410051E0) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR7 (0x410051E4) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET7 (0x410051E5) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS7 (0x410051E6) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG7 (0x410051E7) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR7 (0x410051E8) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET7 (0x410051E9) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 7 */
+#define REG_USB_HOST_CTRLB         (0x41005008) /**< \brief (USB) HOST Control B */
+#define REG_USB_HOST_HSOFC         (0x4100500A) /**< \brief (USB) HOST Host Start Of Frame Control */
+#define REG_USB_HOST_STATUS        (0x4100500C) /**< \brief (USB) HOST Status */
+#define REG_USB_HOST_FNUM          (0x41005010) /**< \brief (USB) HOST Host Frame Number */
+#define REG_USB_HOST_FLENHIGH      (0x41005012) /**< \brief (USB) HOST Host Frame Length */
+#define REG_USB_HOST_INTENCLR      (0x41005014) /**< \brief (USB) HOST Host Interrupt Enable Clear */
+#define REG_USB_HOST_INTENSET      (0x41005018) /**< \brief (USB) HOST Host Interrupt Enable Set */
+#define REG_USB_HOST_INTFLAG       (0x4100501C) /**< \brief (USB) HOST Host Interrupt Flag */
+#define REG_USB_HOST_PINTSMRY      (0x41005020) /**< \brief (USB) HOST Pipe Interrupt Summary */
+#define REG_USB_HOST_PIPE_PCFG0    (0x41005100) /**< \brief (USB) HOST_PIPE End Point Configuration 0 */
+#define REG_USB_HOST_PIPE_BINTERVAL0 (0x41005103) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 0 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR0 (0x41005104) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 0 */
+#define REG_USB_HOST_PIPE_PSTATUSSET0 (0x41005105) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 0 */
+#define REG_USB_HOST_PIPE_PSTATUS0 (0x41005106) /**< \brief (USB) HOST_PIPE End Point Pipe Status 0 */
+#define REG_USB_HOST_PIPE_PINTFLAG0 (0x41005107) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 0 */
+#define REG_USB_HOST_PIPE_PINTENCLR0 (0x41005108) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 0 */
+#define REG_USB_HOST_PIPE_PINTENSET0 (0x41005109) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 0 */
+#define REG_USB_HOST_PIPE_PCFG1    (0x41005120) /**< \brief (USB) HOST_PIPE End Point Configuration 1 */
+#define REG_USB_HOST_PIPE_BINTERVAL1 (0x41005123) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 1 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR1 (0x41005124) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 1 */
+#define REG_USB_HOST_PIPE_PSTATUSSET1 (0x41005125) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 1 */
+#define REG_USB_HOST_PIPE_PSTATUS1 (0x41005126) /**< \brief (USB) HOST_PIPE End Point Pipe Status 1 */
+#define REG_USB_HOST_PIPE_PINTFLAG1 (0x41005127) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 1 */
+#define REG_USB_HOST_PIPE_PINTENCLR1 (0x41005128) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 1 */
+#define REG_USB_HOST_PIPE_PINTENSET1 (0x41005129) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 1 */
+#define REG_USB_HOST_PIPE_PCFG2    (0x41005140) /**< \brief (USB) HOST_PIPE End Point Configuration 2 */
+#define REG_USB_HOST_PIPE_BINTERVAL2 (0x41005143) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 2 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR2 (0x41005144) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 2 */
+#define REG_USB_HOST_PIPE_PSTATUSSET2 (0x41005145) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 2 */
+#define REG_USB_HOST_PIPE_PSTATUS2 (0x41005146) /**< \brief (USB) HOST_PIPE End Point Pipe Status 2 */
+#define REG_USB_HOST_PIPE_PINTFLAG2 (0x41005147) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 2 */
+#define REG_USB_HOST_PIPE_PINTENCLR2 (0x41005148) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 2 */
+#define REG_USB_HOST_PIPE_PINTENSET2 (0x41005149) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 2 */
+#define REG_USB_HOST_PIPE_PCFG3    (0x41005160) /**< \brief (USB) HOST_PIPE End Point Configuration 3 */
+#define REG_USB_HOST_PIPE_BINTERVAL3 (0x41005163) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 3 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR3 (0x41005164) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 3 */
+#define REG_USB_HOST_PIPE_PSTATUSSET3 (0x41005165) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 3 */
+#define REG_USB_HOST_PIPE_PSTATUS3 (0x41005166) /**< \brief (USB) HOST_PIPE End Point Pipe Status 3 */
+#define REG_USB_HOST_PIPE_PINTFLAG3 (0x41005167) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 3 */
+#define REG_USB_HOST_PIPE_PINTENCLR3 (0x41005168) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 3 */
+#define REG_USB_HOST_PIPE_PINTENSET3 (0x41005169) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 3 */
+#define REG_USB_HOST_PIPE_PCFG4    (0x41005180) /**< \brief (USB) HOST_PIPE End Point Configuration 4 */
+#define REG_USB_HOST_PIPE_BINTERVAL4 (0x41005183) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 4 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR4 (0x41005184) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 4 */
+#define REG_USB_HOST_PIPE_PSTATUSSET4 (0x41005185) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 4 */
+#define REG_USB_HOST_PIPE_PSTATUS4 (0x41005186) /**< \brief (USB) HOST_PIPE End Point Pipe Status 4 */
+#define REG_USB_HOST_PIPE_PINTFLAG4 (0x41005187) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 4 */
+#define REG_USB_HOST_PIPE_PINTENCLR4 (0x41005188) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 4 */
+#define REG_USB_HOST_PIPE_PINTENSET4 (0x41005189) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 4 */
+#define REG_USB_HOST_PIPE_PCFG5    (0x410051A0) /**< \brief (USB) HOST_PIPE End Point Configuration 5 */
+#define REG_USB_HOST_PIPE_BINTERVAL5 (0x410051A3) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 5 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR5 (0x410051A4) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 5 */
+#define REG_USB_HOST_PIPE_PSTATUSSET5 (0x410051A5) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 5 */
+#define REG_USB_HOST_PIPE_PSTATUS5 (0x410051A6) /**< \brief (USB) HOST_PIPE End Point Pipe Status 5 */
+#define REG_USB_HOST_PIPE_PINTFLAG5 (0x410051A7) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 5 */
+#define REG_USB_HOST_PIPE_PINTENCLR5 (0x410051A8) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 5 */
+#define REG_USB_HOST_PIPE_PINTENSET5 (0x410051A9) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 5 */
+#define REG_USB_HOST_PIPE_PCFG6    (0x410051C0) /**< \brief (USB) HOST_PIPE End Point Configuration 6 */
+#define REG_USB_HOST_PIPE_BINTERVAL6 (0x410051C3) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 6 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR6 (0x410051C4) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 6 */
+#define REG_USB_HOST_PIPE_PSTATUSSET6 (0x410051C5) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 6 */
+#define REG_USB_HOST_PIPE_PSTATUS6 (0x410051C6) /**< \brief (USB) HOST_PIPE End Point Pipe Status 6 */
+#define REG_USB_HOST_PIPE_PINTFLAG6 (0x410051C7) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 6 */
+#define REG_USB_HOST_PIPE_PINTENCLR6 (0x410051C8) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 6 */
+#define REG_USB_HOST_PIPE_PINTENSET6 (0x410051C9) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 6 */
+#define REG_USB_HOST_PIPE_PCFG7    (0x410051E0) /**< \brief (USB) HOST_PIPE End Point Configuration 7 */
+#define REG_USB_HOST_PIPE_BINTERVAL7 (0x410051E3) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 7 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR7 (0x410051E4) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 7 */
+#define REG_USB_HOST_PIPE_PSTATUSSET7 (0x410051E5) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 7 */
+#define REG_USB_HOST_PIPE_PSTATUS7 (0x410051E6) /**< \brief (USB) HOST_PIPE End Point Pipe Status 7 */
+#define REG_USB_HOST_PIPE_PINTFLAG7 (0x410051E7) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 7 */
+#define REG_USB_HOST_PIPE_PINTENCLR7 (0x410051E8) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 7 */
+#define REG_USB_HOST_PIPE_PINTENSET7 (0x410051E9) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 7 */
 #else
-#define REG_USB_CTRLA              (*(RwReg8 *)0x41005000U) /**< \brief (USB) Control A */
-#define REG_USB_SYNCBUSY           (*(RoReg8 *)0x41005002U) /**< \brief (USB) Synchronization Busy */
-#define REG_USB_QOSCTRL            (*(RwReg8 *)0x41005003U) /**< \brief (USB) USB Quality Of Service */
-#define REG_USB_FSMSTATUS          (*(RoReg8 *)0x4100500DU) /**< \brief (USB) Finite State Machine Status */
-#define REG_USB_DESCADD            (*(RwReg  *)0x41005024U) /**< \brief (USB) Descriptor Address */
-#define REG_USB_PADCAL             (*(RwReg16*)0x41005028U) /**< \brief (USB) USB PAD Calibration */
-#define REG_USB_DEVICE_CTRLB       (*(RwReg16*)0x41005008U) /**< \brief (USB) DEVICE Control B */
-#define REG_USB_DEVICE_DADD        (*(RwReg8 *)0x4100500AU) /**< \brief (USB) DEVICE Device Address */
-#define REG_USB_DEVICE_STATUS      (*(RoReg8 *)0x4100500CU) /**< \brief (USB) DEVICE Status */
-#define REG_USB_DEVICE_FNUM        (*(RoReg16*)0x41005010U) /**< \brief (USB) DEVICE Device Frame Number */
-#define REG_USB_DEVICE_INTENCLR    (*(RwReg16*)0x41005014U) /**< \brief (USB) DEVICE Device Interrupt Enable Clear */
-#define REG_USB_DEVICE_INTENSET    (*(RwReg16*)0x41005018U) /**< \brief (USB) DEVICE Device Interrupt Enable Set */
-#define REG_USB_DEVICE_INTFLAG     (*(RwReg16*)0x4100501CU) /**< \brief (USB) DEVICE Device Interrupt Flag */
-#define REG_USB_DEVICE_EPINTSMRY   (*(RoReg16*)0x41005020U) /**< \brief (USB) DEVICE End Point Interrupt Summary */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG0 (*(RwReg8 *)0x41005100U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR0 (*(WoReg8 *)0x41005104U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET0 (*(WoReg8 *)0x41005105U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS0 (*(RoReg8 *)0x41005106U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG0 (*(RwReg8 *)0x41005107U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR0 (*(RwReg8 *)0x41005108U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET0 (*(RwReg8 *)0x41005109U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 0 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG1 (*(RwReg8 *)0x41005120U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR1 (*(WoReg8 *)0x41005124U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET1 (*(WoReg8 *)0x41005125U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS1 (*(RoReg8 *)0x41005126U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG1 (*(RwReg8 *)0x41005127U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR1 (*(RwReg8 *)0x41005128U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET1 (*(RwReg8 *)0x41005129U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 1 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG2 (*(RwReg8 *)0x41005140U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR2 (*(WoReg8 *)0x41005144U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET2 (*(WoReg8 *)0x41005145U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS2 (*(RoReg8 *)0x41005146U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG2 (*(RwReg8 *)0x41005147U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR2 (*(RwReg8 *)0x41005148U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET2 (*(RwReg8 *)0x41005149U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 2 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG3 (*(RwReg8 *)0x41005160U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR3 (*(WoReg8 *)0x41005164U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET3 (*(WoReg8 *)0x41005165U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS3 (*(RoReg8 *)0x41005166U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG3 (*(RwReg8 *)0x41005167U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR3 (*(RwReg8 *)0x41005168U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET3 (*(RwReg8 *)0x41005169U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 3 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG4 (*(RwReg8 *)0x41005180U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR4 (*(WoReg8 *)0x41005184U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET4 (*(WoReg8 *)0x41005185U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS4 (*(RoReg8 *)0x41005186U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG4 (*(RwReg8 *)0x41005187U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR4 (*(RwReg8 *)0x41005188U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET4 (*(RwReg8 *)0x41005189U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 4 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG5 (*(RwReg8 *)0x410051A0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR5 (*(WoReg8 *)0x410051A4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET5 (*(WoReg8 *)0x410051A5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS5 (*(RoReg8 *)0x410051A6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG5 (*(RwReg8 *)0x410051A7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR5 (*(RwReg8 *)0x410051A8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET5 (*(RwReg8 *)0x410051A9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 5 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG6 (*(RwReg8 *)0x410051C0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR6 (*(WoReg8 *)0x410051C4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET6 (*(WoReg8 *)0x410051C5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS6 (*(RoReg8 *)0x410051C6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG6 (*(RwReg8 *)0x410051C7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR6 (*(RwReg8 *)0x410051C8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET6 (*(RwReg8 *)0x410051C9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 6 */
-#define REG_USB_DEVICE_ENDPOINT_EPCFG7 (*(RwReg8 *)0x410051E0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR7 (*(WoReg8 *)0x410051E4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET7 (*(WoReg8 *)0x410051E5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPSTATUS7 (*(RoReg8 *)0x410051E6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG7 (*(RwReg8 *)0x410051E7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR7 (*(RwReg8 *)0x410051E8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 7 */
-#define REG_USB_DEVICE_ENDPOINT_EPINTENSET7 (*(RwReg8 *)0x410051E9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 7 */
-#define REG_USB_HOST_CTRLB         (*(RwReg16*)0x41005008U) /**< \brief (USB) HOST Control B */
-#define REG_USB_HOST_HSOFC         (*(RwReg8 *)0x4100500AU) /**< \brief (USB) HOST Host Start Of Frame Control */
-#define REG_USB_HOST_STATUS        (*(RwReg8 *)0x4100500CU) /**< \brief (USB) HOST Status */
-#define REG_USB_HOST_FNUM          (*(RwReg16*)0x41005010U) /**< \brief (USB) HOST Host Frame Number */
-#define REG_USB_HOST_FLENHIGH      (*(RoReg8 *)0x41005012U) /**< \brief (USB) HOST Host Frame Length */
-#define REG_USB_HOST_INTENCLR      (*(RwReg16*)0x41005014U) /**< \brief (USB) HOST Host Interrupt Enable Clear */
-#define REG_USB_HOST_INTENSET      (*(RwReg16*)0x41005018U) /**< \brief (USB) HOST Host Interrupt Enable Set */
-#define REG_USB_HOST_INTFLAG       (*(RwReg16*)0x4100501CU) /**< \brief (USB) HOST Host Interrupt Flag */
-#define REG_USB_HOST_PINTSMRY      (*(RoReg16*)0x41005020U) /**< \brief (USB) HOST Pipe Interrupt Summary */
-#define REG_USB_HOST_PIPE_PCFG0    (*(RwReg8 *)0x41005100U) /**< \brief (USB) HOST_PIPE End Point Configuration 0 */
-#define REG_USB_HOST_PIPE_BINTERVAL0 (*(RwReg8 *)0x41005103U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 0 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR0 (*(WoReg8 *)0x41005104U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 0 */
-#define REG_USB_HOST_PIPE_PSTATUSSET0 (*(WoReg8 *)0x41005105U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 0 */
-#define REG_USB_HOST_PIPE_PSTATUS0 (*(RoReg8 *)0x41005106U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 0 */
-#define REG_USB_HOST_PIPE_PINTFLAG0 (*(RwReg8 *)0x41005107U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 0 */
-#define REG_USB_HOST_PIPE_PINTENCLR0 (*(RwReg8 *)0x41005108U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 0 */
-#define REG_USB_HOST_PIPE_PINTENSET0 (*(RwReg8 *)0x41005109U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 0 */
-#define REG_USB_HOST_PIPE_PCFG1    (*(RwReg8 *)0x41005120U) /**< \brief (USB) HOST_PIPE End Point Configuration 1 */
-#define REG_USB_HOST_PIPE_BINTERVAL1 (*(RwReg8 *)0x41005123U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 1 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR1 (*(WoReg8 *)0x41005124U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 1 */
-#define REG_USB_HOST_PIPE_PSTATUSSET1 (*(WoReg8 *)0x41005125U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 1 */
-#define REG_USB_HOST_PIPE_PSTATUS1 (*(RoReg8 *)0x41005126U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 1 */
-#define REG_USB_HOST_PIPE_PINTFLAG1 (*(RwReg8 *)0x41005127U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 1 */
-#define REG_USB_HOST_PIPE_PINTENCLR1 (*(RwReg8 *)0x41005128U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 1 */
-#define REG_USB_HOST_PIPE_PINTENSET1 (*(RwReg8 *)0x41005129U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 1 */
-#define REG_USB_HOST_PIPE_PCFG2    (*(RwReg8 *)0x41005140U) /**< \brief (USB) HOST_PIPE End Point Configuration 2 */
-#define REG_USB_HOST_PIPE_BINTERVAL2 (*(RwReg8 *)0x41005143U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 2 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR2 (*(WoReg8 *)0x41005144U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 2 */
-#define REG_USB_HOST_PIPE_PSTATUSSET2 (*(WoReg8 *)0x41005145U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 2 */
-#define REG_USB_HOST_PIPE_PSTATUS2 (*(RoReg8 *)0x41005146U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 2 */
-#define REG_USB_HOST_PIPE_PINTFLAG2 (*(RwReg8 *)0x41005147U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 2 */
-#define REG_USB_HOST_PIPE_PINTENCLR2 (*(RwReg8 *)0x41005148U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 2 */
-#define REG_USB_HOST_PIPE_PINTENSET2 (*(RwReg8 *)0x41005149U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 2 */
-#define REG_USB_HOST_PIPE_PCFG3    (*(RwReg8 *)0x41005160U) /**< \brief (USB) HOST_PIPE End Point Configuration 3 */
-#define REG_USB_HOST_PIPE_BINTERVAL3 (*(RwReg8 *)0x41005163U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 3 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR3 (*(WoReg8 *)0x41005164U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 3 */
-#define REG_USB_HOST_PIPE_PSTATUSSET3 (*(WoReg8 *)0x41005165U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 3 */
-#define REG_USB_HOST_PIPE_PSTATUS3 (*(RoReg8 *)0x41005166U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 3 */
-#define REG_USB_HOST_PIPE_PINTFLAG3 (*(RwReg8 *)0x41005167U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 3 */
-#define REG_USB_HOST_PIPE_PINTENCLR3 (*(RwReg8 *)0x41005168U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 3 */
-#define REG_USB_HOST_PIPE_PINTENSET3 (*(RwReg8 *)0x41005169U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 3 */
-#define REG_USB_HOST_PIPE_PCFG4    (*(RwReg8 *)0x41005180U) /**< \brief (USB) HOST_PIPE End Point Configuration 4 */
-#define REG_USB_HOST_PIPE_BINTERVAL4 (*(RwReg8 *)0x41005183U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 4 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR4 (*(WoReg8 *)0x41005184U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 4 */
-#define REG_USB_HOST_PIPE_PSTATUSSET4 (*(WoReg8 *)0x41005185U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 4 */
-#define REG_USB_HOST_PIPE_PSTATUS4 (*(RoReg8 *)0x41005186U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 4 */
-#define REG_USB_HOST_PIPE_PINTFLAG4 (*(RwReg8 *)0x41005187U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 4 */
-#define REG_USB_HOST_PIPE_PINTENCLR4 (*(RwReg8 *)0x41005188U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 4 */
-#define REG_USB_HOST_PIPE_PINTENSET4 (*(RwReg8 *)0x41005189U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 4 */
-#define REG_USB_HOST_PIPE_PCFG5    (*(RwReg8 *)0x410051A0U) /**< \brief (USB) HOST_PIPE End Point Configuration 5 */
-#define REG_USB_HOST_PIPE_BINTERVAL5 (*(RwReg8 *)0x410051A3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 5 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR5 (*(WoReg8 *)0x410051A4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 5 */
-#define REG_USB_HOST_PIPE_PSTATUSSET5 (*(WoReg8 *)0x410051A5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 5 */
-#define REG_USB_HOST_PIPE_PSTATUS5 (*(RoReg8 *)0x410051A6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 5 */
-#define REG_USB_HOST_PIPE_PINTFLAG5 (*(RwReg8 *)0x410051A7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 5 */
-#define REG_USB_HOST_PIPE_PINTENCLR5 (*(RwReg8 *)0x410051A8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 5 */
-#define REG_USB_HOST_PIPE_PINTENSET5 (*(RwReg8 *)0x410051A9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 5 */
-#define REG_USB_HOST_PIPE_PCFG6    (*(RwReg8 *)0x410051C0U) /**< \brief (USB) HOST_PIPE End Point Configuration 6 */
-#define REG_USB_HOST_PIPE_BINTERVAL6 (*(RwReg8 *)0x410051C3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 6 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR6 (*(WoReg8 *)0x410051C4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 6 */
-#define REG_USB_HOST_PIPE_PSTATUSSET6 (*(WoReg8 *)0x410051C5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 6 */
-#define REG_USB_HOST_PIPE_PSTATUS6 (*(RoReg8 *)0x410051C6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 6 */
-#define REG_USB_HOST_PIPE_PINTFLAG6 (*(RwReg8 *)0x410051C7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 6 */
-#define REG_USB_HOST_PIPE_PINTENCLR6 (*(RwReg8 *)0x410051C8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 6 */
-#define REG_USB_HOST_PIPE_PINTENSET6 (*(RwReg8 *)0x410051C9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 6 */
-#define REG_USB_HOST_PIPE_PCFG7    (*(RwReg8 *)0x410051E0U) /**< \brief (USB) HOST_PIPE End Point Configuration 7 */
-#define REG_USB_HOST_PIPE_BINTERVAL7 (*(RwReg8 *)0x410051E3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 7 */
-#define REG_USB_HOST_PIPE_PSTATUSCLR7 (*(WoReg8 *)0x410051E4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 7 */
-#define REG_USB_HOST_PIPE_PSTATUSSET7 (*(WoReg8 *)0x410051E5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 7 */
-#define REG_USB_HOST_PIPE_PSTATUS7 (*(RoReg8 *)0x410051E6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 7 */
-#define REG_USB_HOST_PIPE_PINTFLAG7 (*(RwReg8 *)0x410051E7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 7 */
-#define REG_USB_HOST_PIPE_PINTENCLR7 (*(RwReg8 *)0x410051E8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 7 */
-#define REG_USB_HOST_PIPE_PINTENSET7 (*(RwReg8 *)0x410051E9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 7 */
+#define REG_USB_CTRLA              (*(RwReg8 *)0x41005000UL) /**< \brief (USB) Control A */
+#define REG_USB_SYNCBUSY           (*(RoReg8 *)0x41005002UL) /**< \brief (USB) Synchronization Busy */
+#define REG_USB_QOSCTRL            (*(RwReg8 *)0x41005003UL) /**< \brief (USB) USB Quality Of Service */
+#define REG_USB_FSMSTATUS          (*(RoReg8 *)0x4100500DUL) /**< \brief (USB) Finite State Machine Status */
+#define REG_USB_DESCADD            (*(RwReg  *)0x41005024UL) /**< \brief (USB) Descriptor Address */
+#define REG_USB_PADCAL             (*(RwReg16*)0x41005028UL) /**< \brief (USB) USB PAD Calibration */
+#define REG_USB_DEVICE_CTRLB       (*(RwReg16*)0x41005008UL) /**< \brief (USB) DEVICE Control B */
+#define REG_USB_DEVICE_DADD        (*(RwReg8 *)0x4100500AUL) /**< \brief (USB) DEVICE Device Address */
+#define REG_USB_DEVICE_STATUS      (*(RoReg8 *)0x4100500CUL) /**< \brief (USB) DEVICE Status */
+#define REG_USB_DEVICE_FNUM        (*(RoReg16*)0x41005010UL) /**< \brief (USB) DEVICE Device Frame Number */
+#define REG_USB_DEVICE_INTENCLR    (*(RwReg16*)0x41005014UL) /**< \brief (USB) DEVICE Device Interrupt Enable Clear */
+#define REG_USB_DEVICE_INTENSET    (*(RwReg16*)0x41005018UL) /**< \brief (USB) DEVICE Device Interrupt Enable Set */
+#define REG_USB_DEVICE_INTFLAG     (*(RwReg16*)0x4100501CUL) /**< \brief (USB) DEVICE Device Interrupt Flag */
+#define REG_USB_DEVICE_EPINTSMRY   (*(RoReg16*)0x41005020UL) /**< \brief (USB) DEVICE End Point Interrupt Summary */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG0 (*(RwReg8 *)0x41005100UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR0 (*(WoReg8 *)0x41005104UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET0 (*(WoReg8 *)0x41005105UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS0 (*(RoReg8 *)0x41005106UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG0 (*(RwReg8 *)0x41005107UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR0 (*(RwReg8 *)0x41005108UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET0 (*(RwReg8 *)0x41005109UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG1 (*(RwReg8 *)0x41005120UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR1 (*(WoReg8 *)0x41005124UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET1 (*(WoReg8 *)0x41005125UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS1 (*(RoReg8 *)0x41005126UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG1 (*(RwReg8 *)0x41005127UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR1 (*(RwReg8 *)0x41005128UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET1 (*(RwReg8 *)0x41005129UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG2 (*(RwReg8 *)0x41005140UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR2 (*(WoReg8 *)0x41005144UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET2 (*(WoReg8 *)0x41005145UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS2 (*(RoReg8 *)0x41005146UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG2 (*(RwReg8 *)0x41005147UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR2 (*(RwReg8 *)0x41005148UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET2 (*(RwReg8 *)0x41005149UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG3 (*(RwReg8 *)0x41005160UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR3 (*(WoReg8 *)0x41005164UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET3 (*(WoReg8 *)0x41005165UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS3 (*(RoReg8 *)0x41005166UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG3 (*(RwReg8 *)0x41005167UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR3 (*(RwReg8 *)0x41005168UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET3 (*(RwReg8 *)0x41005169UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG4 (*(RwReg8 *)0x41005180UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR4 (*(WoReg8 *)0x41005184UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET4 (*(WoReg8 *)0x41005185UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS4 (*(RoReg8 *)0x41005186UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG4 (*(RwReg8 *)0x41005187UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR4 (*(RwReg8 *)0x41005188UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET4 (*(RwReg8 *)0x41005189UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG5 (*(RwReg8 *)0x410051A0UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR5 (*(WoReg8 *)0x410051A4UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET5 (*(WoReg8 *)0x410051A5UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS5 (*(RoReg8 *)0x410051A6UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG5 (*(RwReg8 *)0x410051A7UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR5 (*(RwReg8 *)0x410051A8UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET5 (*(RwReg8 *)0x410051A9UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG6 (*(RwReg8 *)0x410051C0UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR6 (*(WoReg8 *)0x410051C4UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET6 (*(WoReg8 *)0x410051C5UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS6 (*(RoReg8 *)0x410051C6UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG6 (*(RwReg8 *)0x410051C7UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR6 (*(RwReg8 *)0x410051C8UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET6 (*(RwReg8 *)0x410051C9UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG7 (*(RwReg8 *)0x410051E0UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR7 (*(WoReg8 *)0x410051E4UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET7 (*(WoReg8 *)0x410051E5UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS7 (*(RoReg8 *)0x410051E6UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG7 (*(RwReg8 *)0x410051E7UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR7 (*(RwReg8 *)0x410051E8UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET7 (*(RwReg8 *)0x410051E9UL) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 7 */
+#define REG_USB_HOST_CTRLB         (*(RwReg16*)0x41005008UL) /**< \brief (USB) HOST Control B */
+#define REG_USB_HOST_HSOFC         (*(RwReg8 *)0x4100500AUL) /**< \brief (USB) HOST Host Start Of Frame Control */
+#define REG_USB_HOST_STATUS        (*(RwReg8 *)0x4100500CUL) /**< \brief (USB) HOST Status */
+#define REG_USB_HOST_FNUM          (*(RwReg16*)0x41005010UL) /**< \brief (USB) HOST Host Frame Number */
+#define REG_USB_HOST_FLENHIGH      (*(RoReg8 *)0x41005012UL) /**< \brief (USB) HOST Host Frame Length */
+#define REG_USB_HOST_INTENCLR      (*(RwReg16*)0x41005014UL) /**< \brief (USB) HOST Host Interrupt Enable Clear */
+#define REG_USB_HOST_INTENSET      (*(RwReg16*)0x41005018UL) /**< \brief (USB) HOST Host Interrupt Enable Set */
+#define REG_USB_HOST_INTFLAG       (*(RwReg16*)0x4100501CUL) /**< \brief (USB) HOST Host Interrupt Flag */
+#define REG_USB_HOST_PINTSMRY      (*(RoReg16*)0x41005020UL) /**< \brief (USB) HOST Pipe Interrupt Summary */
+#define REG_USB_HOST_PIPE_PCFG0    (*(RwReg8 *)0x41005100UL) /**< \brief (USB) HOST_PIPE End Point Configuration 0 */
+#define REG_USB_HOST_PIPE_BINTERVAL0 (*(RwReg8 *)0x41005103UL) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 0 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR0 (*(WoReg8 *)0x41005104UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 0 */
+#define REG_USB_HOST_PIPE_PSTATUSSET0 (*(WoReg8 *)0x41005105UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 0 */
+#define REG_USB_HOST_PIPE_PSTATUS0 (*(RoReg8 *)0x41005106UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status 0 */
+#define REG_USB_HOST_PIPE_PINTFLAG0 (*(RwReg8 *)0x41005107UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 0 */
+#define REG_USB_HOST_PIPE_PINTENCLR0 (*(RwReg8 *)0x41005108UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 0 */
+#define REG_USB_HOST_PIPE_PINTENSET0 (*(RwReg8 *)0x41005109UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 0 */
+#define REG_USB_HOST_PIPE_PCFG1    (*(RwReg8 *)0x41005120UL) /**< \brief (USB) HOST_PIPE End Point Configuration 1 */
+#define REG_USB_HOST_PIPE_BINTERVAL1 (*(RwReg8 *)0x41005123UL) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 1 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR1 (*(WoReg8 *)0x41005124UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 1 */
+#define REG_USB_HOST_PIPE_PSTATUSSET1 (*(WoReg8 *)0x41005125UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 1 */
+#define REG_USB_HOST_PIPE_PSTATUS1 (*(RoReg8 *)0x41005126UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status 1 */
+#define REG_USB_HOST_PIPE_PINTFLAG1 (*(RwReg8 *)0x41005127UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 1 */
+#define REG_USB_HOST_PIPE_PINTENCLR1 (*(RwReg8 *)0x41005128UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 1 */
+#define REG_USB_HOST_PIPE_PINTENSET1 (*(RwReg8 *)0x41005129UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 1 */
+#define REG_USB_HOST_PIPE_PCFG2    (*(RwReg8 *)0x41005140UL) /**< \brief (USB) HOST_PIPE End Point Configuration 2 */
+#define REG_USB_HOST_PIPE_BINTERVAL2 (*(RwReg8 *)0x41005143UL) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 2 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR2 (*(WoReg8 *)0x41005144UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 2 */
+#define REG_USB_HOST_PIPE_PSTATUSSET2 (*(WoReg8 *)0x41005145UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 2 */
+#define REG_USB_HOST_PIPE_PSTATUS2 (*(RoReg8 *)0x41005146UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status 2 */
+#define REG_USB_HOST_PIPE_PINTFLAG2 (*(RwReg8 *)0x41005147UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 2 */
+#define REG_USB_HOST_PIPE_PINTENCLR2 (*(RwReg8 *)0x41005148UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 2 */
+#define REG_USB_HOST_PIPE_PINTENSET2 (*(RwReg8 *)0x41005149UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 2 */
+#define REG_USB_HOST_PIPE_PCFG3    (*(RwReg8 *)0x41005160UL) /**< \brief (USB) HOST_PIPE End Point Configuration 3 */
+#define REG_USB_HOST_PIPE_BINTERVAL3 (*(RwReg8 *)0x41005163UL) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 3 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR3 (*(WoReg8 *)0x41005164UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 3 */
+#define REG_USB_HOST_PIPE_PSTATUSSET3 (*(WoReg8 *)0x41005165UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 3 */
+#define REG_USB_HOST_PIPE_PSTATUS3 (*(RoReg8 *)0x41005166UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status 3 */
+#define REG_USB_HOST_PIPE_PINTFLAG3 (*(RwReg8 *)0x41005167UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 3 */
+#define REG_USB_HOST_PIPE_PINTENCLR3 (*(RwReg8 *)0x41005168UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 3 */
+#define REG_USB_HOST_PIPE_PINTENSET3 (*(RwReg8 *)0x41005169UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 3 */
+#define REG_USB_HOST_PIPE_PCFG4    (*(RwReg8 *)0x41005180UL) /**< \brief (USB) HOST_PIPE End Point Configuration 4 */
+#define REG_USB_HOST_PIPE_BINTERVAL4 (*(RwReg8 *)0x41005183UL) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 4 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR4 (*(WoReg8 *)0x41005184UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 4 */
+#define REG_USB_HOST_PIPE_PSTATUSSET4 (*(WoReg8 *)0x41005185UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 4 */
+#define REG_USB_HOST_PIPE_PSTATUS4 (*(RoReg8 *)0x41005186UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status 4 */
+#define REG_USB_HOST_PIPE_PINTFLAG4 (*(RwReg8 *)0x41005187UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 4 */
+#define REG_USB_HOST_PIPE_PINTENCLR4 (*(RwReg8 *)0x41005188UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 4 */
+#define REG_USB_HOST_PIPE_PINTENSET4 (*(RwReg8 *)0x41005189UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 4 */
+#define REG_USB_HOST_PIPE_PCFG5    (*(RwReg8 *)0x410051A0UL) /**< \brief (USB) HOST_PIPE End Point Configuration 5 */
+#define REG_USB_HOST_PIPE_BINTERVAL5 (*(RwReg8 *)0x410051A3UL) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 5 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR5 (*(WoReg8 *)0x410051A4UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 5 */
+#define REG_USB_HOST_PIPE_PSTATUSSET5 (*(WoReg8 *)0x410051A5UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 5 */
+#define REG_USB_HOST_PIPE_PSTATUS5 (*(RoReg8 *)0x410051A6UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status 5 */
+#define REG_USB_HOST_PIPE_PINTFLAG5 (*(RwReg8 *)0x410051A7UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 5 */
+#define REG_USB_HOST_PIPE_PINTENCLR5 (*(RwReg8 *)0x410051A8UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 5 */
+#define REG_USB_HOST_PIPE_PINTENSET5 (*(RwReg8 *)0x410051A9UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 5 */
+#define REG_USB_HOST_PIPE_PCFG6    (*(RwReg8 *)0x410051C0UL) /**< \brief (USB) HOST_PIPE End Point Configuration 6 */
+#define REG_USB_HOST_PIPE_BINTERVAL6 (*(RwReg8 *)0x410051C3UL) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 6 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR6 (*(WoReg8 *)0x410051C4UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 6 */
+#define REG_USB_HOST_PIPE_PSTATUSSET6 (*(WoReg8 *)0x410051C5UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 6 */
+#define REG_USB_HOST_PIPE_PSTATUS6 (*(RoReg8 *)0x410051C6UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status 6 */
+#define REG_USB_HOST_PIPE_PINTFLAG6 (*(RwReg8 *)0x410051C7UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 6 */
+#define REG_USB_HOST_PIPE_PINTENCLR6 (*(RwReg8 *)0x410051C8UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 6 */
+#define REG_USB_HOST_PIPE_PINTENSET6 (*(RwReg8 *)0x410051C9UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 6 */
+#define REG_USB_HOST_PIPE_PCFG7    (*(RwReg8 *)0x410051E0UL) /**< \brief (USB) HOST_PIPE End Point Configuration 7 */
+#define REG_USB_HOST_PIPE_BINTERVAL7 (*(RwReg8 *)0x410051E3UL) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 7 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR7 (*(WoReg8 *)0x410051E4UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 7 */
+#define REG_USB_HOST_PIPE_PSTATUSSET7 (*(WoReg8 *)0x410051E5UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 7 */
+#define REG_USB_HOST_PIPE_PSTATUS7 (*(RoReg8 *)0x410051E6UL) /**< \brief (USB) HOST_PIPE End Point Pipe Status 7 */
+#define REG_USB_HOST_PIPE_PINTFLAG7 (*(RwReg8 *)0x410051E7UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 7 */
+#define REG_USB_HOST_PIPE_PINTENCLR7 (*(RwReg8 *)0x410051E8UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 7 */
+#define REG_USB_HOST_PIPE_PINTENSET7 (*(RwReg8 *)0x410051E9UL) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 7 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for USB peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/instance/wdt.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/instance/wdt.h
@@ -3,39 +3,24 @@
  *
  * \brief Instance description for WDT
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -46,23 +31,23 @@
 
 /* ========== Register definition for WDT peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#define REG_WDT_CTRL               (0x40001000U) /**< \brief (WDT) Control */
-#define REG_WDT_CONFIG             (0x40001001U) /**< \brief (WDT) Configuration */
-#define REG_WDT_EWCTRL             (0x40001002U) /**< \brief (WDT) Early Warning Interrupt Control */
-#define REG_WDT_INTENCLR           (0x40001004U) /**< \brief (WDT) Interrupt Enable Clear */
-#define REG_WDT_INTENSET           (0x40001005U) /**< \brief (WDT) Interrupt Enable Set */
-#define REG_WDT_INTFLAG            (0x40001006U) /**< \brief (WDT) Interrupt Flag Status and Clear */
-#define REG_WDT_STATUS             (0x40001007U) /**< \brief (WDT) Status */
-#define REG_WDT_CLEAR              (0x40001008U) /**< \brief (WDT) Clear */
+#define REG_WDT_CTRL               (0x40001000) /**< \brief (WDT) Control */
+#define REG_WDT_CONFIG             (0x40001001) /**< \brief (WDT) Configuration */
+#define REG_WDT_EWCTRL             (0x40001002) /**< \brief (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR           (0x40001004) /**< \brief (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET           (0x40001005) /**< \brief (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG            (0x40001006) /**< \brief (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_STATUS             (0x40001007) /**< \brief (WDT) Status */
+#define REG_WDT_CLEAR              (0x40001008) /**< \brief (WDT) Clear */
 #else
-#define REG_WDT_CTRL               (*(RwReg8 *)0x40001000U) /**< \brief (WDT) Control */
-#define REG_WDT_CONFIG             (*(RwReg8 *)0x40001001U) /**< \brief (WDT) Configuration */
-#define REG_WDT_EWCTRL             (*(RwReg8 *)0x40001002U) /**< \brief (WDT) Early Warning Interrupt Control */
-#define REG_WDT_INTENCLR           (*(RwReg8 *)0x40001004U) /**< \brief (WDT) Interrupt Enable Clear */
-#define REG_WDT_INTENSET           (*(RwReg8 *)0x40001005U) /**< \brief (WDT) Interrupt Enable Set */
-#define REG_WDT_INTFLAG            (*(RwReg8 *)0x40001006U) /**< \brief (WDT) Interrupt Flag Status and Clear */
-#define REG_WDT_STATUS             (*(RoReg8 *)0x40001007U) /**< \brief (WDT) Status */
-#define REG_WDT_CLEAR              (*(WoReg8 *)0x40001008U) /**< \brief (WDT) Clear */
+#define REG_WDT_CTRL               (*(RwReg8 *)0x40001000UL) /**< \brief (WDT) Control */
+#define REG_WDT_CONFIG             (*(RwReg8 *)0x40001001UL) /**< \brief (WDT) Configuration */
+#define REG_WDT_EWCTRL             (*(RwReg8 *)0x40001002UL) /**< \brief (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR           (*(RwReg8 *)0x40001004UL) /**< \brief (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET           (*(RwReg8 *)0x40001005UL) /**< \brief (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG            (*(RwReg8 *)0x40001006UL) /**< \brief (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_STATUS             (*(RoReg8 *)0x40001007UL) /**< \brief (WDT) Status */
+#define REG_WDT_CLEAR              (*(WoReg8 *)0x40001008UL) /**< \brief (WDT) Clear */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance parameters for WDT peripheral ========== */

--- a/cpu/sam0_common/include/vendor/samr21/include/pio/samr21e16a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/pio/samr21e16a.h
@@ -3,39 +3,24 @@
  *
  * \brief Peripheral I/O description for SAMR21E16A
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2017 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -45,644 +30,689 @@
 #define _SAMR21E16A_PIO_
 
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PORT_PA06              (_UL(1) <<  6) /**< \brief PORT Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PORT_PA07              (_UL(1) <<  7) /**< \brief PORT Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PORT_PA08              (_UL(1) <<  8) /**< \brief PORT Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PORT_PA09              (_UL(1) <<  9) /**< \brief PORT Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PORT_PA10              (_UL(1) << 10) /**< \brief PORT Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PORT_PA11              (_UL(1) << 11) /**< \brief PORT Mask  for PA11 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PORT_PA14              (_UL(1) << 14) /**< \brief PORT Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PORT_PA15              (_UL(1) << 15) /**< \brief PORT Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PORT_PA16              (_UL(1) << 16) /**< \brief PORT Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PORT_PA17              (_UL(1) << 17) /**< \brief PORT Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PORT_PA18              (_UL(1) << 18) /**< \brief PORT Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PORT_PA19              (_UL(1) << 19) /**< \brief PORT Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PORT_PA20              (_UL(1) << 20) /**< \brief PORT Mask  for PA20 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PORT_PA24              (_UL(1) << 24) /**< \brief PORT Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PORT_PA25              (_UL(1) << 25) /**< \brief PORT Mask  for PA25 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PORT_PA27              (_UL(1) << 27) /**< \brief PORT Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define PORT_PA28                 (1ul << 28) /**< \brief PORT Mask  for PA28 */
+#define PORT_PA28              (_UL(1) << 28) /**< \brief PORT Mask  for PA28 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PORT_PA30              (_UL(1) << 30) /**< \brief PORT Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PORT_PA31              (_UL(1) << 31) /**< \brief PORT Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define PORT_PB00                 (1ul <<  0) /**< \brief PORT Mask  for PB00 */
+#define PORT_PB00              (_UL(1) <<  0) /**< \brief PORT Mask  for PB00 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PORT_PB08              (_UL(1) <<  8) /**< \brief PORT Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PORT_PB09              (_UL(1) <<  9) /**< \brief PORT Mask  for PB09 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define PORT_PB14                 (1ul << 14) /**< \brief PORT Mask  for PB14 */
+#define PORT_PB14              (_UL(1) << 14) /**< \brief PORT Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define PORT_PB15                 (1ul << 15) /**< \brief PORT Mask  for PB15 */
+#define PORT_PB15              (_UL(1) << 15) /**< \brief PORT Mask  for PB15 */
 #define PIN_PB16                          48  /**< \brief Pin Number for PB16 */
-#define PORT_PB16                 (1ul << 16) /**< \brief PORT Mask  for PB16 */
+#define PORT_PB16              (_UL(1) << 16) /**< \brief PORT Mask  for PB16 */
 #define PIN_PB17                          49  /**< \brief Pin Number for PB17 */
-#define PORT_PB17                 (1ul << 17) /**< \brief PORT Mask  for PB17 */
+#define PORT_PB17              (_UL(1) << 17) /**< \brief PORT Mask  for PB17 */
 #define PIN_PB30                          62  /**< \brief Pin Number for PB30 */
-#define PORT_PB30                 (1ul << 30) /**< \brief PORT Mask  for PB30 */
+#define PORT_PB30              (_UL(1) << 30) /**< \brief PORT Mask  for PB30 */
 #define PIN_PB31                          63  /**< \brief Pin Number for PB31 */
-#define PORT_PB31                 (1ul << 31) /**< \brief PORT Mask  for PB31 */
+#define PORT_PB31              (_UL(1) << 31) /**< \brief PORT Mask  for PB31 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define PORT_PC16                 (1ul << 16) /**< \brief PORT Mask  for PC16 */
+#define PORT_PC16              (_UL(1) << 16) /**< \brief PORT Mask  for PC16 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define PORT_PC18                 (1ul << 18) /**< \brief PORT Mask  for PC18 */
+#define PORT_PC18              (_UL(1) << 18) /**< \brief PORT Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define PORT_PC19                 (1ul << 19) /**< \brief PORT Mask  for PC19 */
+#define PORT_PC19              (_UL(1) << 19) /**< \brief PORT Mask  for PC19 */
 /* ========== PORT definition for GCLK peripheral ========== */
-#define PIN_PB14H_GCLK_IO0                46L  /**< \brief GCLK signal: IO0 on PB14 mux H */
-#define MUX_PB14H_GCLK_IO0                 7L
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
 #define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
-#define PORT_PB14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
-#define MUX_PA14H_GCLK_IO0                 7L
+#define PORT_PB14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
 #define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
-#define PORT_PA14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
-#define MUX_PA27H_GCLK_IO0                 7L
+#define PORT_PA14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
 #define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
-#define PORT_PA27H_GCLK_IO0        (1ul << 27)
-#define PIN_PA28H_GCLK_IO0                28L  /**< \brief GCLK signal: IO0 on PA28 mux H */
-#define MUX_PA28H_GCLK_IO0                 7L
+#define PORT_PA27H_GCLK_IO0    (_UL(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
 #define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
-#define PORT_PA28H_GCLK_IO0        (1ul << 28)
-#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
-#define MUX_PA30H_GCLK_IO0                 7L
+#define PORT_PA28H_GCLK_IO0    (_UL(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
 #define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
-#define PORT_PA30H_GCLK_IO0        (1ul << 30)
-#define PIN_PB15H_GCLK_IO1                47L  /**< \brief GCLK signal: IO1 on PB15 mux H */
-#define MUX_PB15H_GCLK_IO1                 7L
+#define PORT_PA30H_GCLK_IO0    (_UL(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
 #define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
-#define PORT_PB15H_GCLK_IO1        (1ul << 15)
-#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
-#define MUX_PA15H_GCLK_IO1                 7L
+#define PORT_PB15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
 #define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
-#define PORT_PA15H_GCLK_IO1        (1ul << 15)
-#define PIN_PC16F_GCLK_IO1                80L  /**< \brief GCLK signal: IO1 on PC16 mux F */
-#define MUX_PC16F_GCLK_IO1                 5L
+#define PORT_PA15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PC16F_GCLK_IO1             _L_(80) /**< \brief GCLK signal: IO1 on PC16 mux F */
+#define MUX_PC16F_GCLK_IO1              _L_(5)
 #define PINMUX_PC16F_GCLK_IO1      ((PIN_PC16F_GCLK_IO1 << 16) | MUX_PC16F_GCLK_IO1)
-#define PORT_PC16F_GCLK_IO1        (1ul << 16)
-#define PIN_PB16H_GCLK_IO2                48L  /**< \brief GCLK signal: IO2 on PB16 mux H */
-#define MUX_PB16H_GCLK_IO2                 7L
+#define PORT_PC16F_GCLK_IO1    (_UL(1) << 16)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
 #define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
-#define PORT_PB16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
-#define MUX_PA16H_GCLK_IO2                 7L
+#define PORT_PB16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
 #define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
-#define PORT_PA16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
-#define MUX_PA17H_GCLK_IO3                 7L
+#define PORT_PA16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
 #define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
-#define PORT_PA17H_GCLK_IO3        (1ul << 17)
-#define PIN_PB17H_GCLK_IO3                49L  /**< \brief GCLK signal: IO3 on PB17 mux H */
-#define MUX_PB17H_GCLK_IO3                 7L
+#define PORT_PA17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
 #define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
-#define PORT_PB17H_GCLK_IO3        (1ul << 17)
-#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
-#define MUX_PA10H_GCLK_IO4                 7L
+#define PORT_PB17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
 #define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
-#define PORT_PA10H_GCLK_IO4        (1ul << 10)
-#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
-#define MUX_PA20H_GCLK_IO4                 7L
+#define PORT_PA10H_GCLK_IO4    (_UL(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
 #define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
-#define PORT_PA20H_GCLK_IO4        (1ul << 20)
-#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
-#define MUX_PA11H_GCLK_IO5                 7L
+#define PORT_PA20H_GCLK_IO4    (_UL(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
 #define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
-#define PORT_PA11H_GCLK_IO5        (1ul << 11)
+#define PORT_PA11H_GCLK_IO5    (_UL(1) << 11)
 /* ========== PORT definition for EIC peripheral ========== */
-#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
-#define MUX_PA16A_EIC_EXTINT0              0L
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
-#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PB00A_EIC_EXTINT0             32L  /**< \brief EIC signal: EXTINT0 on PB00 mux A */
-#define MUX_PB00A_EIC_EXTINT0              0L
+#define PORT_PA16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
-#define PORT_PB00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PB16A_EIC_EXTINT0             48L  /**< \brief EIC signal: EXTINT0 on PB16 mux A */
-#define MUX_PB16A_EIC_EXTINT0              0L
+#define PORT_PB00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
-#define PORT_PB16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
-#define MUX_PA17A_EIC_EXTINT1              0L
+#define PORT_PB16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
-#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PB17A_EIC_EXTINT1             49L  /**< \brief EIC signal: EXTINT1 on PB17 mux A */
-#define MUX_PB17A_EIC_EXTINT1              0L
+#define PORT_PA17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
-#define PORT_PB17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
-#define MUX_PA18A_EIC_EXTINT2              0L
+#define PORT_PB17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
-#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
-#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
-#define MUX_PA19A_EIC_EXTINT3              0L
+#define PORT_PA18A_EIC_EXTINT2  (_UL(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
-#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
-#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
-#define MUX_PA20A_EIC_EXTINT4              0L
+#define PORT_PA19A_EIC_EXTINT3  (_UL(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
-#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
-#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
-#define MUX_PA06A_EIC_EXTINT6              0L
+#define PORT_PA20A_EIC_EXTINT4  (_UL(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
-#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
-#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
-#define MUX_PA07A_EIC_EXTINT7              0L
+#define PORT_PA06A_EIC_EXTINT6  (_UL(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
-#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
-#define PIN_PA28A_EIC_EXTINT8             28L  /**< \brief EIC signal: EXTINT8 on PA28 mux A */
-#define MUX_PA28A_EIC_EXTINT8              0L
+#define PORT_PA07A_EIC_EXTINT7  (_UL(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
-#define PORT_PA28A_EIC_EXTINT8     (1ul << 28)
-#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
-#define MUX_PB08A_EIC_EXTINT8              0L
+#define PORT_PA28A_EIC_EXTINT8  (_UL(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
-#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
-#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
-#define MUX_PA09A_EIC_EXTINT9              0L
+#define PORT_PB08A_EIC_EXTINT8  (_UL(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
-#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
-#define MUX_PB09A_EIC_EXTINT9              0L
+#define PORT_PA09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
-#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
-#define MUX_PA10A_EIC_EXTINT10             0L
+#define PORT_PB09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
-#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
-#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
-#define MUX_PA30A_EIC_EXTINT10             0L
+#define PORT_PA10A_EIC_EXTINT10  (_UL(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
-#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
-#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
-#define MUX_PA11A_EIC_EXTINT11             0L
+#define PORT_PA30A_EIC_EXTINT10  (_UL(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
-#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
-#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
-#define MUX_PA31A_EIC_EXTINT11             0L
+#define PORT_PA11A_EIC_EXTINT11  (_UL(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
-#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
-#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
-#define MUX_PA24A_EIC_EXTINT12             0L
+#define PORT_PA31A_EIC_EXTINT11  (_UL(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
-#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
-#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
-#define MUX_PA25A_EIC_EXTINT13             0L
+#define PORT_PA24A_EIC_EXTINT12  (_UL(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
-#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
-#define PIN_PB14A_EIC_EXTINT14            46L  /**< \brief EIC signal: EXTINT14 on PB14 mux A */
-#define MUX_PB14A_EIC_EXTINT14             0L
+#define PORT_PA25A_EIC_EXTINT13  (_UL(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
-#define PORT_PB14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PB30A_EIC_EXTINT14            62L  /**< \brief EIC signal: EXTINT14 on PB30 mux A */
-#define MUX_PB30A_EIC_EXTINT14             0L
+#define PORT_PB14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
-#define PORT_PB30A_EIC_EXTINT14    (1ul << 30)
-#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
-#define MUX_PA14A_EIC_EXTINT14             0L
+#define PORT_PB30A_EIC_EXTINT14  (_UL(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
-#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
-#define MUX_PA15A_EIC_EXTINT15             0L
+#define PORT_PA14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
-#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
-#define MUX_PA27A_EIC_EXTINT15             0L
+#define PORT_PA15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
-#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
-#define PIN_PB15A_EIC_EXTINT15            47L  /**< \brief EIC signal: EXTINT15 on PB15 mux A */
-#define MUX_PB15A_EIC_EXTINT15             0L
+#define PORT_PA27A_EIC_EXTINT15  (_UL(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
-#define PORT_PB15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PB31A_EIC_EXTINT15            63L  /**< \brief EIC signal: EXTINT15 on PB31 mux A */
-#define MUX_PB31A_EIC_EXTINT15             0L
+#define PORT_PB15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
-#define PORT_PB31A_EIC_EXTINT15    (1ul << 31)
-#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
-#define MUX_PA08A_EIC_NMI                  0L
+#define PORT_PB31A_EIC_EXTINT15  (_UL(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
 #define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
-#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+#define PORT_PA08A_EIC_NMI     (_UL(1) <<  8)
 /* ========== PORT definition for USB peripheral ========== */
-#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
-#define MUX_PA24G_USB_DM                   6L
+#define PIN_PA24G_USB_DM               _L_(24) /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                _L_(6)
 #define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
-#define PORT_PA24G_USB_DM          (1ul << 24)
-#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
-#define MUX_PA25G_USB_DP                   6L
+#define PORT_PA24G_USB_DM      (_UL(1) << 24)
+#define PIN_PA25G_USB_DP               _L_(25) /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                _L_(6)
 #define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
-#define PORT_PA25G_USB_DP          (1ul << 25)
+#define PORT_PA25G_USB_DP      (_UL(1) << 25)
 /* ========== PORT definition for SERCOM0 peripheral ========== */
-#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
-#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
 #define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
-#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
-#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
-#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PORT_PA08C_SERCOM0_PAD0  (_UL(1) <<  8)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
 #define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
-#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
-#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
-#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PORT_PA09C_SERCOM0_PAD1  (_UL(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
 #define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
-#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
-#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
-#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PORT_PA06D_SERCOM0_PAD2  (_UL(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
 #define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
-#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
-#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
-#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PORT_PA10C_SERCOM0_PAD2  (_UL(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
 #define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
-#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
-#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
-#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PORT_PA07D_SERCOM0_PAD3  (_UL(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
 #define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
-#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL(1) << 11)
 /* ========== PORT definition for SERCOM1 peripheral ========== */
-#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
-#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
 #define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
-#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
-#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
-#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PORT_PA16C_SERCOM1_PAD0  (_UL(1) << 16)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
 #define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
-#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
-#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
-#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PORT_PA17C_SERCOM1_PAD1  (_UL(1) << 17)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
 #define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
-#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
-#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
-#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PORT_PA30D_SERCOM1_PAD2  (_UL(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
 #define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
-#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
-#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
-#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PORT_PA18C_SERCOM1_PAD2  (_UL(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
 #define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
-#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
-#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
-#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PORT_PA31D_SERCOM1_PAD3  (_UL(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
 #define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
-#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL(1) << 19)
 /* ========== PORT definition for SERCOM2 peripheral ========== */
-#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
-#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
 #define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
-#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
-#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
-#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PORT_PA08D_SERCOM2_PAD0  (_UL(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
 #define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
-#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
-#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
-#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PORT_PA09D_SERCOM2_PAD1  (_UL(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
 #define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
-#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
-#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
-#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PORT_PA10D_SERCOM2_PAD2  (_UL(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
 #define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
-#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
-#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
-#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PORT_PA14C_SERCOM2_PAD2  (_UL(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
 #define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
-#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
-#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
-#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PORT_PA11D_SERCOM2_PAD3  (_UL(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
 #define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
-#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL(1) << 15)
 /* ========== PORT definition for SERCOM3 peripheral ========== */
-#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
-#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
 #define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
-#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
-#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
-#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PORT_PA16D_SERCOM3_PAD0  (_UL(1) << 16)
+#define PIN_PA27F_SERCOM3_PAD0         _L_(27) /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0          _L_(5)
 #define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
-#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
-#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
-#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PORT_PA27F_SERCOM3_PAD0  (_UL(1) << 27)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
 #define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
-#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
-#define PIN_PA28F_SERCOM3_PAD1            28L  /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
-#define MUX_PA28F_SERCOM3_PAD1             5L
+#define PORT_PA17D_SERCOM3_PAD1  (_UL(1) << 17)
+#define PIN_PA28F_SERCOM3_PAD1         _L_(28) /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
+#define MUX_PA28F_SERCOM3_PAD1          _L_(5)
 #define PINMUX_PA28F_SERCOM3_PAD1  ((PIN_PA28F_SERCOM3_PAD1 << 16) | MUX_PA28F_SERCOM3_PAD1)
-#define PORT_PA28F_SERCOM3_PAD1    (1ul << 28)
-#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
-#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PORT_PA28F_SERCOM3_PAD1  (_UL(1) << 28)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
-#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
-#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
-#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PORT_PA18D_SERCOM3_PAD2  (_UL(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
-#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
-#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
-#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PORT_PA20D_SERCOM3_PAD2  (_UL(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
 #define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
-#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
-#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
-#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PORT_PA24C_SERCOM3_PAD2  (_UL(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
 #define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
-#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
-#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
-#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PORT_PA19D_SERCOM3_PAD3  (_UL(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
 #define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
-#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for SERCOM4 peripheral ========== */
-#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
-#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
-#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
-#define PIN_PC19F_SERCOM4_PAD0            83L  /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
-#define MUX_PC19F_SERCOM4_PAD0             5L
+#define PORT_PB08D_SERCOM4_PAD0  (_UL(1) <<  8)
+#define PIN_PC19F_SERCOM4_PAD0         _L_(83) /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
+#define MUX_PC19F_SERCOM4_PAD0          _L_(5)
 #define PINMUX_PC19F_SERCOM4_PAD0  ((PIN_PC19F_SERCOM4_PAD0 << 16) | MUX_PC19F_SERCOM4_PAD0)
-#define PORT_PC19F_SERCOM4_PAD0    (1ul << 19)
-#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
-#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PORT_PC19F_SERCOM4_PAD0  (_UL(1) << 19)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
-#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
-#define PIN_PB31F_SERCOM4_PAD1            63L  /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
-#define MUX_PB31F_SERCOM4_PAD1             5L
+#define PORT_PB09D_SERCOM4_PAD1  (_UL(1) <<  9)
+#define PIN_PB31F_SERCOM4_PAD1         _L_(63) /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
+#define MUX_PB31F_SERCOM4_PAD1          _L_(5)
 #define PINMUX_PB31F_SERCOM4_PAD1  ((PIN_PB31F_SERCOM4_PAD1 << 16) | MUX_PB31F_SERCOM4_PAD1)
-#define PORT_PB31F_SERCOM4_PAD1    (1ul << 31)
-#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
-#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PORT_PB31F_SERCOM4_PAD1  (_UL(1) << 31)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
 #define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
-#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB14C_SERCOM4_PAD2            46L  /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
-#define MUX_PB14C_SERCOM4_PAD2             2L
+#define PORT_PA14D_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
 #define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
-#define PORT_PB14C_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB30F_SERCOM4_PAD2            62L  /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
-#define MUX_PB30F_SERCOM4_PAD2             5L
+#define PORT_PB14C_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB30F_SERCOM4_PAD2         _L_(62) /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
+#define MUX_PB30F_SERCOM4_PAD2          _L_(5)
 #define PINMUX_PB30F_SERCOM4_PAD2  ((PIN_PB30F_SERCOM4_PAD2 << 16) | MUX_PB30F_SERCOM4_PAD2)
-#define PORT_PB30F_SERCOM4_PAD2    (1ul << 30)
-#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
-#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PORT_PB30F_SERCOM4_PAD2  (_UL(1) << 30)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
 #define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
-#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PB15C_SERCOM4_PAD3            47L  /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
-#define MUX_PB15C_SERCOM4_PAD3             2L
+#define PORT_PA15D_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
 #define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
-#define PORT_PB15C_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PC18F_SERCOM4_PAD3            82L  /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
-#define MUX_PC18F_SERCOM4_PAD3             5L
+#define PORT_PB15C_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PC18F_SERCOM4_PAD3         _L_(82) /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
+#define MUX_PC18F_SERCOM4_PAD3          _L_(5)
 #define PINMUX_PC18F_SERCOM4_PAD3  ((PIN_PC18F_SERCOM4_PAD3 << 16) | MUX_PC18F_SERCOM4_PAD3)
-#define PORT_PC18F_SERCOM4_PAD3    (1ul << 18)
+#define PORT_PC18F_SERCOM4_PAD3  (_UL(1) << 18)
 /* ========== PORT definition for SERCOM5 peripheral ========== */
-#define PIN_PB16C_SERCOM5_PAD0            48L  /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
-#define MUX_PB16C_SERCOM5_PAD0             2L
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
 #define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
-#define PORT_PB16C_SERCOM5_PAD0    (1ul << 16)
-#define PIN_PB30D_SERCOM5_PAD0            62L  /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
-#define MUX_PB30D_SERCOM5_PAD0             3L
+#define PORT_PB16C_SERCOM5_PAD0  (_UL(1) << 16)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
-#define PORT_PB30D_SERCOM5_PAD0    (1ul << 30)
-#define PIN_PB17C_SERCOM5_PAD1            49L  /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
-#define MUX_PB17C_SERCOM5_PAD1             2L
+#define PORT_PB30D_SERCOM5_PAD0  (_UL(1) << 30)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
 #define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
-#define PORT_PB17C_SERCOM5_PAD1    (1ul << 17)
-#define PIN_PB31D_SERCOM5_PAD1            63L  /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
-#define MUX_PB31D_SERCOM5_PAD1             3L
+#define PORT_PB17C_SERCOM5_PAD1  (_UL(1) << 17)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
-#define PORT_PB31D_SERCOM5_PAD1    (1ul << 31)
-#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
-#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PORT_PB31D_SERCOM5_PAD1  (_UL(1) << 31)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
-#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
-#define PIN_PB00D_SERCOM5_PAD2            32L  /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
-#define MUX_PB00D_SERCOM5_PAD2             3L
+#define PORT_PA24D_SERCOM5_PAD2  (_UL(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
-#define PORT_PB00D_SERCOM5_PAD2    (1ul <<  0)
-#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
-#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PORT_PB00D_SERCOM5_PAD2  (_UL(1) <<  0)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
 #define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
-#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
-#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
-#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PORT_PA20C_SERCOM5_PAD2  (_UL(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
-#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for TCC0 peripheral ========== */
-#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
-#define MUX_PA08E_TCC0_WO0                 4L
+#define PIN_PA08E_TCC0_WO0              _L_(8) /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0              _L_(4)
 #define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
-#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
-#define PIN_PB30E_TCC0_WO0                62L  /**< \brief TCC0 signal: WO0 on PB30 mux E */
-#define MUX_PB30E_TCC0_WO0                 4L
+#define PORT_PA08E_TCC0_WO0    (_UL(1) <<  8)
+#define PIN_PB30E_TCC0_WO0             _L_(62) /**< \brief TCC0 signal: WO0 on PB30 mux E */
+#define MUX_PB30E_TCC0_WO0              _L_(4)
 #define PINMUX_PB30E_TCC0_WO0      ((PIN_PB30E_TCC0_WO0 << 16) | MUX_PB30E_TCC0_WO0)
-#define PORT_PB30E_TCC0_WO0        (1ul << 30)
-#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
-#define MUX_PA16F_TCC0_WO0                 5L
+#define PORT_PB30E_TCC0_WO0    (_UL(1) << 30)
+#define PIN_PA16F_TCC0_WO0             _L_(16) /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0              _L_(5)
 #define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
-#define PORT_PA16F_TCC0_WO0        (1ul << 16)
-#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
-#define MUX_PA09E_TCC0_WO1                 4L
+#define PORT_PA16F_TCC0_WO0    (_UL(1) << 16)
+#define PIN_PA09E_TCC0_WO1              _L_(9) /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1              _L_(4)
 #define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
-#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
-#define PIN_PB31E_TCC0_WO1                63L  /**< \brief TCC0 signal: WO1 on PB31 mux E */
-#define MUX_PB31E_TCC0_WO1                 4L
+#define PORT_PA09E_TCC0_WO1    (_UL(1) <<  9)
+#define PIN_PB31E_TCC0_WO1             _L_(63) /**< \brief TCC0 signal: WO1 on PB31 mux E */
+#define MUX_PB31E_TCC0_WO1              _L_(4)
 #define PINMUX_PB31E_TCC0_WO1      ((PIN_PB31E_TCC0_WO1 << 16) | MUX_PB31E_TCC0_WO1)
-#define PORT_PB31E_TCC0_WO1        (1ul << 31)
-#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
-#define MUX_PA17F_TCC0_WO1                 5L
+#define PORT_PB31E_TCC0_WO1    (_UL(1) << 31)
+#define PIN_PA17F_TCC0_WO1             _L_(17) /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1              _L_(5)
 #define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
-#define PORT_PA17F_TCC0_WO1        (1ul << 17)
-#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
-#define MUX_PA10F_TCC0_WO2                 5L
+#define PORT_PA17F_TCC0_WO1    (_UL(1) << 17)
+#define PIN_PA10F_TCC0_WO2             _L_(10) /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2              _L_(5)
 #define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
-#define PORT_PA10F_TCC0_WO2        (1ul << 10)
-#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
-#define MUX_PA18F_TCC0_WO2                 5L
+#define PORT_PA10F_TCC0_WO2    (_UL(1) << 10)
+#define PIN_PA18F_TCC0_WO2             _L_(18) /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2              _L_(5)
 #define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
-#define PORT_PA18F_TCC0_WO2        (1ul << 18)
-#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
-#define MUX_PA11F_TCC0_WO3                 5L
+#define PORT_PA18F_TCC0_WO2    (_UL(1) << 18)
+#define PIN_PA11F_TCC0_WO3             _L_(11) /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3              _L_(5)
 #define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
-#define PORT_PA11F_TCC0_WO3        (1ul << 11)
-#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
-#define MUX_PA19F_TCC0_WO3                 5L
+#define PORT_PA11F_TCC0_WO3    (_UL(1) << 11)
+#define PIN_PA19F_TCC0_WO3             _L_(19) /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3              _L_(5)
 #define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
-#define PORT_PA19F_TCC0_WO3        (1ul << 19)
-#define PIN_PB16F_TCC0_WO4                48L  /**< \brief TCC0 signal: WO4 on PB16 mux F */
-#define MUX_PB16F_TCC0_WO4                 5L
+#define PORT_PA19F_TCC0_WO3    (_UL(1) << 19)
+#define PIN_PB16F_TCC0_WO4             _L_(48) /**< \brief TCC0 signal: WO4 on PB16 mux F */
+#define MUX_PB16F_TCC0_WO4              _L_(5)
 #define PINMUX_PB16F_TCC0_WO4      ((PIN_PB16F_TCC0_WO4 << 16) | MUX_PB16F_TCC0_WO4)
-#define PORT_PB16F_TCC0_WO4        (1ul << 16)
-#define PIN_PB17F_TCC0_WO5                49L  /**< \brief TCC0 signal: WO5 on PB17 mux F */
-#define MUX_PB17F_TCC0_WO5                 5L
+#define PORT_PB16F_TCC0_WO4    (_UL(1) << 16)
+#define PIN_PB17F_TCC0_WO5             _L_(49) /**< \brief TCC0 signal: WO5 on PB17 mux F */
+#define MUX_PB17F_TCC0_WO5              _L_(5)
 #define PINMUX_PB17F_TCC0_WO5      ((PIN_PB17F_TCC0_WO5 << 16) | MUX_PB17F_TCC0_WO5)
-#define PORT_PB17F_TCC0_WO5        (1ul << 17)
-#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
-#define MUX_PA20F_TCC0_WO6                 5L
+#define PORT_PB17F_TCC0_WO5    (_UL(1) << 17)
+#define PIN_PA20F_TCC0_WO6             _L_(20) /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6              _L_(5)
 #define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
-#define PORT_PA20F_TCC0_WO6        (1ul << 20)
+#define PORT_PA20F_TCC0_WO6    (_UL(1) << 20)
 /* ========== PORT definition for TCC1 peripheral ========== */
-#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
-#define MUX_PA06E_TCC1_WO0                 4L
+#define PIN_PA06E_TCC1_WO0              _L_(6) /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0              _L_(4)
 #define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
-#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
-#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
-#define MUX_PA10E_TCC1_WO0                 4L
+#define PORT_PA06E_TCC1_WO0    (_UL(1) <<  6)
+#define PIN_PA10E_TCC1_WO0             _L_(10) /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0              _L_(4)
 #define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
-#define PORT_PA10E_TCC1_WO0        (1ul << 10)
-#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
-#define MUX_PA30E_TCC1_WO0                 4L
+#define PORT_PA10E_TCC1_WO0    (_UL(1) << 10)
+#define PIN_PA30E_TCC1_WO0             _L_(30) /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0              _L_(4)
 #define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
-#define PORT_PA30E_TCC1_WO0        (1ul << 30)
-#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
-#define MUX_PA07E_TCC1_WO1                 4L
+#define PORT_PA30E_TCC1_WO0    (_UL(1) << 30)
+#define PIN_PA07E_TCC1_WO1              _L_(7) /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1              _L_(4)
 #define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
-#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
-#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
-#define MUX_PA11E_TCC1_WO1                 4L
+#define PORT_PA07E_TCC1_WO1    (_UL(1) <<  7)
+#define PIN_PA11E_TCC1_WO1             _L_(11) /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1              _L_(4)
 #define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
-#define PORT_PA11E_TCC1_WO1        (1ul << 11)
-#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
-#define MUX_PA31E_TCC1_WO1                 4L
+#define PORT_PA11E_TCC1_WO1    (_UL(1) << 11)
+#define PIN_PA31E_TCC1_WO1             _L_(31) /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1              _L_(4)
 #define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
-#define PORT_PA31E_TCC1_WO1        (1ul << 31)
-#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
-#define MUX_PA24F_TCC1_WO2                 5L
+#define PORT_PA31E_TCC1_WO1    (_UL(1) << 31)
+#define PIN_PA24F_TCC1_WO2             _L_(24) /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2              _L_(5)
 #define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
-#define PORT_PA24F_TCC1_WO2        (1ul << 24)
-#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
-#define MUX_PA25F_TCC1_WO3                 5L
+#define PORT_PA24F_TCC1_WO2    (_UL(1) << 24)
+#define PIN_PA25F_TCC1_WO3             _L_(25) /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3              _L_(5)
 #define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
-#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+#define PORT_PA25F_TCC1_WO3    (_UL(1) << 25)
 /* ========== PORT definition for TCC2 peripheral ========== */
-#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
-#define MUX_PA16E_TCC2_WO0                 4L
+#define PIN_PA16E_TCC2_WO0             _L_(16) /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0              _L_(4)
 #define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
-#define PORT_PA16E_TCC2_WO0        (1ul << 16)
-#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
-#define MUX_PA17E_TCC2_WO1                 4L
+#define PORT_PA16E_TCC2_WO0    (_UL(1) << 16)
+#define PIN_PA17E_TCC2_WO1             _L_(17) /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1              _L_(4)
 #define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
-#define PORT_PA17E_TCC2_WO1        (1ul << 17)
+#define PORT_PA17E_TCC2_WO1    (_UL(1) << 17)
 /* ========== PORT definition for TC3 peripheral ========== */
-#define PIN_PA18E_TC3_WO0                 18L  /**< \brief TC3 signal: WO0 on PA18 mux E */
-#define MUX_PA18E_TC3_WO0                  4L
+#define PIN_PA18E_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC3_WO0               _L_(4)
 #define PINMUX_PA18E_TC3_WO0       ((PIN_PA18E_TC3_WO0 << 16) | MUX_PA18E_TC3_WO0)
-#define PORT_PA18E_TC3_WO0         (1ul << 18)
-#define PIN_PA14E_TC3_WO0                 14L  /**< \brief TC3 signal: WO0 on PA14 mux E */
-#define MUX_PA14E_TC3_WO0                  4L
+#define PORT_PA18E_TC3_WO0     (_UL(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
 #define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
-#define PORT_PA14E_TC3_WO0         (1ul << 14)
-#define PIN_PA19E_TC3_WO1                 19L  /**< \brief TC3 signal: WO1 on PA19 mux E */
-#define MUX_PA19E_TC3_WO1                  4L
+#define PORT_PA14E_TC3_WO0     (_UL(1) << 14)
+#define PIN_PA19E_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC3_WO1               _L_(4)
 #define PINMUX_PA19E_TC3_WO1       ((PIN_PA19E_TC3_WO1 << 16) | MUX_PA19E_TC3_WO1)
-#define PORT_PA19E_TC3_WO1         (1ul << 19)
-#define PIN_PA15E_TC3_WO1                 15L  /**< \brief TC3 signal: WO1 on PA15 mux E */
-#define MUX_PA15E_TC3_WO1                  4L
+#define PORT_PA19E_TC3_WO1     (_UL(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
 #define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
-#define PORT_PA15E_TC3_WO1         (1ul << 15)
+#define PORT_PA15E_TC3_WO1     (_UL(1) << 15)
 /* ========== PORT definition for TC4 peripheral ========== */
-#define PIN_PB08E_TC4_WO0                 40L  /**< \brief TC4 signal: WO0 on PB08 mux E */
-#define MUX_PB08E_TC4_WO0                  4L
+#define PIN_PB08E_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC4_WO0               _L_(4)
 #define PINMUX_PB08E_TC4_WO0       ((PIN_PB08E_TC4_WO0 << 16) | MUX_PB08E_TC4_WO0)
-#define PORT_PB08E_TC4_WO0         (1ul <<  8)
-#define PIN_PB09E_TC4_WO1                 41L  /**< \brief TC4 signal: WO1 on PB09 mux E */
-#define MUX_PB09E_TC4_WO1                  4L
+#define PORT_PB08E_TC4_WO0     (_UL(1) <<  8)
+#define PIN_PB09E_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC4_WO1               _L_(4)
 #define PINMUX_PB09E_TC4_WO1       ((PIN_PB09E_TC4_WO1 << 16) | MUX_PB09E_TC4_WO1)
-#define PORT_PB09E_TC4_WO1         (1ul <<  9)
+#define PORT_PB09E_TC4_WO1     (_UL(1) <<  9)
 /* ========== PORT definition for TC5 peripheral ========== */
-#define PIN_PA24E_TC5_WO0                 24L  /**< \brief TC5 signal: WO0 on PA24 mux E */
-#define MUX_PA24E_TC5_WO0                  4L
+#define PIN_PA24E_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC5_WO0               _L_(4)
 #define PINMUX_PA24E_TC5_WO0       ((PIN_PA24E_TC5_WO0 << 16) | MUX_PA24E_TC5_WO0)
-#define PORT_PA24E_TC5_WO0         (1ul << 24)
-#define PIN_PB14E_TC5_WO0                 46L  /**< \brief TC5 signal: WO0 on PB14 mux E */
-#define MUX_PB14E_TC5_WO0                  4L
+#define PORT_PA24E_TC5_WO0     (_UL(1) << 24)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
 #define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
-#define PORT_PB14E_TC5_WO0         (1ul << 14)
-#define PIN_PA25E_TC5_WO1                 25L  /**< \brief TC5 signal: WO1 on PA25 mux E */
-#define MUX_PA25E_TC5_WO1                  4L
+#define PORT_PB14E_TC5_WO0     (_UL(1) << 14)
+#define PIN_PA25E_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC5_WO1               _L_(4)
 #define PINMUX_PA25E_TC5_WO1       ((PIN_PA25E_TC5_WO1 << 16) | MUX_PA25E_TC5_WO1)
-#define PORT_PA25E_TC5_WO1         (1ul << 25)
-#define PIN_PB15E_TC5_WO1                 47L  /**< \brief TC5 signal: WO1 on PB15 mux E */
-#define MUX_PB15E_TC5_WO1                  4L
+#define PORT_PA25E_TC5_WO1     (_UL(1) << 25)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
 #define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
-#define PORT_PB15E_TC5_WO1         (1ul << 15)
+#define PORT_PB15E_TC5_WO1     (_UL(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL(1) << 16)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL(1) << 20)
+#define PIN_PB00E_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux E */
+#define MUX_PB00E_TC7_WO0               _L_(4)
+#define PINMUX_PB00E_TC7_WO0       ((PIN_PB00E_TC7_WO0 << 16) | MUX_PB00E_TC7_WO0)
+#define PORT_PB00E_TC7_WO0     (_UL(1) <<  0)
 /* ========== PORT definition for ADC peripheral ========== */
-#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
-#define MUX_PB08B_ADC_AIN2                 1L
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
 #define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
-#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
-#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
-#define MUX_PB09B_ADC_AIN3                 1L
+#define PORT_PB08B_ADC_AIN2    (_UL(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
 #define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
-#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
-#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
-#define MUX_PA06B_ADC_AIN6                 1L
+#define PORT_PB09B_ADC_AIN3    (_UL(1) <<  9)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
 #define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
-#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
-#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
-#define MUX_PA07B_ADC_AIN7                 1L
+#define PORT_PA06B_ADC_AIN6    (_UL(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
 #define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
-#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
-#define PIN_PB00B_ADC_AIN8                32L  /**< \brief ADC signal: AIN8 on PB00 mux B */
-#define MUX_PB00B_ADC_AIN8                 1L
+#define PORT_PA07B_ADC_AIN7    (_UL(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
 #define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
-#define PORT_PB00B_ADC_AIN8        (1ul <<  0)
-#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
-#define MUX_PA08B_ADC_AIN16                1L
+#define PORT_PB00B_ADC_AIN8    (_UL(1) <<  0)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
 #define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
-#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
-#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
-#define MUX_PA09B_ADC_AIN17                1L
+#define PORT_PA08B_ADC_AIN16   (_UL(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
 #define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
-#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
-#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
-#define MUX_PA10B_ADC_AIN18                1L
+#define PORT_PA09B_ADC_AIN17   (_UL(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
 #define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
-#define PORT_PA10B_ADC_AIN18       (1ul << 10)
-#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
-#define MUX_PA11B_ADC_AIN19                1L
+#define PORT_PA10B_ADC_AIN18   (_UL(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
 #define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
-#define PORT_PA11B_ADC_AIN19       (1ul << 11)
+#define PORT_PA11B_ADC_AIN19   (_UL(1) << 11)
 /* ========== PORT definition for AC peripheral ========== */
-#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
-#define MUX_PA06B_AC_AIN2                  1L
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
 #define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
-#define PORT_PA06B_AC_AIN2         (1ul <<  6)
-#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
-#define MUX_PA07B_AC_AIN3                  1L
+#define PORT_PA06B_AC_AIN2     (_UL(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
 #define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
-#define PORT_PA07B_AC_AIN3         (1ul <<  7)
-#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
-#define MUX_PA18H_AC_CMP0                  7L
+#define PORT_PA07B_AC_AIN3     (_UL(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
 #define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
-#define PORT_PA18H_AC_CMP0         (1ul << 18)
-#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
-#define MUX_PA19H_AC_CMP1                  7L
+#define PORT_PA18H_AC_CMP0     (_UL(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
 #define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
-#define PORT_PA19H_AC_CMP1         (1ul << 19)
+#define PORT_PA19H_AC_CMP1     (_UL(1) << 19)
 /* ========== PORT definition for RFCTRL peripheral ========== */
-#define PIN_PA08F_RFCTRL_FECTRL0           8L  /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
-#define MUX_PA08F_RFCTRL_FECTRL0           5L
+#define PIN_PA08F_RFCTRL_FECTRL0        _L_(8) /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
+#define MUX_PA08F_RFCTRL_FECTRL0        _L_(5)
 #define PINMUX_PA08F_RFCTRL_FECTRL0  ((PIN_PA08F_RFCTRL_FECTRL0 << 16) | MUX_PA08F_RFCTRL_FECTRL0)
-#define PORT_PA08F_RFCTRL_FECTRL0  (1ul <<  8)
-#define PIN_PA09F_RFCTRL_FECTRL1           9L  /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
-#define MUX_PA09F_RFCTRL_FECTRL1           5L
+#define PORT_PA08F_RFCTRL_FECTRL0  (_UL(1) <<  8)
+#define PIN_PA09F_RFCTRL_FECTRL1        _L_(9) /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
+#define MUX_PA09F_RFCTRL_FECTRL1        _L_(5)
 #define PINMUX_PA09F_RFCTRL_FECTRL1  ((PIN_PA09F_RFCTRL_FECTRL1 << 16) | MUX_PA09F_RFCTRL_FECTRL1)
-#define PORT_PA09F_RFCTRL_FECTRL1  (1ul <<  9)
-#define PIN_PA14F_RFCTRL_FECTRL4          14L  /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
-#define MUX_PA14F_RFCTRL_FECTRL4           5L
+#define PORT_PA09F_RFCTRL_FECTRL1  (_UL(1) <<  9)
+#define PIN_PA14F_RFCTRL_FECTRL4       _L_(14) /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
+#define MUX_PA14F_RFCTRL_FECTRL4        _L_(5)
 #define PINMUX_PA14F_RFCTRL_FECTRL4  ((PIN_PA14F_RFCTRL_FECTRL4 << 16) | MUX_PA14F_RFCTRL_FECTRL4)
-#define PORT_PA14F_RFCTRL_FECTRL4  (1ul << 14)
-#define PIN_PA15F_RFCTRL_FECTRL5          15L  /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
-#define MUX_PA15F_RFCTRL_FECTRL5           5L
+#define PORT_PA14F_RFCTRL_FECTRL4  (_UL(1) << 14)
+#define PIN_PA15F_RFCTRL_FECTRL5       _L_(15) /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
+#define MUX_PA15F_RFCTRL_FECTRL5        _L_(5)
 #define PINMUX_PA15F_RFCTRL_FECTRL5  ((PIN_PA15F_RFCTRL_FECTRL5 << 16) | MUX_PA15F_RFCTRL_FECTRL5)
-#define PORT_PA15F_RFCTRL_FECTRL5  (1ul << 15)
+#define PORT_PA15F_RFCTRL_FECTRL5  (_UL(1) << 15)
 
 #endif /* _SAMR21E16A_PIO_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/pio/samr21e17a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/pio/samr21e17a.h
@@ -3,39 +3,24 @@
  *
  * \brief Peripheral I/O description for SAMR21E17A
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2017 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -45,644 +30,689 @@
 #define _SAMR21E17A_PIO_
 
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PORT_PA06              (_UL(1) <<  6) /**< \brief PORT Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PORT_PA07              (_UL(1) <<  7) /**< \brief PORT Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PORT_PA08              (_UL(1) <<  8) /**< \brief PORT Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PORT_PA09              (_UL(1) <<  9) /**< \brief PORT Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PORT_PA10              (_UL(1) << 10) /**< \brief PORT Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PORT_PA11              (_UL(1) << 11) /**< \brief PORT Mask  for PA11 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PORT_PA14              (_UL(1) << 14) /**< \brief PORT Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PORT_PA15              (_UL(1) << 15) /**< \brief PORT Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PORT_PA16              (_UL(1) << 16) /**< \brief PORT Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PORT_PA17              (_UL(1) << 17) /**< \brief PORT Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PORT_PA18              (_UL(1) << 18) /**< \brief PORT Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PORT_PA19              (_UL(1) << 19) /**< \brief PORT Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PORT_PA20              (_UL(1) << 20) /**< \brief PORT Mask  for PA20 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PORT_PA24              (_UL(1) << 24) /**< \brief PORT Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PORT_PA25              (_UL(1) << 25) /**< \brief PORT Mask  for PA25 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PORT_PA27              (_UL(1) << 27) /**< \brief PORT Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define PORT_PA28                 (1ul << 28) /**< \brief PORT Mask  for PA28 */
+#define PORT_PA28              (_UL(1) << 28) /**< \brief PORT Mask  for PA28 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PORT_PA30              (_UL(1) << 30) /**< \brief PORT Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PORT_PA31              (_UL(1) << 31) /**< \brief PORT Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define PORT_PB00                 (1ul <<  0) /**< \brief PORT Mask  for PB00 */
+#define PORT_PB00              (_UL(1) <<  0) /**< \brief PORT Mask  for PB00 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PORT_PB08              (_UL(1) <<  8) /**< \brief PORT Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PORT_PB09              (_UL(1) <<  9) /**< \brief PORT Mask  for PB09 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define PORT_PB14                 (1ul << 14) /**< \brief PORT Mask  for PB14 */
+#define PORT_PB14              (_UL(1) << 14) /**< \brief PORT Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define PORT_PB15                 (1ul << 15) /**< \brief PORT Mask  for PB15 */
+#define PORT_PB15              (_UL(1) << 15) /**< \brief PORT Mask  for PB15 */
 #define PIN_PB16                          48  /**< \brief Pin Number for PB16 */
-#define PORT_PB16                 (1ul << 16) /**< \brief PORT Mask  for PB16 */
+#define PORT_PB16              (_UL(1) << 16) /**< \brief PORT Mask  for PB16 */
 #define PIN_PB17                          49  /**< \brief Pin Number for PB17 */
-#define PORT_PB17                 (1ul << 17) /**< \brief PORT Mask  for PB17 */
+#define PORT_PB17              (_UL(1) << 17) /**< \brief PORT Mask  for PB17 */
 #define PIN_PB30                          62  /**< \brief Pin Number for PB30 */
-#define PORT_PB30                 (1ul << 30) /**< \brief PORT Mask  for PB30 */
+#define PORT_PB30              (_UL(1) << 30) /**< \brief PORT Mask  for PB30 */
 #define PIN_PB31                          63  /**< \brief Pin Number for PB31 */
-#define PORT_PB31                 (1ul << 31) /**< \brief PORT Mask  for PB31 */
+#define PORT_PB31              (_UL(1) << 31) /**< \brief PORT Mask  for PB31 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define PORT_PC16                 (1ul << 16) /**< \brief PORT Mask  for PC16 */
+#define PORT_PC16              (_UL(1) << 16) /**< \brief PORT Mask  for PC16 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define PORT_PC18                 (1ul << 18) /**< \brief PORT Mask  for PC18 */
+#define PORT_PC18              (_UL(1) << 18) /**< \brief PORT Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define PORT_PC19                 (1ul << 19) /**< \brief PORT Mask  for PC19 */
+#define PORT_PC19              (_UL(1) << 19) /**< \brief PORT Mask  for PC19 */
 /* ========== PORT definition for GCLK peripheral ========== */
-#define PIN_PB14H_GCLK_IO0                46L  /**< \brief GCLK signal: IO0 on PB14 mux H */
-#define MUX_PB14H_GCLK_IO0                 7L
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
 #define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
-#define PORT_PB14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
-#define MUX_PA14H_GCLK_IO0                 7L
+#define PORT_PB14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
 #define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
-#define PORT_PA14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
-#define MUX_PA27H_GCLK_IO0                 7L
+#define PORT_PA14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
 #define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
-#define PORT_PA27H_GCLK_IO0        (1ul << 27)
-#define PIN_PA28H_GCLK_IO0                28L  /**< \brief GCLK signal: IO0 on PA28 mux H */
-#define MUX_PA28H_GCLK_IO0                 7L
+#define PORT_PA27H_GCLK_IO0    (_UL(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
 #define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
-#define PORT_PA28H_GCLK_IO0        (1ul << 28)
-#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
-#define MUX_PA30H_GCLK_IO0                 7L
+#define PORT_PA28H_GCLK_IO0    (_UL(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
 #define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
-#define PORT_PA30H_GCLK_IO0        (1ul << 30)
-#define PIN_PB15H_GCLK_IO1                47L  /**< \brief GCLK signal: IO1 on PB15 mux H */
-#define MUX_PB15H_GCLK_IO1                 7L
+#define PORT_PA30H_GCLK_IO0    (_UL(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
 #define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
-#define PORT_PB15H_GCLK_IO1        (1ul << 15)
-#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
-#define MUX_PA15H_GCLK_IO1                 7L
+#define PORT_PB15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
 #define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
-#define PORT_PA15H_GCLK_IO1        (1ul << 15)
-#define PIN_PC16F_GCLK_IO1                80L  /**< \brief GCLK signal: IO1 on PC16 mux F */
-#define MUX_PC16F_GCLK_IO1                 5L
+#define PORT_PA15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PC16F_GCLK_IO1             _L_(80) /**< \brief GCLK signal: IO1 on PC16 mux F */
+#define MUX_PC16F_GCLK_IO1              _L_(5)
 #define PINMUX_PC16F_GCLK_IO1      ((PIN_PC16F_GCLK_IO1 << 16) | MUX_PC16F_GCLK_IO1)
-#define PORT_PC16F_GCLK_IO1        (1ul << 16)
-#define PIN_PB16H_GCLK_IO2                48L  /**< \brief GCLK signal: IO2 on PB16 mux H */
-#define MUX_PB16H_GCLK_IO2                 7L
+#define PORT_PC16F_GCLK_IO1    (_UL(1) << 16)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
 #define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
-#define PORT_PB16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
-#define MUX_PA16H_GCLK_IO2                 7L
+#define PORT_PB16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
 #define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
-#define PORT_PA16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
-#define MUX_PA17H_GCLK_IO3                 7L
+#define PORT_PA16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
 #define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
-#define PORT_PA17H_GCLK_IO3        (1ul << 17)
-#define PIN_PB17H_GCLK_IO3                49L  /**< \brief GCLK signal: IO3 on PB17 mux H */
-#define MUX_PB17H_GCLK_IO3                 7L
+#define PORT_PA17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
 #define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
-#define PORT_PB17H_GCLK_IO3        (1ul << 17)
-#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
-#define MUX_PA10H_GCLK_IO4                 7L
+#define PORT_PB17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
 #define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
-#define PORT_PA10H_GCLK_IO4        (1ul << 10)
-#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
-#define MUX_PA20H_GCLK_IO4                 7L
+#define PORT_PA10H_GCLK_IO4    (_UL(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
 #define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
-#define PORT_PA20H_GCLK_IO4        (1ul << 20)
-#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
-#define MUX_PA11H_GCLK_IO5                 7L
+#define PORT_PA20H_GCLK_IO4    (_UL(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
 #define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
-#define PORT_PA11H_GCLK_IO5        (1ul << 11)
+#define PORT_PA11H_GCLK_IO5    (_UL(1) << 11)
 /* ========== PORT definition for EIC peripheral ========== */
-#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
-#define MUX_PA16A_EIC_EXTINT0              0L
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
-#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PB00A_EIC_EXTINT0             32L  /**< \brief EIC signal: EXTINT0 on PB00 mux A */
-#define MUX_PB00A_EIC_EXTINT0              0L
+#define PORT_PA16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
-#define PORT_PB00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PB16A_EIC_EXTINT0             48L  /**< \brief EIC signal: EXTINT0 on PB16 mux A */
-#define MUX_PB16A_EIC_EXTINT0              0L
+#define PORT_PB00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
-#define PORT_PB16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
-#define MUX_PA17A_EIC_EXTINT1              0L
+#define PORT_PB16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
-#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PB17A_EIC_EXTINT1             49L  /**< \brief EIC signal: EXTINT1 on PB17 mux A */
-#define MUX_PB17A_EIC_EXTINT1              0L
+#define PORT_PA17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
-#define PORT_PB17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
-#define MUX_PA18A_EIC_EXTINT2              0L
+#define PORT_PB17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
-#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
-#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
-#define MUX_PA19A_EIC_EXTINT3              0L
+#define PORT_PA18A_EIC_EXTINT2  (_UL(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
-#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
-#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
-#define MUX_PA20A_EIC_EXTINT4              0L
+#define PORT_PA19A_EIC_EXTINT3  (_UL(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
-#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
-#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
-#define MUX_PA06A_EIC_EXTINT6              0L
+#define PORT_PA20A_EIC_EXTINT4  (_UL(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
-#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
-#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
-#define MUX_PA07A_EIC_EXTINT7              0L
+#define PORT_PA06A_EIC_EXTINT6  (_UL(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
-#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
-#define PIN_PA28A_EIC_EXTINT8             28L  /**< \brief EIC signal: EXTINT8 on PA28 mux A */
-#define MUX_PA28A_EIC_EXTINT8              0L
+#define PORT_PA07A_EIC_EXTINT7  (_UL(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
-#define PORT_PA28A_EIC_EXTINT8     (1ul << 28)
-#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
-#define MUX_PB08A_EIC_EXTINT8              0L
+#define PORT_PA28A_EIC_EXTINT8  (_UL(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
-#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
-#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
-#define MUX_PA09A_EIC_EXTINT9              0L
+#define PORT_PB08A_EIC_EXTINT8  (_UL(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
-#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
-#define MUX_PB09A_EIC_EXTINT9              0L
+#define PORT_PA09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
-#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
-#define MUX_PA10A_EIC_EXTINT10             0L
+#define PORT_PB09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
-#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
-#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
-#define MUX_PA30A_EIC_EXTINT10             0L
+#define PORT_PA10A_EIC_EXTINT10  (_UL(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
-#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
-#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
-#define MUX_PA11A_EIC_EXTINT11             0L
+#define PORT_PA30A_EIC_EXTINT10  (_UL(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
-#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
-#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
-#define MUX_PA31A_EIC_EXTINT11             0L
+#define PORT_PA11A_EIC_EXTINT11  (_UL(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
-#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
-#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
-#define MUX_PA24A_EIC_EXTINT12             0L
+#define PORT_PA31A_EIC_EXTINT11  (_UL(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
-#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
-#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
-#define MUX_PA25A_EIC_EXTINT13             0L
+#define PORT_PA24A_EIC_EXTINT12  (_UL(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
-#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
-#define PIN_PB14A_EIC_EXTINT14            46L  /**< \brief EIC signal: EXTINT14 on PB14 mux A */
-#define MUX_PB14A_EIC_EXTINT14             0L
+#define PORT_PA25A_EIC_EXTINT13  (_UL(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
-#define PORT_PB14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PB30A_EIC_EXTINT14            62L  /**< \brief EIC signal: EXTINT14 on PB30 mux A */
-#define MUX_PB30A_EIC_EXTINT14             0L
+#define PORT_PB14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
-#define PORT_PB30A_EIC_EXTINT14    (1ul << 30)
-#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
-#define MUX_PA14A_EIC_EXTINT14             0L
+#define PORT_PB30A_EIC_EXTINT14  (_UL(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
-#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
-#define MUX_PA15A_EIC_EXTINT15             0L
+#define PORT_PA14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
-#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
-#define MUX_PA27A_EIC_EXTINT15             0L
+#define PORT_PA15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
-#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
-#define PIN_PB15A_EIC_EXTINT15            47L  /**< \brief EIC signal: EXTINT15 on PB15 mux A */
-#define MUX_PB15A_EIC_EXTINT15             0L
+#define PORT_PA27A_EIC_EXTINT15  (_UL(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
-#define PORT_PB15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PB31A_EIC_EXTINT15            63L  /**< \brief EIC signal: EXTINT15 on PB31 mux A */
-#define MUX_PB31A_EIC_EXTINT15             0L
+#define PORT_PB15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
-#define PORT_PB31A_EIC_EXTINT15    (1ul << 31)
-#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
-#define MUX_PA08A_EIC_NMI                  0L
+#define PORT_PB31A_EIC_EXTINT15  (_UL(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
 #define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
-#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+#define PORT_PA08A_EIC_NMI     (_UL(1) <<  8)
 /* ========== PORT definition for USB peripheral ========== */
-#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
-#define MUX_PA24G_USB_DM                   6L
+#define PIN_PA24G_USB_DM               _L_(24) /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                _L_(6)
 #define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
-#define PORT_PA24G_USB_DM          (1ul << 24)
-#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
-#define MUX_PA25G_USB_DP                   6L
+#define PORT_PA24G_USB_DM      (_UL(1) << 24)
+#define PIN_PA25G_USB_DP               _L_(25) /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                _L_(6)
 #define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
-#define PORT_PA25G_USB_DP          (1ul << 25)
+#define PORT_PA25G_USB_DP      (_UL(1) << 25)
 /* ========== PORT definition for SERCOM0 peripheral ========== */
-#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
-#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
 #define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
-#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
-#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
-#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PORT_PA08C_SERCOM0_PAD0  (_UL(1) <<  8)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
 #define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
-#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
-#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
-#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PORT_PA09C_SERCOM0_PAD1  (_UL(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
 #define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
-#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
-#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
-#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PORT_PA06D_SERCOM0_PAD2  (_UL(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
 #define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
-#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
-#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
-#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PORT_PA10C_SERCOM0_PAD2  (_UL(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
 #define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
-#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
-#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
-#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PORT_PA07D_SERCOM0_PAD3  (_UL(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
 #define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
-#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL(1) << 11)
 /* ========== PORT definition for SERCOM1 peripheral ========== */
-#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
-#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
 #define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
-#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
-#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
-#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PORT_PA16C_SERCOM1_PAD0  (_UL(1) << 16)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
 #define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
-#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
-#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
-#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PORT_PA17C_SERCOM1_PAD1  (_UL(1) << 17)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
 #define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
-#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
-#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
-#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PORT_PA30D_SERCOM1_PAD2  (_UL(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
 #define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
-#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
-#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
-#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PORT_PA18C_SERCOM1_PAD2  (_UL(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
 #define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
-#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
-#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
-#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PORT_PA31D_SERCOM1_PAD3  (_UL(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
 #define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
-#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL(1) << 19)
 /* ========== PORT definition for SERCOM2 peripheral ========== */
-#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
-#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
 #define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
-#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
-#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
-#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PORT_PA08D_SERCOM2_PAD0  (_UL(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
 #define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
-#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
-#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
-#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PORT_PA09D_SERCOM2_PAD1  (_UL(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
 #define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
-#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
-#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
-#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PORT_PA10D_SERCOM2_PAD2  (_UL(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
 #define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
-#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
-#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
-#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PORT_PA14C_SERCOM2_PAD2  (_UL(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
 #define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
-#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
-#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
-#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PORT_PA11D_SERCOM2_PAD3  (_UL(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
 #define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
-#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL(1) << 15)
 /* ========== PORT definition for SERCOM3 peripheral ========== */
-#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
-#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
 #define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
-#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
-#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
-#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PORT_PA16D_SERCOM3_PAD0  (_UL(1) << 16)
+#define PIN_PA27F_SERCOM3_PAD0         _L_(27) /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0          _L_(5)
 #define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
-#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
-#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
-#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PORT_PA27F_SERCOM3_PAD0  (_UL(1) << 27)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
 #define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
-#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
-#define PIN_PA28F_SERCOM3_PAD1            28L  /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
-#define MUX_PA28F_SERCOM3_PAD1             5L
+#define PORT_PA17D_SERCOM3_PAD1  (_UL(1) << 17)
+#define PIN_PA28F_SERCOM3_PAD1         _L_(28) /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
+#define MUX_PA28F_SERCOM3_PAD1          _L_(5)
 #define PINMUX_PA28F_SERCOM3_PAD1  ((PIN_PA28F_SERCOM3_PAD1 << 16) | MUX_PA28F_SERCOM3_PAD1)
-#define PORT_PA28F_SERCOM3_PAD1    (1ul << 28)
-#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
-#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PORT_PA28F_SERCOM3_PAD1  (_UL(1) << 28)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
-#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
-#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
-#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PORT_PA18D_SERCOM3_PAD2  (_UL(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
-#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
-#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
-#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PORT_PA20D_SERCOM3_PAD2  (_UL(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
 #define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
-#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
-#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
-#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PORT_PA24C_SERCOM3_PAD2  (_UL(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
 #define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
-#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
-#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
-#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PORT_PA19D_SERCOM3_PAD3  (_UL(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
 #define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
-#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for SERCOM4 peripheral ========== */
-#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
-#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
-#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
-#define PIN_PC19F_SERCOM4_PAD0            83L  /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
-#define MUX_PC19F_SERCOM4_PAD0             5L
+#define PORT_PB08D_SERCOM4_PAD0  (_UL(1) <<  8)
+#define PIN_PC19F_SERCOM4_PAD0         _L_(83) /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
+#define MUX_PC19F_SERCOM4_PAD0          _L_(5)
 #define PINMUX_PC19F_SERCOM4_PAD0  ((PIN_PC19F_SERCOM4_PAD0 << 16) | MUX_PC19F_SERCOM4_PAD0)
-#define PORT_PC19F_SERCOM4_PAD0    (1ul << 19)
-#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
-#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PORT_PC19F_SERCOM4_PAD0  (_UL(1) << 19)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
-#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
-#define PIN_PB31F_SERCOM4_PAD1            63L  /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
-#define MUX_PB31F_SERCOM4_PAD1             5L
+#define PORT_PB09D_SERCOM4_PAD1  (_UL(1) <<  9)
+#define PIN_PB31F_SERCOM4_PAD1         _L_(63) /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
+#define MUX_PB31F_SERCOM4_PAD1          _L_(5)
 #define PINMUX_PB31F_SERCOM4_PAD1  ((PIN_PB31F_SERCOM4_PAD1 << 16) | MUX_PB31F_SERCOM4_PAD1)
-#define PORT_PB31F_SERCOM4_PAD1    (1ul << 31)
-#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
-#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PORT_PB31F_SERCOM4_PAD1  (_UL(1) << 31)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
 #define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
-#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB14C_SERCOM4_PAD2            46L  /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
-#define MUX_PB14C_SERCOM4_PAD2             2L
+#define PORT_PA14D_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
 #define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
-#define PORT_PB14C_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB30F_SERCOM4_PAD2            62L  /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
-#define MUX_PB30F_SERCOM4_PAD2             5L
+#define PORT_PB14C_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB30F_SERCOM4_PAD2         _L_(62) /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
+#define MUX_PB30F_SERCOM4_PAD2          _L_(5)
 #define PINMUX_PB30F_SERCOM4_PAD2  ((PIN_PB30F_SERCOM4_PAD2 << 16) | MUX_PB30F_SERCOM4_PAD2)
-#define PORT_PB30F_SERCOM4_PAD2    (1ul << 30)
-#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
-#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PORT_PB30F_SERCOM4_PAD2  (_UL(1) << 30)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
 #define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
-#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PB15C_SERCOM4_PAD3            47L  /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
-#define MUX_PB15C_SERCOM4_PAD3             2L
+#define PORT_PA15D_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
 #define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
-#define PORT_PB15C_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PC18F_SERCOM4_PAD3            82L  /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
-#define MUX_PC18F_SERCOM4_PAD3             5L
+#define PORT_PB15C_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PC18F_SERCOM4_PAD3         _L_(82) /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
+#define MUX_PC18F_SERCOM4_PAD3          _L_(5)
 #define PINMUX_PC18F_SERCOM4_PAD3  ((PIN_PC18F_SERCOM4_PAD3 << 16) | MUX_PC18F_SERCOM4_PAD3)
-#define PORT_PC18F_SERCOM4_PAD3    (1ul << 18)
+#define PORT_PC18F_SERCOM4_PAD3  (_UL(1) << 18)
 /* ========== PORT definition for SERCOM5 peripheral ========== */
-#define PIN_PB16C_SERCOM5_PAD0            48L  /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
-#define MUX_PB16C_SERCOM5_PAD0             2L
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
 #define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
-#define PORT_PB16C_SERCOM5_PAD0    (1ul << 16)
-#define PIN_PB30D_SERCOM5_PAD0            62L  /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
-#define MUX_PB30D_SERCOM5_PAD0             3L
+#define PORT_PB16C_SERCOM5_PAD0  (_UL(1) << 16)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
-#define PORT_PB30D_SERCOM5_PAD0    (1ul << 30)
-#define PIN_PB17C_SERCOM5_PAD1            49L  /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
-#define MUX_PB17C_SERCOM5_PAD1             2L
+#define PORT_PB30D_SERCOM5_PAD0  (_UL(1) << 30)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
 #define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
-#define PORT_PB17C_SERCOM5_PAD1    (1ul << 17)
-#define PIN_PB31D_SERCOM5_PAD1            63L  /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
-#define MUX_PB31D_SERCOM5_PAD1             3L
+#define PORT_PB17C_SERCOM5_PAD1  (_UL(1) << 17)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
-#define PORT_PB31D_SERCOM5_PAD1    (1ul << 31)
-#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
-#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PORT_PB31D_SERCOM5_PAD1  (_UL(1) << 31)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
-#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
-#define PIN_PB00D_SERCOM5_PAD2            32L  /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
-#define MUX_PB00D_SERCOM5_PAD2             3L
+#define PORT_PA24D_SERCOM5_PAD2  (_UL(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
-#define PORT_PB00D_SERCOM5_PAD2    (1ul <<  0)
-#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
-#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PORT_PB00D_SERCOM5_PAD2  (_UL(1) <<  0)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
 #define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
-#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
-#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
-#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PORT_PA20C_SERCOM5_PAD2  (_UL(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
-#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for TCC0 peripheral ========== */
-#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
-#define MUX_PA08E_TCC0_WO0                 4L
+#define PIN_PA08E_TCC0_WO0              _L_(8) /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0              _L_(4)
 #define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
-#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
-#define PIN_PB30E_TCC0_WO0                62L  /**< \brief TCC0 signal: WO0 on PB30 mux E */
-#define MUX_PB30E_TCC0_WO0                 4L
+#define PORT_PA08E_TCC0_WO0    (_UL(1) <<  8)
+#define PIN_PB30E_TCC0_WO0             _L_(62) /**< \brief TCC0 signal: WO0 on PB30 mux E */
+#define MUX_PB30E_TCC0_WO0              _L_(4)
 #define PINMUX_PB30E_TCC0_WO0      ((PIN_PB30E_TCC0_WO0 << 16) | MUX_PB30E_TCC0_WO0)
-#define PORT_PB30E_TCC0_WO0        (1ul << 30)
-#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
-#define MUX_PA16F_TCC0_WO0                 5L
+#define PORT_PB30E_TCC0_WO0    (_UL(1) << 30)
+#define PIN_PA16F_TCC0_WO0             _L_(16) /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0              _L_(5)
 #define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
-#define PORT_PA16F_TCC0_WO0        (1ul << 16)
-#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
-#define MUX_PA09E_TCC0_WO1                 4L
+#define PORT_PA16F_TCC0_WO0    (_UL(1) << 16)
+#define PIN_PA09E_TCC0_WO1              _L_(9) /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1              _L_(4)
 #define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
-#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
-#define PIN_PB31E_TCC0_WO1                63L  /**< \brief TCC0 signal: WO1 on PB31 mux E */
-#define MUX_PB31E_TCC0_WO1                 4L
+#define PORT_PA09E_TCC0_WO1    (_UL(1) <<  9)
+#define PIN_PB31E_TCC0_WO1             _L_(63) /**< \brief TCC0 signal: WO1 on PB31 mux E */
+#define MUX_PB31E_TCC0_WO1              _L_(4)
 #define PINMUX_PB31E_TCC0_WO1      ((PIN_PB31E_TCC0_WO1 << 16) | MUX_PB31E_TCC0_WO1)
-#define PORT_PB31E_TCC0_WO1        (1ul << 31)
-#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
-#define MUX_PA17F_TCC0_WO1                 5L
+#define PORT_PB31E_TCC0_WO1    (_UL(1) << 31)
+#define PIN_PA17F_TCC0_WO1             _L_(17) /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1              _L_(5)
 #define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
-#define PORT_PA17F_TCC0_WO1        (1ul << 17)
-#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
-#define MUX_PA10F_TCC0_WO2                 5L
+#define PORT_PA17F_TCC0_WO1    (_UL(1) << 17)
+#define PIN_PA10F_TCC0_WO2             _L_(10) /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2              _L_(5)
 #define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
-#define PORT_PA10F_TCC0_WO2        (1ul << 10)
-#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
-#define MUX_PA18F_TCC0_WO2                 5L
+#define PORT_PA10F_TCC0_WO2    (_UL(1) << 10)
+#define PIN_PA18F_TCC0_WO2             _L_(18) /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2              _L_(5)
 #define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
-#define PORT_PA18F_TCC0_WO2        (1ul << 18)
-#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
-#define MUX_PA11F_TCC0_WO3                 5L
+#define PORT_PA18F_TCC0_WO2    (_UL(1) << 18)
+#define PIN_PA11F_TCC0_WO3             _L_(11) /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3              _L_(5)
 #define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
-#define PORT_PA11F_TCC0_WO3        (1ul << 11)
-#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
-#define MUX_PA19F_TCC0_WO3                 5L
+#define PORT_PA11F_TCC0_WO3    (_UL(1) << 11)
+#define PIN_PA19F_TCC0_WO3             _L_(19) /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3              _L_(5)
 #define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
-#define PORT_PA19F_TCC0_WO3        (1ul << 19)
-#define PIN_PB16F_TCC0_WO4                48L  /**< \brief TCC0 signal: WO4 on PB16 mux F */
-#define MUX_PB16F_TCC0_WO4                 5L
+#define PORT_PA19F_TCC0_WO3    (_UL(1) << 19)
+#define PIN_PB16F_TCC0_WO4             _L_(48) /**< \brief TCC0 signal: WO4 on PB16 mux F */
+#define MUX_PB16F_TCC0_WO4              _L_(5)
 #define PINMUX_PB16F_TCC0_WO4      ((PIN_PB16F_TCC0_WO4 << 16) | MUX_PB16F_TCC0_WO4)
-#define PORT_PB16F_TCC0_WO4        (1ul << 16)
-#define PIN_PB17F_TCC0_WO5                49L  /**< \brief TCC0 signal: WO5 on PB17 mux F */
-#define MUX_PB17F_TCC0_WO5                 5L
+#define PORT_PB16F_TCC0_WO4    (_UL(1) << 16)
+#define PIN_PB17F_TCC0_WO5             _L_(49) /**< \brief TCC0 signal: WO5 on PB17 mux F */
+#define MUX_PB17F_TCC0_WO5              _L_(5)
 #define PINMUX_PB17F_TCC0_WO5      ((PIN_PB17F_TCC0_WO5 << 16) | MUX_PB17F_TCC0_WO5)
-#define PORT_PB17F_TCC0_WO5        (1ul << 17)
-#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
-#define MUX_PA20F_TCC0_WO6                 5L
+#define PORT_PB17F_TCC0_WO5    (_UL(1) << 17)
+#define PIN_PA20F_TCC0_WO6             _L_(20) /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6              _L_(5)
 #define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
-#define PORT_PA20F_TCC0_WO6        (1ul << 20)
+#define PORT_PA20F_TCC0_WO6    (_UL(1) << 20)
 /* ========== PORT definition for TCC1 peripheral ========== */
-#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
-#define MUX_PA06E_TCC1_WO0                 4L
+#define PIN_PA06E_TCC1_WO0              _L_(6) /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0              _L_(4)
 #define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
-#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
-#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
-#define MUX_PA10E_TCC1_WO0                 4L
+#define PORT_PA06E_TCC1_WO0    (_UL(1) <<  6)
+#define PIN_PA10E_TCC1_WO0             _L_(10) /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0              _L_(4)
 #define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
-#define PORT_PA10E_TCC1_WO0        (1ul << 10)
-#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
-#define MUX_PA30E_TCC1_WO0                 4L
+#define PORT_PA10E_TCC1_WO0    (_UL(1) << 10)
+#define PIN_PA30E_TCC1_WO0             _L_(30) /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0              _L_(4)
 #define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
-#define PORT_PA30E_TCC1_WO0        (1ul << 30)
-#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
-#define MUX_PA07E_TCC1_WO1                 4L
+#define PORT_PA30E_TCC1_WO0    (_UL(1) << 30)
+#define PIN_PA07E_TCC1_WO1              _L_(7) /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1              _L_(4)
 #define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
-#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
-#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
-#define MUX_PA11E_TCC1_WO1                 4L
+#define PORT_PA07E_TCC1_WO1    (_UL(1) <<  7)
+#define PIN_PA11E_TCC1_WO1             _L_(11) /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1              _L_(4)
 #define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
-#define PORT_PA11E_TCC1_WO1        (1ul << 11)
-#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
-#define MUX_PA31E_TCC1_WO1                 4L
+#define PORT_PA11E_TCC1_WO1    (_UL(1) << 11)
+#define PIN_PA31E_TCC1_WO1             _L_(31) /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1              _L_(4)
 #define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
-#define PORT_PA31E_TCC1_WO1        (1ul << 31)
-#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
-#define MUX_PA24F_TCC1_WO2                 5L
+#define PORT_PA31E_TCC1_WO1    (_UL(1) << 31)
+#define PIN_PA24F_TCC1_WO2             _L_(24) /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2              _L_(5)
 #define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
-#define PORT_PA24F_TCC1_WO2        (1ul << 24)
-#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
-#define MUX_PA25F_TCC1_WO3                 5L
+#define PORT_PA24F_TCC1_WO2    (_UL(1) << 24)
+#define PIN_PA25F_TCC1_WO3             _L_(25) /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3              _L_(5)
 #define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
-#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+#define PORT_PA25F_TCC1_WO3    (_UL(1) << 25)
 /* ========== PORT definition for TCC2 peripheral ========== */
-#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
-#define MUX_PA16E_TCC2_WO0                 4L
+#define PIN_PA16E_TCC2_WO0             _L_(16) /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0              _L_(4)
 #define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
-#define PORT_PA16E_TCC2_WO0        (1ul << 16)
-#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
-#define MUX_PA17E_TCC2_WO1                 4L
+#define PORT_PA16E_TCC2_WO0    (_UL(1) << 16)
+#define PIN_PA17E_TCC2_WO1             _L_(17) /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1              _L_(4)
 #define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
-#define PORT_PA17E_TCC2_WO1        (1ul << 17)
+#define PORT_PA17E_TCC2_WO1    (_UL(1) << 17)
 /* ========== PORT definition for TC3 peripheral ========== */
-#define PIN_PA18E_TC3_WO0                 18L  /**< \brief TC3 signal: WO0 on PA18 mux E */
-#define MUX_PA18E_TC3_WO0                  4L
+#define PIN_PA18E_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC3_WO0               _L_(4)
 #define PINMUX_PA18E_TC3_WO0       ((PIN_PA18E_TC3_WO0 << 16) | MUX_PA18E_TC3_WO0)
-#define PORT_PA18E_TC3_WO0         (1ul << 18)
-#define PIN_PA14E_TC3_WO0                 14L  /**< \brief TC3 signal: WO0 on PA14 mux E */
-#define MUX_PA14E_TC3_WO0                  4L
+#define PORT_PA18E_TC3_WO0     (_UL(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
 #define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
-#define PORT_PA14E_TC3_WO0         (1ul << 14)
-#define PIN_PA19E_TC3_WO1                 19L  /**< \brief TC3 signal: WO1 on PA19 mux E */
-#define MUX_PA19E_TC3_WO1                  4L
+#define PORT_PA14E_TC3_WO0     (_UL(1) << 14)
+#define PIN_PA19E_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC3_WO1               _L_(4)
 #define PINMUX_PA19E_TC3_WO1       ((PIN_PA19E_TC3_WO1 << 16) | MUX_PA19E_TC3_WO1)
-#define PORT_PA19E_TC3_WO1         (1ul << 19)
-#define PIN_PA15E_TC3_WO1                 15L  /**< \brief TC3 signal: WO1 on PA15 mux E */
-#define MUX_PA15E_TC3_WO1                  4L
+#define PORT_PA19E_TC3_WO1     (_UL(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
 #define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
-#define PORT_PA15E_TC3_WO1         (1ul << 15)
+#define PORT_PA15E_TC3_WO1     (_UL(1) << 15)
 /* ========== PORT definition for TC4 peripheral ========== */
-#define PIN_PB08E_TC4_WO0                 40L  /**< \brief TC4 signal: WO0 on PB08 mux E */
-#define MUX_PB08E_TC4_WO0                  4L
+#define PIN_PB08E_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC4_WO0               _L_(4)
 #define PINMUX_PB08E_TC4_WO0       ((PIN_PB08E_TC4_WO0 << 16) | MUX_PB08E_TC4_WO0)
-#define PORT_PB08E_TC4_WO0         (1ul <<  8)
-#define PIN_PB09E_TC4_WO1                 41L  /**< \brief TC4 signal: WO1 on PB09 mux E */
-#define MUX_PB09E_TC4_WO1                  4L
+#define PORT_PB08E_TC4_WO0     (_UL(1) <<  8)
+#define PIN_PB09E_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC4_WO1               _L_(4)
 #define PINMUX_PB09E_TC4_WO1       ((PIN_PB09E_TC4_WO1 << 16) | MUX_PB09E_TC4_WO1)
-#define PORT_PB09E_TC4_WO1         (1ul <<  9)
+#define PORT_PB09E_TC4_WO1     (_UL(1) <<  9)
 /* ========== PORT definition for TC5 peripheral ========== */
-#define PIN_PA24E_TC5_WO0                 24L  /**< \brief TC5 signal: WO0 on PA24 mux E */
-#define MUX_PA24E_TC5_WO0                  4L
+#define PIN_PA24E_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC5_WO0               _L_(4)
 #define PINMUX_PA24E_TC5_WO0       ((PIN_PA24E_TC5_WO0 << 16) | MUX_PA24E_TC5_WO0)
-#define PORT_PA24E_TC5_WO0         (1ul << 24)
-#define PIN_PB14E_TC5_WO0                 46L  /**< \brief TC5 signal: WO0 on PB14 mux E */
-#define MUX_PB14E_TC5_WO0                  4L
+#define PORT_PA24E_TC5_WO0     (_UL(1) << 24)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
 #define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
-#define PORT_PB14E_TC5_WO0         (1ul << 14)
-#define PIN_PA25E_TC5_WO1                 25L  /**< \brief TC5 signal: WO1 on PA25 mux E */
-#define MUX_PA25E_TC5_WO1                  4L
+#define PORT_PB14E_TC5_WO0     (_UL(1) << 14)
+#define PIN_PA25E_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC5_WO1               _L_(4)
 #define PINMUX_PA25E_TC5_WO1       ((PIN_PA25E_TC5_WO1 << 16) | MUX_PA25E_TC5_WO1)
-#define PORT_PA25E_TC5_WO1         (1ul << 25)
-#define PIN_PB15E_TC5_WO1                 47L  /**< \brief TC5 signal: WO1 on PB15 mux E */
-#define MUX_PB15E_TC5_WO1                  4L
+#define PORT_PA25E_TC5_WO1     (_UL(1) << 25)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
 #define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
-#define PORT_PB15E_TC5_WO1         (1ul << 15)
+#define PORT_PB15E_TC5_WO1     (_UL(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL(1) << 16)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL(1) << 20)
+#define PIN_PB00E_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux E */
+#define MUX_PB00E_TC7_WO0               _L_(4)
+#define PINMUX_PB00E_TC7_WO0       ((PIN_PB00E_TC7_WO0 << 16) | MUX_PB00E_TC7_WO0)
+#define PORT_PB00E_TC7_WO0     (_UL(1) <<  0)
 /* ========== PORT definition for ADC peripheral ========== */
-#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
-#define MUX_PB08B_ADC_AIN2                 1L
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
 #define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
-#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
-#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
-#define MUX_PB09B_ADC_AIN3                 1L
+#define PORT_PB08B_ADC_AIN2    (_UL(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
 #define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
-#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
-#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
-#define MUX_PA06B_ADC_AIN6                 1L
+#define PORT_PB09B_ADC_AIN3    (_UL(1) <<  9)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
 #define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
-#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
-#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
-#define MUX_PA07B_ADC_AIN7                 1L
+#define PORT_PA06B_ADC_AIN6    (_UL(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
 #define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
-#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
-#define PIN_PB00B_ADC_AIN8                32L  /**< \brief ADC signal: AIN8 on PB00 mux B */
-#define MUX_PB00B_ADC_AIN8                 1L
+#define PORT_PA07B_ADC_AIN7    (_UL(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
 #define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
-#define PORT_PB00B_ADC_AIN8        (1ul <<  0)
-#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
-#define MUX_PA08B_ADC_AIN16                1L
+#define PORT_PB00B_ADC_AIN8    (_UL(1) <<  0)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
 #define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
-#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
-#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
-#define MUX_PA09B_ADC_AIN17                1L
+#define PORT_PA08B_ADC_AIN16   (_UL(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
 #define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
-#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
-#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
-#define MUX_PA10B_ADC_AIN18                1L
+#define PORT_PA09B_ADC_AIN17   (_UL(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
 #define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
-#define PORT_PA10B_ADC_AIN18       (1ul << 10)
-#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
-#define MUX_PA11B_ADC_AIN19                1L
+#define PORT_PA10B_ADC_AIN18   (_UL(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
 #define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
-#define PORT_PA11B_ADC_AIN19       (1ul << 11)
+#define PORT_PA11B_ADC_AIN19   (_UL(1) << 11)
 /* ========== PORT definition for AC peripheral ========== */
-#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
-#define MUX_PA06B_AC_AIN2                  1L
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
 #define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
-#define PORT_PA06B_AC_AIN2         (1ul <<  6)
-#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
-#define MUX_PA07B_AC_AIN3                  1L
+#define PORT_PA06B_AC_AIN2     (_UL(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
 #define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
-#define PORT_PA07B_AC_AIN3         (1ul <<  7)
-#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
-#define MUX_PA18H_AC_CMP0                  7L
+#define PORT_PA07B_AC_AIN3     (_UL(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
 #define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
-#define PORT_PA18H_AC_CMP0         (1ul << 18)
-#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
-#define MUX_PA19H_AC_CMP1                  7L
+#define PORT_PA18H_AC_CMP0     (_UL(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
 #define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
-#define PORT_PA19H_AC_CMP1         (1ul << 19)
+#define PORT_PA19H_AC_CMP1     (_UL(1) << 19)
 /* ========== PORT definition for RFCTRL peripheral ========== */
-#define PIN_PA08F_RFCTRL_FECTRL0           8L  /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
-#define MUX_PA08F_RFCTRL_FECTRL0           5L
+#define PIN_PA08F_RFCTRL_FECTRL0        _L_(8) /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
+#define MUX_PA08F_RFCTRL_FECTRL0        _L_(5)
 #define PINMUX_PA08F_RFCTRL_FECTRL0  ((PIN_PA08F_RFCTRL_FECTRL0 << 16) | MUX_PA08F_RFCTRL_FECTRL0)
-#define PORT_PA08F_RFCTRL_FECTRL0  (1ul <<  8)
-#define PIN_PA09F_RFCTRL_FECTRL1           9L  /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
-#define MUX_PA09F_RFCTRL_FECTRL1           5L
+#define PORT_PA08F_RFCTRL_FECTRL0  (_UL(1) <<  8)
+#define PIN_PA09F_RFCTRL_FECTRL1        _L_(9) /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
+#define MUX_PA09F_RFCTRL_FECTRL1        _L_(5)
 #define PINMUX_PA09F_RFCTRL_FECTRL1  ((PIN_PA09F_RFCTRL_FECTRL1 << 16) | MUX_PA09F_RFCTRL_FECTRL1)
-#define PORT_PA09F_RFCTRL_FECTRL1  (1ul <<  9)
-#define PIN_PA14F_RFCTRL_FECTRL4          14L  /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
-#define MUX_PA14F_RFCTRL_FECTRL4           5L
+#define PORT_PA09F_RFCTRL_FECTRL1  (_UL(1) <<  9)
+#define PIN_PA14F_RFCTRL_FECTRL4       _L_(14) /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
+#define MUX_PA14F_RFCTRL_FECTRL4        _L_(5)
 #define PINMUX_PA14F_RFCTRL_FECTRL4  ((PIN_PA14F_RFCTRL_FECTRL4 << 16) | MUX_PA14F_RFCTRL_FECTRL4)
-#define PORT_PA14F_RFCTRL_FECTRL4  (1ul << 14)
-#define PIN_PA15F_RFCTRL_FECTRL5          15L  /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
-#define MUX_PA15F_RFCTRL_FECTRL5           5L
+#define PORT_PA14F_RFCTRL_FECTRL4  (_UL(1) << 14)
+#define PIN_PA15F_RFCTRL_FECTRL5       _L_(15) /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
+#define MUX_PA15F_RFCTRL_FECTRL5        _L_(5)
 #define PINMUX_PA15F_RFCTRL_FECTRL5  ((PIN_PA15F_RFCTRL_FECTRL5 << 16) | MUX_PA15F_RFCTRL_FECTRL5)
-#define PORT_PA15F_RFCTRL_FECTRL5  (1ul << 15)
+#define PORT_PA15F_RFCTRL_FECTRL5  (_UL(1) << 15)
 
 #endif /* _SAMR21E17A_PIO_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/pio/samr21e18a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/pio/samr21e18a.h
@@ -3,39 +3,24 @@
  *
  * \brief Peripheral I/O description for SAMR21E18A
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2017 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -45,644 +30,689 @@
 #define _SAMR21E18A_PIO_
 
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PORT_PA06              (_UL(1) <<  6) /**< \brief PORT Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PORT_PA07              (_UL(1) <<  7) /**< \brief PORT Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PORT_PA08              (_UL(1) <<  8) /**< \brief PORT Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PORT_PA09              (_UL(1) <<  9) /**< \brief PORT Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PORT_PA10              (_UL(1) << 10) /**< \brief PORT Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PORT_PA11              (_UL(1) << 11) /**< \brief PORT Mask  for PA11 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PORT_PA14              (_UL(1) << 14) /**< \brief PORT Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PORT_PA15              (_UL(1) << 15) /**< \brief PORT Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PORT_PA16              (_UL(1) << 16) /**< \brief PORT Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PORT_PA17              (_UL(1) << 17) /**< \brief PORT Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PORT_PA18              (_UL(1) << 18) /**< \brief PORT Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PORT_PA19              (_UL(1) << 19) /**< \brief PORT Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PORT_PA20              (_UL(1) << 20) /**< \brief PORT Mask  for PA20 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PORT_PA24              (_UL(1) << 24) /**< \brief PORT Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PORT_PA25              (_UL(1) << 25) /**< \brief PORT Mask  for PA25 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PORT_PA27              (_UL(1) << 27) /**< \brief PORT Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define PORT_PA28                 (1ul << 28) /**< \brief PORT Mask  for PA28 */
+#define PORT_PA28              (_UL(1) << 28) /**< \brief PORT Mask  for PA28 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PORT_PA30              (_UL(1) << 30) /**< \brief PORT Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PORT_PA31              (_UL(1) << 31) /**< \brief PORT Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define PORT_PB00                 (1ul <<  0) /**< \brief PORT Mask  for PB00 */
+#define PORT_PB00              (_UL(1) <<  0) /**< \brief PORT Mask  for PB00 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PORT_PB08              (_UL(1) <<  8) /**< \brief PORT Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PORT_PB09              (_UL(1) <<  9) /**< \brief PORT Mask  for PB09 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define PORT_PB14                 (1ul << 14) /**< \brief PORT Mask  for PB14 */
+#define PORT_PB14              (_UL(1) << 14) /**< \brief PORT Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define PORT_PB15                 (1ul << 15) /**< \brief PORT Mask  for PB15 */
+#define PORT_PB15              (_UL(1) << 15) /**< \brief PORT Mask  for PB15 */
 #define PIN_PB16                          48  /**< \brief Pin Number for PB16 */
-#define PORT_PB16                 (1ul << 16) /**< \brief PORT Mask  for PB16 */
+#define PORT_PB16              (_UL(1) << 16) /**< \brief PORT Mask  for PB16 */
 #define PIN_PB17                          49  /**< \brief Pin Number for PB17 */
-#define PORT_PB17                 (1ul << 17) /**< \brief PORT Mask  for PB17 */
+#define PORT_PB17              (_UL(1) << 17) /**< \brief PORT Mask  for PB17 */
 #define PIN_PB30                          62  /**< \brief Pin Number for PB30 */
-#define PORT_PB30                 (1ul << 30) /**< \brief PORT Mask  for PB30 */
+#define PORT_PB30              (_UL(1) << 30) /**< \brief PORT Mask  for PB30 */
 #define PIN_PB31                          63  /**< \brief Pin Number for PB31 */
-#define PORT_PB31                 (1ul << 31) /**< \brief PORT Mask  for PB31 */
+#define PORT_PB31              (_UL(1) << 31) /**< \brief PORT Mask  for PB31 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define PORT_PC16                 (1ul << 16) /**< \brief PORT Mask  for PC16 */
+#define PORT_PC16              (_UL(1) << 16) /**< \brief PORT Mask  for PC16 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define PORT_PC18                 (1ul << 18) /**< \brief PORT Mask  for PC18 */
+#define PORT_PC18              (_UL(1) << 18) /**< \brief PORT Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define PORT_PC19                 (1ul << 19) /**< \brief PORT Mask  for PC19 */
+#define PORT_PC19              (_UL(1) << 19) /**< \brief PORT Mask  for PC19 */
 /* ========== PORT definition for GCLK peripheral ========== */
-#define PIN_PB14H_GCLK_IO0                46L  /**< \brief GCLK signal: IO0 on PB14 mux H */
-#define MUX_PB14H_GCLK_IO0                 7L
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
 #define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
-#define PORT_PB14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
-#define MUX_PA14H_GCLK_IO0                 7L
+#define PORT_PB14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
 #define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
-#define PORT_PA14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
-#define MUX_PA27H_GCLK_IO0                 7L
+#define PORT_PA14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
 #define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
-#define PORT_PA27H_GCLK_IO0        (1ul << 27)
-#define PIN_PA28H_GCLK_IO0                28L  /**< \brief GCLK signal: IO0 on PA28 mux H */
-#define MUX_PA28H_GCLK_IO0                 7L
+#define PORT_PA27H_GCLK_IO0    (_UL(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
 #define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
-#define PORT_PA28H_GCLK_IO0        (1ul << 28)
-#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
-#define MUX_PA30H_GCLK_IO0                 7L
+#define PORT_PA28H_GCLK_IO0    (_UL(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
 #define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
-#define PORT_PA30H_GCLK_IO0        (1ul << 30)
-#define PIN_PB15H_GCLK_IO1                47L  /**< \brief GCLK signal: IO1 on PB15 mux H */
-#define MUX_PB15H_GCLK_IO1                 7L
+#define PORT_PA30H_GCLK_IO0    (_UL(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
 #define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
-#define PORT_PB15H_GCLK_IO1        (1ul << 15)
-#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
-#define MUX_PA15H_GCLK_IO1                 7L
+#define PORT_PB15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
 #define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
-#define PORT_PA15H_GCLK_IO1        (1ul << 15)
-#define PIN_PC16F_GCLK_IO1                80L  /**< \brief GCLK signal: IO1 on PC16 mux F */
-#define MUX_PC16F_GCLK_IO1                 5L
+#define PORT_PA15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PC16F_GCLK_IO1             _L_(80) /**< \brief GCLK signal: IO1 on PC16 mux F */
+#define MUX_PC16F_GCLK_IO1              _L_(5)
 #define PINMUX_PC16F_GCLK_IO1      ((PIN_PC16F_GCLK_IO1 << 16) | MUX_PC16F_GCLK_IO1)
-#define PORT_PC16F_GCLK_IO1        (1ul << 16)
-#define PIN_PB16H_GCLK_IO2                48L  /**< \brief GCLK signal: IO2 on PB16 mux H */
-#define MUX_PB16H_GCLK_IO2                 7L
+#define PORT_PC16F_GCLK_IO1    (_UL(1) << 16)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
 #define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
-#define PORT_PB16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
-#define MUX_PA16H_GCLK_IO2                 7L
+#define PORT_PB16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
 #define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
-#define PORT_PA16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
-#define MUX_PA17H_GCLK_IO3                 7L
+#define PORT_PA16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
 #define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
-#define PORT_PA17H_GCLK_IO3        (1ul << 17)
-#define PIN_PB17H_GCLK_IO3                49L  /**< \brief GCLK signal: IO3 on PB17 mux H */
-#define MUX_PB17H_GCLK_IO3                 7L
+#define PORT_PA17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
 #define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
-#define PORT_PB17H_GCLK_IO3        (1ul << 17)
-#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
-#define MUX_PA10H_GCLK_IO4                 7L
+#define PORT_PB17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
 #define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
-#define PORT_PA10H_GCLK_IO4        (1ul << 10)
-#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
-#define MUX_PA20H_GCLK_IO4                 7L
+#define PORT_PA10H_GCLK_IO4    (_UL(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
 #define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
-#define PORT_PA20H_GCLK_IO4        (1ul << 20)
-#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
-#define MUX_PA11H_GCLK_IO5                 7L
+#define PORT_PA20H_GCLK_IO4    (_UL(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
 #define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
-#define PORT_PA11H_GCLK_IO5        (1ul << 11)
+#define PORT_PA11H_GCLK_IO5    (_UL(1) << 11)
 /* ========== PORT definition for EIC peripheral ========== */
-#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
-#define MUX_PA16A_EIC_EXTINT0              0L
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
-#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PB00A_EIC_EXTINT0             32L  /**< \brief EIC signal: EXTINT0 on PB00 mux A */
-#define MUX_PB00A_EIC_EXTINT0              0L
+#define PORT_PA16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
-#define PORT_PB00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PB16A_EIC_EXTINT0             48L  /**< \brief EIC signal: EXTINT0 on PB16 mux A */
-#define MUX_PB16A_EIC_EXTINT0              0L
+#define PORT_PB00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
-#define PORT_PB16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
-#define MUX_PA17A_EIC_EXTINT1              0L
+#define PORT_PB16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
-#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PB17A_EIC_EXTINT1             49L  /**< \brief EIC signal: EXTINT1 on PB17 mux A */
-#define MUX_PB17A_EIC_EXTINT1              0L
+#define PORT_PA17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
-#define PORT_PB17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
-#define MUX_PA18A_EIC_EXTINT2              0L
+#define PORT_PB17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
-#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
-#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
-#define MUX_PA19A_EIC_EXTINT3              0L
+#define PORT_PA18A_EIC_EXTINT2  (_UL(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
-#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
-#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
-#define MUX_PA20A_EIC_EXTINT4              0L
+#define PORT_PA19A_EIC_EXTINT3  (_UL(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
-#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
-#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
-#define MUX_PA06A_EIC_EXTINT6              0L
+#define PORT_PA20A_EIC_EXTINT4  (_UL(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
-#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
-#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
-#define MUX_PA07A_EIC_EXTINT7              0L
+#define PORT_PA06A_EIC_EXTINT6  (_UL(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
-#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
-#define PIN_PA28A_EIC_EXTINT8             28L  /**< \brief EIC signal: EXTINT8 on PA28 mux A */
-#define MUX_PA28A_EIC_EXTINT8              0L
+#define PORT_PA07A_EIC_EXTINT7  (_UL(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
-#define PORT_PA28A_EIC_EXTINT8     (1ul << 28)
-#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
-#define MUX_PB08A_EIC_EXTINT8              0L
+#define PORT_PA28A_EIC_EXTINT8  (_UL(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
-#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
-#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
-#define MUX_PA09A_EIC_EXTINT9              0L
+#define PORT_PB08A_EIC_EXTINT8  (_UL(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
-#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
-#define MUX_PB09A_EIC_EXTINT9              0L
+#define PORT_PA09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
-#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
-#define MUX_PA10A_EIC_EXTINT10             0L
+#define PORT_PB09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
-#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
-#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
-#define MUX_PA30A_EIC_EXTINT10             0L
+#define PORT_PA10A_EIC_EXTINT10  (_UL(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
-#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
-#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
-#define MUX_PA11A_EIC_EXTINT11             0L
+#define PORT_PA30A_EIC_EXTINT10  (_UL(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
-#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
-#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
-#define MUX_PA31A_EIC_EXTINT11             0L
+#define PORT_PA11A_EIC_EXTINT11  (_UL(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
-#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
-#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
-#define MUX_PA24A_EIC_EXTINT12             0L
+#define PORT_PA31A_EIC_EXTINT11  (_UL(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
-#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
-#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
-#define MUX_PA25A_EIC_EXTINT13             0L
+#define PORT_PA24A_EIC_EXTINT12  (_UL(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
-#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
-#define PIN_PB14A_EIC_EXTINT14            46L  /**< \brief EIC signal: EXTINT14 on PB14 mux A */
-#define MUX_PB14A_EIC_EXTINT14             0L
+#define PORT_PA25A_EIC_EXTINT13  (_UL(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
-#define PORT_PB14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PB30A_EIC_EXTINT14            62L  /**< \brief EIC signal: EXTINT14 on PB30 mux A */
-#define MUX_PB30A_EIC_EXTINT14             0L
+#define PORT_PB14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
-#define PORT_PB30A_EIC_EXTINT14    (1ul << 30)
-#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
-#define MUX_PA14A_EIC_EXTINT14             0L
+#define PORT_PB30A_EIC_EXTINT14  (_UL(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
-#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
-#define MUX_PA15A_EIC_EXTINT15             0L
+#define PORT_PA14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
-#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
-#define MUX_PA27A_EIC_EXTINT15             0L
+#define PORT_PA15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
-#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
-#define PIN_PB15A_EIC_EXTINT15            47L  /**< \brief EIC signal: EXTINT15 on PB15 mux A */
-#define MUX_PB15A_EIC_EXTINT15             0L
+#define PORT_PA27A_EIC_EXTINT15  (_UL(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
-#define PORT_PB15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PB31A_EIC_EXTINT15            63L  /**< \brief EIC signal: EXTINT15 on PB31 mux A */
-#define MUX_PB31A_EIC_EXTINT15             0L
+#define PORT_PB15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
-#define PORT_PB31A_EIC_EXTINT15    (1ul << 31)
-#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
-#define MUX_PA08A_EIC_NMI                  0L
+#define PORT_PB31A_EIC_EXTINT15  (_UL(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
 #define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
-#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+#define PORT_PA08A_EIC_NMI     (_UL(1) <<  8)
 /* ========== PORT definition for USB peripheral ========== */
-#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
-#define MUX_PA24G_USB_DM                   6L
+#define PIN_PA24G_USB_DM               _L_(24) /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                _L_(6)
 #define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
-#define PORT_PA24G_USB_DM          (1ul << 24)
-#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
-#define MUX_PA25G_USB_DP                   6L
+#define PORT_PA24G_USB_DM      (_UL(1) << 24)
+#define PIN_PA25G_USB_DP               _L_(25) /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                _L_(6)
 #define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
-#define PORT_PA25G_USB_DP          (1ul << 25)
+#define PORT_PA25G_USB_DP      (_UL(1) << 25)
 /* ========== PORT definition for SERCOM0 peripheral ========== */
-#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
-#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
 #define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
-#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
-#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
-#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PORT_PA08C_SERCOM0_PAD0  (_UL(1) <<  8)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
 #define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
-#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
-#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
-#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PORT_PA09C_SERCOM0_PAD1  (_UL(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
 #define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
-#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
-#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
-#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PORT_PA06D_SERCOM0_PAD2  (_UL(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
 #define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
-#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
-#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
-#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PORT_PA10C_SERCOM0_PAD2  (_UL(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
 #define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
-#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
-#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
-#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PORT_PA07D_SERCOM0_PAD3  (_UL(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
 #define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
-#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL(1) << 11)
 /* ========== PORT definition for SERCOM1 peripheral ========== */
-#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
-#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
 #define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
-#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
-#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
-#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PORT_PA16C_SERCOM1_PAD0  (_UL(1) << 16)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
 #define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
-#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
-#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
-#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PORT_PA17C_SERCOM1_PAD1  (_UL(1) << 17)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
 #define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
-#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
-#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
-#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PORT_PA30D_SERCOM1_PAD2  (_UL(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
 #define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
-#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
-#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
-#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PORT_PA18C_SERCOM1_PAD2  (_UL(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
 #define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
-#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
-#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
-#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PORT_PA31D_SERCOM1_PAD3  (_UL(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
 #define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
-#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL(1) << 19)
 /* ========== PORT definition for SERCOM2 peripheral ========== */
-#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
-#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
 #define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
-#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
-#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
-#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PORT_PA08D_SERCOM2_PAD0  (_UL(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
 #define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
-#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
-#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
-#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PORT_PA09D_SERCOM2_PAD1  (_UL(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
 #define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
-#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
-#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
-#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PORT_PA10D_SERCOM2_PAD2  (_UL(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
 #define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
-#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
-#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
-#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PORT_PA14C_SERCOM2_PAD2  (_UL(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
 #define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
-#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
-#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
-#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PORT_PA11D_SERCOM2_PAD3  (_UL(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
 #define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
-#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL(1) << 15)
 /* ========== PORT definition for SERCOM3 peripheral ========== */
-#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
-#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
 #define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
-#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
-#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
-#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PORT_PA16D_SERCOM3_PAD0  (_UL(1) << 16)
+#define PIN_PA27F_SERCOM3_PAD0         _L_(27) /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0          _L_(5)
 #define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
-#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
-#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
-#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PORT_PA27F_SERCOM3_PAD0  (_UL(1) << 27)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
 #define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
-#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
-#define PIN_PA28F_SERCOM3_PAD1            28L  /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
-#define MUX_PA28F_SERCOM3_PAD1             5L
+#define PORT_PA17D_SERCOM3_PAD1  (_UL(1) << 17)
+#define PIN_PA28F_SERCOM3_PAD1         _L_(28) /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
+#define MUX_PA28F_SERCOM3_PAD1          _L_(5)
 #define PINMUX_PA28F_SERCOM3_PAD1  ((PIN_PA28F_SERCOM3_PAD1 << 16) | MUX_PA28F_SERCOM3_PAD1)
-#define PORT_PA28F_SERCOM3_PAD1    (1ul << 28)
-#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
-#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PORT_PA28F_SERCOM3_PAD1  (_UL(1) << 28)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
-#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
-#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
-#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PORT_PA18D_SERCOM3_PAD2  (_UL(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
-#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
-#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
-#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PORT_PA20D_SERCOM3_PAD2  (_UL(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
 #define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
-#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
-#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
-#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PORT_PA24C_SERCOM3_PAD2  (_UL(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
 #define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
-#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
-#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
-#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PORT_PA19D_SERCOM3_PAD3  (_UL(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
 #define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
-#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for SERCOM4 peripheral ========== */
-#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
-#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
-#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
-#define PIN_PC19F_SERCOM4_PAD0            83L  /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
-#define MUX_PC19F_SERCOM4_PAD0             5L
+#define PORT_PB08D_SERCOM4_PAD0  (_UL(1) <<  8)
+#define PIN_PC19F_SERCOM4_PAD0         _L_(83) /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
+#define MUX_PC19F_SERCOM4_PAD0          _L_(5)
 #define PINMUX_PC19F_SERCOM4_PAD0  ((PIN_PC19F_SERCOM4_PAD0 << 16) | MUX_PC19F_SERCOM4_PAD0)
-#define PORT_PC19F_SERCOM4_PAD0    (1ul << 19)
-#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
-#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PORT_PC19F_SERCOM4_PAD0  (_UL(1) << 19)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
-#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
-#define PIN_PB31F_SERCOM4_PAD1            63L  /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
-#define MUX_PB31F_SERCOM4_PAD1             5L
+#define PORT_PB09D_SERCOM4_PAD1  (_UL(1) <<  9)
+#define PIN_PB31F_SERCOM4_PAD1         _L_(63) /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
+#define MUX_PB31F_SERCOM4_PAD1          _L_(5)
 #define PINMUX_PB31F_SERCOM4_PAD1  ((PIN_PB31F_SERCOM4_PAD1 << 16) | MUX_PB31F_SERCOM4_PAD1)
-#define PORT_PB31F_SERCOM4_PAD1    (1ul << 31)
-#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
-#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PORT_PB31F_SERCOM4_PAD1  (_UL(1) << 31)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
 #define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
-#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB14C_SERCOM4_PAD2            46L  /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
-#define MUX_PB14C_SERCOM4_PAD2             2L
+#define PORT_PA14D_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
 #define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
-#define PORT_PB14C_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB30F_SERCOM4_PAD2            62L  /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
-#define MUX_PB30F_SERCOM4_PAD2             5L
+#define PORT_PB14C_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB30F_SERCOM4_PAD2         _L_(62) /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
+#define MUX_PB30F_SERCOM4_PAD2          _L_(5)
 #define PINMUX_PB30F_SERCOM4_PAD2  ((PIN_PB30F_SERCOM4_PAD2 << 16) | MUX_PB30F_SERCOM4_PAD2)
-#define PORT_PB30F_SERCOM4_PAD2    (1ul << 30)
-#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
-#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PORT_PB30F_SERCOM4_PAD2  (_UL(1) << 30)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
 #define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
-#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PB15C_SERCOM4_PAD3            47L  /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
-#define MUX_PB15C_SERCOM4_PAD3             2L
+#define PORT_PA15D_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
 #define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
-#define PORT_PB15C_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PC18F_SERCOM4_PAD3            82L  /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
-#define MUX_PC18F_SERCOM4_PAD3             5L
+#define PORT_PB15C_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PC18F_SERCOM4_PAD3         _L_(82) /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
+#define MUX_PC18F_SERCOM4_PAD3          _L_(5)
 #define PINMUX_PC18F_SERCOM4_PAD3  ((PIN_PC18F_SERCOM4_PAD3 << 16) | MUX_PC18F_SERCOM4_PAD3)
-#define PORT_PC18F_SERCOM4_PAD3    (1ul << 18)
+#define PORT_PC18F_SERCOM4_PAD3  (_UL(1) << 18)
 /* ========== PORT definition for SERCOM5 peripheral ========== */
-#define PIN_PB16C_SERCOM5_PAD0            48L  /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
-#define MUX_PB16C_SERCOM5_PAD0             2L
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
 #define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
-#define PORT_PB16C_SERCOM5_PAD0    (1ul << 16)
-#define PIN_PB30D_SERCOM5_PAD0            62L  /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
-#define MUX_PB30D_SERCOM5_PAD0             3L
+#define PORT_PB16C_SERCOM5_PAD0  (_UL(1) << 16)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
-#define PORT_PB30D_SERCOM5_PAD0    (1ul << 30)
-#define PIN_PB17C_SERCOM5_PAD1            49L  /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
-#define MUX_PB17C_SERCOM5_PAD1             2L
+#define PORT_PB30D_SERCOM5_PAD0  (_UL(1) << 30)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
 #define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
-#define PORT_PB17C_SERCOM5_PAD1    (1ul << 17)
-#define PIN_PB31D_SERCOM5_PAD1            63L  /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
-#define MUX_PB31D_SERCOM5_PAD1             3L
+#define PORT_PB17C_SERCOM5_PAD1  (_UL(1) << 17)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
-#define PORT_PB31D_SERCOM5_PAD1    (1ul << 31)
-#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
-#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PORT_PB31D_SERCOM5_PAD1  (_UL(1) << 31)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
-#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
-#define PIN_PB00D_SERCOM5_PAD2            32L  /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
-#define MUX_PB00D_SERCOM5_PAD2             3L
+#define PORT_PA24D_SERCOM5_PAD2  (_UL(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
-#define PORT_PB00D_SERCOM5_PAD2    (1ul <<  0)
-#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
-#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PORT_PB00D_SERCOM5_PAD2  (_UL(1) <<  0)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
 #define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
-#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
-#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
-#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PORT_PA20C_SERCOM5_PAD2  (_UL(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
-#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for TCC0 peripheral ========== */
-#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
-#define MUX_PA08E_TCC0_WO0                 4L
+#define PIN_PA08E_TCC0_WO0              _L_(8) /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0              _L_(4)
 #define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
-#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
-#define PIN_PB30E_TCC0_WO0                62L  /**< \brief TCC0 signal: WO0 on PB30 mux E */
-#define MUX_PB30E_TCC0_WO0                 4L
+#define PORT_PA08E_TCC0_WO0    (_UL(1) <<  8)
+#define PIN_PB30E_TCC0_WO0             _L_(62) /**< \brief TCC0 signal: WO0 on PB30 mux E */
+#define MUX_PB30E_TCC0_WO0              _L_(4)
 #define PINMUX_PB30E_TCC0_WO0      ((PIN_PB30E_TCC0_WO0 << 16) | MUX_PB30E_TCC0_WO0)
-#define PORT_PB30E_TCC0_WO0        (1ul << 30)
-#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
-#define MUX_PA16F_TCC0_WO0                 5L
+#define PORT_PB30E_TCC0_WO0    (_UL(1) << 30)
+#define PIN_PA16F_TCC0_WO0             _L_(16) /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0              _L_(5)
 #define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
-#define PORT_PA16F_TCC0_WO0        (1ul << 16)
-#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
-#define MUX_PA09E_TCC0_WO1                 4L
+#define PORT_PA16F_TCC0_WO0    (_UL(1) << 16)
+#define PIN_PA09E_TCC0_WO1              _L_(9) /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1              _L_(4)
 #define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
-#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
-#define PIN_PB31E_TCC0_WO1                63L  /**< \brief TCC0 signal: WO1 on PB31 mux E */
-#define MUX_PB31E_TCC0_WO1                 4L
+#define PORT_PA09E_TCC0_WO1    (_UL(1) <<  9)
+#define PIN_PB31E_TCC0_WO1             _L_(63) /**< \brief TCC0 signal: WO1 on PB31 mux E */
+#define MUX_PB31E_TCC0_WO1              _L_(4)
 #define PINMUX_PB31E_TCC0_WO1      ((PIN_PB31E_TCC0_WO1 << 16) | MUX_PB31E_TCC0_WO1)
-#define PORT_PB31E_TCC0_WO1        (1ul << 31)
-#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
-#define MUX_PA17F_TCC0_WO1                 5L
+#define PORT_PB31E_TCC0_WO1    (_UL(1) << 31)
+#define PIN_PA17F_TCC0_WO1             _L_(17) /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1              _L_(5)
 #define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
-#define PORT_PA17F_TCC0_WO1        (1ul << 17)
-#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
-#define MUX_PA10F_TCC0_WO2                 5L
+#define PORT_PA17F_TCC0_WO1    (_UL(1) << 17)
+#define PIN_PA10F_TCC0_WO2             _L_(10) /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2              _L_(5)
 #define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
-#define PORT_PA10F_TCC0_WO2        (1ul << 10)
-#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
-#define MUX_PA18F_TCC0_WO2                 5L
+#define PORT_PA10F_TCC0_WO2    (_UL(1) << 10)
+#define PIN_PA18F_TCC0_WO2             _L_(18) /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2              _L_(5)
 #define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
-#define PORT_PA18F_TCC0_WO2        (1ul << 18)
-#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
-#define MUX_PA11F_TCC0_WO3                 5L
+#define PORT_PA18F_TCC0_WO2    (_UL(1) << 18)
+#define PIN_PA11F_TCC0_WO3             _L_(11) /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3              _L_(5)
 #define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
-#define PORT_PA11F_TCC0_WO3        (1ul << 11)
-#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
-#define MUX_PA19F_TCC0_WO3                 5L
+#define PORT_PA11F_TCC0_WO3    (_UL(1) << 11)
+#define PIN_PA19F_TCC0_WO3             _L_(19) /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3              _L_(5)
 #define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
-#define PORT_PA19F_TCC0_WO3        (1ul << 19)
-#define PIN_PB16F_TCC0_WO4                48L  /**< \brief TCC0 signal: WO4 on PB16 mux F */
-#define MUX_PB16F_TCC0_WO4                 5L
+#define PORT_PA19F_TCC0_WO3    (_UL(1) << 19)
+#define PIN_PB16F_TCC0_WO4             _L_(48) /**< \brief TCC0 signal: WO4 on PB16 mux F */
+#define MUX_PB16F_TCC0_WO4              _L_(5)
 #define PINMUX_PB16F_TCC0_WO4      ((PIN_PB16F_TCC0_WO4 << 16) | MUX_PB16F_TCC0_WO4)
-#define PORT_PB16F_TCC0_WO4        (1ul << 16)
-#define PIN_PB17F_TCC0_WO5                49L  /**< \brief TCC0 signal: WO5 on PB17 mux F */
-#define MUX_PB17F_TCC0_WO5                 5L
+#define PORT_PB16F_TCC0_WO4    (_UL(1) << 16)
+#define PIN_PB17F_TCC0_WO5             _L_(49) /**< \brief TCC0 signal: WO5 on PB17 mux F */
+#define MUX_PB17F_TCC0_WO5              _L_(5)
 #define PINMUX_PB17F_TCC0_WO5      ((PIN_PB17F_TCC0_WO5 << 16) | MUX_PB17F_TCC0_WO5)
-#define PORT_PB17F_TCC0_WO5        (1ul << 17)
-#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
-#define MUX_PA20F_TCC0_WO6                 5L
+#define PORT_PB17F_TCC0_WO5    (_UL(1) << 17)
+#define PIN_PA20F_TCC0_WO6             _L_(20) /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6              _L_(5)
 #define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
-#define PORT_PA20F_TCC0_WO6        (1ul << 20)
+#define PORT_PA20F_TCC0_WO6    (_UL(1) << 20)
 /* ========== PORT definition for TCC1 peripheral ========== */
-#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
-#define MUX_PA06E_TCC1_WO0                 4L
+#define PIN_PA06E_TCC1_WO0              _L_(6) /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0              _L_(4)
 #define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
-#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
-#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
-#define MUX_PA10E_TCC1_WO0                 4L
+#define PORT_PA06E_TCC1_WO0    (_UL(1) <<  6)
+#define PIN_PA10E_TCC1_WO0             _L_(10) /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0              _L_(4)
 #define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
-#define PORT_PA10E_TCC1_WO0        (1ul << 10)
-#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
-#define MUX_PA30E_TCC1_WO0                 4L
+#define PORT_PA10E_TCC1_WO0    (_UL(1) << 10)
+#define PIN_PA30E_TCC1_WO0             _L_(30) /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0              _L_(4)
 #define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
-#define PORT_PA30E_TCC1_WO0        (1ul << 30)
-#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
-#define MUX_PA07E_TCC1_WO1                 4L
+#define PORT_PA30E_TCC1_WO0    (_UL(1) << 30)
+#define PIN_PA07E_TCC1_WO1              _L_(7) /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1              _L_(4)
 #define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
-#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
-#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
-#define MUX_PA11E_TCC1_WO1                 4L
+#define PORT_PA07E_TCC1_WO1    (_UL(1) <<  7)
+#define PIN_PA11E_TCC1_WO1             _L_(11) /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1              _L_(4)
 #define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
-#define PORT_PA11E_TCC1_WO1        (1ul << 11)
-#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
-#define MUX_PA31E_TCC1_WO1                 4L
+#define PORT_PA11E_TCC1_WO1    (_UL(1) << 11)
+#define PIN_PA31E_TCC1_WO1             _L_(31) /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1              _L_(4)
 #define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
-#define PORT_PA31E_TCC1_WO1        (1ul << 31)
-#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
-#define MUX_PA24F_TCC1_WO2                 5L
+#define PORT_PA31E_TCC1_WO1    (_UL(1) << 31)
+#define PIN_PA24F_TCC1_WO2             _L_(24) /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2              _L_(5)
 #define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
-#define PORT_PA24F_TCC1_WO2        (1ul << 24)
-#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
-#define MUX_PA25F_TCC1_WO3                 5L
+#define PORT_PA24F_TCC1_WO2    (_UL(1) << 24)
+#define PIN_PA25F_TCC1_WO3             _L_(25) /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3              _L_(5)
 #define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
-#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+#define PORT_PA25F_TCC1_WO3    (_UL(1) << 25)
 /* ========== PORT definition for TCC2 peripheral ========== */
-#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
-#define MUX_PA16E_TCC2_WO0                 4L
+#define PIN_PA16E_TCC2_WO0             _L_(16) /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0              _L_(4)
 #define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
-#define PORT_PA16E_TCC2_WO0        (1ul << 16)
-#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
-#define MUX_PA17E_TCC2_WO1                 4L
+#define PORT_PA16E_TCC2_WO0    (_UL(1) << 16)
+#define PIN_PA17E_TCC2_WO1             _L_(17) /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1              _L_(4)
 #define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
-#define PORT_PA17E_TCC2_WO1        (1ul << 17)
+#define PORT_PA17E_TCC2_WO1    (_UL(1) << 17)
 /* ========== PORT definition for TC3 peripheral ========== */
-#define PIN_PA18E_TC3_WO0                 18L  /**< \brief TC3 signal: WO0 on PA18 mux E */
-#define MUX_PA18E_TC3_WO0                  4L
+#define PIN_PA18E_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC3_WO0               _L_(4)
 #define PINMUX_PA18E_TC3_WO0       ((PIN_PA18E_TC3_WO0 << 16) | MUX_PA18E_TC3_WO0)
-#define PORT_PA18E_TC3_WO0         (1ul << 18)
-#define PIN_PA14E_TC3_WO0                 14L  /**< \brief TC3 signal: WO0 on PA14 mux E */
-#define MUX_PA14E_TC3_WO0                  4L
+#define PORT_PA18E_TC3_WO0     (_UL(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
 #define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
-#define PORT_PA14E_TC3_WO0         (1ul << 14)
-#define PIN_PA19E_TC3_WO1                 19L  /**< \brief TC3 signal: WO1 on PA19 mux E */
-#define MUX_PA19E_TC3_WO1                  4L
+#define PORT_PA14E_TC3_WO0     (_UL(1) << 14)
+#define PIN_PA19E_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC3_WO1               _L_(4)
 #define PINMUX_PA19E_TC3_WO1       ((PIN_PA19E_TC3_WO1 << 16) | MUX_PA19E_TC3_WO1)
-#define PORT_PA19E_TC3_WO1         (1ul << 19)
-#define PIN_PA15E_TC3_WO1                 15L  /**< \brief TC3 signal: WO1 on PA15 mux E */
-#define MUX_PA15E_TC3_WO1                  4L
+#define PORT_PA19E_TC3_WO1     (_UL(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
 #define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
-#define PORT_PA15E_TC3_WO1         (1ul << 15)
+#define PORT_PA15E_TC3_WO1     (_UL(1) << 15)
 /* ========== PORT definition for TC4 peripheral ========== */
-#define PIN_PB08E_TC4_WO0                 40L  /**< \brief TC4 signal: WO0 on PB08 mux E */
-#define MUX_PB08E_TC4_WO0                  4L
+#define PIN_PB08E_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC4_WO0               _L_(4)
 #define PINMUX_PB08E_TC4_WO0       ((PIN_PB08E_TC4_WO0 << 16) | MUX_PB08E_TC4_WO0)
-#define PORT_PB08E_TC4_WO0         (1ul <<  8)
-#define PIN_PB09E_TC4_WO1                 41L  /**< \brief TC4 signal: WO1 on PB09 mux E */
-#define MUX_PB09E_TC4_WO1                  4L
+#define PORT_PB08E_TC4_WO0     (_UL(1) <<  8)
+#define PIN_PB09E_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC4_WO1               _L_(4)
 #define PINMUX_PB09E_TC4_WO1       ((PIN_PB09E_TC4_WO1 << 16) | MUX_PB09E_TC4_WO1)
-#define PORT_PB09E_TC4_WO1         (1ul <<  9)
+#define PORT_PB09E_TC4_WO1     (_UL(1) <<  9)
 /* ========== PORT definition for TC5 peripheral ========== */
-#define PIN_PA24E_TC5_WO0                 24L  /**< \brief TC5 signal: WO0 on PA24 mux E */
-#define MUX_PA24E_TC5_WO0                  4L
+#define PIN_PA24E_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC5_WO0               _L_(4)
 #define PINMUX_PA24E_TC5_WO0       ((PIN_PA24E_TC5_WO0 << 16) | MUX_PA24E_TC5_WO0)
-#define PORT_PA24E_TC5_WO0         (1ul << 24)
-#define PIN_PB14E_TC5_WO0                 46L  /**< \brief TC5 signal: WO0 on PB14 mux E */
-#define MUX_PB14E_TC5_WO0                  4L
+#define PORT_PA24E_TC5_WO0     (_UL(1) << 24)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
 #define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
-#define PORT_PB14E_TC5_WO0         (1ul << 14)
-#define PIN_PA25E_TC5_WO1                 25L  /**< \brief TC5 signal: WO1 on PA25 mux E */
-#define MUX_PA25E_TC5_WO1                  4L
+#define PORT_PB14E_TC5_WO0     (_UL(1) << 14)
+#define PIN_PA25E_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC5_WO1               _L_(4)
 #define PINMUX_PA25E_TC5_WO1       ((PIN_PA25E_TC5_WO1 << 16) | MUX_PA25E_TC5_WO1)
-#define PORT_PA25E_TC5_WO1         (1ul << 25)
-#define PIN_PB15E_TC5_WO1                 47L  /**< \brief TC5 signal: WO1 on PB15 mux E */
-#define MUX_PB15E_TC5_WO1                  4L
+#define PORT_PA25E_TC5_WO1     (_UL(1) << 25)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
 #define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
-#define PORT_PB15E_TC5_WO1         (1ul << 15)
+#define PORT_PB15E_TC5_WO1     (_UL(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL(1) << 16)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL(1) << 20)
+#define PIN_PB00E_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux E */
+#define MUX_PB00E_TC7_WO0               _L_(4)
+#define PINMUX_PB00E_TC7_WO0       ((PIN_PB00E_TC7_WO0 << 16) | MUX_PB00E_TC7_WO0)
+#define PORT_PB00E_TC7_WO0     (_UL(1) <<  0)
 /* ========== PORT definition for ADC peripheral ========== */
-#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
-#define MUX_PB08B_ADC_AIN2                 1L
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
 #define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
-#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
-#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
-#define MUX_PB09B_ADC_AIN3                 1L
+#define PORT_PB08B_ADC_AIN2    (_UL(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
 #define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
-#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
-#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
-#define MUX_PA06B_ADC_AIN6                 1L
+#define PORT_PB09B_ADC_AIN3    (_UL(1) <<  9)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
 #define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
-#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
-#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
-#define MUX_PA07B_ADC_AIN7                 1L
+#define PORT_PA06B_ADC_AIN6    (_UL(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
 #define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
-#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
-#define PIN_PB00B_ADC_AIN8                32L  /**< \brief ADC signal: AIN8 on PB00 mux B */
-#define MUX_PB00B_ADC_AIN8                 1L
+#define PORT_PA07B_ADC_AIN7    (_UL(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
 #define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
-#define PORT_PB00B_ADC_AIN8        (1ul <<  0)
-#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
-#define MUX_PA08B_ADC_AIN16                1L
+#define PORT_PB00B_ADC_AIN8    (_UL(1) <<  0)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
 #define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
-#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
-#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
-#define MUX_PA09B_ADC_AIN17                1L
+#define PORT_PA08B_ADC_AIN16   (_UL(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
 #define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
-#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
-#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
-#define MUX_PA10B_ADC_AIN18                1L
+#define PORT_PA09B_ADC_AIN17   (_UL(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
 #define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
-#define PORT_PA10B_ADC_AIN18       (1ul << 10)
-#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
-#define MUX_PA11B_ADC_AIN19                1L
+#define PORT_PA10B_ADC_AIN18   (_UL(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
 #define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
-#define PORT_PA11B_ADC_AIN19       (1ul << 11)
+#define PORT_PA11B_ADC_AIN19   (_UL(1) << 11)
 /* ========== PORT definition for AC peripheral ========== */
-#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
-#define MUX_PA06B_AC_AIN2                  1L
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
 #define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
-#define PORT_PA06B_AC_AIN2         (1ul <<  6)
-#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
-#define MUX_PA07B_AC_AIN3                  1L
+#define PORT_PA06B_AC_AIN2     (_UL(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
 #define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
-#define PORT_PA07B_AC_AIN3         (1ul <<  7)
-#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
-#define MUX_PA18H_AC_CMP0                  7L
+#define PORT_PA07B_AC_AIN3     (_UL(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
 #define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
-#define PORT_PA18H_AC_CMP0         (1ul << 18)
-#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
-#define MUX_PA19H_AC_CMP1                  7L
+#define PORT_PA18H_AC_CMP0     (_UL(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
 #define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
-#define PORT_PA19H_AC_CMP1         (1ul << 19)
+#define PORT_PA19H_AC_CMP1     (_UL(1) << 19)
 /* ========== PORT definition for RFCTRL peripheral ========== */
-#define PIN_PA08F_RFCTRL_FECTRL0           8L  /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
-#define MUX_PA08F_RFCTRL_FECTRL0           5L
+#define PIN_PA08F_RFCTRL_FECTRL0        _L_(8) /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
+#define MUX_PA08F_RFCTRL_FECTRL0        _L_(5)
 #define PINMUX_PA08F_RFCTRL_FECTRL0  ((PIN_PA08F_RFCTRL_FECTRL0 << 16) | MUX_PA08F_RFCTRL_FECTRL0)
-#define PORT_PA08F_RFCTRL_FECTRL0  (1ul <<  8)
-#define PIN_PA09F_RFCTRL_FECTRL1           9L  /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
-#define MUX_PA09F_RFCTRL_FECTRL1           5L
+#define PORT_PA08F_RFCTRL_FECTRL0  (_UL(1) <<  8)
+#define PIN_PA09F_RFCTRL_FECTRL1        _L_(9) /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
+#define MUX_PA09F_RFCTRL_FECTRL1        _L_(5)
 #define PINMUX_PA09F_RFCTRL_FECTRL1  ((PIN_PA09F_RFCTRL_FECTRL1 << 16) | MUX_PA09F_RFCTRL_FECTRL1)
-#define PORT_PA09F_RFCTRL_FECTRL1  (1ul <<  9)
-#define PIN_PA14F_RFCTRL_FECTRL4          14L  /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
-#define MUX_PA14F_RFCTRL_FECTRL4           5L
+#define PORT_PA09F_RFCTRL_FECTRL1  (_UL(1) <<  9)
+#define PIN_PA14F_RFCTRL_FECTRL4       _L_(14) /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
+#define MUX_PA14F_RFCTRL_FECTRL4        _L_(5)
 #define PINMUX_PA14F_RFCTRL_FECTRL4  ((PIN_PA14F_RFCTRL_FECTRL4 << 16) | MUX_PA14F_RFCTRL_FECTRL4)
-#define PORT_PA14F_RFCTRL_FECTRL4  (1ul << 14)
-#define PIN_PA15F_RFCTRL_FECTRL5          15L  /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
-#define MUX_PA15F_RFCTRL_FECTRL5           5L
+#define PORT_PA14F_RFCTRL_FECTRL4  (_UL(1) << 14)
+#define PIN_PA15F_RFCTRL_FECTRL5       _L_(15) /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
+#define MUX_PA15F_RFCTRL_FECTRL5        _L_(5)
 #define PINMUX_PA15F_RFCTRL_FECTRL5  ((PIN_PA15F_RFCTRL_FECTRL5 << 16) | MUX_PA15F_RFCTRL_FECTRL5)
-#define PORT_PA15F_RFCTRL_FECTRL5  (1ul << 15)
+#define PORT_PA15F_RFCTRL_FECTRL5  (_UL(1) << 15)
 
 #endif /* _SAMR21E18A_PIO_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/pio/samr21e19a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/pio/samr21e19a.h
@@ -3,39 +3,24 @@
  *
  * \brief Peripheral I/O description for SAMR21E19A
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2017 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -45,781 +30,806 @@
 #define _SAMR21E19A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define PORT_PA00                 (1ul <<  0) /**< \brief PORT Mask  for PA00 */
+#define PORT_PA00              (_UL(1) <<  0) /**< \brief PORT Mask  for PA00 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PORT_PA06              (_UL(1) <<  6) /**< \brief PORT Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PORT_PA07              (_UL(1) <<  7) /**< \brief PORT Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PORT_PA08              (_UL(1) <<  8) /**< \brief PORT Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PORT_PA09              (_UL(1) <<  9) /**< \brief PORT Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PORT_PA10              (_UL(1) << 10) /**< \brief PORT Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PORT_PA11              (_UL(1) << 11) /**< \brief PORT Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define PORT_PA12                 (1ul << 12) /**< \brief PORT Mask  for PA12 */
+#define PORT_PA12              (_UL(1) << 12) /**< \brief PORT Mask  for PA12 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PORT_PA14              (_UL(1) << 14) /**< \brief PORT Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PORT_PA15              (_UL(1) << 15) /**< \brief PORT Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PORT_PA16              (_UL(1) << 16) /**< \brief PORT Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PORT_PA17              (_UL(1) << 17) /**< \brief PORT Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PORT_PA18              (_UL(1) << 18) /**< \brief PORT Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PORT_PA19              (_UL(1) << 19) /**< \brief PORT Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PORT_PA20              (_UL(1) << 20) /**< \brief PORT Mask  for PA20 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define PORT_PA22                 (1ul << 22) /**< \brief PORT Mask  for PA22 */
+#define PORT_PA22              (_UL(1) << 22) /**< \brief PORT Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define PORT_PA23                 (1ul << 23) /**< \brief PORT Mask  for PA23 */
+#define PORT_PA23              (_UL(1) << 23) /**< \brief PORT Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PORT_PA24              (_UL(1) << 24) /**< \brief PORT Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PORT_PA25              (_UL(1) << 25) /**< \brief PORT Mask  for PA25 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PORT_PA27              (_UL(1) << 27) /**< \brief PORT Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define PORT_PA28                 (1ul << 28) /**< \brief PORT Mask  for PA28 */
+#define PORT_PA28              (_UL(1) << 28) /**< \brief PORT Mask  for PA28 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PORT_PA30              (_UL(1) << 30) /**< \brief PORT Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PORT_PA31              (_UL(1) << 31) /**< \brief PORT Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define PORT_PB00                 (1ul <<  0) /**< \brief PORT Mask  for PB00 */
+#define PORT_PB00              (_UL(1) <<  0) /**< \brief PORT Mask  for PB00 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PORT_PB08              (_UL(1) <<  8) /**< \brief PORT Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PORT_PB09              (_UL(1) <<  9) /**< \brief PORT Mask  for PB09 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define PORT_PB14                 (1ul << 14) /**< \brief PORT Mask  for PB14 */
+#define PORT_PB14              (_UL(1) << 14) /**< \brief PORT Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define PORT_PB15                 (1ul << 15) /**< \brief PORT Mask  for PB15 */
+#define PORT_PB15              (_UL(1) << 15) /**< \brief PORT Mask  for PB15 */
 #define PIN_PB16                          48  /**< \brief Pin Number for PB16 */
-#define PORT_PB16                 (1ul << 16) /**< \brief PORT Mask  for PB16 */
+#define PORT_PB16              (_UL(1) << 16) /**< \brief PORT Mask  for PB16 */
 #define PIN_PB17                          49  /**< \brief Pin Number for PB17 */
-#define PORT_PB17                 (1ul << 17) /**< \brief PORT Mask  for PB17 */
+#define PORT_PB17              (_UL(1) << 17) /**< \brief PORT Mask  for PB17 */
 #define PIN_PB22                          54  /**< \brief Pin Number for PB22 */
-#define PORT_PB22                 (1ul << 22) /**< \brief PORT Mask  for PB22 */
+#define PORT_PB22              (_UL(1) << 22) /**< \brief PORT Mask  for PB22 */
 #define PIN_PB23                          55  /**< \brief Pin Number for PB23 */
-#define PORT_PB23                 (1ul << 23) /**< \brief PORT Mask  for PB23 */
+#define PORT_PB23              (_UL(1) << 23) /**< \brief PORT Mask  for PB23 */
 #define PIN_PB30                          62  /**< \brief Pin Number for PB30 */
-#define PORT_PB30                 (1ul << 30) /**< \brief PORT Mask  for PB30 */
+#define PORT_PB30              (_UL(1) << 30) /**< \brief PORT Mask  for PB30 */
 #define PIN_PB31                          63  /**< \brief Pin Number for PB31 */
-#define PORT_PB31                 (1ul << 31) /**< \brief PORT Mask  for PB31 */
+#define PORT_PB31              (_UL(1) << 31) /**< \brief PORT Mask  for PB31 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define PORT_PC16                 (1ul << 16) /**< \brief PORT Mask  for PC16 */
+#define PORT_PC16              (_UL(1) << 16) /**< \brief PORT Mask  for PC16 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define PORT_PC18                 (1ul << 18) /**< \brief PORT Mask  for PC18 */
+#define PORT_PC18              (_UL(1) << 18) /**< \brief PORT Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define PORT_PC19                 (1ul << 19) /**< \brief PORT Mask  for PC19 */
+#define PORT_PC19              (_UL(1) << 19) /**< \brief PORT Mask  for PC19 */
 /* ========== PORT definition for GCLK peripheral ========== */
-#define PIN_PB14H_GCLK_IO0                46L  /**< \brief GCLK signal: IO0 on PB14 mux H */
-#define MUX_PB14H_GCLK_IO0                 7L
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
 #define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
-#define PORT_PB14H_GCLK_IO0        (1ul << 14)
-#define PIN_PB22H_GCLK_IO0                54L  /**< \brief GCLK signal: IO0 on PB22 mux H */
-#define MUX_PB22H_GCLK_IO0                 7L
+#define PORT_PB14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
 #define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
-#define PORT_PB22H_GCLK_IO0        (1ul << 22)
-#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
-#define MUX_PA14H_GCLK_IO0                 7L
+#define PORT_PB22H_GCLK_IO0    (_UL(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
 #define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
-#define PORT_PA14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
-#define MUX_PA27H_GCLK_IO0                 7L
+#define PORT_PA14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
 #define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
-#define PORT_PA27H_GCLK_IO0        (1ul << 27)
-#define PIN_PA28H_GCLK_IO0                28L  /**< \brief GCLK signal: IO0 on PA28 mux H */
-#define MUX_PA28H_GCLK_IO0                 7L
+#define PORT_PA27H_GCLK_IO0    (_UL(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
 #define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
-#define PORT_PA28H_GCLK_IO0        (1ul << 28)
-#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
-#define MUX_PA30H_GCLK_IO0                 7L
+#define PORT_PA28H_GCLK_IO0    (_UL(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
 #define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
-#define PORT_PA30H_GCLK_IO0        (1ul << 30)
-#define PIN_PB15H_GCLK_IO1                47L  /**< \brief GCLK signal: IO1 on PB15 mux H */
-#define MUX_PB15H_GCLK_IO1                 7L
+#define PORT_PA30H_GCLK_IO0    (_UL(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
 #define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
-#define PORT_PB15H_GCLK_IO1        (1ul << 15)
-#define PIN_PB23H_GCLK_IO1                55L  /**< \brief GCLK signal: IO1 on PB23 mux H */
-#define MUX_PB23H_GCLK_IO1                 7L
+#define PORT_PB15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
 #define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
-#define PORT_PB23H_GCLK_IO1        (1ul << 23)
-#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
-#define MUX_PA15H_GCLK_IO1                 7L
+#define PORT_PB23H_GCLK_IO1    (_UL(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
 #define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
-#define PORT_PA15H_GCLK_IO1        (1ul << 15)
-#define PIN_PB16H_GCLK_IO2                48L  /**< \brief GCLK signal: IO2 on PB16 mux H */
-#define MUX_PB16H_GCLK_IO2                 7L
+#define PORT_PA15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
 #define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
-#define PORT_PB16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
-#define MUX_PA16H_GCLK_IO2                 7L
+#define PORT_PB16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
 #define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
-#define PORT_PA16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
-#define MUX_PA17H_GCLK_IO3                 7L
+#define PORT_PA16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
 #define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
-#define PORT_PA17H_GCLK_IO3        (1ul << 17)
-#define PIN_PB17H_GCLK_IO3                49L  /**< \brief GCLK signal: IO3 on PB17 mux H */
-#define MUX_PB17H_GCLK_IO3                 7L
+#define PORT_PA17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
 #define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
-#define PORT_PB17H_GCLK_IO3        (1ul << 17)
-#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
-#define MUX_PA10H_GCLK_IO4                 7L
+#define PORT_PB17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
 #define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
-#define PORT_PA10H_GCLK_IO4        (1ul << 10)
-#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
-#define MUX_PA20H_GCLK_IO4                 7L
+#define PORT_PA10H_GCLK_IO4    (_UL(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
 #define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
-#define PORT_PA20H_GCLK_IO4        (1ul << 20)
-#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
-#define MUX_PA11H_GCLK_IO5                 7L
+#define PORT_PA20H_GCLK_IO4    (_UL(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
 #define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
-#define PORT_PA11H_GCLK_IO5        (1ul << 11)
-#define PIN_PA22H_GCLK_IO6                22L  /**< \brief GCLK signal: IO6 on PA22 mux H */
-#define MUX_PA22H_GCLK_IO6                 7L
+#define PORT_PA11H_GCLK_IO5    (_UL(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
 #define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
-#define PORT_PA22H_GCLK_IO6        (1ul << 22)
-#define PIN_PA23H_GCLK_IO7                23L  /**< \brief GCLK signal: IO7 on PA23 mux H */
-#define MUX_PA23H_GCLK_IO7                 7L
+#define PORT_PA22H_GCLK_IO6    (_UL(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
 #define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
-#define PORT_PA23H_GCLK_IO7        (1ul << 23)
+#define PORT_PA23H_GCLK_IO7    (_UL(1) << 23)
 /* ========== PORT definition for EIC peripheral ========== */
-#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
-#define MUX_PA16A_EIC_EXTINT0              0L
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
-#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PB00A_EIC_EXTINT0             32L  /**< \brief EIC signal: EXTINT0 on PB00 mux A */
-#define MUX_PB00A_EIC_EXTINT0              0L
+#define PORT_PA16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
-#define PORT_PB00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PB16A_EIC_EXTINT0             48L  /**< \brief EIC signal: EXTINT0 on PB16 mux A */
-#define MUX_PB16A_EIC_EXTINT0              0L
+#define PORT_PB00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
-#define PORT_PB16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PA00A_EIC_EXTINT0              0L  /**< \brief EIC signal: EXTINT0 on PA00 mux A */
-#define MUX_PA00A_EIC_EXTINT0              0L
+#define PORT_PB16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
-#define PORT_PA00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
-#define MUX_PA17A_EIC_EXTINT1              0L
+#define PORT_PA00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
-#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PB17A_EIC_EXTINT1             49L  /**< \brief EIC signal: EXTINT1 on PB17 mux A */
-#define MUX_PB17A_EIC_EXTINT1              0L
+#define PORT_PA17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
-#define PORT_PB17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
-#define MUX_PA18A_EIC_EXTINT2              0L
+#define PORT_PB17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
-#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
-#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
-#define MUX_PA19A_EIC_EXTINT3              0L
+#define PORT_PA18A_EIC_EXTINT2  (_UL(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
-#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
-#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
-#define MUX_PA20A_EIC_EXTINT4              0L
+#define PORT_PA19A_EIC_EXTINT3  (_UL(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
-#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
-#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
-#define MUX_PA06A_EIC_EXTINT6              0L
+#define PORT_PA20A_EIC_EXTINT4  (_UL(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
-#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
-#define PIN_PA22A_EIC_EXTINT6             22L  /**< \brief EIC signal: EXTINT6 on PA22 mux A */
-#define MUX_PA22A_EIC_EXTINT6              0L
+#define PORT_PA06A_EIC_EXTINT6  (_UL(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
-#define PORT_PA22A_EIC_EXTINT6     (1ul << 22)
-#define PIN_PB22A_EIC_EXTINT6             54L  /**< \brief EIC signal: EXTINT6 on PB22 mux A */
-#define MUX_PB22A_EIC_EXTINT6              0L
+#define PORT_PA22A_EIC_EXTINT6  (_UL(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
-#define PORT_PB22A_EIC_EXTINT6     (1ul << 22)
-#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
-#define MUX_PA07A_EIC_EXTINT7              0L
+#define PORT_PB22A_EIC_EXTINT6  (_UL(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
-#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
-#define PIN_PA23A_EIC_EXTINT7             23L  /**< \brief EIC signal: EXTINT7 on PA23 mux A */
-#define MUX_PA23A_EIC_EXTINT7              0L
+#define PORT_PA07A_EIC_EXTINT7  (_UL(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
-#define PORT_PA23A_EIC_EXTINT7     (1ul << 23)
-#define PIN_PB23A_EIC_EXTINT7             55L  /**< \brief EIC signal: EXTINT7 on PB23 mux A */
-#define MUX_PB23A_EIC_EXTINT7              0L
+#define PORT_PA23A_EIC_EXTINT7  (_UL(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
-#define PORT_PB23A_EIC_EXTINT7     (1ul << 23)
-#define PIN_PA28A_EIC_EXTINT8             28L  /**< \brief EIC signal: EXTINT8 on PA28 mux A */
-#define MUX_PA28A_EIC_EXTINT8              0L
+#define PORT_PB23A_EIC_EXTINT7  (_UL(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
-#define PORT_PA28A_EIC_EXTINT8     (1ul << 28)
-#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
-#define MUX_PB08A_EIC_EXTINT8              0L
+#define PORT_PA28A_EIC_EXTINT8  (_UL(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
-#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
-#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
-#define MUX_PA09A_EIC_EXTINT9              0L
+#define PORT_PB08A_EIC_EXTINT8  (_UL(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
-#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
-#define MUX_PB09A_EIC_EXTINT9              0L
+#define PORT_PA09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
-#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
-#define MUX_PA10A_EIC_EXTINT10             0L
+#define PORT_PB09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
-#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
-#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
-#define MUX_PA30A_EIC_EXTINT10             0L
+#define PORT_PA10A_EIC_EXTINT10  (_UL(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
-#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
-#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
-#define MUX_PA11A_EIC_EXTINT11             0L
+#define PORT_PA30A_EIC_EXTINT10  (_UL(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
-#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
-#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
-#define MUX_PA31A_EIC_EXTINT11             0L
+#define PORT_PA11A_EIC_EXTINT11  (_UL(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
-#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
-#define PIN_PA12A_EIC_EXTINT12            12L  /**< \brief EIC signal: EXTINT12 on PA12 mux A */
-#define MUX_PA12A_EIC_EXTINT12             0L
+#define PORT_PA31A_EIC_EXTINT11  (_UL(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
-#define PORT_PA12A_EIC_EXTINT12    (1ul << 12)
-#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
-#define MUX_PA24A_EIC_EXTINT12             0L
+#define PORT_PA12A_EIC_EXTINT12  (_UL(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
-#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
-#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
-#define MUX_PA25A_EIC_EXTINT13             0L
+#define PORT_PA24A_EIC_EXTINT12  (_UL(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
-#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
-#define PIN_PB14A_EIC_EXTINT14            46L  /**< \brief EIC signal: EXTINT14 on PB14 mux A */
-#define MUX_PB14A_EIC_EXTINT14             0L
+#define PORT_PA25A_EIC_EXTINT13  (_UL(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
-#define PORT_PB14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PB30A_EIC_EXTINT14            62L  /**< \brief EIC signal: EXTINT14 on PB30 mux A */
-#define MUX_PB30A_EIC_EXTINT14             0L
+#define PORT_PB14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
-#define PORT_PB30A_EIC_EXTINT14    (1ul << 30)
-#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
-#define MUX_PA14A_EIC_EXTINT14             0L
+#define PORT_PB30A_EIC_EXTINT14  (_UL(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
-#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
-#define MUX_PA15A_EIC_EXTINT15             0L
+#define PORT_PA14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
-#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
-#define MUX_PA27A_EIC_EXTINT15             0L
+#define PORT_PA15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
-#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
-#define PIN_PB15A_EIC_EXTINT15            47L  /**< \brief EIC signal: EXTINT15 on PB15 mux A */
-#define MUX_PB15A_EIC_EXTINT15             0L
+#define PORT_PA27A_EIC_EXTINT15  (_UL(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
-#define PORT_PB15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PB31A_EIC_EXTINT15            63L  /**< \brief EIC signal: EXTINT15 on PB31 mux A */
-#define MUX_PB31A_EIC_EXTINT15             0L
+#define PORT_PB15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
-#define PORT_PB31A_EIC_EXTINT15    (1ul << 31)
-#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
-#define MUX_PA08A_EIC_NMI                  0L
+#define PORT_PB31A_EIC_EXTINT15  (_UL(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
 #define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
-#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+#define PORT_PA08A_EIC_NMI     (_UL(1) <<  8)
 /* ========== PORT definition for USB peripheral ========== */
-#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
-#define MUX_PA24G_USB_DM                   6L
+#define PIN_PA24G_USB_DM               _L_(24) /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                _L_(6)
 #define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
-#define PORT_PA24G_USB_DM          (1ul << 24)
-#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
-#define MUX_PA25G_USB_DP                   6L
+#define PORT_PA24G_USB_DM      (_UL(1) << 24)
+#define PIN_PA25G_USB_DP               _L_(25) /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                _L_(6)
 #define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
-#define PORT_PA25G_USB_DP          (1ul << 25)
-#define PIN_PA23G_USB_SOF_1KHZ            23L  /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
-#define MUX_PA23G_USB_SOF_1KHZ             6L
+#define PORT_PA25G_USB_DP      (_UL(1) << 25)
+#define PIN_PA23G_USB_SOF_1KHZ         _L_(23) /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
+#define MUX_PA23G_USB_SOF_1KHZ          _L_(6)
 #define PINMUX_PA23G_USB_SOF_1KHZ  ((PIN_PA23G_USB_SOF_1KHZ << 16) | MUX_PA23G_USB_SOF_1KHZ)
-#define PORT_PA23G_USB_SOF_1KHZ    (1ul << 23)
+#define PORT_PA23G_USB_SOF_1KHZ  (_UL(1) << 23)
 /* ========== PORT definition for SERCOM0 peripheral ========== */
-#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
-#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
 #define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
-#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
-#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
-#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PORT_PA08C_SERCOM0_PAD0  (_UL(1) <<  8)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
 #define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
-#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
-#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
-#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PORT_PA09C_SERCOM0_PAD1  (_UL(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
 #define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
-#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
-#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
-#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PORT_PA06D_SERCOM0_PAD2  (_UL(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
 #define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
-#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
-#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
-#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PORT_PA10C_SERCOM0_PAD2  (_UL(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
 #define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
-#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
-#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
-#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PORT_PA07D_SERCOM0_PAD3  (_UL(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
 #define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
-#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL(1) << 11)
 /* ========== PORT definition for SERCOM1 peripheral ========== */
-#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
-#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
 #define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
-#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
-#define PIN_PA00D_SERCOM1_PAD0             0L  /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
-#define MUX_PA00D_SERCOM1_PAD0             3L
+#define PORT_PA16C_SERCOM1_PAD0  (_UL(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
 #define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
-#define PORT_PA00D_SERCOM1_PAD0    (1ul <<  0)
-#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
-#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PORT_PA00D_SERCOM1_PAD0  (_UL(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
 #define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
-#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
-#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
-#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PORT_PA17C_SERCOM1_PAD1  (_UL(1) << 17)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
 #define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
-#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
-#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
-#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PORT_PA30D_SERCOM1_PAD2  (_UL(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
 #define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
-#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
-#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
-#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PORT_PA18C_SERCOM1_PAD2  (_UL(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
 #define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
-#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
-#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
-#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PORT_PA31D_SERCOM1_PAD3  (_UL(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
 #define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
-#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL(1) << 19)
 /* ========== PORT definition for SERCOM2 peripheral ========== */
-#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
-#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
 #define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
-#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
-#define PIN_PA12C_SERCOM2_PAD0            12L  /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
-#define MUX_PA12C_SERCOM2_PAD0             2L
+#define PORT_PA08D_SERCOM2_PAD0  (_UL(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
 #define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
-#define PORT_PA12C_SERCOM2_PAD0    (1ul << 12)
-#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
-#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PORT_PA12C_SERCOM2_PAD0  (_UL(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
 #define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
-#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
-#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
-#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PORT_PA09D_SERCOM2_PAD1  (_UL(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
 #define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
-#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
-#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
-#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PORT_PA10D_SERCOM2_PAD2  (_UL(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
 #define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
-#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
-#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
-#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PORT_PA14C_SERCOM2_PAD2  (_UL(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
 #define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
-#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
-#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
-#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PORT_PA11D_SERCOM2_PAD3  (_UL(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
 #define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
-#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL(1) << 15)
 /* ========== PORT definition for SERCOM3 peripheral ========== */
-#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
-#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
 #define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
-#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
-#define PIN_PA22C_SERCOM3_PAD0            22L  /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
-#define MUX_PA22C_SERCOM3_PAD0             2L
+#define PORT_PA16D_SERCOM3_PAD0  (_UL(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
 #define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
-#define PORT_PA22C_SERCOM3_PAD0    (1ul << 22)
-#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
-#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PORT_PA22C_SERCOM3_PAD0  (_UL(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
 #define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
-#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
-#define PIN_PA23C_SERCOM3_PAD1            23L  /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
-#define MUX_PA23C_SERCOM3_PAD1             2L
+#define PORT_PA17D_SERCOM3_PAD1  (_UL(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
 #define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
-#define PORT_PA23C_SERCOM3_PAD1    (1ul << 23)
-#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
-#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PORT_PA23C_SERCOM3_PAD1  (_UL(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
-#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
-#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
-#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PORT_PA18D_SERCOM3_PAD2  (_UL(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
-#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
-#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
-#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PORT_PA20D_SERCOM3_PAD2  (_UL(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
 #define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
-#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
-#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
-#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PORT_PA24C_SERCOM3_PAD2  (_UL(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
 #define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
-#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
-#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
-#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PORT_PA19D_SERCOM3_PAD3  (_UL(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
 #define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
-#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for SERCOM4 peripheral ========== */
-#define PIN_PA12D_SERCOM4_PAD0            12L  /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
-#define MUX_PA12D_SERCOM4_PAD0             3L
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
-#define PORT_PA12D_SERCOM4_PAD0    (1ul << 12)
-#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
-#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PORT_PA12D_SERCOM4_PAD0  (_UL(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
-#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
-#define PIN_PC19F_SERCOM4_PAD0            83L  /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
-#define MUX_PC19F_SERCOM4_PAD0             5L
-#define PINMUX_PC19F_SERCOM4_PAD0  ((PIN_PC19F_SERCOM4_PAD0 << 16) | MUX_PC19F_SERCOM4_PAD0)
-#define PORT_PC19F_SERCOM4_PAD0    (1ul << 19)
-
-#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
-#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PORT_PB08D_SERCOM4_PAD0  (_UL(1) <<  8)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
-#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
-#define PIN_PB31F_SERCOM4_PAD1            63L  /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
-#define MUX_PB31F_SERCOM4_PAD1             5L
-#define PINMUX_PB31F_SERCOM4_PAD1  ((PIN_PB31F_SERCOM4_PAD1 << 16) | MUX_PB31F_SERCOM4_PAD1)
-#define PORT_PB31F_SERCOM4_PAD1    (1ul << 31)
-#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
-#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PORT_PB09D_SERCOM4_PAD1  (_UL(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
 #define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
-#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB14C_SERCOM4_PAD2            46L  /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
-#define MUX_PB14C_SERCOM4_PAD2             2L
+#define PORT_PA14D_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
 #define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
-#define PORT_PB14C_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB30F_SERCOM4_PAD2            62L  /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
-#define MUX_PB30F_SERCOM4_PAD2             5L
-#define PINMUX_PB30F_SERCOM4_PAD2  ((PIN_PB30F_SERCOM4_PAD2 << 16) | MUX_PB30F_SERCOM4_PAD2)
-#define PORT_PB30F_SERCOM4_PAD2    (1ul << 30)
-#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
-#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PORT_PB14C_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
 #define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
-#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PB15C_SERCOM4_PAD3            47L  /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
-#define MUX_PB15C_SERCOM4_PAD3             2L
+#define PORT_PA15D_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
 #define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
-#define PORT_PB15C_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PC18F_SERCOM4_PAD3            82L  /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
-#define MUX_PC18F_SERCOM4_PAD3             5L
-#define PINMUX_PC18F_SERCOM4_PAD3  ((PIN_PC18F_SERCOM4_PAD3 << 16) | MUX_PC18F_SERCOM4_PAD3)
-#define PORT_PC18F_SERCOM4_PAD3    (1ul << 18)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL(1) << 15)
 /* ========== PORT definition for SERCOM5 peripheral ========== */
-#define PIN_PB16C_SERCOM5_PAD0            48L  /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
-#define MUX_PB16C_SERCOM5_PAD0             2L
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
 #define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
-#define PORT_PB16C_SERCOM5_PAD0    (1ul << 16)
-#define PIN_PA22D_SERCOM5_PAD0            22L  /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
-#define MUX_PA22D_SERCOM5_PAD0             3L
+#define PORT_PB16C_SERCOM5_PAD0  (_UL(1) << 16)
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
-#define PORT_PA22D_SERCOM5_PAD0    (1ul << 22)
-#define PIN_PB30D_SERCOM5_PAD0            62L  /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
-#define MUX_PB30D_SERCOM5_PAD0             3L
+#define PORT_PA22D_SERCOM5_PAD0  (_UL(1) << 22)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
-#define PORT_PB30D_SERCOM5_PAD0    (1ul << 30)
-#define PIN_PB17C_SERCOM5_PAD1            49L  /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
-#define MUX_PB17C_SERCOM5_PAD1             2L
+#define PORT_PB30D_SERCOM5_PAD0  (_UL(1) << 30)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
 #define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
-#define PORT_PB17C_SERCOM5_PAD1    (1ul << 17)
-#define PIN_PA23D_SERCOM5_PAD1            23L  /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
-#define MUX_PA23D_SERCOM5_PAD1             3L
+#define PORT_PB17C_SERCOM5_PAD1  (_UL(1) << 17)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
-#define PORT_PA23D_SERCOM5_PAD1    (1ul << 23)
-#define PIN_PB31D_SERCOM5_PAD1            63L  /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
-#define MUX_PB31D_SERCOM5_PAD1             3L
+#define PORT_PA23D_SERCOM5_PAD1  (_UL(1) << 23)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
-#define PORT_PB31D_SERCOM5_PAD1    (1ul << 31)
-#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
-#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PORT_PB31D_SERCOM5_PAD1  (_UL(1) << 31)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
-#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
-#define PIN_PB00D_SERCOM5_PAD2            32L  /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
-#define MUX_PB00D_SERCOM5_PAD2             3L
+#define PORT_PA24D_SERCOM5_PAD2  (_UL(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
-#define PORT_PB00D_SERCOM5_PAD2    (1ul <<  0)
-#define PIN_PB22D_SERCOM5_PAD2            54L  /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
-#define MUX_PB22D_SERCOM5_PAD2             3L
+#define PORT_PB00D_SERCOM5_PAD2  (_UL(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
-#define PORT_PB22D_SERCOM5_PAD2    (1ul << 22)
-#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
-#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PORT_PB22D_SERCOM5_PAD2  (_UL(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
 #define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
-#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
-#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
-#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PORT_PA20C_SERCOM5_PAD2  (_UL(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
-#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
-#define PIN_PB23D_SERCOM5_PAD3            55L  /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
-#define MUX_PB23D_SERCOM5_PAD3             3L
+#define PORT_PA25D_SERCOM5_PAD3  (_UL(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
-#define PORT_PB23D_SERCOM5_PAD3    (1ul << 23)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL(1) << 23)
 /* ========== PORT definition for TCC0 peripheral ========== */
-#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
-#define MUX_PA08E_TCC0_WO0                 4L
+#define PIN_PA08E_TCC0_WO0              _L_(8) /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0              _L_(4)
 #define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
-#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
-#define PIN_PB30E_TCC0_WO0                62L  /**< \brief TCC0 signal: WO0 on PB30 mux E */
-#define MUX_PB30E_TCC0_WO0                 4L
+#define PORT_PA08E_TCC0_WO0    (_UL(1) <<  8)
+#define PIN_PB30E_TCC0_WO0             _L_(62) /**< \brief TCC0 signal: WO0 on PB30 mux E */
+#define MUX_PB30E_TCC0_WO0              _L_(4)
 #define PINMUX_PB30E_TCC0_WO0      ((PIN_PB30E_TCC0_WO0 << 16) | MUX_PB30E_TCC0_WO0)
-#define PORT_PB30E_TCC0_WO0        (1ul << 30)
-#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
-#define MUX_PA09E_TCC0_WO1                 4L
+#define PORT_PB30E_TCC0_WO0    (_UL(1) << 30)
+#define PIN_PA09E_TCC0_WO1              _L_(9) /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1              _L_(4)
 #define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
-#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
-#define PIN_PB31E_TCC0_WO1                63L  /**< \brief TCC0 signal: WO1 on PB31 mux E */
-#define MUX_PB31E_TCC0_WO1                 4L
+#define PORT_PA09E_TCC0_WO1    (_UL(1) <<  9)
+#define PIN_PB31E_TCC0_WO1             _L_(63) /**< \brief TCC0 signal: WO1 on PB31 mux E */
+#define MUX_PB31E_TCC0_WO1              _L_(4)
 #define PINMUX_PB31E_TCC0_WO1      ((PIN_PB31E_TCC0_WO1 << 16) | MUX_PB31E_TCC0_WO1)
-#define PORT_PB31E_TCC0_WO1        (1ul << 31)
-#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
-#define MUX_PA10F_TCC0_WO2                 5L
+#define PORT_PB31E_TCC0_WO1    (_UL(1) << 31)
+#define PIN_PA10F_TCC0_WO2             _L_(10) /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2              _L_(5)
 #define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
-#define PORT_PA10F_TCC0_WO2        (1ul << 10)
-#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
-#define MUX_PA18F_TCC0_WO2                 5L
+#define PORT_PA10F_TCC0_WO2    (_UL(1) << 10)
+#define PIN_PA18F_TCC0_WO2             _L_(18) /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2              _L_(5)
 #define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
-#define PORT_PA18F_TCC0_WO2        (1ul << 18)
-#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
-#define MUX_PA11F_TCC0_WO3                 5L
+#define PORT_PA18F_TCC0_WO2    (_UL(1) << 18)
+#define PIN_PA11F_TCC0_WO3             _L_(11) /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3              _L_(5)
 #define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
-#define PORT_PA11F_TCC0_WO3        (1ul << 11)
-#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
-#define MUX_PA19F_TCC0_WO3                 5L
+#define PORT_PA11F_TCC0_WO3    (_UL(1) << 11)
+#define PIN_PA19F_TCC0_WO3             _L_(19) /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3              _L_(5)
 #define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
-#define PORT_PA19F_TCC0_WO3        (1ul << 19)
-#define PIN_PA14F_TCC0_WO4                14L  /**< \brief TCC0 signal: WO4 on PA14 mux F */
-#define MUX_PA14F_TCC0_WO4                 5L
+#define PORT_PA19F_TCC0_WO3    (_UL(1) << 19)
+#define PIN_PA14F_TCC0_WO4             _L_(14) /**< \brief TCC0 signal: WO4 on PA14 mux F */
+#define MUX_PA14F_TCC0_WO4              _L_(5)
 #define PINMUX_PA14F_TCC0_WO4      ((PIN_PA14F_TCC0_WO4 << 16) | MUX_PA14F_TCC0_WO4)
-#define PORT_PA14F_TCC0_WO4        (1ul << 14)
-#define PIN_PA22F_TCC0_WO4                22L  /**< \brief TCC0 signal: WO4 on PA22 mux F */
-#define MUX_PA22F_TCC0_WO4                 5L
+#define PORT_PA14F_TCC0_WO4    (_UL(1) << 14)
+#define PIN_PA22F_TCC0_WO4             _L_(22) /**< \brief TCC0 signal: WO4 on PA22 mux F */
+#define MUX_PA22F_TCC0_WO4              _L_(5)
 #define PINMUX_PA22F_TCC0_WO4      ((PIN_PA22F_TCC0_WO4 << 16) | MUX_PA22F_TCC0_WO4)
-#define PORT_PA22F_TCC0_WO4        (1ul << 22)
-#define PIN_PB16F_TCC0_WO4                48L  /**< \brief TCC0 signal: WO4 on PB16 mux F */
-#define MUX_PB16F_TCC0_WO4                 5L
+#define PORT_PA22F_TCC0_WO4    (_UL(1) << 22)
+#define PIN_PB16F_TCC0_WO4             _L_(48) /**< \brief TCC0 signal: WO4 on PB16 mux F */
+#define MUX_PB16F_TCC0_WO4              _L_(5)
 #define PINMUX_PB16F_TCC0_WO4      ((PIN_PB16F_TCC0_WO4 << 16) | MUX_PB16F_TCC0_WO4)
-#define PORT_PB16F_TCC0_WO4        (1ul << 16)
-#define PIN_PA15F_TCC0_WO5                15L  /**< \brief TCC0 signal: WO5 on PA15 mux F */
-#define MUX_PA15F_TCC0_WO5                 5L
+#define PORT_PB16F_TCC0_WO4    (_UL(1) << 16)
+#define PIN_PA15F_TCC0_WO5             _L_(15) /**< \brief TCC0 signal: WO5 on PA15 mux F */
+#define MUX_PA15F_TCC0_WO5              _L_(5)
 #define PINMUX_PA15F_TCC0_WO5      ((PIN_PA15F_TCC0_WO5 << 16) | MUX_PA15F_TCC0_WO5)
-#define PORT_PA15F_TCC0_WO5        (1ul << 15)
-#define PIN_PA23F_TCC0_WO5                23L  /**< \brief TCC0 signal: WO5 on PA23 mux F */
-#define MUX_PA23F_TCC0_WO5                 5L
+#define PORT_PA15F_TCC0_WO5    (_UL(1) << 15)
+#define PIN_PA23F_TCC0_WO5             _L_(23) /**< \brief TCC0 signal: WO5 on PA23 mux F */
+#define MUX_PA23F_TCC0_WO5              _L_(5)
 #define PINMUX_PA23F_TCC0_WO5      ((PIN_PA23F_TCC0_WO5 << 16) | MUX_PA23F_TCC0_WO5)
-#define PORT_PA23F_TCC0_WO5        (1ul << 23)
-#define PIN_PB17F_TCC0_WO5                49L  /**< \brief TCC0 signal: WO5 on PB17 mux F */
-#define MUX_PB17F_TCC0_WO5                 5L
+#define PORT_PA23F_TCC0_WO5    (_UL(1) << 23)
+#define PIN_PB17F_TCC0_WO5             _L_(49) /**< \brief TCC0 signal: WO5 on PB17 mux F */
+#define MUX_PB17F_TCC0_WO5              _L_(5)
 #define PINMUX_PB17F_TCC0_WO5      ((PIN_PB17F_TCC0_WO5 << 16) | MUX_PB17F_TCC0_WO5)
-#define PORT_PB17F_TCC0_WO5        (1ul << 17)
-#define PIN_PA12F_TCC0_WO6                12L  /**< \brief TCC0 signal: WO6 on PA12 mux F */
-#define MUX_PA12F_TCC0_WO6                 5L
+#define PORT_PB17F_TCC0_WO5    (_UL(1) << 17)
+#define PIN_PA12F_TCC0_WO6             _L_(12) /**< \brief TCC0 signal: WO6 on PA12 mux F */
+#define MUX_PA12F_TCC0_WO6              _L_(5)
 #define PINMUX_PA12F_TCC0_WO6      ((PIN_PA12F_TCC0_WO6 << 16) | MUX_PA12F_TCC0_WO6)
-#define PORT_PA12F_TCC0_WO6        (1ul << 12)
-#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
-#define MUX_PA20F_TCC0_WO6                 5L
+#define PORT_PA12F_TCC0_WO6    (_UL(1) << 12)
+#define PIN_PA20F_TCC0_WO6             _L_(20) /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6              _L_(5)
 #define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
-#define PORT_PA20F_TCC0_WO6        (1ul << 20)
-#define PIN_PA16F_TCC0_WO6                16L  /**< \brief TCC0 signal: WO6 on PA16 mux F */
-#define MUX_PA16F_TCC0_WO6                 5L
+#define PORT_PA20F_TCC0_WO6    (_UL(1) << 20)
+#define PIN_PA16F_TCC0_WO6             _L_(16) /**< \brief TCC0 signal: WO6 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO6              _L_(5)
 #define PINMUX_PA16F_TCC0_WO6      ((PIN_PA16F_TCC0_WO6 << 16) | MUX_PA16F_TCC0_WO6)
-#define PORT_PA16F_TCC0_WO6        (1ul << 16)
-#define PIN_PA17F_TCC0_WO7                17L  /**< \brief TCC0 signal: WO7 on PA17 mux F */
-#define MUX_PA17F_TCC0_WO7                 5L
+#define PORT_PA16F_TCC0_WO6    (_UL(1) << 16)
+#define PIN_PA17F_TCC0_WO7             _L_(17) /**< \brief TCC0 signal: WO7 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO7              _L_(5)
 #define PINMUX_PA17F_TCC0_WO7      ((PIN_PA17F_TCC0_WO7 << 16) | MUX_PA17F_TCC0_WO7)
-#define PORT_PA17F_TCC0_WO7        (1ul << 17)
+#define PORT_PA17F_TCC0_WO7    (_UL(1) << 17)
 /* ========== PORT definition for TCC1 peripheral ========== */
-#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
-#define MUX_PA06E_TCC1_WO0                 4L
+#define PIN_PA06E_TCC1_WO0              _L_(6) /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0              _L_(4)
 #define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
-#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
-#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
-#define MUX_PA10E_TCC1_WO0                 4L
+#define PORT_PA06E_TCC1_WO0    (_UL(1) <<  6)
+#define PIN_PA10E_TCC1_WO0             _L_(10) /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0              _L_(4)
 #define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
-#define PORT_PA10E_TCC1_WO0        (1ul << 10)
-#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
-#define MUX_PA30E_TCC1_WO0                 4L
+#define PORT_PA10E_TCC1_WO0    (_UL(1) << 10)
+#define PIN_PA30E_TCC1_WO0             _L_(30) /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0              _L_(4)
 #define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
-#define PORT_PA30E_TCC1_WO0        (1ul << 30)
-#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
-#define MUX_PA07E_TCC1_WO1                 4L
+#define PORT_PA30E_TCC1_WO0    (_UL(1) << 30)
+#define PIN_PA07E_TCC1_WO1              _L_(7) /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1              _L_(4)
 #define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
-#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
-#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
-#define MUX_PA11E_TCC1_WO1                 4L
+#define PORT_PA07E_TCC1_WO1    (_UL(1) <<  7)
+#define PIN_PA11E_TCC1_WO1             _L_(11) /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1              _L_(4)
 #define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
-#define PORT_PA11E_TCC1_WO1        (1ul << 11)
-#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
-#define MUX_PA31E_TCC1_WO1                 4L
+#define PORT_PA11E_TCC1_WO1    (_UL(1) << 11)
+#define PIN_PA31E_TCC1_WO1             _L_(31) /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1              _L_(4)
 #define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
-#define PORT_PA31E_TCC1_WO1        (1ul << 31)
-#define PIN_PA08F_TCC1_WO2                 8L  /**< \brief TCC1 signal: WO2 on PA08 mux F */
-#define MUX_PA08F_TCC1_WO2                 5L
+#define PORT_PA31E_TCC1_WO1    (_UL(1) << 31)
+#define PIN_PA08F_TCC1_WO2              _L_(8) /**< \brief TCC1 signal: WO2 on PA08 mux F */
+#define MUX_PA08F_TCC1_WO2              _L_(5)
 #define PINMUX_PA08F_TCC1_WO2      ((PIN_PA08F_TCC1_WO2 << 16) | MUX_PA08F_TCC1_WO2)
-#define PORT_PA08F_TCC1_WO2        (1ul <<  8)
-#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
-#define MUX_PA24F_TCC1_WO2                 5L
+#define PORT_PA08F_TCC1_WO2    (_UL(1) <<  8)
+#define PIN_PA24F_TCC1_WO2             _L_(24) /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2              _L_(5)
 #define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
-#define PORT_PA24F_TCC1_WO2        (1ul << 24)
-#define PIN_PB30F_TCC1_WO2                62L  /**< \brief TCC1 signal: WO2 on PB30 mux F */
-#define MUX_PB30F_TCC1_WO2                 5L
+#define PORT_PA24F_TCC1_WO2    (_UL(1) << 24)
+#define PIN_PB30F_TCC1_WO2             _L_(62) /**< \brief TCC1 signal: WO2 on PB30 mux F */
+#define MUX_PB30F_TCC1_WO2              _L_(5)
 #define PINMUX_PB30F_TCC1_WO2      ((PIN_PB30F_TCC1_WO2 << 16) | MUX_PB30F_TCC1_WO2)
-#define PORT_PB30F_TCC1_WO2        (1ul << 30)
-#define PIN_PA09F_TCC1_WO3                 9L  /**< \brief TCC1 signal: WO3 on PA09 mux F */
-#define MUX_PA09F_TCC1_WO3                 5L
+#define PORT_PB30F_TCC1_WO2    (_UL(1) << 30)
+#define PIN_PA09F_TCC1_WO3              _L_(9) /**< \brief TCC1 signal: WO3 on PA09 mux F */
+#define MUX_PA09F_TCC1_WO3              _L_(5)
 #define PINMUX_PA09F_TCC1_WO3      ((PIN_PA09F_TCC1_WO3 << 16) | MUX_PA09F_TCC1_WO3)
-#define PORT_PA09F_TCC1_WO3        (1ul <<  9)
-#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
-#define MUX_PA25F_TCC1_WO3                 5L
+#define PORT_PA09F_TCC1_WO3    (_UL(1) <<  9)
+#define PIN_PA25F_TCC1_WO3             _L_(25) /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3              _L_(5)
 #define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
-#define PORT_PA25F_TCC1_WO3        (1ul << 25)
-#define PIN_PB31F_TCC1_WO3                63L  /**< \brief TCC1 signal: WO3 on PB31 mux F */
-#define MUX_PB31F_TCC1_WO3                 5L
+#define PORT_PA25F_TCC1_WO3    (_UL(1) << 25)
+#define PIN_PB31F_TCC1_WO3             _L_(63) /**< \brief TCC1 signal: WO3 on PB31 mux F */
+#define MUX_PB31F_TCC1_WO3              _L_(5)
 #define PINMUX_PB31F_TCC1_WO3      ((PIN_PB31F_TCC1_WO3 << 16) | MUX_PB31F_TCC1_WO3)
-#define PORT_PB31F_TCC1_WO3        (1ul << 31)
+#define PORT_PB31F_TCC1_WO3    (_UL(1) << 31)
 /* ========== PORT definition for TCC2 peripheral ========== */
-#define PIN_PA12E_TCC2_WO0                12L  /**< \brief TCC2 signal: WO0 on PA12 mux E */
-#define MUX_PA12E_TCC2_WO0                 4L
+#define PIN_PA12E_TCC2_WO0             _L_(12) /**< \brief TCC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TCC2_WO0              _L_(4)
 #define PINMUX_PA12E_TCC2_WO0      ((PIN_PA12E_TCC2_WO0 << 16) | MUX_PA12E_TCC2_WO0)
-#define PORT_PA12E_TCC2_WO0        (1ul << 12)
-#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
-#define MUX_PA16E_TCC2_WO0                 4L
+#define PORT_PA12E_TCC2_WO0    (_UL(1) << 12)
+#define PIN_PA16E_TCC2_WO0             _L_(16) /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0              _L_(4)
 #define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
-#define PORT_PA16E_TCC2_WO0        (1ul << 16)
-#define PIN_PA00E_TCC2_WO0                 0L  /**< \brief TCC2 signal: WO0 on PA00 mux E */
-#define MUX_PA00E_TCC2_WO0                 4L
+#define PORT_PA16E_TCC2_WO0    (_UL(1) << 16)
+#define PIN_PA00E_TCC2_WO0              _L_(0) /**< \brief TCC2 signal: WO0 on PA00 mux E */
+#define MUX_PA00E_TCC2_WO0              _L_(4)
 #define PINMUX_PA00E_TCC2_WO0      ((PIN_PA00E_TCC2_WO0 << 16) | MUX_PA00E_TCC2_WO0)
-#define PORT_PA00E_TCC2_WO0        (1ul <<  0)
-#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
-#define MUX_PA17E_TCC2_WO1                 4L
+#define PORT_PA00E_TCC2_WO0    (_UL(1) <<  0)
+#define PIN_PA17E_TCC2_WO1             _L_(17) /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1              _L_(4)
 #define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
-#define PORT_PA17E_TCC2_WO1        (1ul << 17)
+#define PORT_PA17E_TCC2_WO1    (_UL(1) << 17)
 /* ========== PORT definition for TC3 peripheral ========== */
-#define PIN_PA18E_TC3_WO0                 18L  /**< \brief TC3 signal: WO0 on PA18 mux E */
-#define MUX_PA18E_TC3_WO0                  4L
+#define PIN_PA18E_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC3_WO0               _L_(4)
 #define PINMUX_PA18E_TC3_WO0       ((PIN_PA18E_TC3_WO0 << 16) | MUX_PA18E_TC3_WO0)
-#define PORT_PA18E_TC3_WO0         (1ul << 18)
-#define PIN_PA14E_TC3_WO0                 14L  /**< \brief TC3 signal: WO0 on PA14 mux E */
-#define MUX_PA14E_TC3_WO0                  4L
+#define PORT_PA18E_TC3_WO0     (_UL(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
 #define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
-#define PORT_PA14E_TC3_WO0         (1ul << 14)
-#define PIN_PA19E_TC3_WO1                 19L  /**< \brief TC3 signal: WO1 on PA19 mux E */
-#define MUX_PA19E_TC3_WO1                  4L
+#define PORT_PA14E_TC3_WO0     (_UL(1) << 14)
+#define PIN_PA19E_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC3_WO1               _L_(4)
 #define PINMUX_PA19E_TC3_WO1       ((PIN_PA19E_TC3_WO1 << 16) | MUX_PA19E_TC3_WO1)
-#define PORT_PA19E_TC3_WO1         (1ul << 19)
-#define PIN_PA15E_TC3_WO1                 15L  /**< \brief TC3 signal: WO1 on PA15 mux E */
-#define MUX_PA15E_TC3_WO1                  4L
+#define PORT_PA19E_TC3_WO1     (_UL(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
 #define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
-#define PORT_PA15E_TC3_WO1         (1ul << 15)
+#define PORT_PA15E_TC3_WO1     (_UL(1) << 15)
 /* ========== PORT definition for TC4 peripheral ========== */
-#define PIN_PA22E_TC4_WO0                 22L  /**< \brief TC4 signal: WO0 on PA22 mux E */
-#define MUX_PA22E_TC4_WO0                  4L
+#define PIN_PA22E_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux E */
+#define MUX_PA22E_TC4_WO0               _L_(4)
 #define PINMUX_PA22E_TC4_WO0       ((PIN_PA22E_TC4_WO0 << 16) | MUX_PA22E_TC4_WO0)
-#define PORT_PA22E_TC4_WO0         (1ul << 22)
-#define PIN_PB08E_TC4_WO0                 40L  /**< \brief TC4 signal: WO0 on PB08 mux E */
-#define MUX_PB08E_TC4_WO0                  4L
+#define PORT_PA22E_TC4_WO0     (_UL(1) << 22)
+#define PIN_PB08E_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC4_WO0               _L_(4)
 #define PINMUX_PB08E_TC4_WO0       ((PIN_PB08E_TC4_WO0 << 16) | MUX_PB08E_TC4_WO0)
-#define PORT_PB08E_TC4_WO0         (1ul <<  8)
-#define PIN_PA23E_TC4_WO1                 23L  /**< \brief TC4 signal: WO1 on PA23 mux E */
-#define MUX_PA23E_TC4_WO1                  4L
+#define PORT_PB08E_TC4_WO0     (_UL(1) <<  8)
+#define PIN_PA23E_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux E */
+#define MUX_PA23E_TC4_WO1               _L_(4)
 #define PINMUX_PA23E_TC4_WO1       ((PIN_PA23E_TC4_WO1 << 16) | MUX_PA23E_TC4_WO1)
-#define PORT_PA23E_TC4_WO1         (1ul << 23)
-#define PIN_PB09E_TC4_WO1                 41L  /**< \brief TC4 signal: WO1 on PB09 mux E */
-#define MUX_PB09E_TC4_WO1                  4L
+#define PORT_PA23E_TC4_WO1     (_UL(1) << 23)
+#define PIN_PB09E_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC4_WO1               _L_(4)
 #define PINMUX_PB09E_TC4_WO1       ((PIN_PB09E_TC4_WO1 << 16) | MUX_PB09E_TC4_WO1)
-#define PORT_PB09E_TC4_WO1         (1ul <<  9)
+#define PORT_PB09E_TC4_WO1     (_UL(1) <<  9)
 /* ========== PORT definition for TC5 peripheral ========== */
-#define PIN_PA24E_TC5_WO0                 24L  /**< \brief TC5 signal: WO0 on PA24 mux E */
-#define MUX_PA24E_TC5_WO0                  4L
+#define PIN_PA24E_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC5_WO0               _L_(4)
 #define PINMUX_PA24E_TC5_WO0       ((PIN_PA24E_TC5_WO0 << 16) | MUX_PA24E_TC5_WO0)
-#define PORT_PA24E_TC5_WO0         (1ul << 24)
-#define PIN_PB14E_TC5_WO0                 46L  /**< \brief TC5 signal: WO0 on PB14 mux E */
-#define MUX_PB14E_TC5_WO0                  4L
+#define PORT_PA24E_TC5_WO0     (_UL(1) << 24)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
 #define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
-#define PORT_PB14E_TC5_WO0         (1ul << 14)
-#define PIN_PA25E_TC5_WO1                 25L  /**< \brief TC5 signal: WO1 on PA25 mux E */
-#define MUX_PA25E_TC5_WO1                  4L
+#define PORT_PB14E_TC5_WO0     (_UL(1) << 14)
+#define PIN_PA25E_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC5_WO1               _L_(4)
 #define PINMUX_PA25E_TC5_WO1       ((PIN_PA25E_TC5_WO1 << 16) | MUX_PA25E_TC5_WO1)
-#define PORT_PA25E_TC5_WO1         (1ul << 25)
-#define PIN_PB15E_TC5_WO1                 47L  /**< \brief TC5 signal: WO1 on PB15 mux E */
-#define MUX_PB15E_TC5_WO1                  4L
+#define PORT_PA25E_TC5_WO1     (_UL(1) << 25)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
 #define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
-#define PORT_PB15E_TC5_WO1         (1ul << 15)
+#define PORT_PB15E_TC5_WO1     (_UL(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL(1) << 16)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL(1) << 20)
+#define PIN_PB00E_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux E */
+#define MUX_PB00E_TC7_WO0               _L_(4)
+#define PINMUX_PB00E_TC7_WO0       ((PIN_PB00E_TC7_WO0 << 16) | MUX_PB00E_TC7_WO0)
+#define PORT_PB00E_TC7_WO0     (_UL(1) <<  0)
+#define PIN_PB22E_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux E */
+#define MUX_PB22E_TC7_WO0               _L_(4)
+#define PINMUX_PB22E_TC7_WO0       ((PIN_PB22E_TC7_WO0 << 16) | MUX_PB22E_TC7_WO0)
+#define PORT_PB22E_TC7_WO0     (_UL(1) << 22)
+#define PIN_PB23E_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux E */
+#define MUX_PB23E_TC7_WO1               _L_(4)
+#define PINMUX_PB23E_TC7_WO1       ((PIN_PB23E_TC7_WO1 << 16) | MUX_PB23E_TC7_WO1)
+#define PORT_PB23E_TC7_WO1     (_UL(1) << 23)
 /* ========== PORT definition for ADC peripheral ========== */
-#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
-#define MUX_PB08B_ADC_AIN2                 1L
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
 #define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
-#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
-#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
-#define MUX_PB09B_ADC_AIN3                 1L
+#define PORT_PB08B_ADC_AIN2    (_UL(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
 #define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
-#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
-#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
-#define MUX_PA06B_ADC_AIN6                 1L
+#define PORT_PB09B_ADC_AIN3    (_UL(1) <<  9)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
 #define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
-#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
-#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
-#define MUX_PA07B_ADC_AIN7                 1L
+#define PORT_PA06B_ADC_AIN6    (_UL(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
 #define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
-#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
-#define PIN_PB00B_ADC_AIN8                32L  /**< \brief ADC signal: AIN8 on PB00 mux B */
-#define MUX_PB00B_ADC_AIN8                 1L
+#define PORT_PA07B_ADC_AIN7    (_UL(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
 #define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
-#define PORT_PB00B_ADC_AIN8        (1ul <<  0)
-#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
-#define MUX_PA08B_ADC_AIN16                1L
+#define PORT_PB00B_ADC_AIN8    (_UL(1) <<  0)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
 #define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
-#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
-#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
-#define MUX_PA09B_ADC_AIN17                1L
+#define PORT_PA08B_ADC_AIN16   (_UL(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
 #define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
-#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
-#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
-#define MUX_PA10B_ADC_AIN18                1L
+#define PORT_PA09B_ADC_AIN17   (_UL(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
 #define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
-#define PORT_PA10B_ADC_AIN18       (1ul << 10)
-#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
-#define MUX_PA11B_ADC_AIN19                1L
+#define PORT_PA10B_ADC_AIN18   (_UL(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
 #define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
-#define PORT_PA11B_ADC_AIN19       (1ul << 11)
+#define PORT_PA11B_ADC_AIN19   (_UL(1) << 11)
 /* ========== PORT definition for AC peripheral ========== */
-#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
-#define MUX_PA06B_AC_AIN2                  1L
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
 #define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
-#define PORT_PA06B_AC_AIN2         (1ul <<  6)
-#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
-#define MUX_PA07B_AC_AIN3                  1L
+#define PORT_PA06B_AC_AIN2     (_UL(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
 #define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
-#define PORT_PA07B_AC_AIN3         (1ul <<  7)
-#define PIN_PA12H_AC_CMP0                 12L  /**< \brief AC signal: CMP0 on PA12 mux H */
-#define MUX_PA12H_AC_CMP0                  7L
+#define PORT_PA07B_AC_AIN3     (_UL(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
 #define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
-#define PORT_PA12H_AC_CMP0         (1ul << 12)
-#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
-#define MUX_PA18H_AC_CMP0                  7L
+#define PORT_PA12H_AC_CMP0     (_UL(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
 #define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
-#define PORT_PA18H_AC_CMP0         (1ul << 18)
-#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
-#define MUX_PA19H_AC_CMP1                  7L
+#define PORT_PA18H_AC_CMP0     (_UL(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
 #define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
-#define PORT_PA19H_AC_CMP1         (1ul << 19)
-/* ========== PORT definition for RFCTRL peripheral ========== */
-#define PIN_PA08F_RFCTRL_FECTRL0           8L  /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
-#define MUX_PA08F_RFCTRL_FECTRL0           5L
-#define PINMUX_PA08F_RFCTRL_FECTRL0  ((PIN_PA08F_RFCTRL_FECTRL0 << 16) | MUX_PA08F_RFCTRL_FECTRL0)
-#define PORT_PA08F_RFCTRL_FECTRL0  (1ul <<  8)
-#define PIN_PA09F_RFCTRL_FECTRL1           9L  /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
-#define MUX_PA09F_RFCTRL_FECTRL1           5L
-#define PINMUX_PA09F_RFCTRL_FECTRL1  ((PIN_PA09F_RFCTRL_FECTRL1 << 16) | MUX_PA09F_RFCTRL_FECTRL1)
-#define PORT_PA09F_RFCTRL_FECTRL1  (1ul <<  9)
-#define PIN_PA14F_RFCTRL_FECTRL4          14L  /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
-#define MUX_PA14F_RFCTRL_FECTRL4           5L
-#define PINMUX_PA14F_RFCTRL_FECTRL4  ((PIN_PA14F_RFCTRL_FECTRL4 << 16) | MUX_PA14F_RFCTRL_FECTRL4)
-#define PORT_PA14F_RFCTRL_FECTRL4  (1ul << 14)
-#define PIN_PA15F_RFCTRL_FECTRL5          15L  /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
-#define MUX_PA15F_RFCTRL_FECTRL5           5L
-#define PINMUX_PA15F_RFCTRL_FECTRL5  ((PIN_PA15F_RFCTRL_FECTRL5 << 16) | MUX_PA15F_RFCTRL_FECTRL5)
-#define PORT_PA15F_RFCTRL_FECTRL5  (1ul << 15)
+#define PORT_PA19H_AC_CMP1     (_UL(1) << 19)
 
 #endif /* _SAMR21E19A_PIO_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/pio/samr21g16a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/pio/samr21g16a.h
@@ -3,39 +3,24 @@
  *
  * \brief Peripheral I/O description for SAMR21G16A
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2017 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -45,884 +30,957 @@
 #define _SAMR21G16A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define PORT_PA00                 (1ul <<  0) /**< \brief PORT Mask  for PA00 */
+#define PORT_PA00              (_UL(1) <<  0) /**< \brief PORT Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define PORT_PA01                 (1ul <<  1) /**< \brief PORT Mask  for PA01 */
+#define PORT_PA01              (_UL(1) <<  1) /**< \brief PORT Mask  for PA01 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define PORT_PA04                 (1ul <<  4) /**< \brief PORT Mask  for PA04 */
+#define PORT_PA04              (_UL(1) <<  4) /**< \brief PORT Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define PORT_PA05                 (1ul <<  5) /**< \brief PORT Mask  for PA05 */
+#define PORT_PA05              (_UL(1) <<  5) /**< \brief PORT Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PORT_PA06              (_UL(1) <<  6) /**< \brief PORT Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PORT_PA07              (_UL(1) <<  7) /**< \brief PORT Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PORT_PA08              (_UL(1) <<  8) /**< \brief PORT Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PORT_PA09              (_UL(1) <<  9) /**< \brief PORT Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PORT_PA10              (_UL(1) << 10) /**< \brief PORT Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PORT_PA11              (_UL(1) << 11) /**< \brief PORT Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define PORT_PA12                 (1ul << 12) /**< \brief PORT Mask  for PA12 */
+#define PORT_PA12              (_UL(1) << 12) /**< \brief PORT Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define PORT_PA13                 (1ul << 13) /**< \brief PORT Mask  for PA13 */
+#define PORT_PA13              (_UL(1) << 13) /**< \brief PORT Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PORT_PA14              (_UL(1) << 14) /**< \brief PORT Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PORT_PA15              (_UL(1) << 15) /**< \brief PORT Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PORT_PA16              (_UL(1) << 16) /**< \brief PORT Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PORT_PA17              (_UL(1) << 17) /**< \brief PORT Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PORT_PA18              (_UL(1) << 18) /**< \brief PORT Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PORT_PA19              (_UL(1) << 19) /**< \brief PORT Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PORT_PA20              (_UL(1) << 20) /**< \brief PORT Mask  for PA20 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define PORT_PA22                 (1ul << 22) /**< \brief PORT Mask  for PA22 */
+#define PORT_PA22              (_UL(1) << 22) /**< \brief PORT Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define PORT_PA23                 (1ul << 23) /**< \brief PORT Mask  for PA23 */
+#define PORT_PA23              (_UL(1) << 23) /**< \brief PORT Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PORT_PA24              (_UL(1) << 24) /**< \brief PORT Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PORT_PA25              (_UL(1) << 25) /**< \brief PORT Mask  for PA25 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PORT_PA27              (_UL(1) << 27) /**< \brief PORT Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define PORT_PA28                 (1ul << 28) /**< \brief PORT Mask  for PA28 */
+#define PORT_PA28              (_UL(1) << 28) /**< \brief PORT Mask  for PA28 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PORT_PA30              (_UL(1) << 30) /**< \brief PORT Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PORT_PA31              (_UL(1) << 31) /**< \brief PORT Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define PORT_PB00                 (1ul <<  0) /**< \brief PORT Mask  for PB00 */
+#define PORT_PB00              (_UL(1) <<  0) /**< \brief PORT Mask  for PB00 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define PORT_PB02                 (1ul <<  2) /**< \brief PORT Mask  for PB02 */
+#define PORT_PB02              (_UL(1) <<  2) /**< \brief PORT Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define PORT_PB03                 (1ul <<  3) /**< \brief PORT Mask  for PB03 */
+#define PORT_PB03              (_UL(1) <<  3) /**< \brief PORT Mask  for PB03 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PORT_PB08              (_UL(1) <<  8) /**< \brief PORT Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PORT_PB09              (_UL(1) <<  9) /**< \brief PORT Mask  for PB09 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define PORT_PB14                 (1ul << 14) /**< \brief PORT Mask  for PB14 */
+#define PORT_PB14              (_UL(1) << 14) /**< \brief PORT Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define PORT_PB15                 (1ul << 15) /**< \brief PORT Mask  for PB15 */
+#define PORT_PB15              (_UL(1) << 15) /**< \brief PORT Mask  for PB15 */
 #define PIN_PB16                          48  /**< \brief Pin Number for PB16 */
-#define PORT_PB16                 (1ul << 16) /**< \brief PORT Mask  for PB16 */
+#define PORT_PB16              (_UL(1) << 16) /**< \brief PORT Mask  for PB16 */
 #define PIN_PB17                          49  /**< \brief Pin Number for PB17 */
-#define PORT_PB17                 (1ul << 17) /**< \brief PORT Mask  for PB17 */
+#define PORT_PB17              (_UL(1) << 17) /**< \brief PORT Mask  for PB17 */
 #define PIN_PB22                          54  /**< \brief Pin Number for PB22 */
-#define PORT_PB22                 (1ul << 22) /**< \brief PORT Mask  for PB22 */
+#define PORT_PB22              (_UL(1) << 22) /**< \brief PORT Mask  for PB22 */
 #define PIN_PB23                          55  /**< \brief Pin Number for PB23 */
-#define PORT_PB23                 (1ul << 23) /**< \brief PORT Mask  for PB23 */
+#define PORT_PB23              (_UL(1) << 23) /**< \brief PORT Mask  for PB23 */
 #define PIN_PB30                          62  /**< \brief Pin Number for PB30 */
-#define PORT_PB30                 (1ul << 30) /**< \brief PORT Mask  for PB30 */
+#define PORT_PB30              (_UL(1) << 30) /**< \brief PORT Mask  for PB30 */
 #define PIN_PB31                          63  /**< \brief Pin Number for PB31 */
-#define PORT_PB31                 (1ul << 31) /**< \brief PORT Mask  for PB31 */
+#define PORT_PB31              (_UL(1) << 31) /**< \brief PORT Mask  for PB31 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define PORT_PC16                 (1ul << 16) /**< \brief PORT Mask  for PC16 */
+#define PORT_PC16              (_UL(1) << 16) /**< \brief PORT Mask  for PC16 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define PORT_PC18                 (1ul << 18) /**< \brief PORT Mask  for PC18 */
+#define PORT_PC18              (_UL(1) << 18) /**< \brief PORT Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define PORT_PC19                 (1ul << 19) /**< \brief PORT Mask  for PC19 */
+#define PORT_PC19              (_UL(1) << 19) /**< \brief PORT Mask  for PC19 */
 /* ========== PORT definition for GCLK peripheral ========== */
-#define PIN_PB14H_GCLK_IO0                46L  /**< \brief GCLK signal: IO0 on PB14 mux H */
-#define MUX_PB14H_GCLK_IO0                 7L
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
 #define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
-#define PORT_PB14H_GCLK_IO0        (1ul << 14)
-#define PIN_PB22H_GCLK_IO0                54L  /**< \brief GCLK signal: IO0 on PB22 mux H */
-#define MUX_PB22H_GCLK_IO0                 7L
+#define PORT_PB14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
 #define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
-#define PORT_PB22H_GCLK_IO0        (1ul << 22)
-#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
-#define MUX_PA14H_GCLK_IO0                 7L
+#define PORT_PB22H_GCLK_IO0    (_UL(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
 #define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
-#define PORT_PA14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
-#define MUX_PA27H_GCLK_IO0                 7L
+#define PORT_PA14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
 #define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
-#define PORT_PA27H_GCLK_IO0        (1ul << 27)
-#define PIN_PA28H_GCLK_IO0                28L  /**< \brief GCLK signal: IO0 on PA28 mux H */
-#define MUX_PA28H_GCLK_IO0                 7L
+#define PORT_PA27H_GCLK_IO0    (_UL(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
 #define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
-#define PORT_PA28H_GCLK_IO0        (1ul << 28)
-#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
-#define MUX_PA30H_GCLK_IO0                 7L
+#define PORT_PA28H_GCLK_IO0    (_UL(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
 #define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
-#define PORT_PA30H_GCLK_IO0        (1ul << 30)
-#define PIN_PB15H_GCLK_IO1                47L  /**< \brief GCLK signal: IO1 on PB15 mux H */
-#define MUX_PB15H_GCLK_IO1                 7L
+#define PORT_PA30H_GCLK_IO0    (_UL(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
 #define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
-#define PORT_PB15H_GCLK_IO1        (1ul << 15)
-#define PIN_PB23H_GCLK_IO1                55L  /**< \brief GCLK signal: IO1 on PB23 mux H */
-#define MUX_PB23H_GCLK_IO1                 7L
+#define PORT_PB15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
 #define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
-#define PORT_PB23H_GCLK_IO1        (1ul << 23)
-#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
-#define MUX_PA15H_GCLK_IO1                 7L
+#define PORT_PB23H_GCLK_IO1    (_UL(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
 #define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
-#define PORT_PA15H_GCLK_IO1        (1ul << 15)
-#define PIN_PC16F_GCLK_IO1                80L  /**< \brief GCLK signal: IO1 on PC16 mux F */
-#define MUX_PC16F_GCLK_IO1                 5L
+#define PORT_PA15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PC16F_GCLK_IO1             _L_(80) /**< \brief GCLK signal: IO1 on PC16 mux F */
+#define MUX_PC16F_GCLK_IO1              _L_(5)
 #define PINMUX_PC16F_GCLK_IO1      ((PIN_PC16F_GCLK_IO1 << 16) | MUX_PC16F_GCLK_IO1)
-#define PORT_PC16F_GCLK_IO1        (1ul << 16)
-#define PIN_PB16H_GCLK_IO2                48L  /**< \brief GCLK signal: IO2 on PB16 mux H */
-#define MUX_PB16H_GCLK_IO2                 7L
+#define PORT_PC16F_GCLK_IO1    (_UL(1) << 16)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
 #define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
-#define PORT_PB16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
-#define MUX_PA16H_GCLK_IO2                 7L
+#define PORT_PB16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
 #define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
-#define PORT_PA16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
-#define MUX_PA17H_GCLK_IO3                 7L
+#define PORT_PA16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
 #define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
-#define PORT_PA17H_GCLK_IO3        (1ul << 17)
-#define PIN_PB17H_GCLK_IO3                49L  /**< \brief GCLK signal: IO3 on PB17 mux H */
-#define MUX_PB17H_GCLK_IO3                 7L
+#define PORT_PA17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
 #define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
-#define PORT_PB17H_GCLK_IO3        (1ul << 17)
-#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
-#define MUX_PA10H_GCLK_IO4                 7L
+#define PORT_PB17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
 #define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
-#define PORT_PA10H_GCLK_IO4        (1ul << 10)
-#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
-#define MUX_PA20H_GCLK_IO4                 7L
+#define PORT_PA10H_GCLK_IO4    (_UL(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
 #define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
-#define PORT_PA20H_GCLK_IO4        (1ul << 20)
-#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
-#define MUX_PA11H_GCLK_IO5                 7L
+#define PORT_PA20H_GCLK_IO4    (_UL(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
 #define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
-#define PORT_PA11H_GCLK_IO5        (1ul << 11)
-#define PIN_PA22H_GCLK_IO6                22L  /**< \brief GCLK signal: IO6 on PA22 mux H */
-#define MUX_PA22H_GCLK_IO6                 7L
+#define PORT_PA11H_GCLK_IO5    (_UL(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
 #define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
-#define PORT_PA22H_GCLK_IO6        (1ul << 22)
-#define PIN_PA23H_GCLK_IO7                23L  /**< \brief GCLK signal: IO7 on PA23 mux H */
-#define MUX_PA23H_GCLK_IO7                 7L
+#define PORT_PA22H_GCLK_IO6    (_UL(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
 #define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
-#define PORT_PA23H_GCLK_IO7        (1ul << 23)
+#define PORT_PA23H_GCLK_IO7    (_UL(1) << 23)
 /* ========== PORT definition for EIC peripheral ========== */
-#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
-#define MUX_PA16A_EIC_EXTINT0              0L
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
-#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PB00A_EIC_EXTINT0             32L  /**< \brief EIC signal: EXTINT0 on PB00 mux A */
-#define MUX_PB00A_EIC_EXTINT0              0L
+#define PORT_PA16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
-#define PORT_PB00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PB16A_EIC_EXTINT0             48L  /**< \brief EIC signal: EXTINT0 on PB16 mux A */
-#define MUX_PB16A_EIC_EXTINT0              0L
+#define PORT_PB00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
-#define PORT_PB16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PA00A_EIC_EXTINT0              0L  /**< \brief EIC signal: EXTINT0 on PA00 mux A */
-#define MUX_PA00A_EIC_EXTINT0              0L
+#define PORT_PB16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
-#define PORT_PA00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
-#define MUX_PA17A_EIC_EXTINT1              0L
+#define PORT_PA00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
-#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PB17A_EIC_EXTINT1             49L  /**< \brief EIC signal: EXTINT1 on PB17 mux A */
-#define MUX_PB17A_EIC_EXTINT1              0L
+#define PORT_PA17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
-#define PORT_PB17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PA01A_EIC_EXTINT1              1L  /**< \brief EIC signal: EXTINT1 on PA01 mux A */
-#define MUX_PA01A_EIC_EXTINT1              0L
+#define PORT_PB17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
-#define PORT_PA01A_EIC_EXTINT1     (1ul <<  1)
-#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
-#define MUX_PA18A_EIC_EXTINT2              0L
+#define PORT_PA01A_EIC_EXTINT1  (_UL(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
-#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
-#define PIN_PB02A_EIC_EXTINT2             34L  /**< \brief EIC signal: EXTINT2 on PB02 mux A */
-#define MUX_PB02A_EIC_EXTINT2              0L
+#define PORT_PA18A_EIC_EXTINT2  (_UL(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
-#define PORT_PB02A_EIC_EXTINT2     (1ul <<  2)
-#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
-#define MUX_PA19A_EIC_EXTINT3              0L
+#define PORT_PB02A_EIC_EXTINT2  (_UL(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
-#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
-#define PIN_PB03A_EIC_EXTINT3             35L  /**< \brief EIC signal: EXTINT3 on PB03 mux A */
-#define MUX_PB03A_EIC_EXTINT3              0L
+#define PORT_PA19A_EIC_EXTINT3  (_UL(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
-#define PORT_PB03A_EIC_EXTINT3     (1ul <<  3)
-#define PIN_PA04A_EIC_EXTINT4              4L  /**< \brief EIC signal: EXTINT4 on PA04 mux A */
-#define MUX_PA04A_EIC_EXTINT4              0L
+#define PORT_PB03A_EIC_EXTINT3  (_UL(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
-#define PORT_PA04A_EIC_EXTINT4     (1ul <<  4)
-#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
-#define MUX_PA20A_EIC_EXTINT4              0L
+#define PORT_PA04A_EIC_EXTINT4  (_UL(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
-#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
-#define PIN_PA05A_EIC_EXTINT5              5L  /**< \brief EIC signal: EXTINT5 on PA05 mux A */
-#define MUX_PA05A_EIC_EXTINT5              0L
+#define PORT_PA20A_EIC_EXTINT4  (_UL(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
 #define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
-#define PORT_PA05A_EIC_EXTINT5     (1ul <<  5)
-#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
-#define MUX_PA06A_EIC_EXTINT6              0L
+#define PORT_PA05A_EIC_EXTINT5  (_UL(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
-#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
-#define PIN_PA22A_EIC_EXTINT6             22L  /**< \brief EIC signal: EXTINT6 on PA22 mux A */
-#define MUX_PA22A_EIC_EXTINT6              0L
+#define PORT_PA06A_EIC_EXTINT6  (_UL(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
-#define PORT_PA22A_EIC_EXTINT6     (1ul << 22)
-#define PIN_PB22A_EIC_EXTINT6             54L  /**< \brief EIC signal: EXTINT6 on PB22 mux A */
-#define MUX_PB22A_EIC_EXTINT6              0L
+#define PORT_PA22A_EIC_EXTINT6  (_UL(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
-#define PORT_PB22A_EIC_EXTINT6     (1ul << 22)
-#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
-#define MUX_PA07A_EIC_EXTINT7              0L
+#define PORT_PB22A_EIC_EXTINT6  (_UL(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
-#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
-#define PIN_PA23A_EIC_EXTINT7             23L  /**< \brief EIC signal: EXTINT7 on PA23 mux A */
-#define MUX_PA23A_EIC_EXTINT7              0L
+#define PORT_PA07A_EIC_EXTINT7  (_UL(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
-#define PORT_PA23A_EIC_EXTINT7     (1ul << 23)
-#define PIN_PB23A_EIC_EXTINT7             55L  /**< \brief EIC signal: EXTINT7 on PB23 mux A */
-#define MUX_PB23A_EIC_EXTINT7              0L
+#define PORT_PA23A_EIC_EXTINT7  (_UL(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
-#define PORT_PB23A_EIC_EXTINT7     (1ul << 23)
-#define PIN_PA28A_EIC_EXTINT8             28L  /**< \brief EIC signal: EXTINT8 on PA28 mux A */
-#define MUX_PA28A_EIC_EXTINT8              0L
+#define PORT_PB23A_EIC_EXTINT7  (_UL(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
-#define PORT_PA28A_EIC_EXTINT8     (1ul << 28)
-#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
-#define MUX_PB08A_EIC_EXTINT8              0L
+#define PORT_PA28A_EIC_EXTINT8  (_UL(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
-#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
-#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
-#define MUX_PA09A_EIC_EXTINT9              0L
+#define PORT_PB08A_EIC_EXTINT8  (_UL(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
-#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
-#define MUX_PB09A_EIC_EXTINT9              0L
+#define PORT_PA09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
-#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
-#define MUX_PA10A_EIC_EXTINT10             0L
+#define PORT_PB09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
-#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
-#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
-#define MUX_PA30A_EIC_EXTINT10             0L
+#define PORT_PA10A_EIC_EXTINT10  (_UL(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
-#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
-#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
-#define MUX_PA11A_EIC_EXTINT11             0L
+#define PORT_PA30A_EIC_EXTINT10  (_UL(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
-#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
-#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
-#define MUX_PA31A_EIC_EXTINT11             0L
+#define PORT_PA11A_EIC_EXTINT11  (_UL(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
-#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
-#define PIN_PA12A_EIC_EXTINT12            12L  /**< \brief EIC signal: EXTINT12 on PA12 mux A */
-#define MUX_PA12A_EIC_EXTINT12             0L
+#define PORT_PA31A_EIC_EXTINT11  (_UL(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
-#define PORT_PA12A_EIC_EXTINT12    (1ul << 12)
-#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
-#define MUX_PA24A_EIC_EXTINT12             0L
+#define PORT_PA12A_EIC_EXTINT12  (_UL(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
-#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
-#define PIN_PA13A_EIC_EXTINT13            13L  /**< \brief EIC signal: EXTINT13 on PA13 mux A */
-#define MUX_PA13A_EIC_EXTINT13             0L
+#define PORT_PA24A_EIC_EXTINT12  (_UL(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
-#define PORT_PA13A_EIC_EXTINT13    (1ul << 13)
-#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
-#define MUX_PA25A_EIC_EXTINT13             0L
+#define PORT_PA13A_EIC_EXTINT13  (_UL(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
-#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
-#define PIN_PB14A_EIC_EXTINT14            46L  /**< \brief EIC signal: EXTINT14 on PB14 mux A */
-#define MUX_PB14A_EIC_EXTINT14             0L
+#define PORT_PA25A_EIC_EXTINT13  (_UL(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
-#define PORT_PB14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PB30A_EIC_EXTINT14            62L  /**< \brief EIC signal: EXTINT14 on PB30 mux A */
-#define MUX_PB30A_EIC_EXTINT14             0L
+#define PORT_PB14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
-#define PORT_PB30A_EIC_EXTINT14    (1ul << 30)
-#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
-#define MUX_PA14A_EIC_EXTINT14             0L
+#define PORT_PB30A_EIC_EXTINT14  (_UL(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
-#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
-#define MUX_PA15A_EIC_EXTINT15             0L
+#define PORT_PA14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
-#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
-#define MUX_PA27A_EIC_EXTINT15             0L
+#define PORT_PA15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
-#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
-#define PIN_PB15A_EIC_EXTINT15            47L  /**< \brief EIC signal: EXTINT15 on PB15 mux A */
-#define MUX_PB15A_EIC_EXTINT15             0L
+#define PORT_PA27A_EIC_EXTINT15  (_UL(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
-#define PORT_PB15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PB31A_EIC_EXTINT15            63L  /**< \brief EIC signal: EXTINT15 on PB31 mux A */
-#define MUX_PB31A_EIC_EXTINT15             0L
+#define PORT_PB15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
-#define PORT_PB31A_EIC_EXTINT15    (1ul << 31)
-#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
-#define MUX_PA08A_EIC_NMI                  0L
+#define PORT_PB31A_EIC_EXTINT15  (_UL(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
 #define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
-#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+#define PORT_PA08A_EIC_NMI     (_UL(1) <<  8)
 /* ========== PORT definition for USB peripheral ========== */
-#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
-#define MUX_PA24G_USB_DM                   6L
+#define PIN_PA24G_USB_DM               _L_(24) /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                _L_(6)
 #define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
-#define PORT_PA24G_USB_DM          (1ul << 24)
-#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
-#define MUX_PA25G_USB_DP                   6L
+#define PORT_PA24G_USB_DM      (_UL(1) << 24)
+#define PIN_PA25G_USB_DP               _L_(25) /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                _L_(6)
 #define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
-#define PORT_PA25G_USB_DP          (1ul << 25)
-#define PIN_PA23G_USB_SOF_1KHZ            23L  /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
-#define MUX_PA23G_USB_SOF_1KHZ             6L
+#define PORT_PA25G_USB_DP      (_UL(1) << 25)
+#define PIN_PA23G_USB_SOF_1KHZ         _L_(23) /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
+#define MUX_PA23G_USB_SOF_1KHZ          _L_(6)
 #define PINMUX_PA23G_USB_SOF_1KHZ  ((PIN_PA23G_USB_SOF_1KHZ << 16) | MUX_PA23G_USB_SOF_1KHZ)
-#define PORT_PA23G_USB_SOF_1KHZ    (1ul << 23)
+#define PORT_PA23G_USB_SOF_1KHZ  (_UL(1) << 23)
 /* ========== PORT definition for SERCOM0 peripheral ========== */
-#define PIN_PA04D_SERCOM0_PAD0             4L  /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
-#define MUX_PA04D_SERCOM0_PAD0             3L
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
 #define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
-#define PORT_PA04D_SERCOM0_PAD0    (1ul <<  4)
-#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
-#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PORT_PA04D_SERCOM0_PAD0  (_UL(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
 #define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
-#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
-#define PIN_PA05D_SERCOM0_PAD1             5L  /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
-#define MUX_PA05D_SERCOM0_PAD1             3L
+#define PORT_PA08C_SERCOM0_PAD0  (_UL(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
 #define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
-#define PORT_PA05D_SERCOM0_PAD1    (1ul <<  5)
-#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
-#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PORT_PA05D_SERCOM0_PAD1  (_UL(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
 #define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
-#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
-#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
-#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PORT_PA09C_SERCOM0_PAD1  (_UL(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
 #define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
-#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
-#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
-#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PORT_PA06D_SERCOM0_PAD2  (_UL(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
 #define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
-#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
-#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
-#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PORT_PA10C_SERCOM0_PAD2  (_UL(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
 #define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
-#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
-#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
-#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PORT_PA07D_SERCOM0_PAD3  (_UL(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
 #define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
-#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL(1) << 11)
 /* ========== PORT definition for SERCOM1 peripheral ========== */
-#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
-#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
 #define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
-#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
-#define PIN_PA00D_SERCOM1_PAD0             0L  /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
-#define MUX_PA00D_SERCOM1_PAD0             3L
+#define PORT_PA16C_SERCOM1_PAD0  (_UL(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
 #define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
-#define PORT_PA00D_SERCOM1_PAD0    (1ul <<  0)
-#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
-#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PORT_PA00D_SERCOM1_PAD0  (_UL(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
 #define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
-#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
-#define PIN_PA01D_SERCOM1_PAD1             1L  /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
-#define MUX_PA01D_SERCOM1_PAD1             3L
+#define PORT_PA17C_SERCOM1_PAD1  (_UL(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
 #define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
-#define PORT_PA01D_SERCOM1_PAD1    (1ul <<  1)
-#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
-#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PORT_PA01D_SERCOM1_PAD1  (_UL(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
 #define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
-#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
-#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
-#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PORT_PA30D_SERCOM1_PAD2  (_UL(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
 #define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
-#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
-#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
-#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PORT_PA18C_SERCOM1_PAD2  (_UL(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
 #define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
-#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
-#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
-#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PORT_PA31D_SERCOM1_PAD3  (_UL(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
 #define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
-#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL(1) << 19)
 /* ========== PORT definition for SERCOM2 peripheral ========== */
-#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
-#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
 #define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
-#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
-#define PIN_PA12C_SERCOM2_PAD0            12L  /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
-#define MUX_PA12C_SERCOM2_PAD0             2L
+#define PORT_PA08D_SERCOM2_PAD0  (_UL(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
 #define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
-#define PORT_PA12C_SERCOM2_PAD0    (1ul << 12)
-#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
-#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PORT_PA12C_SERCOM2_PAD0  (_UL(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
 #define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
-#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
-#define PIN_PA13C_SERCOM2_PAD1            13L  /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
-#define MUX_PA13C_SERCOM2_PAD1             2L
+#define PORT_PA09D_SERCOM2_PAD1  (_UL(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
 #define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
-#define PORT_PA13C_SERCOM2_PAD1    (1ul << 13)
-#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
-#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PORT_PA13C_SERCOM2_PAD1  (_UL(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
 #define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
-#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
-#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
-#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PORT_PA10D_SERCOM2_PAD2  (_UL(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
 #define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
-#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
-#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
-#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PORT_PA14C_SERCOM2_PAD2  (_UL(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
 #define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
-#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
-#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
-#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PORT_PA11D_SERCOM2_PAD3  (_UL(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
 #define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
-#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL(1) << 15)
 /* ========== PORT definition for SERCOM3 peripheral ========== */
-#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
-#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
 #define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
-#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
-#define PIN_PA22C_SERCOM3_PAD0            22L  /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
-#define MUX_PA22C_SERCOM3_PAD0             2L
+#define PORT_PA16D_SERCOM3_PAD0  (_UL(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
 #define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
-#define PORT_PA22C_SERCOM3_PAD0    (1ul << 22)
-#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
-#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PORT_PA22C_SERCOM3_PAD0  (_UL(1) << 22)
+#define PIN_PA27F_SERCOM3_PAD0         _L_(27) /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0          _L_(5)
 #define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
-#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
-#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
-#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PORT_PA27F_SERCOM3_PAD0  (_UL(1) << 27)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
 #define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
-#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
-#define PIN_PA23C_SERCOM3_PAD1            23L  /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
-#define MUX_PA23C_SERCOM3_PAD1             2L
+#define PORT_PA17D_SERCOM3_PAD1  (_UL(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
 #define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
-#define PORT_PA23C_SERCOM3_PAD1    (1ul << 23)
-#define PIN_PA28F_SERCOM3_PAD1            28L  /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
-#define MUX_PA28F_SERCOM3_PAD1             5L
+#define PORT_PA23C_SERCOM3_PAD1  (_UL(1) << 23)
+#define PIN_PA28F_SERCOM3_PAD1         _L_(28) /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
+#define MUX_PA28F_SERCOM3_PAD1          _L_(5)
 #define PINMUX_PA28F_SERCOM3_PAD1  ((PIN_PA28F_SERCOM3_PAD1 << 16) | MUX_PA28F_SERCOM3_PAD1)
-#define PORT_PA28F_SERCOM3_PAD1    (1ul << 28)
-#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
-#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PORT_PA28F_SERCOM3_PAD1  (_UL(1) << 28)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
-#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
-#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
-#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PORT_PA18D_SERCOM3_PAD2  (_UL(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
-#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
-#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
-#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PORT_PA20D_SERCOM3_PAD2  (_UL(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
 #define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
-#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
-#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
-#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PORT_PA24C_SERCOM3_PAD2  (_UL(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
 #define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
-#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
-#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
-#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PORT_PA19D_SERCOM3_PAD3  (_UL(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
 #define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
-#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for SERCOM4 peripheral ========== */
-#define PIN_PA12D_SERCOM4_PAD0            12L  /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
-#define MUX_PA12D_SERCOM4_PAD0             3L
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
-#define PORT_PA12D_SERCOM4_PAD0    (1ul << 12)
-#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
-#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PORT_PA12D_SERCOM4_PAD0  (_UL(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
-#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
-#define PIN_PC19F_SERCOM4_PAD0            83L  /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
-#define MUX_PC19F_SERCOM4_PAD0             5L
+#define PORT_PB08D_SERCOM4_PAD0  (_UL(1) <<  8)
+#define PIN_PC19F_SERCOM4_PAD0         _L_(83) /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
+#define MUX_PC19F_SERCOM4_PAD0          _L_(5)
 #define PINMUX_PC19F_SERCOM4_PAD0  ((PIN_PC19F_SERCOM4_PAD0 << 16) | MUX_PC19F_SERCOM4_PAD0)
-#define PORT_PC19F_SERCOM4_PAD0    (1ul << 19)
-#define PIN_PA13D_SERCOM4_PAD1            13L  /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
-#define MUX_PA13D_SERCOM4_PAD1             3L
+#define PORT_PC19F_SERCOM4_PAD0  (_UL(1) << 19)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
-#define PORT_PA13D_SERCOM4_PAD1    (1ul << 13)
-#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
-#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PORT_PA13D_SERCOM4_PAD1  (_UL(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
-#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
-#define PIN_PB31F_SERCOM4_PAD1            63L  /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
-#define MUX_PB31F_SERCOM4_PAD1             5L
+#define PORT_PB09D_SERCOM4_PAD1  (_UL(1) <<  9)
+#define PIN_PB31F_SERCOM4_PAD1         _L_(63) /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
+#define MUX_PB31F_SERCOM4_PAD1          _L_(5)
 #define PINMUX_PB31F_SERCOM4_PAD1  ((PIN_PB31F_SERCOM4_PAD1 << 16) | MUX_PB31F_SERCOM4_PAD1)
-#define PORT_PB31F_SERCOM4_PAD1    (1ul << 31)
-#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
-#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PORT_PB31F_SERCOM4_PAD1  (_UL(1) << 31)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
 #define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
-#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB14C_SERCOM4_PAD2            46L  /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
-#define MUX_PB14C_SERCOM4_PAD2             2L
+#define PORT_PA14D_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
 #define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
-#define PORT_PB14C_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB30F_SERCOM4_PAD2            62L  /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
-#define MUX_PB30F_SERCOM4_PAD2             5L
+#define PORT_PB14C_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB30F_SERCOM4_PAD2         _L_(62) /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
+#define MUX_PB30F_SERCOM4_PAD2          _L_(5)
 #define PINMUX_PB30F_SERCOM4_PAD2  ((PIN_PB30F_SERCOM4_PAD2 << 16) | MUX_PB30F_SERCOM4_PAD2)
-#define PORT_PB30F_SERCOM4_PAD2    (1ul << 30)
-#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
-#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PORT_PB30F_SERCOM4_PAD2  (_UL(1) << 30)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
 #define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
-#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PB15C_SERCOM4_PAD3            47L  /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
-#define MUX_PB15C_SERCOM4_PAD3             2L
+#define PORT_PA15D_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
 #define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
-#define PORT_PB15C_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PC18F_SERCOM4_PAD3            82L  /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
-#define MUX_PC18F_SERCOM4_PAD3             5L
+#define PORT_PB15C_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PC18F_SERCOM4_PAD3         _L_(82) /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
+#define MUX_PC18F_SERCOM4_PAD3          _L_(5)
 #define PINMUX_PC18F_SERCOM4_PAD3  ((PIN_PC18F_SERCOM4_PAD3 << 16) | MUX_PC18F_SERCOM4_PAD3)
-#define PORT_PC18F_SERCOM4_PAD3    (1ul << 18)
+#define PORT_PC18F_SERCOM4_PAD3  (_UL(1) << 18)
 /* ========== PORT definition for SERCOM5 peripheral ========== */
-#define PIN_PB16C_SERCOM5_PAD0            48L  /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
-#define MUX_PB16C_SERCOM5_PAD0             2L
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
 #define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
-#define PORT_PB16C_SERCOM5_PAD0    (1ul << 16)
-#define PIN_PA22D_SERCOM5_PAD0            22L  /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
-#define MUX_PA22D_SERCOM5_PAD0             3L
+#define PORT_PB16C_SERCOM5_PAD0  (_UL(1) << 16)
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
-#define PORT_PA22D_SERCOM5_PAD0    (1ul << 22)
-#define PIN_PB02D_SERCOM5_PAD0            34L  /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
-#define MUX_PB02D_SERCOM5_PAD0             3L
+#define PORT_PA22D_SERCOM5_PAD0  (_UL(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
-#define PORT_PB02D_SERCOM5_PAD0    (1ul <<  2)
-#define PIN_PB30D_SERCOM5_PAD0            62L  /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
-#define MUX_PB30D_SERCOM5_PAD0             3L
+#define PORT_PB02D_SERCOM5_PAD0  (_UL(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
-#define PORT_PB30D_SERCOM5_PAD0    (1ul << 30)
-#define PIN_PB17C_SERCOM5_PAD1            49L  /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
-#define MUX_PB17C_SERCOM5_PAD1             2L
+#define PORT_PB30D_SERCOM5_PAD0  (_UL(1) << 30)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
 #define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
-#define PORT_PB17C_SERCOM5_PAD1    (1ul << 17)
-#define PIN_PA23D_SERCOM5_PAD1            23L  /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
-#define MUX_PA23D_SERCOM5_PAD1             3L
+#define PORT_PB17C_SERCOM5_PAD1  (_UL(1) << 17)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
-#define PORT_PA23D_SERCOM5_PAD1    (1ul << 23)
-#define PIN_PB03D_SERCOM5_PAD1            35L  /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
-#define MUX_PB03D_SERCOM5_PAD1             3L
+#define PORT_PA23D_SERCOM5_PAD1  (_UL(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
-#define PORT_PB03D_SERCOM5_PAD1    (1ul <<  3)
-#define PIN_PB31D_SERCOM5_PAD1            63L  /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
-#define MUX_PB31D_SERCOM5_PAD1             3L
+#define PORT_PB03D_SERCOM5_PAD1  (_UL(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
-#define PORT_PB31D_SERCOM5_PAD1    (1ul << 31)
-#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
-#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PORT_PB31D_SERCOM5_PAD1  (_UL(1) << 31)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
-#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
-#define PIN_PB00D_SERCOM5_PAD2            32L  /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
-#define MUX_PB00D_SERCOM5_PAD2             3L
+#define PORT_PA24D_SERCOM5_PAD2  (_UL(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
-#define PORT_PB00D_SERCOM5_PAD2    (1ul <<  0)
-#define PIN_PB22D_SERCOM5_PAD2            54L  /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
-#define MUX_PB22D_SERCOM5_PAD2             3L
+#define PORT_PB00D_SERCOM5_PAD2  (_UL(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
-#define PORT_PB22D_SERCOM5_PAD2    (1ul << 22)
-#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
-#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PORT_PB22D_SERCOM5_PAD2  (_UL(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
 #define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
-#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
-#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
-#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PORT_PA20C_SERCOM5_PAD2  (_UL(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
-#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
-#define PIN_PB23D_SERCOM5_PAD3            55L  /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
-#define MUX_PB23D_SERCOM5_PAD3             3L
+#define PORT_PA25D_SERCOM5_PAD3  (_UL(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
-#define PORT_PB23D_SERCOM5_PAD3    (1ul << 23)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL(1) << 23)
 /* ========== PORT definition for TCC0 peripheral ========== */
-#define PIN_PA04E_TCC0_WO0                 4L  /**< \brief TCC0 signal: WO0 on PA04 mux E */
-#define MUX_PA04E_TCC0_WO0                 4L
+#define PIN_PA04E_TCC0_WO0              _L_(4) /**< \brief TCC0 signal: WO0 on PA04 mux E */
+#define MUX_PA04E_TCC0_WO0              _L_(4)
 #define PINMUX_PA04E_TCC0_WO0      ((PIN_PA04E_TCC0_WO0 << 16) | MUX_PA04E_TCC0_WO0)
-#define PORT_PA04E_TCC0_WO0        (1ul <<  4)
-#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
-#define MUX_PA08E_TCC0_WO0                 4L
+#define PORT_PA04E_TCC0_WO0    (_UL(1) <<  4)
+#define PIN_PA08E_TCC0_WO0              _L_(8) /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0              _L_(4)
 #define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
-#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
-#define PIN_PB30E_TCC0_WO0                62L  /**< \brief TCC0 signal: WO0 on PB30 mux E */
-#define MUX_PB30E_TCC0_WO0                 4L
+#define PORT_PA08E_TCC0_WO0    (_UL(1) <<  8)
+#define PIN_PB30E_TCC0_WO0             _L_(62) /**< \brief TCC0 signal: WO0 on PB30 mux E */
+#define MUX_PB30E_TCC0_WO0              _L_(4)
 #define PINMUX_PB30E_TCC0_WO0      ((PIN_PB30E_TCC0_WO0 << 16) | MUX_PB30E_TCC0_WO0)
-#define PORT_PB30E_TCC0_WO0        (1ul << 30)
-#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
-#define MUX_PA16F_TCC0_WO0                 5L
+#define PORT_PB30E_TCC0_WO0    (_UL(1) << 30)
+#define PIN_PA16F_TCC0_WO0             _L_(16) /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0              _L_(5)
 #define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
-#define PORT_PA16F_TCC0_WO0        (1ul << 16)
-#define PIN_PA05E_TCC0_WO1                 5L  /**< \brief TCC0 signal: WO1 on PA05 mux E */
-#define MUX_PA05E_TCC0_WO1                 4L
+#define PORT_PA16F_TCC0_WO0    (_UL(1) << 16)
+#define PIN_PA05E_TCC0_WO1              _L_(5) /**< \brief TCC0 signal: WO1 on PA05 mux E */
+#define MUX_PA05E_TCC0_WO1              _L_(4)
 #define PINMUX_PA05E_TCC0_WO1      ((PIN_PA05E_TCC0_WO1 << 16) | MUX_PA05E_TCC0_WO1)
-#define PORT_PA05E_TCC0_WO1        (1ul <<  5)
-#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
-#define MUX_PA09E_TCC0_WO1                 4L
+#define PORT_PA05E_TCC0_WO1    (_UL(1) <<  5)
+#define PIN_PA09E_TCC0_WO1              _L_(9) /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1              _L_(4)
 #define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
-#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
-#define PIN_PB31E_TCC0_WO1                63L  /**< \brief TCC0 signal: WO1 on PB31 mux E */
-#define MUX_PB31E_TCC0_WO1                 4L
+#define PORT_PA09E_TCC0_WO1    (_UL(1) <<  9)
+#define PIN_PB31E_TCC0_WO1             _L_(63) /**< \brief TCC0 signal: WO1 on PB31 mux E */
+#define MUX_PB31E_TCC0_WO1              _L_(4)
 #define PINMUX_PB31E_TCC0_WO1      ((PIN_PB31E_TCC0_WO1 << 16) | MUX_PB31E_TCC0_WO1)
-#define PORT_PB31E_TCC0_WO1        (1ul << 31)
-#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
-#define MUX_PA17F_TCC0_WO1                 5L
+#define PORT_PB31E_TCC0_WO1    (_UL(1) << 31)
+#define PIN_PA17F_TCC0_WO1             _L_(17) /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1              _L_(5)
 #define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
-#define PORT_PA17F_TCC0_WO1        (1ul << 17)
-#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
-#define MUX_PA10F_TCC0_WO2                 5L
+#define PORT_PA17F_TCC0_WO1    (_UL(1) << 17)
+#define PIN_PA10F_TCC0_WO2             _L_(10) /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2              _L_(5)
 #define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
-#define PORT_PA10F_TCC0_WO2        (1ul << 10)
-#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
-#define MUX_PA18F_TCC0_WO2                 5L
+#define PORT_PA10F_TCC0_WO2    (_UL(1) << 10)
+#define PIN_PA18F_TCC0_WO2             _L_(18) /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2              _L_(5)
 #define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
-#define PORT_PA18F_TCC0_WO2        (1ul << 18)
-#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
-#define MUX_PA11F_TCC0_WO3                 5L
+#define PORT_PA18F_TCC0_WO2    (_UL(1) << 18)
+#define PIN_PA11F_TCC0_WO3             _L_(11) /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3              _L_(5)
 #define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
-#define PORT_PA11F_TCC0_WO3        (1ul << 11)
-#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
-#define MUX_PA19F_TCC0_WO3                 5L
+#define PORT_PA11F_TCC0_WO3    (_UL(1) << 11)
+#define PIN_PA19F_TCC0_WO3             _L_(19) /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3              _L_(5)
 #define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
-#define PORT_PA19F_TCC0_WO3        (1ul << 19)
-#define PIN_PA22F_TCC0_WO4                22L  /**< \brief TCC0 signal: WO4 on PA22 mux F */
-#define MUX_PA22F_TCC0_WO4                 5L
+#define PORT_PA19F_TCC0_WO3    (_UL(1) << 19)
+#define PIN_PA22F_TCC0_WO4             _L_(22) /**< \brief TCC0 signal: WO4 on PA22 mux F */
+#define MUX_PA22F_TCC0_WO4              _L_(5)
 #define PINMUX_PA22F_TCC0_WO4      ((PIN_PA22F_TCC0_WO4 << 16) | MUX_PA22F_TCC0_WO4)
-#define PORT_PA22F_TCC0_WO4        (1ul << 22)
-#define PIN_PB16F_TCC0_WO4                48L  /**< \brief TCC0 signal: WO4 on PB16 mux F */
-#define MUX_PB16F_TCC0_WO4                 5L
+#define PORT_PA22F_TCC0_WO4    (_UL(1) << 22)
+#define PIN_PB16F_TCC0_WO4             _L_(48) /**< \brief TCC0 signal: WO4 on PB16 mux F */
+#define MUX_PB16F_TCC0_WO4              _L_(5)
 #define PINMUX_PB16F_TCC0_WO4      ((PIN_PB16F_TCC0_WO4 << 16) | MUX_PB16F_TCC0_WO4)
-#define PORT_PB16F_TCC0_WO4        (1ul << 16)
-#define PIN_PA23F_TCC0_WO5                23L  /**< \brief TCC0 signal: WO5 on PA23 mux F */
-#define MUX_PA23F_TCC0_WO5                 5L
+#define PORT_PB16F_TCC0_WO4    (_UL(1) << 16)
+#define PIN_PA23F_TCC0_WO5             _L_(23) /**< \brief TCC0 signal: WO5 on PA23 mux F */
+#define MUX_PA23F_TCC0_WO5              _L_(5)
 #define PINMUX_PA23F_TCC0_WO5      ((PIN_PA23F_TCC0_WO5 << 16) | MUX_PA23F_TCC0_WO5)
-#define PORT_PA23F_TCC0_WO5        (1ul << 23)
-#define PIN_PB17F_TCC0_WO5                49L  /**< \brief TCC0 signal: WO5 on PB17 mux F */
-#define MUX_PB17F_TCC0_WO5                 5L
+#define PORT_PA23F_TCC0_WO5    (_UL(1) << 23)
+#define PIN_PB17F_TCC0_WO5             _L_(49) /**< \brief TCC0 signal: WO5 on PB17 mux F */
+#define MUX_PB17F_TCC0_WO5              _L_(5)
 #define PINMUX_PB17F_TCC0_WO5      ((PIN_PB17F_TCC0_WO5 << 16) | MUX_PB17F_TCC0_WO5)
-#define PORT_PB17F_TCC0_WO5        (1ul << 17)
-#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
-#define MUX_PA20F_TCC0_WO6                 5L
+#define PORT_PB17F_TCC0_WO5    (_UL(1) << 17)
+#define PIN_PA20F_TCC0_WO6             _L_(20) /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6              _L_(5)
 #define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
-#define PORT_PA20F_TCC0_WO6        (1ul << 20)
+#define PORT_PA20F_TCC0_WO6    (_UL(1) << 20)
 /* ========== PORT definition for TCC1 peripheral ========== */
-#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
-#define MUX_PA06E_TCC1_WO0                 4L
+#define PIN_PA06E_TCC1_WO0              _L_(6) /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0              _L_(4)
 #define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
-#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
-#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
-#define MUX_PA10E_TCC1_WO0                 4L
+#define PORT_PA06E_TCC1_WO0    (_UL(1) <<  6)
+#define PIN_PA10E_TCC1_WO0             _L_(10) /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0              _L_(4)
 #define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
-#define PORT_PA10E_TCC1_WO0        (1ul << 10)
-#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
-#define MUX_PA30E_TCC1_WO0                 4L
+#define PORT_PA10E_TCC1_WO0    (_UL(1) << 10)
+#define PIN_PA30E_TCC1_WO0             _L_(30) /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0              _L_(4)
 #define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
-#define PORT_PA30E_TCC1_WO0        (1ul << 30)
-#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
-#define MUX_PA07E_TCC1_WO1                 4L
+#define PORT_PA30E_TCC1_WO0    (_UL(1) << 30)
+#define PIN_PA07E_TCC1_WO1              _L_(7) /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1              _L_(4)
 #define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
-#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
-#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
-#define MUX_PA11E_TCC1_WO1                 4L
+#define PORT_PA07E_TCC1_WO1    (_UL(1) <<  7)
+#define PIN_PA11E_TCC1_WO1             _L_(11) /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1              _L_(4)
 #define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
-#define PORT_PA11E_TCC1_WO1        (1ul << 11)
-#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
-#define MUX_PA31E_TCC1_WO1                 4L
+#define PORT_PA11E_TCC1_WO1    (_UL(1) << 11)
+#define PIN_PA31E_TCC1_WO1             _L_(31) /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1              _L_(4)
 #define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
-#define PORT_PA31E_TCC1_WO1        (1ul << 31)
-#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
-#define MUX_PA24F_TCC1_WO2                 5L
+#define PORT_PA31E_TCC1_WO1    (_UL(1) << 31)
+#define PIN_PA24F_TCC1_WO2             _L_(24) /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2              _L_(5)
 #define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
-#define PORT_PA24F_TCC1_WO2        (1ul << 24)
-#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
-#define MUX_PA25F_TCC1_WO3                 5L
+#define PORT_PA24F_TCC1_WO2    (_UL(1) << 24)
+#define PIN_PA25F_TCC1_WO3             _L_(25) /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3              _L_(5)
 #define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
-#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+#define PORT_PA25F_TCC1_WO3    (_UL(1) << 25)
 /* ========== PORT definition for TCC2 peripheral ========== */
-#define PIN_PA12E_TCC2_WO0                12L  /**< \brief TCC2 signal: WO0 on PA12 mux E */
-#define MUX_PA12E_TCC2_WO0                 4L
+#define PIN_PA12E_TCC2_WO0             _L_(12) /**< \brief TCC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TCC2_WO0              _L_(4)
 #define PINMUX_PA12E_TCC2_WO0      ((PIN_PA12E_TCC2_WO0 << 16) | MUX_PA12E_TCC2_WO0)
-#define PORT_PA12E_TCC2_WO0        (1ul << 12)
-#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
-#define MUX_PA16E_TCC2_WO0                 4L
+#define PORT_PA12E_TCC2_WO0    (_UL(1) << 12)
+#define PIN_PA16E_TCC2_WO0             _L_(16) /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0              _L_(4)
 #define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
-#define PORT_PA16E_TCC2_WO0        (1ul << 16)
-#define PIN_PA00E_TCC2_WO0                 0L  /**< \brief TCC2 signal: WO0 on PA00 mux E */
-#define MUX_PA00E_TCC2_WO0                 4L
+#define PORT_PA16E_TCC2_WO0    (_UL(1) << 16)
+#define PIN_PA00E_TCC2_WO0              _L_(0) /**< \brief TCC2 signal: WO0 on PA00 mux E */
+#define MUX_PA00E_TCC2_WO0              _L_(4)
 #define PINMUX_PA00E_TCC2_WO0      ((PIN_PA00E_TCC2_WO0 << 16) | MUX_PA00E_TCC2_WO0)
-#define PORT_PA00E_TCC2_WO0        (1ul <<  0)
-#define PIN_PA13E_TCC2_WO1                13L  /**< \brief TCC2 signal: WO1 on PA13 mux E */
-#define MUX_PA13E_TCC2_WO1                 4L
+#define PORT_PA00E_TCC2_WO0    (_UL(1) <<  0)
+#define PIN_PA13E_TCC2_WO1             _L_(13) /**< \brief TCC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TCC2_WO1              _L_(4)
 #define PINMUX_PA13E_TCC2_WO1      ((PIN_PA13E_TCC2_WO1 << 16) | MUX_PA13E_TCC2_WO1)
-#define PORT_PA13E_TCC2_WO1        (1ul << 13)
-#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
-#define MUX_PA17E_TCC2_WO1                 4L
+#define PORT_PA13E_TCC2_WO1    (_UL(1) << 13)
+#define PIN_PA17E_TCC2_WO1             _L_(17) /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1              _L_(4)
 #define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
-#define PORT_PA17E_TCC2_WO1        (1ul << 17)
-#define PIN_PA01E_TCC2_WO1                 1L  /**< \brief TCC2 signal: WO1 on PA01 mux E */
-#define MUX_PA01E_TCC2_WO1                 4L
+#define PORT_PA17E_TCC2_WO1    (_UL(1) << 17)
+#define PIN_PA01E_TCC2_WO1              _L_(1) /**< \brief TCC2 signal: WO1 on PA01 mux E */
+#define MUX_PA01E_TCC2_WO1              _L_(4)
 #define PINMUX_PA01E_TCC2_WO1      ((PIN_PA01E_TCC2_WO1 << 16) | MUX_PA01E_TCC2_WO1)
-#define PORT_PA01E_TCC2_WO1        (1ul <<  1)
+#define PORT_PA01E_TCC2_WO1    (_UL(1) <<  1)
 /* ========== PORT definition for TC3 peripheral ========== */
-#define PIN_PA18E_TC3_WO0                 18L  /**< \brief TC3 signal: WO0 on PA18 mux E */
-#define MUX_PA18E_TC3_WO0                  4L
+#define PIN_PA18E_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC3_WO0               _L_(4)
 #define PINMUX_PA18E_TC3_WO0       ((PIN_PA18E_TC3_WO0 << 16) | MUX_PA18E_TC3_WO0)
-#define PORT_PA18E_TC3_WO0         (1ul << 18)
-#define PIN_PA14E_TC3_WO0                 14L  /**< \brief TC3 signal: WO0 on PA14 mux E */
-#define MUX_PA14E_TC3_WO0                  4L
+#define PORT_PA18E_TC3_WO0     (_UL(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
 #define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
-#define PORT_PA14E_TC3_WO0         (1ul << 14)
-#define PIN_PA19E_TC3_WO1                 19L  /**< \brief TC3 signal: WO1 on PA19 mux E */
-#define MUX_PA19E_TC3_WO1                  4L
+#define PORT_PA14E_TC3_WO0     (_UL(1) << 14)
+#define PIN_PA19E_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC3_WO1               _L_(4)
 #define PINMUX_PA19E_TC3_WO1       ((PIN_PA19E_TC3_WO1 << 16) | MUX_PA19E_TC3_WO1)
-#define PORT_PA19E_TC3_WO1         (1ul << 19)
-#define PIN_PA15E_TC3_WO1                 15L  /**< \brief TC3 signal: WO1 on PA15 mux E */
-#define MUX_PA15E_TC3_WO1                  4L
+#define PORT_PA19E_TC3_WO1     (_UL(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
 #define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
-#define PORT_PA15E_TC3_WO1         (1ul << 15)
+#define PORT_PA15E_TC3_WO1     (_UL(1) << 15)
 /* ========== PORT definition for TC4 peripheral ========== */
-#define PIN_PA22E_TC4_WO0                 22L  /**< \brief TC4 signal: WO0 on PA22 mux E */
-#define MUX_PA22E_TC4_WO0                  4L
+#define PIN_PA22E_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux E */
+#define MUX_PA22E_TC4_WO0               _L_(4)
 #define PINMUX_PA22E_TC4_WO0       ((PIN_PA22E_TC4_WO0 << 16) | MUX_PA22E_TC4_WO0)
-#define PORT_PA22E_TC4_WO0         (1ul << 22)
-#define PIN_PB08E_TC4_WO0                 40L  /**< \brief TC4 signal: WO0 on PB08 mux E */
-#define MUX_PB08E_TC4_WO0                  4L
+#define PORT_PA22E_TC4_WO0     (_UL(1) << 22)
+#define PIN_PB08E_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC4_WO0               _L_(4)
 #define PINMUX_PB08E_TC4_WO0       ((PIN_PB08E_TC4_WO0 << 16) | MUX_PB08E_TC4_WO0)
-#define PORT_PB08E_TC4_WO0         (1ul <<  8)
-#define PIN_PA23E_TC4_WO1                 23L  /**< \brief TC4 signal: WO1 on PA23 mux E */
-#define MUX_PA23E_TC4_WO1                  4L
+#define PORT_PB08E_TC4_WO0     (_UL(1) <<  8)
+#define PIN_PA23E_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux E */
+#define MUX_PA23E_TC4_WO1               _L_(4)
 #define PINMUX_PA23E_TC4_WO1       ((PIN_PA23E_TC4_WO1 << 16) | MUX_PA23E_TC4_WO1)
-#define PORT_PA23E_TC4_WO1         (1ul << 23)
-#define PIN_PB09E_TC4_WO1                 41L  /**< \brief TC4 signal: WO1 on PB09 mux E */
-#define MUX_PB09E_TC4_WO1                  4L
+#define PORT_PA23E_TC4_WO1     (_UL(1) << 23)
+#define PIN_PB09E_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC4_WO1               _L_(4)
 #define PINMUX_PB09E_TC4_WO1       ((PIN_PB09E_TC4_WO1 << 16) | MUX_PB09E_TC4_WO1)
-#define PORT_PB09E_TC4_WO1         (1ul <<  9)
+#define PORT_PB09E_TC4_WO1     (_UL(1) <<  9)
 /* ========== PORT definition for TC5 peripheral ========== */
-#define PIN_PA24E_TC5_WO0                 24L  /**< \brief TC5 signal: WO0 on PA24 mux E */
-#define MUX_PA24E_TC5_WO0                  4L
+#define PIN_PA24E_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC5_WO0               _L_(4)
 #define PINMUX_PA24E_TC5_WO0       ((PIN_PA24E_TC5_WO0 << 16) | MUX_PA24E_TC5_WO0)
-#define PORT_PA24E_TC5_WO0         (1ul << 24)
-#define PIN_PB14E_TC5_WO0                 46L  /**< \brief TC5 signal: WO0 on PB14 mux E */
-#define MUX_PB14E_TC5_WO0                  4L
+#define PORT_PA24E_TC5_WO0     (_UL(1) << 24)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
 #define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
-#define PORT_PB14E_TC5_WO0         (1ul << 14)
-#define PIN_PA25E_TC5_WO1                 25L  /**< \brief TC5 signal: WO1 on PA25 mux E */
-#define MUX_PA25E_TC5_WO1                  4L
+#define PORT_PB14E_TC5_WO0     (_UL(1) << 14)
+#define PIN_PA25E_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC5_WO1               _L_(4)
 #define PINMUX_PA25E_TC5_WO1       ((PIN_PA25E_TC5_WO1 << 16) | MUX_PA25E_TC5_WO1)
-#define PORT_PA25E_TC5_WO1         (1ul << 25)
-#define PIN_PB15E_TC5_WO1                 47L  /**< \brief TC5 signal: WO1 on PB15 mux E */
-#define MUX_PB15E_TC5_WO1                  4L
+#define PORT_PA25E_TC5_WO1     (_UL(1) << 25)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
 #define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
-#define PORT_PB15E_TC5_WO1         (1ul << 15)
+#define PORT_PB15E_TC5_WO1     (_UL(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02E_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux E */
+#define MUX_PB02E_TC6_WO0               _L_(4)
+#define PINMUX_PB02E_TC6_WO0       ((PIN_PB02E_TC6_WO0 << 16) | MUX_PB02E_TC6_WO0)
+#define PORT_PB02E_TC6_WO0     (_UL(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL(1) << 16)
+#define PIN_PB03E_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux E */
+#define MUX_PB03E_TC6_WO1               _L_(4)
+#define PINMUX_PB03E_TC6_WO1       ((PIN_PB03E_TC6_WO1 << 16) | MUX_PB03E_TC6_WO1)
+#define PORT_PB03E_TC6_WO1     (_UL(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL(1) << 20)
+#define PIN_PB00E_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux E */
+#define MUX_PB00E_TC7_WO0               _L_(4)
+#define PINMUX_PB00E_TC7_WO0       ((PIN_PB00E_TC7_WO0 << 16) | MUX_PB00E_TC7_WO0)
+#define PORT_PB00E_TC7_WO0     (_UL(1) <<  0)
+#define PIN_PB22E_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux E */
+#define MUX_PB22E_TC7_WO0               _L_(4)
+#define PINMUX_PB22E_TC7_WO0       ((PIN_PB22E_TC7_WO0 << 16) | MUX_PB22E_TC7_WO0)
+#define PORT_PB22E_TC7_WO0     (_UL(1) << 22)
+#define PIN_PB23E_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux E */
+#define MUX_PB23E_TC7_WO1               _L_(4)
+#define PINMUX_PB23E_TC7_WO1       ((PIN_PB23E_TC7_WO1 << 16) | MUX_PB23E_TC7_WO1)
+#define PORT_PB23E_TC7_WO1     (_UL(1) << 23)
 /* ========== PORT definition for ADC peripheral ========== */
-#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
-#define MUX_PB08B_ADC_AIN2                 1L
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
 #define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
-#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
-#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
-#define MUX_PB09B_ADC_AIN3                 1L
+#define PORT_PB08B_ADC_AIN2    (_UL(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
 #define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
-#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
-#define PIN_PA04B_ADC_AIN4                 4L  /**< \brief ADC signal: AIN4 on PA04 mux B */
-#define MUX_PA04B_ADC_AIN4                 1L
+#define PORT_PB09B_ADC_AIN3    (_UL(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
 #define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
-#define PORT_PA04B_ADC_AIN4        (1ul <<  4)
-#define PIN_PA05B_ADC_AIN5                 5L  /**< \brief ADC signal: AIN5 on PA05 mux B */
-#define MUX_PA05B_ADC_AIN5                 1L
+#define PORT_PA04B_ADC_AIN4    (_UL(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
 #define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
-#define PORT_PA05B_ADC_AIN5        (1ul <<  5)
-#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
-#define MUX_PA06B_ADC_AIN6                 1L
+#define PORT_PA05B_ADC_AIN5    (_UL(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
 #define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
-#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
-#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
-#define MUX_PA07B_ADC_AIN7                 1L
+#define PORT_PA06B_ADC_AIN6    (_UL(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
 #define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
-#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
-#define PIN_PB00B_ADC_AIN8                32L  /**< \brief ADC signal: AIN8 on PB00 mux B */
-#define MUX_PB00B_ADC_AIN8                 1L
+#define PORT_PA07B_ADC_AIN7    (_UL(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
 #define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
-#define PORT_PB00B_ADC_AIN8        (1ul <<  0)
-#define PIN_PB02B_ADC_AIN10               34L  /**< \brief ADC signal: AIN10 on PB02 mux B */
-#define MUX_PB02B_ADC_AIN10                1L
+#define PORT_PB00B_ADC_AIN8    (_UL(1) <<  0)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
 #define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
-#define PORT_PB02B_ADC_AIN10       (1ul <<  2)
-#define PIN_PB03B_ADC_AIN11               35L  /**< \brief ADC signal: AIN11 on PB03 mux B */
-#define MUX_PB03B_ADC_AIN11                1L
+#define PORT_PB02B_ADC_AIN10   (_UL(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
 #define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
-#define PORT_PB03B_ADC_AIN11       (1ul <<  3)
-#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
-#define MUX_PA08B_ADC_AIN16                1L
+#define PORT_PB03B_ADC_AIN11   (_UL(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
 #define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
-#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
-#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
-#define MUX_PA09B_ADC_AIN17                1L
+#define PORT_PA08B_ADC_AIN16   (_UL(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
 #define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
-#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
-#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
-#define MUX_PA10B_ADC_AIN18                1L
+#define PORT_PA09B_ADC_AIN17   (_UL(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
 #define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
-#define PORT_PA10B_ADC_AIN18       (1ul << 10)
-#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
-#define MUX_PA11B_ADC_AIN19                1L
+#define PORT_PA10B_ADC_AIN18   (_UL(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
 #define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
-#define PORT_PA11B_ADC_AIN19       (1ul << 11)
-#define PIN_PA04B_ADC_VREFP                4L  /**< \brief ADC signal: VREFP on PA04 mux B */
-#define MUX_PA04B_ADC_VREFP                1L
+#define PORT_PA11B_ADC_AIN19   (_UL(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
 #define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
-#define PORT_PA04B_ADC_VREFP       (1ul <<  4)
+#define PORT_PA04B_ADC_VREFP   (_UL(1) <<  4)
 /* ========== PORT definition for AC peripheral ========== */
-#define PIN_PA04B_AC_AIN0                  4L  /**< \brief AC signal: AIN0 on PA04 mux B */
-#define MUX_PA04B_AC_AIN0                  1L
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
 #define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
-#define PORT_PA04B_AC_AIN0         (1ul <<  4)
-#define PIN_PA05B_AC_AIN1                  5L  /**< \brief AC signal: AIN1 on PA05 mux B */
-#define MUX_PA05B_AC_AIN1                  1L
+#define PORT_PA04B_AC_AIN0     (_UL(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
 #define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
-#define PORT_PA05B_AC_AIN1         (1ul <<  5)
-#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
-#define MUX_PA06B_AC_AIN2                  1L
+#define PORT_PA05B_AC_AIN1     (_UL(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
 #define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
-#define PORT_PA06B_AC_AIN2         (1ul <<  6)
-#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
-#define MUX_PA07B_AC_AIN3                  1L
+#define PORT_PA06B_AC_AIN2     (_UL(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
 #define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
-#define PORT_PA07B_AC_AIN3         (1ul <<  7)
-#define PIN_PA12H_AC_CMP0                 12L  /**< \brief AC signal: CMP0 on PA12 mux H */
-#define MUX_PA12H_AC_CMP0                  7L
+#define PORT_PA07B_AC_AIN3     (_UL(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
 #define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
-#define PORT_PA12H_AC_CMP0         (1ul << 12)
-#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
-#define MUX_PA18H_AC_CMP0                  7L
+#define PORT_PA12H_AC_CMP0     (_UL(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
 #define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
-#define PORT_PA18H_AC_CMP0         (1ul << 18)
-#define PIN_PA13H_AC_CMP1                 13L  /**< \brief AC signal: CMP1 on PA13 mux H */
-#define MUX_PA13H_AC_CMP1                  7L
+#define PORT_PA18H_AC_CMP0     (_UL(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
 #define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
-#define PORT_PA13H_AC_CMP1         (1ul << 13)
-#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
-#define MUX_PA19H_AC_CMP1                  7L
+#define PORT_PA13H_AC_CMP1     (_UL(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
 #define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
-#define PORT_PA19H_AC_CMP1         (1ul << 19)
+#define PORT_PA19H_AC_CMP1     (_UL(1) << 19)
 /* ========== PORT definition for RFCTRL peripheral ========== */
-#define PIN_PA08F_RFCTRL_FECTRL0           8L  /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
-#define MUX_PA08F_RFCTRL_FECTRL0           5L
+#define PIN_PA08F_RFCTRL_FECTRL0        _L_(8) /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
+#define MUX_PA08F_RFCTRL_FECTRL0        _L_(5)
 #define PINMUX_PA08F_RFCTRL_FECTRL0  ((PIN_PA08F_RFCTRL_FECTRL0 << 16) | MUX_PA08F_RFCTRL_FECTRL0)
-#define PORT_PA08F_RFCTRL_FECTRL0  (1ul <<  8)
-#define PIN_PA09F_RFCTRL_FECTRL1           9L  /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
-#define MUX_PA09F_RFCTRL_FECTRL1           5L
+#define PORT_PA08F_RFCTRL_FECTRL0  (_UL(1) <<  8)
+#define PIN_PA09F_RFCTRL_FECTRL1        _L_(9) /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
+#define MUX_PA09F_RFCTRL_FECTRL1        _L_(5)
 #define PINMUX_PA09F_RFCTRL_FECTRL1  ((PIN_PA09F_RFCTRL_FECTRL1 << 16) | MUX_PA09F_RFCTRL_FECTRL1)
-#define PORT_PA09F_RFCTRL_FECTRL1  (1ul <<  9)
-#define PIN_PA12F_RFCTRL_FECTRL2          12L  /**< \brief RFCTRL signal: FECTRL2 on PA12 mux F */
-#define MUX_PA12F_RFCTRL_FECTRL2           5L
+#define PORT_PA09F_RFCTRL_FECTRL1  (_UL(1) <<  9)
+#define PIN_PA12F_RFCTRL_FECTRL2       _L_(12) /**< \brief RFCTRL signal: FECTRL2 on PA12 mux F */
+#define MUX_PA12F_RFCTRL_FECTRL2        _L_(5)
 #define PINMUX_PA12F_RFCTRL_FECTRL2  ((PIN_PA12F_RFCTRL_FECTRL2 << 16) | MUX_PA12F_RFCTRL_FECTRL2)
-#define PORT_PA12F_RFCTRL_FECTRL2  (1ul << 12)
-#define PIN_PA13F_RFCTRL_FECTRL3          13L  /**< \brief RFCTRL signal: FECTRL3 on PA13 mux F */
-#define MUX_PA13F_RFCTRL_FECTRL3           5L
+#define PORT_PA12F_RFCTRL_FECTRL2  (_UL(1) << 12)
+#define PIN_PA13F_RFCTRL_FECTRL3       _L_(13) /**< \brief RFCTRL signal: FECTRL3 on PA13 mux F */
+#define MUX_PA13F_RFCTRL_FECTRL3        _L_(5)
 #define PINMUX_PA13F_RFCTRL_FECTRL3  ((PIN_PA13F_RFCTRL_FECTRL3 << 16) | MUX_PA13F_RFCTRL_FECTRL3)
-#define PORT_PA13F_RFCTRL_FECTRL3  (1ul << 13)
-#define PIN_PA14F_RFCTRL_FECTRL4          14L  /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
-#define MUX_PA14F_RFCTRL_FECTRL4           5L
+#define PORT_PA13F_RFCTRL_FECTRL3  (_UL(1) << 13)
+#define PIN_PA14F_RFCTRL_FECTRL4       _L_(14) /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
+#define MUX_PA14F_RFCTRL_FECTRL4        _L_(5)
 #define PINMUX_PA14F_RFCTRL_FECTRL4  ((PIN_PA14F_RFCTRL_FECTRL4 << 16) | MUX_PA14F_RFCTRL_FECTRL4)
-#define PORT_PA14F_RFCTRL_FECTRL4  (1ul << 14)
-#define PIN_PA15F_RFCTRL_FECTRL5          15L  /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
-#define MUX_PA15F_RFCTRL_FECTRL5           5L
+#define PORT_PA14F_RFCTRL_FECTRL4  (_UL(1) << 14)
+#define PIN_PA15F_RFCTRL_FECTRL5       _L_(15) /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
+#define MUX_PA15F_RFCTRL_FECTRL5        _L_(5)
 #define PINMUX_PA15F_RFCTRL_FECTRL5  ((PIN_PA15F_RFCTRL_FECTRL5 << 16) | MUX_PA15F_RFCTRL_FECTRL5)
-#define PORT_PA15F_RFCTRL_FECTRL5  (1ul << 15)
+#define PORT_PA15F_RFCTRL_FECTRL5  (_UL(1) << 15)
 
 #endif /* _SAMR21G16A_PIO_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/pio/samr21g17a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/pio/samr21g17a.h
@@ -3,39 +3,24 @@
  *
  * \brief Peripheral I/O description for SAMR21G17A
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2017 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -45,884 +30,957 @@
 #define _SAMR21G17A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define PORT_PA00                 (1ul <<  0) /**< \brief PORT Mask  for PA00 */
+#define PORT_PA00              (_UL(1) <<  0) /**< \brief PORT Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define PORT_PA01                 (1ul <<  1) /**< \brief PORT Mask  for PA01 */
+#define PORT_PA01              (_UL(1) <<  1) /**< \brief PORT Mask  for PA01 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define PORT_PA04                 (1ul <<  4) /**< \brief PORT Mask  for PA04 */
+#define PORT_PA04              (_UL(1) <<  4) /**< \brief PORT Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define PORT_PA05                 (1ul <<  5) /**< \brief PORT Mask  for PA05 */
+#define PORT_PA05              (_UL(1) <<  5) /**< \brief PORT Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PORT_PA06              (_UL(1) <<  6) /**< \brief PORT Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PORT_PA07              (_UL(1) <<  7) /**< \brief PORT Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PORT_PA08              (_UL(1) <<  8) /**< \brief PORT Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PORT_PA09              (_UL(1) <<  9) /**< \brief PORT Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PORT_PA10              (_UL(1) << 10) /**< \brief PORT Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PORT_PA11              (_UL(1) << 11) /**< \brief PORT Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define PORT_PA12                 (1ul << 12) /**< \brief PORT Mask  for PA12 */
+#define PORT_PA12              (_UL(1) << 12) /**< \brief PORT Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define PORT_PA13                 (1ul << 13) /**< \brief PORT Mask  for PA13 */
+#define PORT_PA13              (_UL(1) << 13) /**< \brief PORT Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PORT_PA14              (_UL(1) << 14) /**< \brief PORT Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PORT_PA15              (_UL(1) << 15) /**< \brief PORT Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PORT_PA16              (_UL(1) << 16) /**< \brief PORT Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PORT_PA17              (_UL(1) << 17) /**< \brief PORT Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PORT_PA18              (_UL(1) << 18) /**< \brief PORT Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PORT_PA19              (_UL(1) << 19) /**< \brief PORT Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PORT_PA20              (_UL(1) << 20) /**< \brief PORT Mask  for PA20 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define PORT_PA22                 (1ul << 22) /**< \brief PORT Mask  for PA22 */
+#define PORT_PA22              (_UL(1) << 22) /**< \brief PORT Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define PORT_PA23                 (1ul << 23) /**< \brief PORT Mask  for PA23 */
+#define PORT_PA23              (_UL(1) << 23) /**< \brief PORT Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PORT_PA24              (_UL(1) << 24) /**< \brief PORT Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PORT_PA25              (_UL(1) << 25) /**< \brief PORT Mask  for PA25 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PORT_PA27              (_UL(1) << 27) /**< \brief PORT Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define PORT_PA28                 (1ul << 28) /**< \brief PORT Mask  for PA28 */
+#define PORT_PA28              (_UL(1) << 28) /**< \brief PORT Mask  for PA28 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PORT_PA30              (_UL(1) << 30) /**< \brief PORT Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PORT_PA31              (_UL(1) << 31) /**< \brief PORT Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define PORT_PB00                 (1ul <<  0) /**< \brief PORT Mask  for PB00 */
+#define PORT_PB00              (_UL(1) <<  0) /**< \brief PORT Mask  for PB00 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define PORT_PB02                 (1ul <<  2) /**< \brief PORT Mask  for PB02 */
+#define PORT_PB02              (_UL(1) <<  2) /**< \brief PORT Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define PORT_PB03                 (1ul <<  3) /**< \brief PORT Mask  for PB03 */
+#define PORT_PB03              (_UL(1) <<  3) /**< \brief PORT Mask  for PB03 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PORT_PB08              (_UL(1) <<  8) /**< \brief PORT Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PORT_PB09              (_UL(1) <<  9) /**< \brief PORT Mask  for PB09 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define PORT_PB14                 (1ul << 14) /**< \brief PORT Mask  for PB14 */
+#define PORT_PB14              (_UL(1) << 14) /**< \brief PORT Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define PORT_PB15                 (1ul << 15) /**< \brief PORT Mask  for PB15 */
+#define PORT_PB15              (_UL(1) << 15) /**< \brief PORT Mask  for PB15 */
 #define PIN_PB16                          48  /**< \brief Pin Number for PB16 */
-#define PORT_PB16                 (1ul << 16) /**< \brief PORT Mask  for PB16 */
+#define PORT_PB16              (_UL(1) << 16) /**< \brief PORT Mask  for PB16 */
 #define PIN_PB17                          49  /**< \brief Pin Number for PB17 */
-#define PORT_PB17                 (1ul << 17) /**< \brief PORT Mask  for PB17 */
+#define PORT_PB17              (_UL(1) << 17) /**< \brief PORT Mask  for PB17 */
 #define PIN_PB22                          54  /**< \brief Pin Number for PB22 */
-#define PORT_PB22                 (1ul << 22) /**< \brief PORT Mask  for PB22 */
+#define PORT_PB22              (_UL(1) << 22) /**< \brief PORT Mask  for PB22 */
 #define PIN_PB23                          55  /**< \brief Pin Number for PB23 */
-#define PORT_PB23                 (1ul << 23) /**< \brief PORT Mask  for PB23 */
+#define PORT_PB23              (_UL(1) << 23) /**< \brief PORT Mask  for PB23 */
 #define PIN_PB30                          62  /**< \brief Pin Number for PB30 */
-#define PORT_PB30                 (1ul << 30) /**< \brief PORT Mask  for PB30 */
+#define PORT_PB30              (_UL(1) << 30) /**< \brief PORT Mask  for PB30 */
 #define PIN_PB31                          63  /**< \brief Pin Number for PB31 */
-#define PORT_PB31                 (1ul << 31) /**< \brief PORT Mask  for PB31 */
+#define PORT_PB31              (_UL(1) << 31) /**< \brief PORT Mask  for PB31 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define PORT_PC16                 (1ul << 16) /**< \brief PORT Mask  for PC16 */
+#define PORT_PC16              (_UL(1) << 16) /**< \brief PORT Mask  for PC16 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define PORT_PC18                 (1ul << 18) /**< \brief PORT Mask  for PC18 */
+#define PORT_PC18              (_UL(1) << 18) /**< \brief PORT Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define PORT_PC19                 (1ul << 19) /**< \brief PORT Mask  for PC19 */
+#define PORT_PC19              (_UL(1) << 19) /**< \brief PORT Mask  for PC19 */
 /* ========== PORT definition for GCLK peripheral ========== */
-#define PIN_PB14H_GCLK_IO0                46L  /**< \brief GCLK signal: IO0 on PB14 mux H */
-#define MUX_PB14H_GCLK_IO0                 7L
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
 #define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
-#define PORT_PB14H_GCLK_IO0        (1ul << 14)
-#define PIN_PB22H_GCLK_IO0                54L  /**< \brief GCLK signal: IO0 on PB22 mux H */
-#define MUX_PB22H_GCLK_IO0                 7L
+#define PORT_PB14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
 #define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
-#define PORT_PB22H_GCLK_IO0        (1ul << 22)
-#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
-#define MUX_PA14H_GCLK_IO0                 7L
+#define PORT_PB22H_GCLK_IO0    (_UL(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
 #define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
-#define PORT_PA14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
-#define MUX_PA27H_GCLK_IO0                 7L
+#define PORT_PA14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
 #define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
-#define PORT_PA27H_GCLK_IO0        (1ul << 27)
-#define PIN_PA28H_GCLK_IO0                28L  /**< \brief GCLK signal: IO0 on PA28 mux H */
-#define MUX_PA28H_GCLK_IO0                 7L
+#define PORT_PA27H_GCLK_IO0    (_UL(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
 #define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
-#define PORT_PA28H_GCLK_IO0        (1ul << 28)
-#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
-#define MUX_PA30H_GCLK_IO0                 7L
+#define PORT_PA28H_GCLK_IO0    (_UL(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
 #define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
-#define PORT_PA30H_GCLK_IO0        (1ul << 30)
-#define PIN_PB15H_GCLK_IO1                47L  /**< \brief GCLK signal: IO1 on PB15 mux H */
-#define MUX_PB15H_GCLK_IO1                 7L
+#define PORT_PA30H_GCLK_IO0    (_UL(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
 #define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
-#define PORT_PB15H_GCLK_IO1        (1ul << 15)
-#define PIN_PB23H_GCLK_IO1                55L  /**< \brief GCLK signal: IO1 on PB23 mux H */
-#define MUX_PB23H_GCLK_IO1                 7L
+#define PORT_PB15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
 #define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
-#define PORT_PB23H_GCLK_IO1        (1ul << 23)
-#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
-#define MUX_PA15H_GCLK_IO1                 7L
+#define PORT_PB23H_GCLK_IO1    (_UL(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
 #define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
-#define PORT_PA15H_GCLK_IO1        (1ul << 15)
-#define PIN_PC16F_GCLK_IO1                80L  /**< \brief GCLK signal: IO1 on PC16 mux F */
-#define MUX_PC16F_GCLK_IO1                 5L
+#define PORT_PA15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PC16F_GCLK_IO1             _L_(80) /**< \brief GCLK signal: IO1 on PC16 mux F */
+#define MUX_PC16F_GCLK_IO1              _L_(5)
 #define PINMUX_PC16F_GCLK_IO1      ((PIN_PC16F_GCLK_IO1 << 16) | MUX_PC16F_GCLK_IO1)
-#define PORT_PC16F_GCLK_IO1        (1ul << 16)
-#define PIN_PB16H_GCLK_IO2                48L  /**< \brief GCLK signal: IO2 on PB16 mux H */
-#define MUX_PB16H_GCLK_IO2                 7L
+#define PORT_PC16F_GCLK_IO1    (_UL(1) << 16)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
 #define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
-#define PORT_PB16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
-#define MUX_PA16H_GCLK_IO2                 7L
+#define PORT_PB16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
 #define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
-#define PORT_PA16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
-#define MUX_PA17H_GCLK_IO3                 7L
+#define PORT_PA16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
 #define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
-#define PORT_PA17H_GCLK_IO3        (1ul << 17)
-#define PIN_PB17H_GCLK_IO3                49L  /**< \brief GCLK signal: IO3 on PB17 mux H */
-#define MUX_PB17H_GCLK_IO3                 7L
+#define PORT_PA17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
 #define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
-#define PORT_PB17H_GCLK_IO3        (1ul << 17)
-#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
-#define MUX_PA10H_GCLK_IO4                 7L
+#define PORT_PB17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
 #define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
-#define PORT_PA10H_GCLK_IO4        (1ul << 10)
-#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
-#define MUX_PA20H_GCLK_IO4                 7L
+#define PORT_PA10H_GCLK_IO4    (_UL(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
 #define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
-#define PORT_PA20H_GCLK_IO4        (1ul << 20)
-#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
-#define MUX_PA11H_GCLK_IO5                 7L
+#define PORT_PA20H_GCLK_IO4    (_UL(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
 #define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
-#define PORT_PA11H_GCLK_IO5        (1ul << 11)
-#define PIN_PA22H_GCLK_IO6                22L  /**< \brief GCLK signal: IO6 on PA22 mux H */
-#define MUX_PA22H_GCLK_IO6                 7L
+#define PORT_PA11H_GCLK_IO5    (_UL(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
 #define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
-#define PORT_PA22H_GCLK_IO6        (1ul << 22)
-#define PIN_PA23H_GCLK_IO7                23L  /**< \brief GCLK signal: IO7 on PA23 mux H */
-#define MUX_PA23H_GCLK_IO7                 7L
+#define PORT_PA22H_GCLK_IO6    (_UL(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
 #define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
-#define PORT_PA23H_GCLK_IO7        (1ul << 23)
+#define PORT_PA23H_GCLK_IO7    (_UL(1) << 23)
 /* ========== PORT definition for EIC peripheral ========== */
-#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
-#define MUX_PA16A_EIC_EXTINT0              0L
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
-#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PB00A_EIC_EXTINT0             32L  /**< \brief EIC signal: EXTINT0 on PB00 mux A */
-#define MUX_PB00A_EIC_EXTINT0              0L
+#define PORT_PA16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
-#define PORT_PB00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PB16A_EIC_EXTINT0             48L  /**< \brief EIC signal: EXTINT0 on PB16 mux A */
-#define MUX_PB16A_EIC_EXTINT0              0L
+#define PORT_PB00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
-#define PORT_PB16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PA00A_EIC_EXTINT0              0L  /**< \brief EIC signal: EXTINT0 on PA00 mux A */
-#define MUX_PA00A_EIC_EXTINT0              0L
+#define PORT_PB16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
-#define PORT_PA00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
-#define MUX_PA17A_EIC_EXTINT1              0L
+#define PORT_PA00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
-#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PB17A_EIC_EXTINT1             49L  /**< \brief EIC signal: EXTINT1 on PB17 mux A */
-#define MUX_PB17A_EIC_EXTINT1              0L
+#define PORT_PA17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
-#define PORT_PB17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PA01A_EIC_EXTINT1              1L  /**< \brief EIC signal: EXTINT1 on PA01 mux A */
-#define MUX_PA01A_EIC_EXTINT1              0L
+#define PORT_PB17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
-#define PORT_PA01A_EIC_EXTINT1     (1ul <<  1)
-#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
-#define MUX_PA18A_EIC_EXTINT2              0L
+#define PORT_PA01A_EIC_EXTINT1  (_UL(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
-#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
-#define PIN_PB02A_EIC_EXTINT2             34L  /**< \brief EIC signal: EXTINT2 on PB02 mux A */
-#define MUX_PB02A_EIC_EXTINT2              0L
+#define PORT_PA18A_EIC_EXTINT2  (_UL(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
-#define PORT_PB02A_EIC_EXTINT2     (1ul <<  2)
-#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
-#define MUX_PA19A_EIC_EXTINT3              0L
+#define PORT_PB02A_EIC_EXTINT2  (_UL(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
-#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
-#define PIN_PB03A_EIC_EXTINT3             35L  /**< \brief EIC signal: EXTINT3 on PB03 mux A */
-#define MUX_PB03A_EIC_EXTINT3              0L
+#define PORT_PA19A_EIC_EXTINT3  (_UL(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
-#define PORT_PB03A_EIC_EXTINT3     (1ul <<  3)
-#define PIN_PA04A_EIC_EXTINT4              4L  /**< \brief EIC signal: EXTINT4 on PA04 mux A */
-#define MUX_PA04A_EIC_EXTINT4              0L
+#define PORT_PB03A_EIC_EXTINT3  (_UL(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
-#define PORT_PA04A_EIC_EXTINT4     (1ul <<  4)
-#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
-#define MUX_PA20A_EIC_EXTINT4              0L
+#define PORT_PA04A_EIC_EXTINT4  (_UL(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
-#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
-#define PIN_PA05A_EIC_EXTINT5              5L  /**< \brief EIC signal: EXTINT5 on PA05 mux A */
-#define MUX_PA05A_EIC_EXTINT5              0L
+#define PORT_PA20A_EIC_EXTINT4  (_UL(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
 #define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
-#define PORT_PA05A_EIC_EXTINT5     (1ul <<  5)
-#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
-#define MUX_PA06A_EIC_EXTINT6              0L
+#define PORT_PA05A_EIC_EXTINT5  (_UL(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
-#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
-#define PIN_PA22A_EIC_EXTINT6             22L  /**< \brief EIC signal: EXTINT6 on PA22 mux A */
-#define MUX_PA22A_EIC_EXTINT6              0L
+#define PORT_PA06A_EIC_EXTINT6  (_UL(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
-#define PORT_PA22A_EIC_EXTINT6     (1ul << 22)
-#define PIN_PB22A_EIC_EXTINT6             54L  /**< \brief EIC signal: EXTINT6 on PB22 mux A */
-#define MUX_PB22A_EIC_EXTINT6              0L
+#define PORT_PA22A_EIC_EXTINT6  (_UL(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
-#define PORT_PB22A_EIC_EXTINT6     (1ul << 22)
-#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
-#define MUX_PA07A_EIC_EXTINT7              0L
+#define PORT_PB22A_EIC_EXTINT6  (_UL(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
-#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
-#define PIN_PA23A_EIC_EXTINT7             23L  /**< \brief EIC signal: EXTINT7 on PA23 mux A */
-#define MUX_PA23A_EIC_EXTINT7              0L
+#define PORT_PA07A_EIC_EXTINT7  (_UL(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
-#define PORT_PA23A_EIC_EXTINT7     (1ul << 23)
-#define PIN_PB23A_EIC_EXTINT7             55L  /**< \brief EIC signal: EXTINT7 on PB23 mux A */
-#define MUX_PB23A_EIC_EXTINT7              0L
+#define PORT_PA23A_EIC_EXTINT7  (_UL(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
-#define PORT_PB23A_EIC_EXTINT7     (1ul << 23)
-#define PIN_PA28A_EIC_EXTINT8             28L  /**< \brief EIC signal: EXTINT8 on PA28 mux A */
-#define MUX_PA28A_EIC_EXTINT8              0L
+#define PORT_PB23A_EIC_EXTINT7  (_UL(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
-#define PORT_PA28A_EIC_EXTINT8     (1ul << 28)
-#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
-#define MUX_PB08A_EIC_EXTINT8              0L
+#define PORT_PA28A_EIC_EXTINT8  (_UL(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
-#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
-#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
-#define MUX_PA09A_EIC_EXTINT9              0L
+#define PORT_PB08A_EIC_EXTINT8  (_UL(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
-#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
-#define MUX_PB09A_EIC_EXTINT9              0L
+#define PORT_PA09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
-#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
-#define MUX_PA10A_EIC_EXTINT10             0L
+#define PORT_PB09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
-#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
-#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
-#define MUX_PA30A_EIC_EXTINT10             0L
+#define PORT_PA10A_EIC_EXTINT10  (_UL(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
-#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
-#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
-#define MUX_PA11A_EIC_EXTINT11             0L
+#define PORT_PA30A_EIC_EXTINT10  (_UL(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
-#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
-#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
-#define MUX_PA31A_EIC_EXTINT11             0L
+#define PORT_PA11A_EIC_EXTINT11  (_UL(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
-#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
-#define PIN_PA12A_EIC_EXTINT12            12L  /**< \brief EIC signal: EXTINT12 on PA12 mux A */
-#define MUX_PA12A_EIC_EXTINT12             0L
+#define PORT_PA31A_EIC_EXTINT11  (_UL(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
-#define PORT_PA12A_EIC_EXTINT12    (1ul << 12)
-#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
-#define MUX_PA24A_EIC_EXTINT12             0L
+#define PORT_PA12A_EIC_EXTINT12  (_UL(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
-#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
-#define PIN_PA13A_EIC_EXTINT13            13L  /**< \brief EIC signal: EXTINT13 on PA13 mux A */
-#define MUX_PA13A_EIC_EXTINT13             0L
+#define PORT_PA24A_EIC_EXTINT12  (_UL(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
-#define PORT_PA13A_EIC_EXTINT13    (1ul << 13)
-#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
-#define MUX_PA25A_EIC_EXTINT13             0L
+#define PORT_PA13A_EIC_EXTINT13  (_UL(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
-#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
-#define PIN_PB14A_EIC_EXTINT14            46L  /**< \brief EIC signal: EXTINT14 on PB14 mux A */
-#define MUX_PB14A_EIC_EXTINT14             0L
+#define PORT_PA25A_EIC_EXTINT13  (_UL(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
-#define PORT_PB14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PB30A_EIC_EXTINT14            62L  /**< \brief EIC signal: EXTINT14 on PB30 mux A */
-#define MUX_PB30A_EIC_EXTINT14             0L
+#define PORT_PB14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
-#define PORT_PB30A_EIC_EXTINT14    (1ul << 30)
-#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
-#define MUX_PA14A_EIC_EXTINT14             0L
+#define PORT_PB30A_EIC_EXTINT14  (_UL(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
-#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
-#define MUX_PA15A_EIC_EXTINT15             0L
+#define PORT_PA14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
-#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
-#define MUX_PA27A_EIC_EXTINT15             0L
+#define PORT_PA15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
-#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
-#define PIN_PB15A_EIC_EXTINT15            47L  /**< \brief EIC signal: EXTINT15 on PB15 mux A */
-#define MUX_PB15A_EIC_EXTINT15             0L
+#define PORT_PA27A_EIC_EXTINT15  (_UL(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
-#define PORT_PB15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PB31A_EIC_EXTINT15            63L  /**< \brief EIC signal: EXTINT15 on PB31 mux A */
-#define MUX_PB31A_EIC_EXTINT15             0L
+#define PORT_PB15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
-#define PORT_PB31A_EIC_EXTINT15    (1ul << 31)
-#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
-#define MUX_PA08A_EIC_NMI                  0L
+#define PORT_PB31A_EIC_EXTINT15  (_UL(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
 #define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
-#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+#define PORT_PA08A_EIC_NMI     (_UL(1) <<  8)
 /* ========== PORT definition for USB peripheral ========== */
-#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
-#define MUX_PA24G_USB_DM                   6L
+#define PIN_PA24G_USB_DM               _L_(24) /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                _L_(6)
 #define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
-#define PORT_PA24G_USB_DM          (1ul << 24)
-#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
-#define MUX_PA25G_USB_DP                   6L
+#define PORT_PA24G_USB_DM      (_UL(1) << 24)
+#define PIN_PA25G_USB_DP               _L_(25) /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                _L_(6)
 #define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
-#define PORT_PA25G_USB_DP          (1ul << 25)
-#define PIN_PA23G_USB_SOF_1KHZ            23L  /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
-#define MUX_PA23G_USB_SOF_1KHZ             6L
+#define PORT_PA25G_USB_DP      (_UL(1) << 25)
+#define PIN_PA23G_USB_SOF_1KHZ         _L_(23) /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
+#define MUX_PA23G_USB_SOF_1KHZ          _L_(6)
 #define PINMUX_PA23G_USB_SOF_1KHZ  ((PIN_PA23G_USB_SOF_1KHZ << 16) | MUX_PA23G_USB_SOF_1KHZ)
-#define PORT_PA23G_USB_SOF_1KHZ    (1ul << 23)
+#define PORT_PA23G_USB_SOF_1KHZ  (_UL(1) << 23)
 /* ========== PORT definition for SERCOM0 peripheral ========== */
-#define PIN_PA04D_SERCOM0_PAD0             4L  /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
-#define MUX_PA04D_SERCOM0_PAD0             3L
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
 #define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
-#define PORT_PA04D_SERCOM0_PAD0    (1ul <<  4)
-#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
-#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PORT_PA04D_SERCOM0_PAD0  (_UL(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
 #define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
-#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
-#define PIN_PA05D_SERCOM0_PAD1             5L  /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
-#define MUX_PA05D_SERCOM0_PAD1             3L
+#define PORT_PA08C_SERCOM0_PAD0  (_UL(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
 #define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
-#define PORT_PA05D_SERCOM0_PAD1    (1ul <<  5)
-#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
-#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PORT_PA05D_SERCOM0_PAD1  (_UL(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
 #define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
-#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
-#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
-#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PORT_PA09C_SERCOM0_PAD1  (_UL(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
 #define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
-#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
-#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
-#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PORT_PA06D_SERCOM0_PAD2  (_UL(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
 #define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
-#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
-#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
-#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PORT_PA10C_SERCOM0_PAD2  (_UL(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
 #define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
-#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
-#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
-#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PORT_PA07D_SERCOM0_PAD3  (_UL(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
 #define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
-#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL(1) << 11)
 /* ========== PORT definition for SERCOM1 peripheral ========== */
-#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
-#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
 #define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
-#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
-#define PIN_PA00D_SERCOM1_PAD0             0L  /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
-#define MUX_PA00D_SERCOM1_PAD0             3L
+#define PORT_PA16C_SERCOM1_PAD0  (_UL(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
 #define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
-#define PORT_PA00D_SERCOM1_PAD0    (1ul <<  0)
-#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
-#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PORT_PA00D_SERCOM1_PAD0  (_UL(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
 #define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
-#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
-#define PIN_PA01D_SERCOM1_PAD1             1L  /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
-#define MUX_PA01D_SERCOM1_PAD1             3L
+#define PORT_PA17C_SERCOM1_PAD1  (_UL(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
 #define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
-#define PORT_PA01D_SERCOM1_PAD1    (1ul <<  1)
-#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
-#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PORT_PA01D_SERCOM1_PAD1  (_UL(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
 #define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
-#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
-#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
-#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PORT_PA30D_SERCOM1_PAD2  (_UL(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
 #define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
-#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
-#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
-#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PORT_PA18C_SERCOM1_PAD2  (_UL(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
 #define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
-#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
-#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
-#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PORT_PA31D_SERCOM1_PAD3  (_UL(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
 #define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
-#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL(1) << 19)
 /* ========== PORT definition for SERCOM2 peripheral ========== */
-#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
-#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
 #define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
-#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
-#define PIN_PA12C_SERCOM2_PAD0            12L  /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
-#define MUX_PA12C_SERCOM2_PAD0             2L
+#define PORT_PA08D_SERCOM2_PAD0  (_UL(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
 #define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
-#define PORT_PA12C_SERCOM2_PAD0    (1ul << 12)
-#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
-#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PORT_PA12C_SERCOM2_PAD0  (_UL(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
 #define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
-#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
-#define PIN_PA13C_SERCOM2_PAD1            13L  /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
-#define MUX_PA13C_SERCOM2_PAD1             2L
+#define PORT_PA09D_SERCOM2_PAD1  (_UL(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
 #define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
-#define PORT_PA13C_SERCOM2_PAD1    (1ul << 13)
-#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
-#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PORT_PA13C_SERCOM2_PAD1  (_UL(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
 #define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
-#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
-#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
-#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PORT_PA10D_SERCOM2_PAD2  (_UL(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
 #define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
-#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
-#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
-#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PORT_PA14C_SERCOM2_PAD2  (_UL(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
 #define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
-#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
-#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
-#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PORT_PA11D_SERCOM2_PAD3  (_UL(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
 #define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
-#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL(1) << 15)
 /* ========== PORT definition for SERCOM3 peripheral ========== */
-#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
-#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
 #define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
-#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
-#define PIN_PA22C_SERCOM3_PAD0            22L  /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
-#define MUX_PA22C_SERCOM3_PAD0             2L
+#define PORT_PA16D_SERCOM3_PAD0  (_UL(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
 #define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
-#define PORT_PA22C_SERCOM3_PAD0    (1ul << 22)
-#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
-#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PORT_PA22C_SERCOM3_PAD0  (_UL(1) << 22)
+#define PIN_PA27F_SERCOM3_PAD0         _L_(27) /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0          _L_(5)
 #define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
-#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
-#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
-#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PORT_PA27F_SERCOM3_PAD0  (_UL(1) << 27)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
 #define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
-#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
-#define PIN_PA23C_SERCOM3_PAD1            23L  /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
-#define MUX_PA23C_SERCOM3_PAD1             2L
+#define PORT_PA17D_SERCOM3_PAD1  (_UL(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
 #define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
-#define PORT_PA23C_SERCOM3_PAD1    (1ul << 23)
-#define PIN_PA28F_SERCOM3_PAD1            28L  /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
-#define MUX_PA28F_SERCOM3_PAD1             5L
+#define PORT_PA23C_SERCOM3_PAD1  (_UL(1) << 23)
+#define PIN_PA28F_SERCOM3_PAD1         _L_(28) /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
+#define MUX_PA28F_SERCOM3_PAD1          _L_(5)
 #define PINMUX_PA28F_SERCOM3_PAD1  ((PIN_PA28F_SERCOM3_PAD1 << 16) | MUX_PA28F_SERCOM3_PAD1)
-#define PORT_PA28F_SERCOM3_PAD1    (1ul << 28)
-#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
-#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PORT_PA28F_SERCOM3_PAD1  (_UL(1) << 28)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
-#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
-#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
-#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PORT_PA18D_SERCOM3_PAD2  (_UL(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
-#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
-#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
-#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PORT_PA20D_SERCOM3_PAD2  (_UL(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
 #define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
-#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
-#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
-#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PORT_PA24C_SERCOM3_PAD2  (_UL(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
 #define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
-#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
-#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
-#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PORT_PA19D_SERCOM3_PAD3  (_UL(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
 #define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
-#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for SERCOM4 peripheral ========== */
-#define PIN_PA12D_SERCOM4_PAD0            12L  /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
-#define MUX_PA12D_SERCOM4_PAD0             3L
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
-#define PORT_PA12D_SERCOM4_PAD0    (1ul << 12)
-#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
-#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PORT_PA12D_SERCOM4_PAD0  (_UL(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
-#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
-#define PIN_PC19F_SERCOM4_PAD0            83L  /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
-#define MUX_PC19F_SERCOM4_PAD0             5L
+#define PORT_PB08D_SERCOM4_PAD0  (_UL(1) <<  8)
+#define PIN_PC19F_SERCOM4_PAD0         _L_(83) /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
+#define MUX_PC19F_SERCOM4_PAD0          _L_(5)
 #define PINMUX_PC19F_SERCOM4_PAD0  ((PIN_PC19F_SERCOM4_PAD0 << 16) | MUX_PC19F_SERCOM4_PAD0)
-#define PORT_PC19F_SERCOM4_PAD0    (1ul << 19)
-#define PIN_PA13D_SERCOM4_PAD1            13L  /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
-#define MUX_PA13D_SERCOM4_PAD1             3L
+#define PORT_PC19F_SERCOM4_PAD0  (_UL(1) << 19)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
-#define PORT_PA13D_SERCOM4_PAD1    (1ul << 13)
-#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
-#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PORT_PA13D_SERCOM4_PAD1  (_UL(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
-#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
-#define PIN_PB31F_SERCOM4_PAD1            63L  /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
-#define MUX_PB31F_SERCOM4_PAD1             5L
+#define PORT_PB09D_SERCOM4_PAD1  (_UL(1) <<  9)
+#define PIN_PB31F_SERCOM4_PAD1         _L_(63) /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
+#define MUX_PB31F_SERCOM4_PAD1          _L_(5)
 #define PINMUX_PB31F_SERCOM4_PAD1  ((PIN_PB31F_SERCOM4_PAD1 << 16) | MUX_PB31F_SERCOM4_PAD1)
-#define PORT_PB31F_SERCOM4_PAD1    (1ul << 31)
-#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
-#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PORT_PB31F_SERCOM4_PAD1  (_UL(1) << 31)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
 #define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
-#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB14C_SERCOM4_PAD2            46L  /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
-#define MUX_PB14C_SERCOM4_PAD2             2L
+#define PORT_PA14D_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
 #define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
-#define PORT_PB14C_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB30F_SERCOM4_PAD2            62L  /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
-#define MUX_PB30F_SERCOM4_PAD2             5L
+#define PORT_PB14C_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB30F_SERCOM4_PAD2         _L_(62) /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
+#define MUX_PB30F_SERCOM4_PAD2          _L_(5)
 #define PINMUX_PB30F_SERCOM4_PAD2  ((PIN_PB30F_SERCOM4_PAD2 << 16) | MUX_PB30F_SERCOM4_PAD2)
-#define PORT_PB30F_SERCOM4_PAD2    (1ul << 30)
-#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
-#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PORT_PB30F_SERCOM4_PAD2  (_UL(1) << 30)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
 #define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
-#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PB15C_SERCOM4_PAD3            47L  /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
-#define MUX_PB15C_SERCOM4_PAD3             2L
+#define PORT_PA15D_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
 #define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
-#define PORT_PB15C_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PC18F_SERCOM4_PAD3            82L  /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
-#define MUX_PC18F_SERCOM4_PAD3             5L
+#define PORT_PB15C_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PC18F_SERCOM4_PAD3         _L_(82) /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
+#define MUX_PC18F_SERCOM4_PAD3          _L_(5)
 #define PINMUX_PC18F_SERCOM4_PAD3  ((PIN_PC18F_SERCOM4_PAD3 << 16) | MUX_PC18F_SERCOM4_PAD3)
-#define PORT_PC18F_SERCOM4_PAD3    (1ul << 18)
+#define PORT_PC18F_SERCOM4_PAD3  (_UL(1) << 18)
 /* ========== PORT definition for SERCOM5 peripheral ========== */
-#define PIN_PB16C_SERCOM5_PAD0            48L  /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
-#define MUX_PB16C_SERCOM5_PAD0             2L
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
 #define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
-#define PORT_PB16C_SERCOM5_PAD0    (1ul << 16)
-#define PIN_PA22D_SERCOM5_PAD0            22L  /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
-#define MUX_PA22D_SERCOM5_PAD0             3L
+#define PORT_PB16C_SERCOM5_PAD0  (_UL(1) << 16)
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
-#define PORT_PA22D_SERCOM5_PAD0    (1ul << 22)
-#define PIN_PB02D_SERCOM5_PAD0            34L  /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
-#define MUX_PB02D_SERCOM5_PAD0             3L
+#define PORT_PA22D_SERCOM5_PAD0  (_UL(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
-#define PORT_PB02D_SERCOM5_PAD0    (1ul <<  2)
-#define PIN_PB30D_SERCOM5_PAD0            62L  /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
-#define MUX_PB30D_SERCOM5_PAD0             3L
+#define PORT_PB02D_SERCOM5_PAD0  (_UL(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
-#define PORT_PB30D_SERCOM5_PAD0    (1ul << 30)
-#define PIN_PB17C_SERCOM5_PAD1            49L  /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
-#define MUX_PB17C_SERCOM5_PAD1             2L
+#define PORT_PB30D_SERCOM5_PAD0  (_UL(1) << 30)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
 #define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
-#define PORT_PB17C_SERCOM5_PAD1    (1ul << 17)
-#define PIN_PA23D_SERCOM5_PAD1            23L  /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
-#define MUX_PA23D_SERCOM5_PAD1             3L
+#define PORT_PB17C_SERCOM5_PAD1  (_UL(1) << 17)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
-#define PORT_PA23D_SERCOM5_PAD1    (1ul << 23)
-#define PIN_PB03D_SERCOM5_PAD1            35L  /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
-#define MUX_PB03D_SERCOM5_PAD1             3L
+#define PORT_PA23D_SERCOM5_PAD1  (_UL(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
-#define PORT_PB03D_SERCOM5_PAD1    (1ul <<  3)
-#define PIN_PB31D_SERCOM5_PAD1            63L  /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
-#define MUX_PB31D_SERCOM5_PAD1             3L
+#define PORT_PB03D_SERCOM5_PAD1  (_UL(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
-#define PORT_PB31D_SERCOM5_PAD1    (1ul << 31)
-#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
-#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PORT_PB31D_SERCOM5_PAD1  (_UL(1) << 31)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
-#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
-#define PIN_PB00D_SERCOM5_PAD2            32L  /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
-#define MUX_PB00D_SERCOM5_PAD2             3L
+#define PORT_PA24D_SERCOM5_PAD2  (_UL(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
-#define PORT_PB00D_SERCOM5_PAD2    (1ul <<  0)
-#define PIN_PB22D_SERCOM5_PAD2            54L  /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
-#define MUX_PB22D_SERCOM5_PAD2             3L
+#define PORT_PB00D_SERCOM5_PAD2  (_UL(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
-#define PORT_PB22D_SERCOM5_PAD2    (1ul << 22)
-#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
-#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PORT_PB22D_SERCOM5_PAD2  (_UL(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
 #define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
-#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
-#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
-#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PORT_PA20C_SERCOM5_PAD2  (_UL(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
-#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
-#define PIN_PB23D_SERCOM5_PAD3            55L  /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
-#define MUX_PB23D_SERCOM5_PAD3             3L
+#define PORT_PA25D_SERCOM5_PAD3  (_UL(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
-#define PORT_PB23D_SERCOM5_PAD3    (1ul << 23)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL(1) << 23)
 /* ========== PORT definition for TCC0 peripheral ========== */
-#define PIN_PA04E_TCC0_WO0                 4L  /**< \brief TCC0 signal: WO0 on PA04 mux E */
-#define MUX_PA04E_TCC0_WO0                 4L
+#define PIN_PA04E_TCC0_WO0              _L_(4) /**< \brief TCC0 signal: WO0 on PA04 mux E */
+#define MUX_PA04E_TCC0_WO0              _L_(4)
 #define PINMUX_PA04E_TCC0_WO0      ((PIN_PA04E_TCC0_WO0 << 16) | MUX_PA04E_TCC0_WO0)
-#define PORT_PA04E_TCC0_WO0        (1ul <<  4)
-#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
-#define MUX_PA08E_TCC0_WO0                 4L
+#define PORT_PA04E_TCC0_WO0    (_UL(1) <<  4)
+#define PIN_PA08E_TCC0_WO0              _L_(8) /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0              _L_(4)
 #define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
-#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
-#define PIN_PB30E_TCC0_WO0                62L  /**< \brief TCC0 signal: WO0 on PB30 mux E */
-#define MUX_PB30E_TCC0_WO0                 4L
+#define PORT_PA08E_TCC0_WO0    (_UL(1) <<  8)
+#define PIN_PB30E_TCC0_WO0             _L_(62) /**< \brief TCC0 signal: WO0 on PB30 mux E */
+#define MUX_PB30E_TCC0_WO0              _L_(4)
 #define PINMUX_PB30E_TCC0_WO0      ((PIN_PB30E_TCC0_WO0 << 16) | MUX_PB30E_TCC0_WO0)
-#define PORT_PB30E_TCC0_WO0        (1ul << 30)
-#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
-#define MUX_PA16F_TCC0_WO0                 5L
+#define PORT_PB30E_TCC0_WO0    (_UL(1) << 30)
+#define PIN_PA16F_TCC0_WO0             _L_(16) /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0              _L_(5)
 #define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
-#define PORT_PA16F_TCC0_WO0        (1ul << 16)
-#define PIN_PA05E_TCC0_WO1                 5L  /**< \brief TCC0 signal: WO1 on PA05 mux E */
-#define MUX_PA05E_TCC0_WO1                 4L
+#define PORT_PA16F_TCC0_WO0    (_UL(1) << 16)
+#define PIN_PA05E_TCC0_WO1              _L_(5) /**< \brief TCC0 signal: WO1 on PA05 mux E */
+#define MUX_PA05E_TCC0_WO1              _L_(4)
 #define PINMUX_PA05E_TCC0_WO1      ((PIN_PA05E_TCC0_WO1 << 16) | MUX_PA05E_TCC0_WO1)
-#define PORT_PA05E_TCC0_WO1        (1ul <<  5)
-#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
-#define MUX_PA09E_TCC0_WO1                 4L
+#define PORT_PA05E_TCC0_WO1    (_UL(1) <<  5)
+#define PIN_PA09E_TCC0_WO1              _L_(9) /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1              _L_(4)
 #define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
-#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
-#define PIN_PB31E_TCC0_WO1                63L  /**< \brief TCC0 signal: WO1 on PB31 mux E */
-#define MUX_PB31E_TCC0_WO1                 4L
+#define PORT_PA09E_TCC0_WO1    (_UL(1) <<  9)
+#define PIN_PB31E_TCC0_WO1             _L_(63) /**< \brief TCC0 signal: WO1 on PB31 mux E */
+#define MUX_PB31E_TCC0_WO1              _L_(4)
 #define PINMUX_PB31E_TCC0_WO1      ((PIN_PB31E_TCC0_WO1 << 16) | MUX_PB31E_TCC0_WO1)
-#define PORT_PB31E_TCC0_WO1        (1ul << 31)
-#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
-#define MUX_PA17F_TCC0_WO1                 5L
+#define PORT_PB31E_TCC0_WO1    (_UL(1) << 31)
+#define PIN_PA17F_TCC0_WO1             _L_(17) /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1              _L_(5)
 #define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
-#define PORT_PA17F_TCC0_WO1        (1ul << 17)
-#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
-#define MUX_PA10F_TCC0_WO2                 5L
+#define PORT_PA17F_TCC0_WO1    (_UL(1) << 17)
+#define PIN_PA10F_TCC0_WO2             _L_(10) /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2              _L_(5)
 #define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
-#define PORT_PA10F_TCC0_WO2        (1ul << 10)
-#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
-#define MUX_PA18F_TCC0_WO2                 5L
+#define PORT_PA10F_TCC0_WO2    (_UL(1) << 10)
+#define PIN_PA18F_TCC0_WO2             _L_(18) /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2              _L_(5)
 #define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
-#define PORT_PA18F_TCC0_WO2        (1ul << 18)
-#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
-#define MUX_PA11F_TCC0_WO3                 5L
+#define PORT_PA18F_TCC0_WO2    (_UL(1) << 18)
+#define PIN_PA11F_TCC0_WO3             _L_(11) /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3              _L_(5)
 #define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
-#define PORT_PA11F_TCC0_WO3        (1ul << 11)
-#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
-#define MUX_PA19F_TCC0_WO3                 5L
+#define PORT_PA11F_TCC0_WO3    (_UL(1) << 11)
+#define PIN_PA19F_TCC0_WO3             _L_(19) /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3              _L_(5)
 #define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
-#define PORT_PA19F_TCC0_WO3        (1ul << 19)
-#define PIN_PA22F_TCC0_WO4                22L  /**< \brief TCC0 signal: WO4 on PA22 mux F */
-#define MUX_PA22F_TCC0_WO4                 5L
+#define PORT_PA19F_TCC0_WO3    (_UL(1) << 19)
+#define PIN_PA22F_TCC0_WO4             _L_(22) /**< \brief TCC0 signal: WO4 on PA22 mux F */
+#define MUX_PA22F_TCC0_WO4              _L_(5)
 #define PINMUX_PA22F_TCC0_WO4      ((PIN_PA22F_TCC0_WO4 << 16) | MUX_PA22F_TCC0_WO4)
-#define PORT_PA22F_TCC0_WO4        (1ul << 22)
-#define PIN_PB16F_TCC0_WO4                48L  /**< \brief TCC0 signal: WO4 on PB16 mux F */
-#define MUX_PB16F_TCC0_WO4                 5L
+#define PORT_PA22F_TCC0_WO4    (_UL(1) << 22)
+#define PIN_PB16F_TCC0_WO4             _L_(48) /**< \brief TCC0 signal: WO4 on PB16 mux F */
+#define MUX_PB16F_TCC0_WO4              _L_(5)
 #define PINMUX_PB16F_TCC0_WO4      ((PIN_PB16F_TCC0_WO4 << 16) | MUX_PB16F_TCC0_WO4)
-#define PORT_PB16F_TCC0_WO4        (1ul << 16)
-#define PIN_PA23F_TCC0_WO5                23L  /**< \brief TCC0 signal: WO5 on PA23 mux F */
-#define MUX_PA23F_TCC0_WO5                 5L
+#define PORT_PB16F_TCC0_WO4    (_UL(1) << 16)
+#define PIN_PA23F_TCC0_WO5             _L_(23) /**< \brief TCC0 signal: WO5 on PA23 mux F */
+#define MUX_PA23F_TCC0_WO5              _L_(5)
 #define PINMUX_PA23F_TCC0_WO5      ((PIN_PA23F_TCC0_WO5 << 16) | MUX_PA23F_TCC0_WO5)
-#define PORT_PA23F_TCC0_WO5        (1ul << 23)
-#define PIN_PB17F_TCC0_WO5                49L  /**< \brief TCC0 signal: WO5 on PB17 mux F */
-#define MUX_PB17F_TCC0_WO5                 5L
+#define PORT_PA23F_TCC0_WO5    (_UL(1) << 23)
+#define PIN_PB17F_TCC0_WO5             _L_(49) /**< \brief TCC0 signal: WO5 on PB17 mux F */
+#define MUX_PB17F_TCC0_WO5              _L_(5)
 #define PINMUX_PB17F_TCC0_WO5      ((PIN_PB17F_TCC0_WO5 << 16) | MUX_PB17F_TCC0_WO5)
-#define PORT_PB17F_TCC0_WO5        (1ul << 17)
-#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
-#define MUX_PA20F_TCC0_WO6                 5L
+#define PORT_PB17F_TCC0_WO5    (_UL(1) << 17)
+#define PIN_PA20F_TCC0_WO6             _L_(20) /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6              _L_(5)
 #define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
-#define PORT_PA20F_TCC0_WO6        (1ul << 20)
+#define PORT_PA20F_TCC0_WO6    (_UL(1) << 20)
 /* ========== PORT definition for TCC1 peripheral ========== */
-#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
-#define MUX_PA06E_TCC1_WO0                 4L
+#define PIN_PA06E_TCC1_WO0              _L_(6) /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0              _L_(4)
 #define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
-#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
-#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
-#define MUX_PA10E_TCC1_WO0                 4L
+#define PORT_PA06E_TCC1_WO0    (_UL(1) <<  6)
+#define PIN_PA10E_TCC1_WO0             _L_(10) /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0              _L_(4)
 #define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
-#define PORT_PA10E_TCC1_WO0        (1ul << 10)
-#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
-#define MUX_PA30E_TCC1_WO0                 4L
+#define PORT_PA10E_TCC1_WO0    (_UL(1) << 10)
+#define PIN_PA30E_TCC1_WO0             _L_(30) /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0              _L_(4)
 #define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
-#define PORT_PA30E_TCC1_WO0        (1ul << 30)
-#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
-#define MUX_PA07E_TCC1_WO1                 4L
+#define PORT_PA30E_TCC1_WO0    (_UL(1) << 30)
+#define PIN_PA07E_TCC1_WO1              _L_(7) /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1              _L_(4)
 #define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
-#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
-#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
-#define MUX_PA11E_TCC1_WO1                 4L
+#define PORT_PA07E_TCC1_WO1    (_UL(1) <<  7)
+#define PIN_PA11E_TCC1_WO1             _L_(11) /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1              _L_(4)
 #define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
-#define PORT_PA11E_TCC1_WO1        (1ul << 11)
-#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
-#define MUX_PA31E_TCC1_WO1                 4L
+#define PORT_PA11E_TCC1_WO1    (_UL(1) << 11)
+#define PIN_PA31E_TCC1_WO1             _L_(31) /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1              _L_(4)
 #define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
-#define PORT_PA31E_TCC1_WO1        (1ul << 31)
-#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
-#define MUX_PA24F_TCC1_WO2                 5L
+#define PORT_PA31E_TCC1_WO1    (_UL(1) << 31)
+#define PIN_PA24F_TCC1_WO2             _L_(24) /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2              _L_(5)
 #define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
-#define PORT_PA24F_TCC1_WO2        (1ul << 24)
-#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
-#define MUX_PA25F_TCC1_WO3                 5L
+#define PORT_PA24F_TCC1_WO2    (_UL(1) << 24)
+#define PIN_PA25F_TCC1_WO3             _L_(25) /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3              _L_(5)
 #define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
-#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+#define PORT_PA25F_TCC1_WO3    (_UL(1) << 25)
 /* ========== PORT definition for TCC2 peripheral ========== */
-#define PIN_PA12E_TCC2_WO0                12L  /**< \brief TCC2 signal: WO0 on PA12 mux E */
-#define MUX_PA12E_TCC2_WO0                 4L
+#define PIN_PA12E_TCC2_WO0             _L_(12) /**< \brief TCC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TCC2_WO0              _L_(4)
 #define PINMUX_PA12E_TCC2_WO0      ((PIN_PA12E_TCC2_WO0 << 16) | MUX_PA12E_TCC2_WO0)
-#define PORT_PA12E_TCC2_WO0        (1ul << 12)
-#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
-#define MUX_PA16E_TCC2_WO0                 4L
+#define PORT_PA12E_TCC2_WO0    (_UL(1) << 12)
+#define PIN_PA16E_TCC2_WO0             _L_(16) /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0              _L_(4)
 #define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
-#define PORT_PA16E_TCC2_WO0        (1ul << 16)
-#define PIN_PA00E_TCC2_WO0                 0L  /**< \brief TCC2 signal: WO0 on PA00 mux E */
-#define MUX_PA00E_TCC2_WO0                 4L
+#define PORT_PA16E_TCC2_WO0    (_UL(1) << 16)
+#define PIN_PA00E_TCC2_WO0              _L_(0) /**< \brief TCC2 signal: WO0 on PA00 mux E */
+#define MUX_PA00E_TCC2_WO0              _L_(4)
 #define PINMUX_PA00E_TCC2_WO0      ((PIN_PA00E_TCC2_WO0 << 16) | MUX_PA00E_TCC2_WO0)
-#define PORT_PA00E_TCC2_WO0        (1ul <<  0)
-#define PIN_PA13E_TCC2_WO1                13L  /**< \brief TCC2 signal: WO1 on PA13 mux E */
-#define MUX_PA13E_TCC2_WO1                 4L
+#define PORT_PA00E_TCC2_WO0    (_UL(1) <<  0)
+#define PIN_PA13E_TCC2_WO1             _L_(13) /**< \brief TCC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TCC2_WO1              _L_(4)
 #define PINMUX_PA13E_TCC2_WO1      ((PIN_PA13E_TCC2_WO1 << 16) | MUX_PA13E_TCC2_WO1)
-#define PORT_PA13E_TCC2_WO1        (1ul << 13)
-#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
-#define MUX_PA17E_TCC2_WO1                 4L
+#define PORT_PA13E_TCC2_WO1    (_UL(1) << 13)
+#define PIN_PA17E_TCC2_WO1             _L_(17) /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1              _L_(4)
 #define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
-#define PORT_PA17E_TCC2_WO1        (1ul << 17)
-#define PIN_PA01E_TCC2_WO1                 1L  /**< \brief TCC2 signal: WO1 on PA01 mux E */
-#define MUX_PA01E_TCC2_WO1                 4L
+#define PORT_PA17E_TCC2_WO1    (_UL(1) << 17)
+#define PIN_PA01E_TCC2_WO1              _L_(1) /**< \brief TCC2 signal: WO1 on PA01 mux E */
+#define MUX_PA01E_TCC2_WO1              _L_(4)
 #define PINMUX_PA01E_TCC2_WO1      ((PIN_PA01E_TCC2_WO1 << 16) | MUX_PA01E_TCC2_WO1)
-#define PORT_PA01E_TCC2_WO1        (1ul <<  1)
+#define PORT_PA01E_TCC2_WO1    (_UL(1) <<  1)
 /* ========== PORT definition for TC3 peripheral ========== */
-#define PIN_PA18E_TC3_WO0                 18L  /**< \brief TC3 signal: WO0 on PA18 mux E */
-#define MUX_PA18E_TC3_WO0                  4L
+#define PIN_PA18E_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC3_WO0               _L_(4)
 #define PINMUX_PA18E_TC3_WO0       ((PIN_PA18E_TC3_WO0 << 16) | MUX_PA18E_TC3_WO0)
-#define PORT_PA18E_TC3_WO0         (1ul << 18)
-#define PIN_PA14E_TC3_WO0                 14L  /**< \brief TC3 signal: WO0 on PA14 mux E */
-#define MUX_PA14E_TC3_WO0                  4L
+#define PORT_PA18E_TC3_WO0     (_UL(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
 #define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
-#define PORT_PA14E_TC3_WO0         (1ul << 14)
-#define PIN_PA19E_TC3_WO1                 19L  /**< \brief TC3 signal: WO1 on PA19 mux E */
-#define MUX_PA19E_TC3_WO1                  4L
+#define PORT_PA14E_TC3_WO0     (_UL(1) << 14)
+#define PIN_PA19E_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC3_WO1               _L_(4)
 #define PINMUX_PA19E_TC3_WO1       ((PIN_PA19E_TC3_WO1 << 16) | MUX_PA19E_TC3_WO1)
-#define PORT_PA19E_TC3_WO1         (1ul << 19)
-#define PIN_PA15E_TC3_WO1                 15L  /**< \brief TC3 signal: WO1 on PA15 mux E */
-#define MUX_PA15E_TC3_WO1                  4L
+#define PORT_PA19E_TC3_WO1     (_UL(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
 #define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
-#define PORT_PA15E_TC3_WO1         (1ul << 15)
+#define PORT_PA15E_TC3_WO1     (_UL(1) << 15)
 /* ========== PORT definition for TC4 peripheral ========== */
-#define PIN_PA22E_TC4_WO0                 22L  /**< \brief TC4 signal: WO0 on PA22 mux E */
-#define MUX_PA22E_TC4_WO0                  4L
+#define PIN_PA22E_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux E */
+#define MUX_PA22E_TC4_WO0               _L_(4)
 #define PINMUX_PA22E_TC4_WO0       ((PIN_PA22E_TC4_WO0 << 16) | MUX_PA22E_TC4_WO0)
-#define PORT_PA22E_TC4_WO0         (1ul << 22)
-#define PIN_PB08E_TC4_WO0                 40L  /**< \brief TC4 signal: WO0 on PB08 mux E */
-#define MUX_PB08E_TC4_WO0                  4L
+#define PORT_PA22E_TC4_WO0     (_UL(1) << 22)
+#define PIN_PB08E_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC4_WO0               _L_(4)
 #define PINMUX_PB08E_TC4_WO0       ((PIN_PB08E_TC4_WO0 << 16) | MUX_PB08E_TC4_WO0)
-#define PORT_PB08E_TC4_WO0         (1ul <<  8)
-#define PIN_PA23E_TC4_WO1                 23L  /**< \brief TC4 signal: WO1 on PA23 mux E */
-#define MUX_PA23E_TC4_WO1                  4L
+#define PORT_PB08E_TC4_WO0     (_UL(1) <<  8)
+#define PIN_PA23E_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux E */
+#define MUX_PA23E_TC4_WO1               _L_(4)
 #define PINMUX_PA23E_TC4_WO1       ((PIN_PA23E_TC4_WO1 << 16) | MUX_PA23E_TC4_WO1)
-#define PORT_PA23E_TC4_WO1         (1ul << 23)
-#define PIN_PB09E_TC4_WO1                 41L  /**< \brief TC4 signal: WO1 on PB09 mux E */
-#define MUX_PB09E_TC4_WO1                  4L
+#define PORT_PA23E_TC4_WO1     (_UL(1) << 23)
+#define PIN_PB09E_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC4_WO1               _L_(4)
 #define PINMUX_PB09E_TC4_WO1       ((PIN_PB09E_TC4_WO1 << 16) | MUX_PB09E_TC4_WO1)
-#define PORT_PB09E_TC4_WO1         (1ul <<  9)
+#define PORT_PB09E_TC4_WO1     (_UL(1) <<  9)
 /* ========== PORT definition for TC5 peripheral ========== */
-#define PIN_PA24E_TC5_WO0                 24L  /**< \brief TC5 signal: WO0 on PA24 mux E */
-#define MUX_PA24E_TC5_WO0                  4L
+#define PIN_PA24E_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC5_WO0               _L_(4)
 #define PINMUX_PA24E_TC5_WO0       ((PIN_PA24E_TC5_WO0 << 16) | MUX_PA24E_TC5_WO0)
-#define PORT_PA24E_TC5_WO0         (1ul << 24)
-#define PIN_PB14E_TC5_WO0                 46L  /**< \brief TC5 signal: WO0 on PB14 mux E */
-#define MUX_PB14E_TC5_WO0                  4L
+#define PORT_PA24E_TC5_WO0     (_UL(1) << 24)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
 #define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
-#define PORT_PB14E_TC5_WO0         (1ul << 14)
-#define PIN_PA25E_TC5_WO1                 25L  /**< \brief TC5 signal: WO1 on PA25 mux E */
-#define MUX_PA25E_TC5_WO1                  4L
+#define PORT_PB14E_TC5_WO0     (_UL(1) << 14)
+#define PIN_PA25E_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC5_WO1               _L_(4)
 #define PINMUX_PA25E_TC5_WO1       ((PIN_PA25E_TC5_WO1 << 16) | MUX_PA25E_TC5_WO1)
-#define PORT_PA25E_TC5_WO1         (1ul << 25)
-#define PIN_PB15E_TC5_WO1                 47L  /**< \brief TC5 signal: WO1 on PB15 mux E */
-#define MUX_PB15E_TC5_WO1                  4L
+#define PORT_PA25E_TC5_WO1     (_UL(1) << 25)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
 #define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
-#define PORT_PB15E_TC5_WO1         (1ul << 15)
+#define PORT_PB15E_TC5_WO1     (_UL(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02E_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux E */
+#define MUX_PB02E_TC6_WO0               _L_(4)
+#define PINMUX_PB02E_TC6_WO0       ((PIN_PB02E_TC6_WO0 << 16) | MUX_PB02E_TC6_WO0)
+#define PORT_PB02E_TC6_WO0     (_UL(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL(1) << 16)
+#define PIN_PB03E_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux E */
+#define MUX_PB03E_TC6_WO1               _L_(4)
+#define PINMUX_PB03E_TC6_WO1       ((PIN_PB03E_TC6_WO1 << 16) | MUX_PB03E_TC6_WO1)
+#define PORT_PB03E_TC6_WO1     (_UL(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL(1) << 20)
+#define PIN_PB00E_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux E */
+#define MUX_PB00E_TC7_WO0               _L_(4)
+#define PINMUX_PB00E_TC7_WO0       ((PIN_PB00E_TC7_WO0 << 16) | MUX_PB00E_TC7_WO0)
+#define PORT_PB00E_TC7_WO0     (_UL(1) <<  0)
+#define PIN_PB22E_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux E */
+#define MUX_PB22E_TC7_WO0               _L_(4)
+#define PINMUX_PB22E_TC7_WO0       ((PIN_PB22E_TC7_WO0 << 16) | MUX_PB22E_TC7_WO0)
+#define PORT_PB22E_TC7_WO0     (_UL(1) << 22)
+#define PIN_PB23E_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux E */
+#define MUX_PB23E_TC7_WO1               _L_(4)
+#define PINMUX_PB23E_TC7_WO1       ((PIN_PB23E_TC7_WO1 << 16) | MUX_PB23E_TC7_WO1)
+#define PORT_PB23E_TC7_WO1     (_UL(1) << 23)
 /* ========== PORT definition for ADC peripheral ========== */
-#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
-#define MUX_PB08B_ADC_AIN2                 1L
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
 #define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
-#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
-#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
-#define MUX_PB09B_ADC_AIN3                 1L
+#define PORT_PB08B_ADC_AIN2    (_UL(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
 #define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
-#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
-#define PIN_PA04B_ADC_AIN4                 4L  /**< \brief ADC signal: AIN4 on PA04 mux B */
-#define MUX_PA04B_ADC_AIN4                 1L
+#define PORT_PB09B_ADC_AIN3    (_UL(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
 #define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
-#define PORT_PA04B_ADC_AIN4        (1ul <<  4)
-#define PIN_PA05B_ADC_AIN5                 5L  /**< \brief ADC signal: AIN5 on PA05 mux B */
-#define MUX_PA05B_ADC_AIN5                 1L
+#define PORT_PA04B_ADC_AIN4    (_UL(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
 #define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
-#define PORT_PA05B_ADC_AIN5        (1ul <<  5)
-#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
-#define MUX_PA06B_ADC_AIN6                 1L
+#define PORT_PA05B_ADC_AIN5    (_UL(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
 #define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
-#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
-#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
-#define MUX_PA07B_ADC_AIN7                 1L
+#define PORT_PA06B_ADC_AIN6    (_UL(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
 #define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
-#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
-#define PIN_PB00B_ADC_AIN8                32L  /**< \brief ADC signal: AIN8 on PB00 mux B */
-#define MUX_PB00B_ADC_AIN8                 1L
+#define PORT_PA07B_ADC_AIN7    (_UL(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
 #define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
-#define PORT_PB00B_ADC_AIN8        (1ul <<  0)
-#define PIN_PB02B_ADC_AIN10               34L  /**< \brief ADC signal: AIN10 on PB02 mux B */
-#define MUX_PB02B_ADC_AIN10                1L
+#define PORT_PB00B_ADC_AIN8    (_UL(1) <<  0)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
 #define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
-#define PORT_PB02B_ADC_AIN10       (1ul <<  2)
-#define PIN_PB03B_ADC_AIN11               35L  /**< \brief ADC signal: AIN11 on PB03 mux B */
-#define MUX_PB03B_ADC_AIN11                1L
+#define PORT_PB02B_ADC_AIN10   (_UL(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
 #define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
-#define PORT_PB03B_ADC_AIN11       (1ul <<  3)
-#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
-#define MUX_PA08B_ADC_AIN16                1L
+#define PORT_PB03B_ADC_AIN11   (_UL(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
 #define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
-#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
-#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
-#define MUX_PA09B_ADC_AIN17                1L
+#define PORT_PA08B_ADC_AIN16   (_UL(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
 #define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
-#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
-#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
-#define MUX_PA10B_ADC_AIN18                1L
+#define PORT_PA09B_ADC_AIN17   (_UL(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
 #define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
-#define PORT_PA10B_ADC_AIN18       (1ul << 10)
-#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
-#define MUX_PA11B_ADC_AIN19                1L
+#define PORT_PA10B_ADC_AIN18   (_UL(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
 #define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
-#define PORT_PA11B_ADC_AIN19       (1ul << 11)
-#define PIN_PA04B_ADC_VREFP                4L  /**< \brief ADC signal: VREFP on PA04 mux B */
-#define MUX_PA04B_ADC_VREFP                1L
+#define PORT_PA11B_ADC_AIN19   (_UL(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
 #define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
-#define PORT_PA04B_ADC_VREFP       (1ul <<  4)
+#define PORT_PA04B_ADC_VREFP   (_UL(1) <<  4)
 /* ========== PORT definition for AC peripheral ========== */
-#define PIN_PA04B_AC_AIN0                  4L  /**< \brief AC signal: AIN0 on PA04 mux B */
-#define MUX_PA04B_AC_AIN0                  1L
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
 #define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
-#define PORT_PA04B_AC_AIN0         (1ul <<  4)
-#define PIN_PA05B_AC_AIN1                  5L  /**< \brief AC signal: AIN1 on PA05 mux B */
-#define MUX_PA05B_AC_AIN1                  1L
+#define PORT_PA04B_AC_AIN0     (_UL(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
 #define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
-#define PORT_PA05B_AC_AIN1         (1ul <<  5)
-#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
-#define MUX_PA06B_AC_AIN2                  1L
+#define PORT_PA05B_AC_AIN1     (_UL(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
 #define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
-#define PORT_PA06B_AC_AIN2         (1ul <<  6)
-#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
-#define MUX_PA07B_AC_AIN3                  1L
+#define PORT_PA06B_AC_AIN2     (_UL(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
 #define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
-#define PORT_PA07B_AC_AIN3         (1ul <<  7)
-#define PIN_PA12H_AC_CMP0                 12L  /**< \brief AC signal: CMP0 on PA12 mux H */
-#define MUX_PA12H_AC_CMP0                  7L
+#define PORT_PA07B_AC_AIN3     (_UL(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
 #define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
-#define PORT_PA12H_AC_CMP0         (1ul << 12)
-#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
-#define MUX_PA18H_AC_CMP0                  7L
+#define PORT_PA12H_AC_CMP0     (_UL(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
 #define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
-#define PORT_PA18H_AC_CMP0         (1ul << 18)
-#define PIN_PA13H_AC_CMP1                 13L  /**< \brief AC signal: CMP1 on PA13 mux H */
-#define MUX_PA13H_AC_CMP1                  7L
+#define PORT_PA18H_AC_CMP0     (_UL(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
 #define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
-#define PORT_PA13H_AC_CMP1         (1ul << 13)
-#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
-#define MUX_PA19H_AC_CMP1                  7L
+#define PORT_PA13H_AC_CMP1     (_UL(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
 #define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
-#define PORT_PA19H_AC_CMP1         (1ul << 19)
+#define PORT_PA19H_AC_CMP1     (_UL(1) << 19)
 /* ========== PORT definition for RFCTRL peripheral ========== */
-#define PIN_PA08F_RFCTRL_FECTRL0           8L  /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
-#define MUX_PA08F_RFCTRL_FECTRL0           5L
+#define PIN_PA08F_RFCTRL_FECTRL0        _L_(8) /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
+#define MUX_PA08F_RFCTRL_FECTRL0        _L_(5)
 #define PINMUX_PA08F_RFCTRL_FECTRL0  ((PIN_PA08F_RFCTRL_FECTRL0 << 16) | MUX_PA08F_RFCTRL_FECTRL0)
-#define PORT_PA08F_RFCTRL_FECTRL0  (1ul <<  8)
-#define PIN_PA09F_RFCTRL_FECTRL1           9L  /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
-#define MUX_PA09F_RFCTRL_FECTRL1           5L
+#define PORT_PA08F_RFCTRL_FECTRL0  (_UL(1) <<  8)
+#define PIN_PA09F_RFCTRL_FECTRL1        _L_(9) /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
+#define MUX_PA09F_RFCTRL_FECTRL1        _L_(5)
 #define PINMUX_PA09F_RFCTRL_FECTRL1  ((PIN_PA09F_RFCTRL_FECTRL1 << 16) | MUX_PA09F_RFCTRL_FECTRL1)
-#define PORT_PA09F_RFCTRL_FECTRL1  (1ul <<  9)
-#define PIN_PA12F_RFCTRL_FECTRL2          12L  /**< \brief RFCTRL signal: FECTRL2 on PA12 mux F */
-#define MUX_PA12F_RFCTRL_FECTRL2           5L
+#define PORT_PA09F_RFCTRL_FECTRL1  (_UL(1) <<  9)
+#define PIN_PA12F_RFCTRL_FECTRL2       _L_(12) /**< \brief RFCTRL signal: FECTRL2 on PA12 mux F */
+#define MUX_PA12F_RFCTRL_FECTRL2        _L_(5)
 #define PINMUX_PA12F_RFCTRL_FECTRL2  ((PIN_PA12F_RFCTRL_FECTRL2 << 16) | MUX_PA12F_RFCTRL_FECTRL2)
-#define PORT_PA12F_RFCTRL_FECTRL2  (1ul << 12)
-#define PIN_PA13F_RFCTRL_FECTRL3          13L  /**< \brief RFCTRL signal: FECTRL3 on PA13 mux F */
-#define MUX_PA13F_RFCTRL_FECTRL3           5L
+#define PORT_PA12F_RFCTRL_FECTRL2  (_UL(1) << 12)
+#define PIN_PA13F_RFCTRL_FECTRL3       _L_(13) /**< \brief RFCTRL signal: FECTRL3 on PA13 mux F */
+#define MUX_PA13F_RFCTRL_FECTRL3        _L_(5)
 #define PINMUX_PA13F_RFCTRL_FECTRL3  ((PIN_PA13F_RFCTRL_FECTRL3 << 16) | MUX_PA13F_RFCTRL_FECTRL3)
-#define PORT_PA13F_RFCTRL_FECTRL3  (1ul << 13)
-#define PIN_PA14F_RFCTRL_FECTRL4          14L  /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
-#define MUX_PA14F_RFCTRL_FECTRL4           5L
+#define PORT_PA13F_RFCTRL_FECTRL3  (_UL(1) << 13)
+#define PIN_PA14F_RFCTRL_FECTRL4       _L_(14) /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
+#define MUX_PA14F_RFCTRL_FECTRL4        _L_(5)
 #define PINMUX_PA14F_RFCTRL_FECTRL4  ((PIN_PA14F_RFCTRL_FECTRL4 << 16) | MUX_PA14F_RFCTRL_FECTRL4)
-#define PORT_PA14F_RFCTRL_FECTRL4  (1ul << 14)
-#define PIN_PA15F_RFCTRL_FECTRL5          15L  /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
-#define MUX_PA15F_RFCTRL_FECTRL5           5L
+#define PORT_PA14F_RFCTRL_FECTRL4  (_UL(1) << 14)
+#define PIN_PA15F_RFCTRL_FECTRL5       _L_(15) /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
+#define MUX_PA15F_RFCTRL_FECTRL5        _L_(5)
 #define PINMUX_PA15F_RFCTRL_FECTRL5  ((PIN_PA15F_RFCTRL_FECTRL5 << 16) | MUX_PA15F_RFCTRL_FECTRL5)
-#define PORT_PA15F_RFCTRL_FECTRL5  (1ul << 15)
+#define PORT_PA15F_RFCTRL_FECTRL5  (_UL(1) << 15)
 
 #endif /* _SAMR21G17A_PIO_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/pio/samr21g18a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/pio/samr21g18a.h
@@ -3,39 +3,24 @@
  *
  * \brief Peripheral I/O description for SAMR21G18A
  *
- * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2017 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -45,884 +30,957 @@
 #define _SAMR21G18A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define PORT_PA00                 (1ul <<  0) /**< \brief PORT Mask  for PA00 */
+#define PORT_PA00              (_UL(1) <<  0) /**< \brief PORT Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define PORT_PA01                 (1ul <<  1) /**< \brief PORT Mask  for PA01 */
+#define PORT_PA01              (_UL(1) <<  1) /**< \brief PORT Mask  for PA01 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define PORT_PA04                 (1ul <<  4) /**< \brief PORT Mask  for PA04 */
+#define PORT_PA04              (_UL(1) <<  4) /**< \brief PORT Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define PORT_PA05                 (1ul <<  5) /**< \brief PORT Mask  for PA05 */
+#define PORT_PA05              (_UL(1) <<  5) /**< \brief PORT Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PORT_PA06              (_UL(1) <<  6) /**< \brief PORT Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PORT_PA07              (_UL(1) <<  7) /**< \brief PORT Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PORT_PA08              (_UL(1) <<  8) /**< \brief PORT Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PORT_PA09              (_UL(1) <<  9) /**< \brief PORT Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PORT_PA10              (_UL(1) << 10) /**< \brief PORT Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PORT_PA11              (_UL(1) << 11) /**< \brief PORT Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define PORT_PA12                 (1ul << 12) /**< \brief PORT Mask  for PA12 */
+#define PORT_PA12              (_UL(1) << 12) /**< \brief PORT Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define PORT_PA13                 (1ul << 13) /**< \brief PORT Mask  for PA13 */
+#define PORT_PA13              (_UL(1) << 13) /**< \brief PORT Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PORT_PA14              (_UL(1) << 14) /**< \brief PORT Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PORT_PA15              (_UL(1) << 15) /**< \brief PORT Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PORT_PA16              (_UL(1) << 16) /**< \brief PORT Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PORT_PA17              (_UL(1) << 17) /**< \brief PORT Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PORT_PA18              (_UL(1) << 18) /**< \brief PORT Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PORT_PA19              (_UL(1) << 19) /**< \brief PORT Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PORT_PA20              (_UL(1) << 20) /**< \brief PORT Mask  for PA20 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define PORT_PA22                 (1ul << 22) /**< \brief PORT Mask  for PA22 */
+#define PORT_PA22              (_UL(1) << 22) /**< \brief PORT Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define PORT_PA23                 (1ul << 23) /**< \brief PORT Mask  for PA23 */
+#define PORT_PA23              (_UL(1) << 23) /**< \brief PORT Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PORT_PA24              (_UL(1) << 24) /**< \brief PORT Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PORT_PA25              (_UL(1) << 25) /**< \brief PORT Mask  for PA25 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PORT_PA27              (_UL(1) << 27) /**< \brief PORT Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define PORT_PA28                 (1ul << 28) /**< \brief PORT Mask  for PA28 */
+#define PORT_PA28              (_UL(1) << 28) /**< \brief PORT Mask  for PA28 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PORT_PA30              (_UL(1) << 30) /**< \brief PORT Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PORT_PA31              (_UL(1) << 31) /**< \brief PORT Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define PORT_PB00                 (1ul <<  0) /**< \brief PORT Mask  for PB00 */
+#define PORT_PB00              (_UL(1) <<  0) /**< \brief PORT Mask  for PB00 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define PORT_PB02                 (1ul <<  2) /**< \brief PORT Mask  for PB02 */
+#define PORT_PB02              (_UL(1) <<  2) /**< \brief PORT Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define PORT_PB03                 (1ul <<  3) /**< \brief PORT Mask  for PB03 */
+#define PORT_PB03              (_UL(1) <<  3) /**< \brief PORT Mask  for PB03 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PORT_PB08              (_UL(1) <<  8) /**< \brief PORT Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PORT_PB09              (_UL(1) <<  9) /**< \brief PORT Mask  for PB09 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define PORT_PB14                 (1ul << 14) /**< \brief PORT Mask  for PB14 */
+#define PORT_PB14              (_UL(1) << 14) /**< \brief PORT Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define PORT_PB15                 (1ul << 15) /**< \brief PORT Mask  for PB15 */
+#define PORT_PB15              (_UL(1) << 15) /**< \brief PORT Mask  for PB15 */
 #define PIN_PB16                          48  /**< \brief Pin Number for PB16 */
-#define PORT_PB16                 (1ul << 16) /**< \brief PORT Mask  for PB16 */
+#define PORT_PB16              (_UL(1) << 16) /**< \brief PORT Mask  for PB16 */
 #define PIN_PB17                          49  /**< \brief Pin Number for PB17 */
-#define PORT_PB17                 (1ul << 17) /**< \brief PORT Mask  for PB17 */
+#define PORT_PB17              (_UL(1) << 17) /**< \brief PORT Mask  for PB17 */
 #define PIN_PB22                          54  /**< \brief Pin Number for PB22 */
-#define PORT_PB22                 (1ul << 22) /**< \brief PORT Mask  for PB22 */
+#define PORT_PB22              (_UL(1) << 22) /**< \brief PORT Mask  for PB22 */
 #define PIN_PB23                          55  /**< \brief Pin Number for PB23 */
-#define PORT_PB23                 (1ul << 23) /**< \brief PORT Mask  for PB23 */
+#define PORT_PB23              (_UL(1) << 23) /**< \brief PORT Mask  for PB23 */
 #define PIN_PB30                          62  /**< \brief Pin Number for PB30 */
-#define PORT_PB30                 (1ul << 30) /**< \brief PORT Mask  for PB30 */
+#define PORT_PB30              (_UL(1) << 30) /**< \brief PORT Mask  for PB30 */
 #define PIN_PB31                          63  /**< \brief Pin Number for PB31 */
-#define PORT_PB31                 (1ul << 31) /**< \brief PORT Mask  for PB31 */
+#define PORT_PB31              (_UL(1) << 31) /**< \brief PORT Mask  for PB31 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define PORT_PC16                 (1ul << 16) /**< \brief PORT Mask  for PC16 */
+#define PORT_PC16              (_UL(1) << 16) /**< \brief PORT Mask  for PC16 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define PORT_PC18                 (1ul << 18) /**< \brief PORT Mask  for PC18 */
+#define PORT_PC18              (_UL(1) << 18) /**< \brief PORT Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define PORT_PC19                 (1ul << 19) /**< \brief PORT Mask  for PC19 */
+#define PORT_PC19              (_UL(1) << 19) /**< \brief PORT Mask  for PC19 */
 /* ========== PORT definition for GCLK peripheral ========== */
-#define PIN_PB14H_GCLK_IO0                46L  /**< \brief GCLK signal: IO0 on PB14 mux H */
-#define MUX_PB14H_GCLK_IO0                 7L
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
 #define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
-#define PORT_PB14H_GCLK_IO0        (1ul << 14)
-#define PIN_PB22H_GCLK_IO0                54L  /**< \brief GCLK signal: IO0 on PB22 mux H */
-#define MUX_PB22H_GCLK_IO0                 7L
+#define PORT_PB14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
 #define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
-#define PORT_PB22H_GCLK_IO0        (1ul << 22)
-#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
-#define MUX_PA14H_GCLK_IO0                 7L
+#define PORT_PB22H_GCLK_IO0    (_UL(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
 #define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
-#define PORT_PA14H_GCLK_IO0        (1ul << 14)
-#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
-#define MUX_PA27H_GCLK_IO0                 7L
+#define PORT_PA14H_GCLK_IO0    (_UL(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
 #define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
-#define PORT_PA27H_GCLK_IO0        (1ul << 27)
-#define PIN_PA28H_GCLK_IO0                28L  /**< \brief GCLK signal: IO0 on PA28 mux H */
-#define MUX_PA28H_GCLK_IO0                 7L
+#define PORT_PA27H_GCLK_IO0    (_UL(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
 #define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
-#define PORT_PA28H_GCLK_IO0        (1ul << 28)
-#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
-#define MUX_PA30H_GCLK_IO0                 7L
+#define PORT_PA28H_GCLK_IO0    (_UL(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
 #define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
-#define PORT_PA30H_GCLK_IO0        (1ul << 30)
-#define PIN_PB15H_GCLK_IO1                47L  /**< \brief GCLK signal: IO1 on PB15 mux H */
-#define MUX_PB15H_GCLK_IO1                 7L
+#define PORT_PA30H_GCLK_IO0    (_UL(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
 #define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
-#define PORT_PB15H_GCLK_IO1        (1ul << 15)
-#define PIN_PB23H_GCLK_IO1                55L  /**< \brief GCLK signal: IO1 on PB23 mux H */
-#define MUX_PB23H_GCLK_IO1                 7L
+#define PORT_PB15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
 #define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
-#define PORT_PB23H_GCLK_IO1        (1ul << 23)
-#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
-#define MUX_PA15H_GCLK_IO1                 7L
+#define PORT_PB23H_GCLK_IO1    (_UL(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
 #define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
-#define PORT_PA15H_GCLK_IO1        (1ul << 15)
-#define PIN_PC16F_GCLK_IO1                80L  /**< \brief GCLK signal: IO1 on PC16 mux F */
-#define MUX_PC16F_GCLK_IO1                 5L
+#define PORT_PA15H_GCLK_IO1    (_UL(1) << 15)
+#define PIN_PC16F_GCLK_IO1             _L_(80) /**< \brief GCLK signal: IO1 on PC16 mux F */
+#define MUX_PC16F_GCLK_IO1              _L_(5)
 #define PINMUX_PC16F_GCLK_IO1      ((PIN_PC16F_GCLK_IO1 << 16) | MUX_PC16F_GCLK_IO1)
-#define PORT_PC16F_GCLK_IO1        (1ul << 16)
-#define PIN_PB16H_GCLK_IO2                48L  /**< \brief GCLK signal: IO2 on PB16 mux H */
-#define MUX_PB16H_GCLK_IO2                 7L
+#define PORT_PC16F_GCLK_IO1    (_UL(1) << 16)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
 #define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
-#define PORT_PB16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
-#define MUX_PA16H_GCLK_IO2                 7L
+#define PORT_PB16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
 #define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
-#define PORT_PA16H_GCLK_IO2        (1ul << 16)
-#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
-#define MUX_PA17H_GCLK_IO3                 7L
+#define PORT_PA16H_GCLK_IO2    (_UL(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
 #define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
-#define PORT_PA17H_GCLK_IO3        (1ul << 17)
-#define PIN_PB17H_GCLK_IO3                49L  /**< \brief GCLK signal: IO3 on PB17 mux H */
-#define MUX_PB17H_GCLK_IO3                 7L
+#define PORT_PA17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
 #define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
-#define PORT_PB17H_GCLK_IO3        (1ul << 17)
-#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
-#define MUX_PA10H_GCLK_IO4                 7L
+#define PORT_PB17H_GCLK_IO3    (_UL(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
 #define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
-#define PORT_PA10H_GCLK_IO4        (1ul << 10)
-#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
-#define MUX_PA20H_GCLK_IO4                 7L
+#define PORT_PA10H_GCLK_IO4    (_UL(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
 #define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
-#define PORT_PA20H_GCLK_IO4        (1ul << 20)
-#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
-#define MUX_PA11H_GCLK_IO5                 7L
+#define PORT_PA20H_GCLK_IO4    (_UL(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
 #define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
-#define PORT_PA11H_GCLK_IO5        (1ul << 11)
-#define PIN_PA22H_GCLK_IO6                22L  /**< \brief GCLK signal: IO6 on PA22 mux H */
-#define MUX_PA22H_GCLK_IO6                 7L
+#define PORT_PA11H_GCLK_IO5    (_UL(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
 #define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
-#define PORT_PA22H_GCLK_IO6        (1ul << 22)
-#define PIN_PA23H_GCLK_IO7                23L  /**< \brief GCLK signal: IO7 on PA23 mux H */
-#define MUX_PA23H_GCLK_IO7                 7L
+#define PORT_PA22H_GCLK_IO6    (_UL(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
 #define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
-#define PORT_PA23H_GCLK_IO7        (1ul << 23)
+#define PORT_PA23H_GCLK_IO7    (_UL(1) << 23)
 /* ========== PORT definition for EIC peripheral ========== */
-#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
-#define MUX_PA16A_EIC_EXTINT0              0L
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
-#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PB00A_EIC_EXTINT0             32L  /**< \brief EIC signal: EXTINT0 on PB00 mux A */
-#define MUX_PB00A_EIC_EXTINT0              0L
+#define PORT_PA16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
-#define PORT_PB00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PB16A_EIC_EXTINT0             48L  /**< \brief EIC signal: EXTINT0 on PB16 mux A */
-#define MUX_PB16A_EIC_EXTINT0              0L
+#define PORT_PB00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
-#define PORT_PB16A_EIC_EXTINT0     (1ul << 16)
-#define PIN_PA00A_EIC_EXTINT0              0L  /**< \brief EIC signal: EXTINT0 on PA00 mux A */
-#define MUX_PA00A_EIC_EXTINT0              0L
+#define PORT_PB16A_EIC_EXTINT0  (_UL(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
 #define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
-#define PORT_PA00A_EIC_EXTINT0     (1ul <<  0)
-#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
-#define MUX_PA17A_EIC_EXTINT1              0L
+#define PORT_PA00A_EIC_EXTINT0  (_UL(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
-#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PB17A_EIC_EXTINT1             49L  /**< \brief EIC signal: EXTINT1 on PB17 mux A */
-#define MUX_PB17A_EIC_EXTINT1              0L
+#define PORT_PA17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
-#define PORT_PB17A_EIC_EXTINT1     (1ul << 17)
-#define PIN_PA01A_EIC_EXTINT1              1L  /**< \brief EIC signal: EXTINT1 on PA01 mux A */
-#define MUX_PA01A_EIC_EXTINT1              0L
+#define PORT_PB17A_EIC_EXTINT1  (_UL(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
 #define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
-#define PORT_PA01A_EIC_EXTINT1     (1ul <<  1)
-#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
-#define MUX_PA18A_EIC_EXTINT2              0L
+#define PORT_PA01A_EIC_EXTINT1  (_UL(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
-#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
-#define PIN_PB02A_EIC_EXTINT2             34L  /**< \brief EIC signal: EXTINT2 on PB02 mux A */
-#define MUX_PB02A_EIC_EXTINT2              0L
+#define PORT_PA18A_EIC_EXTINT2  (_UL(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
 #define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
-#define PORT_PB02A_EIC_EXTINT2     (1ul <<  2)
-#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
-#define MUX_PA19A_EIC_EXTINT3              0L
+#define PORT_PB02A_EIC_EXTINT2  (_UL(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
-#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
-#define PIN_PB03A_EIC_EXTINT3             35L  /**< \brief EIC signal: EXTINT3 on PB03 mux A */
-#define MUX_PB03A_EIC_EXTINT3              0L
+#define PORT_PA19A_EIC_EXTINT3  (_UL(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
 #define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
-#define PORT_PB03A_EIC_EXTINT3     (1ul <<  3)
-#define PIN_PA04A_EIC_EXTINT4              4L  /**< \brief EIC signal: EXTINT4 on PA04 mux A */
-#define MUX_PA04A_EIC_EXTINT4              0L
+#define PORT_PB03A_EIC_EXTINT3  (_UL(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
-#define PORT_PA04A_EIC_EXTINT4     (1ul <<  4)
-#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
-#define MUX_PA20A_EIC_EXTINT4              0L
+#define PORT_PA04A_EIC_EXTINT4  (_UL(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
 #define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
-#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
-#define PIN_PA05A_EIC_EXTINT5              5L  /**< \brief EIC signal: EXTINT5 on PA05 mux A */
-#define MUX_PA05A_EIC_EXTINT5              0L
+#define PORT_PA20A_EIC_EXTINT4  (_UL(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
 #define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
-#define PORT_PA05A_EIC_EXTINT5     (1ul <<  5)
-#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
-#define MUX_PA06A_EIC_EXTINT6              0L
+#define PORT_PA05A_EIC_EXTINT5  (_UL(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
-#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
-#define PIN_PA22A_EIC_EXTINT6             22L  /**< \brief EIC signal: EXTINT6 on PA22 mux A */
-#define MUX_PA22A_EIC_EXTINT6              0L
+#define PORT_PA06A_EIC_EXTINT6  (_UL(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
-#define PORT_PA22A_EIC_EXTINT6     (1ul << 22)
-#define PIN_PB22A_EIC_EXTINT6             54L  /**< \brief EIC signal: EXTINT6 on PB22 mux A */
-#define MUX_PB22A_EIC_EXTINT6              0L
+#define PORT_PA22A_EIC_EXTINT6  (_UL(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
 #define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
-#define PORT_PB22A_EIC_EXTINT6     (1ul << 22)
-#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
-#define MUX_PA07A_EIC_EXTINT7              0L
+#define PORT_PB22A_EIC_EXTINT6  (_UL(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
-#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
-#define PIN_PA23A_EIC_EXTINT7             23L  /**< \brief EIC signal: EXTINT7 on PA23 mux A */
-#define MUX_PA23A_EIC_EXTINT7              0L
+#define PORT_PA07A_EIC_EXTINT7  (_UL(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
-#define PORT_PA23A_EIC_EXTINT7     (1ul << 23)
-#define PIN_PB23A_EIC_EXTINT7             55L  /**< \brief EIC signal: EXTINT7 on PB23 mux A */
-#define MUX_PB23A_EIC_EXTINT7              0L
+#define PORT_PA23A_EIC_EXTINT7  (_UL(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
 #define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
-#define PORT_PB23A_EIC_EXTINT7     (1ul << 23)
-#define PIN_PA28A_EIC_EXTINT8             28L  /**< \brief EIC signal: EXTINT8 on PA28 mux A */
-#define MUX_PA28A_EIC_EXTINT8              0L
+#define PORT_PB23A_EIC_EXTINT7  (_UL(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
-#define PORT_PA28A_EIC_EXTINT8     (1ul << 28)
-#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
-#define MUX_PB08A_EIC_EXTINT8              0L
+#define PORT_PA28A_EIC_EXTINT8  (_UL(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
 #define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
-#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
-#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
-#define MUX_PA09A_EIC_EXTINT9              0L
+#define PORT_PB08A_EIC_EXTINT8  (_UL(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
-#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
-#define MUX_PB09A_EIC_EXTINT9              0L
+#define PORT_PA09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
 #define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
-#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
-#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
-#define MUX_PA10A_EIC_EXTINT10             0L
+#define PORT_PB09A_EIC_EXTINT9  (_UL(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
-#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
-#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
-#define MUX_PA30A_EIC_EXTINT10             0L
+#define PORT_PA10A_EIC_EXTINT10  (_UL(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
 #define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
-#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
-#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
-#define MUX_PA11A_EIC_EXTINT11             0L
+#define PORT_PA30A_EIC_EXTINT10  (_UL(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
-#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
-#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
-#define MUX_PA31A_EIC_EXTINT11             0L
+#define PORT_PA11A_EIC_EXTINT11  (_UL(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
 #define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
-#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
-#define PIN_PA12A_EIC_EXTINT12            12L  /**< \brief EIC signal: EXTINT12 on PA12 mux A */
-#define MUX_PA12A_EIC_EXTINT12             0L
+#define PORT_PA31A_EIC_EXTINT11  (_UL(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
-#define PORT_PA12A_EIC_EXTINT12    (1ul << 12)
-#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
-#define MUX_PA24A_EIC_EXTINT12             0L
+#define PORT_PA12A_EIC_EXTINT12  (_UL(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
 #define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
-#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
-#define PIN_PA13A_EIC_EXTINT13            13L  /**< \brief EIC signal: EXTINT13 on PA13 mux A */
-#define MUX_PA13A_EIC_EXTINT13             0L
+#define PORT_PA24A_EIC_EXTINT12  (_UL(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
-#define PORT_PA13A_EIC_EXTINT13    (1ul << 13)
-#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
-#define MUX_PA25A_EIC_EXTINT13             0L
+#define PORT_PA13A_EIC_EXTINT13  (_UL(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
 #define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
-#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
-#define PIN_PB14A_EIC_EXTINT14            46L  /**< \brief EIC signal: EXTINT14 on PB14 mux A */
-#define MUX_PB14A_EIC_EXTINT14             0L
+#define PORT_PA25A_EIC_EXTINT13  (_UL(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
-#define PORT_PB14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PB30A_EIC_EXTINT14            62L  /**< \brief EIC signal: EXTINT14 on PB30 mux A */
-#define MUX_PB30A_EIC_EXTINT14             0L
+#define PORT_PB14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
-#define PORT_PB30A_EIC_EXTINT14    (1ul << 30)
-#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
-#define MUX_PA14A_EIC_EXTINT14             0L
+#define PORT_PB30A_EIC_EXTINT14  (_UL(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
 #define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
-#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
-#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
-#define MUX_PA15A_EIC_EXTINT15             0L
+#define PORT_PA14A_EIC_EXTINT14  (_UL(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
-#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
-#define MUX_PA27A_EIC_EXTINT15             0L
+#define PORT_PA15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
-#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
-#define PIN_PB15A_EIC_EXTINT15            47L  /**< \brief EIC signal: EXTINT15 on PB15 mux A */
-#define MUX_PB15A_EIC_EXTINT15             0L
+#define PORT_PA27A_EIC_EXTINT15  (_UL(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
-#define PORT_PB15A_EIC_EXTINT15    (1ul << 15)
-#define PIN_PB31A_EIC_EXTINT15            63L  /**< \brief EIC signal: EXTINT15 on PB31 mux A */
-#define MUX_PB31A_EIC_EXTINT15             0L
+#define PORT_PB15A_EIC_EXTINT15  (_UL(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
 #define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
-#define PORT_PB31A_EIC_EXTINT15    (1ul << 31)
-#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
-#define MUX_PA08A_EIC_NMI                  0L
+#define PORT_PB31A_EIC_EXTINT15  (_UL(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
 #define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
-#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+#define PORT_PA08A_EIC_NMI     (_UL(1) <<  8)
 /* ========== PORT definition for USB peripheral ========== */
-#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
-#define MUX_PA24G_USB_DM                   6L
+#define PIN_PA24G_USB_DM               _L_(24) /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                _L_(6)
 #define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
-#define PORT_PA24G_USB_DM          (1ul << 24)
-#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
-#define MUX_PA25G_USB_DP                   6L
+#define PORT_PA24G_USB_DM      (_UL(1) << 24)
+#define PIN_PA25G_USB_DP               _L_(25) /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                _L_(6)
 #define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
-#define PORT_PA25G_USB_DP          (1ul << 25)
-#define PIN_PA23G_USB_SOF_1KHZ            23L  /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
-#define MUX_PA23G_USB_SOF_1KHZ             6L
+#define PORT_PA25G_USB_DP      (_UL(1) << 25)
+#define PIN_PA23G_USB_SOF_1KHZ         _L_(23) /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
+#define MUX_PA23G_USB_SOF_1KHZ          _L_(6)
 #define PINMUX_PA23G_USB_SOF_1KHZ  ((PIN_PA23G_USB_SOF_1KHZ << 16) | MUX_PA23G_USB_SOF_1KHZ)
-#define PORT_PA23G_USB_SOF_1KHZ    (1ul << 23)
+#define PORT_PA23G_USB_SOF_1KHZ  (_UL(1) << 23)
 /* ========== PORT definition for SERCOM0 peripheral ========== */
-#define PIN_PA04D_SERCOM0_PAD0             4L  /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
-#define MUX_PA04D_SERCOM0_PAD0             3L
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
 #define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
-#define PORT_PA04D_SERCOM0_PAD0    (1ul <<  4)
-#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
-#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PORT_PA04D_SERCOM0_PAD0  (_UL(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
 #define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
-#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
-#define PIN_PA05D_SERCOM0_PAD1             5L  /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
-#define MUX_PA05D_SERCOM0_PAD1             3L
+#define PORT_PA08C_SERCOM0_PAD0  (_UL(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
 #define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
-#define PORT_PA05D_SERCOM0_PAD1    (1ul <<  5)
-#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
-#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PORT_PA05D_SERCOM0_PAD1  (_UL(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
 #define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
-#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
-#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
-#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PORT_PA09C_SERCOM0_PAD1  (_UL(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
 #define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
-#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
-#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
-#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PORT_PA06D_SERCOM0_PAD2  (_UL(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
 #define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
-#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
-#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
-#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PORT_PA10C_SERCOM0_PAD2  (_UL(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
 #define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
-#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
-#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
-#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PORT_PA07D_SERCOM0_PAD3  (_UL(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
 #define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
-#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL(1) << 11)
 /* ========== PORT definition for SERCOM1 peripheral ========== */
-#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
-#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
 #define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
-#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
-#define PIN_PA00D_SERCOM1_PAD0             0L  /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
-#define MUX_PA00D_SERCOM1_PAD0             3L
+#define PORT_PA16C_SERCOM1_PAD0  (_UL(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
 #define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
-#define PORT_PA00D_SERCOM1_PAD0    (1ul <<  0)
-#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
-#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PORT_PA00D_SERCOM1_PAD0  (_UL(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
 #define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
-#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
-#define PIN_PA01D_SERCOM1_PAD1             1L  /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
-#define MUX_PA01D_SERCOM1_PAD1             3L
+#define PORT_PA17C_SERCOM1_PAD1  (_UL(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
 #define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
-#define PORT_PA01D_SERCOM1_PAD1    (1ul <<  1)
-#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
-#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PORT_PA01D_SERCOM1_PAD1  (_UL(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
 #define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
-#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
-#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
-#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PORT_PA30D_SERCOM1_PAD2  (_UL(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
 #define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
-#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
-#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
-#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PORT_PA18C_SERCOM1_PAD2  (_UL(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
 #define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
-#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
-#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
-#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PORT_PA31D_SERCOM1_PAD3  (_UL(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
 #define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
-#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL(1) << 19)
 /* ========== PORT definition for SERCOM2 peripheral ========== */
-#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
-#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
 #define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
-#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
-#define PIN_PA12C_SERCOM2_PAD0            12L  /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
-#define MUX_PA12C_SERCOM2_PAD0             2L
+#define PORT_PA08D_SERCOM2_PAD0  (_UL(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
 #define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
-#define PORT_PA12C_SERCOM2_PAD0    (1ul << 12)
-#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
-#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PORT_PA12C_SERCOM2_PAD0  (_UL(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
 #define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
-#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
-#define PIN_PA13C_SERCOM2_PAD1            13L  /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
-#define MUX_PA13C_SERCOM2_PAD1             2L
+#define PORT_PA09D_SERCOM2_PAD1  (_UL(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
 #define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
-#define PORT_PA13C_SERCOM2_PAD1    (1ul << 13)
-#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
-#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PORT_PA13C_SERCOM2_PAD1  (_UL(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
 #define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
-#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
-#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
-#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PORT_PA10D_SERCOM2_PAD2  (_UL(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
 #define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
-#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
-#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
-#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PORT_PA14C_SERCOM2_PAD2  (_UL(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
 #define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
-#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
-#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
-#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PORT_PA11D_SERCOM2_PAD3  (_UL(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
 #define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
-#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL(1) << 15)
 /* ========== PORT definition for SERCOM3 peripheral ========== */
-#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
-#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
 #define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
-#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
-#define PIN_PA22C_SERCOM3_PAD0            22L  /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
-#define MUX_PA22C_SERCOM3_PAD0             2L
+#define PORT_PA16D_SERCOM3_PAD0  (_UL(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
 #define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
-#define PORT_PA22C_SERCOM3_PAD0    (1ul << 22)
-#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
-#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PORT_PA22C_SERCOM3_PAD0  (_UL(1) << 22)
+#define PIN_PA27F_SERCOM3_PAD0         _L_(27) /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0          _L_(5)
 #define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
-#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
-#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
-#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PORT_PA27F_SERCOM3_PAD0  (_UL(1) << 27)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
 #define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
-#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
-#define PIN_PA23C_SERCOM3_PAD1            23L  /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
-#define MUX_PA23C_SERCOM3_PAD1             2L
+#define PORT_PA17D_SERCOM3_PAD1  (_UL(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
 #define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
-#define PORT_PA23C_SERCOM3_PAD1    (1ul << 23)
-#define PIN_PA28F_SERCOM3_PAD1            28L  /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
-#define MUX_PA28F_SERCOM3_PAD1             5L
+#define PORT_PA23C_SERCOM3_PAD1  (_UL(1) << 23)
+#define PIN_PA28F_SERCOM3_PAD1         _L_(28) /**< \brief SERCOM3 signal: PAD1 on PA28 mux F */
+#define MUX_PA28F_SERCOM3_PAD1          _L_(5)
 #define PINMUX_PA28F_SERCOM3_PAD1  ((PIN_PA28F_SERCOM3_PAD1 << 16) | MUX_PA28F_SERCOM3_PAD1)
-#define PORT_PA28F_SERCOM3_PAD1    (1ul << 28)
-#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
-#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PORT_PA28F_SERCOM3_PAD1  (_UL(1) << 28)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
-#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
-#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
-#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PORT_PA18D_SERCOM3_PAD2  (_UL(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
 #define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
-#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
-#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
-#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PORT_PA20D_SERCOM3_PAD2  (_UL(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
 #define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
-#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
-#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
-#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PORT_PA24C_SERCOM3_PAD2  (_UL(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
 #define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
-#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
-#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
-#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PORT_PA19D_SERCOM3_PAD3  (_UL(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
 #define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
-#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL(1) << 25)
 /* ========== PORT definition for SERCOM4 peripheral ========== */
-#define PIN_PA12D_SERCOM4_PAD0            12L  /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
-#define MUX_PA12D_SERCOM4_PAD0             3L
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
-#define PORT_PA12D_SERCOM4_PAD0    (1ul << 12)
-#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
-#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PORT_PA12D_SERCOM4_PAD0  (_UL(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
 #define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
-#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
-#define PIN_PC19F_SERCOM4_PAD0            83L  /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
-#define MUX_PC19F_SERCOM4_PAD0             5L
+#define PORT_PB08D_SERCOM4_PAD0  (_UL(1) <<  8)
+#define PIN_PC19F_SERCOM4_PAD0         _L_(83) /**< \brief SERCOM4 signal: PAD0 on PC19 mux F */
+#define MUX_PC19F_SERCOM4_PAD0          _L_(5)
 #define PINMUX_PC19F_SERCOM4_PAD0  ((PIN_PC19F_SERCOM4_PAD0 << 16) | MUX_PC19F_SERCOM4_PAD0)
-#define PORT_PC19F_SERCOM4_PAD0    (1ul << 19)
-#define PIN_PA13D_SERCOM4_PAD1            13L  /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
-#define MUX_PA13D_SERCOM4_PAD1             3L
+#define PORT_PC19F_SERCOM4_PAD0  (_UL(1) << 19)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
-#define PORT_PA13D_SERCOM4_PAD1    (1ul << 13)
-#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
-#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PORT_PA13D_SERCOM4_PAD1  (_UL(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
 #define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
-#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
-#define PIN_PB31F_SERCOM4_PAD1            63L  /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
-#define MUX_PB31F_SERCOM4_PAD1             5L
+#define PORT_PB09D_SERCOM4_PAD1  (_UL(1) <<  9)
+#define PIN_PB31F_SERCOM4_PAD1         _L_(63) /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
+#define MUX_PB31F_SERCOM4_PAD1          _L_(5)
 #define PINMUX_PB31F_SERCOM4_PAD1  ((PIN_PB31F_SERCOM4_PAD1 << 16) | MUX_PB31F_SERCOM4_PAD1)
-#define PORT_PB31F_SERCOM4_PAD1    (1ul << 31)
-#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
-#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PORT_PB31F_SERCOM4_PAD1  (_UL(1) << 31)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
 #define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
-#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB14C_SERCOM4_PAD2            46L  /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
-#define MUX_PB14C_SERCOM4_PAD2             2L
+#define PORT_PA14D_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
 #define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
-#define PORT_PB14C_SERCOM4_PAD2    (1ul << 14)
-#define PIN_PB30F_SERCOM4_PAD2            62L  /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
-#define MUX_PB30F_SERCOM4_PAD2             5L
+#define PORT_PB14C_SERCOM4_PAD2  (_UL(1) << 14)
+#define PIN_PB30F_SERCOM4_PAD2         _L_(62) /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
+#define MUX_PB30F_SERCOM4_PAD2          _L_(5)
 #define PINMUX_PB30F_SERCOM4_PAD2  ((PIN_PB30F_SERCOM4_PAD2 << 16) | MUX_PB30F_SERCOM4_PAD2)
-#define PORT_PB30F_SERCOM4_PAD2    (1ul << 30)
-#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
-#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PORT_PB30F_SERCOM4_PAD2  (_UL(1) << 30)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
 #define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
-#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PB15C_SERCOM4_PAD3            47L  /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
-#define MUX_PB15C_SERCOM4_PAD3             2L
+#define PORT_PA15D_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
 #define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
-#define PORT_PB15C_SERCOM4_PAD3    (1ul << 15)
-#define PIN_PC18F_SERCOM4_PAD3            82L  /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
-#define MUX_PC18F_SERCOM4_PAD3             5L
+#define PORT_PB15C_SERCOM4_PAD3  (_UL(1) << 15)
+#define PIN_PC18F_SERCOM4_PAD3         _L_(82) /**< \brief SERCOM4 signal: PAD3 on PC18 mux F */
+#define MUX_PC18F_SERCOM4_PAD3          _L_(5)
 #define PINMUX_PC18F_SERCOM4_PAD3  ((PIN_PC18F_SERCOM4_PAD3 << 16) | MUX_PC18F_SERCOM4_PAD3)
-#define PORT_PC18F_SERCOM4_PAD3    (1ul << 18)
+#define PORT_PC18F_SERCOM4_PAD3  (_UL(1) << 18)
 /* ========== PORT definition for SERCOM5 peripheral ========== */
-#define PIN_PB16C_SERCOM5_PAD0            48L  /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
-#define MUX_PB16C_SERCOM5_PAD0             2L
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
 #define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
-#define PORT_PB16C_SERCOM5_PAD0    (1ul << 16)
-#define PIN_PA22D_SERCOM5_PAD0            22L  /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
-#define MUX_PA22D_SERCOM5_PAD0             3L
+#define PORT_PB16C_SERCOM5_PAD0  (_UL(1) << 16)
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
-#define PORT_PA22D_SERCOM5_PAD0    (1ul << 22)
-#define PIN_PB02D_SERCOM5_PAD0            34L  /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
-#define MUX_PB02D_SERCOM5_PAD0             3L
+#define PORT_PA22D_SERCOM5_PAD0  (_UL(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
-#define PORT_PB02D_SERCOM5_PAD0    (1ul <<  2)
-#define PIN_PB30D_SERCOM5_PAD0            62L  /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
-#define MUX_PB30D_SERCOM5_PAD0             3L
+#define PORT_PB02D_SERCOM5_PAD0  (_UL(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
 #define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
-#define PORT_PB30D_SERCOM5_PAD0    (1ul << 30)
-#define PIN_PB17C_SERCOM5_PAD1            49L  /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
-#define MUX_PB17C_SERCOM5_PAD1             2L
+#define PORT_PB30D_SERCOM5_PAD0  (_UL(1) << 30)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
 #define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
-#define PORT_PB17C_SERCOM5_PAD1    (1ul << 17)
-#define PIN_PA23D_SERCOM5_PAD1            23L  /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
-#define MUX_PA23D_SERCOM5_PAD1             3L
+#define PORT_PB17C_SERCOM5_PAD1  (_UL(1) << 17)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
-#define PORT_PA23D_SERCOM5_PAD1    (1ul << 23)
-#define PIN_PB03D_SERCOM5_PAD1            35L  /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
-#define MUX_PB03D_SERCOM5_PAD1             3L
+#define PORT_PA23D_SERCOM5_PAD1  (_UL(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
-#define PORT_PB03D_SERCOM5_PAD1    (1ul <<  3)
-#define PIN_PB31D_SERCOM5_PAD1            63L  /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
-#define MUX_PB31D_SERCOM5_PAD1             3L
+#define PORT_PB03D_SERCOM5_PAD1  (_UL(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
 #define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
-#define PORT_PB31D_SERCOM5_PAD1    (1ul << 31)
-#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
-#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PORT_PB31D_SERCOM5_PAD1  (_UL(1) << 31)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
-#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
-#define PIN_PB00D_SERCOM5_PAD2            32L  /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
-#define MUX_PB00D_SERCOM5_PAD2             3L
+#define PORT_PA24D_SERCOM5_PAD2  (_UL(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
-#define PORT_PB00D_SERCOM5_PAD2    (1ul <<  0)
-#define PIN_PB22D_SERCOM5_PAD2            54L  /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
-#define MUX_PB22D_SERCOM5_PAD2             3L
+#define PORT_PB00D_SERCOM5_PAD2  (_UL(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
 #define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
-#define PORT_PB22D_SERCOM5_PAD2    (1ul << 22)
-#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
-#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PORT_PB22D_SERCOM5_PAD2  (_UL(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
 #define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
-#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
-#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
-#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PORT_PA20C_SERCOM5_PAD2  (_UL(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
-#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
-#define PIN_PB23D_SERCOM5_PAD3            55L  /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
-#define MUX_PB23D_SERCOM5_PAD3             3L
+#define PORT_PA25D_SERCOM5_PAD3  (_UL(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
 #define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
-#define PORT_PB23D_SERCOM5_PAD3    (1ul << 23)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL(1) << 23)
 /* ========== PORT definition for TCC0 peripheral ========== */
-#define PIN_PA04E_TCC0_WO0                 4L  /**< \brief TCC0 signal: WO0 on PA04 mux E */
-#define MUX_PA04E_TCC0_WO0                 4L
+#define PIN_PA04E_TCC0_WO0              _L_(4) /**< \brief TCC0 signal: WO0 on PA04 mux E */
+#define MUX_PA04E_TCC0_WO0              _L_(4)
 #define PINMUX_PA04E_TCC0_WO0      ((PIN_PA04E_TCC0_WO0 << 16) | MUX_PA04E_TCC0_WO0)
-#define PORT_PA04E_TCC0_WO0        (1ul <<  4)
-#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
-#define MUX_PA08E_TCC0_WO0                 4L
+#define PORT_PA04E_TCC0_WO0    (_UL(1) <<  4)
+#define PIN_PA08E_TCC0_WO0              _L_(8) /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0              _L_(4)
 #define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
-#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
-#define PIN_PB30E_TCC0_WO0                62L  /**< \brief TCC0 signal: WO0 on PB30 mux E */
-#define MUX_PB30E_TCC0_WO0                 4L
+#define PORT_PA08E_TCC0_WO0    (_UL(1) <<  8)
+#define PIN_PB30E_TCC0_WO0             _L_(62) /**< \brief TCC0 signal: WO0 on PB30 mux E */
+#define MUX_PB30E_TCC0_WO0              _L_(4)
 #define PINMUX_PB30E_TCC0_WO0      ((PIN_PB30E_TCC0_WO0 << 16) | MUX_PB30E_TCC0_WO0)
-#define PORT_PB30E_TCC0_WO0        (1ul << 30)
-#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
-#define MUX_PA16F_TCC0_WO0                 5L
+#define PORT_PB30E_TCC0_WO0    (_UL(1) << 30)
+#define PIN_PA16F_TCC0_WO0             _L_(16) /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0              _L_(5)
 #define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
-#define PORT_PA16F_TCC0_WO0        (1ul << 16)
-#define PIN_PA05E_TCC0_WO1                 5L  /**< \brief TCC0 signal: WO1 on PA05 mux E */
-#define MUX_PA05E_TCC0_WO1                 4L
+#define PORT_PA16F_TCC0_WO0    (_UL(1) << 16)
+#define PIN_PA05E_TCC0_WO1              _L_(5) /**< \brief TCC0 signal: WO1 on PA05 mux E */
+#define MUX_PA05E_TCC0_WO1              _L_(4)
 #define PINMUX_PA05E_TCC0_WO1      ((PIN_PA05E_TCC0_WO1 << 16) | MUX_PA05E_TCC0_WO1)
-#define PORT_PA05E_TCC0_WO1        (1ul <<  5)
-#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
-#define MUX_PA09E_TCC0_WO1                 4L
+#define PORT_PA05E_TCC0_WO1    (_UL(1) <<  5)
+#define PIN_PA09E_TCC0_WO1              _L_(9) /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1              _L_(4)
 #define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
-#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
-#define PIN_PB31E_TCC0_WO1                63L  /**< \brief TCC0 signal: WO1 on PB31 mux E */
-#define MUX_PB31E_TCC0_WO1                 4L
+#define PORT_PA09E_TCC0_WO1    (_UL(1) <<  9)
+#define PIN_PB31E_TCC0_WO1             _L_(63) /**< \brief TCC0 signal: WO1 on PB31 mux E */
+#define MUX_PB31E_TCC0_WO1              _L_(4)
 #define PINMUX_PB31E_TCC0_WO1      ((PIN_PB31E_TCC0_WO1 << 16) | MUX_PB31E_TCC0_WO1)
-#define PORT_PB31E_TCC0_WO1        (1ul << 31)
-#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
-#define MUX_PA17F_TCC0_WO1                 5L
+#define PORT_PB31E_TCC0_WO1    (_UL(1) << 31)
+#define PIN_PA17F_TCC0_WO1             _L_(17) /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1              _L_(5)
 #define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
-#define PORT_PA17F_TCC0_WO1        (1ul << 17)
-#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
-#define MUX_PA10F_TCC0_WO2                 5L
+#define PORT_PA17F_TCC0_WO1    (_UL(1) << 17)
+#define PIN_PA10F_TCC0_WO2             _L_(10) /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2              _L_(5)
 #define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
-#define PORT_PA10F_TCC0_WO2        (1ul << 10)
-#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
-#define MUX_PA18F_TCC0_WO2                 5L
+#define PORT_PA10F_TCC0_WO2    (_UL(1) << 10)
+#define PIN_PA18F_TCC0_WO2             _L_(18) /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2              _L_(5)
 #define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
-#define PORT_PA18F_TCC0_WO2        (1ul << 18)
-#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
-#define MUX_PA11F_TCC0_WO3                 5L
+#define PORT_PA18F_TCC0_WO2    (_UL(1) << 18)
+#define PIN_PA11F_TCC0_WO3             _L_(11) /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3              _L_(5)
 #define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
-#define PORT_PA11F_TCC0_WO3        (1ul << 11)
-#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
-#define MUX_PA19F_TCC0_WO3                 5L
+#define PORT_PA11F_TCC0_WO3    (_UL(1) << 11)
+#define PIN_PA19F_TCC0_WO3             _L_(19) /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3              _L_(5)
 #define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
-#define PORT_PA19F_TCC0_WO3        (1ul << 19)
-#define PIN_PA22F_TCC0_WO4                22L  /**< \brief TCC0 signal: WO4 on PA22 mux F */
-#define MUX_PA22F_TCC0_WO4                 5L
+#define PORT_PA19F_TCC0_WO3    (_UL(1) << 19)
+#define PIN_PA22F_TCC0_WO4             _L_(22) /**< \brief TCC0 signal: WO4 on PA22 mux F */
+#define MUX_PA22F_TCC0_WO4              _L_(5)
 #define PINMUX_PA22F_TCC0_WO4      ((PIN_PA22F_TCC0_WO4 << 16) | MUX_PA22F_TCC0_WO4)
-#define PORT_PA22F_TCC0_WO4        (1ul << 22)
-#define PIN_PB16F_TCC0_WO4                48L  /**< \brief TCC0 signal: WO4 on PB16 mux F */
-#define MUX_PB16F_TCC0_WO4                 5L
+#define PORT_PA22F_TCC0_WO4    (_UL(1) << 22)
+#define PIN_PB16F_TCC0_WO4             _L_(48) /**< \brief TCC0 signal: WO4 on PB16 mux F */
+#define MUX_PB16F_TCC0_WO4              _L_(5)
 #define PINMUX_PB16F_TCC0_WO4      ((PIN_PB16F_TCC0_WO4 << 16) | MUX_PB16F_TCC0_WO4)
-#define PORT_PB16F_TCC0_WO4        (1ul << 16)
-#define PIN_PA23F_TCC0_WO5                23L  /**< \brief TCC0 signal: WO5 on PA23 mux F */
-#define MUX_PA23F_TCC0_WO5                 5L
+#define PORT_PB16F_TCC0_WO4    (_UL(1) << 16)
+#define PIN_PA23F_TCC0_WO5             _L_(23) /**< \brief TCC0 signal: WO5 on PA23 mux F */
+#define MUX_PA23F_TCC0_WO5              _L_(5)
 #define PINMUX_PA23F_TCC0_WO5      ((PIN_PA23F_TCC0_WO5 << 16) | MUX_PA23F_TCC0_WO5)
-#define PORT_PA23F_TCC0_WO5        (1ul << 23)
-#define PIN_PB17F_TCC0_WO5                49L  /**< \brief TCC0 signal: WO5 on PB17 mux F */
-#define MUX_PB17F_TCC0_WO5                 5L
+#define PORT_PA23F_TCC0_WO5    (_UL(1) << 23)
+#define PIN_PB17F_TCC0_WO5             _L_(49) /**< \brief TCC0 signal: WO5 on PB17 mux F */
+#define MUX_PB17F_TCC0_WO5              _L_(5)
 #define PINMUX_PB17F_TCC0_WO5      ((PIN_PB17F_TCC0_WO5 << 16) | MUX_PB17F_TCC0_WO5)
-#define PORT_PB17F_TCC0_WO5        (1ul << 17)
-#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
-#define MUX_PA20F_TCC0_WO6                 5L
+#define PORT_PB17F_TCC0_WO5    (_UL(1) << 17)
+#define PIN_PA20F_TCC0_WO6             _L_(20) /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6              _L_(5)
 #define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
-#define PORT_PA20F_TCC0_WO6        (1ul << 20)
+#define PORT_PA20F_TCC0_WO6    (_UL(1) << 20)
 /* ========== PORT definition for TCC1 peripheral ========== */
-#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
-#define MUX_PA06E_TCC1_WO0                 4L
+#define PIN_PA06E_TCC1_WO0              _L_(6) /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0              _L_(4)
 #define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
-#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
-#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
-#define MUX_PA10E_TCC1_WO0                 4L
+#define PORT_PA06E_TCC1_WO0    (_UL(1) <<  6)
+#define PIN_PA10E_TCC1_WO0             _L_(10) /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0              _L_(4)
 #define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
-#define PORT_PA10E_TCC1_WO0        (1ul << 10)
-#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
-#define MUX_PA30E_TCC1_WO0                 4L
+#define PORT_PA10E_TCC1_WO0    (_UL(1) << 10)
+#define PIN_PA30E_TCC1_WO0             _L_(30) /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0              _L_(4)
 #define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
-#define PORT_PA30E_TCC1_WO0        (1ul << 30)
-#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
-#define MUX_PA07E_TCC1_WO1                 4L
+#define PORT_PA30E_TCC1_WO0    (_UL(1) << 30)
+#define PIN_PA07E_TCC1_WO1              _L_(7) /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1              _L_(4)
 #define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
-#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
-#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
-#define MUX_PA11E_TCC1_WO1                 4L
+#define PORT_PA07E_TCC1_WO1    (_UL(1) <<  7)
+#define PIN_PA11E_TCC1_WO1             _L_(11) /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1              _L_(4)
 #define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
-#define PORT_PA11E_TCC1_WO1        (1ul << 11)
-#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
-#define MUX_PA31E_TCC1_WO1                 4L
+#define PORT_PA11E_TCC1_WO1    (_UL(1) << 11)
+#define PIN_PA31E_TCC1_WO1             _L_(31) /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1              _L_(4)
 #define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
-#define PORT_PA31E_TCC1_WO1        (1ul << 31)
-#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
-#define MUX_PA24F_TCC1_WO2                 5L
+#define PORT_PA31E_TCC1_WO1    (_UL(1) << 31)
+#define PIN_PA24F_TCC1_WO2             _L_(24) /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2              _L_(5)
 #define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
-#define PORT_PA24F_TCC1_WO2        (1ul << 24)
-#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
-#define MUX_PA25F_TCC1_WO3                 5L
+#define PORT_PA24F_TCC1_WO2    (_UL(1) << 24)
+#define PIN_PA25F_TCC1_WO3             _L_(25) /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3              _L_(5)
 #define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
-#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+#define PORT_PA25F_TCC1_WO3    (_UL(1) << 25)
 /* ========== PORT definition for TCC2 peripheral ========== */
-#define PIN_PA12E_TCC2_WO0                12L  /**< \brief TCC2 signal: WO0 on PA12 mux E */
-#define MUX_PA12E_TCC2_WO0                 4L
+#define PIN_PA12E_TCC2_WO0             _L_(12) /**< \brief TCC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TCC2_WO0              _L_(4)
 #define PINMUX_PA12E_TCC2_WO0      ((PIN_PA12E_TCC2_WO0 << 16) | MUX_PA12E_TCC2_WO0)
-#define PORT_PA12E_TCC2_WO0        (1ul << 12)
-#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
-#define MUX_PA16E_TCC2_WO0                 4L
+#define PORT_PA12E_TCC2_WO0    (_UL(1) << 12)
+#define PIN_PA16E_TCC2_WO0             _L_(16) /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0              _L_(4)
 #define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
-#define PORT_PA16E_TCC2_WO0        (1ul << 16)
-#define PIN_PA00E_TCC2_WO0                 0L  /**< \brief TCC2 signal: WO0 on PA00 mux E */
-#define MUX_PA00E_TCC2_WO0                 4L
+#define PORT_PA16E_TCC2_WO0    (_UL(1) << 16)
+#define PIN_PA00E_TCC2_WO0              _L_(0) /**< \brief TCC2 signal: WO0 on PA00 mux E */
+#define MUX_PA00E_TCC2_WO0              _L_(4)
 #define PINMUX_PA00E_TCC2_WO0      ((PIN_PA00E_TCC2_WO0 << 16) | MUX_PA00E_TCC2_WO0)
-#define PORT_PA00E_TCC2_WO0        (1ul <<  0)
-#define PIN_PA13E_TCC2_WO1                13L  /**< \brief TCC2 signal: WO1 on PA13 mux E */
-#define MUX_PA13E_TCC2_WO1                 4L
+#define PORT_PA00E_TCC2_WO0    (_UL(1) <<  0)
+#define PIN_PA13E_TCC2_WO1             _L_(13) /**< \brief TCC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TCC2_WO1              _L_(4)
 #define PINMUX_PA13E_TCC2_WO1      ((PIN_PA13E_TCC2_WO1 << 16) | MUX_PA13E_TCC2_WO1)
-#define PORT_PA13E_TCC2_WO1        (1ul << 13)
-#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
-#define MUX_PA17E_TCC2_WO1                 4L
+#define PORT_PA13E_TCC2_WO1    (_UL(1) << 13)
+#define PIN_PA17E_TCC2_WO1             _L_(17) /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1              _L_(4)
 #define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
-#define PORT_PA17E_TCC2_WO1        (1ul << 17)
-#define PIN_PA01E_TCC2_WO1                 1L  /**< \brief TCC2 signal: WO1 on PA01 mux E */
-#define MUX_PA01E_TCC2_WO1                 4L
+#define PORT_PA17E_TCC2_WO1    (_UL(1) << 17)
+#define PIN_PA01E_TCC2_WO1              _L_(1) /**< \brief TCC2 signal: WO1 on PA01 mux E */
+#define MUX_PA01E_TCC2_WO1              _L_(4)
 #define PINMUX_PA01E_TCC2_WO1      ((PIN_PA01E_TCC2_WO1 << 16) | MUX_PA01E_TCC2_WO1)
-#define PORT_PA01E_TCC2_WO1        (1ul <<  1)
+#define PORT_PA01E_TCC2_WO1    (_UL(1) <<  1)
 /* ========== PORT definition for TC3 peripheral ========== */
-#define PIN_PA18E_TC3_WO0                 18L  /**< \brief TC3 signal: WO0 on PA18 mux E */
-#define MUX_PA18E_TC3_WO0                  4L
+#define PIN_PA18E_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC3_WO0               _L_(4)
 #define PINMUX_PA18E_TC3_WO0       ((PIN_PA18E_TC3_WO0 << 16) | MUX_PA18E_TC3_WO0)
-#define PORT_PA18E_TC3_WO0         (1ul << 18)
-#define PIN_PA14E_TC3_WO0                 14L  /**< \brief TC3 signal: WO0 on PA14 mux E */
-#define MUX_PA14E_TC3_WO0                  4L
+#define PORT_PA18E_TC3_WO0     (_UL(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
 #define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
-#define PORT_PA14E_TC3_WO0         (1ul << 14)
-#define PIN_PA19E_TC3_WO1                 19L  /**< \brief TC3 signal: WO1 on PA19 mux E */
-#define MUX_PA19E_TC3_WO1                  4L
+#define PORT_PA14E_TC3_WO0     (_UL(1) << 14)
+#define PIN_PA19E_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC3_WO1               _L_(4)
 #define PINMUX_PA19E_TC3_WO1       ((PIN_PA19E_TC3_WO1 << 16) | MUX_PA19E_TC3_WO1)
-#define PORT_PA19E_TC3_WO1         (1ul << 19)
-#define PIN_PA15E_TC3_WO1                 15L  /**< \brief TC3 signal: WO1 on PA15 mux E */
-#define MUX_PA15E_TC3_WO1                  4L
+#define PORT_PA19E_TC3_WO1     (_UL(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
 #define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
-#define PORT_PA15E_TC3_WO1         (1ul << 15)
+#define PORT_PA15E_TC3_WO1     (_UL(1) << 15)
 /* ========== PORT definition for TC4 peripheral ========== */
-#define PIN_PA22E_TC4_WO0                 22L  /**< \brief TC4 signal: WO0 on PA22 mux E */
-#define MUX_PA22E_TC4_WO0                  4L
+#define PIN_PA22E_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux E */
+#define MUX_PA22E_TC4_WO0               _L_(4)
 #define PINMUX_PA22E_TC4_WO0       ((PIN_PA22E_TC4_WO0 << 16) | MUX_PA22E_TC4_WO0)
-#define PORT_PA22E_TC4_WO0         (1ul << 22)
-#define PIN_PB08E_TC4_WO0                 40L  /**< \brief TC4 signal: WO0 on PB08 mux E */
-#define MUX_PB08E_TC4_WO0                  4L
+#define PORT_PA22E_TC4_WO0     (_UL(1) << 22)
+#define PIN_PB08E_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC4_WO0               _L_(4)
 #define PINMUX_PB08E_TC4_WO0       ((PIN_PB08E_TC4_WO0 << 16) | MUX_PB08E_TC4_WO0)
-#define PORT_PB08E_TC4_WO0         (1ul <<  8)
-#define PIN_PA23E_TC4_WO1                 23L  /**< \brief TC4 signal: WO1 on PA23 mux E */
-#define MUX_PA23E_TC4_WO1                  4L
+#define PORT_PB08E_TC4_WO0     (_UL(1) <<  8)
+#define PIN_PA23E_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux E */
+#define MUX_PA23E_TC4_WO1               _L_(4)
 #define PINMUX_PA23E_TC4_WO1       ((PIN_PA23E_TC4_WO1 << 16) | MUX_PA23E_TC4_WO1)
-#define PORT_PA23E_TC4_WO1         (1ul << 23)
-#define PIN_PB09E_TC4_WO1                 41L  /**< \brief TC4 signal: WO1 on PB09 mux E */
-#define MUX_PB09E_TC4_WO1                  4L
+#define PORT_PA23E_TC4_WO1     (_UL(1) << 23)
+#define PIN_PB09E_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC4_WO1               _L_(4)
 #define PINMUX_PB09E_TC4_WO1       ((PIN_PB09E_TC4_WO1 << 16) | MUX_PB09E_TC4_WO1)
-#define PORT_PB09E_TC4_WO1         (1ul <<  9)
+#define PORT_PB09E_TC4_WO1     (_UL(1) <<  9)
 /* ========== PORT definition for TC5 peripheral ========== */
-#define PIN_PA24E_TC5_WO0                 24L  /**< \brief TC5 signal: WO0 on PA24 mux E */
-#define MUX_PA24E_TC5_WO0                  4L
+#define PIN_PA24E_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC5_WO0               _L_(4)
 #define PINMUX_PA24E_TC5_WO0       ((PIN_PA24E_TC5_WO0 << 16) | MUX_PA24E_TC5_WO0)
-#define PORT_PA24E_TC5_WO0         (1ul << 24)
-#define PIN_PB14E_TC5_WO0                 46L  /**< \brief TC5 signal: WO0 on PB14 mux E */
-#define MUX_PB14E_TC5_WO0                  4L
+#define PORT_PA24E_TC5_WO0     (_UL(1) << 24)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
 #define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
-#define PORT_PB14E_TC5_WO0         (1ul << 14)
-#define PIN_PA25E_TC5_WO1                 25L  /**< \brief TC5 signal: WO1 on PA25 mux E */
-#define MUX_PA25E_TC5_WO1                  4L
+#define PORT_PB14E_TC5_WO0     (_UL(1) << 14)
+#define PIN_PA25E_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC5_WO1               _L_(4)
 #define PINMUX_PA25E_TC5_WO1       ((PIN_PA25E_TC5_WO1 << 16) | MUX_PA25E_TC5_WO1)
-#define PORT_PA25E_TC5_WO1         (1ul << 25)
-#define PIN_PB15E_TC5_WO1                 47L  /**< \brief TC5 signal: WO1 on PB15 mux E */
-#define MUX_PB15E_TC5_WO1                  4L
+#define PORT_PA25E_TC5_WO1     (_UL(1) << 25)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
 #define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
-#define PORT_PB15E_TC5_WO1         (1ul << 15)
+#define PORT_PB15E_TC5_WO1     (_UL(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02E_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux E */
+#define MUX_PB02E_TC6_WO0               _L_(4)
+#define PINMUX_PB02E_TC6_WO0       ((PIN_PB02E_TC6_WO0 << 16) | MUX_PB02E_TC6_WO0)
+#define PORT_PB02E_TC6_WO0     (_UL(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL(1) << 16)
+#define PIN_PB03E_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux E */
+#define MUX_PB03E_TC6_WO1               _L_(4)
+#define PINMUX_PB03E_TC6_WO1       ((PIN_PB03E_TC6_WO1 << 16) | MUX_PB03E_TC6_WO1)
+#define PORT_PB03E_TC6_WO1     (_UL(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL(1) << 20)
+#define PIN_PB00E_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux E */
+#define MUX_PB00E_TC7_WO0               _L_(4)
+#define PINMUX_PB00E_TC7_WO0       ((PIN_PB00E_TC7_WO0 << 16) | MUX_PB00E_TC7_WO0)
+#define PORT_PB00E_TC7_WO0     (_UL(1) <<  0)
+#define PIN_PB22E_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux E */
+#define MUX_PB22E_TC7_WO0               _L_(4)
+#define PINMUX_PB22E_TC7_WO0       ((PIN_PB22E_TC7_WO0 << 16) | MUX_PB22E_TC7_WO0)
+#define PORT_PB22E_TC7_WO0     (_UL(1) << 22)
+#define PIN_PB23E_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux E */
+#define MUX_PB23E_TC7_WO1               _L_(4)
+#define PINMUX_PB23E_TC7_WO1       ((PIN_PB23E_TC7_WO1 << 16) | MUX_PB23E_TC7_WO1)
+#define PORT_PB23E_TC7_WO1     (_UL(1) << 23)
 /* ========== PORT definition for ADC peripheral ========== */
-#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
-#define MUX_PB08B_ADC_AIN2                 1L
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
 #define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
-#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
-#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
-#define MUX_PB09B_ADC_AIN3                 1L
+#define PORT_PB08B_ADC_AIN2    (_UL(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
 #define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
-#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
-#define PIN_PA04B_ADC_AIN4                 4L  /**< \brief ADC signal: AIN4 on PA04 mux B */
-#define MUX_PA04B_ADC_AIN4                 1L
+#define PORT_PB09B_ADC_AIN3    (_UL(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
 #define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
-#define PORT_PA04B_ADC_AIN4        (1ul <<  4)
-#define PIN_PA05B_ADC_AIN5                 5L  /**< \brief ADC signal: AIN5 on PA05 mux B */
-#define MUX_PA05B_ADC_AIN5                 1L
+#define PORT_PA04B_ADC_AIN4    (_UL(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
 #define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
-#define PORT_PA05B_ADC_AIN5        (1ul <<  5)
-#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
-#define MUX_PA06B_ADC_AIN6                 1L
+#define PORT_PA05B_ADC_AIN5    (_UL(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
 #define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
-#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
-#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
-#define MUX_PA07B_ADC_AIN7                 1L
+#define PORT_PA06B_ADC_AIN6    (_UL(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
 #define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
-#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
-#define PIN_PB00B_ADC_AIN8                32L  /**< \brief ADC signal: AIN8 on PB00 mux B */
-#define MUX_PB00B_ADC_AIN8                 1L
+#define PORT_PA07B_ADC_AIN7    (_UL(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
 #define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
-#define PORT_PB00B_ADC_AIN8        (1ul <<  0)
-#define PIN_PB02B_ADC_AIN10               34L  /**< \brief ADC signal: AIN10 on PB02 mux B */
-#define MUX_PB02B_ADC_AIN10                1L
+#define PORT_PB00B_ADC_AIN8    (_UL(1) <<  0)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
 #define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
-#define PORT_PB02B_ADC_AIN10       (1ul <<  2)
-#define PIN_PB03B_ADC_AIN11               35L  /**< \brief ADC signal: AIN11 on PB03 mux B */
-#define MUX_PB03B_ADC_AIN11                1L
+#define PORT_PB02B_ADC_AIN10   (_UL(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
 #define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
-#define PORT_PB03B_ADC_AIN11       (1ul <<  3)
-#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
-#define MUX_PA08B_ADC_AIN16                1L
+#define PORT_PB03B_ADC_AIN11   (_UL(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
 #define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
-#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
-#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
-#define MUX_PA09B_ADC_AIN17                1L
+#define PORT_PA08B_ADC_AIN16   (_UL(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
 #define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
-#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
-#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
-#define MUX_PA10B_ADC_AIN18                1L
+#define PORT_PA09B_ADC_AIN17   (_UL(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
 #define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
-#define PORT_PA10B_ADC_AIN18       (1ul << 10)
-#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
-#define MUX_PA11B_ADC_AIN19                1L
+#define PORT_PA10B_ADC_AIN18   (_UL(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
 #define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
-#define PORT_PA11B_ADC_AIN19       (1ul << 11)
-#define PIN_PA04B_ADC_VREFP                4L  /**< \brief ADC signal: VREFP on PA04 mux B */
-#define MUX_PA04B_ADC_VREFP                1L
+#define PORT_PA11B_ADC_AIN19   (_UL(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
 #define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
-#define PORT_PA04B_ADC_VREFP       (1ul <<  4)
+#define PORT_PA04B_ADC_VREFP   (_UL(1) <<  4)
 /* ========== PORT definition for AC peripheral ========== */
-#define PIN_PA04B_AC_AIN0                  4L  /**< \brief AC signal: AIN0 on PA04 mux B */
-#define MUX_PA04B_AC_AIN0                  1L
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
 #define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
-#define PORT_PA04B_AC_AIN0         (1ul <<  4)
-#define PIN_PA05B_AC_AIN1                  5L  /**< \brief AC signal: AIN1 on PA05 mux B */
-#define MUX_PA05B_AC_AIN1                  1L
+#define PORT_PA04B_AC_AIN0     (_UL(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
 #define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
-#define PORT_PA05B_AC_AIN1         (1ul <<  5)
-#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
-#define MUX_PA06B_AC_AIN2                  1L
+#define PORT_PA05B_AC_AIN1     (_UL(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
 #define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
-#define PORT_PA06B_AC_AIN2         (1ul <<  6)
-#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
-#define MUX_PA07B_AC_AIN3                  1L
+#define PORT_PA06B_AC_AIN2     (_UL(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
 #define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
-#define PORT_PA07B_AC_AIN3         (1ul <<  7)
-#define PIN_PA12H_AC_CMP0                 12L  /**< \brief AC signal: CMP0 on PA12 mux H */
-#define MUX_PA12H_AC_CMP0                  7L
+#define PORT_PA07B_AC_AIN3     (_UL(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
 #define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
-#define PORT_PA12H_AC_CMP0         (1ul << 12)
-#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
-#define MUX_PA18H_AC_CMP0                  7L
+#define PORT_PA12H_AC_CMP0     (_UL(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
 #define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
-#define PORT_PA18H_AC_CMP0         (1ul << 18)
-#define PIN_PA13H_AC_CMP1                 13L  /**< \brief AC signal: CMP1 on PA13 mux H */
-#define MUX_PA13H_AC_CMP1                  7L
+#define PORT_PA18H_AC_CMP0     (_UL(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
 #define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
-#define PORT_PA13H_AC_CMP1         (1ul << 13)
-#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
-#define MUX_PA19H_AC_CMP1                  7L
+#define PORT_PA13H_AC_CMP1     (_UL(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
 #define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
-#define PORT_PA19H_AC_CMP1         (1ul << 19)
+#define PORT_PA19H_AC_CMP1     (_UL(1) << 19)
 /* ========== PORT definition for RFCTRL peripheral ========== */
-#define PIN_PA08F_RFCTRL_FECTRL0           8L  /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
-#define MUX_PA08F_RFCTRL_FECTRL0           5L
+#define PIN_PA08F_RFCTRL_FECTRL0        _L_(8) /**< \brief RFCTRL signal: FECTRL0 on PA08 mux F */
+#define MUX_PA08F_RFCTRL_FECTRL0        _L_(5)
 #define PINMUX_PA08F_RFCTRL_FECTRL0  ((PIN_PA08F_RFCTRL_FECTRL0 << 16) | MUX_PA08F_RFCTRL_FECTRL0)
-#define PORT_PA08F_RFCTRL_FECTRL0  (1ul <<  8)
-#define PIN_PA09F_RFCTRL_FECTRL1           9L  /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
-#define MUX_PA09F_RFCTRL_FECTRL1           5L
+#define PORT_PA08F_RFCTRL_FECTRL0  (_UL(1) <<  8)
+#define PIN_PA09F_RFCTRL_FECTRL1        _L_(9) /**< \brief RFCTRL signal: FECTRL1 on PA09 mux F */
+#define MUX_PA09F_RFCTRL_FECTRL1        _L_(5)
 #define PINMUX_PA09F_RFCTRL_FECTRL1  ((PIN_PA09F_RFCTRL_FECTRL1 << 16) | MUX_PA09F_RFCTRL_FECTRL1)
-#define PORT_PA09F_RFCTRL_FECTRL1  (1ul <<  9)
-#define PIN_PA12F_RFCTRL_FECTRL2          12L  /**< \brief RFCTRL signal: FECTRL2 on PA12 mux F */
-#define MUX_PA12F_RFCTRL_FECTRL2           5L
+#define PORT_PA09F_RFCTRL_FECTRL1  (_UL(1) <<  9)
+#define PIN_PA12F_RFCTRL_FECTRL2       _L_(12) /**< \brief RFCTRL signal: FECTRL2 on PA12 mux F */
+#define MUX_PA12F_RFCTRL_FECTRL2        _L_(5)
 #define PINMUX_PA12F_RFCTRL_FECTRL2  ((PIN_PA12F_RFCTRL_FECTRL2 << 16) | MUX_PA12F_RFCTRL_FECTRL2)
-#define PORT_PA12F_RFCTRL_FECTRL2  (1ul << 12)
-#define PIN_PA13F_RFCTRL_FECTRL3          13L  /**< \brief RFCTRL signal: FECTRL3 on PA13 mux F */
-#define MUX_PA13F_RFCTRL_FECTRL3           5L
+#define PORT_PA12F_RFCTRL_FECTRL2  (_UL(1) << 12)
+#define PIN_PA13F_RFCTRL_FECTRL3       _L_(13) /**< \brief RFCTRL signal: FECTRL3 on PA13 mux F */
+#define MUX_PA13F_RFCTRL_FECTRL3        _L_(5)
 #define PINMUX_PA13F_RFCTRL_FECTRL3  ((PIN_PA13F_RFCTRL_FECTRL3 << 16) | MUX_PA13F_RFCTRL_FECTRL3)
-#define PORT_PA13F_RFCTRL_FECTRL3  (1ul << 13)
-#define PIN_PA14F_RFCTRL_FECTRL4          14L  /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
-#define MUX_PA14F_RFCTRL_FECTRL4           5L
+#define PORT_PA13F_RFCTRL_FECTRL3  (_UL(1) << 13)
+#define PIN_PA14F_RFCTRL_FECTRL4       _L_(14) /**< \brief RFCTRL signal: FECTRL4 on PA14 mux F */
+#define MUX_PA14F_RFCTRL_FECTRL4        _L_(5)
 #define PINMUX_PA14F_RFCTRL_FECTRL4  ((PIN_PA14F_RFCTRL_FECTRL4 << 16) | MUX_PA14F_RFCTRL_FECTRL4)
-#define PORT_PA14F_RFCTRL_FECTRL4  (1ul << 14)
-#define PIN_PA15F_RFCTRL_FECTRL5          15L  /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
-#define MUX_PA15F_RFCTRL_FECTRL5           5L
+#define PORT_PA14F_RFCTRL_FECTRL4  (_UL(1) << 14)
+#define PIN_PA15F_RFCTRL_FECTRL5       _L_(15) /**< \brief RFCTRL signal: FECTRL5 on PA15 mux F */
+#define MUX_PA15F_RFCTRL_FECTRL5        _L_(5)
 #define PINMUX_PA15F_RFCTRL_FECTRL5  ((PIN_PA15F_RFCTRL_FECTRL5 << 16) | MUX_PA15F_RFCTRL_FECTRL5)
-#define PORT_PA15F_RFCTRL_FECTRL5  (1ul << 15)
+#define PORT_PA15F_RFCTRL_FECTRL5  (_UL(1) << 15)
 
 #endif /* _SAMR21G18A_PIO_ */

--- a/cpu/sam0_common/include/vendor/samr21/include/samr21e16a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/samr21e16a.h
@@ -3,39 +3,24 @@
  *
  * \brief Header file for SAMR21E16A
  *
- * Copyright (c) 2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -72,15 +57,21 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#define CAST(type, value) ((type *)(value))
-#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#if !defined(_UL)
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
 #else
-#define CAST(type, value) (value)
-#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#if !defined(_UL)
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
 #endif
 
 /* ************************************************************************** */
@@ -120,8 +111,11 @@ typedef enum IRQn
   TC3_IRQn                 = 18, /**< 18 SAMR21E16A Basic Timer Counter 3 (TC3) */
   TC4_IRQn                 = 19, /**< 19 SAMR21E16A Basic Timer Counter 4 (TC4) */
   TC5_IRQn                 = 20, /**< 20 SAMR21E16A Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 21, /**< 21 SAMR21E16A Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 22, /**< 22 SAMR21E16A Basic Timer Counter 7 (TC7) */
   ADC_IRQn                 = 23, /**< 23 SAMR21E16A Analog Digital Converter (ADC) */
   AC_IRQn                  = 24, /**< 24 SAMR21E16A Analog Comparators (AC) */
+  DAC_IRQn                 = 25, /**< 25 SAMR21E16A Digital Analog Converter (DAC) */
   PTC_IRQn                 = 26, /**< 26 SAMR21E16A Peripheral Touch Controller (PTC) */
 
   PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
@@ -136,16 +130,16 @@ typedef struct _DeviceVectors
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
   void* pfnHardFault_Handler;
-  void* pfnReservedM12;
-  void* pfnReservedM11;
-  void* pfnReservedM10;
-  void* pfnReservedM9;
-  void* pfnReservedM8;
-  void* pfnReservedM7;
-  void* pfnReservedM6;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
   void* pfnSVC_Handler;
-  void* pfnReservedM4;
-  void* pfnReservedM3;
+  void* pvReservedM4;
+  void* pvReservedM3;
   void* pfnPendSV_Handler;
   void* pfnSysTick_Handler;
 
@@ -171,14 +165,14 @@ typedef struct _DeviceVectors
   void* pfnTC3_Handler;                   /* 18 Basic Timer Counter 3 */
   void* pfnTC4_Handler;                   /* 19 Basic Timer Counter 4 */
   void* pfnTC5_Handler;                   /* 20 Basic Timer Counter 5 */
-  void* pfnReserved21;
-  void* pfnReserved22;
+  void* pfnTC6_Handler;                   /* 21 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 22 Basic Timer Counter 7 */
   void* pfnADC_Handler;                   /* 23 Analog Digital Converter */
   void* pfnAC_Handler;                    /* 24 Analog Comparators */
-  void* pfnReserved25;
+  void* pfnDAC_Handler;                   /* 25 Digital Analog Converter */
   void* pfnPTC_Handler;                   /* 26 Peripheral Touch Controller */
-  void* pfnReserved27;
-  void* pfnReserved28;
+  void* pvReserved27;
+  void* pvReserved28;
 } DeviceVectors;
 
 /* Cortex-M0+ processor handlers */
@@ -211,15 +205,18 @@ void TCC2_Handler                ( void );
 void TC3_Handler                 ( void );
 void TC4_Handler                 ( void );
 void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
 void ADC_Handler                 ( void );
 void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
 void PTC_Handler                 ( void );
 
 /*
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#define LITTLE_ENDIAN          1        
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
@@ -245,6 +242,7 @@ void PTC_Handler                 ( void );
 
 #include "component/ac.h"
 #include "component/adc.h"
+#include "component/dac.h"
 #include "component/dmac.h"
 #include "component/dsu.h"
 #include "component/eic.h"
@@ -274,6 +272,7 @@ void PTC_Handler                 ( void );
 
 #include "instance/ac.h"
 #include "instance/adc.h"
+#include "instance/dac.h"
 #include "instance/dmac.h"
 #include "instance/dsu.h"
 #include "instance/eic.h"
@@ -299,6 +298,8 @@ void PTC_Handler                 ( void );
 #include "instance/tc3.h"
 #include "instance/tc4.h"
 #include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
 #include "instance/tcc0.h"
 #include "instance/tcc1.h"
 #include "instance/tcc2.h"
@@ -346,12 +347,15 @@ void PTC_Handler                 ( void );
 #define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
 #define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
 #define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
 #define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
 #define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
 #define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
 #define ID_RFCTRL        85 /**< \brief RF233 control module (RFCTRL) */
 
-#define ID_PERIPH_COUNT  86 /**< \brief Number of peripheral IDs */
+#define ID_PERIPH_COUNT  86 /**< \brief Max number of peripheral IDs */
 /*@}*/
 
 /* ************************************************************************** */
@@ -361,46 +365,50 @@ void PTC_Handler                 ( void );
 /*@{*/
 
 #if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
-#define AC                            (0x42004400UL) /**< \brief (AC) APB Base Address */
-#define ADC                           (0x42004000UL) /**< \brief (ADC) APB Base Address */
-#define DMAC                          (0x41004800UL) /**< \brief (DMAC) APB Base Address */
-#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
-#define EIC                           (0x40001800UL) /**< \brief (EIC) APB Base Address */
-#define EVSYS                         (0x42000400UL) /**< \brief (EVSYS) APB Base Address */
-#define GCLK                          (0x40000C00UL) /**< \brief (GCLK) APB Base Address */
-#define SBMATRIX                      (0x41007000UL) /**< \brief (SBMATRIX) APB Base Address */
-#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
-#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
-#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
-#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
-#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
-#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
-#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
-#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
-#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
-#define PAC0                          (0x40000000UL) /**< \brief (PAC0) APB Base Address */
-#define PAC1                          (0x41000000UL) /**< \brief (PAC1) APB Base Address */
-#define PAC2                          (0x42000000UL) /**< \brief (PAC2) APB Base Address */
-#define PM                            (0x40000400UL) /**< \brief (PM) APB Base Address */
-#define PORT                          (0x41004400UL) /**< \brief (PORT) APB Base Address */
-#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
-#define RFCTRL                        (0x42005400UL) /**< \brief (RFCTRL) APB Base Address */
-#define RTC                           (0x40001400UL) /**< \brief (RTC) APB Base Address */
-#define SERCOM0                       (0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
-#define SERCOM1                       (0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
-#define SERCOM2                       (0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
-#define SERCOM3                       (0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
-#define SERCOM4                       (0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
-#define SERCOM5                       (0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
-#define SYSCTRL                       (0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
-#define TC3                           (0x42002C00UL) /**< \brief (TC3) APB Base Address */
-#define TC4                           (0x42003000UL) /**< \brief (TC4) APB Base Address */
-#define TC5                           (0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TCC0                          (0x42002000UL) /**< \brief (TCC0) APB Base Address */
-#define TCC1                          (0x42002400UL) /**< \brief (TCC1) APB Base Address */
-#define TCC2                          (0x42002800UL) /**< \brief (TCC2) APB Base Address */
-#define USB                           (0x41005000UL) /**< \brief (USB) APB Base Address */
-#define WDT                           (0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x41004800) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define SBMATRIX                      (0x41007000) /**< \brief (SBMATRIX) APB Base Address */
+#define MTB                           (0x41006000) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RFCTRL                        (0x42005400) /**< \brief (RFCTRL) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define TCC0                          (0x42002000) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42002400) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42002800) /**< \brief (TCC2) APB Base Address */
+#define USB                           (0x41005000) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
 #else
 #define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
 #define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
@@ -409,6 +417,10 @@ void PTC_Handler                 ( void );
 #define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
 #define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
 #define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
 
 #define DMAC              ((Dmac     *)0x41004800UL) /**< \brief (DMAC) APB Base Address */
 #define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
@@ -463,7 +475,10 @@ void PTC_Handler                 ( void );
 #define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
 #define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
 #define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
 
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
 #define PTC_GCLK_ID       34
 #define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
 #define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
@@ -492,8 +507,10 @@ void PTC_Handler                 ( void );
 #define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
 #define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
 #define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
-#define TC_INSTS          { TC3, TC4, TC5 }          /**< \brief (TC) Instances List */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       5                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
 
 #define TCC0              ((Tcc      *)0x42002000UL) /**< \brief (TCC0) APB Base Address */
 #define TCC1              ((Tcc      *)0x42002400UL) /**< \brief (TCC1) APB Base Address */
@@ -525,21 +542,21 @@ void PTC_Handler                 ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAMR21E16A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            0x10000UL /* 64 kB */
+#define FLASH_SIZE            _UL(0x00010000) /* 64 kB */
 #define FLASH_PAGE_SIZE       64
 #define FLASH_NB_OF_PAGES     1024
 #define FLASH_USER_PAGE_SIZE  64
-#define HMCRAMC0_SIZE         0x4000UL /* 16 kB */
+#define HMCRAMC0_SIZE         _UL(0x00004000) /* 16 kB */
 
-#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
-#define HMCRAMC0_ADDR         (0x20000000u) /**< HMCRAMC0 base address */
-#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
-#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
-#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
-#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HMCRAMC0_ADDR         _UL(0x20000000) /**< HMCRAMC0 base address */
+#define HPB0_ADDR             _UL(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL(0xE0000000) /**< PPB base address */
 
-#define DSU_DID_RESETVALUE    0x1001001EUL
+#define DSU_DID_RESETVALUE    _UL(0x1001031E)
 #define EIC_EXTINT_NUM        16
 #define PORT_GROUPS           3
 #define SIP_CONFIG            RF233

--- a/cpu/sam0_common/include/vendor/samr21/include/samr21e17a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/samr21e17a.h
@@ -3,39 +3,24 @@
  *
  * \brief Header file for SAMR21E17A
  *
- * Copyright (c) 2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -72,15 +57,21 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#define CAST(type, value) ((type *)(value))
-#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#if !defined(_UL)
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
 #else
-#define CAST(type, value) (value)
-#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#if !defined(_UL)
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
 #endif
 
 /* ************************************************************************** */
@@ -120,8 +111,11 @@ typedef enum IRQn
   TC3_IRQn                 = 18, /**< 18 SAMR21E17A Basic Timer Counter 3 (TC3) */
   TC4_IRQn                 = 19, /**< 19 SAMR21E17A Basic Timer Counter 4 (TC4) */
   TC5_IRQn                 = 20, /**< 20 SAMR21E17A Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 21, /**< 21 SAMR21E17A Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 22, /**< 22 SAMR21E17A Basic Timer Counter 7 (TC7) */
   ADC_IRQn                 = 23, /**< 23 SAMR21E17A Analog Digital Converter (ADC) */
   AC_IRQn                  = 24, /**< 24 SAMR21E17A Analog Comparators (AC) */
+  DAC_IRQn                 = 25, /**< 25 SAMR21E17A Digital Analog Converter (DAC) */
   PTC_IRQn                 = 26, /**< 26 SAMR21E17A Peripheral Touch Controller (PTC) */
 
   PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
@@ -136,16 +130,16 @@ typedef struct _DeviceVectors
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
   void* pfnHardFault_Handler;
-  void* pfnReservedM12;
-  void* pfnReservedM11;
-  void* pfnReservedM10;
-  void* pfnReservedM9;
-  void* pfnReservedM8;
-  void* pfnReservedM7;
-  void* pfnReservedM6;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
   void* pfnSVC_Handler;
-  void* pfnReservedM4;
-  void* pfnReservedM3;
+  void* pvReservedM4;
+  void* pvReservedM3;
   void* pfnPendSV_Handler;
   void* pfnSysTick_Handler;
 
@@ -171,14 +165,14 @@ typedef struct _DeviceVectors
   void* pfnTC3_Handler;                   /* 18 Basic Timer Counter 3 */
   void* pfnTC4_Handler;                   /* 19 Basic Timer Counter 4 */
   void* pfnTC5_Handler;                   /* 20 Basic Timer Counter 5 */
-  void* pfnReserved21;
-  void* pfnReserved22;
+  void* pfnTC6_Handler;                   /* 21 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 22 Basic Timer Counter 7 */
   void* pfnADC_Handler;                   /* 23 Analog Digital Converter */
   void* pfnAC_Handler;                    /* 24 Analog Comparators */
-  void* pfnReserved25;
+  void* pfnDAC_Handler;                   /* 25 Digital Analog Converter */
   void* pfnPTC_Handler;                   /* 26 Peripheral Touch Controller */
-  void* pfnReserved27;
-  void* pfnReserved28;
+  void* pvReserved27;
+  void* pvReserved28;
 } DeviceVectors;
 
 /* Cortex-M0+ processor handlers */
@@ -211,15 +205,18 @@ void TCC2_Handler                ( void );
 void TC3_Handler                 ( void );
 void TC4_Handler                 ( void );
 void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
 void ADC_Handler                 ( void );
 void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
 void PTC_Handler                 ( void );
 
 /*
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#define LITTLE_ENDIAN          1        
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
@@ -245,6 +242,7 @@ void PTC_Handler                 ( void );
 
 #include "component/ac.h"
 #include "component/adc.h"
+#include "component/dac.h"
 #include "component/dmac.h"
 #include "component/dsu.h"
 #include "component/eic.h"
@@ -274,6 +272,7 @@ void PTC_Handler                 ( void );
 
 #include "instance/ac.h"
 #include "instance/adc.h"
+#include "instance/dac.h"
 #include "instance/dmac.h"
 #include "instance/dsu.h"
 #include "instance/eic.h"
@@ -299,6 +298,8 @@ void PTC_Handler                 ( void );
 #include "instance/tc3.h"
 #include "instance/tc4.h"
 #include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
 #include "instance/tcc0.h"
 #include "instance/tcc1.h"
 #include "instance/tcc2.h"
@@ -346,12 +347,15 @@ void PTC_Handler                 ( void );
 #define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
 #define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
 #define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
 #define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
 #define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
 #define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
 #define ID_RFCTRL        85 /**< \brief RF233 control module (RFCTRL) */
 
-#define ID_PERIPH_COUNT  86 /**< \brief Number of peripheral IDs */
+#define ID_PERIPH_COUNT  86 /**< \brief Max number of peripheral IDs */
 /*@}*/
 
 /* ************************************************************************** */
@@ -361,46 +365,50 @@ void PTC_Handler                 ( void );
 /*@{*/
 
 #if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
-#define AC                            (0x42004400UL) /**< \brief (AC) APB Base Address */
-#define ADC                           (0x42004000UL) /**< \brief (ADC) APB Base Address */
-#define DMAC                          (0x41004800UL) /**< \brief (DMAC) APB Base Address */
-#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
-#define EIC                           (0x40001800UL) /**< \brief (EIC) APB Base Address */
-#define EVSYS                         (0x42000400UL) /**< \brief (EVSYS) APB Base Address */
-#define GCLK                          (0x40000C00UL) /**< \brief (GCLK) APB Base Address */
-#define SBMATRIX                      (0x41007000UL) /**< \brief (SBMATRIX) APB Base Address */
-#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
-#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
-#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
-#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
-#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
-#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
-#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
-#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
-#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
-#define PAC0                          (0x40000000UL) /**< \brief (PAC0) APB Base Address */
-#define PAC1                          (0x41000000UL) /**< \brief (PAC1) APB Base Address */
-#define PAC2                          (0x42000000UL) /**< \brief (PAC2) APB Base Address */
-#define PM                            (0x40000400UL) /**< \brief (PM) APB Base Address */
-#define PORT                          (0x41004400UL) /**< \brief (PORT) APB Base Address */
-#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
-#define RFCTRL                        (0x42005400UL) /**< \brief (RFCTRL) APB Base Address */
-#define RTC                           (0x40001400UL) /**< \brief (RTC) APB Base Address */
-#define SERCOM0                       (0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
-#define SERCOM1                       (0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
-#define SERCOM2                       (0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
-#define SERCOM3                       (0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
-#define SERCOM4                       (0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
-#define SERCOM5                       (0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
-#define SYSCTRL                       (0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
-#define TC3                           (0x42002C00UL) /**< \brief (TC3) APB Base Address */
-#define TC4                           (0x42003000UL) /**< \brief (TC4) APB Base Address */
-#define TC5                           (0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TCC0                          (0x42002000UL) /**< \brief (TCC0) APB Base Address */
-#define TCC1                          (0x42002400UL) /**< \brief (TCC1) APB Base Address */
-#define TCC2                          (0x42002800UL) /**< \brief (TCC2) APB Base Address */
-#define USB                           (0x41005000UL) /**< \brief (USB) APB Base Address */
-#define WDT                           (0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x41004800) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define SBMATRIX                      (0x41007000) /**< \brief (SBMATRIX) APB Base Address */
+#define MTB                           (0x41006000) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RFCTRL                        (0x42005400) /**< \brief (RFCTRL) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define TCC0                          (0x42002000) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42002400) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42002800) /**< \brief (TCC2) APB Base Address */
+#define USB                           (0x41005000) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
 #else
 #define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
 #define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
@@ -409,6 +417,10 @@ void PTC_Handler                 ( void );
 #define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
 #define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
 #define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
 
 #define DMAC              ((Dmac     *)0x41004800UL) /**< \brief (DMAC) APB Base Address */
 #define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
@@ -463,7 +475,10 @@ void PTC_Handler                 ( void );
 #define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
 #define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
 #define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
 
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
 #define PTC_GCLK_ID       34
 #define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
 #define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
@@ -492,8 +507,10 @@ void PTC_Handler                 ( void );
 #define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
 #define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
 #define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
-#define TC_INSTS          { TC3, TC4, TC5 }          /**< \brief (TC) Instances List */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       5                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
 
 #define TCC0              ((Tcc      *)0x42002000UL) /**< \brief (TCC0) APB Base Address */
 #define TCC1              ((Tcc      *)0x42002400UL) /**< \brief (TCC1) APB Base Address */
@@ -525,21 +542,21 @@ void PTC_Handler                 ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAMR21E17A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            0x20000UL /* 128 kB */
+#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
 #define FLASH_PAGE_SIZE       64
 #define FLASH_NB_OF_PAGES     2048
 #define FLASH_USER_PAGE_SIZE  64
-#define HMCRAMC0_SIZE         0x8000UL /* 32 kB */
+#define HMCRAMC0_SIZE         _UL(0x00008000) /* 32 kB */
 
-#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
-#define HMCRAMC0_ADDR         (0x20000000u) /**< HMCRAMC0 base address */
-#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
-#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
-#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
-#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HMCRAMC0_ADDR         _UL(0x20000000) /**< HMCRAMC0 base address */
+#define HPB0_ADDR             _UL(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL(0xE0000000) /**< PPB base address */
 
-#define DSU_DID_RESETVALUE    0x1001001DUL
+#define DSU_DID_RESETVALUE    _UL(0x1001031D)
 #define EIC_EXTINT_NUM        16
 #define PORT_GROUPS           3
 #define SIP_CONFIG            RF233

--- a/cpu/sam0_common/include/vendor/samr21/include/samr21e18a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/samr21e18a.h
@@ -3,39 +3,24 @@
  *
  * \brief Header file for SAMR21E18A
  *
- * Copyright (c) 2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -72,15 +57,21 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#define CAST(type, value) ((type *)(value))
-#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#if !defined(_UL)
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
 #else
-#define CAST(type, value) (value)
-#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#if !defined(_UL)
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
 #endif
 
 /* ************************************************************************** */
@@ -120,8 +111,11 @@ typedef enum IRQn
   TC3_IRQn                 = 18, /**< 18 SAMR21E18A Basic Timer Counter 3 (TC3) */
   TC4_IRQn                 = 19, /**< 19 SAMR21E18A Basic Timer Counter 4 (TC4) */
   TC5_IRQn                 = 20, /**< 20 SAMR21E18A Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 21, /**< 21 SAMR21E18A Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 22, /**< 22 SAMR21E18A Basic Timer Counter 7 (TC7) */
   ADC_IRQn                 = 23, /**< 23 SAMR21E18A Analog Digital Converter (ADC) */
   AC_IRQn                  = 24, /**< 24 SAMR21E18A Analog Comparators (AC) */
+  DAC_IRQn                 = 25, /**< 25 SAMR21E18A Digital Analog Converter (DAC) */
   PTC_IRQn                 = 26, /**< 26 SAMR21E18A Peripheral Touch Controller (PTC) */
 
   PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
@@ -136,16 +130,16 @@ typedef struct _DeviceVectors
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
   void* pfnHardFault_Handler;
-  void* pfnReservedM12;
-  void* pfnReservedM11;
-  void* pfnReservedM10;
-  void* pfnReservedM9;
-  void* pfnReservedM8;
-  void* pfnReservedM7;
-  void* pfnReservedM6;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
   void* pfnSVC_Handler;
-  void* pfnReservedM4;
-  void* pfnReservedM3;
+  void* pvReservedM4;
+  void* pvReservedM3;
   void* pfnPendSV_Handler;
   void* pfnSysTick_Handler;
 
@@ -171,14 +165,14 @@ typedef struct _DeviceVectors
   void* pfnTC3_Handler;                   /* 18 Basic Timer Counter 3 */
   void* pfnTC4_Handler;                   /* 19 Basic Timer Counter 4 */
   void* pfnTC5_Handler;                   /* 20 Basic Timer Counter 5 */
-  void* pfnReserved21;
-  void* pfnReserved22;
+  void* pfnTC6_Handler;                   /* 21 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 22 Basic Timer Counter 7 */
   void* pfnADC_Handler;                   /* 23 Analog Digital Converter */
   void* pfnAC_Handler;                    /* 24 Analog Comparators */
-  void* pfnReserved25;
+  void* pfnDAC_Handler;                   /* 25 Digital Analog Converter */
   void* pfnPTC_Handler;                   /* 26 Peripheral Touch Controller */
-  void* pfnReserved27;
-  void* pfnReserved28;
+  void* pvReserved27;
+  void* pvReserved28;
 } DeviceVectors;
 
 /* Cortex-M0+ processor handlers */
@@ -211,15 +205,18 @@ void TCC2_Handler                ( void );
 void TC3_Handler                 ( void );
 void TC4_Handler                 ( void );
 void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
 void ADC_Handler                 ( void );
 void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
 void PTC_Handler                 ( void );
 
 /*
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#define LITTLE_ENDIAN          1        
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
@@ -245,6 +242,7 @@ void PTC_Handler                 ( void );
 
 #include "component/ac.h"
 #include "component/adc.h"
+#include "component/dac.h"
 #include "component/dmac.h"
 #include "component/dsu.h"
 #include "component/eic.h"
@@ -274,6 +272,7 @@ void PTC_Handler                 ( void );
 
 #include "instance/ac.h"
 #include "instance/adc.h"
+#include "instance/dac.h"
 #include "instance/dmac.h"
 #include "instance/dsu.h"
 #include "instance/eic.h"
@@ -299,6 +298,8 @@ void PTC_Handler                 ( void );
 #include "instance/tc3.h"
 #include "instance/tc4.h"
 #include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
 #include "instance/tcc0.h"
 #include "instance/tcc1.h"
 #include "instance/tcc2.h"
@@ -346,12 +347,15 @@ void PTC_Handler                 ( void );
 #define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
 #define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
 #define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
 #define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
 #define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
 #define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
 #define ID_RFCTRL        85 /**< \brief RF233 control module (RFCTRL) */
 
-#define ID_PERIPH_COUNT  86 /**< \brief Number of peripheral IDs */
+#define ID_PERIPH_COUNT  86 /**< \brief Max number of peripheral IDs */
 /*@}*/
 
 /* ************************************************************************** */
@@ -361,46 +365,50 @@ void PTC_Handler                 ( void );
 /*@{*/
 
 #if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
-#define AC                            (0x42004400UL) /**< \brief (AC) APB Base Address */
-#define ADC                           (0x42004000UL) /**< \brief (ADC) APB Base Address */
-#define DMAC                          (0x41004800UL) /**< \brief (DMAC) APB Base Address */
-#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
-#define EIC                           (0x40001800UL) /**< \brief (EIC) APB Base Address */
-#define EVSYS                         (0x42000400UL) /**< \brief (EVSYS) APB Base Address */
-#define GCLK                          (0x40000C00UL) /**< \brief (GCLK) APB Base Address */
-#define SBMATRIX                      (0x41007000UL) /**< \brief (SBMATRIX) APB Base Address */
-#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
-#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
-#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
-#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
-#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
-#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
-#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
-#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
-#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
-#define PAC0                          (0x40000000UL) /**< \brief (PAC0) APB Base Address */
-#define PAC1                          (0x41000000UL) /**< \brief (PAC1) APB Base Address */
-#define PAC2                          (0x42000000UL) /**< \brief (PAC2) APB Base Address */
-#define PM                            (0x40000400UL) /**< \brief (PM) APB Base Address */
-#define PORT                          (0x41004400UL) /**< \brief (PORT) APB Base Address */
-#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
-#define RFCTRL                        (0x42005400UL) /**< \brief (RFCTRL) APB Base Address */
-#define RTC                           (0x40001400UL) /**< \brief (RTC) APB Base Address */
-#define SERCOM0                       (0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
-#define SERCOM1                       (0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
-#define SERCOM2                       (0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
-#define SERCOM3                       (0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
-#define SERCOM4                       (0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
-#define SERCOM5                       (0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
-#define SYSCTRL                       (0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
-#define TC3                           (0x42002C00UL) /**< \brief (TC3) APB Base Address */
-#define TC4                           (0x42003000UL) /**< \brief (TC4) APB Base Address */
-#define TC5                           (0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TCC0                          (0x42002000UL) /**< \brief (TCC0) APB Base Address */
-#define TCC1                          (0x42002400UL) /**< \brief (TCC1) APB Base Address */
-#define TCC2                          (0x42002800UL) /**< \brief (TCC2) APB Base Address */
-#define USB                           (0x41005000UL) /**< \brief (USB) APB Base Address */
-#define WDT                           (0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x41004800) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define SBMATRIX                      (0x41007000) /**< \brief (SBMATRIX) APB Base Address */
+#define MTB                           (0x41006000) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RFCTRL                        (0x42005400) /**< \brief (RFCTRL) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define TCC0                          (0x42002000) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42002400) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42002800) /**< \brief (TCC2) APB Base Address */
+#define USB                           (0x41005000) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
 #else
 #define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
 #define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
@@ -409,6 +417,10 @@ void PTC_Handler                 ( void );
 #define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
 #define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
 #define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
 
 #define DMAC              ((Dmac     *)0x41004800UL) /**< \brief (DMAC) APB Base Address */
 #define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
@@ -463,7 +475,10 @@ void PTC_Handler                 ( void );
 #define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
 #define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
 #define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
 
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
 #define PTC_GCLK_ID       34
 #define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
 #define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
@@ -492,8 +507,10 @@ void PTC_Handler                 ( void );
 #define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
 #define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
 #define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
-#define TC_INSTS          { TC3, TC4, TC5 }          /**< \brief (TC) Instances List */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       5                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
 
 #define TCC0              ((Tcc      *)0x42002000UL) /**< \brief (TCC0) APB Base Address */
 #define TCC1              ((Tcc      *)0x42002400UL) /**< \brief (TCC1) APB Base Address */
@@ -525,21 +542,21 @@ void PTC_Handler                 ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAMR21E18A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            0x40000UL /* 256 kB */
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       64
 #define FLASH_NB_OF_PAGES     4096
 #define FLASH_USER_PAGE_SIZE  64
-#define HMCRAMC0_SIZE         0x8000UL /* 32 kB */
+#define HMCRAMC0_SIZE         _UL(0x00008000) /* 32 kB */
 
-#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
-#define HMCRAMC0_ADDR         (0x20000000u) /**< HMCRAMC0 base address */
-#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
-#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
-#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
-#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HMCRAMC0_ADDR         _UL(0x20000000) /**< HMCRAMC0 base address */
+#define HPB0_ADDR             _UL(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL(0xE0000000) /**< PPB base address */
 
-#define DSU_DID_RESETVALUE    0x1001001CUL
+#define DSU_DID_RESETVALUE    _UL(0x1001031C)
 #define EIC_EXTINT_NUM        16
 #define PORT_GROUPS           3
 #define SIP_CONFIG            RF233

--- a/cpu/sam0_common/include/vendor/samr21/include/samr21e19a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/samr21e19a.h
@@ -3,39 +3,24 @@
  *
  * \brief Header file for SAMR21E19A
  *
- * Copyright (c) 2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -72,15 +57,21 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#define CAST(type, value) ((type *)(value))
-#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#if !defined(_UL)
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
 #else
-#define CAST(type, value) (value)
-#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#if !defined(_UL)
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
 #endif
 
 /* ************************************************************************** */
@@ -120,8 +111,11 @@ typedef enum IRQn
   TC3_IRQn                 = 18, /**< 18 SAMR21E19A Basic Timer Counter 3 (TC3) */
   TC4_IRQn                 = 19, /**< 19 SAMR21E19A Basic Timer Counter 4 (TC4) */
   TC5_IRQn                 = 20, /**< 20 SAMR21E19A Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 21, /**< 21 SAMR21E19A Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 22, /**< 22 SAMR21E19A Basic Timer Counter 7 (TC7) */
   ADC_IRQn                 = 23, /**< 23 SAMR21E19A Analog Digital Converter (ADC) */
   AC_IRQn                  = 24, /**< 24 SAMR21E19A Analog Comparators (AC) */
+  DAC_IRQn                 = 25, /**< 25 SAMR21E19A Digital Analog Converter (DAC) */
   PTC_IRQn                 = 26, /**< 26 SAMR21E19A Peripheral Touch Controller (PTC) */
 
   PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
@@ -136,16 +130,16 @@ typedef struct _DeviceVectors
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
   void* pfnHardFault_Handler;
-  void* pfnReservedM12;
-  void* pfnReservedM11;
-  void* pfnReservedM10;
-  void* pfnReservedM9;
-  void* pfnReservedM8;
-  void* pfnReservedM7;
-  void* pfnReservedM6;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
   void* pfnSVC_Handler;
-  void* pfnReservedM4;
-  void* pfnReservedM3;
+  void* pvReservedM4;
+  void* pvReservedM3;
   void* pfnPendSV_Handler;
   void* pfnSysTick_Handler;
 
@@ -171,14 +165,14 @@ typedef struct _DeviceVectors
   void* pfnTC3_Handler;                   /* 18 Basic Timer Counter 3 */
   void* pfnTC4_Handler;                   /* 19 Basic Timer Counter 4 */
   void* pfnTC5_Handler;                   /* 20 Basic Timer Counter 5 */
-  void* pfnReserved21;
-  void* pfnReserved22;
+  void* pfnTC6_Handler;                   /* 21 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 22 Basic Timer Counter 7 */
   void* pfnADC_Handler;                   /* 23 Analog Digital Converter */
   void* pfnAC_Handler;                    /* 24 Analog Comparators */
-  void* pfnReserved25;
+  void* pfnDAC_Handler;                   /* 25 Digital Analog Converter */
   void* pfnPTC_Handler;                   /* 26 Peripheral Touch Controller */
-  void* pfnReserved27;
-  void* pfnReserved28;
+  void* pvReserved27;
+  void* pvReserved28;
 } DeviceVectors;
 
 /* Cortex-M0+ processor handlers */
@@ -211,15 +205,18 @@ void TCC2_Handler                ( void );
 void TC3_Handler                 ( void );
 void TC4_Handler                 ( void );
 void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
 void ADC_Handler                 ( void );
 void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
 void PTC_Handler                 ( void );
 
 /*
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#define LITTLE_ENDIAN          1        
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
@@ -245,6 +242,7 @@ void PTC_Handler                 ( void );
 
 #include "component/ac.h"
 #include "component/adc.h"
+#include "component/dac.h"
 #include "component/dmac.h"
 #include "component/dsu.h"
 #include "component/eic.h"
@@ -274,6 +272,7 @@ void PTC_Handler                 ( void );
 
 #include "instance/ac.h"
 #include "instance/adc.h"
+#include "instance/dac.h"
 #include "instance/dmac.h"
 #include "instance/dsu.h"
 #include "instance/eic.h"
@@ -299,6 +298,8 @@ void PTC_Handler                 ( void );
 #include "instance/tc3.h"
 #include "instance/tc4.h"
 #include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
 #include "instance/tcc0.h"
 #include "instance/tcc1.h"
 #include "instance/tcc2.h"
@@ -346,12 +347,15 @@ void PTC_Handler                 ( void );
 #define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
 #define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
 #define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
 #define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
 #define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
 #define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
 #define ID_RFCTRL        85 /**< \brief RF233 control module (RFCTRL) */
 
-#define ID_PERIPH_COUNT  86 /**< \brief Number of peripheral IDs */
+#define ID_PERIPH_COUNT  86 /**< \brief Max number of peripheral IDs */
 /*@}*/
 
 /* ************************************************************************** */
@@ -361,46 +365,50 @@ void PTC_Handler                 ( void );
 /*@{*/
 
 #if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
-#define AC                            (0x42004400UL) /**< \brief (AC) APB Base Address */
-#define ADC                           (0x42004000UL) /**< \brief (ADC) APB Base Address */
-#define DMAC                          (0x41004800UL) /**< \brief (DMAC) APB Base Address */
-#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
-#define EIC                           (0x40001800UL) /**< \brief (EIC) APB Base Address */
-#define EVSYS                         (0x42000400UL) /**< \brief (EVSYS) APB Base Address */
-#define GCLK                          (0x40000C00UL) /**< \brief (GCLK) APB Base Address */
-#define SBMATRIX                      (0x41007000UL) /**< \brief (SBMATRIX) APB Base Address */
-#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
-#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
-#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
-#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
-#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
-#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
-#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
-#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
-#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
-#define PAC0                          (0x40000000UL) /**< \brief (PAC0) APB Base Address */
-#define PAC1                          (0x41000000UL) /**< \brief (PAC1) APB Base Address */
-#define PAC2                          (0x42000000UL) /**< \brief (PAC2) APB Base Address */
-#define PM                            (0x40000400UL) /**< \brief (PM) APB Base Address */
-#define PORT                          (0x41004400UL) /**< \brief (PORT) APB Base Address */
-#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
-#define RFCTRL                        (0x42005400UL) /**< \brief (RFCTRL) APB Base Address */
-#define RTC                           (0x40001400UL) /**< \brief (RTC) APB Base Address */
-#define SERCOM0                       (0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
-#define SERCOM1                       (0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
-#define SERCOM2                       (0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
-#define SERCOM3                       (0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
-#define SERCOM4                       (0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
-#define SERCOM5                       (0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
-#define SYSCTRL                       (0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
-#define TC3                           (0x42002C00UL) /**< \brief (TC3) APB Base Address */
-#define TC4                           (0x42003000UL) /**< \brief (TC4) APB Base Address */
-#define TC5                           (0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TCC0                          (0x42002000UL) /**< \brief (TCC0) APB Base Address */
-#define TCC1                          (0x42002400UL) /**< \brief (TCC1) APB Base Address */
-#define TCC2                          (0x42002800UL) /**< \brief (TCC2) APB Base Address */
-#define USB                           (0x41005000UL) /**< \brief (USB) APB Base Address */
-#define WDT                           (0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x41004800) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define SBMATRIX                      (0x41007000) /**< \brief (SBMATRIX) APB Base Address */
+#define MTB                           (0x41006000) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RFCTRL                        (0x42005400) /**< \brief (RFCTRL) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define TCC0                          (0x42002000) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42002400) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42002800) /**< \brief (TCC2) APB Base Address */
+#define USB                           (0x41005000) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
 #else
 #define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
 #define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
@@ -409,6 +417,10 @@ void PTC_Handler                 ( void );
 #define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
 #define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
 #define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
 
 #define DMAC              ((Dmac     *)0x41004800UL) /**< \brief (DMAC) APB Base Address */
 #define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
@@ -463,7 +475,10 @@ void PTC_Handler                 ( void );
 #define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
 #define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
 #define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
 
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
 #define PTC_GCLK_ID       34
 #define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
 #define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
@@ -492,8 +507,10 @@ void PTC_Handler                 ( void );
 #define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
 #define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
 #define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
-#define TC_INSTS          { TC3, TC4, TC5 }          /**< \brief (TC) Instances List */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       5                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
 
 #define TCC0              ((Tcc      *)0x42002000UL) /**< \brief (TCC0) APB Base Address */
 #define TCC1              ((Tcc      *)0x42002400UL) /**< \brief (TCC1) APB Base Address */
@@ -525,21 +542,21 @@ void PTC_Handler                 ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAMR21E19A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            0x40000UL /* 256 kB */
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       64
 #define FLASH_NB_OF_PAGES     4096
 #define FLASH_USER_PAGE_SIZE  64
-#define HMCRAMC0_SIZE         0x8000UL /* 32 kB */
+#define HMCRAMC0_SIZE         _UL(0x00008000) /* 32 kB */
 
-#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
-#define HMCRAMC0_ADDR         (0x20000000u) /**< HMCRAMC0 base address */
-#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
-#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
-#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
-#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HMCRAMC0_ADDR         _UL(0x20000000) /**< HMCRAMC0 base address */
+#define HPB0_ADDR             _UL(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL(0xE0000000) /**< PPB base address */
 
-#define DSU_DID_RESETVALUE    0x10010018UL
+#define DSU_DID_RESETVALUE    _UL(0x10010318)
 #define EIC_EXTINT_NUM        16
 #define PORT_GROUPS           3
 #define SIP_CONFIG            RF233+FL512KB

--- a/cpu/sam0_common/include/vendor/samr21/include/samr21g16a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/samr21g16a.h
@@ -3,39 +3,24 @@
  *
  * \brief Header file for SAMR21G16A
  *
- * Copyright (c) 2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -72,15 +57,21 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#define CAST(type, value) ((type *)(value))
-#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#if !defined(_UL)
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
 #else
-#define CAST(type, value) (value)
-#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#if !defined(_UL)
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
 #endif
 
 /* ************************************************************************** */
@@ -120,8 +111,11 @@ typedef enum IRQn
   TC3_IRQn                 = 18, /**< 18 SAMR21G16A Basic Timer Counter 3 (TC3) */
   TC4_IRQn                 = 19, /**< 19 SAMR21G16A Basic Timer Counter 4 (TC4) */
   TC5_IRQn                 = 20, /**< 20 SAMR21G16A Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 21, /**< 21 SAMR21G16A Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 22, /**< 22 SAMR21G16A Basic Timer Counter 7 (TC7) */
   ADC_IRQn                 = 23, /**< 23 SAMR21G16A Analog Digital Converter (ADC) */
   AC_IRQn                  = 24, /**< 24 SAMR21G16A Analog Comparators (AC) */
+  DAC_IRQn                 = 25, /**< 25 SAMR21G16A Digital Analog Converter (DAC) */
   PTC_IRQn                 = 26, /**< 26 SAMR21G16A Peripheral Touch Controller (PTC) */
 
   PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
@@ -136,16 +130,16 @@ typedef struct _DeviceVectors
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
   void* pfnHardFault_Handler;
-  void* pfnReservedM12;
-  void* pfnReservedM11;
-  void* pfnReservedM10;
-  void* pfnReservedM9;
-  void* pfnReservedM8;
-  void* pfnReservedM7;
-  void* pfnReservedM6;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
   void* pfnSVC_Handler;
-  void* pfnReservedM4;
-  void* pfnReservedM3;
+  void* pvReservedM4;
+  void* pvReservedM3;
   void* pfnPendSV_Handler;
   void* pfnSysTick_Handler;
 
@@ -171,14 +165,14 @@ typedef struct _DeviceVectors
   void* pfnTC3_Handler;                   /* 18 Basic Timer Counter 3 */
   void* pfnTC4_Handler;                   /* 19 Basic Timer Counter 4 */
   void* pfnTC5_Handler;                   /* 20 Basic Timer Counter 5 */
-  void* pfnReserved21;
-  void* pfnReserved22;
+  void* pfnTC6_Handler;                   /* 21 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 22 Basic Timer Counter 7 */
   void* pfnADC_Handler;                   /* 23 Analog Digital Converter */
   void* pfnAC_Handler;                    /* 24 Analog Comparators */
-  void* pfnReserved25;
+  void* pfnDAC_Handler;                   /* 25 Digital Analog Converter */
   void* pfnPTC_Handler;                   /* 26 Peripheral Touch Controller */
-  void* pfnReserved27;
-  void* pfnReserved28;
+  void* pvReserved27;
+  void* pvReserved28;
 } DeviceVectors;
 
 /* Cortex-M0+ processor handlers */
@@ -211,15 +205,18 @@ void TCC2_Handler                ( void );
 void TC3_Handler                 ( void );
 void TC4_Handler                 ( void );
 void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
 void ADC_Handler                 ( void );
 void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
 void PTC_Handler                 ( void );
 
 /*
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#define LITTLE_ENDIAN          1        
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
@@ -245,6 +242,7 @@ void PTC_Handler                 ( void );
 
 #include "component/ac.h"
 #include "component/adc.h"
+#include "component/dac.h"
 #include "component/dmac.h"
 #include "component/dsu.h"
 #include "component/eic.h"
@@ -274,6 +272,7 @@ void PTC_Handler                 ( void );
 
 #include "instance/ac.h"
 #include "instance/adc.h"
+#include "instance/dac.h"
 #include "instance/dmac.h"
 #include "instance/dsu.h"
 #include "instance/eic.h"
@@ -299,6 +298,8 @@ void PTC_Handler                 ( void );
 #include "instance/tc3.h"
 #include "instance/tc4.h"
 #include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
 #include "instance/tcc0.h"
 #include "instance/tcc1.h"
 #include "instance/tcc2.h"
@@ -346,12 +347,15 @@ void PTC_Handler                 ( void );
 #define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
 #define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
 #define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
 #define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
 #define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
 #define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
 #define ID_RFCTRL        85 /**< \brief RF233 control module (RFCTRL) */
 
-#define ID_PERIPH_COUNT  86 /**< \brief Number of peripheral IDs */
+#define ID_PERIPH_COUNT  86 /**< \brief Max number of peripheral IDs */
 /*@}*/
 
 /* ************************************************************************** */
@@ -361,46 +365,50 @@ void PTC_Handler                 ( void );
 /*@{*/
 
 #if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
-#define AC                            (0x42004400UL) /**< \brief (AC) APB Base Address */
-#define ADC                           (0x42004000UL) /**< \brief (ADC) APB Base Address */
-#define DMAC                          (0x41004800UL) /**< \brief (DMAC) APB Base Address */
-#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
-#define EIC                           (0x40001800UL) /**< \brief (EIC) APB Base Address */
-#define EVSYS                         (0x42000400UL) /**< \brief (EVSYS) APB Base Address */
-#define GCLK                          (0x40000C00UL) /**< \brief (GCLK) APB Base Address */
-#define SBMATRIX                      (0x41007000UL) /**< \brief (SBMATRIX) APB Base Address */
-#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
-#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
-#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
-#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
-#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
-#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
-#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
-#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
-#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
-#define PAC0                          (0x40000000UL) /**< \brief (PAC0) APB Base Address */
-#define PAC1                          (0x41000000UL) /**< \brief (PAC1) APB Base Address */
-#define PAC2                          (0x42000000UL) /**< \brief (PAC2) APB Base Address */
-#define PM                            (0x40000400UL) /**< \brief (PM) APB Base Address */
-#define PORT                          (0x41004400UL) /**< \brief (PORT) APB Base Address */
-#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
-#define RFCTRL                        (0x42005400UL) /**< \brief (RFCTRL) APB Base Address */
-#define RTC                           (0x40001400UL) /**< \brief (RTC) APB Base Address */
-#define SERCOM0                       (0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
-#define SERCOM1                       (0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
-#define SERCOM2                       (0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
-#define SERCOM3                       (0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
-#define SERCOM4                       (0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
-#define SERCOM5                       (0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
-#define SYSCTRL                       (0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
-#define TC3                           (0x42002C00UL) /**< \brief (TC3) APB Base Address */
-#define TC4                           (0x42003000UL) /**< \brief (TC4) APB Base Address */
-#define TC5                           (0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TCC0                          (0x42002000UL) /**< \brief (TCC0) APB Base Address */
-#define TCC1                          (0x42002400UL) /**< \brief (TCC1) APB Base Address */
-#define TCC2                          (0x42002800UL) /**< \brief (TCC2) APB Base Address */
-#define USB                           (0x41005000UL) /**< \brief (USB) APB Base Address */
-#define WDT                           (0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x41004800) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define SBMATRIX                      (0x41007000) /**< \brief (SBMATRIX) APB Base Address */
+#define MTB                           (0x41006000) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RFCTRL                        (0x42005400) /**< \brief (RFCTRL) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define TCC0                          (0x42002000) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42002400) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42002800) /**< \brief (TCC2) APB Base Address */
+#define USB                           (0x41005000) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
 #else
 #define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
 #define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
@@ -409,6 +417,10 @@ void PTC_Handler                 ( void );
 #define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
 #define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
 #define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
 
 #define DMAC              ((Dmac     *)0x41004800UL) /**< \brief (DMAC) APB Base Address */
 #define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
@@ -463,7 +475,10 @@ void PTC_Handler                 ( void );
 #define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
 #define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
 #define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
 
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
 #define PTC_GCLK_ID       34
 #define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
 #define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
@@ -492,8 +507,10 @@ void PTC_Handler                 ( void );
 #define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
 #define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
 #define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
-#define TC_INSTS          { TC3, TC4, TC5 }          /**< \brief (TC) Instances List */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       5                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
 
 #define TCC0              ((Tcc      *)0x42002000UL) /**< \brief (TCC0) APB Base Address */
 #define TCC1              ((Tcc      *)0x42002400UL) /**< \brief (TCC1) APB Base Address */
@@ -525,21 +542,21 @@ void PTC_Handler                 ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAMR21G16A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            0x10000UL /* 64 kB */
+#define FLASH_SIZE            _UL(0x00010000) /* 64 kB */
 #define FLASH_PAGE_SIZE       64
 #define FLASH_NB_OF_PAGES     1024
 #define FLASH_USER_PAGE_SIZE  64
-#define HMCRAMC0_SIZE         0x4000UL /* 16 kB */
+#define HMCRAMC0_SIZE         _UL(0x00004000) /* 16 kB */
 
-#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
-#define HMCRAMC0_ADDR         (0x20000000u) /**< HMCRAMC0 base address */
-#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
-#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
-#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
-#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HMCRAMC0_ADDR         _UL(0x20000000) /**< HMCRAMC0 base address */
+#define HPB0_ADDR             _UL(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL(0xE0000000) /**< PPB base address */
 
-#define DSU_DID_RESETVALUE    0x1001001BUL
+#define DSU_DID_RESETVALUE    _UL(0x1001031B)
 #define EIC_EXTINT_NUM        16
 #define PORT_GROUPS           3
 #define SIP_CONFIG            RF233

--- a/cpu/sam0_common/include/vendor/samr21/include/samr21g17a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/samr21g17a.h
@@ -3,39 +3,24 @@
  *
  * \brief Header file for SAMR21G17A
  *
- * Copyright (c) 2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -72,15 +57,21 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#define CAST(type, value) ((type *)(value))
-#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#if !defined(_UL)
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
 #else
-#define CAST(type, value) (value)
-#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#if !defined(_UL)
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
 #endif
 
 /* ************************************************************************** */
@@ -120,8 +111,11 @@ typedef enum IRQn
   TC3_IRQn                 = 18, /**< 18 SAMR21G17A Basic Timer Counter 3 (TC3) */
   TC4_IRQn                 = 19, /**< 19 SAMR21G17A Basic Timer Counter 4 (TC4) */
   TC5_IRQn                 = 20, /**< 20 SAMR21G17A Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 21, /**< 21 SAMR21G17A Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 22, /**< 22 SAMR21G17A Basic Timer Counter 7 (TC7) */
   ADC_IRQn                 = 23, /**< 23 SAMR21G17A Analog Digital Converter (ADC) */
   AC_IRQn                  = 24, /**< 24 SAMR21G17A Analog Comparators (AC) */
+  DAC_IRQn                 = 25, /**< 25 SAMR21G17A Digital Analog Converter (DAC) */
   PTC_IRQn                 = 26, /**< 26 SAMR21G17A Peripheral Touch Controller (PTC) */
 
   PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
@@ -136,16 +130,16 @@ typedef struct _DeviceVectors
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
   void* pfnHardFault_Handler;
-  void* pfnReservedM12;
-  void* pfnReservedM11;
-  void* pfnReservedM10;
-  void* pfnReservedM9;
-  void* pfnReservedM8;
-  void* pfnReservedM7;
-  void* pfnReservedM6;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
   void* pfnSVC_Handler;
-  void* pfnReservedM4;
-  void* pfnReservedM3;
+  void* pvReservedM4;
+  void* pvReservedM3;
   void* pfnPendSV_Handler;
   void* pfnSysTick_Handler;
 
@@ -171,14 +165,14 @@ typedef struct _DeviceVectors
   void* pfnTC3_Handler;                   /* 18 Basic Timer Counter 3 */
   void* pfnTC4_Handler;                   /* 19 Basic Timer Counter 4 */
   void* pfnTC5_Handler;                   /* 20 Basic Timer Counter 5 */
-  void* pfnReserved21;
-  void* pfnReserved22;
+  void* pfnTC6_Handler;                   /* 21 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 22 Basic Timer Counter 7 */
   void* pfnADC_Handler;                   /* 23 Analog Digital Converter */
   void* pfnAC_Handler;                    /* 24 Analog Comparators */
-  void* pfnReserved25;
+  void* pfnDAC_Handler;                   /* 25 Digital Analog Converter */
   void* pfnPTC_Handler;                   /* 26 Peripheral Touch Controller */
-  void* pfnReserved27;
-  void* pfnReserved28;
+  void* pvReserved27;
+  void* pvReserved28;
 } DeviceVectors;
 
 /* Cortex-M0+ processor handlers */
@@ -211,15 +205,18 @@ void TCC2_Handler                ( void );
 void TC3_Handler                 ( void );
 void TC4_Handler                 ( void );
 void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
 void ADC_Handler                 ( void );
 void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
 void PTC_Handler                 ( void );
 
 /*
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#define LITTLE_ENDIAN          1        
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
@@ -245,6 +242,7 @@ void PTC_Handler                 ( void );
 
 #include "component/ac.h"
 #include "component/adc.h"
+#include "component/dac.h"
 #include "component/dmac.h"
 #include "component/dsu.h"
 #include "component/eic.h"
@@ -274,6 +272,7 @@ void PTC_Handler                 ( void );
 
 #include "instance/ac.h"
 #include "instance/adc.h"
+#include "instance/dac.h"
 #include "instance/dmac.h"
 #include "instance/dsu.h"
 #include "instance/eic.h"
@@ -299,6 +298,8 @@ void PTC_Handler                 ( void );
 #include "instance/tc3.h"
 #include "instance/tc4.h"
 #include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
 #include "instance/tcc0.h"
 #include "instance/tcc1.h"
 #include "instance/tcc2.h"
@@ -346,12 +347,15 @@ void PTC_Handler                 ( void );
 #define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
 #define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
 #define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
 #define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
 #define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
 #define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
 #define ID_RFCTRL        85 /**< \brief RF233 control module (RFCTRL) */
 
-#define ID_PERIPH_COUNT  86 /**< \brief Number of peripheral IDs */
+#define ID_PERIPH_COUNT  86 /**< \brief Max number of peripheral IDs */
 /*@}*/
 
 /* ************************************************************************** */
@@ -361,46 +365,50 @@ void PTC_Handler                 ( void );
 /*@{*/
 
 #if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
-#define AC                            (0x42004400UL) /**< \brief (AC) APB Base Address */
-#define ADC                           (0x42004000UL) /**< \brief (ADC) APB Base Address */
-#define DMAC                          (0x41004800UL) /**< \brief (DMAC) APB Base Address */
-#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
-#define EIC                           (0x40001800UL) /**< \brief (EIC) APB Base Address */
-#define EVSYS                         (0x42000400UL) /**< \brief (EVSYS) APB Base Address */
-#define GCLK                          (0x40000C00UL) /**< \brief (GCLK) APB Base Address */
-#define SBMATRIX                      (0x41007000UL) /**< \brief (SBMATRIX) APB Base Address */
-#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
-#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
-#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
-#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
-#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
-#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
-#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
-#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
-#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
-#define PAC0                          (0x40000000UL) /**< \brief (PAC0) APB Base Address */
-#define PAC1                          (0x41000000UL) /**< \brief (PAC1) APB Base Address */
-#define PAC2                          (0x42000000UL) /**< \brief (PAC2) APB Base Address */
-#define PM                            (0x40000400UL) /**< \brief (PM) APB Base Address */
-#define PORT                          (0x41004400UL) /**< \brief (PORT) APB Base Address */
-#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
-#define RFCTRL                        (0x42005400UL) /**< \brief (RFCTRL) APB Base Address */
-#define RTC                           (0x40001400UL) /**< \brief (RTC) APB Base Address */
-#define SERCOM0                       (0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
-#define SERCOM1                       (0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
-#define SERCOM2                       (0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
-#define SERCOM3                       (0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
-#define SERCOM4                       (0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
-#define SERCOM5                       (0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
-#define SYSCTRL                       (0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
-#define TC3                           (0x42002C00UL) /**< \brief (TC3) APB Base Address */
-#define TC4                           (0x42003000UL) /**< \brief (TC4) APB Base Address */
-#define TC5                           (0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TCC0                          (0x42002000UL) /**< \brief (TCC0) APB Base Address */
-#define TCC1                          (0x42002400UL) /**< \brief (TCC1) APB Base Address */
-#define TCC2                          (0x42002800UL) /**< \brief (TCC2) APB Base Address */
-#define USB                           (0x41005000UL) /**< \brief (USB) APB Base Address */
-#define WDT                           (0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x41004800) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define SBMATRIX                      (0x41007000) /**< \brief (SBMATRIX) APB Base Address */
+#define MTB                           (0x41006000) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RFCTRL                        (0x42005400) /**< \brief (RFCTRL) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define TCC0                          (0x42002000) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42002400) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42002800) /**< \brief (TCC2) APB Base Address */
+#define USB                           (0x41005000) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
 #else
 #define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
 #define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
@@ -409,6 +417,10 @@ void PTC_Handler                 ( void );
 #define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
 #define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
 #define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
 
 #define DMAC              ((Dmac     *)0x41004800UL) /**< \brief (DMAC) APB Base Address */
 #define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
@@ -463,7 +475,10 @@ void PTC_Handler                 ( void );
 #define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
 #define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
 #define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
 
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
 #define PTC_GCLK_ID       34
 #define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
 #define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
@@ -492,8 +507,10 @@ void PTC_Handler                 ( void );
 #define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
 #define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
 #define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
-#define TC_INSTS          { TC3, TC4, TC5 }          /**< \brief (TC) Instances List */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       5                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
 
 #define TCC0              ((Tcc      *)0x42002000UL) /**< \brief (TCC0) APB Base Address */
 #define TCC1              ((Tcc      *)0x42002400UL) /**< \brief (TCC1) APB Base Address */
@@ -525,21 +542,21 @@ void PTC_Handler                 ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAMR21G17A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            0x20000UL /* 128 kB */
+#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
 #define FLASH_PAGE_SIZE       64
 #define FLASH_NB_OF_PAGES     2048
 #define FLASH_USER_PAGE_SIZE  64
-#define HMCRAMC0_SIZE         0x8000UL /* 32 kB */
+#define HMCRAMC0_SIZE         _UL(0x00008000) /* 32 kB */
 
-#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
-#define HMCRAMC0_ADDR         (0x20000000u) /**< HMCRAMC0 base address */
-#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
-#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
-#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
-#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HMCRAMC0_ADDR         _UL(0x20000000) /**< HMCRAMC0 base address */
+#define HPB0_ADDR             _UL(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL(0xE0000000) /**< PPB base address */
 
-#define DSU_DID_RESETVALUE    0x1001001AUL
+#define DSU_DID_RESETVALUE    _UL(0x1001031A)
 #define EIC_EXTINT_NUM        16
 #define PORT_GROUPS           3
 #define SIP_CONFIG            RF233

--- a/cpu/sam0_common/include/vendor/samr21/include/samr21g18a.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/samr21g18a.h
@@ -3,39 +3,24 @@
  *
  * \brief Header file for SAMR21G18A
  *
- * Copyright (c) 2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * 4. This software may only be redistributed and used in connection with an
- *    Atmel microcontroller product.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * \asf_license_stop
  *
@@ -72,15 +57,21 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#define CAST(type, value) ((type *)(value))
-#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#if !defined(_UL)
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
 #else
-#define CAST(type, value) (value)
-#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#if !defined(_UL)
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
 #endif
 
 /* ************************************************************************** */
@@ -120,8 +111,11 @@ typedef enum IRQn
   TC3_IRQn                 = 18, /**< 18 SAMR21G18A Basic Timer Counter 3 (TC3) */
   TC4_IRQn                 = 19, /**< 19 SAMR21G18A Basic Timer Counter 4 (TC4) */
   TC5_IRQn                 = 20, /**< 20 SAMR21G18A Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 21, /**< 21 SAMR21G18A Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 22, /**< 22 SAMR21G18A Basic Timer Counter 7 (TC7) */
   ADC_IRQn                 = 23, /**< 23 SAMR21G18A Analog Digital Converter (ADC) */
   AC_IRQn                  = 24, /**< 24 SAMR21G18A Analog Comparators (AC) */
+  DAC_IRQn                 = 25, /**< 25 SAMR21G18A Digital Analog Converter (DAC) */
   PTC_IRQn                 = 26, /**< 26 SAMR21G18A Peripheral Touch Controller (PTC) */
 
   PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
@@ -136,16 +130,16 @@ typedef struct _DeviceVectors
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
   void* pfnHardFault_Handler;
-  void* pfnReservedM12;
-  void* pfnReservedM11;
-  void* pfnReservedM10;
-  void* pfnReservedM9;
-  void* pfnReservedM8;
-  void* pfnReservedM7;
-  void* pfnReservedM6;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
   void* pfnSVC_Handler;
-  void* pfnReservedM4;
-  void* pfnReservedM3;
+  void* pvReservedM4;
+  void* pvReservedM3;
   void* pfnPendSV_Handler;
   void* pfnSysTick_Handler;
 
@@ -171,14 +165,14 @@ typedef struct _DeviceVectors
   void* pfnTC3_Handler;                   /* 18 Basic Timer Counter 3 */
   void* pfnTC4_Handler;                   /* 19 Basic Timer Counter 4 */
   void* pfnTC5_Handler;                   /* 20 Basic Timer Counter 5 */
-  void* pfnReserved21;
-  void* pfnReserved22;
+  void* pfnTC6_Handler;                   /* 21 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 22 Basic Timer Counter 7 */
   void* pfnADC_Handler;                   /* 23 Analog Digital Converter */
   void* pfnAC_Handler;                    /* 24 Analog Comparators */
-  void* pfnReserved25;
+  void* pfnDAC_Handler;                   /* 25 Digital Analog Converter */
   void* pfnPTC_Handler;                   /* 26 Peripheral Touch Controller */
-  void* pfnReserved27;
-  void* pfnReserved28;
+  void* pvReserved27;
+  void* pvReserved28;
 } DeviceVectors;
 
 /* Cortex-M0+ processor handlers */
@@ -211,15 +205,18 @@ void TCC2_Handler                ( void );
 void TC3_Handler                 ( void );
 void TC4_Handler                 ( void );
 void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
 void ADC_Handler                 ( void );
 void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
 void PTC_Handler                 ( void );
 
 /*
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#define LITTLE_ENDIAN          1        
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
@@ -245,6 +242,7 @@ void PTC_Handler                 ( void );
 
 #include "component/ac.h"
 #include "component/adc.h"
+#include "component/dac.h"
 #include "component/dmac.h"
 #include "component/dsu.h"
 #include "component/eic.h"
@@ -274,6 +272,7 @@ void PTC_Handler                 ( void );
 
 #include "instance/ac.h"
 #include "instance/adc.h"
+#include "instance/dac.h"
 #include "instance/dmac.h"
 #include "instance/dsu.h"
 #include "instance/eic.h"
@@ -299,6 +298,8 @@ void PTC_Handler                 ( void );
 #include "instance/tc3.h"
 #include "instance/tc4.h"
 #include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
 #include "instance/tcc0.h"
 #include "instance/tcc1.h"
 #include "instance/tcc2.h"
@@ -346,12 +347,15 @@ void PTC_Handler                 ( void );
 #define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
 #define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
 #define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
 #define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
 #define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
 #define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
 #define ID_RFCTRL        85 /**< \brief RF233 control module (RFCTRL) */
 
-#define ID_PERIPH_COUNT  86 /**< \brief Number of peripheral IDs */
+#define ID_PERIPH_COUNT  86 /**< \brief Max number of peripheral IDs */
 /*@}*/
 
 /* ************************************************************************** */
@@ -361,46 +365,50 @@ void PTC_Handler                 ( void );
 /*@{*/
 
 #if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
-#define AC                            (0x42004400UL) /**< \brief (AC) APB Base Address */
-#define ADC                           (0x42004000UL) /**< \brief (ADC) APB Base Address */
-#define DMAC                          (0x41004800UL) /**< \brief (DMAC) APB Base Address */
-#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
-#define EIC                           (0x40001800UL) /**< \brief (EIC) APB Base Address */
-#define EVSYS                         (0x42000400UL) /**< \brief (EVSYS) APB Base Address */
-#define GCLK                          (0x40000C00UL) /**< \brief (GCLK) APB Base Address */
-#define SBMATRIX                      (0x41007000UL) /**< \brief (SBMATRIX) APB Base Address */
-#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
-#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
-#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
-#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
-#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
-#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
-#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
-#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
-#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
-#define PAC0                          (0x40000000UL) /**< \brief (PAC0) APB Base Address */
-#define PAC1                          (0x41000000UL) /**< \brief (PAC1) APB Base Address */
-#define PAC2                          (0x42000000UL) /**< \brief (PAC2) APB Base Address */
-#define PM                            (0x40000400UL) /**< \brief (PM) APB Base Address */
-#define PORT                          (0x41004400UL) /**< \brief (PORT) APB Base Address */
-#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
-#define RFCTRL                        (0x42005400UL) /**< \brief (RFCTRL) APB Base Address */
-#define RTC                           (0x40001400UL) /**< \brief (RTC) APB Base Address */
-#define SERCOM0                       (0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
-#define SERCOM1                       (0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
-#define SERCOM2                       (0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
-#define SERCOM3                       (0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
-#define SERCOM4                       (0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
-#define SERCOM5                       (0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
-#define SYSCTRL                       (0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
-#define TC3                           (0x42002C00UL) /**< \brief (TC3) APB Base Address */
-#define TC4                           (0x42003000UL) /**< \brief (TC4) APB Base Address */
-#define TC5                           (0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TCC0                          (0x42002000UL) /**< \brief (TCC0) APB Base Address */
-#define TCC1                          (0x42002400UL) /**< \brief (TCC1) APB Base Address */
-#define TCC2                          (0x42002800UL) /**< \brief (TCC2) APB Base Address */
-#define USB                           (0x41005000UL) /**< \brief (USB) APB Base Address */
-#define WDT                           (0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x41004800) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define SBMATRIX                      (0x41007000) /**< \brief (SBMATRIX) APB Base Address */
+#define MTB                           (0x41006000) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RFCTRL                        (0x42005400) /**< \brief (RFCTRL) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define TCC0                          (0x42002000) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42002400) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42002800) /**< \brief (TCC2) APB Base Address */
+#define USB                           (0x41005000) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
 #else
 #define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
 #define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
@@ -409,6 +417,10 @@ void PTC_Handler                 ( void );
 #define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
 #define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
 #define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
 
 #define DMAC              ((Dmac     *)0x41004800UL) /**< \brief (DMAC) APB Base Address */
 #define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
@@ -463,7 +475,10 @@ void PTC_Handler                 ( void );
 #define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
 #define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
 #define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
 
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
 #define PTC_GCLK_ID       34
 #define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
 #define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
@@ -492,8 +507,10 @@ void PTC_Handler                 ( void );
 #define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
 #define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
 #define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
-#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
-#define TC_INSTS          { TC3, TC4, TC5 }          /**< \brief (TC) Instances List */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       5                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
 
 #define TCC0              ((Tcc      *)0x42002000UL) /**< \brief (TCC0) APB Base Address */
 #define TCC1              ((Tcc      *)0x42002400UL) /**< \brief (TCC1) APB Base Address */
@@ -525,21 +542,21 @@ void PTC_Handler                 ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAMR21G18A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            0x40000UL /* 256 kB */
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       64
 #define FLASH_NB_OF_PAGES     4096
 #define FLASH_USER_PAGE_SIZE  64
-#define HMCRAMC0_SIZE         0x8000UL /* 32 kB */
+#define HMCRAMC0_SIZE         _UL(0x00008000) /* 32 kB */
 
-#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
-#define HMCRAMC0_ADDR         (0x20000000u) /**< HMCRAMC0 base address */
-#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
-#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
-#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
-#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HMCRAMC0_ADDR         _UL(0x20000000) /**< HMCRAMC0 base address */
+#define HPB0_ADDR             _UL(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL(0xE0000000) /**< PPB base address */
 
-#define DSU_DID_RESETVALUE    0x10010019UL
+#define DSU_DID_RESETVALUE    _UL(0x10010319)
 #define EIC_EXTINT_NUM        16
 #define PORT_GROUPS           3
 #define SIP_CONFIG            RF233


### PR DESCRIPTION
### Contribution description

This updates the samr21 vendor files to the latest version from http://packs.download.atmel.com/

This release adds EXTINT defines compatible with later versions of the sam0 series of MCUs.

### Testing procedure

No change in functionality is expected.

### Issues/PRs references

needed for #13310