### PR TITLE
cpu/esp_common: fixes common CPU configurations

### DIFF
--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -23,6 +23,8 @@
 #define CPU_CONF_H
 
 #include <stdint.h>
+
+#include "cpu_conf_common.h"
 #include "esp_common_log.h"
 #include "xtensa_conf.h"
 #include "xtensa/xtensa_context.h"

--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -34,11 +34,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Declare the heap_stats function as available
- */
-#define HAVE_HEAP_STATS
-
-/**
  * @name   Stack size configuration
  * @{
  */

--- a/cpu/esp32/ld/esp32.common.ld
+++ b/cpu/esp32/ld/esp32.common.ld
@@ -103,8 +103,10 @@ SECTIONS
     *core.a:*(.literal .text .literal.* .text.*)
     *littlefs.a:*(.literal .text .literal.* .text.*)
     *littlefs2.a:*(.literal .text .literal.* .text.*)
+    *newlib_syscalls_default.a:*(.literal .text .literal.* .text.*)
     *spiffs_fs.a:*(.literal .text .literal.* .text.*)
     *spiffs.a:*(.literal .text .literal.* .text.*)
+    *syscalls.o(.literal .text .literal.* .text.*)
     *vfs.a:*(.literal .text .literal.* .text.*)
 
     /* part of the RIOT port that should run in IRAM */

--- a/cpu/esp32/ld/esp32.common.ld
+++ b/cpu/esp32/ld/esp32.common.ld
@@ -90,9 +90,9 @@ SECTIONS
     *(.iram1 .iram1.*)
 
     *libhal.a:(.literal .text .literal.* .text.*)
-    *libgcc.a:lib2funcs.o(.literal .text .literal.* .text.*)
+    *libgcc.a:(.literal .text .literal.* .text.*)
     *libgcov.a:(.literal .text .literal.* .text.*)
-    /* *libc.a:(.literal .text .literal.* .text.*) */
+    *libc.a:*(.literal .text .literal.* .text.*)
 
     /* Xtensa basic functionality written in assembler should be placed in iram */
     *xtensa.a:*(.literal .text .literal.* .text.*)

--- a/cpu/esp32/ld/esp32.common.ld
+++ b/cpu/esp32/ld/esp32.common.ld
@@ -111,6 +111,7 @@ SECTIONS
 
     /* part of the RIOT port that should run in IRAM */
     *cpu.a:*(.literal .text .literal.* .text.*)
+    *esp_common.a:*(.literal .text .literal.* .text.*)
     *periph.a:*(.literal .text .literal.* .text.*)
     *mtd.a:**(.literal .text .literal.* .text.*)
 

--- a/cpu/esp8266/include/cpu_conf.h
+++ b/cpu/esp8266/include/cpu_conf.h
@@ -22,6 +22,7 @@
 #ifndef CPU_CONF_H
 #define CPU_CONF_H
 
+#include "cpu_conf_common.h"
 #include "xtensa_conf.h"
 
 #ifdef __cplusplus

--- a/cpu/esp_common/include/cpu_conf_common.h
+++ b/cpu/esp_common/include/cpu_conf_common.h
@@ -19,8 +19,8 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
+#ifndef CPU_CONF_COMMON_H
+#define CPU_CONF_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,5 +30,5 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
+#endif /* CPU_CONF_COMMON_H */
 /** @} */

--- a/cpu/esp_common/include/cpu_conf_common.h
+++ b/cpu/esp_common/include/cpu_conf_common.h
@@ -22,6 +22,16 @@
 #ifndef CPU_CONF_COMMON_H
 #define CPU_CONF_COMMON_H
 
+/**
+ * @brief   Declare the heap_stats function as available
+ *
+ * Only if module esp_idf_heap is used, a platform specific heap_stats function
+ * has to be used.
+ */
+#ifdef MODULE_ESP_IDF_HEAP
+#define HAVE_HEAP_STATS
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/esp_common/syscalls.c
+++ b/cpu/esp_common/syscalls.c
@@ -332,13 +332,6 @@ unsigned int IRAM_ATTR get_free_heap_size(void)
     return &_eheap - &_sheap - minfo.uordblks;
 }
 
-void heap_stats(void)
-{
-    ets_printf("heap: %u (used %u, free %u) [bytes]\n",
-               &_eheap - &_sheap, &_eheap - &_sheap - get_free_heap_size(),
-               get_free_heap_size());
-}
-
 /* alias for compatibility with espressif/wifi_libs */
 uint32_t esp_get_free_heap_size( void ) __attribute__((alias("get_free_heap_size")));
 


### PR DESCRIPTION
### Contribution description

This PR fixes the handling of `cpu_conf.h` in `cpu/esp_common`. Furthermore, it removes the platform specific `heap_stats` function in `cpu/esp_common` if module `esp_idf_heap` is not used.

ESP CPUs share common definitions in `cpu/esp_common`. There is also a `cpu_conf.h` file in `cpu/esp_common` which should contain common CPU configurations. However, this file was not included in the CPU specific `cpu_conf.h` in `cpu/esp32` and `cpu/esp8266` so that the definitions in this file had no affect. Furthermore, to include this file in CPU specific `cpu_conf.h`, it has to be renamed.

### Testing procedure

Compilation should succeed in Murdock.

### Issues/PRs references

Prerequisite for PR #13517 