### PR TITLE
tests/driver_at86rf215: Fix Makefile.ci

### DIFF
--- a/tests/driver_at86rf215/Makefile.ci
+++ b/tests/driver_at86rf215/Makefile.ci
@@ -2,6 +2,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
+    arduino-nano \
     arduino-uno \
     atmega328p \
     i-nucleo-lrwan1 \


### PR DESCRIPTION
### Contribution description

Added missing board to `Makefile.ci` in `tests/driver_at86rf215`.

### Testing procedure

Murdock should pass

### Issues/PRs references

Introduced in https://github.com/RIOT-OS/RIOT/pull/13583