### PR TITLE
pkg/lwip: use GitHub mirror

### DIFF
--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME=lwip
-PKG_URL=https://git.savannah.nongnu.org/git/lwip.git
+PKG_URL=https://github.com/lwip-tcpip/lwip.git
 # lwIP v2.1.2
 PKG_VERSION=159e31b689577dbf69cf0683bbaffbd71fa5ee10
 PKG_LICENSE=BSD-3-Clause


### PR DESCRIPTION

### Contribution description

https://git.savannah.nongnu.org seems to be rate-limiting us, so switch to a mirror on GitHub.

Of course we shouldn't just use any random GitHub mirror but rather put it on https://github.com/RIOT-OS - consider this a demo.

### Testing procedure

Murdock should stop failing.


### Issues/PRs references

