### PR TITLE
tapsetup: add --uplink option

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -6,6 +6,7 @@ COMMAND=""
 BRNAME="tapbr0"
 TAPNAME="tap"
 DEACTIVATE_IPV6=""
+UPLINK=""
 
 usage() {
     echo "usage: ${PROGRAM} [arguments]" >&2
@@ -22,12 +23,24 @@ usage() {
     echo "                                 (default: tap; ignored on OSX and FreeBSD)" >&2
     echo "   -6, --deactivate-ipv6:        Deactivate IPv6 for the interfaces and bridge" >&2
     echo "                                 (ignored on OSX and FreeBSD)" >&2
+    echo "   -u, --uplink:                 Optional uplink interface" >&2
+    echo "                                 (ignored on OSX and FreeBSD)" >&2
     echo "   -h, --help:                   Prints this text" >&2
 }
 
 unsupported_plattform() {
     echo "unsupported platform" >&2
     echo "(currently supported \`uname -s\` 'Darvin', 'FreeBSD', and 'Linux')" >&2
+}
+
+update_uplink() {
+    if command -v dhclient > /dev/null; then
+        dhclient $1
+    else
+        echo "DHCP client \`dhclient\` not found." >&2
+        echo "Please reconfigure your DHCP client for interface $1" >&2
+        echo "to keep up-link's IPv4 connection." >&2
+    fi
 }
 
 create_bridge() {
@@ -39,6 +52,10 @@ create_bridge() {
             ifconfig ${BRNAME} create || exit 1 ;;
         Linux)
             ip link add name ${BRNAME} type bridge || exit 1
+            if [ -n "${UPLINK}" ]; then
+                echo "using uplink ${UPLINK}"
+                ip link set dev ${UPLINK} master ${BRNAME} || exit 1
+            fi
             if [ -n "${DEACTIVATE_IPV6}" ]; then
                 echo 1 > /proc/sys/net/ipv6/conf/${BRNAME}/disable_ipv6 || exit 1
             fi ;;
@@ -54,7 +71,12 @@ up_bridge() {
         FreeBSD|OSX)
             ifconfig ${BRNAME} up || exit 1 ;;
         Linux)
-            ip link set ${BRNAME} up || exit 1 ;;
+            ip link set ${BRNAME} up || exit 1
+
+            # The bridge is now the new uplink
+            if [ -n "${UPLINK}" ]; then
+                update_uplink ${BRNAME}
+            fi ;;
         *)
             ;;
     esac
@@ -70,10 +92,17 @@ delete_bridge() {
             kldunload if_bridge || exit 1 ;;
         Linux)
             for IF in $(ls /sys/class/net/${BRNAME}/brif); do
-                ip link delete "${IF}"
+                if [ ${IF} != ${UPLINK} ]; then
+                    ip link delete "${IF}"
+                fi
             done
 
-            ip link delete ${BRNAME} || exit 1 ;;
+            ip link delete ${BRNAME} || exit 1
+
+            # restore the old uplink
+            if [ -n "${UPLINK}" ]; then
+                update_uplink ${UPLINK}
+            fi ;;
         OSX)
             ifconfig ${BRNAME} destroy || exit 1 ;;
         *)
@@ -158,6 +187,15 @@ while true ; do
         -h|--help)
             usage
             exit ;;
+        -u|--uplink)
+            case "$2" in
+                "")
+                    usage
+                    exit 2 ;;
+                *)
+                    UPLINK="$2"
+                    shift 2 ;;
+            esac ;;
         -t|--tap)
             case "$2" in
                 "")


### PR DESCRIPTION
### Contribution description

This adds an `--uplink` option to `tapsetup` to bridge the tap-network with an IPv6 enabled uplink interface, providing IPv6-WAN connectivity to `native`.

### Testing procedure

If `eno1` is an Ethernet interface on an IPv6 enabled network and you want to use it as an uplink for the `native` network, run

    sudo dist/tools/tapsetup/tapsetup -u eno1

You can observe that `tapbr0` was created, the interface should have received a global IP from your upstream router.

Now run a native networking example.
Interestingly I would not get a global IP address if I used `gnrc_ipv6_router_default`, only with `gnrc_ipv6_default`. So if you are using `examples/gnrc_networking`, change that line in the `Makefile`.
Alternatively just use `examples/gcoap` which does use `gnrc_ipv6_default`.

    make -C examples/gcoap term

Confirm the native RIOT instance has obtained a global IP address with `ifconfig`:

```
Iface  6  HWaddr: 3A:43:6B:65:16:F0 
          L2-PDU:1500 MTU:1492  HL:255  Source address length: 6
          Link type: wired
          inet6 addr: fe80::3843:6bff:fe65:16f0  scope: link  VAL
          inet6 addr: 2001:16b8:4550:d300:3843:6bff:fe65:16f0  scope: global  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ff65:16f0
```

You should now be able to reach other IPv6 hosts on the Internet:

```
> ping6 2600::
12 bytes from 2600::: icmp_seq=0 ttl=50 time=137.928 ms
12 bytes from 2600::: icmp_seq=1 ttl=50 time=136.887 ms
12 bytes from 2600::: icmp_seq=2 ttl=50 time=136.886 ms

--- 2600:: PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 136.886/137.233/137.928 ms
```

### Bugs

- When deleting the bridge with `tapsetup -d`, be sure to also specify the upstream interface. Otherwise your upstream interface will get removed too. I didn't find a way yet to tell the non-tap interface apart from the tap interfaces.
- ~~While the bridge is active, IPv4 connectivity is broken on your host interface. IPv6 connectivity is unaffected by this.~~

