### PR TITLE
gnrc_dhcpv6_client: configure prefix as compression context on 6LBRs 

### DIFF
--- a/sys/include/net/gnrc/dhcpv6/client/6lbr.h
+++ b/sys/include/net/gnrc/dhcpv6/client/6lbr.h
@@ -35,6 +35,18 @@ extern "C" {
 #endif
 
 /**
+ * @brief   6LoWPAN compression context lifetime for configured prefixes in
+ *          minutes
+ *
+ * Must be between 1 and 255
+ *
+ * @see     [RFC 6775, section 4.2](https://tools.ietf.org/html/rfc6775#section-4.2)
+ */
+#ifndef CONFIG_GNRC_DHCPV6_CLIENT_6LBR_6LO_CTX_MIN
+#define CONFIG_GNRC_DHCPV6_CLIENT_6LBR_6LO_CTX_MIN  (60U)
+#endif
+
+/**
  * @brief   Use static routes to upstream router
  *
  * If set the border router will be configured to have a default route via

--- a/sys/net/gnrc/application_layer/dhcpv6/Kconfig
+++ b/sys/net/gnrc/application_layer/dhcpv6/Kconfig
@@ -13,6 +13,14 @@ config GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM
     help
         Leave 0 to let the client pick the first non-6LoWPAN interface it finds
 
+config GNRC_DHCPV6_CLIENT_6LBR_6LO_CTX_MIN
+    int "6LoWPAN compression context lifetime for configured prefixes in minutes"
+    default 60
+    range 1 255
+    help
+        @see [RFC 6775, section 4.2](https://tools.ietf.org/html/rfc6775#section-4.2)
+
+
 config GNRC_DHCPV6_CLIENT_6LBR_STATIC_ROUTE
     bool "Use static routes to upstream interface"
     help

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -16,7 +16,9 @@
 #include "log.h"
 #include "net/arp.h"
 #include "net/dhcpv6.h"
+#include "net/gnrc/dhcpv6/client/6lbr.h"
 #include "net/gnrc/ipv6/nib/pl.h"
+#include "net/gnrc/sixlowpan/ctx.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/rpl.h"
 #include "net/sock.h"
@@ -70,6 +72,44 @@ unsigned dhcpv6_client_get_duid_l2(unsigned iface, dhcpv6_duid_l2_t *duid)
     return (uint8_t)res + sizeof(dhcpv6_duid_l2_t);
 }
 
+static bool _ctx_match(const gnrc_sixlowpan_ctx_t *ctx,
+                       const ipv6_addr_t *prefix, uint8_t prefix_len)
+{
+    return (ctx != NULL) &&
+           (ctx->prefix_len == prefix_len) &&
+           (ipv6_addr_match_prefix(&ctx->prefix, prefix) >= prefix_len);
+}
+
+static void _update_6ctx(const ipv6_addr_t *prefix, uint8_t prefix_len)
+{
+    gnrc_sixlowpan_ctx_t *ctx = gnrc_sixlowpan_ctx_lookup_addr(prefix);
+    uint8_t cid = 0;
+
+    if (!_ctx_match(ctx, prefix, prefix_len)) {
+        /* While the context is a prefix match, the defined prefix within the
+         * context does not match => use new context */
+        ctx = NULL;
+    }
+    else {
+        cid = ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK;
+    }
+    /* find first free context ID */
+    if (ctx == NULL) {
+        while (((ctx = gnrc_sixlowpan_ctx_lookup_id(cid)) != NULL) &&
+               !_ctx_match(ctx, prefix, prefix_len)) {
+            cid++;
+        }
+    }
+    if (cid < GNRC_SIXLOWPAN_CTX_SIZE) {
+        DEBUG("DHCP client: add compression context %u for prefix %s/%u\n", cid,
+              ipv6_addr_to_str(addr_str, prefix, sizeof(addr_str)),
+              prefix_len);
+        gnrc_sixlowpan_ctx_update(cid, (ipv6_addr_t *)prefix, prefix_len,
+                                  CONFIG_GNRC_DHCPV6_CLIENT_6LBR_6LO_CTX_MIN,
+                                  true);
+    }
+}
+
 void dhcpv6_client_conf_prefix(unsigned iface, const ipv6_addr_t *pfx,
                                unsigned pfx_len, uint32_t valid,
                                uint32_t pref)
