### PR TITLE
boards/esp32: rename BUTTON0_PIN to BTN0_PIN

### DIFF
--- a/boards/esp32-olimex-evb/include/board.h
+++ b/boards/esp32-olimex-evb/include/board.h
@@ -40,7 +40,24 @@
  * @name    Button pin definitions
  * @{
  */
-#define BUTTON0_PIN     GPIO34
+
+/**
+ * @brief   Default button GPIO pin definition
+ */
+#define BTN0_PIN        GPIO34
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.
+ */
+#define BTN0_MODE       GPIO_IN
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
 /** @} */
 
 /**

--- a/boards/esp32-olimex-evb/include/gpio_params.h
+++ b/boards/esp32-olimex-evb/include/gpio_params.h
@@ -39,8 +39,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     #endif
     {
         .name = "BUT1",
-        .pin = BUTTON0_PIN,
-        .mode = GPIO_IN,
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
     },
 };

--- a/boards/esp32-ttgo-t-beam/include/board.h
+++ b/boards/esp32-ttgo-t-beam/include/board.h
@@ -36,11 +36,28 @@
  * @name    Button pin definitions
  * @{
  */
+
+/**
+ * @brief   Default button GPIO pin definition
+ */
 #if MODULE_ESP32_TTGO_T_BEAM_V1_0
-#define BUTTON0_PIN     GPIO38
+#define BTN0_PIN        GPIO38
 #else
-#define BUTTON0_PIN     GPIO39
+#define BTN0_PIN        GPIO39
 #endif
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.
+ */
+#define BTN0_MODE       GPIO_IN
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
 /** @} */
 
 /**

--- a/boards/esp32-ttgo-t-beam/include/gpio_params.h
+++ b/boards/esp32-ttgo-t-beam/include/gpio_params.h
@@ -39,8 +39,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 #endif
     {
         .name = "PRG",
-        .pin = BUTTON0_PIN,
-        .mode = GPIO_IN,
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
     },
 };

--- a/boards/esp32-wroom-32/include/board.h
+++ b/boards/esp32-wroom-32/include/board.h
@@ -37,12 +37,30 @@
  * @name    Button pin definitions
  * @{
  */
+
 /**
-  * Generic ESP32 boards have a BOOT button, which can be used as normal button
-  * during normal operation. Since the GPIO0 pin is pulled up, the button
-  * signal is inverted, i.e., pressing the button will give a low signal.
-  */
-#define BUTTON0_PIN         GPIO0
+ * @brief   Default button GPIO pin definition
+ *
+ * Generic ESP32 boards have a BOOT button connected to GPIO0, which can be
+ * used as button during normal operation. Since the GPIO0 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO0
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.
+ */
+#define BTN0_MODE       GPIO_IN
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+
 /** @} */
 
 /**

--- a/boards/esp32-wroom-32/include/gpio_params.h
+++ b/boards/esp32-wroom-32/include/gpio_params.h
@@ -31,8 +31,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
         .name = "BOOT",
-        .pin = BUTTON0_PIN,
-        .mode = GPIO_IN,
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
     },
 };


### PR DESCRIPTION
### Contribution description

Since a number of applications rely on the existence of the `BTN0_PIN` definition, the `BUTTON0_PIN` definition has been renamed to `BTN0_PIN` in ESP32 board definitions to make them compatible with these applications. For compatibility with earlier versions, `BUTTON0_PIN` is still defined as an alias of `BTN0_PIN`.

### Testing procedure

Compilation of `tests/buttons` and `tests/saul` should still succeed for `esp32-wroom-32`, `esp32-olimex-evb`, `esp32-ttgo-t-beam`.

If there is an according board at hand, these `tests/buttons` should succeed with this PR but fail without this PR.

### Issues/PRs references
