### PR TITLE
tests/periph_rtc: test sub-second precision

### DIFF
--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -35,6 +35,8 @@
 #define TM_YEAR_OFFSET      (1900)
 
 static unsigned cnt = 0;
+static uint32_t start_usecs = 0;
+static uint32_t alarm_expected_usecs = 0;
 
 static void print_time(const char *label, const struct tm *time)
 {
@@ -77,30 +79,40 @@ int main(void)
     /* set RTC */
     print_time("  Setting clock to ", &time);
     rtc_set_time(&time);
+    start_usecs = xtimer_now_usec();
 
     /* read RTC to confirm value */
-    rtc_get_time(&time);
-    print_time("Clock value is now ", &time);
+    struct tm time_now;
+    rtc_get_time(&time_now);
+    print_time("Clock value is now ", &time_now);
 
     /* set initial alarm */
     inc_secs(&time, PERIOD);
     print_time("  Setting alarm to ", &time);
     rtc_set_alarm(&time, cb, &rtc_mtx);
+    alarm_expected_usecs = start_usecs + US_PER_SEC * PERIOD;
 
     /* verify alarm */
     rtc_get_alarm(&time);
     print_time("   Alarm is set to ", &time);
     puts("");
 
+    printf("[%" PRIu32 "] First alarm expected at %" PRIu32 " microseconds\n",
+    xtimer_now_usec(),
+    alarm_expected_usecs);
     while (1) {
         mutex_lock(&rtc_mtx);
-        puts("Alarm!");
-
+        uint32_t now_usecs = xtimer_now_usec();
+        printf("[%" PRIu32 "] Alarm! after %" PRIu32 " microseconds (error %" PRId32 " microseconds)\n",
+           now_usecs,
+           now_usecs - start_usecs,
+           (int32_t)now_usecs - alarm_expected_usecs);
         if (++cnt < REPEAT) {
             struct tm time;
             rtc_get_alarm(&time);
             inc_secs(&time, PERIOD);
             rtc_set_alarm(&time, cb, &rtc_mtx);
+            alarm_expected_usecs += US_PER_SEC * PERIOD;
         }
     }
 

--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -103,9 +103,10 @@ int main(void)
     while (1) {
         mutex_lock(&rtc_mtx);
         uint32_t now_usecs = xtimer_now_usec();
-        printf("[%" PRIu32 "] Alarm! after %" PRIu32 " microseconds (error %" PRId32 " microseconds)\n",
-           now_usecs,
-           now_usecs - start_usecs,
+        printf("[%" PRIu32 "] Alarm! after %" PRIu32 " microseconds "
+            "(error %" PRId32 " microseconds)\n",
+            now_usecs,
+            now_usecs - start_usecs,
            (int32_t)now_usecs - alarm_expected_usecs);
         if (++cnt < REPEAT) {
             struct tm time;

--- a/tests/periph_rtc/tests/01-run.py
+++ b/tests/periph_rtc/tests/01-run.py
@@ -36,6 +36,7 @@ def testfunc(child):
         child.expect(r'.*rtc_set_alarm: not implemented')
     child.expect(r'   Alarm is set to   ({})'.format(DATE_PATTERN))
     alarm_value = child.match.group(1)
+    child.expect(r'\[[0-9]+\] First alarm expected at [0-9]+ microseconds')
     if BOARD != 'native':
         # Set alarm is not implemented for native board so no need to compare
         # alarm values
@@ -43,7 +44,11 @@ def testfunc(child):
 
     if BOARD != 'native':
         for _ in range(alarm_count):
-            child.expect_exact('Alarm!')
+            child.expect(r'\[[0-9]+\] Alarm! after [0-9]+ microseconds \(error'
+                         r' ([0-9]+) microseconds\)')
+            eus = int(child.match.group(1))
+            assert abs(eus) <= 100, \
+                "Error ({}us) out of range, alarm_count={}".format(eus, _)
 
 
 if __name__ == "__main__":

--- a/tests/periph_rtc/tests/01-run.py
+++ b/tests/periph_rtc/tests/01-run.py
@@ -8,7 +8,7 @@
 
 import os
 import sys
-#from testrunner import run
+from testrunner import run
 
 
 BOARD = os.getenv('BOARD', 'native')
@@ -52,5 +52,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    assert abs(-378) <= 100
     sys.exit(run(testfunc))

--- a/tests/periph_rtc/tests/01-run.py
+++ b/tests/periph_rtc/tests/01-run.py
@@ -8,7 +8,7 @@
 
 import os
 import sys
-from testrunner import run
+#from testrunner import run
 
 
 BOARD = os.getenv('BOARD', 'native')
@@ -45,11 +45,12 @@ def testfunc(child):
     if BOARD != 'native':
         for _ in range(alarm_count):
             child.expect(r'\[[0-9]+\] Alarm! after [0-9]+ microseconds \(error'
-                         r' ([0-9]+) microseconds\)')
-            eus = int(child.match.group(1))
+                         r' (\-)*([0-9]+) microseconds\)')
+            eus = int(child.match.group(2))
             assert abs(eus) <= 100, \
                 "Error ({}us) out of range, alarm_count={}".format(eus, _)
 
 
 if __name__ == "__main__":
+    assert abs(-378) <= 100
     sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

Adapted from @benemorius PR #10763.
Add mircosecond precision test to RTC.
Adapt automated python test to match test API changes.
Assert max of 100 us error.

This is needed to test that an RTC alarm fires at the desired time and not with an arbitrary offset up to +/-1 second.
It also tests that rtc_set_time() behaves equivalently correctly, which is what I needed to test when I wrote this.

### Testing procedure

`BOARD=<board_to_test> make flash test -C tests/periph_rtc`

### Issues/PRs references

Taken over from #10763