### PR TITLE
cpu/kinetis: add support for PWM peripherals in addition to FTM

### DIFF
--- a/boards/openlabs-kw41z-mini-256kib/Kconfig
+++ b/boards/openlabs-kw41z-mini-256kib/Kconfig
@@ -14,6 +14,7 @@ config BOARD_OPENLABS_KW41Z_MINI_256KIB
     select HAS_PERIPH_ADC
     select HAS_PERIPH_DAC
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI

--- a/boards/openlabs-kw41z-mini/Kconfig
+++ b/boards/openlabs-kw41z-mini/Kconfig
@@ -14,6 +14,7 @@ config BOARD_OPENLABS_KW41Z_MINI
     select HAS_PERIPH_ADC
     select HAS_PERIPH_DAC
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI

--- a/boards/openlabs-kw41z-mini/Makefile.features
+++ b/boards/openlabs-kw41z-mini/Makefile.features
@@ -5,8 +5,7 @@ CPU_MODEL ?= mkw41z512vht4
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
-# TODO uncomment this after Kinetis PWM support is merged
-# FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/cpu/kinetis/periph/pwm.c
+++ b/cpu/kinetis/periph/pwm.c
@@ -21,6 +21,7 @@
  * @author      Johann Fischer <j.fischer@phytec.de>
  * @author      Jonas Remmert <j.remmert@phytec.de>
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Thomas Stilwell <stilwellt@openlabs.co>
  *
  * @}
  */
@@ -29,21 +30,23 @@
 #include "assert.h"
 #include "periph/pwm.h"
 
-/* This driver uses the FlexTimer module (FTM) for generating PWM signals, but
- * not all Kinetis CPUs have such a module. This preprocessor condition prevents
- * compilation errors when the CPU header lacks the register definitions for the
- * FTM */
-#ifdef FTM0
-
 #define PRESCALER_MAX       (7U)
 
+#ifdef FTM0
 static inline FTM_Type *ftm(pwm_t pwm)
 {
     return pwm_config[pwm].ftm;
 }
+#else /* FTM0 */
+static inline TPM_Type *tpm(pwm_t pwm)
+{
+    return pwm_config[pwm].tpm;
+}
+#endif /* FTM0 */
 
 static void poweron(pwm_t pwm)
 {
+#ifdef FTM0
     int ftm = pwm_config[pwm].ftm_num;
 
 #ifdef SIM_SCGC6_FTM2_SHIFT
@@ -55,7 +58,13 @@ static void poweron(pwm_t pwm)
     else if (ftm == 2) {
         BITBAND_REG32(SIM->SCGC3, SIM_SCGC3_FTM2_SHIFT) = 1;
     }
-#endif
+#endif /* SIM_SCGC6_FTM2_SHIFT */
+
+#else /* FTM0 */
+    bit_set32(&SIM->SCGC6, SIM_SCGC6_TPM0_SHIFT + pwm_config[pwm].tpm_num);
+    SIM->SOPT2 |= SIM_SOPT2_TPMSRC(1);
+
+#endif /* FTM0 */
 }
 
 uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
@@ -84,6 +93,8 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
     /* configure the used timer */
     poweron(pwm);
+
+#ifdef FTM0
     /* disable write protect for changing settings */
     ftm(pwm)->MODE = FTM_MODE_WPDIS_MASK;
     /* clear any existing configuration */
@@ -106,12 +117,39 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
                        PORT_PCR_MUX(pwm_config[pwm].chan[i].af));
         /* set the given mode */
         ftm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnSC = mode;
-        /* and reset the PWM to 0% duty cycle */
-        ftm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnV = 0;
     }
 
     /* and now we start the actual waveform generation */
     ftm(pwm)->SC |= FTM_SC_CLKS(1);
+
+#else /* FTM0 */
+
+    /* apply prescaler and set resolution */
+    tpm(pwm)->SC = TPM_SC_PS(pre);
+    tpm(pwm)->CNT = 0;
+    tpm(pwm)->MOD = (res - 1);
+
+    /* set CPWMS bit in the SC register in case of center aligned mode */
+    if (mode == PWM_CENTER) {
+        tpm(pwm)->SC |= TPM_SC_CPWMS(1);
+    }
+
+    /* setup the configured channels */
+    for (int i = 0; i < (int)pwm_config[pwm].chan_numof; i++) {
+        /* disable channel before configuring */
+        tpm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnSC = 0;
+        while ((tpm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnSC &
+                ~(TPM_CnSC_CHF_MASK)) != 0) {}
+        /* configure the used pin */
+        gpio_init_port(pwm_config[pwm].chan[i].pin,
+                       PORT_PCR_MUX(pwm_config[pwm].chan[i].af));
+        /* set the given mode */
+        tpm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnSC = mode;
+    }
+
+    /* and now we start the actual waveform generation */
+    tpm(pwm)->SC |= TPM_SC_CMOD(1);
+#endif /* FTM0 */
 
     /* finally we need to return the actual applied PWM frequency */
     return (CLOCK_BUSCLOCK >> pre) / res;
