### PR TITLE
usb: Warn on test-ID usage in a unified location

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -662,40 +662,6 @@ endif
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
 	@$(COLOR_ECHO)
 
-# Set USB VID/PID via CFLAGS if not being set via Kconfig
-ifndef CONFIG_USB_VID
-  ifdef USB_VID
-    CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID)
-  endif
-else
-  USB_VID = $(patsubst 0x%,%,$(CONFIG_USB_VID))
-endif
-
-ifndef CONFIG_USB_PID
-  ifdef USB_PID
-    CFLAGS += -DCONFIG_USB_PID=0x$(USB_PID)
-  endif
-else
-  USB_PID = $(patsubst 0x%,%,$(CONFIG_USB_PID))
-endif
-
-# Exported for the benefit of Kconfig
-export USB_VID_TESTING = 1209
-export USB_PID_TESTING = 7D01
-usb_id_check:
-	@if grep --quiet --ignore-case "^$(USB_VID) $(USB_PID)$$" $(RIOTBASE)/dist/usb_id_testing; then \
-		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
-	fi
-	@if [ "$(USB_VID) $(subst D,d,$(USB_PID))" = "1209 7d00" ]; then \
-		$(COLOR_ECHO) "$(COLOR_RED)RIOT standard peripherals code (1209/7D00) cannot be set explicitly.$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)Unset USB_VID / USB_PID for the code to be picked automatically, or set$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)them to \$${USB_VID_TESTING} / \$${USB_PID_TESTING} during development.$(COLOR_RESET)" 1>&2 ; \
-		exit 1; \
-	fi
-.PHONY: usb_id_check
-all: | usb_id_check
-
 # The `clean` needs to be serialized before everything else.
 all $(BASELIBS) $(BUILDDEPS) ..in-docker-container: | $(CLEAN)
 
@@ -838,6 +804,9 @@ include $(RIOTMAKE)/vars.inc.mk
 
 # Include build targets for selected tools
 include $(RIOTMAKE)/tools/targets.inc.mk
+
+# Checks and defaults for USB Vendor and Product ID
+include $(RIOTMAKE)/usb-codes.inc.mk
 
 # Warn if the selected board and drivers don't provide all needed features:
 ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))

--- a/Makefile.include
+++ b/Makefile.include
@@ -662,6 +662,17 @@ endif
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
 	@$(COLOR_ECHO)
 
+# Exported for the benefit of Kconfig
+export USB_VID_TESTING = 1209
+export USB_PID_TESTING = 7D01
+usb_id_check:
+	@if grep --quiet --ignore-case "^$(USB_VID) $(USB_PID)$$" $(RIOTBASE)/dist/usb_id_testing; then \
+		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+	fi
+.PHONY: usb_id_check
+all: | usb_id_check
+
 # The `clean` needs to be serialized before everything else.
 all $(BASELIBS) $(BUILDDEPS) ..in-docker-container: | $(CLEAN)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -662,6 +662,23 @@ endif
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
 	@$(COLOR_ECHO)
 
+# Set USB VID/PID via CFLAGS if not being set via Kconfig
+ifndef CONFIG_USB_VID
+  ifdef USB_VID
+    CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID)
+  endif
+else
+  USB_VID = $(patsubst 0x%,%,$(CONFIG_USB_VID))
+endif
+
+ifndef CONFIG_USB_PID
+  ifdef USB_PID
+    CFLAGS += -DCONFIG_USB_PID=0x$(USB_PID)
+  endif
+else
+  USB_PID = $(patsubst 0x%,%,$(CONFIG_USB_PID))
+endif
+
 # Exported for the benefit of Kconfig
 export USB_VID_TESTING = 1209
 export USB_PID_TESTING = 7D01

--- a/Makefile.include
+++ b/Makefile.include
@@ -687,6 +687,12 @@ usb_id_check:
 		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
 		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi
+	@if [ "$(USB_VID) $(subst D,d,$(USB_PID))" = "1209 7d00" ]; then \
+		$(COLOR_ECHO) "$(COLOR_RED)RIOT standard peripherals code (1209/7D00) cannot be set explicitly.$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)Unset USB_VID / USB_PID for the code to be picked automatically, or set$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)them to \$${USB_VID_TESTING} / \$${USB_PID_TESTING} during development.$(COLOR_RESET)" 1>&2 ; \
+		exit 1; \
+	fi
 .PHONY: usb_id_check
 all: | usb_id_check
 

