### PR TITLE
drivers/mrf24j40: Expose configurations to Kconfig

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -5,5 +5,6 @@
 # directory for more details.
 
 menu "Network Device Drivers"
+rsource "mrf24j40/Kconfig"
 source "$(RIOTCPU)/nrf52/radio/nrf802154/Kconfig"
 endmenu # Network Device Drivers

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -482,9 +482,11 @@ endif
 ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
   USEMODULE += mrf24j40
 
-  # all modules but mrf24j40ma have an external PA
-  ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
-    CFLAGS += -DCONFIG_MRF24J40_USE_EXT_PA_LNA
+  ifndef CONFIG_KCONFIG_MODULE_MRF24J40
+    # all modules but mrf24j40ma have an external PA
+    ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
+      CFLAGS += -DCONFIG_MRF24J40_USE_EXT_PA_LNA
+    endif
   endif
 endif
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -484,7 +484,7 @@ ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
 
   # all modules but mrf24j40ma have an external PA
   ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
-    CFLAGS += -DMRF24J40_USE_EXT_PA_LNA
+    CFLAGS += -DCONFIG_MRF24J40_USE_EXT_PA_LNA
   endif
 endif
 

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -125,11 +125,12 @@ extern "C" {
 /**
  * @brief Enable external PA/LNA control
  *
- * Increase RSSI for MRF24J40MC/MD/ME devices. No effect on MRF24J40MA.
- * For more information, please refer to section 4.2 of MRF24J40 datasheet.
+ * Set to 1 to increase RSSI for MRF24J40MC/MD/ME devices. No effect on
+ * MRF24J40MA. For more information, please refer to section 4.2 of MRF24J40
+ * datasheet.
  */
-#ifndef MRF24J40_USE_EXT_PA_LNA
-#define MRF24J40_USE_EXT_PA_LNA         (0U)
+#if defined(DOXYGEN)
+#define CONFIG_MRF24J40_USE_EXT_PA_LNA
 #endif
 
 /**

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -137,11 +137,11 @@ extern "C" {
  *
  * Perform a write / read to a known register on startup to detect
  * if the device is connected.
- * Enable this if you want the boot not to hang if the device is
+ * Set this to 1 if you want the boot not to hang if the device is
  * not connected / there are SPI errors.
  */
-#ifndef MRF24J40_TEST_SPI_CONNECTION
-#define MRF24J40_TEST_SPI_CONNECTION    (0U)
+#if defined(DOXYGEN)
+#define CONFIG_MRF24J40_TEST_SPI_CONNECTION
 #endif
 /** @} */
 

--- a/drivers/mrf24j40/Kconfig
+++ b/drivers/mrf24j40/Kconfig
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_MRF24J40
+    bool "Configure MRF24J40 driver"
+    depends on MODULE_MRF24J40
+    help
+        Configure the MRF24J40 driver using Kconfig.
+
+if KCONFIG_MODULE_MRF24J40
+
+config MRF24J40_USE_EXT_PA_LNA
+    bool "Enable external PA/LNA control"
+    default y
+    depends on !MODULE_MRF24J40MA
+    help
+        Increase RSSI for MRF24J40MC/MD/ME devices. No effect on MRF24J40MA.
+        For more information, please refer to section 4.2 of MRF24J40 datasheet.
+
+config MRF24J40_TEST_SPI_CONNECTION
+    bool "Enable basic self-test on init"
+    help
+        Perform a write / read to a known register on startup to detect if the
+        device is connected. Enable this if you want the boot not to hang if the
+        device is not connected / there are SPI errors.
+
+endif # KCONFIG_MODULE_MRF24J40

--- a/drivers/mrf24j40/include/mrf24j40_internal.h
+++ b/drivers/mrf24j40/include/mrf24j40_internal.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "mrf24j40.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -123,7 +124,7 @@ void mrf24j40_hardware_reset(mrf24j40_t *dev);
  *
  * @param[in] dev       device to enable the PA & LNA on
  */
-#if MRF24J40_USE_EXT_PA_LNA
+#if IS_ACTIVE(CONFIG_MRF24J40_USE_EXT_PA_LNA)
 void mrf24j40_enable_auto_pa_lna(mrf24j40_t *dev);
 #else
 static inline void mrf24j40_enable_auto_pa_lna(mrf24j40_t *dev) { (void) dev; }
@@ -134,7 +135,7 @@ static inline void mrf24j40_enable_auto_pa_lna(mrf24j40_t *dev) { (void) dev; }
  *
  * @param[in] dev       device to disable the PA & LNA on
  */
-#if MRF24J40_USE_EXT_PA_LNA
+#if IS_ACTIVE(CONFIG_MRF24J40_USE_EXT_PA_LNA)
 void mrf24j40_disable_auto_pa_lna(mrf24j40_t *dev);
 #else
 static inline void mrf24j40_disable_auto_pa_lna(mrf24j40_t *dev) { (void) dev; }
@@ -145,7 +146,7 @@ static inline void mrf24j40_disable_auto_pa_lna(mrf24j40_t *dev) { (void) dev; }
  *
  * @param[in] dev       device enable the LNA on
  */
-#if MRF24J40_USE_EXT_PA_LNA
+#if IS_ACTIVE(CONFIG_MRF24J40_USE_EXT_PA_LNA)
 void mrf24j40_enable_lna(mrf24j40_t *dev);
 #else
 static inline void mrf24j40_enable_lna(mrf24j40_t *dev) { (void) dev; }

--- a/drivers/mrf24j40/mrf24j40_internal.c
+++ b/drivers/mrf24j40/mrf24j40_internal.c
@@ -24,6 +24,7 @@
 #include "xtimer.h"
 #include "mrf24j40_internal.h"
 #include "mrf24j40_registers.h"
+#include "kernel_defines.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -100,24 +101,24 @@ void mrf24j40_enable_lna(mrf24j40_t *dev)
 
 int mrf24j40_init(mrf24j40_t *dev)
 {
-#if MRF24J40_TEST_SPI_CONNECTION
-    /* Check if MRF24J40 is available */
-    uint8_t txmcr = mrf24j40_reg_read_short(dev, MRF24J40_REG_TXMCR);
-    if ((txmcr == 0xFF) || (txmcr == 0x00)) {
-        /* Write default value to TXMCR register */
-        mrf24j40_reg_write_short(dev, MRF24J40_REG_TXMCR, MRF24J40_TXMCR_MACMINBE1 |
-                                                          MRF24J40_TXMCR_MACMINBE0 |
-                                                          MRF24J40_TXMCR_CSMABF2);
-        txmcr = mrf24j40_reg_read_short(dev, MRF24J40_REG_TXMCR);
-        if (txmcr != (MRF24J40_TXMCR_MACMINBE1 |
-                      MRF24J40_TXMCR_MACMINBE0 |
-                      MRF24J40_TXMCR_CSMABF2)) {
-            DEBUG("[mrf24j40] Initialization failure, SPI interface communication failed\n");
-            /* Return to prevents hangup later in the initialization */
-            return -ENODEV;
+    if (IS_ACTIVE(CONFIG_MRF24J40_TEST_SPI_CONNECTION)) {
+        /* Check if MRF24J40 is available */
+        uint8_t txmcr = mrf24j40_reg_read_short(dev, MRF24J40_REG_TXMCR);
+        if ((txmcr == 0xFF) || (txmcr == 0x00)) {
+            /* Write default value to TXMCR register */
+            mrf24j40_reg_write_short(dev, MRF24J40_REG_TXMCR, MRF24J40_TXMCR_MACMINBE1 |
+                                                            MRF24J40_TXMCR_MACMINBE0 |
+                                                            MRF24J40_TXMCR_CSMABF2);
+            txmcr = mrf24j40_reg_read_short(dev, MRF24J40_REG_TXMCR);
+            if (txmcr != (MRF24J40_TXMCR_MACMINBE1 |
+                        MRF24J40_TXMCR_MACMINBE0 |
+                        MRF24J40_TXMCR_CSMABF2)) {
+                DEBUG("[mrf24j40] Initialization failure, SPI interface communication failed\n");
+                /* Return to prevents hangup later in the initialization */
+                return -ENODEV;
+            }
         }
     }
-#endif
 
     mrf24j40_hardware_reset(dev);
 

--- a/drivers/mrf24j40/mrf24j40_internal.c
+++ b/drivers/mrf24j40/mrf24j40_internal.c
@@ -37,7 +37,7 @@ static inline void getbus(mrf24j40_t *dev)
     spi_acquire(SPIDEV, CSPIN, SPI_MODE_0, dev->params.spi_clk);
 }
 
-#if MRF24J40_USE_EXT_PA_LNA
+#if IS_ACTIVE(CONFIG_MRF24J40_USE_EXT_PA_LNA)
 static inline void mrf24j40_reg_and_short(mrf24j40_t *dev, const uint8_t addr, uint8_t value)
 {
     value &= mrf24j40_reg_read_short(dev, addr);
@@ -97,7 +97,7 @@ void mrf24j40_enable_lna(mrf24j40_t *dev)
     mrf24j40_reg_and_short(dev, MRF24J40_REG_GPIO, ~(MRF24J40_GPIO_0 | MRF24J40_GPIO_1));
     mrf24j40_reg_or_short(dev, MRF24J40_REG_GPIO, MRF24J40_GPIO_2 | MRF24J40_GPIO_3);
 }
-#endif /* MRF24J40_USE_EXT_PA_LNA */
+#endif /* CONFIG_MRF24J40_USE_EXT_PA_LNA */
 
 int mrf24j40_init(mrf24j40_t *dev)
 {


### PR DESCRIPTION
### Contribution description
This PR exposes the configurations of the `mrf24j40` radio driver to Kconfig. The usage of the options were modified to match the behaviour of Kconfig, so `IS_ACTIVE` is being used now.

I am setting `MRF24J40_USE_EXT_PA_LNA`  to default y because that's the observed behaviour from `drivers/Makefile.dep`.

### Testing procedure
- Testing with `gnrc_networking` and using some `mrf24j40` module should be working.
- Check that if `mrj24j40ma` is used `MRF24J40_USE_EXT_PA_LNA` is not available.
- Changing options from Kconfig should reflect on the application.

### Issues/PRs references
Part of #12888