### PR TITLE
cpu/cc2538: fix spi_transfer_bytes()

### DIFF
--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -121,6 +121,14 @@ void spi_release(spi_t bus)
     mutex_unlock(&locks[bus]);
 }
 
+static uint8_t _trx(cc2538_ssi_t *dev, uint8_t in)
+{
+    while (!(dev->SR & SSI_SR_TNF)) {}
+    dev->DR = in;
+    while (!(dev->SR & SSI_SR_RNE)) {}
+    return dev->DR;
+}
+
 void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
                         const void *out, void *in, size_t len)
 {
@@ -136,35 +144,19 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
     }
 
     if (!in_buf) {
-        for (size_t i = 0; i < len; i++) {
-            while (!(dev(bus)->SR & SSI_SR_TNF)) {}
-            dev(bus)->DR = out_buf[i];
-            while (!(dev(bus)->SR & SSI_SR_RNE)) {}
-            dev(bus)->DR;
+        for (const void *end = out_buf + len; out_buf != end; ++out_buf) {
+            _trx(dev(bus), *out_buf);
         }
     }
     else if (!out_buf) {
-        size_t in_cnt = 0;
-        for (size_t i = 0; i < len; i++) {
-            while (!(dev(bus)->SR & SSI_SR_TNF)) {}
-            dev(bus)->DR = 0;
-            while (!(dev(bus)->SR & SSI_SR_RNE)) {}
-            in_buf[in_cnt++] = dev(bus)->DR;
-        }
-        /* get remaining bytes */
-        while (dev(bus)->SR & SSI_SR_RNE) {
-            in_buf[in_cnt++] = dev(bus)->DR;
+        for (void *end = in_buf + len; in_buf != end; ++in_buf) {
+            *in_buf = _trx(dev(bus), 0);
         }
     }
     else {
-        for (size_t i = 0; i < len; i++) {
-            while (!(dev(bus)->SR & SSI_SR_TNF)) {}
-            dev(bus)->DR = out_buf[i];
-            while (!(dev(bus)->SR & SSI_SR_RNE)) {}
-            in_buf[i] = dev(bus)->DR;
+        for (void *end = in_buf + len; in_buf != end; ++in_buf, ++out_buf) {
+            *in_buf = _trx(dev(bus), *out_buf);
         }
-        /* wait until no more busy */
-        while ((dev(bus)->SR & SSI_SR_BSY)) {}
     }
 
     if ((!cont) && (cs != SPI_CS_UNDEF)) {

--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -139,9 +139,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         for (size_t i = 0; i < len; i++) {
             while (!(dev(bus)->SR & SSI_SR_TNF)) {}
             dev(bus)->DR = out_buf[i];
-        }
-        /* flush RX FIFO while busy*/
-        while ((dev(bus)->SR & SSI_SR_BSY)) {
+            while (!(dev(bus)->SR & SSI_SR_RNE)) {}
             dev(bus)->DR;
         }
     }


### PR DESCRIPTION
### Contribution description

In the `in_buf == NULL` case, `spi_transfer_bytes()` would only write `DR` for every out byte, but then loop reading `DR` only while SPI is busy.

This is not correct, we have to read as many data bytes as we write, otherwise data bytes remain in the FiFo and will corrupt subsequent reads.

While at it, I also took the chance to clean up `spi_transfer_bytes()` by factoring out DR access into a helper function.

### Testing procedure

Run @guyyst's tests application from https://github.com/RIOT-OS/RIOT/pull/12128#issuecomment-552216507 on the `openmote-b`.

Before this patch, the driver would sometimes read both interrupt status registers as 0 (or some other weird value) and in turn not service the interrupt.

With this the test is running smoothly.

### Issues/PRs references

The issue was discovered while testing the `at86rf215` driver on the `openmote-b`.