--- a/dist/usb_id_testing
+++ b/dist/usb_id_testing
@@ -1,0 +1,20 @@
+# This file contains all codes that should trigger the usb_id_check warning
+# about a test PID being used
+
+1209 0001
+1209 0002
+1209 0003
+1209 0004
+1209 0005
+1209 0006
+1209 0007
+1209 0008
+1209 0009
+1209 000a
+1209 000b
+1209 000c
+1209 000d
+1209 000e
+1209 000f
+1209 0010
+1209 7d01

--- a/examples/usbus_minimal/Kconfig
+++ b/examples/usbus_minimal/Kconfig
@@ -1,5 +1,0 @@
-config USB_VID
-    default 0x$(DEFAULT_VID) if KCONFIG_USB
-
-config USB_PID
-    default 0x$(DEFAULT_PID) if KCONFIG_USB

--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -16,10 +16,8 @@ USEMODULE += usbus
 USEMODULE += auto_init_usbus
 
 # USB device vendor and product ID
-export DEFAULT_VID = 1209
-export DEFAULT_PID = 7D00
-USB_VID ?= $(DEFAULT_VID)
-USB_PID ?= $(DEFAULT_PID)
+USB_VID ?= $(USB_VID_TESTING)
+USB_PID ?= $(USB_PID_TESTING)
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
@@ -41,12 +39,3 @@ ifndef CONFIG_USB_PID
 else
   USB_PID = $(patsubst 0x%,%,$(CONFIG_USB_PID))
 endif
-
-.PHONY: usb_id_check
-usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
-		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
-	fi
-
-all: | usb_id_check

--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -26,16 +26,3 @@ QUIET ?= 1
 SHOULD_RUN_KCONFIG ?=
 
 include $(RIOTBASE)/Makefile.include
-
-# Set USB VID/PID via CFLAGS if not being set via Kconfig
-ifndef CONFIG_USB_VID
-  CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID)
-else
-  USB_VID = $(patsubst 0x%,%,$(CONFIG_USB_VID))
-endif
-
-ifndef CONFIG_USB_PID
-  CFLAGS += -DCONFIG_USB_PID=0x$(USB_PID)
-else
-  USB_PID = $(patsubst 0x%,%,$(CONFIG_USB_PID))
-endif

--- a/makefiles/usb-codes.inc.mk
+++ b/makefiles/usb-codes.inc.mk
@@ -1,0 +1,33 @@
+# Set USB VID/PID via CFLAGS if not being set via Kconfig
+ifndef CONFIG_USB_VID
+  ifdef USB_VID
+    CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID)
+  endif
+else
+  USB_VID = $(patsubst 0x%,%,$(CONFIG_USB_VID))
+endif
+
+ifndef CONFIG_USB_PID
+  ifdef USB_PID
+    CFLAGS += -DCONFIG_USB_PID=0x$(USB_PID)
+  endif
+else
+  USB_PID = $(patsubst 0x%,%,$(CONFIG_USB_PID))
+endif
+
+# Exported for the benefit of Kconfig
+export USB_VID_TESTING = 1209
+export USB_PID_TESTING = 7D01
+usb_id_check:
+	@if grep --quiet --ignore-case "^$(USB_VID) $(USB_PID)$$" $(RIOTBASE)/dist/usb_id_testing; then \
+		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+	fi
+	@if [ "$(USB_VID) $(subst D,d,$(USB_PID))" = "1209 7d00" ]; then \
+		$(COLOR_ECHO) "$(COLOR_RED)RIOT standard peripherals code (1209/7D00) cannot be set explicitly.$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)Unset USB_VID / USB_PID for the code to be picked automatically, or set$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)them to \$${USB_VID_TESTING} / \$${USB_PID_TESTING} during development.$(COLOR_RESET)" 1>&2 ; \
+		exit 1; \
+	fi
+.PHONY: usb_id_check
+all: | usb_id_check

