### PR TITLE
boards/olimexino-stm32: add support for olimexino-stm32 board

### DIFF
--- a/boards/olimexino-stm32/Makefile
+++ b/boards/olimexino-stm32/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/olimexino-stm32/Makefile.dep
+++ b/boards/olimexino-stm32/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/olimexino-stm32/Makefile.features
+++ b/boards/olimexino-stm32/Makefile.features
@@ -1,0 +1,13 @@
+CPU = stm32f1
+CPU_MODEL = stm32f103rb
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_can
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/olimexino-stm32/Makefile.include
+++ b/boards/olimexino-stm32/Makefile.include
@@ -1,0 +1,9 @@
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyUSB0
+PROGRAMMER=stm32flash
+
+# Setup of programmer and serial is shared between STM32 based boards
+include $(RIOTMAKE)/boards/stm32.inc.mk

--- a/boards/olimexino-stm32/board.c
+++ b/boards/olimexino-stm32/board.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Scallog
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_olimexino-stm32
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the OLIMEXINO STM32 board
+ *
+ * @author      Corentin Vigourt <cvigourt@scallog.com>
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+
+    /* initialize the button */
+    gpio_init(BTN0_PIN, BTN0_MODE);
+}
+/** @} */

--- a/boards/olimexino-stm32/doc.txt
+++ b/boards/olimexino-stm32/doc.txt
@@ -1,0 +1,67 @@
+/**
+@defgroup    boards_olimexino-stm32 STM32 Olimexino-stm32
+@ingroup     boards
+@brief       Support for the Olimexino STM32 board
+
+## Overview
+
+The Olimexino-stm32 is a board from Olimexino family supporting a ARM Cortex-M3
+STM32F103RB microcontroller with 20Kb of SRAM and 128Kb of ROM Flash.
+
+## Hardware
+
+![Olimexino STM32](https://www.olimex.com/Products/Duino/STM32/OLIMEXINO-STM32/images/thumbs/310x230/OLIMEXINO-STM32-01.jpg)
+
+### MCU
+| MCU        | STM32F103RB       |
+|:---------- |:----------------- |
+| Family     | ARM Cortex-M3     |
+| Vendor     | ST Microelectronics |
+| RAM        | 20Kb              |
+| Flash      | 128Kb             |
+| Frequency  | up to 72MHz       |
+| FPU        | no                |
+| Timers     | 7 (2x watchdog, 1 SysTick, 4x 16-bit) |
+| ADCs       | 1x 12-bit (16 channels) |
+| UARTs      | 3                 |
+| SPIs       | 2                 |
+| I2Cs       | 2                 |
+| RTC        | 1                 |
+| USB        | 1                 |
+| CAN        | 1                 |
+| Vcc        | 2.0V - 3.6V       |
+| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f103rb.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/cd00171190.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/cd00228163.pdf) |
+| Board Manual | [Board Manual](https://www.olimex.com/Products/Duino/STM32/OLIMEXINO-STM32/resources/OLIMEXINO-STM32.pdf) |
+
+## Implementation Status
+| Device | ID        | Supported | Comments  |
+|:------------- |:------------- |:------------- |:------------- |
+| MCU        | STM32F103RB   | partly    | Energy saving modes not fully utilized |
+| Low-level driver | GPIO    | yes       | |
+|        | PWM       | yes (4 pins available)  |  |
+|        | UART      | 3 UARTs       | USART2 via D0(RX)/D1(TX), USART1 on PA10(RX)/PA09(TX) and USART3 on PB11(RX)/PB10(TX) |
+|        | ADC       | 6 ADCs       | |
+|        | I2C       | yes (I2C1 and I2C2)       | |
+|        | SPI       | yes (SPI1 and SPI2)       | |
+|        | USB       | no        | |
+|        | Timer     | 3 16 bit timers (TIM2, TIM3 and TIM4)       | |
+
+## Flashing the device
+The Olimexino-stm32 needs to be flashed using stm32flash (repo [here](https://github.com/stm32duino/stm32flash)).
+Once you have installed the program, you can flash the board like this:
+
+```
+make BOARD=olimexino-stm32 flash
+```
+and open a terminal using:
+```
+make BOARD=olimexino-stm32 term
+```
+
+USART1 is used for flashing the board whereas USART2 is the serial Output.
+
+## Supported Toolchains
+For using the OLIMEXINO STM32 board you need to use ```arm-none-eabi```.
+ */

