### PR TITLE
gnrc_netif: remove netdev dependency

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -193,6 +193,7 @@ static const gnrc_netif_ops_t _esp_now_ops = {
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_esp_now_create(gnrc_netif_t *netif, char *stack, int stacksize, char priority,

--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -37,7 +37,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     uint8_t mac[ESP_NOW_ADDR_LEN];
     esp_now_pkt_hdr_t esp_hdr;
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
 
     assert(pkt != NULL);
 
@@ -96,7 +96,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     esp_now_netdev_t *esp_now = (esp_now_netdev_t*)dev;
 
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -179,6 +179,7 @@ static const gnrc_netif_ops_t gnrc_nrfmin_ops = {
     .recv = gnrc_nrfmin_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 void gnrc_nrfmin_init(void)

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -103,8 +103,9 @@ static int gnrc_nrfmin_send(gnrc_netif_t *dev, gnrc_pktsnip_t *pkt)
         .iol_len = NRFMIN_HDR_LEN
     };
 
+    netdev_t *_dev = netif->context;
     /* and finally send out the data and release the packet */
-    res = dev->dev->driver->send(dev->dev, &iolist);
+    res = _dev->driver->send(_dev, &iolist);
 
 out:
     gnrc_pktbuf_release(pkt);

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -164,6 +164,7 @@ static const gnrc_netif_ops_t cc1xxx_netif_ops = {
     .recv = cc1xxx_adpt_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_cc1xxx_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -35,7 +35,7 @@
 
 static gnrc_pktsnip_t *cc1xxx_adpt_recv(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     cc1xxx_rx_info_t rx_info;
     int pktlen;
     gnrc_pktsnip_t *payload;
@@ -110,7 +110,7 @@ static int cc1xxx_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     int res;
     size_t size;
-    cc1xxx_t *cc1xxx_dev = (cc1xxx_t *)netif->dev;
+    cc1xxx_t *cc1xxx_dev = (cc1xxx_t *)netif->context;
     gnrc_netif_hdr_t *netif_hdr;
     cc1xxx_l2hdr_t l2hdr;
 
@@ -151,7 +151,8 @@ static int cc1xxx_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     };
 
     DEBUG("[cc1xxx-gnrc] send: triggering the drivers send function\n");
-    res = netif->dev->driver->send(netif->dev, &iolist);
+    netdev_t *_dev = netif->context;
+    res = _dev->driver->send(_dev, &iolist);
 
     gnrc_pktbuf_release(pkt);
 

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -165,6 +165,7 @@ static const gnrc_netif_ops_t _xbee_ops = {
     .recv = xbee_adpt_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_xbee_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -30,7 +30,7 @@
 
 static gnrc_pktsnip_t *xbee_adpt_recv(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     int pktlen;
     int xhdr_len;
     gnrc_pktsnip_t *payload;
@@ -116,12 +116,12 @@ static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     hdr = (gnrc_netif_hdr_t *)pkt->data;
     if (hdr->flags & BCAST) {
         uint16_t addr = 0xffff;
-        res = xbee_build_hdr((xbee_t *)netif->dev, xhdr, size, &addr, 2);
+        res = xbee_build_hdr((xbee_t *)netif->context, xhdr, size, &addr, 2);
         DEBUG("[xbee-gnrc] send: preparing to send broadcast\n");
     }
     else {
         uint8_t *addr = gnrc_netif_hdr_get_dst_addr(hdr);
-        res = xbee_build_hdr((xbee_t *)netif->dev, xhdr, size, addr,
+        res = xbee_build_hdr((xbee_t *)netif->context, xhdr, size, addr,
                              hdr->dst_l2addr_len);
         if (res < 0) {
             if (res == -EOVERFLOW) {
@@ -152,7 +152,8 @@ static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     };
 
     DEBUG("[xbee-gnrc] send: triggering the drivers send function\n");
-    res = netif->dev->driver->send(netif->dev, &iolist);
+    netdev_t *_dev = netif->context;
+    res = _dev->driver->send(_dev, &iolist);
 
     gnrc_pktbuf_release(pkt);
 

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -89,11 +89,14 @@ static void _notify(int handle, nimble_netif_event_t event, uint8_t *addr)
     }
 }
 
-static void _netif_init(gnrc_netif_t *netif)
+static int _netif_init(gnrc_netif_t *netif)
 {
     (void)netif;
 
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+    if (res < 0) {
+        return res;
+    }
     /* save the threads context pointer, so we can set its flags */
     _netif_thread = thread_get_active();
 
@@ -102,6 +105,8 @@ static void _netif_init(gnrc_netif_t *netif)
      * of this */
     _netif.sixlo.max_frag_size = 0;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
+
+    return 0;
 }
 
 static int _send_pkt(nimble_netif_conn_t *conn, gnrc_pktsnip_t *pkt)

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -192,7 +192,7 @@ static const gnrc_netif_ops_t _nimble_netif_ops = {
     .recv = _netif_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
-    .msg_handler = NULL,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 static inline int _netdev_init(netdev_t *dev)

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -243,7 +243,11 @@ static gnrc_pktsnip_t *_netif_recv(gnrc_netif_t *netif)
 
 static void _netif_msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
+    netdev_t *dev = netif->context;
     switch (msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            dev->driver->isr(dev);
+            break;
         case BLE_EVENT_RX_DONE:
             {
                 DEBUG("ble rx:\n");
@@ -251,6 +255,8 @@ static void _netif_msg_handler(gnrc_netif_t *netif, msg_t *msg)
                 ble_mac_busy_rx = 0;
                 break;
             }
+        default:
+            break;
     }
 }
 

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -207,7 +207,7 @@ struct gnrc_netif_ops {
      * recommended to call @ref gnrc_netif_default_init() at the start of the
      * custom initialization function set here.
      */
-    void (*init)(gnrc_netif_t *netif);
+    int (*init)(gnrc_netif_t *netif);
 
     /**
      * @brief   Send a @ref net_gnrc_pkt "packet" over the network interface
@@ -546,8 +546,11 @@ static inline int gnrc_netif_ipv6_group_leave(const gnrc_netif_t *netif,
  * @note    Can also be used to be called *before* a custom operation.
  *
  * @param[in] netif     The network interface.
+ * 
+ * @return  0 on success
+ * @return  negative errno on error
  */
-void gnrc_netif_default_init(gnrc_netif_t *netif);
+int gnrc_netif_default_init(gnrc_netif_t *netif);
 
 /**
  * @brief   Default operation for gnrc_netif_ops_t::get()

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -63,8 +63,8 @@
 #include "net/gnrc/netif/pktq/type.h"
 #endif
 #include "net/ndp.h"
-#include "net/netdev.h"
 #include "net/netopt.h"
+#include "errno.h"
 #ifdef MODULE_NETSTATS_L2
 #include "net/netstats.h"
 #endif

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -115,7 +115,7 @@ typedef struct gnrc_netif_ops gnrc_netif_ops_t;
 typedef struct {
     netif_t netif;                          /**< network interface descriptor */
     const gnrc_netif_ops_t *ops;            /**< Operations of the network interface */
-    netdev_t *dev;                          /**< Network device of the network interface */
+    void *context;                          /**< Network device of the network interface */
     rmutex_t mutex;                         /**< Mutex of the interface */
 #ifdef MODULE_NETSTATS_L2
     netstats_t stats;                       /**< transceiver's statistics */

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -306,6 +306,17 @@ struct gnrc_netif_ops {
 void gnrc_netif_init_devs(void);
 
 /**
+ * @brief   Default msg handler for netdev.
+ *
+ *          This function process the NETDEV_MSG_TYPE_EVENT calling
+ *          `netdev_t::driver::isr`.
+ *
+ * @param[in] netif The network interface.
+ * @param[in] msg   Message to be handled.
+ */
+void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg);
+
+/**
  * @brief   Creates a network interface
  *
  * @param[out] netif    The interface. May not be `NULL`.

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -541,16 +541,30 @@ static inline int gnrc_netif_ipv6_group_leave(const gnrc_netif_t *netif,
 }
 
 /**
+ * @brief   Operation to initialize a @ ref gnrc_netif_t that uses netdev.
+ *
+ * @param[in] netif     The network interface
+ *
+ * @return  0 on success
+ * @return  negative errno on error
+ */
+int gnrc_netif_default_init_netdev(gnrc_netif_t *netif);
+
+/**
  * @brief   Default operation for gnrc_netif_ops_t::init()
+ *
+ *          This is a wrapper for @ref gnrc_netif_default_init_netdev
  *
  * @note    Can also be used to be called *before* a custom operation.
  *
  * @param[in] netif     The network interface.
- * 
- * @return  0 on success
- * @return  negative errno on error
+ *
+ * @return  result of @ref gnrc_netif_default_init_netdev
  */
-int gnrc_netif_default_init(gnrc_netif_t *netif);
+static inline int gnrc_netif_default_init(gnrc_netif_t *netif)
+{
+    return gnrc_netif_default_init_netdev(netif);
+}
 
 /**
  * @brief   Default operation for gnrc_netif_ops_t::get()

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -324,7 +324,7 @@ void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg);
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the network interface's thread.
  * @param[in] name      Name for the network interface. May be NULL.
- * @param[in] dev       Device for the interface.
+ * @param[in] context   Context for the interface
  * @param[in] ops       Operations for the network interface.
  *
  * @note If @ref DEVELHELP is defined netif_params_t::name is used as the
@@ -334,7 +334,7 @@ void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg);
  * @return  negative number on error
  */
 int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
-                      char priority, const char *name, netdev_t *dev,
+                      char priority, const char *name, void *context,
                       const gnrc_netif_ops_t *ops);
 
 /**

--- a/sys/include/net/gnrc/netif/ethernet.h
+++ b/sys/include/net/gnrc/netif/ethernet.h
@@ -19,6 +19,7 @@
 #define NET_GNRC_NETIF_ETHERNET_H
 
 #include "net/gnrc/netif.h"
+#include "net/netdev.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/netif/ieee802154.h
+++ b/sys/include/net/gnrc/netif/ieee802154.h
@@ -19,6 +19,7 @@
 #define NET_GNRC_NETIF_IEEE802154_H
 
 #include "net/gnrc/netif.h"
+#include "net/netdev.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -702,6 +702,31 @@ static inline int gnrc_netif_ndp_addr_len_from_l2ao(gnrc_netif_t *netif,
 #endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN) */
 /** @} */
 
+/**
+ * @brief Post an ISR process request to the event queue
+ *
+ * @note Only available with module `gnrc_netif_events`.
+ *
+ * @param netif pointer to the network interface
+ */
+static inline void gnrc_netif_event_isr(gnrc_netif_t *netif)
+{
+#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
+    event_post(&netif->evq, &netif->event_isr);
+#else
+    (void)netif;
+#endif
+}
+
+/**
+ * @brief Send a queued packet
+ *
+ * @note Only available with module `gnrc_netif_events`.
+ *
+ * @param netif pointer to the network interface
+ */
+void gnrc_netif_send_queued_pkt(gnrc_netif_t *netif);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/netif/lorawan_base.h
+++ b/sys/include/net/gnrc/netif/lorawan_base.h
@@ -19,6 +19,7 @@
 #define NET_GNRC_NETIF_LORAWAN_BASE_H
 
 #include "net/gnrc/netif.h"
+#include "net/netdev.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/netif/raw.h
+++ b/sys/include/net/gnrc/netif/raw.h
@@ -19,6 +19,7 @@
 #ifndef NET_GNRC_NETIF_RAW_H
 #define NET_GNRC_NETIF_RAW_H
 
+#include "net/netdev.h"
 #include "net/gnrc/netif.h"
 
 #ifdef __cplusplus

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1973,7 +1973,12 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
 static void _gomach_msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
+    netdev_t *dev = netif->dev;
     switch (msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            dev->driver-isr(dev);
+            break;
+
         case GNRC_GOMACH_EVENT_RTT_TYPE: {
             _gomach_rtt_handler(msg->content.value, netif);
             break;

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -55,7 +55,7 @@
  */
 static kernel_pid_t gomach_pid;
 
-static void _gomach_init(gnrc_netif_t *netif);
+static int _gomach_init(gnrc_netif_t *netif);
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 static void _gomach_msg_handler(gnrc_netif_t *netif, msg_t *msg);
@@ -2107,11 +2107,14 @@ static void _gomach_event_cb(netdev_t *dev, netdev_event_t event)
     }
 }
 
-static void _gomach_init(gnrc_netif_t *netif)
+static int _gomach_init(gnrc_netif_t *netif)
 {
     netdev_t *dev;
 
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+    if (res < 0) {
+        return res;
+    }
     dev = netif->dev;
     dev->event_callback = _gomach_event_cb;
 
@@ -2207,4 +2210,5 @@ static void _gomach_init(gnrc_netif_t *netif)
         gnrc_gomach_set_update(netif, false);
         gomach_update(netif);
     }
+    return 0;
 }

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -47,8 +47,8 @@
 
 int _gnrc_gomach_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
-    netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_t *dev = netif->context;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->context;
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;
@@ -158,7 +158,7 @@ static int _parse_packet(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt,
     assert(info != NULL);
     assert(pkt != NULL);
 
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->context;
     /* Get the packet sequence number */
     info->seq = ieee802154_get_seq(pkt->next->data);
 
@@ -298,7 +298,8 @@ void gnrc_gomach_set_netdev_state(gnrc_netif_t *netif, netopt_state_t devstate)
 {
     assert(netif != NULL);
 
-    netif->dev->driver->set(netif->dev,
+    netdev_t *dev = netif->context;
+    dev->driver->set(dev,
                             NETOPT_STATE,
                             &devstate,
                             sizeof(devstate));
@@ -328,9 +329,10 @@ int gnrc_gomach_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, netopt_enable_t c
 {
     assert(netif != NULL);
     assert(pkt != NULL);
+    netdev_t *dev = netif->context;
 
     /* Enable/disable CSMA according to the input. */
-    netif->dev->driver->set(netif->dev, NETOPT_CSMA, &csma_enable,
+    dev->driver->set(dev, NETOPT_CSMA, &csma_enable,
                             sizeof(netopt_enable_t));
 
     gnrc_gomach_set_tx_finish(netif, false);

--- a/sys/net/gnrc/link_layer/gomach/include/gomach_internal.h
+++ b/sys/net/gnrc/link_layer/gomach/include/gomach_internal.h
@@ -637,7 +637,8 @@ static inline void gnrc_gomach_set_autoack(gnrc_netif_t *netif, netopt_enable_t 
 {
     assert(netif != NULL);
 
-    netif->dev->driver->set(netif->dev,
+    netdev_t *dev = netif->context;
+    dev->driver->set(dev,
                             NETOPT_AUTOACK,
                             &autoack,
                             sizeof(autoack));
@@ -654,7 +655,8 @@ static inline void gnrc_gomach_set_ack_req(gnrc_netif_t *netif, netopt_enable_t 
 {
     assert(netif != NULL);
 
-    netif->dev->driver->set(netif->dev,
+    netdev_t *dev = netif->context;
+    dev->driver->set(dev,
                             NETOPT_ACK_REQ,
                             &ack_req,
                             sizeof(ack_req));
@@ -672,9 +674,10 @@ static inline netopt_state_t gnrc_gomach_get_netdev_state(gnrc_netif_t *netif)
 {
     assert(netif != NULL);
 
+    netdev_t *dev = netif->context;
     netopt_state_t state;
 
-    if (0 < netif->dev->driver->get(netif->dev,
+    if (0 < dev->driver->get(dev,
                                     NETOPT_STATE,
                                     &state,
                                     sizeof(state))) {
@@ -694,7 +697,7 @@ static inline void gnrc_gomach_turn_channel(gnrc_netif_t *netif, uint16_t channe
 {
     assert(netif != NULL);
 
-    netif->dev->driver->set(netif->dev,
+    dev->driver->set(dev,
                             NETOPT_CHANNEL,
                             &channel_num,
                             sizeof(channel_num));

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -893,7 +893,11 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
 static void _lwmac_msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
+    netdev_t *dev = netif->dev;
     switch (msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            dev->driver->isr(dev);
+            break;
         /* RTT raised an interrupt */
         case GNRC_LWMAC_EVENT_RTT_TYPE: {
             if (gnrc_lwmac_get_dutycycle_active(netif)) {

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -144,9 +144,9 @@ static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
 
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->context;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -893,7 +893,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
 static void _lwmac_msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     switch (msg->type) {
         case NETDEV_MSG_TYPE_EVENT:
             dev->driver->isr(dev);
@@ -949,7 +949,7 @@ static int _lwmac_init(gnrc_netif_t *netif)
     if (res < 0) {
         return res;
     }
-    dev = netif->dev;
+    dev = netif->context;
     dev->event_callback = _lwmac_event_cb;
 
     /* RTT is used for scheduling wakeup */

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -62,7 +62,7 @@ static void rtt_cb(void *arg);
 static void lwmac_set_state(gnrc_netif_t *netif, gnrc_lwmac_state_t newstate);
 static void lwmac_schedule_update(gnrc_netif_t *netif);
 static void rtt_handler(uint32_t event, gnrc_netif_t *netif);
-static void _lwmac_init(gnrc_netif_t *netif);
+static int _lwmac_init(gnrc_netif_t *netif);
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 static void _lwmac_msg_handler(gnrc_netif_t *netif, msg_t *msg);
@@ -941,11 +941,14 @@ static void _lwmac_msg_handler(gnrc_netif_t *netif, msg_t *msg)
     }
 }
 
-static void _lwmac_init(gnrc_netif_t *netif)
+static int _lwmac_init(gnrc_netif_t *netif)
 {
     netdev_t *dev;
 
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+    if (res < 0) {
+        return res;
+    }
     dev = netif->dev;
     dev->event_callback = _lwmac_event_cb;
 
@@ -986,4 +989,5 @@ static void _lwmac_init(gnrc_netif_t *netif)
     netif->mac.prot.lwmac.awake_duration_sum_ticks = 0;
     netif->mac.prot.lwmac.lwmac_info |= GNRC_LWMAC_RADIO_IS_ON;
 #endif
+    return 0;
 }

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -34,8 +34,8 @@
 
 int _gnrc_lwmac_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
-    netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_t *dev = netif->context;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->context;
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;
@@ -186,7 +186,8 @@ int _gnrc_lwmac_parse_packet(gnrc_pktsnip_t *pkt, gnrc_lwmac_packet_info_t *info
 
 void _gnrc_lwmac_set_netdev_state(gnrc_netif_t *netif, netopt_state_t devstate)
 {
-    netif->dev->driver->set(netif->dev,
+    netdev_t *dev = netif->context;
+    dev->driver->set(dev,
                             NETOPT_STATE,
                             &devstate,
                             sizeof(devstate));
@@ -216,7 +217,8 @@ netopt_state_t _gnrc_lwmac_get_netdev_state(gnrc_netif_t *netif)
 {
     netopt_state_t state;
 
-    if (0 < netif->dev->driver->get(netif->dev,
+    netdev_t *dev = netif->context;
+    if (0 < dev->driver->get(dev,
                                     NETOPT_STATE,
                                     &state,
                                     sizeof(state))) {

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -178,7 +178,8 @@ static bool _send_wa(gnrc_netif_t *netif)
 
     /* Disable Auto ACK */
     netopt_enable_t autoack = NETOPT_DISABLE;
-    netif->dev->driver->set(netif->dev, NETOPT_AUTOACK, &autoack,
+    netdev_t *dev = netif->context;
+    dev->driver->set(dev, NETOPT_AUTOACK, &autoack,
                             sizeof(autoack));
 
     /* Send WA */
@@ -191,7 +192,7 @@ static bool _send_wa(gnrc_netif_t *netif)
 
     /* Enable Auto ACK again for data reception */
     autoack = NETOPT_ENABLE;
-    netif->dev->driver->set(netif->dev, NETOPT_AUTOACK, &autoack,
+    dev->driver->set(dev, NETOPT_AUTOACK, &autoack,
                             sizeof(autoack));
 
     return true;
@@ -278,6 +279,8 @@ static uint8_t _packet_process_in_wait_for_data(gnrc_netif_t *netif)
 
 void gnrc_lwmac_rx_start(gnrc_netif_t *netif)
 {
+    netdev_t *dev = netif->context;
+
     if (netif == NULL) {
         return;
     }
@@ -288,7 +291,7 @@ void gnrc_lwmac_rx_start(gnrc_netif_t *netif)
     /* Don't attempt to send a WA if channel is busy to get timings right */
     netif->mac.mac_info &= ~GNRC_NETIF_MAC_INFO_CSMA_ENABLED;
     netopt_enable_t csma_disable = NETOPT_DISABLE;
-    netif->dev->driver->set(netif->dev, NETOPT_CSMA, &csma_disable,
+    dev->driver->set(dev, NETOPT_CSMA, &csma_disable,
                             sizeof(csma_disable));
 
     netif->mac.rx.state = GNRC_LWMAC_RX_STATE_INIT;

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -47,6 +47,7 @@ static const gnrc_netif_ops_t ethernet_ops = {
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = _set,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_ethernet_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -87,7 +87,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     gnrc_pktsnip_t *payload;
     int res;
 
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
 
     if (pkt == NULL) {
         DEBUG("gnrc_netif_ethernet: pkt was NULL\n");
@@ -168,7 +168,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
     gnrc_pktsnip_t *pkt = NULL;
 

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1465,6 +1465,18 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
         netif->stats.tx_bytes += res;
     }
 #endif
+
+void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg)
+{
+    netdev_t *dev = netif->dev;
+    switch(msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
+            dev->driver->isr(dev);
+            break;
+        default:
+            break;
+    }
 }
 
 static void *_gnrc_netif_thread(void *args)
@@ -1534,10 +1546,6 @@ static void *_gnrc_netif_thread(void *args)
                 _send_queued_pkt(netif);
                 break;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-            case NETDEV_MSG_TYPE_EVENT:
-                DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
-                dev->driver->isr(dev);
-                break;
             case GNRC_NETAPI_MSG_TYPE_SND:
                 DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_SND received\n");
                 _send(netif, msg.content.ptr, false);

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -71,8 +71,8 @@ int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
     rmutex_init(&netif->mutex);
     netif->ops = ops;
     netif_register((netif_t*) netif);
-    assert(netif->dev == NULL);
-    netif->dev = netdev;
+    assert(netif->context == NULL);
+    netif->context = netdev;
     res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
                         _gnrc_netif_thread, (void *)netif, name);
     (void)res;
@@ -990,7 +990,7 @@ static void *_gnrc_netif_thread(void *args)
         /* unregister this netif instance */
         netif->ops = NULL;
         netif->pid = KERNEL_PID_UNDEF;
-        netif->dev = NULL;
+        netif->context = NULL;
         return NULL;
     }
 #if DEVELHELP

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1285,7 +1285,7 @@ static void _test_options(gnrc_netif_t *netif)
 }
 #endif /* DEVELHELP */
 
-void gnrc_netif_default_init(gnrc_netif_t *netif)
+int gnrc_netif_default_init(gnrc_netif_t *netif)
 {
     _init_from_device(netif);
 #ifdef DEVELHELP
@@ -1295,6 +1295,7 @@ void gnrc_netif_default_init(gnrc_netif_t *netif)
 #ifdef MODULE_GNRC_IPV6_NIB
     gnrc_ipv6_nib_init_iface(netif);
 #endif
+    return 0;
 }
 
 static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back);

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -46,20 +46,11 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#ifdef MODULE_GNRC_NETIF_EVENTS
-/**
- * @brief   Event type used for passing netdev pointers together with the event
- */
-typedef struct {
-    event_t super;
-    netdev_t *dev;
-} event_netdev_t;
-#endif /* MODULE_GNRC_NETIF_EVENTS */
+#ifdef DEVELHELP
+extern bool options_tested;
+#endif
 
-static void _update_l2addr_from_dev(gnrc_netif_t *netif);
-static void _configure_netdev(netdev_t *dev);
 static void *_gnrc_netif_thread(void *args);
-static void _event_cb(netdev_t *dev, netdev_event_t event);
 
 int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
                       char priority, const char *name, netdev_t *netdev,
@@ -89,24 +80,6 @@ int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
     return 0;
 }
 
-bool gnrc_netif_dev_is_6lo(const gnrc_netif_t *netif)
-{
-    switch (netif->device_type) {
-#ifdef MODULE_GNRC_SIXLOENC
-        case NETDEV_TYPE_ETHERNET:
-            return (netif->flags & GNRC_NETIF_FLAGS_6LO);
-#endif
-        case NETDEV_TYPE_IEEE802154:
-        case NETDEV_TYPE_CC110X:
-        case NETDEV_TYPE_BLE:
-        case NETDEV_TYPE_NRFMIN:
-        case NETDEV_TYPE_ESP_NOW:
-            return true;
-        default:
-            return false;
-    }
-}
-
 unsigned gnrc_netif_numof(void)
 {
     gnrc_netif_t *netif = NULL;
@@ -123,282 +96,6 @@ unsigned gnrc_netif_numof(void)
 gnrc_netif_t *gnrc_netif_iter(const gnrc_netif_t *prev)
 {
     return (gnrc_netif_t*) netif_iter((netif_t*) prev);
-}
-
-int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
-{
-    int res = -ENOTSUP;
-
-    gnrc_netif_acquire(netif);
-    switch (opt->opt) {
-        case NETOPT_6LO:
-            assert(opt->data_len == sizeof(netopt_enable_t));
-            *((netopt_enable_t *)opt->data) =
-                    (netopt_enable_t)gnrc_netif_is_6lo(netif);
-            res = sizeof(netopt_enable_t);
-            break;
-        case NETOPT_HOP_LIMIT:
-            assert(opt->data_len == sizeof(uint8_t));
-            *((uint8_t *)opt->data) = netif->cur_hl;
-            res = sizeof(uint8_t);
-            break;
-        case NETOPT_STATS:
-            /* XXX discussed this with Oleg, it's supposed to be a pointer */
-            switch ((int16_t)opt->context) {
-#if IS_USED(MODULE_NETSTATS_IPV6) && IS_USED(MODULE_GNRC_NETIF_IPV6)
-                case NETSTATS_IPV6:
-                    assert(opt->data_len == sizeof(netstats_t *));
-                    *((netstats_t **)opt->data) = &netif->ipv6.stats;
-                    res = sizeof(&netif->ipv6.stats);
-                    break;
-#endif
-#ifdef MODULE_NETSTATS_L2
-                case NETSTATS_LAYER2:
-                    assert(opt->data_len == sizeof(netstats_t *));
-                    *((netstats_t **)opt->data) = &netif->stats;
-                    res = sizeof(&netif->stats);
-                    break;
-#endif
-                default:
-                    /* take from device */
-                    break;
-            }
-            break;
-#if IS_USED(MODULE_GNRC_NETIF_IPV6)
-        case NETOPT_IPV6_ADDR: {
-                assert(opt->data_len >= sizeof(ipv6_addr_t));
-                ipv6_addr_t *tgt = opt->data;
-
-                res = 0;
-                for (unsigned i = 0;
-                     (res < (int)opt->data_len) &&
-                     (i < CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF);
-                     i++) {
-                    if (netif->ipv6.addrs_flags[i] != 0) {
-                        memcpy(tgt, &netif->ipv6.addrs[i], sizeof(ipv6_addr_t));
-                        res += sizeof(ipv6_addr_t);
-                        tgt++;
-                    }
-                }
-            }
-            break;
-        case NETOPT_IPV6_ADDR_FLAGS: {
-                assert(opt->data_len >= sizeof(uint8_t));
-                uint8_t *tgt = opt->data;
-
-                res = 0;
-                for (unsigned i = 0;
-                     (res < (int)opt->data_len) &&
-                     (i < CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF);
-                     i++) {
-                    if (netif->ipv6.addrs_flags[i] != 0) {
-                        *tgt = netif->ipv6.addrs_flags[i];
-                        res += sizeof(uint8_t);
-                        tgt++;
-                    }
-                }
-            }
-            break;
-        case NETOPT_IPV6_GROUP: {
-                assert(opt->data_len >= sizeof(ipv6_addr_t));
-                ipv6_addr_t *tgt = opt->data;
-
-                res = 0;
-                for (unsigned i = 0;
-                     (res < (int)opt->data_len) &&
-                     (i < GNRC_NETIF_IPV6_GROUPS_NUMOF);
-                     i++) {
-                    if (!ipv6_addr_is_unspecified(&netif->ipv6.groups[i])) {
-                        memcpy(tgt, &netif->ipv6.groups[i],
-                               sizeof(ipv6_addr_t));
-                        res += sizeof(ipv6_addr_t);
-                        tgt++;
-                    }
-                }
-            }
-            break;
-        case NETOPT_IPV6_IID:
-            assert(opt->data_len >= sizeof(eui64_t));
-            res = gnrc_netif_ipv6_get_iid(netif, opt->data);
-            break;
-        case NETOPT_MAX_PDU_SIZE:
-            if (opt->context == GNRC_NETTYPE_IPV6) {
-                assert(opt->data_len == sizeof(uint16_t));
-                *((uint16_t *)opt->data) = netif->ipv6.mtu;
-                res = sizeof(uint16_t);
-            }
-            /* else ask device */
-            break;
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ROUTER)
-        case NETOPT_IPV6_FORWARDING:
-            assert(opt->data_len == sizeof(netopt_enable_t));
-            *((netopt_enable_t *)opt->data) = (gnrc_netif_is_rtr(netif)) ?
-                                              NETOPT_ENABLE : NETOPT_DISABLE;
-            res = sizeof(netopt_enable_t);
-            break;
-        case NETOPT_IPV6_SND_RTR_ADV:
-            assert(opt->data_len == sizeof(netopt_enable_t));
-            *((netopt_enable_t *)opt->data) = (gnrc_netif_is_rtr_adv(netif)) ?
-                                              NETOPT_ENABLE : NETOPT_DISABLE;
-            res = sizeof(netopt_enable_t);
-            break;
-#endif  /* CONFIG_GNRC_IPV6_NIB_ROUTER */
-#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
-#ifdef MODULE_GNRC_SIXLOWPAN_IPHC
-        case NETOPT_6LO_IPHC:
-            assert(opt->data_len == sizeof(netopt_enable_t));
-            *((netopt_enable_t *)opt->data) = (netif->flags &
-                                               GNRC_NETIF_FLAGS_6LO_HC)
-                                            ? NETOPT_ENABLE : NETOPT_DISABLE;
-            res = sizeof(netopt_enable_t);
-            break;
-#endif  /* MODULE_GNRC_SIXLOWPAN_IPHC */
-        default:
-            break;
-    }
-    if (res == -ENOTSUP) {
-        res = netif->dev->driver->get(netif->dev, opt->opt, opt->data,
-                                      opt->data_len);
-    }
-    gnrc_netif_release(netif);
-    return res;
-}
-
-int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
-                               const gnrc_netapi_opt_t *opt)
-{
-    int res = -ENOTSUP;
-
-    gnrc_netif_acquire(netif);
-    switch (opt->opt) {
-        case NETOPT_HOP_LIMIT:
-            assert(opt->data_len == sizeof(uint8_t));
-            netif->cur_hl = *((uint8_t *)opt->data);
-            res = sizeof(uint8_t);
-            break;
-#if IS_USED(MODULE_GNRC_NETIF_IPV6)
-        case NETOPT_IPV6_ADDR: {
-                assert(opt->data_len == sizeof(ipv6_addr_t));
-                /* always assume manually added */
-                uint8_t flags = ((((uint8_t)opt->context & 0xff) &
-                                  ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK) |
-                                 GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
-                uint8_t pfx_len = (uint8_t)(opt->context >> 8U);
-                /* acquire locks a recursive mutex so we are safe calling this
-                 * public function */
-                res = gnrc_netif_ipv6_addr_add_internal(netif, opt->data,
-                                                        pfx_len, flags);
-                if (res >= 0) {
-                    res = sizeof(ipv6_addr_t);
-                }
-            }
-            break;
-        case NETOPT_IPV6_ADDR_REMOVE:
-            assert(opt->data_len == sizeof(ipv6_addr_t));
-            /* acquire locks a recursive mutex so we are safe calling this
-             * public function */
-            gnrc_netif_ipv6_addr_remove_internal(netif, opt->data);
-            res = sizeof(ipv6_addr_t);
-            break;
-        case NETOPT_IPV6_GROUP:
-            assert(opt->data_len == sizeof(ipv6_addr_t));
-            /* acquire locks a recursive mutex so we are safe calling this
-             * public function */
-            res = gnrc_netif_ipv6_group_join_internal(netif, opt->data);
-            if (res >= 0) {
-                res = sizeof(ipv6_addr_t);
-            }
-            break;
-        case NETOPT_IPV6_GROUP_LEAVE:
-            assert(opt->data_len == sizeof(ipv6_addr_t));
-            /* acquire locks a recursive mutex so we are safe calling this
-             * public function */
-            gnrc_netif_ipv6_group_leave_internal(netif, opt->data);
-            res = sizeof(ipv6_addr_t);
-            break;
-        case NETOPT_MAX_PDU_SIZE:
-            if (opt->context == GNRC_NETTYPE_IPV6) {
-                assert(opt->data_len == sizeof(uint16_t));
-                netif->ipv6.mtu = *((uint16_t *)opt->data);
-                res = sizeof(uint16_t);
-            }
-            /* else set device */
-            break;
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ROUTER)
-        case NETOPT_IPV6_FORWARDING:
-            assert(opt->data_len == sizeof(netopt_enable_t));
-            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
-                netif->flags |= GNRC_NETIF_FLAGS_IPV6_FORWARDING;
-            }
-            else {
-                if (gnrc_netif_is_rtr_adv(netif)) {
-                    gnrc_ipv6_nib_change_rtr_adv_iface(netif, false);
-                }
-                netif->flags &= ~GNRC_NETIF_FLAGS_IPV6_FORWARDING;
-            }
-            res = sizeof(netopt_enable_t);
-            break;
-        case NETOPT_IPV6_SND_RTR_ADV:
-            assert(opt->data_len == sizeof(netopt_enable_t));
-            gnrc_ipv6_nib_change_rtr_adv_iface(netif,
-                    (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE));
-            res = sizeof(netopt_enable_t);
-            break;
-#endif  /* CONFIG_GNRC_IPV6_NIB_ROUTER */
-#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
-#ifdef MODULE_GNRC_SIXLOWPAN_IPHC
-        case NETOPT_6LO_IPHC:
-            assert(opt->data_len == sizeof(netopt_enable_t));
-            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
-                netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
-            }
-            else {
-                netif->flags &= ~GNRC_NETIF_FLAGS_6LO_HC;
-            }
-            res = sizeof(netopt_enable_t);
-            break;
-#endif  /* MODULE_GNRC_SIXLOWPAN_IPHC */
-        case NETOPT_RAWMODE:
-            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
-                netif->flags |= GNRC_NETIF_FLAGS_RAWMODE;
-            }
-            else {
-                netif->flags &= ~GNRC_NETIF_FLAGS_RAWMODE;
-            }
-            /* Also propagate to the netdev device */
-            netif->dev->driver->set(netif->dev, NETOPT_RAWMODE, opt->data,
-                                      opt->data_len);
-            res = sizeof(netopt_enable_t);
-            break;
-        default:
-            break;
-    }
-    if (res == -ENOTSUP) {
-        res = netif->dev->driver->set(netif->dev, opt->opt, opt->data,
-                                      opt->data_len);
-        if (res > 0) {
-            switch (opt->opt) {
-                case NETOPT_ADDRESS:
-                case NETOPT_ADDRESS_LONG:
-                case NETOPT_ADDR_LEN:
-                case NETOPT_SRC_LEN:
-                    _update_l2addr_from_dev(netif);
-                    break;
-                case NETOPT_IEEE802154_PHY:
-                    gnrc_netif_ipv6_init_mtu(netif);
-                    break;
-                case NETOPT_STATE:
-                    if (*((netopt_state_t *)opt->data) == NETOPT_STATE_RESET) {
-                        _configure_netdev(netif->dev);
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-    }
-    gnrc_netif_release(netif);
-    return res;
 }
 
 gnrc_netif_t *gnrc_netif_get_by_pid(kernel_pid_t pid)
@@ -1123,232 +820,7 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
 }
 #endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
 
-static void _update_l2addr_from_dev(gnrc_netif_t *netif)
-{
-    netdev_t *dev = netif->dev;
-    int res;
-    netopt_t opt = gnrc_netif_get_l2addr_opt(netif);
-
-    res = dev->driver->get(dev, opt, netif->l2addr,
-                           sizeof(netif->l2addr));
-    if (res != -ENOTSUP) {
-        netif->flags |= GNRC_NETIF_FLAGS_HAS_L2ADDR;
-    }
-    else {
-        /* If no address is provided but still an address length given above,
-         * we are in an invalid state */
-        assert(netif->l2addr_len == 0);
-    }
-    if (res > 0) {
-        netif->l2addr_len = res;
-    }
-}
-
-static void _init_from_device(gnrc_netif_t *netif)
-{
-    int res;
-    netdev_t *dev = netif->dev;
-    uint16_t tmp;
-
-    res = dev->driver->get(dev, NETOPT_DEVICE_TYPE, &tmp, sizeof(tmp));
-    (void)res;
-    assert(res == sizeof(tmp));
-    netif->device_type = (uint8_t)tmp;
-    gnrc_netif_ipv6_init_mtu(netif);
-    _update_l2addr_from_dev(netif);
-}
-
-static void _configure_netdev(netdev_t *dev)
-{
-    /* Enable RX- and TX-complete interrupts */
-    static const netopt_enable_t enable = NETOPT_ENABLE;
-    int res = dev->driver->set(dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
-    if (res < 0) {
-        DEBUG("gnrc_netif: enable NETOPT_RX_END_IRQ failed: %d\n", res);
-    }
-    if (IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ)) {
-        res = dev->driver->set(dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
-        if (res < 0) {
-            DEBUG("gnrc_netif: enable NETOPT_TX_END_IRQ failed: %d\n", res);
-        }
-    }
-}
-
-#ifdef DEVELHELP
-static bool options_tested = false;
-
-/* checks if a device supports all required options and functions */
-static void _test_options(gnrc_netif_t *netif)
-{
-    uint8_t dummy_addr[GNRC_NETIF_L2ADDR_MAXLEN] = { 0 };
-    ndp_opt_t dummy_opt = { .len = 1U };
-    uint64_t tmp64 = 0ULL;
-
-    (void)dummy_addr;
-    (void)dummy_opt;
-    (void)tmp64;
-#if (GNRC_NETIF_L2ADDR_MAXLEN > 0)
-    /* check if address was set in _update_l2addr_from_dev()
-     * (NETOPT_DEVICE_TYPE already tested in _configure_netdev()) and
-     * if MTU and max. fragment size was set properly by
-     * gnrc_netif_ipv6_init_mtu()
-     * all checked types below have link-layer addresses so we don't need to
-     * check `GNRC_NETIF_FLAGS_HAS_L2ADDR` */
-    switch (netif->device_type) {
-#ifdef TEST_SUITES
-        case NETDEV_TYPE_TEST:
-            /* make no assumptions about test devices */
-            break;
-#endif
-        case NETDEV_TYPE_BLE:
-        case NETDEV_TYPE_ETHERNET:
-        case NETDEV_TYPE_ESP_NOW:
-            assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
-            assert(ETHERNET_ADDR_LEN == netif->l2addr_len);
-#if IS_USED(MODULE_GNRC_NETIF_IPV6)
-            switch (netif->device_type) {
-                case NETDEV_TYPE_BLE:
-                    assert(netif->ipv6.mtu == IPV6_MIN_MTU);
-                    break;
-                case NETDEV_TYPE_ETHERNET:
-                    assert(netif->ipv6.mtu == ETHERNET_DATA_LEN);
-                    break;
-                case NETDEV_TYPE_ESP_NOW:
-                    assert(netif->ipv6.mtu <= ETHERNET_DATA_LEN);
-            }
-#endif  /* IS_USED(MODULE GNRC_NETIF_IPV6) */
-            break;
-        case NETDEV_TYPE_IEEE802154:
-        case NETDEV_TYPE_NRFMIN: {
-            gnrc_nettype_t tmp;
-
-            /* in case assert() evaluates to NOP */
-            (void)tmp;
-            assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
-            assert((IEEE802154_SHORT_ADDRESS_LEN == netif->l2addr_len) ||
-                   (IEEE802154_LONG_ADDRESS_LEN == netif->l2addr_len));
-#if IS_USED(MODULE_GNRC_NETIF_IPV6)
-#if IS_USED(MODULE_GNRC_NETIF_6LO)
-#if IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU)
-            assert(netif->ipv6.mtu >= IPV6_MIN_MTU);
-#else /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
-            assert(netif->ipv6.mtu == IPV6_MIN_MTU);
-#endif /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
-            assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
-                                                       &tmp, sizeof(tmp)));
-#else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */
-            assert(netif->ipv6.mtu < UINT16_MAX);
-#endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
-#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
-#ifdef MODULE_GNRC_SIXLOWPAN_ND
-            assert((netif->device_type != NETDEV_TYPE_IEEE802154) ||
-                   (-ENOTSUP != netif->dev->driver->get(netif->dev,
-                                                        NETOPT_ADDRESS_LONG,
-                                                        &dummy_addr,
-                                                        sizeof(dummy_addr))));
-#endif  /* MODULE_GNRC_SIXLOWPAN_ND */
-            break;
-        }
-        case NETDEV_TYPE_CC110X:
-            assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
-            assert(1U == netif->l2addr_len);
-#if IS_USED(MODULE_GNRC_NETIF_IPV6)
-            assert(netif->ipv6.mtu < UINT16_MAX);
-#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
-            break;
-        case NETDEV_TYPE_LORA: /* LoRa doesn't provide L2 ADDR */
-        case NETDEV_TYPE_SLIP:
-            assert(!(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR));
-            assert(0U == netif->l2addr_len);
-            /* don't check MTU here for now since I'm not sure the current
-             * one is correct ^^" "*/
-            break;
-        default:
-            /* device type not supported yet, please amend case above when
-             * porting new device type */
-            assert(false);
-    }
-    /* These functions only apply to network devices having link-layers */
-    if (netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR) {
-#if IS_USED(MODULE_GNRC_NETIF_IPV6)
-        assert(-ENOTSUP != gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&tmp64));
-        assert(-ENOTSUP != gnrc_netif_ndp_addr_len_from_l2ao(netif,
-                                                             &dummy_opt));
-#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
-        assert(-ENOTSUP != gnrc_netif_ipv6_iid_to_addr(netif, (eui64_t *)&tmp64,
-                                                       dummy_addr));
-#endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
-    }
-#endif /* (GNRC_NETIF_L2ADDR_MAXLEN > 0) */
-    options_tested = true;
-}
-#endif /* DEVELHELP */
-
-int gnrc_netif_default_init(gnrc_netif_t *netif)
-{
-    gnrc_netif_acquire(netif);
-    netdev_t *dev = netif->dev;
-    netif->pid = sched_active_pid;
-
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
-    netif->event_isr.handler = _event_handler_isr,
-    /* set up the event queue */
-    event_queue_init(&netif->evq);
-#endif /* MODULE_GNRC_NETIF_EVENTS */
-
-    /* register the event callback with the device driver */
-    dev->event_callback = _event_cb;
-    dev->context = netif;
-    /* initialize low-level driver */
-    int res = dev->driver->init(dev);
-    if (res < 0) {
-        LOG_ERROR("gnrc_netif: netdev init failed: %d\n", res);
-        /* unregister this netif instance */
-        dev->event_callback = NULL;
-        dev->context = NULL;
-        return -EINVAL;
-    }
-    _configure_netdev(dev);
-    _init_from_device(netif);
-#ifdef DEVELHELP
-    _test_options(netif);
-#endif
-    netif->cur_hl = CONFIG_GNRC_NETIF_DEFAULT_HL;
-#ifdef MODULE_GNRC_IPV6_NIB
-    gnrc_ipv6_nib_init_iface(netif);
-#endif
-#ifdef MODULE_NETSTATS_L2
-    memset(&netif->stats, 0, sizeof(netstats_t));
-#endif
-    /* now let rest of GNRC use the interface */
-    gnrc_netif_release(netif);
-    return 0;
-}
-
 static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back);
-
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
-/**
- * @brief   Call the ISR handler from an event
- *
- * @param[in]   evp     pointer to the event
- */
-static void _event_handler_isr(event_t *evp)
-{
-    gnrc_netif_t *netif = container_of(evp, gnrc_netif_t, event_isr);
-    netif->dev->driver->isr(netif->dev);
-}
-#endif
-
-static inline void _event_post(gnrc_netif_t *netif)
-{
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
-    event_post(&netif->evq, &netif->event_isr);
-#else
-    (void)netif;
-#endif
-}
 
 /**
  * @brief   Retrieve the netif event queue if enabled
@@ -1415,7 +887,7 @@ static void _process_events_await_msg(gnrc_netif_t *netif, msg_t *msg)
     }
 }
 
-static void _send_queued_pkt(gnrc_netif_t *netif)
+void gnrc_netif_send_queued_pkt(gnrc_netif_t *netif)
 {
     (void)netif;
 #if IS_USED(MODULE_GNRC_NETIF_PKTQ)
@@ -1441,7 +913,7 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
         put_res = gnrc_netif_pktq_put(netif, pkt);
         if (put_res == 0) {
             DEBUG("gnrc_netif: (re-)queued pkt %p\n", (void *)pkt);
-            _send_queued_pkt(netif);
+            gnrc_netif_send_queued_pkt(netif);
             return;
         }
         else {
@@ -1494,18 +966,6 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
         netif->stats.tx_bytes += res;
     }
 #endif
-
-void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg)
-{
-    netdev_t *dev = netif->dev;
-    switch(msg->type) {
-        case NETDEV_MSG_TYPE_EVENT:
-            DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
-            dev->driver->isr(dev);
-            break;
-        default:
-            break;
-    }
 }
 
 static void *_gnrc_netif_thread(void *args)
@@ -1526,7 +986,7 @@ static void *_gnrc_netif_thread(void *args)
 #endif /* MODULE_GNRC_NETIF_EVENTS */
 
     if ((res = netif->ops->init(netif)) < 0) {
-        LOG_ERROR("gnrc_netif: netdev init failed: %d\n", res);
+        LOG_ERROR("gnrc_netif: init failed: %d\n", res);
         /* unregister this netif instance */
         netif->ops = NULL;
         netif->pid = KERNEL_PID_UNDEF;
@@ -1546,13 +1006,13 @@ static void *_gnrc_netif_thread(void *args)
          * The function will not return until a message has been received. */
         _process_events_await_msg(netif, &msg);
 
-        /* dispatch netdev, MAC and gnrc_netapi messages */
+        /* dispatch network device, MAC and gnrc_netapi messages */
         DEBUG("gnrc_netif: message %u\n", (unsigned)msg.type);
         switch (msg.type) {
 #if IS_USED(MODULE_GNRC_NETIF_PKTQ)
             case GNRC_NETIF_PKTQ_DEQUEUE_MSG:
                 DEBUG("gnrc_netif: send from packet send queue\n");
-                _send_queued_pkt(netif);
+                gnrc_netif_send_queued_pkt(netif);
                 break;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
             case GNRC_NETAPI_MSG_TYPE_SND:
@@ -1613,81 +1073,5 @@ static void *_gnrc_netif_thread(void *args)
     }
     /* never reached */
     return NULL;
-}
-
-static void _pass_on_packet(gnrc_pktsnip_t *pkt)
-{
-    /* throw away packet if no one is interested */
-    if (!gnrc_netapi_dispatch_receive(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL,
-                                      pkt)) {
-        DEBUG("gnrc_netif: unable to forward packet of type %i\n", pkt->type);
-        gnrc_pktbuf_release(pkt);
-        return;
-    }
-}
-
-static void _event_cb(netdev_t *dev, netdev_event_t event)
-{
-    gnrc_netif_t *netif = (gnrc_netif_t *) dev->context;
-
-    if (event == NETDEV_EVENT_ISR) {
-        if (IS_USED(MODULE_GNRC_NETIF_EVENTS)) {
-            _event_post(netif);
-        }
-        else {
-            msg_t msg = { .type = NETDEV_MSG_TYPE_EVENT,
-                          .content = { .ptr = netif } };
-
-            if (msg_send(&msg, netif->pid) <= 0) {
-                puts("gnrc_netif: possibly lost interrupt.");
-            }
-        }
-    }
-    else {
-        DEBUG("gnrc_netif: event triggered -> %i\n", event);
-        gnrc_pktsnip_t *pkt = NULL;
-        switch (event) {
-            case NETDEV_EVENT_RX_COMPLETE:
-                pkt = netif->ops->recv(netif);
-                /* send packet previously queued within netif due to the lower
-                 * layer being busy.
-                 * Further packets will be sent on later TX_COMPLETE */
-                _send_queued_pkt(netif);
-                if (pkt) {
-                    _pass_on_packet(pkt);
-                }
-                break;
-#if IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ)
-            case NETDEV_EVENT_TX_COMPLETE:
-                /* send packet previously queued within netif due to the lower
-                 * layer being busy.
-                 * Further packets will be sent on later TX_COMPLETE or
-                 * TX_MEDIUM_BUSY */
-                _send_queued_pkt(netif);
-#if IS_USED(MODULE_NETSTATS_L2)
-                /* we are the only ones supposed to touch this variable,
-                 * so no acquire necessary */
-                netif->stats.tx_success++;
-#endif  /* IS_USED(MODULE_NETSTATS_L2) */
-                break;
-#endif  /* IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-#if IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ)
-            case NETDEV_EVENT_TX_MEDIUM_BUSY:
-                /* send packet previously queued within netif due to the lower
-                 * layer being busy.
-                 * Further packets will be sent on later TX_COMPLETE or
-                 * TX_MEDIUM_BUSY */
-                _send_queued_pkt(netif);
-#if IS_USED(MODULE_NETSTATS_L2)
-                /* we are the only ones supposed to touch this variable,
-                 * so no acquire necessary */
-                netif->stats.tx_failed++;
-#endif  /* IS_USED(MODULE_NETSTATS_L2) */
-                break;
-#endif  /* IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-            default:
-                DEBUG("gnrc_netif: warning: unhandled event %u.\n", event);
-        }
-    }
 }
 /** @} */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -53,7 +53,7 @@ extern bool options_tested;
 static void *_gnrc_netif_thread(void *args);
 
 int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
-                      char priority, const char *name, netdev_t *netdev,
+                      char priority, const char *name, void *context,
                       const gnrc_netif_ops_t *ops)
 {
     int res;
@@ -72,7 +72,7 @@ int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
     netif->ops = ops;
     netif_register((netif_t*) netif);
     assert(netif->context == NULL);
-    netif->context = netdev;
+    netif->context = context;
     res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
                         _gnrc_netif_thread, (void *)netif, name);
     (void)res;

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -42,7 +42,7 @@ netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif)
     defined(MODULE_NORDIC_SOFTDEVICE_BLE) || defined(MODULE_NIMBLE_NETIF)
         case NETDEV_TYPE_IEEE802154:
         case NETDEV_TYPE_BLE: {
-                netdev_t *dev = netif->dev;
+                netdev_t *dev = netif->context;
                 int r;
                 uint16_t tmp;
 
@@ -75,7 +75,7 @@ int gnrc_netif_eui64_from_addr(const gnrc_netif_t *netif,
                  * provided */
                 switch (addr_len) {
                     case IEEE802154_SHORT_ADDRESS_LEN: {
-                        netdev_t *dev = netif->dev;
+                        netdev_t *dev = netif->context;
                         return dev->driver->get(dev, NETOPT_ADDRESS_LONG, eui64,
                                                 sizeof(eui64_t));
                     }
@@ -128,7 +128,7 @@ void gnrc_netif_init_6ln(gnrc_netif_t *netif)
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)
 void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     int res;
     uint16_t tmp;
 

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -21,6 +21,7 @@
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)
 #include "net/ipv6.h"
 #endif
+#include "net/netdev.h"
 #include "net/gnrc/netif.h"
 #include "net/eui48.h"
 #include "net/ethernet.h"

--- a/sys/net/gnrc/netif/gnrc_netif_netdev.c
+++ b/sys/net/gnrc/netif/gnrc_netif_netdev.c
@@ -1,0 +1,643 @@
+/*
+ * Copyright (C) 2014-2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ * @author  René Kijewski <rene.kijewski@fu-berlin.de>
+ * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ */
+
+#include "net/ethernet.h"
+#include "net/ipv6.h"
+#ifdef MODULE_GNRC_IPV6_NIB
+#include "net/gnrc/ipv6/nib.h"
+#include "net/gnrc/ipv6.h"
+#endif /* MODULE_GNRC_IPV6_NIB */
+#include "net/gnrc/netif.h"
+#include "net/gnrc/netif/internal.h"
+#include "net/gnrc.h"
+#include "net/netdev.h"
+
+#include "log.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#ifdef MODULE_GNRC_NETIF_EVENTS
+/**
+ * @brief   Event type used for passing netdev pointers together with the event
+ */
+typedef struct {
+    event_t super;
+    netdev_t *dev;
+} event_netdev_t;
+#endif /* MODULE_GNRC_NETIF_EVENTS */
+
+static void _configure_netdev(netdev_t *dev);
+static void _event_cb(netdev_t *dev, netdev_event_t event);
+static void _update_l2addr_from_dev(gnrc_netif_t *netif);
+
+int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
+{
+    int res = -ENOTSUP;
+
+    gnrc_netif_acquire(netif);
+    switch (opt->opt) {
+        case NETOPT_6LO:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+            *((netopt_enable_t *)opt->data) =
+                    (netopt_enable_t)gnrc_netif_is_6lo(netif);
+            res = sizeof(netopt_enable_t);
+            break;
+        case NETOPT_HOP_LIMIT:
+            assert(opt->data_len == sizeof(uint8_t));
+            *((uint8_t *)opt->data) = netif->cur_hl;
+            res = sizeof(uint8_t);
+            break;
+        case NETOPT_STATS:
+            /* XXX discussed this with Oleg, it's supposed to be a pointer */
+            switch ((int16_t)opt->context) {
+#if IS_USED(MODULE_NETSTATS_IPV6) && IS_USED(MODULE_GNRC_NETIF_IPV6)
+                case NETSTATS_IPV6:
+                    assert(opt->data_len == sizeof(netstats_t *));
+                    *((netstats_t **)opt->data) = &netif->ipv6.stats;
+                    res = sizeof(&netif->ipv6.stats);
+                    break;
+#endif
+#ifdef MODULE_NETSTATS_L2
+                case NETSTATS_LAYER2:
+                    assert(opt->data_len == sizeof(netstats_t *));
+                    *((netstats_t **)opt->data) = &netif->stats;
+                    res = sizeof(&netif->stats);
+                    break;
+#endif
+                default:
+                    /* take from device */
+                    break;
+            }
+            break;
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
+        case NETOPT_IPV6_ADDR: {
+                assert(opt->data_len >= sizeof(ipv6_addr_t));
+                ipv6_addr_t *tgt = opt->data;
+
+                res = 0;
+                for (unsigned i = 0;
+                     (res < (int)opt->data_len) &&
+                     (i < CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF);
+                     i++) {
+                    if (netif->ipv6.addrs_flags[i] != 0) {
+                        memcpy(tgt, &netif->ipv6.addrs[i], sizeof(ipv6_addr_t));
+                        res += sizeof(ipv6_addr_t);
+                        tgt++;
+                    }
+                }
+            }
+            break;
+        case NETOPT_IPV6_ADDR_FLAGS: {
+                assert(opt->data_len >= sizeof(uint8_t));
+                uint8_t *tgt = opt->data;
+
+                res = 0;
+                for (unsigned i = 0;
+                     (res < (int)opt->data_len) &&
+                     (i < CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF);
+                     i++) {
+                    if (netif->ipv6.addrs_flags[i] != 0) {
+                        *tgt = netif->ipv6.addrs_flags[i];
+                        res += sizeof(uint8_t);
+                        tgt++;
+                    }
+                }
+            }
+            break;
+        case NETOPT_IPV6_GROUP: {
+                assert(opt->data_len >= sizeof(ipv6_addr_t));
+                ipv6_addr_t *tgt = opt->data;
+
+                res = 0;
+                for (unsigned i = 0;
+                     (res < (int)opt->data_len) &&
+                     (i < GNRC_NETIF_IPV6_GROUPS_NUMOF);
+                     i++) {
+                    if (!ipv6_addr_is_unspecified(&netif->ipv6.groups[i])) {
+                        memcpy(tgt, &netif->ipv6.groups[i],
+                               sizeof(ipv6_addr_t));
+                        res += sizeof(ipv6_addr_t);
+                        tgt++;
+                    }
+                }
+            }
+            break;
+        case NETOPT_IPV6_IID:
+            assert(opt->data_len >= sizeof(eui64_t));
+            res = gnrc_netif_ipv6_get_iid(netif, opt->data);
+            break;
+        case NETOPT_MAX_PDU_SIZE:
+            if (opt->context == GNRC_NETTYPE_IPV6) {
+                assert(opt->data_len == sizeof(uint16_t));
+                *((uint16_t *)opt->data) = netif->ipv6.mtu;
+                res = sizeof(uint16_t);
+            }
+            /* else ask device */
+            break;
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ROUTER)
+        case NETOPT_IPV6_FORWARDING:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+            *((netopt_enable_t *)opt->data) = (gnrc_netif_is_rtr(netif)) ?
+                                              NETOPT_ENABLE : NETOPT_DISABLE;
+            res = sizeof(netopt_enable_t);
+            break;
+        case NETOPT_IPV6_SND_RTR_ADV:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+            *((netopt_enable_t *)opt->data) = (gnrc_netif_is_rtr_adv(netif)) ?
+                                              NETOPT_ENABLE : NETOPT_DISABLE;
+            res = sizeof(netopt_enable_t);
+            break;
+#endif  /* CONFIG_GNRC_IPV6_NIB_ROUTER */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
+#ifdef MODULE_GNRC_SIXLOWPAN_IPHC
+        case NETOPT_6LO_IPHC:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+            *((netopt_enable_t *)opt->data) = (netif->flags &
+                                               GNRC_NETIF_FLAGS_6LO_HC)
+                                            ? NETOPT_ENABLE : NETOPT_DISABLE;
+            res = sizeof(netopt_enable_t);
+            break;
+#endif  /* MODULE_GNRC_SIXLOWPAN_IPHC */
+        default:
+            break;
+    }
+    if (res == -ENOTSUP) {
+        res = netif->dev->driver->get(netif->dev, opt->opt, opt->data,
+                                      opt->data_len);
+    }
+    gnrc_netif_release(netif);
+    return res;
+}
+
+int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
+                               const gnrc_netapi_opt_t *opt)
+{
+    int res = -ENOTSUP;
+
+    gnrc_netif_acquire(netif);
+    switch (opt->opt) {
+        case NETOPT_HOP_LIMIT:
+            assert(opt->data_len == sizeof(uint8_t));
+            netif->cur_hl = *((uint8_t *)opt->data);
+            res = sizeof(uint8_t);
+            break;
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
+        case NETOPT_IPV6_ADDR: {
+                assert(opt->data_len == sizeof(ipv6_addr_t));
+                /* always assume manually added */
+                uint8_t flags = ((((uint8_t)opt->context & 0xff) &
+                                  ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK) |
+                                 GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
+                uint8_t pfx_len = (uint8_t)(opt->context >> 8U);
+                /* acquire locks a recursive mutex so we are safe calling this
+                 * public function */
+                res = gnrc_netif_ipv6_addr_add_internal(netif, opt->data,
+                                                        pfx_len, flags);
+                if (res >= 0) {
+                    res = sizeof(ipv6_addr_t);
+                }
+            }
+            break;
+        case NETOPT_IPV6_ADDR_REMOVE:
+            assert(opt->data_len == sizeof(ipv6_addr_t));
+            /* acquire locks a recursive mutex so we are safe calling this
+             * public function */
+            gnrc_netif_ipv6_addr_remove_internal(netif, opt->data);
+            res = sizeof(ipv6_addr_t);
+            break;
+        case NETOPT_IPV6_GROUP:
+            assert(opt->data_len == sizeof(ipv6_addr_t));
+            /* acquire locks a recursive mutex so we are safe calling this
+             * public function */
+            res = gnrc_netif_ipv6_group_join_internal(netif, opt->data);
+            if (res >= 0) {
+                res = sizeof(ipv6_addr_t);
+            }
+            break;
+        case NETOPT_IPV6_GROUP_LEAVE:
+            assert(opt->data_len == sizeof(ipv6_addr_t));
+            /* acquire locks a recursive mutex so we are safe calling this
+             * public function */
+            gnrc_netif_ipv6_group_leave_internal(netif, opt->data);
+            res = sizeof(ipv6_addr_t);
+            break;
+        case NETOPT_MAX_PDU_SIZE:
+            if (opt->context == GNRC_NETTYPE_IPV6) {
+                assert(opt->data_len == sizeof(uint16_t));
+                netif->ipv6.mtu = *((uint16_t *)opt->data);
+                res = sizeof(uint16_t);
+            }
+            /* else set device */
+            break;
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ROUTER)
+        case NETOPT_IPV6_FORWARDING:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
+                netif->flags |= GNRC_NETIF_FLAGS_IPV6_FORWARDING;
+            }
+            else {
+                if (gnrc_netif_is_rtr_adv(netif)) {
+                    gnrc_ipv6_nib_change_rtr_adv_iface(netif, false);
+                }
+                netif->flags &= ~GNRC_NETIF_FLAGS_IPV6_FORWARDING;
+            }
+            res = sizeof(netopt_enable_t);
+            break;
+        case NETOPT_IPV6_SND_RTR_ADV:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+            gnrc_ipv6_nib_change_rtr_adv_iface(netif,
+                    (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE));
+            res = sizeof(netopt_enable_t);
+            break;
+#endif  /* CONFIG_GNRC_IPV6_NIB_ROUTER */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
+#ifdef MODULE_GNRC_SIXLOWPAN_IPHC
+        case NETOPT_6LO_IPHC:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
+                netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
+            }
+            else {
+                netif->flags &= ~GNRC_NETIF_FLAGS_6LO_HC;
+            }
+            res = sizeof(netopt_enable_t);
+            break;
+#endif  /* MODULE_GNRC_SIXLOWPAN_IPHC */
+        case NETOPT_RAWMODE:
+            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
+                netif->flags |= GNRC_NETIF_FLAGS_RAWMODE;
+            }
+            else {
+                netif->flags &= ~GNRC_NETIF_FLAGS_RAWMODE;
+            }
+            /* Also propagate to the netdev device */
+            netif->dev->driver->set(netif->dev, NETOPT_RAWMODE, opt->data,
+                                      opt->data_len);
+            res = sizeof(netopt_enable_t);
+            break;
+        default:
+            break;
+    }
+    if (res == -ENOTSUP) {
+        res = netif->dev->driver->set(netif->dev, opt->opt, opt->data,
+                                      opt->data_len);
+        if (res > 0) {
+            switch (opt->opt) {
+                case NETOPT_ADDRESS:
+                case NETOPT_ADDRESS_LONG:
+                case NETOPT_ADDR_LEN:
+                case NETOPT_SRC_LEN:
+                    _update_l2addr_from_dev(netif);
+                    break;
+                case NETOPT_IEEE802154_PHY:
+                    gnrc_netif_ipv6_init_mtu(netif);
+                    break;
+                case NETOPT_STATE:
+                    if (*((netopt_state_t *)opt->data) == NETOPT_STATE_RESET) {
+                        _configure_netdev(netif->dev);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    gnrc_netif_release(netif);
+    return res;
+}
+
+static void _configure_netdev(netdev_t *dev)
+{
+    /* Enable RX- and TX-complete interrupts */
+    static const netopt_enable_t enable = NETOPT_ENABLE;
+    int res = dev->driver->set(dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
+    if (res < 0) {
+        DEBUG("gnrc_netif: enable NETOPT_RX_END_IRQ failed: %d\n", res);
+    }
+    if (IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ)) {
+        res = dev->driver->set(dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
+        if (res < 0) {
+            DEBUG("gnrc_netif: enable NETOPT_TX_END_IRQ failed: %d\n", res);
+        }
+    }
+}
+
+static void _init_from_device(gnrc_netif_t *netif)
+{
+    int res;
+    netdev_t *dev = netif->dev;
+    uint16_t tmp;
+
+    res = dev->driver->get(dev, NETOPT_DEVICE_TYPE, &tmp, sizeof(tmp));
+    (void)res;
+    assert(res == sizeof(tmp));
+    netif->device_type = (uint8_t)tmp;
+    gnrc_netif_ipv6_init_mtu(netif);
+    _update_l2addr_from_dev(netif);
+}
+
+static void _update_l2addr_from_dev(gnrc_netif_t *netif)
+{
+    netdev_t *dev = netif->dev;
+    int res;
+    netopt_t opt = gnrc_netif_get_l2addr_opt(netif);
+
+    res = dev->driver->get(dev, opt, netif->l2addr,
+                           sizeof(netif->l2addr));
+    if (res != -ENOTSUP) {
+        netif->flags |= GNRC_NETIF_FLAGS_HAS_L2ADDR;
+    }
+    else {
+        /* If no address is provided but still an address length given above,
+         * we are in an invalid state */
+        assert(netif->l2addr_len == 0);
+    }
+    if (res > 0) {
+        netif->l2addr_len = res;
+    }
+}
+
+bool gnrc_netif_dev_is_6lo(const gnrc_netif_t *netif)
+{
+    switch (netif->device_type) {
+#ifdef MODULE_GNRC_SIXLOENC
+        case NETDEV_TYPE_ETHERNET:
+            return (netif->flags & GNRC_NETIF_FLAGS_6LO);
+#endif
+        case NETDEV_TYPE_IEEE802154:
+        case NETDEV_TYPE_CC110X:
+        case NETDEV_TYPE_BLE:
+        case NETDEV_TYPE_NRFMIN:
+        case NETDEV_TYPE_ESP_NOW:
+            return true;
+        default:
+            return false;
+    }
+}
+
+#ifdef DEVELHELP
+bool options_tested = false;
+
+/* checks if a device supports all required options and functions */
+static void _test_options(gnrc_netif_t *netif)
+{
+    uint8_t dummy_addr[GNRC_NETIF_L2ADDR_MAXLEN] = { 0 };
+    ndp_opt_t dummy_opt = { .len = 1U };
+    uint64_t tmp64 = 0ULL;
+
+    (void)dummy_addr;
+    (void)dummy_opt;
+    (void)tmp64;
+#if (GNRC_NETIF_L2ADDR_MAXLEN > 0)
+    /* check if address was set in _update_l2addr_from_dev()
+     * (NETOPT_DEVICE_TYPE already tested in _configure_netdev()) and
+     * if MTU and max. fragment size was set properly by
+     * gnrc_netif_ipv6_init_mtu()
+     * all checked types below have link-layer addresses so we don't need to
+     * check `GNRC_NETIF_FLAGS_HAS_L2ADDR` */
+    switch (netif->device_type) {
+#ifdef TEST_SUITES
+        case NETDEV_TYPE_TEST:
+            /* make no assumptions about test devices */
+            break;
+#endif
+        case NETDEV_TYPE_BLE:
+        case NETDEV_TYPE_ETHERNET:
+        case NETDEV_TYPE_ESP_NOW:
+            assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
+            assert(ETHERNET_ADDR_LEN == netif->l2addr_len);
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
+            switch (netif->device_type) {
+                case NETDEV_TYPE_BLE:
+                    assert(netif->ipv6.mtu == IPV6_MIN_MTU);
+                    break;
+                case NETDEV_TYPE_ETHERNET:
+                    assert(netif->ipv6.mtu == ETHERNET_DATA_LEN);
+                    break;
+                case NETDEV_TYPE_ESP_NOW:
+                    assert(netif->ipv6.mtu <= ETHERNET_DATA_LEN);
+            }
+#endif  /* IS_USED(MODULE GNRC_NETIF_IPV6) */
+            break;
+        case NETDEV_TYPE_IEEE802154:
+        case NETDEV_TYPE_NRFMIN: {
+            gnrc_nettype_t tmp;
+
+            /* in case assert() evaluates to NOP */
+            (void)tmp;
+            assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
+            assert((IEEE802154_SHORT_ADDRESS_LEN == netif->l2addr_len) ||
+                   (IEEE802154_LONG_ADDRESS_LEN == netif->l2addr_len));
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
+#if IS_USED(MODULE_GNRC_NETIF_6LO)
+#if IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU)
+            assert(netif->ipv6.mtu >= IPV6_MIN_MTU);
+#else /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
+            assert(netif->ipv6.mtu == IPV6_MIN_MTU);
+#endif /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
+            assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
+                                                       &tmp, sizeof(tmp)));
+#else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */
+            assert(netif->ipv6.mtu < UINT16_MAX);
+#endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
+#ifdef MODULE_GNRC_SIXLOWPAN_ND
+            assert((netif->device_type != NETDEV_TYPE_IEEE802154) ||
+                   (-ENOTSUP != netif->dev->driver->get(netif->dev,
+                                                        NETOPT_ADDRESS_LONG,
+                                                        &dummy_addr,
+                                                        sizeof(dummy_addr))));
+#endif  /* MODULE_GNRC_SIXLOWPAN_ND */
+            break;
+        }
+        case NETDEV_TYPE_CC110X:
+            assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
+            assert(1U == netif->l2addr_len);
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
+            assert(netif->ipv6.mtu < UINT16_MAX);
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
+            break;
+        case NETDEV_TYPE_LORA: /* LoRa doesn't provide L2 ADDR */
+        case NETDEV_TYPE_SLIP:
+            assert(!(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR));
+            assert(0U == netif->l2addr_len);
+            /* don't check MTU here for now since I'm not sure the current
+             * one is correct ^^" "*/
+            break;
+        default:
+            /* device type not supported yet, please amend case above when
+             * porting new device type */
+            assert(false);
+    }
+    /* These functions only apply to network devices having link-layers */
+    if (netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR) {
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
+        assert(-ENOTSUP != gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&tmp64));
+        assert(-ENOTSUP != gnrc_netif_ndp_addr_len_from_l2ao(netif,
+                                                             &dummy_opt));
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
+        assert(-ENOTSUP != gnrc_netif_ipv6_iid_to_addr(netif, (eui64_t *)&tmp64,
+                                                       dummy_addr));
+#endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
+    }
+#endif /* (GNRC_NETIF_L2ADDR_MAXLEN > 0) */
+    options_tested = true;
+}
+#endif /* DEVELHELP */
+
+#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
+/**
+ * @brief   Call the ISR handler from an event
+ *
+ * @param[in]   evp     pointer to the event
+ */
+static void _event_handler_isr(event_t *evp)
+{
+    gnrc_netif_t *netif = container_of(evp, gnrc_netif_t, event_isr);
+    netif->dev->driver->isr(netif->dev);
+}
+#endif
+
+int gnrc_netif_default_init(gnrc_netif_t *netif)
+{
+    gnrc_netif_acquire(netif);
+    netdev_t *dev = netif->dev;
+    netif->pid = sched_active_pid;
+
+#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
+    netif->event_isr.handler = _event_handler_isr,
+#endif /* MODULE_GNRC_NETIF_EVENTS */
+
+    /* register the event callback with the device driver */
+    dev->event_callback = _event_cb;
+    dev->context = netif;
+    /* initialize low-level driver */
+    int res = dev->driver->init(dev);
+    if (res < 0) {
+        LOG_ERROR("gnrc_netif: netdev init failed: %d\n", res);
+        /* unregister this netif instance */
+        dev->event_callback = NULL;
+        dev->context = NULL;
+        return -EINVAL;
+    }
+    _configure_netdev(dev);
+    _init_from_device(netif);
+#ifdef DEVELHELP
+    _test_options(netif);
+#endif
+    netif->cur_hl = CONFIG_GNRC_NETIF_DEFAULT_HL;
+#ifdef MODULE_GNRC_IPV6_NIB
+    gnrc_ipv6_nib_init_iface(netif);
+#endif
+#ifdef MODULE_NETSTATS_L2
+    memset(&netif->stats, 0, sizeof(netstats_t));
+#endif
+    /* now let rest of GNRC use the interface */
+    gnrc_netif_release(netif);
+    return 0;
+}
+
+
+void gnrc_netif_msg_handler_netdev(gnrc_netif_t *netif, msg_t *msg)
+{
+    netdev_t *dev = netif->dev;
+    switch(msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
+            dev->driver->isr(dev);
+            break;
+        default:
+            break;
+    }
+}
+
+static void _pass_on_packet(gnrc_pktsnip_t *pkt)
+{
+    /* throw away packet if no one is interested */
+    if (!gnrc_netapi_dispatch_receive(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
+        DEBUG("gnrc_netif: unable to forward packet of type %i\n", pkt->type);
+        gnrc_pktbuf_release(pkt);
+        return;
+    }
+}
+
+static void _event_cb(netdev_t *dev, netdev_event_t event)
+{
+    gnrc_netif_t *netif = (gnrc_netif_t *) dev->context;
+
+    if (event == NETDEV_EVENT_ISR) {
+        if (IS_USED(MODULE_GNRC_NETIF_EVENTS)) {
+            gnrc_netif_event_isr(netif);
+        }
+        else {
+            msg_t msg = { .type = NETDEV_MSG_TYPE_EVENT,
+                          .content = { .ptr = netif } };
+
+            if (msg_send(&msg, netif->pid) <= 0) {
+                puts("gnrc_netif: possibly lost interrupt.");
+            }
+        }
+    }
+    else {
+        DEBUG("gnrc_netif: event triggered -> %i\n", event);
+        gnrc_pktsnip_t *pkt = NULL;
+        switch (event) {
+            case NETDEV_EVENT_RX_COMPLETE:
+                pkt = netif->ops->recv(netif);
+                /* send packet previously queued within netif due to the lower
+                 * layer being busy.
+                 * Further packets will be sent on later TX_COMPLETE */
+                gnrc_netif_send_queued_pkt(netif);
+                if (pkt) {
+                    _pass_on_packet(pkt);
+                }
+                break;
+#if IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ)
+            case NETDEV_EVENT_TX_COMPLETE:
+                /* send packet previously queued within netif due to the lower
+                 * layer being busy.
+                 * Further packets will be sent on later TX_COMPLETE or
+                 * TX_MEDIUM_BUSY */
+                gnrc_netif_send_queued_pkt(netif);
+#if IS_USED(MODULE_NETSTATS_L2)
+                /* we are the only ones supposed to touch this variable,
+                 * so no acquire necessary */
+                netif->stats.tx_success++;
+#endif  /* IS_USED(MODULE_NETSTATS_L2) */
+                break;
+#endif  /* IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ) */
+#if IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ)
+            case NETDEV_EVENT_TX_MEDIUM_BUSY:
+                /* send packet previously queued within netif due to the lower
+                 * layer being busy.
+                 * Further packets will be sent on later TX_COMPLETE or
+                 * TX_MEDIUM_BUSY */
+                gnrc_netif_send_queued_pkt(netif);
+#if IS_USED(MODULE_NETSTATS_L2)
+                /* we are the only ones supposed to touch this variable,
+                 * so no acquire necessary */
+                netif->stats.tx_failed++;
+#endif  /* IS_USED(MODULE_NETSTATS_L2) */
+                break;
+#endif  /* IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ) */
+            default:
+                DEBUG("gnrc_netif: warning: unhandled event %u.\n", event);
+        }
+    }
+}

--- a/sys/net/gnrc/netif/gnrc_netif_netdev.c
+++ b/sys/net/gnrc/netif/gnrc_netif_netdev.c
@@ -514,7 +514,7 @@ static void _event_handler_isr(event_t *evp)
 }
 #endif
 
-int gnrc_netif_default_init(gnrc_netif_t *netif)
+int gnrc_netif_default_init_netdev(gnrc_netif_t *netif)
 {
     gnrc_netif_acquire(netif);
     netdev_t *dev = netif->dev;

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -50,7 +50,7 @@ static inline uint8_t _get_version(uint8_t *data)
 
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
     gnrc_pktsnip_t *pkt = NULL;
 
@@ -105,7 +105,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         pkt = gnrc_pktbuf_remove_snip(pkt, pkt);
     }
 
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
 
 #ifdef MODULE_NETSTATS_L2
     netif->stats.tx_unicast_count++;

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -33,6 +33,7 @@ static const gnrc_netif_ops_t raw_ops = {
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_raw_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -37,6 +37,7 @@ static const gnrc_netif_ops_t ieee802154_ops = {
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 int gnrc_netif_ieee802154_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -95,7 +95,7 @@ static inline bool _already_received(gnrc_netif_t *netif,
 
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
     netdev_ieee802154_rx_info_t rx_info;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
@@ -220,8 +220,8 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
-    netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_t *dev = netif->context;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->context;
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -214,9 +214,11 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
 
 static void _msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
-    (void) netif;
-    (void) msg;
+    netdev_t *dev = netif->dev;
     switch (msg->type) {
+        case NETDEV_MSG_TYPE_EVENT:
+            dev->driver->isr(dev);
+            break;
         case MSG_TYPE_TIMEOUT:
             gnrc_lorawan_open_rx_window(&netif->lorawan.mac);
             break;

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -38,7 +38,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 static void _msg_handler(gnrc_netif_t *netif, msg_t *msg);
 static int _get(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt);
 static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt);
-static void _init(gnrc_netif_t *netif);
+static int _init(gnrc_netif_t *netif);
 
 static const gnrc_netif_ops_t lorawan_ops = {
     .init = _init,
@@ -164,9 +164,12 @@ netdev_t *gnrc_lorawan_get_netdev(gnrc_lorawan_t *mac)
     return netif->dev;
 }
 
-static void _init(gnrc_netif_t *netif)
+static int _init(gnrc_netif_t *netif)
 {
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+    if (res < 0) {
+        return res;
+    }
     netif->dev->event_callback = _driver_cb;
     _reset(netif);
 
@@ -179,6 +182,7 @@ static void _init(gnrc_netif_t *netif)
 
     _set_be_addr(&netif->lorawan.mac, _devaddr);
     gnrc_lorawan_init(&netif->lorawan.mac, netif->lorawan.nwkskey, netif->lorawan.appskey);
+    return 0;
 }
 
 int gnrc_netif_lorawan_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -27,6 +27,7 @@
 #include "net/gnrc/pktqueue.h"
 #include "net/gnrc/sixlowpan/nd.h"
 #include "net/ndp.h"
+#include "net/netdev.h"
 #include "net/sixlowpan/nd.h"
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_DNS)
 #include "net/sock/dns.h"

--- a/tests/gnrc_ipv6_fwd_w_sub/main.c
+++ b/tests/gnrc_ipv6_fwd_w_sub/main.c
@@ -158,7 +158,7 @@ static int _run_test(int argc, char **argv)
         xtimer_usleep(200);
     }
     /* activate dumping of sent ethernet frames */
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->context,
                             _dump_etherframe);
     /* first, test forwarding without subscription */
     subscribers = gnrc_netapi_dispatch_receive(GNRC_NETTYPE_IPV6,

--- a/tests/gnrc_ndp/main.c
+++ b/tests/gnrc_ndp/main.c
@@ -1229,6 +1229,7 @@ static const gnrc_netif_ops_t _test_netif_ops = {
     .recv = _test_netif_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = _test_netif_set,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 static int _netdev_test_address_long(netdev_t *dev, void *value, size_t max_len)

--- a/tests/gnrc_netif/common.c
+++ b/tests/gnrc_netif/common.c
@@ -71,7 +71,7 @@ static int _dump_send_packet(netdev_t *netdev, const iolist_t *iolist)
 void _test_trigger_recv(gnrc_netif_t *netif, const uint8_t *data,
                         size_t data_len)
 {
-    netdev_t *dev = netif->dev;
+    netdev_t *dev = netif->context;
 
     expect(data_len <= ETHERNET_DATA_LEN);
     if ((data != NULL) || (data_len > 0)) {

--- a/tests/gnrc_netif/common.h
+++ b/tests/gnrc_netif/common.h
@@ -20,6 +20,7 @@
 #define COMMON_H
 
 
+#include "net/netdev.h"
 #include "net/gnrc/netif.h"
 
 #ifdef __cplusplus

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -69,7 +69,7 @@ static const gnrc_netif_ops_t default_ops = {
     .recv = _mock_netif_recv,
     .get = gnrc_netif_get_from_netdev,
     .set = gnrc_netif_set_from_netdev,
-    .msg_handler = NULL,
+    .msg_handler = gnrc_netif_msg_handler_netdev,
 };
 
 static void _set_up(void)

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -126,7 +126,7 @@ static void test_creation(void)
     TEST_ASSERT_NOT_NULL((ptr = gnrc_netif_iter(ptr)));
     TEST_ASSERT_NULL((ptr = gnrc_netif_iter(ptr)));
     TEST_ASSERT_NOT_NULL(ethernet_netif.ops);
-    TEST_ASSERT_NOT_NULL(ethernet_netif.dev);
+    TEST_ASSERT_NOT_NULL(ethernet_netif.context);
     TEST_ASSERT_EQUAL_INT(ETHERNET_DATA_LEN, ethernet_netif.ipv6.mtu);
     TEST_ASSERT_EQUAL_INT(CONFIG_GNRC_NETIF_DEFAULT_HL, ethernet_netif.cur_hl);
     TEST_ASSERT_EQUAL_INT(NETDEV_TYPE_ETHERNET, ethernet_netif.device_type);
@@ -145,7 +145,7 @@ static void test_creation(void)
     TEST_ASSERT_NOT_NULL((ptr = gnrc_netif_iter(ptr)));
     TEST_ASSERT_NULL((ptr = gnrc_netif_iter(ptr)));
     TEST_ASSERT_NOT_NULL(ieee802154_netif.ops);
-    TEST_ASSERT_NOT_NULL(ieee802154_netif.dev);
+    TEST_ASSERT_NOT_NULL(ieee802154_netif.context);
     TEST_ASSERT_EQUAL_INT(IPV6_MIN_MTU, ieee802154_netif.ipv6.mtu);
     TEST_ASSERT_EQUAL_INT(TEST_IEEE802154_MAX_FRAG_SIZE,
                           ieee802154_netif.sixlo.max_frag_size);
@@ -164,7 +164,7 @@ static void test_creation(void)
                 GNRC_NETIF_PRIO, "netif", devs[i], &default_ops
             )), 0);
         TEST_ASSERT_NOT_NULL(netifs[i].ops);
-        TEST_ASSERT_NOT_NULL(netifs[i].dev);
+        TEST_ASSERT_NOT_NULL(netifs[i].context);
         TEST_ASSERT_EQUAL_INT(CONFIG_GNRC_NETIF_DEFAULT_HL, netifs[i].cur_hl);
         TEST_ASSERT_EQUAL_INT(NETDEV_TYPE_TEST, netifs[i].device_type);
         TEST_ASSERT(netifs[i].pid > KERNEL_PID_UNDEF);

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -50,7 +50,7 @@ static char ieee802154_netif_stack[ETHERNET_STACKSIZE];
 static char netifs_stack[DEFAULT_DEVS_NUMOF][THREAD_STACKSIZE_DEFAULT];
 static bool init_called = false;
 
-static inline void _test_init(gnrc_netif_t *netif);
+static inline int _test_init(gnrc_netif_t *netif);
 static inline int _mock_netif_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static inline gnrc_pktsnip_t *_mock_netif_recv(gnrc_netif_t * netif);
 static int _get_netdev_address(netdev_t *dev, void *value, size_t max_len);
@@ -101,11 +101,15 @@ static void _set_up(void)
     while (msg_try_receive(&msg) > 0) {}
 }
 
-static inline void _test_init(gnrc_netif_t *netif)
+static inline int _test_init(gnrc_netif_t *netif)
 {
     (void)netif;
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+    if (res < 0) {
+        return res;
+    }
     init_called = true;
+    return 0;
 }
 
 static void test_creation(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the strict dependency between `gnrc_netif` and `netdev`.
This allows the usage of non-netdev link layers/devices for GNRC without adding dummy netdev handlers (e.g https://github.com/RIOT-OS/RIOT/blob/master/pkg/nimble/netif/nimble_netif.c#L278).


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
This should be carefully tested. All `gnrc_netif` implementation (eth, esp, nimble, lorawan, etc) should still work. Maybe running the Release Tests could be a good idea.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on https://github.com/RIOT-OS/RIOT/pull/13608
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
