### PR TITLE
cpu/sam0_common: add samd21j17d

### DIFF
--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -15,6 +15,10 @@ ifneq (,$(filter saml10e16a saml11e16a,$(CPU_MODEL)))
   ROM_LEN ?= 64K
   RAM_LEN ?= 16K
 endif
+ifneq (,$(filter samd21j17d,$(CPU_MODEL)))
+  ROM_LEN ?= 128K
+  RAM_LEN ?= 16K
+endif
 ifneq (,$(filter samd51j20a same54p20a,$(CPU_MODEL)))
   ROM_LEN ?= 1024K
   RAM_LEN ?= 256K


### PR DESCRIPTION
### Contribution description
ROM_LEN and RAM_LEN defines for the SAMD21J17D CPU added to cpu/sam0_common


### Testing procedure
Compilation for a custom board based on SAMD21J17D CPU