### PR TITLE
drivers/srf08: cleanup driver configuration scheme

### DIFF
--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -320,6 +320,10 @@ ifneq (,$(filter srf04,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/srf04/include
 endif
 
+ifneq (,$(filter srf08,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/srf08/include
+endif
+
 ifneq (,$(filter stmpe811,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/stmpe811/include
 endif

--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -35,9 +35,6 @@
 extern "C" {
 #endif
 
-/** @brief   The sensors default I2C address */
-#define SRF08_DEFAULT_ADDR              112
-
 /** @brief   The sensors command register (write) */
 #define SRF08_COMMAND_REG               0x0
 
@@ -66,11 +63,18 @@ extern "C" {
 #define SRF08_MAX_GAIN                  0x1F
 
 /**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    i2c_t i2c;                  /**< I2C device the sensor is connected to */
+    uint8_t addr;               /**< I2C bus address of the sensor */
+} srf08_params_t;
+
+/**
  * @brief   Device descriptor for SRF08 sensors
  */
 typedef struct {
-    i2c_t i2c;               /**< I2C device the sensor is connected to */
-    uint8_t addr;            /**< I2C bus address of the sensor */
+    srf08_params_t params;      /**< Initialization parameters */
 } srf08_t;
 
 /**
@@ -89,15 +93,14 @@ typedef enum {
  * @brief   Initialize the SRF08 ultrasonic sensor
  *
  * @param[in] dev           device descriptor of an SRF08 sensor
- * @param[in] i2c           I2C device the sensor is connected to
- * @param[in] addr          I2C address of the sensor
+ * @param[in] params        initialization parameters
  *
  * @return                  0 on successful initialization
  * @return                  -3 on max. range error
  * @return                  -4 on max. gain error
  *
  */
-int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr);
+int srf08_init(srf08_t *dev, const srf08_params_t *params);
 
 /**
  * @brief   Set the maximum range of the SRF08.

--- a/drivers/srf08/include/srf08_params.h
+++ b/drivers/srf08/include/srf08_params.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_srf08
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for srf08 devices
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef SRF08_PARAMS_H
+#define SRF08_PARAMS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "board.h"
+#include "srf08.h"
+
+/**
+ * @name   Default configuration parameters for SRF08 device
+ * @{
+ */
+#ifndef SRF08_PARAM_I2C
+#define SRF08_PARAM_I2C         I2C_DEV(0)
+#endif
+#ifndef SRF08_PARAM_ADDR
+#define SRF08_PARAM_ADDR        (0x70)  /* 0xE0 shifted by 1 */
+#endif
+
+#ifndef SRF08_PARAMS
+#define SRF08_PARAMS            { .i2c  = SRF08_PARAM_I2C, \
+                                  .addr = SRF08_PARAM_ADDR }
+#endif
+/** @} */
+
+/**
+ * @brief   SRF08 configuration
+ */
+static const srf08_params_t srf08_params[] = {
+    SRF08_PARAMS
+};
+
+/**
+ * @brief   Number of SRF08 devices
+ */
+#define SRF08_NUMOF     ARRAY_SIZE(srf08_params)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SRF08_PARAMS_H */
+/** @} */

--- a/drivers/srf08/srf08.c
+++ b/drivers/srf08/srf08.c
@@ -24,18 +24,22 @@
 
 #include <stdint.h>
 #include <stdio.h>
+
 #include "xtimer.h"
-#include "srf08.h"
 #include "periph/i2c.h"
+
+#include "srf08.h"
+#include "srf08_params.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#define SRF08_DEV_I2C       (dev->params.i2c)
+#define SRF08_DEV_ADDR      (dev->params.addr)
 
-int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr)
+int srf08_init(srf08_t *dev, const srf08_params_t *params)
 {
-    dev->i2c = i2c;
-    dev->addr = addr;
+    dev->params = *params;
 
     /* set the maximum range */
     if (srf08_set_max_range(dev, SRF08_MAX_RANGE_6M) < 0) {
@@ -56,10 +60,10 @@ int srf08_set_max_range(const srf08_t *dev, uint8_t max_range)
     int status;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    status = i2c_write_reg(dev->i2c, dev->addr, SRF08_RANGE_REG, max_range, 0);
+    i2c_acquire(SRF08_DEV_I2C);
+    status = i2c_write_reg(SRF08_DEV_I2C, SRF08_DEV_ADDR, SRF08_RANGE_REG, max_range, 0);
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_release(SRF08_DEV_I2C);
 
     return status;
 }
@@ -70,10 +74,10 @@ int srf08_set_max_gain(const srf08_t *dev, uint8_t gain)
     int status;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    status = i2c_write_reg(dev->i2c, dev->addr, SRF08_GAIN_REG, gain, 0);
+    i2c_acquire(SRF08_DEV_I2C);
+    status = i2c_write_reg(SRF08_DEV_I2C, SRF08_DEV_ADDR, SRF08_GAIN_REG, gain, 0);
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_release(SRF08_DEV_I2C);
 
     return status;
 }
@@ -89,12 +93,12 @@ int srf08_get_distances(const srf08_t *dev, uint16_t *range_array,
     char max_reg_no_read = (num_echos * sizeof(range_bytes)) +1;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
+    i2c_acquire(SRF08_DEV_I2C);
     /* set ranging mode */
-    status = i2c_write_reg(dev->i2c, dev->addr, SRF08_COMMAND_REG,
+    status = i2c_write_reg(SRF08_DEV_I2C, SRF08_DEV_ADDR, SRF08_COMMAND_REG,
                            ranging_mode, 0);
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_release(SRF08_DEV_I2C);
 
     if (status != 0) {
         DEBUG("Write the ranging command to the i2c-interface is failed\n");
@@ -113,12 +117,12 @@ int srf08_get_distances(const srf08_t *dev, uint16_t *range_array,
          register_location += sizeof(range_bytes)) {
 
         /* Acquire exclusive access to the bus. */
-        i2c_acquire(dev->i2c);
+        i2c_acquire(SRF08_DEV_I2C);
         /* read the echo bytes */
-        status = i2c_read_regs(dev->i2c, dev->addr, register_location,
+        status = i2c_read_regs(SRF08_DEV_I2C, SRF08_DEV_ADDR, register_location,
                                range_bytes, sizeof(range_bytes), 0);
         /* Release the bus for other threads. */
-        i2c_release(dev->i2c);
+        i2c_release(SRF08_DEV_I2C);
 
         if (status != 0) {
             DEBUG("Read the echo bytes from the i2c-interface is failed\n");

--- a/tests/driver_srf08/Makefile
+++ b/tests/driver_srf08/Makefile
@@ -3,16 +3,4 @@ include ../Makefile.tests_common
 USEMODULE += xtimer
 USEMODULE += srf08
 
-# set default device parameters in case they are undefined
-export TEST_SRF08_I2C   ?= I2C_DEV\(0\)
-export TEST_SRF08_SPEED ?= I2C_SPEED_NORMAL
-export TEST_MODE        ?= SRF08_MODE_CM
-export TEST_NUM_ECHOS   ?= 3
-
-# export parameters
-CFLAGS += -DTEST_SRF08_I2C=$(TEST_SRF08_I2C)
-CFLAGS += -DTEST_SRF08_SPEED=$(TEST_SRF08_SPEED)
-CFLAGS += -DTEST_MODE=$(TEST_MODE)
-CFLAGS += -DTEST_NUM_ECHOS=$(TEST_NUM_ECHOS)
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_srf08/main.c
+++ b/tests/driver_srf08/main.c
@@ -19,37 +19,33 @@
  *
  * @}
  */
-#ifndef TEST_SRF08_I2C
-#error "TEST_SRF08_I2C not defined"
-#endif
-#ifndef TEST_SRF08_SPEED
-#error "TEST_SRF08_SPEED not defined"
-#endif
-#ifndef TEST_MODE
-#error "TEST_MODE not defined"
-#endif
-#ifndef TEST_NUM_ECHOS
-#error "TEST_NUM_ECHOS not defined"
-#endif
 
 #include <stdio.h>
 
 #include "xtimer.h"
 #include "srf08.h"
+#include "srf08_params.h"
 #include "periph/i2c.h"
 
- #define SLEEP_USEC  (1000 * 1000U)
+#ifndef TEST_MODE
+#define TEST_MODE           (SRF08_MODE_CM)
+#endif
+#ifndef TEST_NUM_ECHOS
+#define TEST_NUM_ECHOS      (3U)
+#endif
 
- static srf08_t srf08_0;
+#define SLEEP_USEC          (1000 * US_PER_MS)
+
+static srf08_t srf08_0;
 
 int main(void)
 {
     puts("SRF08 ultrasonic ranger test application\n");
-    printf("Initializing SRF08 sensor at I2C_%i... ", TEST_SRF08_I2C);
+    printf("Initializing SRF08 sensor at I2C_%i... ", srf08_params[0].i2c);
 
     int res;
 
-    res = srf08_init(&srf08_0, TEST_SRF08_I2C, SRF08_DEFAULT_ADDR);
+    res = srf08_init(&srf08_0, &srf08_params[0]);
 
     if (res < 0) {
         printf("[Failed]");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR rework the srf08 driver to make it more consistent with the initialization and configuration scheme used in RIOT.

The test application is also adapted.

This PR is not tested (I don't have the hardware...) but I don't think the test application was working before since the I2C address was not set correctly (i2c speed was set instead...). In this PR, the default I2C address is set to `0xE0` which seems to be the default value for this sensor ([reference](https://www.robot-electronics.co.uk/htm/srf08tech.html)).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The test application should work:

```
make BOARD=<board of your setup> -C tests/driver_srf08 flash term
```



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
