### PR TITLE
cpu/sam0_common: mitigate rounding errors of SPI baud rate calculation

### DIFF
--- a/boards/samr30-xpro/include/board.h
+++ b/boards/samr30-xpro/include/board.h
@@ -36,7 +36,7 @@ extern "C" {
 #define AT86RF2XX_PARAM_INT         GPIO_PIN(PB, 0)
 #define AT86RF2XX_PARAM_SLEEP       GPIO_PIN(PA, 20)
 #define AT86RF2XX_PARAM_RESET       GPIO_PIN(PB, 15)
-#define AT86RF2XX_PARAM_SPI_CLK     SPI_CLK_1MHZ
+#define AT86RF2XX_PARAM_SPI_CLK     SPI_CLK_5MHZ
 /** @}*/
 
 /**

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -103,8 +103,11 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 
     /* configure bus clock, in synchronous mode its calculated from
      * BAUD.reg = (f_ref / (2 * f_bus) - 1)
-     * with f_ref := CLOCK_CORECLOCK as defined by the board */
-    const uint8_t baud = (sam0_gclk_freq(spi_config[bus].gclk_src) / (2 * clk) - 1);
+     * with f_ref := CLOCK_CORECLOCK as defined by the board
+     * to mitigate the rounding error due to integer arithmetic, the
+     * equation is modified to
+     * BAUD.reg = ((f_ref + f_bus) / (2 * f_bus) - 1) */
+    const uint8_t baud = ((sam0_gclk_freq(spi_config[bus].gclk_src) + clk) / (2 * clk) - 1);
 
     /* configure device to be master and set mode and pads,
      *


### PR DESCRIPTION

### Contribution description

After the merge of #13526 @benpicco pointed out that there is room for improvement of the SPI baud rate calculation. This PR implements his proposed formula.

I checked this using a spread sheet. I highlighted cells with a higher frequency than expected resp. desired if the CPU is clocked with 16MHz. Those configurations may cause communication errors since the peripheral may not handle the high SPI clock.

![baud rate comparison](https://user-images.githubusercontent.com/6105784/75772361-146ff280-5d4c-11ea-9c8c-cd7e842b67e7.png)

Furthermore, I reverted the commit of #13526. The desired frequency of 5MHz now results into 4MHz, not 8MHz.

### Testing procedure

`examples/gnrc_networking` should work of the `samr30-xpro` board.


### Issues/PRs references

#13526 