### PR TITLE
drivers/at86rf2xx: use luid_get_eui64() / luid_get_short()

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -90,6 +90,7 @@ static void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev)
 void at86rf2xx_reset(at86rf2xx_t *dev)
 {
     eui64_t addr_long;
+    network_uint16_t addr_short;
 
     at86rf2xx_hardware_reset(dev);
 
@@ -100,14 +101,13 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
         at86rf2xx_set_state(dev, AT86RF2XX_STATE_FORCE_TRX_OFF);
     }
 
-    /* get an 8-byte unique ID to use as hardware address */
-    luid_get(addr_long.uint8, IEEE802154_LONG_ADDRESS_LEN);
-    /* make sure we mark the address as non-multicast and not globally unique */
-    addr_long.uint8[0] &= ~(0x01);
-    addr_long.uint8[0] |=  (0x02);
+    /* generate EUI-64 and short address */
+    luid_get_eui64(&addr_long);
+    luid_get_short(&addr_short);
+
     /* set short and long address */
     at86rf2xx_set_addr_long(dev, &addr_long);
-    at86rf2xx_set_addr_short(dev, &addr_long.uint16[ARRAY_SIZE(addr_long.uint16) - 1]);
+    at86rf2xx_set_addr_short(dev, &addr_short);
 
     /* set default channel */
     at86rf2xx_set_chan(dev, AT86RF2XX_DEFAULT_CHANNEL);


### PR DESCRIPTION
### Contribution description

Use dedicated helper functions to generate long and short address.
`luid_get_short()` will use the 'next' pseudo-random luid instead of re-using the previous one, so this might alleviate the address collisions observed in #13358


### Testing procedure

- send and receive should still work using both the long and the short address (*tested locally with two `samr21-xpro`*)
- repeat the steps outlined in #13358

### Issues/PRs references

Maybe fixes #13358
