### PR TITLE
sys/net/sock/sock_util: use MODULE_FMT instead of RIOT_VERSION

### DIFF
--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -29,7 +29,7 @@
 #include "net/sock/udp.h"
 #include "net/sock/util.h"
 
-#ifdef RIOT_VERSION
+#ifdef MODULE_FMT
 #include "fmt.h"
 #endif
 
@@ -63,7 +63,7 @@ int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint, char *addr_str, uint16_t *por
 
 #if defined(SOCK_HAS_IPV6)
     if ((endpoint->family == AF_INET6) && endpoint->netif) {
-#ifdef RIOT_VERSION
+#ifdef MODULE_FMT
         char *tmp = addr_str + strlen(addr_str);
         *tmp++ = '%';
         tmp += fmt_u16_dec(tmp, endpoint->netif);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

sock_util used ot check RIOT_VERSION for selecting fmt functions.
RIOT's Makefile.dep sets fmt as a dependency for sock_util,
so the usual MODULE_FMT can be used.

One special case less.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The unittests `tests-sock_util` should still pass and compile to same code:

```
[kaspar@ng riot/tests/unittests (sock_util_ifdef_module_fmt)]$ RIOT_CI_BUILD=1 make tests-sock_util -j8
Building application "tests_unittests" for "native" with MCU "native".

   text    data     bss     dec     hex filename
  42382     800   47960   91142   16406 /home/kaspar/src/riot/tests/unittests/bin/native/tests_unittests.elf
[kaspar@ng riot/tests/unittests (sock_util_ifdef_module_fmt)]$ git co master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
[kaspar@ng riot/tests/unittests (master)]$ RIOT_CI_BUILD=1 make tests-sock_util -j8
Building application "tests_unittests" for "native" with MCU "native".

   text    data     bss     dec     hex filename
  42382     800   47960   91142   16406 /home/kaspar/src/riot/tests/unittests/bin/native/tests_unittests.elf
[kaspar@ng riot/tests/unittests (master)]$
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
