### PR TITLE
sys/net/gnrc: Flag esp_now as 6LN

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -105,6 +105,9 @@ void gnrc_netif_init_6ln(gnrc_netif_t *netif)
 #ifdef MODULE_CC110X
         case NETDEV_TYPE_CC110X:
 #endif
+#ifdef MODULE_ESP_NOW
+        case NETDEV_TYPE_ESP_NOW:
+#endif
         case NETDEV_TYPE_NRFMIN:
 #if GNRC_IPV6_NIB_CONF_6LN
             netif->flags |= GNRC_NETIF_FLAGS_6LN;


### PR DESCRIPTION
### Contribution description

In gnrc_netif_init_6ln() the flag GNRC_NETIF_FLAGS_6LN is accidentally not set for esp_now devices. This commit fixes this.

### Testing procedure

Running `ifconfig` in `examples/gnrc_networking` e.g. on the `esp8266-esp-12x` shows no IPv6 address with master. With this PR, the address should show up again and `ping6`ing should work.

### Issues/PRs references

same as #12683
