### PR TITLE
[smoke test] Remove msp430 from blacklists

### DIFF
--- a/pkg/libfixmath/Makefile.dep
+++ b/pkg/libfixmath/Makefile.dep
@@ -2,7 +2,4 @@ ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))
   # libfixmath unittests use shift operand incompatible with 8bit
   # architecture int type.
   FEATURES_BLACKLIST += arch_8bit
-
-  # The round function is not provided by the msp430 toolchain
-  FEATURES_BLACKLIST += arch_msp430
 endif

--- a/pkg/semtech-loramac/Makefile.dep
+++ b/pkg/semtech-loramac/Makefile.dep
@@ -5,7 +5,3 @@ USEMODULE += semtech_loramac_mac
 USEMODULE += semtech_loramac_mac_region
 USEMODULE += semtech_loramac_crypto
 USEMODULE += semtech_loramac_arch
-
-# The build fails on MSP430 because the toolchain doesn't provide
-# EXIT_SUCCESS/EXIT_FAILURE macros
-FEATURES_BLACKLIST += arch_msp430

--- a/pkg/ubasic/Makefile.dep
+++ b/pkg/ubasic/Makefile.dep
@@ -1,9 +1,6 @@
 # avr-libc does not provide `clock `required by ubasic_tests
 FEATURES_BLACKLIST += arch_avr8
 
-# msp430-libc does not provide `stdout` variable required by ubasic_tests
-FEATURES_BLACKLIST += arch_msp430
-
 # newlib for MIPS does not provide _times_r
 FEATURES_BLACKLIST += arch_mips32r2
 

--- a/tests/driver_cc110x/Makefile
+++ b/tests/driver_cc110x/Makefile
@@ -3,9 +3,6 @@ include ../Makefile.tests_common
 
 DEVICE ?= cc1100 # The MSB-A2 uses the CC1100. New boards use CC1101
 
-# stdlib.h for msp430 does not provide EXIT_FAILURE and EXIT_SUCCESS
-BOARD_BLACKLIST += msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
-
 # This test will rely on a human interacting with the shell, so we better add
 # the shell and some commands
 USEMODULE += shell

--- a/tests/driver_dcf77/Makefile
+++ b/tests/driver_dcf77/Makefile
@@ -2,5 +2,4 @@ include ../Makefile.tests_common
 
 USEMODULE += dcf77
 
-FEATURES_BLACKLIST += arch_msp430
 include $(RIOTBASE)/Makefile.include

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -2,9 +2,6 @@
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
-# MSP-430 doesn't support C11's atomic functionality yet
-FEATURES_BLACKLIST += arch_msp430
-
 USEPKG += emb6
 
 USEMODULE += emb6_router

--- a/tests/periph_pm/Makefile
+++ b/tests/periph_pm/Makefile
@@ -1,9 +1,6 @@
 BOARD ?= slstk3401a
 include ../Makefile.tests_common
 
-# method `fflush()` is not defined for MSP-430 (#6445 will fix this)
-BOARD_BLACKLIST := chronos msb-430h msb-430 telosb wsn430-v1_3b wsn430-v1_4 z1
-
 FEATURES_OPTIONAL += periph_rtc
 FEATURES_OPTIONAL += periph_gpio_irq
 

--- a/tests/pkg_minmea/Makefile
+++ b/tests/pkg_minmea/Makefile
@@ -4,7 +4,4 @@ USEPKG += minmea
 
 USEMODULE += fmt
 
-# The MSP-430 toolchain lacks mktime and NAN
-BOARD_BLACKLIST := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -4,7 +4,4 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += timex
 
-# The MSP-430 toolchain lacks sscanf:
-BOARD_BLACKLIST := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/unittests/tests-rtc/Makefile.include
+++ b/tests/unittests/tests-rtc/Makefile.include
@@ -2,9 +2,6 @@ CFLAGS += -DRTC_NORMALIZE_COMPAT=1
 
 USEMODULE += periph_rtc_common
 
-# MSP-430's libc does not provide `mktime()` used by this test
-FEATURES_BLACKLIST += arch_msp430
-
 # AVR/ATmega uses `int8_t` for `struct tm` which leads to integer overflows
 # in these tests
 FEATURES_BLACKLIST += arch_avr8


### PR DESCRIPTION
### Contribution description

With the updated toolchain, the blacklisting of msp430 might not be needed anymore.
Let's find out!

### Testing procedure

Murdock will tell if the blacklisting is still needed.


### Issues/PRs references
~~made possible by https://github.com/RIOT-OS/riotdocker/pull/99~~
#12457 - oops, this has not been merged yet. Will rebase once it's in.
