### PR TITLE
tests: fix compilation problems with NDEBUG

### DIFF
--- a/cpu/nrf51/periph/pwm.c
+++ b/cpu/nrf51/periph/pwm.c
@@ -121,6 +121,10 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
 void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
 {
+#ifdef NDEBUG
+    (void)dev;
+    (void)channel;
+#endif
     assert((dev == 0) && (channel == 0));
 
     /*
@@ -192,6 +196,9 @@ void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
 
 uint8_t pwm_channels(pwm_t dev)
 {
+#ifdef NDEBUG
+    (void)dev;
+#endif
     assert(dev == 0);
     return 1;
 }

--- a/cpu/stm32_common/periph/usbdev.c
+++ b/cpu/stm32_common/periph/usbdev.c
@@ -205,6 +205,9 @@ void usbdev_init_lowlevel(void)
     for (size_t i = 0; i < USBDEV_NUMOF; i++) {
         ep_idx += _setup(&_usbdevs[i], &stm32_usb_otg_fshs_config[i], ep_idx);
     }
+#ifdef NDEBUG
+    (void)ep_idx;
+#endif
     assert(ep_idx == _TOTAL_NUM_ENDPOINTS);
 }
 
@@ -416,7 +419,7 @@ static usbdev_ep_t *_get_ep(stm32_usb_otg_fshs_t *usbdev, unsigned num,
     return dir == USB_EP_DIR_IN ? &usbdev->in[num] : &usbdev->out[num];
 }
 
-#ifdef DEVELHELP
+#if defined(DEVELHELP) && !defined(NDEBUG)
 static size_t _total_fifo_size(const stm32_usb_otg_fshs_config_t *conf)
 {
     if (conf->type == STM32_USB_OTG_FS) {
@@ -435,7 +438,7 @@ static size_t _total_fifo_size(const stm32_usb_otg_fshs_config_t *conf)
     }
 
 }
-#endif /* DEVELHELP */
+#endif /* defined(DEVELHELP) && !defined(NDEBUG) */
 
 static void _configure_tx_fifo(stm32_usb_otg_fshs_t *usbdev, size_t num,
                                size_t len)

--- a/drivers/mtd_mapper/mtd_mapper.c
+++ b/drivers/mtd_mapper/mtd_mapper.c
@@ -73,6 +73,9 @@ static int _init(mtd_dev_t *mtd)
            backing_mtd->pages_per_sector * backing_mtd->sector_count *
            backing_mtd->page_size);
 
+    /* avoid unused variable warning if compiled with NDEBUG */
+    (void)backing_mtd;
+
     _lock(region);
     int res = _init_target(region);
     _unlock(region);

--- a/examples/ndn-ping/ndn_ping.c
+++ b/examples/ndn-ping/ndn_ping.c
@@ -23,6 +23,7 @@
 
 #include "thread.h"
 #include "random.h"
+#include "test_utils/expect.h"
 
 #include "ndn-riot/app.h"
 #include "ndn-riot/ndn.h"
@@ -57,7 +58,7 @@ static int on_data(ndn_block_t* interest, ndn_block_t* data)
 
     ndn_block_t name;
     int r = ndn_data_get_name(data, &name);
-    assert(r == 0);
+    expect(r == 0);
     printf("client (pid=%" PRIkernel_pid "): data received, name=",
            handle->id);
     ndn_name_print(&name);
@@ -65,8 +66,8 @@ static int on_data(ndn_block_t* interest, ndn_block_t* data)
 
     ndn_block_t content;
     r = ndn_data_get_content(data, &content);
-    assert(r == 0);
-    assert(content.len == 6);
+    expect(r == 0);
+    expect(content.len == 6);
 
     printf("client (pid=%" PRIkernel_pid "): content=%02X%02X%02X%02X\n",
            handle->id, *(content.buf + 2), *(content.buf + 3),
@@ -90,7 +91,7 @@ static int on_timeout(ndn_block_t* interest)
 {
     ndn_block_t name;
     int r = ndn_interest_get_name(interest, &name);
-    assert(r == 0);
+    expect(r == 0);
 
     printf("client (pid=%" PRIkernel_pid "): interest timeout, name=",
            handle->id);

--- a/pkg/ubasic/patches/0001-replace-assert-by-expect.patch
+++ b/pkg/ubasic/patches/0001-replace-assert-by-expect.patch
@@ -1,0 +1,61 @@
+From 6b996a7060a746023011ee60eb4ea2c5b4d76970 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Tue, 25 Feb 2020 15:42:53 +0100
+Subject: [PATCH 1/1] replace assert by expect
+
+---
+ tests.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/tests.c b/tests.c
+index 96f60b8..a7bab89 100644
+--- a/tests.c
++++ b/tests.c
+@@ -31,7 +31,7 @@
+ 
+ #include <time.h>
+ #include <stdio.h>
+-#include <assert.h>
++#include "test_utils/expect.h"
+ #include "ubasic.h"
+ 
+ static const char program_let[] =
+@@ -82,7 +82,7 @@ VARIABLE_TYPE peek(VARIABLE_TYPE arg) {
+ 
+ /*---------------------------------------------------------------------------*/
+ void poke(VARIABLE_TYPE arg, VARIABLE_TYPE value) {
+-    assert(arg == value);
++    expect(arg == value);
+ }
+ 
+ /*---------------------------------------------------------------------------*/
+@@ -114,20 +114,20 @@ int
+ main(void)
+ {
+   run(program_let);
+-  assert(ubasic_get_variable(0) == 42);
++  expect(ubasic_get_variable(0) == 42);
+ 
+   run(program_goto);
+-  assert(ubasic_get_variable(2) == 108);
++  expect(ubasic_get_variable(2) == 108);
+ 
+   run(program_loop);
+-  assert(ubasic_get_variable(0) == (VARIABLE_TYPE)(126 * 126 * 10));
++  expect(ubasic_get_variable(0) == (VARIABLE_TYPE)(126 * 126 * 10));
+ 
+   run(program_fibs);
+-  assert(ubasic_get_variable(1) == 89);
++  expect(ubasic_get_variable(1) == 89);
+ 
+   run(program_peek_poke);
+-  assert(ubasic_get_variable(0) == 123);
+-  assert(ubasic_get_variable(25) == 123);
++  expect(ubasic_get_variable(0) == 123);
++  expect(ubasic_get_variable(25) == 123);
+ 
+   return 0;
+ }
+-- 
+2.17.1
+

--- a/tests/bench_timers/main.c
+++ b/tests/bench_timers/main.c
@@ -39,6 +39,7 @@
 #include "board.h"
 #include "cpu.h"
 #include "periph/timer.h"
+#include "test_utils/expect.h"
 
 #include "print_results.h"
 #include "spin_random.h"
@@ -676,7 +677,7 @@ int main(void)
     print_str("state vector total memory usage = ");
     print_u32_dec(sizeof(ref_states));
     print_str(" bytes\n");
-    assert(log2test < TEST_LOG2NUM);
+    expect(log2test < TEST_LOG2NUM);
     print_str("TIM_TEST_DEV = ");
     print_u32_dec(TIM_TEST_DEV);
     print_str(", TIM_TEST_FREQ = ");

--- a/tests/bench_xtimer/main.c
+++ b/tests/bench_xtimer/main.c
@@ -19,7 +19,8 @@
  */
 
 #include <stdio.h>
-#include <test_utils/expect.h>
+
+#include "test_utils/expect.h"
 
 #include "msg.h"
 #include "thread.h"

--- a/tests/cpp11_condition_variable/main.cpp
+++ b/tests/cpp11_condition_variable/main.cpp
@@ -20,13 +20,14 @@
 
 #include <string>
 #include <cstdio>
-#include <cassert>
 #include <system_error>
 
 #include "riot/mutex.hpp"
 #include "riot/chrono.hpp"
 #include "riot/thread.hpp"
 #include "riot/condition_variable.hpp"
+
+#include "test_utils/expect.h"
 
 using namespace std;
 using namespace riot;
@@ -62,7 +63,7 @@ int main() {
       cv.wait(lk, [&processed] { return processed; });
     }
     string expected = "Example data after processing";
-    assert(data == expected);
+    expect(data == expected);
     worker.join();
   }
   puts("Done\n");
@@ -102,7 +103,7 @@ int main() {
     cv.wait_for(lk, chrono::seconds(timeout));
     xtimer_now_timex(&after);
     auto diff = timex_sub(after, before);
-    assert(diff.seconds >= timeout);
+    expect(diff.seconds >= timeout);
   }
   puts("Done\n");
 
@@ -119,7 +120,7 @@ int main() {
     cv.wait_until(lk, time);
     xtimer_now_timex(&after);
     auto diff = timex_sub(after, before);
-    assert(diff.seconds >= timeout);
+    expect(diff.seconds >= timeout);
   }
   puts("Done\n");
 

--- a/tests/cpp11_mutex/main.cpp
+++ b/tests/cpp11_mutex/main.cpp
@@ -19,13 +19,14 @@
  */
 #include <string>
 #include <cstdio>
-#include <cassert>
 #include <system_error>
 
 #include "riot/mutex.hpp"
 #include "riot/chrono.hpp"
 #include "riot/thread.hpp"
 #include "riot/condition_variable.hpp"
+
+#include "test_utils/expect.h"
 
 using namespace std;
 using namespace riot;
@@ -46,16 +47,22 @@ int main() {
         m.unlock();
       }
     };
+#ifndef NDEBUG
+    /* We can't use expect here, otherwise cppcheck will produce errors */
     assert(resource == 0);
+#endif
     auto start = std::chrono::system_clock::now();
     thread t1(f);
     thread t2(f);
     t1.join();
     t2.join();
+#ifndef NDEBUG
+    /* We can't use expect here, otherwise cppcheck will produce errors */
     assert(resource == 6);
+#endif
     auto duration = std::chrono::duration_cast
       <chrono::milliseconds>(std::chrono::system_clock::now() - start);
-    assert(duration.count() >= 600);
+    expect(duration.count() >= 600);
   }
   puts("Done\n");
 
@@ -65,7 +72,7 @@ int main() {
     m.lock();
     thread([&m] {
              auto res = m.try_lock();
-             assert(res == false);
+             expect(res == false);
            }).detach();
     m.unlock();
   }
@@ -74,7 +81,7 @@ int main() {
     mutex m;
     thread([&m] {
              auto res = m.try_lock();
-             assert(res == true);
+             expect(res == true);
              m.unlock();
            }).detach();
   }

--- a/tests/driver_motor_driver/main.c
+++ b/tests/driver_motor_driver/main.c
@@ -21,9 +21,10 @@
 #include <string.h>
 
 /* RIOT includes */
-#include <log.h>
-#include <motor_driver.h>
-#include <xtimer.h>
+#include "log.h"
+#include "motor_driver.h"
+#include "test_utils/expect.h"
+#include "xtimer.h"
 
 /* set interval to 20 milli-second */
 #define INTERVAL (3000 * US_PER_MS)
@@ -78,7 +79,7 @@ void motion_control(void)
     if (ret) {
         LOG_ERROR("motor_driver_init failed with error code %d\n", ret);
     }
-    assert(ret == 0);
+    expect(ret == 0);
 
     for (;;) {
         /* BRAKE - duty cycle 100% */

--- a/tests/embunit/main.c
+++ b/tests/embunit/main.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "assert.h"
 #include "embUnit.h"
 
 #define TEST_STRING_7   ("7")

--- a/tests/events/main.c
+++ b/tests/events/main.c
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 
+#include "test_utils/expect.h"
 #include "thread.h"
 #include "event.h"
 #include "event/timeout.h"
@@ -50,8 +51,8 @@ static event_t delayed_event2 = { .handler = delayed_callback2 };
 static void callback(event_t *arg)
 {
     order++;
-    assert(order == 3);
-    assert(arg == &event);
+    expect(order == 3);
+    expect(arg == &event);
     printf("triggered 0x%08x\n", (unsigned)arg);
 }
 
@@ -67,8 +68,8 @@ static event_callback_t noevent_callback = EVENT_CALLBACK_INIT(forbidden_callbac
 static void custom_callback(event_t *event)
 {
     order++;
-    assert(order == 4);
-    assert(event == (event_t *)&custom_event);
+    expect(order == 4);
+    expect(event == (event_t *)&custom_event);
     custom_event_t *custom_event = (custom_event_t *)event;
     printf("triggered custom event with text: \"%s\"\n", custom_event->text);
 }
@@ -76,10 +77,10 @@ static void custom_callback(event_t *event)
 static void timed_callback(void *arg)
 {
     order++;
-    assert(order == 5);
-    assert(arg == event_callback.arg);
+    expect(order == 5);
+    expect(arg == event_callback.arg);
     uint32_t now = xtimer_now_usec();
-    assert((now - before >= 100000LU));
+    expect((now - before >= 100000LU));
     printf("triggered timed callback with arg 0x%08x after %" PRIu32 "us\n", (unsigned)arg, now - before);
     puts("[SUCCESS]");
 }
@@ -91,23 +92,23 @@ static void forbidden_callback(void *arg)
     puts("call to forbidden callback");
     puts("[FAILED]");
     while (1) {
-        assert(false);
+        expect(false);
     }
 }
 
 static void delayed_callback1(event_t *arg)
 {
     order++;
-    assert(order == 1);
-    assert(arg == &delayed_event1);
+    expect(order == 1);
+    expect(arg == &delayed_event1);
     printf("triggered delayed event %p\n", (void *)arg);
 }
 
 static void delayed_callback2(event_t *arg)
 {
     order++;
-    assert(order == 2);
-    assert(arg == &delayed_event2);
+    expect(order == 2);
+    expect(arg == &delayed_event2);
     printf("triggered delayed event %p\n", (void *)arg);
 }
 

--- a/tests/gnrc_ipv6_ext_frag/main.c
+++ b/tests/gnrc_ipv6_ext_frag/main.c
@@ -39,6 +39,7 @@
 #include "od.h"
 #include "random.h"
 #include "shell.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #define TEST_SAMPLE         "This is a test. Failure might sometimes be an " \
@@ -640,7 +641,7 @@ static int unittests(int argc, char** argv)
 static int mock_get_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = NETDEV_TYPE_TEST;
     return sizeof(uint16_t);
 }
@@ -648,8 +649,8 @@ static int mock_get_device_type(netdev_t *dev, void *value, size_t max_len)
 static int mock_get_max_packet_size(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
-    assert(eth_netif != NULL);
+    expect(max_len == sizeof(uint16_t));
+    expect(eth_netif != NULL);
     *((uint16_t *)value) = eth_netif->ipv6.mtu - 8;
     return sizeof(uint16_t);
 }

--- a/tests/gnrc_ipv6_fwd_w_sub/main.c
+++ b/tests/gnrc_ipv6_fwd_w_sub/main.c
@@ -19,7 +19,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <stdio.h>
 
@@ -35,6 +34,7 @@
 #include "od.h"
 #include "sched.h"
 #include "shell.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 #include "xtimer.h"
 
@@ -133,11 +133,11 @@ static gnrc_pktsnip_t *_build_recvd_pkt(void)
     gnrc_pktsnip_t *pkt;
 
     netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
-    assert(netif);
+    expect(netif);
     gnrc_netif_hdr_set_netif(netif->data, _mock_netif);
     pkt = gnrc_pktbuf_add(netif, _l2_payload, sizeof(_l2_payload),
                           GNRC_NETTYPE_IPV6);
-    assert(pkt);
+    expect(pkt);
     return pkt;
 }
 
@@ -153,7 +153,7 @@ static int _run_test(int argc, char **argv)
                                                  THREAD_PRIORITY_MAIN - 1, 0,
                                                  _dumper_thread, NULL,
                                                  "dumper"));
-        assert(_dumper.target.pid > KERNEL_PID_UNDEF);
+        expect(_dumper.target.pid > KERNEL_PID_UNDEF);
         /* give dumper thread time to run */
         xtimer_usleep(200);
     }
@@ -165,15 +165,15 @@ static int _run_test(int argc, char **argv)
                                                GNRC_NETREG_DEMUX_CTX_ALL,
                                                _build_recvd_pkt());
     /* only IPv6 should be subscribed at the moment */
-    assert(subscribers == 1);
+    expect(subscribers == 1);
     /* subscribe dumper thread for any IPv6 packets */
     gnrc_netreg_register(GNRC_NETTYPE_IPV6, &_dumper);
     /* now test forwarding with subscription */
     subscribers = gnrc_netapi_dispatch_receive(GNRC_NETTYPE_IPV6,
                                                GNRC_NETREG_DEMUX_CTX_ALL,
                                                _build_recvd_pkt());
-    /* assert 2 subscribers: IPv6 and gnrc_pktdump as registered above */
-    assert(subscribers == 2);
+    /* expect 2 subscribers: IPv6 and gnrc_pktdump as registered above */
+    expect(subscribers == 2);
     return 0;
 }
 
@@ -186,11 +186,11 @@ int main(void)
     /* define neighbor to forward to */
     res = gnrc_ipv6_nib_nc_set(&_nbr_link_local, _mock_netif->pid,
                                _nbr_mac, sizeof(_nbr_mac));
-    assert(res == 0);
+    expect(res == 0);
     /* set route to neighbor */
     res = gnrc_ipv6_nib_ft_add(&_dst, DST_PFX_LEN, &_nbr_link_local,
                                _mock_netif->pid, 0);
