### PR TITLE
cpu/cc2538: RTT: implement missing API functions

### DIFF
--- a/cpu/cc2538/periph/rtt.c
+++ b/cpu/cc2538/periph/rtt.c
@@ -32,7 +32,8 @@ static void *alarm_arg;
 static rtt_cb_t overflow_cb = NULL;
 static void *overflow_arg;
 
-static uint32_t rtt_offset = 0;
+static uint32_t rtt_alarm;
+static uint32_t rtt_offset;
 
 static inline void _rtt_irq_enable(void)
 {
@@ -95,11 +96,18 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
     SMWDTHROSC_ST1 = (alarm >>  8) & 0xFF;
     SMWDTHROSC_ST0 = alarm & 0xFF;
 
+    rtt_alarm = alarm;
+
     /* set callback*/
     alarm_cb = cb;
     alarm_arg = arg;
 
     irq_restore(irq);
+}
+
+uint32_t rtt_get_alarm(void)
+{
+    return rtt_alarm - rtt_offset;
 }
 
 void rtt_clear_alarm(void)

--- a/cpu/cc2538/periph/rtt.c
+++ b/cpu/cc2538/periph/rtt.c
@@ -24,6 +24,9 @@
 #include "cpu.h"
 #include "periph/rtt.h"
 
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
 #define SMWDTHROSC_STLOAD_STLOAD_MASK  (0x00000001)
 
 /* allocate memory for alarm and overflow callbacks + args */
@@ -34,6 +37,11 @@ static void *overflow_arg;
 
 static uint32_t rtt_alarm;
 static uint32_t rtt_offset;
+
+static enum {
+    RTT_ALARM,
+    RTT_OVERFLOW
+} rtt_next_alarm;
 
 static inline void _rtt_irq_enable(void)
 {
@@ -78,7 +86,23 @@ uint32_t rtt_get_counter(void)
 
 void rtt_set_counter(uint32_t counter)
 {
+    rtt_alarm -= rtt_offset;
     rtt_offset = _rtt_get_counter() + counter;
+    rtt_alarm += rtt_offset;
+
+    /* re-set the overflow callback */
+    if (overflow_cb) {
+        rtt_set_overflow_cb(overflow_cb, overflow_arg);
+    }
+}
+
+static void _set_alarm(uint32_t alarm)
+{
+    while (!(SMWDTHROSC_STLOAD & SMWDTHROSC_STLOAD_STLOAD_MASK)) {}
+    SMWDTHROSC_ST3 = (alarm >> 24) & 0xFF;
+    SMWDTHROSC_ST2 = (alarm >> 16) & 0xFF;
+    SMWDTHROSC_ST1 = (alarm >>  8) & 0xFF;
+    SMWDTHROSC_ST0 = alarm & 0xFF;
 }
 
 void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
@@ -86,21 +110,22 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
     assert(cb && !(alarm & ~RTT_MAX_VALUE));
 
     unsigned irq = irq_disable();
+    uint32_t now = _rtt_get_counter();
 
-    alarm += rtt_offset;
-
-    /* set alarm value */
-    while (!(SMWDTHROSC_STLOAD & SMWDTHROSC_STLOAD_STLOAD_MASK)) {}
-    SMWDTHROSC_ST3 = (alarm >> 24) & 0xFF;
-    SMWDTHROSC_ST2 = (alarm >> 16) & 0xFF;
-    SMWDTHROSC_ST1 = (alarm >>  8) & 0xFF;
-    SMWDTHROSC_ST0 = alarm & 0xFF;
-
-    rtt_alarm = alarm;
+    rtt_alarm = alarm + rtt_offset;
 
     /* set callback*/
     alarm_cb = cb;
     alarm_arg = arg;
+
+    DEBUG("rtt_set_alarm(%lu), alarm in %lu ticks, overflow in %lu ticks\n",
+          alarm, rtt_alarm - now, rtt_offset - now);
+
+    /* only set overflow alarm if it happens before the scheduled alarm */
+    if (overflow_cb == NULL || (rtt_offset - now >= rtt_alarm - now)) {
+        rtt_next_alarm = RTT_ALARM;
+        _set_alarm(rtt_alarm);
+    }
 
     irq_restore(irq);
 }
