### PR TITLE
lora: remove LORA_FREQUENCY_RESOLUTION_DEFAULT from LoRa configurations

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -95,6 +95,7 @@ extern "C" {
 #ifndef SX127X_DIO_PULL_MODE
 #define SX127X_DIO_PULL_MODE             (GPIO_IN_PD) /**< pull down DIOx */
 #endif
+
 /** @} */
 
 /**

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -125,7 +125,14 @@ void sx127x_set_syncword(sx127x_t *dev, uint8_t syncword)
  */
 static inline uint32_t _freq_to_hw_value(uint32_t freq)
 {
-    return (freq << 8) / 15625;
+    unsigned pow = 6;
+    do {
+        freq /= 5;
+        freq <<= 1;
+    } while (--pow);
+    freq <<= 2;
+
+    return freq;
 }
 
 /**
@@ -133,7 +140,14 @@ static inline uint32_t _freq_to_hw_value(uint32_t freq)
  */
 static inline uint32_t _hw_value_to_freq(uint32_t frf)
 {
-    return (frf * 15625) >> 8;
+    unsigned pow = 6;
+    frf >>= 2;
+    do {
+        frf *= 5;
+        frf >>= 1;
+    } while (--pow);
+
+    return frf;
 }
 
 uint32_t sx127x_get_channel(const sx127x_t *dev)

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -116,13 +116,15 @@ void sx127x_read_fifo(const sx127x_t *dev, uint8_t *buffer, uint8_t size)
 void sx1276_rx_chain_calibration(sx127x_t *dev)
 {
     uint8_t reg_pa_config_init_val;
-    uint32_t initial_freq;
+    uint8_t frfmsb;
+    uint8_t frfmid;
+    uint8_t frflsb;
 
     /* Save context */
     reg_pa_config_init_val = sx127x_reg_read(dev, SX127X_REG_PACONFIG);
-    initial_freq = (double) (((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
-                             | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8)
-                             | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * (double)LORA_FREQUENCY_RESOLUTION_DEFAULT;
+    frfmsb = sx127x_reg_read(dev, SX127X_REG_FRFMSB);
+    frfmid = sx127x_reg_read(dev, SX127X_REG_FRFMID);
+    frflsb = sx127x_reg_read(dev, SX127X_REG_FRFLSB);
 
     /* Cut the PA just in case, RFO output, power = -1 dBm */
     sx127x_reg_write(dev, SX127X_REG_PACONFIG, 0x00);
@@ -151,7 +153,9 @@ void sx1276_rx_chain_calibration(sx127x_t *dev)
 
     /* Restore context */
     sx127x_reg_write(dev, SX127X_REG_PACONFIG, reg_pa_config_init_val);
-    sx127x_set_channel(dev, initial_freq);
+    sx127x_reg_write(dev, SX127X_REG_FRFMSB, frfmsb);
+    sx127x_reg_write(dev, SX127X_REG_FRFMID, frfmid);
+    sx127x_reg_write(dev, SX127X_REG_FRFLSB, frflsb);
 }
 #endif
 

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -33,11 +33,6 @@ extern "C" {
  * @ingroup  config
  * @{
  */
-/** @brief Frequency resolution in Hz */
-#ifndef LORA_FREQUENCY_RESOLUTION_DEFAULT
-#define LORA_FREQUENCY_RESOLUTION_DEFAULT      (61.03515625)
-#endif
-
 /** @brief Preamble length, same for Tx and Rx */
 #ifndef LORA_PREAMBLE_LENGTH_DEFAULT
 #define LORA_PREAMBLE_LENGTH_DEFAULT           (8U)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The `LORA_FREQUENCY_RESOLUTION_DEFAULT` variable is the frequency step of the SX127x transceiver. This is not intended to be configured by the user and it's not specific to LoRa. 

This PR moves thisconfiguration to a SX127X_FREQUENCY_STEP macro.

The immediate follow up of this PR is LoRa and LoRaWAN Kconfig configurations.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
It should be enough to check if `sx127x` applications (gnrc_lorawan, lorawan example) still compile.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
