### PR TITLE
doc: fix undefined typedef docu

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -91,7 +91,8 @@
 #endif
 
 /**
- * @brief forward declaration for thread_t, defined in thread.h
+ * @typedef thread_t
+ * Forward declaration for thread_t, defined in thread.h
  */
 typedef struct _thread thread_t;
 

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -96,8 +96,8 @@
 typedef struct _thread thread_t;
 
 /**
- * @name Thread states supported by RIOT
- * @{
+ * @enum thread_status_t
+ * Thread states supported by RIOT
  */
 typedef enum {
     STATUS_STOPPED,                 /**< has terminated                           */
@@ -115,7 +115,6 @@ typedef enum {
     STATUS_PENDING,                 /**< waiting to be scheduled to run           */
     STATUS_NUMOF                    /**< number of supported thread states        */
 } thread_status_t;
-/** @} */
 
 /**
  * @name Helpers to work with thread states


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Rework documentation of enum with typedef, i.e. remove grouping
as it is not required.


### Testing procedure

run `make doc` on master and this PR, on master you'll see following error:

```
RIOT/core/include/sched.h:102: warning: Member thread_status_t (enumeration) of group core_sched is not documented.
```

which is fixed here.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
