### PR TITLE
auto_init: some more cleanup and unification

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -24,9 +24,6 @@
 #include "auto_init.h"
 #include "log.h"
 
-#define ENABLE_DEBUG (0)
-#include "debug.h"
-
 void auto_init(void)
 {
 #ifdef MODULE_AUTO_INIT_RANDOM
@@ -596,7 +593,7 @@ void auto_init(void)
 #endif /* MODULE_AUTO_INIT_DHCPV6_CLIENT */
 
 #ifdef MODULE_GNRC_DHCPV6_CLIENT_6LBR
-    DEBUG("auto_init 6LoWPAN border router DHCPv6 client");
+    LOG_DEBUG("Auto init 6LoWPAN border router DHCPv6 client\n");
     extern void gnrc_dhcpv6_client_6lbr_init(void);
     gnrc_dhcpv6_client_6lbr_init();
 #endif /* MODULE_GNRC_DHCPV6_CLIENT_6LBR */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -16,6 +16,7 @@
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  * @}
  */
 #include <stdint.h>
@@ -24,142 +25,12 @@
 #include "auto_init.h"
 #include "log.h"
 
-void auto_init(void)
-{
-#ifdef MODULE_AUTO_INIT_RANDOM
-    LOG_DEBUG("Auto init random.\n");
-    extern void auto_init_random(void);
-    auto_init_random();
-#endif
-#ifdef MODULE_AUTO_INIT_XTIMER
-    LOG_DEBUG("Auto init xtimer.\n");
-    extern void xtimer_init(void);
-    xtimer_init();
-#endif
-#ifdef MODULE_SCHEDSTATISTICS
-    LOG_DEBUG("Auto init schedstatistics.\n");
-    extern void init_schedstatistics(void);
-    init_schedstatistics();
-#endif
-#ifdef MODULE_EVENT_THREAD
-    LOG_DEBUG("Auto init event threads.\n");
-    extern void auto_init_event_thread(void);
-    auto_init_event_thread();
-#endif
-#ifdef MODULE_MCI
-    LOG_DEBUG("Auto init mci.\n");
-    extern void mci_initialize(void);
-    mci_initialize();
-#endif
-#ifdef MODULE_PROFILING
-    LOG_DEBUG("Auto init profiling.\n");
-    extern void profiling_init(void);
-    profiling_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
-    LOG_DEBUG("Auto init gnrc_pktbuf.\n");
-    extern void gnrc_pktbuf_init(void);
-    gnrc_pktbuf_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
-    LOG_DEBUG("Auto init gnrc_pktdump.\n");
-    extern void gnrc_pktdump_init(void);
-    gnrc_pktdump_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
-    LOG_DEBUG("Auto init gnrc_sixlowpan.\n");
-    extern void gnrc_sixlowpan_init(void);
-    gnrc_sixlowpan_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_IPV6
-    LOG_DEBUG("Auto init gnrc_ipv6.\n");
-    extern void gnrc_ipv6_init(void);
-    gnrc_ipv6_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_UDP
-    LOG_DEBUG("Auto init gnrc_udp.\n");
-    extern void gnrc_udp_init(void);
-    gnrc_udp_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_TCP
-    LOG_DEBUG("Auto init gnrc_tcp.\n");
-    extern void gnrc_tcp_init(void);
-    gnrc_tcp_init();
-#endif
-#ifdef MODULE_AUTO_INIT_LWIP
-    LOG_DEBUG("Bootstraping lwIP.\n");
-    extern void lwip_bootstrap(void);
-    lwip_bootstrap();
-#endif
-#ifdef MODULE_OPENTHREAD
-    LOG_DEBUG("Bootstrapping openthread.\n");
-    extern void openthread_bootstrap(void);
-    openthread_bootstrap();
-#endif
-#ifdef MODULE_GCOAP
-    if (!IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
-        LOG_DEBUG("Auto init gcoap.\n");
-        extern void gcoap_init(void);
-        gcoap_init();
-    }
-#endif
-#ifdef MODULE_DEVFS
-    LOG_DEBUG("Mounting /dev.\n");
-    extern void auto_init_devfs(void);
-    auto_init_devfs();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
-    LOG_DEBUG("Auto init gnrc_ipv6_nib.\n");
-    extern void gnrc_ipv6_nib_init(void);
-    gnrc_ipv6_nib_init();
-#endif
-#ifdef MODULE_SKALD
-    LOG_DEBUG("Auto init Skald.\n");
-    extern void skald_init(void);
-    skald_init();
-#endif
-#ifdef MODULE_CORD_COMMON
-    LOG_DEBUG("Auto init cord_common.\n");
-    extern void cord_common_init(void);
-    cord_common_init();
-#endif
-#ifdef MODULE_CORD_EP_STANDALONE
-    LOG_DEBUG("Auto init cord_ep_standalone.\n");
-    extern void cord_ep_standalone_run(void);
-    cord_ep_standalone_run();
-#endif
-#ifdef MODULE_ASYMCUTE
-    LOG_DEBUG("Auto init Asymcute.\n");
-    extern void asymcute_handler_run(void);
-    asymcute_handler_run();
-#endif
-#ifdef MODULE_NIMBLE
-    LOG_DEBUG("Auto init NimBLE.\n");
-    extern void nimble_riot_init(void);
-    nimble_riot_init();
-#endif
-#ifdef MODULE_AUTO_INIT_LORAMAC
-    LOG_DEBUG("Auto init loramac.\n");
-    extern void auto_init_loramac(void);
-    auto_init_loramac();
-#endif
-#ifdef MODULE_SOCK_DTLS
-    LOG_DEBUG("Auto init sock_dtls.\n");
-    extern void sock_dtls_init(void);
-    sock_dtls_init();
-#endif
-
-/* initialize USB devices */
-#ifdef MODULE_AUTO_INIT_USBUS
-    LOG_DEBUG("Auto init USB.\n");
-    extern void auto_init_usb(void);
-    auto_init_usb();
-#endif
-
-/* initialize network devices */
 #ifdef MODULE_AUTO_INIT_GNRC_NETIF
-    LOG_DEBUG("Auto init gnrc_netif.\n");
-
+/**
+ * @brief   Initializes network devices
+ */
+static void _auto_init_gnrc_netif(void)
+{
 #ifdef MODULE_STM32_ETH
     extern void auto_init_stm32_eth(void);
     auto_init_stm32_eth();
@@ -281,36 +152,15 @@ void auto_init(void)
     extern void auto_init_nrf802154(void);
     auto_init_nrf802154();
 #endif
-
+}
 #endif /* MODULE_AUTO_INIT_GNRC_NETIF */
 
-#ifdef MODULE_AUTO_INIT_GNRC_UHCPC
-    LOG_DEBUG("Auto init gnrc_uhcpc.\n");
-    extern void auto_init_gnrc_uhcpc(void);
-    auto_init_gnrc_uhcpc();
-#endif
-
-/* initialize NDN module after the network devices are initialized */
-#ifdef MODULE_NDN_RIOT
-    LOG_DEBUG("Auto init NDN.\n");
-    extern void ndn_init(void);
-    ndn_init();
-#endif
-
-/* initialize sensors and actuators */
-#ifdef MODULE_SHT1X
-    /* The sht1x module needs to be initialized regardless of SAUL being used,
-     * as the shell commands rely on auto-initialization. auto_init_sht1x also
-     * performs SAUL registration, but only if module auto_init_saul is used.
-     */
-    LOG_DEBUG("Auto init sht1x.\n");
-    extern void auto_init_sht1x(void);
-    auto_init_sht1x();
-#endif
-
 #ifdef MODULE_AUTO_INIT_SAUL
-    LOG_DEBUG("Auto init SAUL.\n");
-
+/**
+ * @brief   Initializes sensors and actuators for SAUL
+ */
+void _auto_init_saul(void)
+{
 #ifdef MODULE_SAUL_ADC
     extern void auto_init_adc(void);
     auto_init_adc();
@@ -536,6 +386,173 @@ void auto_init(void)
     auto_init_veml6070();
 #endif
 
+}
+#endif /* MODULE_AUTO_INIT_SAUL*/
+
+void auto_init(void)
+{
+#ifdef MODULE_AUTO_INIT_RANDOM
+    LOG_DEBUG("Auto init random.\n");
+    extern void auto_init_random(void);
+    auto_init_random();
+#endif
+#ifdef MODULE_AUTO_INIT_XTIMER
+    LOG_DEBUG("Auto init xtimer.\n");
+    extern void xtimer_init(void);
+    xtimer_init();
+#endif
+#ifdef MODULE_SCHEDSTATISTICS
+    LOG_DEBUG("Auto init schedstatistics.\n");
+    extern void init_schedstatistics(void);
+    init_schedstatistics();
+#endif
+#ifdef MODULE_EVENT_THREAD
+    LOG_DEBUG("Auto init event threads.\n");
+    extern void auto_init_event_thread(void);
+    auto_init_event_thread();
+#endif
+#ifdef MODULE_MCI
+    LOG_DEBUG("Auto init mci.\n");
+    extern void mci_initialize(void);
+    mci_initialize();
+#endif
+#ifdef MODULE_PROFILING
+    LOG_DEBUG("Auto init profiling.\n");
+    extern void profiling_init(void);
+    profiling_init();
+#endif
+#ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
+    LOG_DEBUG("Auto init gnrc_pktbuf.\n");
+    extern void gnrc_pktbuf_init(void);
+    gnrc_pktbuf_init();
+#endif
+#ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
+    LOG_DEBUG("Auto init gnrc_pktdump.\n");
+    extern void gnrc_pktdump_init(void);
+    gnrc_pktdump_init();
+#endif
+#ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
+    LOG_DEBUG("Auto init gnrc_sixlowpan.\n");
+    extern void gnrc_sixlowpan_init(void);
+    gnrc_sixlowpan_init();
+#endif
+#ifdef MODULE_AUTO_INIT_GNRC_IPV6
+    LOG_DEBUG("Auto init gnrc_ipv6.\n");
+    extern void gnrc_ipv6_init(void);
+    gnrc_ipv6_init();
+#endif
+#ifdef MODULE_AUTO_INIT_GNRC_UDP
+    LOG_DEBUG("Auto init gnrc_udp.\n");
+    extern void gnrc_udp_init(void);
+    gnrc_udp_init();
+#endif
+#ifdef MODULE_AUTO_INIT_GNRC_TCP
+    LOG_DEBUG("Auto init gnrc_tcp.\n");
+    extern void gnrc_tcp_init(void);
+    gnrc_tcp_init();
+#endif
+#ifdef MODULE_AUTO_INIT_LWIP
+    LOG_DEBUG("Bootstraping lwIP.\n");
+    extern void lwip_bootstrap(void);
+    lwip_bootstrap();
+#endif
+#ifdef MODULE_OPENTHREAD
+    LOG_DEBUG("Bootstrapping openthread.\n");
+    extern void openthread_bootstrap(void);
+    openthread_bootstrap();
+#endif
+#ifdef MODULE_GCOAP
+    if (!IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
+        LOG_DEBUG("Auto init gcoap.\n");
+        extern void gcoap_init(void);
+        gcoap_init();
+    }
+#endif
+#ifdef MODULE_DEVFS
+    LOG_DEBUG("Mounting /dev.\n");
+    extern void auto_init_devfs(void);
+    auto_init_devfs();
+#endif
+#ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
+    LOG_DEBUG("Auto init gnrc_ipv6_nib.\n");
+    extern void gnrc_ipv6_nib_init(void);
+    gnrc_ipv6_nib_init();
+#endif
+#ifdef MODULE_SKALD
+    LOG_DEBUG("Auto init Skald.\n");
+    extern void skald_init(void);
+    skald_init();
+#endif
+#ifdef MODULE_CORD_COMMON
+    LOG_DEBUG("Auto init cord_common.\n");
+    extern void cord_common_init(void);
+    cord_common_init();
+#endif
+#ifdef MODULE_CORD_EP_STANDALONE
+    LOG_DEBUG("Auto init cord_ep_standalone.\n");
+    extern void cord_ep_standalone_run(void);
+    cord_ep_standalone_run();
+#endif
+#ifdef MODULE_ASYMCUTE
+    LOG_DEBUG("Auto init Asymcute.\n");
+    extern void asymcute_handler_run(void);
+    asymcute_handler_run();
+#endif
+#ifdef MODULE_NIMBLE
+    LOG_DEBUG("Auto init NimBLE.\n");
+    extern void nimble_riot_init(void);
+    nimble_riot_init();
+#endif
+#ifdef MODULE_AUTO_INIT_LORAMAC
+    LOG_DEBUG("Auto init loramac.\n");
+    extern void auto_init_loramac(void);
+    auto_init_loramac();
+#endif
+#ifdef MODULE_SOCK_DTLS
+    LOG_DEBUG("Auto init sock_dtls.\n");
+    extern void sock_dtls_init(void);
+    sock_dtls_init();
+#endif
+
+/* initialize USB devices */
+#ifdef MODULE_AUTO_INIT_USBUS
+    LOG_DEBUG("Auto init USB.\n");
+    extern void auto_init_usb(void);
+    auto_init_usb();
+#endif
+
+#ifdef MODULE_AUTO_INIT_GNRC_NETIF
+    LOG_DEBUG("Auto init gnrc_netif.\n");
+    _auto_init_gnrc_netif();
+#endif /* MODULE_AUTO_INIT_GNRC_NETIF */
+
+#ifdef MODULE_AUTO_INIT_GNRC_UHCPC
+    LOG_DEBUG("Auto init gnrc_uhcpc.\n");
+    extern void auto_init_gnrc_uhcpc(void);
+    auto_init_gnrc_uhcpc();
+#endif
+
+/* initialize NDN module after the network devices are initialized */
+#ifdef MODULE_NDN_RIOT
+    LOG_DEBUG("Auto init NDN.\n");
+    extern void ndn_init(void);
+    ndn_init();
+#endif
+
+/* initialize sensors and actuators */
+#ifdef MODULE_SHT1X
+    /* The sht1x module needs to be initialized regardless of SAUL being used,
+     * as the shell commands rely on auto-initialization. auto_init_sht1x also
+     * performs SAUL registration, but only if module auto_init_saul is used.
+     */
+    LOG_DEBUG("Auto init sht1x.\n");
+    extern void auto_init_sht1x(void);
+    auto_init_sht1x();
+#endif
+
+#ifdef MODULE_AUTO_INIT_SAUL
+    LOG_DEBUG("Auto init SAUL.\n");
+    _auto_init_saul();
 #endif /* MODULE_AUTO_INIT_SAUL */
 
 #ifdef MODULE_AUTO_INIT_GNRC_RPL

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -23,595 +23,587 @@
 #include <stdio.h>
 
 #include "auto_init.h"
+#include "kernel_defines.h"
 #include "log.h"
 
-#ifdef MODULE_AUTO_INIT_GNRC_NETIF
 /**
  * @brief   Initializes network devices
  */
 static void _auto_init_gnrc_netif(void)
 {
-#ifdef MODULE_STM32_ETH
-    extern void auto_init_stm32_eth(void);
-    auto_init_stm32_eth();
-#endif
+    if (IS_USED(MODULE_STM32_ETH)) {
+        extern void auto_init_stm32_eth(void);
+        auto_init_stm32_eth();
+    }
 
-#ifdef MODULE_AUTO_INIT_AT86RF2XX
-    extern void auto_init_at86rf2xx(void);
-    auto_init_at86rf2xx();
-#endif
+    if (IS_USED(MODULE_AUTO_INIT_AT86RF2XX)) {
+        extern void auto_init_at86rf2xx(void);
+        auto_init_at86rf2xx();
+    }
 
-#ifdef MODULE_MRF24J40
-    extern void auto_init_mrf24j40(void);
-    auto_init_mrf24j40();
-#endif
+    if (IS_USED(MODULE_MRF24J40)) {
+        extern void auto_init_mrf24j40(void);
+        auto_init_mrf24j40();
+    }
 
-#ifdef MODULE_CC110X
-    extern void auto_init_cc110x(void);
-    auto_init_cc110x();
-#endif
+    if (IS_USED(MODULE_CC110X)) {
+        extern void auto_init_cc110x(void);
+        auto_init_cc110x();
+    }
 
-#ifdef MODULE_CC2420
-    extern void auto_init_cc2420(void);
-    auto_init_cc2420();
-#endif
+    if (IS_USED(MODULE_CC2420)) {
+        extern void auto_init_cc2420(void);
+        auto_init_cc2420();
+    }
 
-#ifdef MODULE_ENCX24J600
-    extern void auto_init_encx24j600(void);
-    auto_init_encx24j600();
-#endif
+    if (IS_USED(MODULE_ENCX24J600)) {
+        extern void auto_init_encx24j600(void);
+        auto_init_encx24j600();
+    }
 
-#ifdef MODULE_ENC28J60
-    extern void auto_init_enc28j60(void);
-    auto_init_enc28j60();
-#endif
+    if (IS_USED(MODULE_ENC28J60)) {
+        extern void auto_init_enc28j60(void);
+        auto_init_enc28j60();
+    }
 
-#ifdef MODULE_ESP_ETH
-    extern void auto_init_esp_eth(void);
-    auto_init_esp_eth();
-#endif
+    if (IS_USED(MODULE_ESP_ETH)) {
+        extern void auto_init_esp_eth(void);
+        auto_init_esp_eth();
+    }
 
-/* don't change the order of auto_init_esp_now and auto_init_esp_wifi */
-#ifdef MODULE_ESP_NOW
-    extern void auto_init_esp_now(void);
-    auto_init_esp_now();
-#endif
+    /* don't change the order of auto_init_esp_now and auto_init_esp_wifi */
+    if (IS_USED(MODULE_ESP_NOW)) {
+        extern void auto_init_esp_now(void);
+        auto_init_esp_now();
+    }
 
-/* don't change the order of auto_init_esp_now and auto_init_esp_wifi */
-#ifdef MODULE_ESP_WIFI
-    extern void auto_init_esp_wifi(void);
-    auto_init_esp_wifi();
-#endif
+    /* don't change the order of auto_init_esp_now and auto_init_esp_wifi */
+    if (IS_USED(MODULE_ESP_WIFI)) {
+        extern void auto_init_esp_wifi(void);
+        auto_init_esp_wifi();
+    }
 
-#ifdef MODULE_ETHOS
-    extern void auto_init_ethos(void);
-    auto_init_ethos();
-#endif
+    if (IS_USED(MODULE_ETHOS)) {
+        extern void auto_init_ethos(void);
+        auto_init_ethos();
+    }
 
-#ifdef MODULE_DOSE
-    extern void auto_init_dose(void);
-    auto_init_dose();
-#endif
+    if (IS_USED(MODULE_DOSE)) {
+        extern void auto_init_dose(void);
+        auto_init_dose();
+    }
 
-#ifdef MODULE_SLIPDEV
-    extern void auto_init_slipdev(void);
-    auto_init_slipdev();
-#endif
+    if (IS_USED(MODULE_SLIPDEV)) {
+        extern void auto_init_slipdev(void);
+        auto_init_slipdev();
+    }
 
-#ifdef MODULE_CC2538_RF
-    extern void auto_init_cc2538_rf(void);
-    auto_init_cc2538_rf();
-#endif
+    if (IS_USED(MODULE_CC2538_RF)) {
+        extern void auto_init_cc2538_rf(void);
+        auto_init_cc2538_rf();
+    }
 
-#ifdef MODULE_XBEE
-    extern void auto_init_xbee(void);
-    auto_init_xbee();
-#endif
+    if (IS_USED(MODULE_XBEE)) {
+        extern void auto_init_xbee(void);
+        auto_init_xbee();
+    }
 
-#ifdef MODULE_KW2XRF
-    extern void auto_init_kw2xrf(void);
-    auto_init_kw2xrf();
-#endif
+    if (IS_USED(MODULE_KW2XRF)) {
+        extern void auto_init_kw2xrf(void);
+        auto_init_kw2xrf();
+    }
 
-#ifdef MODULE_USBUS_CDC_ECM
-    extern void auto_init_netdev_cdcecm(void);
-    auto_init_netdev_cdcecm();
-#endif
+    if (IS_USED(MODULE_USBUS_CDC_ECM)) {
+        extern void auto_init_netdev_cdcecm(void);
+        auto_init_netdev_cdcecm();
+    }
 
-#ifdef MODULE_NETDEV_TAP
-    extern void auto_init_netdev_tap(void);
-    auto_init_netdev_tap();
-#endif
+    if (IS_USED(MODULE_NETDEV_TAP)) {
+        extern void auto_init_netdev_tap(void);
+        auto_init_netdev_tap();
+    }
 
-#ifdef MODULE_SOCKET_ZEP
-    extern void auto_init_socket_zep(void);
-    auto_init_socket_zep();
-#endif
+    if (IS_USED(MODULE_SOCKET_ZEP)) {
+        extern void auto_init_socket_zep(void);
+        auto_init_socket_zep();
+    }
 
-#ifdef MODULE_NORDIC_SOFTDEVICE_BLE
-    extern void gnrc_nordic_ble_6lowpan_init(void);
-    gnrc_nordic_ble_6lowpan_init();
-#endif
+    if (IS_USED(MODULE_NORDIC_SOFTDEVICE_BLE)) {
+        extern void gnrc_nordic_ble_6lowpan_init(void);
+        gnrc_nordic_ble_6lowpan_init();
+    }
 
-#ifdef MODULE_NRFMIN
-    extern void gnrc_nrfmin_init(void);
-    gnrc_nrfmin_init();
-#endif
+    if (IS_USED(MODULE_NRFMIN)) {
+        extern void gnrc_nrfmin_init(void);
+        gnrc_nrfmin_init();
+    }
 
-#ifdef MODULE_W5100
-    extern void auto_init_w5100(void);
-    auto_init_w5100();
-#endif
+    if (IS_USED(MODULE_W5100)) {
+        extern void auto_init_w5100(void);
+        auto_init_w5100();
+    }
 
-#if defined(MODULE_SX127X) && !defined(MODULE_SEMTECH_LORAMAC)
-    extern void auto_init_sx127x(void);
-    auto_init_sx127x();
-#endif
+    if (IS_USED(MODULE_SX127X) && !IS_USED(MODULE_SEMTECH_LORAMAC)) {
+        extern void auto_init_sx127x(void);
+        auto_init_sx127x();
+    }
 
-#ifdef MODULE_NRF802154
-    extern void auto_init_nrf802154(void);
-    auto_init_nrf802154();
-#endif
+    if (IS_USED(MODULE_NRF802154)) {
+        extern void auto_init_nrf802154(void);
+        auto_init_nrf802154();
+    }
 }
-#endif /* MODULE_AUTO_INIT_GNRC_NETIF */
 
-#ifdef MODULE_AUTO_INIT_SAUL
 /**
  * @brief   Initializes sensors and actuators for SAUL
  */
 void _auto_init_saul(void)
 {
-#ifdef MODULE_SAUL_ADC
-    extern void auto_init_adc(void);
-    auto_init_adc();
-#endif
-#ifdef MODULE_SAUL_GPIO
-    extern void auto_init_gpio(void);
-    auto_init_gpio();
-#endif
-#ifdef MODULE_SAUL_NRF_TEMPERATURE
-    extern void auto_init_nrf_temperature(void);
-    auto_init_nrf_temperature();
-#endif
-#ifdef MODULE_AD7746
-    extern void auto_init_ad7746(void);
-    auto_init_ad7746();
-#endif
-#ifdef MODULE_ADCXX1C
-    extern void auto_init_adcxx1c(void);
-    auto_init_adcxx1c();
-#endif
-#ifdef MODULE_ADS101X
-    extern void auto_init_ads101x(void);
-    auto_init_ads101x();
-#endif
-#ifdef MODULE_ADXL345
-    extern void auto_init_adxl345(void);
-    auto_init_adxl345();
-#endif
-#ifdef MODULE_BMP180
-    extern void auto_init_bmp180(void);
-    auto_init_bmp180();
-#endif
-#ifdef MODULE_BMX280
-    extern void auto_init_bmx280(void);
-    auto_init_bmx280();
-#endif
-#ifdef MODULE_BMX055
-    extern void auto_init_bmx055(void);
-    auto_init_bmx055();
-#endif
-#ifdef MODULE_CCS811
-    extern void auto_init_ccs811(void);
-    auto_init_ccs811();
-#endif
-#ifdef MODULE_DHT
-    extern void auto_init_dht(void);
-    auto_init_dht();
-#endif
-#ifdef MODULE_DS18
-    extern void auto_init_ds18(void);
-    auto_init_ds18();
-#endif
-#ifdef MODULE_DS75LX
-    extern void auto_init_ds75lx(void);
-    auto_init_ds75lx();
-#endif
-#ifdef MODULE_FXOS8700
-    extern void auto_init_fxos8700(void);
-    auto_init_fxos8700();
-#endif
-#ifdef MODULE_GROVE_LEDBAR
-    extern void auto_init_grove_ledbar(void);
-    auto_init_grove_ledbar();
-#endif
-#ifdef MODULE_HDC1000
-    extern void auto_init_hdc1000(void);
-    auto_init_hdc1000();
-#endif
-#ifdef MODULE_HTS221
-    extern void auto_init_hts221(void);
-    auto_init_hts221();
-#endif
-#ifdef MODULE_INA2XX
-    extern void auto_init_ina2xx(void);
-    auto_init_ina2xx();
-#endif
-#ifdef MODULE_INA3221
-    extern void auto_init_ina3221(void);
-    auto_init_ina3221();
-#endif
-#ifdef MODULE_IO1_XPLAINED
-    extern void auto_init_io1_xplained(void);
-    auto_init_io1_xplained();
-#endif
-#ifdef MODULE_ISL29020
-    extern void auto_init_isl29020(void);
-    auto_init_isl29020();
-#endif
-#ifdef MODULE_ITG320X
-    extern void auto_init_itg320x(void);
-    auto_init_itg320x();
-#endif
-#ifdef MODULE_JC42
-    extern void auto_init_jc42(void);
-    auto_init_jc42();
-#endif
-#ifdef MODULE_L3G4200D
-    extern void auto_init_l3g4200d(void);
-    auto_init_l3g4200d();
-#endif
-#ifdef MODULE_LIS2DH12
-    extern void auto_init_lis2dh12(void);
-    auto_init_lis2dh12();
-#endif
-#ifdef MODULE_LIS3DH
-    extern void auto_init_lis3dh(void);
-    auto_init_lis3dh();
-#endif
-#ifdef MODULE_LIS3MDL
-    extern void auto_init_lis3mdl(void);
-    auto_init_lis3mdl();
-#endif
-#ifdef MODULE_LPSXXX
-    extern void auto_init_lpsxxx(void);
-    auto_init_lpsxxx();
-#endif
-#ifdef MODULE_LSM303DLHC
-    extern void auto_init_lsm303dlhc(void);
-    auto_init_lsm303dlhc();
-#endif
-#ifdef MODULE_LSM6DSL
-    extern void auto_init_lsm6dsl(void);
-    auto_init_lsm6dsl();
-#endif
-#ifdef MODULE_LTC4150
-    extern void auto_init_ltc4150(void);
-    auto_init_ltc4150();
- #endif
-#ifdef MODULE_MAG3110
-    extern void auto_init_mag3110(void);
-    auto_init_mag3110();
-#endif
-#ifdef MODULE_MMA7660
-    extern void auto_init_mma7660(void);
-    auto_init_mma7660();
-#endif
-#ifdef MODULE_MMA8X5X
-    extern void auto_init_mma8x5x(void);
-    auto_init_mma8x5x();
-#endif
-#ifdef MODULE_MPL3115A2
-    extern void auto_init_mpl3115a2(void);
-    auto_init_mpl3115a2();
-#endif
-#ifdef MODULE_MPU9X50
-    extern void auto_init_mpu9x50(void);
-    auto_init_mpu9x50();
-#endif
-#ifdef MODULE_OPT3001
-    extern void auto_init_opt3001(void);
-    auto_init_opt3001();
-#endif
-#ifdef MODULE_PCA9685
-    extern void auto_init_pca9685(void);
-    auto_init_pca9685();
-#endif
-#ifdef MODULE_PH_OEM
-    extern void auto_init_ph_oem(void);
-    auto_init_ph_oem();
-#endif
-#ifdef MODULE_PIR
-    extern void auto_init_pir(void);
-    auto_init_pir();
-#endif
-#ifdef MODULE_PULSE_COUNTER
-    extern void auto_init_pulse_counter(void);
-    auto_init_pulse_counter();
-#endif
-#ifdef MODULE_QMC5883L
-    extern void auto_init_qmc5883l(void);
-    auto_init_qmc5883l();
-#endif
-#ifdef MODULE_SHT2X
-    extern void auto_init_sht2x(void);
-    auto_init_sht2x();
-#endif
-#ifdef MODULE_SHT3X
-    extern void auto_init_sht3x(void);
-    auto_init_sht3x();
-#endif
-#ifdef MODULE_SHTC1
-    extern void auto_init_shtc1(void);
-    auto_init_shtc1();
-#endif
-#ifdef MODULE_SDS011
-    extern void auto_init_sds011(void);
-    auto_init_sds011();
-#endif
-#ifdef MODULE_SI114X
-    extern void auto_init_si114x(void);
-    auto_init_si114x();
-#endif
-#ifdef MODULE_SI70XX
-    extern void auto_init_si70xx(void);
-    auto_init_si70xx();
-#endif
-#ifdef MODULE_SPS30
-    extern void auto_init_sps30(void);
-    auto_init_sps30();
-#endif
-#ifdef MODULE_TCS37727
-    extern void auto_init_tcs37727(void);
-    auto_init_tcs37727();
-#endif
-#ifdef MODULE_TMP006
-    extern void auto_init_tmp00x(void);
-    auto_init_tmp00x();
-#endif
-#ifdef MODULE_TSL2561
-    extern void auto_init_tsl2561(void);
-    auto_init_tsl2561();
-#endif
-#ifdef MODULE_TSL4531X
-    extern void auto_init_tsl4531x(void);
-    auto_init_tsl4531x();
-#endif
-#ifdef MODULE_VCNL40X0
-    extern void auto_init_vcnl40x0(void);
-    auto_init_vcnl40x0();
-#endif
-#ifdef MODULE_VEML6070
-    extern void auto_init_veml6070(void);
-    auto_init_veml6070();
-#endif
-
+    if (IS_USED(MODULE_SAUL_ADC)) {
+        extern void auto_init_adc(void);
+        auto_init_adc();
+    }
+    if (IS_USED(MODULE_SAUL_GPIO)) {
+        extern void auto_init_gpio(void);
+        auto_init_gpio();
+    }
+    if (IS_USED(MODULE_SAUL_NRF_TEMPERATURE)) {
+        extern void auto_init_nrf_temperature(void);
+        auto_init_nrf_temperature();
+    }
+    if (IS_USED(MODULE_AD7746)) {
+        extern void auto_init_ad7746(void);
+        auto_init_ad7746();
+    }
+    if (IS_USED(MODULE_ADCXX1C)) {
+        extern void auto_init_adcxx1c(void);
+        auto_init_adcxx1c();
+    }
+    if (IS_USED(MODULE_ADS101X)) {
+        extern void auto_init_ads101x(void);
+        auto_init_ads101x();
+    }
+    if (IS_USED(MODULE_ADXL345)) {
+        extern void auto_init_adxl345(void);
+        auto_init_adxl345();
+    }
+    if (IS_USED(MODULE_BMP180)) {
+        extern void auto_init_bmp180(void);
+        auto_init_bmp180();
+    }
+    if (IS_USED(MODULE_BMX280)) {
+        extern void auto_init_bmx280(void);
+        auto_init_bmx280();
+    }
+    if (IS_USED(MODULE_BMX055)) {
+        extern void auto_init_bmx055(void);
+        auto_init_bmx055();
+    }
+    if (IS_USED(MODULE_CCS811)) {
+        extern void auto_init_ccs811(void);
+        auto_init_ccs811();
+    }
+    if (IS_USED(MODULE_DHT)) {
+        extern void auto_init_dht(void);
+        auto_init_dht();
+    }
+    if (IS_USED(MODULE_DS18)) {
+        extern void auto_init_ds18(void);
+        auto_init_ds18();
+    }
+    if (IS_USED(MODULE_DS75LX)) {
+        extern void auto_init_ds75lx(void);
+        auto_init_ds75lx();
+    }
+    if (IS_USED(MODULE_FXOS8700)) {
+        extern void auto_init_fxos8700(void);
+        auto_init_fxos8700();
+    }
+    if (IS_USED(MODULE_GROVE_LEDBAR)) {
+        extern void auto_init_grove_ledbar(void);
+        auto_init_grove_ledbar();
+    }
+    if (IS_USED(MODULE_HDC1000)) {
+        extern void auto_init_hdc1000(void);
+        auto_init_hdc1000();
+    }
+    if (IS_USED(MODULE_HTS221)) {
+        extern void auto_init_hts221(void);
+        auto_init_hts221();
+    }
+    if (IS_USED(MODULE_INA2XX)) {
+        extern void auto_init_ina2xx(void);
+        auto_init_ina2xx();
+    }
+    if (IS_USED(MODULE_INA3221)) {
+        extern void auto_init_ina3221(void);
+        auto_init_ina3221();
+    }
+    if (IS_USED(MODULE_IO1_XPLAINED)) {
+        extern void auto_init_io1_xplained(void);
+        auto_init_io1_xplained();
+    }
+    if (IS_USED(MODULE_ISL29020)) {
+        extern void auto_init_isl29020(void);
+        auto_init_isl29020();
+    }
+    if (IS_USED(MODULE_ITG320X)) {
+        extern void auto_init_itg320x(void);
+        auto_init_itg320x();
+    }
+    if (IS_USED(MODULE_JC42)) {
+        extern void auto_init_jc42(void);
+        auto_init_jc42();
+    }
+    if (IS_USED(MODULE_L3G4200D)) {
+        extern void auto_init_l3g4200d(void);
+        auto_init_l3g4200d();
+    }
+    if (IS_USED(MODULE_LIS2DH12)) {
+        extern void auto_init_lis2dh12(void);
+        auto_init_lis2dh12();
+    }
+    if (IS_USED(MODULE_LIS3DH)) {
+        extern void auto_init_lis3dh(void);
+        auto_init_lis3dh();
+    }
+    if (IS_USED(MODULE_LIS3MDL)) {
+        extern void auto_init_lis3mdl(void);
+        auto_init_lis3mdl();
+    }
+    if (IS_USED(MODULE_LPSXXX)) {
+        extern void auto_init_lpsxxx(void);
+        auto_init_lpsxxx();
+    }
+    if (IS_USED(MODULE_LSM303DLHC)) {
+        extern void auto_init_lsm303dlhc(void);
+        auto_init_lsm303dlhc();
+    }
+    if (IS_USED(MODULE_LSM6DSL)) {
+        extern void auto_init_lsm6dsl(void);
+        auto_init_lsm6dsl();
+    }
+    if (IS_USED(MODULE_LTC4150)) {
+        extern void auto_init_ltc4150(void);
+        auto_init_ltc4150();
+    }
+    if (IS_USED(MODULE_MAG3110)) {
+        extern void auto_init_mag3110(void);
+        auto_init_mag3110();
+    }
+    if (IS_USED(MODULE_MMA7660)) {
+        extern void auto_init_mma7660(void);
+        auto_init_mma7660();
+    }
+    if (IS_USED(MODULE_MMA8X5X)) {
+        extern void auto_init_mma8x5x(void);
+        auto_init_mma8x5x();
+    }
+    if (IS_USED(MODULE_MPL3115A2)) {
+        extern void auto_init_mpl3115a2(void);
+        auto_init_mpl3115a2();
+    }
+    if (IS_USED(MODULE_MPU9X50)) {
+        extern void auto_init_mpu9x50(void);
+        auto_init_mpu9x50();
+    }
+    if (IS_USED(MODULE_OPT3001)) {
+        extern void auto_init_opt3001(void);
+        auto_init_opt3001();
+    }
+    if (IS_USED(MODULE_PCA9685)) {
+        extern void auto_init_pca9685(void);
+        auto_init_pca9685();
+    }
+    if (IS_USED(MODULE_PH_OEM)) {
+        extern void auto_init_ph_oem(void);
+        auto_init_ph_oem();
+    }
+    if (IS_USED(MODULE_PIR)) {
+        extern void auto_init_pir(void);
+        auto_init_pir();
+    }
+    if (IS_USED(MODULE_PULSE_COUNTER)) {
+        extern void auto_init_pulse_counter(void);
+        auto_init_pulse_counter();
+    }
+    if (IS_USED(MODULE_QMC5883L)) {
+        extern void auto_init_qmc5883l(void);
+        auto_init_qmc5883l();
+    }
+    if (IS_USED(MODULE_SHT2X)) {
+        extern void auto_init_sht2x(void);
+        auto_init_sht2x();
+    }
+    if (IS_USED(MODULE_SHT3X)) {
+        extern void auto_init_sht3x(void);
+        auto_init_sht3x();
+    }
+    if (IS_USED(MODULE_SHTC1)) {
+        extern void auto_init_shtc1(void);
+        auto_init_shtc1();
+    }
+    if (IS_USED(MODULE_SDS011)) {
+        extern void auto_init_sds011(void);
+        auto_init_sds011();
+    }
+    if (IS_USED(MODULE_SI114X)) {
+        extern void auto_init_si114x(void);
+        auto_init_si114x();
+    }
+    if (IS_USED(MODULE_SI70XX)) {
+        extern void auto_init_si70xx(void);
+        auto_init_si70xx();
+    }
+    if (IS_USED(MODULE_SPS30)) {
+        extern void auto_init_sps30(void);
+        auto_init_sps30();
+    }
+    if (IS_USED(MODULE_TCS37727)) {
+        extern void auto_init_tcs37727(void);
+        auto_init_tcs37727();
+    }
+    if (IS_USED(MODULE_TMP006)) {
+        extern void auto_init_tmp00x(void);
+        auto_init_tmp00x();
+    }
+    if (IS_USED(MODULE_TSL2561)) {
+        extern void auto_init_tsl2561(void);
+        auto_init_tsl2561();
+    }
+    if (IS_USED(MODULE_TSL4531X)) {
+        extern void auto_init_tsl4531x(void);
+        auto_init_tsl4531x();
+    }
+    if (IS_USED(MODULE_VCNL40X0)) {
+        extern void auto_init_vcnl40x0(void);
+        auto_init_vcnl40x0();
+    }
+    if (IS_USED(MODULE_VEML6070)) {
+        extern void auto_init_veml6070(void);
+        auto_init_veml6070();
+    }
 }
-#endif /* MODULE_AUTO_INIT_SAUL*/
 
 void auto_init(void)
 {
-#ifdef MODULE_AUTO_INIT_RANDOM
-    LOG_DEBUG("Auto init random.\n");
-    extern void auto_init_random(void);
-    auto_init_random();
-#endif
-#ifdef MODULE_AUTO_INIT_XTIMER
-    LOG_DEBUG("Auto init xtimer.\n");
-    extern void xtimer_init(void);
-    xtimer_init();
-#endif
-#ifdef MODULE_SCHEDSTATISTICS
-    LOG_DEBUG("Auto init schedstatistics.\n");
-    extern void init_schedstatistics(void);
-    init_schedstatistics();
-#endif
-#ifdef MODULE_EVENT_THREAD
-    LOG_DEBUG("Auto init event threads.\n");
-    extern void auto_init_event_thread(void);
-    auto_init_event_thread();
-#endif
-#ifdef MODULE_MCI
-    LOG_DEBUG("Auto init mci.\n");
-    extern void mci_initialize(void);
-    mci_initialize();
-#endif
-#ifdef MODULE_PROFILING
-    LOG_DEBUG("Auto init profiling.\n");
-    extern void profiling_init(void);
-    profiling_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
-    LOG_DEBUG("Auto init gnrc_pktbuf.\n");
-    extern void gnrc_pktbuf_init(void);
-    gnrc_pktbuf_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
-    LOG_DEBUG("Auto init gnrc_pktdump.\n");
-    extern void gnrc_pktdump_init(void);
-    gnrc_pktdump_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
-    LOG_DEBUG("Auto init gnrc_sixlowpan.\n");
-    extern void gnrc_sixlowpan_init(void);
-    gnrc_sixlowpan_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_IPV6
-    LOG_DEBUG("Auto init gnrc_ipv6.\n");
-    extern void gnrc_ipv6_init(void);
-    gnrc_ipv6_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_UDP
-    LOG_DEBUG("Auto init gnrc_udp.\n");
-    extern void gnrc_udp_init(void);
-    gnrc_udp_init();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_TCP
-    LOG_DEBUG("Auto init gnrc_tcp.\n");
-    extern void gnrc_tcp_init(void);
-    gnrc_tcp_init();
-#endif
-#ifdef MODULE_AUTO_INIT_LWIP
-    LOG_DEBUG("Bootstraping lwIP.\n");
-    extern void lwip_bootstrap(void);
-    lwip_bootstrap();
-#endif
-#ifdef MODULE_OPENTHREAD
-    LOG_DEBUG("Bootstrapping openthread.\n");
-    extern void openthread_bootstrap(void);
-    openthread_bootstrap();
-#endif
-#ifdef MODULE_GCOAP
-    if (!IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
+    if (IS_USED(MODULE_AUTO_INIT_RANDOM)) {
+        LOG_DEBUG("Auto init random.\n");
+        extern void auto_init_random(void);
+        auto_init_random();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_XTIMER)) {
+        LOG_DEBUG("Auto init xtimer.\n");
+        extern void xtimer_init(void);
+        xtimer_init();
+    }
+    if (IS_USED(MODULE_SCHEDSTATISTICS)) {
+        LOG_DEBUG("Auto init schedstatistics.\n");
+        extern void init_schedstatistics(void);
+        init_schedstatistics();
+    }
+    if (IS_USED(MODULE_EVENT_THREAD)) {
+        LOG_DEBUG("Auto init event threads.\n");
+        extern void auto_init_event_thread(void);
+        auto_init_event_thread();
+    }
+    if (IS_USED(MODULE_MCI)) {
+        LOG_DEBUG("Auto init mci.\n");
+        extern void mci_initialize(void);
+        mci_initialize();
+    }
+    if (IS_USED(MODULE_PROFILING)) {
+        LOG_DEBUG("Auto init profiling.\n");
+        extern void profiling_init(void);
+        profiling_init();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_PKTBUF)) {
+        LOG_DEBUG("Auto init gnrc_pktbuf.\n");
+        extern void gnrc_pktbuf_init(void);
+        gnrc_pktbuf_init();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_PKTDUMP)) {
+        LOG_DEBUG("Auto init gnrc_pktdump.\n");
+        extern void gnrc_pktdump_init(void);
+        gnrc_pktdump_init();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_SIXLOWPAN)) {
+        LOG_DEBUG("Auto init gnrc_sixlowpan.\n");
+        extern void gnrc_sixlowpan_init(void);
+        gnrc_sixlowpan_init();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_IPV6)) {
+        LOG_DEBUG("Auto init gnrc_ipv6.\n");
+        extern void gnrc_ipv6_init(void);
+        gnrc_ipv6_init();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_UDP)) {
+        LOG_DEBUG("Auto init gnrc_udp.\n");
+        extern void gnrc_udp_init(void);
+        gnrc_udp_init();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_TCP)) {
+        LOG_DEBUG("Auto init gnrc_tcp.\n");
+        extern void gnrc_tcp_init(void);
+        gnrc_tcp_init();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_LWIP)) {
+        LOG_DEBUG("Bootstraping lwIP.\n");
+        extern void lwip_bootstrap(void);
+        lwip_bootstrap();
+    }
+    if (IS_USED(MODULE_OPENTHREAD)) {
+        LOG_DEBUG("Bootstrapping openthread.\n");
+        extern void openthread_bootstrap(void);
+        openthread_bootstrap();
+    }
+    if (IS_USED(MODULE_GCOAP) &&
+        !IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
         LOG_DEBUG("Auto init gcoap.\n");
         extern void gcoap_init(void);
         gcoap_init();
     }
