### PR TITLE
net/nanocoap: add uquery improvements

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -979,14 +979,15 @@ ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val
  * @note Use this only for null-terminated string. See @ref coap_opt_add_uquery2()
  *       for non null-terminated string.
  *
- * @param[in,out] pkt         The package that is being build
+ * @param[in,out] pkt         Packet being built
  * @param[in]     key         Key to add to the query string
  * @param[in]     val         Value to assign to @p key (may be NULL)
  *
  * @pre     ((pkt != NULL) && (key != NULL))
  *
- * @return  overall length of new query string
- * @return  -1 on error
+ * @return        number of bytes written to pkt buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or pkt full
  */
 ssize_t coap_opt_add_uquery(coap_pkt_t *pkt, const char *key, const char *val);
 
@@ -994,16 +995,18 @@ ssize_t coap_opt_add_uquery(coap_pkt_t *pkt, const char *key, const char *val);
  * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
  *
  *
- * @param[in,out] pkt         The package that is being build
+ * @param[in,out] pkt         Packet being built
  * @param[in]     key         Key to add to the query string
  * @param[in]     key_len     Length of @p key
  * @param[in]     val         Value to assign to @p key (may be NULL)
  * @param[in]     val_len     Length of @p val. 0 if @p val is NULL
  *
- * @pre     ((pkt != NULL) && (key != NULL) && (key_len > 0))
+ * @pre     ((pkt != NULL) && (key != NULL) && (key_len > 0)
+ *              && ((val_len == 0) || ((val != NULL) && (val_len > 0))))
  *
- * @return  overall length of new query string
- * @return  -1 on error
+ * @return        number of bytes written to pkt buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or pkt full
  */
 ssize_t coap_opt_add_uquery2(coap_pkt_t *pkt, const char *key, size_t key_len,
                              const char *val, size_t val_len);

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -860,10 +860,11 @@ ssize_t coap_opt_add_uquery2(coap_pkt_t *pkt, const char *key, size_t key_len,
     assert(!val_len || (val && val_len));
 
     char qs[NANOCOAP_QS_MAX];
+    /* length including '=' */
     size_t qs_len = key_len + ((val && val_len) ? (val_len + 1) : 0);
 
     /* test if the query string fits */
-    if (qs_len >= NANOCOAP_QS_MAX) {
+    if (qs_len > NANOCOAP_QS_MAX) {
         return -1;
     }
 
@@ -872,9 +873,8 @@ ssize_t coap_opt_add_uquery2(coap_pkt_t *pkt, const char *key, size_t key_len,
         qs[key_len] = '=';
         memcpy(&qs[key_len + 1], val, val_len);
     }
-    qs[qs_len] = '\0';
 
-    return coap_opt_add_string(pkt, COAP_OPT_URI_QUERY, qs, '&');
+    return _add_opt_pkt(pkt, COAP_OPT_URI_QUERY, (uint8_t *)qs, qs_len);
 }
 
 ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val, size_t val_len)


### PR DESCRIPTION
### Contribution description
We recently migrated/extended the creation of a Uri-Query option from `gcoap_add_qstring()` to the new functions `coap_opt_add_uquery()` and `coap_opt_add_uquery2()`. This PR adds some improvements to those new functions:

1. Add a unit test for `coap_opt_add_uquery2()`
1. Directly use `_add_opt_pkt()` to append the option rather than the less efficient `coap_opt_add_string()`, which was a holdover from the gcoap based implementation
1. Update the documentation on return types to match the code

### Testing procedure
Run the nanocoap unit tests, and build/verify the documentation for the functions.

### Issues/PRs references
Need for unit test described in #13022.