### PR TITLE
drivers/ili9341: add missing xtimer module dependency

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -237,6 +237,7 @@ endif
 ifneq (,$(filter ili9341,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
   FEATURES_REQUIRED += periph_gpio
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter ina2%,$(USEMODULE)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the xtimer module as explicit dependency for the ili9341 display driver. Since there's a strong dependency of the driver implementation with xtimer, it should be added in the drivers/Makefile.dep file.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- This could become more visible in #13262 if I push some extra changes (a test application that just use the disp_dev module and ili9341 without use of xtimer in the application).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Might be required by #13262 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
