### PR TITLE
examples/gnrc_lorawan: set RX2 DR to 3 only for ABP

### DIFF
--- a/examples/gnrc_lorawan/Makefile
+++ b/examples/gnrc_lorawan/Makefile
@@ -37,10 +37,12 @@ CFLAGS += -DLORAMAC_APP_EUI_DEFAULT=\{0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,
 CFLAGS += -DLORAMAC_DEV_EUI_DEFAULT=\{0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\}
 
 # Uncomment and replace with proper keys for joining with ABP
+# For TTN, It's necessary to set the RX2 DR to 3
 # NOTE: This values will be overriten in case of OTAA.
 #CFLAGS += -DLORAMAC_DEV_ADDR_DEFAULT=\{0x00\,0x00\,0x00\,0x00\}
 #CFLAGS += -DLORAMAC_NWK_SKEY_DEFAULT=\{0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\}
 #CFLAGS += -DLORAMAC_APP_SKEY_DEFAULT=\{0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\,0x00\}
+#CFLAGS += -DLORAMAC_DEFAULT_RX2_DR=LORAMAC_DR_3
 
 # Comment/uncomment as necessary
 CFLAGS += -DLORAMAC_DEFAULT_JOIN_PROCEDURE=LORAMAC_JOIN_OTAA
@@ -50,9 +52,6 @@ CFLAGS += -DLORAMAC_DEFAULT_JOIN_PROCEDURE=LORAMAC_JOIN_OTAA
 # If uncommented, the default value (DR0) is used.
 # Note this value is also used for the OTAA.
 #CFLAGS += -DLORAMAC_DEFAULT_DR=LORAMAC_DR_5
-
-# Set the default RX2 datarate to DR3 (used by The Things Network)
-CFLAGS += -DLORAMAC_DEFAULT_RX2_DR=LORAMAC_DR_3
 
 # Set default messages to unconfirmable
 CFLAGS += -DLORAMAC_DEFAULT_TX_MODE=LORAMAC_TX_CNF


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR sets the default RX2 DR to RIOT default (DR 0) when ABP is not used.
DR 0 is needed for the second reception window if OTAA is used, so the current example has problems to join if the Join Accept packet is sent there.

With this change, the `gnrc_lorawan` example should join in the first attempt.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make -C examples/gnrc_lorawan`

```
ifconfig 4 set deveui <DEVEUI>
ifconfig 4 set deveui <APPEUI>
ifconfig 4 set deveui <APPKEY>
ifconfig 4 up
/* Wait 7 seconds */
ifconfig
```
It should display `Link: up`:
```
2020-02-14 13:52:36,194 #  ifconfig
2020-02-14 13:52:36,203 # Iface  4  HWaddr: 26:01:26:E0  Frequency: 869524963Hz  BW: 125kHz  SF: 12  CR: 4/5  Link: up 
2020-02-14 13:52:36,211 #            TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
2020-02-14 13:52:36,213 #           IQ_INVERT 
2020-02-14 13:52:36,217 #           RX_SINGLE OTAA L2-PDU:255 
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
