### PR TITLE
boards: set samd21-arduino-bootloader as DEFAULT_MODULE

### DIFF
--- a/boards/common/arduino-mkr/Makefile
+++ b/boards/common/arduino-mkr/Makefile
@@ -1,3 +1,8 @@
 MODULE = boards_common_arduino-mkr
 
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # Add the samd21-arduino-bootloader directory to the build
+  DIRS += $(RIOTBOARD)/common/samd21-arduino-bootloader
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/arduino-mkr/Makefile.dep
+++ b/boards/common/arduino-mkr/Makefile.dep
@@ -2,5 +2,13 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-# setup the samd21 arduino bootloader related dependencies
-include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep
+# use arduino-bootloader only if no other stdio_% other than stdio_cdc_acm
+# is requested
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_%,$(USEMODULE))))
+  USEMODULE += boards_common_samd21-arduino-bootloader
+endif
+
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # setup the samd21 arduino bootloader related dependencies
+  include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep
+endif

--- a/boards/common/samd21-arduino-bootloader/Makefile.dep
+++ b/boards/common/samd21-arduino-bootloader/Makefile.dep
@@ -1,10 +1,5 @@
-# Provide stdio over USB by default
-# This is a temporary solution until management of stdio is correctly
-# handled by the build system
-DEFAULT_MODULE += stdio_cdc_acm
-
 # This boards requires support for Arduino bootloader.
 USEMODULE += usb_board_reset
-USEMODULE += boards_common_samd21-arduino-bootloader
+USEMODULE += stdio_cdc_acm
 
 FEATURES_REQUIRED += bootloader_arduino

--- a/boards/common/samd21-arduino-bootloader/Makefile.include
+++ b/boards/common/samd21-arduino-bootloader/Makefile.include
@@ -26,6 +26,3 @@ term-delay:
 
 TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
 $(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
-
-# Add the samd21-arduino-bootloader directory to the build
-DIRS += $(RIOTBOARD)/common/samd21-arduino-bootloader

--- a/boards/common/samd21-arduino-bootloader/reset.c
+++ b/boards/common/samd21-arduino-bootloader/reset.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#ifdef MODULE_BOARDS_COMMON_SAMD21_ARDUINO_BOOTLOADER
+
 #define USB_H_USER_IS_RIOT_INTERNAL
 
 #include "usb_board_reset.h"
@@ -41,3 +43,6 @@ void usb_board_reset_in_bootloader(void)
 
     usb_board_reset_in_application();
 }
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_BOARDS_COMMON_SAMD21_ARDUINO_BOOTLOADER */

--- a/boards/common/sodaq/Makefile
+++ b/boards/common/sodaq/Makefile
@@ -1,3 +1,8 @@
 MODULE = boards_common_sodaq
 
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # Add the samd21-arduino-bootloader directory to the build
+  DIRS += $(RIOTBOARD)/common/samd21-arduino-bootloader
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/sodaq/Makefile.dep
+++ b/boards/common/sodaq/Makefile.dep
@@ -2,5 +2,13 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-# setup the samd21 arduino bootloader related dependencies
-include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep
+# use arduino-bootloader only if no other stdio_% other than stdio_cdc_acm
+# is requested
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_%,$(USEMODULE))))
+  USEMODULE += boards_common_samd21-arduino-bootloader
+endif
+
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # setup the samd21 arduino bootloader related dependencies
+  include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep
+endif

--- a/boards/feather-m0/Makefile
+++ b/boards/feather-m0/Makefile
@@ -1,3 +1,8 @@
 MODULE = board
 
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # Add the samd21-arduino-bootloader directory to the build
+  DIRS += $(RIOTBOARD)/common/samd21-arduino-bootloader
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/feather-m0/Makefile.dep
+++ b/boards/feather-m0/Makefile.dep
@@ -2,5 +2,13 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-# setup the samd21 arduino bootloader related dependencies
-include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep
+# use arduino-bootloader only if no other stdio_% other than stdio_cdc_acm
+# is requested
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_%,$(USEMODULE))))
+  USEMODULE += boards_common_samd21-arduino-bootloader
+endif
+
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # setup the samd21 arduino bootloader related dependencies
+  include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep
+endif

--- a/boards/sodaq-one/Makefile
+++ b/boards/sodaq-one/Makefile
@@ -1,3 +1,8 @@
 MODULE = board
 
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # Add the samd21-arduino-bootloader directory to the build
+  DIRS += $(RIOTBOARD)/common/samd21-arduino-bootloader
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/sodaq-sara-aff/Makefile
+++ b/boards/sodaq-sara-aff/Makefile
@@ -1,3 +1,8 @@
 MODULE = board
 
+ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
+  # Add the samd21-arduino-bootloader directory to the build
+  DIRS += $(RIOTBOARD)/common/samd21-arduino-bootloader
+endif
+
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

This PR proposes using `DEFAULT_MODULE` for the `samd-arduino-bootloader`. Since in #12304 it was stated that this `MODULE` was desired as the `DEFAULT` it will not be disabled automatically if another `stdio_%` is requested.
This could be done by moving the inclusion of dependencies to `stdio.in.mk`

