### PR TITLE
gnrc_rpl: add default value to GNRC_RPL_DEFAULT_NETIF

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -488,6 +488,13 @@ extern netstats_rpl_t gnrc_rpl_netstats;
 #endif
 
 /**
+ * @brief Default network interface for GNRC RPL
+ */
+#ifndef GNRC_RPL_DEFAULT_NETIF
+#define GNRC_RPL_DEFAULT_NETIF (KERNEL_PID_UNDEF)
+#endif
+
+/**
  * @brief Initialization of the RPL thread.
  *
  * @param[in] if_pid            PID of the interface

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
@@ -28,35 +28,37 @@
 
 void auto_init_gnrc_rpl(void)
 {
-#if (GNRC_NETIF_NUMOF == 1)
-    gnrc_netif_t *netif = gnrc_netif_iter(NULL);
-    if (netif == NULL) {
-        /* XXX this is just a work-around ideally this would happen with
-         * an `up` event of the interface */
-        LOG_INFO("Unable to auto-initialize RPL. No interfaces found.\n");
-        return;
-    }
-    DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n",
-          netif->pid);
-    gnrc_rpl_init(netif->pid);
-    return;
-#elif defined(GNRC_RPL_DEFAULT_NETIF)
-    if (gnrc_netif_get_by_pid(GNRC_RPL_DEFAULT_NETIF) != NULL) {
+    if (GNRC_NETIF_NUMOF == 1) {
+        gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+        if (netif == NULL) {
+            /* XXX this is just a work-around ideally this would happen with
+             * an `up` event of the interface */
+            LOG_INFO("Unable to auto-initialize RPL. No interfaces found.\n");
+            return;
+        }
         DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n",
-              GNRC_RPL_DEFAULT_NETIF);
-        gnrc_rpl_init(GNRC_RPL_DEFAULT_NETIF);
+              netif->pid);
+        gnrc_rpl_init(netif->pid);
         return;
     }
-    /* XXX this is just a work-around ideally this would happen with
-     * an `up` event of the GNRC_RPL_DEFAULT_NETIF */
-    DEBUG("auto_init_gnrc_rpl: could not initialize RPL on interface %" PRIkernel_pid" - "
-          "interface does not exist\n", GNRC_RPL_DEFAULT_NETIF);
-    return;
-#else
-    /* XXX this is just a work-around ideally this should be defined in some
-     * run-time interface configuration */
-    DEBUG("auto_init_gnrc_rpl: please specify an interface by setting GNRC_RPL_DEFAULT_NETIF\n");
-#endif
+    else if (GNRC_RPL_DEFAULT_NETIF != KERNEL_PID_UNDEF) {
+        if (gnrc_netif_get_by_pid(GNRC_RPL_DEFAULT_NETIF) != NULL) {
+            DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n",
+                  (kernel_pid_t) GNRC_RPL_DEFAULT_NETIF);
+            gnrc_rpl_init(GNRC_RPL_DEFAULT_NETIF);
+            return;
+        }
+        /* XXX this is just a work-around ideally this would happen with
+         * an `up` event of the GNRC_RPL_DEFAULT_NETIF */
+        DEBUG("auto_init_gnrc_rpl: could not initialize RPL on interface %" PRIkernel_pid" - "
+              "interface does not exist\n", (kernel_pid_t) GNRC_RPL_DEFAULT_NETIF);
+        return;
+    }
+    else {
+        /* XXX this is just a work-around ideally this should be defined in some
+         * run-time interface configuration */
+        DEBUG("auto_init_gnrc_rpl: please specify an interface by setting GNRC_RPL_DEFAULT_NETIF\n");
+    }
 }
 #else
 typedef int dont_be_pedantic;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
See https://github.com/RIOT-OS/RIOT/pull/13226#discussion_r391695379
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Test with `gnrc_networking`. Check that RPL still compile and works as expected.
Then, try manually setting the GNRC_RPL_DEFAULT_NETIF to the ieee802.15.4 interface and check that everything works
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/13226
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
