### PR TITLE
drivers/ds18: fix doxygen group of ds18_internal.h

### DIFF
--- a/drivers/ds18/ds18_internal.h
+++ b/drivers/ds18/ds18_internal.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     drivers_sensors
+ * @ingroup     drivers_ds18
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description

![image](https://user-images.githubusercontent.com/1301112/75465480-fe97b180-5988-11ea-9402-80d29be4f488.png)


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
