### PR TITLE
tests: add check_unittests helper function

### DIFF
--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -9,6 +9,7 @@
 
 import os
 import sys
+from functools import partial
 from traceback import print_tb
 import pexpect
 
@@ -44,3 +45,16 @@ def run(testfunc, timeout=TIMEOUT, echo=True, traceback=False):
         print("")
         teardown_child(child)
     return 0
+
+
+def check_unittests(child, timeout=TIMEOUT, nb_tests=None):
+    _tests = r'\d+' if nb_tests is None else int(nb_tests)
+    child.expect(r'OK \({} tests\)'.format(_tests), timeout=timeout)
+
+
+def run_check_unittests(timeout=TIMEOUT, echo=True, traceback=False,
+                        nb_tests=None):
+    _unittests_func = partial(check_unittests,
+                              timeout=timeout, nb_tests=nb_tests)
+
+    return run(_unittests_func, timeout, echo, traceback)

--- a/tests/cpp_ctors/tests/01-run.py
+++ b/tests/cpp_ctors/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/devfs/tests/01-run.py
+++ b/tests/devfs/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/embunit/tests/01-run.py
+++ b/tests/embunit/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/gnrc_ipv6_ext_frag/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext_frag/tests/01-run.py
@@ -16,7 +16,7 @@ import time
 
 from scapy.all import Ether, ICMPv6PacketTooBig, IPv6, IPv6ExtHdrFragment, \
                       UDP, raw, sendp, srp1
-from testrunner import run
+from testrunner import run, check_unittests
 
 
 RECV_BUFSIZE = 2 * 1500
@@ -319,7 +319,7 @@ def testfunc(child):
     tap = get_bridge(os.environ["TAP"])
 
     child.sendline("unittests")
-    child.expect(r"OK \((\d+) tests\)")     # wait for and check result of unittests
+    check_unittests(child)  # wait for and check result of unittests
     print("." * int(child.match.group(1)), end="", flush=True)
 
     lladdr_src = get_host_lladdr(tap)

--- a/tests/gnrc_ipv6_nib/tests/01-run.py
+++ b/tests/gnrc_ipv6_nib/tests/01-run.py
@@ -8,12 +8,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r"OK \(\d+ tests\)")
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/gnrc_ipv6_nib_6ln/tests/01-run.py
+++ b/tests/gnrc_ipv6_nib_6ln/tests/01-run.py
@@ -8,12 +8,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r"OK \(\d+ tests\)")
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/gnrc_ndp/tests/01-run.py
+++ b/tests/gnrc_ndp/tests/01-run.py
@@ -8,13 +8,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    # 1st 6LoWPAN fragment
-    child.expect(r"OK \(\d+ tests\)")
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/gnrc_netif/tests/01-run.py
+++ b/tests/gnrc_netif/tests/01-run.py
@@ -8,12 +8,12 @@
 # directory for more details.
 
 import sys
-from testrunner import run
+from testrunner import run, check_unittests
 
 
 def testfunc(child):
     # embUnit tests
-    child.expect(r"OK \(\d+ tests\)")
+    check_unittests(child)
     # output cross-checked hex data with WireShark -> "Import from Hex Dump..."
     # test_netapi_send__raw_unicast_ethernet_packet
     child.expect("Sending data from Ethernet device:")

--- a/tests/gnrc_rpl_srh/tests/01-run.py
+++ b/tests/gnrc_rpl_srh/tests/01-run.py
@@ -18,7 +18,7 @@ from scapy.all import Ether, IPv6, UDP, \
                       IPv6ExtHdrFragment, IPv6ExtHdrRouting, \
                       ICMPv6ParamProblem, ICMPv6TimeExceeded, \
                       sendp, srp1, sniff
-from testrunner import run
+from testrunner import run, check_unittests
 
 
 EXT_HDR_NH = {
@@ -338,7 +338,7 @@ def testfunc(child):
     global sniffer
     tap = get_bridge(os.environ["TAP"])
     child.sendline("unittests")
-    child.expect(r"OK \((\d+) tests\)")     # wait for and check result of unittests
+    check_unittests(child)  # wait for and check result of unittests
     print("." * int(child.match.group(1)), end="", flush=True)
     lladdr_src = get_host_lladdr(tap)
     child.sendline("ifconfig")

--- a/tests/gnrc_sixlowpan_frag/tests/01-run.py
+++ b/tests/gnrc_sixlowpan_frag/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/tests/01-run.py
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/tests/01-run.py
@@ -7,7 +7,7 @@
 # directory for more details.
 
 import sys
-from testrunner import run
+from testrunner import run, check_unittests
 
 
 def testfunc(child):
@@ -88,7 +88,7 @@ def testfunc(child):
         )
         child.expect_exact("Original fragmentation header:")
         child.expect_exact("IPHC headers + payload:")
