### PR TITLE
cpu/cortexm: move CPU_ARCH/FAM to Makefile.features

### DIFF
--- a/cpu/cc2538/Makefile.features
+++ b/cpu/cc2538/Makefile.features
@@ -1,3 +1,5 @@
+CPU_ARCH = cortex-m3
+
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_hwrng

--- a/cpu/cc2538/Makefile.include
+++ b/cpu/cc2538/Makefile.include
@@ -1,3 +1,1 @@
-CPU_ARCH = cortex-m3
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/cc26x0/Makefile.features
+++ b/cpu/cc26x0/Makefile.features
@@ -1,1 +1,3 @@
+CPU_ARCH = cortex-m3
+
 -include $(RIOTCPU)/cc26xx_cc13xx/Makefile.features

--- a/cpu/cc26x0/Makefile.include
+++ b/cpu/cc26x0/Makefile.include
@@ -1,4 +1,3 @@
-CPU_ARCH = cortex-m3
 CPU_VARIANT = x0
 
 VECTORS_O = $(BINDIR)/cc26xx_cc13xx/vectors.o

--- a/cpu/cc26x2_cc13x2/Makefile.features
+++ b/cpu/cc26x2_cc13x2/Makefile.features
@@ -1,1 +1,3 @@
+CPU_ARCH = cortex-m4f
+
 -include $(RIOTCPU)/cc26xx_cc13xx/Makefile.features

--- a/cpu/cc26x2_cc13x2/Makefile.include
+++ b/cpu/cc26x2_cc13x2/Makefile.include
@@ -1,4 +1,3 @@
-CPU_ARCH = cortex-m4f
 CPU_VARIANT = x2
 
 VECTORS_O = $(BINDIR)/cc26xx_cc13xx/vectors.o

--- a/cpu/ezr32wg/Makefile.features
+++ b/cpu/ezr32wg/Makefile.features
@@ -1,3 +1,5 @@
+CPU_ARCH = cortex-m4f
+
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 

--- a/cpu/ezr32wg/Makefile.include
+++ b/cpu/ezr32wg/Makefile.include
@@ -1,3 +1,1 @@
-CPU_ARCH = cortex-m4f
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/lm4f120/Makefile.features
+++ b/cpu/lm4f120/Makefile.features
@@ -1,1 +1,3 @@
+CPU_ARCH = cortex-m4f
+
 -include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/lm4f120/Makefile.include
+++ b/cpu/lm4f120/Makefile.include
@@ -1,5 +1,3 @@
-CPU_ARCH = cortex-m4f
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk
 
 include $(RIOTCPU)/stellaris_common/Makefile.include

--- a/cpu/lpc1768/Makefile.features
+++ b/cpu/lpc1768/Makefile.features
@@ -1,5 +1,7 @@
+CPU_ARCH = cortex-m3
 # This CPU only implements one CPU_MODEL with the same name
 CPU_MODEL = lpc1768
+
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_pm
 

--- a/cpu/lpc1768/Makefile.include
+++ b/cpu/lpc1768/Makefile.include
@@ -1,3 +1,1 @@
-CPU_ARCH = cortex-m3
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/nrf51/Makefile.features
+++ b/cpu/nrf51/Makefile.features
@@ -1,1 +1,4 @@
+CPU_ARCH = cortex-m0
+CPU_FAM  = nrf51
+
 -include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf51/Makefile.include
+++ b/cpu/nrf51/Makefile.include
@@ -1,5 +1,2 @@
-CPU_ARCH = cortex-m0
-CPU_FAM  = nrf51
-
 include $(RIOTCPU)/nrf5x_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/nrf52/Makefile.features
+++ b/cpu/nrf52/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m4f
+CPU_FAM  = nrf52
+
 # The ADC does not depend on any board configuration, so always available
 FEATURES_PROVIDED += periph_adc
 

--- a/cpu/nrf52/Makefile.include
+++ b/cpu/nrf52/Makefile.include
@@ -1,6 +1,3 @@
-CPU_ARCH = cortex-m4f
-CPU_FAM  = nrf52
-
 # Slot size is determined by "((total_flash_size - RIOTBOOT_LEN) / 2)".
 # If RIOTBOOT_LEN uses an uneven number of flashpages, the remainder of the
 # flash cannot be divided by two slots while staying FLASHPAGE_SIZE aligned.

