### PR TITLE
tests/driver_ws281x: resolve weird feature dependencies

### DIFF
--- a/tests/driver_ws281x/Makefile
+++ b/tests/driver_ws281x/Makefile
@@ -7,9 +7,15 @@ N ?= 8
 
 USEMODULE += ws281x
 
-ifneq (native, $(BOARD))
-  FEATURES_REQUIRED += arch_avr8
-endif
+# Currently the ws281x only supports AVR-based platforms and native
+# (via VT100 terminals).
+# See https://doc.riot-os.org/group__drivers__ws281x.html
+FEATURES_BLACKLIST += arch_arm
+FEATURES_BLACKLIST += arch_esp32
+FEATURES_BLACKLIST += arch_esp8266
+FEATURES_BLACKLIST += arch_mips32r2
+FEATURES_BLACKLIST += arch_msp430
+FEATURES_BLACKLIST += arch_riscv
 
 # Only AVR boards CPU clocked at 8MHz or 16 MHz are supported. The Waspmote Pro
 # is clocked at 14.7456 MHz :-/


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While browsing through some features I'm interested in, I stumbled upon this weird construct in the `Makefile` of `tests/ws281x`. It was [commented on in the PR that introduced it](https://github.com/RIOT-OS/RIOT/pull/12793#discussion_r350407588) but to me no proper reason was given why not just `FEATURES_BLACKLIST` was used.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
BOARD=native make -C tests/driver_ws281x/ info-boards-supported
```

has the same output as

```sh
make -C tests/driver_ws281x/ info-boards-supported
```

(in master, all boards are outputted for the first).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
