### PR TITLE
cc26xx_cc13xx: add RF related registers definitions

### DIFF
--- a/cpu/cc26x0/include/cc26x0_prcm.h
+++ b/cpu/cc26x0/include/cc26x0_prcm.h
@@ -202,6 +202,40 @@ typedef struct {
 
 #define AON_WUC ((aon_wuc_regs_t *) (AON_WUC_BASE)) /**< AON_WUC register bank */
 
+/**
+ * AON_RTC registers
+ */
+typedef struct {
+    reg32_t CTL; /**< Control */
+    reg32_t EVFLAGS; /**< Event Flags, RTC Status */
+    reg32_t SEC; /**< Second Counter Value, Integer Part */
+    reg32_t SUBSEC; /**< Second Counter Value, Fractional Part */
+    reg32_t SUBSECINC; /**< Subseconds Increment */
+    reg32_t CHCTL; /**< Channel Configuration */
+    reg32_t CH0CMP; /**< Channel 0 Compare Value */
+    reg32_t CH1CMP; /**< Channel 1 Compare Value */
+    reg32_t CH2CMP; /**< Channel 2 Compare Value */
+    reg32_t CH2CMPINC; /**< Channel 2 Compare Value Auto-increment */
+    reg32_t CH1CAPT; /**< Channel 1 Capture Value */
+    reg32_t SYNC; /**< AON Synchronization */
+} aon_rtc_regs_t;
+
+/**
+ * @brief   RTC_UPD is a 16 KHz signal used to sync up the radio timer. The
+ *          16 Khz is SCLK_LF divided by 2
+ * @details 0h = RTC_UPD signal is forced to 0
+ *          1h = RTC_UPD signal is toggling @16 kHz
+ */
+#define AON_RTC_CTL_RTC_UPD_EN 0x00000002
+
+/** @ingroup cpu_specific_peripheral_memory_map
+  * @{
+  */
+#define AON_RTC_BASE (PERIPH_BASE + 0x92000) /**< AON_RTC base address */
+/** @} */
+
+#define AON_RTC ((aon_rtc_regs_t *) (AON_RTC_BASE)) /**< AON_RTC register bank */
+
 
 /**
  * PRCM registers

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -105,6 +105,42 @@ typedef struct {
 #define AON_PMCTL ((aon_pmctl_regs_t *) (AON_PMCTL_BASE)) /**< AON_PMCTL register bank */
 
 /**
+ * AON_RTC registers
+ */
+typedef struct {
+    reg32_t CTL; /**< Control */
+    reg32_t EVFLAGS; /**< Event Flags, RTC Status */
+    reg32_t SEC; /**< Second Counter Value, Integer Part */
+    reg32_t SUBSEC; /**< Second Counter Value, Fractional Part */
+    reg32_t SUBSECINC; /**< Subseconds Increment */
+    reg32_t CHCTL; /**< Channel Configuration */
+    reg32_t CH0CMP; /**< Channel 0 Compare Value */
+    reg32_t CH1CMP; /**< Channel 1 Compare Value */
+    reg32_t CH2CMP; /**< Channel 2 Compare Value */
+    reg32_t CH2CMPINC; /**< Channel 2 Compare Value Auto-increment */
+    reg32_t CH1CAPT; /**< Channel 1 Capture Value */
+    reg32_t SYNC; /**< AON Synchronization */
+    reg32_t TIME; /**< Current Counter Value */
+    reg32_t SYNCLF; /**< Synchronization to SCLK_LF */
+} aon_rtc_regs_t;
+
+/**
+ * @brief   RTC_UPD is a 16 KHz signal used to sync up the radio timer. The
+ *          16 Khz is SCLK_LF divided by 2
+ * @details 0h = RTC_UPD signal is forced to 0
+ *          1h = RTC_UPD signal is toggling @16 kHz
+ */
+#define AON_RTC_CTL_RTC_UPD_EN 0x00000002
+
+/** @ingroup cpu_specific_peripheral_memory_map
+  * @{
+  */
+#define AON_RTC_BASE (PERIPH_BASE + 0x92000) /**< AON_RTC base address */
+/** @} */
+
+#define AON_RTC ((aon_rtc_regs_t *) (AON_RTC_BASE)) /**< AON_RTC register bank */
+
+/**
  * PRCM registers
  */
 typedef struct {

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
@@ -119,8 +119,9 @@ typedef enum IRQn
 /** @ingroup cpu_specific_peripheral_memory_map
   * @{
   */
-#define FLASH_BASE                  0x00000000 /**< FLASH base address */
-#define PERIPH_BASE                 0x40000000 /**< Peripheral base address */
+#define FLASH_BASE         0x00000000 /**< FLASH base address */
+#define PERIPH_BASE        0x40000000 /**< Peripheral base address */
+#define PERIPH_BASE_NONBUF 0x60000000 /**< Peripheral base address (nonbuf) */
 /*@}*/
 
 #ifdef __cplusplus

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_rfc.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_rfc.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_cc26xx_cc13xx_definitions
+ * @{
+ *
+ * @file
+ * @brief           CC26xx/CC13xx MCU I/O register definitions
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef CC26XX_CC13XX_RFC_H
+#define CC26XX_CC13XX_RFC_H
+
+#include "cc26xx_cc13xx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   RFC_DBELL registers
+ */
+typedef struct {
+    reg32_t CMDR; /**< Doorbell Command Register */
+    reg32_t CMDSTA; /**< Doorbell Command Status Register */
+    reg32_t RFHWIFG; /**< Interrupt Flags From RF Hardware Modules */
+    reg32_t RFHWIEN; /**< Interrupt Enable For RF Hardware Modules */
+    reg32_t RFCPEIFG; /**< Interrupt Flags For Command and Packet Engine
+                           Generated Interrupts */
+    reg32_t RFCPEIEN; /**< Interrupt Enable For Command and Packet Engine
+                           Generated Interrupts */
+    reg32_t RFCPEISL; /**< Interrupt Vector Selection For Command and Packet
+                          Engine Generated Interrupts */
+    reg32_t RFACKIFG; /**< Doorbell Command Acknowledgement Interrupt Flag */
+    reg32_t SYSGPOCTL; /**< RF Core General Purpose Output Control */
+} rfc_dbell_regs_t;
+
+/**
+ * @brief   RFC_DBELL definitions
+ * @{
+ */
+
+/**
+ * @brief   RFCHWIFG/RFCHWIEN interrupt flags
+ */
+typedef enum {
+    HW_IRQ_FSCA     = (1 << 1),
+    HW_IRQ_MDMDONE  = (1 << 2),
+    HW_IRQ_MDMIN    = (1 << 3),
+    HW_IRQ_MDMOUT   = (1 << 4),
+    HW_IRQ_MDMSOFT  = (1 << 5),
+    HW_IRQ_TRCTK    = (1 << 6),
+    HW_IRQ_RFEDONE  = (1 << 8),
+    HW_IRQ_RFESOFT0 = (1 << 9),
+    HW_IRQ_RFESOFT1 = (1 << 10),
+    HW_IRQ_RFESOFT2 = (1 << 11),
+    HW_IRQ_RATCH0   = (1 << 12),
+    HW_IRQ_RATCH1   = (1 << 13),
+    HW_IRQ_RATCH2   = (1 << 14),
+    HW_IRQ_RATCH3   = (1 << 15),
+    HW_IRQ_RATCH4   = (1 << 16),
+    HW_IRQ_RATCH5   = (1 << 17),
+    HW_IRQ_RATCH6   = (1 << 18),
+    HW_IRQ_RATCH7   = (1 << 19)
+} rf_hw_irq_t;
+
+/**
+ * @brief   RFCPEIEN/RFCPEIFG/RFCPEISL interrupt flags
+ */
+typedef enum {
+    CPE_IRQ_COMMAND_DONE         = (1 << 0),
+    CPE_IRQ_LAST_COMMAND_DONE    = (1 << 1),
+    CPE_IRQ_FG_COMMAND_DONE      = (1 << 2),
+    CPE_IRQ_LAST_FG_COMMAND_DONE = (1 << 3),
+    CPE_IRQ_TX_DONE              = (1 << 4),
+    CPE_IRQ_TX_ACK               = (1 << 5),
+    CPE_IRQ_TX_CTRL              = (1 << 6),
+    CPE_IRQ_TX_CTRL_ACK          = (1 << 7),
+    CPE_IRQ_TX_CTRL_ACK_ACK      = (1 << 8),
+    CPE_IRQ_TX_RETRANS           = (1 << 9),
+    CPE_IRQ_TX_ENTRY_DONE        = (1 << 10),
+    CPE_IRQ_TX_BUFFER_CHANGED    = (1 << 11),
+#ifdef CPU_VARIANT_X2
+    CPE_IRQ_COMMAND_STARTED      = (1 << 12),
+    CPE_IRQ_FG_COMMAND_STARTED   = (1 << 13),
+#else
+    CPE_IRQ_IRQ12                = (1 << 12),
+    CPE_IRQ_IRQ13                = (1 << 13),
+#endif
+    CPE_IRQ_IRQ14                = (1 << 14),
+    CPE_IRQ_IRQ15                = (1 << 15),
+    CPE_IRQ_RX_OK                = (1 << 16),
+    CPE_IRQ_RX_NOK               = (1 << 17),
+    CPE_IRQ_RX_IGNORED           = (1 << 18),
+    CPE_IRQ_RX_EMPTY             = (1 << 19),
+    CPE_IRQ_RX_CTRL              = (1 << 20),
+    CPE_IRQ_RX_CTRL_ACK          = (1 << 21),
+    CPE_IRQ_RX_BUF_FULL          = (1 << 22),
+    CPE_IRQ_RX_ENTRY_DONE        = (1 << 23),
+    CPE_IRQ_RX_DATA_WRITTEN      = (1 << 24),
+    CPE_IRQ_RX_N_DATA_WRITTEN    = (1 << 25),
+    CPE_IRQ_RX_ABORTED           = (1 << 26),
+    CPE_IRQ_IRQ27                = (1 << 27),
+    CPE_IRQ_SYNTH_NO_LOCK        = (1 << 28),
+    CPE_IRQ_MODULES_UNLOCKED     = (1 << 29),
+    CPE_IRQ_BOOT_DONE            = (1 << 30),
+    CPE_IRQ_INTERNAL_ERROR       = (1 << 31),
+} rf_cpe_irq_t;
+
+#define RFACKIFG_ACKFLAG 0x1
+/** @} */
+
+/**
+ * @ingroup cpu_specific_peripheral_memory_map
+ * @{
+ */
+#define RFC_DBELL_BASE (PERIPH_BASE + 0x41000) /**< RFC_DBELL base address */
+#define RFC_DBELL_BASE_NONBUF (PERIPH_BASE_NONBUF + 0x41000) /**< RFC_DBELL base address */
+/** @} */
+
+#define RFC_DBELL ((rfc_dbell_regs_t *) (RFC_DBELL_BASE)) /**< RFC_DBELL register bank */
+#define RFC_DBELL_NONBUF ((rfc_dbell_regs_t *) (RFC_DBELL_BASE_NONBUF)) /**< RFC_DBELL register bank */
+
+/**
+ * @brief   RFC_PWR registers
+ */
+typedef struct {
+    reg32_t PWMCLKEN; /**< RF Core Power Management and Clock Enable */
+} rfc_pwr_regs_t;
+
+/**
+ * @brief   RFC_PWR definitions
+ * @{
+ */
+#define PWMCLKEN_RFCTRC 0x400
+#define PWMCLKEN_FSCA   0x200
+#define PWMCLKEN_PHA    0x100
+#define PWMCLKEN_RAT    0x80
+#define PWMCLKEN_RFERAM 0x40
+#define PWMCLKEN_MDMRAM 0x10
+#define PWMCLKEN_MDM    0x8
+#define PWMCLKEN_CPERAM 0x4
+#define PWMCLKEN_CPE    0x2
+#define PWMCLKEN_RFC    0x1
+/** @} */
+
+/**
+ * @ingroup cpu_specific_peripheral_memory_map
+ * @{
+ */
+#define RFC_PWR_BASE (PERIPH_BASE + 0x40000) /**< RFC_PWR base address */
+#define RFC_PWR_BASE_NONBUF (PERIPH_BASE_NONBUF + 0x40000) /**< RFC_PWR base address */
+/** @} */
+
+#define RFC_PWR ((rfc_pwr_regs_t *) (RFC_PWR_BASE)) /**< RFC_PWR register bank */
+#define RFC_PWR_NONBUF ((rfc_pwr_regs_t *) (RFC_PWR_BASE_NONBUF)) /**< RFC_PWR register bank */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC26XX_CC13XX_RFC_H */
+
+/*@}*/

--- a/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
@@ -29,6 +29,7 @@
 #include "cc26xx_cc13xx_gpt.h"
 #include "cc26xx_cc13xx_i2c.h"
 #include "cc26xx_cc13xx_ioc.h"
+#include "cc26xx_cc13xx_rfc.h"
 #include "cc26xx_cc13xx_uart.h"
 #include "cc26xx_cc13xx_vims.h"
 #include "cc26xx_cc13xx_wdt.h"


### PR DESCRIPTION
### Contribution description

I've added some register definitions to reduce the mental overhead, and the review process of the CC13x2 RF driver. These are just some of the registers needed to interact with the RF Core. This can be merged as is, I can rebase the driver PR if this gets merged.

This is an step to avoid the use of external packages (TI SDK).

### Testing procedure

None for the moment. These are just definitions.

### Issues/PRs references

Depends on #13629 
