### PR TITLE
sys/xtimer: use thread flags for xtimer_msg_receive_timeout()

### DIFF
--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -233,12 +233,12 @@ static inline void xtimer_set64(xtimer_t *timer, uint64_t period_us)
 #ifdef MODULE_CORE_MSG
 static inline int xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout)
 {
-    return _xtimer_msg_receive_timeout(msg, _xtimer_ticks_from_usec(timeout));
+    return _xtimer_msg_receive_timeout(msg, timeout);
 }
 
 static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout)
 {
-    return _xtimer_msg_receive_timeout64(msg, _xtimer_ticks_from_usec64(timeout));
+    return _xtimer_msg_receive_timeout64(msg, timeout);
 }
 
 static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This changes xtimer_msg_receive_timeout() to use thread flags instead of a canary message, for the timeout. This is one way to fix the issue found in #13345.

It does add a dependency to "core_thread_flags", adding ~200b code on ARM, if thread flags are otherwise unused.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Fixes 13345.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
