### PR TITLE
cpu/sam0_common: gpio: add gpio_disable_mux() function

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -386,6 +386,13 @@ static inline void sam0_cortexm_sleep(int deep)
 }
 
 /**
+ * @brief   Disable alternate function (PMUX setting) for a PORT pin
+ *
+ * @param[in] pin   Pin to reset the multiplexing for
+ */
+void gpio_disable_mux(gpio_t pin);
+
+/**
  * @brief   Returns the frequency of a GCLK provider.
  *
  * @param[in] id    The ID of the GCLK

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -92,6 +92,14 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux)
     port->PMUX[pin_pos >> 1].reg |=  (mux << (4 * (pin_pos & 0x1)));
 }
 
+void gpio_disable_mux(gpio_t pin)
+{
+    PortGroup* port = _port(pin);
+    int pin_pos = _pin_pos(pin);
+
+    port->PINCFG[pin_pos].reg &= ~PORT_PINCFG_PMUXEN;
+}
+
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
     PortGroup* port = _port(pin);


### PR DESCRIPTION

### Contribution description

Adds the inverse to the to `gpio_init_mux()` helper function.

I've split this off #13421 since I also need that function for re-configuring SPI & UART.
It's useful in general to being able to undo the mux configuration again.

### Testing procedure

nothing to test yet

### Issues/PRs references
#13421