### PR TITLE
Add optional support for executable space protections

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -30,6 +30,10 @@ ifneq (,$(filter mpu_stack_guard,$(USEMODULE)))
   FEATURES_REQUIRED += cortexm_mpu
 endif
 
+ifneq (,$(filter mpu_noexec_ram,$(USEMODULE)))
+  FEATURES_REQUIRED += cortexm_mpu
+endif
+
 ifneq (,$(filter auto_init_gnrc_netif,$(USEMODULE)))
   USEMODULE += gnrc_netif_init_devs
 endif

--- a/core/sched.c
+++ b/core/sched.c
@@ -121,7 +121,7 @@ int __attribute__((used)) sched_run(void)
 
 #ifdef MODULE_MPU_STACK_GUARD
     mpu_configure(
-        1,                                                /* MPU region 1 */
+        2,                                                /* MPU region 2 */
         (uintptr_t)sched_active_thread->stack_start + 31, /* Base Address (rounded up) */
         MPU_ATTR(1, AP_RO_RO, 0, 1, 0, 1, MPU_SIZE_32B)   /* Attributes and Size */
     );

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -152,7 +152,7 @@ void reset_handler_default(void)
      * executable. This is the Cortex-M SRAM region used for on-chip RAM.
      */
     mpu_configure(
-        2,                                               /* Region 0 and 1 are used by mpu_stack_guard */
+        0,                                               /* Region 0 (lowest priority) */
         (uintptr_t)&_sram,                               /* RAM base address */
         MPU_ATTR(1, AP_RW_RW, 0, 1, 0, 1, MPU_SIZE_512M) /* Allow read/write but no exec */
     );
@@ -161,7 +161,7 @@ void reset_handler_default(void)
 #ifdef MODULE_MPU_STACK_GUARD
     if (((uintptr_t)&_sstack) != SRAM_BASE) {
         mpu_configure(
-            0,                                              /* MPU region 0 */
+            1,                                              /* MPU region 1 */
             (uintptr_t)&_sstack + 31,                       /* Base Address (rounded up) */
             MPU_ATTR(1, AP_RO_RO, 0, 1, 0, 1, MPU_SIZE_32B) /* Attributes and Size */
         );

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -17,6 +17,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Joakim Gebart <joakim.gebart@eistec.se>
+ * @author      Sören Tempel <tempel@uni-bremen.de>
  *
  * @}
  */
@@ -139,8 +140,25 @@ void reset_handler_default(void)
     }
 #endif /* CPU_HAS_BACKUP_RAM */
 
-#ifdef MODULE_MPU_STACK_GUARD
+#if defined(MODULE_MPU_STACK_GUARD) || defined(MODULE_MPU_NOEXEC_RAM)
     mpu_enable();
