### PR TITLE
cpu/atmega_common: Fix reboot issues

### DIFF
--- a/cpu/atmega_common/cpu.c
+++ b/cpu/atmega_common/cpu.c
@@ -36,6 +36,13 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#ifndef MCUSR
+/* In older ATmegas the MCUSR register was still named MCUCSR. Current avrlibc
+ * versions provide the MCUSR macro for those as well, but adding a fallback
+ * here doesn't hurt*/
+#define MCUSR MCUCSR
+#endif /* !MCUSR */
+
 /*
 * Since atmega MCUs do not feature a software reset, the watchdog timer
 * is being used. It will be set to the shortest time and then force a
@@ -51,7 +58,7 @@
 */
 uint8_t mcusr_mirror __attribute__((section(".noinit")));
 uint8_t soft_rst __attribute__((section(".noinit")));
-void get_mcusr(void) __attribute__((naked)) __attribute__((section(".init0")));
+void get_mcusr(void) __attribute__((naked, section(".init0"), used));
 
 void get_mcusr(void)
 {
@@ -62,13 +69,8 @@ void get_mcusr(void)
     __asm__ __volatile__("mov %0, r2\n" : "=r" (mcusr_mirror) :);
 #else
     /* save the reset flags */
-#ifdef MCUCSR
-  mcusr_mirror = MCUCSR;
-  MCUSR = 0;
-#else
-  mcusr_mirror = MCUSR;
-  MCUSR = 0;
-#endif
+    mcusr_mirror = MCUSR;
+    MCUSR = 0;
     wdt_disable();
 #endif
 }


### PR DESCRIPTION
### Contribution description

- Mark `get_mcusr()` with attribute `used`, so it does not get optimized out on LTO
    - This fixes a reboot loop when compiled with `LTO=1`, as the watchdog timer (wdt) is not disabled after the reboot without `get_mcusr()`
- Allow using the Optiboot bootloader with the Arduino Nano
    - The stock bootloader of the Arduino Nano sucks (huge, slow) compared to Optiboot
    - The stock bootloader has an issue with the way RIOT performs the soft reboot. (Without having looked into it: I guess it does neither disable nor feed the watchdog, casing it to trigger while waiting for a programmer.)

### Testing procedure

1. Grab an Arduino Nano with a stock bootloader, flash and run `examples/default` (but disable module `saul_default` in the Makefile to not overflow RAM)
    - The command `reboot` should get the board stuck in a reboot loop with master
2. Flash Optiboot on the Arduino Nano 
    - Flashing the board with `ARDUINO_NANO_OPTIBOOT=1` exported should work with this PR (but not in master)
    - The reboot loop should be gone
3. Compile `examples/default` (without `saul_default`) with `LTO=1` on any ATmega Board except an Arduino Nano with stock bootloader
    - In master the shell command `reboot` will cause a reboot loop
    - With this PR the reboot loop should be fixed

### Issues/PRs references

Fixes: https://github.com/RIOT-OS/RIOT/issues/12854