-#endif
-#ifdef MODULE_DEVFS
-    LOG_DEBUG("Mounting /dev.\n");
-    extern void auto_init_devfs(void);
-    auto_init_devfs();
-#endif
-#ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
-    LOG_DEBUG("Auto init gnrc_ipv6_nib.\n");
-    extern void gnrc_ipv6_nib_init(void);
-    gnrc_ipv6_nib_init();
-#endif
-#ifdef MODULE_SKALD
-    LOG_DEBUG("Auto init Skald.\n");
-    extern void skald_init(void);
-    skald_init();
-#endif
-#ifdef MODULE_CORD_COMMON
-    LOG_DEBUG("Auto init cord_common.\n");
-    extern void cord_common_init(void);
-    cord_common_init();
-#endif
-#ifdef MODULE_CORD_EP_STANDALONE
-    LOG_DEBUG("Auto init cord_ep_standalone.\n");
-    extern void cord_ep_standalone_run(void);
-    cord_ep_standalone_run();
-#endif
-#ifdef MODULE_ASYMCUTE
-    LOG_DEBUG("Auto init Asymcute.\n");
-    extern void asymcute_handler_run(void);
-    asymcute_handler_run();
-#endif
-#ifdef MODULE_NIMBLE
-    LOG_DEBUG("Auto init NimBLE.\n");
-    extern void nimble_riot_init(void);
-    nimble_riot_init();
-#endif
-#ifdef MODULE_AUTO_INIT_LORAMAC
-    LOG_DEBUG("Auto init loramac.\n");
-    extern void auto_init_loramac(void);
-    auto_init_loramac();
-#endif
-#ifdef MODULE_SOCK_DTLS
-    LOG_DEBUG("Auto init sock_dtls.\n");
-    extern void sock_dtls_init(void);
-    sock_dtls_init();
-#endif
+    if (IS_USED(MODULE_DEVFS)) {
+        LOG_DEBUG("Mounting /dev.\n");
+        extern void auto_init_devfs(void);
+        auto_init_devfs();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_IPV6_NIB)) {
+        LOG_DEBUG("Auto init gnrc_ipv6_nib.\n");
+        extern void gnrc_ipv6_nib_init(void);
+        gnrc_ipv6_nib_init();
+    }
+    if (IS_USED(MODULE_SKALD)) {
+        LOG_DEBUG("Auto init Skald.\n");
+        extern void skald_init(void);
+        skald_init();
+    }
+    if (IS_USED(MODULE_CORD_COMMON)) {
+        LOG_DEBUG("Auto init cord_common.\n");
+        extern void cord_common_init(void);
+        cord_common_init();
+    }
+    if (IS_USED(MODULE_CORD_EP_STANDALONE)) {
+        LOG_DEBUG("Auto init cord_ep_standalone.\n");
+        extern void cord_ep_standalone_run(void);
+        cord_ep_standalone_run();
+    }
+    if (IS_USED(MODULE_ASYMCUTE)) {
+        LOG_DEBUG("Auto init Asymcute.\n");
+        extern void asymcute_handler_run(void);
+        asymcute_handler_run();
+    }
+    if (IS_USED(MODULE_NIMBLE)) {
+        LOG_DEBUG("Auto init NimBLE.\n");
+        extern void nimble_riot_init(void);
+        nimble_riot_init();
+    }
+    if (IS_USED(MODULE_AUTO_INIT_LORAMAC)) {
+        LOG_DEBUG("Auto init loramac.\n");
+        extern void auto_init_loramac(void);
+        auto_init_loramac();
+    }
+    if (IS_USED(MODULE_SOCK_DTLS)) {
+        LOG_DEBUG("Auto init sock_dtls.\n");
+        extern void sock_dtls_init(void);
+        sock_dtls_init();
+    }
 
