### PR TITLE
net/gcoap: use sock_async and events

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -875,8 +875,11 @@ endif
 
 ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += nanocoap
-  USEMODULE += gnrc_sock_udp
+  USEMODULE += gnrc_sock_async
+  USEMODULE += sock_async_event
   USEMODULE += sock_util
+  USEMODULE += event_callback
+  USEMODULE += event_timeout
 endif
 
 ifneq (,$(filter luid,$(USEMODULE)))

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -347,6 +347,8 @@
 
 #include <stdint.h>
 
+#include "event/callback.h"
+#include "event/timeout.h"
 #include "net/ipv6/addr.h"
 #include "net/sock/udp.h"
 #include "net/nanocoap.h"
@@ -496,19 +498,6 @@ extern "C" {
 #ifndef CONFIG_GCOAP_NON_TIMEOUT
 #define CONFIG_GCOAP_NON_TIMEOUT       (5000000U)
 #endif
-
-/**
- * @brief   Identifies waiting timed out for a response to a sent message
- */
-#define GCOAP_MSG_TYPE_TIMEOUT  (0x1501)
-
-/**
- * @brief   Identifies a request to interrupt listening for an incoming message
- *          on a sock
- *
- * Allows the event loop to process IPC messages.
- */
-#define GCOAP_MSG_TYPE_INTR     (0x1502)
 
 /**
  * @ingroup net_gcoap_conf
@@ -677,8 +666,8 @@ struct gcoap_request_memo {
     sock_udp_ep_t remote_ep;            /**< Remote endpoint */
     gcoap_resp_handler_t resp_handler;  /**< Callback for the response */
     void *context;                      /**< ptr to user defined context data */
-    xtimer_t response_timer;            /**< Limits wait for response */
-    msg_t timeout_msg;                  /**< For response timer */
+    event_timeout_t resp_evt_tmout;     /**< Limits wait for response */
+    event_callback_t resp_tmout_cb;     /**< Callback for response timeout */
 };
 
 /**

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -363,13 +363,6 @@ extern "C" {
  * @{
  */
 /**
- * @brief  Size for module message queue
- */
-#ifndef CONFIG_GCOAP_MSG_QUEUE_SIZE
-#define CONFIG_GCOAP_MSG_QUEUE_SIZE    (4)
-#endif
-
-/**
  * @brief   Server port; use RFC 7252 default if not defined
  */
 #ifndef CONFIG_GCOAP_PORT
@@ -480,14 +473,6 @@ extern "C" {
  * @brief   Value for send_limit in request memo when non-confirmable type
  */
 #define GCOAP_SEND_LIMIT_NON    (-1)
-
-/**
- * @ingroup net_gcoap_conf
- * @brief   Time in usec that the event loop waits for an incoming CoAP message
- */
-#ifndef CONFIG_GCOAP_RECV_TIMEOUT
-#define CONFIG_GCOAP_RECV_TIMEOUT      (1 * US_PER_SEC)
-#endif
 
 #ifdef DOXYGEN
 /**

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -139,7 +139,7 @@ static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type)
         ssize_t res = sock_udp_recv(sock, _listen_buf, sizeof(_listen_buf),
                                     0, &remote);
         if (res <= 0) {
-            DEBUG("gcoap: udp recv failure: %d\n", res);
+            DEBUG("gcoap: udp recv failure: %d\n", (int)res);
             return;
         }
 


### PR DESCRIPTION
### Contribution description
From its inception gcoap has implemented asynchronous message processing. However, this implementation has included a custom `msg_t` queue handler for timeouts, as well as stack specific handling to break out of a blocking call to `sock_udp_recv()`. The new sock_async and event queue modules implement generic message queue processing and timeout events that can supplant gcoap's custom solutions. This PR performs that replacement with no change in gcoap's feature set.

Abstraction has a cost, and we measured the increase in size of the executable and RAM use. For the gcoap example built for a samr21-xpro:

- text +896 bytes
- data +32 bytes
- bss +8 bytes

We also saw RAM increase by 32 bytes via `ps` command.

### Testing procedure
Run the gcoap example or your favorite app. There should not be any change in functionality for client request handling or server response handling.

### Issues/PRs references
N/A
