### PR TITLE
esp-wifi: allow connecting to open networks

### DIFF
--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -688,12 +688,18 @@ static const netdev_driver_t _esp_wifi_driver =
 static wifi_config_t wifi_config_sta = {
     .sta = {
         .ssid = ESP_WIFI_SSID,
+#ifdef ESP_WIFI_PASS
         .password = ESP_WIFI_PASS,
+#endif
         .channel = 0,
         .scan_method = WIFI_ALL_CHANNEL_SCAN,
         .sort_method = WIFI_CONNECT_AP_BY_SIGNAL,
         .threshold.rssi = -127,
+#ifdef ESP_WIFI_PASS
         .threshold.authmode = WIFI_AUTH_WPA_WPA2_PSK
+#else
+        .threshold.authmode = WIFI_AUTH_OPEN
+#endif
     }
 };
 
@@ -720,8 +726,12 @@ static wifi_config_t wifi_config_ap = {
         .ssid = ESP_WIFI_SSID,
         .ssid_len = ARRAY_SIZE(ESP_WIFI_SSID),
         .ssid_hidden = 1,               /* don't make the AP visible */
+#ifdef ESP_WIFI_PASS
         .password = ESP_WIFI_PASS,
         .authmode = WIFI_AUTH_WPA2_PSK,
+#else
+        .authmode = WIFI_AUTH_OPEN,
+#endif
         .max_connection = 0,            /* don't allow connections */
         .beacon_interval = 60000,       /* send beacon only every 60 s */
     }

--- a/cpu/esp_common/esp-wifi/esp_wifi_params.h
+++ b/cpu/esp_common/esp-wifi/esp_wifi_params.h
@@ -51,7 +51,7 @@
 /**
  * @brief   Passphrase used for the AP as clear text (max. 64 chars).
  */
-#ifndef ESP_WIFI_PASS
+#ifdef DOXYGEN
 #define ESP_WIFI_PASS       "ThisistheRIOTporttoESP"
 #endif
 


### PR DESCRIPTION
### Contribution description

It is often useful to connect to an open network.
Intuitively I would assume `esp_wifi` would do that if `ESP_WIFI_PASS` is not set, but the password 'ThisistheRIOTporttoESP' would be used instead.

Sp allow connecting to unencrypted WiFis if `ESP_WIFI_PASS` is not set.

### Testing procedure

- connect to an open WiFi without setting `ESP_WIFI_PASS`
- connect to an encrypted WiFi by setting `ESP_WIFI_PASS`


### Issues/PRs references

stumbled upon this in #13005