### PR TITLE
mtd_spi_nor: Add chip wait timings to debug output

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -272,6 +272,9 @@ static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us
 {
     unsigned i = 0, j = 0;
     uint32_t div = 2;
+#if ENABLE_DEBUG && defined(MODULE_XTIMER)
+    uint32_t diff = xtimer_now_usec();
+#endif
     do {
         uint8_t status;
         mtd_spi_cmd_read(dev, dev->opcode->rdsr, &status, sizeof(status));
@@ -304,7 +307,12 @@ static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us
         thread_yield();
 #endif
     } while (1);
-    DEBUG("wait loop %u times, yield %u times\n", i, j);
+    DEBUG("wait loop %u times, yield %u times", i, j);
+#if ENABLE_DEBUG && defined(MODULE_XTIMER)
+    diff = xtimer_now_usec() - diff;
+    DEBUG(", total wait %"PRIu32"us", diff);
+#endif
+    DEBUG("\n");
 }
 
 static int mtd_spi_nor_init(mtd_dev_t *mtd)


### PR DESCRIPTION
### Contribution description

While testing RIOT-OS#9349 I found it very useful to have the actual wait timing in the debug output. This PR adds that output.

It got a bit complicated due to the optional dependency of mtd_spi_nor on xtimer.

### Testing procedure

Run your favorite MTD SPI NOR test with xtimer enabled.

### Issues/PRs references

Follow-up to #9349 