### PR TITLE
boards: nucleo*: Cleanup documentation

### DIFF
--- a/boards/nucleo-f030r8/doc.txt
+++ b/boards/nucleo-f030r8/doc.txt
@@ -5,34 +5,34 @@
 
 ## Overview
 
-The Nucleo-F030 is a board from ST's Nucleo family supporting a ARM Cortex-M0
+The Nucleo-F030R8 is a board from ST's Nucleo family supporting a ARM Cortex-M0
 STM32F030R8 microcontroller with 8Kb of SRAM and 64Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F030](http://www.open-electronics.org/wp-
+![Nucleo64 F030R8](http://www.open-electronics.org/wp-
 content/uploads/2015/08/Figura2-500x467.png)
 
 
 
 ### MCU
 | MCU        | STM32F030R8       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M0     |
-| Vendor | ST Microelectronics   |
-| RAM        | 8Kb |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M0     |
+| Vendor     | ST Microelectronics |
+| RAM        | 8Kb               |
 | Flash      | 64Kb              |
-| Frequency  | up to 48MHz) |
+| Frequency  | up to 48MHz       |
 | FPU        | no                |
-| Timers | 11 (2x watchdog, 1 SysTick, 8x 16-bit)    |
+| Timers     | 10 (2x watchdog, 1 SysTick, 7x 16-bit)    |
 | ADCs       | 1x 12-bit         |
-| UARTs      | 6                 |
+| UARTs      | 2                 |
 | SPIs       | 2                 |
 | I2Cs       | 2                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/en/evaluation-tools/nucleo-f030r8.html) |
-| Reference Manual | [Reference Manual](http://www.st.com/resource/en/datasheet/stm32f030r8.pdf) |
+| Vcc        | 2.4V - 3.6V       |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f030r8.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00091010.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00051352.pdf) |
 | Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|
 
@@ -53,22 +53,22 @@ content/uploads/2015/08/Figura2-500x467.png)
 
 
 ## Flashing the device
-The ST Nucleo-F030 board includes an on-board ST-LINK V2 programmer. The
+The ST Nucleo-F030R8 board includes an on-board ST-LINK V2 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f030 flash
+make BOARD=nucleo-f030r8 flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f030 debug
+make BOARD=nucleo-f030r8 debug
 ```
 
 
 ## Supported Toolchains
-For using the ST Nucleo-F030 board we strongly recommend the usage of the
+For using the ST Nucleo-F030R8 board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f070rb/doc.txt
+++ b/boards/nucleo-f070rb/doc.txt
@@ -5,36 +5,37 @@
 
 ## Overview
 
-The Nucleo-F070 is a board from ST's Nucleo family supporting a ARM Cortex-M0
+The Nucleo-F070RB is a board from ST's Nucleo family supporting a ARM Cortex-M0
 STM32F070RB microcontroller with 16Kb of SRAM and 128Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F070](http://www.open-electronics.org/wp-
+![Nucleo64 F070RB](http://www.open-electronics.org/wp-
 content/uploads/2015/08/Figura2-500x467.png)
 
 
 
 ### MCU
 | MCU        | STM32F070RB           |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M0     |
-| Vendor | ST Microelectronics   |
-| RAM        | 16Kb |
-| Flash      | 128Kb             |
-| Frequency  | up to 48MHz) |
-| FPU        | no                |
-| Timers | 11 (2x watchdog, 1 SysTick, 8x 16-bit)    |
-| ADCs       | 1x 12-bit         |
-| UARTs      | 4                 |
-| SPIs       | 2                 |
-| I2Cs       | 2                 |
-| RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/en/evaluation-tools/nucleo-f070rb.html) |
-| Reference Manual | [Reference Manual](http://www.st.com/resource/en/datasheet/stm32f070rb.pdf) |
+|:---------- |:--------------------- |
+| Family     | ARM Cortex-M0         |
+| Vendor     | ST Microelectronics   |
+| RAM        | 16Kb                  |
+| Flash      | 128Kb                 |
+| Frequency  | up to 48MHz           |
+| FPU        | no                    |
+| Timers     | 11 (2x watchdog, 1 SysTick, 8x 16-bit) |
+| ADCs       | 1x 12-bit (16 channels) |
+| UARTs      | 4                     |
+| SPIs       | 2                     |
+| I2Cs       | 2                     |
+| RTC        | 1                     |
+| USB        | 1                     |
+| Vcc        | 2.4V - 3.6V           |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f070rb.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00091010.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00051352.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf) |
 
 
 
@@ -53,22 +54,22 @@ content/uploads/2015/08/Figura2-500x467.png)
 
 
 ## Flashing the device
-The ST Nucleo-F070 board includes an on-board ST-LINK V2 programmer. The
+The ST Nucleo-F070RB board includes an on-board ST-LINK V2 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f070 flash
+make BOARD=nucleo-f070rb flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f070 debug
+make BOARD=nucleo-f070rb debug
 ```
 
 
 ## Supported Toolchains
-For using the ST Nucleo-F070 board we strongly recommend the usage of the
+For using the ST Nucleo-F070RB board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f072rb/doc.txt
+++ b/boards/nucleo-f072rb/doc.txt
@@ -5,33 +5,35 @@
 
 ## Overview
 
