### PR TITLE
cc26xx_cc13xx: power common code

### DIFF
--- a/cpu/cc26x0/Makefile.dep
+++ b/cpu/cc26x0/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += cc26xx_cc13xx
+
 include ${RIOTCPU}/cc26xx_cc13xx/Makefile.dep

--- a/cpu/cc26x0/include/cc26x0_prcm.h
+++ b/cpu/cc26x0/include/cc26x0_prcm.h
@@ -342,10 +342,12 @@ typedef struct {
 /** @ingroup cpu_specific_peripheral_memory_map
   * @{
   */
-#define PRCM_BASE       0x40082000 /**< PRCM base address */
+#define PRCM_BASE        (PERIPH_BASE + 0x82000) /**< PRCM base address */
+#define PRCM_BASE_NONBUF (PERIPH_BASE_NONBUF + 0x82000) /**< PRCM base address (nonbuf) */
 /*@}*/
 
-#define PRCM ((prcm_regs_t *) (PRCM_BASE)) /**< PRCM register bank */
+#define PRCM        ((prcm_regs_t *) (PRCM_BASE)) /**< PRCM register bank */
+#define PRCM_NONBUF ((prcm_regs_t *) (PRCM_BASE_NONBUF)) /**< PRCM register bank (nonbuf) */
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/cpu/cc26x0/include/cc26x0_prcm.h
+++ b/cpu/cc26x0/include/cc26x0_prcm.h
@@ -337,6 +337,10 @@ typedef struct {
 #define PDSTAT1_CPU_ON      0x2
 #define PDSTAT1_RFC_ON      0x4
 #define PDSTAT1_VIMS_ON     0x8
+
+#define GPIOCLKGR_CLK_EN       0x1
+#define I2CCLKGR_CLK_EN        0x1
+#define UARTCLKGR_CLK_EN_UART0 0x1
 /** @} */
 
 /** @ingroup cpu_specific_peripheral_memory_map

--- a/cpu/cc26x0/periph/i2c.c
+++ b/cpu/cc26x0/periph/i2c.c
@@ -31,6 +31,8 @@
 #include "cpu.h"
 #include "periph/i2c.h"
 
+#include "cc26xx_cc13xx_power.h"
+
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
@@ -96,17 +98,14 @@ void i2c_init(i2c_t devnum)
 
     /* Make sure everything is shut off in case of reinit */
     I2C->MCR = 0;
-    PRCM->I2CCLKGR = 0;
 
     /* Enable serial power domain */
     if (!power_is_domain_enabled(POWER_DOMAIN_SERIAL)) {
         power_enable_domain(POWER_DOMAIN_SERIAL);
     }
 
-    /* enable i2c clock in run mode */
-    PRCM->I2CCLKGR = 1;
-    PRCM->CLKLOADCTL |= CLKLOADCTL_LOAD;
-    while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) {}
+    /* enable I2C clock in run mode */
+    power_clock_enable_i2c();
 
     /* configure pins */
     IOC->CFG[I2C_SDA_PIN] = (IOCFG_PORTID_I2C_MSSDA

--- a/cpu/cc26x0/periph/i2c.c
+++ b/cpu/cc26x0/periph/i2c.c
@@ -95,13 +95,13 @@ void i2c_init(i2c_t devnum)
     assert(devnum < I2C_NUMOF);
 
     /* Make sure everything is shut off in case of reinit */
-    PRCM->PDCTL0SERIAL = 0;
     I2C->MCR = 0;
     PRCM->I2CCLKGR = 0;
 
-    /* enable SERIAL power domain */
-    PRCM->PDCTL0SERIAL = 1;
-    while (!(PRCM->PDSTAT0 & PDSTAT0_SERIAL_ON)) {}
+    /* Enable serial power domain */
+    if (!power_is_domain_enabled(POWER_DOMAIN_SERIAL)) {
+        power_enable_domain(POWER_DOMAIN_SERIAL);
+    }
 
     /* enable i2c clock in run mode */
     PRCM->I2CCLKGR = 1;

--- a/cpu/cc26x2_cc13x2/Makefile.dep
+++ b/cpu/cc26x2_cc13x2/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += cc26xx_cc13xx
+
 include ${RIOTCPU}/cc26xx_cc13xx/Makefile.dep

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -254,6 +254,11 @@ typedef struct {
 #define PDSTAT1_CPU_ON      0x2
 #define PDSTAT1_RFC_ON      0x4
 #define PDSTAT1_VIMS_ON     0x8
+
+#define GPIOCLKGR_CLK_EN       0x1
+#define I2CCLKGR_CLK_EN        0x1
+#define UARTCLKGR_CLK_EN_UART0 0x1
+#define UARTCLKGR_CLK_EN_UART1 0x1
 /** @} */
 
 /** @ingroup cpu_specific_peripheral_memory_map

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -259,10 +259,12 @@ typedef struct {
 /** @ingroup cpu_specific_peripheral_memory_map
   * @{
   */
-#define PRCM_BASE       0x40082000 /**< PRCM base address */
+#define PRCM_BASE        (PERIPH_BASE + 0x82000) /**< PRCM base address */
+#define PRCM_BASE_NONBUF (PERIPH_BASE_NONBUF + 0x82000) /**< PRCM base address (nonbuf) */
 /*@}*/
 
-#define PRCM ((prcm_regs_t *) (PRCM_BASE)) /**< PRCM register bank */
+#define PRCM        ((prcm_regs_t *) (PRCM_BASE)) /**< PRCM register bank */
+#define PRCM_NONBUF ((prcm_regs_t *) (PRCM_BASE_NONBUF)) /**< PRCM register bank (nonbuf) */
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_power.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_power.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_cc26xx_cc13xx
+ * @{
+ *
+ * @file
+ * @brief           CC26xx/CC13xx Power management
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef CC26XX_CC13XX_POWER_H
+#define CC26XX_CC13XX_POWER_H
+
+#include <cc26xx_cc13xx.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Power domains
+ */
+typedef enum {
+    POWER_DOMAIN_PERIPHERALS, /**< Peripherals domain */
+    POWER_DOMAIN_SERIAL, /**< Serial domain */
+    POWER_DOMAIN_RFC, /**< RF Core domain */
+    POWER_DOMAIN_CPU, /**< CPU domain */
+    POWER_DOMAIN_VIMS, /**< VIMS domain */
+} power_domain_t;
+
+/**
+ * @brief   Is power domain enabled?
+ *
+ * @param[in] domain The domain.
+ *
+ * @return true Is enabled.
+ * @return false Is not enabled.
+ */
+bool power_is_domain_enabled(const power_domain_t domain);
+
+/**
+ * @brief   Enable the specified power domain.
+ *
+ * @params[in] domain The domain.
+ */
+void power_enable_domain(const power_domain_t domain);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* CC26XX_CC13XX_POWER_H */
+
+/*@}*/

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_power.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_power.h
@@ -22,6 +22,8 @@
 #include <cc26xx_cc13xx.h>
 #include <stdbool.h>
 
+#include "periph/uart.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,9 +52,40 @@ bool power_is_domain_enabled(const power_domain_t domain);
 /**
  * @brief   Enable the specified power domain.
  *
- * @params[in] domain The domain.
+ * @param[in] domain The domain.
  */
 void power_enable_domain(const power_domain_t domain);
+
+/**
+ * @brief   Enable GPIO clock
+ */
+void power_clock_enable_gpio(void);
+
+/**
+ * @brief   Enable General Purpose Timer clock
+ *
+ * @param[in] tim The timer to enable
+ */
+void power_clock_enable_gpt(uint32_t tim);
+
+/**
+ * @brief   Enable I2C clock
+ */
+void power_clock_enable_i2c(void);
+
+/**
+ * @brief   Enable UART clocks
+ *
+ * @param[in] uart The UART number
+ */
+void power_clock_enable_uart(uart_t uart);
+
+/**
+ * @brief   Disable UART clocks
+ *
+ * @param[in] uart The UART number
+ */
+void power_clock_disable_uart(uart_t uart);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/cpu/cc26xx_cc13xx/periph/gpio.c
+++ b/cpu/cc26xx_cc13xx/periph/gpio.c
@@ -22,6 +22,8 @@
 #include "cpu.h"
 #include "periph/gpio.h"
 
+#include "cc26xx_cc13xx_power.h"
+
 #define DOE_SHIFT               (29U)
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
@@ -44,9 +46,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     }
 
     /* enable GPIO clock */
-    PRCM->GPIOCLKGR |= 1;
-    PRCM->CLKLOADCTL |= CLKLOADCTL_LOAD;
-    while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) ;
+    power_clock_enable_gpio();
 
     /* configure the GPIO mode */
     IOC->CFG[pin] = mode;

--- a/cpu/cc26xx_cc13xx/periph/gpio.c
+++ b/cpu/cc26xx_cc13xx/periph/gpio.c
@@ -38,9 +38,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     if ((unsigned int)pin > 31)
         return -1;
 
+    /* enable peripherals power domain */
+    if (!power_is_domain_enabled(POWER_DOMAIN_PERIPHERALS)) {
+        power_enable_domain(POWER_DOMAIN_PERIPHERALS);
+    }
+
     /* enable GPIO clock */
-    PRCM->PDCTL0 |= PDCTL0_PERIPH_ON;
-    while(!(PRCM->PDSTAT0 & PDSTAT0_PERIPH_ON)) ;
     PRCM->GPIOCLKGR |= 1;
     PRCM->CLKLOADCTL |= CLKLOADCTL_LOAD;
     while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) ;

--- a/cpu/cc26xx_cc13xx/periph/timer.c
+++ b/cpu/cc26xx_cc13xx/periph/timer.c
@@ -29,6 +29,8 @@
 #include "periph_conf.h"
 #include "periph/timer.h"
 
+#include "cc26xx_cc13xx_power.h"
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -105,9 +107,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     }
 
     /* enable the timer clock */
