### PR TITLE
sock_async: add optional callback argument

### DIFF
--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -183,7 +183,7 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
 #ifdef SOCK_HAS_ASYNC
 void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb, void *arg)
 {
-    (void)arg;
+    sock->base.async_cb_arg = arg;
     sock->base.async_cb.ip = cb;
 }
 

--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -181,8 +181,9 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
 }
 
 #ifdef SOCK_HAS_ASYNC
-void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb)
+void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb, void *arg)
 {
+    (void)arg;
     sock->base.async_cb.ip = cb;
 }
 

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -312,7 +312,7 @@ static void _netconn_cb(struct netconn *conn, enum netconn_evt evt,
                 break;
         }
         if (flags && sock->async_cb.gen) {
-            sock->async_cb.gen(sock, flags);
+            sock->async_cb.gen(sock, flags, NULL);
         }
     }
 #else

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -312,7 +312,7 @@ static void _netconn_cb(struct netconn *conn, enum netconn_evt evt,
                 break;
         }
         if (flags && sock->async_cb.gen) {
-            sock->async_cb.gen(sock, flags, NULL);
+            sock->async_cb.gen(sock, flags, sock->async_cb_arg);
         }
     }
 #else

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -380,13 +380,16 @@ ssize_t sock_tcp_write(sock_tcp_t *sock, const void *data, size_t len)
 }
 
 #ifdef SOCK_HAS_ASYNC
-void sock_tcp_set_cb(sock_tcp_t *sock, sock_tcp_cb_t cb)
+void sock_tcp_set_cb(sock_tcp_t *sock, sock_tcp_cb_t cb, void *arg)
 {
+    (void)arg;
     sock->base.async_cb.tcp = cb;
 }
 
-void sock_tcp_queue_set_cb(sock_tcp_queue_t *queue, sock_tcp_queue_cb_t cb)
+void sock_tcp_queue_set_cb(sock_tcp_queue_t *queue, sock_tcp_queue_cb_t cb,
+                           void *arg)
 {
+    (void)arg;
     queue->base.async_cb.tcp_queue = cb;
 }
 

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -382,14 +382,14 @@ ssize_t sock_tcp_write(sock_tcp_t *sock, const void *data, size_t len)
 #ifdef SOCK_HAS_ASYNC
 void sock_tcp_set_cb(sock_tcp_t *sock, sock_tcp_cb_t cb, void *arg)
 {
-    (void)arg;
+    sock->base.async_cb_arg = arg;
     sock->base.async_cb.tcp = cb;
 }
 
 void sock_tcp_queue_set_cb(sock_tcp_queue_t *queue, sock_tcp_queue_cb_t cb,
                            void *arg)
 {
-    (void)arg;
+    queue->base.async_cb_arg = arg;
     queue->base.async_cb.tcp_queue = cb;
 }
 

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -138,7 +138,7 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
 #ifdef SOCK_HAS_ASYNC
 void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *arg)
 {
-    (void)arg;
+    sock->base.async_cb_arg = arg;
     sock->base.async_cb.udp = cb;
 }
 

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -136,8 +136,9 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
 }
 
 #ifdef SOCK_HAS_ASYNC
-void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb)
+void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *arg)
 {
+    (void)arg;
     sock->base.async_cb.udp = cb;
 }
 

--- a/pkg/lwip/include/sock_types.h
+++ b/pkg/lwip/include/sock_types.h
@@ -40,7 +40,8 @@ typedef struct lwip_sock_base lwip_sock_base_t;
  * @internal
  */
 typedef void (*lwip_sock_cb_t)(lwip_sock_base_t *sock,
-                               sock_async_flags_t flags);
+                               sock_async_flags_t flags,
+                               void *arg);
 #endif  /* SOCK_HAS_ASYNC */
 
 /**

--- a/pkg/lwip/include/sock_types.h
+++ b/pkg/lwip/include/sock_types.h
@@ -75,6 +75,7 @@ struct lwip_sock_base {
         sock_udp_cb_t udp;          /**< UDP version */
 #endif
     } async_cb;
+    void *async_cb_arg;             /**< asynchronous callback argument */
 #ifdef SOCK_HAS_ASYNC_CTX
     sock_async_ctx_t async_ctx;     /**< asynchronous event context */
 #endif  /* SOCK_HAS_ASYNC_CTX */

--- a/sys/include/net/sock/async.h
+++ b/sys/include/net/sock/async.h
@@ -42,10 +42,11 @@ extern "C" {
  *
  * @note    Only available with @ref SOCK_HAS_ASYNC defined.
  *
- * @param[in] sock  A DTLS sock object.
- * @param[in] cb    An event callback. May be NULL to unset event callback.
+ * @param[in] sock      A DTLS sock object.
+ * @param[in] cb        An event callback. May be NULL to unset event callback.
+ * @param[in] cb_arg    Argument to provide to @p cb. May be NULL.
  */
-void sock_dtls_set_cb(sock_dtls_t *sock, sock_dtls_cb_t cb);
+void sock_dtls_set_cb(sock_dtls_t *sock, sock_dtls_cb_t cb, void *cb_arg);
 #endif  /* defined(MODULE_SOCK_DTLS) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_IP) || defined(DOXYGEN)
@@ -61,8 +62,9 @@ void sock_dtls_set_cb(sock_dtls_t *sock, sock_dtls_cb_t cb);
  *
  * @param[in] sock  A raw IPv4/IPv6 sock object.
  * @param[in] cb    An event callback. May be NULL to unset event callback.
+ * @param[in] cb_arg    Argument to provide to @p cb. May be NULL.
  */
-void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb);
+void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb, void *cb_arg);
 #endif  /* defined(MODULE_SOCK_IP) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_TCP) || defined(DOXYGEN)
@@ -76,10 +78,11 @@ void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb);
  *
  * @note    Only available with @ref SOCK_HAS_ASYNC defined.
  *
