### PR TITLE
 stdio_semihosting: Initial include of Semihosting-based STDIO 

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -96,6 +96,8 @@
 # the target when starting a debug session. 'reset halt' can also be used
 # depending on the type of target.
 : ${OPENOCD_DBG_START_CMD:=-c 'halt'}
+# Extra commands to add when using debug
+: ${OPENOCD_DBG_EXTRA_CMD:=}
 # command used to reset the board
 : ${OPENOCD_CMD_RESET_RUN:="-c 'reset run'"}
 # This is an optional offset to the base address that can be used to flash an
@@ -329,6 +331,7 @@ do_debug() {
             -c 'telnet_port ${TELNET_PORT}' \
             -c 'gdb_port ${GDB_PORT}' \
             -c 'init' \
+            ${OPENOCD_DBG_EXTRA_CMD} \
             -c 'targets' \
             ${OPENOCD_DBG_START_CMD} \
             -l /dev/null & \
@@ -356,6 +359,7 @@ do_debugserver() {
             -c 'telnet_port ${TELNET_PORT}' \
             -c 'gdb_port ${GDB_PORT}' \
             -c 'init' \
+            ${OPENOCD_DBG_EXTRA_CMD} \
             -c 'targets' \
             -c 'halt'"
 }

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -4,6 +4,7 @@ STDIO_MODULES = \
   stdio_ethos \
   stdio_null \
   stdio_rtt \
+  stdio_semihosting \
   stdio_uart \
   #
 
@@ -48,4 +49,9 @@ ifeq (,$(filter stdio_cdc_acm,$(USEMODULE)))
   # stdio_cdc_acm module is not used
   FEATURES_BLACKLIST += bootloader_arduino
   FEATURES_BLACKLIST += bootloader_nrfutil
+endif
+
+ifneq (,$(filter stdio_semihosting,$(USEMODULE)))
+  USEMODULE += xtimer
+  FEATURES_REQUIRED += arch_cortexm
 endif

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -33,6 +33,5 @@ else ifeq ($(RIOT_TERMINAL),semihosting)
   TERMPROG = $(DEBUGGER)
   TERMFLAGS = $(DEBUGGER_FLAGS)
   OPENOCD_DBG_EXTRA_CMD += -c 'arm semihosting enable'
-  OPENOCD_DBG_EXTRA_CMD += -c 'set remotetimeout 10000' 
   $(call target-export-variables,term cleanterm,OPENOCD_DBG_EXTRA_CMD)
 endif

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -29,4 +29,10 @@ else ifeq ($(RIOT_TERMINAL),miniterm)
 else ifeq ($(RIOT_TERMINAL),jlink)
   TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
   TERMFLAGS = term-rtt
+else ifeq ($(RIOT_TERMINAL),semihosting)
+  TERMPROG = $(DEBUGGER)
+  TERMFLAGS = $(DEBUGGER_FLAGS)
+  OPENOCD_DBG_EXTRA_CMD += -c 'arm semihosting enable'
+  OPENOCD_DBG_EXTRA_CMD += -c 'set remotetimeout 10000' 
+  $(call target-export-variables,term cleanterm,OPENOCD_DBG_EXTRA_CMD)
 endif

--- a/sys/include/stdio_semihosting.h
+++ b/sys/include/stdio_semihosting.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_stdio_semihosting STDIO over Semihosting
+ * @ingroup     sys
+ *
+ * @brief       Standard input/output backend using ARM Semihosting
+ *
+ * The ARM Semihosting provides an STDIO backend using the ARM Semihosting
+ * protocol. The main advantage of Semihosting is that is allows STDIO over the
+ * SWD/JTAG debugging interface already available on ARM microcontrollers.
+ *
+ * ARM Semihosting works by using the breakpoint instructing to trigger the
+ * debugger to read the output or to write the input chars. Please be aware that
+ * this might skew the timing of your application.
+ *
+ * The main disadvantage of Semihosting is that it is relative slow (even when
+ * compared to serial uart), and that it requires an active debug session to
+ * handle the breakpoint instructions. Without an active debug session the CPU
+ * will halt on the first STDIO activity until the breakpoint is handled by the
+ * debugger. Don't forget to disable the Semihosting module or replace it with
+ * stdio_null when switching to production builds.
+ *
+ * As this is an ARM specific protocol, this module will only work on ARM-based
+ * microcontrollers.
+ *
+ * ## Usage
+ *
+ * Enable Semihosting-based stdio by adding the following module to your
+ * makefile:
+ *
+ * ```
+ * USEMODULE += stdio_semihosting
+ * ```
+ *
+ * If semihosting is not the default stdio mechanism of your board, the
+ * `RIOT_TERMINAL` variable has to be set to `semihosting`:
+ *
+ * ```
+ * make term RIOT_TERMINAL=semihosting
+ * ```
+ *
+ * Launching the terminal will start an OpenOCD session with semihosting
+ * enabled. This can be used for both STDIO interaction and for debugging the
+ * firmware.
+ *
+ * @{
+ * @file
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef STDIO_SEMIHOSTING_H
+#define STDIO_SEMIHOSTING_H
+
+#include "stdio_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable reception for Semihosting
+ *
+ * Automatically enabled when including the `stdin` module
+ */
+#define STDIO_SEMIHOSTING_RX            (IS_USED(MODULE_STDIN))
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* STDIO_SEMIHOSTING_H */

--- a/sys/stdio_semihosting/Makefile
+++ b/sys/stdio_semihosting/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/stdio_semihosting/stdio_semihosting.c
+++ b/sys/stdio_semihosting/stdio_semihosting.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       STDIO over ARM Semihosting implementation
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include "stdio_semihosting.h"
+#include "xtimer.h"
+
+#if MODULE_VFS
+#include "vfs.h"
+#endif
+
+/**
+ * @brief Rate at which the stdin read polls (breaks) the debugger for input
+ * data
+ */
+#define STDIO_SEMIHOSTING_POLL_RATE     (10 * US_PER_MS)
+
+/**
+ * @brief ARM Semihosting STDIN file descriptor
+ */
+#define STDIO_SEMIHOSTING_F_STDIN       (1)
+
+/**
+ * @brief ARM Semihosting STDOUT file descriptor
+ */
+#define STDIO_SEMIHOSTING_F_STDOUT      (1)
+
+/**
+ * @name ARM Semihosting commands
+ *
+ * Extend when required
+ * @{
+ */
+#define STDIO_SEMIHOSTING_SYS_WRITE     (0x05) /**< Write command */
+#define STDIO_SEMIHOSTING_SYS_READ      (0x06) /**< Read command  */
+/** @} */
+
+static bool _semihosting_connected(void) {
+#ifdef CoreDebug_DHCSR_C_DEBUGEN_Msk
+    /* Best effort attempt to detect if a debug session is active */
+    return CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
+#else
+    return true;
+#endif
+}
+
+static uint32_t _semihosting_raw(int cmd, uint32_t *args)
+{
+    uint32_t result = 0;
+    /* Moves cmd and args to r0 and r1. Then triggers a breakpoint.
+     * Finally moves the results stored in r0 to result
+     */
+    __asm__(
+        "mov r0, %[cmd] \n"
+        "mov r1, %[args] \n"
+        "bkpt #0xAB \n"
+        "mov %[result], r0\n"
+        : /* Outputs */
+        [result] "=r" (result)
+        : /* Inputs */
+        [cmd] "r" (cmd),
+        [args] "r" (args)
+        : /* Clobbered registers */
+        "r0", "r1", "memory"
+    );
+    return result;
+}
+
+static size_t _semihosting_write(const uint8_t *buffer, size_t len)
+{
+    uint32_t args[3] = {
+        STDIO_SEMIHOSTING_F_STDOUT,
+        (uint32_t)buffer,
+        (uint32_t)len,
+    };
+    return _semihosting_raw(STDIO_SEMIHOSTING_SYS_WRITE, args);
+}
+
+static ssize_t _semihosting_read(uint8_t *buffer, size_t len)
+{
+    uint32_t args[3] = {
+        STDIO_SEMIHOSTING_F_STDIN,
+        (uint32_t)buffer,
+        (uint32_t)len,
+    };
+    size_t remaining = _semihosting_raw(STDIO_SEMIHOSTING_SYS_READ, args);
+    return len - remaining;
+}
+
+void stdio_init(void)
+{
+#if MODULE_VFS
+    vfs_bind_stdio();
+#endif
+}
+
+ssize_t stdio_read(void* buffer, size_t count)
+{
+    if (STDIO_SEMIHOSTING_RX) {
+        xtimer_ticks32_t last_wakeup = xtimer_now();
+        ssize_t bytes_read = _semihosting_read(buffer, count);
+        while (bytes_read == 0) {
+            xtimer_periodic_wakeup(&last_wakeup, STDIO_SEMIHOSTING_POLL_RATE);
+            bytes_read = _semihosting_read(buffer, count);
+        }
+        return bytes_read;
+    }
+    return -ENOTSUP;
+}
+
+ssize_t stdio_write(const void* buffer, size_t len)
+{
+    if (!_semihosting_connected()) {
+        return len;
+    }
+    size_t remaining = _semihosting_write(buffer, len);
+    return len - remaining;
+}

--- a/tests/sys_stdio_semihosting/Makefile
+++ b/tests/sys_stdio_semihosting/Makefile
@@ -1,0 +1,10 @@
+include ../Makefile.tests_common
+
+USEMODULE += stdio_semihosting
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+RIOT_TERMINAL = semihosting
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys_stdio_semihosting/README.md
+++ b/tests/sys_stdio_semihosting/README.md
@@ -1,0 +1,13 @@
+# Semihosting STDIO test
+
+This test aims to test ARM semihosting based STDIO on RIOT. The test is manual,
+starting a debugger on the CI for automated test is not supported.
+
+## Usage
+
+1. Flash the test on a board with an ARM-based MCU.
+2. Use `make term RIOT_TERMINAL=semihosting` to start a debug session with
+   semihosting enabled.
+3. Restart the microcontroller via the debug session.
+
+The shell prompt should be available in the GDB session.

--- a/tests/sys_stdio_semihosting/main.c
+++ b/tests/sys_stdio_semihosting/main.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       STDIO Semihosting test application using simple shell
+ *              interaction
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "shell_commands.h"
+
+int main(void)
+{
+    puts("STDIO semihosting test application");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR adds ARM Semihosting-based STDIO capabilities. It allows STDIO over SWD/JTAG, similar to the Segger RTT protocol, but without requiring the proprietary Jlink binaries or a Jlink programmer to function. Only ARM MCUs are supported (but I've heard rumors that RISC-V has something similar). The big downsides are that Semihosting is relative slow and that it requires an active debugging session (at all times) when it is enabled. This last bit because it throws breakpoint instructions for write and read requests from the host.

Currently the terminal used is OpenOCD in debugger mode. Maybe this can be refined at some point by not halting the CPU when starting the terminal, but that's for later.

### Testing procedure

- Use the provided test application to verify the functionality
- Check the provided docs.

I haven't tested it with pyOCD. It is probably also possible to use pyOCD for this, but that can be included in a follow-up PR.

### Issues/PRs references

None