### PR TITLE
cpu/stm32_common/periph: Fix multicast filtering

### DIFF
--- a/cpu/stm32_common/periph/eth.c
+++ b/cpu/stm32_common/periph/eth.c
@@ -211,6 +211,8 @@ int stm32_eth_init(void)
 
     /* pass all */
     //ETH->MACFFR |= ETH_MACFFR_RA;
+    /* pass on perfect filter match and pass all multicast address matches */
+    ETH->MACFFR |= ETH_MACFFR_PAM;
 
     /* store forward */
     ETH->DMAOMR |= (ETH_DMAOMR_RSF | ETH_DMAOMR_TSF | ETH_DMAOMR_OSF);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

After #13383  fixed the eth unicast filtering on stm32 , there were problems (described in #13383 ) when using IP. This PR is a fix for this problem by reactivating the passing of all frames with a multicast address. 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

None.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#13383 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
