### PR TITLE
cpu/kinetis: add mkw41z256vht4 to no-hwrng list

### DIFF
--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -1,7 +1,7 @@
 FEATURES_PROVIDED += periph_cpuid
 
-# TRNG driver is not implemented for mkw41z512vht4 model
-_KINETIS_CPU_MODELS_WITHOUT_HWRNG += mkw41z512vht4
+# TRNG driver is not implemented for mkw41z models
+_KINETIS_CPU_MODELS_WITHOUT_HWRNG += mkw41z256vht4 mkw41z512vht4
 # No HWRNG in mk20d7 devices
 _KINETIS_CPU_MODELS_WITHOUT_HWRNG += mk20dx256vlh7
 


### PR DESCRIPTION
### Contribution description

Some versions of the `openlabs-kw41z-mini` come with this chip instead of `kw41z512`, so let's also add that to the list.

Take from @benemorius' [`openlabs`](https://github.com/benemorius/RIOT/commits/openlabs) branch. 

### Testing procedure

Compilation with this CPU will otherwise fail as HWRNG is not implemented.

### Issues/PRs references