-/* initialize USB devices */
-#ifdef MODULE_AUTO_INIT_USBUS
-    LOG_DEBUG("Auto init USB.\n");
-    extern void auto_init_usb(void);
-    auto_init_usb();
-#endif
+    /* initialize USB devices */
+    if (IS_USED(MODULE_AUTO_INIT_USBUS)) {
+        LOG_DEBUG("Auto init USB.\n");
+        extern void auto_init_usb(void);
+        auto_init_usb();
+    }
 
-#ifdef MODULE_AUTO_INIT_GNRC_NETIF
-    LOG_DEBUG("Auto init gnrc_netif.\n");
-    _auto_init_gnrc_netif();
-#endif /* MODULE_AUTO_INIT_GNRC_NETIF */
+    /* initialize network devices */
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_NETIF)) {
+        LOG_DEBUG("Auto init gnrc_netif.\n");
+        _auto_init_gnrc_netif();
+    }
 
-#ifdef MODULE_AUTO_INIT_GNRC_UHCPC
-    LOG_DEBUG("Auto init gnrc_uhcpc.\n");
-    extern void auto_init_gnrc_uhcpc(void);
-    auto_init_gnrc_uhcpc();
-#endif
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_UHCPC)) {
+        LOG_DEBUG("Auto init gnrc_uhcpc.\n");
+        extern void auto_init_gnrc_uhcpc(void);
+        auto_init_gnrc_uhcpc();
+    }
 
