### PR TITLE
Boards/stm32l4: Add USB peripheral configuration for stm32l4-based boards

### DIFF
--- a/boards/b-l475e-iot01a/Makefile.features
+++ b/boards/b-l475e-iot01a/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -21,6 +21,7 @@
 
 #include "periph_cpu.h"
 #include "cfg_rtt_default.h"
+#include "cfg_usb_otg_fs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -9,6 +9,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart periph_lpuart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -22,6 +22,7 @@
 #include "periph_cpu.h"
 #include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_rtt_default.h"
+#include "cfg_usb_otg_fs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/nucleo-l4r5zi/Makefile.features
+++ b/boards/nucleo-l4r5zi/Makefile.features
@@ -9,6 +9,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/nucleo-l4r5zi/include/periph_conf.h
+++ b/boards/nucleo-l4r5zi/include/periph_conf.h
@@ -22,6 +22,7 @@
 #include "periph_cpu.h"
 #include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_rtt_default.h"
+#include "cfg_usb_otg_fs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/p-l496g-cell02/Makefile.features
+++ b/boards/p-l496g-cell02/Makefile.features
@@ -10,3 +10,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev

--- a/boards/p-l496g-cell02/include/periph_conf.h
+++ b/boards/p-l496g-cell02/include/periph_conf.h
@@ -22,6 +22,7 @@
 #include "periph_cpu.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
+#include "cfg_usb_otg_fs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -21,6 +21,7 @@
 
 #include "periph_cpu.h"
 #include "cfg_rtt_default.h"
+#include "cfg_usb_otg_fs.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description

Split out from #12556. This PR adds the USB peripheral configuration for the L4-based microcontrollers. They share the common USB peripheral from the F2, F4 and F7 series but as of now are not working. The host computer does not detect the USB device.

I suspect an issue with the clock configuration but I haven't had time to look at it in depth.

### Testing procedure

Flash the usbdev example or one of the tests on an L4-based board.

### Issues/PRs references

split off from (and based on) #12556