@@ -110,6 +150,9 @@ void dhcpv6_client_conf_prefix(unsigned iface, const ipv6_addr_t *pfx,
         if (IS_USED(MODULE_GNRC_IPV6_NIB) &&
             GNRC_IPV6_NIB_CONF_6LBR &&
             GNRC_IPV6_NIB_CONF_MULTIHOP_P6C) {
+            if (IS_USED(MODULE_GNRC_SIXLOWPAN_CTX)) {
+                _update_6ctx(pfx, pfx_len);
+            }
             (void)gnrc_ipv6_nib_abr_add(&addr);
         }
         if (IS_USED(MODULE_GNRC_RPL)) {

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -107,18 +107,21 @@ void dhcpv6_client_conf_prefix(unsigned iface, const ipv6_addr_t *pfx,
                          (UINT32_MAX - 1) : pref * MS_PER_SEC;
         }
         gnrc_ipv6_nib_pl_set(netif->pid, pfx, pfx_len, valid, pref);
-#if defined(MODULE_GNRC_IPV6_NIB) && GNRC_IPV6_NIB_CONF_6LBR && \
-        GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
-        gnrc_ipv6_nib_abr_add(&addr);
-#endif
-#ifdef MODULE_GNRC_RPL
-        gnrc_rpl_init(netif->pid);
-        gnrc_rpl_instance_t *inst = gnrc_rpl_instance_get(GNRC_RPL_DEFAULT_INSTANCE);
-        if (inst) {
-            gnrc_rpl_instance_remove(inst);
+        if (IS_USED(MODULE_GNRC_IPV6_NIB) &&
+            GNRC_IPV6_NIB_CONF_6LBR &&
+            GNRC_IPV6_NIB_CONF_MULTIHOP_P6C) {
+            (void)gnrc_ipv6_nib_abr_add(&addr);
         }
-        gnrc_rpl_root_init(GNRC_RPL_DEFAULT_INSTANCE, &addr, false, false);
-#endif
+        if (IS_USED(MODULE_GNRC_RPL)) {
+            gnrc_rpl_init(netif->pid);
+            gnrc_rpl_instance_t *inst = gnrc_rpl_instance_get(
+                    GNRC_RPL_DEFAULT_INSTANCE
+                );
+            if (inst) {
+                gnrc_rpl_instance_remove(inst);
+            }
+            gnrc_rpl_root_init(GNRC_RPL_DEFAULT_INSTANCE, &addr, false, false);
+        }
     }
 }
 

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -149,7 +149,8 @@ void dhcpv6_client_conf_prefix(unsigned iface, const ipv6_addr_t *pfx,
         gnrc_ipv6_nib_pl_set(netif->pid, pfx, pfx_len, valid, pref);
         if (IS_USED(MODULE_GNRC_IPV6_NIB) &&
             GNRC_IPV6_NIB_CONF_6LBR &&
-            GNRC_IPV6_NIB_CONF_MULTIHOP_P6C) {
+            GNRC_IPV6_NIB_CONF_MULTIHOP_P6C &&
+            gnrc_netif_is_6ln(netif)) {
             if (IS_USED(MODULE_GNRC_SIXLOWPAN_CTX)) {
                 _update_6ctx(pfx, pfx_len);
             }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Same deal as #8576, just for DHCPv6: This adds a 6LoWPAN compression context for the newly configured prefix.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and run `examples/gnrc_border_router` using `USE_DHCPV6=1` with a DHCPv6 server running on the TAP interface (see example's Makefile)

```sh
USE_DHCPV6=1 make -C examples/gnrc_border_router flash
make -C examples/gnrc_border_router term
```

(can be run with one `make` invocation once #13484 is merged). After the prefix for the 6LoWPAN interface was configured (check with `ifconfig`) a compression context should also be configured (check with `6ctx`).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #13424 and #8576.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