-/* initialize NDN module after the network devices are initialized */
-#ifdef MODULE_NDN_RIOT
-    LOG_DEBUG("Auto init NDN.\n");
-    extern void ndn_init(void);
-    ndn_init();
-#endif
+    /* initialize NDN module after the network devices are initialized */
+    if (IS_USED(MODULE_NDN_RIOT)) {
+        LOG_DEBUG("Auto init NDN.\n");
+        extern void ndn_init(void);
+        ndn_init();
+    }
 
-/* initialize sensors and actuators */
-#ifdef MODULE_SHT1X
-    /* The sht1x module needs to be initialized regardless of SAUL being used,
-     * as the shell commands rely on auto-initialization. auto_init_sht1x also
-     * performs SAUL registration, but only if module auto_init_saul is used.
-     */
-    LOG_DEBUG("Auto init sht1x.\n");
-    extern void auto_init_sht1x(void);
-    auto_init_sht1x();
-#endif
+    /* initialize sensors and actuators */
+    if (IS_USED(MODULE_SHT1X)) {
+        /* The sht1x module needs to be initialized regardless of SAUL being used,
+         * as the shell commands rely on auto-initialization. auto_init_sht1x also
+         * performs SAUL registration, but only if module auto_init_saul is used.
+         */
+        LOG_DEBUG("Auto init sht1x.\n");
+        extern void auto_init_sht1x(void);
+        auto_init_sht1x();
+    }
 
