### PR TITLE
xtimer_msg_receive_timeout: only send timeout msg if thread still waits for it

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -107,6 +107,18 @@ static void _callback_msg(void* arg)
     msg_send_int(msg, msg->sender_pid);
 }
 
+static void _callback_timeout_msg(void* arg)
+{
+    msg_t *msg = (msg_t*)arg;
+    thread_t* t = (thread_t*) sched_threads[msg->sender_pid];
+
+    /* only send the message if the thread is still waiting to receive one */
+    if (t->status == STATUS_RECEIVE_BLOCKED)
+    {
+        msg_send_int(msg, msg->sender_pid);
+    }
+}
+
 static inline void _setup_msg(xtimer_t *timer, msg_t *msg, kernel_pid_t target_pid)
 {
     timer->callback = _callback_msg;
@@ -128,17 +140,6 @@ void _xtimer_set_msg64(xtimer_t *timer, uint64_t offset, msg_t *msg, kernel_pid_
     _xtimer_set64(timer, offset, offset >> 32);
 }
 
-/* Prepares the message to trigger the timeout.
- * Additionally, the xtimer_t struct gets initialized.
- */
-static void _setup_timer_msg(msg_t *m, xtimer_t *t)
-{
-    m->type = MSG_XTIMER;
-    m->content.ptr = m;
-
-    t->offset = t->long_offset = 0;
-}
-
 /* Waits for incoming message or timeout. */
 static int _msg_wait(msg_t *m, msg_t *tmsg, xtimer_t *t)
 {
@@ -154,20 +155,20 @@ static int _msg_wait(msg_t *m, msg_t *tmsg, xtimer_t *t)
 }
 
 int _xtimer_msg_receive_timeout64(msg_t *m, uint64_t timeout_ticks) {
-    msg_t tmsg;
-    xtimer_t t;
-    _setup_timer_msg(&tmsg, &t);
-    _xtimer_set_msg64(&t, timeout_ticks, &tmsg, sched_active_pid);
+    msg_t tmsg = { .sender_pid  = sched_active_pid,
+                   .type        = MSG_XTIMER,
+                   .content.ptr = &tmsg };
+
+    xtimer_t t = { .callback = _callback_timeout_msg,
+                   .arg      = &tmsg };
+
+    _xtimer_set64(&t, timeout_ticks, timeout_ticks >> 32);
     return _msg_wait(m, &tmsg, &t);
 }
 
 int _xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout_ticks)
 {
-    msg_t tmsg;
-    xtimer_t t;
-    _setup_timer_msg(&tmsg, &t);
-    _xtimer_set_msg(&t, timeout_ticks, &tmsg, sched_active_pid);
-    return _msg_wait(msg, &tmsg, &t);
+    return _xtimer_msg_receive_timeout64(msg, timeout_ticks);
 }
 #endif /* MODULE_CORE_MSG */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes #13345 without requiring `core_thread_flags`.
The idea came from @JulianHolzwarth [#13345 (comment)](https://github.com/RIOT-OS/RIOT/issues/13345#issuecomment-591516868)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
In master the following snipped crashes, with this PR it should work.
See #13345 for further details.
<summary><details>

```c
#include <stdio.h>
#include <string.h>

#include "xtimer.h"
#include "msg.h"
#include "thread.h"

#define DELAY       (100UL * US_PER_MS)
xtimer_t timer;

static void timer_event(void *arg) {
    kernel_pid_t *pid = (kernel_pid_t*)arg;
    msg_t msg = {
        .content.value = 1
    };
    puts("Interrupt");
    msg_send_int(&msg, *pid);
    puts("msg send");

    xtimer_set(&timer, DELAY-20);
}

int main(void)
{
    static msg_t rcv_queue[2];

    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
    printf("This board features a(n) %s MCU.\n", RIOT_MCU);

    msg_init_queue(rcv_queue, 2);
    timer.callback = timer_event;
    kernel_pid_t pid = thread_getpid();
    timer.arg = (void*)&pid;
    
    xtimer_set(&timer, DELAY-20);

    while (1) {
        puts("wait");
    	xtimer_msg_receive_timeout(rcv_queue, DELAY);
    	puts("received");
    	xtimer_sleep(1);
    }
    return 0;
}
```
</details></summary>

### Issues/PRs references
Alternative to #13429.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
