### PR TITLE
examples/dtls-wolfssl: cleanup output messages

### DIFF
--- a/examples/dtls-wolfssl/dtls-client.c
+++ b/examples/dtls-wolfssl/dtls-client.c
@@ -111,20 +111,20 @@ int dtls_client(int argc, char **argv)
     else {
         gnrc_netif_t *netif = gnrc_netif_get_by_pid(atoi(iface));
         if (netif == NULL) {
-            LOG(LOG_ERROR, "ERROR: interface not valid");
+            LOG(LOG_ERROR, "ERROR: interface not valid\n");
             usage(argv[0]);
             return -1;
         }
         remote.netif = (uint16_t)netif->pid;
     }
     if (ipv6_addr_from_str((ipv6_addr_t *)remote.addr.ipv6, addr_str) == NULL) {
-        LOG(LOG_ERROR, "ERROR: unable to parse destination address");
+        LOG(LOG_ERROR, "ERROR: unable to parse destination address\n");
         usage(argv[0]);
         return -1;
     }
     remote.port = SERVER_PORT;
     if (sock_dtls_create(sk, &local, &remote, 0, wolfDTLSv1_2_client_method()) != 0) {
-        LOG(LOG_ERROR, "ERROR: Unable to create DTLS sock");
+        LOG(LOG_ERROR, "ERROR: Unable to create DTLS sock\n");
         return -1;
     }
 
@@ -147,7 +147,7 @@ int dtls_client(int argc, char **argv)
     if (sock_dtls_session_create(sk) < 0)
         return -1;
     wolfSSL_dtls_set_timeout_init(sk->ssl, 5);
-    LOG(LOG_INFO, "connecting to server...");
+    LOG(LOG_INFO, "connecting to server...\n");
     /* attempt to connect until the connection is successful */
     do {
         ret = wolfSSL_connect(sk->ssl);
@@ -179,13 +179,13 @@ int dtls_client(int argc, char **argv)
     /* wait for a reply, indefinitely */
     do {
         ret = wolfSSL_read(sk->ssl, buf, APP_DTLS_BUF_SIZE - 1);
-        LOG(LOG_INFO, "wolfSSL_read returned %d\r\n", ret);
+        LOG(LOG_INFO, "wolfSSL_read returned %d\n", ret);
     } while (ret <= 0);
     buf[ret] = (char)0;
-    LOG(LOG_INFO, "Received: '%s'\r\n", buf);
+    LOG(LOG_INFO, "Received: '%s'\n", buf);
 
     /* Clean up and exit. */
-    LOG(LOG_INFO, "Closing connection.\r\n");
+    LOG(LOG_INFO, "Closing connection.\n");
     sock_dtls_session_destroy(sk);
     sock_dtls_close(sk);
     return 0;

--- a/examples/dtls-wolfssl/dtls-server.c
+++ b/examples/dtls-wolfssl/dtls-server.c
@@ -94,7 +94,7 @@ int dtls_server(int argc, char **argv)
     (void)argv;
 
     if (sock_dtls_create(sk, &local, NULL, 0, wolfDTLSv1_2_server_method()) != 0) {
-        LOG(LOG_ERROR, "ERROR: Unable to create DTLS sock\r\n");
+        LOG(LOG_ERROR, "ERROR: Unable to create DTLS sock\n");
         return -1;
     }
 
@@ -103,7 +103,7 @@ int dtls_server(int argc, char **argv)
     if (wolfSSL_CTX_use_certificate_buffer(sk->ctx, server_cert,
                 server_cert_len, SSL_FILETYPE_ASN1 ) != SSL_SUCCESS)
     {
-        LOG(LOG_ERROR, "Failed to load certificate from memory.\r\n");
+        LOG(LOG_ERROR, "Failed to load certificate from memory.\n");
         return -1;
     }
 
@@ -111,7 +111,7 @@ int dtls_server(int argc, char **argv)
     if (wolfSSL_CTX_use_PrivateKey_buffer(sk->ctx, server_key,
                 server_key_len, SSL_FILETYPE_ASN1 ) != SSL_SUCCESS)
     {
-        LOG(LOG_ERROR, "Failed to load private key from memory.\r\n");
+        LOG(LOG_ERROR, "Failed to load private key from memory.\n");
         return -1;
     }
 #else
@@ -123,7 +123,7 @@ int dtls_server(int argc, char **argv)
     ret = sock_dtls_session_create(sk);
     if (ret < 0)
     {
-        LOG(LOG_ERROR, "Failed to create DTLS session (err: %s)\r\n", strerror(-ret));
+        LOG(LOG_ERROR, "Failed to create DTLS session (err: %s)\n", strerror(-ret));
         return -1;
     }
 
@@ -141,19 +141,19 @@ int dtls_server(int argc, char **argv)
         }
 
         /* Wait until data is received */
