### PR TITLE
sys/riotboot: provide riotboot_slot_offset()

### DIFF
--- a/sys/include/riotboot/slot.h
+++ b/sys/include/riotboot/slot.h
@@ -94,6 +94,11 @@ static inline void riotboot_slot_print_hdr(unsigned slot)
 }
 
 /**
+ * @brief Get the offset (in flash, in bytes) for a given slot.
+ */
+size_t riotboot_slot_offset(unsigned slot);
+
+/**
  * @brief  Dump the addresses of all configured slots
  *
  */

--- a/sys/riotboot/slot.c
+++ b/sys/riotboot/slot.c
@@ -93,3 +93,8 @@ const riotboot_hdr_t *riotboot_slot_get_hdr(unsigned slot)
 
     return riotboot_slots[slot];
 }
+
+size_t riotboot_slot_offset(unsigned slot)
+{
+    return (size_t)riotboot_slot_get_hdr(slot) - CPU_FLASH_BASE;
+}

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -85,8 +85,7 @@ static int _cond_comp_offset(suit_v4_manifest_t *manifest, int key, nanocbor_val
     (void)key;
     uint32_t offset;
     nanocbor_get_uint32(it, &offset);
-    uint32_t other_offset = (uint32_t)riotboot_slot_get_hdr(riotboot_slot_other()) \
-                            - CPU_FLASH_BASE;
+    uint32_t other_offset = (uint32_t)riotboot_slot_offset(riotboot_slot_other());
     LOG_INFO("Comparing manifest offset %u with other slot offset %u\n",
            (unsigned)offset, (unsigned)other_offset);
     return other_offset == offset ? 0 : -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, a slot's offset in flash was calculated within the suit handler code by getting the address of a slot's header and subtracting CPU_FLASH_BASE.
That's ugly (and won't work if there is no CPU_FLASH_BASE, e.g., in a unittest running on native which we have in the queue).

This PR factors out that calculation into a function `riotboot_slot_offset(slotnum)`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
