### PR TITLE
gnrc/lorawan: fix netopt_state_t value handling

### DIFF
--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -351,7 +351,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
     switch(opt) {
         case NETOPT_STATE:
-            assert(len <= sizeof(netopt_state_t));
+            assert(len == sizeof(netopt_state_t));
             return _set_state(dev, *((const netopt_state_t*) val));
 
         case NETOPT_DEVICE_TYPE:

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -143,7 +143,7 @@ void gnrc_lorawan_open_rx_window(gnrc_lorawan_t *mac)
     if (mac->state == LORAWAN_STATE_RX_1) {
         xtimer_set_msg(&mac->rx, _DRIFT_FACTOR, &mac->msg, thread_getpid());
     }
-    uint8_t state = NETOPT_STATE_RX;
+    netopt_state_t state = NETOPT_STATE_RX;
     dev->driver->set(dev, NETOPT_STATE, &state, sizeof(state));
 }
 


### PR DESCRIPTION
### Contribution description

This PR fixes a problem found while trying to get LoRaWAN working with GNRC netif.

In function `gnrc_lorawan_open_rx_window` the state of the device driver is set to `NETOPT_STATE_RX`: https://github.com/RIOT-OS/RIOT/blob/2cc3d386fd94fae14f8ed95a1252c14e2cefef9b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c#L146-L147 In case of `sx127x` it calls https://github.com/RIOT-OS/RIOT/blob/2cc3d386fd94fae14f8ed95a1252c14e2cefef9b/drivers/sx127x/sx127x_netdev.c#L341 which in turn calls https://github.com/RIOT-OS/RIOT/blob/2cc3d386fd94fae14f8ed95a1252c14e2cefef9b/drivers/sx127x/sx127x_netdev.c#L354-L355

However, `netopt_state_t` is an enumeration type that is not necessarily one byte on some platforms, such as ESP32.

As a result, the option value from `gnrc_lorawan_open_rx_window` was given with a length of 1 byte, but the value casted into the type `netopt_state_t` was expected to have more than 1 byte. Thus, setting the state didn't work.

It took a lot of time to find out this problem since the assertion was still true. The assert in `_set` should therefore test for the exact length of the expected time.

### Testing procedure

`examples/gnr_lorawan` should still work for other platforms.

### Issues/PRs references