### PR TITLE
drivers/periph/wdt: Expose configurations to Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -9,6 +9,8 @@ mainmenu "RIOT Configuration"
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
+orsource "$(RIOTCPU)/$(CPU)/Kconfig"
+
 # The application may declare new symbols as well
 osource "$(APPDIR)/Kconfig"
 

--- a/cpu/sam0_common/Kconfig
+++ b/cpu/sam0_common/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAMILY_SAM0
+    bool
+    default y
+    select HAS_WDT_WARNING_PERIOD
+
+rsource "periph/Kconfig"

--- a/cpu/sam0_common/periph/Kconfig
+++ b/cpu/sam0_common/periph/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config WDT_WARNING_PERIOD
+    depends on HAS_WDT_WARNING_PERIOD && KCONFIG_MODULE_PERIPH_WDT
+    default 1

--- a/cpu/sam0_common/periph/wdt.c
+++ b/cpu/sam0_common/periph/wdt.c
@@ -193,7 +193,7 @@ void wdt_setup_reboot_with_callback(uint32_t min_time, uint32_t max_time,
     cb_arg = arg;
 
     if (cb != NULL) {
-        uint32_t warning_offset = ms_to_per(WDT_WARNING_PERIOD);
+        uint32_t warning_offset = ms_to_per(CONFIG_WDT_WARNING_PERIOD);
 
         if (warning_offset == 0) {
             warning_offset = 1;

--- a/cpu/samd21/Kconfig
+++ b/cpu/samd21/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+source "$(RIOTCPU)/sam0_common/Kconfig"

--- a/cpu/samd5x/Kconfig
+++ b/cpu/samd5x/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+source "$(RIOTCPU)/sam0_common/Kconfig"

--- a/cpu/saml1x/Kconfig
+++ b/cpu/saml1x/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+source "$(RIOTCPU)/sam0_common/Kconfig"

--- a/cpu/saml21/Kconfig
+++ b/cpu/saml21/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+source "$(RIOTCPU)/sam0_common/Kconfig"

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -6,4 +6,5 @@
 
 menu "Drivers"
 rsource "Kconfig.net"
+rsource "periph_common/Kconfig"
 endmenu # Drivers

--- a/drivers/include/periph/wdt.h
+++ b/drivers/include/periph/wdt.h
@@ -111,8 +111,8 @@
  * This function is highly platform dependent so check the platform documentation
  * for details on its constraints.
  *
- * The callback will be executed WDT_WARNING_PERIOD before the actual reboot.
- * The value of WDT_WARNING_PERIOD may be configurable or a fixed value. But is
+ * The callback will be executed CONFIG_WDT_WARNING_PERIOD before the actual reboot.
+ * The value of CONFIG_WDT_WARNING_PERIOD may be configurable or a fixed value. But is
  * in any case defined at compile time. Specific platform implementation should
  * assert improper values.
  *
@@ -146,10 +146,10 @@
  *
  * @verbatim
  * |---------------------MAX_TIME-----------------------|
- *                             |---WDT_WARNING_PERIOD---|
- *                             ^                        ^
- *                             |                        |
- *                        wdt_cb()                   reboot
+ *                      |---CONFIG_WDT_WARNING_PERIOD---|
+ *                      ^                               ^
+ *                      |                               |
+ *                   wdt_cb()                        reboot
  * @endverbatim
  *
  * To include this feature, (If your platform supports it) in your application
@@ -276,13 +276,13 @@ void wdt_init(void);
  * @{
  */
 /**
- * @def     WDT_WARNING_PERIOD
+ * @def     CONFIG_WDT_WARNING_PERIOD
  *
  * @brief   Period (ms) before reboot where wdt_cb() is executed.
  *          Defined per implementation.
  */
-#ifndef WDT_WARNING_PERIOD
-#define WDT_WARNING_PERIOD          (1)
+#ifndef CONFIG_WDT_WARNING_PERIOD
+#define CONFIG_WDT_WARNING_PERIOD          (1)
 #endif
 /** @} */
 

--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+menuconfig KCONFIG_MODULE_PERIPH_WDT
+    bool "Configure Watchdog peripheral"
+    depends on MODULE_PERIPH_WDT
+    help
+        Configure Watchdog peripheral using Kconfig.
+
+if KCONFIG_MODULE_PERIPH_WDT
+
+config WDT_WARNING_PERIOD
+    int "Warning period (in ms)"
+    depends on HAS_WDT_WARNING_PERIOD
+    help
+        Period in ms before reboot where wdt_cb() is executed.
+
+endif # KCONFIG_MODULE_PERIPH_WDT
+
+config HAS_WDT_WARNING_PERIOD
+    bool
+    help
+        Indicates that a CPU provides a warning period configuration option.


### PR DESCRIPTION
### Contribution description
This moves `WDT_WARNING_PERIOD` configuration macro to `CONFIG_` namespace and exposes it to Kconfig.

### Testing procedure
Check that the value can be changed via menuconfig.

### Issues/PRs references
Part of #12888