### PR TITLE
boards: Fix presence of FPU

### DIFF
--- a/boards/nucleo-f030r8/doc.txt
+++ b/boards/nucleo-f030r8/doc.txt
@@ -23,7 +23,7 @@ content/uploads/2015/08/Figura2-500x467.png)
 | RAM        | 8Kb |
 | Flash      | 64Kb              |
 | Frequency  | up to 48MHz) |
-| FPU        | yes               |
+| FPU        | no                |
 | Timers | 11 (2x watchdog, 1 SysTick, 8x 16-bit)    |
 | ADCs       | 1x 12-bit         |
 | UARTs      | 6                 |

--- a/boards/nucleo-f070rb/doc.txt
+++ b/boards/nucleo-f070rb/doc.txt
@@ -23,7 +23,7 @@ content/uploads/2015/08/Figura2-500x467.png)
 | RAM        | 16Kb |
 | Flash      | 128Kb             |
 | Frequency  | up to 48MHz) |
-| FPU        | yes               |
+| FPU        | no                |
 | Timers | 11 (2x watchdog, 1 SysTick, 8x 16-bit)    |
 | ADCs       | 1x 12-bit         |
 | UARTs      | 4                 |

--- a/boards/nucleo-f072rb/doc.txt
+++ b/boards/nucleo-f072rb/doc.txt
@@ -21,7 +21,7 @@ STM32F072RB microcontroller with 16Kb of SRAM and 128Kb of ROM Flash.
 | RAM        | 16Kb |
 | Flash      | 128Kb             |
 | Frequency  | up to 48MHz) |
-| FPU        | yes               |
+| FPU        | no                |
 | Timers | 12 (2x watchdog, 1 SysTick, 8x 16-bit, 1x 32-bit) |
 | ADCs       | 1x 12-bit (up to 16 channels)         |
 | UARTs      | 4                 |

--- a/boards/nucleo-f103rb/doc.txt
+++ b/boards/nucleo-f103rb/doc.txt
@@ -20,7 +20,7 @@ STM32F103RB microcontroller with 20Kb of SRAM and 128Kb of ROM Flash.
 | RAM        | 20Kb |
 | Flash      | 128Kb             |
 | Frequency  | up to 72MHz    |
-| FPU        | yes               |
+| FPU        | no                |
 | Timers | 7 (2x watchdog, 1 SysTick, 4x 16-bit) |
 | ADCs       | 1x 12-bit         |
 | UARTs      | 3                 |

--- a/boards/nucleo-f207zg/doc.txt
+++ b/boards/nucleo-f207zg/doc.txt
@@ -22,7 +22,7 @@ STM32F207ZG microcontroller with 128Kb of SRAM and 1Mb of ROM Flash.
 | RAM        | 128Kb |
 | Flash      | 1Mb               |
 | Frequency  | up to 120MHz |
-| FPU        | yes               |
+| FPU        | no                |
 | Timers | 17 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |
 | ADCs       | 3x 12-bit         |
 | UARTs      | 4                 |

--- a/boards/spark-core/doc.txt
+++ b/boards/spark-core/doc.txt
@@ -25,7 +25,7 @@ Link to [product website](http://docs.spark.io/hardware/).
 | RAM        | 20Kb  |
 | Flash      | 128Kb             |
 | Frequency  | up to 72MHz (using the on-board 8MHz Oszillator of the ST- Link) |
-| FPU        | yes               |
+| FPU        | no                |
 | Timers | 10 (9x 16-bit, 1x 32-bit [TIM2])  |
 | ADCs       | 4x 12-bit         |
 | UARTs      | 5                 |


### PR DESCRIPTION
### Contribution description

In the documentation of a few boards, FPU was marked as present. However Cortex-M0, Cortex-M0+ and Cortex-M3 MCU cannot have a FPU. Only Cortex-M4, Cortex-M7 may have a FPU.

### Testing procedure

None.

### Issues/PRs references

None.