### PR TITLE
tools/cc2538-bsl: deduplicate buildsystem integration

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -19,9 +19,7 @@ RESET ?= $(RIOTBOARD)/cc2538dk/dist/reset.sh
 PROGRAMMER ?= cc2538-bsl
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
-  FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  FLASHDEPS += $(FLASHER)
-  FFLAGS  = -p "$(PROG_DEV)" -e -w -v $(FLASHFILE)
+  include $(RIOTMAKE)/tools/cc2538-bsl.inc.mk
 else ifeq ($(PROGRAMMER),jlink)
   FLASHER = $(RIOTBOARD)/cc2538dk/dist/flash.sh
   FFLAGS  = $(BINDIR) $(FLASHFILE)

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -11,10 +11,8 @@ ifneq (,$(PORT_BSL))
 endif
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
-  RESET ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py -p "$(PROG_DEV)"
-  FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  FLASHDEPS += $(FLASHER)
-  FFLAGS  = -p "$(PROG_DEV)" -e -w -v -b 115200 $(FLASHFILE)
+  PROG_BAUD ?= 115200
+  include $(RIOTMAKE)/tools/cc2538-bsl.inc.mk
 else ifeq ($(PROGRAMMER),jlink)
   FLASHER = $(RIOTBOARD)/common/remote/dist/flash.sh
   FFLAGS  = $(BINDIR) $(FLASHFILE)

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -16,11 +16,9 @@ endif
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
   FLASHFILE ?= $(HEXFILE)
-  FLASHER = $(RIOTBASE)/dist/tools/cc2538-bsl/cc2538-bsl.py
-  FLASHDEPS += $(FLASHER)
-  FFLAGS  = -p "$(PROG_DEV)" --bootloader-invert-lines -e -w -v -b 460800 $(FLASHFILE)
-  RESET ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  RESET_FLAGS ?= -p "$(PROG_DEV)" --bootloader-invert-lines
+  FFLAGS_OPTS ?= --bootloader-invert-lines
+  PROG_BAUD ?= 460800
+  include $(RIOTMAKE)/tools/cc2538-bsl.inc.mk
 else ifeq ($(PROGRAMMER),jlink)
   # Special flashing and reset scripts are required due to board hardware
   export FLASH_ADDR = 0x200000

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -14,9 +14,7 @@ ifeq ($(PROGRAMMER),jlink)
   export JLINK_IF := JTAG
   export TUI := 1
   include $(RIOTMAKE)/tools/jlink.inc.mk
-else
-  FLASHFILE ?= $(BINFILE)
-  FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  FLASHDEPS += $(FLASHER)
-  FFLAGS  = -p "$(PROG_DEV)" -e -w -v -b 460800 $(FLASHFILE)
+else ifeq ($(PROGRAMMER),cc2538-bsl)
+  PROG_BAUD ?= 460800
+  include $(RIOTMAKE)/tools/cc2538-bsl.inc.mk
 endif

--- a/makefiles/tools/cc2538-bsl.inc.mk
+++ b/makefiles/tools/cc2538-bsl.inc.mk
@@ -1,0 +1,9 @@
+FLASHFILE ?= $(BINFILE)
+FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
+FFLAGS_OPTS ?=
+PROG_BAUD ?= 500000	# default value in cc2538-bsl
+FFLAGS  = -p "$(PROG_DEV)" $(FFLAGS_OPTS) -e -w -v -b $(PROG_BAUD) $(FLASHFILE)
+
+RESET ?= $(FLASHER) -p "$(PROG_DEV)" $(FFLAGS_OPTS)
+
+FLASHDEPS += $(FLASHER)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduces a common `cc2538-bsl.inc.mk` file for managing this flashing tool. It follows the same scheme as other flashers (openocd, jlink, etc).

All related boards are modified to use this tool.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Verify that all related boards (`remote-*`, `firefly`, `openmote-b`, `cc2538-*`) can still be flashed/reset.

<details><summary>remote-reva</summary>

- **flash**
```
$ make BOARD=remote-reva -C examples/default/ --no-print-directory flash
Building application "default" for "remote-reva" with MCU "cc2538".

"make" -C /work/riot/RIOT/boards/remote-reva
"make" -C /work/riot/RIOT/boards/common/remote
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/cc2538
"make" -C /work/riot/RIOT/cpu/cc2538/periph
"make" -C /work/riot/RIOT/cpu/cc2538/radio
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/netdev_ieee802154
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/net/gnrc
"make" -C /work/riot/RIOT/sys/net/gnrc/netapi
"make" -C /work/riot/RIOT/sys/net/gnrc/netif
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/ieee802154
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /work/riot/RIOT/sys/net/gnrc/netreg
"make" -C /work/riot/RIOT/sys/net/gnrc/pkt
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /work/riot/RIOT/sys/net/gnrc/pktdump
"make" -C /work/riot/RIOT/sys/net/link_layer/ieee802154
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/netif
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/od
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  36232	    128	   5960	  42320	   a550	/work/riot/RIOT/examples/default/bin/remote-reva/default.elf
/work/riot/RIOT/dist/tools/cc2538-bsl/cc2538-bsl.py -p "/dev/ttyUSB0" -e -w -v -b 115200 /work/riot/RIOT/examples/default/bin/remote-reva/default.bin
Opening port /dev/ttyUSB0, baud 115200
Reading data from /work/riot/RIOT/examples/default/bin/remote-reva/default.bin
Cannot auto-detect firmware filetype: Assuming .bin
Connecting to target...
CC2538 PG2.0: 512KB Flash, 32KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:06:16:0F:71
    Performing mass erase
Erasing 524288 bytes starting at address 0x00200000
    Erase done
Writing 524288 bytes starting at address 0x00200000
Write 16 bytes at 0x0027FFF0F8
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0x81cbf793)
```

- **reset**
```
$ make BOARD=remote-reva -C examples/default/ --no-print-directory reset
/work/riot/RIOT/dist/tools/cc2538-bsl/cc2538-bsl.py -p "/dev/ttyUSB0"  
Opening port /dev/ttyUSB0, baud 500000
Connecting to target...
CC2538 PG2.0: 512KB Flash, 32KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:06:16:0F:71
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
