### PR TITLE
boards/samr30-xpro: fix AT86RF212B communication

### DIFF
--- a/boards/samr30-xpro/include/board.h
+++ b/boards/samr30-xpro/include/board.h
@@ -36,7 +36,7 @@ extern "C" {
 #define AT86RF2XX_PARAM_INT         GPIO_PIN(PB, 0)
 #define AT86RF2XX_PARAM_SLEEP       GPIO_PIN(PA, 20)
 #define AT86RF2XX_PARAM_RESET       GPIO_PIN(PB, 15)
-#define AT86RF2XX_PARAM_SPI_CLK     SPI_CLK_5MHZ
+#define AT86RF2XX_PARAM_SPI_CLK     SPI_CLK_1MHZ
 /** @}*/
 
 /**


### PR DESCRIPTION
### Contribution description

~~According to the SAMR30 datasheet, the baud rate for synchronus communications (in this case SPI) must fulfill `f_BAUD <= f_REF/2` with `f_REF = f_GLCK/2`. (cf. [0] Table 13-53)~~

~~The board is clocked with 16MHz, thus the maximum baud rate is 4MHz.~~

Due to integer arithmetic, the resulting SPI clock is 8MHz when the GCLK is sourced with 16MHz. This is too fast for the AT86RF212B.

Without this patch I am faced with many checksum mismatches when receiving packets with the AT86RF212B.

[0] http://ww1.microchip.com/downloads/en/DeviceDoc/70005303B.pdf

### Testing procedure

`examples/gnrc_networking` should work flawlessly with this patch to ping between two boards

### Issues/PRs references

*none*