### PR TITLE
Add bh1900nux driver

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -70,6 +70,10 @@ ifneq (,$(filter bh1750fvi,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter bh1900nux,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter bmp180,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += xtimer

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -30,6 +30,10 @@ ifneq (,$(filter bh1750fvi,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bh1750fvi/include
 endif
 
+ifneq (,$(filter bh1900nux,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bh1900nux/include
+endif
+
 ifneq (,$(filter bmp180,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bmp180/include
 endif

--- a/drivers/bh1900nux/Makefile
+++ b/drivers/bh1900nux/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/bh1900nux/bh1900nux.c
+++ b/drivers/bh1900nux/bh1900nux.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Nalys
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_bh1900nux
+ * @{
+ *
+ * @file
+ * @brief       BH1900NUX temperature sensor driver implementation
+ *
+ * @author      Wouter Symons <wsymons@nalys-group.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "bh1900nux.h"
+#include "byteorder.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+int bh1900nux_init(bh1900nux_t *dev, const bh1900nux_params_t *params)
+{
+    if ((dev == NULL) | (params == NULL)) {
+        return -1;
+    }
+
+    /* initialize the device descriptor */
+    dev->i2c = params->i2c;
+    dev->addr = params->addr;
+
+    return BH1900NUX_OK;
+}
+
+int bh1900nux_read(const bh1900nux_t *dev, int16_t *temp)
+{
+    int ret = 0;
+    int16_t raw;
+
+    /* Read raw sensor value */
+    DEBUG("[bh1900nux] read temperature\n");
+    ret = i2c_acquire(dev->i2c);
+    if (ret < 0) {
+        return BH1900NUX_ERR_I2C;
+    }
+    ret = i2c_read_regs(dev->i2c, dev->addr, BH1900NUX_REG_ADDR, &raw, sizeof(raw), 0);
+    if (ret < 0) {
+        return ret;
+    }
+    i2c_release(dev->i2c);
+
+    /* Calculate temperature */
+    raw = (int16_t) ntohs(raw) >> 4;
+    *temp = ((int32_t) raw * 1000) / 16;
+
+    return BH1900NUX_OK;
+}

--- a/drivers/bh1900nux/include/bh1900nux_params.h
+++ b/drivers/bh1900nux/include/bh1900nux_params.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Nalys
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_bh1900nux
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for BH1900NUX devices
+ *
+ * @author      Wouter Symons <wsymons@nalys-group.com>
+ */
+
+#ifndef BH1900NUX_PARAMS_H
+#define BH1900NUX_PARAMS_H
+
+#include "board.h"
+#include "bh1900nux.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for BH1900NUX devices
+ * @{
+ */
+#ifndef BH1900NUX_PARAM_I2C
+#define BH1900NUX_PARAM_I2C         I2C_DEV(0)
+#endif
+#ifndef BH1900NUX_PARAM_ADDR
+#define BH1900NUX_PARAM_ADDR        (BH1900NUX_DEFAULT_ADDR)
+#endif
+
+#ifndef BH1900NUX_PARAMS
+#define BH1900NUX_PARAMS            { .i2c = BH1900NUX_PARAM_I2C,   \
+                                      .addr = BH1900NUX_PARAM_ADDR }
+#endif
+/**@}*/
+
+/**
+ * @brief   BH1900NUX configuration
+ */
+static const bh1900nux_params_t bh1900nux_params[] =
+{
+    BH1900NUX_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BH1900NUX_PARAMS_H */
+/** @} */

--- a/drivers/include/bh1900nux.h
+++ b/drivers/include/bh1900nux.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 Nalys
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_bh1900nux BH1900NUX Temperature sensor
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the Rohm BH1900NUX Temperature sensor
+ *
+ * @{
+ * @file
+ * @brief       Interface definition for the  BH1900NUX temperature sensor
+ *
+ * @author      Wouter Symons <wsymons@nalys-group.com>
+ */
+
+#ifndef BH1900NUX_H
+#define BH1900NUX_H
+
+#include "periph/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Possible I2C bus addresses of the device
+ *
+ * The actual address of the device depends on the states of the slave address pins.
+ * @{
+ */
+#define BH1900NUX_ADDR_1          (0x48)        /**< A2:L A1:L A0:L*/
+#define BH1900NUX_ADDR_2          (0x49)        /**< A2:L A1:L A0:H*/
+#define BH1900NUX_ADDR_3          (0x4a)        /**< A2:L A1:H A0:L*/
+#define BH1900NUX_ADDR_4          (0x4b)        /**< A2:L A1:H A0:H*/
+#define BH1900NUX_ADDR_5          (0x4c)        /**< A2:H A1:L A0:L*/
+#define BH1900NUX_ADDR_6          (0x4d)        /**< A2:H A1:L A0:H*/
+#define BH1900NUX_ADDR_7          (0x4e)        /**< A2:H A1:H A0:L*/
+#define BH1900NUX_ADDR_8          (0x4f)        /**< A2:H A1:H A0:H*/
+/** @} */
+
+/**
+ * @name    Temperature register address
+ *
+ * Address of the temperature resister
+ * @{
+ */
+#define BH1900NUX_REG_ADDR      (0x00)
+/** @} */
+
+/**
+ * @brief   Default address of BH1900NUX sensors
+ */
+#define BH1900NUX_DEFAULT_ADDR          BH1900NUX_ADDR_1
+
+/**
+ * @brief   Maximum I2C bus speed to use with the device
+ */
+#define BH1900NUX_I2C_MAX_CLK           I2C_SPEED_FAST
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    BH1900NUX_OK        =  0,   /**< everything was fine */
+    BH1900NUX_ERR_I2C   = -1    /**< error initializing the I2C bus */
+};
+
+/**
+ * @brief   Device descriptor for BH1900NUX devices
+ */
+typedef struct {
+    i2c_t i2c;          /**< I2C bus the device is connected to */
+    uint8_t addr;       /**< slave address of the device */
+} bh1900nux_t;
+
+/**
+ * @brief   Set of configuration parameters for BH1900NUX devices
+ */
+typedef struct {
+    i2c_t i2c;          /**< I2C bus the device is connected to */
+    uint8_t addr;       /**< slave address of the device */
+} bh1900nux_params_t;
+
+/**
+ * @brief   Initialize the given BH1900NUX device
+ *
+ * @param[out] dev      device descriptor of the targeted device
+ * @param[in] params    device configuration (i2c bus, address and bus clock)
+ *
+ * @return      0 on success
+ * @return      -1 if unable to speak to the device
+ */
+int bh1900nux_init(bh1900nux_t *dev, const bh1900nux_params_t *params);
+
+/**
+ * @brief   Read the temperature measerd by the device [MILICELSIUS].
+ *
+ * The result value is the measured temperature in MILICELSUIS and ranges
+ * from -30 to 95.
+ *
+ * @param[in] dev       device descriptor of the targeted device
+ * @param[out] temp     temperature output
+ *
+ * @return  BH1900NUX_OK on success
+ * @return  BH1900NUX_ERR_I2C on failure
+ */
+int bh1900nux_read(const bh1900nux_t *dev,  int16_t *temp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BH1900NUX_H */
+/** @} */

--- a/tests/driver_bh1900nux/Makefile
+++ b/tests/driver_bh1900nux/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+USEMODULE += bh1900nux
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bh1900nux/README.md
+++ b/tests/driver_bh1900nux/README.md
@@ -1,0 +1,14 @@
+# About
+This test application is created for testing/demonstrating the BH1900NUX driver.
+It uses the default device parameters as specified in
+`drivers/bh1900nux/include/bh1900nux.h`. To override these setting, you
+can simply do this by defining these parameters as compiler flags while uilding,
+e.g.:
+```
+$ CFLAGS="-DBH1900NUX_PARAM_I2C=I2C_DEV(1)"" make all
+```
+
+# Usage
+Simply flash this example to your board and it will read the sensor value 5
+times per second and print the sampled value to STDIO. You can verify the values
+by holding your finger on the sensor to heat it up, or blow on it to cool it down.

--- a/tests/driver_bh1900nux/main.c
+++ b/tests/driver_bh1900nux/main.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Nalys
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the BH1900NUX Temperature sensor
+ *
+ * @author      Wouter Symons <wsymons@nalys-group.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "bh1900nux.h"
+#include "bh1900nux_params.h"
+
+#define RATE        (200LU * US_PER_MS)      /* 200ms */
+
+int main(void)
+{
+    int res = 0;
+    int16_t temp = 0;
+    bh1900nux_t dev;
+    xtimer_ticks32_t last = xtimer_now();
+
+    puts("bh1900nux temperature sensor test\n");
+
+    /* initialize the device */
+    res = bh1900nux_init(&dev, &bh1900nux_params[0]);
+    if (res != BH1900NUX_OK) {
+        puts("error: unable to initialize sensor [I2C initialization error]");
+        return 1;
+    }
+
+    /* periodically read the sensor */
+    while (1) {
+        bh1900nux_read(&dev, &temp);
+        printf("temperature: %d.%d deg. C\n", (int)temp / 1000, temp % 1000);
+        xtimer_periodic_wakeup(&last, RATE);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description
Adds a driver for the BH1900NUX temperature sensor. 
I used the BH1750FVI driver by @haukepetersen as a reference so that drivers for sensors of the same family would have the same structure. 

### Testing procedure
- Connect the sensor to your device
- Change default parameters if they differ from yours
- Run test app
