### PR TITLE
doc: fix broken links

### DIFF
--- a/boards/arduino-zero/doc.txt
+++ b/boards/arduino-zero/doc.txt
@@ -31,7 +31,7 @@ This board is available [here](https://store.arduino.cc/product/GBX00003).
 | SPIs       | max 6 (see UART)                  |
 | I2Cs       | max 6 (see UART)              |
 | Vcc        | 1.8V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.atmel.com/Images/Atmel-42181-SAM-D21_Datasheet.pdf) |
+| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_Data%20Sheet_DS40001882E.pdf) |
 
 ### User Interface
 

--- a/boards/avr-rss2/doc.txt
+++ b/boards/avr-rss2/doc.txt
@@ -58,7 +58,7 @@ export PATH=$PATH:/usr/local/avr8-gnu-toolchain-linux_x86/bin (32-bit)
 ```
 apt-get install avrdude
 ```
-For MacOS, there is a [HomeBrewpackage](https://formula.brew.sh/formula/avrdude#default)
+For MacOS, there is a [HomeBrewpackage](https://formulae.brew.sh/formula/avrdude#default)
 that can be installed with the command:
 ```
 brew install avrdude

--- a/boards/cc2538dk/doc.txt
+++ b/boards/cc2538dk/doc.txt
@@ -42,9 +42,9 @@ internal bootloader, then run:
 
 Activating this bootloader is NOT enabled if the flash content is in factory
 default state (e.g. after unboxing). To set the bits in the CCA accordingly you
-have to follow the guidelines found
-[here](http://processors.wiki.ti.com/index.php/CC2538_Bootloader_Backdoor). To
-manage this first time access you have to download the
+have to follow the guidelines found [here]
+(https://web.archive.org/web/20170610111337/http://processors.wiki.ti.com/index.php/CC2538_Bootloader_Backdoor).
+To manage this first time access you have to download the
 ["Uniflash"](http://processors.wiki.ti.com/index.php/Category:CCS_UniFlash) tool
 at TI's website.
 
@@ -58,8 +58,9 @@ FTDI driver manually:
 If the path `/sys/bus/usb-serial/drivers/ftdi_sio/` doesn't exist, you also
 have to load the module `ftdi_sio` by hand.  Alternatively, you can install a
 `udev` rule that configures this on device connection, see [this post on TI's
-E2E site](https://e2e.ti.com/support/microcontrollers/c2000/f/171/p/359074/18434
-85#1843485) for details.
+E2E site]
+(https://e2e.ti.com/support/microcontrollers/c2000/f/171/p/359074/1843485#1843485)
+for details.
 
 RIOT will use /dev/ttyUSB1 by default, but if the UART is given a different
 device name, you can specity it to RIOT using the PORT variable:
@@ -109,8 +110,8 @@ $ csrutil status
 System Integrity Protection status: disabled.
 ```
 
-Afterwards you'll be able to install this [driver](https://cdn.sparkfun.com/a
-ssets/learn_tutorials/7/4/FTDIUSBSerialDriver_v2_3.dmg).
+Afterwards you'll be able to install this [driver]
+(https://cdn.sparkfun.com/assets/learn_tutorials/7/4/FTDIUSBSerialDriver_v2_3.dmg).
 
 If everything goes OK reboot your Mac and then edit
 `/System/Library/Extensions/FTDIUSBSerialDriver.kext/Contents/Info.plist` with a

--- a/boards/cc2650stk/doc.txt
+++ b/boards/cc2650stk/doc.txt
@@ -9,9 +9,8 @@ The CC2650STK is an 'IoT kit' with 10 sensors, a fancy case, and a radio unit
 that is capable of irradiating IEEE802.15.4 and BLE (or SMART or whatever they
 call it now).
 
- - [Official homepage](http://www.ti.com/tool/cc2650stk)
- - [Another official homepage](http://www.ti.com/ww/en/wireless_connectivity/sensortag2015)
- - [Platform](http://www.ti.com/product/CC2650) <- CPU data sheet here
+ - [Official homepage](https://www.ti.com/tool/cc2650stk)
+ - [Platform](https://www.ti.com/product/CC2650) <- CPU data sheet here
 
 Use `BOARD=cc2650stk` for building RIOT for this platform.
 
@@ -33,7 +32,7 @@ Use `BOARD=cc2650stk` for building RIOT for this platform.
 | I2C        | 1                 |
 | I2S        | 1                 |
 | Datasheet  | [Datasheet](http://www.ti.com/lit/ds/symlink/cc2650.pdf) |
-| Reference Manual | [Reference Manual](http://www.ti.com/lit/ug/swcu117d/swcu117d.pdf) |
+| Reference Manual | [Reference Manual](https://www.ti.com/lit/ug/swcu117h/swcu117h.pdf) |
 
 ## Implementation Status
 
@@ -55,8 +54,9 @@ The arm-none-eabi toolchain works fine. You can get it
 
 ## Programming and Debugging
 
-You'll need [debugging hardware](http://processors.wiki.ti.com/index.php/CC13xx_CC26xx_Tools_Overview#Debuggers).
-So far, the [XDS110 debug probe](http://www.ti.com/tool/CC-DEVPACK-DEBUG) has
+You'll need [debugging hardware]
+(https://processors.wiki.ti.com/index.php?title=CC13xx_CC26xx_Tools_Overview#Debuggers).
+So far, the [XDS110 debug probe](https://www.ti.com/tool/CC-DEVPACK-DEBUG) has
 been tested. That bugger requires you to load a firmware onto it each time it
 powers up. The tool is contained in the Uniflash utility or the `CodeComposer
 Studio` from TI. Look for a folder called `uscif` in the installation directory,
@@ -67,7 +67,7 @@ The process is relying on proprietary TI softsoftware. If you're on Windows
 you can use the stuff linked to on the product websites.
 
 On Linux, there's an application called
-[Uniflash](http://www.ti.com/tool/uniflash). Sadly, you'll have to install the
+[Uniflash](https://www.ti.com/tool/uniflash). Sadly, you'll have to install the
 whole IDE just to get the scripting interface :-[
 
 No idea about MacOSX.
@@ -107,7 +107,7 @@ implement the most common roles of a BLE network.
 
 References: [BlueTooth Core Specification v4.2](https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439),
 [Core Specification Supplement v6](https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=302735),
-[BLE Becons by TI](http://www.ti.com.cn/cn/lit/an/swra475/swra475.pdf)
+[BLE Becons by TI](https://www.ti.com/lit/an/swra475a/swra475a.pdf)
 
 ## BLE packet format for advertising channels
 
@@ -146,7 +146,7 @@ rfc_ble_param_advertiser_t
 | PDU Type              | 4 bits | `ropCmd.commandNo` | PDU Type is solely dependent on the command type. See below. |
 | RFU                   | 2 bits | - | Reserved for Future Use (RFU): [You can't touch this.](https://www.youtube.com/watch?v=otCpCn0l4Wo) Assumed to be 0.|
 | TxAdd                 | 1 bit  | `pParams->advConfig.deviceAddrType` | The field value is specific to the PDU type. |
-| RxAdd                 | 1 bit  | - | The field value is specific to the PDU type. According to the TI documentation ([23.6.4.4](http://www.ti.com/lit/ug/swcu117d/swcu117d.pdf)), this field is not available to configure and thus assumed to be 0. |
+| RxAdd                 | 1 bit  | - | The field value is specific to the PDU type. According to the TI documentation ([23.6.4.4](https://www.ti.com/lit/ug/swcu117h/swcu117h.pdf)), this field is not available to configure and thus assumed to be 0. |
 | Length                | 6 bits | `pParams->advLen` + 6| Indicates the length of the payload field in bytes. 6 is added to account for the advertiser address. The payload length ranges from 6 to 37 bytes. |
 | RFU                   | 2 bits | - | Reserved for Future Use (RFU): [You can't touch this.](https://www.youtube.com/watch?v=otCpCn0l4Wo) Assumed to be 0 |
 | Advertiser address | 6 bytes | `pParams->pDeviceAddress` | First element of the payload. The different formats of address types are illustrated [here](https://cloud.githubusercontent.com/assets/14371243/15826564/4c7f5f54-2c08-11e6-8051-dc0a018f6e42.png).|

--- a/boards/chronos/doc.txt
+++ b/boards/chronos/doc.txt
@@ -5,8 +5,8 @@
 
 # Hardware
 
-![TI eZ430-Chronos running RIOT](http://riot-os.org/images/hardware-watch-
-riot.png)
+![TI eZ430-Chronos running RIOT]
+(http://riot-os.org/images/hardware-watch-riot.png)
 
 # MCU
 | MCU        | TI CC430F6137     |

--- a/boards/common/blxxxpill/doc.txt
+++ b/boards/common/blxxxpill/doc.txt
@@ -1,5 +1,5 @@
 /**
-@defgroup    boards_common_blxxxpill Common code for bluepill and blackpill
+@defgroup    boards_common_blxxxpill Blackpill and Bluepill common code
 @ingroup     boards_common
 @brief       Support for cheap stm32f103c8 based boards such as bluepill and blackpill.
 
@@ -15,8 +15,8 @@ There are also versions that only report to have 32 KiB, but actually have
 
 ## Hardware
 
-![bluepill](https://camo.githubusercontent.com/8df2fb54f87527bdd57fe007352d72c1f377d08f/687474703a2f2f77696b692e73746d33326475696e6f2e636f6d2f696d616765732f7468756d622f312f31392f53544d33325f426c75655f50696c6c5f746f702e6a70672f38303070782d53544d33325f426c75655f50696c6c5f746f702e6a7067)
-
+![bluepill]
+(https://camo.githubusercontent.com/6122268d77e4677a08d0e13e2e2aaf070a0a6a69/687474703a2f2f73312e62696c642e6d652f62696c6465722f3131303431372f38383135303232313438363837343334302e6a7067)
 ### MCU
 
 | MCU       | STM32F103C8               |
@@ -140,14 +140,11 @@ Try [eBay][eBay] or [AliExpress][AliExpress].
 
 ## Further reading
 
-* https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?title=Blue_Pill
-* https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?title=Maple_Mini#Clones
-* http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-
-arm-cortex-mcus/stm32-mainstream-mcus/stm32f1-series/stm32f103/stm32f103c8.html
+- [Blue Pill Wiki](https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?title=Blue_Pill)
+- [Maple Mini Wiki](https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?title=Maple_Mini#Clones)
+- [STM32F103C8 Datasheet](http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-mainstream-mcus/stm32f1-series/stm32f103/stm32f103c8.html)
 
-[Datasheet]: http://www.st.com/content/ccc/resource/technical/document/datash
-eet/33/d4/6f/1d/df/0b/4c/6d/CD00161566.pdf/files/CD00161566.pdf/jcr:content/tran
-slations/en.CD00161566.pdf
+[Datasheet]: http://www.st.com/content/ccc/resource/technical/document/datasheet/33/d4/6f/1d/df/0b/4c/6d/CD00161566.pdf/files/CD00161566.pdf/jcr:content/translations/en.CD00161566.pdf
 [Flashsize]:
 https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?title=Blue_Pill#128_KB_flash_on_C8_version
 [eBay]: https://www.ebay.com/sch/i.html?_nkw=stm32f103c8
@@ -156,6 +153,5 @@ https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?
 [USB]:
 https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/index.php?title=Blue_Pill#Hardware_installation
 [imgTop]:
-https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/images/thumb/1/19/STM32_Blue_Pill_top.jpg/800px-
-STM32_Blue_Pill_top.jpg
+https://web.archive.org/web/20190428082446/http://wiki.stm32duino.com/images/thumb/1/19/STM32_Blue_Pill_top.jpg/800px-STM32_Blue_Pill_top.jpg
  */

--- a/boards/common/slwstk6000b/doc.txt
+++ b/boards/common/slwstk6000b/doc.txt
@@ -90,7 +90,8 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf)
+peripherals. You are advised to read [AN0004.1]
+(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/derfmega128/doc.txt
+++ b/boards/derfmega128/doc.txt
@@ -8,10 +8,33 @@ deRFmega128 is a family of modules produced by Dresden Elektronik.
 deRFmega128 modules are based on [ATmega128rfa1](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8266-MCU_Wireless-ATmega128RFA1_Datasheet.pdf),
 MCUs. It include 16MHz main and 32K RTC crystalls and (depending on module type) integrated or not integrated 2.4GHz antenna.
 
-These modules are available in three variants: [deRFmega128-22M00](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m00.html) with integrated antenna,
-[deRFmega128-22M10](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m10.html), and [deRFmega128-22M12](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m12.html) without integrated antenna.
+These modules are available in different variants:
+- [deRFmega128-22M00]
+  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m00.html)
+  with integrated antenna,
+- [deRFmega128-22M10]
+  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m10.html)
+  without integrated antenna.
+- [deRFmega128-22A00]
+  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22a00.html)
+  with connectors and integrated antenna,
+- [deRFmega128-22A02]
+  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22a02.html)
+  with connectors, but without integrated antenna.
+- [deRFmega128-22C00]
+  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22c00.html)
+  solderable with integrated antenna,
+- [deRFmega128-22C02]
+  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22c02.html)
+  solderable without integrated antenna.
 
 # Hardware
-The [datasheet](https://usermanual.wiki/dresden-elektronik-ingenieurtechnik/MEGA23M12.15-MEGA23M12-User-Manual/info) for modules.
 
+For details see the according data sheets:
+- [deRFmega128-22M00 and deRFmega128-22M10]
+  (https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22M00-22M10-DBT-de.pdf)
+- [deRFmega128-22A00 and deRFmega128-22C00]
+  (https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22A00-C00-DBT-de.pdf)
+- [deRFmega128-22A02 and deRFmega128-22C02]
+  (https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22A02-C02-DBT-de.pdf)
  */

--- a/boards/esp32-mh-et-live-minikit/doc.txt
+++ b/boards/esp32-mh-et-live-minikit/doc.txt
@@ -24,7 +24,11 @@
 
 ## <a name="overview"> Overview </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-The MH-ET LIVE MiniKit for ESP32 uses the ESP32-WROOM-32 module. It is a very interesting development kit as it uses in the stackable Wemos D1 Mini format. Thus, all [shields for Wemos D1 mini](https://wiki.wemos.cc/products:d1_mini_shields) for ESP8266 can also be used with ESP32. Examples for such shields are:
+The MH-ET LIVE MiniKit for ESP32 uses the ESP32-WROOM-32 module. It is a very
+interesting development kit as it uses in the stackable Wemos D1 Mini format.
+Thus, all [shields for Wemos D1 mini]
+(https://docs.wemos.cc/en/latest/d1_mini_shiled/index.html) for ESP8266
+can also be used with ESP32. Examples for such shields are:
 
 - Micro SD-Card Shield
 - MRF24J40 IEEE 802.15.4 radio Shield
@@ -41,7 +45,7 @@ MH-ET LIVE MiniKit for ESP32 belongs to the class of general purpose boards wher
 
 This stackable platform was tested in an RIOT application with:
 
-- [Micro SD-Card Shield](https://wiki.wemos.cc/products:d1_mini_shields:micro_sd_card_shield)
+- [Micro SD-Card Shield](https://docs.wemos.cc/en/latest/d1_mini_shiled/micro_sd.html)
 - MRF24J40 IEEE 802.15.4 radio Shield (contact gunar@schorcht.net for more information)
 - BMP180 Pressure Sensor Shield
 

--- a/boards/esp32-wemos-lolin-d32-pro/doc.txt
+++ b/boards/esp32-wemos-lolin-d32-pro/doc.txt
@@ -32,8 +32,11 @@ Wemos LOLIN D32 Pro is a development board that uses the ESP32-WROVER module whi
 
 Wemos LOLIN D32 Pro belongs to the class of general purpose boards where most ESP32 pins are broken out for easier access.
 
-\htmlonly<style>div.image img[src="https://wiki.wemos.cc/_media/products:d32:d32_pro_v2.0.0_1_16x9.jpg"]{width:600px;}</style>\endhtmlonly
-@image html "https://wiki.wemos.cc/_media/products:d32:d32_pro_v2.0.0_1_16x9.jpg" "Wemos LOLIN D32 PRO"
+\htmlonly<style>div.image
+img[src="https://docs.wemos.cc/en/latest/_static/boards/d32_pro_v2.0.0_1_16x16.jpg"]
+{width:400px;}</style>\endhtmlonly
+@image html
+"https://docs.wemos.cc/en/latest/_static/boards/d32_pro_v2.0.0_1_16x16.jpg" "Wemos LOLIN D32 PRO"
 
 ## <a name="hardware"> Hardware </a> &nbsp;&nbsp; [[TOC](#toc)]
 
@@ -129,7 +132,8 @@ For other parameters, the default values defined by the drivers can be used.
 
 The following picture shows the pinout of WEMOS LOLIN D32 PRO board as defined by the default board configuration. The light green GPIOs are not used by configured on-board hardware components and can be used for any purpose. However, if optional off-board hardware modules are used, these GPIOs may also be occupied, see \ref esp32_wemos-lolin-d32-pro_table_board_configuration "optional functions" in table board configuration.
 
-The corresponding board schematic can be found [here](https://wiki.wemos.cc/_media/products:d32:sch_d32_pro_v2.0.0.pdf).
+The corresponding board schematic can be found [here]
+(https://docs.wemos.cc/en/latest/_static/files/sch_d32_pro_v2.0.0.pdf).
 
 \anchor esp32_wemos-lolin-d32-pro_pinout
 @image html "https://gitlab.com/gschorcht/RIOT.wiki-Images/raw/master/esp32/Wemos_LOLIN_D32_PRO_pinout.png?inline=false" "Wemos LOLIN D32 PRO pinout"

--- a/boards/esp8266-esp-12x/doc.txt
+++ b/boards/esp8266-esp-12x/doc.txt
@@ -52,7 +52,15 @@ For detailed information about ESP8266 as well as configuring and compiling RIOT
 ## <a name="wemos_lolin_d1_mini"> WEMOS LOLIN D1 mini </a>
 
 
-[WEMOS LOLIN D1 mini](https://wiki.wemos.cc/products:retired:d1_mini_v2.2.0) is a very interesting board series as it offers a stackable ESP8266 platform. This board can be easily extended with a large number of compatible peripheral shields, e.g. a micro SD card shield, an IR controller shield, a battery shield, and various sensor and actuator shields, see [D1 mini shields](https://wiki.wemos.cc/start#d1_mini_shields) for more information. This makes it possible to create different hardware configurations without the need for a soldering iron or a breadboard.
+[WEMOS LOLIN D1 mini]
+(https://www.wemos.cc/en/latest/d1/d1_mini.html)
+is a very interesting board series as it offers a stackable ESP8266 platform.
+This board can be easily extended with a large number of compatible peripheral
+shields, e.g. a micro SD card shield, an IR controller shield, a battery
+shield, and various sensor and actuator shields, see [D1 mini shields]
+(https://docs.wemos.cc/en/latest/d1_mini_shiled/index.html) for more
+information. This makes it possible to create different hardware configurations
+without the need for a soldering iron or a breadboard.
 
 \htmlonly
 <style>div.image img[src="https://gitlab.com/gschorcht/RIOT.wiki-Images/raw/master/esp8266/Wemos_D1_mini_Stack.png?inline=false"]{width:400px;}</style>
@@ -68,7 +76,8 @@ There is also a MRF24J40 shield that can be used to extend the board with an IEE
 
 There are several versions of WEMOS LOLIN D1 mini, which only differ in the size of the flash memory and the MCU version used. All versions have a microUSB port with flash / boot / reset logic that makes flashing much easier. Their peripherals are equal and work with the default ESP8266 ESP-12x board definition.
 
-For more information, see [D1 Boards] (https://wiki.wemos.cc/start#d1_boards).
+For more information, see [D1 Boards]
+(https://docs.wemos.cc/en/latest/d1/d1_mini.html).
 
 <center>
 Board        | MCU       | Flash    | Antenna | Remark

--- a/boards/esp8266-olimex-mod/doc.txt
+++ b/boards/esp8266-olimex-mod/doc.txt
@@ -42,7 +42,7 @@ WiFi        | built in
 Vcc         | 2.5 - 3.6 V
 Datasheet   | [Datasheet](https://www.espressif.com/sites/default/files/documentation/0a-esp8266ex_datasheet_en.pdf)
 Technical Reference | [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf)
-Board Schematic | [Board Schematic](https://github.com/OLIMEX/ESP8266/raw/master/HARDWARE/MOD-WIFI-ESP8266-DEV/MOD-WIFI-ESP8266-DEV_schematic.pdf)
+Board Schematic | [Board Schematic](https://github.com/OLIMEX/ESP8266/blob/master/HARDWARE/MOD-WIFI-ESP8266-DEV/MOD-WiFi-ESP8266-DEV%20revision%20B1/MOD-WiFi-ESP8266-DEV_Rev_B1.pdf)
 </center>
 
 @note For detailed information about ESP8266, see \ref esp8266_riot.

--- a/boards/ikea-tradfri/doc.txt
+++ b/boards/ikea-tradfri/doc.txt
@@ -94,7 +94,8 @@ Pin 1 is on the top-left side with only 6 contacts.
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf)
+peripherals. You are advised to read [AN0004.1]
+(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/iotlab-m3/doc.txt
+++ b/boards/iotlab-m3/doc.txt
@@ -7,24 +7,24 @@
 
 | MCU    | [ST2M32F103REY](http://www.st.com/web/catalog/mmc/FM141/SC1169/SS1031/LN1565/PF164485) – 32-bits, 64kB RAM |
 |-------|-------------------------------------------------------------------------------------------------------------------|
-|sensors | Light ([ISL29020](http://www.intersil.com/en/products/optoelectronics/ambient-light-sensors/light-to-digital-sensors/ISL29020.html)) |
+|sensors | Light ([ISL29020](https://www.renesas.com/kr/en/products/sensors/ambient-light-sensors/light-to-digital-sensors/device/ISL29020.html)) |
 | | Pressure ([LPS331AP](http://www.st.com/web/catalog/sense_power/FM89/SC1316/PF251601)) |
 | | Tri-axis accelerometer/magnetometer ([LSM303DLHC](http://www.st.com/web/catalog/sense_power/FM89/SC1449/PF251940)) |
 | | Tri-axis gyrometer ([L3G4200D](http://www.st.com/web/catalog/sense_power/FM89/SC1288/PF250373)) |
-| external memory    | 128 Mbits external Nor flash ([N25Q128A13E1240F](http://www.datasheet4u.com/download.php?id=683085)) |
+| external memory    | 128 Mbits external Nor flash ([N25Q128A13E1240F](https://www.micron.com/-/media/client/global/documents/products/data-sheet/nor-flash/serial-nor/n25q/n25q_128mb_3v_65nm.pdf)) |
 | power  | 3,7V LiPo battery – 650 mAh ([063040](http://www.gmbattery.com/Datasheet/LIPO/LIPO-063040.pdf)) |
 | radio chipset   | [AT86RF231](http://www.atmel.com/images/doc8111.pdf) |
 | | a IEEE802.15.4-compliant radio at 2.4 GHz |
 
 ## Board HW overview
 
-![IoT-LAB M3 Layout](https://www.iot-lab.info/wp-
-content/uploads/2013/10/m3opennode.png)
+![IoT-LAB M3 Layout]
+(https://www.iot-lab.info/wp-content/uploads/2013/10/m3opennode.png)
 
 ### Board Architecture
 
-![IoT-LAB M3 Architecture](https://github.com/iot-lab/iot-
-lab/wiki/Images/archiopenm3.png)
+![IoT-LAB M3 Architecture]
+(https://github.com/iot-lab/iot-lab/wiki/Images/archiopenm3.png)
 
 ### [Board schematics](http://github.com/iot-lab/iot-lab/wiki/Docs/openm3-schematics.pdf)
 , wiring, pinouts, etc...

--- a/boards/limifrog-v1/doc.txt
+++ b/boards/limifrog-v1/doc.txt
@@ -6,12 +6,13 @@
 ## Overview
 LimiFrog-v1 arose from the La BlueFrog board. LimiFrog-v1 contains the first
 hardware revision of that kickstarter project. LimiFrog-v2 is already there and
-the RIOT support will follow. [LimiFrog](http://www.limifrog.io/home-en-
-kickstarter/) features a variety of sensors as well as an OLED Display and a BLE
+the RIOT support will follow.
+[LimiFrog](https://github.com/LimiFrog/LimiFrog-HW)
+features a variety of sensors as well as an OLED Display and a BLE
 (Bluetooth Low-Energy) module.
 
 ## Hardware
-![Limifrog-v1](http://www.limifrog.io/wordpress/wp-content/uploads/2015/07/LeadingPhoto-W500px.jpg)
+![Limifrog-v1](https://www.cnx-software.com/wp-content/uploads/2015/09/Limifrog.jpg)
 ![limifrog-v1 pinout](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/limifrog-v1_pinout.png)
 
 ### MCU
@@ -73,7 +74,8 @@ kickstarter/) features a variety of sensors as well as an OLED Display and a BLE
 
 The LimiFrog-v1 has no on-board programmer nor an USB-UART converter. It can
 be programmed by using the integrated ST-Link/V2 programmer of any STM32Fx-
-discovery board. See Hardware section [here](@ref boards_yunjia-nrf51822) for an example.
+discovery board. See the Hardware subsection in Flashing and Debugging section
+[here](@ref boards_yunjia-nrf51822) for an example.
 Another way is to use a stand-alone ST-Link V2 programmer as shown in the
 picture.
 

--- a/boards/msb-430/include/board.h
+++ b/boards/msb-430/include/board.h
@@ -11,7 +11,7 @@
  *
  * @details
  * See
- * http://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/Z_Finished_Projects/ScatterWeb/modules/mod_MSB-430.html
+ * https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/modules/mod_MSB-430.html
  * for circuit diagram etc.
  *
  * <h2>Components</h2>

--- a/boards/msb-430h/doc.txt
+++ b/boards/msb-430h/doc.txt
@@ -23,8 +23,8 @@
 | SPIs       | 2 |
 | I2Cs       | 1     |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet / Reference Manual   | [Datasheet](http://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/Z_Finished_Projects/ScatterWeb/moduleComponents/msp430f1612.pdf?1346661398) |
-| User Guide | [User Guide](http://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/Z_Finished_Projects/ScatterWeb/moduleComponents/MSP430slau049f.pdf?1346661398)|
+| Datasheet / Reference Manual   | [Datasheet](https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/moduleComponents/msp430f1612.pdf) |
+| User Guide | [User Guide](https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/moduleComponents/MSP430slau049f.pdf)|
 
 ## Radio
 
@@ -54,9 +54,9 @@ This should take care of everything!
 ## Using the shell
 
 The shell is using the UART interface of the MSB-430H at 115200 baud. You
-need a 3.3V TTL serial cable. For USB connections you could use a [FTDI connector](http://apple.clickandbuild.com/cnb/shop/ftdichip?productID=53&op=catalogue-product_info-null&prodCategoryID=105)
+need a 3.3V TTL serial cable. For USB connections you could use a FTDI connector.
 
 ## More information
 
-[FU Berlin info page on the MSB-430H](http://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/Z_Finished_Projects/ScatterWeb/modules/mod_MSB-430H.html)
+[FU Berlin info page on the MSB-430H](https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/modules/mod_MSB-430H.html)
  */

--- a/boards/msba2/doc.txt
+++ b/boards/msba2/doc.txt
@@ -26,7 +26,7 @@
 
 ![Circuit Diagram II](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/MSBA2_circuit_back.png)
 
-[MSB-A2 page @ Freie Universität Berlin/CST](http://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/Z_Finished_Projects/ScatterWeb/modules/mod_MSB-A2.html)
+[MSB-A2 page @ Freie Universität Berlin/CST](https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/modules/mod_MSB-A2.html)
 
 
 ## Flashing

--- a/boards/msbiot/doc.txt
+++ b/boards/msbiot/doc.txt
@@ -101,7 +101,7 @@ automatically loaded when the pseudo module `netdev_default` is used.
 | Type                      | Sub-1GHz RF Transceiver                                           |
 | Vendor                    | Texas Instruments                                                 |
 | Datasheet                 | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1101.pdf)          |
-| Errata Sheet              | [Errata Sheet](http://www.ti.com/lit/er/swrz020d/swrz020d.pdf)    |
+| Errata Sheet              | [Errata Sheet](https://www.ti.com/lit/er/swrz020e/swrz020e.pdf)   |
 | Other Technical Documents | [TI Webpage](http://www.ti.com/product/CC1101/technicaldocuments) |
 | Driver                    | @ref drivers_cc110x                                               |
 | SPI Device                | SPI1 (Mapped to SPI_0 in RIOT)                                    |
@@ -136,10 +136,10 @@ on the inclusion.
 |:------------------------- |:----------------------------------------------------------------- |
 | Type                      | 802.11b/g Wi-Fi Module                                            |
 | Vendor                    | Texas Instruments                                                 |
-| Datasheet                 | [Datasheet](http://www.ti.com/lit/ds/symlink/cc3000.pdf)          |
+| Datasheet                 | [Datasheet](https://web.archive.org/web/20171109015601/http://www.ti.com/lit/ds/symlink/cc3000.pdf) |
 | Errata Sheet              | [Errata Sheet](http://www.ti.com/lit/er/swrz044b/swrz044b.pdf)    |
-| Other Technical Documents | [TI Webpage](http://www.ti.com/product/CC3000/technicaldocuments) |
-| TI Wiki                   | [Wiki](http://processors.wiki.ti.com/index.php/CC3000)            |
+| Other Technical Documents | [TI Webpage](https://web.archive.org/web/20190825013529/http://www.ti.com/product/CC3000/technicaldocuments) |
+| TI Support Forum          | [WiFi Forum](https://e2e.ti.com/support/wireless-connectivity/wifi/f/968) |
 | Driver                    | [Pull Request](https://github.com/RIOT-OS/RIOT/pull/2603)         |
 | SPI Device                | SPI2 (Mapped to SPI_1 in RIOT)                                    |
 | SCL                       | PB10                                                              |
@@ -169,8 +169,8 @@ found [here](https://github.com/RIOT-OS/RIOT/tree/master/tests/driver_mpu9x50).
 |:--------------------- |:------------------------------------------------------------------------------------------------- |
 | Type                  | Nine-Axis MotionTracking Device (Gyro, Accel and Compass)                                         |
 | Vendor                | Invensense                                                                                        |
-| Product Specification | [Product Specification](http://www.invensense.com/mems/gyro/documents/PS-MPU-9150A-00v4_3.pdf)    |
-| Register Map          | [Register Map](http://www.invensense.com/mems/gyro/documents/RM-MPU-9150A-00v4_2.pdf)             |
+| Product Specification | [Product Specification](https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-9150-Datasheet.pdf)    |
+| Register Map          | [Register Map](https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-9150-Register-Map.pdf)             |
 | Driver                | @ref drivers_mpu9x50                                                                              |
 | I²C Device            | I2C1 (Mapped to I2C_0 in RIOT)                                                                    |
 | SCL                   | PB6                                                                                               |

--- a/boards/mulle/doc.txt
+++ b/boards/mulle/doc.txt
@@ -3,13 +3,15 @@
 @ingroup     boards
 @brief       Support for Eistec Mulle IoT boards
 
-![Mulle](http://eistec.github.io/images/mulle-small.jpg)
+![Mulle]
+(https://web.archive.org/web/20161213064400im_/http://eistec.github.io/images/mulle-small.jpg)
 
 The Mulle is a miniature wireless Embedded Internet System suitable for
 wireless sensors connected to the Internet of Things, and designed for rapid
-prototyping. It can be bought directly from [Eistec AB](http://www.eistec.se).
+prototyping.
 
- - [Official homepage](http://www.eistec.se/mulle)
+ - [Official homepage (Archived)]
+   (https://web.archive.org/web/20161213064400/http://www.eistec.se/mulle)
  - [Eistec wiki](https://github.com/eistec/mulle/wiki)
 
 Use `BOARD=mulle` for building RIOT for this platform.

--- a/boards/native/doc.txt
+++ b/boards/native/doc.txt
@@ -6,8 +6,8 @@
 [Family: native](https://github.com/RIOT-OS/RIOT/wiki/Family:-native)
 
 # Overview
-![Terminal running RIOT native](https://raw.githubusercontent.com/wiki/RIOT-
-OS/RIOT/images/Native.jpg)
+![Terminal running RIOT native]
+(https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/Native.jpg)
 
 # Hardware
 - CPU: Host CPU

--- a/boards/nrf51dk/doc.txt
+++ b/boards/nrf51dk/doc.txt
@@ -16,10 +16,11 @@ well with UART: the shell is only working on RX but not TX.
 
 Thus, we recommend to update the flasher ship with DAPLink as described
 [here](https://armmbed.github.io/DAPLink/?board=Nordic-nRF51-DK):
-1. Download [this firmware](https://armmbed.github.io/DAPLink//firmware/0251_sam3u2c_mkit_dk_dongle_nrf5x_0x5000.bin)
+1. Download and extract [this release package](https://github.com/ARMmbed/DAPLink/releases/download/v0251/0251_release_package_9295000c.zip)
 2. While holding down the boards reset button, connect the boards USB debug
    port to the computer. It should enumerate as `BOOTLOADER`
-3. Using a filesystem browser, drag-n-drop the firmware file to the
+3. Using a filesystem browser, drag-n-drop the firmware
+   `0251_sam3u2c_mkit_dk_dongle_nrf5x_0x5000.bin` file to the
    `BOOTLOADER` folder
 4. Power-cycle the board, a new DAPLink mount point should appear
 

--- a/boards/nrf51dongle/doc.txt
+++ b/boards/nrf51dongle/doc.txt
@@ -18,7 +18,8 @@ While the pca10000 contains an on-board J-Link debugger, the pca10005 boards
 have to be flashed/debugged using the (included) external J-Link device.
 
 ## Hardware:
-![Nordic Semiconductor nrF51822 Development Kit](https://www.nordicsemi.com/var/ezwebin_site/storage/images/media/images/products/nrf51822-dk/422047-1-eng-GB/nRF51822-DK.jpg)
+![Nordic Semiconductor nrF51822 Development Kit]
+(https://www.nordicsemi.com/-/media/Images/Products/DevKits/nRF51-Series/nRF51-Dongle-promo.png)
 
 | MCU        | NRF51822QFAA      |
 |:------------- |:--------------------- |
@@ -35,8 +36,8 @@ have to be flashed/debugged using the (included) external J-Link device.
 | I2Cs       | 2                 |
 | Radio         | 2.4GHz BLE compatiple, +4dBm to -20 dBm output, -93 dBm RX sensitivity |
 | Vcc        | 1.8V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.freqchina.com/cn/down.asp?ID=135) (pdf file) |
-| Reference Manual | [Reference Manual](http://www.100y.com.tw/pdf_file/39-Nordic-NRF51822.pdf) |
+| Datasheet  | [Datasheet](https://infocenter.nordicsemi.com/pdf/nRF51822_PS_v3.3.pdf) |
+| Reference Manual | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.1.pdf) |
 
 
 ## Flashing the Device:

--- a/boards/nrf52dk/doc.txt
+++ b/boards/nrf52dk/doc.txt
@@ -38,7 +38,7 @@ board](https://github.com/d00616/temp/raw/master/nrf52-minidev.jpg)
 | Radio         | 2.4GHz BLE compatiple, -20 dBm to +4 dBm output, -96 dBm RX sensitivity |
 | Vcc        | 1.7V - 3.6V           |
 | Datasheet  | [Datasheet](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52832) |
-| Reference Manual | [Reference Manual](http://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52%2Fdita%2Fnrf52%2Fnrf52_series.html&cp=1) |
+| Reference Manual | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf) |
 
 ##Pin layout
 

--- a/boards/nucleo-f030r8/doc.txt
+++ b/boards/nucleo-f030r8/doc.txt
@@ -10,8 +10,8 @@ STM32F030R8 microcontroller with 8Kb of SRAM and 64Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F030R8](http://www.open-electronics.org/wp-
-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F030R8]
+(http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 
 

--- a/boards/nucleo-f070rb/doc.txt
+++ b/boards/nucleo-f070rb/doc.txt
@@ -10,8 +10,8 @@ STM32F070RB microcontroller with 16Kb of SRAM and 128Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F070RB](http://www.open-electronics.org/wp-
-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F070RB]
+(http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 
 

--- a/boards/nucleo-f401re/doc.txt
+++ b/boards/nucleo-f401re/doc.txt
@@ -66,8 +66,7 @@ make BOARD=nucleo-f401re debug
 ## Supported Toolchains
 
 For using the ST Nucleo-F401RE board we strongly recommend the usage of the
-[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-
-embedded)
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
 
 ## Issues with old Hardware Revisions

--- a/boards/nucleo-f411re/doc.txt
+++ b/boards/nucleo-f411re/doc.txt
@@ -66,7 +66,6 @@ make BOARD=nucleo-f411re debug
 ## Supported Toolchains
 
 For using the ST Nucleo-F411RE board we strongly recommend the usage of the
-[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-
-embedded)
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f446re/doc.txt
+++ b/boards/nucleo-f446re/doc.txt
@@ -10,8 +10,8 @@ STM32F446RE microcontroller with 128Kb of RAM and 512Kb of ROM Flash.
 
 ## Hardware
 
-![Nucleo64 F446RE](http://www.open-electronics.org/wp-
-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F446RE]
+(http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 ### MCU
 
@@ -68,7 +68,6 @@ make BOARD=nucleo-f446re debug
 ## Supported Toolchains
 
 For using the ST Nucleo-F446RE board we strongly recommend the usage of the
-[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-
-embedded)
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/nucleo-f446ze/doc.txt
+++ b/boards/nucleo-f446ze/doc.txt
@@ -67,7 +67,6 @@ make BOARD=nucleo-f446ze debug
 ## Supported Toolchains
 
 For using the ST Nucleo-F446ZE board we strongly recommend the usage of the
-[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-
-embedded)
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
  */

--- a/boards/openmote-cc2538/doc.txt
+++ b/boards/openmote-cc2538/doc.txt
@@ -10,8 +10,8 @@ SoC combining an ARM Cortex-M3 microcontroller with an IEEE802.15.4 radio.
 
 ## Hardware
 
-![openmote](https://raw.githubusercontent.com/wiki/RIOT-
-OS/RIOT/images/openmote.jpg)
+![openmote]
+(https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/openmote.jpg)
 
 | MCU        | CC2538SF53        |
 |:------------- |:--------------------- |

--- a/boards/pba-d-01-kw2x/doc.txt
+++ b/boards/pba-d-01-kw2x/doc.txt
@@ -84,7 +84,7 @@ The actual pin configuration of the board for RIOT can be found in
 | Pressure Sensor    | [MPL3115A2](http://www.nxp.com/products/sensors/pressure-sensors/barometric-pressure-15-to-115-kpa/20-to-110kpa-absolute-digital-pressure-sensor:MPL3115A2?) | yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/2123) |
 | Tri-axis Accelerometer | [MMA8652FC](http://www.nxp.com/products/sensors/accelerometers/3-axis-accelerometers/2g-4g-8g-low-g-12-bit-digital-accelerometer:MMA8652FC)   | yes | [mainline](https://github.com/RIOT-OS/RIOT/pull/2119) |
 | Magnetometer   | [MAG3110FCR1](http://www.nxp.com/products/sensors/magnetometers/sample-data-sets-for-inertial-and-magnetic-sensors/freescale-high-accuracy-3d-magnetometer:MAG3110)   | yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/2121) |
-| Light Sensor   | [TCS3772](https://ams.com/jpn/content/download/291143/1065677/file/TCS3772_Datasheet_EN_v1.pdf)   | yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/3135) |
-| IR-Termopile Sensor    | [TMP006](http://www.ti.com/product/TMP006)    |yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/2148) |
+| Light Sensor   | [TCS3772](https://ams.com/documents/20143/36005/TCS3772_DS000175_3-00.pdf/8689a345-f46b-d3f0-f839-eb8d38ead80d)   | yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/3135) |
+| IR-Termopile Sensor    | [TMP006](http://www.ti.com/ww/eu/sensampbook/tmp006.pdf)    |yes       | [mainline](https://github.com/RIOT-OS/RIOT/pull/2148) |
 | Capacitive Button  | PCB   | yes        | [mainline](https://github.com/RIOT-OS/RIOT/pull/7147) |
  */

--- a/boards/phynode-kw41z/doc.txt
+++ b/boards/phynode-kw41z/doc.txt
@@ -22,7 +22,7 @@ There board also provides an SSD1673 Active Matrix EPD 150x200 Display Driver
 <img src="https://www.phytec.eu/fileadmin/user_upload/images/content/1.Products/IoT/ePaper_IoTKit_4.png"
      alt="PhyNODE-KW41Z" />
 
-[board-web-page]: https://www.phytec.eu/product-eu/internet-of-things/iot-enablement-kit-4/
+[board-web-page]: https://www.phytec.de/fileadmin/user_upload/downloads/Manuals/L-847e_0.pdf
 
 ### Flash the board
 

--- a/boards/remote-pa/README.md
+++ b/boards/remote-pa/README.md
@@ -110,8 +110,12 @@ On Linux:
 
 More Reading
 ============
-2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
-3. [CC1120 sub-1GHz RF transceiver][cc1120]
+1. [Zolertia RE-Mote website][remote-site]
+2. [Zolertia Wiki page][zolertia-wiki]
+3. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
+4. [CC1120 sub-1GHz RF transceiver][cc1120]
 
+[remote-site]: https://zolertia.io/product/re-mote/ "Zolertia RE-Mote"
+[zolertia-wiki]: https://github.com/Zolertia/Resources/wiki
 [cc1120]: http://www.ti.com/cc1120 "CC1120"
 [cc2538]: http://www.ti.com/product/cc2538     "CC2538"

--- a/boards/remote-pa/doc.txt
+++ b/boards/remote-pa/doc.txt
@@ -1,5 +1,89 @@
 /**
-@defgroup    boards_remote-pa Re-Mote Prototype A
+@defgroup    boards_remote-pa RE-Mote Prototype A
 @ingroup     boards
-@brief       Support for the Re-Mote board prototype A
+@brief       Support for the RE-Mote board prototype A
+
+The `RE-Mote` has three versions, a first prototype A (`remote-pa`) only
+distributed to beta testers, its following revision A (`remote-reva`), and the
+latest revision B (`remote-revb`) which are commercially available. The
+following section focuses on the revision A.
+
+The official RE-Mote wiki page is maintained by Zolertia at:
+
+https://github.com/Zolertia/Resources/wiki
+
+# Components
+
+| MCU   | [CC2538 (ARM Cortex-M3 with on-board 2.4GHz radio)](http://www.ti.com/product/CC2538) |
+|-------|-----------------------------------------------------------------------------------------------------|
+| Radio | Two radio interfaces (IEEE 802.15.4): [2.4GHz](http://www.ti.com/product/CC2538) and [863-950MHz](http://www.ti.com/product/CC1200) |
+|  | RP-SMA connector for external antenna (with a RF switch to select either 2.4GHz/Sub-GHz radio)           |
+| USB-to-Serial | [CP2104](https://www.silabs.com/products/interface/Pages/cp2104-mini.aspx) |
+| Peripherals | RTCC, built-in battery charger for LiPo batteries, External WDT (optional), Micro-SD |
+| Others | RGB LED, power management block (150nA when the mote is shutdown)|
+
+# Porting status
+
+In terms of hardware support, the following drivers have been implemented
+for CC2538 System-on-Chip:
+
+- UART
+- Random number generator
+- Low Power Modes
+- General-Purpose Timers
+- I2C/SPI library
+- LEDs
+- Buttons
+- RF 2.4GHz built-in in CC2538
+- RF switch to programmatically drive either 2.4GHz or sub-1GHz to a single
+  RP-SMA
+
+And under work or pending at CC2538 base CPU:
+
+- Built-in core temperature and battery sensor.
+- CC1200 sub-1GHz radio interface.
+- Micro-SD external storage.
+- ADC
+- USB (in CDC-ACM).
+- uDMA Controller.
+
+# Layout
+
+![layout](http://i.imgur.com/4bV6lyYl.png)
+
+# Flashing
+
+The RE-Mote has built-in support to flash over USB using the BSL.  Previous
+versions required to unlock the bootloader by manually pressing the `user
+button` and `reset button`, but the current version handles the sequence with an
+on-board PIC, so automatically unlocks the bootloader upon flashing.
+
+e.g.
+```
+Bash
+$ make BOARD=remote-reva flash
+```
+
+The RE-Mote in its current Revision A has the following pin-out:
+
+![RE-Mote pin-out (front)](https://raw.githubusercontent.com/contiki-os/contiki/master/platform/zoul/images/remote-reva-pinout-front.png)
+![RE-Mote pin-out (back)](https://raw.githubusercontent.com/contiki-os/contiki/master/platform/zoul/images/remote-reva-pinout-back.png)
+
+# Pin out and connectors
+
+## RE-Mote ports and connectors
+
+![](http://i.imgur.com/TF21Hin.png)
+
+![](http://i.imgur.com/J7aisKJ.png)
+
+## RE-Mote on-board connectors pin-out
+
+The RE-Mote uses the [Molex 5-pin WM4903-ND male header connector](http://datasheets.globalspec.com/ds/5843/DigiKey/6D12815C-098E-40A3-86A0-22A3C50B75BA) to
+connect digital sensors based on I2C and SPI protocols, as well as other sensors
+or actuators you may need to connect.  The pins are 2.54 mm spaced and the
+connector has the following pin-out:
+
+![](http://i.imgur.com/2DZ17PV.png)
+![](http://i.imgur.com/q7Hb7Y8.png)
  */

--- a/boards/remote-reva/README.md
+++ b/boards/remote-reva/README.md
@@ -67,7 +67,7 @@ Else install from <https://launchpad.net/gcc-arm-embedded>
 Drivers
 -------
 The RE-Mote features a CP2104 serial-to-USB module, the driver is commonly found in most OS, but if required it can be downloaded
-from <https://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
+from <https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers>
 
 
 ### For the CC2538EM (USB CDC-ACM)
@@ -105,7 +105,7 @@ More Reading
 2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
 3. [CC1200 sub-1GHz RF transceiver][cc1200]
 
-[remote-site]: https://zolertia.io/product/re-mote-suite/ "Zolertia RE-Mote"
+[remote-site]: https://zolertia.io/product/re-mote/ "Zolertia RE-Mote"
 [zolertia-wiki]: https://github.com/Zolertia/Resources/wiki
 [cc1200]: http://www.ti.com/product/cc1200     "CC1200"
 [cc2538]: http://www.ti.com/product/cc2538     "CC2538"

--- a/boards/remote-reva/doc.txt
+++ b/boards/remote-reva/doc.txt
@@ -10,7 +10,7 @@ following section focuses on the revision A.
 
 The official RE-Mote wiki page is maintained by Zolertia at:
 
-https://github.com/Zolertia/Resources/wiki
+https://github.com/Zolertia/Resources/wiki/RE-Mote
 
 # Components
 
@@ -18,34 +18,34 @@ https://github.com/Zolertia/Resources/wiki
 |-------|-----------------------------------------------------------------------------------------------------|
 | Radio | Two radio interfaces (IEEE 802.15.4): [2.4GHz](http://www.ti.com/product/CC2538) and [863-950MHz](http://www.ti.com/product/CC1200) |
 |  | RP-SMA connector for external antenna (with a RF switch to select either 2.4GHz/Sub-GHz radio)           |
-| USB-to-Serial | [CP2104](https://www.silabs.com/products/interface/Pages/cp2104-mini.aspx) |
+| USB-to-Serial | [CP2104](https://www.silabs.com/documents/public/data-sheets/cp2104.pdf) |
 | Peripherals | RTCC, built-in battery charger for LiPo batteries, External WDT (optional), Micro-SD |
 | Others | RGB LED, power management block (150nA when the mote is shutdown)|
 
 # Porting status
 
-In terms of hardware support, the following drivers have been implemented:
+In terms of hardware support, the following drivers have been implemented
+for CC2538 System-on-Chip:
 
-* CC2538 System-on-Chip:
-* UART
-* Random number generator
-* Low Power Modes
-* General-Purpose Timers
-* I2C/SPI library
-* LEDs
-* Buttons
-* RF 2.4GHz built-in in CC2538
-* RF switch to programmatically drive either 2.4GHz or sub-1GHz to a single
-RP-SMA
+- UART
+- Random number generator
+- Low Power Modes
+- General-Purpose Timers
+- I2C/SPI library
+- LEDs
+- Buttons
+- RF 2.4GHz built-in in CC2538
+- RF switch to programmatically drive either 2.4GHz or sub-1GHz to a single
+  RP-SMA
 
-And under work or pending at cc2538 base cpu:
+And under work or pending at CC2538 base CPU:
 
-* Built-in core temperature and battery sensor.
-* CC1200 sub-1GHz radio interface.
-* Micro-SD external storage.
-* ADC
-* USB (in CDC-ACM).
-* uDMA Controller.
+- Built-in core temperature and battery sensor.
+- CC1200 sub-1GHz radio interface.
+- Micro-SD external storage.
+- ADC
+- USB (in CDC-ACM).
+- uDMA Controller.
 
 # Layout
 

--- a/boards/remote-revb/README.md
+++ b/boards/remote-revb/README.md
@@ -73,7 +73,7 @@ Else install from <https://launchpad.net/gcc-arm-embedded>
 Drivers
 -------
 The RE-Mote features a CP2104 serial-to-USB module, the driver is commonly found in most OS, but if required it can be downloaded
-from <https://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
+from <https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers>
 
 
 ### For the CC2538EM (USB CDC-ACM)
@@ -108,10 +108,10 @@ More Reading
 ============
 1. [Zolertia RE-Mote website][remote-site]
 2. [Zolertia Wiki page][zolertia-wiki]
-2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
-3. [CC1200 sub-1GHz RF transceiver][cc1200]
+3. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
+4. [CC1200 sub-1GHz RF transceiver][cc1200]
 
-[remote-site]: https://zolertia.io/product/re-mote-suite/ "Zolertia RE-Mote"
+[remote-site]: https://zolertia.io/product/re-mote/ "Zolertia RE-Mote"
 [zolertia-wiki]: https://github.com/Zolertia/Resources/wiki
 [cc1200]: http://www.ti.com/product/cc1200     "CC1200"
 [cc2538]: http://www.ti.com/product/cc2538     "CC2538"

--- a/boards/remote-revb/doc.txt
+++ b/boards/remote-revb/doc.txt
@@ -2,4 +2,88 @@
 @defgroup    boards_remote-revb RE-Mote Revision B
 @ingroup     boards
 @brief       Support for the RE-Mote board Revision B
+
+The `RE-Mote` has three versions, a first prototype A (`remote-pa`) only
+distributed to beta testers, its following revision A (`remote-reva`), and the
+latest revision B (`remote-revb`) which are commercially available. The
+following section focuses on the revision A.
+
+The official RE-Mote wiki page is maintained by Zolertia at:
+
+https://github.com/Zolertia/Resources/wiki
+
+# Components
+
+| MCU   | [CC2538 (ARM Cortex-M3 with on-board 2.4GHz radio)](http://www.ti.com/product/CC2538) |
+|-------|-----------------------------------------------------------------------------------------------------|
+| Radio | Two radio interfaces (IEEE 802.15.4): [2.4GHz](http://www.ti.com/product/CC2538) and [863-950MHz](http://www.ti.com/product/CC1200) |
+|  | RP-SMA connector for external antenna (with a RF switch to select either 2.4GHz/Sub-GHz radio)           |
+| USB-to-Serial | [CP2104](https://www.silabs.com/documents/public/data-sheets/cp2104.pdf) |
+| Peripherals | RTCC, built-in battery charger for LiPo batteries, External WDT (optional), Micro-SD |
+| Others | RGB LED, power management block (150nA when the mote is shutdown)|
+
+# Porting status
+
+In terms of hardware support, the following drivers have been implemented
+for CC2538 System-on-Chip:
+
+- UART
+- Random number generator
+- Low Power Modes
+- General-Purpose Timers
+- I2C/SPI library
+- LEDs
+- Buttons
+- RF 2.4GHz built-in in CC2538
+- RF switch to programmatically drive either 2.4GHz or sub-1GHz to a single
+  RP-SMA
+
+And under work or pending at CC2538 base CPU:
+
+- Built-in core temperature and battery sensor.
+- CC1200 sub-1GHz radio interface.
+- Micro-SD external storage.
+- ADC
+- USB (in CDC-ACM).
+- uDMA Controller.
+
+# Layout
+
+![layout](http://i.imgur.com/4bV6lyYl.png)
+
+# Flashing
+
+The RE-Mote has built-in support to flash over USB using the BSL.  Previous
+versions required to unlock the bootloader by manually pressing the `user
+button` and `reset button`, but the current version handles the sequence with an
+on-board PIC, so automatically unlocks the bootloader upon flashing.
+
+e.g.
+```
+Bash
+$ make BOARD=remote-reva flash
+```
+
+The RE-Mote in its current Revision A has the following pin-out:
+
+![RE-Mote pin-out (front)](https://raw.githubusercontent.com/contiki-os/contiki/master/platform/zoul/images/remote-reva-pinout-front.png)
+![RE-Mote pin-out (back)](https://raw.githubusercontent.com/contiki-os/contiki/master/platform/zoul/images/remote-reva-pinout-back.png)
+
+# Pin out and connectors
+
+## RE-Mote ports and connectors
+
+![](http://i.imgur.com/TF21Hin.png)
+
+![](http://i.imgur.com/J7aisKJ.png)
+
+## RE-Mote on-board connectors pin-out
+
+The RE-Mote uses the [Molex 5-pin WM4903-ND male header connector](http://datasheets.globalspec.com/ds/5843/DigiKey/6D12815C-098E-40A3-86A0-22A3C50B75BA) to
+connect digital sensors based on I2C and SPI protocols, as well as other sensors
+or actuators you may need to connect.  The pins are 2.54 mm spaced and the
+connector has the following pin-out:
+
+![](http://i.imgur.com/2DZ17PV.png)
+![](http://i.imgur.com/q7Hb7Y8.png)
  */

--- a/boards/samd21-xpro/doc.txt
+++ b/boards/samd21-xpro/doc.txt
@@ -33,7 +33,7 @@ The samd21-xpro is available from various hardware vendors for ~30USD (as of
 | SPIs       | max 6 (see UART)                  |
 | I2Cs       | max 6 (see UART)              |
 | Vcc        | 1.62V - 3.63V         |
-| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/40001882A.pdf) |
+| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_Data%20Sheet_DS40001882E.pdf) |
 | Board Manual   | [Board Manual](http://www.atmel.com/Images/Atmel-42220-SAMD21-Xplained-Pro_User-Guide.pdf)|
 
 ### User Interface

--- a/boards/seeeduino_arch-pro/doc.txt
+++ b/boards/seeeduino_arch-pro/doc.txt
@@ -28,10 +28,10 @@ interface.
 | SPIs            | 2x USART                                 |
 | I2Cs            | 2x                                       |
 | Vcc             | 2.4V - 3.6V                              |
-| Datasheet       | [Datasheet](http://www.nxp.com/documents/data_sheet/LPC1768_66_65_64.pdf)|
+| Datasheet       | [Datasheet](https://www.nxp.com/docs/en/data-sheet/LPC1769_68_67_66_65_64_63.pdf)|
 | Manual          | [Manual](http://www.nxp.com/documents/user_manual/UM10360.pdf)|
 | Board Manual    | [Board Manual](http://www.seeedstudio.com/wiki/Arch_Pro)|
-| Board Schematic | [Board Schematic](http://www.seeedstudio.com/wiki/File:Arch_Pro_V1.0_Schematic.pdf)  |
+| Board Schematic | [Board Schematic](https://raw.githubusercontent.com/SeeedDocument/Arch_Pro/master/res/Arch_Pro_V1.0_Schematic.pdf)  |
 
 ### Pinout
 

--- a/boards/slstk3401a/doc.txt
+++ b/boards/slstk3401a/doc.txt
@@ -138,7 +138,8 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf)
+peripherals. You are advised to read [AN0004.1]
+(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/slstk3402a/doc.txt
+++ b/boards/slstk3402a/doc.txt
@@ -140,7 +140,8 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf)
+peripherals. You are advised to read [AN0004.1]
+(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/sltb001a/doc.txt
+++ b/boards/sltb001a/doc.txt
@@ -118,7 +118,8 @@ expects data from the MCU with the same settings.
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf)
+peripherals. You are advised to read [AN0004.1]
+(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/sodaq-autonomo/doc.txt
+++ b/boards/sodaq-autonomo/doc.txt
@@ -31,7 +31,7 @@ The Autonomo is available from the SODAQ [shop](http://shop.sodaq.com/).
 | SPIs       | max 6 (see UART)                  |
 | I2Cs       | max 6 (see UART)              |
 | Vcc        | 1.8V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.atmel.com/Images/Atmel-42181-SAM-D21_Datasheet.pdf) |
+| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_Data%20Sheet_DS40001882E.pdf) |
 
 ### User Interface
 

--- a/boards/spark-core/doc.txt
+++ b/boards/spark-core/doc.txt
@@ -12,8 +12,8 @@ when you're ready to integrate the Core into your product, you can.
 
 ## Hardware
 
-![Spark-Core image](https://raw.githubusercontent.com/wiki/RIOT-
-OS/RIOT/images/spark-core.jpg)
+![Spark-Core image]
+(https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/spark-core.jpg)
 
 Link to [product website](http://docs.spark.io/hardware/).
 
@@ -112,8 +112,9 @@ Use the UART
 Pin mapping in RIOT
 ===================
 
-Please refer to [this document](http://docs.spark.io/assets/images/spark-
-pinout.png) for RIOTs static pin mapping chosen for this board. This mapping is
-completely arbitrary, it can be adjusted in `boards/spark-
-core/include/periph_conf.h`
+The following image shows RIOT's static pin mapping chosen for this board.
+This mapping is completely arbitrary, it can be adjusted in
+`boards/spark-core/include/periph_conf.h`
+![Pin Mappin](http://docs.spark.io/assets/images/spark-pinout.png)
+
  */

--- a/boards/stk3600/doc.txt
+++ b/boards/stk3600/doc.txt
@@ -137,7 +137,8 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf)
+peripherals. You are advised to read [AN0004.0]
+(https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/stk3700/doc.txt
+++ b/boards/stk3700/doc.txt
@@ -137,7 +137,8 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf)
+peripherals. You are advised to read [AN0004.0]
+(https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/stm32f3discovery/doc.txt
+++ b/boards/stm32f3discovery/doc.txt
@@ -15,7 +15,8 @@ and 3-axis magnetometer).
 The board does however not provide any radio capabilities, radio devices have
 to be connected externally via I2C, SPI, UART or similar.
 
-See [this page](https://github.com/RIOT-OS/RIOT/wiki/Getting-started-with-STM32F%5B0%7C3%7C4%5Ddiscovery-boards)
+See [this page]
+(https://github.com/RIOT-OS/RIOT/wiki/Getting-started-with-STM32F%5B0%7C3%7C4%5Ddiscovery-boards)
 for a quick getting started guide.
 
 ## Hardware
@@ -38,10 +39,10 @@ for a quick getting started guide.
 | SPIs       | 3                 |
 | I2Cs       | 2                 |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/web/en/resource/technical/document/datasheet/DM00058181.pdf) |
-| Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00043574.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/programming_manual/DM00046982.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00063382.pdf)|
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f303vc.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00043574.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
+| Board Manual   | [Board Manual](https://www.st.com/resource/en/user_manual/dm00063382.pdf)|
 
 ### RIOT static pin mapping
 
@@ -75,8 +76,7 @@ e-compass.
 |:------------- |:--------------------- |
 | Type       | Accelerometer and magnetometer |
 | Vendor | ST Microelectronics   |
-| Datasheet  | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00027543.pdf)|
-| Errata Sheet  | [Errata Sheet](http://www.st.com/st-web-ui/static/active/en/fragment/legal/statements/disclaimer/disclaimer_errata.pdf)|
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/lsm303dlhc.pdf)|
 | Connected to   | I2C_0         |
 | Pin Config:    | |
 | Device | I2C1          |
@@ -96,8 +96,7 @@ An 3-axis gyroscope is soldered on the board.
 |:------------- |:--------------------- |
 | Type       | Gyroscope     |
 | Vendor | ST Microelectronics   |
-| Datasheet  | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00036465.pdf)    |
-| Errata Sheet  | [Errata Sheet](http://www.st.com/st-web-ui/static/active/en/fragment/legal/statements/disclaimer/disclaimer_errata.pdf)|
+| Datasheet  | [Datasheet](https://www.mouser.de/datasheet/2/389/l3gd20-954745.pdf)    |
 | Connected to   | SPI_0         |
 | Pin Config:    | |
 | Device | SPI1          |

--- a/boards/stm32f4discovery/doc.txt
+++ b/boards/stm32f4discovery/doc.txt
@@ -27,10 +27,10 @@ for a quick getting started guide.
 | SPIs       | 3                 |
 | I2Cs       | 3                 |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/web/en/resource/technical/document/datasheet/DM00037051.pdf) |
-| Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031020.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/DM00023388.pdf) |
-| Board Manual   | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/DM00039084.pdf)|
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f407vg.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/dm00046982.pdf) |
+| Board Manual   | [Board Manual](https://www.st.com/resource/en/user_manual/dm00039084.pdf)|
 
 ### RIOT pin mapping
 
@@ -88,7 +88,7 @@ The STM32F4discovery board contains a on-board MEMS audio sensor.
 |:------------- |:--------------------- |
 | Type       | Audio sensor |
 | Vendor | ST Microelectronics   |
-| Datasheet  | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00025467.pdf)|
+| Datasheet  | [Datasheet](http://www.mouser.com/pdfdocs/STM_MP45DT02_Datasheet.PDF)|
 | Connected to   | n/a           |
 | Pin Config:    | |
 | Device | I2S2          |
@@ -177,5 +177,5 @@ is a good value to start with.
 ### OS X & make term
 If you want the terminal to work using `make term` command and get a message
 about missing tty device install the driver from
-http://www.silabs.com/products/mcu/pages/usbtouartbridgevcpdrivers.aspx .
+https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers .
  */

--- a/boards/telosb/doc.txt
+++ b/boards/telosb/doc.txt
@@ -20,8 +20,8 @@
 | SPIs       | 2 |
 | I2Cs       | 1     |
 | Vcc        | 2.0V - 3.6V           |
-| Datasheet / Reference Manual   | [Datasheet](http://www.ti.com/lit/gpn/msp430f1611) |
-| User Guide | [User Guide](http://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/Z_Finished_Projects/ScatterWeb/moduleComponents/MSP430slau049f.pdf?1346661398)|
+| Datasheet / Reference Manual   | [Datasheet](https://www.ti.com/product/MSP430F1611) |
+| User Guide | [User Guide](https://www.ti.com/lit/ug/slau049f/slau049f.pdf)|
 
 ## Radio
 
@@ -53,5 +53,5 @@ The shell is using the UART interface of the TelosB at 115200 baud.
 
 ## More information
 
-[advanticsys](http://www.advanticsys.com/shop/mtmcm5000msp-p-14.html)
+[MEMSIC](http://www.memsic.com/userfiles/files/DataSheets/WSN/telosb_datasheet.pdf)
  */

--- a/boards/yunjia-nrf51822/doc.txt
+++ b/boards/yunjia-nrf51822/doc.txt
@@ -11,7 +11,7 @@ priced module utilizing Nordics NRF51822QFAA SoC. The SoC features 16Kb of RAM,
 with a 2.4GHz radio that supports both Nordics proprietary ShockBurst as well as
 Bluetooth Low Energy (BLE).
 
-The board is available for example on [ebay](http://www.ebay.com/sch/i.html?_from=R40&_trksid=p2050601.m570.l1313.TR0.TRC0.H0.Xnrf51822&_nkw=nrf51822&_sacat=0)
+The board is available for example on [ebay](https://www.ebay.com/sch/i.html?_nkw=nrf51822)
 or at [aliexpress](http://www.aliexpress.com/wholesale?SearchText=nrf51822&catId=0&initiative_id=SB_20140804233951) for something around 8-10 USD.
 
 ## Hardware
@@ -32,8 +32,8 @@ or at [aliexpress](http://www.aliexpress.com/wholesale?SearchText=nrf51822&catId
 | SPIs       | 2                 |
 | I2Cs       | 2                 |
 | Vcc        | 1.8V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.freqchina.com/cn/down.asp?ID=135) (pdf file) |
-| Reference Manual | [Reference Manual](http://www.100y.com.tw/pdf_file/39-Nordic-NRF51822.pdf) |
+| Datasheet  | [Datasheet](https://infocenter.nordicsemi.com/pdf/nRF51822_PS_v3.3.pdf) |
+| Reference Manual | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.1.pdf) |
 
 
 ##  Flashing and Debugging
@@ -52,7 +52,7 @@ First of all make sure the your ST-Link device is detected and can be
 accessed properly. In Linux you might have to adept your `udev` rules
 accordingly:
 ```
-wget https://raw.githubusercontent.com/texane/stlink/master/49-stlinkv2.rules
+wget https://raw.githubusercontent.com/texane/stlink/master/etc/udev/rules.d/49-stlinkv2.rules
 sudo cp 49-stlinkv2.rules /etc/udev/rules.d/
 sudo udevadm control --reload-rules
 sudo udevadm trigger
@@ -60,7 +60,7 @@ sudo udevadm trigger
 now replug the usb cable and flash.
 
 Have a look at the 'Setting up udev rules' section in this
-[README file](https://github.com/texane/stlink/blob/master/README)
+[README file](https://github.com/texane/stlink/)
 if you need help.
 
 Second you need to enable the stand-alone ST-Link mode of the discovery board

--- a/boards/z1/doc.txt
+++ b/boards/z1/doc.txt
@@ -24,7 +24,7 @@ the link right here.
 The Z1 starter platform -- an extended version with some supplementary basic
 actuators, phidgets and ziglets connectors, SMA-RP connector for a concrete
 antenna, battery (2xAA) enclosure, and MSP430 JTAG connector
--- is [also available](http://zolertia.com/products/Z1_Starter_Platform).
+-- is [also available](https://github.com/Zolertia/Resources/wiki/The-Z1-mote).
 This RIOT port also supports this version, except that supplementary
 actuators (multi-color LED, wheel potentiometer, buzzer) are not directly
 defined. This will be done as soon as possible.

--- a/doc/doxygen/src/porting-boards.md
+++ b/doc/doxygen/src/porting-boards.md
@@ -150,7 +150,7 @@ The documentation must be under the proper doxygen group, you can compile the
 documentation by calling `make doc` and then open the generated html file on
 any browser.
 
-```md
+@code
 /**
 @defgroup    boards_foo FooBoard
 @ingroup     boards
@@ -170,7 +170,7 @@ any browser.
   ...
 
 */
-```
+@endcode
 
 # Using Common code                                         {#common-board-code}
 
@@ -183,7 +183,7 @@ already defined in the common code. Unless having specific configurations or
 initialization you might not need a `board.c` or `board.h`. Another common use
 case is common peripheral configurations:
 
-```diff
+@code
 -\#include "cfg_timer_tim5.h"
 +/**
 + * @name   Timer configuration
@@ -203,7 +203,7 @@ case is common peripheral configurations:
 +
 +#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 +/** @} */
-```
+@endcode
 
 If you want to use common makefiles, include them at the end of the specific
 `Makefile`, e.g. for a `Makefile.features`:
@@ -281,7 +281,7 @@ In this case some special considerations must be taken with the makefiles:
   `include $(RIOTBOARD)/foo-parent/Makefile.*include*`
 
 An example can be found in
-[`tests/external_board_native`](https://github.com/RIOT-OS/RIOT/tree/master/tests/external_board_native`)
+[`tests/external_board_native`](https://github.com/RIOT-OS/RIOT/tree/master/tests/external_board_native)
 
 # Tools                                                          {#boards-tools}
 

--- a/drivers/ccs811/doc.txt
+++ b/drivers/ccs811/doc.txt
@@ -102,7 +102,8 @@ raw data.
 @note
 - After setting the mode, the sensor is in conditioning period that needs
   up to 20 minutes, before accurate readings are generated, see the
-  [data sheet](https://ams.com/documents/20143/36005/CCS811_DS000459_6-00.pdf/c7091525-c7e5-37ac-eedb-b6c6828b0dcf)
+  [data sheet]
+  (https://ams.com/documents/20143/36005/CCS811_DS000459_7-00.pdf/3cfdaea5-b602-fe28-1a14-18776b61a35a)
   for more details.
 - During the early-live (burn-in) period, the CCS811 sensor should run
   for 48 hours in the selected mode of operation to ensure sensor

--- a/drivers/sdcard_spi/include/sdcard_spi_internal.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_internal.h
@@ -16,7 +16,7 @@
  *              "SD Specifications Part 1 Physical Layer Simplified Specification".
  *              References to the sd specs in this file apply to Version 5.00
  *              from August 10, 2016. For further details see
- *              https://www.sdcard.org/downloads/pls/pdf/part1_500.pdf.
+ *              https://www.sdcard.org/downloads/pls/
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */

--- a/drivers/sht3x/doc.txt
+++ b/drivers/sht3x/doc.txt
@@ -89,7 +89,13 @@ All driver functions return 0 on success or one of a negative error code defined
 
 ## Repeatability
 
-The SHT3x sensor supports **three levels of repeatability** (low, medium and high). The stated repeatability is 3 times the standard deviation of multiple consecutive measurements at the stated repeatability and at constant ambient conditions. It is a measure for the noise on the physical sensor output. Different measurement modes allow for high/medium/low repeatability. [Datasheet SHT3x-DIS](https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/0_Datasheets/Humidity/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf)
+The SHT3x sensor supports **three levels of repeatability** (low, medium and
+high). The stated repeatability is 3 times the standard deviation of multiple
+consecutive measurements at the stated repeatability and at constant ambient
+conditions. It is a measure for the noise on the physical sensor output.
+Different measurement modes allow for high/medium/low repeatability.
+[Datasheet SHT3x-DIS]
+(https://developer.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf)
 
 The repeatability settings influences the measurement duration as well as the power consumption of the sensor. The measurement takes typically 2.5 ms with low repeatability, 4.5 ms with medium repeatability and 12.5 ms with high repeatability. That is, the measurement produces a noticeable delay in execution.
 

--- a/examples/emcute_mqttsn/README.md
+++ b/examples/emcute_mqttsn/README.md
@@ -14,7 +14,7 @@ In general, any MQTT-SN capable broker or broker/gateway setup will do.
 Following a quick instruction on how-to setup the Mosquitto Real Simple Message
 Broker:
 
-1. Get the RSMB here: https://github.com/eclipse/mosquitto.rsmb:
+1. Get the RSMB here: https://github.com/eclipse/mosquitto.rsmb
 ```
 git clone https://github.com/eclipse/mosquitto.rsmb.git
 ```

--- a/pkg/lua/doc.txt
+++ b/pkg/lua/doc.txt
@@ -110,9 +110,9 @@
  *
  * ### Patches
  *
- * A version of Lua with the patches applied is available at
- * https://github.com/riot-appstore/lua. It can be downloaded and compiled in
- * desktop computer, and the official test suite (https://www.lua.org/tests/)
+ * A version of Lua with the patches applied is available at [GitHub]
+ * (https://github.com/riot-appstore/lua) It can be downloaded and compiled in
+ * desktop computer, and the official [test suite](https://www.lua.org/tests/)
  * can then be run.
  *
  * Alternatively, the patches in this package can be directly applied to the

--- a/pkg/wakaama/include/lwm2m_client_connection.h
+++ b/pkg/wakaama/include/lwm2m_client_connection.h
@@ -5,10 +5,10 @@
 * are made available under the terms of the Eclipse Public License v1.0
 * and Eclipse Distribution License v1.0 which accompany this distribution.
 *
-* The Eclipse Public License is available at
+* The Eclipse Public License is available at:
 *    http://www.eclipse.org/legal/epl-v10.html
-* The Eclipse Distribution License is available at
-*    http://www.eclipse.org/org/documents/edl-v10.php.
+* The Eclipse Distribution License is available at:
+*    http://www.eclipse.org/org/documents/edl-v10.php
 *
 * Contributors:
 *    Simon Bernard - initial API and implementation

--- a/sys/include/can/can.h
+++ b/sys/include/can/can.h
@@ -107,8 +107,8 @@ struct can_filter {
  * @brief CAN bit-timing parameters
  *
  * For further information, please read chapter "8 BIT TIMING
- * REQUIREMENTS" of the "Bosch CAN Specification version 2.0"
- * at http://www.semiconductors.bosch.de/pdf/can2spec.pdf.
+ * REQUIREMENTS" of the "Bosch CAN Specification version 2.0":
+ * https://www.kvaser.com/software/7330130980914/V1/can2spec.pdf
  */
 struct can_bittiming {
     uint32_t bitrate;      /**< Bit-rate in bits/second */

--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -11,7 +11,7 @@
  * @ingroup  sys
  * @brief RIOT Unittests based on the EmbUnit Framework
  *
- * @see http://embunit.sourceforge.net/embunit/
+ * @see https://sourceforge.net/projects/embunit
  *
  * @note Please refer to https://github.com/RIOT-OS/RIOT/wiki/Testing-RIOT
  *

--- a/sys/include/net/eui64.h
+++ b/sys/include/net/eui64.h
@@ -10,7 +10,7 @@
  * @defgroup    net_eui64   IEEE EUI-64 identifier
  * @ingroup     net
  * @brief       Type definition of the IEEE EUI-64 identifier
- * @see         <a href="http://standards.ieee.org/regauth/oui/tutorials/EUI64.html">
+ * @see         <a href="https://web.archive.org/web/20170730083229/http://standards.ieee.org:80/develop/regauth/tut/eui64.pdf">
  *                  IEEE, "Guidelines for 64-bit Global Identifier (EUI-64)"
  *              </a>
  * @{

--- a/sys/include/net/lorawan/hdr.h
+++ b/sys/include/net/lorawan/hdr.h
@@ -64,7 +64,7 @@ extern "C" {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * @see <a href="https://www.lora-alliance.org/portals/0/specs/LoRaWAN%20Specification%201R0.pdf">
+ * @see <a href="https://lora-alliance.org/sites/default/files/2018-07/lorawan1.0.3.pdf">
  *          LoRaWAN spcefication, section 4
  *      </a>
  */

--- a/tests/driver_bmx280/README.md
+++ b/tests/driver_bmx280/README.md
@@ -5,8 +5,8 @@ pressure and temperature. The BME280 can also measure relative humidity.
 ## Usage
 The application will initialize the BME280/BMP280 device and display its
 calibration coefficients. More information can be found on the
-[Bosch website][1], in the [BST-BME280_DS001-11 datasheet] [2] and in the
-[BST-BMP280-DS001-12  datasheet] [3].
+[Bosch BME280 website][1], on the [Bosch BMP280 website][2],
+in the [BME280 datasheet][3] and in the [BMP280 datasheet][4].
 
 Notice that it is necessary to first read the temperature even if only one
 of the other values (humidity or pressure) is needed. This is described in
@@ -33,6 +33,7 @@ the bmp280, add `DRIVER=bmp280` to the previous command:
 
 
 For more information, see the datasheets:
-[1]: http://www.bosch-sensortec.com/en/bst/products/all_products/bme280
-[2]: https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280_DS001-11.pdf
-[3]: https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BMP280-DS001-12.pdf
+[1]: https://www.bosch-sensortec.com/products/environmental-sensors/humidity-sensors-bme280/
+[2]: https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/pressure-sensors-bmp280-1.html
+[3]: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme280-ds002.pdf
+[4]: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp280-ds001.pdf

--- a/tests/driver_si114x/README.md
+++ b/tests/driver_si114x/README.md
@@ -3,7 +3,7 @@
 #### Introduction
 
 The Si114X (Si1145, Si1146 and Si1147) sensors are UV, light and proximity sensors.
-More information in the [datasheet](https://www.silabs.com/Support%20Documents%2FTechnicalDocs%2FSi1145-46-47.pdf).
+More information in the [datasheet](https://www.silabs.com/documents/public/data-sheets/Si1145-46-47.pdf).
 
 #### Expected results
 

--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -11,8 +11,8 @@ See [Semtech LoRamac-node repository](https://github.com/Lora-net/LoRaMac-node)
 to have a look at the original package code.
 
 This application can only be used with Semtech
-[SX1272](http://www.semtech.com/images/datasheet/sx1272.pdf) or
-[SX1276](http://www.semtech.com/images/datasheet/sx1276.pdf) radio devices.
+[SX1272](https://semtech.my.salesforce.com/sfc/p/#E0000000JelG/a/440000001NCE/v_VBhk1IolDgxwwnOpcS_vTFxPfSEPQbuneK3mWsXlU) or
+[SX1276](https://semtech.my.salesforce.com/sfc/p/#E0000000JelG/a/2R0000001OKs/Bs97dmPXeatnbdoJNVMIDaKDlQz8q1N_gxDcgqi7g2o) radio devices.
 
 ## Application configuration
 

--- a/tests/pkg_tensorflow-lite/README.md
+++ b/tests/pkg_tensorflow-lite/README.md
@@ -7,7 +7,7 @@ microcontrollers:
   MLP (Multi-Layer Perceptron) model and how to reuse it in a RIOT application.
   The code of this example is provided as an external module in the
   [mnist](mnist) directory.
-- The other example, [Hello World](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/experimental/micro/examples/hello_world),
+- The other example, [Hello World](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/micro/examples/hello_world),
   taken as-is from TensorFlow Lite code, simply replicates a `sine` function
   from a trained model.
 

--- a/tests/pkg_wolfcrypt-ed25519-verify/README.md
+++ b/tests/pkg_wolfcrypt-ed25519-verify/README.md
@@ -2,7 +2,7 @@
 
 This is a demo of a signature verification using wolfCrypt.
 
-wolfCrypt is part of [wolfSSL](https://www.wolfss.com) which provides several different cryptographic services.
+wolfCrypt is part of [wolfSSL](https://www.wolfssl.com) which provides several different cryptographic services.
 
 In this test, a text message is signed using Edwards-curve digital signature algorithm,
 using the Ed25519 signature scheme.


### PR DESCRIPTION
### Contribution description

This PR fixes a lot of broken links in `*/doc.tx`, `*/*.md` and `*/*.h` files that are used for Doxygen documentation.

A lot of broken links were identified with the `urlcheck` tool in PR #13532. I went through all these broken links and tried to fix them:

1. Most of them could be fixed simply by replacing them with their current URL.
2. A number of them had to be replaced with the URLs of their archived web-site at `web.archive.org` since they don't exist no longer. Either the domain does not exist at all, such as `eistec.se` for the `mulle` board, or certain pages or documents are no longer available. This was the case for the following files:
   - `boards/msbiot/doc.txt`: Documentation for the TI CC3000 is no longer available at `ti.com`.
   - `boards/cc2538dk/doc.txt`: `CC2538_Bootloader_Backdoor.pdf` is no longer available.
   - `boards/mulle/doc.txt`: Domain `eistec.se` does no longer exist.
   - `sys/include/net/eui64.h`: `eui64.pdf` Guidelines for 64-bit Global Identifier (EUI-64) are no longer available on the IEEE web page.

   Using archived web pages in our documentation is not new, we have it used already in several cases.
3. Some of them require some rework from the code onwers since the statements might not be valid anymore:
   - `boards/frdm-k64f/doc.txt`: Repository `https://github.com/jfischer-phytec-iot/openocd` does no longer exist.
   - `boards/spark-core/doc.txt`: `https://github.com/spark/core-firmware/tree/bootloader-patch-update1` does no longer exist, it might be `https://github.com/particle-iot/device-os/tree/bootloader-patch-update` now.
   - `examples/nanocoap_server/README.md`: Firefox Copper plugin (`copper-270430`) does is no longer available.
   - `tests/pkg_microcoap/README.md`: Firefox Copper plugin (`copper-270430`) does is no longer available.

### Testing procedure

Generate the document with `make doc` and check for valid URLs.

### Issues/PRs references

The tool to check for broken links PR #13532 