- * @param[in] sock  A TCP sock object.
- * @param[in] cb    An event callback. May be NULL to unset event callback.
+ * @param[in] sock      A TCP sock object.
+ * @param[in] cb        An event callback. May be NULL to unset event callback.
+ * @param[in] cb_arg    Argument to provide to @p cb. May be NULL.
  */
-void sock_tcp_set_cb(sock_tcp_t *sock, sock_tcp_cb_t cb);
+void sock_tcp_set_cb(sock_tcp_t *sock, sock_tcp_cb_t cb, void *cb_arg);
 
 /**
  * @brief   Sets event callback for @ref sock_tcp_queue_t
@@ -91,10 +94,12 @@ void sock_tcp_set_cb(sock_tcp_t *sock, sock_tcp_cb_t cb);
  *
  * @note    Only available with @ref SOCK_HAS_ASYNC defined.
  *
- * @param[in] queue A TCP listening queue.
- * @param[in] cb    An event callback. May be NULL to unset event callback.
+ * @param[in] queue     A TCP listening queue.
+ * @param[in] cb        An event callback. May be NULL to unset event callback.
+ * @param[in] cb_arg    Argument to provide to @p cb. May be NULL.
  */
-void sock_tcp_queue_set_cb(sock_tcp_queue_t *queue, sock_tcp_queue_cb_t cb);
+void sock_tcp_queue_set_cb(sock_tcp_queue_t *queue, sock_tcp_queue_cb_t cb,
+                           void *cb_arg);
 #endif  /* defined(MODULE_SOCK_TCP) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_UDP) || defined(DOXYGEN)
@@ -108,10 +113,11 @@ void sock_tcp_queue_set_cb(sock_tcp_queue_t *queue, sock_tcp_queue_cb_t cb);
  *
  * @note    Only available with @ref SOCK_HAS_ASYNC defined.
  *
- * @param[in] sock  A UDP sock object.
- * @param[in] cb    An event callback. May be NULL to unset event callback.
+ * @param[in] sock      A UDP sock object.
+ * @param[in] cb        An event callback. May be NULL to unset event callback.
+ * @param[in] cb_arg    Argument to provide to @p cb
  */
-void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb);
+void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *cb_arg);
 #endif  /* defined(MODULE_SOCK_UDP) || defined(DOXYGEN) */
 
 #if defined(SOCK_HAS_ASYNC_CTX) || defined(DOXYGEN)

--- a/sys/include/net/sock/async/event.h
+++ b/sys/include/net/sock/async/event.h
@@ -66,7 +66,7 @@
  *     }
  *
  *     event_queue_init(&queue);
- *     sock_udp_event_init(&sock, &queue, handler);
+ *     sock_udp_event_init(&sock, &queue, handler, NULL);
  *     event_loop(&queue);
  *     return 0;
  * }
@@ -146,7 +146,7 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
  *     event_queue_init(&queue);
- *     sock_udp_event_init(&sock, &queue, handler);
+ *     sock_udp_event_init(&sock, &queue, handler, NULL);
  *     event_loop(&queue);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
@@ -181,15 +181,16 @@ extern "C" {
  * @brief   Makes a DTLS sock able to handle asynchronous events using
  *          @ref sys_event.
  *
- * @param[in] sock      A DTLS sock object.
- * @param[in] ev_queue  The queue the events on @p sock will be added to.
- * @param[in] handler   The event handler function to call on an event on
- *                      @p sock.
+ * @param[in] sock          A DTLS sock object.
+ * @param[in] ev_queue      The queue the events on @p sock will be added to.
+ * @param[in] handler       The event handler function to call on an event on
+ *                          @p sock.
+ * @param[in] handler_arg   Argument to provided to @p handler.
  *
  * @note    Only available with module `sock_dtls`.
  */
 void sock_dtls_event_init(sock_dtls_t *sock, event_queue_t *ev_queue,
-                          sock_dtls_cb_t handler);
+                          sock_dtls_cb_t handler, void *handler_arg);
 #endif  /* defined(MODULE_SOCK_DTLS) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_IP) || defined(DOXYGEN)
@@ -197,15 +198,16 @@ void sock_dtls_event_init(sock_dtls_t *sock, event_queue_t *ev_queue,
  * @brief   Makes a raw IPv4/IPv6 sock able to handle asynchronous events using
  *          @ref sys_event.
  *
- * @param[in] sock      A raw IPv4/IPv6 sock object.
- * @param[in] ev_queue  The queue the events on @p sock will be added to.
- * @param[in] handler   The event handler function to call on an event on
- *                      @p sock.
+ * @param[in] sock          A raw IPv4/IPv6 sock object.
+ * @param[in] ev_queue      The queue the events on @p sock will be added to.
+ * @param[in] handler       The event handler function to call on an event on
+ *                          @p sock.
+ * @param[in] handler_arg   Argument to provided to @p handler.
  *
  * @note    Only available with module `sock_ip`.
  */
 void sock_ip_event_init(sock_ip_t *sock, event_queue_t *ev_queue,
-                        sock_ip_cb_t handler);
+                        sock_ip_cb_t handler, void *handler_arg);
 #endif  /* defined(MODULE_SOCK_IP) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_TCP) || defined(DOXYGEN)
