### PR TITLE
drivers/at86rf2xx: reset hardware before reading any register

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -91,8 +91,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
 {
     eui64_t addr_long;
 
-    at86rf2xx_hardware_reset(dev);
-
     netdev_ieee802154_reset(&dev->netdev);
 
     /* Reset state machine to ensure a known state */

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -98,6 +98,9 @@ static int _init(netdev_t *netdev)
     spi_release(dev->params.spi);
 #endif
 
+    /* reset hardware into a defined state */
+    at86rf2xx_hardware_reset(dev);
+
     /* test if the device is responding */
     if (at86rf2xx_reg_read(dev, AT86RF2XX_REG__PART_NUM) != AT86RF2XX_PARTNUM) {
         DEBUG("[at86rf2xx] error: unable to read correct part number\n");
@@ -274,6 +277,7 @@ static int _set_state(at86rf2xx_t *dev, netopt_state_t state)
             }
             break;
         case NETOPT_STATE_RESET:
+            at86rf2xx_hardware_reset(dev);
             at86rf2xx_reset(dev);
             break;
         default:


### PR DESCRIPTION
### Contribution description

This PR adds a hardware reset before the at86 version register is read. Currently we read the version register before resetting but this only works most of the time. In particular, if the mcu resets while the radio is in the sleep state then the driver will fail to initialize the radio due to being unable to read the version register.

### Testing procedure

* run gnrc_networking example
* put radio to sleep with `ifconfig 7 set state sleep`
* reboot without power cycling
* run `ifconfig`
* without this pr, the previous step triggers a crash