### PR TITLE
sys/phydat: improvement of phydat_dump including test application

### DIFF
--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -70,22 +70,26 @@ void phydat_dump(phydat_t *data, uint8_t dim)
             printf("[%u] ", (unsigned int)i);
         }
         else {
-            printf("     ");
+            printf("    ");
         }
         if (scale_prefix) {
-            printf("%6d %c", (int)data->val[i], scale_prefix);
+            printf("%11d %c", (int)data->val[i], scale_prefix);
         }
         else if (data->scale == 0) {
-            printf("%6d", (int)data->val[i]);
+            printf("%11d ", (int)data->val[i]);
         }
-        else if ((data->scale > -5) && (data->scale < 0)) {
-            char num[8];
+        else if ((data->scale > -6) && (data->scale < 0)) {
+            char num[9];
             size_t len = fmt_s16_dfp(num, data->val[i], data->scale);
+            assert(len < 9);
             num[len] = '\0';
-            printf("%s", num);
+            printf("%11s ", num);
         }
         else {
-            printf("%iE%i", (int)data->val[i], (int)data->scale);
+            char num[12];
+            snprintf(num, sizeof(num), "%ie%i",
+                     (int)data->val[i], (int)data->scale);
+            printf("%11s ", num);
         }
 
         printf("%s\n", phydat_unit_to_str(data->unit));

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include "assert.h"
 #include "fmt.h"
 #include "phydat.h"
 
@@ -31,6 +32,20 @@ void phydat_dump(phydat_t *data, uint8_t dim)
         return;
     }
     printf("Data:");
