### PR TITLE
sys/ecc: fix assertion in golay2412

### DIFF
--- a/sys/ecc/golay2412.c
+++ b/sys/ecc/golay2412.c
@@ -146,7 +146,7 @@ static uint32_t golay2412_matrix_mul(uint32_t _v,
 static uint32_t golay2412_encode_symbol(uint32_t _sym_dec, const uint32_t *_A)
 {
     /* validate input */
-    assert(_sym_dec > (1 << 12));
+    assert(_sym_dec < (1 << 12));
 
     /* compute encoded/transmitted message: v = m*G */
     return golay2412_matrix_mul(_sym_dec, _A, 24);


### PR DESCRIPTION
The function golay2412_encode_symbol takes a 12 bit symbol and turns it into a 24 bit symbol. To process the input it can't be greater than 12 bit.
Currently the assertion fails, when the input is smaller than 13 bit, which should actually be correct.
This fixes it. 

### Issues/PRs references

Fixes #13353
