### PR TITLE
cpu/samd21: fix long startup times

### DIFF
--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -115,8 +115,7 @@ static void clk_init(void)
 
 #if CLOCK_USE_XOSC32_DFLL || !GEN2_ULP32K || !GEN3_ULP32K
     /* Use External 32.768KHz Oscillator */
-    SYSCTRL->XOSC32K.reg =  SYSCTRL_XOSC32K_ONDEMAND |
-                            SYSCTRL_XOSC32K_EN32K |
+    SYSCTRL->XOSC32K.reg =  SYSCTRL_XOSC32K_EN32K |
                             SYSCTRL_XOSC32K_XTALEN |
                             SYSCTRL_XOSC32K_STARTUP(XOSC32_STARTUP_TIME) |
                             SYSCTRL_XOSC32K_RUNSTDBY;

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -32,7 +32,7 @@
 #endif
 
 #ifndef GEN3_ULP32K
-#define GEN3_ULP32K         1
+#define GEN3_ULP32K         GEN2_ULP32K
 #endif
 
 #ifndef XOSC32_STARTUP_TIME


### PR DESCRIPTION
### Contribution description

CI would always fail with `examples/micropython` on `samr21-xpro`.
This was due to an unexpectedly high startup time (~2.5s) after #13306.

Turns out not running the external 32kHz oscillator in on-demand mode fixes this.
It also fixes the `tests/periph_wdt` test when we use this oscillator for the watchdog timer, so no need to select the internal low power oscillator for this.

### Testing procedure

Make sure the following tests are successful (Murdock will also run those)

- `tests/periph_rtt`
- `tests/periph_rtc`
- `tests/periph_wdt`
- `examples/micropython`

You will also observe a significantly reduced start up time.

### Issues/PRs references
introduced by #13306
