### PR TITLE
Makefile.dep: filter periph_init modules

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1060,22 +1060,28 @@ USEPKG := $(sort $(USEPKG))
 ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
   include $(RIOTBASE)/Makefile.dep
 else
+
   # set all USED periph_% init modules as DEFAULT_MODULE
   ifneq (,$(filter periph_init, $(USEMODULE)))
-    DEFAULT_MODULE += $(subst periph_,periph_init_,$(filter periph_%,$(USEMODULE)))
+      # To enable adding periph_% modules through the environment we cant use
+      # FEATURES_USED since the MODULE might be added directly as USEMODULE
+      PERIPH_MODULES_NO_INIT = periph_init% periph_common
+      PERIPH_MODULES = $(filter periph_%,$(USEMODULE))
+      PERIPH_INIT_MODULES = $(subst periph_,periph_init_,\
+        $(filter-out $(PERIPH_MODULES_NO_INIT),$(PERIPH_MODULES)))
+      DEFAULT_MODULE += $(PERIPH_INIT_MODULES)
+  endif
+
+  # add periph_init_% modules to USEMODULE unless disabled
+  ifneq (,$(filter periph_init, $(USEMODULE)))
+    USEMODULE += $(filter $(PERIPH_INIT_MODULES),\
+      $(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
   endif
 
   # Add auto_init_% DEFAULT_MODULES. This is done after the recursive cach since
   # none of these modules can trigger dependency resolution.
-  DEFAULT_MODULE := $(sort $(DEFAULT_MODULE))
   ifneq (,$(filter auto_init,$(USEMODULE)))
     USEMODULE += $(filter auto_init_%,$(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
-  endif
-
-  # Add auto_init_periph_% to DEFAULT_MODULES. This is done after the recursive
-  # cach since none of these modules can trigger dependency resolution.
-  ifneq (,$(filter periph_init,$(USEMODULE)))
-    USEMODULE += $(filter periph_init_%,$(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
   endif
 
   # Add test_utils_interactive_sync_shell
@@ -1084,5 +1090,7 @@ else
       $(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE)))
   endif
 
+  # Sort and remove duplicates
+  DEFAULT_MODULE := $(sort $(DEFAULT_MODULE))
   USEMODULE := $(sort $(USEMODULE))
 endif


### PR DESCRIPTION
### Contribution description

This is PR is based on some of the cleanups in #13349. ~~It moves handling of `MODULES` that implement `FEATURES` to its own `makefile`~~. In doing so it also fixes the issue mentioned in https://github.com/RIOT-OS/RIOT/pull/13639#issuecomment-599555719_.

### Testing procedure

- Reproduce testing procedure in #13639, and verify all modules included.

- Green murdock

- I'm running `save_all_dependencies_resolution_variables.sh`

### Issues/PRs references

Based on #13349
Fixes issues introduced in #13639 
