### PR TITLE
fix DNS resolution in ping6

### DIFF
--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -57,8 +57,8 @@ typedef struct {
 #define SOCK_DNS_PORT           (53)
 #define SOCK_DNS_RETRIES        (2)
 
-#define SOCK_DNS_MAX_NAME_LEN   (64U)       /* we're in embedded context. */
-#define SOCK_DNS_QUERYBUF_LEN   (sizeof(sock_dns_hdr_t) + 4 + SOCK_DNS_MAX_NAME_LEN)
+#define SOCK_DNS_BUF_LEN        (128)       /* we're in embedded context. */
+#define SOCK_DNS_MAX_NAME_LEN   (SOCK_DNS_BUF_LEN - sizeof(sock_dns_hdr_t) - 4)
 /** @} */
 
 /**

--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -80,8 +80,8 @@ typedef struct {
  * @param[out]  addr_out        buffer to write result into
  * @param[in]   family          Either AF_INET, AF_INET6 or AF_UNSPEC
  *
- * @return      0 on success
- * @return      !=0 otherwise
+ * @return      the size of the resolved address on success
+ * @return      < 0 otherwise
  */
 int sock_dns_query(const char *domain_name, void *addr_out, int family);
 

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -157,7 +157,7 @@ static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family
             return -EBADMSG;
         }
         bufpos += RR_RDLENGTH_LENGTH;
