### PR TITLE
cpu/stm32f103: Allow boards to expose JTAG pins as GPIOs

### DIFF
--- a/boards/common/blxxxpill/include/board_common.h
+++ b/boards/common/blxxxpill/include/board_common.h
@@ -67,6 +67,14 @@ void board_init(void);
 #define XTIMER_BACKOFF      (19)
 /** @} */
 
+/* The boards debug header only exports  SWD, so JTAG-only pins PA15, PB3(*),
+ * and PB4 can be remapped as regular GPIOs instead. (Note: PB3 is also used as
+ * SWO.  The user needs to take care to not enable SWO with the debugger while
+ * at the same time PB3 is used as GPIO. But RIOT does not use SWO in any case,
+ * so if a user adds this feature in her/his own code, she/he should be well
+ * aware of this.)
+ */
+#define STM32F1_DISABLE_JTAG    /**< Disable JTAG to allow pins being used as GPIOs */
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f103rb/Makefile.include
+++ b/boards/nucleo-f103rb/Makefile.include
@@ -1,2 +1,9 @@
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include
+
+# On-board debugger uses SWD, so JTAG-only pins PA15, PB3(*), and PB4 can be
+# remapped as regular GPIOs instead. (Note: PB3 is also used as SWO. The user
+# needs to take care to not enable SWO with the debugger while at the same time
+# PB3 is used as GPIO. But RIOT does not use SWO in any case, so if a user adds
+# this feature in her/his own code, she/he should be well aware of this.)
+CFLAGS += -DSTM32F1_DISABLE_JTAG

--- a/cpu/stm32_common/cpu_init.c
+++ b/cpu/stm32_common/cpu_init.c
@@ -37,6 +37,7 @@
 #include "stmclk.h"
 #include "periph_cpu.h"
 #include "periph/init.h"
+#include "board.h"
 
 #if defined (CPU_FAM_STM32L4)
 #define BIT_APB_PWREN       RCC_APB1ENR1_PWREN
@@ -163,6 +164,12 @@ void cpu_init(void)
 #endif
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     stdio_init();
+
+#ifdef STM32F1_DISABLE_JTAG
+    RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
+    AFIO->MAPR |= AFIO_MAPR_SWJ_CFG_JTAGDISABLE;
+#endif
+
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -88,16 +88,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     /* enable the clock for the selected port */
     periph_clk_en(APB2, (RCC_APB2ENR_IOPAEN << _port_num(pin)));
 
-#ifdef BOARD_NUCLEO_F103RB
-    /* disable the default SWJ RST mode to allow using the pin as IO
-       this may also work on other f103 based boards but it was only tested on
-       nucleo-f103rb */
-    if ((pin_num == 4) && _port_num(pin)) {
-        RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
-        AFIO->MAPR |= AFIO_MAPR_SWJ_CFG_NOJNTRST;
-    }
-#endif
-
     /* set pin mode */
     port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
     port->CR[pin_num >> 3] |=  ((mode & MODE_MASK) << ((pin_num & 0x7) * 4));


### PR DESCRIPTION
### Contribution description

- Allow STM32F103 boards to (optionally) disable JTAG in order to make those pins available as GPIOS
- Removed partial solution for that on the Nucleo-F103RB, as the new solution does the same but more efficient
- Used this feature on the Nucleo-F103RB and the Bluepill / Blackpill boards

### Testing procedure

PB3, PB4 and PA15 should now be usable as regular GPIOs.

### Issues/PRs references

None