### PR TITLE
gnrc_netif: remove NETDEV_MSG_TYPE_EVENT processing from thread

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -190,6 +190,7 @@ static const gnrc_netif_ops_t _esp_now_ops = {
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_esp_now_create(gnrc_netif_t *netif, char *stack, int stacksize, char priority,

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -177,6 +177,7 @@ static const gnrc_netif_ops_t gnrc_nrfmin_ops = {
     .recv = gnrc_nrfmin_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 void gnrc_nrfmin_init(void)

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -165,6 +165,7 @@ static const gnrc_netif_ops_t cc1xxx_netif_ops = {
     .recv = cc1xxx_adpt_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_cc1xxx_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -164,6 +164,7 @@ static const gnrc_netif_ops_t _xbee_ops = {
     .recv = xbee_adpt_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_xbee_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -178,7 +178,7 @@ static const gnrc_netif_ops_t _nimble_netif_ops = {
     .recv = _netif_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
-    .msg_handler = NULL,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 static inline int _netdev_init(netdev_t *dev)

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -307,6 +307,18 @@ struct gnrc_netif_ops {
 void gnrc_netif_init_devs(void);
 
 /**
+ * @brief   Default msg handler for netdev.
+ *
+ *          This function defines a @ref gnrc_netif_ops::msg_handler
+ *          that implements @ref NETDEV_MSG_TYPE_EVENT by calling
+ *          @ref netdev_t::driver::isr.
+ *
+ * @param[in] netif The network interface.
+ * @param[in] msg   Message to be handled.
+ */
+void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg);
+
+/**
  * @brief   Creates a network interface
  *
  * @param[out] netif    The interface. May not be `NULL`.

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1978,6 +1978,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 static void _gomach_msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
     switch (msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            gnrc_netif_msg_handler_netdev(netif, msg);
+            break;
+
         case GNRC_GOMACH_EVENT_RTT_TYPE: {
             _gomach_rtt_handler(msg->content.value, netif);
             break;

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -898,6 +898,9 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 static void _lwmac_msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
     switch (msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            gnrc_netif_msg_handler_netdev(netif, msg);
+            break;
         /* RTT raised an interrupt */
         case GNRC_LWMAC_EVENT_RTT_TYPE: {
             if (gnrc_lwmac_get_dutycycle_active(netif)) {

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -49,6 +49,7 @@ static const gnrc_netif_ops_t ethernet_ops = {
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = _set,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_ethernet_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1635,12 +1635,12 @@ void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg)
 {
     netdev_t *dev = netif->dev;
     switch(msg->type) {
-        case NETDEV_MSG_TYPE_EVENT:
-            DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
-            dev->driver->isr(dev);
-            break;
-        default:
-            break;
+    case NETDEV_MSG_TYPE_EVENT:
+        DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
+        dev->driver->isr(dev);
+        break;
+    default:
+        break;
     }
 }
 
@@ -1706,10 +1706,6 @@ static void *_gnrc_netif_thread(void *args)
                 _send_queued_pkt(netif);
                 break;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-            case NETDEV_MSG_TYPE_EVENT:
-                DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
-                dev->driver->isr(dev);
-                break;
             case GNRC_NETAPI_MSG_TYPE_SND:
                 DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_SND received\n");
                 _send(netif, msg.content.ptr, false);

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1631,6 +1631,19 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
 #endif /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
 }
 
+void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg)
+{
+    netdev_t *dev = netif->dev;
+    switch(msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
+            dev->driver->isr(dev);
+            break;
+        default:
+            break;
+    }
+}
+
 static void *_gnrc_netif_thread(void *args)
 {
     gnrc_netapi_opt_t *opt;

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -34,6 +34,7 @@ static const gnrc_netif_ops_t raw_ops = {
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_raw_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -35,6 +35,7 @@ static const gnrc_netif_ops_t ieee802154_ops = {
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_ieee802154_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -272,9 +272,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
 
 static void _msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
-    (void)netif;
-    (void)msg;
     switch (msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            gnrc_netif_msg_handler_netdev(netif, msg);
+            break;
         case MSG_TYPE_TIMEOUT:
             gnrc_lorawan_open_rx_window(&netif->lorawan.mac);
             break;

--- a/tests/gnrc_ndp/main.c
+++ b/tests/gnrc_ndp/main.c
@@ -1246,6 +1246,7 @@ static const gnrc_netif_ops_t _test_netif_ops = {
     .recv = _test_netif_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = _test_netif_set,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 static int _netdev_test_address_long(netdev_t *dev, void *value, size_t max_len)

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -79,7 +79,7 @@ static const gnrc_netif_ops_t default_ops = {
     .recv = _mock_netif_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
-    .msg_handler = NULL,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 static void _set_up(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR is the first one for removing the `netdev` dependency in `gnrc_netif`.
It moves the NETDEV_EVENT_MSG_TYPE_EVENT handling to each `netif->ops->msg_handler`. That way an implementation of `gnrc_netif_ops_t` can use other mechanisms for handling device ISRs.

With some follow ups it will be possible to use `gnrc_netif` without `netdev`, so it's possible to directly hook drivers or other interfaces (radio HALs, etc).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Besides Murdock compile tests, this should be tested to ensure all `gnrc_netif_ops_t` implementation still work (gnrc_netif_ethernet, gnrc_netif_lorawan, etc).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