-        if ((bufpos + addrlen) >= buflim) {
+        if ((bufpos + addrlen) > buflim) {
             return -EBADMSG;
         }
 

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -170,8 +170,7 @@ static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family
 
 int sock_dns_query(const char *domain_name, void *addr_out, int family)
 {
-    uint8_t buf[SOCK_DNS_QUERYBUF_LEN];
-    uint8_t reply_buf[512];
+    static uint8_t dns_buf[SOCK_DNS_BUF_LEN];
 
     if (sock_dns_server.port == 0) {
         return -ECONNREFUSED;
@@ -181,33 +180,6 @@ int sock_dns_query(const char *domain_name, void *addr_out, int family)
         return -ENOSPC;
     }
 
-    sock_dns_hdr_t *hdr = (sock_dns_hdr_t*) buf;
-    memset(hdr, 0, sizeof(*hdr));
-    hdr->id = 0; /* random? */
-    hdr->flags = htons(0x0120);
-    hdr->qdcount = htons(1 + (family == AF_UNSPEC));
-
-    uint8_t *bufpos = buf + sizeof(*hdr);
-
-    unsigned _name_ptr;
-    if ((family == AF_INET6) || (family == AF_UNSPEC)) {
-        _name_ptr = (bufpos - buf);
-        bufpos += _enc_domain_name(bufpos, domain_name);
-        bufpos += _put_short(bufpos, htons(DNS_TYPE_AAAA));
-        bufpos += _put_short(bufpos, htons(DNS_CLASS_IN));
-    }
-
-    if ((family == AF_INET) || (family == AF_UNSPEC)) {
-        if (family == AF_UNSPEC) {
-            bufpos += _put_short(bufpos, htons((0xc000) | (_name_ptr)));
-        }
-        else {
-            bufpos += _enc_domain_name(bufpos, domain_name);
-        }
-        bufpos += _put_short(bufpos, htons(DNS_TYPE_A));
-        bufpos += _put_short(bufpos, htons(DNS_CLASS_IN));
-    }
-
     sock_udp_t sock_dns;
 
     ssize_t res = sock_udp_create(&sock_dns, NULL, &sock_dns_server, 0);
@@ -215,15 +187,45 @@ int sock_dns_query(const char *domain_name, void *addr_out, int family)
         goto out;
     }
 
+    uint16_t id = 0; /* random? */
     for (int i = 0; i < SOCK_DNS_RETRIES; i++) {
+        uint8_t *buf = dns_buf;
+
+        sock_dns_hdr_t *hdr = (sock_dns_hdr_t*) buf;
+        memset(hdr, 0, sizeof(*hdr));
+        hdr->id = id;
+        hdr->flags = htons(0x0120);
+        hdr->qdcount = htons(1 + (family == AF_UNSPEC));
+
+        uint8_t *bufpos = buf + sizeof(*hdr);
+
+        unsigned _name_ptr;
+        if ((family == AF_INET6) || (family == AF_UNSPEC)) {
+            _name_ptr = (bufpos - buf);
+            bufpos += _enc_domain_name(bufpos, domain_name);
+            bufpos += _put_short(bufpos, htons(DNS_TYPE_AAAA));
+            bufpos += _put_short(bufpos, htons(DNS_CLASS_IN));
+        }
+
+        if ((family == AF_INET) || (family == AF_UNSPEC)) {
+            if (family == AF_UNSPEC) {
+                bufpos += _put_short(bufpos, htons((0xc000) | (_name_ptr)));
+            }
+            else {
+                bufpos += _enc_domain_name(bufpos, domain_name);
+            }
+            bufpos += _put_short(bufpos, htons(DNS_TYPE_A));
+            bufpos += _put_short(bufpos, htons(DNS_CLASS_IN));
+        }
+
         res = sock_udp_send(&sock_dns, buf, (bufpos-buf), NULL);
         if (res <= 0) {
             continue;
         }
-        res = sock_udp_recv(&sock_dns, reply_buf, sizeof(reply_buf), 1000000LU, NULL);
+        res = sock_udp_recv(&sock_dns, dns_buf, sizeof(dns_buf), 1000000LU, NULL);
         if (res > 0) {
             if (res > (int)DNS_MIN_REPLY_LEN) {
-                if ((res = _parse_dns_reply(reply_buf, res, addr_out,
+                if ((res = _parse_dns_reply(dns_buf, res, addr_out,
                                             family)) > 0) {
                     goto out;
                 }

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -178,6 +178,7 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
             data->hostname = arg;
 #ifdef MODULE_SOCK_DNS
             if (sock_dns_query(data->hostname, &data->host, AF_INET6) == 0) {
+                res = 0;
                 continue;
             }
 #endif

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -177,7 +177,8 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
 
             data->hostname = arg;
 #ifdef MODULE_SOCK_DNS
-            if (sock_dns_query(data->hostname, &data->host, AF_INET6) == 0) {
+            if (strchr(data->hostname, ':') == NULL &&
+                sock_dns_query(data->hostname, &data->host, AF_INET6) == 0) {
                 res = 0;
                 continue;
             }

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -178,7 +178,7 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
             data->hostname = arg;
 #ifdef MODULE_SOCK_DNS
             if (strchr(data->hostname, ':') == NULL &&
-                sock_dns_query(data->hostname, &data->host, AF_INET6) == 0) {
+                sock_dns_query(data->hostname, &data->host, AF_INET6) > 0) {
                 res = 0;
                 continue;
             }


### PR DESCRIPTION
### Contribution description

Previously DNS resolution in `ping6` would always fail.
This was due to a slew of minor bugs in `sock_dns` and `gnrc_icmpv6_echo`.
This PR fixes them, so DNS resolution is working properly now.

### Testing procedure

If you are using a board with direct WiFi or Ethernet connection (e.g. esp8266 or esp32), it should suffice to add `USEMODULE += sock_dns` to `examples/gnrc_networking`.

On a 6LoWPAN device, the border router (`examples/gnrc_border_router`) doesn't seem to forward DNS information, so you have to resort to `tests/gnrc_sock_dns` to being able to set the DNS server manually by calling e.g. `dns server 2620:119:35::35:`.

You should now be able to ping a host by name:

```
2020-02-22 20:10:44,986 #  ping6 riot-os.org
2020-02-22 20:10:45,114 # 12 bytes from 2a01:4f8:151:64::11: icmp_seq=0 ttl=56 time=71.772 ms
2020-02-22 20:10:46,071 # 12 bytes from 2a01:4f8:151:64::11: icmp_seq=1 ttl=56 time=29.318 ms
2020-02-22 20:10:47,122 # 12 bytes from 2a01:4f8:151:64::11: icmp_seq=2 ttl=56 time=79.199 ms
```

### Issues/PRs references

fixes #13447
follow-up on #13443
