### PR TITLE
boards/esp32: remove MCU feature table in board documentation

### DIFF
--- a/boards/esp32-mh-et-live-minikit/doc.txt
+++ b/boards/esp32-mh-et-live-minikit/doc.txt
@@ -60,37 +60,8 @@ This section describes
 
 ### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-Most features of the board are provided by the ESP32 SoC. The following table summarizes these features and gives an overview of which of these features are supported by RIOT. For detailed information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
-
-<center>
-MCU         | ESP32     | Supported by RIOT
-------------|-----------|------------------
-Vendor      | Espressif | |
-Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
-FPU         | yes (ULP - Ultra low power co-processor) | no
-RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 448 kByte | yes
-Flash       | 512 kByte ... 16 MByte |  yes
-Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
-Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no
-Timers      | 4 x 64 bit | yes
-ADCs        | 2 x SAR-ADC with up to 18 x 12 bit channels total | yes
-DACs        | 2 x DAC with 8 bit | yes
-GPIOs       | 34 (6 of them are only inputs) | yes
-I2Cs        | 2 | yes
-SPIs        | 4 | yes
-UARTs       | 3 | yes
-WiFi        | IEEE 802.11 b/g/n built in | yes
-Bluetooth   | v4.2 BR/EDR and BLE | no
-Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | yes
-IR          | up to 8 channels TX/RX | no
-Motor PWM   | 2 devices x 6 channels | yes
-LED PWM     | 16 channels | no
-Crypto      | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG | no
-Vcc         | 2.5 - 3.6 V | |
-Documents   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) | |
-</center>
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
 
 ### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
 

--- a/boards/esp32-olimex-evb/doc.txt
+++ b/boards/esp32-olimex-evb/doc.txt
@@ -53,37 +53,8 @@ This section describes
 
 ### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-Most features of the boards are provided by the ESP32 SoC. The following table summarizes these features and gives an overview of which of these features are supported by RIOT. For detailed information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
-
-<center>
-MCU         | ESP32     | Supported by RIOT
-------------|-----------|------------------
-Vendor      | Espressif | |
-Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
-FPU         | yes (ULP - Ultra low power co-processor) | no
-RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 448 kByte | yes
-Flash       | 512 kByte ... 16 MByte |  yes
-Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
-Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no
-Timers      | 4 x 64 bit | yes
-ADCs        | 2 x SAR-ADC with up to 18 x 12 bit channels total | yes
-DACs        | 2 x DAC with 8 bit | yes
-GPIOs       | 34 (6 of them are only inputs) | yes
-I2Cs        | 2 | yes
-SPIs        | 4 | yes
-UARTs       | 3 | yes
-WiFi        | IEEE 802.11 b/g/n built in | yes
-Bluetooth   | v4.2 BR/EDR and BLE | no
-Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | yes
-IR          | up to 8 channels TX/RX | no
-Motor PWM   | 2 devices x 6 channels | yes
-LED PWM     | 16 channels | no
-Crypto      | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG | no
-Vcc         | 2.5 - 3.6 V | |
-Documents   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) | |
-</center>
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
 
 ### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
 

--- a/boards/esp32-ttgo-t-beam/doc.txt
+++ b/boards/esp32-ttgo-t-beam/doc.txt
@@ -50,40 +50,8 @@ This section describes
 
 ### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-Most features of the board are provided by the ESP32 SoC. The following
-table summarizes these features and gives an overview of which of these
-features are supported by RIOT. For detailed information about the ESP32,
-see section \ref esp32_mcu "MCU ESP32".
-
-<center>
-MCU         | ESP32     | Supported by RIOT
-------------|-----------|------------------
-Vendor      | Espressif | |
-Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
-FPU         | yes (ULP - Ultra low power co-processor) | no
-RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 448 kByte | yes
-Flash       | 512 kByte ... 16 MByte |  yes
-Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
-Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no
-Timers      | 4 x 64 bit | yes
-ADCs        | 2 x SAR-ADC with up to 18 x 12 bit channels total | yes
-DACs        | 2 x DAC with 8 bit | yes
-GPIOs       | 34 (6 of them are only inputs) | yes
-I2Cs        | 2 | yes
-SPIs        | 4 | yes
-UARTs       | 3 | yes
-WiFi        | IEEE 802.11 b/g/n built in | yes
-Bluetooth   | v4.2 BR/EDR and BLE | no
-Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | yes
-IR          | up to 8 channels TX/RX | no
-Motor PWM   | 2 devices x 6 channels | yes
-LED PWM     | 16 channels | no
-Crypto      | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG | no
-Vcc         | 2.5 - 3.6 V | |
-Documents   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) | |
-</center>
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
 
 ### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
 

--- a/boards/esp32-wemos-lolin-d32-pro/doc.txt
+++ b/boards/esp32-wemos-lolin-d32-pro/doc.txt
@@ -46,37 +46,8 @@ This section describes
 
 ### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-Most features of the board are provided by the ESP32 SoC. The following table summarizes these features and gives an overview of which of these features are supported by RIOT. For detailed information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
