### PR TITLE
boards/samXXX-xpro: clear LED on init

### DIFF
--- a/boards/common/saml1x/board.c
+++ b/boards/common/saml1x/board.c
@@ -34,11 +34,11 @@ void board_init(void)
 
 }
 
-
 /**
  * @brief Initialize the boards on-board LED
  */
 void led_init(void)
 {
-    gpio_init(GPIO_PIN(PA, 7), GPIO_OUT);
+    gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
 }

--- a/boards/samd21-xpro/board.c
+++ b/boards/samd21-xpro/board.c
@@ -28,6 +28,7 @@ void board_init(void)
 {
     /* initialize the on-board LED */
     gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
 
     /* initialize the on-board button */
     gpio_init(BTN0_PIN, BTN0_MODE);

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -25,6 +25,7 @@ void board_init(void)
 {
     /* initialize the on-board LED */
     gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
 
     /* initialize the on-board button */
     gpio_init(BTN0_PIN, BTN0_MODE);

--- a/boards/saml21-xpro/board.c
+++ b/boards/saml21-xpro/board.c
@@ -44,5 +44,6 @@ void board_init(void)
  */
 void led_init(void)
 {
-    gpio_init(GPIO_PIN(PB,10), GPIO_OUT);
+    gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
 }

--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -39,6 +39,8 @@ void board_init(void)
 {
     /* initialize the on-board LED */
     gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
+
     /* initialize the on-board antenna switch */
     gpio_init(RFCTL1_PIN, GPIO_OUT);
     gpio_init(RFCTL2_PIN, GPIO_OUT);


### PR DESCRIPTION
### Contribution description

The LED on the sam-xpro boards is active low, so we have to turn it off manually, otherwise it's always on.


### Testing procedure

Flash any sam…-xpro board.
The on-board LED should be off.

### Issues/PRs references
none, but makes the LED more useful for debugging.
