### PR TITLE
drivers/sx127x: changes in DIO handling

### DIFF
--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -289,6 +289,10 @@ static int _init_gpios(sx127x_t *dev)
             return res;
         }
     }
+    else {
+        /* if frequency hopping is enabled, DIO2 pin must be defined */
+        assert(LORA_FREQUENCY_HOPPING_DEFAULT == false);
+    }
 
     /* check if DIO3 pin is defined */
     if (dev->params.dio3_pin != GPIO_UNDEF) {

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -282,13 +282,14 @@ void sx127x_set_rx(sx127x_t *dev)
                                  /* SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL | */
                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
 
-                /* DIO0=RxDone, DIO2=FhssChangeChannel, DIO3=ValidHeader */
+                /* DIO0=RxDone, DIO1=RxTimeout, DIO2=FhssChangeChannel, DIO3=ValidHeader */
                 sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
                                  (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
                                   SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
                                   SX127X_RF_LORA_DIOMAPPING1_DIO2_MASK &
                                   SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_00 |
+                                 SX127X_RF_LORA_DIOMAPPING1_DIO1_00 |
                                  SX127X_RF_LORA_DIOMAPPING1_DIO2_00 |
                                  SX127X_RF_LORA_DIOMAPPING1_DIO3_01);
             }
@@ -303,12 +304,13 @@ void sx127x_set_rx(sx127x_t *dev)
                                  SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL |
                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
 
-                /* DIO0=RxDone, DIO3=ValidHeader */
+                /* DIO0=RxDone, DIO1=RxTimeout, DIO3=ValidHeader */
                 sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
                                  (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
                                   SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
                                   SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_00 |
+                                 SX127X_RF_LORA_DIOMAPPING1_DIO1_00 |
                                  SX127X_RF_LORA_DIOMAPPING1_DIO3_01);
             }
 
@@ -353,9 +355,9 @@ void sx127x_set_tx(sx127x_t *dev)
                                  SX127X_RF_LORA_IRQFLAGS_RXDONE |
                                  SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
                                  SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
-                                 /* RFLR_IRQFLAGS_TXDONE | */
+                                 /* SX127X_RF_LORA_IRQFLAGS_TXDONE | */
                                  SX127X_RF_LORA_IRQFLAGS_CADDONE |
-                                 /* RFLR_IRQFLAGS_FHSSCHANGEDCHANNEL | */
+                                 /* SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL | */
                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
 
                 /* DIO0=TxDone, DIO2=FhssChangeChannel */

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -201,11 +201,20 @@ void sx127x_start_cad(sx127x_t *dev)
                              /* | SX127X_RF_LORA_IRQFLAGS_CADDETECTED*/
                              );
 
-            /* DIO3 = CADDone */
-            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
-                             (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
-                              SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
-                             SX127X_RF_LORA_DIOMAPPING1_DIO3_00);
+            if (dev->params.dio3_pin != GPIO_UNDEF) {
+                /* DIO3 = CADDone */
+                sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
+                                 (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
+                                  SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
+                                 SX127X_RF_LORA_DIOMAPPING1_DIO3_00);
+            }
+            else {
+                /* DIO0 = CADDone */
+                sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
+                                 (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
+                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK) |
+                                 SX127X_RF_LORA_DIOMAPPING1_DIO0_10);
+            }
 
             sx127x_set_state(dev,  SX127X_RF_CAD);
             sx127x_set_op_mode(dev, SX127X_RF_LORA_OPMODE_CAD);

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -721,6 +721,11 @@ void _on_dio3_irq(void *arg)
             break;
         default:
             DEBUG("[sx127x] netdev: sx127x_on_dio3: unknown state");
+            /* at least the related interrupts should be cleared in this case */
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                             SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
+                             SX127X_RF_LORA_IRQFLAGS_CADDETECTED |
+                             SX127X_RF_LORA_IRQFLAGS_CADDONE);
             break;
     }
 }


### PR DESCRIPTION
### Contribution description

There are boards that don't have connected all DIO lines. For example, `esp32-ttgo-t-beam` and `esp32-heltec-lora32-v2` (PR #11265) don't have connected `DIO3` which is used in the `sx127x` driver for the CAD procedure. This is also the case for the [Dragino LoraShield](http://www.dragino.com/products/module/item/102-lora-shield.html).

Therefore, this PR changes the DIO line handling as following:

- If `DIO3` pin is not defined, the `CapDone` interrupt is mapped to `DIO0` (commit https://github.com/RIOT-OS/RIOT/commit/56040e3369c2f8b0c8f8955dfe7967f409f667a3). This allows the use of CAP even on boards where the `DIO3` line is not connected..
- If `DIO3` pin is not defined, at least the related interrupt flags have to be cleared in `_on_dio3_irq` (https://github.com/RIOT-OS/RIOT/commit/87021a0b186a36ae02f0513ca701f2847f21905c). Otherwise the `ValidHeader` interrupt flag keeps pending.
- Since frequency hopping requires the `DIO2` interrupt to work, https://github.com/RIOT-OS/RIOT/commit/1eb8701965f8f82f62ced9de13669bce660cabe0 ensures that `DIO2` pin is defined if frequency hopping is enabled (`LORA_FREQUENCY_HOPPING_DEFAULT = true`).
- Since the `RxTimeout` interrupt is enabled during receive, `DIO1` mapping should be set also to `RxTimeout` in case the driver is extended in future and `DIO1` mapping is changed for any reason (commit https://github.com/RIOT-OS/RIOT/commit/e3a82cd6fc3bed60ebdf3393ec87844aed8cf7d8).

Space for improvement: Since the `FhssChangeChannel` interrupt could also be mapped to `DIO1`, it would be possible to support also boards that don't have connected `DIO2` line.

### Testing procedure

- `tests/driver_sx127x` and/or `examples/lorawan` should still work for any LoRa-Board.
to test commit https://github.com/RIOT-OS/RIOT/commit/56040e3369c2f8b0c8f8955dfe7967f409f667a3 and https://github.com/RIOT-OS/RIOT/commit/87021a0b186a36ae02f0513ca701f2847f21905c 

- Use `tests/driver_sx127x` as following to test commit https://github.com/RIOT-OS/RIOT/commit/56040e3369c2f8b0c8f8955dfe7967f409f667a3as:
   ```
   CFLAGS='-DDEBUG_ASSERT_VERBOSE make BOARD=... -C tests/driver_sx127x flash term
   ```
   should still work, but
   ```
   CFLAGS='-DDEBUG_ASSERT_VERBOSE -DLORA_FREQUENCY_HOPPING_DEFAULT=true -DSX127X_PARAM_DIO2=GPIO_UNDEF' make BOARD=... -C tests/driver_sx127x flash term
   ```
   should result into a failed assertion.

### Issues/PRs references
