### PR TITLE
boards/pinetime: add defines for controlling the backlight pin

### DIFF
--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -53,6 +53,17 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Backlight control defines, default uses LCD_BACKLIGHT_LOW values
+ * @{
+ */
+#ifndef BACKLIGHT_MASK
+#define BACKLIGHT_MASK              (1 << 14)
+#endif
+#define BACKLIGHT_ON                (NRF_P0->OUTCLR = BACKLIGHT_MASK)
+#define BACKLIGHT_OFF               (NRF_P0->OUTSET = BACKLIGHT_MASK)
+/** @ */
+
+/**
  * @name LCD configuration
  * @{
  */

--- a/drivers/include/disp_dev.h
+++ b/drivers/include/disp_dev.h
@@ -27,6 +27,16 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "board.h"
+
+#ifndef BACKLIGHT_ON
+#define BACKLIGHT_ON
+#endif
+
+#ifndef BACKLIGHT_OFF
+#define BACKLIGHT_OFF
+#endif
+
 /**
  * @brief   Forward declaration for display device struct
  */
@@ -133,10 +143,26 @@ uint8_t disp_dev_color_depth(disp_dev_t *dev);
 /**
  * @brief   Invert the display device colors
  *
- * @param[in] dev       Network device descriptor
+ * @param[in] dev       Pointer to the display device
  * @param[in] invert    Invert mode (true if invert, false otherwise)
  */
 void disp_dev_set_invert(disp_dev_t *dev, bool invert);
+
+/**
+ * @brief   Enable the backlight pin
+ */
+static inline void disp_dev_backlight_on(void)
+{
+    BACKLIGHT_ON;
+}
+
+/**
+ * @brief   Disable the backlight pin
+ */
+static inline void disp_dev_backlight_off(void)
+{
+    BACKLIGHT_OFF;
+}
 
 #ifdef __cplusplus
 }

--- a/tests/disp_dev/main.c
+++ b/tests/disp_dev/main.c
@@ -35,17 +35,13 @@ static ili9341_t ili9341;
 
 int main(void)
 {
-#ifdef BOARD_PINETIME
-    /* on PineTime, enable the backlight */
-    gpio_clear(LCD_BACKLIGHT_LOW);
-#endif
-
     ili9341_init(&ili9341, &ili9341_params[0]);
 
     disp_dev_t *dev = (disp_dev_t *)&ili9341;
     dev->driver = &ili9341_disp_dev_driver;
 
     disp_dev_set_invert(dev, true);
+    disp_dev_backlight_on();
 
     uint16_t max_width = disp_dev_width(dev);
     uint16_t max_height = disp_dev_height(dev);

--- a/tests/driver_ili9341/main.c
+++ b/tests/driver_ili9341/main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include "xtimer.h"
+#include "board.h"
 #include "ili9341.h"
 #include "ili9341_params.h"
 
@@ -34,9 +35,9 @@ int main(void)
     /* initialize the sensor */
     printf("Initializing display...");
 
-#ifdef BOARD_PINETIME
-    /* on PineTime, enable the backlight */
-    gpio_clear(LCD_BACKLIGHT_LOW);
+    /* Enable backlight if macro is defined */
+#ifdef BACKLIGHT_ON
+    BACKLIGHT_ON;
 #endif
 
     if (ili9341_init(&dev, &ili9341_params[0]) == 0) {

--- a/tests/pkg_lvgl/main.c
+++ b/tests/pkg_lvgl/main.c
@@ -131,6 +131,9 @@ int main(void)
     disp_dev_t *disp_dev = (disp_dev_t *)&dev;
     disp_dev->driver = &ili9341_disp_dev_driver;
 
+    /* Enable backlight */
+    disp_dev_backlight_on();
+
     /* Initialize the concrete display driver */
     ili9341_init(&dev, &ili9341_params[0]);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds some defines (`BACKLIGHT_ON`, `BACKLIGHT_OFF`) for controlling the Pinetime backlight pin.
These defines are meant to be generic, similar to on-board LED macros, and should be defined in boards that need it (the adafruit-clue needs it for example).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Check the `tests/driver_ili9341`, `tests/disp_dev` and `tests/pkg_lvgl` are displaying something on the pinetime
- Check that with any other applications (`examples/hello-world`) the screen remains off.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will help with #13276 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
