### PR TITLE
xtimer: properly expose xtimer_usleep64()

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -151,6 +151,15 @@ static inline void xtimer_sleep(uint32_t seconds);
 static inline void xtimer_usleep(uint32_t microseconds);
 
 /**
+ * @brief Pause the execution of a thread for some microseconds
+ *
+ * See xtimer_usleep() for more information.
+ *
+ * @param[in] microseconds  the amount of microseconds the thread should sleep
+ */
+static inline void xtimer_usleep64(uint64_t microseconds);
+
+/**
  * @brief Stop execution of a thread for some time
  *
  * Don't expect nanosecond accuracy. As of now, this function just calls


### PR DESCRIPTION
### Contribution description
`xtimer_usleep64()` is currently implemented (see `sys/include/xtimer/implementation.h`), but not properly exposed in the actual xtimer API (`sys/include/xtimer.h`). Although the function was callable and usable before, this PR prevents any future (internal) xtimer changes from braking code that uses this function. Also having it documented does probably not hurt...

### Testing procedure
- check the doxygen output
- IMO not really any test needed, as no actual code was changed... But if there is an urge to run something, simply call `xtimer_usleep64()` with `timeout > UINT32_MAX` in any example and wait for > 1,19 hours, the blocked thread should continue properly after the specified timeout...

### Issues/PRs references
see https://github.com/apache/mynewt-nimble/pull/753