### PR TITLE
vera++: remove non-zero exit code

### DIFF
--- a/dist/tools/vera++/check.sh
+++ b/dist/tools/vera++/check.sh
@@ -29,8 +29,8 @@ VERA_CMD="vera++ --root $CURDIR --exclusions $CURDIR/exclude $_QUIET"
 
 if [ $WARNING -ne 0 ]; then
     echo "$FILES" | $VERA_CMD --profile riot \
-        --parameters $CURDIR/profiles/riot_params.txt | sed 's/^/warning: /g'
+        --parameters $CURDIR/profiles/riot_params.txt -w | sed 's/^/warning: /g'
 fi
 
 echo "$FILES" | $VERA_CMD --profile riot_force \
-    --parameters $CURDIR/profiles/riot_force_params.txt --error
+    --parameters $CURDIR/profiles/riot_force_params.txt -w


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As pointed out in https://github.com/RIOT-OS/RIOT/pull/13400#issuecomment-587593011, Vera++ is producing several errors for existing code.

In order to ease the migration, I propose to move remove the non-zero exit code for Vera++, fix all issues found by Vera++ (similar to https://github.com/RIOT-OS/RIOT/pull/12558) and then re enable it back.

This PR basically tells Vera++ to always exit with error code 0. Errors and warning are still displayed in Travis.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#12558
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
