### PR TITLE
sock_async_event: fix race-condition

### DIFF
--- a/sys/net/sock/async/event/sock_async_event.c
+++ b/sys/net/sock/async/event/sock_async_event.c
@@ -13,14 +13,20 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include "irq.h"
 #include "net/sock/async/event.h"
 
 static void _event_handler(event_t *ev)
 {
     sock_event_t *event = (sock_event_t *)ev;
+    unsigned state = irq_disable();
+    sock_async_flags_t _type = event->type;
 
-    event->cb.generic(event->sock, event->type);
     event->type = 0;
+    irq_restore(state);
+    if (_type) {
+        event->cb.generic(event->sock, _type);
+    }
 }
 
 static inline void _cb(void *sock, sock_async_flags_t type,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
If a new event is fired during the execution of the event callback, `event->type` might change. However as `event->type` is set to 0 after the execution of the callback, that leads to it being 0 on the next round of the event handler's execution, leading in the event getting lost.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- `make -C tests/gnrc_sock_async_event flash test` should still work with a board of your choice.
- To confirm the race condition
    - try `tests/lwip` with #13427 merged and start a TCP server with `tcp server start 1337`
    - connect to that server from your host machine using `netcat` (e.g. nc fe80::0200:dead:beef:affe%tapbr0 1337 when using `native`)
    - With this PR the closing of the connection when hitting `Ctrl+C` in `netcat` is registered and printed to stdout. You can reconnect to the TCP server by starting a new `netcat` process.
    - Without this PR the closing of the connection when hitting `Ctrl+C` in `netcat` is not registered. Reconnecting to the TCP server is not possible (accept will error with an `-ENOMEM`).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered in #13427.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
