### PR TITLE
feather-nrf52840: use CDC ACM as default STDIO

### DIFF
--- a/boards/feather-nrf52840/Makefile.dep
+++ b/boards/feather-nrf52840/Makefile.dep
@@ -1,5 +1,7 @@
-# Use Segger's RTT by default for stdio on this board
-DEFAULT_MODULE += stdio_rtt
+# Provide stdio over USB by default
+# This is a temporary solution until management of stdio is correctly
+# handled by the build system
+DEFAULT_MODULE += stdio_cdc_acm
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides `stdio_cdc_acm` as default STDIO for the `feather-nrf52840` board.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Everything should still pass the CI, `example/hello-world` still works on `feather-nrf52840`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #12304.
Depends on ~~#13703~~ (merged).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #98scription
76.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
