### PR TITLE
sys: add units.h for helper macros 

### DIFF
--- a/core/include/macros/units.h
+++ b/core/include/macros/units.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     core_macros
+ * @{
+ *
+ * @file
+ * @brief       Unit helper macros
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef MACROS_UNITS_H
+#define MACROS_UNITS_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @brief   A macro to return the bytes in x KiB
+ */
+#define KiB(x) ((unsigned long long)(x) << 10)
+
+/**
+ * @brief   A macro to return the bytes in x MiB
+ */
+#define MiB(x) (KiB(x) << 10)
+
+/**
+ * @brief   A macro to return the bytes in x GiB
+ */
+#define GiB(x) (MiB(x) << 10)
+
+/**
+ * @brief   A macro to return the Hz in x kHz
+ */
+#define KHZ(x)    ((x) * 1000ULL)
+
+/**
+ * @brief   A macro to return the Hz in x MHz
+ */
+#define MHZ(x) (KHZ(x) * 1000ULL)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MACROS_UNITS_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

I got tired of counting zeros in frequency defines, so add a few helper macros to make defining frequency and sizes easier.

I wasn't sure if I could fit those into `kernel_defines.h` or if that's out of scope.
But tbh it feels much nicer to just include `util.h` for such utility functions. 

### Testing procedure

nothing to test

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