+#endif
+
+#ifdef MODULE_MPU_NOEXEC_RAM
+    /* Mark the RAM non executable. This is a protection mechanism which
+     * makes exploitation of buffer overflows significantly harder.
+     *
+     * This marks the memory region from 0x20000000 to 0x3FFFFFFF as non
+     * executable. This is the Cortex-M SRAM region used for on-chip RAM.
+     */
+    mpu_configure(
+        2,                                               /* Region 0 and 1 are used by mpu_stack_guard */
+        (uintptr_t)&_sram,                               /* RAM base address */
+        MPU_ATTR(1, AP_RW_RW, 0, 1, 0, 1, MPU_SIZE_512M) /* Allow read/write but no exec */
+    );
+#endif
+
+#ifdef MODULE_MPU_STACK_GUARD
     if (((uintptr_t)&_sstack) != SRAM_BASE) {
         mpu_configure(
             0,                                              /* MPU region 0 */

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -56,6 +56,7 @@ PSEUDOMODULES += log_printfnoformat
 PSEUDOMODULES += log_color
 PSEUDOMODULES += lora
 PSEUDOMODULES += mpu_stack_guard
+PSEUDOMODULES += mpu_noexec_ram
 PSEUDOMODULES += nanocoap_%
 PSEUDOMODULES += netdev_default
 PSEUDOMODULES += netstats

--- a/tests/mpu_noexec_ram/Makefile
+++ b/tests/mpu_noexec_ram/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += mpu_noexec_ram
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mpu_noexec_ram/README.md
+++ b/tests/mpu_noexec_ram/README.md
@@ -1,0 +1,10 @@
+# mpu_noexec_ram
+
+Tests for the `mpu_noexec_ram` pseudomodule. As this module is currently
+only supported on Cortex M devices, the test case is a bit ARM specific.
+
+## Output
+
+With `USEMODULE += mpu_noexec_ram` in `Makefile` this application should
+execute a kernel panic from the `MEM MANAGE HANDLER`. Without this
+pseudomodule activated, it will run into a hard fault.

--- a/tests/mpu_noexec_ram/main.c
+++ b/tests/mpu_noexec_ram/main.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Sören Tempel <tempel@uni-bremen.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief Test application for the mpu_noexec_stack pseudo-module
+ *
+ * @author Sören Tempel <tempel@uni-bremen.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "cpu.h"
+#include "mpu.h"
+
+/* RIOT's MPU headers gracefully fail when no MPU is present.
+ * Use this to catch if RIOT's features are correctly gating MPU use.
+ */
+#if !__MPU_PRESENT
+#error "(!__MPU_PRESENT)"
+#endif
+
+#define JMPBUF_SIZE 3
+
+int main(void)
+{
+    uint32_t buf[JMPBUF_SIZE];
+
+    /* Fill the buffer with invalid instructions */
+    for (unsigned i = 0; i < JMPBUF_SIZE; i++) {
+        buf[i] = UINT32_MAX;
+    }
+
+    puts("Attempting to jump to stack buffer ...\n");
+    __asm__ volatile ("BX %0"
+                      : /* no output operands */
+                      : "r" ((uint8_t*)&buf + 1)); /* LSB must be set for thumb2 */
+
+    return 0;
+}

--- a/tests/mpu_noexec_ram/tests/01-run.py
+++ b/tests/mpu_noexec_ram/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Sören Tempel <tempel@uni-bremen.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("MEM MANAGE HANDLER\r\n")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=10))


### PR DESCRIPTION
### Contribution description

[Executable space protections][0] are a protection mechanism for
operating system security which mitigate exploitation of buffer
overflows. The exploit payload, used for exploiting buffer overflows, is
often placed in the buffer itself. As an example, consider the exploit
for `sock_dns` from #10739.

Considering a stack-based buffer overflow, the attacker can simply
overwrite the function return address with the address of the buffer
thereby causing the code contained in it to be executed. I've worked on
techniques for preventing the overwrite of the function return address
(#13119, #13175) but these can be circumvented. As such, conventional
operating system also mark the text and data segment non-executable to
prevent attackers from placing exploit payloads there (executable space
protections). Enforcing this efficiently requires a memory protection or
memory management unit.

I noticed recently that RIOT already supports the Cortex-M4 MPU. Using
this MPU on the `nucleo-f401re` I came up with an implementation of
executable space protections for RIOT. The implementation is entirely
optional and must be activated explicitly by using the `mpu_noexec_ram`
pseudomodule. When activated, the entire SRAM section is marked as non
executable, reads- and writes are still allowed.

Kudos to @pyropeter for helping out with this.

### Testing procedure

The changes proposed here also include a test for this pseudo module.
The test is further described in `tests/mpu_noexec_ram/README.md`. The
test successfully passed with `BOARD=nucleo-f401re`.

### Issues/PRs references

Executable space protections can be circumvented through code-reuse
attacks (e.g. [return-to-libc][1] or [ROP][2] in the general case). These attacks
can be mitigated through address randomization techniques such as ASLR.
While ASLR is not deemed employable on constrained devices, a different
address randomization technique, often referred to as link time reordering is.

This technique has been implemented by myself for RIOT in #13176. I
would highly recommended that this is merged as well though this PR does
not technically depend on it.

[0]: https://en.wikipedia.org/wiki/Executable_space_protection
[1]: https://en.wikipedia.org/wiki/Return-to-libc_attack
[2]: https://en.wikipedia.org/wiki/Return-oriented_programming