### PR TITLE
sys/auto_init: cleanup / unify / DEBUG -> LOG_DEBUG

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -112,12 +112,12 @@
 void auto_init(void)
 {
 #ifdef MODULE_AUTO_INIT_RANDOM
-    LOG_DEBUG("Auto init random module.\n");
+    LOG_DEBUG("Auto init random.\n");
     void auto_init_random(void);
     auto_init_random();
 #endif
 #ifdef MODULE_AUTO_INIT_XTIMER
-    LOG_DEBUG("Auto init xtimer module.\n");
+    LOG_DEBUG("Auto init xtimer.\n");
     xtimer_init();
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
@@ -130,7 +130,7 @@ void auto_init(void)
     auto_init_event_thread();
 #endif
 #ifdef MODULE_MCI
-    LOG_DEBUG("Auto init mci module.\n");
+    LOG_DEBUG("Auto init mci.\n");
     mci_initialize();
 #endif
 #ifdef MODULE_PROFILING
@@ -139,27 +139,27 @@ void auto_init(void)
     profiling_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
-    LOG_DEBUG("Auto init gnrc_pktbuf module\n");
+    LOG_DEBUG("Auto init gnrc_pktbuf.\n");
     gnrc_pktbuf_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
-    LOG_DEBUG("Auto init gnrc_pktdump module.\n");
+    LOG_DEBUG("Auto init gnrc_pktdump.\n");
     gnrc_pktdump_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
-    LOG_DEBUG("Auto init gnrc_sixlowpan module.\n");
+    LOG_DEBUG("Auto init gnrc_sixlowpan.\n");
     gnrc_sixlowpan_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_IPV6
-    LOG_DEBUG("Auto init gnrc_ipv6 module.\n");
+    LOG_DEBUG("Auto init gnrc_ipv6.\n");
     gnrc_ipv6_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_UDP
-    LOG_DEBUG("Auto init UDP module.\n");
+    LOG_DEBUG("Auto init gnrc_udp.\n");
     gnrc_udp_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_TCP
-    LOG_DEBUG("Auto init TCP module\n");
+    LOG_DEBUG("Auto init gnrc_tcp.\n");
     gnrc_tcp_init();
 #endif
 #ifdef MODULE_AUTO_INIT_LWIP
@@ -173,39 +173,39 @@ void auto_init(void)
 #endif
 #ifdef MODULE_GCOAP
     if (!IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
-        LOG_DEBUG("Auto init gcoap module.\n");
+        LOG_DEBUG("Auto init gcoap.\n");
         gcoap_init();
     }
 #endif
 #ifdef MODULE_DEVFS
-    LOG_DEBUG("Mounting /dev\n");
+    LOG_DEBUG("Mounting /dev.\n");
     extern void auto_init_devfs(void);
     auto_init_devfs();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
-    LOG_DEBUG("Auto init gnrc_ipv6_nib module.\n");
+    LOG_DEBUG("Auto init gnrc_ipv6_nib.\n");
     gnrc_ipv6_nib_init();
 #endif
 #ifdef MODULE_SKALD
-    LOG_DEBUG("Auto init Skald\n");
+    LOG_DEBUG("Auto init Skald.\n");
     skald_init();
 #endif
 #ifdef MODULE_CORD_COMMON
-    LOG_DEBUG("Auto init cord_common module\n");
+    LOG_DEBUG("Auto init cord_common.\n");
     extern void cord_common_init(void);
     cord_common_init();
 #endif
 #ifdef MODULE_CORD_EP_STANDALONE
-    LOG_DEBUG("Auto init cord_ep_standalone\n");
+    LOG_DEBUG("Auto init cord_ep_standalone.\n");
     extern void cord_ep_standalone_run(void);
     cord_ep_standalone_run();
 #endif
 #ifdef MODULE_ASYMCUTE
-    LOG_DEBUG("Auto init Asymcute\n");
+    LOG_DEBUG("Auto init Asymcute.\n");
     asymcute_handler_run();
 #endif
 #ifdef MODULE_NIMBLE
-    LOG_DEBUG("Auto init NimBLE\n");
+    LOG_DEBUG("Auto init NimBLE.\n");
     extern void nimble_riot_init(void);
     nimble_riot_init();
 #endif
@@ -215,7 +215,7 @@ void auto_init(void)
     auto_init_loramac();
 #endif
 #ifdef MODULE_SOCK_DTLS
-    LOG_DEBUG("Auto init sock_dtls\n");
+    LOG_DEBUG("Auto init sock_dtls.\n");
     sock_dtls_init();
 #endif
 
@@ -228,7 +228,7 @@ void auto_init(void)
 
 /* initialize network devices */
 #ifdef MODULE_AUTO_INIT_GNRC_NETIF
-    LOG_DEBUG("Auto init gnrc netif.\n");
+    LOG_DEBUG("Auto init gnrc_netif.\n");
 
 #ifdef MODULE_STM32_ETH
     extern void auto_init_stm32_eth(void);
@@ -362,7 +362,7 @@ void auto_init(void)
 
 /* initialize NDN module after the network devices are initialized */
 #ifdef MODULE_NDN_RIOT
-    LOG_DEBUG("Auto init NDN module.\n");
+    LOG_DEBUG("Auto init NDN.\n");
     ndn_init();
 #endif
 
@@ -372,13 +372,13 @@ void auto_init(void)
      * as the shell commands rely on auto-initialization. auto_init_sht1x also
      * performs SAUL registration, but only if module auto_init_saul is used.
      */
-    LOG_DEBUG("Auto init SHT1X module (SHT10/SHT11/SHT15 sensor driver).\n");
+    LOG_DEBUG("Auto init sht1x.\n");
     extern void auto_init_sht1x(void);
     auto_init_sht1x();
 #endif
 
 #ifdef MODULE_AUTO_INIT_SAUL
-    LOG_DEBUG("auto_init SAUL\n");
+    LOG_DEBUG("Auto init SAUL.\n");
 
 #ifdef MODULE_SAUL_ADC
     extern void auto_init_adc(void);
@@ -611,7 +611,7 @@ void auto_init(void)
 
 /* initialize storage devices */
 #ifdef MODULE_AUTO_INIT_STORAGE
-    LOG_DEBUG("auto_init STORAGE\n");
+    LOG_DEBUG("Auto init STORAGE.\n");
 
 #ifdef MODULE_SDCARD_SPI
     extern void auto_init_sdcard_spi(void);
@@ -621,7 +621,7 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_STORAGE */
 
 #ifdef MODULE_AUTO_INIT_CAN
-    LOG_DEBUG("auto_init CAN\n");
+    LOG_DEBUG("Auto init CAN.\n");
 
     extern void auto_init_candev(void);
     auto_init_candev();
@@ -651,7 +651,7 @@ void auto_init(void)
 #endif /* MODULE_TEST_UTILS_INTERACTIVE_SYNC */
 
 #ifdef MODULE_AUTO_INIT_DHCPV6_CLIENT
-    LOG_DEBUG("auto_init DHCPv6 client\n");
+    LOG_DEBUG("Auto init DHCPv6 client.\n");
     extern void dhcpv6_client_auto_init(void);
     dhcpv6_client_auto_init();
 #endif /* MODULE_AUTO_INIT_DHCPV6_CLIENT */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -1,7 +1,9 @@
 /**
  * Auto initialization for used modules
  *
- * Copyright (C) 2013  INRIA.
+ * Copyright (C) 2020 Freie Universität Berlin
+ *               2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2013  INRIA.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -13,6 +15,7 @@
  * @brief   initializes any used module that has a trivial init function
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 #include <stdint.h>
@@ -108,6 +111,7 @@
 void auto_init(void)
 {
 #ifdef MODULE_AUTO_INIT_RANDOM
+    DEBUG("Auto init random module.\n");
     void auto_init_random(void);
     auto_init_random();
 #endif
@@ -116,9 +120,11 @@ void auto_init(void)
     xtimer_init();
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
+    DEBUG("Auto init schedstatistics.\n");
     init_schedstatistics();
 #endif
 #ifdef MODULE_EVENT_THREAD
+    DEBUG("Auto init event threads.\n");
     extern void auto_init_event_thread(void);
     auto_init_event_thread();
 #endif
@@ -127,6 +133,7 @@ void auto_init(void)
     mci_initialize();
 #endif
 #ifdef MODULE_PROFILING
+    DEBUG("Auto init profiling.\n");
     extern void profiling_init(void);
     profiling_init();
 #endif
@@ -159,6 +166,7 @@ void auto_init(void)
     lwip_bootstrap();
 #endif
 #ifdef MODULE_OPENTHREAD
+    DEBUG("Bootstrapping openthread.\n");
     extern void openthread_bootstrap(void);
     openthread_bootstrap();
 #endif
@@ -201,6 +209,7 @@ void auto_init(void)
     nimble_riot_init();
 #endif
 #ifdef MODULE_AUTO_INIT_LORAMAC
+    DEBUG("Auto init loramac.\n");
     extern void auto_init_loramac(void);
     auto_init_loramac();
 #endif
@@ -211,12 +220,14 @@ void auto_init(void)
 
 /* initialize USB devices */
 #ifdef MODULE_AUTO_INIT_USBUS
+    DEBUG("Auto init USB.\n");
     extern void auto_init_usb(void);
     auto_init_usb();
 #endif
 
 /* initialize network devices */
 #ifdef MODULE_AUTO_INIT_GNRC_NETIF
+    DEBUG("Auto init gnrc netif.\n");
 
 #ifdef MODULE_STM32_ETH
     extern void auto_init_stm32_eth(void);
@@ -343,6 +354,7 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_GNRC_NETIF */
 
 #ifdef MODULE_AUTO_INIT_GNRC_UHCPC
+    DEBUG("Auto init gnrc_uhcpc.\n");
     extern void auto_init_gnrc_uhcpc(void);
     auto_init_gnrc_uhcpc();
 #endif
@@ -591,12 +603,9 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_SAUL */
 
 #ifdef MODULE_AUTO_INIT_GNRC_RPL
-
-#ifdef MODULE_AUTO_INIT_GNRC_RPL
+    DEBUG("Auto init gnrc_rpl.\n");
     extern void auto_init_gnrc_rpl(void);
     auto_init_gnrc_rpl();
-#endif
-
 #endif /* MODULE_AUTO_INIT_GNRC_RPL */
 
 /* initialize storage devices */
@@ -619,6 +628,7 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_CAN */
 
 #ifdef MODULE_SUIT
+    DEBUG("Auto init SUIT conditions.\n");
     extern void suit_init_conditions(void);
     suit_init_conditions();
 #endif /* MODULE_SUIT */
@@ -626,6 +636,7 @@ void auto_init(void)
 #ifdef MODULE_AUTO_INIT_SECURITY
 
 #ifdef MODULE_CRYPTOAUTHLIB
+    DEBUG("Auto init cryptoauthlib.\n");
     extern void auto_init_atca(void);
     auto_init_atca();
 #endif  /* MODULE_CRYPTOAUTHLIB */
@@ -639,7 +650,7 @@ void auto_init(void)
 #endif /* MODULE_TEST_UTILS_INTERACTIVE_SYNC */
 
 #ifdef MODULE_AUTO_INIT_DHCPV6_CLIENT
-    DEBUG("auto_init DHCPv6 client");
+    DEBUG("auto_init DHCPv6 client\n");
     extern void dhcpv6_client_auto_init(void);
     dhcpv6_client_auto_init();
 #endif /* MODULE_AUTO_INIT_DHCPV6_CLIENT */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 
 #include "auto_init.h"
+#include "log.h"
 
 #ifdef MODULE_MCI
 #include "diskio.h"
@@ -111,123 +112,123 @@
 void auto_init(void)
 {
 #ifdef MODULE_AUTO_INIT_RANDOM
-    DEBUG("Auto init random module.\n");
+    LOG_DEBUG("Auto init random module.\n");
     void auto_init_random(void);
     auto_init_random();
 #endif
 #ifdef MODULE_AUTO_INIT_XTIMER
-    DEBUG("Auto init xtimer module.\n");
+    LOG_DEBUG("Auto init xtimer module.\n");
     xtimer_init();
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
-    DEBUG("Auto init schedstatistics.\n");
+    LOG_DEBUG("Auto init schedstatistics.\n");
     init_schedstatistics();
 #endif
 #ifdef MODULE_EVENT_THREAD
-    DEBUG("Auto init event threads.\n");
+    LOG_DEBUG("Auto init event threads.\n");
     extern void auto_init_event_thread(void);
     auto_init_event_thread();
 #endif
 #ifdef MODULE_MCI
-    DEBUG("Auto init mci module.\n");
+    LOG_DEBUG("Auto init mci module.\n");
     mci_initialize();
 #endif
 #ifdef MODULE_PROFILING
-    DEBUG("Auto init profiling.\n");
+    LOG_DEBUG("Auto init profiling.\n");
     extern void profiling_init(void);
     profiling_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
-    DEBUG("Auto init gnrc_pktbuf module\n");
+    LOG_DEBUG("Auto init gnrc_pktbuf module\n");
     gnrc_pktbuf_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
-    DEBUG("Auto init gnrc_pktdump module.\n");
+    LOG_DEBUG("Auto init gnrc_pktdump module.\n");
     gnrc_pktdump_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
-    DEBUG("Auto init gnrc_sixlowpan module.\n");
+    LOG_DEBUG("Auto init gnrc_sixlowpan module.\n");
     gnrc_sixlowpan_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_IPV6
-    DEBUG("Auto init gnrc_ipv6 module.\n");
+    LOG_DEBUG("Auto init gnrc_ipv6 module.\n");
     gnrc_ipv6_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_UDP
-    DEBUG("Auto init UDP module.\n");
+    LOG_DEBUG("Auto init UDP module.\n");
     gnrc_udp_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_TCP
-    DEBUG("Auto init TCP module\n");
+    LOG_DEBUG("Auto init TCP module\n");
     gnrc_tcp_init();
 #endif
 #ifdef MODULE_AUTO_INIT_LWIP
-    DEBUG("Bootstraping lwIP.\n");
+    LOG_DEBUG("Bootstraping lwIP.\n");
     lwip_bootstrap();
 #endif
 #ifdef MODULE_OPENTHREAD
-    DEBUG("Bootstrapping openthread.\n");
+    LOG_DEBUG("Bootstrapping openthread.\n");
     extern void openthread_bootstrap(void);
     openthread_bootstrap();
 #endif
 #ifdef MODULE_GCOAP
     if (!IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
-        DEBUG("Auto init gcoap module.\n");
+        LOG_DEBUG("Auto init gcoap module.\n");
         gcoap_init();
     }
 #endif
 #ifdef MODULE_DEVFS
-    DEBUG("Mounting /dev\n");
+    LOG_DEBUG("Mounting /dev\n");
     extern void auto_init_devfs(void);
     auto_init_devfs();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
-    DEBUG("Auto init gnrc_ipv6_nib module.\n");
+    LOG_DEBUG("Auto init gnrc_ipv6_nib module.\n");
     gnrc_ipv6_nib_init();
 #endif
 #ifdef MODULE_SKALD
-    DEBUG("Auto init Skald\n");
+    LOG_DEBUG("Auto init Skald\n");
     skald_init();
 #endif
 #ifdef MODULE_CORD_COMMON
-    DEBUG("Auto init cord_common module\n");
+    LOG_DEBUG("Auto init cord_common module\n");
     extern void cord_common_init(void);
     cord_common_init();
 #endif
 #ifdef MODULE_CORD_EP_STANDALONE
-    DEBUG("Auto init cord_ep_standalone\n");
+    LOG_DEBUG("Auto init cord_ep_standalone\n");
     extern void cord_ep_standalone_run(void);
     cord_ep_standalone_run();
 #endif
 #ifdef MODULE_ASYMCUTE
-    DEBUG("Auto init Asymcute\n");
+    LOG_DEBUG("Auto init Asymcute\n");
     asymcute_handler_run();
 #endif
 #ifdef MODULE_NIMBLE
-    DEBUG("Auto init NimBLE\n");
+    LOG_DEBUG("Auto init NimBLE\n");
     extern void nimble_riot_init(void);
     nimble_riot_init();
 #endif
 #ifdef MODULE_AUTO_INIT_LORAMAC
-    DEBUG("Auto init loramac.\n");
+    LOG_DEBUG("Auto init loramac.\n");
     extern void auto_init_loramac(void);
     auto_init_loramac();
 #endif
 #ifdef MODULE_SOCK_DTLS
-    DEBUG("Auto init sock_dtls\n");
+    LOG_DEBUG("Auto init sock_dtls\n");
     sock_dtls_init();
 #endif
 
 /* initialize USB devices */
 #ifdef MODULE_AUTO_INIT_USBUS
-    DEBUG("Auto init USB.\n");
+    LOG_DEBUG("Auto init USB.\n");
     extern void auto_init_usb(void);
     auto_init_usb();
 #endif
 
 /* initialize network devices */
 #ifdef MODULE_AUTO_INIT_GNRC_NETIF
-    DEBUG("Auto init gnrc netif.\n");
+    LOG_DEBUG("Auto init gnrc netif.\n");
 
 #ifdef MODULE_STM32_ETH
     extern void auto_init_stm32_eth(void);
@@ -354,14 +355,14 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_GNRC_NETIF */
 
 #ifdef MODULE_AUTO_INIT_GNRC_UHCPC
-    DEBUG("Auto init gnrc_uhcpc.\n");
+    LOG_DEBUG("Auto init gnrc_uhcpc.\n");
     extern void auto_init_gnrc_uhcpc(void);
     auto_init_gnrc_uhcpc();
 #endif
 
 /* initialize NDN module after the network devices are initialized */
 #ifdef MODULE_NDN_RIOT
-    DEBUG("Auto init NDN module.\n");
+    LOG_DEBUG("Auto init NDN module.\n");
     ndn_init();
 #endif
 
@@ -371,13 +372,13 @@ void auto_init(void)
      * as the shell commands rely on auto-initialization. auto_init_sht1x also
      * performs SAUL registration, but only if module auto_init_saul is used.
      */
-    DEBUG("Auto init SHT1X module (SHT10/SHT11/SHT15 sensor driver).\n");
+    LOG_DEBUG("Auto init SHT1X module (SHT10/SHT11/SHT15 sensor driver).\n");
     extern void auto_init_sht1x(void);
     auto_init_sht1x();
 #endif
 
 #ifdef MODULE_AUTO_INIT_SAUL
-    DEBUG("auto_init SAUL\n");
+    LOG_DEBUG("auto_init SAUL\n");
 
 #ifdef MODULE_SAUL_ADC
     extern void auto_init_adc(void);
@@ -603,14 +604,14 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_SAUL */
 
 #ifdef MODULE_AUTO_INIT_GNRC_RPL
-    DEBUG("Auto init gnrc_rpl.\n");
+    LOG_DEBUG("Auto init gnrc_rpl.\n");
     extern void auto_init_gnrc_rpl(void);
     auto_init_gnrc_rpl();
 #endif /* MODULE_AUTO_INIT_GNRC_RPL */
 
 /* initialize storage devices */
 #ifdef MODULE_AUTO_INIT_STORAGE
-    DEBUG("auto_init STORAGE\n");
+    LOG_DEBUG("auto_init STORAGE\n");
 
 #ifdef MODULE_SDCARD_SPI
     extern void auto_init_sdcard_spi(void);
@@ -620,7 +621,7 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_STORAGE */
 
 #ifdef MODULE_AUTO_INIT_CAN
-    DEBUG("auto_init CAN\n");
+    LOG_DEBUG("auto_init CAN\n");
 
     extern void auto_init_candev(void);
     auto_init_candev();
@@ -628,7 +629,7 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_CAN */
 
 #ifdef MODULE_SUIT
-    DEBUG("Auto init SUIT conditions.\n");
+    LOG_DEBUG("Auto init SUIT conditions.\n");
     extern void suit_init_conditions(void);
     suit_init_conditions();
 #endif /* MODULE_SUIT */
@@ -636,7 +637,7 @@ void auto_init(void)
 #ifdef MODULE_AUTO_INIT_SECURITY
 
 #ifdef MODULE_CRYPTOAUTHLIB
-    DEBUG("Auto init cryptoauthlib.\n");
+    LOG_DEBUG("Auto init cryptoauthlib.\n");
     extern void auto_init_atca(void);
     auto_init_atca();
 #endif  /* MODULE_CRYPTOAUTHLIB */
@@ -650,7 +651,7 @@ void auto_init(void)
 #endif /* MODULE_TEST_UTILS_INTERACTIVE_SYNC */
 
 #ifdef MODULE_AUTO_INIT_DHCPV6_CLIENT
-    DEBUG("auto_init DHCPv6 client\n");
+    LOG_DEBUG("auto_init DHCPv6 client\n");
     extern void dhcpv6_client_auto_init(void);
     dhcpv6_client_auto_init();
 #endif /* MODULE_AUTO_INIT_DHCPV6_CLIENT */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I realized that some modules would print a message when debug out put is enabled, some would not.
That's ... confusing. :)

This PR adds a message to all modules (that are not drivers).
Also, it changes DEBUG to LOG_DEBUG.
Lastly, I tried to unify and sometimes shorten the messages a bit.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
