### PR TITLE
makefiles/tools/cc2538-bsl.inc.mk: allow FLASHER override

### DIFF
--- a/makefiles/tools/cc2538-bsl.inc.mk
+++ b/makefiles/tools/cc2538-bsl.inc.mk
@@ -6,4 +6,6 @@ FFLAGS  = -p "$(PROG_DEV)" $(FFLAGS_OPTS) -e -w -v -b $(PROG_BAUD) $(FLASHFILE)
 
 RESET ?= $(FLASHER) -p "$(PROG_DEV)" $(FFLAGS_OPTS)
 
-FLASHDEPS += $(FLASHER)
+ifeq ($(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py,$(FLASHER))
+  FLASHDEPS += $(FLASHER)
+endif


### PR DESCRIPTION
### Contribution description

If flasher is changed than make will still see it as a FLASH
dependency and try to execute the target which will likely not
exist.

A use case for this is when flashing on a remote machine and setting
FLASHER=ssh to then execute the FLASHER on the remote.

This PR adds the same kind of guard BOSSA has.

### Testing procedure

This is the file I use for remote flashing https://github.com/fjmolinas/ci-riot-tribe/blob/master/local/ci-boards.mk.pre.

Flashing on a remote machine with master

```
BOARD=openmote-b TRIBE_CI=1 make -C examples/gnrc_networking flash -j3: 
make: *** No rule to make target 'ssh', needed by 'flash'.  Stop.
```

with this PR works fine

```
rsync --chmod=ugo=rwX /home/francisco/workspace/RIOT3/examples/gnrc_networking/bin/openmote-b/gnrc_networking.hex ci@ci-riot-tribe.saclay.inria.fr:/builds/boards/bin/openmote-b_flashfile.hex
ssh ci@ci-riot-tribe.saclay.inria.fr 'IMAGE_OFFSET= BOARD=openmote-b QUIET=0 make --no-print-directory -C /builds/boards flash-only FLASHFILE=/builds/boards/bin/openmote-b_flashfile.hex'
/builds/boards/RIOT/dist/tools/cc2538-bsl/cc2538-bsl.py -p "/dev/riot/tty-openmote-b" --bootloader-invert-lines -e -w -v -b 460800 /builds/boards/bin/openmote-b_flashfile.hex
Opening port /dev/riot/tty-openmote-b, baud 460800
Reading data from /builds/boards/bin/openmote-b_flashfile.hex
Your firmware looks like an Intel Hex file
Connecting to target...
CC2538 PG2.0: 512KB Flash, 32KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:14:B5:B5:76
    Performing mass erase
Erasing 524288 bytes starting at address 0x00200000
    Erase done
Writing 524288 bytes starting at address 0x00200000
Write 16 bytes at 0x0027FFF0F8
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0xf6c32d95)
make: Leaving directory '/home/francisco/w
```