### PR TITLE
cpu/cc2538: handle cc2538_rf deps in Makefile.dep

### DIFF
--- a/boards/cc2538dk/Makefile.dep
+++ b/boards/cc2538dk/Makefile.dep
@@ -1,3 +1,3 @@
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += cc2538_rf
 endif

--- a/boards/cc2538dk/Makefile.dep
+++ b/boards/cc2538dk/Makefile.dep
@@ -1,5 +1,3 @@
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  USEMODULE += netif
   USEMODULE += cc2538_rf
-  USEMODULE += netdev_ieee802154
 endif

--- a/boards/common/remote/Makefile.dep
+++ b/boards/common/remote/Makefile.dep
@@ -1,7 +1,5 @@
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  USEMODULE += netif
   USEMODULE += cc2538_rf
-  USEMODULE += netdev_ieee802154
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))

--- a/boards/common/remote/Makefile.dep
+++ b/boards/common/remote/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += cc2538_rf
 endif
 

--- a/boards/openmote-b/Makefile.dep
+++ b/boards/openmote-b/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += cc2538_rf
 endif
 

--- a/boards/openmote-b/Makefile.dep
+++ b/boards/openmote-b/Makefile.dep
@@ -1,10 +1,8 @@
+ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+  USEMODULE += cc2538_rf
+endif
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += si7006
-endif
-
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  USEMODULE += netif
-  USEMODULE += cc2538_rf
-  USEMODULE += netdev_ieee802154
 endif

--- a/boards/openmote-cc2538/Makefile.dep
+++ b/boards/openmote-cc2538/Makefile.dep
@@ -1,3 +1,3 @@
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += cc2538_rf
 endif

--- a/boards/openmote-cc2538/Makefile.dep
+++ b/boards/openmote-cc2538/Makefile.dep
@@ -1,5 +1,3 @@
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  USEMODULE += netif
   USEMODULE += cc2538_rf
-  USEMODULE += netdev_ieee802154
 endif

--- a/cpu/cc2538/Makefile.dep
+++ b/cpu/cc2538/Makefile.dep
@@ -1,0 +1,4 @@
+ifneq (,$(filter cc2538_rf,$(USEMODULE)))
+  USEMODULE += netdev_ieee802154
+  USEMODULE += netif
+endif


### PR DESCRIPTION
### Contribution description

Move handling of `cc2538_rf` deps to `cpu/cc2538` and use `cc2538_rf` as `netdev_default` (it was not pulled in when gnrc was not used).

### Testing procedure

Compile `examples/gnrc_networking` for one of the boards, everything should still be up and running:

`BOARD=openmote-b make -C examples/gnrc_networking flash cleanterm`

```
ifconfig
ifconfig
Iface  7  HWaddr: 6F:FF  Channel: 26  Page: 0  NID: 0x23
          Long HWaddr: 00:12:4B:00:14:B5:B5:AF 
           TX-Power: 0dBm  State: IDLE 
          AUTOACK  L2-PDU:102 MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::212:4b00:14b5:b5af  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffb5:b5af
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 12 (Multicast: 12)  bytes 502
            TX succeeded 0 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 12 (Multicast: 12)  bytes 754
            TX succeeded 12 errors 0

```