-The Nucleo-F072 is a board from ST's Nucleo family supporting a ARM Cortex-M0
+The Nucleo-F072RB is a board from ST's Nucleo family supporting a ARM Cortex-M0
 STM32F072RB microcontroller with 16Kb of SRAM and 128Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F072](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F072RB](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 
 ### MCU
-| MCU        | STM32F072RB           |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M0     |
-| Vendor | ST Microelectronics   |
-| RAM        | 16Kb |
+| MCU        | STM32F072RB       |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M0     |
+| Vendor     | ST Microelectronics |
+| RAM        | 16Kb              |
 | Flash      | 128Kb             |
-| Frequency  | up to 48MHz) |
+| Frequency  | up to 48MHz       |
 | FPU        | no                |
-| Timers | 12 (2x watchdog, 1 SysTick, 8x 16-bit, 1x 32-bit) |
-| ADCs       | 1x 12-bit (up to 16 channels)         |
+| Timers     | 12 (2x watchdog, 1 SysTick, 8x 16-bit, 1x 32-bit) |
+| ADCs       | 1x 12-bit (up to 16 channels) |
 | UARTs      | 4                 |
 | SPIs       | 2                 |
 | I2Cs       | 2                 |
+| CAN        | 1                 |
+| USB        | 1                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/en/evaluation-tools/nucleo-f072rb.html) |
-| Reference Manual | [Reference Manual](http://www.st.com/resource/en/datasheet/stm32f072rb.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/resource/en/reference_manual/dm00031936.pdf) |
+| Vcc        | 2.0V - 3.6V       |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f072rb.pdf) |
+| Reference Manual | [Reference Manual](http://www.st.com/resource/en/reference_manual/dm00031936.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/dm00051352.pdf) |
 | Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|
 
 
@@ -52,22 +54,22 @@ STM32F072RB microcontroller with 16Kb of SRAM and 128Kb of ROM Flash.
 
 
 ## Flashing the device
-The ST Nucleo-F072 board includes an on-board ST-LINK V2 programmer. The
+The ST Nucleo-F072RB board includes an on-board ST-LINK V2 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f072 flash
+make BOARD=nucleo-f072rb flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f072 debug
+make BOARD=nucleo-f072rb debug
 ```
 
 
 ## Supported Toolchains
-For using the ST Nucleo-F072 board we strongly recommend the usage of the
+For using the ST Nucleo-F072RB board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f091rc/doc.txt
+++ b/boards/nucleo-f091rc/doc.txt
@@ -5,34 +5,35 @@
 
 ## Overview
 
-The Nucleo-F091 is a board from ST's Nucleo family supporting a ARM Cortex-M0
-STM32F091 microcontroller with 32Kb of RAM and 256Kb of ROM.
+The Nucleo-F091RC is a board from ST's Nucleo family supporting a ARM Cortex-M0
+STM32F091RC microcontroller with 32Kb of RAM and 256Kb of ROM.
 
 ## Hardware
 
-![STM32F3discovery image](http://media.digikey.com/Photos/STMicro%20Photos/MFG_NUCLEO.jpg)
-![nucleo-f091 pinout](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo-f091_pinout.png)
+![Nucleo64 F091RC](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
+![nucleo-f091rc pinout](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo-f091_pinout.png)
 
 
 ### MCU
 | MCU        | STM32F091RC       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M0     |
-| Vendor | ST Microelectronics   |
-| RAM        | 32Kb |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M0     |
+| Vendor     | ST Microelectronics |
+| RAM        | 32Kb              |
 | Flash      | 256Kb             |
-| Frequency  | up to 48MHz (using the on-board 8MHz Oszillator of the ST-Link) |
+| Frequency  | up to 48MHz       |
 | FPU        | no                |
-| Timers | 9 (8x 16-bit, 1x 32-bit [TIM2])   |
-| ADCs       | 1x 12-bit         |
+| Timers     | 12 (8x 16-bit, 1x 32-bit [TIM2], 1x Systick, 2x watchdog) |
+| ADCs       | 1x 12-bit (up to 16 channels) |
 | UARTs      | 8                 |
 | SPIs       | 2                 |
 | I2Cs       | 2                 |
-| Vcc        | 2.0V - 3.6V           |
+| CAN        | 1                 |
+| Vcc        | 2.0V - 3.6V       |
 | Datasheet  | [Datasheet](http://www.st.com/web/en/resource/technical/document/datasheet/DM00115237.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031936.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00051352.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf) |
 
 ### RIOT static pin mapping
 please refer to [this](https://docs.google.com/spreadsheets/d/1gnxsux5WpFrn-33Ivb9nGgTBqooqgDYxRkhZms-cvsc/edit?usp=sharing)
@@ -41,16 +42,16 @@ document for the pin mapping as implemenented in `boards/nucleo-f091/include/per
 ### User Interface
 1 Button:
 
-| NAME   | USER  |
+| NAME  | USER  |
 |:----- |:----- |
-| Pin    | PC13  |
+| Pin   | PC13  |
 
 1 LEDs:
 
-| NAME   | LED_GREEN |
-| -----  | ------------- |
-| Color  | orange    |
-| Pin    | PA5           |
+| NAME   | LD2   |
+| -----  | ----- |
+| Color  | green |
+| Pin    | PA5   |
 
 
 ## Implementation Status
@@ -67,22 +68,22 @@ document for the pin mapping as implemenented in `boards/nucleo-f091/include/per
 
 
 ## Flashing the device
-The ST Nucleo-F091 board includes an on-board ST-LINK V2 programmer. The
+The ST Nucleo-F091RC board includes an on-board ST-LINK V2 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f091 flash
+make BOARD=nucleo-f091rc flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f091 debug
+make BOARD=nucleo-f091rc debug
 ```
 
 
 ## Supported Toolchains
-For using the ST Nucleo-F091 board we strongly recommend the usage of the
+For using the ST Nucleo-F091RC board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f103rb/doc.txt
+++ b/boards/nucleo-f103rb/doc.txt
@@ -5,33 +5,35 @@
 
 ## Overview
 
-The Nucleo-F103 is a board from ST's Nucleo family supporting a ARM Cortex-M3
+The Nucleo-F103RB is a board from ST's Nucleo family supporting a ARM Cortex-M3
 STM32F103RB microcontroller with 20Kb of SRAM and 128Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F103](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F103RB](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 ### MCU
 | MCU        | STM32F103RB       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M3     |
-| Vendor | ST Microelectronics   |
-| RAM        | 20Kb |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M3     |
+| Vendor     | ST Microelectronics |
+| RAM        | 20Kb              |
 | Flash      | 128Kb             |
-| Frequency  | up to 72MHz    |
+| Frequency  | up to 72MHz       |
 | FPU        | no                |
-| Timers | 7 (2x watchdog, 1 SysTick, 4x 16-bit) |
-| ADCs       | 1x 12-bit         |
+| Timers     | 7 (2x watchdog, 1 SysTick, 4x 16-bit) |
+| ADCs       | 1x 12-bit (16 channels) |
 | UARTs      | 3                 |
 | SPIs       | 2                 |
 | I2Cs       | 2                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/en/evaluation-tools/nucleo-f103rb.html) |
