### PR TITLE
drivers/apd99xx: fix wait long initialization

### DIFF
--- a/drivers/apds99xx/apds99xx.c
+++ b/drivers/apds99xx/apds99xx.c
@@ -147,6 +147,11 @@ int apds99xx_init(apds99xx_t *dev, const apds99xx_params_t *params)
         return -APDS99XX_ERROR_I2C;
     }
 
+    if (_update_reg(dev, APDS99XX_REG_CONFIG, APDS99XX_REG_WLONG,
+                    dev->params.wait_long)) {
+        return -APDS99XX_ERROR_I2C;
+    }
+
     return APDS99XX_OK;
 }
 


### PR DESCRIPTION
### Contribution description

This PR fixes the initialization function. The parameter `wait_long` defined in `apds99xx_params_t` is not set in inialization.

### Testing procedure

Use `tests/driver_apds99xx_full` with and without this PR
```
CFLAGS='-DAPDS99XX_PARAM_WAIT_LONG=1 -DAPDS99XX_PARAM_WAIT_STEPS=100 -DAPDS99XX_PARAM_INT_PIN=<your pin>' \
BOARD=<your board> make -C tests/driver_apds99xx_full/ flash test
```
Without this PR, new measurements should repeat in less than a second. With the PR, new measurements should be repeated with a period of about 3 seconds.

### Issues/PRs references