### PR TITLE
sys/ztimer: make ztimer_overhead() return signed result

### DIFF
--- a/sys/include/ztimer/overhead.h
+++ b/sys/include/ztimer/overhead.h
@@ -41,7 +41,7 @@ extern "C" {
  * @param[in]   base    base interval to use
  * @return  (time from ztimer_set() until callback) - base
  */
-uint32_t ztimer_overhead(ztimer_clock_t *clock, uint32_t base);
+int32_t ztimer_overhead(ztimer_clock_t *clock, uint32_t base);
 
 #endif /* ZTIMER_OVERHEAD_H */
 /** @} */

--- a/sys/ztimer/overhead.c
+++ b/sys/ztimer/overhead.c
@@ -35,7 +35,7 @@ static void _callback(void *arg)
     *callback_arg->val = ztimer_now(callback_arg->clock);
 }
 
-uint32_t ztimer_overhead(ztimer_clock_t *clock, uint32_t base)
+int32_t ztimer_overhead(ztimer_clock_t *clock, uint32_t base)
 {
     volatile uint32_t after = 0;
     uint32_t pre;

--- a/tests/ztimer_overhead/main.c
+++ b/tests/ztimer_overhead/main.c
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <inttypes.h>
 
 #include "ztimer.h"
@@ -32,16 +33,17 @@ int main(void)
 {
     uint32_t total = 0;
 
-    uint16_t min = 0xFFFF;
-    uint16_t max = 0;
+    int32_t min = INT32_MAX;
+    int32_t max = INT32_MIN;
 
     /* unset configured adjustment */
     /* ZTIMER_USEC->adjust = 0; */
+    printf("ZTIMER_USEC->adjust = %" PRIu32 "\n", ZTIMER_USEC->adjust);
 
     unsigned n = SAMPLES;
     while (n--) {
-        unsigned overhead = ztimer_overhead(ZTIMER_USEC, BASE);
-        total += overhead;
+        int32_t overhead = ztimer_overhead(ZTIMER_USEC, BASE);
+        total += labs(overhead);
         if (overhead < min) {
             min = overhead;
         }
@@ -50,7 +52,8 @@ int main(void)
         }
     }
 
-    printf("min=%u max=%u avg=%" PRIu32 "\n", min, max, (total / SAMPLES));
+    printf("min=%" PRIi32 " max=%" PRIi32 " avg_diff=%" PRIi32 "\n", min, max,
+           (total / SAMPLES));
 
     return 0;
 }

--- a/tests/ztimer_overhead/tests/01-run.py
+++ b/tests/ztimer_overhead/tests/01-run.py
@@ -11,7 +11,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"min=\d+ max=\d+ avg=\d+\r\n")
+    child.expect(r"min=-?\d+ max=-?\d+ avg_diff=\d+\r\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Current ztimer_overhead() overflows if the timer triggers too early. Fix to return `int32_t`.
Also updates `tests/ztimer_overhead` (only user of the function).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Override the adjust value for building to see an effect with or without this PR:
`CFLAGS="-DCONFIG_ZTIMER_USEC_ADJUST=100" make -Ctests/ztimer_overhead`.

~~Without #13570, maybe manually add `ZTIMER_USEC->adjust = 100`, in main.c before the main loop.~~

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/13549 also works with signed overhead.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