-#ifdef MODULE_AUTO_INIT_SAUL
-    LOG_DEBUG("Auto init SAUL.\n");
-    _auto_init_saul();
-#endif /* MODULE_AUTO_INIT_SAUL */
+    if (IS_USED(MODULE_AUTO_INIT_SAUL)) {
+        LOG_DEBUG("Auto init SAUL.\n");
+        _auto_init_saul();
+    }
 
-#ifdef MODULE_AUTO_INIT_GNRC_RPL
-    LOG_DEBUG("Auto init gnrc_rpl.\n");
-    extern void auto_init_gnrc_rpl(void);
-    auto_init_gnrc_rpl();
-#endif /* MODULE_AUTO_INIT_GNRC_RPL */
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_RPL)) {
+        LOG_DEBUG("Auto init gnrc_rpl.\n");
+        extern void auto_init_gnrc_rpl(void);
+        auto_init_gnrc_rpl();
+    }
 
-/* initialize storage devices */
-#ifdef MODULE_AUTO_INIT_STORAGE
-    LOG_DEBUG("Auto init STORAGE.\n");
+    /* initialize storage devices */
+    if (IS_USED(MODULE_AUTO_INIT_STORAGE)) {
+        LOG_DEBUG("Auto init STORAGE.\n");
 
-#ifdef MODULE_SDCARD_SPI
-    extern void auto_init_sdcard_spi(void);
-    auto_init_sdcard_spi();
-#endif
+        if (IS_USED(MODULE_SDCARD_SPI)) {
+            extern void auto_init_sdcard_spi(void);
+            auto_init_sdcard_spi();
+        }
+    }
 
