### PR TITLE
tests/suit_v4_manifest: Add test for manifest parsing

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -986,11 +986,15 @@ ifneq (,$(filter suit_v4,$(USEMODULE)))
   USEMODULE += libcose_crypt_c25519
   USEMODULE += suit_conditions
 
-  # SUIT depends on riotboot support and some extra riotboot modules
-  FEATURES_REQUIRED += riotboot
-  USEMODULE += riotboot_slot
-  USEMODULE += riotboot_flashwrite
-  USEMODULE += riotboot_flashwrite_verify_sha256
+  # tests/suit_v4_manifest has some mock implementations,
+  # so only add the dependencies if not building the test.
+  ifeq (,$(filter suit_v4_test,$(USEMODULE)))
+    # SUIT depends on riotboot support and some extra riotboot modules
+    FEATURES_REQUIRED += riotboot
+    USEMODULE += riotboot_slot
+    USEMODULE += riotboot_flashwrite
+    USEMODULE += riotboot_flashwrite_verify_sha256
+  endif
 endif
 
 ifneq (,$(filter suit_conditions,$(USEMODULE)))

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -19,6 +19,7 @@
 
 #include <inttypes.h>
 
+#include "kernel_defines.h"
 #include "suit/conditions.h"
 #include "suit/v4/suit.h"
 #include "suit/v4/handlers.h"

--- a/tests/suit_v4_manifest/Makefile
+++ b/tests/suit_v4_manifest/Makefile
@@ -1,0 +1,34 @@
+include ../Makefile.tests_common
+
+USEMODULE += suit_v4
+USEMODULE += riotboot_hdr
+USEMODULE += embunit
+
+# Lots of structs on the stack and crypto verification
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(8*THREAD_STACKSIZE_DEFAULT\)
+
+BLOBS += $(wildcard bin/manifests/manifest*.bin)
+
+PSEUDOMODULES += suit_v4_test
+USEMODULE += suit_v4_test
+
+ifeq (native, $(BOARD))
+  # Fake some flash support
+  CFLAGS += -DFLASHPAGE_SIZE=256 -DFLASHPAGE_NUMOF=16
+  FEATURES_PROVIDED += periph_flashpage
+endif
+
+FEATURES_REQUIRED += periph_flashpage
+
+BUILDDEPS += create_test_data
+
+include $(RIOTBASE)/Makefile.include
+include $(RIOTMAKE)/suit.v4.inc.mk
+
+# Export to use with the test data script
+export SUIT_SEC
+export SUIT_PUB
+
+create_test_data: $(SUIT_SEC) $(SUIT_PUB_HDR)
+	@mkdir -p $(BINDIRBASE)/manifests
+	sh create_test_data.sh

--- a/tests/suit_v4_manifest/Makefile.ci
+++ b/tests/suit_v4_manifest/Makefile.ci
@@ -1,0 +1,10 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    i-nucleo-lrwan1 \
+    nucleo-f042k6 \
+    nucleo-f030r8 \
+    nucleo-l031k6 \
+    nucleo-l053r8 \
+    stm32f0discovery \
+    stm32f030f4-demo\
+    stm32l0538-disco \
+    #

--- a/tests/suit_v4_manifest/create_test_data.sh
+++ b/tests/suit_v4_manifest/create_test_data.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+MANIFEST_DIR="${BINDIRBASE}/manifests"
+
+gen_manifest() {
+  local out="$1"
+  shift
+  local seqnr="$1"
+  shift
+
+  "${RIOTBASE}/dist/tools/suit_v4/gen_manifest.py" \
+    --template "${RIOTBASE}/dist/tools/suit_v4/test-2img.json" \
+    --urlroot "test://test" \
+    --seqnr "$seqnr" \
+    --uuid-vendor "riot-os.org" \
+    --uuid-class "$BOARD" \
+    --offsets 0x1000,0x2000 \
+    -o "$out" \
+    "$1" "$2"
+}
+
+sign_manifest() {
+  local in="$1"
+  local out="$2"
+
+  "${RIOTBASE}/dist/tools/suit_v4/sign-04.py" "${SUIT_SEC}" "${SUIT_PUB}" "$in" "$out"
+}
+
+# random invalid manifest
+echo foo > "${MANIFEST_DIR}/manifest0.bin"
+
+# random valid cbor
+gen_manifest "${MANIFEST_DIR}/manifest1.bin" 1 "${MANIFEST_DIR}/manifest0.bin" \
+    "${MANIFEST_DIR}/manifest0.bin"
+
+# manifest with invalid seqnr
+sign_manifest "${MANIFEST_DIR}/manifest1.bin" "${MANIFEST_DIR}/manifest2.bin"
+
+# manifest with valid signature and seqnr, invalid class id
+( BOARD=invalid gen_manifest "${MANIFEST_DIR}/manifest3_unsigned.bin" 2 \
+    "${MANIFEST_DIR}/manifest0.bin" "${MANIFEST_DIR}/manifest0.bin")
+sign_manifest "${MANIFEST_DIR}/manifest3_unsigned.bin" "${MANIFEST_DIR}/manifest3.bin"
+
+# manifest with valid signature and seqnr, valid class id, must pass the test
+gen_manifest "${MANIFEST_DIR}/manifest4_unsigned.bin" 2 "${MANIFEST_DIR}/manifest0.bin" \
+    "${MANIFEST_DIR}/manifest0.bin"
+sign_manifest "${MANIFEST_DIR}/manifest4_unsigned.bin" "${MANIFEST_DIR}/manifest4.bin"

