### PR TITLE
tests/event_threads: remove arch_arm7 from blacklist

### DIFF
--- a/cpu/arm7_common/arm_cpu.c
+++ b/cpu/arm7_common/arm_cpu.c
@@ -25,6 +25,13 @@
 #define STACK_MARKER    (0x77777777)
 #define REGISTER_CNT    (12)
 
+__attribute__((used, section(".usr_stack"))) uint8_t usr_stack[USR_STACKSIZE];
+__attribute__((used, section(".und_stack"))) uint8_t und_stack[UND_STACKSIZE];
+__attribute__((used, section(".fiq_stack"))) uint8_t fiq_stack[FIQ_STACKSIZE];
+__attribute__((used, section(".irq_stack"))) uint8_t irq_stack[ISR_STACKSIZE];
+__attribute__((used, section(".abt_stack"))) uint8_t abt_stack[ABT_STACKSIZE];
+__attribute__((used, section(".svc_stack"))) uint8_t svc_stack[ISR_STACKSIZE];
+
 void thread_yield_higher(void)
 {
     if (irq_is_in()) {
@@ -121,16 +128,13 @@ void *thread_isr_stack_pointer(void)
 /* This function returns the number of bytes used on the ISR stack */
 int thread_isr_stack_usage(void)
 {
-    extern uintptr_t __stack_irq_start;
-    extern uintptr_t __stack_irq_size;
+    uint32_t *ptr = (uint32_t*) &irq_stack[0];
 
-    uintptr_t *ptr = &__stack_irq_start - (unsigned) &__stack_irq_size;
-
-    while(((*ptr) == STACK_CANARY_WORD) && (ptr < &__stack_irq_start)) {
+    while(((*ptr) == STACK_CANARY_WORD) && (ptr < (uint32_t*) &irq_stack[ISR_STACKSIZE])) {
         ++ptr;
     }
 
-    ptrdiff_t num_used_words = &__stack_irq_start - ptr;
+    ptrdiff_t num_used_words = (uint32_t*) &irq_stack[ISR_STACKSIZE] - ptr;
 
     return num_used_words;
 }

--- a/cpu/lpc2387/include/cpu_conf.h
+++ b/cpu/lpc2387/include/cpu_conf.h
@@ -76,11 +76,45 @@ extern "C" {
 #define PUF_SRAM_ATTRIBUTES __attribute__((used, section(".noinit")))
 
 /**
- * @brief   Stack size used for the exception (ISR) stack
+ * @brief   Stack size used for the undefined instruction interrupt stack
  * @{
  */
-extern unsigned __stack_irq_size;
-#define ISR_STACKSIZE                   ((unsigned) &__stack_irq_size)
+#define UND_STACKSIZE                   (4)
+/** @} */
+
+/**
+ * @brief   Stack size used for the abort interrupt stack
+ * @{
+ */
+#define ABT_STACKSIZE                   (4)
+/** @} */
+
+/**
+ * @brief   Stack size used for the interrupt (ISR) stack
+ * @{
+ */
+#define ISR_STACKSIZE                   (400)
+/** @} */
+
+/**
+ * @brief   Stack size used for the fast interrupt (FIQ) stack
+ * @{
+ */
+#define FIQ_STACKSIZE                   (64)
+/** @} */
+
+/**
+ * @brief   Stack size used for the supervisor mode (SVC) stack
+ * @{
+ */
+#define SVC_STACKSIZE                   (400)
+/** @} */
+
+/**
+ * @brief   Stack size used for the user mode/kernel init stack
+ * @{
+ */
+#define USR_STACKSIZE                   (4096)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/lpc2387/ldscripts/lpc2387.ld
+++ b/cpu/lpc2387/ldscripts/lpc2387.ld
@@ -17,14 +17,6 @@ MEMORY
     ram_ethernet        : ORIGIN = 0x7FE00000, LENGTH = 16K     /* ethernet RAM                             */
 }
 
-__stack_und_size = 4;           /* stack for "undefined instruction" interrupts             */
-__stack_abt_size = 4;           /* stack for "abort" interrupts                             */
-__stack_fiq_size = 64;          /* stack for "FIQ" interrupts                               */
-__stack_irq_size = 400;         /* stack for "IRQ" normal interrupts                        */
-__stack_svc_size = 400;         /* stack for "SVC" supervisor mode                          */
-__stack_usr_size = 4096;        /* stack for user operation (kernel init)                   */
-__stack_size = __stack_und_size + __stack_abt_size + __stack_fiq_size + __stack_irq_size + __stack_svc_size + __stack_usr_size;
-
 /* now define the output sections  */
 SECTIONS
 {
@@ -112,18 +104,17 @@ SECTIONS
     .stack (NOLOAD) :
     {
         PROVIDE(__stack_start = .);
-
-        . = . + __stack_usr_size;
+        KEEP (*(.usr_stack))
         __stack_usr_start = .;
-        . = . + __stack_und_size;
+        KEEP (*(.und_stack))
         __stack_und_start = .;
-        . = . + __stack_fiq_size;
+        KEEP (*(.fiq_stack))
         __stack_fiq_start = .;
-        . = . + __stack_irq_size;
+        KEEP (*(.irq_stack))
         __stack_irq_start = .;
-        . = . + __stack_abt_size;
+        KEEP (*(.abt_stack))
         __stack_abt_start = .;
-        . = . + __stack_svc_size;
+        KEEP (*(.svc_stack))
         __stack_svc_start = .;
 
         PROVIDE(__stack_end = .);

--- a/tests/event_threads/Makefile
+++ b/tests/event_threads/Makefile
@@ -2,7 +2,4 @@ include ../Makefile.tests_common
 
 USEMODULE += event_thread_highest event_thread_medium event_thread_lowest
 
-# arm7 has an issue with it's ISR_STACKSIZE define
-FEATURES_BLACKLIST += arch_arm7
-
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

To be used for array dimensions, `ISR_STACKSIZE` must be a constant at compile time.
We can't rely on the linker to fill it in later through information from the linker script.
The duplication of information is unfortunate, but I suppose everyone else is doing it.

### Testing procedure

`tests/event_threads` should compile (and run) on `msba2`.

### Issues/PRs references

introduced by #12474
touches #4693
