### PR TITLE
sys/test_utils: reduce the RAM usage by `expect` on AVR

### DIFF
--- a/sys/include/test_utils/expect.h
+++ b/sys/include/test_utils/expect.h
@@ -45,12 +45,10 @@ extern "C" {
  *
  * @param[in] file  The file name of the file the expectation failed in
  * @param[in] line  The code line of @p file the expectation failed in
- * @param[in] cond  The failed condition as string
  */
-NORETURN static inline void _expect_failure(const char *file, unsigned line,
-                                            const char *cond)
+NORETURN static inline void _expect_failure(const char *file, unsigned line)
 {
-    printf("%s:%u => failed condition \"%s\"\n", file, line, cond);
+    printf("%s:%u => failed condition\n", file, line);
     core_panic(PANIC_EXPECT_FAIL, "CONDITION FAILED.");
 }
 
@@ -83,7 +81,7 @@ NORETURN static inline void _expect_failure(const char *file, unsigned line,
  *
  */
 #define expect(cond) ((cond) ? (void)0 :  _expect_failure(RIOT_FILE_RELATIVE, \
-                                                          __LINE__, #cond))
+                                                          __LINE__))
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

This PR modifies the `expect` macro in `sys/test_utils` to reduce the RAM usage on AVR platform. It doesn't use the condition as a string constant anymore.

With PR #13268 `expect` macro was introduced. However, using the `expect` macro instead of the  `assert` macro significantly increases the data size in RAM on AVR platform. The reason is that the `expect` macro uses the condition as string constant. String constants are placed in RAM instead of ROM on AVR platform.

For example, `tests/periph_eeprom` with only 21 uses of `expect` needs already 278 bytes more RAM. A test application such as `tests/gnrc_sock_ip`, where `assert` is used much more intensively, the increase of RAM is more than 2 kBytes. As a result, there is not enough memory for further AVR boards.

Since the `expect` macro always outputs the file and line number where the condition failed, the developer has all information required to locate the problem. The additional output of the condition is not required. Removing the output of the condition reduces the RAM usage a lot. For example, `tests/gnrc_sock_ip` requires only 28 bytes more than with `assert` if the `expect` macro doesn't use the condition as string constant.

### Testing procedure

Compilation in Murdock should succeed.

### Issues/PRs references