### PR TITLE
sys/xtimer: xtimer_msg_receive_timeout(): early out if msg available

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -161,7 +161,11 @@ static int _msg_wait(msg_t *m, msg_t *tmsg, xtimer_t *t)
     }
 }
 
-int _xtimer_msg_receive_timeout64(msg_t *m, uint64_t timeout_ticks) {
+int _xtimer_msg_receive_timeout64(msg_t *m, uint64_t timeout_ticks)
+{
+    if (msg_try_receive(m) == 1) {
+        return 1;
+    }
     msg_t tmsg;
     xtimer_t t;
     _setup_timer_msg(&tmsg, &t);
@@ -171,6 +175,9 @@ int _xtimer_msg_receive_timeout64(msg_t *m, uint64_t timeout_ticks) {
 
 int _xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout_ticks)
 {
+    if (msg_try_receive(msg) == 1) {
+        return 1;
+    }
     msg_t tmsg;
     xtimer_t t;
     _setup_timer_msg(&tmsg, &t);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, xtimer_msg_receive_timeout() would always set a timer to send a timer message after timeout, then jump into `msg_receive()`.
This PR returns early if there's already a message waiting.

Fixes #13345.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
