### PR TITLE
cpu/sam0*: enhance power saving by switching EIC clock source during STANDBY mode

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -353,13 +353,35 @@ typedef struct {
 void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
 
 /**
+ * @brief   Called before the power management enters a power mode
+ *
+ * @param[in] deep
+ */
+void gpio_pm_cb_enter(int deep);
+
+/**
+ * @brief   Called after the power management left a power mode
+ *
+ * @param[in] deep
+ */
+void gpio_pm_cb_leave(int deep);
+
+/**
  * @brief   Wrapper for cortexm_sleep calling power management callbacks
  *
  * @param[in] deep
  */
 static inline void sam0_cortexm_sleep(int deep)
 {
+#ifdef MODULE_PERIPH_GPIO
+    gpio_pm_cb_enter(deep);
+#endif
+
     cortexm_sleep(deep);
+
+#ifdef MODULE_PERIPH_GPIO
+    gpio_pm_cb_leave(deep);
+#endif
 }
 
 /**

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -353,6 +353,16 @@ typedef struct {
 void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
 
 /**
+ * @brief   Wrapper for cortexm_sleep calling power management callbacks
+ *
+ * @param[in] deep
+ */
+static inline void sam0_cortexm_sleep(int deep)
+{
+    cortexm_sleep(deep);
+}
+
+/**
  * @brief   Returns the frequency of a GCLK provider.
  *
  * @param[in] id    The ID of the GCLK

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -56,6 +56,14 @@
 #define _EIC EIC
 #endif
 
+/**
+ * @brief   Clock source for the External Interrupt Controller
+ */
+typedef enum {
+    _EIC_CLOCK_FAST,
+    _EIC_CLOCK_SLOW
+} gpio_eic_clock_t;
+
 static gpio_isr_ctx_t gpio_config[NUMOF_IRQS];
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
@@ -155,6 +163,13 @@ void gpio_write(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
+
+#ifdef CPU_FAM_SAMD21
+#define EIC_SYNC() while (_EIC->STATUS.bit.SYNCBUSY)
+#else
+#define EIC_SYNC() while (_EIC->SYNCBUSY.bit.ENABLE)
+#endif
+
 static int _exti(gpio_t pin)
 {
     unsigned port_num = ((pin >> 7) & 0x03);
@@ -196,7 +211,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN(SAM0_GCLK_MAIN);
     /* disable the EIC module*/
     _EIC->CTRLA.reg = 0;
-    while (_EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
+    EIC_SYNC();
 #endif
     /* configure the active flank */
     _EIC->CONFIG[exti >> 3].reg &= ~(0xf << ((exti & 0x7) * 4));
@@ -217,13 +232,53 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     _EIC->WAKEUP.reg |= (1 << exti);
     /* enable the EIC module*/
     _EIC->CTRL.reg = EIC_CTRL_ENABLE;
-    while (_EIC->STATUS.reg & EIC_STATUS_SYNCBUSY) {}
+    EIC_SYNC();
 #else /* CPU_FAM_SAML21 */
     /* enable the EIC module*/
     _EIC->CTRLA.reg = EIC_CTRLA_ENABLE;
-    while (_EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
+    EIC_SYNC();
 #endif
     return 0;
+}
+
+inline static void reenable_eic(gpio_eic_clock_t clock) {
+#if !defined(CPU_SAMD21)
+    uint32_t ctrla_reg = EIC_CTRLA_ENABLE;
+
+    EIC->CTRLA.reg = 0;
+    EIC_SYNC();
+
+    if (clock == _EIC_CLOCK_SLOW) {
+        ctrla_reg |= EIC_CTRLA_CKSEL;
+    }
+
+    EIC->CTRLA.reg = ctrla_reg;
+    EIC_SYNC();
+#endif
+}
+
+void gpio_pm_cb_enter(int deep)
+{
+#if defined(PM_SLEEPCFG_SLEEPMODE_STANDBY)
+    (void) deep;
+
+    if (PM->SLEEPCFG.bit.SLEEPMODE == PM_SLEEPCFG_SLEEPMODE_STANDBY) {
+        DEBUG_PUTS("gpio: switching EIC to slow clock");
+        reenable_eic(_EIC_CLOCK_SLOW);
+    }
+#endif
+}
+
+void gpio_pm_cb_leave(int deep)
+{
+#if defined(PM_SLEEPCFG_SLEEPMODE_STANDBY)
+    (void) deep;
+
+    if (PM->SLEEPCFG.bit.SLEEPMODE == PM_SLEEPCFG_SLEEPMODE_STANDBY) {
+        DEBUG_PUTS("gpio: switching EIC to fast clock");
+        reenable_eic(_EIC_CLOCK_FAST);
+    }
+#endif
 }
 
 void gpio_irq_enable(gpio_t pin)
@@ -284,5 +339,17 @@ ISR_EICn(15)
 ISR_EICn(_other)
 #endif /* CPU_SAML1X */
 #endif /* CPU_SAML1X || CPU_SAMD5X */
+
+#else /* MODULE_PERIPH_GPIO_IRQ */
+
+void gpio_pm_cb_enter(int deep)
+{
+    (void) deep;
+}
+
+void gpio_pm_cb_leave(int deep)
+{
+    (void) deep;
+}
 
 #endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/samd21/periph/pm.c
+++ b/cpu/samd21/periph/pm.c
@@ -82,5 +82,5 @@ void pm_set(unsigned mode)
             break;
     }
 
-    cortexm_sleep(deep);
+    sam0_cortexm_sleep(deep);
 }

--- a/cpu/samd5x/periph/pm.c
+++ b/cpu/samd5x/periph/pm.c
@@ -57,5 +57,5 @@ void pm_set(unsigned mode)
     /* make sure value has been set */
     while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
 
-    cortexm_sleep(deep);
+    sam0_cortexm_sleep(deep);
 }

--- a/cpu/saml1x/periph/pm.c
+++ b/cpu/saml1x/periph/pm.c
@@ -47,5 +47,5 @@ void pm_set(unsigned mode)
         while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
     }
 
