### PR TITLE
pkg/monocypher: bump to version 3.0.0

### DIFF
--- a/pkg/monocypher/Makefile
+++ b/pkg/monocypher/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=monocypher
 PKG_URL=https://github.com/LoupVaillant/Monocypher
-PKG_VERSION=d9cc2aea29158971ed4b7dc074efdcb35e7183d5
+PKG_VERSION=ff334e288a667c5cd8500c04d1e2ebd601b9f215
 PKG_LICENSE=CC-0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/monocypher/Makefile.dep
+++ b/pkg/monocypher/Makefile.dep
@@ -1,4 +1,5 @@
-USEMODULE += monocypher_sha512
+# SHA-512 & ED25519
+USEMODULE += monocypher_optional
 
 # monocypher is only supported by 32 bit architectures
 FEATURES_REQUIRED += arch_32bit

--- a/pkg/monocypher/Makefile.include
+++ b/pkg/monocypher/Makefile.include
@@ -1,7 +1,8 @@
 INCLUDES += -I$(PKGDIRBASE)/monocypher/src
 INCLUDES += -I$(PKGDIRBASE)/monocypher/src/optional
 
-ifneq (,$(filter monocypher_sha512,$(USEMODULE)))
-  CFLAGS += -DED25519_SHA512
+ifneq (,$(filter monocypher_optional,$(USEMODULE)))
   DIRS += $(PKGDIRBASE)/monocypher/src/optional
 endif
+
+CFLAGS += -DBLAKE2_NO_UNROLLING

--- a/pkg/monocypher/patches/0001-Monocypher-add-riot-makefiles.patch
+++ b/pkg/monocypher/patches/0001-Monocypher-add-riot-makefiles.patch
@@ -25,9 +25,8 @@ index 0000000..784d588
 --- /dev/null
 +++ b/src/optional/Makefile
 @@ -0,0 +1,3 @@
-+MODULE := monocypher_sha512
++MODULE := monocypher_optional
 +
 +include $(RIOTBASE)/Makefile.base
 -- 
 2.16.4
-


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A simple update of the Monocypher package. The 3.0.0 version was released by Loup Vaillant on 19 January 2020. It could be great to upgrade the version as it's a new major release.

### Testing procedure

I have an application using Monocypher. I've just changed the commit version of Monocypher, recompiled and tested the new release with it.
Nothing wrong to signal. The only downside with this test is that I use only a few methods from the library.
