### PR TITLE
boards/openlabs-kw41z-mini: documentation fixes

### DIFF
--- a/boards/openlabs-kw41z-mini-256kib/doc.txt
+++ b/boards/openlabs-kw41z-mini-256kib/doc.txt
@@ -1,0 +1,22 @@
+/**
+@defgroup    boards_openlabs-kw41z-mini-256kib openlabs.co kw41z-mini-256kib board
+@ingroup     boards
+@brief       Support for openlabs-kw41z-mini (256kib Version)
+
+### General information
+
+The board is identical to the @ref boards_openlabs-kw41z-mini except that it uses the
+`mkw41z256vht4` (256k ROM) instead of the `mkw41z512vht4` (512k ROM).
+
+## Identification
+
+The only way to tell the two board versions apart is by checking the print on the
+microcontroller.
+
+### M41W 8VT4 1N16S CTDFMD for the 256kiB version
+![openlabs-kw41z-mini-256kib](https://user-images.githubusercontent.com/1301112/75628764-7578b880-5bdc-11ea-9d45-28f37a23fa68.jpg)
+
+### M41W 9VT4 1N16S CTHHQP for the 512kiB version
+![openlabs-kw41z-mini](https://user-images.githubusercontent.com/1301112/75628762-74478b80-5bdc-11ea-83ca-277e263867f6.jpg)
+
+*/

--- a/boards/openlabs-kw41z-mini/doc.txt
+++ b/boards/openlabs-kw41z-mini/doc.txt
@@ -11,6 +11,9 @@ source files located at https://openlabs.co/OSHW/kw41z-mini
 A driver for the radio transceiver is available in [#12277](https://github.com/RIOT-OS/RIOT/pull/12277)
 (802.15.4 only).
 
+@note A version of this board exists that comes with the `M41W8VT4` (256k ROM)
+instead of the `M41W9VT4` (512k ROM). The boards are otherwise identical.
+See @ref boards_openlabs-kw41z-mini-256kib if you happen to have this version.
 
 ### Programming Pinout
 

--- a/boards/openlabs-kw41z-mini/doc.txt
+++ b/boards/openlabs-kw41z-mini/doc.txt
@@ -3,12 +3,13 @@
 @ingroup     boards
 @brief       Support for openlabs-kw41z-mini
 
- ### General information
+### General information
 
 This is an open-source development board shipped by openlabs.co with
 source files located at https://openlabs.co/OSHW/kw41z-mini
 
-A driver for the radio transceiver is available in #12277 (802.15.4 only).
+A driver for the radio transceiver is available in [#12277](https://github.com/RIOT-OS/RIOT/pull/12277)
+(802.15.4 only).
 
 
 ### Programming Pinout
@@ -16,83 +17,89 @@ A driver for the radio transceiver is available in #12277 (802.15.4 only).
 Programming and debugging can be done with a Raspberry Pi (or equivalent)
 running OpenOCD.
 
-
-    Pi GPIO Pins       kw41z-mini
- ====================================
-                  ||
-    GPIO_19 ------||------- RST
-                  ||
-    GPIO_20 ------||------- SWDCLK
-                  ||
-    GPIO_21 ------||------- SWDIO
-                  ||
-      3.3V -------||------- 3.3V
-                  ||
-       GND -------||------- GND
-                  ||
-
+       Pi GPIO Pins       kw41z-mini
+    ====================================
+                     ||
+       GPIO_19 ------||------- RST
+                     ||
+       GPIO_20 ------||------- SWDCLK
+                     ||
+       GPIO_21 ------||------- SWDIO
+                     ||
+         3.3V -------||------- 3.3V
+                     ||
+          GND -------||------- GND
+                     ||
 
 ### Compiling and Flashing
 
 # install build deps for openocd
-apt install git build-essential libtool automake
+
+    apt install git build-essential libtool automake
+
 # fetch and build openocd with support for JTAG via RPi or generic GPIO
-git clone https://github.com/beduino-project/openocd.git
-cd openocd
-./bootstrap
-./configure --enable-bcm2835gpio --enable-sysfsgpio
-make -j4 && sudo make install
+
+    git clone https://github.com/beduino-project/openocd.git
+    cd openocd
+    ./bootstrap
+    ./configure --enable-bcm2835gpio --enable-sysfsgpio
+    make -j4 && sudo make install
 
 # install arm toolchain
-apt install git gcc-arm-none-eabi gdb-arm-none-eabi
-# fetch Riot
-git clone https://github.com/RIOT-OS/RIOT.git
-# build and flash the gnrc_networking example
-cd RIOT/examples/gnrc_networking
-BOARD=openlabs-kw41z-mini CFLAGS+="-DKW41ZRF_ENABLE_LEDS=1" make -j4 flash
 
+    apt install git gcc-arm-none-eabi gdb-arm-none-eabi
+
+# fetch Riot
+
+    git clone https://github.com/RIOT-OS/RIOT.git
+
+# build and flash the gnrc_networking example
+
+    cd RIOT/examples/gnrc_networking
+    BOARD=openlabs-kw41z-mini CFLAGS+="-DKW41ZRF_ENABLE_LEDS=1" make -j4 flash
 
 ### Debug Uart Pinout
 
 It is also possible to use the Pi for connecting to the debug uart.
 
-
-    Pi GPIO Pins     kw41z-mini
- ==================================
-                 ||
-     UART TX ----||------ RXI
-                 ||
-     UART RX ----||------ TXO
-                 ||
-       GND ------||------ GND
-                 ||
-
+       Pi GPIO Pins     kw41z-mini
+    ==================================
+                    ||
+        UART TX ----||------ RXI
+                    ||
+        UART RX ----||------ TXO
+                    ||
+          GND ------||------ GND
+                    ||
 
 # enable the uart on the Pi
-echo "enable_uart=1" >> /boot/config.txt
-reboot
-# install serial terminal
-apt install picocom
-# run serial terminal to access debug uart
-picocom -b115200 /dev/serial0
 
+    echo "enable_uart=1" >> /boot/config.txt
+    reboot
+
+# install serial terminal
+
+    apt install picocom
+
+# run serial terminal to access debug uart
+
+    picocom -b115200 /dev/serial0
 
 It is recommended (if possible) to switch the Pi to the better-clocked
 uart for higher baud rates:
 
-echo "dtoverlay=disable-bt" >> /boot/config.txt
-reboot
-
+    echo "dtoverlay=disable-bt" >> /boot/config.txt
+    reboot
 
 ### Notes
 
 To get a working radio, add #12277 and uncomment the lines in
-boards/openlabs-kw41z-mini/Makefile.dep
+`boards/openlabs-kw41z-mini/Makefile.dep`
 
-The DAC output is on pin PTB18.
+The DAC output is on pin `PTB18`.
 
-ADC input A3 needs a hack applied to cpu/kinetis/periph/adc.c to remove
-ADC_CFG2_MUXSEL_MASK from CFG2 to switch to the correct mux setting.
+ADC input A3 needs a hack applied to `cpu/kinetis/periph/adc.c` to remove
+`ADC_CFG2_MUXSEL_MASK` from `CFG2` to switch to the correct mux setting.
 
 The PWM peripheral on this board isn't supported in the Kinetis PWM driver yet.
 


### PR DESCRIPTION
### Contribution description

This fixes the rendering of the `boards/openlabs-kw41z-mini` documentation and adds a note about the `boards/openlabs-kw41z-mini-256kib`


### Testing procedure

Run `make doc` and check the generated file at `doc/doxygen/html/group__boards__openlabs-kw41z-mini.html`

### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/13524#issuecomment-597664359
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