-| Reference Manual | [Reference Manual](http://www.st.com/resource/en/datasheet/stm32f103rb.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00051352.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|
+| USB        | 1                 |
+| CAN        | 1                 |
+| Vcc        | 2.0V - 3.6V       |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f103rb.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/cd00171190.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/cd00228163.pdf) |
+| Board Manual | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf) |
 
 ## Implementation Status
 | Device | ID        | Supported | Comments  |
@@ -47,22 +49,22 @@ STM32F103RB microcontroller with 20Kb of SRAM and 128Kb of ROM Flash.
 |        | Timer     | 2 16 bit timers (TIM2 and TIM3)       | |
 
 ## Flashing the device
-The ST Nucleo-F103 board includes an on-board ST-LINK V2 programmer. The
+The ST Nucleo-F103RB board includes an on-board ST-LINK V2 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing:
 
 ```
-make BOARD=nucleo-f103 flash
+make BOARD=nucleo-f103rb flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f103 debug
+make BOARD=nucleo-f103rb debug
 ```
 
 
 ## Supported Toolchains
-For using the ST Nucleo-F103 board we strongly recommend the usage of the
+For using the ST Nucleo-F103RB board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f207zg/doc.txt
+++ b/boards/nucleo-f207zg/doc.txt
@@ -5,35 +5,38 @@
 
 ## Overview
 
-The Nucleo144-F207 is a board from ST's Nucleo family supporting a ARM
+The Nucleo-F207ZG is a board from ST's Nucleo family supporting a ARM
 Cortex-M3
 STM32F207ZG microcontroller with 128Kb of SRAM and 1Mb of ROM Flash.
 
 ## Hardware
 
-![Nucleo144 F207](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo144-board.png)
+![Nucleo144 F207ZG](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo144-board.png)
 
 ### MCU
 
 | MCU        | STM32F207ZG       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M3     |
-| Vendor | ST Microelectronics   |
-| RAM        | 128Kb |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M3     |
+| Vendor     | ST Microelectronics |
+| RAM        | 128Kb             |
 | Flash      | 1Mb               |
-| Frequency  | up to 120MHz |
+| Frequency  | up to 120MHz      |
 | FPU        | no                |
-| Timers | 17 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |
-| ADCs       | 3x 12-bit         |
-| UARTs      | 4                 |
+| Timers     | 17 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |
+| ADCs       | 3x 12-bit (24 channels) |
+| UARTs      | 6                 |
 | SPIs       | 3                 |
 | I2Cs       | 3                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
+| CAN        | 2                 |
+| USB        | 1                 |
+| Ethernet   | 1                 |
+| Vcc        | 1.8V - 3.6V       |
 | Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f207zg.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/resource/en/reference_manual/cd00225773.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/cd00228163.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00244518.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/resource/en/user_manual/dm00244518.pdf) |
 
 ## Implementation Status
 
