### PR TITLE
examples/dtls-sock: fix timeout msg stays in mbox

### DIFF
--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -118,13 +118,13 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     res = credman_add(&credential);
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
-        printf("Error cannot add credential to system: %zd\n", res);
+        printf("Error cannot add credential to system: %d\n", (int)res);
         return -1;
     }
 
     res = sock_dtls_session_create(&dtls_sock, &remote, &session);
     if (res < 0) {
-        printf("Error creating session: %zd\n", res);
+        printf("Error creating session: %d\n", (int)res);
         sock_dtls_close(&dtls_sock);
         sock_udp_close(&udp_sock);
         return -1;

--- a/examples/dtls-sock/dtls-server.c
+++ b/examples/dtls-sock/dtls-server.c
@@ -103,7 +103,7 @@ void *dtls_server_wrapper(void *arg)
     res = credman_add(&credential);
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
-        printf("Error cannot add credential to system: %zd\n", res);
+        printf("Error cannot add credential to system: %d\n", (int)res);
         return NULL;
     }
 
@@ -116,14 +116,14 @@ void *dtls_server_wrapper(void *arg)
                                   10 * US_PER_SEC);
             if (res < 0) {
                 if (res != -ETIMEDOUT) {
-                    printf("Error receiving UDP over DTLS %zd", res);
+                    printf("Error receiving UDP over DTLS %d", (int)res);
                 }
                 continue;
             }
-            printf("Received %zd bytes -- (echo!)\n", res);
+            printf("Received %d bytes -- (echo!)\n", (int)res);
             res = sock_dtls_send(&sock, &session, rcv, (size_t)res);
             if (res < 0) {
-                printf("Error resending DTLS message: %zd", res);
+                printf("Error resending DTLS message: %d", (int)res);
             }
         }
     }

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -24,8 +24,6 @@
 #include "debug.h"
 #include "dtls_debug.h"
 
-#define DTLS_EVENT_TIMEOUT      (0x01E1)
-
 #define DTLS_HANDSHAKE_BUFSIZE  (256)       /**< Size buffer used in handshake
                                                 to hold credentials */
 /* ECC handshake takes more time */
@@ -34,8 +32,6 @@
 #else
 #define DTLS_HANDSHAKE_TIMEOUT  (1 * US_PER_SEC)
 #endif  /* CONFIG_DTLS_ECC */
-
-static void _timeout_callback(void *arg);
 
 #ifdef CONFIG_DTLS_PSK
 static int _get_psk_info(struct dtls_context_t *ctx, const session_t *session,
@@ -348,18 +344,13 @@ ssize_t sock_dtls_send(sock_dtls_t *sock, sock_dtls_session_t *remote,
         }
         else if (res > 0) {
             /* handshake initiated, wait until connected or timed out */
-            xtimer_t timeout_timer;
-            timeout_timer.callback = _timeout_callback;
-            timeout_timer.arg = sock;
-            xtimer_set(&timeout_timer, DTLS_HANDSHAKE_TIMEOUT);
 
             msg_t msg;
             do {
-                mbox_get(&sock->mbox, &msg);
-            } while ((msg.type != DTLS_EVENT_CONNECTED) &&
-                     (msg.type != DTLS_EVENT_TIMEOUT));
-
-            if (msg.type == DTLS_EVENT_TIMEOUT) {
+                res = xtimer_msg_receive_timeout(&msg, 3 * DTLS_HANDSHAKE_TIMEOUT);
+            }
+            while ((res != -1) && (msg.type != DTLS_EVENT_CONNECTED));
+            if (res == -1) {
                 DEBUG("sock_dtls: handshake process timed out\n");
 
                 /* deletes peer created in dtls_connect() before */
@@ -367,12 +358,10 @@ ssize_t sock_dtls_send(sock_dtls_t *sock, sock_dtls_session_t *remote,
                 dtls_reset_peer(sock->dtls_ctx, peer);
                 return -EHOSTUNREACH;
             }
-            xtimer_remove(&timeout_timer);
         }
     }
 
-    return dtls_write(sock->dtls_ctx, &remote->dtls_session, (uint8_t *)data,
-                      len);
+    return dtls_write(sock->dtls_ctx, &remote->dtls_session, (uint8_t *)data, len);
 }
 
 static ssize_t _copy_buffer(sock_dtls_t *sock, void *data, size_t max_len)
@@ -393,8 +382,6 @@ static ssize_t _copy_buffer(sock_dtls_t *sock, void *data, size_t max_len)
 ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
                        void *data, size_t max_len, uint32_t timeout)
 {
-    xtimer_t timeout_timer;
-
     assert(sock);
     assert(data);
     assert(remote);
@@ -402,11 +389,6 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
     if (sock->buf != NULL) {
         /* there is already decrypted data available */
         return _copy_buffer(sock, data, max_len);
-    }
-    if ((timeout != SOCK_NO_TIMEOUT) && (timeout != 0)) {
-        timeout_timer.callback = _timeout_callback;
-        timeout_timer.arg = sock;
-        xtimer_set(&timeout_timer, timeout);
     }
 
     /* loop breaks when timeout or application data read */
@@ -416,9 +398,12 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
                                     &remote->ep);
         if (res <= 0) {
             DEBUG("sock_dtls: error receiving UDP packet: %zd\n", res);
-            xtimer_remove(&timeout_timer);
             return res;
         }
