### PR TITLE
Kconfig: Include application-specific symbols first

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -9,11 +9,11 @@ mainmenu "RIOT Configuration"
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
-rsource "drivers/Kconfig"
-rsource "sys/Kconfig"
-
 # The application may declare new symbols as well
 osource "$(APPDIR)/Kconfig"
+
+rsource "drivers/Kconfig"
+rsource "sys/Kconfig"
 
 comment "RIOT is in a migration phase."
 comment "Some configuration options may not be here. Use CFLAGS instead."


### PR DESCRIPTION
### Contribution description
Currently the application-specific Kconfig file is being included last. But the may be the case where an application would want to override some symbols defaults. To do that, we need to move the `osource` directive first in the root Kconfig.

### Testing procedure
- All configurations should be working as usual.
- You should see the `Application` menu first now in `tests/kconfig` when running `make menuconfig`.

### Issues/PRs references
Use case came up in #13307