-    PRCM->GPTCLKGR |= (1 << tim);
-    PRCM->CLKLOADCTL = CLKLOADCTL_LOAD;
-    while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) {}
+    power_clock_enable_gpt(tim);
 
     /* disable (and reset) timer */
     dev(tim)->CTL = 0;

--- a/cpu/cc26xx_cc13xx/periph/uart.c
+++ b/cpu/cc26xx_cc13xx/periph/uart.c
@@ -24,6 +24,8 @@
 #include "periph/uart.h"
 #include "periph_conf.h"
 
+#include "cc26xx_cc13xx_power.h"
+
 /**
  * @brief   Bit mask for the fractional part of the baudrate
  */
@@ -161,9 +163,8 @@ void uart_poweron(uart_t uart)
 
     uart_regs_t *uart_reg = uart_config[uart].regs;
 
-    PRCM->UARTCLKGR |= 0x1;
-    PRCM->CLKLOADCTL = CLKLOADCTL_LOAD;
-    while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) {}
+    /* Enable clock for this UART */
+    power_clock_enable_uart(uart);
 
     uart_reg->CTL = ENABLE_MASK;
 }
@@ -176,10 +177,8 @@ void uart_poweroff(uart_t uart)
 
     uart_reg->CTL = 0;
 
-    PRCM->UARTCLKGR = 0;
-    PRCM->CLKLOADCTL = CLKLOADCTL_LOAD;
-    while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) {}
-
+    /* Disable clock for this UART */
+    power_clock_disable_uart(uart);
 }
 
 static void isr_uart(uart_t uart)