-#endif /* MODULE_AUTO_INIT_STORAGE */
 
-#ifdef MODULE_AUTO_INIT_CAN
-    LOG_DEBUG("Auto init CAN.\n");
+    if (IS_USED(MODULE_AUTO_INIT_CAN)) {
+        LOG_DEBUG("Auto init CAN.\n");
 
-    extern void auto_init_candev(void);
-    auto_init_candev();
+        extern void auto_init_candev(void);
+        auto_init_candev();
+    }
 
-#endif /* MODULE_AUTO_INIT_CAN */
+    if (IS_USED(MODULE_SUIT)) {
+        LOG_DEBUG("Auto init SUIT conditions.\n");
+        extern void suit_init_conditions(void);
+        suit_init_conditions();
+    }
 
-#ifdef MODULE_SUIT
-    LOG_DEBUG("Auto init SUIT conditions.\n");
-    extern void suit_init_conditions(void);
-    suit_init_conditions();
-#endif /* MODULE_SUIT */
+    if (IS_USED(MODULE_AUTO_INIT_SECURITY)) {
+        if (IS_USED(MODULE_CRYPTOAUTHLIB)) {
+            LOG_DEBUG("Auto init cryptoauthlib.\n");
+            extern void auto_init_atca(void);
+            auto_init_atca();
+        }
+    }
 