--- a/makefiles/usb-codes.inc.mk
+++ b/makefiles/usb-codes.inc.mk
@@ -16,8 +16,8 @@ else
 endif
 
 # Exported for the benefit of Kconfig
-export USB_VID_TESTING = 1209
-export USB_PID_TESTING = 7D01
+USB_VID_TESTING = 1209
+USB_PID_TESTING = 7D01
 usb_id_check:
 	@if grep --quiet --ignore-case "^$(USB_VID) $(USB_PID)$$" $(RIOTBASE)/dist/usb_id_testing; then \
 		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -51,7 +51,7 @@ extern "C" {
 #define CONFIG_USB_PID INTERNAL_PERIPHERAL_PID
 #else
 #error Please configure your vendor and product IDs. For development, you may \
-    set CONFIG_USB_VID=0x1209 CONFIG_USB_PID=0x7D01.
+    set USB_VID=${USB_VID_TESTING} USB_PID=${USB_PID_TESTING}.
 #endif
 #endif
 

--- a/sys/usb/Kconfig
+++ b/sys/usb/Kconfig
@@ -45,12 +45,14 @@ endchoice
 config USB_PID
     hex "Product ID"
     range 0x0000 0xFFFF
+    default 0x$(USB_PID_TESTING) if KCONFIG_USB
     help
         You must provide your own PID.
 
 config USB_VID
     hex "Vendor ID"
     range 0x0000 0xFFFF
+    default 0x$(USB_VID_TESTING) if KCONFIG_USB
     help
         You must provide your own VID.
 

--- a/sys/usb/Kconfig
+++ b/sys/usb/Kconfig
@@ -45,14 +45,14 @@ endchoice
 config USB_PID
     hex "Product ID"
     range 0x0000 0xFFFF
-    default 0x$(USB_PID_TESTING) if KCONFIG_USB
+    default 0x$(USB_PID_TESTING)
     help
         You must provide your own PID.
 
 config USB_VID
     hex "Vendor ID"
     range 0x0000 0xFFFF
-    default 0x$(USB_VID_TESTING) if KCONFIG_USB
+    default 0x$(USB_VID_TESTING)
     help
         You must provide your own VID.
 

--- a/sys/usb/Kconfig
+++ b/sys/usb/Kconfig
@@ -45,14 +45,14 @@ endchoice
 config USB_PID
     hex "Product ID"
     range 0x0000 0xFFFF
-    default 0x$(USB_PID_TESTING)
+    default 0x7D01
     help
         You must provide your own PID.
 
 config USB_VID
     hex "Vendor ID"
     range 0x0000 0xFFFF
-    default 0x$(USB_VID_TESTING)
+    default 0x1209
     help
         You must provide your own VID.
 

--- a/tests/usbus/Makefile
+++ b/tests/usbus/Makefile
@@ -6,20 +6,9 @@ FEATURES_PROVIDED += periph_usbdev
 DISABLE_MODULE += auto_init_usbus
 
 # USB device vendor and product ID
-DEFAULT_VID = 1209
-DEFAULT_PID = 7D00
-USB_VID ?= $(DEFAULT_VID)
-USB_PID ?= $(DEFAULT_PID)
+USB_VID ?= $(USB_VID_TESTING)
+USB_PID ?= $(USB_PID_TESTING)
 
 CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID) -DCONFIG_USB_PID=0x$(USB_PID)
 
 include $(RIOTBASE)/Makefile.include
-
-.PHONY: usb_id_check
-usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) ] || [ $(USB_PID) = $(DEFAULT_PID) ] ; then \
-		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
-	fi
-
-all: | usb_id_check

--- a/tests/usbus/Makefile
+++ b/tests/usbus/Makefile
@@ -9,6 +9,4 @@ DISABLE_MODULE += auto_init_usbus
 USB_VID ?= $(USB_VID_TESTING)
 USB_PID ?= $(USB_PID_TESTING)
 
-CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID) -DCONFIG_USB_PID=0x$(USB_PID)
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/usbus_cdc_acm_stdio/Makefile
+++ b/tests/usbus_cdc_acm_stdio/Makefile
@@ -6,21 +6,4 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# USB device vendor and product ID
-DEFAULT_VID = 1209
-DEFAULT_PID = 7D00
-USB_VID ?= $(DEFAULT_VID)
-USB_PID ?= $(DEFAULT_PID)
-
-CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID) -DCONFIG_USB_PID=0x$(USB_PID)
-
 include $(RIOTBASE)/Makefile.include
