### PR TITLE
gnrc/lorawan: support for single channel gateways

### DIFF
--- a/sys/include/net/gnrc/lorawan/region.h
+++ b/sys/include/net/gnrc/lorawan/region.h
@@ -29,10 +29,15 @@ extern "C" {
  * @brief Default LoRaWAN channels for current region (EU868)
  */
 static const uint32_t gnrc_lorawan_default_channels[] = {
+#ifdef GNRC_LORAWAN_SINGLE_CHANNEL
+    GNRC_LORAWAN_SINGLE_CHANNEL
+#else
     868100000UL,
     868300000UL,
     868500000UL
+#endif
 };
+
 
 #define GNRC_LORAWAN_DEFAULT_CHANNELS_NUMOF \
     ARRAY_SIZE(gnrc_lorawan_default_channels) /**< Number of default channels */

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
@@ -96,6 +96,10 @@ uint32_t gnrc_lorawan_pick_channel(gnrc_lorawan_t *mac)
 
 void gnrc_lorawan_process_cflist(gnrc_lorawan_t *mac, uint8_t *cflist)
 {
+#ifdef GNRC_LORAWAN_SINGLE_CHANNEL
+    (void)mac;
+    (void)cflist;
+#else
     /* TODO: Check CFListType to 0 */
     for (unsigned i = GNRC_LORAWAN_DEFAULT_CHANNELS_NUMOF; i < 8; i++) {
         le_uint32_t cl;
@@ -104,6 +108,7 @@ void gnrc_lorawan_process_cflist(gnrc_lorawan_t *mac, uint8_t *cflist)
         mac->channel[i] = byteorder_ntohl(byteorder_ltobl(cl)) * 100;
         cflist += GNRC_LORAWAN_CFLIST_ENTRY_SIZE;
     }
+#endif
 }
 
 uint8_t gnrc_lorawan_region_mac_payload_max(uint8_t datarate)


### PR DESCRIPTION
### Contribution description

This PR allows the use of `gnrc/lorawan` with single channel gateways.

There are a number of cheap single/dual channel gateways on the market, for example the [Dragino LG02](http://www.dragino.com/products/lora-lorawan-gateway/item/135-lg02.html). Although they are not recommended for LoRaWAN use, they are inexpensive tools for playing with and testing RIOT's LoRa functions. However, the use of different channels for the join procedure and the send function avoids the use of such a single-channel gateway.

Therefore, this PR introduces a compile time variable `GNRC_LORAWAN_SINGLE_CHANNEL`, which can be used to define a single frequency. When this variable is defined, only this frequency is set in `gnrc_lorawan_default_channels` during initialization and the channel configuration in `gnrc_lorawan_process_cflist` after joining is disabled.

### Testing procedure

Set `ENABLE_DEBUG` to 1 in `drivers/sx127x/sx172x_getset.c` and flash `examples/gnrc_lorawan` for any LoRa-Board with
```
CFLAGS='-DGNRC_LORAWAN_SINGLE_CHANNEL=868100000UL ...' make BOARD=... -C examples/gnrc_lorawan flash
```
Use command `ifconfig 4 up` to join and `send 4 RIOT` afterwards. All `sx172x_set_channel` calls should show the configured frequency.
```
[sx127x] Set channel: 868100000
```

### Issues/PRs references
