### PR TITLE
nrf5x: Add and enable configuration for the built-in DC/DC converter

### DIFF
--- a/boards/acd52832/include/periph_conf.h
+++ b/boards/acd52832/include/periph_conf.h
@@ -80,6 +80,11 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -41,6 +41,11 @@ static const pwm_conf_t pwm_config[] = {
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf51dk/include/periph_conf.h
+++ b/boards/nrf51dk/include/periph_conf.h
@@ -74,6 +74,11 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf52832-mdk/include/periph_conf.h
+++ b/boards/nrf52832-mdk/include/periph_conf.h
@@ -40,6 +40,11 @@ extern "C" {
 #define UART_PIN_TX         GPIO_PIN(0,20)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -51,6 +51,11 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/particle-argon/include/periph_conf.h
+++ b/boards/particle-argon/include/periph_conf.h
@@ -56,6 +56,11 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/particle-boron/include/periph_conf.h
+++ b/boards/particle-boron/include/periph_conf.h
@@ -55,6 +55,12 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
+
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/particle-xenon/include/periph_conf.h
+++ b/boards/particle-xenon/include/periph_conf.h
@@ -47,6 +47,11 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/pinetime/include/periph_conf.h
+++ b/boards/pinetime/include/periph_conf.h
@@ -63,6 +63,11 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/reel/include/periph_conf.h
+++ b/boards/reel/include/periph_conf.h
@@ -66,6 +66,11 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/ruuvitag/include/periph_conf.h
+++ b/boards/ruuvitag/include/periph_conf.h
@@ -54,6 +54,11 @@ static const spi_conf_t spi_config[] = {
 #define UART_PIN_TX         GPIO_PIN(0, 5)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/thingy52/include/periph_conf.h
+++ b/boards/thingy52/include/periph_conf.h
@@ -62,6 +62,11 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf51/cpu.c
+++ b/cpu/nrf51/cpu.c
@@ -19,6 +19,7 @@
 
 #include "cpu.h"
 #include "nrf_clock.h"
+#include "nrfx.h"
 #include "periph_conf.h"
 #include "periph/init.h"
 #include "stdio_base.h"
@@ -30,6 +31,8 @@ void cpu_init(void)
 {
     /* initialize the Cortex-M core */
     cortexm_init();
+    /* Enable the DC/DC power converter */
+    nrfx_dcdc_init();
     /* setup the HF clock */
     clock_init_hf();
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */

--- a/cpu/nrf52/cpu.c
+++ b/cpu/nrf52/cpu.c
@@ -23,6 +23,7 @@
 #define DONT_OVERRIDE_NVIC
 
 #include "cpu.h"
+#include "nrfx.h"
 #include "nrf_clock.h"
 #include "periph_conf.h"
 #include "periph/init.h"
@@ -61,6 +62,8 @@ void cpu_init(void)
         NRF_CLOCK->EVENTS_DONE = 0;
         NRF_CLOCK->EVENTS_CTTO = 0;
     }
+    /* Enable the DC/DC power converter */
+    nrfx_dcdc_init();
 
     /* initialize hf clock */
     clock_init_hf();

--- a/cpu/nrf5x_common/include/nrfx.h
+++ b/cpu/nrf5x_common/include/nrfx.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2020 Inria
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,18 +16,34 @@
  * @brief           nrfx compatibility layer
  *
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author          Koen Zandberg <koen@bergzand.net>
  */
 
 #ifndef NRFX_H
 #define NRFX_H
 
 #include "cpu_conf.h"
+#include "periph_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* nothing else to do here */
+/**
+ * @brief Enable the internal DC/DC power converter for the NRF5x MCU.
+ *
+ * The internal DC/DC converter is more efficient compared to the LDO regulator.
+ * The downside of the DC/DC converter is that it requires an external inductor
+ * to be present on the board. Enabling the DC/DC converter is guarded with
+ * NRF5X_ENABLE_DCDC, this macro must be defined if the DC/DC converter is to be
+ * enabled.
+ */
+static inline void nrfx_dcdc_init(void)
+{
+#ifdef NRF5X_ENABLE_DCDC
+    NRF_POWER->DCDCEN = 1;
+#endif
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

The nrf5x type microcontrollers have both an LDO regulator and a DC/DC converter to reduce the core voltage to 1.35V. The internal DC/DC converter is more efficient compared to the LDO
regulator.  The downside of the DC/DC converter is that it requires an
external inductor to be present on the board. Enabling the DC/DC
converter is guarded with NRF5X_ENABLE_DCDC, this macro must be defined
if the DC/DC converter is to be enabled.

This PR adds functionality to enable the DC/DC converter based on a macro define. All boards 
identified to have the required inductor on the PCB have this define enabled in the `periph_conf.h`.

I've measured power consumption of the particle-xenon board during an `xtimer_spin(30 * US_PER_SEC)` call to simulate a worst case CPU load condition. With the DC/DC converter disabled this results in a draw of 6mA. With the DC/DC converter enabled this is reduced to 2.5mA. When the CPU is idle the impact is not that big, I measured around 1mA in both cases, probably limited by the accuracy of the multimeter.

### Testing procedure

Confirm that the modified boards indeed have the inductor present. It must be between the `DCC` and the `DEC4` pin of the MCU (figure 14, page 79 of the nRF52832 product specification). Usually the boards have two different valued series inductors between these two pins.

- [x] acd52832 https://aconno.de/wp-content/uploads/2016/09/ACN52832_data_sheet.pdf p14
- [x] nrf52xxxdk
- [x] nrf51dk https://www.nordicsemi.com/-/media/Software-and-other-downloads/Dev-Kits/nRF51-DK/nRF51-DK---Hardware-files-1_2_0.zip schematics pdf p2
- [x] nrf52832-mdk https://wiki.makerdiary.com/nrf52832-mdk/hardware/nRF52832-MDK_SCH_V2.0.pdf p4
- [x] nrf52840-mdk https://wiki.makerdiary.com/nrf52840-mdk/hardware/nrf52840-mdk-schematic_v1_0.pdf p5
- [x] particle-argon https://docs.particle.io/datasheets/wi-fi/argon-datasheet/#nrf52840
- [x] particle-boron https://docs.particle.io/datasheets/cellular/boron-datasheet/#nrf52840
- [x] particle-xenon (@bergzand tested)
- [x] pinetime http://files.pine64.org/doc/PineTime/PineTime%20Schematic-V1.0a-20191103.pdf
- [x] reel https://www.phytec.eu/fileadmin/user_upload/images/content/Landingpage/PBA-D-05-1507-1-001.pdf p2
- [x] ruuvitag https://github.com/ruuvi/ruuvitag_hw/blob/master/ruuvitag_revb71/ruuvitag_revb71_schematic.pdf
- [x] thingy52 https://infocenter.nordicsemi.com/pdf/Thingy_UG_v1.1.pdf p37


Preferably also test if the modified boards still work and as a bonus measure the drop in power consumption.

### Issues/PRs references

None