@@ -213,29 +215,31 @@ void sock_ip_event_init(sock_ip_t *sock, event_queue_t *ev_queue,
  * @brief   Makes a TCP sock able to handle asynchronous events using
  *          @ref sys_event.
  *
- * @param[in] sock      A TCP sock object.
- * @param[in] ev_queue  The queue the events on @p sock will be added to.
- * @param[in] handler   The event handler function to call on an event on
- *                      @p sock.
+ * @param[in] sock          A TCP sock object.
+ * @param[in] ev_queue      The queue the events on @p sock will be added to.
+ * @param[in] handler       The event handler function to call on an event on
+ *                          @p sock.
+ * @param[in] handler_arg   Argument to provided to @p handler.
  *
  * @note    Only available with module `sock_tcp`.
  */
 void sock_tcp_event_init(sock_tcp_t *sock, event_queue_t *ev_queue,
-                         sock_tcp_cb_t handler);
+                         sock_tcp_cb_t handler, void *handler_arg);
 
 /**
  * @brief   Makes a TCP listening queue able to handle asynchronous events using
  *          @ref sys_event.
  *
- * @param[in] queue     A TCP listening queue.
- * @param[in] ev_queue  The queue the events on @p sock will be added to.
- * @param[in] handler   The event handler function to call on an event on
- *                      @p sock.
+ * @param[in] queue         A TCP listening queue.
+ * @param[in] ev_queue      The queue the events on @p sock will be added to.
+ * @param[in] handler       The event handler function to call on an event on
+ *                          @p sock.
+ * @param[in] handler_arg   Argument to provided to @p handler.
  *
  * @note    Only available with module `sock_tcp`.
  */
 void sock_tcp_queue_event_init(sock_tcp_queue_t *queue, event_queue_t *ev_queue,
-                               sock_tcp_queue_cb_t handler);
+                               sock_tcp_queue_cb_t handler, void *handler_arg);
 #endif  /* defined(MODULE_SOCK_TCP) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_UDP) || defined(DOXYGEN)
@@ -243,15 +247,16 @@ void sock_tcp_queue_event_init(sock_tcp_queue_t *queue, event_queue_t *ev_queue,
  * @brief   Makes a UDP sock able to handle asynchronous events using
  *          @ref sys_event.
  *
- * @param[in] sock      A UDP sock object.
- * @param[in] ev_queue  The queue the events on @p sock will be added to.
- * @param[in] handler   The event handler function to call on an event on
- *                      @p sock.
+ * @param[in] sock          A UDP sock object.
+ * @param[in] ev_queue      The queue the events on @p sock will be added to.
+ * @param[in] handler       The event handler function to call on an event on
+ *                          @p sock.
+ * @param[in] handler_arg   Argument to provided to @p handler.
  *
  * @note    Only available with module `sock_udp`.
  */
 void sock_udp_event_init(sock_udp_t *sock, event_queue_t *ev_queue,
-                         sock_udp_cb_t handler);
+                         sock_udp_cb_t handler, void *handler_arg);
 #endif  /* defined(MODULE_SOCK_UDP) || defined(DOXYGEN) */
 
 #ifdef __cplusplus

--- a/sys/include/net/sock/async/event.h
+++ b/sys/include/net/sock/async/event.h
@@ -36,8 +36,9 @@
  * event_queue_t queue;
  * uint8_t buf[128];
  *
- * void handler(sock_udp_t *sock, sock_async_flags_t type)
+ * void handler(sock_udp_t *sock, sock_async_flags_t type, void *arg)
  * {
+ *     (void)arg;
  *     if (type & SOCK_ASYNC_MSG_RECV) {
  *         sock_udp_ep_t remote;
  *         ssize_t res;
@@ -101,8 +102,9 @@
  * send, we print an according message:
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
- * void handler(sock_udp_t *sock, sock_async_flags_t type)
+ * void handler(sock_udp_t *sock, sock_async_flags_t type, void *arg)
  * {
+ *     (void)arg;
  *     if (type & SOCK_ASYNC_MSG_RECV) {
  *         sock_udp_ep_t remote;
  *         ssize_t res;

--- a/sys/include/net/sock/async/types.h
+++ b/sys/include/net/sock/async/types.h
@@ -54,8 +54,11 @@ typedef struct sock_dtls sock_dtls_t;       /**< forward declare for async */
  *                  - @ref SOCK_ASYNC_MSG_SENT,
  *                  - @ref SOCK_ASYNC_PATH_PROP, or
  *                  - a combination of them.
+ * @param[in] arg   Argument provided when setting the callback using
+ *                  @ref sock_dtls_set_cb(). May be NULL.
  */
-typedef void (*sock_dtls_cb_t)(sock_dtls_t *sock, sock_async_flags_t flags);
+typedef void (*sock_dtls_cb_t)(sock_dtls_t *sock, sock_async_flags_t flags,
+                               void *arg);
 #endif  /* defined(MODULE_SOCK_DTLS) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_IP) || defined(DOXYGEN)
@@ -74,8 +77,11 @@ typedef struct sock_ip sock_ip_t;       /**< forward declare for async */
  *                  - @ref SOCK_ASYNC_MSG_SENT,
  *                  - @ref SOCK_ASYNC_PATH_PROP, or
  *                  - a combination of them.
+ * @param[in] arg   Argument provided when setting the callback using
+ *                  @ref sock_ip_set_cb(). May be NULL.
  */
-typedef void (*sock_ip_cb_t)(sock_ip_t *sock, sock_async_flags_t flags);
+typedef void (*sock_ip_cb_t)(sock_ip_t *sock, sock_async_flags_t flags,
+                             void *arg);
 #endif  /* defined(MODULE_SOCK_IP) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_TCP) || defined(DOXYGEN)
@@ -97,8 +103,11 @@ typedef struct sock_tcp_queue sock_tcp_queue_t;/**< forward declare for async */
  *                  - @ref SOCK_ASYNC_MSG_SENT,
  *                  - @ref SOCK_ASYNC_PATH_PROP, or
  *                  - a combination of them.
+ * @param[in] arg   Argument provided when setting the callback using
+ *                  @ref sock_tcp_set_cb(). May be NULL.
  */
-typedef void (*sock_tcp_cb_t)(sock_tcp_t *sock, sock_async_flags_t flags);
+typedef void (*sock_tcp_cb_t)(sock_tcp_t *sock, sock_async_flags_t flags,
+                              void *arg);
 
 /**
  * @brief   Event callback for @ref sock_tcp_queue_t
@@ -110,9 +119,12 @@ typedef void (*sock_tcp_cb_t)(sock_tcp_t *sock, sock_async_flags_t flags);
  * @param[in] queue The TCP listening queue the event happened on
  * @param[in] flags The event flags. The only expected value is @ref
  *                  SOCK_ASYNC_CONN_RECV.
+ * @param[in] arg   Argument provided when setting the callback using
+ *                  @ref sock_tcp_queue_set_cb(). May be NULL.
  */
 typedef void (*sock_tcp_queue_cb_t)(sock_tcp_queue_t *queue,
-                                    sock_async_flags_t flags);
+                                    sock_async_flags_t flags,
+                                    void *arg);
 #endif  /* defined(MODULE_SOCK_TCP) || defined(DOXYGEN) */
 
 #if defined(MODULE_SOCK_UDP) || defined(DOXYGEN)
@@ -131,8 +143,11 @@ typedef struct sock_udp sock_udp_t;     /**< forward declare for async */
  *                  - @ref SOCK_ASYNC_MSG_SENT,
  *                  - @ref SOCK_ASYNC_PATH_PROP, or
  *                  - a combination of them.
+ * @param[in] arg   Argument provided when setting the callback using
+ *                  @ref sock_udp_set_cb(). May be NULL.
  */
-typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t type);
+typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t type,
+                              void *arg);
 #endif  /* defined(MODULE_SOCK_UDP) || defined(DOXYGEN) */
 
 #ifdef SOCK_HAS_ASYNC_CTX

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -121,7 +121,7 @@ static void *_event_loop(void *arg)
     }
 
     event_queue_init(&_queue);
