### PR TITLE
cpu/cc2538: don't sleep in IDLE

### DIFF
--- a/cpu/cc2538/periph/pm.c
+++ b/cpu/cc2538/periph/pm.c
@@ -51,6 +51,10 @@ void pm_set(unsigned mode)
             deep = true;
             SYS_CTRL_PMCTL = 0x0;
             break;
+            /* FIXME: Timers don't work when using cortexm_sleep()
+                      So don't sleep at all until we have figured this out. */
+        default:
+            return;
     }
 
     if (deep) {


### PR DESCRIPTION
### Contribution description

For some reason timers can't wake up the CPU from even the lightest of sleep modes.

Since this is a serious regression, just don't attempt to sleep at all when IDLE mode is selected.

Ideally we should always use mode 3 (`SYS_CTRL_PMCTL = 0x0`) for IDLE, just [like Contiki](https://contiki-ng.readthedocs.io/en/master/_api/cc2538_2lpm_8c_source.html).

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `examples/timer_periodic_wakeup` on a CC2538 board (`openmote-b`, `remote-revb`, etc)

On master, the test will be stuck without printing anything.

With this PR the test should output something every second again.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/commit/5d8c00e302f6d4089720adaebf82b1bcf6bd91fa#r37853962