### PR TITLE
sys/usbus: Expose configurations to Kconfig

### DIFF
--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -80,8 +80,8 @@ extern "C" {
  * large amount of data often over the control endpoint, a minimal size should
  * be sufficient
  */
-#ifndef USBUS_EP0_SIZE
-#define USBUS_EP0_SIZE              64
+#ifndef CONFIG_USBUS_EP0_SIZE
+#define CONFIG_USBUS_EP0_SIZE              64
 #endif
 /** @} */
 

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -29,6 +29,7 @@
 #include "clist.h"
 #include "event.h"
 #include "kernel_types.h"
+#include "kernel_defines.h"
 #include "msg.h"
 #include "thread.h"
 
@@ -62,12 +63,14 @@ extern "C" {
 /**
  * @brief USBUS auto attach setting
  *
- * When set, the USBUS thread will automatically enable the USB pull-up
+ * When set to 1, the USBUS thread will automatically enable the USB pull-up
  * resistor after initializing the thread. This will signal to the host
  * that the USB peripheral is ready for use.
  */
-#ifndef USBUS_AUTO_ATTACH
-#define USBUS_AUTO_ATTACH           (1)
+#ifndef CONFIG_USBUS_AUTO_ATTACH
+#if !IS_ACTIVE(KCONFIG_MODULE_USBUS)
+#define CONFIG_USBUS_AUTO_ATTACH            1
+#endif
 #endif
 
 /**

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -80,6 +80,16 @@ extern "C" {
  * large amount of data often over the control endpoint, a minimal size should
  * be sufficient
  */
+#if IS_ACTIVE(CONFIG_USBUS_EP0_SIZE_8)
+#define CONFIG_USBUS_EP0_SIZE               8
+#elif IS_ACTIVE(CONFIG_USBUS_EP0_SIZE_16)
+#define CONFIG_USBUS_EP0_SIZE              16
+#elif IS_ACTIVE(CONFIG_USBUS_EP0_SIZE_32)
+#define CONFIG_USBUS_EP0_SIZE              32
+#elif IS_ACTIVE(CONFIG_USBUS_EP0_SIZE_64)
+#define CONFIG_USBUS_EP0_SIZE              64
+#endif
+
 #ifndef CONFIG_USBUS_EP0_SIZE
 #define CONFIG_USBUS_EP0_SIZE              64
 #endif

--- a/sys/usb/Kconfig
+++ b/sys/usb/Kconfig
@@ -79,4 +79,6 @@ config USB_DEFAULT_LANGID
     help
         The default value is EN-US (0x0409).
 
+
+rsource "usbus/Kconfig"
 endif # KCONFIG_USB

--- a/sys/usb/usbus/Kconfig
+++ b/sys/usb/usbus/Kconfig
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_USBUS
+    bool "Configure USB Unified Stack (USBUS)"
+    depends on MODULE_USBUS
+    help
+        Configure the USBUS module via Kconfig.
+
+if KCONFIG_MODULE_USBUS
+
+config USBUS_AUTO_ATTACH
+    bool "Auto attach"
+    default y
+    help
+        When set, the USBUS thread will automatically enable the USB pull-up
+        resistor after initializing the thread. This will signal to the host
+        that the USB peripheral is ready for use.
+
+choice
+    bool "Endpoint 0 buffer size"
+    default USBUS_EP0_SIZE_64
+    help
+        This configures the buffer size of the control endpoint. Unless you
+        transfer large amount of data often over the control endpoint, a minimal
+        size should be sufficient.
+
+config USBUS_EP0_SIZE_8
+    bool "8"
+
+config USBUS_EP0_SIZE_16
+    bool "16"
+
+config USBUS_EP0_SIZE_32
+    bool "32"
+
+config USBUS_EP0_SIZE_64
+    bool "64"
+
+endchoice
+
+endif # KCONFIG_MODULE_USBUS

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -18,6 +18,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include "kernel_defines.h"
 #include "bitarithm.h"
 #include "event.h"
 #include "thread.h"
@@ -248,11 +249,11 @@ static void *_usbus_thread(void *args)
     /* Initialize handlers */
     _usbus_init_handlers(usbus);
 
-#if (USBUS_AUTO_ATTACH)
-    static const usbopt_enable_t _enable = USBOPT_ENABLE;
-    usbdev_set(dev, USBOPT_ATTACH, &_enable,
-               sizeof(usbopt_enable_t));
-#endif
+    if (IS_ACTIVE(CONFIG_USBUS_AUTO_ATTACH)) {
+        static const usbopt_enable_t _enable = USBOPT_ENABLE;
+        usbdev_set(dev, USBOPT_ATTACH, &_enable,
+                   sizeof(usbopt_enable_t));
+    }
 
     while (1) {
         thread_flags_t flags = thread_flags_wait_any(

--- a/sys/usb/usbus/usbus_control.c
+++ b/sys/usb/usbus/usbus_control.c
@@ -331,9 +331,9 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
     ep0_handler->control_request_state = USBUS_CONTROL_REQUEST_STATE_READY;
 
     ep0_handler->in = usbus_add_endpoint(usbus, NULL, USB_EP_TYPE_CONTROL,
-                                         USB_EP_DIR_IN, USBUS_EP0_SIZE)->ep;
+                                         USB_EP_DIR_IN, CONFIG_USBUS_EP0_SIZE)->ep;
     ep0_handler->out = usbus_add_endpoint(usbus, NULL, USB_EP_TYPE_CONTROL,
-                                          USB_EP_DIR_OUT, USBUS_EP0_SIZE)->ep;
+                                          USB_EP_DIR_OUT, CONFIG_USBUS_EP0_SIZE)->ep;
 }
 
 static int _handle_tr_complete(usbus_t *usbus,

--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -275,7 +275,7 @@ size_t usbus_fmt_descriptor_dev(usbus_t *usbus)
     desc.length = sizeof(usb_descriptor_device_t);
     desc.type = USB_TYPE_DESCRIPTOR_DEVICE;
     desc.bcd_usb = CONFIG_USB_SPEC_BCDVERSION;
-    desc.max_packet_size = USBUS_EP0_SIZE;
+    desc.max_packet_size = CONFIG_USBUS_EP0_SIZE;
     desc.vendor_id = CONFIG_USB_VID;
     desc.product_id = CONFIG_USB_PID;
     desc.manufacturer_idx = usbus->manuf.idx;


### PR DESCRIPTION
### Contribution description
This moves `USBUS_AUTO_ATTACH` and `USBUS_EP0_SIZE` configuration options to the `CONFIG_` namespace, and exposes them to Kconfig.

### Testing procedure
Test with `examples/usbus_minimal`: Should work normally and you should be able to change options via Kconfig.

### Issues/PRs references
Part of #12888