-    sock_udp_event_init(&_sock, &_queue, _on_sock_evt);
+    sock_udp_event_init(&_sock, &_queue, _on_sock_evt, NULL);
     event_loop(&_queue);
 
     return 0;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -46,7 +46,7 @@
 
 /* Internal functions */
 static void *_event_loop(void *arg);
-static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type);
+static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type, void *arg);
 static ssize_t _well_known_core_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                                          sock_udp_ep_t *remote);
@@ -128,12 +128,13 @@ static void *_event_loop(void *arg)
 }
 
 /* Handles sock events from the event queue. */
-static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type)
+static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type, void *arg)
 {
     coap_pkt_t pdu;
     sock_udp_ep_t remote;
     gcoap_request_memo_t *memo = NULL;
 
+    (void)arg;
     if (type & SOCK_ASYNC_MSG_RECV) {
         ssize_t res = sock_udp_recv(sock, _listen_buf, sizeof(_listen_buf),
                                     0, &remote);

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -58,7 +58,7 @@ static void _netapi_cb(uint16_t cmd, gnrc_pktsnip_t *pkt, void *ctx)
                         (void *)&reg->mbox);
         }
         if (reg->async_cb.generic) {
-            reg->async_cb.generic(reg, SOCK_ASYNC_MSG_RECV);
+            reg->async_cb.generic(reg, SOCK_ASYNC_MSG_RECV, NULL);
         }
     }
 }

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -58,7 +58,7 @@ static void _netapi_cb(uint16_t cmd, gnrc_pktsnip_t *pkt, void *ctx)
                         (void *)&reg->mbox);
         }
         if (reg->async_cb.generic) {
-            reg->async_cb.generic(reg, SOCK_ASYNC_MSG_RECV, NULL);
+            reg->async_cb.generic(reg, SOCK_ASYNC_MSG_RECV, reg->async_cb_arg);
         }
     }
 }

--- a/sys/net/gnrc/sock/include/sock_types.h
+++ b/sys/net/gnrc/sock/include/sock_types.h
@@ -87,6 +87,7 @@ struct gnrc_sock_reg {
         sock_udp_cb_t udp;              /**< UDP version */
 #endif
     } async_cb;
+    void *async_cb_arg;                 /**< asynchronous callback argument */
 #ifdef SOCK_HAS_ASYNC_CTX
     sock_async_ctx_t async_ctx;         /**< asynchronous event context */
 #endif

--- a/sys/net/gnrc/sock/include/sock_types.h
+++ b/sys/net/gnrc/sock/include/sock_types.h
@@ -55,7 +55,8 @@ typedef struct gnrc_sock_reg gnrc_sock_reg_t;
  * @internal
  */
 typedef void (*gnrc_sock_reg_cb_t)(gnrc_sock_reg_t *sock,
-                                   sock_async_flags_t flags);
+                                   sock_async_flags_t flags,
+                                   void *arg);
 #endif  /* SOCK_HAS_ASYNC */
 
 /**

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -198,7 +198,7 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
 #ifdef SOCK_HAS_ASYNC
     if ((sock != NULL) && (sock->reg.async_cb.ip)) {
         sock->reg.async_cb.ip(sock, SOCK_ASYNC_MSG_SENT,
-                              NULL);
+                              sock->reg.async_cb_arg);
     }
 #endif  /* SOCK_HAS_ASYNC */
     return res;
@@ -207,7 +207,7 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
 #ifdef SOCK_HAS_ASYNC
 void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb, void *arg)
 {
-    (void)arg;
+    sock->reg.async_cb_arg = arg;
     sock->reg.async_cb.ip = cb;
 }
 

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -205,8 +205,9 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
 }
 
 #ifdef SOCK_HAS_ASYNC
-void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb)
+void sock_ip_set_cb(sock_ip_t *sock, sock_ip_cb_t cb, void *arg)
 {
+    (void)arg;
     sock->reg.async_cb.ip = cb;
 }
 

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -197,7 +197,8 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
     }
 #ifdef SOCK_HAS_ASYNC
     if ((sock != NULL) && (sock->reg.async_cb.ip)) {
-        sock->reg.async_cb.ip(sock, SOCK_ASYNC_MSG_SENT);
+        sock->reg.async_cb.ip(sock, SOCK_ASYNC_MSG_SENT,
+                              NULL);
     }
 #endif  /* SOCK_HAS_ASYNC */
     return res;

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -319,7 +319,8 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
     }
 #ifdef SOCK_HAS_ASYNC
     if ((sock != NULL) && (sock->reg.async_cb.udp)) {
-        sock->reg.async_cb.udp(sock, SOCK_ASYNC_MSG_SENT);
+        sock->reg.async_cb.udp(sock, SOCK_ASYNC_MSG_SENT,
+                               NULL);
     }
 #endif  /* SOCK_HAS_ASYNC */
     return res;

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -327,8 +327,9 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
 }
 
 #ifdef SOCK_HAS_ASYNC
