### PR TITLE
examples/nimble_hrs: extend README with Web Bluetooth

### DIFF
--- a/examples/nimble_heart_rate_sensor/README.md
+++ b/examples/nimble_heart_rate_sensor/README.md
@@ -5,6 +5,9 @@ notifications by implementing a mock-up BLE heart rate sensor. Once flashed on
 a node, you can connect to it using any phone or device capable of using such a
 heart rate sensor, e.g. Nordics `nRF Toolbox` for Android
 (https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrftoolbox).
+With browsers supporting the experimental [Web Bluetooth API](https://webbluetoothcg.github.io/web-bluetooth/)
+(currently only the Chromium / Chrome family), this can also be accessed from a
+[demo web application](https://webbluetoothcg.github.io/demos/heart-rate-sensor/).
 
 The heart rate sensor is simulated by simply providing an up- and down counter
 for its BPM value.


### PR DESCRIPTION
### Contribution description

Documentation of nimble heart rate sensor is extended by a link to a Web Bluetooth application that can interact with the sensor.

This serves two purposes:
* It shows a path to quick testing that does not depend on the Google Play store.
* It gives an entry point into the world of Web Bluetooth, which is not always trivial because it (at least the Chrome implementation, unsure about the standard) relies on the services to be sent out in the advertising data, not only when queried for services.

### Testing procedure

* Flash nimble_heart_rate_sensor example.
* Get a Chromium browser on a device that is BLE capable
  * I've only been successful from Android devices; Chromium on Debian GNU/Linux has been showing me the device's presence but not its data, which is a consistent failure mode in all my BLE access from my PC.
* Go to https://webbluetoothcg.github.io/demos/heart-rate-sensor/ as per the README, press the heart button, and select the RIOT heart rate sensor from the browser's permission dialogue.