### PR TITLE
boards/native: add deprecation warnings for `make all-debug`

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -91,15 +91,13 @@ debug-valgrind-server: export VALGRIND_FLAGS ?= --vgdb=yes --vgdb-error=0 -v \
 	--read-var-info=yes
 term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
 term-gprof: TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELFFILE)
-all-valgrind: CFLAGS += -DHAVE_VALGRIND_H -g3
+all-valgrind: CFLAGS += -DHAVE_VALGRIND_H
 all-valgrind: export NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
-all-debug: CFLAGS += -g3
-all-cachegrind: CFLAGS += -g3
 all-gprof: CFLAGS += -pg
 all-gprof: LINKFLAGS += -pg
-all-asan: CFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
+all-asan: CFLAGS += -fsanitize=address -fno-omit-frame-pointer
 all-asan: CFLAGS += -DNATIVE_MEMORY
-all-asan: LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer -g3
+all-asan: LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer
 
 INCLUDES += $(NATIVEINCLUDES)
 

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -128,6 +128,7 @@ endif
 all: # do not override first target
 
 all-debug: all
+	@$(COLOR_ECHO) '$(COLOR_RED)`all-debug` is deprecated, just use `all`$(COLOR_RESET)'
 
 all-gprof: all
 

--- a/boards/native/doc.txt
+++ b/boards/native/doc.txt
@@ -20,4 +20,12 @@ OS/RIOT/images/Native.jpg)
 - PWM: Dummy PWM
 - QDEC: Emulated according to PWM
 - SPI: Runtime configurable - `/dev/spidev*` are supported (Linux host only)
+
+# Building native with debug flags
+@deprecated `make all-debug` is deprecated; `make all` now builds with debugs
+            flags by default. The target will be removed after the 2020.10
+            release.
+
+To build with debug flags for `native` use `make all-debug` instead of
+`make all`
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Being a frequent user of `make all-debug` and a good girl scout, I decided to clean up a bit after #13423 ;-).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
make all-debug
```

should print a deprecation warning now.

```
make doc
```
should show a note on that in `doc/doxygen/html/deprecated.html` and `all-...` should still work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #13423.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
