### PR TITLE
make.dep/gcoap: remove gnrc dependency

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -875,7 +875,6 @@ endif
 
 ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += nanocoap
-  USEMODULE += gnrc_sock_udp
   USEMODULE += sock_util
 endif
 


### PR DESCRIPTION
### Contribution description
This PR is a simple followup to #12931 to remove gcoap's dependency on the `gnrc_sock_udp` module. gcoap already depends on `sock_util`, which depends on `sock_udp`. #12931 uses the `sock_udp` dependency to bring in `gnrc_sock_udp` only when the `gnrc` module is used.

This PR is the first in a series to allow use of the lwIP stack with gcoap, as you can see in my [gcoap/lwip_for_example](https://github.com/kb2ma/RIOT/commits/gcoap/lwip_for_example) branch.

### Testing procedure
Compile the gcoap example, and compile and run the gcoap unit tests.

### Issues/PRs references
Based on #12931.