-void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb)
+void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *arg)
 {
+    (void)arg;
     sock->reg.async_cb.udp = cb;
 }
 

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -320,7 +320,7 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
 #ifdef SOCK_HAS_ASYNC
     if ((sock != NULL) && (sock->reg.async_cb.udp)) {
         sock->reg.async_cb.udp(sock, SOCK_ASYNC_MSG_SENT,
-                               NULL);
+                               sock->reg.async_cb_arg);
     }
 #endif  /* SOCK_HAS_ASYNC */
     return res;
@@ -329,7 +329,7 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
 #ifdef SOCK_HAS_ASYNC
 void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *arg)
 {
-    (void)arg;
+    sock->reg.async_cb_arg = arg;
     sock->reg.async_cb.udp = cb;
 }
 

--- a/sys/net/sock/async/event/sock_async_ctx.h
+++ b/sys/net/sock/async/event/sock_async_ctx.h
@@ -54,6 +54,7 @@ typedef struct {
     event_t super;              /**< event structure that gets extended */
     sock_event_cb_t cb;         /**< callback */
     void *sock;                 /**< generic pointer to a @ref net_sock object */
+    void *cb_arg;               /**< callback argument */
     sock_async_flags_t type;    /**< types of the event */
 } sock_event_t;
 

--- a/sys/net/sock/async/event/sock_async_ctx.h
+++ b/sys/net/sock/async/event/sock_async_ctx.h
@@ -28,7 +28,10 @@ extern "C" {
  * @brief   Generalized callback type
  */
 typedef union {
-    void (*generic)(void *, sock_async_flags_t);    /**< anything goes */
+    /**
+     * @brief   anything goes
+     */
+    void (*generic)(void *, sock_async_flags_t, void *);
 #ifdef MODULE_SOCK_DTLS
     sock_dtls_cb_t dtls;                            /**< DTLS callback */
 #endif

--- a/sys/net/sock/async/event/sock_async_event.c
+++ b/sys/net/sock/async/event/sock_async_event.c
@@ -59,7 +59,7 @@ void sock_dtls_event_init(sock_dtls_t *sock, event_queue_t *ev_queue,
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.dtls = handler;
-    sock_dtls_set_cb(sock, _dtls_cb);
+    sock_dtls_set_cb(sock, _dtls_cb, NULL);
 }
 #endif /* MODULE_SOCK_DTLS */
 
@@ -77,7 +77,7 @@ void sock_ip_event_init(sock_ip_t *sock, event_queue_t *ev_queue,
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.ip = handler;
-    sock_ip_set_cb(sock, _ip_cb);
+    sock_ip_set_cb(sock, _ip_cb, NULL);
 }
 #endif  /* MODULE_SOCK_IP */
 
@@ -95,7 +95,7 @@ void sock_tcp_event_init(sock_tcp_t *sock, event_queue_t *ev_queue,
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.tcp = handler;
-    sock_tcp_set_cb(sock, _tcp_cb);
+    sock_tcp_set_cb(sock, _tcp_cb, NULL);
 }
 
 static void _tcp_queue_cb(sock_tcp_queue_t *queue, sock_async_flags_t type,
@@ -113,7 +113,7 @@ void sock_tcp_queue_event_init(sock_tcp_queue_t *queue,
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.tcp_queue = handler;
-    sock_tcp_queue_set_cb(queue, _tcp_queue_cb);
+    sock_tcp_queue_set_cb(queue, _tcp_queue_cb, NULL);
 }
 #endif /* MODULE_SOCK_TCP */
 
@@ -131,7 +131,7 @@ void sock_udp_event_init(sock_udp_t *sock, event_queue_t *ev_queue,
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.udp = handler;
-    sock_udp_set_cb(sock, _udp_cb);
+    sock_udp_set_cb(sock, _udp_cb, NULL);
 }
 #endif /* MODULE_SOCK_UDP */
 

--- a/sys/net/sock/async/event/sock_async_event.c
+++ b/sys/net/sock/async/event/sock_async_event.c
@@ -25,14 +25,15 @@ static void _event_handler(event_t *ev)
     event->type = 0;
     irq_restore(state);
     if (_type) {
-        event->cb.generic(event->sock, _type, NULL);
+        event->cb.generic(event->sock, _type, event->cb_arg);
     }
 }
 
-static inline void _cb(void *sock, sock_async_flags_t type,
+static inline void _cb(void *sock, sock_async_flags_t type, void *arg,
                        sock_async_ctx_t *ctx)
 {
     ctx->event.sock = sock;
+    ctx->event.cb_arg = arg;
     ctx->event.type |= type;
     event_post(ctx->queue, &ctx->event.super);
 }
@@ -48,90 +49,84 @@ static void _set_ctx(sock_async_ctx_t *ctx, event_queue_t *ev_queue)
 #ifdef MODULE_SOCK_DTLS
 static void _dtls_cb(sock_dtls_t *sock, sock_async_flags_t type, void *arg)
 {
-    (void)arg;
-    _cb(sock, type, sock_dtls_get_async_ctx(sock));
+    _cb(sock, type, arg, sock_dtls_get_async_ctx(sock));
 }
 
 void sock_dtls_event_init(sock_dtls_t *sock, event_queue_t *ev_queue,
-                         sock_dtls_cb_t handler)
+                         sock_dtls_cb_t handler, void *handler_arg)
 {
     sock_async_ctx_t *ctx = sock_dtls_get_async_ctx(sock);
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.dtls = handler;
-    sock_dtls_set_cb(sock, _dtls_cb, NULL);
+    sock_dtls_set_cb(sock, _dtls_cb, handler_arg);
 }
 #endif /* MODULE_SOCK_DTLS */
 
 #ifdef MODULE_SOCK_IP
 static void _ip_cb(sock_ip_t *sock, sock_async_flags_t type, void *arg)
 {
-    (void)arg;
-    _cb(sock, type, sock_ip_get_async_ctx(sock));
+    _cb(sock, type, arg, sock_ip_get_async_ctx(sock));
 }
 
 void sock_ip_event_init(sock_ip_t *sock, event_queue_t *ev_queue,
-                        sock_ip_cb_t handler)
+                        sock_ip_cb_t handler, void *handler_arg)
 {
     sock_async_ctx_t *ctx = sock_ip_get_async_ctx(sock);
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.ip = handler;
-    sock_ip_set_cb(sock, _ip_cb, NULL);
+    sock_ip_set_cb(sock, _ip_cb, handler_arg);
 }
 #endif  /* MODULE_SOCK_IP */
 
 #ifdef MODULE_SOCK_TCP
 static void _tcp_cb(sock_tcp_t *sock, sock_async_flags_t type, void *arg)
 {
-    (void)arg;
-    _cb(sock, type, sock_tcp_get_async_ctx(sock));
+    _cb(sock, type, arg, sock_tcp_get_async_ctx(sock));
 }
 
 void sock_tcp_event_init(sock_tcp_t *sock, event_queue_t *ev_queue,
-                         sock_tcp_cb_t handler)
+                         sock_tcp_cb_t handler, void *handler_arg)
 {
     sock_async_ctx_t *ctx = sock_tcp_get_async_ctx(sock);
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.tcp = handler;
-    sock_tcp_set_cb(sock, _tcp_cb, NULL);
+    sock_tcp_set_cb(sock, _tcp_cb, handler_arg);
 }
 
 static void _tcp_queue_cb(sock_tcp_queue_t *queue, sock_async_flags_t type,
                           void *arg)
 {
-    (void)arg;
-    _cb(queue, type, sock_tcp_queue_get_async_ctx(queue));
+    _cb(queue, type, arg, sock_tcp_queue_get_async_ctx(queue));
 }
 
