### PR TITLE
boards: update doc of phyNode (pba-d-01-kw2x)

### DIFF
--- a/boards/pba-d-01-kw2x/doc.txt
+++ b/boards/pba-d-01-kw2x/doc.txt
@@ -9,17 +9,15 @@ Designed and produced by PHYTEC Messtechnik GmbH, D-55129 Mainz.
 contact@phytec.de
 
 ## Overview
-The [Phytec IoT wiki](https://github.com/PHYTEC-Messtechnik-GmbH/phynode-riot-examples/wiki)
-describes the phyWAVE module and the phyNODE board more
-detailed. The links below will guide you directly to the corresponding chapter:
- * [Overview](https://github.com/PHYTEC-Messtechnik-GmbH/phynode-riot-examples/wiki/)
- * [Introduction](https://github.com/PHYTEC-Messtechnik-GmbH/phynode-riot-examples/wiki/Introduction)
- * Hardware descriptions for the
-[phyWAVE](https://github.com/PHYTEC-Messtechnik-GmbH/phynode-riot-examples/wiki/phyWAVE-KW2x-Characteristics)
-and the
-[phyNODE](https://github.com/PHYTEC-Messtechnik-GmbH/phynode-riot-examples/wiki/phyNODE-Characteristics)
- * [Toolchain, build and debug Information](https://github.com/PHYTEC-Messtechnik-GmbH/phynode-riot-examples/wiki/RIOT-getting-started#toolchain-summary)
- * [A detailed step-by-step Guide that explains how to set up the Environment](https://github.com/PHYTEC-Messtechnik-GmbH/phynode-riot-examples/wiki/RIOT-getting-started#step-by-step-installation-guide)
+
+The phyNODE evaluation board consists of a [phyWAVE](https://www.phytec.de/produkte/internet-of-things/phywave/)
+module mounted on a common PCB with several sensor and actuator modules.
+The board provides 2 USB ports. The one next to the white imprint *cmsis-dap*
+is meant for development (debug and flash). The second one, next to the golden
+*PHYTEC* imprint, is connected to the USB peripheral of the MCU and may be used
+by a firmware (currently not supported).
+
+
 The implementation status of the phyWAVE and phyNODE peripherals are listed
 below. You can find links to the corresponding Pull Requests which may give you
 a code reference.
@@ -27,11 +25,10 @@ a code reference.
 <img src="https://raw.githubusercontent.com/jremmert-phytec-iot/Pictures_Phytec_IOT/master/EvalBoard_3.png" width="800" />
 phyNODE board with equipped phyWAVE-KW2x processor/radio-module.
 
-### Details
-The PCB-pieces with the mounted sensors can be separated from the evaluation
-board to capture sensor values from specific spatial points.
+@note The PCB-pieces with the mounted sensors can be separated from the
+      evaluation board to capture sensor values from specific spatial points.
 
-### Pinout Reference
+## Pinout Reference
 
 The board features an Arduino like header connector to mount shields. The
 spacing of the 4 pin rows is a bit offset, thus shields might not fit perfectly.

--- a/boards/pba-d-01-kw2x/doc.txt
+++ b/boards/pba-d-01-kw2x/doc.txt
@@ -86,5 +86,5 @@ The actual pin configuration of the board for RIOT can be found in
 | Magnetometer   | [MAG3110FCR1](http://www.nxp.com/products/sensors/magnetometers/sample-data-sets-for-inertial-and-magnetic-sensors/freescale-high-accuracy-3d-magnetometer:MAG3110)   | yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/2121) |
 | Light Sensor   | [TCS3772](https://ams.com/jpn/content/download/291143/1065677/file/TCS3772_Datasheet_EN_v1.pdf)   | yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/3135) |
 | IR-Termopile Sensor    | [TMP006](http://www.ti.com/product/TMP006)    |yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/2148) |
-| Capacitive Button  | PCB   | no        | planned |
+| Capacitive Button  | PCB   | yes        | [mainline](https://github.com/RIOT-OS/RIOT/pull/7147) |
  */

--- a/boards/pba-d-01-kw2x/doc.txt
+++ b/boards/pba-d-01-kw2x/doc.txt
@@ -31,7 +31,41 @@ phyNODE board with equipped phyWAVE-KW2x processor/radio-module.
 The PCB-pieces with the mounted sensors can be separated from the evaluation
 board to capture sensor values from specific spatial points.
 
-[Pinout reference](https://github.com/PHYTEC-Messtechnik-GmbH/phynode-riot-examples/wiki/Interfaces)
+### Pinout Reference
+
+The board features an Arduino like header connector to mount shields. The
+spacing of the 4 pin rows is a bit offset, thus shields might not fit perfectly.
+
+The pinout below shows the vendor specific naming and functionality.
+The actual pin configuration of the board for RIOT can be found in
+[periph_conf.h](https://github.com/RIOT-OS/RIOT/blob/master/boards/pba-d-01-kw2x/include/periph_conf.h).
+
+@note Not all signals and pins are compatible with Arduino Uno R3.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                             _X1____________________
+                            |                   D15 |___DIO21, PE19, I2C0 SCL
+                            |                   D14 |___DIO20, PE18, I2C0 SDA
+                            |                  AREF |___AREF,  VCC3V3
+                            |                  GND3 |___GND
+                        X___| RESERVED          D13 |___DIO3,  PC5,  SPI0 SCK
+                   VCC3V3___| IOREF             D12 |___DIO5,  PC7,  SPI0 MISO
+                   nRESET___| RST TGTMCU        D11 |___DIO4,  PC6,  SPI0 MOSI
+                   VCC3V3___| P3V3              D10 |___DIO2,  PC4,  SPI0 CS0
+              P5V USB OUT___| P5V USB            D9 |___DIO9,  PD4,  PWM
+                GND_________| GND2               D8 |___DIO6,  PD1
+                        \___| GND1                  |
+                        X___| P5_9V VIN          D7 |___DIO24, PA1,  PWM,  TDI2
+                            |                    D6 |___DIO25, PA2,  PWM,  TDO2
+ DIO15, PE2, ADC         ___| A0                 D5 |___DIO11, PD6,  PWM
+ DIO16, PE3, ADC, TDO1   ___| A1                 D4 |___DIO29, PA19, TCLKIN
+ DIO12, PD7, ADC         ___| A2                 D3 |___DIO27, PA4,  PWM
+ DIO10, PD5, ADC         ___| A3                 D2 |___DIO17, PE4,  LLWU, TDI1
+ DIO13, PE0, ADC, I2CSDA ___| A4                 D1 |___DIO8,  PD3,  UART2 TX
+ DIO14, PE1, ADC, I2CSCL ___| A5                 D0 |___DIO7,  PD2,  UART2 RX
+                             -----------------------
+                             Arduino Uno R3 Connector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ## Implementation Status
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This updates the documentation of the phyNode (pba-d-01-kw2x) board, because PhyTec (vendor) removed most of the GitHub content we linked to. Hence I add an ASCII for the pinout reference, removed/replaced dead links and updated the supported feature list.


### Testing procedure

Run make doc and have a look at it under boards->pba-d-01-kw2x.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
