### PR TITLE
cpu/saml21: unblock IDLE modes by default

### DIFF
--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -27,6 +27,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Override the default initial PM blocker
+ *
+ * STANDBY and BACKUP mode are blocked by default. Idle modes are enabled.
+ */
+#define PM_BLOCKER_INITIAL      0x00000101
+
+/**
  * @brief   The Low Power SRAM is not retained during deep sleep.
  */
 #define CPU_BACKUP_RAM_NOT_RETAINED (1)


### PR DESCRIPTION
### Contribution description

I've seen that the `cpu/samd21` CPU unblocks the IDLE modes by default.

I think this is also useful addition to the SAML21. The user won't notice that the CPU goes into IDLE mode when RIOT switches into the idle thread.

### Testing procedure

`tests/periph_pm` should bring the CPU into STANDBY mode just by issuing the command `unblock 1`. Without this patch nothing will change after the command and the CPU stays active.
