### PR TITLE
shell/gnrc_icmpv6_echo: fix build with USEMODULE += sock_dns

### DIFF
--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -36,6 +36,9 @@
 #ifdef MODULE_GNRC_IPV6_NIB
 #include "net/gnrc/ipv6/nib/nc.h"
 #endif
+#ifdef MODULE_SOCK_DNS
+#include "net/sock/dns.h"
+#endif
 #include "net/icmpv6.h"
 #include "net/ipv6.h"
 #include "timex.h"

--- a/tests/gnrc_sock_dns/main.c
+++ b/tests/gnrc_sock_dns/main.c
@@ -26,6 +26,9 @@
 #include "net/sock/dns.h"
 #include "shell.h"
 
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
 static int _dns(int argc, char **argv);
 
 static const shell_command_t _shell_commands[] = {
@@ -102,6 +105,10 @@ static int _dns(int argc, char **argv)
 
 int main(void)
 {
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+
     /* start shell */
     shell_run(_shell_commands, _shell_buffer, sizeof(_shell_buffer));
     return 0;


### PR DESCRIPTION
### Contribution description

When `sock_dns` is used, `ping6` will call `sock_dns_query()` in [`_configure()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/shell/commands/sc_gnrc_icmpv6_echo.c#L176).
This function is only available if we include the `net/sock/dns.h` header.

### Testing procedure

Add `USEMODULE += sock_dns` to e.g. `examples/gnrc_networking`

### Issues/PRs references

Unfortunately this is not enough to make DNS resolution in `ping6` work.
`sock_dns_query()` will always fail as no DNS server is configured, and if a server is configured it will crash on resolution.

But I'll create a separate issue for that.