+
+    if (data->unit == UNIT_TIME) {
+        assert(dim == 3);
+        printf("\t%02d:%02d:%02d\n",
+               data->val[2], data->val[1], data->val[0]);
+        return;
+    }
+    if (data->unit == UNIT_DATE) {
+        assert(dim == 3);
+        printf("\t%04d-%02d-%02d\n",
+               data->val[2], data->val[1], data->val[0]);
+        return;
+    }
+
     for (uint8_t i = 0; i < dim; i++) {
         char scale_prefix;
 

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -97,6 +97,7 @@ const char *phydat_unit_to_str(uint8_t unit)
         case UNIT_GS:       return "Gs";
         case UNIT_BAR:      return "Bar";
         case UNIT_PA:       return "Pa";
+        case UNIT_PERMILL:  return "permille";
         case UNIT_PPM:      return "ppm";
         case UNIT_PPB:      return "ppb";
         case UNIT_CD:       return "cd";

--- a/tests/phydat_dump/Makefile
+++ b/tests/phydat_dump/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += phydat
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/phydat_dump/main.c
+++ b/tests/phydat_dump/main.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ *
+ * @file
+ * @brief       Visual test for the conversion from phydat to a string
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ */
+
+#include <stdio.h>
+
+#include "phydat.h"
+
+typedef struct {
+    phydat_t dat;
+    uint8_t dim;
+} _phydat_test_t;
+
+_phydat_test_t _test_vector[] =
+{
+    { .dim = 1, .dat = { .val = { 1234 }, .unit = UNIT_TEMP_C, .scale = -2 } },
+    { .dim = 1, .dat = { .val = { 1234 }, .unit = UNIT_TEMP_F, .scale = -2 } },
+    { .dim = 1, .dat = { .val = { 1234 }, .unit = UNIT_TEMP_K, .scale = -1 } },
+    { .dim = 1, .dat = { .val = { 1234 }, .unit = UNIT_LUX, .scale = -1 } },
+    { .dim = 3, .dat = { .val = { 1234, 13456, -14567 }, .unit = UNIT_M, .scale = 0 } },
+    { .dim = 3, .dat = { .val = { 1234, 13456, -14567 }, .unit = UNIT_M, .scale = 1 } },
+    { .dim = 3, .dat = { .val = { 1234, 13456, -14567 }, .unit = UNIT_M, .scale = 3 } },
+    { .dim = 3, .dat = { .val = { 1234, 13456, -14567 }, .unit = UNIT_M, .scale = -2 } },
+    { .dim = 3, .dat = { .val = { 1234, 13456, -14567 }, .unit = UNIT_M, .scale = -3 } },
+    { .dim = 1, .dat = { .val = { -12345 }, .unit = UNIT_M2, .scale = -5 } },
+    { .dim = 1, .dat = { .val = { -12345 }, .unit = UNIT_M3, .scale = -6 } },
+    { .dim = 3, .dat = { .val = { 12, 34, 5678}, .unit = UNIT_G, .scale = -2 } },
+    { .dim = 3, .dat = { .val = { 123, 345, 678 }, .unit = UNIT_DPS, .scale = -3 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_GR, .scale = -1 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_A, .scale = 3 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_V, .scale = 6 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_W, .scale = 7 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_GS, .scale = -1 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_DBM, .scale = -3 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_COULOMB, .scale = 0 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_F, .scale = -6 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_F, .scale = -7 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_PH, .scale = -2 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_BAR, .scale = 0 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_PA, .scale = 2 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_CD, .scale = -2 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_CTS, .scale = -3 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_PERCENT, .scale = -3 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_PERMILL, .scale = -4 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_PPM, .scale = -6 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_PPB, .scale = -9 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_GPM3, .scale = -1 } },
+    { .dim = 1, .dat = { .val = { 12345 }, .unit = UNIT_CPM3, .scale = -1 } },
+    { .dim = 3, .dat = { .val = { 56, 34, 12 }, .unit = UNIT_TIME, .scale = -1 } },
+    { .dim = 3, .dat = { .val = { 27, 2, 2020 }, .unit = UNIT_DATE, .scale = -1 } },
+};
+
+int main(void)
+{
+    puts("Visual phydat test application");
+
+    for (unsigned int i = 0; i < ARRAY_SIZE(_test_vector); i++) {
+        phydat_dump(&_test_vector[i].dat, _test_vector[i].dim);
+    }
+    return 0;
+}

--- a/tests/phydat_dump/tests/01-run.py
+++ b/tests/phydat_dump/tests/01-run.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect('Visual phydat test application\r\n')
+    child.expect('Data:\t          12.34 °C\r\n')
+    child.expect('Data:\t          12.34 °F\r\n')
+    child.expect('Data:\t          123.4 K\r\n')
+    child.expect('Data:\t          123.4 lx\r\n')
+    child.expect('Data:\t\[0\]        1234 m\r\n')
+    child.expect('\t\[1\]       13456 m\r\n')
+    child.expect('\t\[2\]      -14567 m\r\n')
+    child.expect('Data:\t\[0\]      1234e1 m\r\n')
+    child.expect('\t\[1\]     13456e1 m\r\n')
+    child.expect('\t\[2\]    -14567e1 m\r\n')
+    child.expect('Data:\t\[0\]        1234 km\r\n')
+    child.expect('\t\[1\]       13456 km\r\n')
+    child.expect('\t\[2\]      -14567 km\r\n')
+    child.expect('Data:\t\[0\]       12.34 m\r\n')
+    child.expect('\t\[1\]      134.56 m\r\n')
+    child.expect('\t\[2\]     -145.67 m\r\n')
+    child.expect('Data:\t\[0\]        1234 mm\r\n')
+    child.expect('\t\[1\]       13456 mm\r\n')
+    child.expect('\t\[2\]      -14567 mm\r\n')
+    child.expect('Data:\t       -0.12345 m\^2\r\n')
+    child.expect('Data:\t      -12345e-6 m\^3\r\n')
+    child.expect('Data:\t\[0\]        0.12 g\r\n')
+    child.expect('\t\[1\]        0.34 g\r\n')
+    child.expect('\t\[2\]       56.78 g\r\n')
+    child.expect('Data:\t\[0\]         123 mdps\r\n')
+    child.expect('\t\[1\]         345 mdps\r\n')
+    child.expect('\t\[2\]         678 mdps\r\n')
+    child.expect('Data:\t         1234.5 G\r\n')
+    child.expect('Data:\t          12345 kA\r\n')
+    child.expect('Data:\t          12345 MV\r\n')
+    child.expect('Data:\t        12345e7 W\r\n')
+    child.expect('Data:\t         1234.5 Gs\r\n')
+    child.expect('Data:\t         12.345 dBm\r\n')
+    child.expect('Data:\t          12345 C\r\n')
+    child.expect('Data:\t          12345 uF\r\n')
+    child.expect('Data:\t       12345e-7 F\r\n')
+    child.expect('Data:\t         123.45 pH\r\n')
+    child.expect('Data:\t          12345 Bar\r\n')
+    child.expect('Data:\t          12345 hPa\r\n')
+    child.expect('Data:\t         123.45 cd\r\n')
+    child.expect('Data:\t          12345 mcts\r\n')
+    child.expect('Data:\t         12.345 %\r\n')
+    child.expect('Data:\t         1.2345 permille\r\n')
+    child.expect('Data:\t          12345 uppm\r\n')
+    child.expect('Data:\t          12345 nppb\r\n')
+    child.expect('Data:\t         1234.5 g/m\^3\r\n')
+    child.expect('Data:\t         1234.5 #/m\^3\r\n')
+    child.expect('Data:\t12:34:56\r\n')
+    child.expect('Data:\t2020-02-27\r\n')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=10))


