### PR TITLE
[RFC] sys/ztimer: power management for the different clocks

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -281,6 +281,16 @@ typedef struct {
      * @brief   Cancel any set target
      */
     void (*cancel)(ztimer_clock_t *clock);
+
+    /**
+     * @brief   Acquire the underlying hardware clock
+     */
+    void (*acquire)(ztimer_clock_t *clock);
+
+    /**
+     * @brief   Release the underlying hardware clock
+     */
+    void (*release)(ztimer_clock_t *clock);
 } ztimer_ops_t;
 
 /**

--- a/sys/ztimer/periph_rtc.c
+++ b/sys/ztimer/periph_rtc.c
@@ -134,6 +134,8 @@ static const ztimer_ops_t _ztimer_periph_rtc_ops = {
     .set = _ztimer_periph_rtc_set,
     .now = _ztimer_periph_rtc_now,
     .cancel = _ztimer_periph_rtc_cancel,
+    .acquire = NULL,
+    .release = NULL,
 };
 
 void ztimer_periph_rtc_init(ztimer_periph_rtc_t *clock)

--- a/sys/ztimer/periph_rtt.c
+++ b/sys/ztimer/periph_rtt.c
@@ -70,6 +70,8 @@ static const ztimer_ops_t _ztimer_periph_rtt_ops = {
     .set = _ztimer_periph_rtt_set,
     .now = _ztimer_periph_rtt_now,
     .cancel = _ztimer_periph_rtt_cancel,
+    .acquire = NULL,
+    .release = NULL,
 };
 
 void ztimer_periph_rtt_init(ztimer_periph_rtt_t *clock)

--- a/sys/ztimer/periph_timer.c
+++ b/sys/ztimer/periph_timer.c
@@ -70,6 +70,8 @@ static const ztimer_ops_t _ztimer_periph_timer_ops = {
     .set = _ztimer_periph_timer_set,
     .now = _ztimer_periph_timer_now,
     .cancel = _ztimer_periph_timer_cancel,
+    .acquire = NULL,
+    .release = NULL,
 };
 
 void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev, unsigned long freq,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

ztimer has been designed to handle different clock sources and picks the right one for a timeout requested by the users.

This has the potential to handle power management seamlessly! Since clocks with higher frequencies tend to consume more power than those with lower frequencies, we can react according to the currently demanded clocks.

If a high frequency clock has no timers to handle, we cloud disable it to save energy.

This, of course, comes with a cost: `timer_now()` calls that base on the high frequency clock stuck while it is disabled.

This PR introduces a callback approach to notify whether a clock is actually required by a timer or not. It is more meant to be a basis for discussion. Maybe we can develop a solution that fits best: Power saving but also the smallest impact on the accuracy.

### Testing procedure

Pick a board that disables the high frequency timers in a certain PM level. Unblock all power levels including that one. Set the CFLAG `CONFIG_ZTIMER_PERIPH_TIMER_PM_LAYER=[the certain PM level]`.

That certain PM level should be blocked/unblocked depending whether a timer based on `ZTIMER_USEC` is running.

If the proposed concept is accepted, I will add a test for this case.

### Issues/PRs references

Closes #13580 