### PR TITLE
cpu/cc2538: fix GPT3 IRQ definition

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -27,6 +27,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    Clock system configuration
+ * @{
+ */
+#define CLOCK_CORECLOCK     (16000000U)     /* desired core clock frequency, 16MHz */
+/** @} */
+
+/**
  * @name    Timer configuration
  *
  * General purpose timers (GPT[0-3]) are configured consecutively and in order

--- a/boards/common/remote/include/cfg_clk_default.h
+++ b/boards/common/remote/include/cfg_clk_default.h
@@ -30,7 +30,7 @@ extern "C" {
  * @name Clock system configuration
  * @{
  */
-#define CLOCK_CORECLOCK     (32000000U) /* 32MHz */
+#define CLOCK_CORECLOCK     (16000000U) /* 16MHz */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -33,7 +33,7 @@
  * @name    Clock system configuration
  * @{
  */
-#define CLOCK_CORECLOCK     (32000000U)     /* desired core clock frequency, 32MHz */
+#define CLOCK_CORECLOCK     (16000000U)     /* desired core clock frequency, 16MHz */
 /** @} */
 
 /**

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -31,7 +31,7 @@
  * @name    Clock system configuration
  * @{
  */
-#define CLOCK_CORECLOCK     (32000000U)     /* desired core clock frequency, 32MHz */
+#define CLOCK_CORECLOCK     (16000000U)     /* desired core clock frequency, 16MHz */
 /** @} */
 
 /**

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -67,8 +67,21 @@ static inline void _irq_enable(tim_t tim)
     DEBUG("%s(%u)\n", __FUNCTION__, tim);
 
     if (tim < TIMER_NUMOF) {
-        IRQn_Type irqn = GPTIMER_0A_IRQn + (2 * tim);
-
+        IRQn_Type irqn;
+        switch (tim) {
+            case 0:
+                irqn = GPTIMER_0A_IRQn;
+                break;
+            case 1:
+                irqn = GPTIMER_1A_IRQn;
+                break;
+            case 2:
+                irqn = GPTIMER_2A_IRQn;
+                break;
+            case 3:
+                irqn = GPTIMER_3A_IRQn;
+                break;
+        }
         NVIC_SetPriority(irqn, TIMER_IRQ_PRIO);
         NVIC_EnableIRQ(irqn);
 

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -21,10 +21,20 @@ BOARDS_TIMER_32kHz := \
     frdm-k22f \
     #
 
+BOARDS_TIMER_16MHz := \
+  cc2538dk \
+  openmote-b \
+  openmote-cc2538 \
+  remote-reva \
+  remote-revb \
+  #
+
 ifneq (,$(filter $(BOARDS_TIMER_25kHz),$(BOARD)))
   TIMER_SPEED ?= 250000
 else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
   TIMER_SPEED ?= 32768
+else ifneq (,$(filter $(BOARDS_TIMER_16MHz),$(BOARD)))
+  TIMER_SPEED ?= 16000000
 endif
 
 TIMER_SPEED ?= 1000000


### PR DESCRIPTION
### Contribution description

The GPT irq was wrongly defined for the forth GPT timer since although 1-3 are in row in the IRQ table, `GPTIMER_3x_IRQn` jump 10 spots in the table.

For `cc2538` when `GPT` are in  `GPTMCFG_32_BIT_TIMER` mode the timer must run at the same speed as the `system clock`. Currently for all `cc2538` this is `16Mhz`. This PR also sets the timer speed in `tests/periph_timer` to 16Mhz.

This PR also fixes wrong `CORE_CLOCK` definition for this boards. (clock setup could be cleaned up but that is another PR)

### Testing procedure

Test on any of these boards   cc2538dk ppenmote-b =openmote-cc2538 remote-reva remote-revb`.

- Test fails in master on  timers 1 and 3 with `1Mhz`:

<details><summary>BOARD=openmote-b make -C tests/periph_timer/ flash</summary>

```
2020-03-19 16:27:22,187 # Available timers: 4
2020-03-19 16:27:22,187 # 
2020-03-19 16:27:22,188 # Testing TIMER_0:
2020-03-19 16:27:22,188 # TIMER_0: initialization successful
2020-03-19 16:27:22,189 # TIMER_0: stopped
2020-03-19 16:27:22,189 # TIMER_0: set channel 0 to 5000
2020-03-19 16:27:22,201 # TIMER_0: set channel 1 to 10000
2020-03-19 16:27:22,202 # TIMER_0: starting
2020-03-19 16:27:22,218 # TIMER_0: channel 0 fired at SW count     5334 - init:     5334
2020-03-19 16:27:22,219 # TIMER_0: channel 1 fired at SW count    10664 - diff:     5330
2020-03-19 16:27:22,219 # 
2020-03-19 16:27:22,220 # Testing TIMER_1:
2020-03-19 16:27:22,220 # TIMER_1: ERROR on initialization - skipping
2020-03-19 16:27:22,221 # 
2020-03-19 16:27:22,221 # 
2020-03-19 16:27:22,221 # Testing TIMER_2:
2020-03-19 16:27:22,233 # TIMER_2: initialization successful
2020-03-19 16:27:22,234 # TIMER_2: stopped
2020-03-19 16:27:22,234 # TIMER_2: set channel 0 to 5000
2020-03-19 16:27:22,235 # TIMER_2: set channel 1 to 10000
2020-03-19 16:27:22,235 # TIMER_2: starting
2020-03-19 16:27:22,251 # TIMER_2: channel 0 fired at SW count     5334 - init:     5334
2020-03-19 16:27:22,253 # TIMER_2: channel 1 fired at SW count    10664 - diff:     5330
2020-03-19 16:27:22,253 # 
2020-03-19 16:27:22,253 # Testing TIMER_3:
2020-03-19 16:27:22,266 # TIMER_3: ERROR on initialization - skipping
2020-03-19 16:27:22,266 # 
2020-03-19 16:27:22,266 # 
2020-03-19 16:27:22,266 # TEST FAILED
```
</details>

- Test fails on timer 3 because of IRQ definition even with `16Mhz definition`.

<details><summary>TIMER_SPEED=16000000 BOARD=openmote-b make -C tests/periph_timer/ flash</summary>

```
main(): This is RIOT! (Version: 2020.04-devel-1334-g52cf43-HEAD)

Test for peripheral TIMERs

Available timers: 4

Testing TIMER_0:
TIMER_0: initialization successful
TIMER_0: stopped
TIMER_0: set channel 0 to 5000
TIMER_0: set channel 1 to 10000
TIMER_0: starting
TIMER_0: channel 0 fired at SW count      357 - init:      357
TIMER_0: channel 1 fired at SW count      710 - diff:      353

Testing TIMER_1:
TIMER_1: initialization successful
TIMER_1: stopped
TIMER_1: set channel 0 to 5000
TIMER_1: starting
TIMER_1: channel 0 fired at SW count      357 - init:      357

Testing TIMER_2:
TIMER_2: initialization successful
TIMER_2: stopped
TIMER_2: set channel 0 to 5000
TIMER_2: set channel 1 to 10000
TIMER_2: starting
TIMER_2: channel 0 fired at SW count      357 - init:      357
TIMER_2: channel 1 fired at SW count      710 - diff:      353

Testing TIMER_3:
TIMER_3: initialization successful
TIMER_3: stopped
TIMER_3: set channel 0 to 5000
TIMER_3: starting
Timeout in expect script at "child.expect('TEST SUCCEEDED')" (tests/periph_timer/tests/01-run.py:21)
```
</details>

- Test passing with this pr on `remote-revb` and `openmote-b`

<details><summary>BOARD=openmote-b make -C tests/periph_timer/ flash</summary>

```
2020-03-19 16:15:04,851 # main(): This is RIOT! (Version: 2020.04-devel-1333-gefb11-HEAD)
2020-03-19 16:15:04,852 # 
2020-03-19 16:15:04,867 # Test for peripheral TIMERs
2020-03-19 16:15:04,867 # 
2020-03-19 16:15:04,867 # Available timers: 4
2020-03-19 16:15:04,868 # 
2020-03-19 16:15:04,868 # Testing TIMER_0:
2020-03-19 16:15:04,869 # TIMER_0: initialization successful
2020-03-19 16:15:04,869 # TIMER_0: stopped
2020-03-19 16:15:04,870 # TIMER_0: set channel 0 to 5000
2020-03-19 16:15:04,870 # TIMER_0: set channel 1 to 10000
2020-03-19 16:15:04,882 # TIMER_0: starting
2020-03-19 16:15:04,884 # TIMER_0: channel 0 fired at SW count      333 - init:      333
2020-03-19 16:15:04,885 # TIMER_0: channel 1 fired at SW count      662 - diff:      329
2020-03-19 16:15:04,886 # 
2020-03-19 16:15:04,886 # Testing TIMER_1:
2020-03-19 16:15:04,887 # TIMER_1: initialization successful
2020-03-19 16:15:04,899 # TIMER_1: stopped
2020-03-19 16:15:04,899 # TIMER_1: set channel 0 to 5000
2020-03-19 16:15:04,900 # TIMER_1: starting
2020-03-19 16:15:04,901 # TIMER_1: channel 0 fired at SW count      334 - init:      334
2020-03-19 16:15:04,901 # 
2020-03-19 16:15:04,902 # Testing TIMER_2:
2020-03-19 16:15:04,903 # TIMER_2: initialization successful
2020-03-19 16:15:04,915 # TIMER_2: stopped
2020-03-19 16:15:04,916 # TIMER_2: set channel 0 to 5000
2020-03-19 16:15:04,916 # TIMER_2: set channel 1 to 10000
2020-03-19 16:15:04,917 # TIMER_2: starting
2020-03-19 16:15:04,919 # TIMER_2: channel 0 fired at SW count      333 - init:      333
2020-03-19 16:15:04,931 # TIMER_2: channel 1 fired at SW count      662 - diff:      329
2020-03-19 16:15:04,931 # 
2020-03-19 16:15:04,932 # Testing TIMER_3:
2020-03-19 16:15:04,932 # TIMER_3: initialization successful
2020-03-19 16:15:04,933 # TIMER_3: stopped
2020-03-19 16:15:04,933 # TIMER_3: set channel 0 to 5000
2020-03-19 16:15:04,934 # TIMER_3: starting
2020-03-19 16:15:04,947 # TIMER_3: channel 0 fired at SW count      334 - init:      334
2020-03-19 16:15:04,947 # 
2020-03-19 16:15:04,948 # TEST SUCCEEDED
```
</details>

<details><summary>BOARD=remote-revb make -C tests/periph_timer/ flash</summary>

```
2020-03-19 16:16:15,829 # main(): This is RIOT! (Version: 2020.04-devel-1333-gefb11-HEAD)
2020-03-19 16:16:15,830 # 
2020-03-19 16:16:15,831 # Test for peripheral TIMERs
2020-03-19 16:16:15,831 # 
2020-03-19 16:16:15,832 # Available timers: 4
2020-03-19 16:16:15,832 # 
2020-03-19 16:16:15,833 # Testing TIMER_0:
2020-03-19 16:16:15,834 # TIMER_0: initialization successful
2020-03-19 16:16:15,835 # TIMER_0: stopped
2020-03-19 16:16:15,836 # TIMER_0: set channel 0 to 5000
2020-03-19 16:16:15,838 # TIMER_0: set channel 1 to 10000
2020-03-19 16:16:15,839 # TIMER_0: starting
2020-03-19 16:16:15,841 # TIMER_0: channel 0 fired at SW count      357 - init:      357
2020-03-19 16:16:15,842 # TIMER_0: channel 1 fired at SW count      710 - diff:      353
2020-03-19 16:16:15,843 # 
2020-03-19 16:16:15,843 # Testing TIMER_1:
2020-03-19 16:16:15,844 # TIMER_1: initialization successful
2020-03-19 16:16:15,844 # TIMER_1: stopped
2020-03-19 16:16:15,845 # TIMER_1: set channel 0 to 5000
2020-03-19 16:16:15,845 # TIMER_1: starting
2020-03-19 16:16:15,846 # TIMER_1: channel 0 fired at SW count      357 - init:      357
2020-03-19 16:16:15,846 # 
2020-03-19 16:16:15,847 # Testing TIMER_2:
2020-03-19 16:16:15,847 # TIMER_2: initialization successful
2020-03-19 16:16:15,848 # TIMER_2: stopped
2020-03-19 16:16:15,848 # TIMER_2: set channel 0 to 5000
2020-03-19 16:16:15,849 # TIMER_2: set channel 1 to 10000
2020-03-19 16:16:15,849 # TIMER_2: starting
2020-03-19 16:16:15,850 # TIMER_2: channel 0 fired at SW count      357 - init:      357
2020-03-19 16:16:15,851 # TIMER_2: channel 1 fired at SW count      710 - diff:      353
2020-03-19 16:16:15,852 # 
2020-03-19 16:16:15,852 # Testing TIMER_3:
2020-03-19 16:16:15,853 # TIMER_3: initialization successful
2020-03-19 16:16:15,853 # TIMER_3: stopped
2020-03-19 16:16:15,854 # TIMER_3: set channel 0 to 5000
2020-03-19 16:16:15,854 # TIMER_3: starting
2020-03-19 16:16:15,855 # TIMER_3: channel 0 fired at SW count      357 - init:      357
2020-03-19 16:16:15,855 # 
2020-03-19 16:16:15,856 # TEST SUCCEEDED
```
</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
