### PR TITLE
tests/emcute: Use test_utils_interactive_sync_shell to sync

### DIFF
--- a/tests/emcute/tests/01-run.py
+++ b/tests/emcute/tests/01-run.py
@@ -105,9 +105,9 @@ class MQTTSNServer(Automaton):
     # >>> automaton states <<< #
     @ATMT.state(initial=1)
     def BEGIN(self):
-        utils.test_utils_interactive_sync(self.spawn,
-                                          TEST_INTERACTIVE_RETRIES,
-                                          TEST_INTERACTIVE_DELAY)
+        utils.test_utils_interactive_sync_shell(self.spawn,
+                                                TEST_INTERACTIVE_RETRIES,
+                                                TEST_INTERACTIVE_DELAY)
         raise self.CONNECT_FROM_NODE()
 
     @ATMT.state()


### PR DESCRIPTION
### Contribution description

This changes the `emcute` test script to use the sync function `test_utils_interactive_sync_shell`, introduced in #13613. Currently the test is failing, as it is waiting to sync by sending an 'r'.

### Testing procedure
Run the emcute test, it should pass.

### Issues/PRs references
#13613