@@ -56,15 +59,15 @@ OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo144-f207 flash
+make BOARD=nucleo-f207zg flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo144-f207 debug
+make BOARD=nucleo-f207zg debug
 ```
 
 ## Supported Toolchains
-For using the ST Nucleo144-F207 board we strongly recommend the usage of the
+For using the ST Nucleo-F207ZG board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f302r8/doc.txt
+++ b/boards/nucleo-f302r8/doc.txt
@@ -5,9 +5,7 @@
 
 ## Overview
 
-Not yet available upstream, see [PR 6615](https://github.com/RIOT-OS/RIOT/pull/6615)
-
-The [Nucleo-F302](http://www.st.com/en/evaluation-tools/nucleo-f302r8.html)
+The [Nucleo-F302R8](http://www.st.com/en/evaluation-tools/nucleo-f302r8.html)
 is
 a board from ST's Nucleo family supporting a ARM Cortex-M4
 [STM32F302R8](http://www.st.com/en/microcontrollers/stm32f302r8.html)
@@ -20,24 +18,26 @@ microcontroller with 16KB of RAM and 64KB of ROM.
 
 ### MCU
 | MCU        | STM32F302R8           |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
+|:---------- |:--------------------- |
+| Family     | ARM Cortex-M4         |
+| Vendor     | ST Microelectronics   |
 | RAM        | 16KB                  |
-| Flash      | 64KB          |
-| Frequency  | up to 72MHz |
-| FPU        | yes               |
-| Timers | 9 (5x 16-bit, 1x 32-bit [TIM2], 2 watchdog, 1 systick)    |
-| ADCs       | 1 with selectable resolution (6,8,10,12-bit)          |
-| UARTs      | 3                 |
-| SPIs       | 2                 |
-| I2Cs       | 3                 |
-| RTC        | 1                 |
+| Flash      | 64KB                  |
+| Frequency  | up to 72MHz           |
+| FPU        | yes                   |
+| Timers     | 9 (5x 16-bit, 1x 32-bit [TIM2], 2x watchdog, 1x systick) |
+| ADCs       | 1 with selectable resolution (6,8,10,12-bit) |
+| UARTs      | 3                     |
+| SPIs       | 2                     |
+| I2Cs       | 3                     |
+| RTC        | 1                     |
+| CAN        | 1                     |
+| USB        | 1                     |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f302r6.pdf) |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f302r8.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/resource/en/reference_manual/dm00094349.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf) |
 
 
 ## Implementation Status
@@ -56,17 +56,17 @@ microcontroller with 16KB of RAM and 64KB of ROM.
 
 ## Flashing the device
 
-The ST Nucleo-F302 board includes an on-board ST-LINK V2-1 programmer.
+The ST Nucleo-F302R8 board includes an on-board ST-LINK V2-1 programmer.
 The easiest way to program the board is to use OpenOCD. Once you have
 installed OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD)
 for installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f302 flash
+make BOARD=nucleo-f302r8 flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f302 debug
+make BOARD=nucleo-f302r8 debug
 ```
 
 ### Troubleshooting
@@ -78,6 +78,6 @@ the ST Link firmware update tool following
 [this documentation](http://www.st.com/en/embedded-software/stsw-link007.html).
 
 ## Supported Toolchains
-For using the ST Nucleo-F303RE board we strongly recommend the usage of
+For using the ST Nucleo-F302R8 board we strongly recommend the usage of
 the [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded) toolchain.
  */

--- a/boards/nucleo-f303k8/doc.txt
+++ b/boards/nucleo-f303k8/doc.txt
@@ -5,43 +5,41 @@
 
 ## Overview
 
-The Nucleo-F303 is a board from ST's Nucleo family supporting a ARM Cortex-M4
-STM32F303RE
-microcontroller with 64Kb of RAM and 512Kb of ROM.
+The Nucleo-F303K8 is a board from ST's Nucleo family supporting a ARM Cortex-M4
+STM32F303K8 microcontroller with 12Kb of RAM and 64Kb of ROM.
 
 ## Hardware
 
-![nucleo image](http://media.digikey.com/Photos/STMicro%20Photos/MFG_NUCLEO.jpg)
-![nucleo-f303 pinout](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo-f303_pinout.png)
+![nucleo image](https://www.st.com/bin/ecommerce/api/image.PF262496.en.feature-description-include-personalized-no-cpn-medium.jpg)
 
 
 ### MCU
-| MCU        | STM32F303RE           |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 64Kb                  |
-| Flash      | 512Kb         |
-| Frequency  | up to 72MHz) |
-| FPU        | yes               |
-| Timers | 14 (13x 16-bit, 1x 32-bit [TIM2]) |
-| ADCs       | 4x 12-bit         |
-| UARTs      | 5                 |
-| SPIs       | 4                 |
-| I2Cs       | 3                 |
-| RTC        | 1                 |
+| MCU        | STM32F303K8           |
+|:---------- |:--------------------- |
+| Family     | ARM Cortex-M4         |
+| Vendor     | ST Microelectronics   |
+| RAM        | 12Kb                  |
+| Flash      | 64Kb                  |
+| Frequency  | up to 72MHz           |
+| FPU        | yes                   |
+| Timers     | 8 (4x 16-bit, 1x 32-bit [TIM2], 2x watchdog, 1x Systick) |
+| ADCs       | 2x 12-bit (9 channels) |
+| UARTs      | 2                     |
+| SPIs       | 1                     |
+| I2Cs       | 1                     |
+| RTC        | 1                     |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00118585.pdf) |
-| Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00043574.pdf) |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f303k8.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00043574.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00046982.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
+| Board Manual   | [Board Manual](https://www.st.com/resource/en/user_manual/dm00231744.pdf)|
 
 
 
 ## Implementation Status
 | Device | ID        | Supported | Comments  |
 |:------------- |:------------- |:------------- |:------------- |
-| MCU        | STM32F303RE   | partly    | Energy saving modes not fully utilized |
+| MCU        | STM32F303K8   | partly    | Energy saving modes not fully utilized |
 | Low-level driver | GPIO    | yes       | |
 |        | PWM       | one PWM   | |
 |        | UART      | three UART    | |
@@ -52,22 +50,22 @@ microcontroller with 64Kb of RAM and 512Kb of ROM.
 
 
 ## Flashing the device
-The ST Nucleo-F303RE board includes an on-board ST-LINK V2 programmer.
+The ST Nucleo-F303K8 board includes an on-board ST-LINK V2 programmer.
 The easiest way to program the board is to use OpenOCD. Once you have
 installed OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD)
 for installation instructions), you can flash the board simply by typing.
 
 ```
-make flash
+BOARD=nucleo-f303k8 make flash
 ```
 and debug via GDB by simply typing
 ```
-make debug
+BOARD=nucleo-f303k8 make debug
 ```
 
 
 ## Supported Toolchains