--- a/cpu/sam3/Makefile.features
+++ b/cpu/sam3/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m3
+CPU_FAM  = sam3
+
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
 

--- a/cpu/sam3/Makefile.include
+++ b/cpu/sam3/Makefile.include
@@ -1,5 +1,2 @@
-CPU_ARCH = cortex-m3
-CPU_FAM  = sam3
-
 include $(RIOTCPU)/sam_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/samd21/Makefile.features
+++ b/cpu/samd21/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m0plus
+CPU_FAM  = samd21
+
 FEATURES_PROVIDED += puf_sram
 
 -include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/samd21/Makefile.include
+++ b/cpu/samd21/Makefile.include
@@ -1,6 +1,3 @@
-CPU_ARCH = cortex-m0plus
-CPU_FAM  = samd21
-
 ifneq (,$(filter samd21%a,$(CPU_MODEL)))
   CFLAGS += -DCPU_SAMD21A
 endif

--- a/cpu/samd5x/Makefile.features
+++ b/cpu/samd5x/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m4f
+CPU_FAM  = samd5x
+
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += backup_ram
 

--- a/cpu/samd5x/Makefile.include
+++ b/cpu/samd5x/Makefile.include
@@ -1,6 +1,3 @@
-CPU_ARCH = cortex-m4f
-CPU_FAM  = samd5x
-
 ifneq (,$(filter samd51%,$(CPU_MODEL)))
   CFLAGS += -DCPU_SAMD51
 endif

--- a/cpu/saml1x/Makefile.features
+++ b/cpu/saml1x/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m23
+CPU_FAM  = saml1x
+
 FEATURES_PROVIDED += periph_hwrng
 
 include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml1x/Makefile.include
+++ b/cpu/saml1x/Makefile.include
@@ -1,5 +1,3 @@
-CPU_ARCH = cortex-m23
-
 ifneq (,$(filter saml10%,$(CPU_MODEL)))
   CFLAGS += -DCPU_SAML10
 endif

--- a/cpu/saml21/Makefile.features
+++ b/cpu/saml21/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m0plus
+CPU_FAM  = saml21
+
 # The SAMR30 line of MCUs does not contain a TRNG
 BOARDS_WITHOUT_HWRNG += samr30-xpro
 

--- a/cpu/saml21/Makefile.include
+++ b/cpu/saml21/Makefile.include
@@ -1,6 +1,3 @@
-CPU_ARCH = cortex-m0plus
-CPU_FAM  = saml21
-
 ifneq (,$(filter saml21%a,$(CPU_MODEL)))
   CFLAGS += -DCPU_SAML21A
 endif

--- a/cpu/stm32f0/Makefile.features
+++ b/cpu/stm32f0/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m0
+CPU_FAM  = stm32f0
+
 ifeq (,$(filter nucleo-f031k6,$(BOARD)))
   FEATURES_PROVIDED += periph_flashpage
   FEATURES_PROVIDED += periph_flashpage_raw

--- a/cpu/stm32f0/Makefile.include
+++ b/cpu/stm32f0/Makefile.include
@@ -1,5 +1,2 @@
-CPU_ARCH = cortex-m0
-CPU_FAM  = stm32f0
-
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32f1/Makefile.features
+++ b/cpu/stm32f1/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m3
+CPU_FAM  = stm32f1
+
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
 FEATURES_PROVIDED += periph_rtc

--- a/cpu/stm32f1/Makefile.include
+++ b/cpu/stm32f1/Makefile.include
@@ -1,5 +1,2 @@
-CPU_ARCH = cortex-m3
-CPU_FAM  = stm32f1
-
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32f2/Makefile.features
+++ b/cpu/stm32f2/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m3
+CPU_FAM  = stm32f2
+
 FEATURES_PROVIDED += periph_hwrng
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f2/Makefile.include
+++ b/cpu/stm32f2/Makefile.include
@@ -1,6 +1,3 @@
-CPU_ARCH = cortex-m3
-CPU_FAM  = stm32f2
-
 # STM32F2 uses sectors instead of pages, where the minimum sector length is 16KB
 # (the first sector), therefore RIOTBOOT_LEN must be 16KB to cover a whole sector.
 RIOTBOOT_LEN ?= 0x4000

