### PR TITLE
boards/cc1312-launchpad: add OpenOCD configuration

### DIFF
--- a/boards/cc1312-launchpad/Makefile.include
+++ b/boards/cc1312-launchpad/Makefile.include
@@ -8,4 +8,4 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # configure the flash tool
-include $(RIOTMAKE)/tools/uniflash.inc.mk
+include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/cc1312-launchpad/doc.txt
+++ b/boards/cc1312-launchpad/doc.txt
@@ -40,7 +40,9 @@ provides the default pinout for the board.
 The LAUNCHXL-CC1312R1 comes with an XDS110 on-board debug probe that provides
 programming, flashing and debugging capabilities.
 
-### Installing CCS and Uniflash
+### Using TI tools
+
+#### Installing CCS and Uniflash
 
 The TI's Code Composer Studio provides the necessary tools to use the debug
 features of the XDS110; Uniflash provides flashing tools. Both programs can
@@ -53,7 +55,7 @@ Before using the XDS110 with the latest CCS/Uniflash versions the firmware for
 it needs to be updated. Texas Instruments has a guide to correctly update it
 [here](http://software-dl.ti.com/ccs/esd/documents/xdsdebugprobes/emu_xds110.html#updating-the-xds110-firmware).
 
-### Setting up the environment
+#### Setting up the environment
 
 In order to make use of the programming and debugging capabilities of the XDS110
 some environment variable needs to be set:
@@ -81,9 +83,40 @@ make debug
 
 It will open GDB and connect to the debug server automatically.
 
-### Reset
+#### Reset
 
 The LAUNCHXL-CC1312R1 provides a reset button but it can also be reset from
 a computer using the `make reset` command.
+
+### Using OpenOCD
+
+To use OpenOCD with the XDS110 you need to use the an special version of
+OpenOCD made by TI (upstream version is not _yet_ compatible). You can
+clone and compile it from source:
+
+```
+# Clone into the openocd-ti folder
+git clone https://git.ti.com/cgit/sdo-emu/openocd openocd-ti
+
+# Change directory to the openocd source code
+cd openocd-ti/openocd
+
+# Configure, build, install
+./configure
+make
+sudo make install
+```
+
+#### Setting up the environment
+
+Now that we have the TI version of OpenOCD we need to export the `PROGRAMMER`
+environment variable, this is to enable OpenOCD instead of Uniflash.
+
+```
+export PROGRAMMER=openocd
+```
+
+Now we can just do `make debug-server` and then `make debug`, this all using
+OpenOCD.
 
 */

--- a/boards/cc1352-launchpad/Makefile.include
+++ b/boards/cc1352-launchpad/Makefile.include
@@ -8,4 +8,4 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # configure the flash tool
-include $(RIOTMAKE)/tools/uniflash.inc.mk
+include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/common/cc26x2_cc13x2/Makefile.include
+++ b/boards/common/cc26x2_cc13x2/Makefile.include
@@ -1,0 +1,10 @@
+# configure the flash tool
+PROGRAMMER ?= uniflash
+
+OPENOCD_CONFIG ?= $(RIOTBOARD)/common/cc26x2_cc13x2/dist/openocd.cfg
+
+ifeq ($(PROGRAMMER),uniflash)
+  include $(RIOTMAKE)/tools/uniflash.inc.mk
+else ifeq ($(PROGRAMMER),openocd)
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+endif

--- a/boards/common/cc26x2_cc13x2/dist/openocd.cfg
+++ b/boards/common/cc26x2_cc13x2/dist/openocd.cfg
@@ -1,0 +1,11 @@
+source [find interface/xds110.cfg]
+
+transport select jtag
+gdb_memory_map enable
+gdb_flash_program enable
+
+source [find target/ti_cc26x2.cfg]
+
+adapter_nsrst_assert_width 250
+adapter_nsrst_delay 400
+adapter_khz 1000


### PR DESCRIPTION
### Contribution description

This enables OpenOCD for the CC1312 LaunchPad.

All we need is:

- The Texas Instruments version of OpenOCD
  (https://git.ti.com/cgit/sdo-emu/openocd)
- Set the `PROGRAMMER` environment variable to `openocd`.
- Connect a `cc1312-launchpad` and play with the commands.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
