### PR TITLE
[WIP] efm32: add option to use LETIMER as a timer

### DIFF
--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -369,6 +369,30 @@ typedef struct {
 /** @} */
 
 /**
+ * @brief   Static timer number of the Low Energy Timer (LETIMER)
+ *
+ * @note    This timer is configured like any other tim_t, but needs no
+ *          configuration in timer_conf_t because there exists only one LETIMER
+ *          per device. The actual setup is rather limited in that there is no
+ *          arbitrary prescaler present that could help achieve any timer
+ *          frequency; LETIMER is (in this implementation) always driven from
+ *          the 32.768kHz LFA clock, and can only be run at this frequency --
+ *          that is limited, but sufficient to use TIMER_LETIMER as XTIMER_DEV
+ *          (with either XTIMER_CHAN, an XTIMER_HZ of 32768 and an XTIMER_WIDTH
+ *          of 16) and thus free up the other timers.
+ *
+ *          To use it as a timer, the board peripheral confiugration file needs
+ *          to `#define TIMER_USE_LETIMER` in order to build the LETIMER code
+ *          and to generate the timer interrupt handler for it.
+ *
+ * @{
+ */
+
+#define TIMER_LETIMER 0xffffffffu
+
+/** @} */
+
+/**
  * @brief   Internal macro for combining UART modes data bits (x), stop bits
  *          (y, in half bits) and parity (z).
  */

--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -14,6 +14,14 @@
  * @file
  * @brief       Low-level timer driver implementation
  *
+ * @note        This implements two distinct timer variants: The TIMER (or
+ *              WTIMER) based implementation that is well configurable using
+ *              `timer_conf_t`, and the simple implementation that uses LETIMER.
+ *
+ *              The LETIMER implementation is odd when it comes to counting:
+ *              The LETIMER always counts down. To make it appear to count up,
+ *              all values that go in and out of it are negated.
+ *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Bas Stottelaar <basstottelaar@gmail.com>
  * @}
@@ -28,10 +36,19 @@
 #include "em_timer.h"
 #include "em_timer_utils.h"
 
+#ifdef TIMER_USE_LETIMER
+#include "em_letimer.h"
+#endif /* TIMER_USE_LETIMER */
+
 /**
  * @brief   This timer implementation has three available channels
  */
 #define CC_CHANNELS      (3U)