--- a/cpu/stm32f3/Makefile.features
+++ b/cpu/stm32f3/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m4f
+CPU_FAM  = stm32f3
+
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
 

--- a/cpu/stm32f3/Makefile.include
+++ b/cpu/stm32f3/Makefile.include
@@ -1,5 +1,2 @@
-CPU_ARCH = cortex-m4f
-CPU_FAM  = stm32f3
-
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32f4/Makefile.features
+++ b/cpu/stm32f4/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m4f
+CPU_FAM  = stm32f4
+
 FEATURES_PROVIDED += periph_hwrng
 
 # the granularity of provided feature definition for STMs is currently by CPU

--- a/cpu/stm32f4/Makefile.include
+++ b/cpu/stm32f4/Makefile.include
@@ -1,6 +1,3 @@
-CPU_ARCH = cortex-m4f
-CPU_FAM  = stm32f4
-
 # STM32F4 uses sectors instead of pages, where the minimum sector length is 16KB
 # (the first sector), therefore RIOTBOOT_LEN must be 16KB to cover a whole sector.
 RIOTBOOT_LEN ?= 0x4000

--- a/cpu/stm32f7/Makefile.features
+++ b/cpu/stm32f7/Makefile.features
@@ -1,2 +1,5 @@
+CPU_ARCH = cortex-m7
+CPU_FAM  = stm32f7
+
 FEATURES_PROVIDED += periph_hwrng
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f7/Makefile.include
+++ b/cpu/stm32f7/Makefile.include
@@ -1,6 +1,3 @@
-CPU_ARCH = cortex-m7
-CPU_FAM  = stm32f7
-
 # STM32F7 uses sectors instead of pages, where the minimum sector length is 16KB or
 # 32kB (the first sector), depending on the CPU_MODEL. Therefore RIOTBOOT_LEN must
 # be 16KB or 32kB to cover a whole sector.

--- a/cpu/stm32l0/Makefile.features
+++ b/cpu/stm32l0/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m0plus
+CPU_FAM  = stm32l0
+
 FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw

--- a/cpu/stm32l0/Makefile.include
+++ b/cpu/stm32l0/Makefile.include
@@ -1,5 +1,2 @@
-CPU_ARCH = cortex-m0plus
-CPU_FAM  = stm32l0
-
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32l1/Makefile.features
+++ b/cpu/stm32l1/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m3
+CPU_FAM  = stm32l1
+
 FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw

--- a/cpu/stm32l1/Makefile.include
+++ b/cpu/stm32l1/Makefile.include
@@ -1,5 +1,2 @@
-CPU_ARCH = cortex-m3
-CPU_FAM  = stm32l1
-
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32l4/Makefile.features
+++ b/cpu/stm32l4/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = cortex-m4f
+CPU_FAM  = stm32l4
+
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
 FEATURES_PROVIDED += periph_hwrng

--- a/cpu/stm32l4/Makefile.include
+++ b/cpu/stm32l4/Makefile.include
@@ -1,6 +1,3 @@
-CPU_ARCH = cortex-m4f
-CPU_FAM  = stm32l4
-
 # "The Vector table must be naturally aligned to a power of two whose alignment
 # value is greater than or equal to number of Exceptions supported x 4"
 # CPU_IRQ_NUMOFF for stm32l4 boards is < 91+16 so (107*4 bytes = 428 bytes ~= 0x200)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR moves CPU_ARCH/CPU_FAM variables defined for cortexm CPUs from Makefile.include to Makefile.features.

This allows for determining earlier if some CortexM sub-architectures provides low-level features, such FPU or MPU.

The efm32 were already updated this way in #13174.
The kinetis family is not adapted yet because it needs more work. This can be done in follow-up PRs.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock should be ok

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Required by ##13391 and #13236. Also related to #9913.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