-#ifdef MODULE_AUTO_INIT_SECURITY
+    if (IS_USED(MODULE_TEST_UTILS_INTERACTIVE_SYNC) &&
+        (!IS_USED(MODULE_SHELL_COMMANDS) || !IS_USED(MODULE_SHELL))) {
+        extern void test_utils_interactive_sync(void);
+        test_utils_interactive_sync();
+    }
 
-#ifdef MODULE_CRYPTOAUTHLIB
-    LOG_DEBUG("Auto init cryptoauthlib.\n");
-    extern void auto_init_atca(void);
-    auto_init_atca();
-#endif  /* MODULE_CRYPTOAUTHLIB */
+    if (IS_USED(MODULE_AUTO_INIT_DHCPV6_CLIENT)) {
+        LOG_DEBUG("Auto init DHCPv6 client.\n");
+        extern void dhcpv6_client_auto_init(void);
+        dhcpv6_client_auto_init();
+    }
 
-#endif  /* MODULE_AUTO_INIT_SECURITY */
-
-#ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
-#if !defined(MODULE_SHELL_COMMANDS) || !defined(MODULE_SHELL)
-    extern void test_utils_interactive_sync(void);
-    test_utils_interactive_sync();
-#endif
-#endif /* MODULE_TEST_UTILS_INTERACTIVE_SYNC */
-
-#ifdef MODULE_AUTO_INIT_DHCPV6_CLIENT
-    LOG_DEBUG("Auto init DHCPv6 client.\n");
-    extern void dhcpv6_client_auto_init(void);
-    dhcpv6_client_auto_init();
-#endif /* MODULE_AUTO_INIT_DHCPV6_CLIENT */
-
-#ifdef MODULE_GNRC_DHCPV6_CLIENT_6LBR
-    LOG_DEBUG("Auto init 6LoWPAN border router DHCPv6 client\n");
-    extern void gnrc_dhcpv6_client_6lbr_init(void);
-    gnrc_dhcpv6_client_6lbr_init();
-#endif /* MODULE_GNRC_DHCPV6_CLIENT_6LBR */
+    if (IS_USED(MODULE_GNRC_DHCPV6_CLIENT_6LBR)) {
+        LOG_DEBUG("Auto init 6LoWPAN border router DHCPv6 client\n");
+        extern void gnrc_dhcpv6_client_6lbr_init(void);
+        gnrc_dhcpv6_client_6lbr_init();
+    }
 }

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -24,88 +24,6 @@
 #include "auto_init.h"
 #include "log.h"
 