```
ifneq (,$(filter $(filter-out stdio_cdc_acm,$(STDIO_MODULES)),$(USEMODULE)))
  # stdio_cdc_acm cannot be used when another STDIO is loaded
  DISABLE_MODULE += stdio_cdc_acm
  # boards_common_samd21-arduino-bootloader depends on stdio_cdc_acm so disable
  # boards_common_samd21-arduino-bootloader if stdio_cdc_acm is disabled
  DISABLE_MODULE += boards_common_samd21-arduino-bootloader
endif

ifneq (,$(filter boards_common_samd21-arduino-bootloader,$(USEMODULE)))
  # setup the samd21 arduino bootloader related dependencies
  include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep
endif
```

But this would change the current behavior.

It selects `stdio_cdc_acm` as a `USEMODULE` and not a `DEFAULT_MODULE` to make more explicit that id using `arduino-bootloader` disabling `stdio_cdc_acm` is simply not possible. So is forcing usage of two `stdio_%` module you would simply get an error.

### Testing procedure

- flashing should still work as before by default

<details><summary>BOARD=arduino-mkrfox1200 make -C tests/xtimer_usleep flash</summary>

```
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
"make" -C /home/francisco/workspace/RIOT/boards/arduino-mkrfox1200
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/boards/common/arduino-mkr
"make" -C /home/francisco/workspace/RIOT/cpu/samd21
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/sam0_common
"make" -C /home/francisco/workspace/RIOT/cpu/samd21/periph
"make" -C /home/francisco/workspace/RIOT/cpu/sam0_common/periph
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/auto_init/usb
"make" -C /home/francisco/workspace/RIOT/sys/event
"make" -C /home/francisco/workspace/RIOT/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/tsrb
"make" -C /home/francisco/workspace/RIOT/sys/usb/usbus
"make" -C /home/francisco/workspace/RIOT/sys/usb_board_reset
"make" -C /home/francisco/workspace/RIOT/sys/usb/usbus/cdc/acm
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  17548	    132	   5908	  23588	   5c24	/home/francisco/workspace/RIOT/tests/xtimer_usleep/bin/arduino-mkrfox1200/tests_xtimer_usleep.elf
/home/francisco/workspace/RIOT/dist/tools/bossa-1.9/bossac -p /dev/ttyACM0 -o 0x2000 -e -i -w -v -b -R /home/francisco/workspace/RIOT/tests/xtimer_usleep/bin/arduino-mkrfox1200/tests_xtimer_usleep.bin
Device       : ATSAMD21x18
Version      : v2.0 [Arduino:XYZ] Mar 10 2017 12:20:17
Address      : 0x0
Pages        : 4096
Page Size    : 64 bytes
Total Size   : 256KB
Planes       : 1
Lock Regions : 16
Locked       : none
Security     : false
BOD          : true
BOR          : true
Erase flash

Done in 0.842 seconds
Write 17680 bytes to flash (277 pages)
[==============================] 100% (277/277 pages)
Done in 0.113 seconds
Verify 17680 bytes of flash
[==============================] 100% (277/277 pages)
Verify successful
Done in 0.144 seconds
Set boot flash true
make: Leaving directory '/home/francisco/workspace/RIOT/tests/xtimer_usleep'
```
</details>

- to use a different `stdio_%`,  arduino bootloader needs to be disabled

<details><summary>USEMODULE+=stdio_rtt BOARD=arduino-mkrfox1200 make -C tests/xtimer_usleep <b>FAILS</b></summary>

```
make: Entering directory '/home/francisco/workspace/RIOT/tests/xtimer_usleep'
Required modules were disabled using DISABLE_MODULE: stdio_cdc_acm stdio_rtt
/home/francisco/workspace/RIOT/tests/xtimer_usleep/../../Makefile.include:844: *** You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line.  Stop.
make: Leaving directory '/home/francisco/workspace/RIOT/tests/xtimer_usleep'
```
</details>
<details><summary>DISABLE_MODULE=boards_common_samd21-arduino-bootloader USEMODULE+=stdio_rtt BOARD=arduino-mkrfox1200 make -C tests/xtimer_usleep<b>OK</b></summary>

```
BOARD=arduino-mkrfox1200 make -C tests/xtimer_usleep
Building application "tests_xtimer_usleep" for "arduino-mkrfox1200" with MCU "samd21".

"make" -C /home/francisco/workspace/RIOT/boards/arduino-mkrfox1200
"make" -C /home/francisco/workspace/RIOT/boards/common/arduino-mkr
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/samd21
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
```
</details>

- If disabled none of the dependencies appear:

<details><summary>DISABLE_MODULE=boards_common_samd21-arduino-bootloader BOARD=arduino-mkrfox1200 make -C tests/xtimer_usleep info-modules --no-print-directory</summary>

```
auto_init
auto_init_xtimer
board
boards_common_arduino-mkr
core
core_init
core_msg
core_panic
cortexm_common
cortexm_common_periph
cpu
div
isrpipe
newlib
newlib_nano
newlib_syscalls_default
periph
periph_common
periph_gpio
periph_init
periph_init_common
periph_init_gpio
periph_init_init
periph_init_pm
periph_init_timer
periph_init_uart
periph_pm
periph_timer
periph_uart
pm_layered
sam0_common_periph
stdin
stdio_uart
stdio_uart_rx
sys
test_utils_interactive_sync
tsrb
xtimer
```
</details>

### Issues/PRs references

Documentation on `DEFAULT_MODULE` use #13651
Extends on  #12304 
See #13650 (review) and #13650 (comment).