### PR TITLE
netdev: add netdev_trigger_event_isr() function

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -36,9 +36,7 @@ static netdev_t *_dev;
 
 void _irq_handler(void)
 {
-    if (_dev->event_callback) {
-        _dev->event_callback(_dev, NETDEV_EVENT_ISR);
-    }
+    netdev_trigger_event_isr(_dev);
 }
 
 static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -99,7 +99,7 @@ static esp_err_t IRAM_ATTR _eth_input_callback(void *buffer, uint16_t len, void 
     memcpy(_esp_eth_dev.rx_buf, buffer, len);
     _esp_eth_dev.rx_len = len;
     _esp_eth_dev.event = SYSTEM_EVENT_ETH_RX_DONE;
-    _esp_eth_dev.netdev.event_callback(&_esp_eth_dev.netdev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr(&_esp_eth_dev.netdev);
 
     mutex_unlock(&_esp_eth_dev.dev_lock);
 
@@ -351,7 +351,7 @@ static esp_err_t IRAM_ATTR _esp_system_event_handler(void *ctx, system_event_t *
             _esp_eth_dev.link_up = true;
             if (SYSTEM_EVENT_MAX) {
                 _esp_eth_dev.event = SYSTEM_EVENT_ETH_CONNECTED;
-                _esp_eth_dev.netdev.event_callback(&_esp_eth_dev.netdev, NETDEV_EVENT_ISR);
+                netdev_trigger_event_isr(&_esp_eth_dev.netdev);
             }
             break;
         case SYSTEM_EVENT_ETH_DISCONNECTED:
@@ -359,7 +359,7 @@ static esp_err_t IRAM_ATTR _esp_system_event_handler(void *ctx, system_event_t *
             _esp_eth_dev.link_up = false;
             if (SYSTEM_EVENT_MAX) {
                 _esp_eth_dev.event = SYSTEM_EVENT_ETH_DISCONNECTED;
-                _esp_eth_dev.netdev.event_callback(&_esp_eth_dev.netdev, NETDEV_EVENT_ISR);
+                netdev_trigger_event_isr(&_esp_eth_dev.netdev);
             }
             break;
         default:

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -185,7 +185,7 @@ static void IRAM_ATTR esp_now_scan_peers_timer_cb(void* arg)
 
     if (dev->netdev.event_callback) {
         dev->scan_event++;
-        dev->netdev.event_callback((netdev_t*)dev, NETDEV_EVENT_ISR);
+        netdev_trigger_event_isr((netdev_t*)dev);
     }
 }
 

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -353,7 +353,7 @@ esp_err_t _esp_wifi_rx_cb(void *buffer, uint16_t len, void *eb)
 
     /* trigger netdev event to read the data */
     _esp_wifi_dev.event_recv++;
-    _esp_wifi_dev.netdev.event_callback(&_esp_wifi_dev.netdev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr(&_esp_wifi_dev.netdev);
 
     /* reset IRQ nesting counter */
     irq_interrupt_nesting--;
@@ -434,7 +434,7 @@ static esp_err_t IRAM_ATTR _esp_system_event_handler(void *ctx, system_event_t *
 
             _esp_wifi_dev.connected = true;
             _esp_wifi_dev.event_conn++;
-            _esp_wifi_dev.netdev.event_callback(&_esp_wifi_dev.netdev, NETDEV_EVENT_ISR);
+            netdev_trigger_event_isr(&_esp_wifi_dev.netdev);
 
             break;
 
@@ -455,7 +455,7 @@ static esp_err_t IRAM_ATTR _esp_system_event_handler(void *ctx, system_event_t *
 
             _esp_wifi_dev.connected = false;
             _esp_wifi_dev.event_disc++;
-            _esp_wifi_dev.netdev.event_callback(&_esp_wifi_dev.netdev, NETDEV_EVENT_ISR);
+            netdev_trigger_event_isr(&_esp_wifi_dev.netdev);
 
             /* call disconnect to reset internal state */
             result = esp_wifi_disconnect();

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -302,7 +302,7 @@ static void _tap_isr(int fd, void *arg) {
     netdev_t *netdev = (netdev_t *)arg;
 
     if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV_EVENT_ISR);
+        netdev_trigger_event_isr(netdev);
     }
     else {
         puts("netdev_tap: _isr: no event callback.");

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -112,7 +112,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     /* simulate TX_STARTED interrupt */
     if (netdev->event_callback) {
         dev->last_event = NETDEV_EVENT_TX_STARTED;
-        netdev->event_callback(netdev, NETDEV_EVENT_ISR);
+        netdev_trigger_event_isr(netdev);
         thread_yield();
     }
     res = writev(dev->sock_fd, v, n + 2);
@@ -123,7 +123,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     /* simulate TX_COMPLETE interrupt */
     if (netdev->event_callback) {
         dev->last_event = NETDEV_EVENT_TX_COMPLETE;
-        netdev->event_callback(netdev, NETDEV_EVENT_ISR);
+        netdev_trigger_event_isr(netdev);
         thread_yield();
     }
 
@@ -283,7 +283,7 @@ static void _socket_isr(int fd, void *arg)
         socket_zep_t *dev = (socket_zep_t *)netdev;
 
         dev->last_event = NETDEV_EVENT_RX_COMPLETE;
-        netdev->event_callback(netdev, NETDEV_EVENT_ISR);
+        netdev_trigger_event_isr(netdev);
     }
 }
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -526,7 +526,7 @@ void isr_radio(void)
                 DEBUG("[nrf802154] Unhandled state: %x\n", (uint8_t)NRF_RADIO->STATE);
         }
         if (_state) {
-            nrf802154_dev.netdev.event_callback(&nrf802154_dev.netdev, NETDEV_EVENT_ISR);
+            netdev_trigger_event_isr(&nrf802154_dev.netdev);
         }
     }
     else {

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -307,7 +307,7 @@ void isr_radio(void)
             }
             else {
                 rx_lock = 0;
-                nrfmin_dev.event_callback(&nrfmin_dev, NETDEV_EVENT_ISR);
+                netdev_trigger_event_isr(&nrfmin_dev);
             }
         }
         else if (state == STATE_TX) {

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -65,11 +65,7 @@ static netdev_t *at86rfmega_dev;
 #else
 static void _irq_handler(void *arg)
 {
-    netdev_t *dev = (netdev_t *) arg;
-
-    if (dev->event_callback) {
-        dev->event_callback(dev, NETDEV_EVENT_ISR);
-    }
+    netdev_trigger_event_isr(arg);
 }
 #endif
 
@@ -762,7 +758,7 @@ ISR(TRX24_RX_END_vect, ISR_BLOCK)
 
     ((at86rf2xx_t *)at86rfmega_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__RX_END;
     /* Call upper layer to process received data */
-    at86rfmega_dev->event_callback(at86rfmega_dev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr(at86rfmega_dev);
 
     atmega_exit_isr();
 }
@@ -806,7 +802,7 @@ ISR(TRX24_TX_END_vect, ISR_BLOCK)
         dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__TX_END;
 
         /* Call upper layer to process if data was send successful */
-        at86rfmega_dev->event_callback(at86rfmega_dev, NETDEV_EVENT_ISR);
+        netdev_trigger_event_isr(at86rfmega_dev);
     }
 
     atmega_exit_isr();

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -89,7 +89,7 @@ void cc110x_on_gdo(void *_dev)
         mutex_unlock(&dev->isr_signal);
     }
     else {
-        dev->netdev.event_callback(&dev->netdev, NETDEV_EVENT_ISR);
+        netdev_trigger_event_isr(&dev->netdev);
     }
 }
 

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -58,9 +58,7 @@ static void _irq_handler(void *arg)
 {
     netdev_t *dev = (netdev_t *)arg;
 
-    if(dev->event_callback) {
-        dev->event_callback(dev, NETDEV_EVENT_ISR);
-    }
+    netdev_trigger_event_isr(dev);
 }
 
 static inline uint16_t to_u16(const void *buf)

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -71,7 +71,7 @@ static dose_signal_t state_transit_blocked(dose_t *ctx, dose_signal_t signal)
          * if this frame should be processed. By queuing NETDEV_EVENT_ISR,
          * the netif thread will call _isr at some time. */
         SETBIT(ctx->flags, DOSE_FLAG_RECV_BUF_DIRTY);
