### PR TITLE
cpu: add BACKUP_RAM attribute

### DIFF
--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -73,6 +73,20 @@ extern "C" {
  */
 #define PUF_SRAM_ATTRIBUTES __attribute__((used, section(".puf")))
 
+#if CPU_HAS_BACKUP_RAM || DOXYGEN
+/**
+ * @brief   Memory marked with this attribute is retained during deep sleep
+ *          and initialized with 0 on cold boot.
+ */
+#define BACKUP_RAM      __attribute__((section(".backup.bss")))
+
+/**
+ * @brief   Memory marked with this attribute is retained during deep sleep
+ *          and initialized with user provided data on cold boot.
+ */
+#define BACKUP_RAM_DATA __attribute__((section(".backup.data")))
+#endif /* CPU_HAS_BACKUP_RAM */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -51,6 +51,18 @@ extern "C" {
  */
 #define PRINTF_BUFSIZ 256
 
+/**
+ * @brief   Memory marked with this attribute is retained during deep sleep
+ *          and initialized with 0 on cold boot.
+ */
+#define BACKUP_RAM      __attribute__((section(".rtc.bss")))
+
+/**
+ * @brief   Memory marked with this attribute is retained during deep sleep
+ *          and initialized with user provided data on cold boot.
+ */
+#define BACKUP_RAM_DATA __attribute__((section(".rtc.data")))
+
 #ifdef __cplusplus
 }
 #endif /* CPU_CONF_H */

--- a/cpu/lpc2387/include/cpu_conf.h
+++ b/cpu/lpc2387/include/cpu_conf.h
@@ -6,7 +6,6 @@
  * directory for more details.
  */
 
-
 #ifndef CPU_CONF_H
 #define CPU_CONF_H
 
@@ -126,6 +125,18 @@ extern "C" {
  *          (primary RAM, USB RAM, Ethernet RAM & Backup RAM)
  */
 #define NUM_HEAPS (4)
+
+/**
+ * @brief   Memory marked with this attribute is retained during deep sleep
+ *          and initialized with 0 on cold boot.
+ */
+#define BACKUP_RAM      __attribute__((section(".backup.bss")))
+
+/**
+ * @brief   Memory marked with this attribute is retained during deep sleep
+ *          and initialized with user provided data on cold boot.
+ */
+#define BACKUP_RAM_DATA __attribute__((section(".backup.data")))
 
 #ifdef __cplusplus
 }

--- a/tests/periph_backup_ram/main.c
+++ b/tests/periph_backup_ram/main.c
@@ -39,7 +39,7 @@ int main(void)
      * counter anyway after wakeup, we did not sleep properly.
      */
     static int counter_noinit __attribute__((section(".noinit")));
-    static int counter __attribute__((section(".backup.bss")));
+    static int counter BACKUP_RAM;
 
     if (counter == 0) {
         puts("\nBackup RAM test\n");


### PR DESCRIPTION
### Contribution description

Many platforms provide a special memory section that is retained during Deep Sleep when all other state is lost.
RIOT already has support for putting data in this memory, but writing `__attribute__((section(".backup.bss")))` is clunky and hard to memorize. 
Even worse, it's not consistent across platforms.

This introduces an easy to use `define` that makes placing things in this memory much easier to look at.
It also allows applications to fall back to using `.noinit` if no backup memory is available by doing

```C
#ifndef BACKUP_RAM
#define BACKUP_RAM __attribute__((section(".noinit")))
#endif
```

Then memory might not be retained during Deep Sleep, but there is a good chance it stays the same across reboots, which might be the next best thing.

### Testing procedure

Only introduces a define for readability, but you can run `tests/periph_backup_ram`.

### Issues/PRs references
suggested in https://github.com/RIOT-OS/RIOT/pull/13519#discussion_r392862279
