### PR TITLE
doxygen/I2C: don't include overridden typedefs

### DIFF
--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -166,6 +166,7 @@ typedef enum {
  */
 #define DAC_NUMOF           (1U)
 
+#ifndef DOXYGEN
 /**
  * @brief   Possible ADC resolution settings
  * @{
@@ -185,6 +186,7 @@ typedef enum {
     ADC_RES_3BIT  = 0b111,  /**< ADC resolution:  3 bit */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   ADC device configuration
@@ -195,6 +197,7 @@ typedef struct {
     uint32_t pinsel_msk;    /**< PINSEL Mask for ADC pin */
 } adc_conf_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Override I2C clock speed values
  * @{
@@ -206,6 +209,7 @@ typedef enum {
     I2C_SPEED_FAST   = 400000,  /**< fast mode:      ~400 kbit/s */
 } i2c_speed_t;
 /* @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   I2C device configuration


### PR DESCRIPTION




<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add missing `#ifndefs` to overridden I2C typedefs for lpc2387 CPU.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make doc`
