### PR TITLE
cpu/saml1x, saml2x, samd5x: select buck voltage regulator when possible

### DIFF
--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -32,6 +32,12 @@ extern "C" {
 #define CLOCK_CORECLOCK     (16000000U)
 
 /**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
  * @name    Timer peripheral configuration
  * @{
  */

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -32,6 +32,12 @@ extern "C" {
 #define CLOCK_CORECLOCK     (120000000U)
 
 /**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
  * @name Timer peripheral configuration
  * @{
  */

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -35,6 +35,12 @@ extern "C" {
 #define CLOCK_CORECLOCK     (48000000U)
 
 /**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
  * @name    Timer peripheral configuration
  * @{
  */

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -32,6 +32,12 @@ extern "C" {
 #define CLOCK_CORECLOCK     (48000000U)
 
 /**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
  * @name    Timer peripheral configuration
  * @{
  */

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -393,6 +393,39 @@ static inline void sam0_cortexm_sleep(int deep)
 void gpio_disable_mux(gpio_t pin);
 
 /**
+ * @brief   Available voltage regulators on the supply controller.
+ */
+typedef enum {
+    SAM0_VREG_LDO,  /*< LDO, always available but not very power efficient */
+    SAM0_VREG_BUCK  /*< Buck converter, efficient but may clash with internal
+                        fast clock generators (see errata sheets) */
+} sam0_supc_t;
+
+/**
+ * @brief       Switch the internal voltage regulator used for generating the
+ *              internal MCU voltages.
+ *              Available options are:
+ *
+ *               - LDO: not very efficient, but will always work
+ *               - BUCK converter: Most efficient, but incompatible with the
+ *                 use of DFLL or DPLL.
+ *                 Please refer to the errata sheet, further restrictions may
+ *                 apply depending on the MCU.
+ *
+ * @param[in]   src
+ */
+static inline void sam0_set_voltage_regulator(sam0_supc_t src)
+{
+#ifdef REG_SUPC_VREG
+    SUPC->VREG.bit.SEL = src;
+    while (!SUPC->STATUS.bit.VREGRDY) {}
+#else
+    (void) src;
+    assert(0);
+#endif
+}
+
+/**
  * @brief   Returns the frequency of a GCLK provider.
  *
  * @param[in] id    The ID of the GCLK

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -368,6 +368,20 @@ void gpio_pm_cb_enter(int deep);
 void gpio_pm_cb_leave(int deep);
 
 /**
+ * @brief   Called before the power management enters a power mode
+ *
+ * @param[in] deep
+ */
+void cpu_pm_cb_enter(int deep);
+
+/**
+ * @brief   Called after the power management left a power mode
+ *
+ * @param[in] deep
+ */
+void cpu_pm_cb_leave(int deep);
+
+/**
  * @brief   Wrapper for cortexm_sleep calling power management callbacks
  *
  * @param[in] deep
@@ -378,7 +392,11 @@ static inline void sam0_cortexm_sleep(int deep)
     gpio_pm_cb_enter(deep);
 #endif
 
+    cpu_pm_cb_enter(deep);
+
     cortexm_sleep(deep);
+
+    cpu_pm_cb_leave(deep);
 
 #ifdef MODULE_PERIPH_GPIO
     gpio_pm_cb_leave(deep);

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -90,6 +90,18 @@ uint32_t sam0_gclk_freq(uint8_t id)
     }
 }
 
+void cpu_pm_cb_enter(int deep)
+{
+    (void) deep;
+    /* will be called before entering sleep */
+}
+
+void cpu_pm_cb_leave(int deep)
+{
+    (void) deep;
+    /* will be called after wake-up */
+}
+
 /**
  * @brief   Configure clock sources and the cpu frequency
  */

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -144,6 +144,18 @@ uint32_t sam0_gclk_freq(uint8_t id)
     }
 }
 
+void cpu_pm_cb_enter(int deep)
+{
+    (void) deep;
+    /* will be called before entering sleep */
+}
+
+void cpu_pm_cb_leave(int deep)
+{
+    (void) deep;
+    /* will be called after wake-up */
+}
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -30,6 +30,16 @@
 #define _NVMCTRL NVMCTRL
 #endif
 
+/* As long as FDPLL is not used, we can default to
+ * always using the buck converter.
+ *
+ * An external inductor needs to be present on the board,
+ * so the feature can only be enabled by the board configuration.
+ */
+#ifndef USE_VREG_BUCK
+#define USE_VREG_BUCK (0)
+#endif
+
 static void _gclk_setup(int gclk, uint32_t reg)
 {
     GCLK->GENCTRL[gclk].reg = reg;
@@ -96,6 +106,11 @@ void cpu_init(void)
 {
     /* initialize the Cortex-M core */
     cortexm_init();
+
+    /* not compatible with 96 MHz FDPLL */
+    if (USE_VREG_BUCK) {
+        sam0_set_voltage_regulator(SAM0_VREG_BUCK);
+    }
 
     /* turn on only needed APB peripherals */
     MCLK->APBAMASK.reg = MCLK_APBAMASK_MCLK

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -99,6 +99,18 @@ uint32_t sam0_gclk_freq(uint8_t id)
     }
 }
 
+void cpu_pm_cb_enter(int deep)
+{
+    (void) deep;
+    /* will be called before entering sleep */
+}
+
+void cpu_pm_cb_leave(int deep)
+{
+    (void) deep;
+    /* will be called after wake-up */
+}
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -136,6 +136,19 @@ static void _dfll_setup(void)
     NVMCTRL->CTRLB.reg |= NVMCTRL_CTRLB_RWS(3);
 #endif
 }
