### PR TITLE
cpu/stm32_common/periph: Fix addr filtering

### DIFF
--- a/cpu/stm32_common/periph/eth.c
+++ b/cpu/stm32_common/periph/eth.c
@@ -118,14 +118,14 @@ void stm32_eth_get_mac(char *out)
     unsigned t;
 
     t = ETH->MACA0HR;
-    out[0] = (t >> 8);
-    out[1] = (t & 0xff);
+    out[5] = (t >> 8);
+    out[4] = (t & 0xff);
 
     t = ETH->MACA0LR;
-    out[2] = (t >> 24);
-    out[3] = (t >> 16);
-    out[4] = (t >> 8);
-    out[5] = (t & 0xff);
+    out[3] = (t >> 24);
+    out[2] = (t >> 16);
+    out[1] = (t >> 8);
+    out[0] = (t & 0xff);
 }
 
 /** Set the mac address. The peripheral supports up to 4 MACs but only one is
@@ -133,8 +133,8 @@ void stm32_eth_get_mac(char *out)
 void stm32_eth_set_mac(const char *mac)
 {
     ETH->MACA0HR &= 0xffff0000;
-    ETH->MACA0HR |= ((mac[0] << 8) | mac[1]);
-    ETH->MACA0LR = ((mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | mac[5]);
+    ETH->MACA0HR |= ((mac[5] << 8) | mac[4]);
+    ETH->MACA0LR = ((mac[3] << 24) | (mac[2] << 16) | (mac[1] << 8) | mac[0]);
 }
 
 /** Initialization of the DMA descriptors to be used */
@@ -211,8 +211,6 @@ int stm32_eth_init(void)
 
     /* pass all */
     //ETH->MACFFR |= ETH_MACFFR_RA;
-    /* perfect filter on address */
-    ETH->MACFFR |= (ETH_MACFFR_PAM | ETH_MACFFR_DAIF);
 
     /* store forward */
     ETH->DMAOMR |= (ETH_DMAOMR_RSF | ETH_DMAOMR_TSF | ETH_DMAOMR_OSF);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the eth reception of stm32_common. So far, every frame was being received, regardless of the destination MAC. To accomplish this the MACFFR was set to unicast filtering and the byte-order of the own MAC was corrected.

This PR was tested using the nucleo-f207zg and the example under examples/default

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

None.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->