### PR TITLE
tests/nordic_softdevice: disable CI testing

### DIFF
--- a/tests/nordic_softdevice/Makefile
+++ b/tests/nordic_softdevice/Makefile
@@ -14,6 +14,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-TEST_ON_CI_WHITELIST += nrf52dk
+# softdevice currently broken on CI
+TEST_ON_CI_BLACKLIST += all
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The nordic softdevice support doesn't work on CI workers, causing unrelated build failures everywhere.

I tried to get the softdevice to work locally, but didn't succeed.
I tried the first commit that introduces it, erased the flash of an nrf52dk, compiled and flashed it there.
Nothing happens on serial.

I suspect the recent ARM toolchain update.

IMO, we should remove ~~it~~ the softdevice ASAP. Anyhow, this PR disables CI testing of `tests/nordic_softdevice`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#13334 marking the softdevice deprecated.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
