### PR TITLE
sys/saul: Remove saul_reg_rm

### DIFF
--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -72,6 +72,15 @@ int saul_reg_add(saul_reg_t *dev);
 /**
  * @brief   Unregister a device from the SAUL registry
  *
+ * @warning   Removing the device at runtime can send applications that have
+ *            looked up that device into invalid states, and should thus be
+ *            avoided.
+ *
+ * @warning   This function must only be used by drivers that advise developers
+ *            using them on how to prevent race conditions when using SAUL.
+ *
+ * None of the SAUL drivers shipped with RIOT call this function.
+ *
  * @param[in] dev       pointer to a registry entry
  *
  * @return      0 on success

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -79,7 +79,8 @@ int saul_reg_add(saul_reg_t *dev);
  * @warning   This function must only be used by drivers that advise developers
  *            using them on how to prevent race conditions when using SAUL.
  *
- * None of the SAUL drivers shipped with RIOT call this function.
+ * @deprecated This function will be removed soon as it is practically unusable
+ *             for the above reasons.
  *
  * @param[in] dev       pointer to a registry entry
  *

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -70,26 +70,6 @@ extern saul_reg_t *saul_reg;
 int saul_reg_add(saul_reg_t *dev);
 
 /**
- * @brief   Unregister a device from the SAUL registry
- *
- * @warning   Removing the device at runtime can send applications that have
- *            looked up that device into invalid states, and should thus be
- *            avoided.
- *
- * @warning   This function must only be used by drivers that advise developers
- *            using them on how to prevent race conditions when using SAUL.
- *
- * @deprecated This function will be removed soon as it is practically unusable
- *             for the above reasons.
- *
- * @param[in] dev       pointer to a registry entry
- *
- * @return      0 on success
- * @return      -ENODEV if device was not found in the registry
- */
-int saul_reg_rm(saul_reg_t *dev);
-
-/**
  * @brief   Find a device by it's position in the registry
  *
  * @param[in] pos       position to look up

--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -54,29 +54,6 @@ int saul_reg_add(saul_reg_t *dev)
     return 0;
 }
 
-int saul_reg_rm(saul_reg_t *dev)
-{
-    saul_reg_t *tmp = saul_reg;
-
-    if (saul_reg == NULL || dev == NULL) {
-        return -ENODEV;
-    }
-    if (saul_reg == dev) {
-        saul_reg = dev->next;
-        return 0;
-    }
-    while (tmp->next && (tmp->next != dev)) {
-        tmp = tmp->next;
-    }
-    if (tmp->next == dev) {
-        tmp->next = dev->next;
-    }
-    else {
-        return -ENODEV;
-    }
-    return 0;
-}
-
 saul_reg_t *saul_reg_find_nth(int pos)
 {
     saul_reg_t *tmp = saul_reg;

--- a/tests/unittests/tests-saul_reg/tests-saul_reg.c
+++ b/tests/unittests/tests-saul_reg/tests-saul_reg.c
@@ -152,7 +152,6 @@ Test *tests_saul_reg_tests(void)
         new_TestFixture(test_reg_find_nth),
         new_TestFixture(test_reg_find_type),
         new_TestFixture(test_reg_find_name),
-        new_TestFixture(test_reg_rm)
     };
 
     EMB_UNIT_TESTCALLER(pkt_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-saul_reg/tests-saul_reg.c
+++ b/tests/unittests/tests-saul_reg/tests-saul_reg.c
@@ -144,46 +144,6 @@ static void test_reg_find_name(void)
     TEST_ASSERT_NULL(dev);
 }
 
-static void test_reg_rm(void)
-{
-    int res;
-
-    TEST_ASSERT_EQUAL_INT(4, count());
-    TEST_ASSERT_EQUAL_STRING("S0", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S3", last()->name);
-
-    res = saul_reg_rm(&s3);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(3, count());
-    TEST_ASSERT_EQUAL_STRING("S0", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S2", last()->name);
-
-    res = saul_reg_rm(&s1);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(2, count());
-    TEST_ASSERT_EQUAL_STRING("S0", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S2", last()->name);
-
-    res = saul_reg_rm(&s1);
-    TEST_ASSERT_EQUAL_INT(-ENODEV, res);
-
-    res = saul_reg_rm(NULL);
-    TEST_ASSERT_EQUAL_INT(-ENODEV, res);
-
-    TEST_ASSERT_EQUAL_INT(2, count());
-
-    res = saul_reg_rm(&s0);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(1, count());
-    TEST_ASSERT_EQUAL_STRING("S2", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S2", last()->name);
-
-    res = saul_reg_rm(&s2);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(0, count());
-    TEST_ASSERT_NULL(saul_reg);
-}
-
 Test *tests_saul_reg_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {


### PR DESCRIPTION
### Contribution description

This removes the `saul_reg_rm` function, which has been argued to be difficult to use correctly already in #10605 (in short: The caller would need to know of all possible earlier lookups of the device in the registry).

As per the brief discussion there, there seems not to be any actual use of the problematic function, so removal was suggested.

In case this is approved for a later step after a deprecation, this PR is based on #10605 as to later be applicable after a deprecation period. If it gets accepted right away (without #10605 being merged before), it can still be squashed into a single change.

### Testing procedure

* `git grep saul_reg_rm` in any of your projects that use SAUL
* `cd tests/unittests && make test` still works as the test for saul_reg_rm is removed

There is no other code in RIOT that relies on the function.

### Issues/PRs references

#10605 deprecates the function removed here.