### PR TITLE
pkg/cryptoauthlib: wake pulse implementation for CPUs supporting periph_i2c_reconfigure

### DIFF
--- a/pkg/cryptoauthlib/Makefile.dep
+++ b/pkg/cryptoauthlib/Makefile.dep
@@ -1,4 +1,5 @@
 USEMODULE += xtimer
 FEATURES_REQUIRED += periph_i2c
+FEATURES_OPTIONAL += periph_i2c_reconfigure
 DEFAULT_MODULE += auto_init_security
 USEMODULE += cryptoauthlib_contrib


### PR DESCRIPTION
### Contribution description

Microchip's CryptoAuth devices are connected solely by I2C SCL and SDA. They must be woken up with a LOW pulse on the SDA line with a duration of at least 100us.

The current implementation sends the data octet 0x00 onto the I2C bus. If the bus speed is blow 133kHz this works flawlessly. But if the bus is driven with 400kHz or even 1MHz (which is supported by the CryptoAuth devices), the wake pulse is too short and the device remains sleeping.

This PR changes the wake sequence for all CPUs that support the `periph_i2c_reconfigure` feature: The SDA pin is muxed back to GPIO functionality and a wake pulse is sent by `gpio_clear()`. After that, it is muxed back to the I2C peripheral.

### Testing procedure

I grabbed a SAMR30-XPRO board and applied the following patch:

```diff
diff --git a/boards/samr30-xpro/include/periph_conf.h b/boards/samr30-xpro/include/periph_conf.h
index a49035f23..72fb85a05 100644
--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -109,7 +109,7 @@ static const spi_conf_t spi_config[] = {
 static const i2c_conf_t i2c_config[] = {
     {
         .dev      = &(SERCOM1->I2CM),
-        .speed    = I2C_SPEED_NORMAL,
+        .speed    = I2C_SPEED_FAST,
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_C,
```

Afterwards I connected an ATECC608A to `I2C_DEV(0)` and tested `tests/pkg_cryptoauthlib_compare_sha256`:

```
jue@bart ~/P/R/t/pkg_cryptoauthlib_compare_sha256 $ make BOARD=samr30-xpro flash term
2020-05-06 11:55:03,041 # main(): This is RIOT! (Version: 2020.07-devel-449-g3e0d2a-feature/cryptoauthlib-gpio-wake)
2020-05-06 11:55:03,043 # RIOT SHA256: Success
2020-05-06 11:55:03,055 # ATCA SHA256: Success
```

### Issues/PRs references

#13014 
