### PR TITLE
sliptty/start_network.sh: fix if no argument is given

### DIFF
--- a/dist/tools/sliptty/start_network.sh
+++ b/dist/tools/sliptty/start_network.sh
@@ -119,12 +119,11 @@ while getopts ehI: opt; do
 done
 
 PREFIX="$1"
-shift
-
 if [ -z "$PREFIX" ]; then
     usage $0
     exit 1
 fi
+shift
 
 create_tun && \
 if [ ${SLIP_ONLY} -ne 1 ]; then


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
If the script start_network.sh from **sliptty** is called without any argument the shift in line 122 throws an error (shift: can't shift that many), the usage info is not shown in that case.

This PR just adds a condition that checks if an argument is available.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Just call the script without an argument - the error should appear. Apply this PR and try it again - now the usage message should come up.

```
./start_network.sh 
./start_network.sh: 122: shift: can't shift that many
```
After:
```
./start_network.sh 
usage: ./start_network.sh [-I <sl0>] [-e] [-g <addr>/<prefix_len>] <prefix> serial [baudrate]
usage: ./start_network.sh [-I <sl0>] [-e] [-g <addr>/<prefix_len>] <prefix> tcp:host [port]

```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
