### PR TITLE
cpu/cc2538: implement periph/pm

### DIFF
--- a/cpu/cc2538/Makefile.dep
+++ b/cpu/cc2538/Makefile.dep
@@ -2,3 +2,5 @@ ifneq (,$(filter cc2538_rf,$(USEMODULE)))
   USEMODULE += netdev_ieee802154
   USEMODULE += netif
 endif
+
+USEMODULE += pm_layered

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -53,10 +53,10 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
- * @name    Power management configuration
+ * @name    Power mode configuration
  * @{
  */
-#define PROVIDES_PM_SET_LOWEST_CORTEXM
+#define PM_NUM_MODES        (4)
 /** @} */
 
 /**

--- a/cpu/cc2538/periph/pm.c
+++ b/cpu/cc2538/periph/pm.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *               2017 Freie Universität Berlin
+ * Copyright (C) 2020 ML!PA Consulting GmbH
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -8,25 +7,70 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_cc2538
  * @ingroup     drivers_periph_pm
  * @{
  *
  * @file
- * @brief       common periph/pm functions
+ * @brief       Implementation of the kernels power management interface
  *
- * @author      Kaspar Schleiser <kaspar@schleiser.de>
- * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  *
  * @}
  */
 
-#include "cpu.h"
+#include "vendor/hw_nvic.h"
 #include "periph/pm.h"
 
-#ifdef PROVIDES_PM_SET_LOWEST_CORTEXM
-void pm_set_lowest(void)
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void pm_set(unsigned mode)
 {
-    /* don't do anything here */
+    bool deep = false;
+    bool switch_osc = false;
+
+    switch (mode) {
+        case 0:
+            /* lowest 16k RAM are lost here, wake by GPIO */
+            SYS_CTRL_PMCTL = 0x3;
+            deep = true;
+            break;
+        case 1:
+            /* lowest 16k RAM are lost here, wake by GPIO & RTT */
+            SYS_CTRL_PMCTL = 0x2;
+            deep = true;
+            break;
+        case 2:
+            /* all memory retained, wake by GPIO, RTT & USB */
+            SYS_CTRL_PMCTL = 0x1;
+            deep = true;
+            break;
+        case 3:
+            /* all memory retained, wake by any interrupt source */
+            deep = true;
+            SYS_CTRL_PMCTL = 0x0;
+            break;
+    }
+
+    if (deep) {
+        *(cc2538_reg_t*) NVIC_SYS_CTRL |= NVIC_SYS_CTRL_SLEEPDEEP;
+
+        /* If we used the 32 MHz clock, we have to switch to 16 MHz for deep sleep */
+        switch_osc = !SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC;
+    }
+
+    /* switch to 16 MHz clock */
+    if (switch_osc) {
+        SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC = 1;
+        while (!SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC) {}
+    }
+
+    cortexm_sleep(deep);
+
+    /* switch back to 32 MHz clock */
+    if (switch_osc) {
+        SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC = 0;
+        while (SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC) {}
+    }
 }
-#endif


### PR DESCRIPTION

### Contribution description

cc2538 implements 4 sleep modes:
 - In the lightest mode (3 in RIOT) any interrupt source can wake up the CPU.
 - In mode 2, only RTT, GPIO or USB may wake the CPU.
 - In mode 1 only RTT and GPIO can wake the CPU.
 - In mode 0 only GPIO can wake the CPU.

In mode 0 and 1 the lower 16k RAM are lost.
This is a problem since those are usually used by RIOT.

The linkerscripts in `cc2538/ldscripts` take different approaches towards that.
Some only use the upper 16k and leave the other half to be managed by the application.

`cc2538sf53.ld` which is used by `openmote-b` uses the entire RAM starting at the lower half, so it will not be able to wake up from those modes.

A quick fix to test those modes with `tests/periph_pm` would be

```patch
--- a/cpu/cc2538/ldscripts/cc2538sf53.ld
+++ b/cpu/cc2538/ldscripts/cc2538sf53.ld
@@ -21,7 +21,7 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x00200000, LENGTH = 512K - 44
     cca         : ORIGIN = 0x0027ffd4, LENGTH = 44
-    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 32K
+    ram (w!rx)  : ORIGIN = 0x20004000, LENGTH = 16K
 }
```



### Testing procedure

Connect a current meter to the SENSE1 headers of the `openmote-b` to measure the current consumption.

Run `tests/periph_pm` and `set` the four different sleep modes.
You should be able to see a drop in current consumption.
You should be able to wake up from each mode by pressing the USER button on the board.

Waking up from `set 1` and `set 0` will not be possible unless you apply the above patch.

### Issues/PRs references
none
