### PR TITLE
Makefile.dep: Fix duplicate modules from USEMODULE

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1052,10 +1052,12 @@ USEMODULE := $(sort $(USEMODULE))
 USEPKG := $(sort $(USEPKG))
 ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
   include $(RIOTBASE)/Makefile.dep
-endif
-
-# Add auto_init_% DEFAULT_MODULES. This is done after the recursive cach since
-# none of these modules can trigger dependency resolution.
-ifneq (,$(filter auto_init,$(USEMODULE)))
-  USEMODULE += $(filter auto_init_%,$(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
+else
+  # Add auto_init_% DEFAULT_MODULES. This is done after the recursive cach since
+  # none of these modules can trigger dependency resolution.
+  ifneq (,$(filter auto_init,$(USEMODULE)))
+    DEFAULT_MODULE := $(sort $(DEFAULT_MODULE))
+    USEMODULE += $(filter auto_init_%,$(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
+    USEMODULE := $(sort $(USEMODULE))
+  endif
 endif


### PR DESCRIPTION
### Contribution description
With the changes introduced in #13089 the list of `USEMODULE`s shows multiple times `auto_init_%` modules. 

There are multiple reasons for this:
1. The logic that adds the `auto_init_%`  `DEFAULT_MODULES` to `USEMODULE` is placed at the end of `Makefile.dep`, which means that it gets executed multiple times (due to recursive inclusion of `Makefile.dep`).
2. `DEFAULT_MODULES` is not sorted (unlike `USEMODULE`) so it holds duplicates.
3. In `Makefile.include` `USEMODULE` is extended with the not-disabled `DEFAULT_MODULE`s, but the assignment is not simply expanded, so it only gets expended after a first iteration of `Makefile.dep`. This means that the `DEFAULT_MODULE` list may already have new elements.

Printing `USEMODULE` and filtering duplicates, for example, for `examples/gcoap` returns:

```sh
make info-debug-variable-USEMODULE | tr " " "\n" | sort | uniq -d
```

**On master:**
```
auto_init_gnrc_ipv6
auto_init_gnrc_ipv6_nib
auto_init_gnrc_pktbuf
auto_init_gnrc_udp
auto_init_random
auto_init_xtimer
```
**With PR:**
```sh
# empty
```

### Testing procedure
- Check with `make info-debug-variable-USEMODULE` that modules are not longer duplicated, and the list of not duplicated is the same.

### Issues/PRs references
#13089