### PR TITLE
cpu: PM_NUM_MODES must only count non-IDLE modes

### DIFF
--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -132,7 +132,7 @@ typedef uint16_t gpio_t;
 /**
  * @brief   number of usable power modes
  */
-#define PM_NUM_MODES    (1U)
+#define PM_NUM_MODES    (0U)
 
 #ifdef RTC
 /* All Kinetis CPUs have exactly one RTC hardware module, except for the KL02

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -36,7 +36,7 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (4)
+#define PM_NUM_MODES        (3)
 /** @} */
 
 /**

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -95,17 +95,6 @@ enum {
  */
 #define GPIO_MODE(pr, ie, pe)   (pr | (ie << 1) | (pe << 2))
 
-/**
- * @name    Power mode configuration
- * @{
- */
-#ifdef CPU_SAML1X
-#define PM_NUM_MODES        (2)
-#else
-#define PM_NUM_MODES        (3)
-#endif
-/** @} */
-
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -29,6 +29,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (3)
+/** @} */
+
+/**
  * @brief   Override the default initial PM blocker
  * @todo   Idle modes are enabled by default, deep sleep mode blocked
  */

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -44,6 +44,13 @@ extern "C" {
 #define SAM0_DPLL_FREQ_MAX_HZ   (200000000U)
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (3)
+/** @} */
+
+/**
  * @name   SAMD5x GCLK definitions
  * @{
  */

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -27,6 +27,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (1)
+/** @} */
+
+/**
  * @brief   Override the default initial PM blocker
  * @todo   Idle modes are enabled by default, deep sleep mode blocked
  */

--- a/cpu/saml1x/periph/pm.c
+++ b/cpu/saml1x/periph/pm.c
@@ -26,26 +26,24 @@
 
 void pm_set(unsigned mode)
 {
-    if (mode < PM_NUM_MODES) {
-        uint32_t _mode;
+    uint32_t _mode;
 
-        switch (mode) {
-            case 0:
-                DEBUG_PUTS("pm_set(): setting STANDBY mode.");
-                _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
-                break;
-            default: /* Falls through */
-            case 1:
-                DEBUG_PUTS("pm_set(): setting IDLE mode.");
-                _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
-                break;
-        }
-
-        /* write sleep configuration */
-        PM->SLEEPCFG.bit.SLEEPMODE = _mode;
-        /* make sure value has been set */
-        while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
+    switch (mode) {
+        case 0:
+            DEBUG_PUTS("pm_set(): setting STANDBY mode.");
+            _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
+            break;
+        default: /* Falls through */
+        case 1:
+            DEBUG_PUTS("pm_set(): setting IDLE mode.");
+            _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
+            break;
     }
+
+    /* write sleep configuration */
+    PM->SLEEPCFG.bit.SLEEPMODE = _mode;
+    /* make sure value has been set */
+    while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
 
     sam0_cortexm_sleep(0);
 }

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -32,6 +32,13 @@ extern "C" {
 #define CPU_BACKUP_RAM_NOT_RETAINED (1)
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (2)
+/** @} */
+
+/**
  * @name   SAML21 GCLK definitions
  * @{
  */

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -26,34 +26,32 @@
 
 void pm_set(unsigned mode)
 {
-    if (mode < PM_NUM_MODES) {
-        uint32_t _mode;
+    uint32_t _mode;
 
-        switch (mode) {
-            case 0:
-                DEBUG_PUTS("pm_set(): setting BACKUP mode.");
-                _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
-                break;
-            case 1:
-                DEBUG_PUTS("pm_set(): setting STANDBY mode.");
-                _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
-                break;
-            default: /* Falls through */
-            case 2:
-                DEBUG_PUTS("pm_set(): setting IDLE mode.");
+    switch (mode) {
+        case 0:
+            DEBUG_PUTS("pm_set(): setting BACKUP mode.");
+            _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
+            break;
+        case 1:
+            DEBUG_PUTS("pm_set(): setting STANDBY mode.");
+            _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
+            break;
+        default: /* Falls through */
+        case 2:
+            DEBUG_PUTS("pm_set(): setting IDLE mode.");
 #if !defined(PM_SLEEPCFG_SLEEPMODE_IDLE2)
-                _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
+            _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
 #else
-                _mode = PM_SLEEPCFG_SLEEPMODE_IDLE2;
+            _mode = PM_SLEEPCFG_SLEEPMODE_IDLE2;
 #endif
-                break;
-        }
-
-        /* write sleep configuration */
-        PM->SLEEPCFG.bit.SLEEPMODE = _mode;
-        /* make sure value has been set */
-        while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
+            break;
     }
+
+    /* write sleep configuration */
+    PM->SLEEPCFG.bit.SLEEPMODE = _mode;
+    /* make sure value has been set */
+    while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
 
     sam0_cortexm_sleep(0);
 }

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -57,11 +57,6 @@ extern "C" {
 #define GPIO_MODE(mode, cnf, odr)       (mode | (cnf << 2) | (odr << 4))
 
 /**
- * @brief   Define the number of available PM modes
- */
-#define PM_NUM_MODES        (2U)
-
-/**
  * @brief  Define the config flag for stop mode
  */
 #define PM_STOP_CONFIG      (PWR_CR_LPDS)


### PR DESCRIPTION
### Contribution description

From the [documentation](https://riot-os.org/api/group__sys__pm__layered.html):

 - CPUs define up to 4 power modes (from zero, the lowest power mode,
   to `PM_NUM_MODES-1`, the highest)
 - **there is an implicit extra idle mode (which has the number `PM_NUM_MODES`)**

I must say that an 'implicit extra mode' is a very surprising concept, but most implementations did get it right that there are in fact `PM_NUM_MODES + 1` modes.

This fixes the ones that didn't.

### Testing procedure

Run `tests/periph_pm` and observe the power consumption

I tested the sam0 CPUs and manually checked the code of the other implementations.

### Issues/PRs references

I noticed that saml21 would not wake up from STANDBY (mode 1) in `tests/periph_pm`.
It would briefly wake up, but immediately go back to STANDBY.

It turned out that pm_layered would always call `pm_set(3)`, which is [out of range](https://github.com/RIOT-OS/RIOT/blob/master/cpu/saml21/periph/pm.c#L29).
As a result, the `SLEEPMODE` register would never be written and the previous value (STANDBY) would be used.

Another side effect was that the CPU never entered idle mode.
With this patch, IDLE consumption drops from 750µA to 368µA.