-For using the ST Nucleo-F303RE board we strongly recommend the usage of the
+For using the ST Nucleo-F303K8 board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f303re/doc.txt
+++ b/boards/nucleo-f303re/doc.txt
@@ -5,36 +5,38 @@
 
 ## Overview
 
-The Nucleo-F303 is a board from ST's Nucleo family supporting a ARM Cortex-M4
+The Nucleo-F303RE is a board from ST's Nucleo family supporting a ARM Cortex-M4
 STM32F303RE
 microcontroller with 64Kb of RAM and 512Kb of ROM.
 
 ## Hardware
 
-![nucleo image](http://media.digikey.com/Photos/STMicro%20Photos/MFG_NUCLEO.jpg)
+![Nucleo64 F303RE](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 ![nucleo-f303 pinout](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo-f303_pinout.png)
 
 
 ### MCU
-| MCU        | STM32F303RE           |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 64Kb                  |
-| Flash      | 512Kb         |
-| Frequency  | up to 72MHz) |
+| MCU        | STM32F303RE       |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M4     |
+| Vendor     | ST Microelectronics |
+| RAM        | 64Kb              |
+| Flash      | 512Kb             |
+| Frequency  | up to 72MHz       |
 | FPU        | yes               |
-| Timers | 14 (13x 16-bit, 1x 32-bit [TIM2]) |
-| ADCs       | 4x 12-bit         |
+| Timers     | 13 (9x 16-bit, 1x 32-bit [TIM2], 1x Systick, 2x watchdog) |
+| ADCs       | 4x 12-bit (22 channels) |
 | UARTs      | 5                 |
 | SPIs       | 4                 |
 | I2Cs       | 3                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00118585.pdf) |
+| CAN        | 1                 |
+| USB        | 1                 |
+| Vcc        | 2.0V - 3.6V       |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f303re.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00043574.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00046982.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf) |
 
 
 
@@ -58,11 +60,11 @@ installed OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD)
 for installation instructions), you can flash the board simply by typing.
 
 ```
-make flash
+BOARD=nucleo-f303re make flash
 ```
 and debug via GDB by simply typing
 ```
-make debug
+BOARD=nucleo-f303re make debug
 ```
 
 

--- a/boards/nucleo-f303ze/doc.txt
+++ b/boards/nucleo-f303ze/doc.txt
@@ -5,43 +5,44 @@
 
 ## Overview
 
-The Nucleo-F303 is a board from ST's Nucleo family supporting a ARM Cortex-M4
-STM32F303RE
+The Nucleo-F303ZE is a board from ST's Nucleo family supporting a ARM Cortex-M4
+STM32F303ZE
 microcontroller with 64Kb of RAM and 512Kb of ROM.
 
 ## Hardware
 
-![nucleo image](http://media.digikey.com/Photos/STMicro%20Photos/MFG_NUCLEO.jpg)
-![nucleo-f303 pinout](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo-f303_pinout.png)
+![Nucleo144 F303ZE](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo144-board.png)
 
 
 ### MCU
-| MCU        | STM32F303RE           |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 64Kb                  |
-| Flash      | 512Kb         |
-| Frequency  | up to 72MHz) |
+| MCU        | STM32F303ZE       |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M4     |
+| Vendor     | ST Microelectronics |
+| RAM        | 64Kb              |
+| Flash      | 512Kb             |
+| Frequency  | up to 72MHz       |
 | FPU        | yes               |
-| Timers | 14 (13x 16-bit, 1x 32-bit [TIM2]) |
-| ADCs       | 4x 12-bit         |
+| Timers     | 14 (10x 16-bit, 1x 32-bit [TIM2], 1x Systick, 2x watchdog) |
+| ADCs       | 4x 12-bit (40 channels) |
 | UARTs      | 5                 |
 | SPIs       | 4                 |
 | I2Cs       | 3                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00118585.pdf) |
+| CAN        | 1                 |
+| USB        | 1                 |
+| Vcc        | 2.0V - 3.6V       |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f303ze.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00043574.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00046982.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/dm00244518.pdf) |
 
 
 
 ## Implementation Status
 | Device | ID        | Supported | Comments  |
 |:------------- |:------------- |:------------- |:------------- |
-| MCU        | STM32F303RE   | partly    | Energy saving modes not fully utilized |
+| MCU        | STM32F303ZE   | partly    | Energy saving modes not fully utilized |
 | Low-level driver | GPIO    | yes       | |
 |        | PWM       | one PWM   | |
 |        | UART      | three UART    | |
@@ -52,22 +53,22 @@ microcontroller with 64Kb of RAM and 512Kb of ROM.
 
 
 ## Flashing the device