-void sock_tcp_queue_event_init(sock_tcp_queue_t *queue,
-                               event_queue_t *ev_queue,
-                               sock_tcp_queue_cb_t handler)
+void sock_tcp_queue_event_init(sock_tcp_queue_t *queue, event_queue_t *ev_queue,
+                               sock_tcp_queue_cb_t handler, void *handler_arg)
 {
     sock_async_ctx_t *ctx = sock_tcp_queue_get_async_ctx(queue);
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.tcp_queue = handler;
-    sock_tcp_queue_set_cb(queue, _tcp_queue_cb, NULL);
+    sock_tcp_queue_set_cb(queue, _tcp_queue_cb, handler_arg);
 }
 #endif /* MODULE_SOCK_TCP */
 
 #ifdef MODULE_SOCK_UDP
 static void _udp_cb(sock_udp_t *sock, sock_async_flags_t type, void *arg)
 {
-    (void)arg;
-    _cb(sock, type, sock_udp_get_async_ctx(sock));
+    _cb(sock, type, arg, sock_udp_get_async_ctx(sock));
 }
 
 void sock_udp_event_init(sock_udp_t *sock, event_queue_t *ev_queue,
-                         sock_udp_cb_t handler)
+                         sock_udp_cb_t handler, void *handler_arg)
 {
     sock_async_ctx_t *ctx = sock_udp_get_async_ctx(sock);
 
     _set_ctx(ctx, ev_queue);
     ctx->event.cb.udp = handler;
-    sock_udp_set_cb(sock, _udp_cb, NULL);
+    sock_udp_set_cb(sock, _udp_cb, handler_arg);
 }
 #endif /* MODULE_SOCK_UDP */
 

--- a/sys/net/sock/async/event/sock_async_event.c
+++ b/sys/net/sock/async/event/sock_async_event.c
@@ -25,7 +25,7 @@ static void _event_handler(event_t *ev)
     event->type = 0;
     irq_restore(state);
     if (_type) {
-        event->cb.generic(event->sock, _type);
+        event->cb.generic(event->sock, _type, NULL);
     }
 }
 
@@ -46,8 +46,9 @@ static void _set_ctx(sock_async_ctx_t *ctx, event_queue_t *ev_queue)
 }
 
 #ifdef MODULE_SOCK_DTLS
-static void _dtls_cb(sock_dtls_t *sock, sock_async_flags_t type)
+static void _dtls_cb(sock_dtls_t *sock, sock_async_flags_t type, void *arg)
 {
+    (void)arg;
     _cb(sock, type, sock_dtls_get_async_ctx(sock));
 }
 
@@ -63,8 +64,9 @@ void sock_dtls_event_init(sock_dtls_t *sock, event_queue_t *ev_queue,
 #endif /* MODULE_SOCK_DTLS */
 
 #ifdef MODULE_SOCK_IP
-static void _ip_cb(sock_ip_t *sock, sock_async_flags_t type)
+static void _ip_cb(sock_ip_t *sock, sock_async_flags_t type, void *arg)
 {
+    (void)arg;
     _cb(sock, type, sock_ip_get_async_ctx(sock));
 }
 
@@ -80,8 +82,9 @@ void sock_ip_event_init(sock_ip_t *sock, event_queue_t *ev_queue,
 #endif  /* MODULE_SOCK_IP */
 
 #ifdef MODULE_SOCK_TCP
-static void _tcp_cb(sock_tcp_t *sock, sock_async_flags_t type)
+static void _tcp_cb(sock_tcp_t *sock, sock_async_flags_t type, void *arg)
 {
+    (void)arg;
     _cb(sock, type, sock_tcp_get_async_ctx(sock));
 }
 
@@ -95,8 +98,10 @@ void sock_tcp_event_init(sock_tcp_t *sock, event_queue_t *ev_queue,
     sock_tcp_set_cb(sock, _tcp_cb);
 }
 
-static void _tcp_queue_cb(sock_tcp_queue_t *queue, sock_async_flags_t type)
+static void _tcp_queue_cb(sock_tcp_queue_t *queue, sock_async_flags_t type,
+                          void *arg)
 {
+    (void)arg;
     _cb(queue, type, sock_tcp_queue_get_async_ctx(queue));
 }
 
@@ -113,8 +118,9 @@ void sock_tcp_queue_event_init(sock_tcp_queue_t *queue,
 #endif /* MODULE_SOCK_TCP */
 
 #ifdef MODULE_SOCK_UDP
-static void _udp_cb(sock_udp_t *sock, sock_async_flags_t type)
+static void _udp_cb(sock_udp_t *sock, sock_async_flags_t type, void *arg)
 {
+    (void)arg;
     _cb(sock, type, sock_udp_get_async_ctx(sock));
 }
 

--- a/tests/gnrc_sock_async_event/main.c
+++ b/tests/gnrc_sock_async_event/main.c
@@ -69,8 +69,9 @@ ipv6_hdr_t *gnrc_ipv6_get_header(gnrc_pktsnip_t *pkt)
     return ((ipv6_hdr_t*) tmp->data);
 }
 
-static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags)
+static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 {
+    (void)arg;
     printf("UDP event triggered: %04X\n", flags);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_udp_ep_t remote;
@@ -90,8 +91,9 @@ static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags)
     }
 }
 
