### PR TITLE
sock: amend with zero-copy receive functions

### DIFF
--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -245,6 +245,19 @@ struct _sock_tl_ep {
     uint16_t port;          /**< transport layer port (in host byte order) */
 };
 
+/**
+ * @brief   Releases the stack-internal buffer space provided by the
+ *          `sock_*_recv_buf()` functions.
+ *
+ * @see
+ *  - @ref sock_dtls_recv_buf()
+ *  - @ref sock_ip_recv_buf()
+ *  - @ref sock_udp_recv_buf()
+ *
+ * @param[in] buf_ctx   Stack-internal buffer context to release.
+ */
+void sock_recv_buf_free(void *buf_ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -607,6 +607,37 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
                        void *data, size_t maxlen, uint32_t timeout);
 
 /**
+ * @brief Decrypts and provides stack-internal buffer space containing a
+ *        message from a remote peer.
+ *
+ * @param[in] sock      DTLS sock to use.
+ * @param[out] remote   Remote DTLS session of the received data.
+ *                      Cannot be NULL.
+ * @param[out] data     Pointer to a stack-internal buffer space containing the
+ *                      received data.
+ * @param[out] buf_ctx  Stack-internal buffer context. Must be used to release
+ *                      the buffer space using @ref sock_recv_buf_free() after
+ *                      the data in @p data was handled.
+ * @param[in] timeout   Receive timeout in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be SOCK_NO_TIMEOUT to wait until data
+ *                      is available.
+ *
+ * @note Function may block if data is not available and @p timeout != 0
+ *
+ * @return The number of bytes received on success
+ * @return  -EADDRNOTAVAIL, if the local endpoint of @p sock is not set.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_dtls_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+ssize_t sock_dtls_recv_buf(sock_dtls_t *sock, sock_dtls_session_t *remote,
+                           void **data, void **buf_ctx, uint32_t timeout);
+
+/**
  * @brief Encrypts and sends a message to a remote peer
  *
  * @param[in] sock      DTLS sock to use

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -427,6 +427,42 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
                      uint32_t timeout, sock_ip_ep_t *remote);
 
 /**
+ * @brief   Provides stack-internal buffer space containing an IPv4/IPv6
+ *          message from remote end point
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (buf_ctx != NULL)`
+ *
+ * @param[in] sock      A raw IPv4/IPv6 sock object.
+ * @param[out] data     Pointer to a stack-internal buffer space containing the
+ *                      received data.
+ * @param[out] buf_ctx  Stack-internal buffer context. Must be used to release
+ *                      the buffer space using @ref sock_recv_buf_free() after
+ *                      the data in @p data was handled.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be NULL, if it is not required by the application.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ *
+ * @return  The number of bytes received on success.
+ * @return  0, if no received data is available, but everything is in order.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_ip_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+ssize_t sock_ip_recv_buf(sock_ip_t *sock, void **data, void **buf_ctx,
+                         uint32_t timeout, sock_ip_ep_t *remote);
+
+/**
  * @brief   Sends a message over IPv4/IPv6 to remote end point
  *
  * @pre `((sock != NULL || remote != NULL)) && (if (len != 0): (data != NULL))`

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -384,7 +384,7 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  *
  * @pre `(sock != NULL) && (data != NULL) && (max_len > 0)`
  *
- * @param[in] sock      A raw IPv4/IPv6 sock object.
+ * @param[in] sock      A UDP sock object.
  * @param[out] data     Pointer where the received data should be stored.
  * @param[in] max_len   Maximum space available at @p data.
  * @param[in] timeout   Timeout for receive in microseconds.
@@ -454,7 +454,7 @@ ssize_t sock_udp_recv_buf(sock_udp_t *sock, void **data, void **buf_ctx,
  *
  * @pre `((sock != NULL || remote != NULL)) && (if (len != 0): (data != NULL))`
  *
- * @param[in] sock      A raw IPv4/IPv6 sock object. May be `NULL`.
+ * @param[in] sock      A UDP sock object. May be `NULL`.
  *                      A sensible local end point should be selected by the
  *                      implementation in that case.
  * @param[in] data      Pointer where the received data should be stored.

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -414,6 +414,42 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
                       uint32_t timeout, sock_udp_ep_t *remote);
 
 /**
+ * @brief   Provides stack-internal buffer space containing a UDP message from
+ *          a remote end point
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (buf_ctx != NULL)`
+ *
+ * @param[in] sock      A UDP sock object.
+ * @param[out] data     Pointer to a stack-internal buffer space containing the
+ *                      received data.
+ * @param[out] buf_ctx  Stack-internal buffer context. Must be used to release
+ *                      the buffer space using @ref sock_recv_buf_free() after
+ *                      the data in @p data was handled.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ *
+ * @return  The number of bytes received on success.
+ * @return  0, if no received data is available, but everything is in order.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_udp_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+ssize_t sock_udp_recv_buf(sock_udp_t *sock, void **data, void **buf_ctx,
+                          uint32_t timeout, sock_udp_ep_t *remote);
+
+/**
  * @brief   Sends a UDP message to remote end point
  *
  * @pre `((sock != NULL || remote != NULL)) && (if (len != 0): (data != NULL))`


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This change amends the `sock` API by a set of functions to `sock` that allow provisioning of stack-internal buffers to the caller on receive.

This allows to cover two use-cases:

1. Zero-copy systems: if the stacks supported the buffer space provided by these functions can be the same that was filled in the link-layer
2. asynchronous receive within a wrapping sock layer (e.g. `sock_dtls` wrapping `sock_udp`): to receive packets of the lower level protocol asynchronously, the wrapping implementation layer would currently need to allocate its own buffer space, introducing a third buffer space in addition to the one of the application and the network stack. For a wrapping layer this is undesirable.

While there are security considerations exposing stack internal memory space to the caller, I believe they are minor, as in the end the application developer is the person in control of the node.

This change only amends the `sock` API and does not change it, so even though it is an API change, it should only require one ACK.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Only API amendments here, no functional implementation (yet). So just check if

```
make doc
```

succeeds. All `sock` tests should still compile (Murdock can do that).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/12907#discussion_r390914377
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
