### PR TITLE
drivers/periph_common: add periph_init% modules

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1047,6 +1047,11 @@ FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
 # FEATURES_USED is defined in Makefile.features
 USEMODULE += $(filter periph_%,$(FEATURES_USED))
 
+# set all USED periph_% init modules as DEFAULT_MODULE
+ifneq (,$(filter periph_init, $(USEMODULE)))
+  DEFAULT_MODULE += $(subst periph_,periph_init_,$(filter periph_%,$(FEATURES_USED)))
+endif
+
 # select cpu_check_address pseudomodule if the corresponding feature is used
 USEMODULE += $(filter cpu_check_address, $(FEATURES_USED))
 
@@ -1067,9 +1072,16 @@ ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
 else
   # Add auto_init_% DEFAULT_MODULES. This is done after the recursive cach since
   # none of these modules can trigger dependency resolution.
+  DEFAULT_MODULE := $(sort $(DEFAULT_MODULE))
   ifneq (,$(filter auto_init,$(USEMODULE)))
-    DEFAULT_MODULE := $(sort $(DEFAULT_MODULE))
     USEMODULE += $(filter auto_init_%,$(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
-    USEMODULE := $(sort $(USEMODULE))
   endif
+
+  # Add auto_init_periph_% to DEFAULT_MODULES. This is done after the recursive
+  # cach since none of these modules can trigger dependency resolution.
+  ifneq (,$(filter periph_init,$(USEMODULE)))
+    USEMODULE += $(filter periph_init_%,$(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
+  endif
+
+  USEMODULE := $(sort $(USEMODULE))
 endif

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -22,63 +22,68 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
-#ifdef MODULE_PERIPH_I2C
+#ifdef MODULE_PERIPH_INIT
+#ifdef MODULE_PERIPH_INIT_I2C
 #include "periph/i2c.h"
 #endif
-#ifdef MODULE_PERIPH_SPI
+#ifdef MODULE_PERIPH_INIT_SPI
 #include "periph/spi.h"
 #endif
-#ifdef MODULE_PERIPH_RTC
+#ifdef MODULE_PERIPH_INIT_RTC
 #include "periph/rtc.h"
 #endif
-#ifdef MODULE_PERIPH_RTT
+#ifdef MODULE_PERIPH_INIT_RTT
 #include "periph/rtt.h"
 #endif
-#ifdef MODULE_PERIPH_HWRNG
+#ifdef MODULE_PERIPH_INIT_HWRNG
 #include "periph/hwrng.h"
 #endif
-#ifdef MODULE_PERIPH_USBDEV
+#ifdef MODULE_PERIPH_INIT_USBDEV
 #include "periph/usbdev.h"
 #endif
-#ifdef MODULE_PERIPH_WDT
+#ifdef MODULE_PERIPH_INIT_WDT
 #include "periph/wdt.h"
 #endif
+#endif /* MODULE_PERIPH_INIT */
 
 void periph_init(void)
 {
+#ifdef MODULE_PERIPH_INIT
     /* initialize configured I2C devices */
-#ifdef MODULE_PERIPH_I2C
+#ifdef MODULE_PERIPH_INIT_I2C
     for (unsigned i = 0; i < I2C_NUMOF; i++) {
         i2c_init(I2C_DEV(i));
     }
 #endif
 
     /* initialize configured SPI devices */
-#ifdef MODULE_PERIPH_SPI
+#ifdef MODULE_PERIPH_INIT_SPI
     for (unsigned i = 0; i < SPI_NUMOF; i++) {
         spi_init(SPI_DEV(i));
     }
 #endif
 
     /* Initialize RTC */
-#ifdef MODULE_PERIPH_RTC
+#ifdef MODULE_PERIPH_INIT_RTC
     rtc_init();
 #endif
 
     /* Initialize RTT */
-#ifdef MODULE_PERIPH_RTT
+#ifdef MODULE_PERIPH_INIT_RTT
     rtt_init();
 #endif
 
-#ifdef MODULE_PERIPH_HWRNG
+#ifdef MODULE_PERIPH_INIT_HWRNG
     hwrng_init();
 #endif
 
-#ifdef MODULE_PERIPH_USBDEV
+#ifdef MODULE_PERIPH_INIT_USBDEV
     usbdev_init_lowlevel();
 #endif
 
-#if defined(MODULE_PERIPH_WDT) && WDT_HAS_INIT
+#if defined(MODULE_PERIPH_INIT_WDT) && WDT_HAS_INIT
     wdt_init();
 #endif
+
+#endif /* MODULE_PERIPH_INIT */
 }

--- a/makefiles/defaultmodules.inc.mk
+++ b/makefiles/defaultmodules.inc.mk
@@ -1,3 +1,6 @@
 DEFAULT_MODULE += board cpu core core_init core_msg core_panic sys
 
 DEFAULT_MODULE += auto_init
+
+# Initialize all used peripherals by default
+DEFAULT_MODULE += periph_init

--- a/tests/periph_rtt/Makefile
+++ b/tests/periph_rtt/Makefile
@@ -3,6 +3,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_rtt
 
-DISABLE_MODULE += auto_init
+DISABLE_MODULE += periph_init_rtt
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_rtt/main.c
+++ b/tests/periph_rtt/main.c
@@ -29,8 +29,6 @@
 #include "periph_conf.h"
 #include "periph/rtt.h"
 
-#include "test_utils/interactive_sync.h"
-
 #define TICKS_TO_WAIT       (5 * RTT_FREQUENCY)
 
 static volatile uint32_t last;
@@ -48,8 +46,6 @@ void cb(void *arg)
 
 int main(void)
 {
-    test_utils_interactive_sync();
-
     puts("\nRIOT RTT low-level driver test");
     puts("This test will display 'Hello' every 5 seconds\n");
 


### PR DESCRIPTION
### Contribution description

Following up on #13089 this PR allows disabling `periph_%`auto initialization by adding explicit `periph_init_%` modules for each one of them.

Since they are not initlalized by the `auto-init` module I added a `periph_init` module that just handles enabling or disabling `periph` initialization.

### Testing procedure

- Normal build:

```
make -C tests/xtimer_usleep info-debug-variable-USEMODULE --no-print-directory
auto_init auto_init_xtimer board core core_init core_msg core_panic cpu div native-drivers periph periph_common periph_gpio periph_init periph_init_gpio periph_init_pm periph_init_timer periph_pm periph_timer periph_uart stdin stdio_native sys test_utils_interactive_sync xtimer
```

- Disable one `periph_init_%`

```
DISABLE_MODULE+=periph_init_timer make -C tests/xtimer_usleep info-debug-variable-USEMODULE --no-print-directory
auto_init auto_init_xtimer board core core_init core_msg core_panic cpu div native-drivers periph periph_common periph_gpio periph_init periph_init_gpio periph_init_pm periph_pm periph_timer periph_uart stdin stdio_native sys test_utils_interactive_sync xtimer
```

- Disable all `periph_init`

```
DISABLE_MODULE+=periph_init make -C tests/xtimer_usleep info-debug-variable-USEMODULE --no-print-directory
auto_init auto_init_xtimer board core core_init core_msg core_panic cpu div native-drivers periph periph_common periph_gpio periph_pm periph_timer periph_uart stdin stdio_native sys test_utils_interactive_sync xtimer

```

- Murdock should run all tests.

### Issues/PRs references

Fixes #11026
~~depends on #13401~~
