### PR TITLE
pkg/cryptoauthlib: enable boards to set auto init parameters

### DIFF
--- a/pkg/cryptoauthlib/include/atca_params.h
+++ b/pkg/cryptoauthlib/include/atca_params.h
@@ -20,6 +20,7 @@
 #ifndef ATCA_PARAMS_H
 #define ATCA_PARAMS_H
 
+#include "board.h"
 #include "cryptoauthlib.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION

### Contribution description

This PR enables the board's `board.h` to define the auto init parameters for cryptoauthlib devices. This comes in handy if one of the supported chips is part of the board.

### Testing procedure

Run `tests/pkg_cryptoauthlib_internal-tests` on a board that has modified cryptoauthlib parameters set.

### Issues/PRs references

#13014