-        child.expect(r"OK \((\d+) tests\)")
+        check_unittests(child)
         assert int(child.match.group(1)) >= 4
 
 

--- a/tests/l2util/tests/01-run.py
+++ b/tests/l2util/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/libc_newlib/tests/01-run.py
+++ b/tests/libc_newlib/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r"OK \([0-9]+ tests\)")
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/mtd_flashpage/tests/01-run.py
+++ b/tests/mtd_flashpage/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/mtd_mapper/tests/01-run.py
+++ b/tests/mtd_mapper/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_c25519/tests/01-run.py
+++ b/tests/pkg_c25519/tests/01-run.py
@@ -10,17 +10,15 @@
 import os
 import sys
 
+from testrunner import run_check_unittests
+from testrunner import TIMEOUT as DEFAULT_TIMEOUT
 
-def testfunc(child):
-    board = os.environ['BOARD']
-    # Increase timeout on "real" hardware
-    # 170 seconds on `arduino-mega2560`
-    timeout = 200 if board != 'native' else -1
-    child.expect(r"OK \(2 tests\)", timeout=timeout)
+
+BOARD = os.environ['BOARD']
+# Increase timeout on "real" hardware
+# 170 seconds on `arduino-mega2560`
+TIMEOUT = 200 if BOARD != 'native' else DEFAULT_TIMEOUT
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTBASE'],
-                                 'dist/tools/testrunner'))
-    from testrunner import run
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(timeout=TIMEOUT))

--- a/tests/pkg_cifra/tests/01-run.py
+++ b/tests/pkg_cifra/tests/01-run.py
@@ -8,12 +8,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r"OK \(\d+ tests\)")
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_cn-cbor/tests/01-run.py
+++ b/tests/pkg_cn-cbor/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_hacl/tests/01-run.py
+++ b/tests/pkg_hacl/tests/01-run.py
@@ -7,7 +7,7 @@
 # directory for more details.
 
 import sys
-from testrunner import run
+from testrunner import run_check_unittests
 
 
 # increase the default timeout to 30s, on samr30-xpro this test takes 20s to
@@ -15,9 +15,5 @@ from testrunner import run
 TIMEOUT = 30
 
 
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)', timeout=TIMEOUT)
-
-
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(timeout=TIMEOUT))

--- a/tests/pkg_heatshrink/tests/01-run.py
+++ b/tests/pkg_heatshrink/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_libb2/tests/01-run.py
+++ b/tests/pkg_libb2/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect_exact('OK (2 tests)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(nb_tests=2))

--- a/tests/pkg_libcose/tests/01-run.py
+++ b/tests/pkg_libcose/tests/01-run.py
@@ -8,20 +8,15 @@
 
 import os
 import sys
-from testrunner import run
+from testrunner import run_check_unittests
+from testrunner import TIMEOUT as DEFAULT_TIMEOUT
 
 
+BOARD = os.environ['BOARD']
 # on real hardware, this test application can take several minutes to
 # complete (~4min on microbit)
-HW_TIMEOUT = 300
-
-
-def testfunc(child):
-    board = os.environ['BOARD']
-    # Increase timeout on "real" hardware
-    timeout = HW_TIMEOUT if board != 'native' else -1
-    child.expect(r'OK \(\d+ tests\)', timeout=timeout)
+TIMEOUT = 300 if BOARD != 'native' else DEFAULT_TIMEOUT
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(timeout=TIMEOUT))