--- a/boards/olimexino-stm32/include/board.h
+++ b/boards/olimexino-stm32/include/board.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Scallog
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_olimexino-stm32
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the OLIMEXINO STM32 board
+ *
+ * @author      Corentin Vigourt <cvigourt@scallog.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+#define XTIMER_BACKOFF              (19)
+/** @} */
+
+/**
+ * @name LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PORT           GPIOA
+#define LED0_PIN            GPIO_PIN(PORT_A, 1)
+#define LED0_MASK           (1 << 1)
+
+#define LED1_PORT           GPIOA
+#define LED1_PIN            GPIO_PIN(PORT_A, 5)
+#define LED1_MASK           (1 << 5)
+
+#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
+#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
+#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+
+#define LED1_ON             (LED1_PORT->BSRR = LED1_MASK)
+#define LED1_OFF            (LED1_PORT->BSRR = (LED1_MASK << 16))
+#define LED1_TOGGLE         (LED1_PORT->ODR  ^= LED1_MASK)
+
+#define LED_PANIC           LED0_ON
+/** @} */
+
+/**
+ * @name User button
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_C, 9)
+#define BTN0_MODE           GPIO_IN
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/olimexino-stm32/include/gpio_params.h
+++ b/boards/olimexino-stm32/include/gpio_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Scallog
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_olimexino-stm32
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Corentin Vigourt <cvigourt@scallog.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED2",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED1",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "BUT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/olimexino-stm32/include/periph_conf.h
+++ b/boards/olimexino-stm32/include/periph_conf.h
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2020 Scallog
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_olimexino-stm32
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the OLIMEXINO STM32 board
+ *
+ * @author      Corentin Vigourt <cvigourt@scallog.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz */
+#define CLOCK_CORECLOCK      (72000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE            (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE            (1)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV       RCC_CFGR_PPRE1_DIV2        /* max 36MHz */
+#define CLOCK_APB1           (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2_DIV       RCC_CFGR_PPRE2_DIV1        /* max 72MHz */
+#define CLOCK_APB2           (CLOCK_CORECLOCK / 1)
+
+/* PLL factors */
+#define CLOCK_PLL_PREDIV     (1)
+#define CLOCK_PLL_MUL        (9)
+/** @} */
+
+/**
+ * @name   ADC configuration
+ * @{
+ */
+#define ADC_CONFIG {                \
+        { GPIO_PIN(PORT_C, 0), 0, 10 }, \
+        { GPIO_PIN(PORT_C, 1), 0, 11 }, \
+        { GPIO_PIN(PORT_C, 2), 0, 12 }, \
+        { GPIO_PIN(PORT_C, 3), 0, 13 }, \
+        { GPIO_PIN(PORT_C, 4), 0, 14 }, \
+        { GPIO_PIN(PORT_C, 5), 0, 15 }  \
+}
+
+#define ADC_NUMOF           (6)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan = { { .pin = GPIO_PIN(PORT_A,   8), .cc_chan = 0 },
+                  { .pin = GPIO_PIN(PORT_A,   9), .cc_chan = 1 },
+                  { .pin = GPIO_PIN(PORT_A,  10), .cc_chan = 2 },
+                  { .pin = GPIO_PIN(PORT_A,  11), .cc_chan = 3 } },
+        .af = GPIO_AF_OUT_PP,
+        .bus = APB2
+    },
+    {
+        .dev = TIM2,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .chan = { { .pin = GPIO_PIN(PORT_A,  0), .cc_chan = 0 },
+                  { .pin = GPIO_PIN(PORT_A,  1), .cc_chan = 1 },
+                  { .pin = GPIO_PIN(PORT_A,  2), .cc_chan = 2 },
+                  { .pin = GPIO_PIN(PORT_A,  3), .cc_chan = 3 } },
+        .af = GPIO_AF_OUT_PP,
+        .bus = APB1
+    },
+    {
+        .dev = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .chan = { { .pin = GPIO_PIN(PORT_A,  6), .cc_chan = 0 },
+                  { .pin = GPIO_PIN(PORT_A,  7), .cc_chan = 1 },
+                  { .pin = GPIO_PIN(PORT_B,  0), .cc_chan = 2 },
+                  { .pin = GPIO_PIN(PORT_B,  1), .cc_chan = 3 } },
+        .af = GPIO_AF_OUT_PP,
+        .bus = APB1
+    },
+    {
+        .dev = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan = { { .pin = GPIO_PIN(PORT_B, 6), .cc_chan = 0 },
+                  { .pin = GPIO_PIN(PORT_B, 7), .cc_chan = 1 },
+                  { .pin = GPIO_PIN(PORT_B, 8), .cc_chan = 2 },
+                  { .pin = GPIO_PIN(PORT_B, 9), .cc_chan = 3 } },
+        .af = GPIO_AF_OUT_PP,
+        .bus = APB1
+    }
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev = TIM2,
+        .max = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus = APB1,
+        .irqn = TIM2_IRQn
+    },
+    {
+        .dev = TIM3,
+        .max = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus = APB1,
+        .irqn = TIM3_IRQn
+    },
+    {
+        .dev = TIM4,
+        .max = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .bus = APB1,
+        .irqn = TIM4_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
+#define TIMER_2_ISR         isr_tim4
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = USART2,
+        .rcc_mask = RCC_APB1ENR_USART2EN,
+        .rx_pin = GPIO_PIN(PORT_A, 3),
+        .tx_pin = GPIO_PIN(PORT_A, 2),
+        .bus = APB1,
+        .irqn = USART2_IRQn
+    },
+    {
+        .dev = USART1,
+        .rcc_mask = RCC_APB2ENR_USART1EN,
+        .rx_pin = GPIO_PIN(PORT_A, 10),
+        .tx_pin = GPIO_PIN(PORT_A, 9),
+        .bus = APB2,
+        .irqn = USART1_IRQn
+    },
+    {
+        .dev = USART3,
+        .rcc_mask = RCC_APB1ENR_USART3EN,
+        .rx_pin = GPIO_PIN(PORT_B, 11),
+        .tx_pin = GPIO_PIN(PORT_B, 10),
+        .bus = APB1,
+        .irqn = USART3_IRQn
+    }
+};
+
+#define UART_0_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart3)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_IRQ_PRIO        1
+
+#define RTT_DEV             RTC
+#define RTT_IRQ             RTC_IRQn
+#define RTT_ISR             isr_rtc
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_FREQUENCY       (16384)         /* in Hz */
+#define RTT_PRESCALER       (0x1)           /* run with ~16 kHz Hz */
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @note    This board may require external pullup resistors for i2c operation.
+ * @{
+ */
+
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = I2C1,
+        .speed = I2C_SPEED_NORMAL,
+        .scl_pin = GPIO_PIN(PORT_B, 8),
+        .sda_pin = GPIO_PIN(PORT_B, 9),
+        .bus = APB1,
+        .rcc_mask = RCC_APB1ENR_I2C1EN,
+        .clk = CLOCK_APB1,
+        .irqn = I2C1_EV_IRQn
+    },
+    {
+        .dev = I2C2,
+        .speed = I2C_SPEED_NORMAL,
+        .scl_pin = GPIO_PIN(PORT_B, 10),
+        .sda_pin = GPIO_PIN(PORT_B, 11),
+        .bus = APB1,
+        .rcc_mask = RCC_APB1ENR_I2C2EN,
+        .clk = CLOCK_APB1,
+        .irqn = I2C2_EV_IRQn
+    }
+};
+
+#define I2C_0_ISR           isr_i2c1_ev
+#define I2C_1_ISR           isr_i2c2_ev
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 36000000Hz */
+        7,  /* -> 140625Hz */
+        6,  /* -> 281250Hz */
+        4,  /* -> 1125000Hz */
+        2,  /* -> 4500000Hz */
+        1   /* -> 9000000Hz */
+    },
+    {       /* for APB2 @ 72000000Hz */
+        7,  /* -> 281250Hz */
+        7,  /* -> 281250Hz */
+        5,  /* -> 1125000Hz */
+        3,  /* -> 4500000Hz */
+        2   /* -> 9000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin = GPIO_UNDEF,
+        .rccmask = RCC_APB2ENR_SPI1EN,
+        .apbbus = APB2
+    },
+    {
+        .dev = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 15),
+        .miso_pin = GPIO_PIN(PORT_B, 14),
+        .sclk_pin = GPIO_PIN(PORT_B, 13),
+        .cs_pin = GPIO_UNDEF,
+        .rccmask = RCC_APB1ENR_SPI2EN,
+        .apbbus = APB1
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \
+    olimexino-stm32 \
     opencm904 \
     saml10-xpro \
     saml11-xpro \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -41,6 +41,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \
+    olimexino-stm32 \
     opencm904 \
     saml10-xpro \
     saml11-xpro \

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -31,6 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \
+    olimexino-stm32 \
     opencm904 \
     saml10-xpro \
     saml11-xpro \

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -47,6 +47,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l053r8 \
     nucleo-l073rz \
     nz32-sc151 \
+    olimexino-stm32 \
     opencm904 \
     openmote-b \
     openmote-cc2538 \

--- a/examples/lua_basic/Makefile.ci
+++ b/examples/lua_basic/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f410rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
+    olimexino-stm32 \
     opencm904 \
     saml10-xpro \
     saml11-xpro \

--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -1,6 +1,6 @@
 PROGRAMMER ?= openocd
 
-PROGRAMMERS_SUPPORTED := bmp dfu-util openocd
+PROGRAMMERS_SUPPORTED := bmp dfu-util openocd stm32flash
 
 ifeq (,$(filter $(PROGRAMMER), $(PROGRAMMERS_SUPPORTED)))
   $(error Programmer $(PROGRAMMER) not supported)
@@ -55,4 +55,12 @@ ifeq (dfu-util,$(PROGRAMMER))
   FLASHFILE ?= $(BINFILE)
   DFU_FLAGS ?= -a 2
   FFLAGS = -d $(DFU_USB_ID) $(DFU_FLAGS) -D $(FLASHFILE)
+endif
+
+ifeq (stm32flash,$(PROGRAMMER))
+	FLASHER = stm32flash
+	DEBUGGER =
+	FLASHFILE ?= $(BINFILE)
+	PROG_BAUD ?= 57600
+	FFLAGS = -b $(PROG_BAUD) -w $(FLASHFILE) -g 0x0 $(PORT)
 endif

--- a/tests/bench_xtimer/Makefile.ci
+++ b/tests/bench_xtimer/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    olimexino-stm32 \
+    #

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -40,6 +40,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \
+    olimexino-stm32 \
     opencm904 \
     saml10-xpro \
     saml11-xpro \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -42,6 +42,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \
+    olimexino-stm32 \
     opencm904 \
     saml10-xpro \
     saml11-xpro \

--- a/tests/pkg_utensor/Makefile.ci
+++ b/tests/pkg_utensor/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f410rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
+    olimexino-stm32 \
     opencm904 \
     saml10-xpro \
     saml11-xpro \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -62,6 +62,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l432kc \
     nucleo-l433rc \
     nz32-sc151 \
+    olimexino-stm32 \
     opencm904 \
     pba-d-01-kw2x \
     samd21-xpro \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR is a board support package for Olimexino-stm32 board.
It uses a STM32F103RB as CPU.

Currently, the package has theses features :
* ADC
* CAN
* I2C
* PWM
* RTC
* RTT
* SPI
* TIMER
* UART

I just need to add:
* DMA Support
* Arduino support

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I tested the board using some tests presents in RIOT:
* example/hello-world
* tests/irq
* tests/leds
* tests/periph_adc
* tests/periph_gpio
* tests/periph_i2c
* tests/periph_pwm
* tests/periph_rtc
* tests/periph_rtt
* test/peripg_spi
* tests/periph_timer
* tests/periph_uart

For SPI and I2C tests, I use an Arduino Mega as interface.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
N/A
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
