### PR TITLE
makefiles/sam0.inc.mk: fix detection of JLinkExe

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -28,7 +28,7 @@ ifeq ($(DEBUG_ADAPTER),dap)
   PROGRAMMER ?= edbg
 else ifeq ($(DEBUG_ADAPTER),jlink)
   # only use JLinkExe if it's installed
-  ifneq (,$(shell command -v JLinkExe))
+  ifneq (,$(shell which JLinkExe))
     PROGRAMMER ?= jlink
   else
     PROGRAMMER ?= openocd


### PR DESCRIPTION
### Contribution description

`command -v` doesn't work for me (Ubuntu), but `which` finds the correct JLinkExe.

### Testing procedure

Flash a board with `DEBUG_ADAPTER ?= jlink` while having Seggers `JLinkExe` installed.

### Issues/PRs references

This fixes that odd

> `make: command: Command not found`

you get when flashing a board with <pre>DEBUG_ADAPTER<font color="#CC0000"> ?= </font>jlink</pre>

#11725