### PR TITLE
boards/nucleo-l152re: fix uart1 pinout config

### DIFF
--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -104,8 +104,8 @@ static const uart_conf_t uart_config[] = {
     {
         .dev      = USART1,
         .rcc_mask = RCC_APB2ENR_USART1EN,
-        .rx_pin   = GPIO_PIN(PORT_A, 9),
-        .tx_pin   = GPIO_PIN(PORT_A, 10),
+        .rx_pin   = GPIO_PIN(PORT_A, 10),
+        .tx_pin   = GPIO_PIN(PORT_A, 9),
         .rx_af    = GPIO_AF7,
         .tx_af    = GPIO_AF7,
         .bus      = APB2,


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

According to the pinout the rx and tx pin need to be the other way around.
Though the swapped tx and rx pins allow the uart to work in loopback, it is still not correct.
The PA10 functions as an RX pin even though PA10 states TX pin in the periph_conf.
With this fixed the pullup for the rx is configured correctly and noise doesn't trigger the line.

This change sets the .tx_pin from PA10 to PA9 and the .rx_pin from PA9 to PA10.


### Testing procedure

To test run the:
`BOARD=nucleo-l152re make flash term -C tests/periph_uart`

Then try to check each the TX pin outputs and the RX pin receives.

Also leave the RX floating to verify the pullup is active.

With master the RX pin will get a whole bunch of `0x000` with this PR it fixes it.

Also just look at any pinout or any other nucleo board...

### Issues/PRs references