### PR TITLE
gnrc_uhcpc: ensure compression context is managed by the ABR

### DIFF
--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -135,7 +135,17 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
 #endif
         return;
     }
-
+    else if (!ipv6_addr_is_unspecified(&_prefix)) {
+        gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR_REMOVE, 0,
+                        &_prefix, sizeof(_prefix));
+#if defined(MODULE_GNRC_IPV6_NIB) && GNRC_IPV6_NIB_CONF_6LBR && \
+    GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
+        gnrc_ipv6_nib_abr_del(&_prefix);
+#endif
+        LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): removed old prefix %s/64\n",
+                 ipv6_addr_to_str(addr_str, &_prefix, sizeof(addr_str)));
+    }
+    memcpy(&_prefix, prefix, sizeof(_prefix));
     gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR, (64 << 8),
         /* always update 6LoWPAN compression context so it does not time out, we
          * can't just remove it anyway according to the RFC */
@@ -152,28 +162,14 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
     }
     gnrc_rpl_root_init(GNRC_RPL_DEFAULT_INSTANCE, (ipv6_addr_t*)prefix, false, false);
 #endif
-    gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR_REMOVE, 0,
-                    &_prefix, sizeof(_prefix));
     LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix %s/64\n",
              ipv6_addr_to_str(addr_str, (ipv6_addr_t *)prefix, sizeof(addr_str)));
-
-    if (!ipv6_addr_is_unspecified(&_prefix)) {
-        gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR_REMOVE, 0,
-                        &_prefix, sizeof(_prefix));
-#if defined(MODULE_GNRC_IPV6_NIB) && GNRC_IPV6_NIB_CONF_6LBR && \
-    GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
-        gnrc_ipv6_nib_abr_del(&_prefix);
-#endif
-        LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): removed old prefix %s/64\n",
-                 ipv6_addr_to_str(addr_str, &_prefix, sizeof(addr_str)));
-    }
 
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX
     /* update compression context last in case previous context was removed by
      * gnrc_ipv6_nib_abr_del() above */
     _update_6ctx((ipv6_addr_t *)prefix, 64);
 #endif
-    memcpy(&_prefix, prefix, 16);
 }
 
 extern void uhcp_client(uhcp_iface_t iface);

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -150,6 +150,10 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
         /* always update 6LoWPAN compression context so it does not time out, we
          * can't just remove it anyway according to the RFC */
                     prefix, sizeof(ipv6_addr_t));
+#ifdef MODULE_GNRC_SIXLOWPAN_CTX
+    /* add compression before ABR to add it automatically to its context list */
+    _update_6ctx((ipv6_addr_t *)prefix, 64);
+#endif
 #if defined(MODULE_GNRC_IPV6_NIB) && GNRC_IPV6_NIB_CONF_6LBR && \
     GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
     gnrc_ipv6_nib_abr_add((ipv6_addr_t *)prefix);
@@ -164,12 +168,6 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
 #endif
     LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix %s/64\n",
              ipv6_addr_to_str(addr_str, (ipv6_addr_t *)prefix, sizeof(addr_str)));
-
-#ifdef MODULE_GNRC_SIXLOWPAN_CTX
-    /* update compression context last in case previous context was removed by
-     * gnrc_ipv6_nib_abr_del() above */
-    _update_6ctx((ipv6_addr_t *)prefix, 64);
-#endif
 }
 
 extern void uhcp_client(uhcp_iface_t iface);

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -147,8 +147,6 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
     }
     memcpy(&_prefix, prefix, sizeof(_prefix));
     gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR, (64 << 8),
-        /* always update 6LoWPAN compression context so it does not time out, we
-         * can't just remove it anyway according to the RFC */
                     prefix, sizeof(ipv6_addr_t));
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX
     /* add compression before ABR to add it automatically to its context list */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash `gnrc_border_router` and `gnrc_networking` to a node respectively. Run `make term` for the border router using UHCP. When the `gnrc_networking` node receives its prefix it also should receive a 6LoWPAN compression context. Check with

```
2020-03-05 13:04:23,477 #  6ctx
2020-03-05 13:04:23,477 # cid|prefix                                     |C|ltime
2020-03-05 13:04:23,478 # -----------------------------------------------------------
2020-03-05 13:04:23,478 #   0|                             2001:db8::/64 |1|   60min
```

When restarting the `make term` the border router with (do **not** reset or reflash)

```sh
IPV6_PREFIX=2001:db8:1::/64 make -C examples/gnrc_border_router/ term
```

the old context should be removed and replaced with the new one when the prefix is updated:

```
6ctx
6ctx
cid|prefix                                     |C|ltime
-----------------------------------------------------------
  0|                             2001:db8::/64 |1|   60min
> uhcp_client(): sending REQ...
got packet from fe80::20e3:19ff:feee:2a93 port 39409
uhcp: push from fe80::20e3:19ff:feee:2a93:39409 prefix=2001:db8:1::/64
gnrc_uhcpc: uhcp_handle_prefix(): removed old prefix 2001:db8::28ab:dc15:5401:6478/64
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8:1:0:28ab:dc15:5401:6478/64
gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix 2001:db8:1:0:28ab:dc15:5401:6478/64
6ctx
6ctx
cid|prefix                                     |C|ltime
-----------------------------------------------------------
  0|                           2001:db8:1::/64 |1|   60min
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes regression mentioned in https://github.com/RIOT-OS/RIOT/pull/8576#issuecomment-594934664
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
