### PR TITLE
sys/crypto: define cipher using a module instead of CFLAGS

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -71,7 +71,7 @@ ifneq (,$(filter gnrc_lorawan,$(USEMODULE)))
   USEMODULE += xtimer
   USEMODULE += random
   USEMODULE += hashes
-  USEMODULE += crypto
+  USEMODULE += crypto_aes
   USEMODULE += netdev_layer
   USEMODULE += gnrc_neterr
 endif

--- a/examples/gnrc_lorawan/Makefile
+++ b/examples/gnrc_lorawan/Makefile
@@ -19,9 +19,6 @@ DRIVER ?= sx1276
 
 USEMODULE += $(DRIVER)
 
-# Required for the cipher module */
-CFLAGS += -DCRYPTO_AES
-#
 # We can reduce the size of the packet buffer for LoRaWAN, since there's no IP
 # support. This will reduce RAM consumption.
 CFLAGS += -DGNRC_PKTBUF_SIZE=512

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -9,6 +9,7 @@ PSEUDOMODULES += cord_ep_standalone
 PSEUDOMODULES += core_%
 PSEUDOMODULES += cortexm_fpu
 PSEUDOMODULES += cpu_check_address
+PSEUDOMODULES += crypto_%	# crypto_aes or crypto_3des
 PSEUDOMODULES += devfs_%
 PSEUDOMODULES += dhcpv6_%
 PSEUDOMODULES += ecc_%

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -16,7 +16,11 @@ ifneq (,$(filter i2c_scan,$(USEMODULE)))
 endif
 
 ifneq (,$(filter prng_fortuna,$(USEMODULE)))
-  CFLAGS += -DCRYPTO_AES
+  USEMODULE += crypto_aes
+endif
+
+ifneq (,$(filter crypto_%,$(USEMODULE)))
+  USEMODULE += crypto
 endif
 
 include $(RIOTBASE)/sys/test_utils/Makefile.dep

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -19,6 +19,10 @@ ifneq (,$(filter prng_fortuna,$(USEMODULE)))
   USEMODULE += crypto_aes
 endif
 
+ifneq (,$(filter crypto_aes_%,$(USEMODULE)))
+  USEMODULE += crypto_aes
+endif
+
 ifneq (,$(filter crypto_%,$(USEMODULE)))
   USEMODULE += crypto
 endif

--- a/sys/crypto/doc.txt
+++ b/sys/crypto/doc.txt
@@ -15,18 +15,18 @@
  *
  * @section ciphers Ciphers
  *
- * Riot supports the following block ciphers:
+ * RIOT supports the following block ciphers:
  *  * AES-128
+ *  * 3DES (deprecated)
  *  * NULL
  *
- * You can use them directly by adding "crypto" to your USEMODULE-List.
+ * You can use them directly by adding `crypto_aes` or `crypto_3des` to your
+ * USEMODULE-List.
  * While you can use the ciphers functions directly, you should resort to
  * the generic API for block ciphers whenever possible.
  *
- * Additionally you need to set a CFLAG for each cipher you want to use in your Makefile:
- *  * AES-128: CFLAGS += -DCRYPTO_AES
- * Setting the CFLAGS initializes a sufficient large buffer size of the cipher_context_t,
- * used by the ciphers for en-/de-cryption operations.
+ * Depending on the selected block ciphers, a sufficient large buffer size of
+ * the cipher_context_t is used for en-/de-cryption operations.
  *
  * Example:
  * @code

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -30,16 +30,9 @@ extern "C" {
 
 /* Shared header file for all cipher algorithms */
 
-/* Set the algorithms that should be compiled in here. When these defines
- * are set, then packets will be compiled 5 times.
- */
-// #define CRYPTO_THREEDES
-// #define CRYPTO_AES
-
 /** @brief the length of keys in bytes */
 #define CIPHERS_MAX_KEY_SIZE 20
 #define CIPHER_MAX_BLOCK_SIZE 16
-
 
 /**
  * Context sizes needed for the different ciphers.
@@ -48,9 +41,9 @@ extern "C" {
  * threedes     needs 24  bytes                           <br>
  * aes          needs CIPHERS_MAX_KEY_SIZE bytes          <br>
  */
-#if defined(CRYPTO_THREEDES)
+#if defined(MODULE_CRYPTO_3DES)
     #define CIPHER_MAX_CONTEXT_SIZE 24
-#elif defined(CRYPTO_AES)
+#elif defined(MODULE_CRYPTO_AES)
     #define CIPHER_MAX_CONTEXT_SIZE CIPHERS_MAX_KEY_SIZE
 #else
 /* 0 is not a possibility because 0-sized arrays are not allowed in ISO C */

--- a/tests/sys_crypto/Makefile
+++ b/tests/sys_crypto/Makefile
@@ -2,8 +2,7 @@ include ../Makefile.tests_common
 
 USEMODULE += embunit
 
-USEMODULE += crypto
+USEMODULE += crypto_3des
 USEMODULE += cipher_modes
-CFLAGS += -DCRYPTO_THREEDES
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/unittests/tests-hashes/Makefile.include
+++ b/tests/unittests/tests-hashes/Makefile.include
@@ -1,3 +1,2 @@
 USEMODULE += hashes
-USEMODULE += crypto
-CFLAGS += -DCRYPTO_AES
+USEMODULE += crypto_aes


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Using CFLAGS for defining the type of cipher used with module crypto is not very handy from a user point of view.
This PR introduces the `crypto_%` pseudomodules (only `crypto_aes` and `crypto_3des` are possible) and makes use of them where needed.

So now instead of using:
```mk
USEMODULE += crypto
CFLAGS += -DCRYPTO_AES
```
only 
```mk
USEMODULE += crypto_aes
```
is needed. Much more simpler :)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `tests/sys_crypto` is still working (can be tested on different boards):

<details><summary>make -C tests/sys_crypto flash test</summary>

```
Building application "tests_sys_crypto" for "native" with MCU "native".

"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/cpu/native/vfs
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/crypto
"make" -C /work/riot/RIOT/sys/crypto/modes
"make" -C /work/riot/RIOT/sys/embunit
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
   text	   data	    bss	    dec	    hex	filename
 103670	   2601	  50472	 156743	  26447	/work/riot/RIOT/tests/sys_crypto/bin/native/tests_sys_crypto.elf
r
/work/riot/RIOT/tests/sys_crypto/bin/native/tests_sys_crypto.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2020.04-devel-987-gfe167-pr/sys/crypto_modules_rework)
..................................
OK (34 tests)

```

</details>

- `tests/unittests/test-hashes` is still working (can be tested on different boards):

<details><summary>make -C tests/unittests tests-hashes flash test</summary>

```
Building application "tests_unittests" for "native" with MCU "native".

"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/cpu/native/vfs
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/crypto
"make" -C /work/riot/RIOT/sys/embunit
"make" -C /work/riot/RIOT/sys/hashes
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/tests/unittests/tests-hashes
   text	   data	    bss	    dec	    hex	filename
  86599	   1608	  48800	 137007	  2172f	/work/riot/RIOT/tests/unittests/bin/native/tests_unittests.elf
true 
r
/work/riot/RIOT/tests/unittests/bin/native/tests_unittests.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.04-devel-987-gfe167-pr/sys/crypto_modules_rework)
Help: Press s to start test, r to print it is ready
READY
s
START
.....................................
OK (37 tests)

```

</details>

- `examples/gnrc_lorawan` is still functional (untested)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
