### PR TITLE
cpu/sam0_common: gpio: reset MUX in gpio_init()

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -106,6 +106,9 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     /* configure the pin cfg */
     port->PINCFG[pin_pos].reg = (mode & MODE_PINCFG_MASK);
 
+    /* reset the pin mux */
+    port->PMUX[pin_pos >> 1].reg &= ~(0xf << (4 * (pin_pos & 0x1)));
+
     /* and set pull-up/pull-down if applicable */
     if (mode == GPIO_IN_PU) {
         port->OUTSET.reg = pin_mask;


### PR DESCRIPTION
### Contribution description

If we call `gpio_init()` on a pin that was previously configured to an alternative function, we need to reset the mux bits.

### Testing procedure

GPIOs should work as they did before, but when re-configuring a pin from an alternative function back to plain GPIO, this saves a call to `gpio_init_mux()`.


### Issues/PRs references

noticed when seeing #13412, but we do something similar when putting a board to sleep and want to ensure that the UART TX pin is not (idle) high.
