### PR TITLE
cpu/sam0_common: derive ROM_LEN & RAM_LEN from part number

### DIFF
--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -4,25 +4,19 @@ CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 # Generate ASF compatible model definition
 CFLAGS += -D__$(call uppercase_and_underscore,$(CPU_MODEL))__
 
-# Set ROM and RAM lengths according to CPU model
-ifneq (,$(filter samd21g18a samd21j18a saml21j18b saml21j18a samr21e18a \
-        samr21g18a samr30g18a samr34j18b,$(CPU_MODEL)))
+# Compute CPU_LINE
+LINE   := $(shell echo $(CPU_MODEL) | sed -E -e 's/^sam([a-z][0-9][0-9])(.)([0-9][0-9])(.)/\1 \2 \3 \4/')
+FAMILY := $(word 1, $(LINE))
+TYPE1  := $(word 2, $(LINE))
+MEMORY := $(word 3, $(LINE))
+TYPE2  := $(word 4, $(LINE))
 
-  ROM_LEN ?= 0x40000
-  RAM_LEN ?= 0x8000
-endif
-ifneq (,$(filter saml10e16a saml11e16a,$(CPU_MODEL)))
-  ROM_LEN ?= 64K
-  RAM_LEN ?= 16K
-endif
-ifneq (,$(filter samd21j17d,$(CPU_MODEL)))
-  ROM_LEN ?= 128K
-  RAM_LEN ?= 16K
-endif
-ifneq (,$(filter samd51j20a same54p20a,$(CPU_MODEL)))
-  ROM_LEN ?= 1024K
-  RAM_LEN ?= 256K
-endif
+# ROM length is directly encoded in the part number
+ROM_LEN := $(shell echo $$((1 << $(MEMORY))))
+
+# get vendor file to extract RAM length
+VENDOR_FILE := $(shell find $(RIOTCPU)/sam0_common/include/vendor/sam$(FAMILY) -name $(CPU_MODEL).h | grep include.*/sam)
+RAM_LEN := $(shell sed -E -n 's/\#define (HMCRAMC0_SIZE|HSRAM_SIZE).*(0x[[:xdigit:]]*).*/\2/p' $(VENDOR_FILE))
 
 ROM_START_ADDR ?= 0x00000000
 RAM_START_ADDR ?= 0x20000000


### PR DESCRIPTION
### Contribution description

The ROM size is encoded in the part number of the Atmel SAM chips.
RAM size is not encoded directly, but it's always a fixed fraction of the ROM size.

 - On SAM D2x/SAML2x it's ⅛ of the ROM.
 - On SAM L1x it's ¼ of the ROM.
 - On SAM D5x RAM is at least 128k and increments by 64k with every ROM increment.


### Testing procedure

I manually confirmed that the resulting `ROM_LEN` and `RAM_LEN`s are still the same for the chips that were listed here before.

### Issues/PRs references
This is the last missing piece missing to do away with having to do changes in RIOT for using a different part number of a supported chip. 