### PR TITLE
gnrc_netif_send: add send function

### DIFF
--- a/examples/gnrc_lorawan/main.c
+++ b/examples/gnrc_lorawan/main.c
@@ -73,7 +73,7 @@ int tx_cmd(int argc, char **argv)
     }
 
     gnrc_netapi_set(interface, NETOPT_LORAWAN_TX_PORT, 0, &port, sizeof(port));
-    gnrc_netapi_send(interface, pkt);
+    gnrc_netif_send(gnrc_netif_get_by_pid(interface), pkt);
 
     msg_t msg;
     /* wait for packet status and check */

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -527,6 +527,20 @@ char *gnrc_netif_addr_to_str(const uint8_t *addr, size_t addr_len, char *out);
  */
 size_t gnrc_netif_addr_from_str(const char *str, uint8_t *out);
 
+/**
+ * @brief   Send a GNRC packet via a given @ref gnrc_netif_t interface.
+ *
+ * @param netif         pointer to the interface
+ * @param pkt           packet to be sent.
+ *
+ * @return              1 if packet was successfully delivered
+ * @return              -1 on error
+ */
+static inline int gnrc_netif_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
+{
+    return gnrc_netapi_send(netif->pid, pkt);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -285,7 +285,7 @@ static void _send_to_iface(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         return;
     }
 #endif
-    if (gnrc_netapi_send(netif->pid, pkt) < 1) {
+    if (gnrc_netif_send(netif, pkt) < 1) {
         DEBUG("ipv6: unable to send packet\n");
         gnrc_pktbuf_release(pkt);
     }

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -95,7 +95,7 @@ void gnrc_sixlowpan_dispatch_send(gnrc_pktsnip_t *pkt, void *context,
     (void)page;
     assert(pkt->type == GNRC_NETTYPE_NETIF);
     gnrc_netif_hdr_t *hdr = pkt->data;
-    if (gnrc_netapi_send(hdr->if_pid, pkt) < 1) {
+    if (gnrc_netif_send(gnrc_netif_get_by_pid(hdr->if_pid), pkt) < 1) {
         DEBUG("6lo: unable to send %p over interface %u\n", (void *)pkt,
               hdr->if_pid);
         gnrc_pktbuf_release(pkt);

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -1401,7 +1401,7 @@ int _gnrc_netif_send(int argc, char **argv)
     nethdr = (gnrc_netif_hdr_t *)hdr->data;
     nethdr->flags = flags;
     /* and send it */
-    if (gnrc_netapi_send(((gnrc_netif_t *)iface)->pid, pkt) < 1) {
+    if (gnrc_netif_send((gnrc_netif_t *)iface, pkt) < 1) {
         puts("error: unable to send");
         gnrc_pktbuf_release(pkt);
         return 1;

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1196,7 +1196,7 @@ static void test_netapi_send__raw_unicast_ethernet_packet(void)
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ethernet_netif->pid, pkt);
+    gnrc_netif_send(ethernet_netif, pkt);
 }
 
 static void test_netapi_send__raw_broadcast_ethernet_packet(void)
@@ -1211,7 +1211,7 @@ static void test_netapi_send__raw_broadcast_ethernet_packet(void)
     hdr = netif->data;
     hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ethernet_netif->pid, pkt);
+    gnrc_netif_send(ethernet_netif, pkt);
 }
 
 static void test_netapi_send__raw_unicast_ieee802154_long_long_packet(void)
@@ -1224,7 +1224,7 @@ static void test_netapi_send__raw_unicast_ieee802154_long_long_packet(void)
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
 }
 
 static void test_netapi_send__raw_unicast_ieee802154_long_short_packet(void)
@@ -1237,7 +1237,7 @@ static void test_netapi_send__raw_unicast_ieee802154_long_short_packet(void)
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
 }
 
 static void test_netapi_send__raw_unicast_ieee802154_short_long_packet1(void)
@@ -1255,7 +1255,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_long_packet1(void)
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
@@ -1275,7 +1275,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_long_packet2(void)
                                                  dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
 }
 
 static void test_netapi_send__raw_unicast_ieee802154_short_short_packet(void)
@@ -1293,7 +1293,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_short_packet(void)
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
@@ -1313,7 +1313,7 @@ static void test_netapi_send__raw_broadcast_ieee802154_long_packet(void)
     hdr = netif->data;
     hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
 }
 
 static void test_netapi_send__raw_broadcast_ieee802154_short_packet(void)
@@ -1333,7 +1333,7 @@ static void test_netapi_send__raw_broadcast_ieee802154_short_packet(void)
     hdr = netif->data;
     hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
@@ -1367,7 +1367,7 @@ static void test_netapi_send__ipv6_unicast_ethernet_packet(void)
                                                  sizeof(dst_netif));
     TEST_ASSERT_NOT_NULL(netif);
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ethernet_netif->pid, pkt);
+    gnrc_netif_send(ethernet_netif, pkt);
 }
 
 static void test_netapi_send__ipv6_multicast_ethernet_packet(void)
@@ -1394,7 +1394,7 @@ static void test_netapi_send__ipv6_multicast_ethernet_packet(void)
     netif_hdr = netif->data;
     netif_hdr->flags |= GNRC_NETIF_HDR_FLAGS_MULTICAST;
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ethernet_netif->pid, pkt);
+    gnrc_netif_send(ethernet_netif, pkt);
 }
 
 static void test_netapi_send__ipv6_unicast_ieee802154_packet(void)
@@ -1423,7 +1423,7 @@ static void test_netapi_send__ipv6_unicast_ieee802154_packet(void)
                                                  sizeof(dst_netif));
     TEST_ASSERT_NOT_NULL(netif);
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
 }
 
 static void test_netapi_send__ipv6_multicast_ieee802154_packet(void)
@@ -1450,7 +1450,7 @@ static void test_netapi_send__ipv6_multicast_ieee802154_packet(void)
     netif_hdr = netif->data;
     netif_hdr->flags |= GNRC_NETIF_HDR_FLAGS_MULTICAST;
     LL_PREPEND(pkt, netif);
-    gnrc_netapi_send(ieee802154_netif->pid, pkt);
+    gnrc_netif_send(ieee802154_netif, pkt);
 }
 
 static void test_netapi_recv__empty_ethernet_payload(void)

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -115,7 +115,7 @@ static int test_send(void)
         return 0;
     }
     /* send packet to MAC layer */
-    gnrc_netapi_send(_mac_pid, pkt);
+    gnrc_netif_send(gnrc_netif_get_by_pid(_mac_pid), pkt);
     /* wait for packet status and check */
     msg_receive(&msg);
     if ((msg.type != GNRC_NETERR_MSG_TYPE) ||


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a function to send a `gnrc_pktsnip_t` on a given `gnrc_netif_t` interface. For now it's basically a wrapper to `gnrc_netapi_send` but this step is necessary to reduce the number of `gnrc_netif` threads to one (or even _zero_ :).

Coming soon PRs for `gnrc_netif_set` and `gnrc_netif_get`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
It should be enough to compile `tests/gnrc_netif` example, `examples/gnrc_networking` and `examples/gnrc_lorawan`. The functionality is still the same.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
