### PR TITLE
cpu/samd5x: allow to use XOSC as clock source

### DIFF
--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -65,6 +65,12 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
  * @name Timer peripheral configuration
  * @{
  */

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -27,9 +27,42 @@ extern "C" {
 #endif
 
 /**
- * @brief   GCLK reference speed
+ * @brief   Use the external oscillator to source all fast clocks.
+ *          This allows us to use the buck voltage regulator for
+ *          maximum power efficiency, but limits the maximum clock
+ *          frequency to 12 MHz.
  */
-#define CLOCK_CORECLOCK     (120000000U)
+#ifndef USE_XOSC_ONLY
+#define USE_XOSC_ONLY       (0)
+#endif
+
+/**
+ * @name    external Oscillator (XOSC1) configuration
+ * @{
+ */
+#define XOSC1_FREQUENCY     MHZ(12)
+/** @} */
+
+/**
+ * @name    desired core clock frequency
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+#if USE_XOSC_ONLY
+#define CLOCK_CORECLOCK     XOSC1_FREQUENCY
+#else
+#define CLOCK_CORECLOCK     MHZ(120)
+#endif
+#endif
+/** @} */
+
+/**
+ * @name    32kHz Oscillator configuration
+ * @{
+ */
+#define EXTERNAL_OSC32_SOURCE                    1
+#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      0
+/** @} */
 
 /**
  * @name Timer peripheral configuration
@@ -215,16 +248,6 @@ static const i2c_conf_t i2c_config[] = {
 };
 
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
-/** @} */
-
-
-/**
- * @name    RTC configuration
- * @{
- */
-#define EXTERNAL_OSC32_SOURCE                    1
-#define INTERNAL_OSC32_SOURCE                    0
-#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      0
 /** @} */
 
 /**

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -81,7 +81,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBAMASK.reg,
         .mclk_mask      = MCLK_APBAMASK_TC0 | MCLK_APBAMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = SAM0_GCLK_8MHZ,
+        .gclk_src       = SAM0_GCLK_TIMER,
         .flags          = TC_CTRLA_MODE_COUNT32,
     },
     {   /* Timer 1 */
@@ -90,7 +90,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBBMASK.reg,
         .mclk_mask      = MCLK_APBBMASK_TC2 | MCLK_APBBMASK_TC3,
         .gclk_id        = TC2_GCLK_ID,
-        .gclk_src       = SAM0_GCLK_8MHZ,
+        .gclk_src       = SAM0_GCLK_TIMER,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };
@@ -123,7 +123,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = SAM0_GCLK_48MHZ,
+        .gclk_src = SAM0_GCLK_PERIPH,
     },
     {    /* EXT1 */
         .dev      = &SERCOM0->USART,
@@ -137,7 +137,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = SAM0_GCLK_48MHZ,
+        .gclk_src = SAM0_GCLK_PERIPH,
     },
     {    /* EXT2 */
         .dev      = &SERCOM5->USART,
@@ -151,7 +151,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = SAM0_GCLK_48MHZ,
+        .gclk_src = SAM0_GCLK_PERIPH,
     },
     {    /* EXT3 */
         .dev      = &SERCOM1->USART,
@@ -165,7 +165,7 @@ static const uart_conf_t uart_config[] = {
         .rx_pad   = UART_PAD_RX_1,
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
-        .gclk_src = SAM0_GCLK_48MHZ,
+        .gclk_src = SAM0_GCLK_PERIPH,
     }
 };
 
@@ -200,7 +200,7 @@ static const spi_conf_t spi_config[] = {
         .clk_mux  = GPIO_MUX_D,
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
-        .gclk_src = SAM0_GCLK_48MHZ,
+        .gclk_src = SAM0_GCLK_PERIPH,
 #ifdef MODULE_PERIPH_DMA
         .tx_trigger = SERCOM4_DMAC_ID_TX,
         .rx_trigger = SERCOM4_DMAC_ID_RX,
@@ -239,7 +239,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PA, 23),
         .sda_pin  = GPIO_PIN(PA, 22),
         .mux      = GPIO_MUX_C,
