### PR TITLE
cpu/native/can/candev_linux: add check for real can 

### DIFF
--- a/cpu/native/can/candev_linux.c
+++ b/cpu/native/can/candev_linux.c
@@ -195,7 +195,14 @@ static int _init(candev_t *candev)
 
     real_bind(dev->sock, (struct sockaddr *)&addr, sizeof(addr));
 
-    _set_bittiming(dev, &candev->bittiming);
+    /* Only set bitrate on real can interfaces.
+     * Not supported on virtual can interfaces ("vcanX") */
+    if (strncmp(dev->conf->interface_name, "can", strlen("can"))) {
+        DEBUG("not setting bitrate on virtual can interface %s\n", dev->conf->interface_name);
+    }
+    else {
+        _set_bittiming(dev, &candev->bittiming);
+    }
 
     DEBUG("CAN linux device ready\n");
 
@@ -300,6 +307,8 @@ static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
     case CANOPT_BITTIMING:
         DEBUG("candev_linux: CANOPT_BITTIMING\n");
 
+        /* Only set bitrate on real can interfaces.
+         * Not supported on virtual can interfaces ("vcanX") */
         if (strncmp(dev->conf->interface_name, "can", strlen("can"))) {
             DEBUG("candev_native: _set: error interface is not real can\n");
             return -EINVAL;


### PR DESCRIPTION
# Contribution description

This is the fix  I proposed in #13309. Like I said there: it's still up for debate whether this fix is the one we want/need, or if there is something else that needs patching (because it's possible that this patch only suppresses the symptoms, and does not address the root cause). 

Anyhow, for me it seems it does not break conn_can (which, as far as I can tell is currently the only app using the code that is altered by this PR), and it does fix the issue for other uses of the candev_native.
Also: it makes this function call consistent with other calls, because the same check is done before these others (see line 305 in candev_linux.c).
And even more so: it makes conn_can compliant with its own "rules". 



### Testing procedure
- Run tests/conn_can: it should not be broken after this fix

### Issues/PRs references

Fixes  #13309. 

