### PR TITLE
sys/ztimer: fix typo in rtt conversion selection

### DIFF
--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -108,7 +108,7 @@ ztimer_clock_t *const ZTIMER_USEC = &_ztimer_convert_frac_usec.super.super;
 #  if MODULE_PERIPH_TIMER_RTT
 static ztimer_periph_timer_rtt_t _ztimer_periph_timer_rtt_msec;
 #  define ZTIMER_RTT_INIT (&_ztimer_periph_timer_rtt_msec)
-#    if RTT_FREQUENCY!=FREQ_1MHZ
+#    if RTT_FREQUENCY!=FREQ_1KHZ
 static ztimer_convert_frac_t _ztimer_convert_frac_msec;
 ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_convert_frac_msec.super;
 #  define ZTIMER_MSEC_CONVERT_LOWER_FREQ    RTT_FREQUENCY


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

ZTIMER_MSEC on RTT needs to convert if RTT frequency is !=1___Hz not _M_Hz.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