--- a/tests/pkg_libhydrogen/tests/01-run.py
+++ b/tests/pkg_libhydrogen/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect_exact('OK (3 tests)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_littlefs/tests/01-run.py
+++ b/tests/pkg_littlefs/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_littlefs2/tests/01-run.py
+++ b/tests/pkg_littlefs2/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_monocypher/tests/01-run.py
+++ b/tests/pkg_monocypher/tests/01-run.py
@@ -8,7 +8,7 @@
 # directory for more details.
 
 import sys
-from testrunner import run
+from testrunner import run_check_unittests
 
 
 # increase the default timeout to 20s, on samr30-xpro this test takes 14s to
@@ -16,9 +16,5 @@ from testrunner import run
 TIMEOUT = 20
 
 
-def testfunc(child):
-    child.expect(r"OK \(2 tests\)", timeout=TIMEOUT)
-
-
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(timeout=TIMEOUT, nb_tests=2))

--- a/tests/pkg_nanocbor/tests/01-run.py
+++ b/tests/pkg_nanocbor/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_qcbor/tests/01-run.py
+++ b/tests/pkg_qcbor/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_qdsa/tests/01-run.py
+++ b/tests/pkg_qdsa/tests/01-run.py
@@ -7,15 +7,11 @@
 # directory for more details.
 
 import sys
-from testrunner import run
+from testrunner import run_check_unittests
 
 # It takes ~11s on nucleo-l152re, so add some margin
 TIMEOUT = 15
 
 
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)', timeout=TIMEOUT)
-
-
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(timeout=TIMEOUT))

--- a/tests/pkg_relic/tests/01-run.py
+++ b/tests/pkg_relic/tests/01-run.py
@@ -7,12 +7,11 @@
 # directory for more details.
 
 import sys
-from testrunner import run
+from testrunner import run_check_unittests
 
 
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)', timeout=120)
+TIMEOUT = 120
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(timeout=TIMEOUT))

--- a/tests/pkg_spiffs/tests/01-run.py
+++ b/tests/pkg_spiffs/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/pkg_tinycbor/tests/01-run.py
+++ b/tests/pkg_tinycbor/tests/01-run.py
@@ -8,12 +8,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r"OK \(1 tests\)")
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(nb_tests=1))

--- a/tests/pkg_tweetnacl/tests/01-run.py
+++ b/tests/pkg_tweetnacl/tests/01-run.py
@@ -8,14 +8,14 @@
 
 import os
 import sys
-from testrunner import run
+from testrunner import run, check_unittests
 
 
 def testfunc(child):
     board = os.environ['BOARD']
     # Increase timeout on "real" hardware
     timeout = 120 if board != 'native' else -1
-    child.expect(r'OK \(\d+ tests\)', timeout=timeout)
+    check_unittests(child, timeout=timeout)
 
 
 if __name__ == "__main__":

--- a/tests/pkg_yxml/tests/01-run.py
+++ b/tests/pkg_yxml/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/riotboot_hdr/tests/01-run.py
+++ b/tests/riotboot_hdr/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r"OK \(\d+ tests\)")
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/sys_crypto/tests/01-run.py
+++ b/tests/sys_crypto/tests/01-run.py
@@ -7,12 +7,8 @@
 # directory for more details.
 
 import sys
-from testrunner import run
-
-
-def testfunc(child):
-    child.expect(r'OK \(\d+ tests\)')
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests())

--- a/tests/unittests/tests/01-run.py
+++ b/tests/unittests/tests/01-run.py
@@ -7,12 +7,11 @@
 # directory for more details.
 
 import sys
-from testrunner import run
+from testrunner import run_check_unittests
 
 
-def testfunc(child):
-    child.expect(u"OK \\([0-9]+ tests\\)")
+TIMEOUT = 120
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc, timeout=120))
+    sys.exit(run_check_unittests(timeout=TIMEOUT))

--- a/tests/usbus/tests/01-run.py
+++ b/tests/usbus/tests/01-run.py
@@ -7,16 +7,9 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-import os
 import sys
-
-
-def testfunc(child):
-    child.expect(r"OK \(1 tests\)")
+from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTBASE'],
-                                 'dist/tools/testrunner'))
-    from testrunner import run
-    sys.exit(run(testfunc))
+    sys.exit(run_check_unittests(nb_tests=1))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduces the `check_unittests` helper function and make use of it with tests using the embUnit module.
For these tests all `testfunc` are almost the same, so this PR removes a lot of duplication. `check_unittests` also takes an `nb_tests` parameter to specify the expected number of successful tests. If the parameter is not set, the default regexp `\d+` is used.

All candidate tests are updated to make use of this new function.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock with `CI: run tests` label set

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
