### PR TITLE
pkg/nimble/autoconn: minor debug message cleanup

### DIFF
--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -218,7 +218,7 @@ static void _on_netif_evt(int handle, nimble_netif_event_t event,
             _state = STATE_IDLE;
             break;
         case NIMBLE_NETIF_ABORT_SLAVE:
-            _evt_dbg("[autoconn] ABORT slave", handle, addr);
+            _evt_dbg("ABORT slave", handle, addr);
             _state = STATE_IDLE;
             break;
         case NIMBLE_NETIF_CONN_UPDATED:


### PR DESCRIPTION
### Contribution description
Minor debug message fix: must have slipped through when remodeling this code prior. The `[autoconn]` is added to the output string in the `_evt_dbg()` function.

### Testing procedure
none really needed

### Issues/PRs references
none