### PR TITLE
pkg/yxml: add Yxml XML parser library package

### DIFF
--- a/pkg/yxml/Makefile
+++ b/pkg/yxml/Makefile
@@ -1,0 +1,9 @@
+PKG_NAME=yxml
+PKG_URL=https://g.blicky.net/yxml.git
+PKG_VERSION=f9438757fc49b9f86961ddb55ae430e36bb88ebb
+PKG_LICENSE=MIT
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/yxml/Makefile.dep
+++ b/pkg/yxml/Makefile.dep
@@ -1,0 +1,2 @@
+# Yxml currently doesn't compile for 16bit int machines
+FEATURES_BLACKLIST += arch_8bit arch_16bit

--- a/pkg/yxml/Makefile.include
+++ b/pkg/yxml/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/yxml

--- a/pkg/yxml/Makefile.yxml
+++ b/pkg/yxml/Makefile.yxml
@@ -1,0 +1,3 @@
+CFLAGS += -Wno-unused-parameter
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/yxml/doc.txt
+++ b/pkg/yxml/doc.txt
@@ -1,0 +1,8 @@
+/**
+ * @defgroup pkg_yxml Yxml XML parser
+ * @ingroup  pkg
+ * @ingroup  sys_serialization
+ * @brief    Provides an XML parser library
+ *
+ * @see      https://dev.yorhel.nl/yxml
+ */

--- a/tests/pkg_yxml/Makefile
+++ b/tests/pkg_yxml/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEPKG += yxml
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_yxml/Makefile.ci
+++ b/tests/pkg_yxml/Makefile.ci
@@ -1,0 +1,5 @@
+BOARD_INSUFFICIENT_MEMORY := \
+        nucleo-f042k6 \
+        nucleo-f031k6 \
+        stm32f030f4-demo \
+    #

--- a/tests/pkg_yxml/main.c
+++ b/tests/pkg_yxml/main.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ * @file
+ * @brief       Tests for the yxml XML parser library package
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @}
+ */
+#include <string.h>
+#include <stdio.h>
+
+#include "embUnit.h"
+#include "yxml.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static char _yxml_buf[1024];
+
+static const char *_doc = "<foo>bar</foo>";
+
+static void test_yxml(void)
+{
+    yxml_t yxml;
+    char content[64];
+
+    /* initialize yxml instance */
+    yxml_init(&yxml, _yxml_buf, sizeof(_yxml_buf));
+
+    /* parse XML document bytewise */
+    for (const char *doc = _doc; *doc; doc++) {
+        yxml_ret_t r = yxml_parse(&yxml, *doc);
+        TEST_ASSERT(r >= 0);
+
+        /* handle tokens */
+        switch (r) {
+            case YXML_OK:
+                break;
+            case YXML_ELEMSTART:
+                DEBUG("YXML_ELEMSTART \"%s\"\n", yxml.elem);
+                TEST_ASSERT_EQUAL_STRING("foo", yxml.elem);
+                memset(content, 0, sizeof(content));
+                break;
+            case YXML_CONTENT:
+                DEBUG_PUTS("YXML_CONTENT");
+                strcat(content, yxml.data);
+                break;
+            case YXML_ELEMEND:
+                DEBUG("YXML_ELEMEND content=\"%s\"\n", content);
+                TEST_ASSERT_EQUAL_STRING("bar", content);
+                break;
+            default:
+                DEBUG("unhandled token %i\n", r);
+        }
+    }
+
+    /* let yxml know the document has ended */
+    TEST_ASSERT_EQUAL_INT(0, yxml_eof(&yxml));
+}
+
+TestRef tests_yxml(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_yxml),
+    };
+
+    EMB_UNIT_TESTCALLER(YxmlTest, 0, 0, fixtures);
+    return (TestRef) & YxmlTest;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_yxml());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/pkg_yxml/tests/01-run.py
+++ b/tests/pkg_yxml/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'OK \(\d+ tests\)')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

From Yxml's [homepage](https://dev.yorhel.nl/yxml):

`Yxml is a small (6 KiB) non-validating yet mostly conforming XML parser written in C. Its primary goals are small binary size, simplicity and correctness. It also happens to be pretty fast.`

When compiled with `-Os` (RIOT's default), the library compiles to ~4kB on Cortex-M.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The PR includes a (very) basic test application.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