-        ctx->netdev.event_callback((netdev_t *) ctx, NETDEV_EVENT_ISR);
+        netdev_trigger_event_isr((netdev_t *) ctx);
     }
 
     if (ctx->sense_pin != GPIO_UNDEF) {

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -253,8 +253,7 @@ static void on_int(void *arg)
     /* disable global interrupt enable bit to avoid losing interrupts */
     cmd_bfc((enc28j60_t *)arg, REG_EIE, -1, EIE_INTIE);
 
-    netdev_t *netdev = (netdev_t *)arg;
-    netdev->event_callback(arg, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr(arg);
 }
 
 static int nd_send(netdev_t *netdev, const iolist_t *iolist)

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -99,7 +99,7 @@ static void encx24j600_isr(void *arg)
     gpio_irq_disable(dev->int_pin);
 
     /* call netdev hook */
-    dev->netdev.event_callback((netdev_t*) dev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr((netdev_t*) dev);
 }
 
 static void _isr(netdev_t *netdev)

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -123,7 +123,8 @@ static void _end_of_frame(ethos_t *dev)
             if (dev->framesize) {
                 assert(dev->last_framesize == 0);
                 dev->last_framesize = dev->framesize;
-                dev->netdev.event_callback((netdev_t*) dev, NETDEV_EVENT_ISR);
+                netdev_trigger_event_isr((netdev_t*) dev);
+
             }
             break;
         case ETHOS_FRAME_TYPE_HELLO:

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -469,7 +469,20 @@ static inline int netdev_set_notsup(netdev_t *dev, netopt_t opt,
     return -ENOTSUP;
 }
 
-
+/**
+ * @brief Informs netdev there was an interrupt request from the network device.
+ *
+ *        This function calls @ref netdev_t::event_callback with
+ *        NETDEV_EVENT_ISR event.
+ *
+ * @param netdev netdev instance of the device associated to the interrupt.
+ */
+static inline void netdev_trigger_event_isr(netdev_t *netdev)
+{
+    if (netdev->event_callback) {
+        netdev->event_callback(netdev, NETDEV_EVENT_ISR);
+    }
+}
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -63,9 +63,7 @@ static void _irq_handler(void *arg)
     /* We use this counter to avoid filling the message queue with redundant ISR events */
     if (num_irqs_queued == num_irqs_handled) {
         ++num_irqs_queued;
-        if (netdev->event_callback) {
-            netdev->event_callback(netdev, NETDEV_EVENT_ISR);
-        }
+        netdev_trigger_event_isr(netdev);
     }
 }
 

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -41,9 +41,8 @@ static void _irq_handler(void *arg)
 {
     netdev_t *dev = (netdev_t *) arg;
 
-    if (dev->event_callback) {
-        dev->event_callback(dev, NETDEV_EVENT_ISR);
-    }
+    netdev_trigger_event_isr(dev);
+
     ((mrf24j40_t *)arg)->irq_flag = 1;
 }
 

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -62,15 +62,11 @@ static void _rx_cb(void *arg, uint8_t c)
         if (dev->int_state == RN2XX3_INT_STATE_MAC_RX_MESSAGE) {
             /* RX state: closing RX buffer */
             dev->rx_buf[(dev->rx_size + 1) / 2] = 0;
-            if (netdev->event_callback) {
-                netdev->event_callback(netdev, NETDEV_EVENT_ISR);
-            }
+            netdev_trigger_event_isr(netdev);
         }
         else if (dev->int_state == RN2XX3_INT_STATE_MAC_TX) {
             /* still in TX state: transmission complete but no data received */
-            if (netdev->event_callback) {
-                netdev->event_callback(netdev, NETDEV_EVENT_ISR);
-            }
+            netdev_trigger_event_isr(netdev);
         }
         dev->resp_size = 0;
         dev->rx_size = 0;

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -64,9 +64,8 @@ static void _slip_rx_cb(void *arg, uint8_t byte)
     tsrb_add_one(&dev->inbuf, byte);
 check_end:
     if (byte == SLIPDEV_END) {
-        if ((dev->state == SLIPDEV_STATE_NET) &&
-            (dev->netdev.event_callback != NULL)) {
-            dev->netdev.event_callback((netdev_t *)dev, NETDEV_EVENT_ISR);
+        if (dev->state == SLIPDEV_STATE_NET) {
+            netdev_trigger_event_isr((netdev_t*) dev);
         }
         dev->state = SLIPDEV_STATE_NONE;
     }

--- a/drivers/stm32_eth/stm32_eth.c
+++ b/drivers/stm32_eth/stm32_eth.c
@@ -57,7 +57,7 @@ void isr_eth(void)
         ETH->DMASR = ETH_DMASR_RS | ETH_DMASR_NIS;
         mutex_unlock(&_rx);
         if (_netdev) {
-            _netdev->event_callback(_netdev, NETDEV_EVENT_ISR);
+            netdev_trigger_event_isr(_netdev);
         }
     }
 

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -221,9 +221,7 @@ uint32_t sx127x_random(sx127x_t *dev)
  */
 void sx127x_isr(netdev_t *dev)
 {
-    if (dev->event_callback) {
-        dev->event_callback(dev, NETDEV_EVENT_ISR);
-    }
+    netdev_trigger_event_isr(dev);
 }
 
 static void sx127x_on_dio_isr(sx127x_t *dev, sx127x_flags_t flag)

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -106,9 +106,7 @@ static void extint(void *arg)
 {
     w5100_t *dev = (w5100_t *)arg;
 
-    if (dev->nd.event_callback) {
-        dev->nd.event_callback(&dev->nd, NETDEV_EVENT_ISR);
-    }
+    netdev_trigger_event_isr(&dev->nd);
 }
 
 void w5100_setup(w5100_t *dev, const w5100_params_t *params)

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -233,9 +233,7 @@ static void _rx_cb(void *arg, uint8_t c)
             dev->rx_buf[dev->rx_count++] = c;
             if (dev->rx_count == dev->rx_limit) {
                 /* packet is complete */
-                if (dev->event_callback) {
-                    dev->event_callback((netdev_t *)dev, NETDEV_EVENT_ISR);
-                }
+                netdev_trigger_event_isr((netdev_t*) dev);
                 dev->int_state = XBEE_INT_STATE_IDLE;
             }
             break;

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm.c
@@ -316,8 +316,8 @@ static void _store_frame_chunk(usbus_cdcecm_device_t *cdcecm)
                   sizeof(size_t));
     memcpy(cdcecm->in_buf + cdcecm->len, buf, len);
     cdcecm->len += len;
