### PR TITLE
cpu/samd5x: use ONDEMAND bit to run clocks on demand

### DIFF
--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -203,4 +203,9 @@ void cpu_init(void)
 
     /* trigger static peripheral initialization */
     periph_init();
+
+    /* set ONDEMAND bit after all clocks have been configured */
+    /* This is to avoid setting the source for the main clock to ONDEMAND before using it. */
+    OSCCTRL->DFLLCTRLA.reg |= OSCCTRL_DFLLCTRLA_ONDEMAND;
+    OSCCTRL->Dpll[0].DPLLCTRLA.reg |= OSCCTRL_DPLLCTRLA_ONDEMAND;
 }


### PR DESCRIPTION
### Contribution description

Set the ONDEMAND bit so clocks are only run if they have a user configured.

This saves 390 µA on same54-xpro.

 - `examples/default`:

    before: 3.88 mA
    after : 3.49 mA

 - `examples/gnrc_networking`: (with REB215-XPRO EXT3)

    before: 13.29 mA
    after : 12.9  mA

The `ONDEMAND` bit is set at the end to avoid the situation of configuring a clock (not used, so it will not run yet) and then connecting GCLK0 to it.
Normally this would enable the clock, but as we just sourced the main clock from a stopped clock, this will never happen.

### Testing procedure

I ran both `examples/default` and `examples/gnrc_networking` with an `at86rf215` module connected.
Other than the drop in power consumption, I noticed no changes, that is send and receiving frames worked just as before.

### Issues/PRs references
inspired by #13406