-    assert(res == 0);
+    expect(res == 0);
     /* start shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/tests/gnrc_ipv6_fwd_w_sub/mockup_netif.c
+++ b/tests/gnrc_ipv6_fwd_w_sub/mockup_netif.c
@@ -19,6 +19,7 @@
 #include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/netif/ethernet.h"
 #include "net/netdev_test.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 
 gnrc_netif_t *_mock_netif = NULL;
@@ -29,7 +30,7 @@ static char _mock_netif_stack[THREAD_STACKSIZE_MAIN];
 static int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = NETDEV_TYPE_ETHERNET;
     return sizeof(uint16_t);
 }
@@ -37,7 +38,7 @@ static int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 static int _get_max_packet_size(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = ETHERNET_DATA_LEN;
     return sizeof(uint16_t);
 }
@@ -47,7 +48,7 @@ static int _get_address(netdev_t *dev, void *value, size_t max_len)
     static const uint8_t addr[] = { _LL0, _LL1, _LL2, _LL3, _LL4, _LL5 };
 
     (void)dev;
-    assert(max_len >= sizeof(addr));
+    expect(max_len >= sizeof(addr));
     memcpy(value, addr, sizeof(addr));
     return sizeof(addr);
 }
@@ -65,14 +66,14 @@ void _tests_init(void)
            _mock_netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
             "mockup_eth", &_mock_netdev.netdev
         );
-    assert(_mock_netif != NULL);
+    expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
     gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
     gnrc_netif_release(_mock_netif);
     /* we do not want to test for SLAAC here so just assure the configured
      * address is valid */
-    assert(!ipv6_addr_is_unspecified(&_mock_netif->ipv6.addrs[0]));
+    expect(!ipv6_addr_is_unspecified(&_mock_netif->ipv6.addrs[0]));
     _mock_netif->ipv6.addrs_flags[0] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
     _mock_netif->ipv6.addrs_flags[0] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID;
 }

--- a/tests/gnrc_ipv6_nib/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib/mockup_netif.c
@@ -22,6 +22,7 @@
 #include "net/gnrc/netif/internal.h"
 #include "net/netdev_test.h"
 #include "sched.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 
 #define _MSG_QUEUE_SIZE  (2)
@@ -35,7 +36,7 @@ static msg_t _main_msg_queue[_MSG_QUEUE_SIZE];
 
 void _common_set_up(void)
 {
-    assert(_mock_netif != NULL);
+    expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
     gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
@@ -45,7 +46,7 @@ void _common_set_up(void)
 int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = NETDEV_TYPE_ETHERNET;
     return sizeof(uint16_t);
 }
@@ -53,7 +54,7 @@ int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 int _get_max_packet_size(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = ETHERNET_DATA_LEN;
     return sizeof(uint16_t);
 }
@@ -63,7 +64,7 @@ int _get_address(netdev_t *dev, void *value, size_t max_len)
     static const uint8_t addr[] = { _LL0, _LL1, _LL2, _LL3, _LL4, _LL5 };
 
     (void)dev;
-    assert(max_len >= sizeof(addr));
+    expect(max_len >= sizeof(addr));
     memcpy(value, addr, sizeof(addr));
     return sizeof(addr);
 }
@@ -82,10 +83,10 @@ void _tests_init(void)
            _mock_netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
             "mockup_eth", &_mock_netdev.netdev
         );
-    assert(_mock_netif != NULL);
+    expect(_mock_netif != NULL);
     /* we do not want to test for SLAAC here so just assure the configured
      * address is valid */
-    assert(!ipv6_addr_is_unspecified(&_mock_netif->ipv6.addrs[0]));
+    expect(!ipv6_addr_is_unspecified(&_mock_netif->ipv6.addrs[0]));
     _mock_netif->ipv6.addrs_flags[0] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
     _mock_netif->ipv6.addrs_flags[0] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID;
     gnrc_netreg_entry_init_pid(&dumper, GNRC_NETREG_DEMUX_CTX_ALL,

--- a/tests/gnrc_ipv6_nib_6ln/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib_6ln/mockup_netif.c
@@ -22,6 +22,7 @@
 #include "net/gnrc/netif/internal.h"
 #include "net/netdev_test.h"
 #include "sched.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 
 #define _MSG_QUEUE_SIZE  (2)
@@ -35,7 +36,7 @@ static msg_t _main_msg_queue[_MSG_QUEUE_SIZE];
 
 void _common_set_up(void)
 {
-    assert(_mock_netif != NULL);
+    expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
     gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
@@ -45,7 +46,7 @@ void _common_set_up(void)
 int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
     return sizeof(uint16_t);
 }
@@ -53,7 +54,7 @@ int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 int _get_max_packet_size(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = 102U;
     return sizeof(uint16_t);
 }
@@ -61,7 +62,7 @@ int _get_max_packet_size(netdev_t *dev, void *value, size_t max_len)
 int _get_src_len(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = IEEE802154_LONG_ADDRESS_LEN;
     return sizeof(uint16_t);
 }
@@ -72,7 +73,7 @@ int _get_address_long(netdev_t *dev, void *value, size_t max_len)
                                     _LL4, _LL5, _LL6, _LL7 };
 
     (void)dev;
-    assert(max_len >= sizeof(addr));
+    expect(max_len >= sizeof(addr));
     memcpy(value, addr, sizeof(addr));
     return sizeof(addr);
 }
@@ -80,7 +81,7 @@ int _get_address_long(netdev_t *dev, void *value, size_t max_len)
 int _get_proto(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(gnrc_nettype_t));
+    expect(max_len == sizeof(gnrc_nettype_t));
     *((gnrc_nettype_t *)value) = GNRC_NETTYPE_SIXLOWPAN;
     return sizeof(gnrc_nettype_t);
 }
@@ -103,7 +104,7 @@ void _tests_init(void)
            _mock_netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
             "mockup_wpan", &_mock_netdev.netdev.netdev
         );
-    assert(_mock_netif != NULL);
+    expect(_mock_netif != NULL);
     gnrc_netreg_entry_init_pid(&dumper, GNRC_NETREG_DEMUX_CTX_ALL,
                                sched_active_pid);
     gnrc_netreg_register(GNRC_NETTYPE_NDP, &dumper);

--- a/tests/gnrc_ndp/main.c
+++ b/tests/gnrc_ndp/main.c
@@ -35,6 +35,7 @@
 #include "net/netdev_test.h"
 #include "net/netopt.h"
 #include "sched.h"
+#include "test_utils/expect.h"
 
 #include "net/gnrc/ndp.h"
 
@@ -1231,7 +1232,7 @@ static const gnrc_netif_ops_t _test_netif_ops = {
 static int _netdev_test_address_long(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len >= sizeof(test_src_l2));
+    expect(max_len >= sizeof(test_src_l2));
     memcpy(value, test_src_l2, sizeof(test_src_l2));
     return sizeof(test_src_l2);
 }
@@ -1239,7 +1240,7 @@ static int _netdev_test_address_long(netdev_t *dev, void *value, size_t max_len)
 static int _netdev_test_proto(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-     assert(max_len == sizeof(gnrc_nettype_t));
+     expect(max_len == sizeof(gnrc_nettype_t));
      *((gnrc_nettype_t *)value) = GNRC_NETTYPE_UNDEF;
      return sizeof(gnrc_nettype_t);
 }
@@ -1247,7 +1248,7 @@ static int _netdev_test_proto(netdev_t *dev, void *value, size_t max_len)
 static int _netdev_test_src_len(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-     assert(max_len == sizeof(uint16_t));
+     expect(max_len == sizeof(uint16_t));
      *((uint16_t *)value) = sizeof(test_src_l2);
      return sizeof(uint16_t);
 }
@@ -1255,7 +1256,7 @@ static int _netdev_test_src_len(netdev_t *dev, void *value, size_t max_len)
 static int _netdev_test_max_pdu_size(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-     assert(max_len == sizeof(uint16_t));
+     expect(max_len == sizeof(uint16_t));
      *((uint16_t *)value) = 100U;
      return sizeof(uint16_t);
 }
@@ -1263,7 +1264,7 @@ static int _netdev_test_max_pdu_size(netdev_t *dev, void *value, size_t max_len)
 static int _netdev_test_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-     assert(max_len == sizeof(uint16_t));
+     expect(max_len == sizeof(uint16_t));
      *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
      return sizeof(uint16_t);
 }

--- a/tests/gnrc_netif/common.c
+++ b/tests/gnrc_netif/common.c
@@ -23,6 +23,7 @@
 #include "net/ipv6.h"
 #include "net/netdev_test.h"
 #include "od.h"
+#include "test_utils/expect.h"
 
 static netdev_test_t _devs[GNRC_NETIF_NUMOF];
 
