### PR TITLE
dist/testrunner: Capture number of unittests that passed

### DIFF
--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -48,8 +48,17 @@ def run(testfunc, timeout=TIMEOUT, echo=True, traceback=False):
 
 
 def check_unittests(child, timeout=TIMEOUT, nb_tests=None):
-    _tests = r'\d+' if nb_tests is None else int(nb_tests)
-    child.expect(r'OK \({} tests\)'.format(_tests), timeout=timeout)
+    """ Check the number of unit tests that passed, and return the amount.
+
+        If the amount of expected tests to pass is known, nd_tests can be set
+        to perform an exact match against that number.
+    """
+    if nb_tests is None:
+        child.expect(r'OK \((\d+) tests\)', timeout=timeout)
+        return int(child.match.group(1))
+    _tests = int(nb_tests)
+    child.expect_exact('OK ({} tests)'.format(_tests), timeout=timeout)
+    return _tests
 
 
 def run_check_unittests(timeout=TIMEOUT, echo=True, traceback=False,

--- a/tests/gnrc_ipv6_ext_frag/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext_frag/tests/01-run.py
@@ -319,8 +319,8 @@ def testfunc(child):
     tap = get_bridge(os.environ["TAP"])
 
     child.sendline("unittests")
-    check_unittests(child)  # wait for and check result of unittests
-    print("." * int(child.match.group(1)), end="", flush=True)
+    # wait for and check result of unittests
+    print("." * check_unittests(child), end="", flush=True)
 
     lladdr_src = get_host_lladdr(tap)
 

--- a/tests/gnrc_rpl_srh/tests/01-run.py
+++ b/tests/gnrc_rpl_srh/tests/01-run.py
@@ -338,8 +338,8 @@ def testfunc(child):
     global sniffer
     tap = get_bridge(os.environ["TAP"])
     child.sendline("unittests")
-    check_unittests(child)  # wait for and check result of unittests
-    print("." * int(child.match.group(1)), end="", flush=True)
+    # wait for and check result of unittests
+    print("." * check_unittests(child), end="", flush=True)
     lladdr_src = get_host_lladdr(tap)
     child.sendline("ifconfig")
     child.expect(r"HWaddr: (?P<hwaddr>[A-Fa-f:0-9]+)\s")

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/tests/01-run.py
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/tests/01-run.py
@@ -88,8 +88,7 @@ def testfunc(child):
         )
         child.expect_exact("Original fragmentation header:")
         child.expect_exact("IPHC headers + payload:")
-        check_unittests(child)
-        assert int(child.match.group(1)) >= 4
+        assert check_unittests(child) >= 4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description
#13642 introduced the `check_unittests` helper function, to verify the result of unit tests on applications. Some tests (e.g. `gnrc_sixlowpan_iphc_w_vrb`, `gnrc_ipv6_ext_frag`) expect the number of passed tests to be captured. This modifies the regex to do that.

### Testing procedure
Run tests which make use of this function, they should pass.


### Issues/PRs references
#13642
