### PR TITLE
gnrc_netif: add netif set and get function

### DIFF
--- a/examples/gnrc_minimal/main.c
+++ b/examples/gnrc_minimal/main.c
@@ -34,7 +34,7 @@ int main(void)
     gnrc_netif_t *netif = NULL;
     while ((netif = gnrc_netif_iter(netif))) {
         ipv6_addr_t ipv6_addrs[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
-        int res = gnrc_netapi_get(netif->pid, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
+        int res = gnrc_netif_get(netif, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
                                   sizeof(ipv6_addrs));
 
         if (res < 0) {

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -294,6 +294,44 @@ gnrc_netif_t *gnrc_netif_iter(const gnrc_netif_t *prev);
 gnrc_netif_t *gnrc_netif_get_by_pid(kernel_pid_t pid);
 
 /**
+ * @brief   Set an option to a given interface
+ *
+ * @param[in] netif     pointer to the network interface
+ * @param[in] opt       option to set
+ * @param[in] context   (optional) context to the given option
+ * @param[in] data      data to set the given option to
+ * @param[in] data_len  size of @p data
+ *
+ * @return  0 on success
+ * @return  negative errno on error
+ */
+static inline int gnrc_netif_set(const gnrc_netif_t *netif, netopt_t opt,
+                                  uint16_t context, const void *data,
+                                  size_t data_len)
+{
+    return gnrc_netapi_set(netif->pid, opt, context, data, data_len);
+}
+
+/**
+ * @brief   Get an option from a given interface
+ *
+ * @param[in] netif     pointer to the network interface
+ * @param[in] opt       option to get
+ * @param[in] context   (optional) context to the given option
+ * @param[in] data      pointer to buffer for reading the option's value
+ * @param[in] data_len  (maximum) number of bytes in @p data
+ *
+ * @return  0 on success
+ * @return  negative errno on error
+ */
+static inline int gnrc_netif_get(const gnrc_netif_t *netif, netopt_t opt,
+                                  uint16_t context, void *data,
+                                  size_t data_len)
+{
+    return gnrc_netapi_get(netif->pid, opt, context, data, data_len);
+}
+
+/**
  * @brief   Gets the (unicast on anycast) IPv6 address of an interface (if IPv6
  *          is supported)
  *

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -358,7 +358,7 @@ static inline int gnrc_netif_ipv6_addrs_get(const gnrc_netif_t *netif,
     assert(netif != NULL);
     assert(addrs != NULL);
     assert(max_len >= sizeof(ipv6_addr_t));
-    return gnrc_netapi_get(netif->pid, NETOPT_IPV6_ADDR, 0, addrs, max_len);
+    return gnrc_netif_get(netif, NETOPT_IPV6_ADDR, 0, addrs, max_len);
 }
 
 /**
@@ -389,7 +389,7 @@ static inline int gnrc_netif_ipv6_addr_add(const gnrc_netif_t *netif,
     assert(netif != NULL);
     assert(addr != NULL);
     assert((pfx_len > 0) && (pfx_len <= 128));
-    return gnrc_netapi_set(netif->pid, NETOPT_IPV6_ADDR,
+    return gnrc_netif_set(netif, NETOPT_IPV6_ADDR,
                            ((pfx_len << 8U) | flags), addr,
                            sizeof(ipv6_addr_t));
 }
@@ -412,7 +412,7 @@ static inline int gnrc_netif_ipv6_addr_remove(const gnrc_netif_t *netif,
 {
     assert(netif != NULL);
     assert(addr != NULL);
-    return gnrc_netapi_set(netif->pid, NETOPT_IPV6_ADDR_REMOVE,
+    return gnrc_netif_set(netif, NETOPT_IPV6_ADDR_REMOVE,
                            0, addr, sizeof(ipv6_addr_t));
 }
 
@@ -443,7 +443,7 @@ static inline int gnrc_netif_ipv6_groups_get(const gnrc_netif_t *netif,
     assert(netif != NULL);
     assert(groups != NULL);
     assert(max_len >= sizeof(ipv6_addr_t));
-    return gnrc_netapi_get(netif->pid, NETOPT_IPV6_GROUP, 0, groups, max_len);
+    return gnrc_netif_get(netif, NETOPT_IPV6_GROUP, 0, groups, max_len);
 }
 
 /**
@@ -465,7 +465,7 @@ static inline int gnrc_netif_ipv6_group_join(const gnrc_netif_t *netif,
 {
     assert(netif != NULL);
     assert(group != NULL);
-    return gnrc_netapi_set(netif->pid, NETOPT_IPV6_GROUP, 0, group,
+    return gnrc_netif_set(netif, NETOPT_IPV6_GROUP, 0, group,
                            sizeof(ipv6_addr_t));
 }
 
@@ -487,7 +487,7 @@ static inline int gnrc_netif_ipv6_group_leave(const gnrc_netif_t *netif,
 {
     assert(netif != NULL);
     assert(group != NULL);
-    return gnrc_netapi_set(netif->pid, NETOPT_IPV6_GROUP_LEAVE, 0, group,
+    return gnrc_netif_set(netif, NETOPT_IPV6_GROUP_LEAVE, 0, group,
                            sizeof(ipv6_addr_t));
 }
 

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -44,7 +44,7 @@ unsigned dhcpv6_client_get_duid_l2(unsigned iface, dhcpv6_duid_l2_t *duid)
         netif = gnrc_netif_get_by_pid(iface);
     }
     assert(netif != NULL);
-    if ((res = gnrc_netapi_get(netif->pid, NETOPT_ADDRESS_LONG, 0,
+    if ((res = gnrc_netif_get(netif, NETOPT_ADDRESS_LONG, 0,
                                l2addr, GNRC_NETIF_L2ADDR_MAXLEN)) > 0) {
         duid->l2type = byteorder_htons(ARP_HWTYPE_EUI64);
     }
@@ -53,7 +53,7 @@ unsigned dhcpv6_client_get_duid_l2(unsigned iface, dhcpv6_duid_l2_t *duid)
             case NETDEV_TYPE_ETHERNET:
             case NETDEV_TYPE_BLE:
             case NETDEV_TYPE_ESP_NOW:
-                if ((res = gnrc_netapi_get(netif->pid,
+                if ((res = gnrc_netif_get(netif,
                                            NETOPT_ADDRESS,
                                            0, l2addr,
                                            GNRC_NETIF_L2ADDR_MAXLEN)) > 0) {
@@ -81,7 +81,7 @@ void dhcpv6_client_conf_prefix(unsigned iface, const ipv6_addr_t *pfx,
     assert(netif != NULL);
     DEBUG("GNRC DHCPv6 client: (re-)configure prefix %s/%d\n",
           ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)), pfx_len);
-    if (gnrc_netapi_get(netif->pid, NETOPT_IPV6_IID, 0, &iid,
+    if (gnrc_netif_get(netif, NETOPT_IPV6_IID, 0, &iid,
                         sizeof(eui64_t)) >= 0) {
         ipv6_addr_set_aiid(&addr, iid.uint8);
     }

--- a/sys/net/gnrc/netif/_netif.c
+++ b/sys/net/gnrc/netif/_netif.c
@@ -37,14 +37,14 @@ int netif_get_opt(netif_t *netif, netopt_t opt, uint16_t context,
                   void *value, size_t max_len)
 {
     gnrc_netif_t *iface = (gnrc_netif_t*) netif;
-    return gnrc_netapi_get(iface->pid, opt, context, value, max_len);
+    return gnrc_netif_get(iface, opt, context, value, max_len);
 }
 
 int netif_set_opt(netif_t *netif, netopt_t opt, uint16_t context,
                   void *value, size_t value_len)
 {
     gnrc_netif_t *iface = (gnrc_netif_t*) netif;
-    return gnrc_netapi_set(iface->pid, opt, context, value, value_len);
+    return gnrc_netif_set(iface, opt, context, value, value_len);
 }
 
 /** @} */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -96,21 +96,21 @@ static bool _try_l2addr_reconfiguration(gnrc_netif_t *netif)
     uint8_t hwaddr[GNRC_NETIF_L2ADDR_MAXLEN];
     uint16_t hwaddr_len;
 
-    if (gnrc_netapi_get(netif->pid, NETOPT_SRC_LEN, 0, &hwaddr_len,
+    if (gnrc_netif_get(netif, NETOPT_SRC_LEN, 0, &hwaddr_len,
                         sizeof(hwaddr_len)) < 0) {
         return false;
     }
     luid_get(hwaddr, hwaddr_len);
 #if GNRC_IPV6_NIB_CONF_6LN
     if (hwaddr_len == IEEE802154_LONG_ADDRESS_LEN) {
-        if (gnrc_netapi_set(netif->pid, NETOPT_ADDRESS_LONG, 0, hwaddr,
+        if (gnrc_netif_set(netif, NETOPT_ADDRESS_LONG, 0, hwaddr,
                             hwaddr_len) < 0) {
             return false;
         }
     }
     else
 #endif
-    if (gnrc_netapi_set(netif->pid, NETOPT_ADDRESS, 0, hwaddr,
+    if (gnrc_netif_set(netif, NETOPT_ADDRESS, 0, hwaddr,
                         hwaddr_len) < 0) {
         return false;
     }

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -715,7 +715,7 @@ static void test_ipv6_get_iid(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ieee802154_ipv6_ll_long.u64[1],
                                     sizeof(res)));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
-                          gnrc_netapi_set(ieee802154_netif->pid,
+                          gnrc_netif_set(ieee802154_netif,
                                           NETOPT_SRC_LEN, 0,
                                           &ieee802154_l2addr_len,
                                           sizeof(ieee802154_l2addr_len)));
@@ -725,7 +725,7 @@ static void test_ipv6_get_iid(void)
     /* reset to source length 8 */
     ieee802154_l2addr_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
-                          gnrc_netapi_set(ieee802154_netif->pid,
+                          gnrc_netif_set(ieee802154_netif,
                                           NETOPT_SRC_LEN, 0,
                                           &ieee802154_l2addr_len,
                                           sizeof(ieee802154_l2addr_len)));
@@ -739,7 +739,7 @@ static void test_netapi_get__HOP_LIMIT(void)
     uint8_t value;
 
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-                          gnrc_netapi_get(netifs[0]->pid, NETOPT_HOP_LIMIT,
+                          gnrc_netif_get(netifs[0], NETOPT_HOP_LIMIT,
                                           0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(netifs[0]->cur_hl, value);
 }
@@ -750,7 +750,7 @@ static void test_netapi_get__IPV6_ADDR(void)
     ipv6_addr_t value[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
 
     test_ipv6_addr_add__success();
-    TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t), gnrc_netapi_get(netifs[0]->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t), gnrc_netif_get(netifs[0],
                                                                NETOPT_IPV6_ADDR,
                                                                0, &value,
                                                                sizeof(value)));
@@ -762,7 +762,7 @@ static void test_netapi_get__IPV6_ADDR_FLAGS(void)
     uint8_t value[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
 
     test_ipv6_addr_add__success();
-    TEST_ASSERT_EQUAL_INT(sizeof(uint8_t), gnrc_netapi_get(netifs[0]->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint8_t), gnrc_netif_get(netifs[0],
                                                            NETOPT_IPV6_ADDR_FLAGS,
                                                            0, &value,
                                                            sizeof(value)));
@@ -775,7 +775,7 @@ static void test_netapi_get__IPV6_GROUP(void)
     ipv6_addr_t value[GNRC_NETIF_IPV6_GROUPS_NUMOF];
 
     test_ipv6_group_join__success();
-    TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t), gnrc_netapi_get(netifs[0]->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t), gnrc_netif_get(netifs[0],
                                                                NETOPT_IPV6_GROUP,
                                                                0, &value,
                                                                sizeof(value)));
@@ -791,22 +791,22 @@ static void test_netapi_get__IPV6_IID(void)
     eui64_t value;
     uint16_t ieee802154_l2addr_len = 2U;
 
-    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ethernet_netif->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netif_get(ethernet_netif,
                                                            NETOPT_IPV6_IID,
                                                            0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ethernet_ipv6_ll.u64[1],
                                     sizeof(value)));
-    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ieee802154_netif->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netif_get(ieee802154_netif,
                                                            NETOPT_IPV6_IID,
                                                            0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ieee802154_ipv6_ll_long.u64[1],
                                     sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
-                          gnrc_netapi_set(ieee802154_netif->pid,
+                          gnrc_netif_set(ieee802154_netif,
                                           NETOPT_SRC_LEN, 0,
                                           &ieee802154_l2addr_len,
                                           sizeof(ieee802154_l2addr_len)));
-    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ieee802154_netif->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netif_get(ieee802154_netif,
                                                            NETOPT_IPV6_IID,
                                                            0, &value,
                                                            sizeof(value)));
@@ -815,11 +815,11 @@ static void test_netapi_get__IPV6_IID(void)
     /* reset to source length 8 */
     ieee802154_l2addr_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
-                          gnrc_netapi_set(ieee802154_netif->pid,
+                          gnrc_netif_set(ieee802154_netif,
                                           NETOPT_SRC_LEN, 0,
                                           &ieee802154_l2addr_len,
                                           sizeof(ieee802154_l2addr_len)));
-    TEST_ASSERT_EQUAL_INT(-ENOTSUP, gnrc_netapi_get(netifs[0]->pid,
+    TEST_ASSERT_EQUAL_INT(-ENOTSUP, gnrc_netif_get(netifs[0],
                                                     NETOPT_IPV6_IID,
                                                     0, &value, sizeof(value)));
 }
@@ -828,32 +828,32 @@ static void test_netapi_get__MAX_PACKET_SIZE(void)
 {
     uint16_t value;
 
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(ethernet_netif->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(ethernet_netif,
                                                             NETOPT_MAX_PDU_SIZE,
                                                             GNRC_NETTYPE_IPV6,
                                                             &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(ETHERNET_DATA_LEN, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(ethernet_netif->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(ethernet_netif,
                                                             NETOPT_MAX_PDU_SIZE,
                                                             GNRC_NETTYPE_NETIF,
                                                             &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(ETHERNET_DATA_LEN, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(ieee802154_netif->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(ieee802154_netif,
                                                             NETOPT_MAX_PDU_SIZE,
                                                             GNRC_NETTYPE_IPV6,
                                                             &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(IPV6_MIN_MTU, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(ieee802154_netif->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(ieee802154_netif,
                                                             NETOPT_MAX_PDU_SIZE,
                                                             GNRC_NETTYPE_NETIF,
                                                             &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(TEST_IEEE802154_MAX_FRAG_SIZE, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(netifs[0]->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(netifs[0],
                                                             NETOPT_MAX_PDU_SIZE,
                                                             GNRC_NETTYPE_IPV6,
                                                             &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(IPV6_MIN_MTU, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(netifs[0]->pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(netifs[0],
                                                             NETOPT_MAX_PDU_SIZE,
                                                             GNRC_NETTYPE_NETIF,
                                                             &value, sizeof(value)));
@@ -865,17 +865,17 @@ static void test_netapi_get__6LO_IPHC(void)
     netopt_enable_t value;
 
     TEST_ASSERT_EQUAL_INT(sizeof(netopt_enable_t),
-                          gnrc_netapi_get(ethernet_netif->pid,
+                          gnrc_netif_get(ethernet_netif,
                                           NETOPT_6LO_IPHC, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(NETOPT_DISABLE, value);
     TEST_ASSERT_EQUAL_INT(sizeof(netopt_enable_t),
-                          gnrc_netapi_get(ieee802154_netif->pid,
+                          gnrc_netif_get(ieee802154_netif,
                                           NETOPT_6LO_IPHC, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(NETOPT_ENABLE, value);
     TEST_ASSERT_EQUAL_INT(sizeof(netopt_enable_t),
-                          gnrc_netapi_get(netifs[0]->pid,
+                          gnrc_netif_get(netifs[0],
                                           NETOPT_6LO_IPHC, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(NETOPT_DISABLE, value);
@@ -888,12 +888,12 @@ static void test_netapi_get__ADDRESS(void)
     uint8_t value[GNRC_NETIF_L2ADDR_MAXLEN];
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-                          gnrc_netapi_get(ethernet_netif->pid,
+                          gnrc_netif_get(ethernet_netif,
                                           NETOPT_ADDRESS, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ethernet, value, sizeof(exp_ethernet)));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-                          gnrc_netapi_get(ieee802154_netif->pid,
+                          gnrc_netif_get(ieee802154_netif,
                                           NETOPT_ADDRESS, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ieee802154, value,
@@ -906,17 +906,17 @@ static void test_netapi_get__ADDRESS_LONG(void)
     uint8_t value[GNRC_NETIF_L2ADDR_MAXLEN];
 
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-                          gnrc_netapi_get(ethernet_netif->pid,
+                          gnrc_netif_get(ethernet_netif,
                                           NETOPT_ADDRESS_LONG, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-                          gnrc_netapi_get(ieee802154_netif->pid,
+                          gnrc_netif_get(ieee802154_netif,
                                           NETOPT_ADDRESS_LONG, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ieee802154, value,
                                     sizeof(exp_ieee802154)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-                          gnrc_netapi_get(netifs[0]->pid,
+                          gnrc_netif_get(netifs[0],
                                           NETOPT_ADDRESS_LONG, 0,
                                           &value, sizeof(value)));
 }
@@ -926,7 +926,7 @@ static void test_netapi_set__HOP_LIMIT(void)
     uint8_t value = 89;
 
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_HOP_LIMIT, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(value, netifs[0]->cur_hl);
@@ -940,7 +940,7 @@ static void test_netapi_set__IPV6_ADDR(void)
 
     TEST_ASSERT(0 > gnrc_netif_ipv6_addr_idx(netifs[0], &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_IPV6_ADDR, context,
                                           &value, sizeof(value)));
     TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_idx(netifs[0], &value));
@@ -953,7 +953,7 @@ static void test_netapi_set__IPV6_ADDR_REMOVE(void)
     test_ipv6_addr_add__success();
     TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_idx(netifs[0], &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_IPV6_ADDR_REMOVE, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT(0 > gnrc_netif_ipv6_addr_idx(netifs[0], &value));
@@ -965,7 +965,7 @@ static void test_netapi_set__IPV6_GROUP(void)
 
     TEST_ASSERT(0 > gnrc_netif_ipv6_group_idx(netifs[0], &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_IPV6_GROUP, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(netifs[0], &value));
@@ -978,7 +978,7 @@ static void test_netapi_set__IPV6_GROUP_LEAVE(void)
     test_ipv6_group_join__success();
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(netifs[0], &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_IPV6_GROUP_LEAVE, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT(0 > gnrc_netif_ipv6_group_idx(netifs[0], &value));
@@ -989,13 +989,13 @@ static void test_netapi_set__MAX_PACKET_SIZE(void)
     uint16_t value = 57194;
 
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_MAX_PDU_SIZE,
                                           GNRC_NETTYPE_IPV6,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(value, netifs[0]->ipv6.mtu);
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_MAX_PDU_SIZE, 0,
                                           &value, sizeof(value)));
 }
@@ -1005,7 +1005,7 @@ static void test_netapi_set__6LO_IPHC(void)
     netopt_enable_t value = NETOPT_ENABLE;
 
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_6LO_IPHC, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT(netifs[0]->flags & GNRC_NETIF_FLAGS_6LO_HC);
@@ -1019,14 +1019,14 @@ static void test_netapi_set__ADDRESS(void)
     uint8_t value[] = { LA1 + 1, LA2 + 2, LA3 + 3, LA4 + 4, LA5 + 5, LA6 + 6 };
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-                          gnrc_netapi_set(ethernet_netif->pid,
+                          gnrc_netif_set(ethernet_netif,
                                           NETOPT_ADDRESS, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(value), ethernet_netif->l2addr_len);
     TEST_ASSERT_EQUAL_INT(0, memcmp(value, ethernet_netif->l2addr,
                                     ETHERNET_ADDR_LEN));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-                          gnrc_netapi_set(ieee802154_netif->pid,
+                          gnrc_netif_set(ieee802154_netif,
                                           NETOPT_ADDRESS, 0,
                                           &value, sizeof(uint16_t)));
     /* we did not change NETOPT_SRC_LEN, so this field shouldn't change */
@@ -1037,7 +1037,7 @@ static void test_netapi_set__ADDRESS(void)
     /* return addresses to previous state for further testing */
     memcpy(value, exp_ethernet, sizeof(exp_ethernet));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-                          gnrc_netapi_set(ethernet_netif->pid,
+                          gnrc_netif_set(ethernet_netif,
                                           NETOPT_ADDRESS, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(value), ethernet_netif->l2addr_len);
@@ -1045,7 +1045,7 @@ static void test_netapi_set__ADDRESS(void)
                                     sizeof(value)));
     memcpy(value, exp_ieee802154, sizeof(exp_ieee802154));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-                          gnrc_netapi_set(ieee802154_netif->pid,
+                          gnrc_netif_set(ieee802154_netif,
                                           NETOPT_ADDRESS, 0,
                                           &value, sizeof(uint16_t)));
 }
@@ -1057,24 +1057,24 @@ static void test_netapi_set__ADDRESS_LONG(void)
                         LA7 + 1, LA8 + 2 };
 
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-                          gnrc_netapi_set(ethernet_netif->pid,
+                          gnrc_netif_set(ethernet_netif,
                                           NETOPT_ADDRESS_LONG, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-                          gnrc_netapi_set(ieee802154_netif->pid,
+                          gnrc_netif_set(ieee802154_netif,
                                           NETOPT_ADDRESS_LONG, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(value), ieee802154_netif->l2addr_len);
     TEST_ASSERT_EQUAL_INT(0, memcmp(value, ieee802154_netif->l2addr,
                                     sizeof(value)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-                          gnrc_netapi_set(netifs[0]->pid,
+                          gnrc_netif_set(netifs[0],
                                           NETOPT_ADDRESS_LONG, 0,
                                           &value, sizeof(value)));
     /* return addresses to previous state for further testing */
     memcpy(value, exp_ieee802154, sizeof(exp_ieee802154));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-                          gnrc_netapi_set(ieee802154_netif->pid,
+                          gnrc_netif_set(ieee802154_netif,
                                           NETOPT_ADDRESS_LONG, 0,
                                           &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(value), ieee802154_netif->l2addr_len);
@@ -1089,21 +1089,21 @@ static void test_netapi_set__SRC_LEN(void)
     uint16_t value = 2U;
 
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-                          gnrc_netapi_set(ethernet_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ethernet_netif, NETOPT_SRC_LEN,
                                           0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(uint16_t),
-                          gnrc_netapi_set(ieee802154_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ieee802154_netif, NETOPT_SRC_LEN,
                                           0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(value, ieee802154_netif->l2addr_len);
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_l2addr, ieee802154_netif->l2addr,
                                     sizeof(exp_l2addr)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-                          gnrc_netapi_set(netifs[0]->pid, NETOPT_SRC_LEN, 0,
+                          gnrc_netif_set(netifs[0], NETOPT_SRC_LEN, 0,
                                           &value, sizeof(value)));
     /* return addresses to previous state for further testing */
     value = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(uint16_t),
-                          gnrc_netapi_set(ieee802154_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ieee802154_netif, NETOPT_SRC_LEN,
                                           0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(value, ieee802154_netif->l2addr_len);
     TEST_ASSERT_EQUAL_INT(0, memcmp(orig_ieee802154, ieee802154_netif->l2addr,
@@ -1250,7 +1250,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_long_packet1(void)
 
     TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-                          gnrc_netapi_set(ieee802154_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ieee802154_netif, NETOPT_SRC_LEN,
                                           0, &src_len, sizeof(src_len)));
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
@@ -1259,7 +1259,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_long_packet1(void)
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-                          gnrc_netapi_set(ieee802154_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ieee802154_netif, NETOPT_SRC_LEN,
                                           0, &src_len, sizeof(src_len)));
 }
 
@@ -1288,7 +1288,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_short_packet(void)
 
     TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-                          gnrc_netapi_set(ieee802154_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ieee802154_netif, NETOPT_SRC_LEN,
                                           0, &src_len, sizeof(src_len)));
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
@@ -1297,7 +1297,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_short_packet(void)
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-                          gnrc_netapi_set(ieee802154_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ieee802154_netif, NETOPT_SRC_LEN,
                                           0, &src_len, sizeof(src_len)));
 }
 
@@ -1326,7 +1326,7 @@ static void test_netapi_send__raw_broadcast_ieee802154_short_packet(void)
 
     TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-                          gnrc_netapi_set(ieee802154_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ieee802154_netif, NETOPT_SRC_LEN,
                                           0, &src_len, sizeof(src_len)));
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
     TEST_ASSERT_NOT_NULL(netif);
@@ -1337,7 +1337,7 @@ static void test_netapi_send__raw_broadcast_ieee802154_short_packet(void)
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-                          gnrc_netapi_set(ieee802154_netif->pid, NETOPT_SRC_LEN,
+                          gnrc_netif_set(ieee802154_netif, NETOPT_SRC_LEN,
                                           0, &src_len, sizeof(src_len)));
 }
 

--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -120,7 +120,7 @@ static void _init_interface(void)
     addr.u8[15] = 0x01;
 
     xtimer_usleep(500); /* wait for thread to start */
-    if (gnrc_netapi_set(netif->pid, NETOPT_IPV6_ADDR, 64U << 8U, &addr,
+    if (gnrc_netif_set(netif, NETOPT_IPV6_ADDR, 64U << 8U, &addr,
                         sizeof(addr)) < 0) {
         printf("error: unable to add IPv6 address fd01::1/64 to interface %u\n",
                netif->pid);

--- a/tests/nanocoap_cli/main.c
+++ b/tests/nanocoap_cli/main.c
@@ -88,14 +88,14 @@ static int _list_all_inet6(int argc, char **argv)
     while ((netif = gnrc_netif_iter(netif))) {
         ipv6_addr_t ipv6_addrs[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
 
-        int res = gnrc_netapi_get(netif->pid, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
+        int res = gnrc_netif_get(netif, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
                                   sizeof(ipv6_addrs));
         if (res >= 0) {
             uint8_t ipv6_addrs_flags[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
 
             memset(ipv6_addrs_flags, 0, sizeof(ipv6_addrs_flags));
             /* assume it to succeed (otherwise array will stay 0) */
-            gnrc_netapi_get(netif->pid, NETOPT_IPV6_ADDR_FLAGS, 0,
+            gnrc_netif_get(netif, NETOPT_IPV6_ADDR_FLAGS, 0,
                             ipv6_addrs_flags, sizeof(ipv6_addrs_flags));
             /* yes, the res of NETOPT_IPV6_ADDR is meant to be here ;-) */
             for (unsigned i = 0; i < (res / sizeof(ipv6_addr_t)); i++) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR is analogue to https://github.com/RIOT-OS/RIOT/pull/13579.
For now this is only a wrapper to `gnrc_netapi_.et`. This will be useful for reducing the number of `gnrc_netif` threads (see #13579).


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Functionalities are still the same, but it would be nice to check if all examples using gnrc_netif still compile.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#13579
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