-The ST Nucleo-F303RE board includes an on-board ST-LINK V2 programmer.
+The ST Nucleo-F303ZE board includes an on-board ST-LINK V2 programmer.
 The easiest way to program the board is to use OpenOCD. Once you have
 installed OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD)
 for installation instructions), you can flash the board simply by typing.
 
 ```
-make flash
+BOARD=nucleo-f303ze make flash
 ```
 and debug via GDB by simply typing
 ```
-make debug
+BOARD=nucleo-f303ze make debug
 ```
 
 
 ## Supported Toolchains
-For using the ST Nucleo-F303RE board we strongly recommend the usage of the
+For using the ST Nucleo-F303ZE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f334r8/doc.txt
+++ b/boards/nucleo-f334r8/doc.txt
@@ -5,35 +5,36 @@
 
 ## Overview
 
-The Nucleo-F334 is a board from ST's Nucleo family supporting a ARM Cortex-M4
+The Nucleo-F334R8 is a board from ST's Nucleo family supporting a ARM Cortex-M4
 STM32F334R8 microcontroller with 12Kb of RAM and 64Kb or ROM.
 
 ## Hardware
 
-![STM32F3discovery image](http://media.digikey.com/Photos/STMicro%20Photos/MFG_NUCLEO.jpg)
+![Nucleo64 F334R8](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 ![nucleo-f334 pinout](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo-f334_pinout.png)
 
 
 ### MCU
-| MCU        | STM32F091RC       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 12Kb |
+| MCU        | STM32F334R8       |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M4     |
+| Vendor     | ST Microelectronics |
+| RAM        | 12Kb              |
 | Flash      | 64Kb              |
-| Frequency  | up to 72MHz) |
+| Frequency  | up to 72MHz       |
 | FPU        | yes               |
-| Timers | 9 (8x 16-bit, 1x 32-bit [TIM2])   |
-| ADCs       | 2x 12-bit         |
-| UARTs      | 8                 |
+| Timers     | 12 (8x 16-bit, 1x 32-bit [TIM2], 1x Systick, 2x watchdog) |
+| ADCs       | 2x 12-bit (21 channels) |
+| UARTs      | 3                 |
 | SPIs       | 1                 |
 | I2Cs       | 1                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/web/en/resource/technical/document/datasheet/DM00115237.pdf) |
-| Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031936.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00051352.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
+| CAN        | 1                 |
+| Vcc        | 2.0V - 3.6V       |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f334r8.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00093941.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
+| Board Manual | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
 
 
 
@@ -58,11 +59,11 @@ OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make flash
+BOARD=nucleo-f334r8 make flash
 ```
 and debug via GDB by simply typing
 ```
-make debug
+BOARD=nucleo-f334r8 make debug
 ```
 
 

--- a/boards/nucleo-f401re/doc.txt
+++ b/boards/nucleo-f401re/doc.txt
@@ -5,35 +5,35 @@
 
 ## Overview
 
-The Nucleo-F401 is a board from ST's Nucleo family supporting a ARM Cortex-M4
+The Nucleo-F401RE is a board from ST's Nucleo family supporting a ARM Cortex-M4
 STM32F401RE microcontroller with 96Kb of SRAM and 512Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F401](http://www.open-electronics.org/wp-
-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F401RE](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 ### MCU
 
 | MCU        | STM32F401RE       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 96Kb |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M4     |
+| Vendor     | ST Microelectronics |
+| RAM        | 96Kb              |
 | Flash      | 512Kb             |
-| Frequency  | up to 84MHz |
+| Frequency  | up to 84MHz       |
 | FPU        | yes               |
-| Timers | 11 (2x watchdog, 1 SysTick, 6x 16-bit, 2x 32-bit [TIM2])  |
-| ADCs       | 1x 12-bit         |
+| Timers     | 11 (2x watchdog, 1 SysTick, 6x 16-bit, 2x 32-bit [TIM2]) |
+| ADCs       | 1x 12-bit (16 channels) |
 | UARTs      | 3                 |
-| SPIs       | 4                 |
+| SPIs       | 3                 |
 | I2Cs       | 3                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
+| USB        | 1                 |
+| Vcc        | 1.7V - 3.6V       |
 | Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f401re.pdf) |
-| Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031936.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00096844.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf) |
 
 ## Implementation Status
 
@@ -56,16 +56,16 @@ OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f401 flash
+make BOARD=nucleo-f401re flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f401 debug
+make BOARD=nucleo-f401re debug
 ```
 
 ## Supported Toolchains
 
-For using the ST Nucleo-F401 board we strongly recommend the usage of the
+For using the ST Nucleo-F401RE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-
 embedded)
 toolchain.

--- a/boards/nucleo-f410rb/doc.txt
+++ b/boards/nucleo-f410rb/doc.txt
@@ -5,36 +5,34 @@
 
 ## Overview
 