-
-<center>
-MCU         | ESP32     | Supported by RIOT
-------------|-----------|------------------
-Vendor      | Espressif | |
-Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
-FPU         | yes (ULP - Ultra low power co-processor) | no
-RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 448 kByte | yes
-Flash       | 512 kByte ... 16 MByte |  yes
-Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
-Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no
-Timers      | 4 x 64 bit | yes
-ADCs        | 2 x SAR-ADC with up to 18 x 12 bit channels total | yes
-DACs        | 2 x DAC with 8 bit | yes
-GPIOs       | 34 (6 of them are only inputs) | yes
-I2Cs        | 2 | yes
-SPIs        | 4 | yes
-UARTs       | 3 | yes
-WiFi        | IEEE 802.11 b/g/n built in | yes
-Bluetooth   | v4.2 BR/EDR and BLE | no
-Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | yes
-IR          | up to 8 channels TX/RX | no
-Motor PWM   | 2 devices x 6 channels | yes
-LED PWM     | 16 channels | no
-Crypto      | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG | no
-Vcc         | 2.5 - 3.6 V | |
-Documents   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) | |
-</center>
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
 
 ### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
 

--- a/boards/esp32-wroom-32/doc.txt
+++ b/boards/esp32-wroom-32/doc.txt
@@ -40,37 +40,8 @@ This section describes
 
 ### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-Most features of ESP32 boards are provided by the ESP32 SoC. The following table summarizes these features and gives an overview of which of these features are supported by RIOT. For detailed information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
-
-<center>
-MCU         | ESP32     | Supported by RIOT
-------------|-----------|------------------
-Vendor      | Espressif | |
-Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
-FPU         | yes (ULP - Ultra low power co-processor) | no
-RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 448 kByte | yes
-Flash       | 512 kByte ... 16 MByte |  yes
-Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
-Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no
-Timers      | 4 x 64 bit | yes
-ADCs        | 2 x SAR-ADC with up to 18 x 12 bit channels total | yes
-DACs        | 2 x DAC with 8 bit | yes
-GPIOs       | 34 (6 of them are only inputs) | yes
-I2Cs        | 2 | yes
-SPIs        | 4 | yes
-UARTs       | 3 | yes
-WiFi        | IEEE 802.11 b/g/n built in | yes
-Bluetooth   | v4.2 BR/EDR and BLE | no
-Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | yes
-IR          | up to 8 channels TX/RX | no
-Motor PWM   | 2 devices x 6 channels | yes
-LED PWM     | 16 channels | no
-Crypto      | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG | no
-Vcc         | 2.5 - 3.6 V | |
-Documents   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) | |
-</center>
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
 
 ### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
 

--- a/boards/esp32-wrover-kit/doc.txt
+++ b/boards/esp32-wrover-kit/doc.txt
@@ -50,37 +50,8 @@ This section describes
 
 ### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-Most features of the board are provided by the ESP32 SoC. The following table summarizes these features and gives an overview of which of these features are supported by RIOT. For detailed information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
-
-<center>
-MCU         | ESP32     | Supported by RIOT
-------------|-----------|------------------
-Vendor      | Espressif | |
-Cores       | 1 or 2 x Tensilica Xtensa LX6 | 1 core
-FPU         | yes (ULP - Ultra low power co-processor) | no
-RAM         | 520 kByte SRAM <br> 16 kByte  RTC SRAM | yes
-ROM         | 448 kByte | yes
-Flash       | 512 kByte ... 16 MByte |  yes
-Frequency   | 240 MHz, 160 MHz, 80 MHz | yes
-Power Consumption | 68 mA @ 240 MHz <br> 44 mA @ 160 MHz <br> 31 mA @ 80 MHz <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> no
-Timers      | 4 x 64 bit | yes
-ADCs        | 2 x SAR-ADC with up to 18 x 12 bit channels total | yes
-DACs        | 2 x DAC with 8 bit | yes
-GPIOs       | 34 (6 of them are only inputs) | yes
-I2Cs        | 2 | yes
-SPIs        | 4 | yes
-UARTs       | 3 | yes
-WiFi        | IEEE 802.11 b/g/n built in | yes
-Bluetooth   | v4.2 BR/EDR and BLE | no
-Ethernet    | MAC interface with dedicated DMA and IEEE 1588 support | yes
-CAN         | version 2.0 | yes
-IR          | up to 8 channels TX/RX | no
-Motor PWM   | 2 devices x 6 channels | yes
-LED PWM     | 16 channels | no
-Crypto      | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG | no
-Vcc         | 2.5 - 3.6 V | |
-Documents   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf) | |
-</center>
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
 
 ### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
 


### PR DESCRIPTION
# Contribution description

This PR provides a very small change of the board documentation of ESP32 boards. Instead of using the same MCU feature table in every board documentation, it refers to the MCU documentation. This makes it easier to maintain the MCU feature table.

### Testing procedure

` make doc` should succeed.

### Issues/PRs references

Should be merged before #13416 is merged. Otherweise, the MCU feature table doesn't match tha MCU feature table in the MCU documentation.