### PR TITLE
CODEOWNERS: remove from Makefile*

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -137,7 +137,4 @@
 
 # KConfig maintainers will be notified about all KConfig changes
 Kconfig                                     @leandrolanzieri @jia200x @cgundogan
-Makefile.dep                                @aabadie @fjmolinas
-Makefile.features                           @aabadie @fjmolinas
-Makefile.include                            @aabadie @fjmolinas
 pm.c                                        @roberthartung @kaspar030


### PR DESCRIPTION
### Contribution description

Being Makefile* codeowner means being tagged in almost every PR, I had also stated in the original PR (@fjmolinas in https://github.com/RIOT-OS/RIOT/pull/13289/files_) that I did not feel confident in being a CODEOWNER here, but the PR was merged while I as AFK and therefore could not insist on that point.

@aabadie asked offline to be removed as well so piggybacking the removal