### PR TITLE
cpu/esp32: support of multiple heaps for newlib malloc

### DIFF
--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -51,6 +51,11 @@ extern "C" {
  */
 #define PRINTF_BUFSIZ 256
 
+/**
+ * @brief   Remaining parts of the various DRAM sections can be used as heap.
+ */
+#define NUM_HEAPS (4)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp32/ld/esp32.common.ld
+++ b/cpu/esp32/ld/esp32.common.ld
@@ -97,6 +97,13 @@ SECTIONS
     _iram_start = ABSOLUTE(0);
   } > iram0_0_seg
 
+  /* If Bluetooth is not used, this DRAM section can be used as heap */
+  . = _data_start_btdm; /* 0x3ffae6e0 */
+  . = ALIGN (4);
+  _sheap1 = ABSOLUTE(.);
+  . = 0x3ffb0000;
+  _eheap1 = ABSOLUTE(.);
+
   .iram0.text :
   {
     /* Code marked as running out of IRAM */
@@ -131,8 +138,21 @@ SECTIONS
 
     INCLUDE esp32.spiram.rom-functions-iram.ld
     _iram_text_end = ABSOLUTE(.);
+
+    /* IRAM can't be used as heap since it only allows 32-bit aligned access */
+    /*
+    . = ALIGN (4);
+    _sheap4 = ABSOLUTE(.);
+    */
   } > iram0_0_seg
 
+  /* IRAM can't be used as heap since it only allows 32-bit aligned access */
+  /*
+  . = 0x400a0000;
+  _eheap4 = ABSOLUTE(.);
+  */
+
+  /* Starts at 0x3ffb000 if Bluetooth is not enabled, 0x3ffc0000 otherwise */
   .dram0.data :
   {
     _data_start = ABSOLUTE(.);
@@ -201,12 +221,22 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } >dram0_0_seg
 
-  /* TODO HEAP handling when BT is used
-     ETS system memory seems to start at 0x3FFE0000 if BT is not used.
-     This is the top of the heap for the app */
-    . = 0x3FFE0000;
+  /* Reserved ROM/ETS data start at 0x3ffe000. */
+  . = 0x3ffe0000;
   _heap_top = ABSOLUTE(.);
   _eheap = ABSOLUTE(.);
+
+  /* Reserved ROM/ETS data region for PRO CPU: 0x3ffe0000 ... 0x3ffe440 */
+  . = 0x3ffe0440;
+  _sheap2 = ABSOLUTE(.);
+  . = 0x3ffe4000;
+  _eheap2 = ABSOLUTE(.);
+
+  /* Reserved ROM/ETS data region for APP CPU: 0x3ffe4000 ... 0x3ffe4350 */
+  . = 0x3ffe4350;
+  _sheap3 = ABSOLUTE(.);
+  . = 0x40000000;
+  _eheap3 = ABSOLUTE(.);
 
   .flash.rodata :
   {

--- a/cpu/esp_common/syscalls.c
+++ b/cpu/esp_common/syscalls.c
@@ -326,10 +326,29 @@ void heap_caps_init(void)
 extern uint8_t  _eheap;     /* end of heap (defined in ld script) */
 extern uint8_t  _sheap;     /* start of heap (defined in ld script) */
 
+extern uint8_t _sheap1;
+extern uint8_t _eheap1;
+
+extern uint8_t _sheap2;
+extern uint8_t _eheap2;
+
+extern uint8_t _sheap3;
+extern uint8_t _eheap3;
+
 unsigned int IRAM_ATTR get_free_heap_size(void)
 {
     struct mallinfo minfo = mallinfo();
-    return &_eheap - &_sheap - minfo.uordblks;
+    unsigned int heap_size = &_eheap - &_sheap;
+#if NUM_HEAPS > 1
+    heap_size += &_eheap1 - &_sheap1;
+#endif
+#if NUM_HEAPS > 2
+    heap_size += &_eheap2 - &_sheap2;
+#endif
+#if NUM_HEAPS > 3
+    heap_size += &_eheap3 - &_sheap3;
+#endif
+    return heap_size - minfo.uordblks;
 }
 
 /* alias for compatibility with espressif/wifi_libs */


### PR DESCRIPTION
### Contribution description

This PR adds support of multiple heaps if module `esp_idf_heap` is not used.

For that purpose the following unused DRAM sections are added as additional heap segments:
```
0x3ffae6e0 ... 0x3ffaffff   heap1   6 kiB
0x3ffe0440 ... 0x3ffe3fff   heap2   14 kiB
0x3ffe4350 ... 0x3fffffff   heap3   111 kiB
```
With these additional heap segments, the overall heap size increases from `180 kiB` to `315` kiB for the `tests/heap_cmd` application.

The standard heap is located in:
```
0x3ffb0000 ... 0x3ffdffff
```
It's size depends on other data since `.data` and `.bss` sections are also placed there. Therefore, the heap starts at `_bss_end`.

### Testing procedure

Use the following command to flash an ESP32 board:
```
CFLAGS='-DNUMBER_OF_TESTS=1 -DCHUNK_SIZE=1000' BOARD=esp32-wroom-32 \
make -C tests/malloc flash
```
Check that all heap segments are used:
```
CHUNK_SIZE: 1000
NUMBER_OF_TESTS: 1
Allocated 1000 Bytes at 0x0x3ffb2900, total 1000
...
Allocated 1000 Bytes at 0x0x3ffdf900, total 182440
Allocated 1000 Bytes at 0x0x3ffae6e8, total 183448
...
Allocated 1000 Bytes at 0x0x3ffafa98, total 188488
Allocated 1000 Bytes at 0x0x3ffe0448, total 189496
...
Allocated 1000 Bytes at 0x0x3ffe3b68, total 203608
Allocated 1000 Bytes at 0x0x3ffe4358, total 204616
...
Allocated 1000 Bytes at 0x0x3ffffb78, total 316504
Allocations count: 314
```

### Issues/PRs references

~Depends on PR #13516~
Requires PR https://github.com/RIOT-OS/riotdocker/pull/102 to work correctly.