### PR TITLE
memarray: fix memarray init

### DIFF
--- a/sys/memarray/memarray.c
+++ b/sys/memarray/memarray.c
@@ -28,6 +28,7 @@ void memarray_init(memarray_t *mem, void *data, size_t size, size_t num)
         void *next = ((char *)mem->free_data) + ((i + 1) * mem->size);
         memcpy(((char *)mem->free_data) + (i * mem->size), &next, sizeof(void *));
     }
+    memset(((char *)mem->free_data) + ((mem->num - 1) * (mem->size)), 0, sizeof(void *));
 }
 
 void *memarray_alloc(memarray_t *mem)

--- a/tests/memarray/main.c
+++ b/tests/memarray/main.c
@@ -35,6 +35,11 @@
 #define NUMBER_OF_TESTS      (12)
 #endif
 
+#ifndef NUMBER_OF_LOOPS
+#define NUMBER_OF_LOOPS      (2)
+#endif
+
+
 extern int _ps_handler(int argc, char **argv);
 
 struct block_t {
@@ -101,15 +106,32 @@ void free_memory(struct block_t *head)
 int main(void)
 {
     printf("MAX_NUMBER_BLOCKS: %d\n", MAX_NUMBER_BLOCKS);
+    printf("NUMBER_OF_LOOPS: %d\n", NUMBER_OF_LOOPS);
     printf("NUMBER_OF_TESTS: %d\n", NUMBER_OF_TESTS);
 
     memory_block_init();
     int count = 0;
+    int loop = 0;
 
     printf("Starting (%d, %u)\n", MAX_NUMBER_BLOCKS, MESSAGE_SIZE);
     _ps_handler(0, NULL);
 
+    printf("LOOP #%i:\n", loop + 1);
+    while (count <  NUMBER_OF_TESTS) {
+        struct block_t *head = (struct block_t *) memarray_alloc(&block_storage);
+
+        printf("TEST #%i:\n", count + 1 );
+        fill_memory(head);
+        free_memory(head);
+
+        count++;
+    }
+
+    count = 0;
+    loop++;
+    printf("LOOP #%i:\n", loop + 1);
     while (count < NUMBER_OF_TESTS) {
+        memory_block_init();
         struct block_t *head = (struct block_t *) memarray_alloc(&block_storage);
 
         printf("TEST #%i:\n", count + 1 );

--- a/tests/memarray/tests/01-run.py
+++ b/tests/memarray/tests/01-run.py
@@ -13,16 +13,20 @@ from testrunner import run
 def testfunc(child):
     child.expect(r'MAX_NUMBER_BLOCKS: (\d+)\r\n')
     max_number_blocks = int(child.match.group(1))
+    child.expect(r'NUMBER_OF_LOOPS: (\d+)\r\n')
+    number_of_loops = int(child.match.group(1))
     child.expect(r'NUMBER_OF_TESTS: (\d+)\r\n')
     number_of_tests = int(child.match.group(1))
-    for test in range(number_of_tests):
-        child.expect_exact("TEST #{}:".format(test + 1))
-        for i in range(max_number_blocks):
-            child.expect(r'\({}, @@@@@@@\) Allocated \d+ Bytes at 0x[a-z0-9]+,'
-                         r' total [0-9]+\r\n'.format(i))
-        for i in range(max_number_blocks):
-            child.expect(r'Free \({}\) \d+ Bytes at 0x[a-z0-9]+,'
-                         ' total [0-9]+\r\n'.format(i))
+    for loop in range(number_of_loops):
+        child.expect_exact("LOOP #{}:".format(loop + 1))
+        for test in range(number_of_tests):
+            child.expect_exact("TEST #{}:".format(test + 1))
+            for i in range(max_number_blocks):
+                child.expect(r'\({}, @@@@@@@\) Allocated \d+ Bytes at 0x[a-z0-9]+,'
+                             r' total [0-9]+\r\n'.format(i))
+            for i in range(max_number_blocks):
+                child.expect(r'Free \({}\) \d+ Bytes at 0x[a-z0-9]+,'
+                             ' total [0-9]+\r\n'.format(i))
     child.expect_exact("Finishing")
 
 


### PR DESCRIPTION

### Contribution description

If memarray data is not initialized to 0 (for instance during a
re-init). The last element of the array is not properly cleared thus
leading to returning an invalid pointer when everything is allocated.


### Testing procedure

- Allocate/free the whole space. 
- Re-init the `memarray`
- Allocate the whole space + 1
- without this patch, an invalid pointer is returned, with this patch, NULL is returned
