### PR TITLE
pkg/minmea: add minmea_getdate()

### DIFF
--- a/pkg/minmea/patches/0001-add-minmea_getdate.patch
+++ b/pkg/minmea/patches/0001-add-minmea_getdate.patch
@@ -1,0 +1,77 @@
+From 4dae7015b3001359ac9365663c3beb78a1a7a2d2 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Thu, 16 May 2019 14:59:07 +0200
+Subject: [PATCH] add minmea_getdate()
+
+The GPS date is internally converted to a struct tm anyway.
+Add a function to make use of this for external users too.
+---
+ minmea.c | 30 +++++++++++++++++++-----------
+ minmea.h |  5 +++++
+ 2 files changed, 24 insertions(+), 11 deletions(-)
+
+diff --git a/minmea.c b/minmea.c
+index 32f7881..e9025a8 100644
+--- a/minmea.c
++++ b/minmea.c
+@@ -612,25 +612,33 @@ bool minmea_parse_zda(struct minmea_sentence_zda *frame, const char *sentence)
+   return true;
+ }
+ 
+-int minmea_gettime(struct timespec *ts, const struct minmea_date *date, const struct minmea_time *time_)
++int minmea_getdate(struct tm *tm, const struct minmea_date *date, const struct minmea_time *time_)
+ {
+     if (date->year == -1 || time_->hours == -1)
+         return -1;
+ 
+-    struct tm tm;
+-    memset(&tm, 0, sizeof(tm));
++    memset(tm, 0, sizeof(*tm));
+     if (date->year < 80) {
+-        tm.tm_year = 2000 + date->year - 1900;  // 2000-2079
++        tm->tm_year = 2000 + date->year - 1900;  // 2000-2079
+     } else if (date->year >= 1900) {
+-        tm.tm_year = date->year - 1900; // 4 digit year, use directly
++        tm->tm_year = date->year - 1900;         // 4 digit year, use directly
+     } else {
+-        tm.tm_year = date->year;    // 1980-1999
++        tm->tm_year = date->year;                // 1980-1999
+     }
+-    tm.tm_mon = date->month - 1;
+-    tm.tm_mday = date->day;
+-    tm.tm_hour = time_->hours;
+-    tm.tm_min = time_->minutes;
+-    tm.tm_sec = time_->seconds;
++    tm->tm_mon = date->month - 1;
++    tm->tm_mday = date->day;
++    tm->tm_hour = time_->hours;
++    tm->tm_min = time_->minutes;
++    tm->tm_sec = time_->seconds;
++
++    return 0;
++}
++
++int minmea_gettime(struct timespec *ts, const struct minmea_date *date, const struct minmea_time *time_)
++{
++    struct tm tm;
++    if (minmea_getdate(&tm, date, time_))
++        return -1;
+ 
+     time_t timestamp = timegm(&tm); /* See README.md if your system lacks timegm(). */
+     if (timestamp != (time_t)-1) {
+diff --git a/minmea.h b/minmea.h
+index 181d8c7..1e01bad 100644
+--- a/minmea.h
++++ b/minmea.h
+@@ -208,6 +208,11 @@ bool minmea_parse_gsv(struct minmea_sentence_gsv *frame, const char *sentence);
+ bool minmea_parse_vtg(struct minmea_sentence_vtg *frame, const char *sentence);
+ bool minmea_parse_zda(struct minmea_sentence_zda *frame, const char *sentence);
+ 
++/**
++ * Convert GPS UTC date/time representation to a UNIX calendar time.
++ */
++int minmea_getdate(struct tm *tm, const struct minmea_date *date, const struct minmea_time *time_);
++
+ /**
+  * Convert GPS UTC date/time representation to a UNIX timestamp.
+  */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add a fucntion to expose the internal `struct tm` that is populated with the GPS date.

This allows for easy syncing the RTC with the GPS time without having to convert back and forth between `struct tm` and `time_t`:

```C
    struct tm now;
    minmea_getdate(&now, data, time);
    rtc_set_time(&now);
```


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

upstream PR: https://github.com/kosma/minmea/pull/45

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