### PR DESCRIPTION
### Contribution description

This PR improves the formatting of the dump of physical data and adds a visual test including a test script for automatic test of correct output.

### Background

When I added the SAUL capabilities in PR #12717, I noticed that the output of physical data differs. As a result I got the following output
```
Data:	     26.29°C
Data:	        993 hPa
Data:	     38.24%
Data:	      29177ohm
```
That is,
- depending on the number format the output is right aligned or not,
- depending on the scale there is a space between the number and the format or not

With the test application included in this PR, all the differences can be observed when 
commit https://github.com/RIOT-OS/RIOT/pull/13509/commits/a9179572067f5e7ec7ac59c088a2e01562dfa9aa  is not applied.

An excerpt from the test output:
```
Data:	[0] 1234E1m
	[1] 13456E1m
	[2] -14567E1m
Data:	[0]   1234 km
	[1]  13456 km
	[2] -14567 km
Data:	[0] 12.34m
	[1] 134.56m
	[2] -145.67m
Data:	[0]   1234 mm
	[1]  13456 mm
	[2] -14567 mm
Data:	     -12345E-5m^2
Data:	     -12345E-6m^3
Data:	      12345 uF
Data:	     12345E-7F
Data:	     123.45pH
Data:	      12345Bar
Data:	      12345 hPa
```
The problems in detail:
- Numbers in floating point format are not right aligned.
- Numbers in exponential format are quite difficult to read with the uppercase `E`, especially with positive exponents.
- If units like `milli`, `kilo`, ... are used, an additional space is before that unit. Otherwise the unit is directly attached to the number.
- There is no string representation for data with unit `UNIT_PERMILL`.
- Data with unit `UNIT_DATA` or `UNIT_TIME` are not dumped in an appropriate format.

### Changes

This PR imrpoves `phydat_dump` as following:
- Numbers are always right aligned with a maximum of 11 chars.
- Number in exponential format use an lowercase `e` for better readability
- There is always a space between the number and the unit.
- Unit `UNIT_PERMILL` has now a string representation.
- Data with `UNIT_DATA` or `UNIT_TIME` are dumped in usual date and time format.

An test application has been added to check the output for defined formats and units visually or automatically with a test script.

The output from the test application with this PR looks like:
```
Data:	[0]      1234e1 m
	[1]     13456e1 m
	[2]    -14567e1 m
Data:	[0]        1234 km
	[1]       13456 km
	[2]      -14567 km
Data:	[0]       12.34 m
	[1]      134.56 m
	[2]     -145.67 m
Data:	[0]        1234 mm
	[1]       13456 mm
	[2]      -14567 mm
Data:	       -0.12345 m^2
Data:	      -12345e-6 m^3
Data:	          12345 uF
Data:	       12345e-7 F
Data:	         123.45 pH
Data:	          12345 Bar
Data:	          12345 hPa
```
### Testing procedure

Use any board to test the PR:
```
BOARD=... make -C tests/phydat_dump flash test
```

### Issues/PRs references