@@ -126,25 +164,38 @@ uint8_t pwm_channels(pwm_t pwm)
 void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 {
     assert((pwm < PWM_NUMOF) && (channel < pwm_config[pwm].chan_numof));
+#ifdef FTM0
     ftm(pwm)->CONTROLS[pwm_config[pwm].chan[channel].ftm_chan].CnV = value;
+#else
+    tpm(pwm)->CONTROLS[pwm_config[pwm].chan[channel].ftm_chan].CnV = value;
+#endif
 }
 
 void pwm_poweron(pwm_t pwm)
 {
     assert(pwm < PWM_NUMOF);
     poweron(pwm);
+
+    /* enable PWM generation */
+#ifdef FTM0
     ftm(pwm)->SC |= FTM_SC_CLKS(1);
+#else
+    tpm(pwm)->SC |= TPM_SC_CMOD(1);
+#endif /* FTM0 */
 }
 
 void pwm_poweroff(pwm_t pwm)
 {
     assert(pwm < PWM_NUMOF);
+
+#ifdef FTM0
+
     int ftm_num = pwm_config[pwm].ftm_num;
 
     /* disable PWM generation */
     ftm(pwm)->SC &= ~(FTM_SC_CLKS_MASK);
 
-    /* and power of the peripheral */
+    /* and power off the peripheral */
 #ifdef SIM_SCGC6_FTM2_SHIFT
     BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_FTM0_SHIFT + ftm_num) = 0;
 #else
@@ -154,7 +205,16 @@ void pwm_poweroff(pwm_t pwm)
     else if (ftm_num == 2) {
         BITBAND_REG32(SIM->SCGC3, SIM_SCGC3_FTM2_SHIFT) = 0;
     }
-#endif
-}
+#endif /* SIM_SCGC6_FTM2_SHIFT */
 
-#endif /* defined(FTM0) */
+#else /* FTM0 */
+
+    /* disable PWM generation */
+    tpm(pwm)->SC &= ~(TPM_SC_CMOD_MASK);
+
+    /* and power off the peripheral */
+    bit_clear32(&SIM->SCGC6, SIM_SCGC6_TPM0_SHIFT + pwm_config[pwm].tpm_num);
+    SIM->SOPT2 &= ~(SIM_SOPT2_TPMSRC_MASK);
+
+#endif /* FTM0 */
+}

--- a/cpu/kinetis/periph/pwm.c
+++ b/cpu/kinetis/periph/pwm.c
@@ -26,6 +26,7 @@
  * @}
  */
 
+#include "bme.h"
 #include "cpu.h"
 #include "assert.h"
 #include "periph/pwm.h"
@@ -39,7 +40,7 @@
 /**
  * @brief   Keeps track of whether PWM is active for power management
  */
-static bool _is_powered_on[PWM_NUMOF];
+static uint8_t _is_powered_on;
 
 #define PRESCALER_MAX       (7U)
 
@@ -57,12 +58,12 @@ static inline TPM_Type *tpm(pwm_t pwm)
 
 static void poweron(pwm_t pwm)
 {
-    if (_is_powered_on[pwm]) {
+    if (_is_powered_on & (1 << pwm)) {
         return;
     }
 
     pm_block(PWM_PM_BLOCKER);
-    _is_powered_on[pwm] = true;
+    bit_set8(&_is_powered_on, pwm);
 
 #ifdef FTM0
     int ftm = pwm_config[pwm].ftm_num;
@@ -210,12 +211,12 @@ void pwm_poweroff(pwm_t pwm)
 {
     assert(pwm < PWM_NUMOF);
 
-    if (!_is_powered_on[pwm]) {
+    if (!(_is_powered_on & (1 << pwm))) {
         return;
     }
 
     pm_unblock(PWM_PM_BLOCKER);
-    _is_powered_on[pwm] = false;
+    bit_clear8(&_is_powered_on, pwm);
 
 #ifdef FTM0
 

--- a/cpu/kinetis/periph/pwm.c
+++ b/cpu/kinetis/periph/pwm.c
@@ -141,6 +141,8 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
                        PORT_PCR_MUX(pwm_config[pwm].chan[i].af));
         /* set the given mode */
         ftm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnSC = mode;
+        /* and reset the PWM to 0% duty cycle */
+        ftm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnV = 0;
     }
 
     /* and now we start the actual waveform generation */
@@ -169,6 +171,8 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
                        PORT_PCR_MUX(pwm_config[pwm].chan[i].af));
         /* set the given mode */
         tpm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnSC = mode;
+        /* and reset the PWM to 0% duty cycle */
+        tpm(pwm)->CONTROLS[pwm_config[pwm].chan[i].ftm_chan].CnV = 0;
     }
 
     /* and now we start the actual waveform generation */

--- a/cpu/kinetis/periph/pwm.c
+++ b/cpu/kinetis/periph/pwm.c
@@ -29,17 +29,11 @@
 #include "cpu.h"
 #include "assert.h"
 #include "periph/pwm.h"
-
-#ifdef MODULE_PWM_LAYERED
 #include "pm_layered.h"
-#else
-#define pm_block(...)
-#define pm_unblock(...)
-#endif
 
 /* This mode will be blocked while PWM is active */
 #ifndef PWM_PM_BLOCKER
-#define PWM_PM_BLOCKER           2
+#define PWM_PM_BLOCKER           KINETIS_PM_STOP
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description
The current Kinetis PWM driver supports only FTM peripherals whereas some MCUs have PWM instead. This PR adds support for Kinetis PWM peripherals.

Most applicable boards don't have any PWM configuration in periph_conf.h and I didn't attempt to add it for boards I don't have, however I could try to address that in a followup PR.

### Testing procedure
kw41z-mini has a PWM configuration already and could be used to test this. I have only kw41z boards to test with so I haven't been able to test FTM for regressions.