### PR TITLE
tools/backport_pr: Add Token Scope check

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -135,6 +135,20 @@ def main():
     if status != 200:
         print("Could not retrieve user: {}".format(user['message']))
         exit(1)
+    # Token-scope-check: Is the token is powerful enough to complete
+    # the Backport?
+    response_headers = dict(g.getheaders())
+    # agithub documentation says it's lower case header field-names but
+    # at this moment it's not
+    if 'X-OAuth-Scopes' in response_headers:
+        scopes = response_headers['X-OAuth-Scopes']
+    else:
+        scopes = response_headers['x-oauth-scopes']
+    scopes_list = [x.strip() for x in scopes.split(',')]
+    if not ('public_repo' in scopes_list or 'repo' in scopes_list):
+        print("missing public_repo scope from token settings."
+              " Please add it on the GitHub webinterface")
+        exit(1)
     username = user['login']
     status, pulldata = g.repos[ORG][REPO].pulls[args.PR].get()
     if status != 200:


### PR DESCRIPTION
While creating a backport #13513 , #13531   i ran into issues using the backport_pr.py script. 
Without the necessary scope it kept going for a long time but failed at the end, leaving a state that is not simple to handle. 

### Contribution description

Patched backup_pr.py to check for repo scope or public_repo and fail early if they are missing.

### Testing procedure

backport a pr using backport_pr.py

try different tokens

token missing repo and public_repo scope should fail early

### Issues/PRs references

backport #13513  should have been #13531
