### PR TITLE
boards: Cleaned up bootloader selection for ATmega

### DIFF
--- a/boards/arduino-duemilanove/Makefile.include
+++ b/boards/arduino-duemilanove/Makefile.include
@@ -3,14 +3,7 @@ PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
-# PROGRAMMER defaults to arduino which is the internal flasher via USB
-# using avrdude. Can be overridden for debugging (which requires changes
-# that require to use an ISP)
-PROGRAMMER ?= arduino
-# configure programmer speed in baud
-FFLAGS_EXTRA += -b 57600
-
-BOOTLOADER_SIZE ?= 2K
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+ARDUINO_DUEMILANOVE_BOOTLOADER ?= atmegaboot
+BOOTLOADER ?= $(ARDUINO_DUEMILANOVE_BOOTLOADER)
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-leonardo/Makefile.include
+++ b/boards/arduino-leonardo/Makefile.include
@@ -11,9 +11,6 @@ BAUD            ?= 9600
 
 # PROGRAMMER defaults to avr109 which is the internal flasher via USB. Can be
 # overridden for debugging (which requires changes that require to use an ISP)
-PROGRAMMER ?= avr109
-
-BOOTLOADER_SIZE ?= 4K
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+BOOTLOADER ?= avr109
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -3,14 +3,7 @@ PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
-# PROGRAMMER defaults to stk500v2 which is the internal flasher via USB
-# using avrdude. Can be overridden for debugging (which requires changes
-# that require to use an ISP)
-PROGRAMMER ?= stk500v2
-# configure programmer speed in baud
-FFLAGS_EXTRA += -b 115200
-
-BOOTLOADER_SIZE ?= 8K
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+ARDUINO_MEGA2560_BOOTLOADER ?= stk500v2
+BOOTLOADER ?= $(ARDUINO_MEGA2560_BOOTLOADER)
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-nano/Makefile.include
+++ b/boards/arduino-nano/Makefile.include
@@ -3,18 +3,7 @@ PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
-PROGRAMMER ?= arduino
-
-ifeq (arduino,$(PROGRAMMER))
-  # the Arduino Nano bootloader is 2KiB in size
-  BOOTLOADER_SIZE ?= 2048
-  # the Nano's bootloader uses 57600 baud for programming
-  FFLAGS_EXTRA += -b 57600
-else
-  # not using the bootloader for programming, thus the whole flash can be used
-  BOOTLOADER_SIZE ?= 0
-endif
-
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+ARDUINO_NANO_BOOTLOADER ?= atmegaboot
+BOOTLOADER ?= $(ARDUINO_NANO_BOOTLOADER)
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-nano/doc.txt
+++ b/boards/arduino-nano/doc.txt
@@ -26,7 +26,7 @@ extensible by using shields.
 | MCU Datasheet | [ATmega328p datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/ATmega48A-PA-88A-PA-168A-PA-328-P-DS-DS40002061A.pdf) |
 | Board Manual  | [Board Manual](https://www.arduino.cc/en/uploads/Main/ArduinoNanoManual23.pdf) |
 
-## Flashing the device
+## Flashing the Device
 Flashing RIOT on the Arduino Nano is quite straight forward, just connect your
 Arduino Nano via the USB connector to your host computer and type:
 
@@ -37,6 +37,28 @@ This should take care of everything!
 We use the open `avrdude` tool to write the new code into the ATmega328p's
 flash
 
-##Caution
+## Using Optiboot
+
+You can use the [Optiboot](https://github.com/Optiboot/optiboot) bootloader
+instead of the stock bootloader for faster programming. Optiboot also is
+smaller (512 byte instead of 2 KiB), so that 1.5 KiB more program memory is
+available for RIOT. Refer to the project page for instructions on how to
+build an flash the bootloader. Don't forgot to also update the fuse settings
+to set the bootloader size to 256 words (512 bytes).
+
+Compile and flash with `make BOARD=arduino-nano BOOTLOADER=optiboot flash` or
+use `export ARDUINO_NANO_BOOTLOADER=optiboot` in order to not have to specify
+the bootloader during compilation and flashing.
+
+## Issues
+
+### RIOT Stuck in Reboot Loop
+
+If RIOT is stuck in a reboot loop e.g. after restarting the device with the
+`reboot` shell command, this is likely caused by an
+[issue with the stock bootloader](https://forum.arduino.cc/index.php?topic=150419.0)
+that can be solved by using Optiboot as bootloader instead (see above).
+
+## Caution
 Don't expect having a working network stack due to very limited resources.
  */

--- a/boards/arduino-uno/Makefile.include
+++ b/boards/arduino-uno/Makefile.include
@@ -3,14 +3,7 @@ PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
-# PROGRAMMER defaults to stk500v2 which is the internal flasher via USB
-# using avrdude. Can be overridden for debugging (which requires changes
-# that require to use an ISP)
-PROGRAMMER ?= arduino
-# configure programmer speed in baud
-FFLAGS_EXTRA += -b 115200
-
-BOOTLOADER_SIZE ?= 512
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+ARDUINO_UNO_BOOTLOADER ?= optiboot
+BOOTLOADER ?= $(ARDUINO_UNO_BOOTLOADER)
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/atmega256rfr2-xpro/Makefile.include
+++ b/boards/atmega256rfr2-xpro/Makefile.include
@@ -2,15 +2,10 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD ?= 115200
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # Use EDBG (xplainedpro) programmer with avrdude
 PROGRAMMER ?= xplainedpro
 
-# This board can be reset via avrdude
-RESET ?= avrdude -c $(PROGRAMMER) -p m256rfr2
 # Use edbg interface for debugging
 DEBUGSERVER_INTERFACE ?= --edbg
 
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/avr-rss2/Makefile.include
+++ b/boards/avr-rss2/Makefile.include
@@ -3,18 +3,8 @@ PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # refine serial port information for pyterm
 BAUD        ?= 115200
-include $(RIOTMAKE)/tools/serial.inc.mk
+AVR_RSS2_BOOTLOADER ?= stk500v2
+BOOTLOADER  ?= $(AVR_RSS2_BOOTLOADER)
+BOOTLOADER_SIZE ?= 4K # Unlike the Arduino Mega2560, the bootloader size is 4K
 
-# PROGRAMMER defaults to wiring which is the internal flasher via USB
-# using avrdude. Can be overridden for debugging (which requires changes
-# that require to use an ISP)
-PROGRAMMER ?= stk500v2
-#
-# see /usr/include/asm-generic/termbits.h for availabel baudrates on your linux system
-
-# From current fuse configuration
-BOOTLOADER_SIZE ?= 4K
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
-
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/common/arduino-atmega/Makefile.include
+++ b/boards/common/arduino-atmega/Makefile.include
@@ -1,10 +1,3 @@
 INCLUDES += -I$(RIOTBOARD)/common/arduino-atmega/include
 
-include $(RIOTMAKE)/tools/serial.inc.mk
-
-# Disable auto erase for flash and avoid error if signature doesn't match
-FFLAGS_EXTRA += -F -D
-
-# include avrdude flashing tool
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/common/atmega/Makefile.include
+++ b/boards/common/atmega/Makefile.include
@@ -1,1 +1,54 @@
 INCLUDES += -I$(RIOTBOARD)/common/atmega/include
+
+# If programmer is not set, set it based on the bootloader used
+ifeq (,$(PROGRAMMER))
+  ifeq (atmegaboot,$(BOOTLOADER))
+    PROGRAMMER = arduino
+    BOOTLOADER_SIZE ?= 2048
+    BOOTLOADER_BAUD ?= 57600
+  endif
+
+  ifeq (optiboot,$(BOOTLOADER))
+    PROGRAMMER = arduino
+    ifneq (,$(filter $(CPU), atmega128rfa1 atmega256rfr2 atmega1281 atmega1284p atmega2560))
+      # The minimum bootloader size on these CPUs is 1 KiB (so 512 Byte are wasted)
+      BOOTLOADER_SIZE ?= 1024
+    else
+      BOOTLOADER_SIZE ?= 512
+    endif
+  endif
+
+  ifeq (stk500v1,$(BOOTLOADER))
+    PROGRAMMER = stk500v1
+    BOOTLOADER_SIZE ?= 8K
+  endif
+
+  ifeq (stk500v2,$(BOOTLOADER))
+    PROGRAMMER = stk500v2
+    BOOTLOADER_SIZE ?= 8K
+    # Disable auto erase; erasing the flash is done implicitly by the bootloader
+    # and explicit erase is not supported
+    FFLAGS_EXTRA += -D
+  endif
+
+  ifeq (avr109,$(BOOTLOADER))
+    PROGRAMMER = avr109
+    BOOTLOADER_SIZE ?= 4K
+  endif
+
+  ifeq (derfmega,$(BOOTLOADER))
+    PROGRAMMER = wiring
+    BOOTLOADER_SIZE ?= 4K
+  endif
+
+  ifneq (,$(BOOTLOADER_BAUD))
+    FFLAGS_EXTRA += -b $(BOOTLOADER_BAUD)
+  endif
+endif
+
+BOOTLOADER_SIZE ?= 0
+ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+
+include $(RIOTMAKE)/tools/serial.inc.mk
+# include avrdude flashing tool
+include $(RIOTMAKE)/tools/avrdude.inc.mk

--- a/boards/derfmega128/Makefile.include
+++ b/boards/derfmega128/Makefile.include
@@ -5,18 +5,6 @@ PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # refine serial port information for pyterm
 BAUD        ?= 115200
-include $(RIOTMAKE)/tools/serial.inc.mk
+BOOTLOADER  ?= derfmega
 
-# PROGRAMMER defaults to wiring which is the internal flasher via USB
-# using avrdude. Can be overridden for debugging (which requires changes
-# that require to use an ISP)
-PROGRAMMER ?= wiring
-# Serial Baud rate for flasher is configured to 500kBaud
-# see /usr/include/asm-generic/termbits.h for availabel baudrates on your linux system
-
-# From current fuse configuration
-BOOTLOADER_SIZE ?= 4K
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
-
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/derfmega256/Makefile.include
+++ b/boards/derfmega256/Makefile.include
@@ -5,18 +5,6 @@ PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # refine serial port information for pyterm
 BAUD        ?= 115200
-include $(RIOTMAKE)/tools/serial.inc.mk
+BOOTLOADER  ?= derfmega
 
-# PROGRAMMER defaults to wiring which is the internal flasher via USB
-# using avrdude. Can be overridden for debugging (which requires changes
-# that require to use an ISP)
-PROGRAMMER ?= wiring
-# Serial Baud rate for flasher is configured to 500kBaud
-# see /usr/include/asm-generic/termbits.h for availabel baudrates on your linux system
-
-# From current fuse configuration
-BOOTLOADER_SIZE ?= 4K
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
-
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -1,7 +1,6 @@
 # Found by checking fuse settings (2048 words so 4KB)
 # https://www.microchip.com/DevelopmentTools/ProductDetails/atmega1284p-xpld
 BOOTLOADER_SIZE ?= 4K
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
 
 # For backward compatibility
 ifneq (,$(AVRDUDE_PORT))
@@ -17,14 +16,10 @@ ifeq ($(OS),Linux)
 else ifeq ($(OS),Darwin)
   PROG_DEV ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 endif
-# avoid error if mcu signature doesn't match
-FFLAGS_EXTRA += -F
 
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
-include $(RIOTMAKE)/tools/serial.inc.mk
 
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -1,23 +1,8 @@
-# Bootloader uses stk500v1 protocol, which usually is implemented in
-# bootloaders of 2K size.
-# http://www.libelium.com/products/waspmote/hardware/
-BOOTLOADER_SIZE ?= 2K
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
-
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 BAUD        ?= 9600
-include $(RIOTMAKE)/tools/serial.inc.mk
+WASPMOTE_PRO_BOOTLOADER ?= stk500v1
+BOOTLOADER  ?= $(WASPMOTE_PRO_BOOTLOADER)
 
-# PROGRAMMER defaults to stk500v1 which is the internal flasher via USB
-# using avrdude. Can be overridden for debugging (which requires changes
-# that require to use an ISP)
-PROGRAMMER ?= stk500v1
-# configure programmer speed in baud
-FFLAGS_EXTRA += -b 115200
-# avoid error if mcu signature doesn't match
-FFLAGS_EXTRA += -F
-
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include


### PR DESCRIPTION
### Contribution description

- Moved setting programming configuration based on the bootloader used to `boards/common/atmega`, so that boards using the same bootloader don't have to duplicate the configuration
- Boards now only set `BOOTLOADER ?= <foo>` to choose the default bootloader
    - Set the bootloader indirectly to allow users specifying their default bootloader for each board  individually in `.profile` or in `.bashrc` e.g. via
```Makefile
ARDUINO_NANO_BOOTLOADER ?= atmegabooot
BOOTLOADER ?= $(ARDUINO_NANO_BOOTLOADER)
```
- As a result all atmega boards can now more easily use custom bootloaders
- Moved the include of `tools/avrdude.mk` and `tools/serial.mk` to `boards/common/atmega`
- Dropped the `RESET ?=` from `atmega256rfr2-xpro`, as this is now added in `tools/avrdude.mk` anyway
- Removed the `-F` flag to force flashing even if `avrdude` detected that the target to flash has a different MCU than RIOT build for
    - This is in general dangerous and should only be done with care by users knowing what they are doing and accepting the risks associated with this

### Testing procedure

Flashing the ATmega based boards should still work

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/13319