### PR TITLE
makefiles/boards/stm32.ink.mk: Use ROM_OFFSET with stm32flash

### DIFF
--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -58,9 +58,11 @@ ifeq (dfu-util,$(PROGRAMMER))
 endif
 
 ifeq (stm32flash,$(PROGRAMMER))
+	ROM_OFFSET ?= 0x0
 	FLASHER = stm32flash
 	DEBUGGER =
 	FLASHFILE ?= $(BINFILE)
 	PROG_BAUD ?= 57600
-	FFLAGS = -b $(PROG_BAUD) -w $(FLASHFILE) -g 0x0 $(PORT)
+	BIN_ADDR ?= $(shell echo  $$(($(ROM_START_ADDR) + $(ROM_OFFSET))))
+	FFLAGS = -v -b $(PROG_BAUD) -w $(FLASHFILE) -S $(BIN_ADDR) -g $(BIN_ADDR) $(PORT)
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Use ROM_OFFSET variable to know where to flash and launch execution with stm32flash.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Tested on an Olimexino STM32 with this command:
```make flash BOARD=olimexino-stm32 ROM_OFFSET=0x5000```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
N/A
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
