### PR TITLE
boards/common/silabs: don't export OPENOCD_CONFIG

### DIFF
--- a/boards/common/silabs/Makefile.include
+++ b/boards/common/silabs/Makefile.include
@@ -4,7 +4,8 @@ INCLUDES += -I$(RIOTBOARD)/common/silabs/drivers/include
 PROGRAMMER ?= jlink
 
 export JLINK_DEVICE ?= ${CPU_MODEL}
-export OPENOCD_CONFIG ?= board/efm32.cfg
+
+OPENOCD_CONFIG ?= board/efm32.cfg
 
 ifeq ($(PROGRAMMER),jlink)
   include $(RIOTMAKE)/tools/jlink.inc.mk


### PR DESCRIPTION


### Contribution description

This fixes a `buildsystem_sanity_check` error.

### Testing procedure

Flashing with `openocd` should still work.

### Issues/PRs references

All Travis builds are currently failing because of this.