-static void _recv_ip(sock_ip_t *sock, sock_async_flags_t flags)
+static void _recv_ip(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 {
+    (void)arg;
     printf("IP event triggered: %04X\n", flags);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_ip_ep_t remote;

--- a/tests/gnrc_sock_async_event/main.c
+++ b/tests/gnrc_sock_async_event/main.c
@@ -71,7 +71,7 @@ ipv6_hdr_t *gnrc_ipv6_get_header(gnrc_pktsnip_t *pkt)
 
 static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 {
-    (void)arg;
+    assert(strcmp(arg, "test") == 0);
     printf("UDP event triggered: %04X\n", flags);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_udp_ep_t remote;
@@ -93,7 +93,7 @@ static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 
 static void _recv_ip(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 {
-    (void)arg;
+    assert(strcmp(arg, "test") == 0);
     printf("IP event triggered: %04X\n", flags);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_ip_ep_t remote;
@@ -128,8 +128,8 @@ int main(void)
     sock_udp_create(&_udp_sock, &local, NULL, 0);
     sock_ip_create(&_ip_sock, (sock_ip_ep_t *)&local, NULL, PROTNUM_UDP, 0);
 
-    sock_udp_event_init(&_udp_sock, &_ev_queue, _recv_udp, NULL);
-    sock_ip_event_init(&_ip_sock, &_ev_queue, _recv_ip, NULL);
+    sock_udp_event_init(&_udp_sock, &_ev_queue, _recv_udp, "test");
+    sock_ip_event_init(&_ip_sock, &_ev_queue, _recv_ip, "test");
     memcpy(remote.addr.ipv6, _test_remote, sizeof(_test_remote));
     remote.port = TEST_PORT - 1;
 

--- a/tests/gnrc_sock_async_event/main.c
+++ b/tests/gnrc_sock_async_event/main.c
@@ -128,8 +128,8 @@ int main(void)
     sock_udp_create(&_udp_sock, &local, NULL, 0);
     sock_ip_create(&_ip_sock, (sock_ip_ep_t *)&local, NULL, PROTNUM_UDP, 0);
 
-    sock_udp_event_init(&_udp_sock, &_ev_queue, _recv_udp);
-    sock_ip_event_init(&_ip_sock, &_ev_queue, _recv_ip);
+    sock_udp_event_init(&_udp_sock, &_ev_queue, _recv_udp, NULL);
+    sock_ip_event_init(&_ip_sock, &_ev_queue, _recv_ip, NULL);
     memcpy(remote.addr.ipv6, _test_remote, sizeof(_test_remote));
     remote.port = TEST_PORT - 1;
 

--- a/tests/lwip/ip.c
+++ b/tests/lwip/ip.c
@@ -44,8 +44,9 @@ static sock_ip_t server_sock;
 static char server_stack[THREAD_STACKSIZE_DEFAULT];
 static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
-static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags)
+static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 {
+    (void)arg;
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_ip_ep_t src;
         int res;

--- a/tests/lwip/ip.c
+++ b/tests/lwip/ip.c
@@ -90,7 +90,7 @@ static void *_server_thread(void *args)
     server_running = true;
     printf("Success: started IP server on protocol %u\n", protocol);
     event_queue_init(&queue);
-    sock_ip_event_init(&server_sock, &queue, _ip_recv);
+    sock_ip_event_init(&server_sock, &queue, _ip_recv, NULL);
     event_loop(&queue);
     return NULL;
 }

--- a/tests/lwip/ip.c
+++ b/tests/lwip/ip.c
@@ -46,7 +46,7 @@ static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
 static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 {
-    (void)arg;
+    assert(strcmp(arg, "test") == 0);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_ip_ep_t src;
         int res;
@@ -90,7 +90,7 @@ static void *_server_thread(void *args)
     server_running = true;
     printf("Success: started IP server on protocol %u\n", protocol);
     event_queue_init(&queue);
-    sock_ip_event_init(&server_sock, &queue, _ip_recv, NULL);
+    sock_ip_event_init(&server_sock, &queue, _ip_recv, "test");
     event_loop(&queue);
     return NULL;
 }

--- a/tests/lwip/tcp.c
+++ b/tests/lwip/tcp.c
@@ -51,7 +51,7 @@ static void _tcp_recv(sock_tcp_t *sock, sock_async_flags_t flags, void *arg)
 {
     sock_tcp_ep_t client;
 
-    (void)arg;
+    assert(strcmp(arg, "test") == 0);
     if (sock_tcp_get_remote(sock, &client) < 0) {
         /* socket was disconnected between event firing and this handler */
         return;
@@ -89,7 +89,7 @@ static void _tcp_recv(sock_tcp_t *sock, sock_async_flags_t flags, void *arg)
 static void _tcp_accept(sock_tcp_queue_t *queue, sock_async_flags_t flags,
                         void *arg)
 {
-    (void)arg;
+    assert(strcmp(arg, "test") == 0);
     if (flags & SOCK_ASYNC_CONN_RECV) {
         sock_tcp_t *sock = NULL;
         int res;
@@ -100,7 +100,7 @@ static void _tcp_accept(sock_tcp_queue_t *queue, sock_async_flags_t flags,
         else {
             sock_tcp_ep_t client;
 
-            sock_tcp_event_init(sock, &_ev_queue, _tcp_recv, NULL);
+            sock_tcp_event_init(sock, &_ev_queue, _tcp_recv, "test");
             sock_tcp_get_remote(sock, &client);
 #ifdef MODULE_LWIP_IPV6
             ipv6_addr_to_str(_addr_str, (ipv6_addr_t *)&client.addr.ipv6,
@@ -132,7 +132,7 @@ static void *_server_thread(void *args)
     printf("Success: started TCP server on port %" PRIu16 "\n",
            server_addr.port);
     event_queue_init(&_ev_queue);
-    sock_tcp_queue_event_init(&server_queue, &_ev_queue, _tcp_accept, NULL);
+    sock_tcp_queue_event_init(&server_queue, &_ev_queue, _tcp_accept, "test");
     event_loop(&_ev_queue);
     return NULL;
 }

--- a/tests/lwip/tcp.c
+++ b/tests/lwip/tcp.c
@@ -47,10 +47,11 @@ static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 static char _addr_str[IPV6_ADDR_MAX_STR_LEN];
 static event_queue_t _ev_queue;
 
-static void _tcp_recv(sock_tcp_t *sock, sock_async_flags_t flags)
+static void _tcp_recv(sock_tcp_t *sock, sock_async_flags_t flags, void *arg)
 {
     sock_tcp_ep_t client;
 
+    (void)arg;
     if (sock_tcp_get_remote(sock, &client) < 0) {
         /* socket was disconnected between event firing and this handler */
         return;
@@ -85,8 +86,10 @@ static void _tcp_recv(sock_tcp_t *sock, sock_async_flags_t flags)
     }
 }
 
-static void _tcp_accept(sock_tcp_queue_t *queue, sock_async_flags_t flags)
+static void _tcp_accept(sock_tcp_queue_t *queue, sock_async_flags_t flags,
+                        void *arg)
 {
+    (void)arg;
     if (flags & SOCK_ASYNC_CONN_RECV) {
         sock_tcp_t *sock = NULL;
         int res;

--- a/tests/lwip/tcp.c
+++ b/tests/lwip/tcp.c
@@ -100,7 +100,7 @@ static void _tcp_accept(sock_tcp_queue_t *queue, sock_async_flags_t flags,
         else {
             sock_tcp_ep_t client;
 
-            sock_tcp_event_init(sock, &_ev_queue, _tcp_recv);
+            sock_tcp_event_init(sock, &_ev_queue, _tcp_recv, NULL);
             sock_tcp_get_remote(sock, &client);
 #ifdef MODULE_LWIP_IPV6
             ipv6_addr_to_str(_addr_str, (ipv6_addr_t *)&client.addr.ipv6,
@@ -132,7 +132,7 @@ static void *_server_thread(void *args)
     printf("Success: started TCP server on port %" PRIu16 "\n",
            server_addr.port);
     event_queue_init(&_ev_queue);
-    sock_tcp_queue_event_init(&server_queue, &_ev_queue, _tcp_accept);
+    sock_tcp_queue_event_init(&server_queue, &_ev_queue, _tcp_accept, NULL);
     event_loop(&_ev_queue);
     return NULL;
 }

--- a/tests/lwip/udp.c
+++ b/tests/lwip/udp.c
@@ -46,7 +46,7 @@ static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
 static void _udp_recv(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 {
-    (void)arg;
+    assert(strcmp(arg, "test") == 0);
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_udp_ep_t src;
         int res;
@@ -93,7 +93,7 @@ static void *_server_thread(void *args)
     printf("Success: started UDP server on port %" PRIu16 "\n",
            server_addr.port);
     event_queue_init(&queue);
-    sock_udp_event_init(&server_sock, &queue, _udp_recv, NULL);
+    sock_udp_event_init(&server_sock, &queue, _udp_recv, "test");
     event_loop(&queue);
     return NULL;
 }

--- a/tests/lwip/udp.c
+++ b/tests/lwip/udp.c
@@ -44,8 +44,9 @@ static sock_udp_t server_sock;
 static char server_stack[THREAD_STACKSIZE_DEFAULT];
 static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
-static void _udp_recv(sock_udp_t *sock, sock_async_flags_t flags)
+static void _udp_recv(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 {
+    (void)arg;
     if (flags & SOCK_ASYNC_MSG_RECV) {
         sock_udp_ep_t src;
         int res;

--- a/tests/lwip/udp.c
+++ b/tests/lwip/udp.c
@@ -93,7 +93,7 @@ static void *_server_thread(void *args)
     printf("Success: started UDP server on port %" PRIu16 "\n",
            server_addr.port);
     event_queue_init(&queue);
-    sock_udp_event_init(&server_sock, &queue, _udp_recv);
+    sock_udp_event_init(&server_sock, &queue, _udp_recv, NULL);
     event_loop(&queue);
     return NULL;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In https://github.com/RIOT-OS/RIOT/pull/12907/files#r390451905 I noticed that there is simply no way to get the surrounding DTLS sock from within the UDP sock's asynchronous callback. As such provides this change a way to provide context argument with the callback, similar as we already do it for `xtimer` or other asynchronous operations (and e.g. `lwip` does to for the asynchronous component of its `sock` equivalent `netconn`).

As `sock_async` is still experimental this API change should only require one ACK.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The following applications should still compile for all supported boards

- `examples/gcoap`
- `tests/gnrc_sock_async_event`
- `tests/lwip`

I amended the tests for GNRC's and lwIP's `sock_async` implementations if the callback argument supplied is correctly handed to the callback. As such the following tests should still pass

- `tests/gnrc_sock_async_event`
- `tests/lwip`

(`make -C tests/lwip tests` only succeeds on `native` and requires to have `dist/tools/tapsetup/tapsetup` run first)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Requirement for this PR came up in https://github.com/RIOT-OS/RIOT/pull/12907/files#r390451905. As such, #12907 depends on this PR.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
