### PR TITLE
dist: factor out static tests from build_and_test.sh

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -329,24 +329,13 @@ run_test() {
 
 # execute static tests
 static_tests() {
-    local repo=${CI_BASE_REPO:-https://github.com/RIOT-OS/RIOT}
-    local branch=${CI_BASE_BRANCH:-master}
-
     print_worker
-
-    OUT="$(git remote add upstream $repo 2>&1 && git fetch upstream ${branch}:${branch} 2>&1)"
-    RES=$?
-    if [ $RES -ne 0 ]; then
-        echo "$OUT"
-        exit 1
-    fi
-
-    BUILDTEST_MCU_GROUP=static-tests ./dist/tools/ci/build_and_test.sh
+    ./dist/tools/ci/static_tests.sh
 }
 
 get_non_compile_jobs() {
     [ "$STATIC_TESTS" = "1" ] && \
-        echo "$0 static_tests###{ \"jobdir\" : \"exclusive\" }"
+        echo "$0 static_tests"
 }
 
 get_jobs() {

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -9,46 +9,6 @@
 
 CI_BASE_BRANCH=${CI_BASE_BRANCH:-master}
 
-function print_result {
-    local RED="\033[0;31m"
-    local GREEN="\033[0;32m"
-    local NO_COLOUR="\033[0m"
-
-    if (( "$1" == 0 )); then
-        echo -e "${GREEN}✓$NO_COLOUR"
-    else
-        echo -e "${RED}x$NO_COLOUR"
-    fi
-}
-
-RESULT=0
-set_result() {
-    NEW_RESULT=$1
-
-    if (( $NEW_RESULT != 0))
-    then
-        RESULT=$NEW_RESULT
-    fi
-}
-
-function run {
-    echo -n "Running '$@' "
-    OUT=$($@ 2>&1)
-    NEW_RESULT=$?
-
-    print_result $NEW_RESULT
-    set_result $NEW_RESULT
-
-    # Indent command output so that its easily discernible from the rest
-    if [ -n "$OUT" ]; then
-        echo "Command output:"
-        echo ""
-        # Using printf to avoid problems if the command output begins with a -
-        (printf "%s\n" "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
-        echo ""
-    fi
-}
-
 if [[ $BUILDTEST_MCU_GROUP ]]
 then
     export BASE_BRANCH="${CI_BASE_BRANCH}"
@@ -80,23 +40,7 @@ then
             exit $RESULT
         fi
 
-        run make print-versions
-
-        run ./dist/tools/commit-msg/check.sh ${CI_BASE_BRANCH}
-        run ./dist/tools/whitespacecheck/check.sh ${CI_BASE_BRANCH}
-        DIFFFILTER="MR" ERROR_EXIT_CODE=0 run ./dist/tools/licenses/check.sh
-        DIFFFILTER="AC" run ./dist/tools/licenses/check.sh
-        run ./dist/tools/doccheck/check.sh
-        run ./dist/tools/externc/check.sh
-        run ./dist/tools/cppcheck/check.sh
-        run ./dist/tools/vera++/check.sh
-        run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
-        run ./dist/tools/coccinelle/check.sh
-        run ./dist/tools/flake8/check.sh
-        run ./dist/tools/headerguards/check.sh
-        run ./dist/tools/buildsystem_sanity_check/check.sh
-        run ./dist/tools/codespell/check.sh
-        exit $RESULT
+        exec ./dist/tools/ci/static_tests.sh
     fi
 
     if [ "$BUILDTEST_MCU_GROUP" == "host" ]; then

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -25,15 +25,15 @@ function print_result {
 set_result() {
     NEW_RESULT=$1
 
-    if (( $NEW_RESULT != 0))
+    if (( NEW_RESULT != 0))
     then
         RESULT=$NEW_RESULT
     fi
 }
 
 function run {
-    echo -n "Running '$@' "
-    OUT=$($@ 2>&1)
+    echo -n "Running \"$*\" "
+    OUT=$("$@" 2>&1)
     NEW_RESULT=$?
 
     print_result $NEW_RESULT
@@ -55,15 +55,15 @@ CI_BASE_BRANCH=${CI_BASE_BRANCH:-master}
 
 export BASE_BRANCH="${CI_BASE_BRANCH}"
 
-run ./dist/tools/commit-msg/check.sh ${CI_BASE_BRANCH}
-run ./dist/tools/whitespacecheck/check.sh ${CI_BASE_BRANCH}
+run ./dist/tools/commit-msg/check.sh "${CI_BASE_BRANCH}"
+run ./dist/tools/whitespacecheck/check.sh "${CI_BASE_BRANCH}"
 DIFFFILTER="MR" ERROR_EXIT_CODE=0 run ./dist/tools/licenses/check.sh
 DIFFFILTER="AC" run ./dist/tools/licenses/check.sh
 run ./dist/tools/doccheck/check.sh
 run ./dist/tools/externc/check.sh
 run ./dist/tools/cppcheck/check.sh
 run ./dist/tools/vera++/check.sh
-run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
+run ./dist/tools/pr_check/pr_check.sh "${CI_BASE_BRANCH}"
 run ./dist/tools/coccinelle/check.sh
 run ./dist/tools/flake8/check.sh
 run ./dist/tools/headerguards/check.sh

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -51,19 +51,26 @@ function run {
 
 RESULT=0
 
+if [ -n "${CI_BASE_COMMIT}" ]; then
+    # on Murdock, there's no base branch in the checkout folder.
+    # Thus, tag it here.
+    echo "-- tagging ${CI_BASE_BRANCH} HEAD commit (${CI_BASE_COMMIT})"
+    git tag "${CI_BASE_BRANCH}" "${CI_BASE_COMMIT}"
+fi
+
 CI_BASE_BRANCH=${CI_BASE_BRANCH:-master}
 
 export BASE_BRANCH="${CI_BASE_BRANCH}"
 
-run ./dist/tools/commit-msg/check.sh "${CI_BASE_BRANCH}"
-run ./dist/tools/whitespacecheck/check.sh "${CI_BASE_BRANCH}"
+run ./dist/tools/commit-msg/check.sh "${BASE_BRANCH}"
+run ./dist/tools/whitespacecheck/check.sh "${BASE_BRANCH}"
 DIFFFILTER="MR" ERROR_EXIT_CODE=0 run ./dist/tools/licenses/check.sh
 DIFFFILTER="AC" run ./dist/tools/licenses/check.sh
 run ./dist/tools/doccheck/check.sh
 run ./dist/tools/externc/check.sh
 run ./dist/tools/cppcheck/check.sh
 run ./dist/tools/vera++/check.sh
-run ./dist/tools/pr_check/pr_check.sh "${CI_BASE_BRANCH}"
+run ./dist/tools/pr_check/pr_check.sh "${BASE_BRANCH}"
 run ./dist/tools/coccinelle/check.sh
 run ./dist/tools/flake8/check.sh
 run ./dist/tools/headerguards/check.sh

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
+#               2020 Inria
+#               2020 Freie Universität Berlin
+#               2015 Philipp Rosenkranz <philipp.rosenkranz@fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+function print_result {
+    local RED="\033[0;31m"
+    local GREEN="\033[0;32m"
+    local NO_COLOUR="\033[0m"
+
+    if (( "$1" == 0 )); then
+        echo -e "${GREEN}✓$NO_COLOUR"
+    else
+        echo -e "${RED}x$NO_COLOUR"
+    fi
+}
+
+set_result() {
+    NEW_RESULT=$1
+
+    if (( $NEW_RESULT != 0))
+    then
+        RESULT=$NEW_RESULT
+    fi
+}
+
+function run {
+    echo -n "Running '$@' "
+    OUT=$($@ 2>&1)
+    NEW_RESULT=$?
+
+    print_result $NEW_RESULT
+    set_result $NEW_RESULT
+
+    # Indent command output so that its easily discernible from the rest
+    if [ -n "$OUT" ]; then
+        echo "Command output:"
+        echo ""
+        # Using printf to avoid problems if the command output begins with a -
+        (printf "%s\n" "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
+        echo ""
+    fi
+}
+
+RESULT=0
+
+CI_BASE_BRANCH=${CI_BASE_BRANCH:-master}
+
+export BASE_BRANCH="${CI_BASE_BRANCH}"
+
+run ./dist/tools/commit-msg/check.sh ${CI_BASE_BRANCH}
+run ./dist/tools/whitespacecheck/check.sh ${CI_BASE_BRANCH}
+DIFFFILTER="MR" ERROR_EXIT_CODE=0 run ./dist/tools/licenses/check.sh
+DIFFFILTER="AC" run ./dist/tools/licenses/check.sh
+run ./dist/tools/doccheck/check.sh
+run ./dist/tools/externc/check.sh
+run ./dist/tools/cppcheck/check.sh
+run ./dist/tools/vera++/check.sh
+run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
+run ./dist/tools/coccinelle/check.sh
+run ./dist/tools/flake8/check.sh
+run ./dist/tools/headerguards/check.sh
+run ./dist/tools/buildsystem_sanity_check/check.sh
+run ./dist/tools/codespell/check.sh
+
+exit $RESULT


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, Murdock was using `./dist/tools/ci/build_and_test.sh`, which is a relic from the Travis times.
This PR factors out the static test execution from that script into `./dist/tools/ci/static_tests.sh`.

Another commit makes Murdock use the new script.
This removes the rebase check, which is redundant in Murdock.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
