### PR TITLE
drivers/mtd_spi_nor: power up MTD on init

### DIFF
--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -54,6 +54,7 @@ static const mtd_spi_nor_params_t mulle_nor_params = {
     .wait_sector_erase = 40LU * US_PER_MS,
     .wait_32k_erase = 20LU * US_PER_MS,
     .wait_4k_erase = 10LU * US_PER_MS,
+    .wait_chip_wake_up = 1LU * US_PER_MS,
     .spi = MULLE_NOR_SPI_DEV,
     .cs = MULLE_NOR_SPI_CS,
     .addr_width = 3,

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -36,6 +36,7 @@ static const mtd_spi_nor_params_t _pinetime_nor_params = {
     .wait_32k_erase = 160LU *US_PER_MS,
     .wait_sector_erase = 70LU * US_PER_MS,
     .wait_4k_erase = 70LU * US_PER_MS,
+    .wait_chip_wake_up = 1LU * US_PER_MS,
     .clk = PINETIME_NOR_SPI_CLK,
     .flag = PINETIME_NOR_FLAGS,
     .spi = PINETIME_NOR_SPI_DEV,

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -92,6 +92,7 @@ typedef struct {
     uint32_t wait_sector_erase; /**< Sector erase wait time in µs */
     uint32_t wait_32k_erase;    /**< 32KB page erase wait time in µs */
     uint32_t wait_4k_erase;     /**< 4KB page erase wait time in µs */
+    uint32_t wait_chip_wake_up; /**< Chip wake up time in µs */
     spi_clk_t clk;           /**< SPI clock */
     uint16_t flag;           /**< Config flags */
     spi_t spi;               /**< SPI bus the device is connected to */

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -248,6 +248,11 @@ static int mtd_spi_read_jedec_id(const mtd_spi_nor_t *dev, mtd_jedec_id_t *out)
             status = -2;
             break;
         }
+        if (jedec.manuf == 0xFF || jedec.manuf == 0x00) {
+            DEBUG_PUTS("mtd_spi_read_jedec_id: failed to read manufacturer ID");
+            status = -3;
+            break;
+        }
         else {
             /* all OK! */
             break;


### PR DESCRIPTION
### Contribution description

Is the flash memory is at sleep then `mtd_spi_nor_init()` will fail since it sends some spi commands on `init`. This PR powers up the `mtd` device during init.

If `xtimer` is used it will sleep before an init to account for wakeup time, I used 1ms.

IMO it make sense to power up the device during the `init` sequence. If this make sense I can update the `mtd` api so it specifies that when calling `init` the device is expected to be powered up.

### Testing procedure

I ran into this bug when trying to flash a pinetime with https://github.com/bosmoment/PineTime-apps since the default firmware sets the flash in sleep mode.

```
[fs]: Initializing file system mount /sys
[fs]: Unable to mount filesystem /sys: -19
[fs]: Unable to format filesystem /sys: -28
0x1a9df
*** RIOT kernel panic:
FAILED ASSERTION.

	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     | runtime  | switches
	  - | isr_stack            | -        - |   - |    512 (  136) | 0x20000000 | 0x200001c8
	  1 | idle                 | pending  Q |  15 |    256 (  132) |
###RTT Client: Connection lost. Going to reconnect.
```

To reproduce in a more controlled fashion you can apply the following patch for any `BOARD` defining `mtd0`, `sensebox_samd21, pinetime, mulle` (or anyboard with a SPI connected flash).

```diff
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a..3afacf74d 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -21,12 +21,23 @@
 
 #include <stdio.h>
 
+#include "mtd.h"
+
+extern mtd_dev_t *mtd0;
+
 int main(void)
 {
     puts("Hello World!");
 
+    if(mtd_init(mtd0) != 0) {
+        puts("mtd_init failed");
+        return -1;
+    }
+
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    mtd_power(mtd0, MTD_POWER_DOWN);
+
     return 0;
 }
```

With this it will fail on master and succeed on this PR (after the reset)

`BOARD=pinetime USEMODULE+="mtd xtimer" make -C examples/hello-world/ flash term`

`BOARD=pinetime USEMODULE+="mtd xtimer" make -C examples/hello-world/ reset`

- master:

```
main(): This is RIOT! (Version: 2020.04-devel-862-gc6d5c-HEAD)
Hello World!
mtd_init failed
```

- PR

```
main(): This is RIOT! (Version: 2020.04-devel-863-g3ca1c1-pr_mtd_powerup)
Hello World!
You are running RIOT on a(n) pinetime board.
This board features a(n) nrf52 MCU.
```