-    if (len < USBUS_CDCECM_EP_DATA_SIZE && cdcecm->netdev.event_callback) {
-        cdcecm->netdev.event_callback(&cdcecm->netdev, NETDEV_EVENT_ISR);
+    if (len < USBUS_CDCECM_EP_DATA_SIZE) {
+        netdev_trigger_event_isr(&cdcecm->netdev);
     }
 }
 

--- a/tests/gnrc_netif/common.c
+++ b/tests/gnrc_netif/common.c
@@ -81,7 +81,7 @@ void _test_trigger_recv(gnrc_netif_t *netif, const uint8_t *data,
         tmp_buffer_bytes = 0;
     }
     assert(dev->event_callback);
-    dev->event_callback(dev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr(dev);
 }
 
 static int _netdev_recv(netdev_t *dev, char *buf, int len, void *info)

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -247,7 +247,7 @@ bool _inject_4packet(uint32_t src, uint32_t dst, uint8_t proto, void *data,
     _netdev_buffer_size = sizeof(ethernet_hdr_t) + sizeof(struct ip_hdr) +
                           data_len;
     mutex_unlock(&_netdev_buffer_mutex);
-    ((netdev_t *)&netdev)->event_callback((netdev_t *)&netdev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr((netdev_t *)&netdev);
 
     return true;
 #else
@@ -279,7 +279,7 @@ bool _inject_6packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
     _netdev_buffer_size = sizeof(ethernet_hdr_t) + sizeof(ipv6_hdr_t) +
                           data_len;
     mutex_unlock(&_netdev_buffer_mutex);
-    ((netdev_t *)&netdev)->event_callback((netdev_t *)&netdev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr((netdev_t *)&netdev);
 
     return true;
 #else

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -259,7 +259,7 @@ bool _inject_4packet(uint32_t src, uint32_t dst, uint16_t src_port,
     _netdev_buffer_size = sizeof(ethernet_hdr_t) + sizeof(struct ip_hdr) +
                           sizeof(udp_hdr_t) + data_len;
     mutex_unlock(&_netdev_buffer_mutex);
-    ((netdev_t *)&netdev)->event_callback((netdev_t *)&netdev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr((netdev_t *)&netdev);
 
     return true;
 #else
@@ -308,7 +308,7 @@ bool _inject_6packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
     _netdev_buffer_size = sizeof(ethernet_hdr_t) + sizeof(ipv6_hdr_t) +
                           sizeof(udp_hdr_t) + data_len;
     mutex_unlock(&_netdev_buffer_mutex);
-    ((netdev_t *)&netdev)->event_callback((netdev_t *)&netdev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr((netdev_t *)&netdev);
 
     return true;
 #else

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -152,7 +152,7 @@ static int test_receive(void)
     /* register for GNRC_NETTYPE_UNDEF */
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &me);
     /* fire ISR event */
-    _dev.netdev.event_callback((netdev_t *)&_dev.netdev, NETDEV_EVENT_ISR);
+    netdev_trigger_event_isr((netdev_t *)&_dev.netdev);
     /* wait for packet from MAC layer*/
     msg_receive(&msg);
     /* check message */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a `netdev_irq_end` function that wraps the `dev->event_callback(dev, NETDEV_EVENT_ISR)`call.

This is a step required in order to separate ISR signals from driver events (RX_DONE, TX_DONE), etc. This is useful when network  stacks have different implementations of driver events but they use the same "recv thread".

I will introduce a `netdev_event_thread` module that redefines this function to use the `event_thread` module for handling device ISRs.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
This should be low hanging fruit. Check if `netdev` drivers still compile (at86rf2xx, ethos).
Running `gnrc_networking` on native should be enough to test functionality.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
