### PR TITLE
examples/nimble_*: use nimble_autoadv module

### DIFF
--- a/examples/nimble_gatt/Makefile
+++ b/examples/nimble_gatt/Makefile
@@ -12,8 +12,10 @@ USEPKG += nimble
 USEMODULE += nimble_svc_gap
 USEMODULE += nimble_svc_gatt
 
-# We also use the AD part of the BLE helper module
-USEMODULE += bluetil_ad
+# Use automated advertising
+USEMODULE += nimble_autoadv
+CFLAGS += -DNIMBLE_AUTOADV_DEVICE_NAME='"NimBLE GATT Example"'
+CFLAGS += -DNIMBLE_AUTOADV_START_MANUALLY=1
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/nimble_heart_rate_sensor/Makefile
+++ b/examples/nimble_heart_rate_sensor/Makefile
@@ -15,8 +15,10 @@ USEPKG += nimble
 USEMODULE += nimble_svc_gap
 USEMODULE += nimble_svc_gatt
 
-# We also use the AD part of the BLE helper module
-USEMODULE += bluetil_ad
+# Use automated advertising
+USEMODULE += nimble_autoadv
+CFLAGS += -DNIMBLE_AUTOADV_DEVICE_NAME='"RIOT Heart Rate Sensor"'
+CFLAGS += -DNIMBLE_AUTOADV_START_MANUALLY=1
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/nimble_heart_rate_sensor/main.c
+++ b/examples/nimble_heart_rate_sensor/main.c
@@ -14,6 +14,7 @@
  * @brief       (Mock-up) BLE heart rate sensor example
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  *
  * @}
  */
@@ -24,6 +25,7 @@
 #include "assert.h"
 #include "event/timeout.h"
 #include "nimble_riot.h"
+#include "nimble_autoadv.h"
 #include "net/bluetil/ad.h"
 #include "timex.h"
 
@@ -40,7 +42,6 @@
 #define BPM_STEP                (2)
 #define BAT_LEVEL               (42U)
 
-static const char *_device_name = "RIOT Heart Rate Sensor";
 static const char *_manufacturer_name = "Unfit Byte Inc.";
 static const char *_model_number = "2A";
 static const char *_serial_number = "a8b302c7f3-29183-x8";
@@ -70,7 +71,6 @@ static int _devinfo_handler(uint16_t conn_handle, uint16_t attr_handle,
 static int _bas_handler(uint16_t conn_handle, uint16_t attr_handle,
                         struct ble_gatt_access_ctxt *ctxt, void *arg);
 
-static void _start_advertising(void);
 static void _start_updating(void);
 static void _stop_updating(void);
 
@@ -215,7 +215,7 @@ static int gap_event_cb(struct ble_gap_event *event, void *arg)
         case BLE_GAP_EVENT_CONNECT:
             if (event->connect.status) {
                 _stop_updating();
-                _start_advertising();
+                nimble_autoadv_start();
                 return 0;
             }
             _conn_handle = event->connect.conn_handle;
@@ -223,7 +223,7 @@ static int gap_event_cb(struct ble_gap_event *event, void *arg)
 
         case BLE_GAP_EVENT_DISCONNECT:
             _stop_updating();
-            _start_advertising();
+            nimble_autoadv_start();
             break;
 
         case BLE_GAP_EVENT_SUBSCRIBE:
@@ -239,22 +239,6 @@ static int gap_event_cb(struct ble_gap_event *event, void *arg)
     }
 
     return 0;
-}
-
-static void _start_advertising(void)
-{
-    struct ble_gap_adv_params advp;
-    int res;
-
-    memset(&advp, 0, sizeof advp);
-    advp.conn_mode = BLE_GAP_CONN_MODE_UND;
-    advp.disc_mode = BLE_GAP_DISC_MODE_GEN;
-    advp.itvl_min  = BLE_GAP_ADV_FAST_INTERVAL1_MIN;
-    advp.itvl_max  = BLE_GAP_ADV_FAST_INTERVAL1_MAX;
-    res = ble_gap_adv_start(nimble_riot_own_addr_type, NULL, BLE_HS_FOREVER,
-                            &advp, gap_event_cb, NULL);
-    assert(res == 0);
-    (void)res;
 }
 
 static void _start_updating(void)
@@ -312,21 +296,29 @@ int main(void)
     assert(res == 0);
 
     /* set the device name */
-    ble_svc_gap_device_name_set(_device_name);
+    ble_svc_gap_device_name_set(NIMBLE_AUTOADV_DEVICE_NAME);
     /* reload the GATT server to link our added services */
     ble_gatts_start();
 
+    struct ble_gap_adv_params advp;
+    memset(&advp, 0, sizeof(advp));
+
+    advp.conn_mode = BLE_GAP_CONN_MODE_UND;
+    advp.disc_mode = BLE_GAP_DISC_MODE_GEN;
+    advp.itvl_min  = BLE_GAP_ADV_FAST_INTERVAL1_MIN;
+    advp.itvl_max  = BLE_GAP_ADV_FAST_INTERVAL1_MAX;
+
+    /* set advertise params */
+    nimble_autoadv_set_ble_gap_adv_params(&advp);
+
     /* configure and set the advertising data */
-    uint8_t buf[BLE_HS_ADV_MAX_SZ];
-    bluetil_ad_t ad;
-    bluetil_ad_init_with_flags(&ad, buf, sizeof(buf), BLUETIL_AD_FLAGS_DEFAULT);
     uint16_t hrs_uuid = BLE_GATT_SVC_HRS;
-    bluetil_ad_add(&ad, BLE_GAP_AD_UUID16_INCOMP, &hrs_uuid, sizeof(hrs_uuid));
-    bluetil_ad_add_name(&ad, _device_name);
-    ble_gap_adv_set_data(ad.buf, ad.pos);
+    nimble_autoadv_add_field(BLE_GAP_AD_UUID16_INCOMP, &hrs_uuid, sizeof(hrs_uuid));
+
+    nimble_auto_adv_set_gap_cb(&gap_event_cb, NULL);
 
     /* start to advertise this node */
-    _start_advertising();
+    nimble_autoadv_start();
 
     /* run an event loop for handling the heart rate update events */
     event_loop(&_eq);


### PR DESCRIPTION
### Contribution description

This PR modifies the example applications `nimble_gatt` and `nimble_heart_rate_sensor` such that they use the new automated advertising module, provided by PR #13425

### Testing procedure

This PR is rebased on top of PR #13425, so you only have to build and test the applications mentioned above.

### Issues/PRs references

#### Dependencies:
- [x] PR #13425
