### PR TITLE
cc2538-bsl.py: fix ERROR: string argument without an encoding

### DIFF
--- a/dist/tools/cc2538-bsl/cc2538-bsl.py
+++ b/dist/tools/cc2538-bsl/cc2538-bsl.py
@@ -140,7 +140,7 @@ class FirmwareFile(object):
         firmware_is_hex = False
 
         if have_magic:
-            file_type = bytearray(magic.from_file(path, True))
+            file_type = bytearray(magic.from_file(path, True), 'ascii')
 
             # from_file() returns bytes with PY3, str with PY2. This comparison
             # will be True in both cases"""


### PR DESCRIPTION
### Contribution description

Fix the

    ERROR: string argument without an encoding

error that would appear with Python 3.7.5 with the `magic` package installed.


### Testing procedure

Run `make BOARD=openmote-b flash`. (No need for an actual board, as this error happens when reading the firmware file)

Make sure you have `python3-magic` (or similar) installed as the error only occurs in the branch where this library is used.

### Issues/PRs references
introduced by 541265ee79b544a5aef74913fb90cdbee437c1bc

I didn't notice the error before as I didn't have the `magic` package installed.