-        .gclk_src = SAM0_GCLK_48MHZ,
+        .gclk_src = SAM0_GCLK_PERIPH,
         .flags    = I2C_FLAG_NONE
     },
     {    /* EXT2, EXT3 */
@@ -248,7 +248,7 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin  = GPIO_PIN(PD, 9),
         .sda_pin  = GPIO_PIN(PD, 8),
         .mux      = GPIO_MUX_C,
-        .gclk_src = SAM0_GCLK_48MHZ,
+        .gclk_src = SAM0_GCLK_PERIPH,
         .flags    = I2C_FLAG_NONE
     }
 };
@@ -275,7 +275,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .dp     = GPIO_PIN(PA, 25),
         .d_mux  = GPIO_MUX_H,
         .device = &USB->DEVICE,
-        .gclk_src = SAM0_GCLK_48MHZ,
+        .gclk_src = SAM0_GCLK_PERIPH,
     }
 };
 /** @} */
@@ -285,7 +285,7 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
  * @{
  */
                             /* Must not exceed 12 MHz */
-#define DAC_CLOCK           SAM0_GCLK_8MHZ
+#define DAC_CLOCK           SAM0_GCLK_TIMER
                             /* Use external reference voltage on PA03 */
                             /* (You have to manually connect PA03 with Vcc) */
                             /* Internal reference only gives 1V */

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -31,6 +31,14 @@
 #define USE_VREG_BUCK   (0)
 #endif
 
+/*
+ * An external inductor needs to be present on the board,
+ * so the feature can only be enabled by the board configuration.
+ */
+#ifndef USE_VREG_BUCK
+#define USE_VREG_BUCK   (0)
+#endif
+
 #if CLOCK_CORECLOCK == 0
 #error Please select CLOCK_CORECLOCK
 #endif
@@ -290,6 +298,9 @@ void cpu_pm_cb_leave(int deep)
  */
 void cpu_init(void)
 {
+    /* CPU starts with DFLL48 as clock source, so we must use the LDO */
+    sam0_set_voltage_regulator(SAM0_VREG_LDO);
+
     /* Disable the RTC module to prevent synchronization issues during CPU init
        if the RTC was running from a previous boot (e.g wakeup from backup) */
     if (RTC->MODE2.CTRLA.bit.ENABLE) {
@@ -361,6 +372,11 @@ void cpu_init(void)
     /* make sure fast clocks are off */
     if (!USE_DFLL) {
         OSCCTRL->DFLLCTRLA.reg = 0;
+    }
+
+    /* when fast internal oscillators are not used, we can turn on the buck converter */
+    if (!USE_DFLL && !USE_DPLL && USE_VREG_BUCK) {
+        sam0_set_voltage_regulator(SAM0_VREG_BUCK);
     }
 
 #ifdef MODULE_PERIPH_DMA

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -223,27 +223,27 @@ void sam0_gclk_enable(uint8_t id)
     /* clocks 0 & 1 are always running */
 
     switch (id) {
-    case SAM0_GCLK_8MHZ:
+    case SAM0_GCLK_TIMER:
         /* 8 MHz clock used by xtimer */
         if (USE_DPLL) {
-            gclk_connect(SAM0_GCLK_8MHZ,
+            gclk_connect(SAM0_GCLK_TIMER,
                          GCLK_SOURCE_DPLL0,
                          GCLK_GENCTRL_DIV(DPLL_DIV * CLOCK_CORECLOCK / MHZ(8)));
         } else if (USE_DFLL) {
-            gclk_connect(SAM0_GCLK_8MHZ,
+            gclk_connect(SAM0_GCLK_TIMER,
                          GCLK_SOURCE_DFLL,
                          GCLK_GENCTRL_DIV(SAM0_DFLL_FREQ_HZ / MHZ(8)));
         } else if (USE_XOSC) {
-            gclk_connect(SAM0_GCLK_8MHZ,
+            gclk_connect(SAM0_GCLK_TIMER,
                          GCLK_SOURCE_ACTIVE_XOSC,
                          GCLK_GENCTRL_DIV(SAM0_XOSC_FREQ_HZ / MHZ(4)));
         }
         break;
-    case SAM0_GCLK_48MHZ:
+    case SAM0_GCLK_PERIPH:
         if (USE_DFLL) {
-            gclk_connect(SAM0_GCLK_48MHZ, GCLK_SOURCE_DFLL, 0);
+            gclk_connect(SAM0_GCLK_PERIPH, GCLK_SOURCE_DFLL, 0);
         } else if (USE_XOSC) {
-            gclk_connect(SAM0_GCLK_48MHZ, GCLK_SOURCE_ACTIVE_XOSC, 0);
+            gclk_connect(SAM0_GCLK_PERIPH, GCLK_SOURCE_ACTIVE_XOSC, 0);
         }
 
         break;
@@ -257,13 +257,13 @@ uint32_t sam0_gclk_freq(uint8_t id)
         return CLOCK_CORECLOCK;
     case SAM0_GCLK_32KHZ:
         return 32768;
-    case SAM0_GCLK_8MHZ:
+    case SAM0_GCLK_TIMER:
         if (USE_XOSC) {
             return MHZ(4);
         } else {
             return MHZ(8);
         }
-    case SAM0_GCLK_48MHZ:
+    case SAM0_GCLK_PERIPH:
         if (USE_DFLL) {
             return SAM0_DFLL_FREQ_HZ;
         } else if (USE_XOSC) {

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -71,12 +71,20 @@
 #define USE_DFLL 0
 #define USE_XOSC 1
 
+#ifndef GCLK_TIMER_HZ
+#define GCLK_TIMER_HZ   MHZ(4)
+#endif
+
 #else /* !USE_XOSC_ONLY */
 
 /* Main clock > 48 MHz -> use DPLL, otherwise use DFLL */
 #define USE_DPLL (CLOCK_CORECLOCK > SAM0_DFLL_FREQ_HZ)
 #define USE_DFLL 1
 #define USE_XOSC 0
+
+#ifndef GCLK_TIMER_HZ
+#define GCLK_TIMER_HZ   MHZ(8)
+#endif
 
 #endif /* USE_XOSC_ONLY */
 
@@ -228,15 +236,15 @@ void sam0_gclk_enable(uint8_t id)
         if (USE_DPLL) {
             gclk_connect(SAM0_GCLK_TIMER,
                          GCLK_SOURCE_DPLL0,
-                         GCLK_GENCTRL_DIV(DPLL_DIV * CLOCK_CORECLOCK / MHZ(8)));
+                         GCLK_GENCTRL_DIV(DPLL_DIV * CLOCK_CORECLOCK / GCLK_TIMER_HZ));
         } else if (USE_DFLL) {
             gclk_connect(SAM0_GCLK_TIMER,
                          GCLK_SOURCE_DFLL,
-                         GCLK_GENCTRL_DIV(SAM0_DFLL_FREQ_HZ / MHZ(8)));
+                         GCLK_GENCTRL_DIV(SAM0_DFLL_FREQ_HZ / GCLK_TIMER_HZ));
         } else if (USE_XOSC) {
             gclk_connect(SAM0_GCLK_TIMER,
                          GCLK_SOURCE_ACTIVE_XOSC,
-                         GCLK_GENCTRL_DIV(SAM0_XOSC_FREQ_HZ / MHZ(4)));
+                         GCLK_GENCTRL_DIV(SAM0_XOSC_FREQ_HZ / GCLK_TIMER_HZ));
         }
         break;
     case SAM0_GCLK_PERIPH:
@@ -258,11 +266,7 @@ uint32_t sam0_gclk_freq(uint8_t id)
     case SAM0_GCLK_32KHZ:
         return 32768;
     case SAM0_GCLK_TIMER:
-        if (USE_XOSC) {
-            return MHZ(4);
-        } else {
-            return MHZ(8);
-        }
+        return GCLK_TIMER_HZ;
     case SAM0_GCLK_PERIPH:
         if (USE_DFLL) {
             return SAM0_DFLL_FREQ_HZ;

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -22,6 +22,7 @@
 
 #include <limits.h>
 
+#include "macros/units.h"
 #include "periph_cpu_common.h"
 
 #ifdef __cplusplus
@@ -31,7 +32,7 @@ extern "C" {
 /**
  * @brief   DFLL runs at at fixed frequency of 48 MHz
  */
-#define SAM0_DFLL_FREQ_HZ       (48000000U)
+#define SAM0_DFLL_FREQ_HZ       MHZ(48)
 
 /**
 ￼ * @brief   XOSC is used to generate a fixed frequency of 48 MHz
@@ -41,12 +42,12 @@ extern "C" {
 /**
  * @brief   DPLL must run with at least 96 MHz
  */
-#define SAM0_DPLL_FREQ_MIN_HZ   (96000000U)
+#define SAM0_DPLL_FREQ_MIN_HZ   MHZ(96)
 
 /**
  * @brief   DPLL frequency must not exceed 200 MHz
  */
-#define SAM0_DPLL_FREQ_MAX_HZ   (200000000U)
+#define SAM0_DPLL_FREQ_MAX_HZ   MHZ(20)
 
 /**
  * @name    Power mode configuration

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -34,6 +34,11 @@ extern "C" {
 #define SAM0_DFLL_FREQ_HZ       (48000000U)
 
 /**
+￼ * @brief   XOSC is used to generate a fixed frequency of 48 MHz
+￼ */
+#define SAM0_XOSC_FREQ_HZ       (XOSC0_FREQUENCY ? XOSC0_FREQUENCY : XOSC1_FREQUENCY)
+
+/**
  * @brief   DPLL must run with at least 96 MHz
  */
 #define SAM0_DPLL_FREQ_MIN_HZ   (96000000U)

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -61,11 +61,19 @@ extern "C" {
  * @{
  */
 enum {
-    SAM0_GCLK_MAIN = 0,                 /**< 120 MHz main clock     */
-    SAM0_GCLK_32KHZ,                    /**< 32 kHz clock           */
-    SAM0_GCLK_8MHZ,                     /**< 8 MHz clock for xTimer */
-    SAM0_GCLK_48MHZ,                    /**< 48 MHz DFLL clock      */
+    SAM0_GCLK_MAIN = 0,                 /**< 120 MHz main clock       */
+    SAM0_GCLK_32KHZ,                    /**< 32 kHz clock             */
+    SAM0_GCLK_TIMER,                    /**< 4-8 MHz clock for xTimer */
+    SAM0_GCLK_PERIPH,                   /**< 12-48 MHz (DFLL) clock   */
 };
+/** @} */
+
+/**
+ * @name   GCLK compatibility definitions
+ * @{
+ */
+#define SAM0_GCLK_8MHZ      SAM0_GCLK_TIMER
+#define SAM0_GCLK_48MHZ     SAM0_GCLK_PERIPH
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

Allow to run the main clock and all peripheral clocks off XOSC.
This is necessary if we want to use the buck voltage regulator.

### Testing procedure

`same54-xpro` should still work

 - with `USE_XOSC_ONLY = 0`, `CLOCK_CORECLOCK = MHZ(120)` (default configuration, DPLL & DFLL in use)
 - with `USE_XOSC_ONLY = 0`, `CLOCK_CORECLOCK = MHZ(48)` (only DFLL is used)
 - with `USE_XOSC_ONLY = 1`, `CLOCK_CORECLOCK = MHZ(12)` (only XOSC0 is used)

### Issues/PRs references

split off and cleaned up from #13441