### PR TITLE
net/eui64: provide 32 bit access

### DIFF
--- a/sys/include/net/eui64.h
+++ b/sys/include/net/eui64.h
@@ -54,8 +54,9 @@ extern "C" {
  */
 typedef union {
     network_uint64_t uint64;     /**< represented as 64 bit value */
-    uint8_t uint8[8];            /**< split into 8 8-bit words. */
-    network_uint16_t uint16[4];  /**< split into 4 16-bit words. */
+    uint8_t uint8[8];            /**< split into 8 8-bit words.   */
+    network_uint16_t uint16[4];  /**< split into 4 16-bit words.  */
+    network_uint32_t uint32[2];  /**< split into 2 32-bit words.  */
 } eui64_t;
 
 /**


### PR DESCRIPTION
### Contribution description

We allow to read `eui64_t` as 8 8-bit values and 4 16-bit values, so also provide access as 2 32bit-values.

### Testing procedure

nothing to test


### Issues/PRs references

Noticed `kw41zrf` stores the long address in two 32bit registers, so it's convenient to have these functions.
