### PR TITLE
tests: clean up use of auto_init

### DIFF
--- a/tests/c11_atomics_cpp_compat/Makefile
+++ b/tests/c11_atomics_cpp_compat/Makefile
@@ -1,9 +1,6 @@
 include ../Makefile.tests_common
 
 # As it is a simple compilation test, only the basic modules are needed
-DISABLE_MODULE := \
-    auto_init \
-    core_msg \
-    #
+DISABLE_MODULE := core_msg
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/irq/Makefile
+++ b/tests/irq/Makefile
@@ -1,6 +1,5 @@
 include ../Makefile.tests_common
 
-USEMODULE += auto_init
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

Disabling `auto_init`causes problems for e.g. `stdio_cdc_acm`, so it should really not be done.
`tests/c11_atomics_cpp_compat` only did this to make the test more 'minimal'.
Since no peripheral drivers are selected by this test, there is nothing to initialize anyway, so this only saves an empty function call.

There is also no need to manually include `auto_init` since this is a default module.

### Testing procedure

The two tests should still succeed. 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
