### PR TITLE
murdock: don't run static tests

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -338,8 +338,6 @@ static_tests() {
         echo "$OUT"
         exit 1
     fi
-
-    BUILDTEST_MCU_GROUP=static-tests ./dist/tools/ci/build_and_test.sh
 }
 
 get_non_compile_jobs() {

--- a/.murdock
+++ b/.murdock
@@ -338,6 +338,8 @@ static_tests() {
         echo "$OUT"
         exit 1
     fi
+
+    # Travis will already run static tests
 }
 
 get_non_compile_jobs() {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Static Tests are already executed by Travis.
Failing Travis will already block the merge, so we don't have to run those tests in Murdock again.

This has two benefits:

 - slightly decreased CI build times
 - Murdock failures will only be caused by build errors.

The last point is my main motivation for this patch.
It often happens that Murdock failures are dismissed during review if a PR is not squashed yet.
Even if there are still build failures, they are not visible at a glance.

Travis will already fail when the PR is not yet squashed, so Murdock doesn't have to check this again and can now only warn about serious issues.


### Testing procedure

 - Murdock should not fail if there is a !fixup commit.
 - Travis should fail if there is a !fixup commit.

### Issues/PRs references

none
