### PR TITLE
tests: fix netopt_state_t value handling in driver_sx127x

### DIFF
--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -266,7 +266,7 @@ int listen_cmd(int argc, char **argv)
     netdev->driver->set(netdev, NETOPT_RX_TIMEOUT, &timeout, sizeof(timeout));
 
     /* Switch to RX state */
-    uint8_t state = NETOPT_STATE_RX;
+    netopt_state_t state = NETOPT_STATE_RX;
     netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(state));
 
     printf("Listen mode set\n");


### PR DESCRIPTION
### Contribution description

This PR fixes the same problem that was described in detail in PR #13591. 

In function `listen_cmd` the state of the device driver is set to `NETOPT_STATE_RX`: https://github.com/RIOT-OS/RIOT/blob/5e9733645f1671189db577beeafbfec6e5b503f7/tests/driver_sx127x/main.c#L269-L270 In case of `sx127x` it calls https://github.com/RIOT-OS/RIOT/blob/2cc3d386fd94fae14f8ed95a1252c14e2cefef9b/drivers/sx127x/sx127x_netdev.c#L341 which in turn calls https://github.com/RIOT-OS/RIOT/blob/2cc3d386fd94fae14f8ed95a1252c14e2cefef9b/drivers/sx127x/sx127x_netdev.c#L354-L355

However, `netopt_state_t` is an enumeration type that is not necessarily one byte on some platforms, such as ESP32. It led to problems when testing on:

- `arduino-due` + Dragino LoRa Shield
- `arduino-mega2560` + Dragino LoRa Shield
- `esp32-wroom-32` + Dragino LoRa Shield
- `esp32-heltec-lora32-v2` (PR #11265)
- `esp32-ttgo-t-beam`

With this fix all boards can listen and send.

### Testing procedure

`tests/driver_sx127x` should still work for STM32 LoRa boards.

### Issues/PRs references

Same problem as fixed by #13591.