### PR TITLE
doc: fix of several documenation structure problems in drivers

### DIFF
--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -51,17 +51,24 @@
  * @brief       Drivers for display devices
  */
 
- /**
+/**
  * @defgroup    drivers_soft_periph Soft Peripheral Driver Interface
  * @ingroup     drivers
  * @brief       Software emulated @ref drivers_periph for UART, SPI, etc
  */
 
- /**
+/**
  * @defgroup    drivers_power Power Supply Drivers
  * @ingroup     drivers
  * @brief       Drivers for power supply devices
  *
  * The group of power supply drivers indludes all kinds of AC/DC, DC/DC supply devices
  * or charger ICs which can be controlled from the host e.g by config pin settings or by bus.
+ */
+
+/**
+ * @defgroup    drivers_misc Miscellaneous Drivers
+ * @ingroup     drivers
+ * @brief       Drivers for different kinds of devices that do not match any
+ *              other category
  */

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    drivers_at AT (Hayes) command set library
- * @ingroup     drivers
+ * @ingroup     drivers_misc
  * @brief       AT (Hayes) command set library
  *
  * This module provides functions to interact with devices using AT commands.

--- a/drivers/include/at24cxxx.h
+++ b/drivers/include/at24cxxx.h
@@ -8,6 +8,7 @@
 
 /**
  * @defgroup    drivers_at24cxxx AT24CXXX EEPROM unit
+ * @ingroup     drivers_misc
  * @brief       Device driver interface for the AT24CXXX EEPROM units
  *
  * @{

--- a/drivers/include/at24mac.h
+++ b/drivers/include/at24mac.h
@@ -7,7 +7,8 @@
  */
 
 /**
- * @defgroup    drivers_at24mac unique ID chip
+ * @defgroup    drivers_at24mac AT24MAC unique ID chip
+ * @ingroup     drivers_misc
  * @brief       Device driver interface for the AT24MAC I2C chip
  * @{
  *

--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -9,8 +9,7 @@
  */
 
 /**
- * @defgroup    drivers_bmx280 BMP280/BME280 temperature, pressure and humidity
- *                             sensor
+ * @defgroup    drivers_bmx280 BMP280/BME280 temperature, pressure and humidity sensor
  * @ingroup     drivers_sensors
  * @brief       Device driver interface for the Bosch BMP280 and BME280 sensors
  *

--- a/drivers/include/sps30.h
+++ b/drivers/include/sps30.h
@@ -7,9 +7,10 @@
  */
 
 /**
- * @defgroup    drivers_sps30 Sensirion SPS30 Particulate Matter Sensor
+ * @defgroup    drivers_sps30 SPS30 Particulate Matter Sensor
  * @ingroup     drivers_sensors
  * @ingroup     drivers_saul
+ * @brief       Driver for the Sensirion SPS30 Particulate Matter Sensor
  *
  * About
  * =====

--- a/pkg/cryptoauthlib/doc.txt
+++ b/pkg/cryptoauthlib/doc.txt
@@ -1,6 +1,6 @@
 /**
  * @defgroup pkg_cryptoauthlib Microchip CryptoAuthentication Library
- * @ingroup  pkg drivers sys_crypto
+ * @ingroup  pkg drivers_misc sys_crypto
  * @brief    Provides the library for Microchip CryptoAuth devices
  * @see      https://github.com/MicrochipTech/cryptoauthlib
  *


### PR DESCRIPTION
### Contribution description

This PR fixes the following problems/inconsistencies in documentation:

- `drivers/at24cxxx` documentation is not assigned to a driver group. Instead it appears in the navigation directly under `Modules` on the same level as `Boards`, `CPU`, ... (Screenshot1).

    ![screenshot_old](https://user-images.githubusercontent.com/31932013/75383642-039f2700-58dd-11ea-9244-9e97296bd413.png)

- `drivers/at24mac` documentation is not assigned to a driver group. Instead it appears in the navigation directly under `Modules` on the same level as `Boards`, `CPU`, .... Further more, the device name is not used in short title in the `@defgroup` command.

- Documentation of `pkg/cryptoauthlib` is placed directly in the driver group on the same level as `Sensor Drivers`, `Network Device Drivers`, ... (see above).
   
- `@defgroup` in `drivers/bmx280` command contains a line break. Therefore, the brief documentation becomes invalid.
   
   ![screenshot_old3](https://user-images.githubusercontent.com/31932013/75421490-a934b380-593a-11ea-9592-5b2c9e619e15.png)

- `drivers/sps30` group definition does not contain a `@brief` command. The `Above` section head is used instead as brief documentation. Furthermore, the short title in `@defgroup` command should start with the sensor name but not the vendor for better readability. The vendor name can be used in `@brief` command.
   
   ![screenshot_old1](https://user-images.githubusercontent.com/31932013/75421359-5e1aa080-593a-11ea-82d2-31920b14402f.png)



In order to address these problems and to allow a clearer organisation of driver documentation, a category `Miscellaneous Drivers` is introduced, which should be used by all drivers who do not clearly match the other categories. The documentation of `drivers/at24xxx`, `pkg/cryptoauthlib` and `drivers/at` are assigned to this new category.

### Testing procedure

Generate the documentation with `make doc`. With this PR it should now look like:

![screenshot_new4](https://user-images.githubusercontent.com/31932013/75423145-68d73480-593e-11ea-9f21-a52f96adfc79.png)

![screenshot_new3](https://user-images.githubusercontent.com/31932013/75422252-6bd12580-593c-11ea-9717-2630edad9560.png)

![screenshot_new2](https://user-images.githubusercontent.com/31932013/75422254-6e337f80-593c-11ea-9344-408fcfdc0915.png)

### Issues/PRs references