### PR TITLE
sliptty/start_network.sh: configure global address for SLIP interface

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -60,6 +60,8 @@
 
 /doc/                                       @aabadie @jia200x
 
+/dist/tools/sliptty/                        @miri64
+
 /drivers/ad7746/                            @leandrolanzieri
 /drivers/at24mac/                           @benpicco
 /drivers/at86rf2xx/                         @daniel-k @Hyungsin @jia200x @smlng @miri64
@@ -76,6 +78,7 @@
 /drivers/pca9685/                           @gschorcht
 /drivers/sht3x/                             @gschorcht
 /drivers/si70xx/                            @basilfx
+/drivers/slipdev/                           @miri64
 /drivers/sx127x/                            @aabadie @jia200x
 /drivers/ws281x/                            @maribu
 /drivers/xbee/                              @haukepetersen @miri64
@@ -125,6 +128,7 @@
 /tests/emb6*                                @miri64
 /tests/gnrc*                                @miri64
 /tests/lwip*                                @miri64
+/tests/slip/                                @miri64
 /tests/unittests                            @miri64
 /tests/*/tests/*.py                         @miri64
 /tests/cpu_efm32_features/                  @basilfx

--- a/dist/tools/sliptty/start_network.sh
+++ b/dist/tools/sliptty/start_network.sh
@@ -3,6 +3,7 @@
 SLIPTTY_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 UHCPD="$(cd "${SLIPTTY_DIR}/../uhcpd/bin" && pwd -P)/uhcpd"
 TUN=sl0
+TUN_GLB="fdea:dbee:f::1/64"
 UHCPD_PID=
 CREATED_IFACE=0
 
@@ -39,6 +40,7 @@ create_tun() {
             ${SUDO} sysctl -w net.ipv6.conf.${TUN}.accept_ra=2
             ${SUDO} ip link set ${TUN} up || exit 1
             ${SUDO} ip address add fe80::1/64 dev ${TUN}
+            ${SUDO} ip address add ${TUN_GLB} dev ${TUN}
             ${SUDO} ip neigh add fe80::2 dev ${TUN}
             ${SUDO} ip route add ${PREFIX} via fe80::2 dev ${TUN}
             ;;
@@ -55,6 +57,16 @@ create_tun() {
             read _
             ${SUDO} ifconfig ${TUN} up || exit 1
             ${SUDO} ifconfig ${TUN} inet6 fe80::1 prefixlen 64
+            TUN_GLB_ADDR=$(echo "${TUN_GLB}" | cut -d/ -f1)
+            TUN_GLB_LEN=$(echo "${TUN_GLB}" | cut -d/ -f2)
+            if [ -z "${TUN_GLB_ADDR}" ] || [ -z "${TUN_GLB_LEN}" ]; then
+                echo "TUN global address (-g) must be of format " \
+                     "<addr>/<prefix_len>" >&2
+                exit 1
+            fi
+            ${SUDO} ifconfig ${TUN} inet6 fe80::1 prefixlen 64
+            ${SUDO} ifconfig ${TUN} inet6 ${TUN_GLB_ADDR} prefixlen \
+                ${TUN_GLB_LEN}
             ${SUDO} route -n add -interface ${TUN} -inet6 -prefixlen 64 \
                     ${PREFIX} fe80::2 || exit 1
             ;;
@@ -89,8 +101,8 @@ start_uhcpd() {
 }
 
 usage() {
-    echo "usage: $1 [-I <sl0>] [-e] <prefix> serial [baudrate]"
-    echo "usage: $1 [-I <sl0>] [-e] <prefix> tcp:host [port]"
+    echo "usage: $1 [-I <sl0>] [-e] [-g <addr>/<prefix_len>] <prefix> serial [baudrate]"
+    echo "usage: $1 [-I <sl0>] [-e] [-g <addr>/<prefix_len>] <prefix> tcp:host [port]"
 }
 
 trap "cleanup" INT QUIT TERM EXIT
@@ -101,6 +113,7 @@ while getopts ehI: opt; do
     case ${opt} in
         e)  SLIP_ONLY=1; shift 1;;
         I)  TUN=${OPTARG}; shift 2;;
+        g)  TUN_GLB=${OPTARG}; shift 2;;
         h)  usage $0; exit 0;;
     esac
 done

--- a/dist/tools/sliptty/start_network.sh
+++ b/dist/tools/sliptty/start_network.sh
@@ -89,8 +89,8 @@ start_uhcpd() {
 }
 
 usage() {
-    echo "usage: $1 [-I <sl0>] <prefix> serial [baudrate]"
-    echo "usage: $1 [-I <sl0>] <prefix> tcp:host [port]"
+    echo "usage: $1 [-I <sl0>] [-e] <prefix> serial [baudrate]"
+    echo "usage: $1 [-I <sl0>] [-e] <prefix> tcp:host [port]"
 }
 
 trap "cleanup" INT QUIT TERM EXIT

--- a/dist/tools/sliptty/start_network.sh
+++ b/dist/tools/sliptty/start_network.sh
@@ -99,7 +99,7 @@ SLIP_ONLY=0
 
 while getopts ehI: opt; do
     case ${opt} in
-        e)  SLIP_ONLY=1;;
+        e)  SLIP_ONLY=1; shift 1;;
         I)  TUN=${OPTARG}; shift 2;;
         h)  usage $0; exit 0;;
     esac

--- a/examples/gnrc_border_router/Makefile.slip.conf
+++ b/examples/gnrc_border_router/Makefile.slip.conf
@@ -4,7 +4,11 @@ CFLAGS += -DSLIPDEV_PARAM_BAUDRATE=$(SLIP_BAUDRATE)
 
 STATIC_ROUTES ?= 1
 
+ifeq (1,$(USE_DHCPV6))
+  SLIP_ONLY=-e
+endif
+
 # Configure terminal parameters
 TERMDEPS += sliptty
 TERMPROG ?= sudo sh $(RIOTTOOLS)/sliptty/start_network.sh
-TERMFLAGS ?= $(IPV6_PREFIX) $(PORT) $(SLIP_BAUDRATE)
+TERMFLAGS ?= $(SLIP_ONLY) $(IPV6_PREFIX) $(PORT) $(SLIP_BAUDRATE)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This way hosts without pre-configured IPv6 addresses can also reach global addresses within a downstream network.

I also piggy-backed some fixes and doc updates for the `-e` parameter to the script. The parameter came in late in #10477 so those fell through.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
From the host ping the global address of the downstream interface of the `examples/gnrc_border_router` application from the SLIP interface. Without this change it won't work (some ping implementations ignore the `-I` argument but print a warning like `ping6: Warning: source address might be selected on device other than: sl0`), with this change it will.

<details><summary>My testing went as follows:</summary>

### Terminal 1

```
$ RIOT_CI_BUILD=1 USE_SLIP=1 make -C examples/gnrc_border_router/ -j16 flash --no-print-directory term
Building application "gnrc_border_router" for "samr21-xpro" with MCU "samd21".

   text	   data	    bss	    dec	    hex	filename
  79164	    140	  22296	 101600	  18ce0	/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/bin/samr21-xpro/gnrc_border_router.elf
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/bin/samr21-xpro/gnrc_border_router.bin --verify || /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/bin/samr21-xpro/gnrc_border_router.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800008319 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev D)
Programming......................................................................................................................................................................................................................................................................................................................... done.
Verification......................................................................................................................................................................................................................................................................................................................... done.
sudo sh /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/sliptty/start_network.sh 2001:db8::/64 /dev/ttyACM0 115200
Device "sl0" does not exist.
net.ipv6.conf.all.forwarding = 1
Activated forwarding for all interfaces.
Deactivate with
    sudo sysctl -w net.ipv6.conf.all.forwarding=0
when not desired without this script
net.ipv6.conf.sl0.accept_ra = 2
Starting dispatch. TUN: 3, Stream: 4, In: 0, Out: 1
uhcp_client(): sending REQ...
got packet from fe80::e304:f552:244f:5f3a port 48209
uhcp: push from fe80::e304:f552:244f:5f3a:48209 prefix=2001:db8::/64
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8::28ab:dc15:5401:6478/64
gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix 2001:db8::28ab:dc15:5401:6478/64
ifconfig
ifconfig
Iface  7 
          MTU:65535  HL:64  RTR  
          RTR_ADV  
          Link type: wired
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff00:2
          
Iface  6  HWaddr: 67:E7  Channel: 26  Page: 0  NID: 0x23
          Long HWaddr: 2A:AB:DC:15:54:01:64:78 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::28ab:dc15:5401:6478  scope: link  VAL
          inet6 addr: 2001:db8::28ab:dc15:5401:6478  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff01:6478
```

### Terminal 2

```
[mlenders@sarajevo RIOT]<3 ping6 -I sl0 2001:db8::28ab:dc15:5401:6478
PING 2001:db8::28ab:dc15:5401:6478(2001:db8::28ab:dc15:5401:6478) from fdea:dbee:f::1 sl0: 56 data bytes
64 bytes from 2001:db8::28ab:dc15:5401:6478: icmp_seq=1 ttl=64 time=19.4 ms
64 bytes from 2001:db8::28ab:dc15:5401:6478: icmp_seq=2 ttl=64 time=19.5 ms
64 bytes from 2001:db8::28ab:dc15:5401:6478: icmp_seq=3 ttl=64 time=19.5 ms
64 bytes from 2001:db8::28ab:dc15:5401:6478: icmp_seq=4 ttl=64 time=19.6 ms
64 bytes from 2001:db8::28ab:dc15:5401:6478: icmp_seq=5 ttl=64 time=19.6 ms
64 bytes from 2001:db8::28ab:dc15:5401:6478: icmp_seq=6 ttl=64 time=19.4 ms
64 bytes from 2001:db8::28ab:dc15:5401:6478: icmp_seq=7 ttl=64 time=19.5 ms
64 bytes from 2001:db8::28ab:dc15:5401:6478: icmp_seq=8 ttl=64 time=19.4 ms
^C
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #10477 and #10480.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
