### PR TITLE
tests/xtimer_overhead: initial commit

### DIFF
--- a/tests/xtimer_overhead/Makefile
+++ b/tests/xtimer_overhead/Makefile
@@ -1,0 +1,6 @@
+DEVELHELP ?= 0
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_overhead/README.md
+++ b/tests/xtimer_overhead/README.md
@@ -1,0 +1,3 @@
+# Introduction
+
+This test application measures 1024 times how much overhead xtimer adds.

--- a/tests/xtimer_overhead/main.c
+++ b/tests/xtimer_overhead/main.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2020 Freie Universität Berlin
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     test
+ * @{
+ *
+ * @file
+ * @brief       xtimer overhead test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "xtimer.h"
+
+#define BASE    1000
+#define SAMPLES 1024
+
+int32_t xtimer_overhead(uint32_t base);
+
+int main(void)
+{
+    uint32_t total = 0;
+
+    int32_t min = INT32_MAX;
+    int32_t max = INT32_MIN;
+
+    unsigned n = SAMPLES;
+    while (n--) {
+        int32_t overhead = xtimer_overhead(BASE);
+        total += labs(overhead);
+        if (overhead < min) {
+            min = overhead;
+        }
+        else if (overhead > max) {
+            max = overhead;
+        }
+    }
+
+    printf("min=%" PRIi32 " max=%" PRIi32 " avg_diff=%" PRIi32 "\n", min, max,
+           (total / SAMPLES));
+
+    return 0;
+}

--- a/tests/xtimer_overhead/overhead.c
+++ b/tests/xtimer_overhead/overhead.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2020 Freie Universität Berlin
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_xtimer_overhead
+ * @{
+ *
+ * @file
+ * @brief       xtimer overhead measurement functions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include "xtimer.h"
+
+typedef struct {
+    volatile uint32_t *val;
+} callback_arg_t;
+
+static void _callback(void *arg)
+{
+    callback_arg_t *callback_arg = (callback_arg_t *)arg;
+
+    *callback_arg->val = xtimer_now_usec();
+}
+
+int32_t xtimer_overhead(uint32_t base)
+{
+    volatile uint32_t after = 0;
+    uint32_t pre;
+
+    callback_arg_t arg = { .val = &after };
+    xtimer_t t = { .callback = _callback, .arg = &arg };
+
+    pre = xtimer_now_usec();
+    xtimer_set(&t, base);
+    while (!after) {}
+    return after - pre - base;
+}

--- a/tests/xtimer_overhead/tests/01-run.py
+++ b/tests/xtimer_overhead/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r"min=-?\d+ max=-?\d+ avg_diff=\d+\r\n")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an xtimer test that figures out xtimer's overhead (and effect of tuning values).

Algorithm:

0. BASE=1000
1. for 1024 times, do
2. pre = xtimer_now_usec()
3. xtimer_set(BASE);
4. wait until timer triggers
5. not down (trigger_time - pre - base)
6. show some stats

In short, this will show how much a timer will trigger early / late in the best case (only one timer set, avoiding very short timers).

The used `xtimer_overhead()` function and this test is a pretty direct port of #11874's `ztimer_overhead()`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
