### PR TITLE
sys/event: add event_wait_timeout64()

### DIFF
--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -115,14 +115,12 @@ event_t *event_wait(event_queue_t *queue)
 }
 
 #ifdef MODULE_XTIMER
-event_t *event_wait_timeout(event_queue_t *queue, uint32_t timeout)
+static event_t *_wait_timeout(event_queue_t *queue, xtimer_t *timer)
 {
     assert(queue);
     event_t *result;
-    xtimer_t timer;
     thread_flags_t flags = 0;
 
-    xtimer_set_timeout_flag(&timer, timeout);
     do {
         result = event_get(queue);
         if (result == NULL) {
@@ -131,10 +129,26 @@ event_t *event_wait_timeout(event_queue_t *queue, uint32_t timeout)
     } while ((result == NULL) && (flags & THREAD_FLAG_EVENT));
 
     if (result) {
-        xtimer_remove(&timer);
+        xtimer_remove(timer);
     }
 
     return result;
+}
+
+event_t *event_wait_timeout(event_queue_t *queue, uint32_t timeout)
+{
+    xtimer_t timer;
+
+    xtimer_set_timeout_flag(&timer, timeout);
+    return _wait_timeout(queue, &timer);
+}
+
+event_t *event_wait_timeout64(event_queue_t *queue, uint64_t timeout)
+{
+    xtimer_t timer;
+
+    xtimer_set_timeout_flag64(&timer, timeout);
+    return _wait_timeout(queue, &timer);
 }
 #endif
 

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -242,6 +242,17 @@ event_t *event_wait(event_queue_t *queue);
  * @return      NULL if timeout expired before an event was posted
  */
 event_t *event_wait_timeout(event_queue_t *queue, uint32_t timeout);
+
+/**
+ * @brief   Get next event from event queue, blocking until timeout expires
+ *
+ * @param[in]   queue    queue to query for an event
+ * @param[in]   timeout  maximum time to wait for an event to be posted in us
+ *
+ * @return      pointer to next event if event was taken from the queue
+ * @return      NULL if timeout expired before an event was posted
+ */
+event_t *event_wait_timeout64(event_queue_t *queue, uint64_t timeout);
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description
Analog to #13370 and #13371, this PR adds the possibility to set an event wait timeout using 64-bit values (so timeouts effectively larger 1,19 hours). In our particular use case this is needed when mapping the NimBLE porting layer to RIOT, which uses 32-bit `ms` values.

In the current state, I introduced a static function, which is shared by both 32- and 64-bit variants for the function. This is the same style that xtimer uses to split between these variants. An alternative however could be to simply map the 32-bit function onto the 64-bit version, gaining some bytes of code size by increasing the run-time overhead slightly - but I don't like that variant too much...

This PR also adds some additional test cases to `tests/event_wait_timeout`.

### Testing procedure
Run and verify `tests/event_wait_timeout` and check the generated Doxygen.

### Issues/PRs references
- this PR is rebased on top of #13371 
- needed by https://github.com/apache/mynewt-nimble/pull/753