### PR TITLE
Makefile.dep: Fix dependency resolution

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1043,13 +1043,13 @@ ifneq (,$(filter periph_%, $(USEMODULE)))
   USEMODULE += periph_common
 endif
 
+ifneq (,$(filter ecc_%,$(USEMODULE)))
+  USEMODULE += ecc
+endif
+
 # recursively catch transitive dependencies
 USEMODULE := $(sort $(USEMODULE))
 USEPKG := $(sort $(USEPKG))
 ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
   include $(RIOTBASE)/Makefile.dep
-endif
-
-ifneq (,$(filter ecc_%,$(USEMODULE)))
-  USEMODULE += ecc
 endif


### PR DESCRIPTION
### Contribution description

The addition of the `ecc` dependency was done after the recursion is done to catch transient dependencies. This could potentially miss transient deps. This PR moves the affected code before the recursion is triggered.

### Testing procedure

The ecc dependency should still be pulled in when some `ecc_%` module is used and compilation of other stuff should not fail (Murdock is again our friend here :-) )

### Issues/PRs references

I did this in [some older still open PR (11238)](https://github.com/RIOT-OS/RIOT/pull/11238), but combined with a lot of alphabetical sorting of the dependency resolution. That PR was a pain to create, will be a pain to rebase, and certainly will be a pain to review and test. This PR should be straightforward to review and test.