### PR TITLE
boards/same54-xpro: don't source peripheral clocks from main clock

### DIFF
--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -86,7 +86,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = SAM0_GCLK_MAIN,
+        .gclk_src = SAM0_GCLK_48MHZ,
     }
 };
 
@@ -112,7 +112,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
-        .gclk_src = SAM0_GCLK_MAIN,
+        .gclk_src = SAM0_GCLK_48MHZ,
 
     }
 };


### PR DESCRIPTION
### Contribution description

Use the dedicated 48 MHz clock as a source for the peripheral clocks.
This was already done for I2C to allow it to work despite the 120 MHz main clock.

Not running the peripherals off the main clock will allow for dynamic re-clocking of the main clock in the future, without affecting the operation of the peripherals.

It also gives more flexibility to the main clock selection in general.

### Testing procedure

SPI and UART should continue to work as before.
(Tested with ATREB215-XPRO connected to EXT3 on `same54-xpro`)

### Issues/PRs references

none