+
+        _ep_to_session(&remote->ep, &remote->dtls_session);
+        res = dtls_handle_message(sock->dtls_ctx, &remote->dtls_session,
+                                  (uint8_t *)data, res);
 
         if ((timeout != SOCK_NO_TIMEOUT) && (timeout != 0)) {
             uint32_t time_passed = (xtimer_now_usec() - start_recv);
@@ -430,21 +415,10 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
                                   (uint8_t *)data, res);
 
         if (sock->buf != NULL) {
-            xtimer_remove(&timeout_timer);
             return _copy_buffer(sock, data, max_len);
         }
-        /* reset msg type */
-        msg_t msg;
-        if (mbox_try_get(&sock->mbox, &msg)) {
-            switch(msg.type) {
-                case DTLS_EVENT_TIMEOUT:
-                    DEBUG("sock_dtls: timed out while decrypting message\n");
-                    return -ETIMEDOUT;
-                default:
-                    break;
-            }
-        }
         else if (timeout == 0) {
+            DEBUG("sock_dtls: timed out while decrypting message\n");
             return -ETIMEDOUT;
         }
     }
@@ -476,13 +450,6 @@ static void _session_to_ep(const session_t *session, sock_udp_ep_t *ep)
     ep->port = session->port;
     ep->netif = session->ifindex;
     memcpy(&ep->addr.ipv6, &session->addr, sizeof(ipv6_addr_t));
-}
-
-static void _timeout_callback(void *arg)
-{
-    msg_t timeout_msg = { .type = DTLS_EVENT_TIMEOUT };
-    sock_dtls_t *sock = arg;
-    mbox_try_put(&sock->mbox, &timeout_msg);
 }
 
 /** @} */

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -98,7 +98,7 @@ static int _write(struct dtls_context_t *ctx, session_t *session, uint8_t *buf,
 
     ssize_t res = sock_udp_send(sock->udp_sock, buf, len, &remote);
     if (res < 0) {
-        DEBUG("sock_dtls: failed to send DTLS record: %zd\n", res);
+        DEBUG("sock_dtls: failed to send DTLS record: %d\n", (int)res);
     }
     return res;
 }
@@ -287,7 +287,7 @@ int sock_dtls_session_create(sock_dtls_t *sock, const sock_udp_ep_t *ep,
     DEBUG("sock_dtls: starting handshake\n");
     res = dtls_connect(sock->dtls_ctx, &remote->dtls_session);
     if (res < 0) {
-        DEBUG("sock_dtls: error establishing a session: %zd\n", res);
+        DEBUG("sock_dtls: error establishing a session: %d\n", (int)res);
         return -ENOMEM;
     }
     else if (res == 0) {
@@ -301,7 +301,7 @@ int sock_dtls_session_create(sock_dtls_t *sock, const sock_udp_ep_t *ep,
         res = sock_udp_recv(sock->udp_sock, rcv_buffer, sizeof(rcv_buffer),
                             DTLS_HANDSHAKE_TIMEOUT, &remote->ep);
         if (res <= 0) {
-            DEBUG("sock_dtls: error receiving handshake messages: %zd\n", res);
+            DEBUG("sock_dtls: error receiving handshake messages: %d\n", (int)res);
             /* deletes peer created in dtls_connect() */
             dtls_peer_t *peer = dtls_get_peer(sock->dtls_ctx,
                                               &remote->dtls_session);
@@ -397,7 +397,7 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
         ssize_t res = sock_udp_recv(sock->udp_sock, data, max_len, timeout,
                                     &remote->ep);
         if (res <= 0) {
-            DEBUG("sock_dtls: error receiving UDP packet: %zd\n", res);
+            DEBUG("sock_dtls: error receiving UDP packet: %d\n", (int)res);
             return res;
         }
 

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -618,6 +618,10 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
  * @note Function may block until a session is created if there is no
  *       existing session with @p remote.
  *
+ * @note Initiating a session through this function will require
+ * @ref sock_dtls_recv() called from another thread to receive the handshake
+ * messages.
+ *
  * @return The number of bytes sent on success
  * @return  -EADDRINUSE, if sock_dtls_t::udp_sock has no local end-point.
  * @return  -EAFNOSUPPORT, if `remote->ep != NULL` and


### PR DESCRIPTION
### Contribution description

This PR fix the timeout issue mentioned in https://github.com/RIOT-OS/RIOT/pull/12907#issuecomment-588928280. 

> When executing dtlss start, then waiting for ~20 seconds and then running dtlsc I get the same as you. [timeout]

10 seconds is the default timeout used for a handshake in sock_dtls. The problem is that the timeout triggers *after* a successful decrypt, sending a msg to the mbox but this message is not read/removed from the mbox because of the successful decryption. Because of that the next time mbox is checked, it will immediately return the timeout msg from last time.

### Testing procedure

1. start a dtls server and wait at least 10 seconds.
2. send a message from a dtls client to the server after the 10 seconds.

With this PR, the client should not return a timeout error (110).