+
+/**
+ * @brief   The LETIMER implementation has two available channels
+ */
+#define LETIMER_CHANNELS (2U)
 
 /**
  * @brief   Timer state memory
@@ -39,7 +56,17 @@
 static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
 
 /**
+ * @brief   Timer state memory for the LETIMER
+ */
+#ifdef TIMER_USE_LETIMER
+static timer_isr_ctx_t isr_ctx_letimer;
+#endif
+
+/**
  * @brief   Check whether device is a using a WTIMER device (32-bit)
+ *
+ * This only gives meaningful results for timers that are either a TIMER or a
+ * WTIMER; LETIMERs need to be treated separately.
  */
 static inline bool _is_wtimer(timer_t dev)
 {
@@ -54,6 +81,29 @@ static inline bool _is_wtimer(timer_t dev)
 
 int timer_init(tim_t dev, unsigned long freq, timer_cb_t callback, void *arg)
 {
+#ifdef TIMER_USE_LETIMER
+    if (dev == TIMER_LETIMER) {
+        if (freq != 32768) {
+            return -1;
+        }
+
+        isr_ctx_letimer.cb = callback;
+        isr_ctx_letimer.arg = arg;
+
+        CMU_ClockEnable(cmuClock_LFA, true);
+        CMU_ClockEnable(cmuClock_LETIMER0, true);
+
+        LETIMER_Reset(LETIMER0);
+        LETIMER_Init_TypeDef init = LETIMER_INIT_DEFAULT;
+        LETIMER_Init(LETIMER0, &init);
+
+        NVIC_ClearPendingIRQ(LETIMER0_IRQn);
+        NVIC_EnableIRQ(LETIMER0_IRQn);
+
+        return 0;
+    }
+#endif /* TIMER_USE_LETIMER */
+
     TIMER_TypeDef *pre, *tim;
 
     /* test if given timer device is valid */
@@ -114,6 +164,23 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t callback, void *arg)
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
+#ifdef TIMER_USE_LETIMER
+    if (dev == TIMER_LETIMER) {
+        if (channel < 0 || channel >= (int) LETIMER_CHANNELS) {
+            return -1;
+        }
+
+        if (value > 0xffff) {
+            return -1;
+        }
+
+        LETIMER_CompareSet(LETIMER0, channel, (uint16_t) ~value);
+        LETIMER_IntEnable(LETIMER0, LETIMER_IF_COMP0 << channel);
+
+        return 0;
+    }
+#endif /* TIMER_USE_LETIMER */
+
     TIMER_TypeDef *tim;
 
     if (channel < 0 || channel >= (int) CC_CHANNELS) {
@@ -134,22 +201,49 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
 int timer_clear(tim_t dev, int channel)
 {
+#ifdef TIMER_USE_LETIMER
+    if (dev == TIMER_LETIMER) {
+        LETIMER_IntDisable(LETIMER0, LETIMER_IF_COMP0 << channel);
+        return 0;
+    }
+#endif /* TIMER_USE_LETIMER */
+
     timer_config[dev].timer.dev->CC[channel].CTRL = _TIMER_CC_CTRL_MODE_OFF;
     return 0;
 }
 
 unsigned int timer_read(tim_t dev)
 {
+#ifdef TIMER_USE_LETIMER
+    if (dev == TIMER_LETIMER) {
+        return (uint16_t) ~LETIMER_CounterGet(LETIMER0);
+    }
+#endif /* TIMER_USE_LETIMER */
+
     return (unsigned int) TIMER_CounterGet(timer_config[dev].timer.dev);
 }
 
 void timer_stop(tim_t dev)
 {
+#ifdef TIMER_USE_LETIMER
+    if (dev == TIMER_LETIMER) {
+        LETIMER_Enable(LETIMER0, false);
+        return;
+    }
+#endif /* TIMER_USE_LETIMER */
+
     TIMER_Enable(timer_config[dev].timer.dev, false);
 }
 
 void timer_start(tim_t dev)
 {
+#ifdef TIMER_USE_LETIMER
+    if (dev == TIMER_LETIMER) {
+        LETIMER_Enable(LETIMER0, true);
+        return;
+    }
+#endif /* TIMER_USE_LETIMER */
+
     TIMER_Enable(timer_config[dev].timer.dev, true);
 }
 
@@ -168,3 +262,20 @@ void TIMER_0_ISR(void)
     cortexm_isr_end();
 }
 #endif /* TIMER_0_ISR */
+
+#ifdef TIMER_USE_LETIMER
+void isr_letimer0(void)
+{
+    LETIMER_TypeDef *tim = LETIMER0;
+
+    for (int i = 0; i < (int) LETIMER_CHANNELS; i++) {
+        if (tim->IF & (LETIMER_IF_COMP0 << i)) {
+            tim->IEN &= ~(LETIMER_IF_COMP0 << i);
+            tim->IFC = (LETIMER_IF_COMP0 << i);
+            isr_ctx_letimer.cb(isr_ctx_letimer.arg, i);
+        }
+    }
+
+    cortexm_isr_end();
+}
+#endif /* TIMER_USE_LETIMER */


### PR DESCRIPTION
### Contribution description

The current timer implementations on EFM32 CPUs depends on joining two adjacent 16-bit timers to create an 1kHz timer. Given that timer in- and outputs are not freely routable and that the timers need to be adjacent, this blocks many other uses of the timers. (For example, the TIMER1 and TIMER2 devices are never free in the same setup).

This adds an additional 16-bit timer implementation based on the LETIMER peripheral of the EFM32. It can only be driven from the low frequency clock, giving it a practical frequency of 32768Hz.

The timer is suitable for use as an xtimer.

### Testing procedure

I have yet to figure that out, that's why the PR is WIP. "It works for me" is probably not good enough ;-)

### Issues/PRs references

I've asked about this long ago on devel (https://lists.riot-os.org/pipermail/devel/2018-November/006008.html), but had it lying around for far too long only in my vendor branch and not in a PR.

This will need a bit of work to apply to master again (possibly I can salvage git-rerere from my vendor branch merges), 