-#ifdef MODULE_MCI
-#include "diskio.h"
-#endif
-
-#ifdef MODULE_AUTO_INIT_XTIMER
-#include "xtimer.h"
-#endif
-
-#ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
-#include "net/gnrc/sixlowpan.h"
-#endif
-
-#ifdef MODULE_AUTO_INIT_GNRC_IPV6
-#include "net/gnrc/ipv6.h"
-#endif
-
-#ifdef MODULE_L2_PING
-#include "l2_ping.h"
-#endif
-
-#ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
-#include "net/gnrc/pktbuf.h"
-#endif
-
-#ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
-#include "net/gnrc/pktdump.h"
-#endif
-
-#ifdef MODULE_AUTO_INIT_GNRC_UDP
-#include "net/gnrc/udp.h"
-#endif
-
-#ifdef MODULE_AUTO_INIT_GNRC_TCP
-#include "net/gnrc/tcp.h"
-#endif
-
-#ifdef MODULE_LWIP
-#include "lwip.h"
-#endif
-
-#ifdef MODULE_OPENTHREAD
-#include "ot.h"
-#endif
-
-#ifdef MODULE_FIB
-#include "net/fib.h"
-#endif
-
-#ifdef MODULE_GCOAP
-#include "net/gcoap.h"
-#endif
-
-#ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
-#include "net/gnrc/ipv6/nib.h"
-#endif
-
-#ifdef MODULE_SKALD
-#include "net/skald.h"
-#endif
-
-#ifdef MODULE_NDN_RIOT
-#include "ndn-riot/ndn.h"
-#endif
-
-#ifdef MODULE_ASYMCUTE
-#include "net/asymcute.h"
-#endif
-
-#ifdef MODULE_SOCK_DTLS
-#include "net/sock/dtls.h"
-#endif
-
-#ifdef MODULE_SCHEDSTATISTICS
-#include "schedstatistics.h"
-#endif
-
-#ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
-#if !defined(MODULE_SHELL_COMMANDS) || !defined(MODULE_SHELL)
-#include "test_utils/interactive_sync.h"
-#endif
-#endif
-
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -113,15 +31,17 @@ void auto_init(void)
 {
 #ifdef MODULE_AUTO_INIT_RANDOM
     LOG_DEBUG("Auto init random.\n");
-    void auto_init_random(void);
+    extern void auto_init_random(void);
     auto_init_random();
 #endif
 #ifdef MODULE_AUTO_INIT_XTIMER
     LOG_DEBUG("Auto init xtimer.\n");
+    extern void xtimer_init(void);
     xtimer_init();
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
     LOG_DEBUG("Auto init schedstatistics.\n");
+    extern void init_schedstatistics(void);
     init_schedstatistics();
 #endif
 #ifdef MODULE_EVENT_THREAD
@@ -131,6 +51,7 @@ void auto_init(void)
 #endif
 #ifdef MODULE_MCI
     LOG_DEBUG("Auto init mci.\n");
+    extern void mci_initialize(void);
     mci_initialize();
 #endif
 #ifdef MODULE_PROFILING
@@ -140,30 +61,37 @@ void auto_init(void)
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_PKTBUF
     LOG_DEBUG("Auto init gnrc_pktbuf.\n");
+    extern void gnrc_pktbuf_init(void);
     gnrc_pktbuf_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_PKTDUMP
     LOG_DEBUG("Auto init gnrc_pktdump.\n");
+    extern void gnrc_pktdump_init(void);
     gnrc_pktdump_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_SIXLOWPAN
     LOG_DEBUG("Auto init gnrc_sixlowpan.\n");
+    extern void gnrc_sixlowpan_init(void);
     gnrc_sixlowpan_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_IPV6
     LOG_DEBUG("Auto init gnrc_ipv6.\n");
+    extern void gnrc_ipv6_init(void);
     gnrc_ipv6_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_UDP
     LOG_DEBUG("Auto init gnrc_udp.\n");
+    extern void gnrc_udp_init(void);
     gnrc_udp_init();
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_TCP
     LOG_DEBUG("Auto init gnrc_tcp.\n");
+    extern void gnrc_tcp_init(void);
     gnrc_tcp_init();
 #endif
 #ifdef MODULE_AUTO_INIT_LWIP
     LOG_DEBUG("Bootstraping lwIP.\n");
+    extern void lwip_bootstrap(void);
     lwip_bootstrap();
 #endif
 #ifdef MODULE_OPENTHREAD
@@ -174,6 +102,7 @@ void auto_init(void)
 #ifdef MODULE_GCOAP
     if (!IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
         LOG_DEBUG("Auto init gcoap.\n");
+        extern void gcoap_init(void);
         gcoap_init();
     }
 #endif
@@ -184,10 +113,12 @@ void auto_init(void)
 #endif
 #ifdef MODULE_AUTO_INIT_GNRC_IPV6_NIB
     LOG_DEBUG("Auto init gnrc_ipv6_nib.\n");
+    extern void gnrc_ipv6_nib_init(void);
     gnrc_ipv6_nib_init();
 #endif
 #ifdef MODULE_SKALD
     LOG_DEBUG("Auto init Skald.\n");
+    extern void skald_init(void);
     skald_init();
 #endif
 #ifdef MODULE_CORD_COMMON
@@ -202,6 +133,7 @@ void auto_init(void)
 #endif
 #ifdef MODULE_ASYMCUTE
     LOG_DEBUG("Auto init Asymcute.\n");
+    extern void asymcute_handler_run(void);
     asymcute_handler_run();
 #endif
 #ifdef MODULE_NIMBLE
@@ -216,6 +148,7 @@ void auto_init(void)
 #endif
 #ifdef MODULE_SOCK_DTLS
     LOG_DEBUG("Auto init sock_dtls.\n");
+    extern void sock_dtls_init(void);
     sock_dtls_init();
 #endif
 
@@ -363,6 +296,7 @@ void auto_init(void)
 /* initialize NDN module after the network devices are initialized */
 #ifdef MODULE_NDN_RIOT
     LOG_DEBUG("Auto init NDN.\n");
+    extern void ndn_init(void);
     ndn_init();
 #endif
 
@@ -650,6 +584,7 @@ void auto_init(void)
 
 #ifdef MODULE_TEST_UTILS_INTERACTIVE_SYNC
 #if !defined(MODULE_SHELL_COMMANDS) || !defined(MODULE_SHELL)
+    extern void test_utils_interactive_sync(void);
     test_utils_interactive_sync();
 #endif
 #endif /* MODULE_TEST_UTILS_INTERACTIVE_SYNC */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I only looked at #13364 after the fact and found some more ways to improve it:
1. Unify the last remaining `DEBUG()` (outputting `"auto_init 6LoWPAN border router DHCPv6 client"`) with the rest and use `LOG_DEBUG()`. Consequently, remove the `debug.h` include
2. Unify how functions are included to use `extern` (to only require one `#ifdef MODULE_…` and consequently remove all unneeded `#include`s
3. Move grouped initializations to their own functions, see https://github.com/RIOT-OS/RIOT/pull/13542#discussion_r387118914 and https://github.com/RIOT-OS/RIOT/pull/13542#discussion_r387119308
3. Use `IS_USED(MODULE_…)` instead of `#ifdef MODULE_` to compile-time check 1., 2., and 3.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
All applications should still compile, auto initialization should still work (running some tests on different boards and `examples/default` and `examples/gnrc_network` should be enough to show that)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #13364.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