-
-.PHONY: usb_id_check
-usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) ] || [ $(USB_PID) = $(DEFAULT_PID) ] ; then \
-		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
-	fi
-
-all: | usb_id_check

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -9,36 +9,4 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# USB device vendor and product ID
-# pid.codes test VID/PID, not globally unique
-export DEFAULT_VID = 1209
-export DEFAULT_PID = 7D00
-USB_VID ?= $(DEFAULT_VID)
-USB_PID ?= $(DEFAULT_PID)
-
 include $(RIOTBASE)/Makefile.include
-
-# Set USB VID/PID via CFLAGS if not being set via Kconfig
-ifndef CONFIG_USB_VID
-  CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID)
-else
-  USB_VID = $(patsubst 0x%,%,$(CONFIG_USB_VID))
-endif
-
-ifndef CONFIG_USB_PID
-  CFLAGS += -DCONFIG_USB_PID=0x$(USB_PID)
-else
-  USB_PID = $(patsubst 0x%,%,$(CONFIG_USB_PID))
-endif
-
-# There is a Kconfig in the app folder, we need to indicate not to run it by default
-SHOULD_RUN_KCONFIG ?=
-
-.PHONY: usb_id_check
-usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
-		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
-	fi
-
-all: | usb_id_check


### PR DESCRIPTION
### Contribution description

As discussed in https://github.com/RIOT-OS/RIOT/issues/12273 and prepared in #13148, there is still a lot of Makefile code that'd get copy-pasted around when applications are started from examples, or (worse) simply removed because it's annoying.

This moves the checks for whether to show a big red warning about using test VID/PIDs into the main build infrastructure.

In particular (quoting the commit), this

* renames DEFAULT_xID to USB_xID_TESTING as it is not really a default
  (if anyting, the 7D00 is, and it's not that)
* moves the check into Makefile
* generalizes the check to all test PID/VID pairs
  * in doing so, fixes the "or" (which would have ruled out warning-free
    use of an allocated pid.codes number), and compares to the actual
    testing PID rather than the RIOT-peripheral PID
* removes all occurrences of duplicated checks in examples or tests,
  leaving definitions only where they are needed
* moves the Kconfig defaults of the usbus_minimal example into the main
  Kconfig, as these are good defaults for all cases when USB is enabled
  manually

### Open issues

* [x] Setting variables currently take two independent paths, they either come from the environment and are set (manually still, I'd pull that over when the rest is clear) to CFLAGS, *or* they come from Kconfig with defines in CFLAGS and also set a `CONFIG_USB_VID` variable in addition to the define.

    The Kconfig-provided CFLAGS are hard to check, so I'd check the CONFIG_USB_VID, but then that'd be another checking path relative to the Makefile-based configuration.

    It'd be tempting to change the USB_VID settings in the makefile-based configuration to CONFIG_USB_VID (as it's exported by Kconfig), but then there'd be a general CFLAGS addition that adds in those, and Kconfig's settings wind up there twice.

    Is there a general pattern that has been established for such cases?

* [x] The code in #13148 fails to detect cases where the 1209:7D00 is set manually, which allows applications to claim that they only use RIOT internal peripherals even though they don't.

    I'd like to add a check for this, but am not sure yet how sever it should be (red warning vs breaking), and whether to test in Makefile or in the C header.

### Testing procedure

* USB examples that only enable RIOT-provided devices (`tests/usbus_cdc_acm`, `tests/usbus_cdc_ecm`) build without any USB specific code in their Makefile, and show as 1209:7D00; they build without showing a warning.
* USB examples that actually do something with USB (`tests/usbus`) set their IDs to in two single lines and then show the warning at build time.
* USB examples that opt in to testing IDs (`examples/usbus_minimal`) can set them and get the warnings without actually copying the warning around.
* USB examples with explicit IDs err out when 1209/7D00 is given explicitly, as needing to set that would be against that code's description.

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/12273

[edit: Added last testing point]