### PR TITLE
Makefile.dep: disable stdio_% modules before they are included

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -440,9 +440,6 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   ifeq (,$(filter newlib_syscalls_%,$(USEMODULE)))
     USEMODULE += newlib_syscalls_default
   endif
-  ifeq (,$(filter stdio_cdc_acm stdio_native stdio_null stdio_rtt slipdev_stdio,$(USEMODULE)))
-    USEMODULE += stdio_uart
-  endif
 endif
 
 ifneq (,$(filter posix_sockets,$(USEMODULE)))
@@ -453,55 +450,12 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
-  USEMODULE += usbus_cdc_acm
-  USEMODULE += isrpipe
-endif
-
-ifneq (,$(filter stdio_rtt,$(USEMODULE)))
-  USEMODULE += xtimer
-endif
-
 ifneq (,$(filter shell,$(USEMODULE)))
   USEMODULE += stdin
 endif
 
-ifneq (,$(filter stdio_ethos,$(USEMODULE)))
-  USEMODULE += ethos
-  USEMODULE += stdin
-  USEMODULE += stdio_uart
-endif
-
-ifneq (,$(filter stdin,$(USEMODULE)))
-  ifneq (,$(filter stdio_uart,$(USEMODULE)))
-    USEMODULE += stdio_uart_rx
-  endif
-endif
-
-ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
-  USEMODULE += isrpipe
-  USEMODULE += stdio_uart
-endif
-
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
-endif
-
-ifneq (,$(filter stdio_cdc_acm stdio_null stdio_uart slipdev_stdio,$(USEMODULE)))
-  # stdio_rtt cannot be used when another STDIO is loaded
-  DISABLE_MODULE += stdio_rtt
-endif
-
-ifneq (,$(filter stdio_rtt stdio_null stdio_uart slipdev_stdio,$(USEMODULE)))
-  # stdio_cdc_acm cannot be used when another STDIO is loaded
-  DISABLE_MODULE += stdio_cdc_acm
-endif
-
-ifeq (,$(filter stdio_cdc_acm,$(USEMODULE)))
-  # The arduino bootloader feature cannot be used if the stdio_cdc_acm module
-  # is not used
-  FEATURES_BLACKLIST += bootloader_arduino
-endif
+# Include all stdio_% dependencies after all USEMODULE += stdio_%
+include $(RIOTBASE)/makefiles/stdio.inc.mk
 
 ifneq (,$(filter isrpipe,$(USEMODULE)))
   USEMODULE += tsrb

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -1,0 +1,64 @@
+STDIO_MODULES = \
+  slipdev_stdio \
+  stdio_cdc_acm \
+  stdio_ethos \
+  stdio_null \
+  stdio_rtt \
+  stdio_uart \
+  #
+
+# Since USEMODULE and DEFAULT_MODULEs are recursively expanded we need to
+# disable DEFAULT_MODULEs before any of there dependencies are evaluated,
+# otherwise the disabled MODULE will be in USEMODULE (triggering) its
+# dependencies, and then removed but leaving its dependencies
+ifneq (,$(filter $(filter-out stdio_rtt,$(STDIO_MODULES)),$(USEMODULE)))
+  # stdio_rtt cannot be used when another STDIO is loaded
+  DISABLE_MODULE += stdio_rtt
+endif
+
+ifneq (,$(filter $(filter-out stdio_cdc_acm,$(STDIO_MODULES)),$(USEMODULE)))
+  # stdio_cdc_acm cannot be used when another STDIO is loaded
+  DISABLE_MODULE += stdio_cdc_acm
+endif
+
+ifneq (,$(filter newlib,$(USEMODULE)))
+  ifeq (,$(filter $(STDIO_MODULES),$(USEMODULE)))
+    USEMODULE += stdio_uart
+  endif
+endif
+
+ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+  USEMODULE += usbus_cdc_acm
+  USEMODULE += isrpipe
+endif
+
+ifneq (,$(filter stdio_rtt,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
+ifneq (,$(filter stdio_ethos,$(USEMODULE)))
+  USEMODULE += ethos
+  USEMODULE += stdin
+  USEMODULE += stdio_uart
+endif
+
+ifneq (,$(filter stdin,$(USEMODULE)))
+  ifneq (,$(filter stdio_uart,$(USEMODULE)))
+    USEMODULE += stdio_uart_rx
+  endif
+endif
+
+ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
+  USEMODULE += isrpipe
+  USEMODULE += stdio_uart
+endif
+
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_uart
+endif
+
+ifeq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+  # The arduino bootloader feature cannot be used if the stdio_cdc_acm module
+  # is not used
+  FEATURES_BLACKLIST += bootloader_arduino
+endif


### PR DESCRIPTION
### Contribution description

This PR moves all `stdio_%` dependency resolution to is own file to cleanup inclusion order and better isolate the dependencies. Maybe #13469 will lead to a parent module and the dependencies can be moved to that `Makefile.dep`?

This PR also fixes disabling of `stdio` modules when this is done not by using `DISABLE_MODULE` directly but by the use of a conflicting `USEMODULE`.

Before this PR because of recursive declaration, on the first pass through `Makefile.dep` `stdio_rtt` would be added and then removed from `USEMODULE` this would lead to having in `USEMODULE` the dependencies of `stdio_rtt` but not the module itself.

By disabling right away we make sure its dependencies are note added.

### Testing procedure

- testing procedure in #13460

- If the new Makefile is not liked I can keep the same changes in `Makefile.dep`

- I haven't changed the order in which `stdio` modules are included so there should be no change here, a green Murdock should be enough.

### Issues/PRs references

Fixes #13460
Related to #13469