-Not yet available upstream, see [PR 6025](https://github.com/RIOT-OS/RIOT/pull/6025)
-
-The Nucleo-F410 is a board from ST's Nucleo family supporting a ARM Cortex-M4
+The Nucleo-F410RB is a board from ST's Nucleo family supporting a ARM Cortex-M4
 STM32F410RB microcontroller with 32Kb of SRAM and 128Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F410](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F410RB](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 ### MCU
 
-| MCU        | STM32F410RB       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 32Kb |
+| MCU        | STM32F410RBT      |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M4     |
+| Vendor     | ST Microelectronics |
+| RAM        | 32Kb              |
 | Flash      | 128Kb             |
-| Frequency  | up to 100MHz |
+| Frequency  | up to 100MHz      |
 | FPU        | yes               |
-| Timers | 9 (2x watchdog, 1 SysTick, 4x 16-bit, 1x 32-bit [TIM2] and 1 low power timer) |
-| ADCs       | 1x 12-bit         |
+| Timers     | 9 (2x watchdog, 1x SysTick, 4x 16-bit, 1x 32-bit [TIM2] and 1 low power timer) |
+| ADCs       | 1x 12-bit (16 channels) |
 | UARTs      | 3                 |
 | SPIs       | 3                 |
 | I2Cs       | 3                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
+| Vcc        | 1.8V - 3.6V       |
 | Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f410rb.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/resource/en/reference_manual/dm00180366.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|
 
 ## Implementation Status
 
@@ -59,16 +57,16 @@ version
 instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f410 flash
+make BOARD=nucleo-f410rb flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f410 debug
+make BOARD=nucleo-f410rb debug
 ```
 
 ## Supported Toolchains
 
-For using the ST Nucleo-F410 board we strongly recommend the usage of the
+For using the ST Nucleo-F410RB board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f411re/doc.txt
+++ b/boards/nucleo-f411re/doc.txt
@@ -5,35 +5,35 @@
 
 ## Overview
 
-The Nucleo-F411 is a board from ST's Nucleo family supporting a ARM Cortex-M4
+The Nucleo-F411RE is a board from ST's Nucleo family supporting a ARM Cortex-M4
 STM32F411RE microcontroller with 128Kb of SRAM and 512Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F401](http://www.open-electronics.org/wp-
-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F411RE](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 ### MCU
 
 | MCU        | STM32F411RE       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 128Kb |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M4     |
+| Vendor     | ST Microelectronics |
+| RAM        | 128Kb             |
 | Flash      | 512Kb             |
-| Frequency  | up to 100MHz |
+| Frequency  | up to 100MHz      |
 | FPU        | yes               |
-| Timers | 11 (2x watchdog, 1 SysTick, 6x 16-bit, 2x 32-bit [TIM2])  |
-| ADCs       | 1x 12-bit         |
+| Timers     | 11 (2x watchdog, 1 SysTick, 7x 16-bit, 1x 32-bit [TIM2]) |
+| ADCs       | 1x 12-bit (16 channels) |
 | UARTs      | 3                 |
 | SPIs       | 5                 |
 | I2Cs       | 3                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
+| USB        | 1                 |
+| Vcc        | 1.7V - 3.6V       |
 | Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f411re.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/resource/en/reference_manual/dm00119316.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf) |
 
 ## Implementation Status
 
@@ -56,16 +56,16 @@ OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f411 flash
+make BOARD=nucleo-f411re flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f411 debug
+make BOARD=nucleo-f411re debug
 ```
 
 ## Supported Toolchains
 
-For using the ST Nucleo-F411 board we strongly recommend the usage of the
+For using the ST Nucleo-F411RE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-
 embedded)
 toolchain.

--- a/boards/nucleo-f446re/doc.txt
+++ b/boards/nucleo-f446re/doc.txt
@@ -5,34 +5,36 @@
 
 ## Overview
 
-The Nucleo-F446 is a board from ST's Nucleo family supporting a ARM Cortex-M4
+The Nucleo-F446RE is a board from ST's Nucleo family supporting a ARM Cortex-M4
 STM32F446RE microcontroller with 128Kb of RAM and 512Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F446](http://www.open-electronics.org/wp-
+![Nucleo64 F446RE](http://www.open-electronics.org/wp-
 content/uploads/2015/08/Figura2-500x467.png)
 
 ### MCU
 
 | MCU        | STM32F446RE       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 128Kb |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M4     |
+| Vendor     | ST Microelectronics |
+| RAM        | 128Kb             |
 | Flash      | 512Kb             |
-| Frequency  | up to 180MHz |
+| Frequency  | up to 180MHz      |
 | FPU        | yes               |
-| Timers | 11 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |
-| ADCs       | 3x 12-bit         |
-| UARTs      | 4                 |
+| Timers     | 17 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |
+| ADCs       | 3x 12-bit (16 channels) |
+| UARTs      | 6                 |
 | SPIs       | 4                 |
 | I2Cs       | 4                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
+| CAN        | 2                 |
+| USB        | 1                 |
+| Vcc        | 1.8V - 3.6V       |
 | Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f446re.pdf) |
-| Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031936.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00051352.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00135183.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
 | Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
 
 ## Implementation Status
