### PR TITLE
sys/ztimer: allow "adjust" config for ztimer_usec, ztimer_msec

### DIFF
--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -155,6 +155,11 @@ void ztimer_init(void)
             FREQ_1MHZ, CONFIG_ZTIMER_USEC_FREQ);
 #    endif
 #  endif
+#  ifdef CONFIG_ZTIMER_USEC_ADJUST
+    LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting adjust value to %i\n",
+            CONFIG_ZTIMER_USEC_ADJUST);
+    ZTIMER_USEC->adjust = CONFIG_ZTIMER_USEC_ADJUST;
+#  endif
 #endif
 
 #ifdef ZTIMER_RTT_INIT
@@ -169,6 +174,11 @@ void ztimer_init(void)
     ztimer_convert_frac_init(&_ztimer_convert_frac_msec,
                              ZTIMER_MSEC_CONVERT_LOWER,
                              FREQ_1KHZ, ZTIMER_MSEC_CONVERT_LOWER_FREQ);
+#  endif
+#  ifdef CONFIG_ZTIMER_MSEC_ADJUST
+    LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting adjust value to %i\n",
+            CONFIG_ZTIMER_MSEC_ADJUST);
+    ZTIMER_MSEC->adjust = CONFIG_ZTIMER_MSEC_ADJUST;
 #  endif
 #endif
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

All platforms have some overhead for setting a timer. This can be measured using `tests/ztimer_overhead`, but currently there's no (easy) way for configuring that value.
Technically, every ztimer has a `adjust` field. Every `ztimer_set()` subtracts that value before handling a timer.

This PR makes it possible to configure those values for ztimer_usec and ztimer_msec, using
`CONFIG_ZTIMER_USEC_ADJUST` e.g., in board.h or on the make command line.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`CFLAGS="-DLOG_LEVEL=LOG_DEBUG" make -Ctests/ztimer_overhead`, then run it, for unadjusted value.

`CFLAGS="-DCONFIG_ZTIMER_USEC_ADJUST=6 -DLOG_LEVEL=LOG_DEBUG" make -Ctests/ztimer_overhead`, then run it, to see adjusted results.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

~~Waiting for #13569.~~ (merged)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
