### PR TITLE
nanocoap: State handler idempotentcy requirement

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -194,6 +194,17 @@ typedef struct {
 
 /**
  * @brief   Resource handler type
+ *
+ * Functions that implement this must be prepared to be called multiple times
+ * for the same request, as the server implementations do not perform message
+ * deduplication. That optimization is [described in the CoAP
+ * specification](https://tools.ietf.org/html/rfc7252#section-4.5).
+ *
+ * This should be trivial for requests of the GET, PUT, DELETE, FETCH and
+ * iPATCH methods, as they are defined as idempotent methods in CoAP.
+ *
+ * For POST, PATCH and other non-idempotent methods, this is an additional
+ * requirement introduced by the contract of this type.
  */
 typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context);
 


### PR DESCRIPTION
Closes: https://github.com/RIOT-OS/RIOT/issues/12938

### Contribution description

None of the two nanocoap servers (nanocoap sock, gcoap) provide deduplication. That's fine but needs to be known to the application implementer.

For most codes (GET, PUT, DELETE), this is a protocol requirement anyway. For POST, good applications are designed to allow this optimization. Still, a developer coming from the HTTP side of things could be unpleasantly surprised if not warned that their handlers can and will be called multiple times.

### Issues/PRs references

Closes https://github.com/RIOT-OS/RIOT/issues/12938