@@ -122,17 +147,17 @@ void rtt_clear_alarm(void)
 void rtt_set_overflow_cb(rtt_cb_t cb, void *arg)
 {
     unsigned irq = irq_disable();
-
-    /* set threshold to RTT_MAX_VALUE */
-    while (!(SMWDTHROSC_STLOAD & SMWDTHROSC_STLOAD_STLOAD_MASK)) {}
-    SMWDTHROSC_ST3 = (rtt_offset >> 24) & 0xFF;
-    SMWDTHROSC_ST2 = (rtt_offset >> 16) & 0xFF;
-    SMWDTHROSC_ST1 = (rtt_offset >>  8) & 0xFF;
-    SMWDTHROSC_ST0 =  rtt_offset & 0xFF;
+    uint32_t now = _rtt_get_counter();
 
     /* set callback*/
     overflow_cb = cb;
     overflow_arg = arg;
+
+    /* only set overflow alarm if it happens before the scheduled alarm */
+    if (alarm_cb == NULL || (rtt_alarm - now > rtt_offset - now)) {
+        rtt_next_alarm = RTT_OVERFLOW;
+        _set_alarm(rtt_offset);
+    }
 
     irq_restore(irq);
 }
@@ -148,17 +173,40 @@ void rtt_clear_overflow_cb(void)
 
 void isr_sleepmode(void)
 {
-    if (alarm_cb) {
+    rtt_cb_t tmp;
+    bool both = (rtt_alarm == rtt_offset);
+
+    switch (rtt_next_alarm) {
+    case RTT_ALARM:
         /* 'consume' the callback (as it might be set again in the cb) */
-        rtt_cb_t tmp = alarm_cb;
+        tmp = alarm_cb;
         alarm_cb = NULL;
         tmp(alarm_arg);
-    }
-    else if (overflow_cb) {
+
+        if (!both) {
+            break;
+        } /* fall-through */
+    case RTT_OVERFLOW:
         /* 'consume' the callback (as it might be set again in the cb) */
-        rtt_cb_t tmp = overflow_cb;
+        tmp = overflow_cb;
         overflow_cb = NULL;
         tmp(overflow_arg);
+        break;
     }
+
+    uint32_t now = _rtt_get_counter();
+
+    if (alarm_cb && (rtt_offset - now >= rtt_alarm - now)) {
+        DEBUG("rtt: next alarm in %lu ticks (RTT)\n", rtt_alarm - now);
+
+        rtt_next_alarm = RTT_ALARM;
+        _set_alarm(rtt_alarm);
+    } else if (overflow_cb && (rtt_alarm - now > rtt_offset - now)) {
+        DEBUG("rtt: next alarm in %lu ticks (OVERFLOW)\n", rtt_offset - now);
+
+        rtt_next_alarm = RTT_OVERFLOW;
+        _set_alarm(rtt_offset);
+    }
+
     cortexm_isr_end();
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The RTT implementation of `cpu/cc2538` is based on the sleep timer, a 32 bit 32kHz timer that can only be read and that only supports one alarm. (No overflow interrupt)

This implements functions that are defined by the RIOT API, but are not directly supported by the hardware:

 - `rtt_set_counter()`: as we can't set the counter directly, add an offset to the raw counter value instead
- `rtt_get_alarm()`: we can't read back the alarm time, so store it in a local variable. This is also needed for
- `rtt_set_overflow_cb()`: In the previous implementation the overflow callback would always overwrite the alarm callback and vice versa.
To fix this, check which event will occur first and set that alarm as well as a flag to tell which alarm it was.
When the alarm rings, set the alarm to the other event if there is one.

### Testing procedure

There are no tests for those functions.

### Issues/PRs references

I implemented those for #13519, but then discovered I don't need them.
So I'm not sure if this should be added just for completeness' sake when we could just as well do without.


