### PR TITLE
code: relax max line length to 120

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -11,7 +11,7 @@
   https://www.kernel.org/doc/Documentation/process/coding-style.rst with the
   following modifications and additions:
     * Line length: aim for no more than 80 characters per line, the absolute
-      maximum should be 100 characters per line.
+      maximum should be 120 characters per line.
     * All line endings shall be set to LF (`\n`). (How to handle line endings in
       Git: https://help.github.com/articles/dealing-with-line-endings)
     * There must be no trailing whitespace in any line.

--- a/CODING_CONVENTIONS_C++.md
+++ b/CODING_CONVENTIONS_C++.md
@@ -127,9 +127,9 @@ void my_class::do_something_else() {
 
 - Use 4 spaces per indentation level.
 
-- The maximum number of characters per line is 80.
-
 - No tabs, ever.
+
+- Aim for 80 characters per line, and do not exceed a maximum of 120.
 
 - Never use C-style casts.
 

--- a/dist/tools/vera++/profiles/riot_force_params.txt
+++ b/dist/tools/vera++/profiles/riot_force_params.txt
@@ -1,2 +1,2 @@
-max-line-length=100
+max-line-length=120
 max-consecutive-empty-lines=1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Relax when vera++ will error bc of line length, set max from 100 to 120 here.


### Testing procedure

let CI run static checks


### Issues/PRs references

- #9778 original PR introducing vera
- #13256 had issues bc of 100 chars length error
