### PR TITLE
net/gcoap: add lwIP support

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -634,6 +634,9 @@ ifneq (,$(filter gnrc,$(USEMODULE)))
   ifneq (,$(filter sock_udp, $(USEMODULE)))
     USEMODULE += gnrc_sock_udp
   endif
+  ifneq (,$(filter sock_async, $(USEMODULE)))
+    USEMODULE += gnrc_sock_async
+  endif
 endif
 
 ifneq (,$(filter gnrc_pktbuf, $(USEMODULE)))
@@ -864,7 +867,6 @@ endif
 
 ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += nanocoap
-  USEMODULE += gnrc_sock_async
   USEMODULE += sock_async_event
   USEMODULE += sock_util
   USEMODULE += event_callback

--- a/cpu/esp8266/include/cpu_conf.h
+++ b/cpu/esp8266/include/cpu_conf.h
@@ -69,6 +69,14 @@ extern "C" {
 #ifndef TCPIP_THREAD_STACKSIZE
 #define TCPIP_THREAD_STACKSIZE        (3072)
 #endif
+
+#ifndef GCOAP_STACK_SIZE
+#ifdef MODULE_GNRC
+#define GCOAP_STACK_SIZE              (1536 + DEBUG_EXTRA_STACKSIZE)
+#elif MODULE_LWIP
+#define GCOAP_STACK_SIZE              (2048 + DEBUG_EXTRA_STACKSIZE)
+#endif
+#endif
 /** @} */
 
 /**

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -11,13 +11,25 @@ RIOTBASE ?= $(CURDIR)/../..
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules
-USEMODULE += gnrc_ipv6_default
+ifeq (1,$(LWIP_IPV6))
+  USEMODULE += ipv6_addr
+  USEMODULE += lwip_netdev
+  USEMODULE += lwip_ipv6_autoconfig
+  USEMODULE += lwip_sock_ip
+  USEMODULE += lwip_sock_udp
+  USEMODULE += lwip_sock_async
+  # Activates recv timeout capability
+  CFLAGS += -DLWIP_SO_RCVTIMEO
+else
+  # GNRC default
+  USEMODULE += gnrc_netdev_default
+  USEMODULE += auto_init_gnrc_netif
+  USEMODULE += gnrc_ipv6_default
+  # Additional networking modules that can be dropped if not needed
+  USEMODULE += gnrc_icmpv6_echo
+endif
 USEMODULE += gcoap
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
 
 # Required by gcoap example
 USEMODULE += od

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -222,6 +222,7 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
 
     remote.family = AF_INET6;
 
+#ifdef MODULE_GNRC_SOCK_UDP
     /* parse for interface */
     char *iface = ipv6_addr_split_iface(addr_str);
     if (!iface) {
@@ -241,15 +242,21 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
         }
         remote.netif = pid;
     }
+#else
+    remote.netif = SOCK_ADDR_ANY_NETIF;
+#endif
+
     /* parse destination address */
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
         puts("gcoap_cli: unable to parse destination address");
         return 0;
     }
+#ifdef MODULE_GNRC_SOCK_UDP
     if ((remote.netif == SOCK_ADDR_ANY_NETIF) && ipv6_addr_is_link_local(&addr)) {
         puts("gcoap_cli: must specify interface for link local target");
         return 0;
     }
+#endif
     memcpy(&remote.addr.ipv6[0], &addr.u8[0], sizeof(addr.u8));
 
     /* parse port */

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -222,41 +222,41 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
 
     remote.family = AF_INET6;
 
-#ifdef MODULE_GNRC_SOCK_UDP
-    /* parse for interface */
-    char *iface = ipv6_addr_split_iface(addr_str);
-    if (!iface) {
-        if (gnrc_netif_numof() == 1) {
-            /* assign the single interface found in gnrc_netif_numof() */
-            remote.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+    if (IS_USED(MODULE_GNRC_SOCK_UDP)) {
+        /* parse for interface */
+        char *iface = ipv6_addr_split_iface(addr_str);
+        if (!iface) {
+            if (gnrc_netif_numof() == 1) {
+                /* assign the single interface found in gnrc_netif_numof() */
+                remote.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+            }
+            else {
+                remote.netif = SOCK_ADDR_ANY_NETIF;
+            }
         }
         else {
-            remote.netif = SOCK_ADDR_ANY_NETIF;
+            int pid = atoi(iface);
+            if (gnrc_netif_get_by_pid(pid) == NULL) {
+                puts("gcoap_cli: interface not valid");
+                return 0;
+            }
+            remote.netif = pid;
         }
     }
     else {
-        int pid = atoi(iface);
-        if (gnrc_netif_get_by_pid(pid) == NULL) {
-            puts("gcoap_cli: interface not valid");
-            return 0;
-        }
-        remote.netif = pid;
+        remote.netif = SOCK_ADDR_ANY_NETIF;
     }
-#else
-    remote.netif = SOCK_ADDR_ANY_NETIF;
-#endif
 
     /* parse destination address */
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
         puts("gcoap_cli: unable to parse destination address");
         return 0;
     }
-#ifdef MODULE_GNRC_SOCK_UDP
-    if ((remote.netif == SOCK_ADDR_ANY_NETIF) && ipv6_addr_is_link_local(&addr)) {
+    if (IS_USED(MODULE_GNRC_SOCK_UDP) && (remote.netif == SOCK_ADDR_ANY_NETIF)
+            && ipv6_addr_is_link_local(&addr)) {
         puts("gcoap_cli: must specify interface for link local target");
         return 0;
     }
-#endif
     memcpy(&remote.addr.ipv6[0], &addr.u8[0], sizeof(addr.u8));
 
     /* parse port */


### PR DESCRIPTION
### Contribution description
#13427 added sock_async support for the lwIP stack. This PR allows gcoap to use that support. My further goal is addition of lwIP based IPv4 support in a follow-on PR based on my [gcoap/lwip_ipv4](https://github.com/kb2ma/RIOT/commits/gcoap/lwip_ipv4) branch. I expect that work will generate some discussion though, so let's defer for the moment. :-)

This PR also allows the gcoap example to build with lwIP.

| Commit | Description |
| -------- | ----------- |
| 462fbfd | Automatically includes module gnrc_sock_async when the sock_async module is included.  The gcoap dependency handler in `Makefile.dep` assumed use of GNRC. #12931 took a similar approach for removal of the GNRC dependency for sock_udp. |
| e374997 | Adds the ability to build the gcoap example on lwIP, and #ifdefs out netif limitations on non-GNRC stacks |
| 7c108bc | Provides more stack space for esp8266 CPUs based on #13606. |

### Testing procedure
Verify the usual gcoap example functionality works -- message send and receive. Watch stack use via `ps`.

### Issues/PRs references
Fixes #13606