### PR TITLE
boards/samr30: add helper for antenna switch

### DIFF
--- a/boards/samr30-xpro/board.c
+++ b/boards/samr30-xpro/board.c
@@ -28,6 +28,18 @@
 
 void led_init(void);
 
+void board_antenna_config(uint8_t antenna)
+{
+    if (antenna == RFCTL_ANTENNA_EXT){
+        gpio_clear(RFCTL1_PIN);
+        gpio_set(RFCTL2_PIN);
+    }
+    else if (antenna == RFCTL_ANTENNA_BOARD){
+        gpio_set(RFCTL1_PIN);
+        gpio_clear(RFCTL2_PIN);
+    }
+}
+
 void board_init(void)
 {
     /* initialize the CPU */
@@ -35,6 +47,12 @@ void board_init(void)
 
     /* initialize the boards LEDs */
     led_init();
+
+    /* initialize the on-board antenna switch */
+    gpio_init(RFCTL1_PIN, GPIO_OUT);
+    gpio_init(RFCTL2_PIN, GPIO_OUT);
+    /* set default antenna switch configuration */
+    board_antenna_config(RFCTL_ANTENNA_DEFAULT);
 }
 
 

--- a/boards/samr30-xpro/include/board.h
+++ b/boards/samr30-xpro/include/board.h
@@ -68,9 +68,39 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Antenna configuration pin interface
+ * @{
+ */
+#define RFCTL1_PIN                  GPIO_PIN(PA, 9)
+#define RFCTL2_PIN                  GPIO_PIN(PA, 12)
+/** @} */
+
+/**
+ * @brief   Antenna configuration values
+ */
+enum {
+    RFCTL_ANTENNA_BOARD,
+    RFCTL_ANTENNA_EXT,
+};
+
+/**
+ * @name    Default antenna configuration
+ * @{
+ */
+#ifndef RFCTL_ANTENNA_DEFAULT
+#define RFCTL_ANTENNA_DEFAULT      RFCTL_ANTENNA_BOARD
+#endif
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+/**
+ * @brief   Set antenna switch
+ */
+void board_antenna_config(uint8_t antenna);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

The `samr30-xpro` board features an on-board chip antenna and a SMA port for an external antenna. The antenna of choice can be selected by a RF switch [1].

This contribution introduce a helper function to control the switch and initializes the board with the chip antenna being selected.

If the GPIOs connected to the RF switch aren't set at all and left in their default state, the switch is in an undefined state and, thus, no antenna is properly connected to the transceiver.

### Testing procedure

1. Verifying the used GPIOs: The *SAMR30 Xplained Pro Design Documentation* [2] includes the schematic of the board.

2. `examples/gnrc_networking` can be used to ping between two boards. With this patch, the radio range should increase significantly.

### Issues/PRs references

*None.*

[1] https://www.mouser.de/datasheet/2/472/200252C-1524771.pdf
[2] https://www.microchip.com/DevelopmentTools/ProductDetails/PartNO/ATSAMR30-XPRO