### PR TITLE
cpu/atmega_common: fix of compilation problem with NDEBUG

### DIFF
--- a/cpu/atmega_common/periph/rtt.c
+++ b/cpu/atmega_common/periph/rtt.c
@@ -206,6 +206,7 @@ static inline uint8_t _rtt_div(uint16_t freq)
     case   128: return 0x6;
     case    32: return 0x7;
     default   : assert(0);
+                return 0;
     }
 }
 


### PR DESCRIPTION
### Contribution description

This PR fixes a compilation problem in `cpu/atmega_common/periph/rtt.c` when `NDEBUG` is defined.

The implementation of `periph_rtt` in `cpu/atmega_commont` uses the `assert` macro to stop the execution if the frequency parameter in `_rtt_div` hasn't a valid value. However, when compiling with `NDEBUG` defined, `assert` doesn't produce any code. As a result, the function has no return statement.

### Testing procedure

Compile the `tests/periph_rtt` application for the `mega-xplained` board with and without the PR.
```
CFLAGS='-DNDEBUG' BOARD=mega-xplained make -C tests/periph_rtt
```
Without the PR the compilation fails, with this PR it should succeed.

### Issues/PRs references