### PR TITLE
pkg/local.mk: Add FORCE target to .PHONY

### DIFF
--- a/pkg/local.mk
+++ b/pkg/local.mk
@@ -6,7 +6,7 @@
 #
 # WARNING: any local changes made to $(PKG_BUILDDIR) *will* get lost!
 
-.PHONY: prepare clean all
+.PHONY: prepare clean all FORCE
 
 all: $(PKG_BUILDDIR)/.prepared
 


### PR DESCRIPTION
### Contribution description
Currently, when setting `PKG_SOURCE_LOCAL` to use a local source of a package, if the `Makefile` uses `FORCE` as a dependency of any of the targets, the build fails.

This PR adds `FORCE` to `.PHONY` in `local.mk`, which is the makefile used for local sources of the packages.

### Testing procedure
Test this using a local copy of a package that, either already uses `FORCE` or add something like this to its `Makefile`:
```patch
all: testing
	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)

testing: FORCE
	$(Q)echo "Testing!"
```


### Issues/PRs references
None