### PR TITLE
sys/newlib_syscalls_default: update heap_stats for multiple heaps

### DIFF
--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -209,7 +209,12 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
 __attribute__((weak)) void heap_stats(void)
 {
     struct mallinfo minfo = mallinfo();
-    long int heap_size = &_eheap - &_sheap;
+    long int heap_size = 0;
+
+    for (unsigned int i = 0; i < NUM_HEAPS; i++) {
+        heap_size += heaps[i].end - heaps[i].start;
+    }
+
     printf("heap: %ld (used %d, free %ld) [bytes]\n",
            heap_size, minfo.uordblks, heap_size - minfo.uordblks);
 }


### PR DESCRIPTION
### Contribution description

Multiple heaps were introduced with PR #12928. This PR updates the `heap_stats` function for multiple heaps.

### Testing procedure

Use a platform which supports multiple heaps, e.g. lpc2387, and use the `heap` command of `tests/heap_cmd` to check the heap size with and without this PR:
```
BOARD=... make -C tests/heap_cmd flash term
> heap
```

### Issues/PRs references