### PR TITLE
drivers/mrf24j40: fix setting MRF24J40_USE_EXT_PA_LNA flag

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -414,7 +414,7 @@ ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
 
   # all modules but mrf24j40ma have an external PA
   ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
-    CFLAGS += -DMRF24J40_USE_EXT_PA_LNA
+    CFLAGS += -DMRF24J40_USE_EXT_PA_LNA=1
   endif
 endif
 


### PR DESCRIPTION

### Contribution description

The `MRF24J40_USE_EXT_PA_LNA` define is checked with

    #if MRF24J40_USE_EXT_PA_LNA
        …
    #endif

However, in `Makefile.dep` where it is enabled for mrf24j40mb,
mrf24j40mc & mrf24j40md it is defined without a value, expecting
a check like

    #ifdef MRF24J40_USE_EXT_PA_LNA
        …
    #endif

This fixes the auto-define.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`USEMODULE += mrf24j40md` should enable `MRF24J40_USE_EXT_PA_LNA`.
`USEMODULE += mrf24j40ma` should not.


### Issues/PRs references


