### PR TITLE
mtd_spi_nor: erase timings in struct

### DIFF
--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -50,6 +50,10 @@ static devfs_t mulle_nvram_devfs = {
 
 static const mtd_spi_nor_params_t mulle_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 16LU * US_PER_SEC,
+    .wait_sector_erase = 40LU * US_PER_MS,
+    .wait_32k_erase = 20LU * US_PER_MS,
+    .wait_4k_erase = 10LU * US_PER_MS,
     .spi = MULLE_NOR_SPI_DEV,
     .cs = MULLE_NOR_SPI_CS,
     .addr_width = 3,

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -27,10 +27,15 @@
 #include "mtd_spi_nor.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "timex.h"
 
 #ifdef MODULE_MTD
 static const mtd_spi_nor_params_t _pinetime_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 9LU * US_PER_SEC,
+    .wait_32k_erase = 160LU *US_PER_MS,
+    .wait_sector_erase = 70LU * US_PER_MS,
+    .wait_4k_erase = 70LU * US_PER_MS,
     .clk = PINETIME_NOR_SPI_CLK,
     .flag = PINETIME_NOR_FLAGS,
     .spi = PINETIME_NOR_SPI_DEV,

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -88,6 +88,10 @@ typedef struct __attribute__((packed)) {
  */
 typedef struct {
     const mtd_spi_nor_opcode_t *opcode; /**< Opcode table for the device */
+    uint32_t wait_chip_erase;   /**< Full chip erase wait time in µs */
+    uint32_t wait_sector_erase; /**< Sector erase wait time in µs */
+    uint32_t wait_32k_erase;    /**< 32KB page erase wait time in µs */
+    uint32_t wait_4k_erase;     /**< 4KB page erase wait time in µs */
     spi_clk_t clk;           /**< SPI clock */
     uint16_t flag;           /**< Config flags */
     spi_t spi;               /**< SPI bus the device is connected to */
@@ -105,6 +109,7 @@ typedef struct {
     mtd_dev_t base;          /**< inherit from mtd_dev_t object */
     const mtd_spi_nor_params_t *params; /**< SPI NOR params */
     mtd_jedec_id_t jedec_id; /**< JEDEC ID of the chip */
+
     /**
      * @brief   bitmask to corresponding to the page address
      *

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -49,22 +49,6 @@
 #define MTD_4K              (4096ul)
 #define MTD_4K_ADDR_MASK    (0xFFF)
 
-#ifndef MTD_SPI_NOR_WAIT_C_ER
-#define MTD_SPI_NOR_WAIT_C_ER       (16 * US_PER_SEC)
-#endif
-
-#ifndef MTD_SPI_NOR_WAIT_S_ER
-#define MTD_SPI_NOR_WAIT_S_ER       (40 * US_PER_MS)
-#endif
-
-#ifndef MTD_SPI_NOR_WAIT_32K_ER
-#define MTD_SPI_NOR_WAIT_32K_ER     (20 * US_PER_MS)
-#endif
-
-#ifndef MTD_SPI_NOR_WAIT_4K_ER
-#define MTD_SPI_NOR_WAIT_4K_ER      (10 * US_PER_MS)
-#endif
-
 static int mtd_spi_nor_init(mtd_dev_t *mtd);
 static int mtd_spi_nor_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t size);
 static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t size);
@@ -514,7 +498,7 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
         if (size == total_size) {
             mtd_spi_cmd(dev, dev->params->opcode->chip_erase);
             size -= total_size;
-            us = MTD_SPI_NOR_WAIT_C_ER;
+            us = dev->params->wait_chip_erase;
         }
         else if ((dev->params->flag & SPI_NOR_F_SECT_32K) && (size >= MTD_32K) &&
                  ((addr & MTD_32K_ADDR_MASK) == 0)) {
@@ -522,7 +506,7 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
             mtd_spi_cmd_addr_write(dev, dev->params->opcode->block_erase_32k, addr_be, NULL, 0);
             addr += MTD_32K;
             size -= MTD_32K;
-            us = MTD_SPI_NOR_WAIT_32K_ER;
+            us = dev->params->wait_32k_erase;
         }
         else if ((dev->params->flag & SPI_NOR_F_SECT_4K) && (size >= MTD_4K) &&
                  ((addr & MTD_4K_ADDR_MASK) == 0)) {
@@ -530,13 +514,13 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
             mtd_spi_cmd_addr_write(dev, dev->params->opcode->sector_erase, addr_be, NULL, 0);
             addr += MTD_4K;
             size -= MTD_4K;
-            us = MTD_SPI_NOR_WAIT_4K_ER;
+            us = dev->params->wait_4k_erase;
         }
         else {
             mtd_spi_cmd_addr_write(dev, dev->params->opcode->block_erase, addr_be, NULL, 0);
             addr += sector_size;
             size -= sector_size;
-            us = MTD_SPI_NOR_WAIT_S_ER;
+            us = dev->params->wait_sector_erase;
         }
 
         /* waiting for the command to complete before continuing */


### PR DESCRIPTION
### Contribution description

This PR moves the defines from RIOT-OS#9349 to the mtd_spi_nor_t struct to be able to:

- configure the timings per NOR flash chip.
- Make it a bit more clear to the developer that these should be configured per board/chip.

### Testing procedure

Run your favorite MTD SPI NOR test. Please make sure to use a board that has an MTD SPI NOR device (Mulle, PineTime (with #13161) etc…)

### Issues/PRs references

Follow-up to #9349 