### PR TITLE
boards/feather-nrf52840: fix LED macros

### DIFF
--- a/boards/feather-nrf52840/include/board.h
+++ b/boards/feather-nrf52840/include/board.h
@@ -40,12 +40,12 @@ extern "C" {
 #define LED1_MASK           (1 << 10)
 #define LED_MASK            (LED0_MASK | LED1_MASK)
 
-#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_ON             (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTCLR = LED0_MASK)
 #define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
 
-#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK)
-#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_ON             (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTCLR = LED1_MASK)
 #define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
 /** @} */
 


### PR DESCRIPTION
### Contribution description
The [schematics](https://learn.adafruit.com/assets/68545) of the `feather-nrf52840` board tell us, that the two onboard LEDs are active high. So the LED macros for this board should reflect that :-)

### Testing procedure
Flash `tests/leds` on the board. Without this PR, both LEDs are turned on and only the active LED is toggled for short amounts of time. With this PR all LEDs are off and only the active one is switched on for short amounts of time, like it should be...

### Issues/PRs references
none