-        LOG(LOG_INFO, "Connection accepted\r\n");
+        LOG(LOG_INFO, "Connection accepted\n");
         ret = wolfSSL_read(sk->ssl, buf, APP_DTLS_BUF_SIZE);
         if (ret > 0) {
             buf[ret] = (char)0;
-            LOG(LOG_INFO, "Received '%s'\r\n", buf);
+            LOG(LOG_INFO, "Received '%s'\n", buf);
         }
 
         /* Send reply */
-        LOG(LOG_INFO, "Sending 'DTLS OK'...\r\n");
+        LOG(LOG_INFO, "Sending 'DTLS OK'...\n");
         wolfSSL_write(sk->ssl, Test_dtls_string, sizeof(Test_dtls_string));
 
         /* Cleanup/shutdown */
-        LOG(LOG_INFO, "Closing connection.\r\n");
+        LOG(LOG_INFO, "Closing connection.\n");
         sock_dtls_session_destroy(sk);
         sock_dtls_close(sk);
         break;

--- a/examples/dtls-wolfssl/main.c
+++ b/examples/dtls-wolfssl/main.c
@@ -62,12 +62,12 @@ int main(void)
     /* we need a message queue for the thread running the shell in order to
      * receive potentially fast incoming networking packets */
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
-    LOG(LOG_INFO, "RIOT wolfSSL DTLS testing implementation");
+    LOG(LOG_INFO, "RIOT wolfSSL DTLS testing implementation\n");
     wolfSSL_Init();
     wolfSSL_Debugging_ON();
 
     /* start shell */
-    LOG(LOG_INFO, "All up, running the shell now");
+    LOG(LOG_INFO, "All up, running the shell now\n");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up line ending of the messages displayed by the `examples/dtls-wolfssl` application: some of them doesn't print a new line (`\n`), others prints both `\r` and `\n` where only `\n` is needed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Verify that the output of the application is correct (tested on an iotlab-m3):

<details><summary>this PR</summary>

```
main(): This is RIOT! (Version: 2020.04-devel-817-g50a58)
RIOT wolfSSL DTLS testing implementation
All up, running the shell now
> ifconfig
ifconfig
Iface  6  HWaddr: 54:67  Channel: 26  Page: 0  NID: 0x23
          Long HWaddr: 02:5D:F6:65:10:6B:11:14 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  6LO  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::5d:f665:106b:1114  scope: link  VAL
          inet6 group: ff02::1
          
> help
help
Command              Description
---------------------------------------
dtlsc                Start a DTLS client
dtlss                Start and stop a DTLS server
reboot               Reboot the node
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
nib                  Configure neighbor information base
ifconfig             Configure network interfaces
6ctx                 6LoWPAN context configuration tool
> ifconfig
ifconfig
Iface  6  HWaddr: 54:67  Channel: 26  Page: 0  NID: 0x23
          Long HWaddr: 02:5D:F6:65:10:6B:11:14 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  6LO  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::5d:f665:106b:1114  scope: link  VAL
          inet6 group: ff02::1
          
> dtlsc fe80::385d:f965:106b:1114
dtlsc fe80::385d:f965:106b:1114
connecting to server...
wolfSSL: Setting peer address and port
wolfSSL_read returned 9
Received: 'DTLS OK!'
Closing connection.
> dtlsc fe80::385d:f965:106b:1114%1
dtlsc fe80::385d:f965:106b:1114%1
ERROR: interface not valid
Usage: dtlsc <server-address>
```

</details>

<details><summary>master</summary>

```
main(): This is RIOT! (Version: 2020.01)
RIOT wolfSSL DTLS testing implementationAll up, running the shell now> 

> help
help
Command              Description
---------------------------------------
dtlsc                Start a DTLS client
dtlss                Start and stop a DTLS server
reboot               Reboot the node
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
nib                  Configure neighbor information base
ifconfig             Configure network interfaces
6ctx                 6LoWPAN context configuration tool
> ifconfig
ifconfig
Iface  6  HWaddr: 11:15  Channel: 26  Page: 0  NID: 0x23
          Long HWaddr: 02:5D:F6:65:10:6B:11:15 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  6LO  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::5d:f665:106b:1115  scope: link  VAL
          inet6 group: ff02::1
          
> dtlsc fe80::385d:f965:106b:1115
dtlsc fe80::385d:f965:106b:1115
connecting to server...wolfSSL: Setting peer address and port
wolfSSL_read returned 9
Received: 'DTLS OK!'
Closing connection.
> dtlsc fe80::385d:f965:106b:1114%1
dtlsc fe80::385d:f965:106b:1114%1
ERROR: interface not validUsage: dtlsc <server-address>
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
