### PR TITLE
Add CAN support for nucleo-l476rg

### DIFF
--- a/boards/nucleo-l476rg/Makefile.features
+++ b/boards/nucleo-l476rg/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32l476rg
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_can
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm

--- a/boards/nucleo-l476rg/doc.txt
+++ b/boards/nucleo-l476rg/doc.txt
@@ -6,23 +6,46 @@
 ### MCU
 
 
-| MCU        |       |
+| MCU        |   STM32L476RG    |
 |:------------- |:--------------------- |
 | Family | ARM Cortex-M4     |
 | Vendor | ST Microelectronics   |
-| RAM        |  |
-| Flash      | |
-| Frequency  | |
-| FPU        | |
-| Timers | |
-| ADCs       | |
-| UARTs      | |
-| SPIs       | |
-| I2Cs       | |
-| RTC        | |
-| Vcc        | |
+| RAM        | 128Kb |
+| Flash      | 1MB             |
+| Frequency  | up to 80MHz |
+| FPU        | yes               |
+| Timers | 16 (2x watchdog, 1 SysTick, 6x 16-bit, 2x 32-bit [TIM2])  |
+| ADCs       | 1x 12-bit         |
+| UARTs      | 3 (two UARTs and one Low-Power UART)                 |
+| SPIs       | 3                 |
+| I2Cs       | 3                 |
+| RTC        | 1                 |
+| CAN        | 1                 |
+| Vcc        | 1.71 V - 3.6V           |
 | Datasheet  | |
 | Reference Manual | [Reference Manual](http://www.st.com/content/ccc/resource/technical/document/reference_manual/02/35/09/0c/4f/f7/40/03/DM00083560.pdf/files/DM00083560.pdf/jcr:content/translations/en.DM00083560.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/content/ccc/resource/technical/document/programming_manual/6c/3a/cb/e7/e4/ea/44/9b/DM00046982.pdf/files/DM00046982.pdf/jcr:content/translations/en.DM00046982.pdf) |
-| Board Manual   | |
+| Board Manual   | [Board Manual](https://www.st.com/content/ccc/resource/technical/document/user_manual/98/2e/fa/4b/e0/82/43/b7/DM00105823.pdf/files/DM00105823.pdf/jcr:content/translations/en.DM00105823.pdf) |
+
+## Flashing the device
+
+The ST Nucleo-L476RG board includes an on-board ST-LINK V2 programmer. The
+easiest way to program the board is to use OpenOCD. Once you have installed
+OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
+installation instructions), you can flash the board simply by typing
+
+```
+make BOARD=nucleo-l476rg flash
+```
+and debug via GDB by simply typing
+```
+make BOARD=nucleo-l476rg debug
+```
+
+
+## Supported Toolchains
+
+For using the ST Nucleo-L476RG board we strongly recommend the usage of the
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
+toolchain.
  */

--- a/cpu/stm32_common/include/can_params.h
+++ b/cpu/stm32_common/include/can_params.h
@@ -39,18 +39,26 @@ static const can_conf_t candev_conf[] = {
         .irqn = CEC_CAN_IRQn,
 #else
         .can = CAN1,
+#if defined(CPU_FAM_STM32L4)
+        .rcc_mask = RCC_APB1ENR1_CAN1EN,
+#else
         .rcc_mask = RCC_APB1ENR_CAN1EN,
         .can_master = CAN1,
         .master_rcc_mask = RCC_APB1ENR_CAN1EN,
         .first_filter = 0,
         .nb_filters = 14,
-#ifndef CPU_FAM_STM32F1
+#endif
+#if  defined(CPU_FAM_STM32F1)
+        .rx_pin = GPIO_PIN(PORT_A, 11),
+        .tx_pin = GPIO_PIN(PORT_A, 12),
+#elif defined(CPU_FAM_STM32L4)
+        .rx_pin = GPIO_PIN(PORT_B, 8),
+        .tx_pin = GPIO_PIN(PORT_B, 9),
+        .af = GPIO_AF9,
+#else
         .rx_pin = GPIO_PIN(PORT_D, 0),
         .tx_pin = GPIO_PIN(PORT_D, 1),
         .af = GPIO_AF9,
-#else
-        .rx_pin = GPIO_PIN(PORT_A, 11),
-        .tx_pin = GPIO_PIN(PORT_A, 12),
 #endif
         .tx_irqn = CAN1_TX_IRQn,
         .rx0_irqn = CAN1_RX0_IRQn,

--- a/cpu/stm32_common/include/candev_stm32.h
+++ b/cpu/stm32_common/include/candev_stm32.h
@@ -41,7 +41,8 @@ extern "C" {
 #define CANDEV_STM32_CHAN_NUMOF 3
 #elif defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
 #define CANDEV_STM32_CHAN_NUMOF 2
-#elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || DOXYGEN
+#elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
+      defined(CPU_FAM_STM32L4) || DOXYGEN
 /** Number of channels in the device (up to 3) */
 #define CANDEV_STM32_CHAN_NUMOF 1
 #else


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
fix #13258 

CAN driver has been added to the STM32 target since commit ae95137f9523. As reported by @vincent-d  it should be work with other STM32' CPUs

I'm trying to extend the support of [priph_can](https://github.com/RIOT-OS/RIOT/blob/master/cpu/stm32_common/periph/can.c) to Nucleo-l476rg:

1. STM32L476RG has only one CAN controller. It's mapped on 
    -  Arduino header CN5: CAN1_RD ( PB_8),  CAN1_TX (PB_9)
    -  Morpho left header CN10: CN5: CAN1_RD ( PA_11),  CAN1_TX (PA_12)
    
   I chose to map the pins on the arduino header (CN5). The alternate function should be AF9 (take a look here to for its [GPIO pin MUX](http://web.eece.maine.edu/~zhu/book/Appendix_I_Alternate_Functions.pdf))
2. I'm using [mcp2551](https://www.microchip.com/wwwproducts/en/en010405) transceiver module, unfortunately, riot-os doesn't have its driver but I did a look to  cf34161789b8a8 42c5c40da9a1 and I should be able to add the missing driver for mcp2551.

3. Goals:
    - I have a couple of Nucleo-l476rg and mcp2551 I would like to try to communicate with each other.
    - I new of RIOT-OS and I never worked with CAN before so I've two questions:

    1. I need the first comment about stm32's periph_can. (It seems to be ok, `can list` shows the registered can periph, )
    2. Supposing that my transceiver was one of two supported by Riot-os I don't understand how to configure it to make it working on my setup. I take I look here  [tests/can_trx](https://github.com/RIOT-OS/RIOT/blob/master/tests/can_trx/main.c) but  I don't understand how to "init code" must be integrated into my case.

thanks

This output is generated by these commits with example [conn_can](https://github.com/RIOT-OS/RIOT/tree/master/tests/conn_can)
```
> reboot
candev_stm32 0x20005a90: power up
turn on (0x20005a90)
main(): This is RIOT! (Version: 2020.04-devel-842-g10af63-stm32l4_can_dev_MASTER)
0: launching receive_thread
1: launching receive_thread
RIOT-OS, MCU=stm32l4 Board=nucleo-l476rg
> ps
	pid | state    Q | pri 
	  1 | pending  Q |  15
	  2 | running  Q |   7
	  3 | bl rx    _ |   5
	  4 | bl rx    _ |   4
	  5 | bl rx    _ |   6
	  6 | bl rx    _ |   6
> help
Command              Description
---------------------------------------
test_can             Test CAN functions
reboot               Reboot the node
ps                   Prints information about running threads.
can                  CAN commands
> can list
CAN #0: can_stm32_0
>
> test_can power_up ifnum 0
candev_stm32 0x20005a90: power up
turn on (0x20005a90)
DIS int (0) (0x20005a90)
> candev_stm32 0x20005a90: power down
turn off (0x20005a90)

> can                    
usage: can <command> [arguments]
commands:
	list
	send ifnum id [B1 .. B8]
	dump ifnum nb ms [id1[:mask1][,id2[:mask2], .. id10:[mask10]]
> can send 0 0x0
candev_stm32 0x20005a90: power up
turn on (0x20005a90)
DIS int (0) (0x20005a90)
_send: candev=0x20005a90, frame=0x20003498
sce irq: error passive
sce irq: bus-off
sce irq: bus-off
...
...
....
sce irq: bus-off
sce irq: bus-off
sce irq: bus-off
tx irq
> sce irq: bus-off
candev_stm32 0x20005a90: power down
turn off (0x20005a90)

> 
```
 