--- a/tests/suit_v4_manifest/main.c
+++ b/tests/suit_v4_manifest/main.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup    tests
+ * @{
+ *
+ * @file
+ * @brief      Tests for module suit_v4
+ *
+ * @author     Kaspar Schleiser <kaspar@schleiser.de>
+ * @author     Koen Zandberg <koen@bergzand.net>
+ */
+
+#include <stdio.h>
+
+#include "kernel_defines.h"
+#include "log.h"
+
+#include "suit/v4/suit.h"
+#include "embUnit.h"
+
+#include "blob/bin/manifests/manifest0.bin.h"
+#include "blob/bin/manifests/manifest1.bin.h"
+#include "blob/bin/manifests/manifest2.bin.h"
+#include "blob/bin/manifests/manifest3.bin.h"
+#include "blob/bin/manifests/manifest4.bin.h"
+
+#define SUIT_URL_MAX            128
+
+typedef struct {
+    const unsigned char *data;
+    size_t len;
+} blob_t;
+
+const blob_t bad[] = {
+    { manifest0_bin, manifest0_bin_len },
+    { manifest1_bin, manifest1_bin_len },
+    { manifest2_bin, manifest2_bin_len },
+    { manifest3_bin, manifest3_bin_len },
+};
+
+const size_t bad_numof = ARRAY_SIZE(bad);
+
+const blob_t good[] = {
+    { manifest4_bin, manifest4_bin_len },
+};
+
+const size_t good_numof = ARRAY_SIZE(good);
+
+static int test_suitv4_manifest(const unsigned char *manifest_bin, size_t manifest_bin_len)
+{
+    char _url[SUIT_URL_MAX];
+    suit_v4_manifest_t manifest;
+    riotboot_flashwrite_t writer;
+    memset(&writer, 0, sizeof(manifest));
+
+    manifest.writer = &writer;
+    manifest.urlbuf = _url;
+    manifest.urlbuf_len = SUIT_URL_MAX;
+
+    return suit_v4_parse(&manifest, manifest_bin, manifest_bin_len);
+}
+
+static void test_suitv4_manifest_01_bad_manifests(void)
+{
+    for (size_t i = 0; i < bad_numof; i++) {
+        printf("\n--- testing bad manifest %u\n", (unsigned)i);
+        int res = test_suitv4_manifest(bad[i].data, bad[i].len);
+        TEST_ASSERT_EQUAL_INT(-1, res);
+    }
+}
+
+static void test_suitv4_manifest_02_good_manifests(void)
+{
+    for (size_t i = 0; i < good_numof; i++) {
+        printf("\n--- testing good manifest %u\n", (unsigned)i);
+        int res = test_suitv4_manifest(good[i].data, good[i].len);
+        TEST_ASSERT_EQUAL_INT(0, res);
+    }
+}
+
+Test *tests_suitv4_manifest(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_suitv4_manifest_01_bad_manifests),
+        new_TestFixture(test_suitv4_manifest_02_good_manifests),
+    };
+
+    EMB_UNIT_TESTCALLER(suitv4_manifest_tests, NULL, NULL, fixtures);
+
+    return (Test *)&suitv4_manifest_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_suitv4_manifest());
+    TESTS_END();
+    return 0;
+}

