### PR TITLE
boards: Use ARRAY_SIZE for setting UART_NUMOF, SPI_NUMOF, I2C_NUMOF

### DIFF
--- a/boards/arduino-mkrwan1300/include/periph_conf.h
+++ b/boards/arduino-mkrwan1300/include/periph_conf.h
@@ -70,7 +70,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_sercom5
 #define UART_1_ISR          isr_sercom4
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -92,7 +92,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/esp8266/include/periph_conf_common.h
+++ b/boards/common/esp8266/include/periph_conf_common.h
@@ -238,7 +238,7 @@ static const uart_conf_t uart_config[] = {
  *
  * @note UART_NUMOF definition must not be changed.
  */
-#define UART_NUMOF  (sizeof(uart_config)/sizeof(uart_config[0]))
+#define UART_NUMOF  ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nrf52/include/cfg_i2c_default.h
+++ b/boards/common/nrf52/include/cfg_i2c_default.h
@@ -38,7 +38,7 @@ static const i2c_conf_t i2c_config[] = {
         .speed = I2C_SPEED_NORMAL
     }
 };
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/pinetime/include/periph_conf.h
+++ b/boards/pinetime/include/periph_conf.h
@@ -60,7 +60,7 @@ static const i2c_conf_t i2c_config[] = {
     }
 };
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f723e-disco/include/periph_conf.h
+++ b/boards/stm32f723e-disco/include/periph_conf.h
@@ -73,7 +73,7 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_0_ISR         isr_tim2
 
-#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -153,7 +153,7 @@ static const uart_conf_t uart_config[] = {
 #define UART_3_ISR          (isr_uart7)
 #define UART_4_ISR          (isr_uart5)
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -176,7 +176,7 @@ static const i2c_conf_t i2c_config[] = {
 
 #define I2C_0_ISR           isr_i2c2_er
 
-#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**
@@ -232,7 +232,7 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

Some boards were not using ARRAY_SIZE for setting `UART_NUMOF`, `I2C_NUMOF and `SPI_NUMOF`. I was a bit surprised that I could not use ARRAY_SIZE for boards that have a LPC2387 cpu (avsextrem, msba2 and mcb2388) so I did not change anything about these boards.

### Testing procedure

A successful build by Murdock should be enough.

I compiled hello-world for the following boards: arduino-mkrwan1300 avsextrem esp8266-olimex-mod  mcb2388 msba2 pinetime stm32f723e-disco.

### Issues/PRs references

None
