### PR TITLE
boards: add openlabs-kw41z-mini-256kib

### DIFF
--- a/boards/openlabs-kw41z-mini-256kib/Makefile
+++ b/boards/openlabs-kw41z-mini-256kib/Makefile
@@ -1,0 +1,2 @@
+DIRS = $(RIOTBOARD)/openlabs-kw41z-mini
+include $(RIOTBASE)/Makefile.base

--- a/boards/openlabs-kw41z-mini-256kib/Makefile.dep
+++ b/boards/openlabs-kw41z-mini-256kib/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/openlabs-kw41z-mini/Makefile.dep

--- a/boards/openlabs-kw41z-mini-256kib/Makefile.features
+++ b/boards/openlabs-kw41z-mini-256kib/Makefile.features
@@ -1,0 +1,2 @@
+CPU_MODEL = mkw41z256vht4
+include $(RIOTBOARD)/openlabs-kw41z-mini/Makefile.features

--- a/boards/openlabs-kw41z-mini-256kib/Makefile.include
+++ b/boards/openlabs-kw41z-mini-256kib/Makefile.include
@@ -1,0 +1,4 @@
+SLOT0_LEN ?= 0x1C000
+
+INCLUDES  += -I$(RIOTBOARD)/openlabs-kw41z-mini/include
+include $(RIOTBOARD)/openlabs-kw41z-mini/Makefile.include

--- a/boards/openlabs-kw41z-mini/Makefile.features
+++ b/boards/openlabs-kw41z-mini/Makefile.features
@@ -1,5 +1,5 @@
 CPU = kinetis
-CPU_MODEL = mkw41z512vht4
+CPU_MODEL ?= mkw41z512vht4
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -63,6 +63,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l433rc \
     nz32-sc151 \
     opencm904 \
+    openlabs-kw41z-mini-256kib \
     pba-d-01-kw2x \
     samd21-xpro \
     saml10-xpro \


### PR DESCRIPTION
### Contribution description

Add the 256k version of the openlabs-kw41z-mini.
They are identical to the openlabs-kw41z-mini except that it uses the `mkw41z256vht4` instead of the `mkw41z512vht4`.

@benemorius says these were only sent out by mistake, but it's rather trivial to support them too and I dislike the idea of not using otherwise perfectly good hardware :wink: 

I also wanted to try how easy it is to support multiple boards that only differ in CPU.

We took a more elaborate approach with the different `blackpill`/`bluepill` versions which also only differ in flash size, but it turns out just providing the basic `Makefiles` is enough.

### Testing procedure

Flash one of the 256k boards with this.

### Issues/PRs references
needs #13522
