### PR TITLE
usbus: allow to set CONFIG_USB_PID/CONFIG_USB_VID by board

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -904,6 +904,13 @@ ifneq (,$(filter usbus,$(USEMODULE)))
   FEATURES_REQUIRED += periph_usbdev
   USEMODULE += core_thread_flags
   USEMODULE += event
+
+  ifneq (,$(CONFIG_USB_VID))
+    CFLAGS += -DCONFIG_USB_VID=0x$(CONFIG_USB_VID)
+  endif
+  ifneq (,$(CONFIG_USB_PID))
+    CFLAGS += -DCONFIG_USB_PID=0x$(CONFIG_USB_PID)
+  endif
 endif
 
 ifneq (,$(filter usbus_cdc_acm,$(USEMODULE)))

--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -18,30 +18,17 @@ USEMODULE += auto_init_usbus
 # USB device vendor and product ID
 export DEFAULT_VID = 1209
 export DEFAULT_PID = 7D00
-USB_VID ?= $(DEFAULT_VID)
-USB_PID ?= $(DEFAULT_PID)
+CONFIG_USB_VID ?= $(DEFAULT_VID)
+CONFIG_USB_PID ?= $(DEFAULT_PID)
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
 
-# Set USB VID/PID via CFLAGS if not being set via Kconfig
-ifndef CONFIG_USB_VID
-  CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID)
-else
-  USB_VID = $(patsubst 0x%,%,$(CONFIG_USB_VID))
-endif
-
-ifndef CONFIG_USB_PID
-  CFLAGS += -DCONFIG_USB_PID=0x$(USB_PID)
-else
-  USB_PID = $(patsubst 0x%,%,$(CONFIG_USB_PID))
-endif
-
 .PHONY: usb_id_check
 usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
+	@if [ $(CONFIG_USB_VID) = $(DEFAULT_VID) -o $(CONFIG_USB_PID) = $(DEFAULT_PID) ] ; then \
 		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
 		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi

--- a/examples/usbus_minimal/README.md
+++ b/examples/usbus_minimal/README.md
@@ -8,7 +8,8 @@ RIOT doesn't own any USB vendor and product ID. To compile this example, add
 your own vendor and product ID to the makefile:
 
 ```
-CFLAGS += -DCONFIG_USB_VID=0xYOURVID -DCONFIG_USB_PID=0xYOURPID
+CONFIG_USB_VID=0xYOURVID
+CONFIG_USB_PID=0xYOURPID
 ```
 
 The example demonstrates basic USB communication between a host and a RIOT

--- a/tests/usbus/Makefile
+++ b/tests/usbus/Makefile
@@ -6,16 +6,14 @@ FEATURES_PROVIDED += periph_usbdev
 # USB device vendor and product ID
 DEFAULT_VID = 1209
 DEFAULT_PID = 7D00
-USB_VID ?= $(DEFAULT_VID)
-USB_PID ?= $(DEFAULT_PID)
-
-CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID) -DCONFIG_USB_PID=0x$(USB_PID)
+CONFIG_USB_VID ?= $(DEFAULT_VID)
+CONFIG_USB_PID ?= $(DEFAULT_PID)
 
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: usb_id_check
 usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) ] || [ $(USB_PID) = $(DEFAULT_PID) ] ; then \
+	@if [ $(CONFIG_USB_VID) = $(DEFAULT_VID) ] || [ $(CONFIG_USB_PID) = $(DEFAULT_PID) ] ; then \
 		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
 		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi

--- a/tests/usbus_cdc_acm_stdio/Makefile
+++ b/tests/usbus_cdc_acm_stdio/Makefile
@@ -8,18 +8,17 @@ USEMODULE += shell_commands
 USEMODULE += ps
 
 # USB device vendor and product ID
+# pid.codes test VID/PID, not globally unique
 DEFAULT_VID = 1209
 DEFAULT_PID = 7D00
-USB_VID ?= $(DEFAULT_VID)
-USB_PID ?= $(DEFAULT_PID)
-
-CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID) -DCONFIG_USB_PID=0x$(USB_PID)
+CONFIG_USB_VID ?= $(DEFAULT_VID)
+CONFIG_USB_PID ?= $(DEFAULT_PID)
 
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: usb_id_check
 usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) ] || [ $(USB_PID) = $(DEFAULT_PID) ] ; then \
+	@if [ $(CONFIG_USB_VID) = $(DEFAULT_VID) ] || [ $(CONFIG_USB_PID) = $(DEFAULT_PID) ] ; then \
 		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
 		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -17,16 +17,14 @@ CFLAGS += -DGNRC_NETIF_NUMOF=2
 # pid.codes test VID/PID, not globally unique
 DEFAULT_VID = 1209
 DEFAULT_PID = 7D00
-USB_VID ?= $(DEFAULT_VID)
-USB_PID ?= $(DEFAULT_PID)
-
-CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID) -DCONFIG_USB_PID=0x$(USB_PID)
+CONFIG_USB_VID ?= $(DEFAULT_VID)
+CONFIG_USB_PID ?= $(DEFAULT_PID)
 
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: usb_id_check
 usb_id_check:
-	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
+	@if [ $(CONFIG_USB_VID) = $(DEFAULT_VID) ] || [ $(CONFIG_USB_PID) = $(DEFAULT_PID) ] ; then \
 		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
 		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi


### PR DESCRIPTION

### Contribution description

Some boards already have a unique PID:VID combination assigned to them.
When running RIOT on these boards, we should keep this ID combination.

Thus allow to set `CONFIG_USB_VID` and `CONFIG_USB_PID` by the board `Makefile.include`.

Tests and examples have to be adapted so they don't set CFLAGS themselves anymore.

### Testing procedure

All boards that don't have a unique VID:PID should still use the Riot ID.
But boards can now specify their own ID.

### Issues/PRs references

Will be used by #12778