### PR TITLE
sys/net/dhcpv6: fixes option length handling in client implementation

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -382,6 +382,7 @@ static int _preparse_advertise(uint8_t *adv, size_t len, uint8_t **buf)
         DEBUG("DHCPv6 client: packet too small or transaction ID wrong\n");
         return -1;
     }
+    len -= sizeof(dhcpv6_msg_t);
     for (dhcpv6_opt_t *opt = (dhcpv6_opt_t *)(&adv[sizeof(dhcpv6_msg_t)]);
          len > 0; len -= _opt_len(opt), opt = _opt_next(opt)) {
         if (len > orig_len) {
@@ -482,7 +483,8 @@ static void _parse_advertise(uint8_t *adv, size_t len)
                     dhcpv6_opt_ia_pd_t *ia_pd = (dhcpv6_opt_ia_pd_t *)opt;
                     unsigned pd_t1, pd_t2;
                     uint32_t ia_id = byteorder_ntohl(ia_pd->ia_id);
-                    size_t ia_pd_len = byteorder_ntohs(ia_pd->len);
+                    size_t ia_pd_len = byteorder_ntohs(ia_pd->len) -
+                                       (sizeof(dhcpv6_opt_ia_pd_t) - sizeof(dhcpv6_opt_t));
                     size_t ia_pd_orig_len = ia_pd_len;
 
                     if (pfx_leases[i].parent.ia_id.id != ia_id) {
@@ -585,7 +587,7 @@ static bool _parse_reply(uint8_t *rep, size_t len)
     if (!_check_status_opt(status)) {
         return false;
     }
-    len = orig_len;
+    len = orig_len - sizeof(dhcpv6_msg_t);
     for (dhcpv6_opt_t *opt = (dhcpv6_opt_t *)(&rep[sizeof(dhcpv6_msg_t)]);
          len > 0; len -= _opt_len(opt), opt = _opt_next(opt)) {
         switch (byteorder_ntohs(opt->type)) {
@@ -596,7 +598,8 @@ static bool _parse_reply(uint8_t *rep, size_t len)
                     ia_pd = (dhcpv6_opt_ia_pd_t *)opt;
                     unsigned pd_t1, pd_t2;
                     uint32_t ia_id = byteorder_ntohl(ia_pd->ia_id);
-                    size_t ia_pd_len = byteorder_ntohs(ia_pd->len);
+                    size_t ia_pd_len = byteorder_ntohs(ia_pd->len) -
+                                       (sizeof(dhcpv6_opt_ia_pd_t) - sizeof(dhcpv6_opt_t));
                     size_t ia_pd_orig_len = ia_pd_len;
 
                     if (lease->parent.ia_id.id != ia_id) {

--- a/tests/gnrc_dhcpv6_client_6lbr/tests/01-run.py
+++ b/tests/gnrc_dhcpv6_client_6lbr/tests/01-run.py
@@ -140,7 +140,7 @@ def testfunc(child):
     sniffer = start_sniffer(iface,
                             stop_filter=lambda pkt: DHCP6_Request in pkt)
     sendp(build_reply_headers(pkt) / DHCP6_Advertise(trid=trid) /
-          cli_id / srv_id / ia_pd, iface=iface, verbose=False)
+          ia_pd / cli_id / srv_id, iface=iface, verbose=False)
 
     # wait for request
     pkt = wait_for_dhcpv6_pkt(iface, sniffer)
@@ -158,7 +158,7 @@ def testfunc(child):
     # reply to request with reply and a prefix provided
     trid = pkt[DHCP6_Request].trid
     sendp(build_reply_headers(pkt) / DHCP6_Reply(trid=trid) /
-          cli_id / srv_id / ia_pd, iface=iface, verbose=False)
+          ia_pd / cli_id / srv_id, iface=iface, verbose=False)
     time.sleep(1)
 
     # check if global address was configured


### PR DESCRIPTION
### Contribution description

This PR contains some small changes to fix the length in option handling.

While testing PR #13545, I had trouble with getting the `IA_PD` option from an `isc-dhcp-server`. With `ENABLE_DEBUG`, I got messages like:
```
DHCPv6 client: ADVERTISE does not contain either server ID, client ID or IA_PD option
DHCPv6 client: packet too small or transaction ID wrong
DHCPv6 client: ADVERTISE options overflow packet boundaries
DHCPv6 client: IA_PD options overflow option boundaries
```
While investigating the problem, I noticed that the length is incorrectly initialized in the option handling, so negative/overflown length values may occur. For example:https://github.com/RIOT-OS/RIOT/blob/24477ae3cbdc2e467caeebc358db805e215df849/sys/net/application_layer/dhcpv6/client.c#L377-L390 In this code, `len` is the total length of the DHCPv6 packet. While `opt` is initialized with the pointer to the first option, `len` is used as is including the DHCPv6 header. As a result, `len` overflows and condition in line 385 becomes true. `len` would have to be reduced by the DHCPv6 header length before the option handling.

### Testing procedure

DHCPv6 with prefix delegation should still work.

### Issues/PRs references
