### PR TITLE
unittests: tests-sixlowpan_ctx: fix prefix check

### DIFF
--- a/tests/unittests/tests-sixlowpan_ctx/tests-sixlowpan_ctx.c
+++ b/tests/unittests/tests-sixlowpan_ctx/tests-sixlowpan_ctx.c
@@ -129,7 +129,7 @@ static void test_sixlowpan_ctx_lookup_addr__same_addr(void)
     TEST_ASSERT_EQUAL_INT(GNRC_SIXLOWPAN_CTX_FLAGS_COMP | DEFAULT_TEST_ID, ctx->flags_id);
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_PREFIX_LEN, ctx->prefix_len);
     TEST_ASSERT(TEST_UINT16 >= ctx->ltime);
-    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ipv6_addr_match_prefix(&addr, &ctx->prefix));
+    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN <= ipv6_addr_match_prefix(&addr, &ctx->prefix));
 }
 
 static void test_sixlowpan_ctx_lookup_addr__other_addr_same_prefix(void)
@@ -144,7 +144,7 @@ static void test_sixlowpan_ctx_lookup_addr__other_addr_same_prefix(void)
     TEST_ASSERT_EQUAL_INT(GNRC_SIXLOWPAN_CTX_FLAGS_COMP | DEFAULT_TEST_ID, ctx->flags_id);
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_PREFIX_LEN, ctx->prefix_len);
     TEST_ASSERT(TEST_UINT16 >= ctx->ltime);
-    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ipv6_addr_match_prefix(&addr1, &ctx->prefix));
+    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN <= ipv6_addr_match_prefix(&addr1, &ctx->prefix));
 }
 
 static void test_sixlowpan_ctx_lookup_addr__other_addr_other_prefix(void)
@@ -179,7 +179,7 @@ static void test_sixlowpan_ctx_lookup_id__success(void)
     TEST_ASSERT_EQUAL_INT(GNRC_SIXLOWPAN_CTX_FLAGS_COMP | DEFAULT_TEST_ID, ctx->flags_id);
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_PREFIX_LEN, ctx->prefix_len);
     TEST_ASSERT(TEST_UINT16 >= ctx->ltime);
-    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ipv6_addr_match_prefix(&addr, &ctx->prefix));
+    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN <= ipv6_addr_match_prefix(&addr, &ctx->prefix));
 }
 
 static void test_sixlowpan_ctx_remove(void)


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The result must be checked for being greater or equal to the targeted value. So for the [Yoda conditions] in those unittests the comparison mast be lesser or equal.

[Yoda conditions]: https://en.wikipedia.org/wiki/Yoda_conditions
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Tests should still pass

```sh
make -C tests/unittests/ tests-sixlowpan_ctx flash-only test
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found while bug hunting for #13471
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