@@ -56,11 +58,11 @@ OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f446 flash
+make BOARD=nucleo-f446re flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f446 debug
+make BOARD=nucleo-f446re debug
 ```
 
 ## Supported Toolchains

--- a/boards/nucleo-f446ze/doc.txt
+++ b/boards/nucleo-f446ze/doc.txt
@@ -5,41 +5,42 @@
 
 ## Overview
 
-The Nucleo-F446 is a board from ST's Nucleo family supporting a ARM Cortex-M4
-STM32F446RE microcontroller with 128Kb of RAM and 512Kb of ROM Flash.
+The Nucleo-F446ZE is a board from ST's Nucleo family supporting a ARM Cortex-M4
+STM32F446ZE microcontroller with 128Kb of RAM and 512Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F446](http://www.open-electronics.org/wp-
-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo144 F446ZE](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/nucleo144-board.png)
 
 ### MCU
 
-| MCU        | STM32F446RE       |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4     |
-| Vendor | ST Microelectronics   |
-| RAM        | 128Kb |
+| MCU        | STM32F446ZE       |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M4     |
+| Vendor     | ST Microelectronics |
+| RAM        | 128Kb             |
 | Flash      | 512Kb             |
-| Frequency  | up to 180MHz |
+| Frequency  | up to 180MHz      |
 | FPU        | yes               |
-| Timers | 11 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |
-| ADCs       | 3x 12-bit         |
-| UARTs      | 4                 |
+| Timers     | 17 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |
+| ADCs       | 3x 12-bit (24 channels) |
+| UARTs      | 6                 |
 | SPIs       | 4                 |
 | I2Cs       | 4                 |
 | RTC        | 1                 |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f446re.pdf) |
-| Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031936.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00051352.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
+| CAN        | 2                 |
+| USB        | 1                 |
+| Vcc        | 1.8V - 3.6V       |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f446ze.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00135183.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/dm00244518.pdf)|
 
 ## Implementation Status
 
 | Device | ID        | Supported | Comments  |
 |:------------- |:------------- |:------------- |:------------- |
-| MCU        | STM32F446RE   | partly    | Energy saving modes not fully utilized |
+| MCU        | STM32F446ZE   | partly    | Energy saving modes not fully utilized |
 | Low-level driver | GPIO    | yes       | |
 |        | PWM       | yes (9 pins available)    |  |
 |        | UART      | 3 UARTs       | USART2 via STLink/USB or D0(RX)/D1(TX), USART3 on PC11(RX)/PC10(TX) and USART1 on PA10(RX)/PA9(TX) |
@@ -50,22 +51,22 @@ content/uploads/2015/08/Figura2-500x467.png)
 
 ## Flashing the device
 
-The ST Nucleo-F446RE board includes an on-board ST-LINK V2 programmer. The
+The ST Nucleo-F446ZE board includes an on-board ST-LINK V2 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-f446 flash
+make BOARD=nucleo-f446ze flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-f446 debug
+make BOARD=nucleo-f446ze debug
 ```
 
 ## Supported Toolchains
 
-For using the ST Nucleo-F446RE board we strongly recommend the usage of the
+For using the ST Nucleo-F446ZE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-
 embedded)
 toolchain.

--- a/boards/nucleo-l152re/doc.txt
+++ b/boards/nucleo-l152re/doc.txt
@@ -5,38 +5,39 @@
 
 ## Hardware
 
-![st-nucleo-l1](https://cloud.githubusercontent.com/assets/56618/5190201/f87455ae-74e3-11e4-9d24-21a334e01858.png)
+![Nucleo64 L152RE](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 
 ### MCU
-| MCU        | STM32L152RE |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M3     |
-| Vendor | ST Microelectronics   |
-| RAM        | 80Kb  |
+| MCU        | STM32L152RE       |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M3     |
+| Vendor     | ST Microelectronics |
+| RAM        | 80Kb              |
 | Flash      | 512Kb             |
-| Frequency  | 32MHz (no external oscilator connected) |
+| EEPROM     | 16KB              |
+| Frequency  | up to 32MHz       |
 | FPU        | no                |
-| Timers | 8 (8x 16-bit, 1x 32-bit [TIM5])   |
-| ADCs       | 1x 42-channel 12-bit          |
-| UARTs      | 3                 |
-| SPIs       | 2                 |
+| Timers     | 12 (8x 16-bit, 1x 32-bit [TIM5], 1x Systick, 2x watchdog) |
+| ADCs       | 1x 12-bit (21 channels) |
+| UARTs      | 5                 |
+| SPIs       | 3-8 (UARTs can be configured as SPIs) |
 | I2Cs       | 2                 |
-| Vcc        | 1.65V - 3.6V          |
-| Datasheet  | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00098321.pdf) |
+| Vcc        | 1.65V - 3.6V      |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l152re.pdf) |
 | Reference Manual | [Reference Manual](http://www.st.com/resource/en/reference_manual/cd00240193.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/CD00228163.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00105823.pdf) |
 
 ### User Interface
 
-2 Button:
+2 Buttons:
 
-| NAME   | USER  | RESET     |
-|:----- |:----- |:--------- |
+| NAME   | USER      | RESET |
+|:------ |:--------- |:----- |
 | Pin    | PC13 (IN) | NRST  |
 
-1 LEDs:
+1 LED:
 
 | NAME   | LD2   |
 | -----  | ----- |
@@ -46,7 +47,7 @@
 
 ## Supported Toolchains
 
-For using the st-nucleo-l1 board we strongly recommend the usage of the [GNU
+For using the Nucleo-L152RE board we strongly recommend the usage of the [GNU
 Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
 


### PR DESCRIPTION
### Contribution description

I found lots of small mistakes in the documentation of the nucleo boards so I mostly focused on checking that all information in the docs are correct. I did not expand much the documentation but I did add the number of Ethernet/CAN/USB peripherals if they were present. If a board's documentation was empty, I did not touch it.

Also, I did not know what to do about the implementation status. What should be in it ? What is supported by the board (content of `periph_conf.h`) ? Or which peripherals of the MCU are currently supported ?

### Testing procedure

None.

### Issues/PRs references

None.