### PR TITLE
tests: use button interrupt flank definition as optionally defined in board definitions

### DIFF
--- a/tests/buttons/main.c
+++ b/tests/buttons/main.c
@@ -25,7 +25,21 @@
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
-#define TEST_FLANK      GPIO_FALLING
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+#ifndef BTN1_INT_FLANK
+#define BTN1_INT_FLANK  GPIO_FALLING
+#endif
+
+#ifndef BTN2_INT_FLANK
+#define BTN2_INT_FLANK  GPIO_FALLING
+#endif
+
+#ifndef BTN3_INT_FLANK
+#define BTN3_INT_FLANK  GPIO_FALLING
+#endif
 
 #ifdef BTN0_PIN /* assuming that first button is always BTN0 */
 static void cb(void *arg)
@@ -39,28 +53,28 @@ int main(void)
     int cnt = 0;
     /* get the number of available buttons and init interrupt handler */
 #ifdef BTN0_PIN
-    if (gpio_init_int(BTN0_PIN, BTN0_MODE, TEST_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(BTN0_PIN, BTN0_MODE, BTN0_INT_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN0!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN1_PIN
-    if (gpio_init_int(BTN1_PIN, BTN1_MODE, TEST_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(BTN1_PIN, BTN1_MODE, BTN1_INT_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN1!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN2_PIN
-    if (gpio_init_int(BTN2_PIN, BTN2_MODE, TEST_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(BTN2_PIN, BTN2_MODE, BTN2_INT_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN2!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN3_PIN
-    if (gpio_init_int(BTN3_PIN, BTN3_MODE, TEST_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(BTN3_PIN, BTN3_MODE, BTN3_INT_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN3!");
         return 1;
     }

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -35,6 +35,10 @@
 #endif
 #include "shell.h"
 
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_RISING
+#endif
+
 #ifdef MODULE_PM_LAYERED
 static int check_mode(int argc, char **argv)
 {
@@ -216,7 +220,6 @@ static void btn_cb(void *ctx)
 }
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-
 /**
  * @brief   List of shell commands for this example.
  */
@@ -256,7 +259,7 @@ int main(void)
 
 #if defined(MODULE_PERIPH_GPIO_IRQ) && defined(BTN0_PIN)
     puts("using BTN0 as wake-up source");
-    gpio_init_int(BTN0_PIN, BTN0_MODE, GPIO_RISING, btn_cb, NULL);
+    gpio_init_int(BTN0_PIN, BTN0_MODE, BTN0_INT_FLANK, btn_cb, NULL);
 #endif
 
     /* run the shell and wait for the user to enter a mode */


### PR DESCRIPTION
### Contribution description

This PR changes two test applications to allow the use of an interrupt flank definition as given by the board definition for the buttons.

For that purpose, the board can optionally define a default interrupt flank `BTN*_INT_FLANK` for each button where `*` is the button number. If the board has defined an interrupt flank, it is used by the test applications for the initialization of the GPIOs. Otherwise the former default flank definition is used.

### Testing procedure

Use any board with buttons and flash `tests/buttons`, for example
```
BOARD=esp32-wroom-32 make -C tests/buttons/ flash term
```
In this case the former default definition `GPIO_FALLING` is used and the interrupt should be triggered when the button is pushed.
```
CFLAGS='-DBTN0_INT_FLANK=GPIO_RISING' BOARD=esp32-wroom-32 make -C tests/buttons/ flash
```
In this case `GPIO_RISING` is used and the interrupt should be triggered when the button is released.

### Issues/PRs references

This change is required to get the `tests/periph_pm` working with PR #13416.