### PR TITLE
drivers/ili9341: cleanup doxygen documentation

### DIFF
--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -7,10 +7,10 @@
  */
 
 /**
- * @defgroup    drivers_ili9341 ili9341 display driver
- * @ingroup     drivers
+ * @defgroup    drivers_ili9341 ILI9341 display driver
+ * @ingroup     drivers_actuators
  *
- * @brief       ili9341 Display driver
+ * @brief       Driver for the ILI9341 display
  *
  * @{
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up a bit the documentation of the ILI9341 so that it renders well in doxygen:
- in master, the entry for this drivers is rendered at the same level of the main driver groups (actuators, sensors, etc), this PR changes the parent group to `drivers_actuators`.
- this PR also improve the group name and brief description.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Check http://doc.riot-os.org/group__drivers.html and verify that the last entry is ili9341 and that it shouldn't be displayed there
- Run `make doc` and verify that the ILI9341 driver is now available under the `Actuators` group

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
