### PR TITLE
boards/pba-d-01-kw2x: add config for tmp006 addr

### DIFF
--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -86,6 +86,14 @@ extern "C"
 /** @}*/
 
 /**
+ * @name TMP006 configuration
+ *
+ * @{
+ */
+#define TMP00X_PARAM_ADDR          (0x41)
+/** @}*/
+
+/**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This fixes the slave address of the tmp006 sensor on the `pba-d-01-kw2x` that was changed in #12022.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
With current master `BOARD=pba-d-01-kw2x make -C examples/saul all flash term` will print the following message at boot:
```
tmp00x_init: error reading device ID!
[auto_init_saul] error initializing tmp00x #0
```
and the command `saul` won't list the tmp00x sensor.
With this PR it will work again.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