--- a/tests/suit_v4_manifest/main.c
+++ b/tests/suit_v4_manifest/main.c
@@ -35,7 +35,7 @@
 
 typedef struct {
     const unsigned char *data;
-    size_t len;
+    const size_t len;
 } blob_t;
 
 const blob_t bad[] = {

--- a/tests/suit_v4_manifest/main.c
+++ b/tests/suit_v4_manifest/main.c
@@ -39,16 +39,17 @@ typedef struct {
 } blob_t;
 
 const blob_t bad[] = {
-    { manifest0_bin, manifest0_bin_len },
-    { manifest1_bin, manifest1_bin_len },
-    { manifest2_bin, manifest2_bin_len },
-    { manifest3_bin, manifest3_bin_len },
+    /* GCC 7.3.1 can't handle manifestx_bin_len here */
+    { manifest0_bin, sizeof(manifest0_bin) },
+    { manifest1_bin, sizeof(manifest1_bin) },
+    { manifest2_bin, sizeof(manifest2_bin) },
+    { manifest3_bin, sizeof(manifest3_bin) },
 };
 
 const size_t bad_numof = ARRAY_SIZE(bad);
 
 const blob_t good[] = {
-    { manifest4_bin, manifest4_bin_len },
+    { manifest4_bin, sizeof(manifest4_bin) },
 };
 
 const size_t good_numof = ARRAY_SIZE(good);

--- a/tests/suit_v4_manifest/suit_v4_test.c
+++ b/tests/suit_v4_manifest/suit_v4_test.c
@@ -1,0 +1,75 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "kernel_defines.h"
+#include "cpu_conf.h"
+
+#include "riotboot/flashwrite.h"
+#include "riotboot/hdr.h"
+
+#define SLOT0_OFFSET 0x1000
+#define SLOT1_OFFSET 0x2000
+
+static riotboot_hdr_t _riotboot_slots[] = {
+    { .magic_number = RIOTBOOT_MAGIC,
+      .version = 1,
+      .start_addr=0x100000,
+    },
+    { .magic_number = RIOTBOOT_MAGIC,
+      .version = 2,
+      .start_addr=0x200000,
+    },
+};
+
+const riotboot_hdr_t * const riotboot_slots[] = {
+    &_riotboot_slots[0],
+    &_riotboot_slots[1],
+};
+
+const unsigned riotboot_slot_numof = ARRAY_SIZE(riotboot_slots);
+
+static int _current_slot;
+
+int riotboot_slot_current(void)
+{
+    return _current_slot;
+}
+
+int riotboot_slot_other(void)
+{
+    return (_current_slot == 0) ? 1 : 0;
+}
+
+const riotboot_hdr_t *riotboot_slot_get_hdr(unsigned slot)
+{
+    assert(slot < riotboot_slot_numof);
+
+    return riotboot_slots[slot];
+}
+
+size_t riotboot_slot_offset(unsigned slot)
+{
+    return (slot == 0) ? SLOT0_OFFSET : SLOT1_OFFSET;
+}
+
+int riotboot_flashwrite_init_raw(riotboot_flashwrite_t *state, int target_slot,
+                                 size_t offset)
+{
+    (void)state;
+    (void)target_slot;
+    (void)offset;
+    puts("riotboot_flashwrite_init_raw() empty mock");
+    return 0;
+}
+
+
+int riotboot_flashwrite_verify_sha256(const uint8_t *sha256_digest,
+                                      size_t img_size, int target_slot)
+{
+    (void)sha256_digest;
+    (void)img_size;
+    (void)target_slot;
+    puts("riotboot_flashwrite_verify_sha256() empty mock");
+    return 0;
+}

--- a/tests/suit_v4_manifest/suit_v4_test.c
+++ b/tests/suit_v4_manifest/suit_v4_test.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Inria
+ *               2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdbool.h>
@@ -63,7 +79,6 @@ int riotboot_flashwrite_init_raw(riotboot_flashwrite_t *state, int target_slot,
     return 0;
 }
 
-
 int riotboot_flashwrite_verify_sha256(const uint8_t *sha256_digest,
                                       size_t img_size, int target_slot)
 {
@@ -73,3 +88,4 @@ int riotboot_flashwrite_verify_sha256(const uint8_t *sha256_digest,
     puts("riotboot_flashwrite_verify_sha256() empty mock");
     return 0;
 }
+/** @} */

--- a/tests/suit_v4_manifest/tests/01-run.py
+++ b/tests/suit_v4_manifest/tests/01-run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Francisco Acosta <francisco.acosta@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    board = os.environ['BOARD']
+    # Increase timeout on "real" hardware
+    timeout = 30 if board != 'native' else -1
+    child.expect(r"OK \(\d+ tests\)", timeout=timeout)
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This PR adds a test for the SUIT manifest parser. A mock flashwrite implementation is included to verify the full parser without having to stop at the fetch stage.

### Testing procedure

1. Review the code!
2. Run the test!

### Issues/PRs references

None