### PR TITLE
gnrc_pktbuf: deprecate gnrc_pktbuf_replace_snip()

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -203,13 +203,19 @@ gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *sni
 /**
  * @brief   Replace a snip from a packet and the packet buffer by another snip.
  *
+ * @deprecated  Function is not used by anyone (not even tested, see
+ *              https://github.com/RIOT-OS/RIOT/issues/5089). Will be removed
+ *              after 2020.10 release.
+ *
  * @param[in] pkt   A packet
  * @param[in] old   snip currently in the packet
  * @param[in] add   snip which will replace old
  *
  * @return  The new reference to @p pkt
  */
-gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *old, gnrc_pktsnip_t *add);
+gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt,
+                                         gnrc_pktsnip_t *old,
+                                         gnrc_pktsnip_t *add);
 
 /**
  * @brief   Reverses snip order of a packet in a write-protected manner.


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The function is unused and unneeded since https://github.com/RIOT-OS/RIOT/pull/9484 and https://github.com/RIOT-OS/RIOT/issues/5089 calls to provide unittests.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
git grep "gnrc_pktbuf_replace_snip"
```
should only show the function declaration and definition.

With

```sh
make doc
```

the function appears in `doc/doxygen/html/deprecated.html`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Resolves #5089
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
