### PR TITLE
boards/openmote-b: add saul config, add note about flashing

### DIFF
--- a/boards/openmote-b/Makefile.dep
+++ b/boards/openmote-b/Makefile.dep
@@ -1,3 +1,8 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += si7006
+endif
+
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += cc2538_rf

--- a/boards/openmote-b/doc.txt
+++ b/boards/openmote-b/doc.txt
@@ -40,6 +40,15 @@ RIOT support flashing with USB by default.
 You may have to specify the flashing port with
 `PORT_DEV=<my_openmote_port> make flash`
 
+The flash tool needs to convert the generated Hex file to RAW format.
+For this it needs to have the intelhex library installed.
+
+    apt install python3-intelhex
+
+or
+
+    pip3 install intelhex
+
 ### Flashing via JTAG
 
 To be able to flash the board via JTAG you need to install Seggers JLinkExe

--- a/boards/openmote-b/include/gpio_params.h
+++ b/boards/openmote-b/include/gpio_params.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_openmote-b
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "LED(yellow)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "LED(orange)",
+        .pin = LED3_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "Button(SW0)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/dist/tools/cc2538-bsl/cc2538-bsl.py
+++ b/dist/tools/cc2538-bsl/cc2538-bsl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2014, Jelmer Tiete <jelmer@tiete.be>.
 # All rights reserved.


### PR DESCRIPTION
### Contribution description
We finally got some `openmote-b`s.

When flashing I noticed the `cc2538-bsl.py` complained about a missing IntelHex library, but the documentation provided no hints how to install that, so I added a line.

I also noticed the tool still uses Python2. Turns out it works just as well with Python3, so I fixed that.

I also added SAUL configuration for the board.

### Testing procedure

Flash `examples/default` on the `openmote-b`.
You should be able to toggle the LEDs with saul and read the temperature and humidity.
Temperature values are way off, but that's a problem with the `si70xx` driver.

### Issues/PRs references
none