-    cortexm_sleep(0);
+    sam0_cortexm_sleep(0);
 }

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -119,7 +119,7 @@ void cpu_init(void)
 
     /* set OSC16M to 16MHz */
     OSCCTRL->OSC16MCTRL.bit.FSEL = 3;
-    OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 0;
+    OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 1;
     OSCCTRL->OSC16MCTRL.bit.RUNSTDBY = 0;
 
     _osc32k_setup();

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -55,5 +55,5 @@ void pm_set(unsigned mode)
         while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
     }
 
-    cortexm_sleep(0);
+    sam0_cortexm_sleep(0);
 }


### PR DESCRIPTION
### Contribution description

This is a follow up PR of issue #13406.

As discussed, the 16MHz clock is set to ONDEMAND mode, so the main clock is only active if it is actually required by the system.

The External Interrupt Controller (EIC) is clocked with the low power 32kHz clock in STANDBY mode.

### Testing procedure

```diff
diff --git a/cpu/saml21/periph/pm.c b/cpu/saml21/periph/pm.c
index ff2e3c5e9..4147afb73 100644
--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -21,7 +21,7 @@
 
 #include "periph/pm.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG (1)
 #include "debug.h"
 
 void pm_set(unsigned mode)
diff --git a/examples/hello-world/Makefile b/examples/hello-world/Makefile
index 258d8e9ba..5f5d3447a 100644
--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -12,6 +12,9 @@ RIOTBASE ?= $(CURDIR)/../..
 # development process:
 DEVELHELP ?= 1
 
+USEMODULE += periph_gpio_irq
+
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a..bdce69402 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,6 +20,15 @@
  */
 
 #include <stdio.h>
+#include "board.h"
+#include "periph/pm.h"
+#include "periph/gpio.h"
+
+void btn (void * ctx)
+{
+    (void) ctx;
+    puts("Huh?");
+}
 
 int main(void)
 {
@@ -28,5 +37,9 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    gpio_init_int(BTN0_PIN, BTN0_MODE, GPIO_FALLING, btn, NULL);
+
+    pm_set(1);
+
     return 0;
 }
```

```
2020-02-19 18:48:31,966 # main(): This is RIOT! (Version: 2018.10-RC1-6870-gae2b8-feature/saml21-pm-low-power)
2020-02-19 18:48:31,967 # Hello World!
2020-02-19 18:48:31,972 # You are running RIOT on a(n) samr30-xpro board.
2020-02-19 18:48:31,975 # This board features a(n) saml21 MCU.
2020-02-19 18:48:31,978 # pm_set(): setting STANDBY mode.
2020-02-19 18:48:31,981 # pm_set(): reduce EIC clock speed
2020-02-19 18:48:35,580 # Huh?
2020-02-19 18:48:35,584 # pm_set(): switch EIC clock back to fast speed
2020-02-19 18:48:37,097 # Huh?
2020-02-19 18:48:37,250 # Huh?
```


### Issues/PRs references

Issue #13406 