@@ -72,7 +73,7 @@ void _test_trigger_recv(gnrc_netif_t *netif, const uint8_t *data,
 {
     netdev_t *dev = netif->dev;
 
-    assert(data_len <= ETHERNET_DATA_LEN);
+    expect(data_len <= ETHERNET_DATA_LEN);
     if ((data != NULL) || (data_len > 0)) {
         tmp_buffer_bytes = data_len;
         memcpy(tmp_buffer, data, data_len);
@@ -80,7 +81,7 @@ void _test_trigger_recv(gnrc_netif_t *netif, const uint8_t *data,
     else {
         tmp_buffer_bytes = 0;
     }
-    assert(dev->event_callback);
+    expect(dev->event_callback);
     netdev_trigger_event_isr(dev);
 }
 
@@ -106,13 +107,13 @@ static int _netdev_recv(netdev_t *dev, char *buf, int len, void *info)
 
 static void _netdev_isr(netdev_t *dev)
 {
-    assert(dev->event_callback);
+    expect(dev->event_callback);
     dev->event_callback(dev, NETDEV_EVENT_RX_COMPLETE);
 }
 
 static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len)
 {
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     (void)max_len;
 
     netdev_test_t *dev = (netdev_test_t *)netdev;
@@ -131,15 +132,15 @@ static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len
 
 static int _get_netdev_proto(netdev_t *dev, void *value, size_t max_len)
 {
-    assert(dev == ieee802154_dev);
-    assert(max_len == sizeof(gnrc_nettype_t));
+    expect(dev == ieee802154_dev);
+    expect(max_len == sizeof(gnrc_nettype_t));
     *((gnrc_nettype_t *)value) = GNRC_NETTYPE_UNDEF;
     return sizeof(gnrc_nettype_t);
 }
 
 static int _get_netdev_max_packet_size(netdev_t *netdev, void *value, size_t max_len)
 {
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     (void)max_len;
 
     netdev_test_t *dev = (netdev_test_t *)netdev;

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -35,6 +35,7 @@
 #include "net/gnrc/netif/internal.h"
 #include "net/netdev_test.h"
 #include "net/netif.h"
+#include "test_utils/expect.h"
 #include "utlist.h"
 #include "xtimer.h"
 
@@ -1669,12 +1670,12 @@ static int _get_netdev_address(netdev_t *dev, void *value, size_t max_len)
     (void)max_len;
 
     if (dev == ethernet_dev) {
-        assert(max_len >= sizeof(ethernet_l2addr));
+        expect(max_len >= sizeof(ethernet_l2addr));
         memcpy(value, ethernet_l2addr, sizeof(ethernet_l2addr));
         return sizeof(ethernet_l2addr);
     }
     else if (dev == ieee802154_dev) {
-        assert(max_len >= sizeof(ieee802154_l2addr_short));
+        expect(max_len >= sizeof(ieee802154_l2addr_short));
         memcpy(value, ieee802154_l2addr_short, sizeof(ieee802154_l2addr_short));
         return sizeof(ieee802154_l2addr_short);
     }
@@ -1685,12 +1686,12 @@ static int _set_netdev_address(netdev_t *dev, const void *value,
                                size_t value_len)
 {
     if (dev == ethernet_dev) {
-        assert(value_len <= sizeof(ethernet_l2addr));
+        expect(value_len <= sizeof(ethernet_l2addr));
         memcpy(ethernet_l2addr, value, value_len);
         return value_len;
     }
     else if (dev == ieee802154_dev) {
-        assert(value_len <= sizeof(ieee802154_l2addr_short));
+        expect(value_len <= sizeof(ieee802154_l2addr_short));
         memcpy(ieee802154_l2addr_short, value, value_len);
         return value_len;
     }
@@ -1702,7 +1703,7 @@ static int _get_netdev_address_long(netdev_t *dev, void *value, size_t max_len)
     (void)max_len;
 
     if (dev == ieee802154_dev) {
-        assert(max_len >= sizeof(ieee802154_l2addr_long));
+        expect(max_len >= sizeof(ieee802154_l2addr_long));
         memcpy(value, ieee802154_l2addr_long, sizeof(ieee802154_l2addr_long));
         return sizeof(ieee802154_l2addr_long);
     }
@@ -1713,7 +1714,7 @@ static int _set_netdev_address_long(netdev_t *dev, const void *value,
                                     size_t value_len)
 {
     if (dev == ieee802154_dev) {
-        assert(value_len <= sizeof(ieee802154_l2addr_long));
+        expect(value_len <= sizeof(ieee802154_l2addr_long));
         memcpy(ieee802154_l2addr_long, value, value_len);
         return value_len;
     }
@@ -1725,7 +1726,7 @@ static int _get_netdev_src_len(netdev_t *dev, void *value, size_t max_len)
     (void)max_len;
 
     if (dev == ieee802154_dev) {
-        assert(max_len == sizeof(uint16_t));
+        expect(max_len == sizeof(uint16_t));
         *((uint16_t *)value) = ieee802154_l2addr_len;
         return sizeof(uint16_t);
     }
@@ -1738,7 +1739,7 @@ static int _set_netdev_src_len(netdev_t *dev, const void *value,
     (void)value_len;
 
     if (dev == ieee802154_dev) {
-        assert(value_len == sizeof(uint16_t));
+        expect(value_len == sizeof(uint16_t));
         ieee802154_l2addr_len = *((uint16_t *)value);
         return sizeof(uint16_t);
     }

--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -35,6 +35,7 @@
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/pktdump.h"
 #include "net/netdev_test.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #define IEEE802154_MAX_FRAG_SIZE    (102)
@@ -51,7 +52,7 @@ static const uint8_t _ieee802154_local_eui64[] = IEEE802154_LOCAL_EUI64;
 
 static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len)
 {
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     (void)netdev;
 
     *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
@@ -60,7 +61,7 @@ static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len
 
 static int _get_netdev_proto(netdev_t *netdev, void *value, size_t max_len)
 {
-    assert(max_len == sizeof(gnrc_nettype_t));
+    expect(max_len == sizeof(gnrc_nettype_t));
     (void)netdev;
 
     *((gnrc_nettype_t *)value) = GNRC_NETTYPE_SIXLOWPAN;
@@ -70,7 +71,7 @@ static int _get_netdev_proto(netdev_t *netdev, void *value, size_t max_len)
 static int _get_netdev_max_packet_size(netdev_t *netdev, void *value,
                                        size_t max_len)
 {
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     (void)netdev;
 
     *((uint16_t *)value) = IEEE802154_MAX_FRAG_SIZE;
@@ -80,7 +81,7 @@ static int _get_netdev_max_packet_size(netdev_t *netdev, void *value,
 static int _get_netdev_src_len(netdev_t *netdev, void *value, size_t max_len)
 {
     (void)netdev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = sizeof(_ieee802154_local_eui64);
     return sizeof(uint16_t);
 }
@@ -88,7 +89,7 @@ static int _get_netdev_src_len(netdev_t *netdev, void *value, size_t max_len)
 static int _get_netdev_addr_long(netdev_t *netdev, void *value, size_t max_len)
 {
     (void)netdev;
-    assert(max_len >= sizeof(_ieee802154_local_eui64));
+    expect(max_len >= sizeof(_ieee802154_local_eui64));
     memcpy(value, _ieee802154_local_eui64, sizeof(_ieee802154_local_eui64));
     return sizeof(_ieee802154_local_eui64);
 }

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/main.c
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/main.c
@@ -26,6 +26,7 @@
 #include "net/gnrc/sixlowpan/frag/vrb.h"
 #include "net/gnrc/ipv6/nib.h"
 #include "net/netdev_test.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 #include "xtimer.h"
 
@@ -252,7 +253,7 @@ static void run_unittests(void)
 
 static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len)
 {
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     (void)netdev;
 
     *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
@@ -261,7 +262,7 @@ static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len
 
 static int _get_netdev_proto(netdev_t *netdev, void *value, size_t max_len)
 {
-    assert(max_len == sizeof(gnrc_nettype_t));
+    expect(max_len == sizeof(gnrc_nettype_t));
     (void)netdev;
 
     *((gnrc_nettype_t *)value) = GNRC_NETTYPE_SIXLOWPAN;
@@ -271,7 +272,7 @@ static int _get_netdev_proto(netdev_t *netdev, void *value, size_t max_len)
 static int _get_netdev_max_pdu_size(netdev_t *netdev, void *value,
                                     size_t max_len)
 {
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     (void)netdev;
 
     *((uint16_t *)value) = sizeof(_test_6lo_payload);
@@ -281,7 +282,7 @@ static int _get_netdev_max_pdu_size(netdev_t *netdev, void *value,
 static int _get_netdev_src_len(netdev_t *netdev, void *value, size_t max_len)
 {
     (void)netdev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = sizeof(_test_dst);
     return sizeof(uint16_t);
 }
@@ -289,7 +290,7 @@ static int _get_netdev_src_len(netdev_t *netdev, void *value, size_t max_len)
 static int _get_netdev_addr_long(netdev_t *netdev, void *value, size_t max_len)
 {
     (void)netdev;
-    assert(max_len >= sizeof(_test_dst));
+    expect(max_len >= sizeof(_test_dst));
     memcpy(value, _test_dst, sizeof(_test_dst));
     return sizeof(_test_dst);
 }

--- a/tests/gnrc_sock_async_event/main.c
+++ b/tests/gnrc_sock_async_event/main.c
@@ -29,6 +29,7 @@
 #include "net/gnrc/udp.h"
 #include "net/protnum.h"
 #include "od.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 
 #include "net/sock/async/event.h"
@@ -62,9 +63,9 @@ ipv6_hdr_t *gnrc_ipv6_get_header(gnrc_pktsnip_t *pkt)
         return NULL;
     }
 
-    assert(tmp->data != NULL);
-    assert(tmp->size >= sizeof(ipv6_hdr_t));
-    assert(ipv6_hdr_is(tmp->data));
+    expect(tmp->data != NULL);
+    expect(tmp->size >= sizeof(ipv6_hdr_t));
+    expect(ipv6_hdr_is(tmp->data));
 
     return ((ipv6_hdr_t*) tmp->data);
 }
@@ -139,18 +140,18 @@ int main(void)
 
     /* create packet to inject for reception */
     pkt = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
-    assert(pkt != NULL);
+    expect(pkt != NULL);
     memset(pkt->data, 0, pkt->size);
     pkt = gnrc_ipv6_hdr_build(pkt, (ipv6_addr_t *)&_test_remote,
                               (ipv6_addr_t *)&_test_local);
-    assert(pkt != NULL);
+    expect(pkt != NULL);
     /* module is not compiled in, so set header type manually */
     pkt->type = GNRC_NETTYPE_IPV6;
     pkt = gnrc_udp_hdr_build(pkt, TEST_PORT - 1, TEST_PORT);
-    assert(pkt != NULL);
+    expect(pkt != NULL);
     pkt = gnrc_pktbuf_add(pkt, _test_payload, sizeof(_test_payload),
                           GNRC_NETTYPE_UNDEF);
-    assert(pkt != NULL);
+    expect(pkt != NULL);
     /* we dispatch twice, so hold one time */
     gnrc_pktbuf_hold(pkt, 1);
 

--- a/tests/gnrc_sock_async_event/main.c
+++ b/tests/gnrc_sock_async_event/main.c
@@ -72,7 +72,7 @@ ipv6_hdr_t *gnrc_ipv6_get_header(gnrc_pktsnip_t *pkt)
 
 static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 {
-    assert(strcmp(arg, "test") == 0);
+    expect(strcmp(arg, "test") == 0);
     printf("UDP event triggered: %04X\n", flags);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_udp_ep_t remote;
@@ -94,7 +94,7 @@ static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 
 static void _recv_ip(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 {
-    assert(strcmp(arg, "test") == 0);
+    expect(strcmp(arg, "test") == 0);
     printf("IP event triggered: %04X\n", flags);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_ip_ep_t remote;

--- a/tests/gnrc_sock_ip/main.c
+++ b/tests/gnrc_sock_ip/main.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include "net/sock/ip.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #include "constants.h"
@@ -46,9 +47,9 @@ static void test_sock_ip_create__EAFNOSUPPORT(void)
     static const sock_ip_ep_t local = { .family = AF_UNSPEC };
     static const sock_ip_ep_t remote = { .family = AF_UNSPEC };
 
-    assert(-EAFNOSUPPORT == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(-EAFNOSUPPORT == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                            SOCK_FLAGS_REUSE_EP));
-    assert(-EAFNOSUPPORT == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(-EAFNOSUPPORT == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                            SOCK_FLAGS_REUSE_EP));
 }
 
@@ -58,7 +59,7 @@ static void test_sock_ip_create__EINVAL_addr(void)
     static const sock_ip_ep_t remote = { .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                      SOCK_FLAGS_REUSE_EP));
 }
 
@@ -69,7 +70,7 @@ static void test_sock_ip_create__EINVAL_netif(void)
                                          .netif = (_TEST_NETIF + 1),
                                          .addr = { .ipv6 = _TEST_ADDR_REMOTE } };
 
-    assert(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                      SOCK_FLAGS_REUSE_EP));
 }
 
@@ -77,10 +78,10 @@ static void test_sock_ip_create__no_endpoints(void)
 {
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
 }
 
 static void test_sock_ip_create__only_local(void)
@@ -88,14 +89,14 @@ static void test_sock_ip_create__only_local(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
 }
 
 static void test_sock_ip_create__only_local_reuse_ep(void)
@@ -103,22 +104,22 @@ static void test_sock_ip_create__only_local_reuse_ep(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t ep, ep2;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_create(&_sock2, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock2, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(0 == sock_ip_get_local(&_sock2, &ep2));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(0 == sock_ip_get_local(&_sock2, &ep2));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep2.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep2.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep2.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep2));
+    expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep2));
     sock_ip_close(&_sock2);
 }
 
@@ -129,13 +130,13 @@ static void test_sock_ip_create__only_remote(void)
                                          .addr = { .ipv6 = _TEST_ADDR_REMOTE } };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
-    assert(0 == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
+    expect(0 == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
 static void test_sock_ip_create__full(void)
@@ -146,25 +147,25 @@ static void test_sock_ip_create__full(void)
                                          .addr = { .ipv6 = _TEST_ADDR_REMOTE } };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(_TEST_NETIF == ep.netif);
-    assert(0 == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_NETIF == ep.netif);
+    expect(0 == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
 static void test_sock_ip_recv__EADDRNOTAVAIL(void)
 {
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
-    assert(-EADDRNOTAVAIL == sock_ip_recv(&_sock, _test_buffer,
+    expect(-EADDRNOTAVAIL == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), SOCK_NO_TIMEOUT,
                                           NULL));
 }
@@ -173,10 +174,10 @@ static void test_sock_ip_recv__EAGAIN(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
-    assert(-EAGAIN == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-EAGAIN == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
                                    0, NULL));
 }
 
@@ -186,13 +187,13 @@ static void test_sock_ip_recv__ENOBUFS(void)
     static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR_LOCAL };
     static const sock_ip_ep_t local = { .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(-ENOBUFS == sock_ip_recv(&_sock, _test_buffer, 2, SOCK_NO_TIMEOUT,
+    expect(-ENOBUFS == sock_ip_recv(&_sock, _test_buffer, 2, SOCK_NO_TIMEOUT,
                                     NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv__EPROTO(void)
@@ -203,24 +204,24 @@ static void test_sock_ip_recv__EPROTO(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(-EPROTO == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-EPROTO == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
                                    SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv__ETIMEDOUT(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
     puts(" * Calling sock_ip_recv()");
-    assert(-ETIMEDOUT == sock_ip_recv(&_sock, _test_buffer,
+    expect(-ETIMEDOUT == sock_ip_recv(&_sock, _test_buffer,
                                       sizeof(_test_buffer), _TEST_TIMEOUT,
                                       NULL));
     printf(" * (timed out with timeout %lu)\n", (long unsigned)_TEST_TIMEOUT);
@@ -234,14 +235,14 @@ static void test_sock_ip_recv__socketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), SOCK_NO_TIMEOUT,
                                           NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv__socketed_with_remote(void)
@@ -253,17 +254,17 @@ static void test_sock_ip_recv__socketed_with_remote(void)
                                          .family = AF_INET6 };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), SOCK_NO_TIMEOUT,
                                           &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv__unsocketed(void)
@@ -273,14 +274,14 @@ static void test_sock_ip_recv__unsocketed(void)
     static const sock_ip_ep_t local = { .addr = { .ipv6 = _TEST_ADDR_LOCAL },
                                         .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), SOCK_NO_TIMEOUT,
                                           NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv__unsocketed_with_remote(void)
@@ -290,17 +291,17 @@ static void test_sock_ip_recv__unsocketed_with_remote(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), SOCK_NO_TIMEOUT,
                                           &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv__with_timeout(void)
@@ -310,17 +311,17 @@ static void test_sock_ip_recv__with_timeout(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), _TEST_TIMEOUT,
                                           &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv__non_blocking(void)
@@ -330,16 +331,16 @@ static void test_sock_ip_recv__non_blocking(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__EAFNOSUPPORT(void)
@@ -347,9 +348,9 @@ static void test_sock_ip_send__EAFNOSUPPORT(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET };
 
-    assert(-EAFNOSUPPORT == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(-EAFNOSUPPORT == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                          _TEST_PROTO, &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__EINVAL_addr(void)
@@ -360,11 +361,11 @@ static void test_sock_ip_send__EINVAL_addr(void)
     static const sock_ip_ep_t remote = { .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+    expect(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
                                    &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__EINVAL_netif(void)
@@ -376,20 +377,20 @@ static void test_sock_ip_send__EINVAL_netif(void)
                                          .family = AF_INET6,
                                          .netif = _TEST_NETIF + 1 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+    expect(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
                                    &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__ENOTCONN(void)
 {
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-ENOTCONN == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(-ENOTCONN == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                      _TEST_PROTO, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__socketed_no_local_no_netif(void)
@@ -398,14 +399,14 @@ static void test_sock_ip_send__socketed_no_local_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__socketed_no_netif(void)
@@ -417,14 +418,14 @@ static void test_sock_ip_send__socketed_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__socketed_no_local(void)
@@ -434,14 +435,14 @@ static void test_sock_ip_send__socketed_no_local(void)
                                          .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__socketed(void)
@@ -454,14 +455,14 @@ static void test_sock_ip_send__socketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__socketed_other_remote(void)
@@ -476,14 +477,14 @@ static void test_sock_ip_send__socketed_other_remote(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &sock_remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &sock_remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__unsocketed_no_local_no_netif(void)
@@ -492,14 +493,14 @@ static void test_sock_ip_send__unsocketed_no_local_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__unsocketed_no_netif(void)
@@ -511,14 +512,14 @@ static void test_sock_ip_send__unsocketed_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__unsocketed_no_local(void)
@@ -528,14 +529,14 @@ static void test_sock_ip_send__unsocketed_no_local(void)
                                          .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__unsocketed(void)
@@ -548,14 +549,14 @@ static void test_sock_ip_send__unsocketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__no_sock_no_netif(void)
@@ -564,12 +565,12 @@ static void test_sock_ip_send__no_sock_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__no_sock(void)
@@ -579,12 +580,12 @@ static void test_sock_ip_send__no_sock(void)
                                          .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                          sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 int main(void)

--- a/tests/gnrc_sock_udp/main.c
+++ b/tests/gnrc_sock_udp/main.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include "net/sock/udp.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #include "constants.h"
@@ -47,8 +48,8 @@ static void test_sock_udp_create__EADDRINUSE(void)
     static const sock_udp_ep_t local = { .family = AF_INET6,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, 0));
-    assert(-EADDRINUSE == sock_udp_create(&_sock2, &local, NULL, 0));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, 0));
+    expect(-EADDRINUSE == sock_udp_create(&_sock2, &local, NULL, 0));
 }
 #endif
 
@@ -61,8 +62,8 @@ static void test_sock_udp_create__EAFNOSUPPORT(void)
     static const sock_udp_ep_t remote = { .family = AF_UNSPEC,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EAFNOSUPPORT == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EAFNOSUPPORT == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EAFNOSUPPORT == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EAFNOSUPPORT == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create__EINVAL_addr(void)
@@ -75,7 +76,7 @@ static void test_sock_udp_create__EINVAL_addr(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create__EINVAL_netif(void)
@@ -89,16 +90,16 @@ static void test_sock_udp_create__EINVAL_netif(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .addr = { .ipv6 = _TEST_ADDR_REMOTE } };
 
-    assert(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create__no_endpoints(void)
 {
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create__only_local(void)
@@ -107,14 +108,14 @@ static void test_sock_udp_create__only_local(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create__only_local_port0(void)
@@ -123,14 +124,14 @@ static void test_sock_udp_create__only_local_port0(void)
                                          .port = 0U };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(0U != ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(0U != ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create__only_local_reuse_ep(void)
@@ -139,22 +140,22 @@ static void test_sock_udp_create__only_local_reuse_ep(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t ep, ep2;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_create(&_sock2, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(0 == sock_udp_get_local(&_sock2, &ep2));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock2, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(0 == sock_udp_get_local(&_sock2, &ep2));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep2.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep2.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep2.netif);
-    assert(_TEST_PORT_LOCAL == ep2.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
+    expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
+    expect(_TEST_PORT_LOCAL == ep2.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
     sock_udp_close(&_sock2);
 }
 
@@ -166,13 +167,13 @@ static void test_sock_udp_create__only_remote(void)
                                           .addr = { .ipv6 = _TEST_ADDR_REMOTE } };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
-    assert(0 == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
+    expect(0 == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 static void test_sock_udp_create__full(void)
@@ -185,25 +186,25 @@ static void test_sock_udp_create__full(void)
                                           .addr = { .ipv6 = _TEST_ADDR_REMOTE } };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(_TEST_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(0 == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(_TEST_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 static void test_sock_udp_recv__EADDRNOTAVAIL(void)
 {
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
 
-    assert(-EADDRNOTAVAIL == sock_udp_recv(&_sock, _test_buffer,
+    expect(-EADDRNOTAVAIL == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
 }
@@ -213,9 +214,9 @@ static void test_sock_udp_recv__EAGAIN(void)
     static const sock_udp_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
 
-    assert(-EAGAIN == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-EAGAIN == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
                                     0, NULL));
 }
 
@@ -226,12 +227,12 @@ static void test_sock_udp_recv__ENOBUFS(void)
     static const sock_udp_ep_t local = { .family = AF_INET6,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"), _TEST_NETIF));
-    assert(-ENOBUFS == sock_udp_recv(&_sock, _test_buffer, 2, SOCK_NO_TIMEOUT,
+    expect(-ENOBUFS == sock_udp_recv(&_sock, _test_buffer, 2, SOCK_NO_TIMEOUT,
                                      NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv__EPROTO(void)
@@ -244,13 +245,13 @@ static void test_sock_udp_recv__EPROTO(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(-EPROTO == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-EPROTO == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
                                     SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv__ETIMEDOUT(void)
@@ -258,10 +259,10 @@ static void test_sock_udp_recv__ETIMEDOUT(void)
     static const sock_udp_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
 
     puts(" * Calling sock_udp_recv()");
-    assert(-ETIMEDOUT == sock_udp_recv(&_sock, _test_buffer,
+    expect(-ETIMEDOUT == sock_udp_recv(&_sock, _test_buffer,
                                        sizeof(_test_buffer), _TEST_TIMEOUT,
                                        NULL));
     printf(" * (timed out with timeout %lu)\n", (long unsigned)_TEST_TIMEOUT);
@@ -277,14 +278,14 @@ static void test_sock_udp_recv__socketed(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv__socketed_with_remote(void)
@@ -298,18 +299,18 @@ static void test_sock_udp_recv__socketed_with_remote(void)
                                           .port = _TEST_PORT_REMOTE };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv__socketed_with_port0(void)
@@ -322,20 +323,20 @@ static void test_sock_udp_recv__socketed_with_port0(void)
                                           .port = _TEST_PORT_REMOTE };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &local));
-    assert(0 != local.port);
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &local));
+    expect(0 != local.port);
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           local.port, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv__unsocketed(void)
@@ -346,14 +347,14 @@ static void test_sock_udp_recv__unsocketed(void)
                                          .family = AF_INET6,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv__unsocketed_with_remote(void)
@@ -364,18 +365,18 @@ static void test_sock_udp_recv__unsocketed_with_remote(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv__with_timeout(void)
@@ -386,18 +387,18 @@ static void test_sock_udp_recv__with_timeout(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer), _TEST_TIMEOUT,
                                            &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv__non_blocking(void)
@@ -408,17 +409,17 @@ static void test_sock_udp_recv__non_blocking(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer), 0, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__EAFNOSUPPORT(void)
@@ -427,9 +428,9 @@ static void test_sock_udp_send__EAFNOSUPPORT(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EAFNOSUPPORT == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(-EAFNOSUPPORT == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                           &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__EINVAL_addr(void)
@@ -442,9 +443,9 @@ static void test_sock_udp_send__EINVAL_addr(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = _TEST_NETIF };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__EINVAL_netif(void)
@@ -458,9 +459,9 @@ static void test_sock_udp_send__EINVAL_netif(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = _TEST_NETIF + 1 };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__EINVAL_port(void)
@@ -468,15 +469,15 @@ static void test_sock_udp_send__EINVAL_port(void)
     static const sock_udp_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
                                           .family = AF_INET6 };
 
-    assert(-EINVAL == sock_udp_send(NULL, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(-EINVAL == sock_udp_send(NULL, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__ENOTCONN(void)
 {
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-ENOTCONN == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), NULL));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-ENOTCONN == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), NULL));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__socketed_no_local_no_netif(void)
@@ -486,14 +487,14 @@ static void test_sock_udp_send__socketed_no_local_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__socketed_no_netif(void)
@@ -507,14 +508,14 @@ static void test_sock_udp_send__socketed_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          SOCK_ADDR_ANY_NETIF, false));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__socketed_no_local(void)
@@ -525,14 +526,14 @@ static void test_sock_udp_send__socketed_no_local(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                          true));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__socketed(void)
@@ -547,14 +548,14 @@ static void test_sock_udp_send__socketed(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__socketed_other_remote(void)
@@ -572,14 +573,14 @@ static void test_sock_udp_send__socketed_other_remote(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &sock_remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &sock_remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__unsocketed_no_local_no_netif(void)
@@ -589,14 +590,14 @@ static void test_sock_udp_send__unsocketed_no_local_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__unsocketed_no_netif(void)
@@ -610,14 +611,14 @@ static void test_sock_udp_send__unsocketed_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          SOCK_ADDR_ANY_NETIF, false));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__unsocketed_no_local(void)
@@ -628,14 +629,14 @@ static void test_sock_udp_send__unsocketed_no_local(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                          true));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__unsocketed(void)
@@ -650,14 +651,14 @@ static void test_sock_udp_send__unsocketed(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__no_sock_no_netif(void)
@@ -667,13 +668,13 @@ static void test_sock_udp_send__no_sock_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__no_sock(void)
@@ -684,13 +685,13 @@ static void test_sock_udp_send__no_sock(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_packet(&ipv6_addr_unspecified, &dst_addr, 0,
                          _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                          _TEST_NETIF, true));
     xtimer_usleep(1000);    /* let GNRC stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 int main(void)

--- a/tests/lua_loader/main.c
+++ b/tests/lua_loader/main.c
@@ -26,10 +26,11 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #include "lua_run.h"
 #include "lua_builtin.h"
+
+#include "test_utils/expect.h"
 
 static const uint8_t pure_module_1[] = "\n\
 return {a='Quando uma lua'}\n\
@@ -81,7 +82,7 @@ int main(void)
     status = lua_riot_do_module("test", lua_mem, LUA_MEM_SIZE,
                                 LUAR_LOAD_BASE, NULL);
 
-    assert(status == LUAR_EXIT);
+    expect(status == LUAR_EXIT);
 
     while (fgets(linebuf, LINEBUF_SZ, stdin) != NULL) {
         int status;
@@ -98,7 +99,7 @@ int main(void)
         status = lua_riot_do_buffer((unsigned char *)linebuf, linelen,
                                     lua_mem, LUA_MEM_SIZE,
                                     LUAR_LOAD_BASE | LUAR_LOAD_PACKAGE, NULL);
-        assert(status == LUAR_EXIT);
+        expect(status == LUAR_EXIT);
     }
 
     return 0;

--- a/tests/lwip/ip.c
+++ b/tests/lwip/ip.c
@@ -27,6 +27,7 @@
 #include "net/sock/ip.h"
 #include "shell.h"
 #include "thread.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #ifdef MODULE_LWIP_IPV6
@@ -46,7 +47,7 @@ static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
 static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 {
-    assert(strcmp(arg, "test") == 0);
+    expect(strcmp(arg, "test") == 0);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_ip_ep_t src;
         int res;

--- a/tests/lwip/tcp.c
+++ b/tests/lwip/tcp.c
@@ -26,6 +26,7 @@
 #include "net/sock/async/event.h"
 #include "net/sock/tcp.h"
 #include "shell.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 #include "xtimer.h"
 
@@ -51,7 +52,7 @@ static void _tcp_recv(sock_tcp_t *sock, sock_async_flags_t flags, void *arg)
 {
     sock_tcp_ep_t client;
 
-    assert(strcmp(arg, "test") == 0);
+    expect(strcmp(arg, "test") == 0);
     if (sock_tcp_get_remote(sock, &client) < 0) {
         /* socket was disconnected between event firing and this handler */
         return;
@@ -89,7 +90,7 @@ static void _tcp_recv(sock_tcp_t *sock, sock_async_flags_t flags, void *arg)
 static void _tcp_accept(sock_tcp_queue_t *queue, sock_async_flags_t flags,
                         void *arg)
 {
-    assert(strcmp(arg, "test") == 0);
+    expect(strcmp(arg, "test") == 0);
     if (flags & SOCK_ASYNC_CONN_RECV) {
         sock_tcp_t *sock = NULL;
         int res;

--- a/tests/lwip/udp.c
+++ b/tests/lwip/udp.c
@@ -26,6 +26,7 @@
 #include "net/sock/async/event.h"
 #include "net/sock/udp.h"
 #include "shell.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 #include "xtimer.h"
 
@@ -46,7 +47,7 @@ static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
 static void _udp_recv(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 {
-    assert(strcmp(arg, "test") == 0);
+    expect(strcmp(arg, "test") == 0);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_udp_ep_t src;
         int res;

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include "net/sock/ip.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #include "constants.h"
@@ -47,9 +48,9 @@ static void test_sock_ip_create4__EAFNOSUPPORT(void)
     static const sock_ip_ep_t local = { .family = AF_UNSPEC };
     static const sock_ip_ep_t remote = { .family = AF_UNSPEC };
 
-    assert(-EAFNOSUPPORT == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(-EAFNOSUPPORT == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                            SOCK_FLAGS_REUSE_EP));
-    assert(-EAFNOSUPPORT == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(-EAFNOSUPPORT == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                            SOCK_FLAGS_REUSE_EP));
 }
 
@@ -59,7 +60,7 @@ static void test_sock_ip_create4__EINVAL_addr(void)
     static const sock_ip_ep_t remote = { .family = AF_INET,
                                          .netif = _TEST_NETIF };
 
-    assert(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                      SOCK_FLAGS_REUSE_EP));
 }
 
@@ -70,7 +71,7 @@ static void test_sock_ip_create4__EINVAL_netif(void)
                                          .netif = (_TEST_NETIF + 1),
                                          .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE } };
 
-    assert(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                      SOCK_FLAGS_REUSE_EP));
 }
 
@@ -78,10 +79,10 @@ static void test_sock_ip_create4__no_endpoints(void)
 {
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
 }
 
 static void test_sock_ip_create4__only_local(void)
@@ -89,13 +90,13 @@ static void test_sock_ip_create4__only_local(void)
     static const sock_ip_ep_t local = { .family = AF_INET };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(0 == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(0 == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
 }
 
 static void test_sock_ip_create4__only_local_reuse_ep(void)
@@ -103,20 +104,20 @@ static void test_sock_ip_create4__only_local_reuse_ep(void)
     static const sock_ip_ep_t local = { .family = AF_INET };
     sock_ip_ep_t ep, ep2;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_create(&_sock2, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock2, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(0 == sock_ip_get_local(&_sock2, &ep2));
-    assert(AF_INET == ep.family);
-    assert(0 == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET == ep2.family);
-    assert(0 == ep2.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep2.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep2));
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(0 == sock_ip_get_local(&_sock2, &ep2));
+    expect(AF_INET == ep.family);
+    expect(0 == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET == ep2.family);
+    expect(0 == ep2.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep2));
     sock_ip_close(&_sock2);
 }
 
@@ -126,14 +127,14 @@ static void test_sock_ip_create4__only_remote(void)
                                          .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE } };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
     /* lwIP binds connected sock implicitly */
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(0 == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(0 == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
 static void test_sock_ip_create4__full(void)
@@ -143,25 +144,25 @@ static void test_sock_ip_create4__full(void)
                                          .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE } };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(AF_INET == ep.family);
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(AF_INET == ep.family);
     /* this can't be guaranteed with lwIP */
-    /* assert(0 == ep.addr.ipv4_u32); */
-    assert(_TEST_NETIF == ep.netif);
-    assert(0 == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
+    /* expect(0 == ep.addr.ipv4_u32); */
+    expect(_TEST_NETIF == ep.netif);
+    expect(0 == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
 static void test_sock_ip_recv4__EADDRNOTAVAIL(void)
 {
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
-    assert(-EADDRNOTAVAIL == sock_ip_recv(&_sock, _test_buffer,
+    expect(-EADDRNOTAVAIL == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, NULL));
 }
 
@@ -169,22 +170,22 @@ static void test_sock_ip_recv4__ENOBUFS(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(-ENOBUFS == sock_ip_recv(&_sock, _test_buffer, 2, 0, NULL));
-    assert(_check_net());
+    expect(-ENOBUFS == sock_ip_recv(&_sock, _test_buffer, 2, 0, NULL));
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv4__EAGAIN(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET, .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
-    assert(-EAGAIN == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-EAGAIN == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
                                    0, NULL));
 }
 
@@ -192,11 +193,11 @@ static void test_sock_ip_recv4__ETIMEDOUT(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET, .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
     puts(" * Calling sock_ip_recv()");
-    assert(-ETIMEDOUT == sock_ip_recv(&_sock, _test_buffer,
+    expect(-ETIMEDOUT == sock_ip_recv(&_sock, _test_buffer,
                                       sizeof(_test_buffer), _TEST_TIMEOUT,
                                       NULL));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
@@ -208,13 +209,13 @@ static void test_sock_ip_recv4__socketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv4__socketed_with_remote(void)
@@ -224,16 +225,16 @@ static void test_sock_ip_recv4__socketed_with_remote(void)
                                          .family = AF_INET };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv4__unsocketed(void)
@@ -241,13 +242,13 @@ static void test_sock_ip_recv4__unsocketed(void)
     static const sock_ip_ep_t local = { .addr = { .ipv4_u32 = _TEST_ADDR4_LOCAL },
                                         .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv4__unsocketed_with_remote(void)
@@ -255,16 +256,16 @@ static void test_sock_ip_recv4__unsocketed_with_remote(void)
     static const sock_ip_ep_t local = { .family = AF_INET };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv4__with_timeout(void)
@@ -272,17 +273,17 @@ static void test_sock_ip_recv4__with_timeout(void)
     static const sock_ip_ep_t local = { .family = AF_INET };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), _TEST_TIMEOUT,
                                           &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv4__non_blocking(void)
@@ -290,16 +291,16 @@ static void test_sock_ip_recv4__non_blocking(void)
     static const sock_ip_ep_t local = { .family = AF_INET };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__EAFNOSUPPORT(void)
@@ -307,9 +308,9 @@ static void test_sock_ip_send4__EAFNOSUPPORT(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_UNSPEC };
 
-    assert(-EAFNOSUPPORT == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(-EAFNOSUPPORT == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                          _TEST_PROTO, &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__EINVAL_addr(void)
@@ -320,11 +321,11 @@ static void test_sock_ip_send4__EINVAL_addr(void)
     static const sock_ip_ep_t remote = { .family = AF_INET,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+    expect(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
                                    &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__EINVAL_netif(void)
@@ -336,11 +337,11 @@ static void test_sock_ip_send4__EINVAL_netif(void)
                                          .family = AF_INET,
                                          .netif = _TEST_NETIF + 1 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+    expect(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
                                    &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__EHOSTUNREACH(void)
@@ -348,17 +349,17 @@ static void test_sock_ip_send4__EHOSTUNREACH(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_WRONG },
                                          .family = AF_INET };
 
-    assert(-EHOSTUNREACH == sock_ip_send(NULL, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+    expect(-EHOSTUNREACH == sock_ip_send(NULL, "ABCD", sizeof("ABCD"), _TEST_PROTO,
                                          &remote));
 }
 
 static void test_sock_ip_send4__ENOTCONN(void)
 {
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-ENOTCONN == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(-ENOTCONN == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                      _TEST_PROTO, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__socketed_no_local_no_netif(void)
@@ -366,14 +367,14 @@ static void test_sock_ip_send4__socketed_no_local_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__socketed_no_netif(void)
@@ -383,14 +384,14 @@ static void test_sock_ip_send4__socketed_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__socketed_no_local(void)
@@ -399,14 +400,14 @@ static void test_sock_ip_send4__socketed_no_local(void)
                                          .family = AF_INET,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__socketed(void)
@@ -417,14 +418,14 @@ static void test_sock_ip_send4__socketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__socketed_other_remote(void)
@@ -437,14 +438,14 @@ static void test_sock_ip_send4__socketed_other_remote(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, &local, &sock_remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &sock_remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__unsocketed_no_local_no_netif(void)
@@ -452,14 +453,14 @@ static void test_sock_ip_send4__unsocketed_no_local_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__unsocketed_no_netif(void)
@@ -469,14 +470,14 @@ static void test_sock_ip_send4__unsocketed_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__unsocketed_no_local(void)
@@ -485,14 +486,14 @@ static void test_sock_ip_send4__unsocketed_no_local(void)
                                          .family = AF_INET,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__unsocketed(void)
@@ -503,14 +504,14 @@ static void test_sock_ip_send4__unsocketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__no_sock_no_netif(void)
@@ -518,12 +519,12 @@ static void test_sock_ip_send4__no_sock_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                          .family = AF_INET };
 
-    assert(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__no_sock(void)
@@ -532,12 +533,12 @@ static void test_sock_ip_send4__no_sock(void)
                                          .family = AF_INET,
                                          .netif = _TEST_NETIF };
 
-    assert(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 #endif  /* MODULE_LWIP_IPV4 */
 
@@ -547,9 +548,9 @@ static void test_sock_ip_create6__EAFNOSUPPORT(void)
     static const sock_ip_ep_t local = { .family = AF_UNSPEC };
     static const sock_ip_ep_t remote = { .family = AF_UNSPEC };
 
-    assert(-EAFNOSUPPORT == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(-EAFNOSUPPORT == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                            SOCK_FLAGS_REUSE_EP));
-    assert(-EAFNOSUPPORT == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(-EAFNOSUPPORT == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                            SOCK_FLAGS_REUSE_EP));
 }
 
@@ -559,7 +560,7 @@ static void test_sock_ip_create6__EINVAL_addr(void)
     static const sock_ip_ep_t remote = { .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                      SOCK_FLAGS_REUSE_EP));
 }
 
@@ -570,7 +571,7 @@ static void test_sock_ip_create6__EINVAL_netif(void)
                                          .netif = (_TEST_NETIF + 1),
                                          .addr = { .ipv6 = _TEST_ADDR6_REMOTE } };
 
-    assert(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                      SOCK_FLAGS_REUSE_EP));
 }
 
@@ -578,10 +579,10 @@ static void test_sock_ip_create6__no_endpoints(void)
 {
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
 }
 
 static void test_sock_ip_create6__only_local(void)
@@ -589,14 +590,14 @@ static void test_sock_ip_create6__only_local(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
 }
 
 static void test_sock_ip_create6__only_local_reuse_ep(void)
@@ -604,22 +605,22 @@ static void test_sock_ip_create6__only_local_reuse_ep(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t ep, ep2;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_create(&_sock2, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock2, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(0 == sock_ip_get_local(&_sock2, &ep2));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(0 == sock_ip_get_local(&_sock2, &ep2));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep2.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep2.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep2.netif);
-    assert(-ENOTCONN == sock_ip_get_remote(&_sock, &ep2));
+    expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
+    expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep2));
     sock_ip_close(&_sock2);
 }
 
@@ -630,14 +631,14 @@ static void test_sock_ip_create6__only_remote(void)
                                          .addr = { .ipv6 = _TEST_ADDR6_REMOTE } };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
     /* lwIP binds connected sock implicitly */
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(0 == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(0 == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
 static void test_sock_ip_create6__full(void)
@@ -648,26 +649,26 @@ static void test_sock_ip_create6__full(void)
                                          .addr = { .ipv6 = _TEST_ADDR6_REMOTE } };
     sock_ip_ep_t ep;
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_ip_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
+    expect(0 == sock_ip_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
     /* this can't be guaranteed with lwIP */
-    /* assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6, */
+    /* expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6, */
     /*               sizeof(ipv6_addr_t)) == 0); */
-    assert(_TEST_NETIF == ep.netif);
-    assert(0 == sock_ip_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_NETIF == ep.netif);
+    expect(0 == sock_ip_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
 static void test_sock_ip_recv6__EADDRNOTAVAIL(void)
 {
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
-    assert(-EADDRNOTAVAIL == sock_ip_recv(&_sock, _test_buffer,
+    expect(-EADDRNOTAVAIL == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, NULL));
 }
 
@@ -675,10 +676,10 @@ static void test_sock_ip_recv6__EAGAIN(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
-    assert(-EAGAIN == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-EAGAIN == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
                                    0, NULL));
 }
 
@@ -688,23 +689,23 @@ static void test_sock_ip_recv6__ENOBUFS(void)
     static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR6_LOCAL };
     static const sock_ip_ep_t local = { .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(-ENOBUFS == sock_ip_recv(&_sock, _test_buffer, 2, 0, NULL));
-    assert(_check_net());
+    expect(-ENOBUFS == sock_ip_recv(&_sock, _test_buffer, 2, 0, NULL));
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv6__ETIMEDOUT(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
 
     puts(" * Calling sock_ip_recv()");
-    assert(-ETIMEDOUT == sock_ip_recv(&_sock, _test_buffer,
+    expect(-ETIMEDOUT == sock_ip_recv(&_sock, _test_buffer,
                                       sizeof(_test_buffer), _TEST_TIMEOUT,
                                       NULL));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
@@ -718,13 +719,13 @@ static void test_sock_ip_recv6__socketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv6__socketed_with_remote(void)
@@ -736,16 +737,16 @@ static void test_sock_ip_recv6__socketed_with_remote(void)
                                          .family = AF_INET6 };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv6__unsocketed(void)
@@ -755,13 +756,13 @@ static void test_sock_ip_recv6__unsocketed(void)
     static const sock_ip_ep_t local = { .addr = { .ipv6 = _TEST_ADDR6_LOCAL },
                                         .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv6__unsocketed_with_remote(void)
@@ -771,16 +772,16 @@ static void test_sock_ip_recv6__unsocketed_with_remote(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv6__with_timeout(void)
@@ -790,17 +791,17 @@ static void test_sock_ip_recv6__with_timeout(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), _TEST_TIMEOUT,
                                           &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_recv6__non_blocking(void)
@@ -810,16 +811,16 @@ static void test_sock_ip_recv6__non_blocking(void)
     static const sock_ip_ep_t local = { .family = AF_INET6 };
     sock_ip_ep_t result;
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_NETIF == result.netif);
-    assert(_check_net());
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__EAFNOSUPPORT(void)
@@ -827,9 +828,9 @@ static void test_sock_ip_send6__EAFNOSUPPORT(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_UNSPEC };
 
-    assert(-EAFNOSUPPORT == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(-EAFNOSUPPORT == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                          _TEST_PROTO, &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__EINVAL_addr(void)
@@ -840,11 +841,11 @@ static void test_sock_ip_send6__EINVAL_addr(void)
     static const sock_ip_ep_t remote = { .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+    expect(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
                                    &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__EINVAL_netif(void)
@@ -856,11 +857,11 @@ static void test_sock_ip_send6__EINVAL_netif(void)
                                          .family = AF_INET6,
                                          .netif = _TEST_NETIF + 1 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+    expect(-EINVAL == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"), _TEST_PROTO,
                                    &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__EHOSTUNREACH(void)
@@ -868,17 +869,17 @@ static void test_sock_ip_send6__EHOSTUNREACH(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_WRONG },
                                          .family = AF_INET6 };
 
-    assert(-EHOSTUNREACH == sock_ip_send(NULL, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+    expect(-EHOSTUNREACH == sock_ip_send(NULL, "ABCD", sizeof("ABCD"), _TEST_PROTO,
                                          &remote));
 }
 
 static void test_sock_ip_send6__ENOTCONN(void)
 {
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(-ENOTCONN == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(-ENOTCONN == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                      _TEST_PROTO, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__socketed_no_local_no_netif(void)
@@ -887,14 +888,14 @@ static void test_sock_ip_send6__socketed_no_local_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__socketed_no_netif(void)
@@ -906,14 +907,14 @@ static void test_sock_ip_send6__socketed_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__socketed_no_local(void)
@@ -923,14 +924,14 @@ static void test_sock_ip_send6__socketed_no_local(void)
                                          .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__socketed(void)
@@ -943,14 +944,14 @@ static void test_sock_ip_send6__socketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, NULL));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__socketed_other_remote(void)
@@ -965,14 +966,14 @@ static void test_sock_ip_send6__socketed_other_remote(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, &sock_remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &sock_remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__unsocketed_no_local_no_netif(void)
@@ -981,14 +982,14 @@ static void test_sock_ip_send6__unsocketed_no_local_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__unsocketed_no_netif(void)
@@ -1000,14 +1001,14 @@ static void test_sock_ip_send6__unsocketed_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__unsocketed_no_local(void)
@@ -1017,14 +1018,14 @@ static void test_sock_ip_send6__unsocketed_no_local(void)
                                          .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__unsocketed(void)
@@ -1037,14 +1038,14 @@ static void test_sock_ip_send6__unsocketed(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(&_sock, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__no_sock_no_netif(void)
@@ -1053,12 +1054,12 @@ static void test_sock_ip_send6__no_sock_no_netif(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                          .family = AF_INET6 };
 
-    assert(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__no_sock(void)
@@ -1068,12 +1069,12 @@ static void test_sock_ip_send6__no_sock(void)
                                          .family = AF_INET6,
                                          .netif = _TEST_NETIF };
 
-    assert(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
                                           _TEST_PROTO, &remote));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 #endif  /* MODULE_LWIP_IPV6 */
 

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -23,6 +23,7 @@
 #include "net/netdev_test.h"
 #include "net/sock.h"
 #include "sched.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #include "lwip.h"
@@ -74,7 +75,7 @@ static int _get_addr(netdev_t *dev, void *value, size_t max_len)
     static const uint8_t _local_ip[] = _TEST_ADDR6_LOCAL;
 
     (void)dev;
-    assert(max_len >= ETHERNET_ADDR_LEN);
+    expect(max_len >= ETHERNET_ADDR_LEN);
     return l2util_ipv6_iid_to_addr(NETDEV_TYPE_ETHERNET,
                                    (eui64_t *)&_local_ip[8],
                                    value);
@@ -154,7 +155,7 @@ void _net_init(void)
     netdev_test_set_recv_cb(&netdev, _netdev_recv);
     netdev_test_set_isr_cb(&netdev, _netdev_isr);
     /* netdev needs to be set-up */
-    assert(netdev.netdev.driver);
+    expect(netdev.netdev.driver);
 #if LWIP_IPV4
     ip4_addr_t local4, mask4, gw4;
     local4.addr = _TEST_ADDR4_LOCAL;
@@ -198,7 +199,7 @@ void _prepare_send_checks(void)
     netdev_test_set_send_cb(&netdev, _netdev_send);
 #if LWIP_ARP
     const ip4_addr_t remote4 = { .addr = _TEST_ADDR4_REMOTE };
-    assert(ERR_OK == etharp_add_static_entry(&remote4, (struct eth_addr *)mac));
+    expect(ERR_OK == etharp_add_static_entry(&remote4, (struct eth_addr *)mac));
 #endif
 #if LWIP_IPV6
     memset(destination_cache, 0,

--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -17,7 +17,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -27,6 +26,7 @@
 #include "net/ipv6/addr.h"
 #include "net/sock/tcp.h"
 #include "sched.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 #include "xtimer.h"
 
@@ -101,7 +101,7 @@ static void test_tcp_connect4__EADDRINUSE(void)
 
     msg_send(&msg, _server);    /* start server on _TEST_PORT_REMOTE */
 
-    assert(-EADDRINUSE == sock_tcp_connect(&_sock, &remote, local_port, 0));
+    expect(-EADDRINUSE == sock_tcp_connect(&_sock, &remote, local_port, 0));
 }
 #endif
 
@@ -111,7 +111,7 @@ static void test_tcp_connect4__EAFNOSUPPORT(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
 
-    assert(-EAFNOSUPPORT == sock_tcp_connect(&_sock, &remote, 0,
+    expect(-EAFNOSUPPORT == sock_tcp_connect(&_sock, &remote, 0,
                                              SOCK_FLAGS_REUSE_EP));
 }
 
@@ -124,7 +124,7 @@ static void test_tcp_connect4__EINVAL_addr(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
 
-    assert(-EINVAL == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_tcp_connect4__EINVAL_netif(void)
@@ -134,7 +134,7 @@ static void test_tcp_connect4__EINVAL_netif(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = (_TEST_NETIF + 1) };
 
-    assert(-EINVAL == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
 }
 
 /* ENETUNREACH not testable in given loopback setup */
@@ -155,12 +155,12 @@ static void test_tcp_connect4__success_without_port(void)
 
     msg_send(&msg, _server);    /* start server on _TEST_PORT_REMOTE */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_tcp_get_remote(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_get_remote(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 static void test_tcp_connect4__success_local_port(void)
 {
@@ -178,15 +178,15 @@ static void test_tcp_connect4__success_local_port(void)
 
     msg_send(&msg, _server);    /* start server on _TEST_PORT_REMOTE */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, local_port, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_tcp_get_local(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(0 == sock_tcp_get_remote(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_tcp_connect(&_sock, &remote, local_port, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_get_local(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_tcp_get_remote(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 #ifdef SO_REUSE
@@ -204,7 +204,7 @@ static void test_tcp_listen4__EADDRINUSE(void)
 
     msg_send(&msg, _server);    /* start server on _TEST_PORT_LOCAL */
 
-    assert(-EADDRINUSE == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(-EADDRINUSE == sock_tcp_listen(&_queue, &local, _queue_array,
                                           _QUEUE_SIZE, 0));
 }
 #endif
@@ -215,7 +215,7 @@ static void test_tcp_listen4__EAFNOSUPPORT(void)
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = SOCK_ADDR_ANY_NETIF };
 
-    assert(-EAFNOSUPPORT == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(-EAFNOSUPPORT == sock_tcp_listen(&_queue, &local, _queue_array,
                                             _QUEUE_SIZE, 0));
 }
 
@@ -226,7 +226,7 @@ static void test_tcp_listen4__EINVAL(void)
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = (_TEST_NETIF + 1) };
 
-    assert(-EINVAL == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(-EINVAL == sock_tcp_listen(&_queue, &local, _queue_array,
                                       _QUEUE_SIZE, 0));
 }
 
@@ -238,13 +238,13 @@ static void test_tcp_listen4__success_any_netif(void)
                                          .netif = SOCK_ADDR_ANY_NETIF };
     sock_tcp_ep_t ep;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, 0));
-    assert(0 == sock_tcp_queue_get_local(&_queue, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_ADDR4_LOCAL == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_tcp_queue_get_local(&_queue, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_ADDR4_LOCAL == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
 }
 
 static void test_tcp_listen4__success_spec_netif(void)
@@ -254,12 +254,12 @@ static void test_tcp_listen4__success_spec_netif(void)
                                          .netif = _TEST_NETIF };
     sock_tcp_ep_t ep;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, 0));
-    assert(0 == sock_tcp_queue_get_local(&_queue, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_tcp_queue_get_local(&_queue, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
 }
 
 /* ECONNABORTED can't be tested in this setup */
@@ -270,16 +270,16 @@ static void test_tcp_accept4__EAGAIN(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_tcp_t *sock;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, SOCK_FLAGS_REUSE_EP));
-    assert(-EAGAIN == sock_tcp_accept(&_queue, &sock, 0));
+    expect(-EAGAIN == sock_tcp_accept(&_queue, &sock, 0));
 }
 
 static void test_tcp_accept4__EINVAL(void)
 {
     sock_tcp_t *sock;
 
-    assert(-EINVAL == sock_tcp_accept(&_queue, &sock, SOCK_NO_TIMEOUT));
+    expect(-EINVAL == sock_tcp_accept(&_queue, &sock, SOCK_NO_TIMEOUT));
 }
 
 static void test_tcp_accept4__ETIMEDOUT(void)
@@ -288,10 +288,10 @@ static void test_tcp_accept4__ETIMEDOUT(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_tcp_t *sock;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, SOCK_FLAGS_REUSE_EP));
     puts(" * Calling sock_tcp_accept()");
-    assert(-ETIMEDOUT == sock_tcp_accept(&_queue, &sock, _TEST_TIMEOUT));
+    expect(-ETIMEDOUT == sock_tcp_accept(&_queue, &sock, _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
 }
 
@@ -309,19 +309,19 @@ static void test_tcp_accept4__success(void)
     _server_addr.port = _TEST_PORT_LOCAL;
     _server_addr.netif = SOCK_ADDR_ANY_NETIF;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, 0));
     msg_send(&msg, _client);    /* start client on _TEST_PORT_REMOTE, connecting
                                  * to _TEST_PORT_LOCAL */
-    assert(0 == sock_tcp_accept(&_queue, &sock, SOCK_NO_TIMEOUT));
-    assert(0 == sock_tcp_get_local(sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(0 == sock_tcp_get_remote(sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_tcp_accept(&_queue, &sock, SOCK_NO_TIMEOUT));
+    expect(0 == sock_tcp_get_local(sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_tcp_get_remote(sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 /* ECONNABORTED can't be tested in this setup */
@@ -342,8 +342,8 @@ static void test_tcp_read4__EAGAIN(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
-    assert(-EAGAIN == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer), 0));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(-EAGAIN == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer), 0));
 }
 
 static void test_tcp_read4__ECONNRESET(void)
@@ -362,17 +362,17 @@ static void test_tcp_read4__ECONNRESET(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_CLOSE;
     msg_send(&msg, _server);        /* close connection at server side */
-    assert(-ECONNRESET == sock_tcp_read(&_sock, _test_buffer,
+    expect(-ECONNRESET == sock_tcp_read(&_sock, _test_buffer,
                                         sizeof(_test_buffer),
                                         SOCK_NO_TIMEOUT));
 }
 
 static void test_tcp_read4__ENOTCONN(void)
 {
-    assert(-ENOTCONN == sock_tcp_read(&_sock, _test_buffer,
+    expect(-ENOTCONN == sock_tcp_read(&_sock, _test_buffer,
                                       sizeof(_test_buffer), SOCK_NO_TIMEOUT));
 }
 
@@ -392,9 +392,9 @@ static void test_tcp_read4__ETIMEDOUT(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     puts(" * Calling sock_tcp_read()");
-    assert(-ETIMEDOUT == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-ETIMEDOUT == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer),
                                        _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
 }
@@ -417,14 +417,14 @@ static void test_tcp_read4__success(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_WRITE;
     msg.content.ptr = (void *)&exp_data;
     msg_send(&msg, _server);        /* write expected data at server */
-    assert(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
                                                         sizeof(_test_buffer),
                                                         SOCK_NO_TIMEOUT));
-    assert(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
 static void test_tcp_read4__success_with_timeout(void)
@@ -445,14 +445,14 @@ static void test_tcp_read4__success_with_timeout(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_WRITE;
     msg.content.ptr = (void *)&exp_data;
     msg_send(&msg, _server);        /* write expected data at server */
-    assert(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
                                                         sizeof(_test_buffer),
                                                         _TEST_TIMEOUT));
-    assert(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
 static void test_tcp_read4__success_non_blocking(void)
@@ -473,21 +473,21 @@ static void test_tcp_read4__success_non_blocking(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_WRITE;
     msg.content.ptr = (void *)&exp_data;
     msg_send(&msg, _server);        /* write expected data at server */
-    assert(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
                                                         sizeof(_test_buffer),
                                                         0));
-    assert(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
 /* ENOTCONN not applicable since lwIP always tries to send */
 
 static void test_tcp_write4__ENOTCONN(void)
 {
-    assert(-ENOTCONN == sock_tcp_write(&_sock, "Hello!", sizeof("Hello!")));
+    expect(-ENOTCONN == sock_tcp_write(&_sock, "Hello!", sizeof("Hello!")));
 }
 
 static void test_tcp_write4__success(void)
@@ -508,13 +508,13 @@ static void test_tcp_write4__success(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_READ;
     msg.content.ptr = (void *)&exp_data;
     msg_send(&msg, _server);        /* write expected data at server */
-    assert(((ssize_t)exp_data.iov_len) == sock_tcp_write(&_sock, "Hello!",
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_write(&_sock, "Hello!",
                                                         sizeof("Hello!")));
-    assert(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
     xtimer_usleep(5000);            /* wait for server */
 }
 #endif /* MODULE_LWIP_IPV4 */
@@ -536,7 +536,7 @@ static void test_tcp_connect6__EADDRINUSE(void)
 
     msg_send(&msg, _server);    /* start server on _TEST_PORT_REMOTE */
 
-    assert(-EADDRINUSE == sock_tcp_connect(&_sock, &remote, local_port, 0));
+    expect(-EADDRINUSE == sock_tcp_connect(&_sock, &remote, local_port, 0));
 }
 #endif
 
@@ -546,7 +546,7 @@ static void test_tcp_connect6__EAFNOSUPPORT(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
 
-    assert(-EAFNOSUPPORT == sock_tcp_connect(&_sock, &remote, 0,
+    expect(-EAFNOSUPPORT == sock_tcp_connect(&_sock, &remote, 0,
                                              SOCK_FLAGS_REUSE_EP));
 }
 
@@ -559,7 +559,7 @@ static void test_tcp_connect6__EINVAL_addr(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
 
-    assert(-EINVAL == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_tcp_connect6__EINVAL_netif(void)
@@ -569,7 +569,7 @@ static void test_tcp_connect6__EINVAL_netif(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = (_TEST_NETIF + 1) };
 
-    assert(-EINVAL == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
 }
 
 /* ENETUNREACH not testable in given loopback setup */
@@ -591,12 +591,12 @@ static void test_tcp_connect6__success_without_port(void)
 
     msg_send(&msg, _server);    /* start server on _TEST_PORT_REMOTE */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_tcp_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 static void test_tcp_connect6__success_local_port(void)
 {
@@ -615,15 +615,15 @@ static void test_tcp_connect6__success_local_port(void)
 
     msg_send(&msg, _server);    /* start server on _TEST_PORT_REMOTE */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, local_port, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_tcp_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(0 == sock_tcp_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_tcp_connect(&_sock, &remote, local_port, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_tcp_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 #ifdef SO_REUSE
@@ -641,7 +641,7 @@ static void test_tcp_listen6__EADDRINUSE(void)
 
     msg_send(&msg, _server);    /* start server on _TEST_PORT_LOCAL */
 
-    assert(-EADDRINUSE == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(-EADDRINUSE == sock_tcp_listen(&_queue, &local, _queue_array,
                                           _QUEUE_SIZE, 0));
 }
 #endif
@@ -652,7 +652,7 @@ static void test_tcp_listen6__EAFNOSUPPORT(void)
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = SOCK_ADDR_ANY_NETIF };
 
-    assert(-EAFNOSUPPORT == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(-EAFNOSUPPORT == sock_tcp_listen(&_queue, &local, _queue_array,
                                             _QUEUE_SIZE, 0));
 }
 
@@ -663,7 +663,7 @@ static void test_tcp_listen6__EINVAL(void)
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = (_TEST_NETIF + 1) };
 
-    assert(-EINVAL == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(-EINVAL == sock_tcp_listen(&_queue, &local, _queue_array,
                                       _QUEUE_SIZE, 0));
 }
 
@@ -676,13 +676,13 @@ static void test_tcp_listen6__success_any_netif(void)
                                          .netif = SOCK_ADDR_ANY_NETIF };
     sock_tcp_ep_t ep;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, 0));
-    assert(0 == sock_tcp_queue_get_local(&_queue, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&local_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_tcp_queue_get_local(&_queue, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&local_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
 }
 
 static void test_tcp_listen6__success_spec_netif(void)
@@ -692,12 +692,12 @@ static void test_tcp_listen6__success_spec_netif(void)
                                          .netif = _TEST_NETIF };
     sock_tcp_ep_t ep;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, 0));
-    assert(0 == sock_tcp_queue_get_local(&_queue, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(_TEST_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_tcp_queue_get_local(&_queue, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(_TEST_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
 }
 
 /* ECONNABORTED can't be tested in this setup */
@@ -708,16 +708,16 @@ static void test_tcp_accept6__EAGAIN(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_tcp_t *sock;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, 0));
-    assert(-EAGAIN == sock_tcp_accept(&_queue, &sock, 0));
+    expect(-EAGAIN == sock_tcp_accept(&_queue, &sock, 0));
 }
 
 static void test_tcp_accept6__EINVAL(void)
 {
     sock_tcp_t *sock;
 
-    assert(-EINVAL == sock_tcp_accept(&_queue, &sock, SOCK_NO_TIMEOUT));
+    expect(-EINVAL == sock_tcp_accept(&_queue, &sock, SOCK_NO_TIMEOUT));
 }
 
 static void test_tcp_accept6__ETIMEDOUT(void)
@@ -726,10 +726,10 @@ static void test_tcp_accept6__ETIMEDOUT(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_tcp_t *sock;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, 0));
     puts(" * Calling sock_tcp_accept()");
-    assert(-ETIMEDOUT == sock_tcp_accept(&_queue, &sock, _TEST_TIMEOUT));
+    expect(-ETIMEDOUT == sock_tcp_accept(&_queue, &sock, _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
 }
 
@@ -748,19 +748,19 @@ static void test_tcp_accept6__success(void)
     _server_addr.port = _TEST_PORT_LOCAL;
     _server_addr.netif = SOCK_ADDR_ANY_NETIF;
 
-    assert(0 == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array,
                                 _QUEUE_SIZE, 0));
     msg_send(&msg, _client);    /* start client on _TEST_PORT_REMOTE, connecting
                                  * to _TEST_PORT_LOCAL */
-    assert(0 == sock_tcp_accept(&_queue, &sock, SOCK_NO_TIMEOUT));
-    assert(0 == sock_tcp_get_local(sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(0 == sock_tcp_get_remote(sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_tcp_accept(&_queue, &sock, SOCK_NO_TIMEOUT));
+    expect(0 == sock_tcp_get_local(sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_tcp_get_remote(sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 /* ECONNABORTED can't be tested in this setup */
@@ -781,8 +781,8 @@ static void test_tcp_read6__EAGAIN(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
-    assert(-EAGAIN == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer), 0));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(-EAGAIN == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer), 0));
 }
 
 static void test_tcp_read6__ECONNRESET(void)
@@ -801,16 +801,16 @@ static void test_tcp_read6__ECONNRESET(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_CLOSE;
     msg_send(&msg, _server);        /* close connection at server side */
-    assert(-ECONNRESET == sock_tcp_read(&_sock, _test_buffer,
+    expect(-ECONNRESET == sock_tcp_read(&_sock, _test_buffer,
                                         sizeof(_test_buffer), SOCK_NO_TIMEOUT));
 }
 
 static void test_tcp_read6__ENOTCONN(void)
 {
-    assert(-ENOTCONN == sock_tcp_read(&_sock, _test_buffer,
+    expect(-ENOTCONN == sock_tcp_read(&_sock, _test_buffer,
                                       sizeof(_test_buffer), SOCK_NO_TIMEOUT));
 }
 
@@ -830,9 +830,9 @@ static void test_tcp_read6__ETIMEDOUT(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     puts(" * Calling sock_tcp_read()");
-    assert(-ETIMEDOUT == sock_tcp_read(&_sock, _test_buffer,
+    expect(-ETIMEDOUT == sock_tcp_read(&_sock, _test_buffer,
                                        sizeof(_test_buffer), _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
 }
@@ -854,14 +854,14 @@ static void test_tcp_read6__success(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_WRITE;
     msg.content.ptr = (void *)&exp_data;
     msg_send(&msg, _server);        /* write expected data at server */
-    assert(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
                                                         sizeof(_test_buffer),
                                                         SOCK_NO_TIMEOUT));
-    assert(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
 static void test_tcp_read6__success_with_timeout(void)
@@ -882,14 +882,14 @@ static void test_tcp_read6__success_with_timeout(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_WRITE;
     msg.content.ptr = (void *)&exp_data;
     msg_send(&msg, _server);        /* write expected data at server */
-    assert(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
                                                         sizeof(_test_buffer),
                                                         _TEST_TIMEOUT));
-    assert(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
 static void test_tcp_read6__success_non_blocking(void)
@@ -910,21 +910,21 @@ static void test_tcp_read6__success_non_blocking(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_WRITE;
     msg.content.ptr = (void *)&exp_data;
     msg_send(&msg, _server);        /* write expected data at server */
-    assert(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
                                                         sizeof(_test_buffer),
                                                         0));
-    assert(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
 /* ENOTCONN not applicable since lwIP always tries to send */
 
 static void test_tcp_write6__ENOTCONN(void)
 {
-    assert(-ENOTCONN == sock_tcp_write(&_sock, "Hello!", sizeof("Hello!")));
+    expect(-ENOTCONN == sock_tcp_write(&_sock, "Hello!", sizeof("Hello!")));
 }
 
 static void test_tcp_write6__success(void)
@@ -945,13 +945,13 @@ static void test_tcp_write6__success(void)
     msg.type = _SERVER_MSG_ACCEPT;
     msg_send(&msg, _server);        /* let server accept */
 
-    assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     msg.type = _SERVER_MSG_READ;
     msg.content.ptr = (void *)&exp_data;
     msg_send(&msg, _server);        /* write expected data at server */
-    assert(((ssize_t)exp_data.iov_len) == sock_tcp_write(&_sock, "Hello!",
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_write(&_sock, "Hello!",
                                                         sizeof("Hello!")));
-    assert(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
     xtimer_usleep(5000);            /* wait for server */
 }
 #endif /* MODULE_LWIP_IPV6 */
@@ -972,10 +972,10 @@ int main(void)
     printf("code 0x%02x\n", code);
     xtimer_init();
     _net_init();
-    assert(0 < thread_create(_client_stack, sizeof(_client_stack),
+    expect(0 < thread_create(_client_stack, sizeof(_client_stack),
                              THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
                              _client_func, NULL, "tcp_client"));
-    assert(0 < thread_create(_server_stack, sizeof(_server_stack),
+    expect(0 < thread_create(_server_stack, sizeof(_server_stack),
                              THREAD_PRIORITY_MAIN - 2, THREAD_CREATE_STACKTEST,
                              _server_func, NULL, "tcp_server"));
     tear_down();
@@ -1086,7 +1086,7 @@ static void *_server_func(void *arg)
         switch (msg.type) {
             case _SERVER_MSG_START:
                 if (!server_started) {
-                    assert(0 == sock_tcp_listen(&_server_queue, &_server_addr,
+                    expect(0 == sock_tcp_listen(&_server_queue, &_server_addr,
                                                 _server_queue_array,
                                                 _SERVER_QUEUE_SIZE,
                                                 SOCK_FLAGS_REUSE_EP));
@@ -1095,7 +1095,7 @@ static void *_server_func(void *arg)
                 break;
             case _SERVER_MSG_ACCEPT:
                 if (server_started) {
-                    assert(0 == sock_tcp_accept(&_server_queue, &sock,
+                    expect(0 == sock_tcp_accept(&_server_queue, &sock,
                                                 SOCK_NO_TIMEOUT));
                 }
                 break;
@@ -1103,17 +1103,17 @@ static void *_server_func(void *arg)
                 if (sock != NULL) {
                     const struct iovec *exp = msg.content.ptr;
 
-                    assert(((ssize_t)exp->iov_len) ==
+                    expect(((ssize_t)exp->iov_len) ==
                            sock_tcp_read(sock, _server_buf, sizeof(_server_buf),
                                          SOCK_NO_TIMEOUT));
-                    assert(memcmp(exp->iov_base, _server_buf, exp->iov_len) == 0);
+                    expect(memcmp(exp->iov_base, _server_buf, exp->iov_len) == 0);
                 }
                 break;
             case _SERVER_MSG_WRITE:
                 if (sock != NULL) {
                     const struct iovec *data = msg.content.ptr;
 
-                    assert(((ssize_t)data->iov_len) ==
+                    expect(((ssize_t)data->iov_len) ==
                            sock_tcp_write(sock, data->iov_base, data->iov_len));
                 }
                 break;
@@ -1153,7 +1153,7 @@ static void *_client_func(void *arg)
             case _CLIENT_MSG_START:
                 if (!client_started) {
                     const uint16_t local_port = (uint16_t)msg.content.value;
-                    assert(0 == sock_tcp_connect(&_client_sock, &_server_addr,
+                    expect(0 == sock_tcp_connect(&_client_sock, &_server_addr,
                                                  local_port, SOCK_FLAGS_REUSE_EP));
                     client_started = true;
                 }
@@ -1162,17 +1162,17 @@ static void *_client_func(void *arg)
                 if (client_started) {
                     const struct iovec *exp = msg.content.ptr;
 
-                    assert(((ssize_t)exp->iov_len) ==
+                    expect(((ssize_t)exp->iov_len) ==
                            sock_tcp_read(&_client_sock, _client_buf,
                                          sizeof(_client_buf), SOCK_NO_TIMEOUT));
-                    assert(memcmp(exp->iov_base, _client_buf, exp->iov_len) == 0);
+                    expect(memcmp(exp->iov_base, _client_buf, exp->iov_len) == 0);
                 }
                 break;
             case _CLIENT_MSG_WRITE:
                 if (client_started) {
                     const struct iovec *data = msg.content.ptr;
 
-                    assert(((ssize_t)data->iov_len) ==
+                    expect(((ssize_t)data->iov_len) ==
                            sock_tcp_write(&_client_sock, data->iov_base,
                                           data->iov_len));
                 }

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include "net/sock/udp.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #include "constants.h"
@@ -48,8 +49,8 @@ static void test_sock_udp_create4__EADDRINUSE(void)
     static const sock_udp_ep_t local = { .family = AF_INET,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, 0));
-    assert(-EADDRINUSE == sock_udp_create(&_sock2, &local, NULL, 0));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, 0));
+    expect(-EADDRINUSE == sock_udp_create(&_sock2, &local, NULL, 0));
 }
 #endif
 
@@ -62,8 +63,8 @@ static void test_sock_udp_create4__EAFNOSUPPORT(void)
     static const sock_udp_ep_t remote = { .family = AF_UNSPEC,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EAFNOSUPPORT == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EAFNOSUPPORT == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EAFNOSUPPORT == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EAFNOSUPPORT == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create4__EINVAL_addr(void)
@@ -76,7 +77,7 @@ static void test_sock_udp_create4__EINVAL_addr(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create4__EINVAL_netif(void)
@@ -90,16 +91,16 @@ static void test_sock_udp_create4__EINVAL_netif(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE } };
 
-    assert(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create4__no_endpoints(void)
 {
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create4__only_local(void)
@@ -108,13 +109,13 @@ static void test_sock_udp_create4__only_local(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(0 == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(0 == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create4__only_local_port0(void)
@@ -123,13 +124,13 @@ static void test_sock_udp_create4__only_local_port0(void)
                                          .port = 0U };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(0 == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(0U != ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(0 == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(0U != ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create4__only_local_reuse_ep(void)
@@ -138,20 +139,20 @@ static void test_sock_udp_create4__only_local_reuse_ep(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t ep, ep2;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_create(&_sock2, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(0 == sock_udp_get_local(&_sock2, &ep2));
-    assert(AF_INET == ep.family);
-    assert(0 == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET == ep2.family);
-    assert(0 == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep2.netif);
-    assert(_TEST_PORT_LOCAL == ep2.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock2, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(0 == sock_udp_get_local(&_sock2, &ep2));
+    expect(AF_INET == ep.family);
+    expect(0 == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET == ep2.family);
+    expect(0 == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
+    expect(_TEST_PORT_LOCAL == ep2.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
     sock_udp_close(&_sock2);
 }
 
@@ -162,14 +163,14 @@ static void test_sock_udp_create4__only_remote(void)
                                           .addr =  { .ipv4_u32 = _TEST_ADDR4_REMOTE } };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
     /* lwIP binds connected sock implicitly */
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(0 == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(0 == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 static void test_sock_udp_create4__full(void)
@@ -181,25 +182,25 @@ static void test_sock_udp_create4__full(void)
                                           .addr =  { .ipv4_u32 = _TEST_ADDR4_REMOTE } };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET == ep.family);
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET == ep.family);
     /* this can't be guaranteed with lwIP */
-    /* assert(0 == ep.addr.ipv4_u32); */
-    assert(_TEST_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(0 == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET == ep.family);
-    assert(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    /* expect(0 == ep.addr.ipv4_u32); */
+    expect(_TEST_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET == ep.family);
+    expect(_TEST_ADDR4_REMOTE == ep.addr.ipv4_u32);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 static void test_sock_udp_recv4__EADDRNOTAVAIL(void)
 {
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
 
-    assert(-EADDRNOTAVAIL == sock_udp_recv(&_sock, _test_buffer,
+    expect(-EADDRNOTAVAIL == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
 }
@@ -209,9 +210,9 @@ static void test_sock_udp_recv4__EAGAIN(void)
     static const sock_udp_ep_t local = { .family = AF_INET, .netif = _TEST_NETIF,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
 
-    assert(-EAGAIN == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-EAGAIN == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
                                     0, NULL));
 }
 
@@ -220,12 +221,12 @@ static void test_sock_udp_recv4__ENOBUFS(void)
     static const sock_udp_ep_t local = { .family = AF_INET,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"), _TEST_NETIF));
-    assert(-ENOBUFS == sock_udp_recv(&_sock, _test_buffer, 2, SOCK_NO_TIMEOUT,
+    expect(-ENOBUFS == sock_udp_recv(&_sock, _test_buffer, 2, SOCK_NO_TIMEOUT,
                                      NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv4__ETIMEDOUT(void)
@@ -233,10 +234,10 @@ static void test_sock_udp_recv4__ETIMEDOUT(void)
     static const sock_udp_ep_t local = { .family = AF_INET, .netif = _TEST_NETIF,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
 
     puts(" * Calling sock_udp_recv()");
-    assert(-ETIMEDOUT == sock_udp_recv(&_sock, _test_buffer,
+    expect(-ETIMEDOUT == sock_udp_recv(&_sock, _test_buffer,
                                        sizeof(_test_buffer), _TEST_TIMEOUT,
                                        NULL));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
@@ -250,14 +251,14 @@ static void test_sock_udp_recv4__socketed(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv4__socketed_with_remote(void)
@@ -269,20 +270,20 @@ static void test_sock_udp_recv4__socketed_with_remote(void)
                                           .port = _TEST_PORT_REMOTE };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv4__socketed_with_port0(void)
@@ -293,22 +294,22 @@ static void test_sock_udp_recv4__socketed_with_port0(void)
                                           .port = _TEST_PORT_REMOTE };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &local));
-    assert(0 != local.port);
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &local));
+    expect(0 != local.port);
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            local.port, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv4__unsocketed(void)
@@ -317,14 +318,14 @@ static void test_sock_udp_recv4__unsocketed(void)
                                          .family = AF_INET,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv4__unsocketed_with_remote(void)
@@ -333,20 +334,20 @@ static void test_sock_udp_recv4__unsocketed_with_remote(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv4__with_timeout(void)
@@ -355,20 +356,20 @@ static void test_sock_udp_recv4__with_timeout(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer), _TEST_TIMEOUT,
                                            &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv4__non_blocking(void)
@@ -377,19 +378,19 @@ static void test_sock_udp_recv4__non_blocking(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer), 0, &result));
-    assert(AF_INET == result.family);
-    assert(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__EAFNOSUPPORT(void)
@@ -398,9 +399,9 @@ static void test_sock_udp_send4__EAFNOSUPPORT(void)
                                           .family = AF_UNSPEC,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EAFNOSUPPORT == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(-EAFNOSUPPORT == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                           &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__EINVAL_addr(void)
@@ -413,9 +414,9 @@ static void test_sock_udp_send4__EINVAL_addr(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = _TEST_NETIF };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__EINVAL_netif(void)
@@ -429,9 +430,9 @@ static void test_sock_udp_send4__EINVAL_netif(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = _TEST_NETIF + 1 };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__EHOSTUNREACH(void)
@@ -440,7 +441,7 @@ static void test_sock_udp_send4__EHOSTUNREACH(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EHOSTUNREACH == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(-EHOSTUNREACH == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                           &remote));
 }
 
@@ -449,15 +450,15 @@ static void test_sock_udp_send4__EINVAL_port(void)
     static const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
                                           .family = AF_INET };
 
-    assert(-EINVAL == sock_udp_send(NULL, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(-EINVAL == sock_udp_send(NULL, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__ENOTCONN(void)
 {
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-ENOTCONN == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), NULL));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-ENOTCONN == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), NULL));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__socketed_no_local_no_netif(void)
@@ -466,13 +467,13 @@ static void test_sock_udp_send4__socketed_no_local_no_netif(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, 0, _TEST_PORT_REMOTE,
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0, _TEST_PORT_REMOTE,
                           "ABCD", sizeof("ABCD"), SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__socketed_no_netif(void)
@@ -484,14 +485,14 @@ static void test_sock_udp_send4__socketed_no_netif(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__socketed_no_local(void)
@@ -501,14 +502,14 @@ static void test_sock_udp_send4__socketed_no_local(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                           true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__socketed(void)
@@ -521,14 +522,14 @@ static void test_sock_udp_send4__socketed(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__socketed_other_remote(void)
@@ -544,14 +545,14 @@ static void test_sock_udp_send4__socketed_other_remote(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &sock_remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &sock_remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__unsocketed_no_local_no_netif(void)
@@ -560,14 +561,14 @@ static void test_sock_udp_send4__unsocketed_no_local_no_netif(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__unsocketed_no_netif(void)
@@ -579,14 +580,14 @@ static void test_sock_udp_send4__unsocketed_no_netif(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__unsocketed_no_local(void)
@@ -596,14 +597,14 @@ static void test_sock_udp_send4__unsocketed_no_local(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                           true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__unsocketed(void)
@@ -616,14 +617,14 @@ static void test_sock_udp_send4__unsocketed(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
+    expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__no_sock_no_netif(void)
@@ -632,13 +633,13 @@ static void test_sock_udp_send4__no_sock_no_netif(void)
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__no_sock(void)
@@ -648,13 +649,13 @@ static void test_sock_udp_send4__no_sock(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
+    expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 #endif /* MODULE_LWIP_IPV4 */
 
@@ -665,8 +666,8 @@ static void test_sock_udp_create6__EADDRINUSE(void)
     static const sock_udp_ep_t local = { .family = AF_INET6,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, 0));
-    assert(-EADDRINUSE == sock_udp_create(&_sock2, &local, NULL, 0));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, 0));
+    expect(-EADDRINUSE == sock_udp_create(&_sock2, &local, NULL, 0));
 }
 #endif
 
@@ -679,8 +680,8 @@ static void test_sock_udp_create6__EAFNOSUPPORT(void)
     static const sock_udp_ep_t remote = { .family = AF_UNSPEC,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EAFNOSUPPORT == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EAFNOSUPPORT == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EAFNOSUPPORT == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EAFNOSUPPORT == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create6__EINVAL_addr(void)
@@ -693,7 +694,7 @@ static void test_sock_udp_create6__EINVAL_addr(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create6__EINVAL_netif(void)
@@ -707,16 +708,16 @@ static void test_sock_udp_create6__EINVAL_netif(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .addr = { .ipv6 = _TEST_ADDR6_REMOTE } };
 
-    assert(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
 }
 
 static void test_sock_udp_create6__no_endpoints(void)
 {
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create6__only_local(void)
@@ -725,14 +726,14 @@ static void test_sock_udp_create6__only_local(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create6__only_local_port0(void)
@@ -741,14 +742,14 @@ static void test_sock_udp_create6__only_local_port0(void)
                                          .port = 0U };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(0U != ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(0U != ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
 }
 
 static void test_sock_udp_create6__only_local_reuse_ep(void)
@@ -757,22 +758,22 @@ static void test_sock_udp_create6__only_local_reuse_ep(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t ep, ep2;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_create(&_sock2, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(0 == sock_udp_get_local(&_sock2, &ep2));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock2, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(0 == sock_udp_get_local(&_sock2, &ep2));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep2.family);
-    assert(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep2.family);
+    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
                   sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep2.netif);
-    assert(_TEST_PORT_LOCAL == ep2.port);
-    assert(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
+    expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
+    expect(_TEST_PORT_LOCAL == ep2.port);
+    expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
     sock_udp_close(&_sock2);
 }
 
@@ -784,14 +785,14 @@ static void test_sock_udp_create6__only_remote(void)
                                           .addr =  { .ipv6 = _TEST_ADDR6_REMOTE } };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
     /* lwIP binds connected sock implicitly */
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(0 == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(0 == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 static void test_sock_udp_create6__full(void)
@@ -804,26 +805,26 @@ static void test_sock_udp_create6__full(void)
                                           .addr =  { .ipv6 = _TEST_ADDR6_REMOTE } };
     sock_udp_ep_t ep;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
     /* this can't be guaranteed with lwIP */
-    /* assert(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6, */
+    /* expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6, */
     /*               sizeof(ipv6_addr_t)) == 0); */
-    assert(_TEST_NETIF == ep.netif);
-    assert(_TEST_PORT_LOCAL == ep.port);
-    assert(0 == sock_udp_get_remote(&_sock, &ep));
-    assert(AF_INET6 == ep.family);
-    assert(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
-    assert(SOCK_ADDR_ANY_NETIF == ep.netif);
-    assert(_TEST_PORT_REMOTE == ep.port);
+    expect(_TEST_NETIF == ep.netif);
+    expect(_TEST_PORT_LOCAL == ep.port);
+    expect(0 == sock_udp_get_remote(&_sock, &ep));
+    expect(AF_INET6 == ep.family);
+    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(SOCK_ADDR_ANY_NETIF == ep.netif);
+    expect(_TEST_PORT_REMOTE == ep.port);
 }
 
 static void test_sock_udp_recv6__EADDRNOTAVAIL(void)
 {
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
 
-    assert(-EADDRNOTAVAIL == sock_udp_recv(&_sock, _test_buffer,
+    expect(-EADDRNOTAVAIL == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
 }
@@ -833,9 +834,9 @@ static void test_sock_udp_recv6__EAGAIN(void)
     static const sock_udp_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
 
-    assert(-EAGAIN == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+    expect(-EAGAIN == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
                                     0, NULL));
 }
 
@@ -846,12 +847,12 @@ static void test_sock_udp_recv6__ENOBUFS(void)
     static const sock_udp_ep_t local = { .family = AF_INET6,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"), _TEST_NETIF));
-    assert(-ENOBUFS == sock_udp_recv(&_sock, _test_buffer, 2,
+    expect(-ENOBUFS == sock_udp_recv(&_sock, _test_buffer, 2,
                                      SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv6__ETIMEDOUT(void)
@@ -859,10 +860,10 @@ static void test_sock_udp_recv6__ETIMEDOUT(void)
     static const sock_udp_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
 
     puts(" * Calling sock_udp_recv()");
-    assert(-ETIMEDOUT == sock_udp_recv(&_sock, _test_buffer,
+    expect(-ETIMEDOUT == sock_udp_recv(&_sock, _test_buffer,
                                        sizeof(_test_buffer), _TEST_TIMEOUT,
                                        NULL));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
@@ -878,14 +879,14 @@ static void test_sock_udp_recv6__socketed(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv6__socketed_with_remote(void)
@@ -899,20 +900,20 @@ static void test_sock_udp_recv6__socketed_with_remote(void)
                                           .port = _TEST_PORT_REMOTE };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv6__socketed_with_port0(void)
@@ -925,22 +926,22 @@ static void test_sock_udp_recv6__socketed_with_port0(void)
                                           .port = _TEST_PORT_REMOTE };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(0 == sock_udp_get_local(&_sock, &local));
-    assert(0 != local.port);
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(0 == sock_udp_get_local(&_sock, &local));
+    expect(0 != local.port);
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            local.port, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv6__unsocketed(void)
@@ -951,14 +952,14 @@ static void test_sock_udp_recv6__unsocketed(void)
                                          .family = AF_INET6,
                                          .port = _TEST_PORT_LOCAL };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, NULL));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv6__unsocketed_with_remote(void)
@@ -969,20 +970,20 @@ static void test_sock_udp_recv6__unsocketed_with_remote(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv6__with_timeout(void)
@@ -993,20 +994,20 @@ static void test_sock_udp_recv6__with_timeout(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer), _TEST_TIMEOUT,
                                            &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_recv6__non_blocking(void)
@@ -1017,19 +1018,19 @@ static void test_sock_udp_recv6__non_blocking(void)
                                          .port = _TEST_PORT_LOCAL };
     sock_udp_ep_t result;
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer), 0, &result));
-    assert(AF_INET6 == result.family);
-    assert(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
-    assert(_TEST_PORT_REMOTE == result.port);
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
-    assert(_TEST_NETIF == result.netif);
+    expect(_TEST_NETIF == result.netif);
 #endif
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__EAFNOSUPPORT(void)
@@ -1038,9 +1039,9 @@ static void test_sock_udp_send6__EAFNOSUPPORT(void)
                                           .family = AF_UNSPEC,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EAFNOSUPPORT == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(-EAFNOSUPPORT == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                           &remote));
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__EINVAL_addr(void)
@@ -1053,9 +1054,9 @@ static void test_sock_udp_send6__EINVAL_addr(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = _TEST_NETIF };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__EINVAL_netif(void)
@@ -1069,9 +1070,9 @@ static void test_sock_udp_send6__EINVAL_netif(void)
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = _TEST_NETIF + 1 };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-EINVAL == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__EHOSTUNREACH(void)
@@ -1080,7 +1081,7 @@ static void test_sock_udp_send6__EHOSTUNREACH(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(-EHOSTUNREACH == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(-EHOSTUNREACH == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                           &remote));
 }
 
@@ -1089,15 +1090,15 @@ static void test_sock_udp_send6__EINVAL_port(void)
     static const sock_udp_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
                                           .family = AF_INET6 };
 
-    assert(-EINVAL == sock_udp_send(NULL, "ABCD", sizeof("ABCD"), &remote));
-    assert(_check_net());
+    expect(-EINVAL == sock_udp_send(NULL, "ABCD", sizeof("ABCD"), &remote));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__ENOTCONN(void)
 {
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(-ENOTCONN == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), NULL));
-    assert(_check_net());
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(-ENOTCONN == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"), NULL));
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__socketed_no_local_no_netif(void)
@@ -1107,14 +1108,14 @@ static void test_sock_udp_send6__socketed_no_local_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__socketed_no_netif(void)
@@ -1128,14 +1129,14 @@ static void test_sock_udp_send6__socketed_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__socketed_no_local(void)
@@ -1146,14 +1147,14 @@ static void test_sock_udp_send6__socketed_no_local(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                           true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__socketed(void)
@@ -1168,14 +1169,14 @@ static void test_sock_udp_send6__socketed(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            NULL));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__socketed_other_remote(void)
@@ -1193,14 +1194,14 @@ static void test_sock_udp_send6__socketed_other_remote(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, &sock_remote, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, &sock_remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__unsocketed_no_local_no_netif(void)
@@ -1210,14 +1211,14 @@ static void test_sock_udp_send6__unsocketed_no_local_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__unsocketed_no_netif(void)
@@ -1231,14 +1232,14 @@ static void test_sock_udp_send6__unsocketed_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__unsocketed_no_local(void)
@@ -1249,14 +1250,14 @@ static void test_sock_udp_send6__unsocketed_no_local(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, NULL, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                           true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__unsocketed(void)
@@ -1271,14 +1272,14 @@ static void test_sock_udp_send6__unsocketed(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
-    assert(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCD") == sock_udp_send(&_sock, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__no_sock_no_netif(void)
@@ -1288,13 +1289,13 @@ static void test_sock_udp_send6__no_sock_no_netif(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__no_sock(void)
@@ -1305,13 +1306,13 @@ static void test_sock_udp_send6__no_sock(void)
                                           .netif = _TEST_NETIF,
                                           .port = _TEST_PORT_REMOTE };
 
-    assert(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+    expect(sizeof("ABCD") == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
                                            &remote));
-    assert(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
+    expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, true));
     xtimer_usleep(1000);    /* let lwIP stack finish */
-    assert(_check_net());
+    expect(_check_net());
 }
 #endif /* MODULE_LWIP_IPV6 */
 

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -24,6 +24,7 @@
 #include "net/sock.h"
 #include "net/udp.h"
 #include "sched.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #include "lwip.h"
@@ -76,7 +77,7 @@ static int _get_addr(netdev_t *dev, void *value, size_t max_len)
     static const uint8_t _local_ip[] = _TEST_ADDR6_LOCAL;
 
     (void)dev;
-    assert(max_len >= ETHERNET_ADDR_LEN);
+    expect(max_len >= ETHERNET_ADDR_LEN);
     return l2util_ipv6_iid_to_addr(NETDEV_TYPE_ETHERNET,
                                    (eui64_t *)&_local_ip[8],
                                    value);
@@ -157,7 +158,7 @@ void _net_init(void)
     netdev_test_set_recv_cb(&netdev, _netdev_recv);
     netdev_test_set_isr_cb(&netdev, _netdev_isr);
     /* netdev needs to be set-up */
-    assert(netdev.netdev.driver);
+    expect(netdev.netdev.driver);
 #if LWIP_IPV4
     ip4_addr_t local4, mask4, gw4;
     local4.addr = _TEST_ADDR4_LOCAL;
@@ -201,7 +202,7 @@ void _prepare_send_checks(void)
     netdev_test_set_send_cb(&netdev, _netdev_send);
 #if LWIP_ARP
     const ip4_addr_t remote4 = { .addr = _TEST_ADDR4_REMOTE };
-    assert(ERR_OK == etharp_add_static_entry(&remote4, (struct eth_addr *)mac));
+    expect(ERR_OK == etharp_add_static_entry(&remote4, (struct eth_addr *)mac));
 #endif
 #if LWIP_IPV6
     memset(destination_cache, 0,

--- a/tests/nimble_l2cap/main.c
+++ b/tests/nimble_l2cap/main.c
@@ -27,7 +27,7 @@
 #include "host/ble_gap.h"
 #include "host/util/util.h"
 
-#include "assert.h"
+#include "test_utils/expect.h"
 #include "shell.h"
 #include "thread.h"
 #include "thread_flags.h"
@@ -59,12 +59,12 @@ static void _on_data(struct ble_l2cap_event *event)
     int res;
     (void)res;
     struct os_mbuf *rxd = event->receive.sdu_rx;
-    assert(rxd != NULL);
+    expect(rxd != NULL);
     int rx_len = (int)OS_MBUF_PKTLEN(rxd);
-    assert(rx_len <= (int)APP_MTU);
+    expect(rx_len <= (int)APP_MTU);
 
     res = os_mbuf_copydata(rxd, 0, rx_len, _rxbuf);
-    assert(res == 0);
+    expect(res == 0);
     _last_rx_seq = _rxbuf[POS_SEQ];
     if (_rxbuf[POS_TYPE] == TYPE_INCTEST) {
         thread_flags_set(_main, FLAG_SYNC);
@@ -72,11 +72,11 @@ static void _on_data(struct ble_l2cap_event *event)
 
     /* free buffer */
     res = os_mbuf_free_chain(rxd);
-    assert(res == 0);
+    expect(res == 0);
     rxd = os_mbuf_get_pkthdr(&_coc_mbuf_pool, 0);
-    assert(rxd != NULL);
+    expect(rxd != NULL);
     res = ble_l2cap_recv_ready(_coc, rxd);
-    assert(res == 0);
+    expect(res == 0);
 }
 
 static int _on_l2cap_evt(struct ble_l2cap_event *event, void *arg)
@@ -103,7 +103,7 @@ static int _on_l2cap_evt(struct ble_l2cap_event *event, void *arg)
             /* this event should never be triggered for the L2CAP client */
             /* fallthrough */
         default:
-            assert(0);
+            expect(0);
             break;
     }
 
@@ -119,10 +119,10 @@ static int _on_gap_evt(struct ble_gap_event *event, void *arg)
         case BLE_GAP_EVENT_CONNECT: {
             _handle = event->connect.conn_handle;
             struct os_mbuf *sdu_rx = os_mbuf_get_pkthdr(&_coc_mbuf_pool, 0);
-            assert(sdu_rx != NULL);
+            expect(sdu_rx != NULL);
             int res = ble_l2cap_connect(_handle, APP_CID, APP_MTU, sdu_rx,
                                        _on_l2cap_evt, NULL);
-            assert(res == 0);
+            expect(res == 0);
             break;
         }
         case BLE_GAP_EVENT_DISCONNECT:
@@ -152,12 +152,12 @@ static void _filter_and_connect(struct ble_gap_disc_desc *disc)
                                   APP_NODENAME, (sizeof(APP_NODENAME) - 1));
     if (res) {
         res = ble_gap_disc_cancel();
-        assert(res == 0);
+        expect(res == 0);
 
         printf("# Found Server, connecting now");
         res = ble_gap_connect(nimble_riot_own_addr_type, &disc->addr,
                               BLE_HS_FOREVER, NULL, _on_gap_evt, NULL);
-        assert(res == 0);
+        expect(res == 0);
     }
 }
 
@@ -183,17 +183,17 @@ static void _send(uint32_t type, uint32_t seq, size_t len)
     (void)res;
     struct os_mbuf *txd;
 
-    assert(_coc);
-    assert(len >= 8);
-    assert(len <= APP_MTU);
+    expect(_coc);
+    expect(len >= 8);
+    expect(len <= APP_MTU);
     printf("# Sending: size %5u seq %5u\n", (unsigned)len, (unsigned)seq);
 
     _txbuf[POS_TYPE] = type;
     _txbuf[POS_SEQ] = seq;
     txd = os_mbuf_get_pkthdr(&_coc_mbuf_pool, 0);
-    assert(txd != NULL);
+    expect(txd != NULL);
     res = os_mbuf_append(txd, _txbuf, len);
-    assert(res == 0);
+    expect(res == 0);
 
     do {
         res = ble_l2cap_send(_coc, txd);
@@ -204,7 +204,7 @@ static void _send(uint32_t type, uint32_t seq, size_t len)
 
     if ((res != 0) && (res != BLE_HS_ESTALLED)) {
         printf("# err: failed to send (%i)\n", res);
-        assert(0);
+        expect(0);
     }
 }
 
@@ -244,7 +244,7 @@ static int _cmd_inctest(int argc, char **argv)
         if (_last_rx_seq != seq) {
             printf("# err: bad sequence number in response (%u)\n",
                    (unsigned)_last_rx_seq);
-            assert(0);
+            expect(0);
         }
     }
     time = (xtimer_now_usec() - time);
@@ -316,16 +316,16 @@ int main(void)
 
     /* initialize buffers and setup the test environment */
     res = os_mempool_init(&_coc_mempool, MBUFCNT, MBUFSIZE, _coc_mem, "appbuf");
-    assert(res == 0);
+    expect(res == 0);
     res = os_mbuf_pool_init(&_coc_mbuf_pool, &_coc_mempool, MBUFSIZE, MBUFCNT);
-    assert(res == 0);
+    expect(res == 0);
 
     /* start scanning for a suitable test server */
     puts("# Scanning now");
     struct ble_gap_disc_params params = { 0 };
     res = ble_gap_disc(nimble_riot_own_addr_type, BLE_HS_FOREVER,
                        &params, _on_scan_evt, NULL);
-    assert(res == 0);
+    expect(res == 0);
 
     /* wait until we are connected to the test server */
     thread_flags_wait_all(FLAG_UP);

--- a/tests/nimble_l2cap_server/main.c
+++ b/tests/nimble_l2cap_server/main.c
@@ -26,7 +26,7 @@
 #include "host/ble_gap.h"
 #include "host/util/util.h"
 
-#include "assert.h"
+#include "test_utils/expect.h"
 #include "net/bluetil/ad.h"
 
 #include "nimble_l2cap_test_conf.h"
@@ -54,21 +54,21 @@ static void _on_data(struct ble_l2cap_event *event)
     struct os_mbuf *rxd;
 
     rxd = event->receive.sdu_rx;
-    assert(rxd != NULL);
+    expect(rxd != NULL);
     int rx_len = (int)OS_MBUF_PKTLEN(rxd);
-    assert(rx_len <= (int)APP_MTU);
+    expect(rx_len <= (int)APP_MTU);
 
     res = os_mbuf_copydata(rxd, 0, rx_len, _rxbuf);
-    assert(res == 0);
+    expect(res == 0);
 
     res = ble_l2cap_send(_coc, rxd);
-    assert((res == 0) || (res == BLE_HS_ESTALLED));
+    expect((res == 0) || (res == BLE_HS_ESTALLED));
 
     /* allocate new mbuf for receiving new data */
     rxd = os_mbuf_get_pkthdr(&_coc_mbuf_pool, 0);
-    assert(rxd != NULL);
+    expect(rxd != NULL);
     res = ble_l2cap_recv_ready(_coc, rxd);
-    assert(res == 0);
+    expect(res == 0);
 
     printf("# Received: len %5i, seq %5u\n", rx_len, (unsigned)_rxbuf[POS_SEQ]);
 }
@@ -112,7 +112,7 @@ static int _on_l2cap_evt(struct ble_l2cap_event *event, void *arg)
             break;
         case BLE_L2CAP_EVENT_COC_ACCEPT: {
             struct os_mbuf *sdu_rx = os_mbuf_get_pkthdr(&_coc_mbuf_pool, 0);
-            assert(sdu_rx != NULL);
+            expect(sdu_rx != NULL);
             ble_l2cap_recv_ready(event->accept.chan, sdu_rx);
             break;
         }
@@ -123,7 +123,7 @@ static int _on_l2cap_evt(struct ble_l2cap_event *event, void *arg)
             /* this event is expected, but we have nothing to do here */
             break;
         default:
-            assert(0);
+            expect(0);
             break;
     }
 
@@ -134,7 +134,7 @@ static void _advertise_now(void)
 {
     int res = ble_gap_adv_start(nimble_riot_own_addr_type, NULL, BLE_HS_FOREVER,
                                 &_adv_params, _on_gap_evt, NULL);
-    assert(res == 0);
+    expect(res == 0);
 }
 
 int main(void)
@@ -145,13 +145,13 @@ int main(void)
 
     /* initialize buffers and setup the test environment */
     res = os_mempool_init(&_coc_mempool, MBUFCNT, MBUFSIZE, _coc_mem, "appbuf");
-    assert(res == 0);
+    expect(res == 0);
     res = os_mbuf_pool_init(&_coc_mbuf_pool, &_coc_mempool, MBUFSIZE, MBUFCNT);
-    assert(res == 0);
+    expect(res == 0);
 
     /* create l2cap server */
     res = ble_l2cap_create_server(APP_CID, APP_MTU, _on_l2cap_evt, NULL);
-    assert(res == 0);
+    expect(res == 0);
 
     /* initialize advertising data and parameters */
     _adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;
@@ -160,7 +160,7 @@ int main(void)
                                BLUETIL_AD_FLAGS_DEFAULT);
     bluetil_ad_add_name(&_ad, APP_NODENAME);
     res = ble_gap_adv_set_data(_ad.buf, (int)_ad.pos);
-    assert(res == 0);
+    expect(res == 0);
 
     /* start advertising the test server */
     _advertise_now();

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -21,9 +21,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
 
 #include "shell.h"
+#include "test_utils/expect.h"
 
 #include "periph/eeprom.h"
 
@@ -222,28 +222,28 @@ static int cmd_test(int argc, char **argv)
 
     /* read/write from beginning of EEPROM */
     size_t ret = eeprom_write(0, (uint8_t *)expected, 4);
-    assert(ret == 4);
+    expect(ret == 4);
 
     char result[4];
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(memcmp(result, expected, 4) == 0);
-    assert(ret == 4);
+    expect(memcmp(result, expected, 4) == 0);
+    expect(ret == 4);
 
     /* read/write at end of EEPROM */
     ret = eeprom_write(EEPROM_SIZE - 4, (uint8_t *)expected, 4);
-    assert(ret == 4);
+    expect(ret == 4);
     memset(result, 0, 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(memcmp(result, expected, 4) == 0);
-    assert(ret == 4);
+    expect(memcmp(result, expected, 4) == 0);
+    expect(ret == 4);
 
     /* read/write single byte */
     eeprom_write_byte(0, 'A');
-    assert(eeprom_read_byte(0) == 'A');
+    expect(eeprom_read_byte(0) == 'A');
     eeprom_write_byte(EEPROM_SIZE - 1, 'A');
-    assert(eeprom_read_byte(EEPROM_SIZE - 1) == 'A');
+    expect(eeprom_read_byte(EEPROM_SIZE - 1) == 'A');
     eeprom_write_byte(EEPROM_SIZE / 2, 'A');
-    assert(eeprom_read_byte(EEPROM_SIZE / 2) == 'A');
+    expect(eeprom_read_byte(EEPROM_SIZE / 2) == 'A');
 
     /* clear some bytes */
     const uint8_t cleared[4] = {
@@ -253,25 +253,25 @@ static int cmd_test(int argc, char **argv)
     eeprom_clear(0, 4);
     memset(result, 0, 4);
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(memcmp(result, cleared, 4) == 0);
-    assert(ret == 4);
+    expect(memcmp(result, cleared, 4) == 0);
+    expect(ret == 4);
 
     eeprom_clear(EEPROM_SIZE - 4, 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(memcmp(result, cleared, 4) == 0);
-    assert(ret == 4);
+    expect(memcmp(result, cleared, 4) == 0);
+    expect(ret == 4);
 
     /* set some bytes */
     eeprom_set(0, 'A', 4);
     ret = eeprom_read(0, (uint8_t *)result, 4);
-    assert(memcmp(result, "AAAA", 4) == 0);
-    assert(ret == 4);
+    expect(memcmp(result, "AAAA", 4) == 0);
+    expect(ret == 4);
 
     memset(result, 0, 4);
     eeprom_set(EEPROM_SIZE - 4, 'A', 4);
     ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
-    assert(memcmp(result, "AAAA", 4) == 0);
-    assert(ret == 4);
+    expect(memcmp(result, "AAAA", 4) == 0);
+    expect(ret == 4);
 
     puts("SUCCESS");
     return 0;

--- a/tests/pkg_cn-cbor/main.c
+++ b/tests/pkg_cn-cbor/main.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "assert.h"
+#include "test_utils/expect.h"
 #include "cn-cbor/cn-cbor.h"
 #include "embUnit.h"
 #include "fmt.h"
@@ -58,7 +58,7 @@ static cn_cbor_context ct =
 static void *cbor_calloc(size_t count, size_t size, void *memblock)
 {
     (void)count;
-    assert(count == 1); /* Count is always 1 with cn-cbor */
+    expect(count == 1); /* Count is always 1 with cn-cbor */
     void *block = memarray_alloc(memblock);
     if (block) {
         memset(block, 0, size);

--- a/tests/pkg_micro-ecc/main.c
+++ b/tests/pkg_micro-ecc/main.c
@@ -36,7 +36,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "assert.h"
+#include "test_utils/expect.h"
 #include "hashes/sha256.h"
 #include "uECC.h"
 
@@ -117,8 +117,8 @@ int main(void)
     const struct uECC_Curve_t *curve = uECC_secp256r1();
     int errorc = 0;
 
-    assert(uECC_curve_private_key_size(curve) <= MAX_CURVE_SIZE);
-    assert(uECC_curve_public_key_size(curve) <= MAX_PUBLIC_KEY_SIZE);
+    expect(uECC_curve_private_key_size(curve) <= MAX_CURVE_SIZE);
+    expect(uECC_curve_public_key_size(curve) <= MAX_PUBLIC_KEY_SIZE);
 
     printf("Testing %d random private key pairs and signature without using HWRNG\n", TESTROUNDS);
 

--- a/tests/socket_zep/main.c
+++ b/tests/socket_zep/main.c
@@ -18,7 +18,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -28,6 +27,7 @@
 #include "sched.h"
 #include "socket_zep.h"
 #include "socket_zep_params.h"
+#include "test_utils/expect.h"
 #include "msg.h"
 #include "od.h"
 
@@ -52,7 +52,7 @@ static void test_init(void)
            p->local_addr, p->local_port, p->remote_addr, p->remote_port);
     socket_zep_setup(&_dev, p);
     netdev->event_callback = _event_cb;
-    assert(netdev->driver->init(netdev) >= 0);
+    expect(netdev->driver->init(netdev) >= 0);
     _print_info(netdev);
 }
 
@@ -62,7 +62,7 @@ static void test_send__iolist_NULL(void)
 
     puts("Send zero-length packet");
     int res = netdev->driver->send(netdev, NULL);
-    assert((res < 0) || (res == 0));
+    expect((res < 0) || (res == 0));
     if ((res < 0) && (errno == ECONNREFUSED)) {
         puts("No remote socket exists (use scripts in `tests/` to have proper tests)");
     }
@@ -79,7 +79,7 @@ static void test_send__iolist_not_NULL(void)
 
     puts("Send 'Hello\\0World\\0'");
     int res =  netdev->driver->send(netdev, iolist);
-    assert((res < 0) || (res == (sizeof("Hello")) + sizeof("World")));
+    expect((res < 0) || (res == (sizeof("Hello")) + sizeof("World")));
     if ((res < 0) && (errno == ECONNREFUSED)) {
         puts("No remote socket exists (use scripts in `tests/` to have proper tests)");
     }
@@ -122,14 +122,14 @@ static void _recv(netdev_t *dev)
     const int exp_len = dev->driver->recv(dev, NULL, 0, NULL);
     int data_len;
 
-    assert(exp_len >= 0);
-    assert(((unsigned)exp_len) <= sizeof(_recvbuf));
+    expect(exp_len >= 0);
+    expect(((unsigned)exp_len) <= sizeof(_recvbuf));
     data_len = dev->driver->recv(dev, _recvbuf, sizeof(_recvbuf), &rx_info);
     if (data_len < 0) {
         puts("Received invalid packet");
     }
     else {
-        assert(data_len <= exp_len);
+        expect(data_len <= exp_len);
         printf("RSSI: %u, LQI: %u, Data:\n", rx_info.rssi, rx_info.lqi);
         if (data_len > 0) {
             od_hex_dump(_recvbuf, data_len, OD_WIDTH_DEFAULT);
@@ -167,9 +167,9 @@ static void _print_info(netdev_t *netdev)
     uint64_t long_addr;
     uint16_t short_addr;
 
-    assert(netdev->driver->get(netdev, NETOPT_ADDRESS, &short_addr,
+    expect(netdev->driver->get(netdev, NETOPT_ADDRESS, &short_addr,
                                sizeof(short_addr)) == sizeof(uint16_t));
-    assert(netdev->driver->get(netdev, NETOPT_ADDRESS_LONG, &long_addr,
+    expect(netdev->driver->get(netdev, NETOPT_ADDRESS_LONG, &long_addr,
                                sizeof(long_addr)) == sizeof(uint64_t));
 
     /* we are on native, so using PRIu* is okay */

--- a/tests/thread_msg_block_race/main.c
+++ b/tests/thread_msg_block_race/main.c
@@ -24,6 +24,7 @@
 
 #include "periph/timer.h"
 #include "random.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 #include "msg.h"
 
@@ -95,7 +96,7 @@ int main(void)
     pid = thread_create(_stack, sizeof(_stack), THREAD_PRIORITY_MAIN + 1,
                         THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
                         _thread, NULL, "nr2");
-    assert(pid != KERNEL_PID_UNDEF);
+    expect(pid != KERNEL_PID_UNDEF);
 
     while (1) {
         msg_t msg = { .type = CANARY_TYPE };

--- a/tests/unittests/tests-gnrc_ipv6/tests-gnrc_ipv6.c
+++ b/tests/unittests/tests-gnrc_ipv6/tests-gnrc_ipv6.c
@@ -21,6 +21,7 @@
 #include "net/gnrc/pktbuf.h"
 
 #include "unittests-constants.h"
+#include "test_utils/expect.h"
 #include "tests-gnrc_ipv6.h"
 
 #define DEFAULT_TEST_SRC    { { \
@@ -56,16 +57,16 @@ static void set_up(void)
 
     gnrc_pktbuf_init();
     _pkt_w_ip_hdr = gnrc_pktbuf_add(NULL, NULL, 1, GNRC_NETTYPE_NETIF);
-    assert(_pkt_w_ip_hdr);
+    expect(_pkt_w_ip_hdr);
     _pkt_w_ip_hdr = gnrc_pktbuf_add(_pkt_w_ip_hdr, &ip, sizeof(ipv6_hdr_t), GNRC_NETTYPE_IPV6);
-    assert(_pkt_w_ip_hdr);
+    expect(_pkt_w_ip_hdr);
     _pkt_w_ip_hdr = gnrc_pktbuf_add(_pkt_w_ip_hdr, NULL, 1, GNRC_NETTYPE_UNDEF);
-    assert(_pkt_w_ip_hdr);
+    expect(_pkt_w_ip_hdr);
 
     _pkt_no_ip_hdr = gnrc_pktbuf_add(NULL, NULL, 1, GNRC_NETTYPE_NETIF);
-    assert(_pkt_no_ip_hdr);
+    expect(_pkt_no_ip_hdr);
     _pkt_no_ip_hdr = gnrc_pktbuf_add(_pkt_no_ip_hdr, NULL, 1, GNRC_NETTYPE_UNDEF);
-    assert(_pkt_no_ip_hdr);
+    expect(_pkt_no_ip_hdr);
 }
 
 static void tear_down(void)

--- a/tests/usbus/usbdev_mock.c
+++ b/tests/usbus/usbdev_mock.c
@@ -19,6 +19,7 @@
 
 #include "embUnit.h"
 #include "periph/usbdev.h"
+#include "test_utils/expect.h"
 #include "usbdev_mock.h"
 
 #define ENABLE_DEBUG    (0)
@@ -121,7 +122,7 @@ int _set(usbdev_t *usbdev, usbopt_t opt,
             res = sizeof(uint8_t);
             break;
         case USBOPT_ATTACH:
-            assert(value_len == sizeof(usbopt_enable_t));
+            expect(value_len == sizeof(usbopt_enable_t));
             res = sizeof(usbopt_enable_t);
             break;
         default:


### PR DESCRIPTION
### Contribution description

This PR fixes compilation problems (hopefully all remaining) when `NDEBUG` is defined.

Now where PR #13268 is merged, test applications should use `expect` instead of `assert` for testing conditions and results. Otherwise, they are not compilable when `NDEBUG` is defined. In difference to `assert`, `expect`  is not compiled out when compiling with  `NDEBUG`.

**NOTE** commit https://github.com/RIOT-OS/RIOT/pull/13466/commits/0c1baf267eb57344e41f411e4a8fb4213eb1f46d is just for the compilation test with `NDEBUG` and has to be dropped before the PR is merged.

### Testing procedure

The compilation in Murdock should succeed with commit https://github.com/RIOT-OS/RIOT/pull/13466/commits/0c1baf267eb57344e41f411e4a8fb4213eb1f46d.

### Issues/PRs references

Fixes #13265
Depends on ~#13465~
Depends on ~#13474~