### PR TITLE
testbed-support: fix compatibility with cli-tools v3

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -1,5 +1,19 @@
 .PHONY: iotlab-exp iotlab-flash iotlab-reset iotlab-term iotlab-check-exp
 
+# There are several deprecated features used here and introduced between
+# versions 2 and 3 of the IoT-LAB cli tools.
+# For backward compatibility, we manage these changes here.
+_CLI_TOOLS_MAJOR_VERSION ?= $(shell iotlab-experiment --version | cut -f1 -d.)
+ifeq (2,$(_CLI_TOOLS_MAJOR_VERSION))
+  _NODES_LIST_OPTION = --resources
+  _NODES_ID_LIST_OPTION = --resources-id
+  _NODES_FLASH_OPTION = --update
+else
+  _NODES_LIST_OPTION = --nodes
+  _NODES_ID_LIST_OPTION = --nodes-id
+  _NODES_FLASH_OPTION = --flash
+endif
+
 IOTLAB_NODES        ?= 5
 IOTLAB_DURATION     ?= 30
 IOTLAB_TYPE         ?= m3:at86rf231
@@ -8,7 +22,7 @@ IOTLAB_USER         ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
 IOTLAB_EXP_ID       ?= $(shell iotlab-experiment get -l --state Running | grep -m 1 '"id"' | grep -Eo '[[:digit:]]+')
 IOTLAB_EXP_NAME     ?= RIOT_EXP
 IOTLAB_DEBUG_PORT   ?= 3333
-IOTLAB_DEBUG_NODE   ?= $(shell iotlab-experiment get -i $(IOTLAB_EXP_ID) --resources | \
+IOTLAB_DEBUG_NODE   ?= $(shell iotlab-experiment get -i $(IOTLAB_EXP_ID) $(_NODES_LIST_OPTION) | \
                          grep -m 1 "network_address" | sed 's/.*-\([0-9]*\)\..*/\1/')
 IOTLAB_AUTHORITY    = "$(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info"
 
@@ -16,7 +30,7 @@ ifeq (,$(filter iotlab-exp,$(MAKECMDGOALS)))
   # derive experiment site from IOTLAB_EXP_ID, if not given and not used with
   # `iotlab_exp`
   IOTLAB_SITE     ?= $(shell iotlab-experiment --format=str --jmespath "keys(items[0])[0]" \
-                             get -ri -i $(IOTLAB_EXP_ID))
+                             get $(_NODES_ID_LIST_OPTION) -i $(IOTLAB_EXP_ID))
 endif
 
 ifneq (,$(findstring m3,$(IOTLAB_TYPE)))
@@ -62,7 +76,7 @@ iotlab-exp: $(IOTLAB_AUTH) all
     endif
 
 iotlab-flash: $(IOTLAB_AUTH) all
-	$(Q)iotlab-node --update $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
+	$(Q)iotlab-node $(_NODES_FLASH_OPTION) $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
 
 iotlab-reset: $(IOTLAB_AUTH)
 	$(Q)iotlab-node --reset -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
@@ -82,7 +96,7 @@ iotlab-stop: $(IOTLAB_AUTH)
 IOTLABTERMFLASHDEPS ?= $(filter iotlab-flash iotlab-exp,$(MAKECMDGOALS))
 
 iotlab-term: $(IOTLABTERMFLASHDEPS)
-	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get -r -i $(IOTLAB_EXP_ID) > /dev/null || \
+	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get $(_NODES_LIST_OPTION) -i $(IOTLAB_EXP_ID) > /dev/null || \
 	                                iotlab-auth -u $(IOTLAB_USER)"
 
 	$(Q)ssh -t $(IOTLAB_AUTHORITY) \

--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -96,9 +96,7 @@ iotlab-stop: $(IOTLAB_AUTH)
 IOTLABTERMFLASHDEPS ?= $(filter iotlab-flash iotlab-exp,$(MAKECMDGOALS))
 
 iotlab-term: $(IOTLABTERMFLASHDEPS)
-	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get $(_NODES_LIST_OPTION) -i $(IOTLAB_EXP_ID) > /dev/null || \
-	                                iotlab-auth -u $(IOTLAB_USER)"
-
+	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get -i $(IOTLAB_EXP_ID) --print > /dev/null || iotlab-auth -u $(IOTLAB_USER)"
 	$(Q)ssh -t $(IOTLAB_AUTHORITY) \
 	"$(if $(IOTLAB_TMUX),tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID) ',) \
 	$(if $(IOTLAB_LOGGING), \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A [new major version of the IoT-LAB cli tools](https://pypi.org/project/iotlabcli/) has just been released.
The major change of this version is the switch to [the new REST API](https://api.iot-lab.info) of the testbed. This change breaks the way the use of IOTLAB_NODE variable in the RIOT build system.

The new version also obsoletes a few options (`--update`, `--resources`) that are used by RIOT testbed support. These options are replaces respectively by `--flash` and `--nodes`.

This PR update the testbed support of RIOT in order to:
- adapt to the 3.0 breaking change and use the previous behavior if 2.x versions of the cli-tools are used. This make RIOT backward compatible if users are still using old version of the cli-tools
- rename the deprecated options to the new ones, when using version != 2.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. Install cli-tools version 2.6.0
- verify that `IOTLAB_NODE` variable can be used to interact with one board in the IoT-LAB testbed:
```
$ pip3 install --user iotlabcli==2.6
$ iotlab-experiment submit -n "test_cli_tools" -d 20 -l 1,archi=m3:at86rf231+site=saclay
$ iotlab-experiment wait
$ IOTLAB_NODE=auto-ssh make BOARD=iotlab-m3 -C examples/default flash term
```
- verify that the other [RIOT integration in IoT-LAB](https://github.com/RIOT-OS/RIOT/blob/master/dist/testbed-support/README.iotlab.md) is working (multiple nodes in an experiment)

2. Install cli-tools version 3.0.0 and repeat the 2 points above. **without this PR the first point doesn't work on master**

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