--- a/cpu/cc26xx_cc13xx/periph/uart.c
+++ b/cpu/cc26xx_cc13xx/periph/uart.c
@@ -57,9 +57,11 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     int rts_pin = uart_config[uart].rts_pin;
     int cts_pin = uart_config[uart].cts_pin;
 #endif
+
     /* enable clocks: serial power domain and UART */
-    PRCM->PDCTL0SERIAL = 1;
-    while (!(PRCM->PDSTAT0 & PDSTAT0_SERIAL_ON)) ;
+    if (!power_is_domain_enabled(POWER_DOMAIN_SERIAL)) {
+        power_enable_domain(POWER_DOMAIN_SERIAL);
+    }
     uart_poweron(uart);
 
     /* disable and reset the UART */

--- a/cpu/cc26xx_cc13xx/power_arch.c
+++ b/cpu/cc26xx_cc13xx/power_arch.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cc26xx_cc13xx
+ * @{
+ *
+ * @file
+ * @brief       Power management abstractions
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+
+#define DOMAIN_ON (1)
+
+bool power_is_domain_enabled(const power_domain_t domain)
+{
+    switch (domain) {
+        case POWER_DOMAIN_PERIPHERALS:
+            return PRCM->PDSTAT0PERIPH == DOMAIN_ON;
+
+        case POWER_DOMAIN_SERIAL:
+            return PRCM->PDSTAT0SERIAL == DOMAIN_ON;
+
+        case POWER_DOMAIN_RFC:
+            /* At least one of the registers need to indicate that the power
+             * domain is on */
+            return (PRCM->PDSTAT1RFC == DOMAIN_ON) ||
+                   (PRCM->PDSTAT0RFC == DOMAIN_ON);
+
+        case POWER_DOMAIN_VIMS:
+            return PRCM->PDSTAT1VIMS == DOMAIN_ON;
+
+        case POWER_DOMAIN_CPU:
+            return PRCM->PDSTAT1CPU == DOMAIN_ON;
+
+        default:
+            return false;
+    }
+
+    return false;
+}
+
+void power_enable_domain(const power_domain_t domain)
+{
+    switch (domain) {
+        case POWER_DOMAIN_PERIPHERALS:
+            PRCM->PDCTL0PERIPH = DOMAIN_ON;
+            break;
+
+        case POWER_DOMAIN_SERIAL:
+            PRCM->PDCTL0SERIAL = DOMAIN_ON;
+            break;
+
+        case POWER_DOMAIN_RFC:
+            /* On CC26x0 MCUs PDCTL1RFC needs to be written too in order to
+             * enable the RF Core power domain. On `cc13x2_cc26x2` it's not
+             * necessary and domain is powered normally. */
+            PRCM->PDCTL0RFC = DOMAIN_ON;
+            PRCM->PDCTL1RFC = DOMAIN_ON;
+            break;
+
+        case POWER_DOMAIN_CPU:
+            PRCM->PDCTL1CPU = DOMAIN_ON;
+            break;
+
+        case POWER_DOMAIN_VIMS:
+            PRCM->PDCTL1VIMS = DOMAIN_ON;
+            break;
+    }
+
+    while (!power_is_domain_enabled(domain)) {}
+}


### PR DESCRIPTION
### Contribution description

This PR adds a common API over PRCM, for enabling and disabling power domains.

This is a precedent to implement other peripherals more easily and to reduce code duplication, also to prevent bugs. This _might_ be used by the radio driver in the near future.

- Fixes a possible error in `i2c_init` for `cc26x0`, because it disabled the serial power domain without checking if uart is using it.
- Fixes a bug in `uart.c`, previously both uarts were being powered off unintentionally because `PRCM->UARTCLKGR` was being cleared without checking for the other uart.

**ToDo**

- [x] Power API to enable/disable clocks for peripherals.

### Testing procedure

Currently this code touches uart, timer, gpio and i2c (for `cc26x0`, untested by me, shouldn't change). Any test for these should run normally without errors or behaviour change.

### Issues/PRs references
