### PR TITLE
drivers/rtt_rtc: add RTT based RTC implementation, enable it for cpu/cc2538, nrf5x_common

### DIFF
--- a/cpu/cc2538/Makefile.dep
+++ b/cpu/cc2538/Makefile.dep
@@ -3,4 +3,8 @@ ifneq (,$(filter cc2538_rf,$(USEMODULE)))
   USEMODULE += netif
 endif
 
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
+  USEMODULE += rtt_rtc
+endif
+
 USEMODULE += pm_layered

--- a/cpu/nrf5x_common/Makefile.dep
+++ b/cpu/nrf5x_common/Makefile.dep
@@ -1,3 +1,7 @@
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
+  USEMODULE += rtt_rtc
+endif
+
 # include nrf5x common periph drivers
 USEMODULE += nrf5x_common_periph
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -558,6 +558,14 @@ ifneq (,$(filter rgbled,$(USEMODULE)))
   USEMODULE += color
 endif
 
+ifneq (,$(filter rtt_rtc,$(USEMODULE)))
+  # Unit tests will use a mock implementation
+  ifeq (,$(UNIT_TESTS))
+    FEATURES_REQUIRED += periph_rtt
+  endif
+  FEATURES_PROVIDED += periph_rtc
+endif
+
 ifneq (,$(filter rn2%3,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_uart

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -43,8 +43,16 @@ extern "C" {
 #endif
 
 #ifndef RTT_FREQUENCY
+
+/* Allow mock-RTT for unit tests */
+#ifdef MOCK_RTT_FREQUENCY
+#define RTT_FREQUENCY MOCK_RTT_FREQUENCY
+#define RTT_MAX_VALUE MOCK_RTT_MAX_VALUE
+#else
+
 #warning "RTT_FREQUENCY undefined. Set RTT_FREQUENCY to the number of ticks" \
          "per second for the current architecture."
+#endif
 #endif
 
 /**

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -63,14 +63,14 @@ void periph_init(void)
     }
 #endif
 
+    /* Initialize RTT before RTC to allow for RTT based RTC implementations */
+#ifdef MODULE_PERIPH_INIT_RTT
+    rtt_init();
+#endif
+
     /* Initialize RTC */
 #ifdef MODULE_PERIPH_INIT_RTC
     rtc_init();
-#endif
-
-    /* Initialize RTT */
-#ifdef MODULE_PERIPH_INIT_RTT
-    rtt_init();
 #endif
 
 #ifdef MODULE_PERIPH_INIT_HWRNG

--- a/drivers/rtt_rtc/Makefile
+++ b/drivers/rtt_rtc/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/rtt_rtc/rtt_rtc.c
+++ b/drivers/rtt_rtc/rtt_rtc.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_periph_rtc
+ * @{
+ *
+ * @file
+ * @brief       Basic RTC implementation based on a RTT
+ *
+ * @note        Unlike a real RTC, this emulated version is not guaranteed to keep
+ *              time across reboots or deep sleep.
+ *              If your hardware provides the means to implement a real RTC, always
+ *              prefer that over this emulated version!
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "periph/rtc.h"
+#include "periph/rtt.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define RTT_SECOND      (RTT_FREQUENCY)
+
+#define _RTT(n)         ((n) & RTT_MAX_VALUE)
+
+#define RTT_SECOND_MAX  (RTT_MAX_VALUE/RTT_FREQUENCY)
+
+#define TICKS(x)        (    (x) * RTT_SECOND)
+#define SECONDS(x)      (_RTT(x) / RTT_SECOND)
+
+/* Place counter in .noinit section if no backup RAM is available.
+   This means the date is undefined at cold boot, but will likely still
+   survive a reboot. */
+#ifndef BACKUP_RAM
+#define BACKUP_RAM      __attribute__((section(".noinit")))
+#endif
+
+static uint32_t rtc_now BACKUP_RAM;         /**< The RTC timestamp when the last RTT alarm triggered */
+static uint32_t last_alarm BACKUP_RAM;      /**< The RTT timestamp of the last alarm */
+
+static uint32_t alarm_time;                 /**< The RTC timestamp of the (user) RTC alarm */
+static rtc_alarm_cb_t alarm_cb;             /**< RTC alarm callback */
+static void *alarm_cb_arg;                  /**< RTC alarm callback argument */
+
+static void _rtt_alarm(void *arg);
+
+/* convert RTT counter into RTC timestamp */
+static inline uint32_t _rtc_now(uint32_t now)
+{
+    return rtc_now + SECONDS(now - last_alarm);
+}
+
+static inline void _set_alarm(uint32_t now, uint32_t next_alarm)
+{
+    rtt_set_alarm(now + next_alarm, _rtt_alarm, NULL);
+}
+
+/* This calculates when the next alarm should happen.
+   Always chooses the longest possible period min(alarm, overflow)
+   to minimize the amount of wake-ups. */
+static void _update_alarm(uint32_t now)
+{
+    uint32_t next_alarm;
+
+    last_alarm = TICKS(SECONDS(now));
+
+    /* no alarm or alarm beyond this period */
+    if ((alarm_cb == NULL)     ||
+        (alarm_time < rtc_now) ||
+        (alarm_time - rtc_now > RTT_SECOND_MAX)) {
+        next_alarm = RTT_SECOND_MAX;
+    } else {
+        /* alarm triggers in this period */
+        next_alarm = alarm_time - rtc_now;
+    }
+
+    /* alarm triggers NOW */
+    if (next_alarm == 0) {
+        next_alarm = RTT_SECOND_MAX;
+        alarm_cb(alarm_cb_arg);
+    }
+
+    _set_alarm(now, TICKS(next_alarm));
+}
+
+/* the RTT alarm callback */
+static void _rtt_alarm(void *arg)
+{
+    (void) arg;
+
+    uint32_t now = rtt_get_counter();
+    rtc_now = _rtc_now(now);
+
+    _update_alarm(now);
+}
+
+void rtc_init(void)
+{
+    /* only update last_alarm on cold boot */
+    if (last_alarm == 0) {
+        last_alarm = rtt_get_counter();
+    }
+
+    _set_alarm(last_alarm, TICKS(RTT_SECOND_MAX));
+}
+
+int rtc_set_time(struct tm *time)
+{
+    rtc_tm_normalize(time);
+
+    /* disable alarm to prevent race condition */
+    rtt_clear_alarm();
+
+    uint32_t now = rtt_get_counter();
+    rtc_now      = rtc_mktime(time);
+
+    /* calculate next wake-up period */
+    _update_alarm(now);
+
+    return 0;
+}
+
+int rtc_get_time(struct tm *time)
+{
+    uint32_t prev = rtc_now;
+
+    /* repeat calculation if an alarm triggered in between */
+    do {
+        uint32_t now = rtt_get_counter();
+        uint32_t tmp = _rtc_now(now);
+
+        rtc_localtime(tmp, time);
+    } while (prev != rtc_now);
+
+    return 0;
+}
+
+int rtc_get_alarm(struct tm *time)
+{
+    rtc_localtime(alarm_time, time);
+
+    return 0;
+}
+
+int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
+{
+    /* disable alarm to prevent race condition */
+    rtt_clear_alarm();
+
+    uint32_t now = rtt_get_counter();
+
+    alarm_time   = rtc_mktime(time);
+    alarm_cb_arg = arg;
+    alarm_cb     = cb;
+
+    rtc_now      = _rtc_now(now);
+    _update_alarm(now);
+
+    return 0;
+}
+
+void rtc_clear_alarm(void)
+{
+    alarm_cb = NULL;
+}
+
+void rtc_poweron(void)
+{
+    rtt_poweron();
+}
+
+void rtc_poweroff(void)
+{
+    rtt_poweroff();
+}

--- a/tests/unittests/tests-rtt_rtc/Makefile
+++ b/tests/unittests/tests-rtt_rtc/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-rtt_rtc/Makefile.include
+++ b/tests/unittests/tests-rtt_rtc/Makefile.include
@@ -1,0 +1,8 @@
+USEMODULE += rtt_rtc
+
+CFLAGS += -DMOCK_RTT_FREQUENCY=32
+CFLAGS += -DMOCK_RTT_MAX_VALUE=0xFFFF
+
+# mulle always enables periph_rtt.
+# This clashes with mock_rtt.
+BOARD_BLACKLIST := mulle

--- a/tests/unittests/tests-rtt_rtc/mock_rtt.c
+++ b/tests/unittests/tests-rtt_rtc/mock_rtt.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief       Mock implementation of a Real-Time Timer
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#include <stddef.h>
+#include "periph/rtt.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static uint32_t counter, alarm;
+static rtt_cb_t alarm_cb, overflow_cb;
+static void *alarm_arg, *overflow_arg;
+
+uint32_t rtt_get_counter(void)
+{
+    DEBUG("%s() = %"PRIu32"\n", __func__, counter);
+    return counter;
+}
+
+void rtt_set_counter(uint32_t _counter)
+{
+    DEBUG("%s(%"PRIu32")\n", __func__, _counter);
+    counter = _counter & RTT_MAX_VALUE;
+}
+
+void rtt_set_alarm(uint32_t _alarm, rtt_cb_t cb, void *arg)
+{
+    DEBUG("%s(%"PRIu32")\n", __func__, _alarm);
+
+    alarm     = _alarm & RTT_MAX_VALUE;
+    alarm_cb  = cb;
+    alarm_arg = arg;
+}
+
+uint32_t rtt_get_alarm(void)
+{
+    return alarm;
+}
+
+void rtt_clear_alarm(void)
+{
+    alarm_cb = NULL;
+}
+
+void rtt_set_overflow_cb(rtt_cb_t cb, void *arg)
+{
+    DEBUG("%s()\n", __func__);
+    overflow_cb  = cb;
+    overflow_arg = arg;
+}
+
+void rtt_clear_overflow_cb(void)
+{
+    overflow_cb = NULL;
+}
+
+void rtt_init(void)
+{
+    counter = 0;
+}
+
+static void _tick(void)
+{
+    counter = (counter + 1) & RTT_MAX_VALUE;
+
+    if (overflow_cb && (counter == 0)) {
+        DEBUG("RTT: overflow\n");
+        overflow_cb(overflow_arg);
+    }
+
+    if (alarm_cb && (counter == alarm)) {
+        DEBUG("RTT: alarm\n");
+        alarm_cb(alarm_arg);
+    }
+}
+
+void rtt_add_ticks(uint64_t ticks)
+{
+    while (ticks--) {
+        _tick();
+    }
+}
+/** @} */

--- a/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c
+++ b/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+#include <string.h>
+#include <errno.h>
+
+#include "embUnit.h"
+#include "periph/rtc.h"
+#include "periph/rtt.h"
+
+void rtt_add_ticks(uint64_t ticks);
+
+static void test_set_time(void)
+{
+    struct tm t1 = {
+        .tm_sec  = 42,
+        .tm_min  = 37,
+        .tm_hour = 13,
+        .tm_mday = 23,
+        .tm_mon  =  5,
+        .tm_year = 120,
+        .tm_wday = 0,
+        .tm_yday = 0,
+        .tm_isdst= 0,
+    };
+    struct tm now;
+
+    rtc_set_time(&t1);
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    rtt_add_ticks(60 * RTT_FREQUENCY);
+    t1.tm_min++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    rtt_add_ticks(60 * 60 * RTT_FREQUENCY);
+    t1.tm_hour++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(t1.tm_hour, now.tm_hour);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    rtt_add_ticks(60 * RTT_FREQUENCY);
+    t1.tm_min++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+}
+
+static void _alarm_cb(void *arg)
+{
+    struct tm now, *expt = arg;
+
+    rtc_get_time(&now);
+
+    TEST_ASSERT_EQUAL_INT(expt->tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(expt->tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(expt, &now));
+
+    /* use dst to signal how often cb was called */
+    expt->tm_isdst++;
+}
+
+static void test_set_alarm(void)
+{
+    struct tm t1 = {
+        .tm_sec  = 42,
+        .tm_min  = 37,
+        .tm_hour = 13,
+        .tm_mday = 23,
+        .tm_mon  =  5,
+        .tm_year = 120,
+        .tm_wday = 0,
+        .tm_yday = 0,
+        .tm_isdst= 0,
+    };
+    struct tm now, alarm = t1;
+    alarm.tm_hour++;
+
+    rtc_set_time(&t1);
+    rtc_set_alarm(&alarm, _alarm_cb, &alarm);
+
+    rtt_add_ticks(60 * RTT_FREQUENCY);
+    t1.tm_min++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    rtt_add_ticks(24*60*60UL * RTT_FREQUENCY);
+    t1.tm_mday++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    TEST_ASSERT_EQUAL_INT(1, alarm.tm_isdst);
+}
+
+static void test_set_alarm_short(void)
+{
+    struct tm t1 = {
+        .tm_sec  = 42,
+        .tm_min  = 37,
+        .tm_hour = 13,
+        .tm_mday = 23,
+        .tm_mon  =  5,
+        .tm_year = 120,
+        .tm_wday = 0,
+        .tm_yday = 0,
+        .tm_isdst= 0,
+    };
+    struct tm now, alarm = t1;
+    alarm.tm_sec += 10;
+
+    rtc_set_time(&t1);
+    rtc_set_alarm(&alarm, _alarm_cb, &alarm);
+
+    rtt_add_ticks(60 * RTT_FREQUENCY);
+    t1.tm_min++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    rtt_add_ticks(60*60 * RTT_FREQUENCY);
+    t1.tm_hour++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    TEST_ASSERT_EQUAL_INT(1, alarm.tm_isdst);
+}
+
+static void test_set_alarm_set_time(void)
+{
+    struct tm t1 = {
+        .tm_sec  = 42,
+        .tm_min  = 37,
+        .tm_hour = 13,
+        .tm_mday = 23,
+        .tm_mon  =  5,
+        .tm_year = 120,
+        .tm_wday = 0,
+        .tm_yday = 0,
+        .tm_isdst= 0,
+    };
+    struct tm now, alarm = t1;
+    alarm.tm_hour += 5;
+
+    rtc_set_time(&t1);
+    rtc_set_alarm(&alarm, _alarm_cb, &alarm);
+
+    t1.tm_hour += 4;
+    rtc_set_time(&t1);
+
+    rtt_add_ticks(60 * RTT_FREQUENCY);
+    t1.tm_min++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    rtt_add_ticks(60*60 * RTT_FREQUENCY);
+    t1.tm_hour++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    TEST_ASSERT_EQUAL_INT(1, alarm.tm_isdst);
+
+    rtc_set_alarm(&alarm, _alarm_cb, &alarm);
+
+    t1.tm_hour--;
+    rtc_set_time(&t1);
+    rtt_add_ticks(60*60 * RTT_FREQUENCY);
+    t1.tm_hour++;
+    rtc_get_time(&now);
+    TEST_ASSERT_EQUAL_INT(t1.tm_sec, now.tm_sec);
+    TEST_ASSERT_EQUAL_INT(t1.tm_min, now.tm_min);
+    TEST_ASSERT_EQUAL_INT(0, rtc_tm_compare(&t1, &now));
+
+    TEST_ASSERT_EQUAL_INT(2, alarm.tm_isdst);
+
+    rtt_add_ticks(60*60 * RTT_FREQUENCY);
+    TEST_ASSERT_EQUAL_INT(2, alarm.tm_isdst);
+}
+
+Test *tests_rtt_rtt_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_set_time),
+        new_TestFixture(test_set_alarm),
+        new_TestFixture(test_set_alarm_short),
+        new_TestFixture(test_set_alarm_set_time),
+    };
+
+    EMB_UNIT_TESTCALLER(rtt_rtc_tests, NULL, NULL, fixtures);
+
+    return (Test *)&rtt_rtc_tests;
+}
+
+void tests_rtt_rtc(void)
+{
+    rtc_init();
+    rtt_add_ticks(10);
+    TESTS_RUN(tests_rtt_rtt_tests());
+}
+/** @} */

--- a/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.h
+++ b/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``rtt_rtc`` module
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#ifndef TESTS_RTT_RTC_H
+#define TESTS_RTT_RTC_H
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_rtt_rtc(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_RTT_RTC_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This adds an emulated RTC based on top of the RTT implementation.
~~It is rather basic in that it only allows alarms to be set one full period of the RTT in the future.
For a 32bit RTT running at 32kHz, this means you can set alarms at most 1½ days in the future.~~

### Testing procedure

Run `tests/periph_rtc` on e.g. `openmote-b`:

```
2020-02-29 16:39:38,199 # This test will display 'Alarm!' every 2 seconds for 4 times
2020-02-29 16:39:38,200 #   Setting clock to   2011-12-13 14:15:57
2020-02-29 16:39:38,211 # Clock value is now   2011-12-13 14:15:57
2020-02-29 16:39:38,212 #   Setting alarm to   2011-12-13 14:15:59
2020-02-29 16:39:38,212 #    Alarm is set to   2011-12-13 14:15:59
2020-02-29 16:39:38,213 # 
2020-02-29 16:39:40,211 # Alarm!
2020-02-29 16:39:42,211 # Alarm!
2020-02-29 16:39:44,210 # Alarm!
2020-02-29 16:39:46,210 # Alarm!
```

### Issues/PRs references
I moved the additions to the RTT driver to #13630
They are not needed anymore.