### PR TITLE
tests: handle cml interactive_sync disabling

### DIFF
--- a/sys/include/test_utils/interactive_sync.h
+++ b/sys/include/test_utils/interactive_sync.h
@@ -32,7 +32,11 @@ extern "C" {
  * @details Wait for a 's' character to return
  *
  */
+#ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
 void test_utils_interactive_sync(void);
+#else
+static inline void test_utils_interactive_sync(void) {}
+#endif
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

If not running the automatic tests then having to enter `s` on every test can be annoying. This can be easily disable by using `DISABLE_MODULE+=test_utils_interactive_sync` but this does not work for tests that need to include it directly in the application, add header guards for this.

### Testing procedure

- with interactive sync `BOARD=pba-d-01-kw2x make -C tests/ps_schedstatistics/ flash term`

```
2020-02-28 17:56:16,923 # main(): This is RIOT! (Version: 2020.04-devel-828-g5fe86-pr_interactive_sync_disable)
2020-02-28 17:56:16,927 # Help: Press s to start test, r to print it is ready
s
2020-02-28 17:56:20,706 # START
2020-02-28 17:56:20,709 # Creating thread #0, next=1
2020-02-28 17:56:20,711 # Creating thread #1, next=2
2020-02-28 17:56:20,713 # Creating thread #2, next=3
2020-02-28 17:56:20,716 # Creating thread #3, next=4
2020-02-28 17:56:20,718 # Creating thread #4, next=0
> 2020-02-28 17:56:21,718 #  
``` 

- without interactive sync 

`DISABLE_MODULE+=test_utils_interactive_sync BOARD=pba-d-01-kw2x make -C tests/ps_schedstatistics/ flash term`

```
2020-02-28 17:57:31,251 #  main(): This is RIOT! (Version: 2020.04-devel-828-g5fe86-pr_interactive_sync_disable)
2020-02-28 17:57:31,253 # Creating thread #0, next=1
2020-02-28 17:57:31,255 # Creating thread #1, next=2
2020-02-28 17:57:31,257 # Creating thread #2, next=3
2020-02-28 17:57:31,260 # Creating thread #3, next=4
2020-02-28 17:57:31,262 # Creating thread #4, next=0
```

In master this would fail since there would be some undefined references.

### Issues reference

The is the remaining case of `tests/periph_rtc` that will be dealt with by #13511