### PR TITLE
Backport/2020.01/fix13179 Revert "boards/nucleo-f767zi: add correct flash bank openocd config"

### DIFF
--- a/boards/common/stm32/dist/stm32f7.cfg
+++ b/boards/common/stm32/dist/stm32f7.cfg
@@ -1,9 +1,3 @@
 source [find target/stm32f7x.cfg]
-
-# specify flash start address: since target/stm32f7x.cfg doesn't, this
-# can be used as backup in case probing fails. When correct address is
-# given, the flash size is obtained from hardware so no need to specify.
-flash bank $_FLASHNAME.riot stm32f2x 0x08000000 0 0 0 $_TARGETNAME
-
 reset_config srst_only
 $_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f767zi/Makefile.include
+++ b/boards/nucleo-f767zi/Makefile.include
@@ -1,12 +1,2 @@
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include
-
-# openocd configuration file for `stm32f7` relies on probing to find out
-# FLASH_ADDR. On this board probing (`flash probe 0`) fails when `srst` is
-# asserted, but `srst` needs to be asserted to be able to flash the `BOARD`
-# when sleeping or after a hardfault.
-# To circumvent this in boards/common/stm32/dist/stm32f7.cfg we define a new
-# flash bank with the appropriate flash start address and specify that this is
-# the flash bank to be used as default configuration instead of the default (1)
-FLASH_BANK ?= 4
-$(call target-export-variables,flash flash-only,FLASH_BANK)

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -213,6 +213,8 @@ _flash_list_raw() {
             -f '${OPENOCD_CONFIG}' \
             ${OPENOCD_EXTRA_RESET_INIT} \
             -c 'init' \
+            -c 'targets' \
+            -c 'reset halt' \
             -c 'flash probe 0' \
             -c 'flash list' \
             -c 'shutdown'" 2>&1 && return

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -105,10 +105,6 @@
 # Valid values: elf, hex, s19, bin (see OpenOCD manual for more information)
 : ${IMAGE_TYPE:=}
 
-# flash bank to read default configuration when probing fails, default to first
-# bank
-: ${FLASH_BANK:=1}
-
 #
 # Examples of alternative debugger configurations
 #
@@ -269,7 +265,8 @@ do_flash() {
     # In case of binary file, IMAGE_OFFSET should include the flash base address
     # This allows flashing normal binary files without env configuration
     if _is_binfile "${IMAGE_FILE}" "${IMAGE_TYPE}"; then
-        FLASH_ADDR=$(_flash_address ${FLASH_BANK})
+        # hardwritten to use the first bank
+        FLASH_ADDR=$(_flash_address 1)
         echo "Binfile detected, adding ROM base address: ${FLASH_ADDR}"
         IMAGE_TYPE=bin
         IMAGE_OFFSET=$(printf "0x%08x\n" "$((${IMAGE_OFFSET} + ${FLASH_ADDR}))")


### PR DESCRIPTION
same as #13470 but fixing the Backport of #13179 , which is #13219

PR #13179 and is #13219 introduced debugging problems for  boards/nucleo-f767zi, unable to set breakpoints with current versions of openocd (its possible with old versions such as the one provided with ubuntu since it is ignoring gdb (hard or soft breakpoint))