### PR TITLE
xtimer: add xtimer_set_timeout_flag64()

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -398,6 +398,7 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b);
  */
 int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
 
+#if defined(MODULE_CORE_THREAD_FLAGS) || defined(DOXYGEN)
 /**
  * @brief    Set timeout thread flag after @p timeout
  *
@@ -408,6 +409,17 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
  * @param[in]   timeout timeout in usec
  */
 void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
+
+/**
+ * @brief    Set timeout thread flag after @p timeout
+ *
+ * See xtimer_set_timeout_flag() for more information.
+ *
+ * @param[in]   t       timer struct to use
+ * @param[in]   timeout timeout in usec
+ */
+void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout);
+#endif
 
 #if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
 /**

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -255,11 +255,22 @@ static void _set_timeout_flag_callback(void* arg)
     thread_flags_set(arg, THREAD_FLAG_TIMEOUT);
 }
 
-void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
+static void _set_timeout_flag_prepare(xtimer_t *t)
 {
     t->callback = _set_timeout_flag_callback;
     t->arg = (thread_t *)sched_active_thread;
     thread_flags_clear(THREAD_FLAG_TIMEOUT);
+}
+
+void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
+{
+    _set_timeout_flag_prepare(t);
     xtimer_set(t, timeout);
+}
+
+void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout)
+{
+    _set_timeout_flag_prepare(t);
+    xtimer_set64(t, timeout);
 }
 #endif

--- a/tests/thread_flags/main.c
+++ b/tests/thread_flags/main.c
@@ -98,6 +98,14 @@ int main(void)
     uint32_t diff = xtimer_now_usec() - before;
     printf("main: timeout triggered. time passed: %"PRIu32"us\n", diff);
 
+    puts("main: setting 100ms timeout (using uint64)...");
+    uint64_t timeout64 = TIMEOUT;
+    before = xtimer_now_usec();
+    xtimer_set_timeout_flag64(&t, timeout64);
+    thread_flags_wait_any(THREAD_FLAG_TIMEOUT);
+    diff = xtimer_now_usec() - before;
+    printf("main: timeout triggered. time passed: %"PRIu32"us\n", diff);
+
     if (diff < (TIMEOUT + THRESHOLD)) {
         puts("SUCCESS");
         return 0;

--- a/tests/thread_flags/tests/01-run.py
+++ b/tests/thread_flags/tests/01-run.py
@@ -24,6 +24,8 @@ def testfunc(child):
     child.expect_exact("thread(): received flags: 0x0008")
     child.expect_exact("main: setting 100ms timeout...")
     child.expect("main: timeout triggered. time passed: [0-9]{6}us")
+    child.expect_exact("main: setting 100ms timeout (using uint64)...")
+    child.expect("main: timeout triggered. time passed: [0-9]{6}us")
     child.expect("SUCCESS")
 
 


### PR DESCRIPTION
### Contribution description
This PR adds `xtimer_set_timeout_flag64()` to `xtimer`. In the same style as we already have e.g. `set_msg()` and `set_msg64()`, there are some use cases that need to set the timeout flag with a timeout greater UINT32_MAX. IMHO this also adds to the APIs consistency of having both 32-bit and 64-bit variants of functions.

This PR also adds a call to `xtimer_set_timeout_flag64` to the `tests/thread_flags` test application.

### Testing procedure
Run `tests/thread_flags` and check doxygen.

### Issues/PRs references
https://github.com/apache/mynewt-nimble/pull/753
