### PR TITLE
net/gcoap: expose remote sock_udp_ep to request handlers

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -91,6 +91,10 @@
 #include <arpa/inet.h>
 #endif
 
+#ifdef MODULE_GCOAP
+#include "net/sock/udp.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -189,6 +193,11 @@ typedef struct {
     coap_optpos_t options[NANOCOAP_NOPTS_MAX];  /**< option offset array     */
 #ifdef MODULE_GCOAP
     uint32_t observe_value;                     /**< observe value           */
+    /**
+     * remote UDP endpoint. As of now, gcoap supports only UDP as transport, so
+     * we use sock_udp_ep_t here directly. If gcoap is extended to provide other
+     * transports, this probably needs to be changed to some union type here */
+    sock_udp_ep_t *udp_remote;
 #endif
 } coap_pkt_t;
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -155,6 +155,9 @@ static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type, void *arg)
             return;
         }
 
+        /* remember set senders port and address for later use */
+        pdu.udp_remote = &remote;
+
         /* validate class and type for incoming */
         switch (coap_get_code_class(&pdu)) {
         /* incoming request */


### PR DESCRIPTION
### Contribution description
I currently have a use case, where I need to know the source UDP-endpoint (IPv6 address + port) of for incoming CoAP request. So far, there was no way that I could see to get access this information from within my application.

This PR adds a pointer to the remote `sock_udp_ep_t` into `coap_pkt_t`. As a pointer to the pkt is passed to a resources event handler, this allows to access a requests source address and port now.

Caveat: the proposed solution hardcodes `sock_udp_ep_t` and with this it is only able to work with with UDP. But for now I don't see this as a problem, as `gcoap` is hardcoded to `sock_udp` anyway. This is also the reason I only included the `udp_remote` field for `nanocaop` in case that `gcoap` is used. This way it does not pull this hardcoded `sock_udp` dependency into `nanocoap`.

### Testing procedure
If build tests and `examples/gcoap` just work as before, nothing is broken by this change.

### Issues/PRs references
none