### PR TITLE
cpu/sam0_common: GPIO IRQ optimizations

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -320,7 +320,11 @@ void gpio_irq_disable(gpio_t pin)
     _EIC->INTENCLR.reg = (1 << exti);
 }
 
+#if defined(CPU_SAML1X)
+void isr_eic_other(void)
+#else
 void isr_eic(void)
+#endif
 {
     /* read & clear interrupt flags */
     uint32_t state = _EIC->INTFLAG.reg;
@@ -342,7 +346,9 @@ void isr_eic(void)
 #define ISR_EICn(n)             \
 void isr_eic ## n (void)        \
 {                               \
-    isr_eic();                  \
+    _EIC->INTFLAG.reg = 1 << n; \
+    gpio_config[n].cb(gpio_config[n].arg); \
+    cortexm_isr_end();          \
 }
 
 ISR_EICn(0)
@@ -354,6 +360,7 @@ ISR_EICn(4)
 ISR_EICn(5)
 ISR_EICn(6)
 ISR_EICn(7)
+#if (NUMOF_IRQS > 8)
 ISR_EICn(8)
 ISR_EICn(9)
 ISR_EICn(10)
@@ -362,9 +369,8 @@ ISR_EICn(12)
 ISR_EICn(13)
 ISR_EICn(14)
 ISR_EICn(15)
-#else
-ISR_EICn(_other)
-#endif /* CPU_SAML1X */
+#endif /* NUMOF_IRQS > 8 */
+#endif /* CPU_SAMD5X */
 #endif /* CPU_SAML1X || CPU_SAMD5X */
 
 #else /* MODULE_PERIPH_GPIO_IRQ */


### PR DESCRIPTION
### Contribution description

This PR aims to speed up handling of external interrupts in two ways:

 - when iterating over the `INTFLAG` bits, only loop as many times as there are bits set
 - On platforms that provide dedicated interrupts for EXTI lines (saml1x, samd5x), use those directly instead of iterating over set bits.

### Testing procedure

GPIO interrupts should still work.

### Issues/PRs references

First commit is the same as #13507
