### PR TITLE
tests/unittests: fix GCC compiler bug in core-atomic for SAML1X

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,9 +1,6 @@
 DEVELHELP ?= 0
 include ../Makefile.tests_common
 
-# temporarily disable building, see #13456.
-BOARD_BLACKLIST := saml10-xpro saml11-xpro
-
 USEMODULE += embunit
 
 ifeq (, $(filter tests-%, $(MAKECMDGOALS)))

--- a/tests/unittests/tests-core/tests-core-atomic.c
+++ b/tests/unittests/tests-core/tests-core-atomic.c
@@ -26,6 +26,11 @@ static void test_atomic_flag(void)
     TEST_ASSERT_EQUAL_INT(0, atomic_flag_test_and_set(&flag));
 }
 
+/* Prevent compiler optimization for SAML1X because of gcc internal bug */
+#ifdef CPU_ARCH_CORTEX_M23
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
+#endif
 /* Test atomic_fetch_add */
 static void test_atomic_inc_positive(void)
 {
@@ -51,11 +56,7 @@ static void test_atomic_inc_negative(void)
         TEST_ASSERT_EQUAL_INT(i + 1, atomic_load(&res));
     }
 }
-/* Prevent compiler optimization for SAML1X because of gcc internal bug */
-#ifdef CPU_SAML1X
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
-#endif
+
 static void test_atomic_inc_rollover(void)
 {
     atomic_int res = ATOMIC_VAR_INIT(INT_MAX - 30);


### PR DESCRIPTION


### Contribution description

This PR provides a quick (dirty ?) fix for SAML1X families and unittests.
In fact, this PR extends a current fix that was there to fix a previous compiler issue when I was porting SAML10/SAML11 MCUs. I don't know if this is the best way to handle it...


### Testing procedure

Compile tests/unittests on SAML10 or SAML11 boards.


### Issues/PRs references
#13459
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
