### PR TITLE
Makefile.dep: periph_init based on USEMODULE

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1066,11 +1066,6 @@ FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
 # FEATURES_USED is defined in Makefile.features
 USEMODULE += $(filter periph_%,$(FEATURES_USED))
 
-# set all USED periph_% init modules as DEFAULT_MODULE
-ifneq (,$(filter periph_init, $(USEMODULE)))
-  DEFAULT_MODULE += $(subst periph_,periph_init_,$(filter periph_%,$(FEATURES_USED)))
-endif
-
 # select cpu_check_address pseudomodule if the corresponding feature is used
 USEMODULE += $(filter cpu_check_address, $(FEATURES_USED))
 
@@ -1089,6 +1084,11 @@ USEPKG := $(sort $(USEPKG))
 ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
   include $(RIOTBASE)/Makefile.dep
 else
+  # set all USED periph_% init modules as DEFAULT_MODULE
+  ifneq (,$(filter periph_init, $(USEMODULE)))
+    DEFAULT_MODULE += $(subst periph_,periph_init_,$(filter periph_%,$(USEMODULE)))
+  endif
+
   # Add auto_init_% DEFAULT_MODULES. This is done after the recursive cach since
   # none of these modules can trigger dependency resolution.
   DEFAULT_MODULE := $(sort $(DEFAULT_MODULE))


### PR DESCRIPTION

### Contribution description

In #13511 @gschorcht pointed out the later PR changed the behaviour when adding `periph_%` `MODULE`s via the commandline. Since `periph_init` check was based on `FEATURES_USED` it didn't take into account if it was added directly as a `USEMODULE`.

This PR now make the rule check `USEMODULE` instead of `FEATURES_USED` to restore the previous behavior. 

### Testing procedure

- testing procedure in #13511 

- With this PR `periph_rtc periph_init_rtc` show up

```
USEMODULE=periph_rtc make -C tests/shell/ info-debug-variable-USEMODULE --no-print-directory | grep rtc
app_metadata auto_init board core core_init core_msg core_panic cpu native-drivers periph periph_common periph_gpio periph_init periph_init_common periph_init_gpio periph_init_init periph_init_pm periph_init_rtc periph_init_uart periph_pm periph_rtc periph_uart ps shell shell_commands stdin stdio_native sys
```

only `periph_rtc` in master:

```
USEMODULE=periph_rtc make -C tests/shell/ info-debug-variable-USEMODULE --no-print-directory | grep rtc
app_metadata auto_init board core core_init core_msg core_panic cpu native-drivers periph periph_common periph_gpio periph_init periph_init_gpio periph_init_pm periph_pm periph_rtc periph_uart ps shell shell_commands stdin stdio_native s
```

_NOTE_: the right way to add periph depdencies should still be through `FEATURES_REQUIRED`, but since it is not how most `MODULE`s are added It made sense adding this handling.

### Issues/PRs references

#13511