+
+void cpu_pm_cb_enter(int deep)
+{
+    (void) deep;
+    /* will be called before entering sleep */
+}
+
+void cpu_pm_cb_leave(int deep)
+{
+    (void) deep;
+    /* will be called after wake-up */
+}
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -23,6 +23,16 @@
 #include "periph_conf.h"
 #include "stdio_base.h"
 
+/* As long as DFLL & DPLL are not used, we can default to
+ * always using the buck converter when available.
+ *
+ * An external inductor needs to be present on the board,
+ * so the feature can only be enabled by the board configuration.
+ */
+#ifndef USE_VREG_BUCK
+#define USE_VREG_BUCK (0)
+#endif
+
 static void _gclk_setup(int gclk, uint32_t reg)
 {
     GCLK->GENCTRL[gclk].reg = reg;
@@ -144,6 +154,11 @@ void cpu_init(void)
 
     /* initialize the Cortex-M core */
     cortexm_init();
+
+    /* not compatible with 48 MHz DFLL & 96 MHz FDPLL */
+    if (USE_VREG_BUCK) {
+        sam0_set_voltage_regulator(SAM0_VREG_BUCK);
+    }
 
     /* turn on only needed APB peripherals */
     MCLK->APBAMASK.reg =

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -26,6 +26,8 @@
 
 void pm_set(unsigned mode)
 {
+    int deep = 0;
+
     if (mode < PM_NUM_MODES) {
         uint32_t _mode;
 
@@ -33,10 +35,12 @@ void pm_set(unsigned mode)
             case 0:
                 DEBUG_PUTS("pm_set(): setting BACKUP mode.");
                 _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
+                deep = 1;
                 break;
             case 1:
                 DEBUG_PUTS("pm_set(): setting STANDBY mode.");
                 _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
+                deep = 1;
                 break;
             default: /* Falls through */
             case 2:
@@ -55,5 +59,5 @@ void pm_set(unsigned mode)
         while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
     }
 
-    sam0_cortexm_sleep(0);
+    sam0_cortexm_sleep(deep);
 }


### PR DESCRIPTION
### Contribution description

On MCUs newer than `samd2x` we can select between LDO and buck converter for on-chip voltage conversion.

As the buck converter is much more efficient, select it by default.

On `same54-xpro` with `examples/default` this gives the following IDLE results:
    
**before:** 4.20 mA
 **after:** 2.06 mA

On `saml21-xpro` with `examples/default` this gives
    
**before:** 750 µA
 **after:** 385 µA

I could not test saml1x due to a lock of hardware.

### Testing procedure

No change in behavior is expected.

### Issues/PRs references
#13415 for further power saving