### PR TITLE
net/gnrc/ipv6/nib: remove direct dependency to xtimer

### DIFF
--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -46,6 +46,7 @@
 #include <stdint.h>
 
 #include "xtimer.h"
+#include "timex.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -104,6 +105,22 @@ void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event);
  * @param[in] evtimer   An event timer
  */
 void evtimer_print(const evtimer_t *evtimer);
+
+/**
+ * @brief   Return the current system time in msec
+ */
+static inline uint32_t evtimer_now_msec(void)
+{
+    return xtimer_now_usec64() / US_PER_MS;
+}
+
+/**
+ * @brief   Return the current system time in minutes
+ */
+static inline uint32_t evtimer_now_min(void)
+{
+    return xtimer_now_usec64() / (US_PER_SEC * SEC_PER_MIN);
+}
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -234,7 +234,7 @@ _nib_abr_entry_t *_handle_abro(const sixlowpan_nd_opt_abr_t *abro)
 
         if (abr->version >= abro_version) {
             abr->version = abro_version;
-            abr->valid_until = _now_min() + ltime;
+            abr->valid_until = evtimer_now_min() + ltime;
         }
         /* correct for default value */
         ltime = (ltime == 0) ? SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT : ltime;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h
@@ -24,7 +24,7 @@
 #include "net/gnrc/ipv6/nib/conf.h"
 #include "net/sixlowpan/nd.h"
 #include "timex.h"
-#include "xtimer.h"
+#include "evtimer.h"
 
 #include "_nib-arsm.h"
 #include "_nib-internal.h"
@@ -32,12 +32,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-static inline uint32_t _now_min(void)
-{
-    return (uint32_t)((xtimer_now_usec64() / (US_PER_SEC * SEC_PER_MIN)) &
-                      UINT32_MAX);
-}
 
 #if GNRC_IPV6_NIB_CONF_6LN || defined(DOXYGEN)
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -13,7 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
-#include "xtimer.h"
+#include "evtimer.h"
 #include "net/gnrc/ndp.h"
 #include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/netif/internal.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -788,7 +788,7 @@ _nib_offl_entry_t *_nib_pl_add(unsigned iface,
     }
     assert(valid_ltime >= pref_ltime);
     if ((valid_ltime != UINT32_MAX) || (pref_ltime != UINT32_MAX)) {
-        uint32_t now = (xtimer_now_usec64() / US_PER_MS) & UINT32_MAX;
+        uint32_t now = evtimer_now_msec();
         if (pref_ltime != UINT32_MAX) {
             _evtimer_add(dst, GNRC_IPV6_NIB_PFX_TIMEOUT, &dst->pfx_timeout,
                          pref_ltime);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -63,7 +63,7 @@ void _handle_snd_mc_ra(gnrc_netif_t *netif)
         if ((final_ra && (next_scheduled > NDP_MAX_RA_INTERVAL_MS)) ||
             gnrc_netif_is_rtr_adv(netif)) {
             _snd_rtr_advs(netif, NULL, final_ra);
-            netif->ipv6.last_ra = (xtimer_now_usec64() / US_PER_MS) & UINT32_MAX;
+            netif->ipv6.last_ra = evtimer_now_msec();
             if ((netif->ipv6.ra_sent < NDP_MAX_INIT_RA_NUMOF) || final_ra) {
                 if ((netif->ipv6.ra_sent < NDP_MAX_INIT_RA_NUMOF) &&
                     (next_ra_time > NDP_MAX_INIT_RA_INTERVAL)) {
@@ -100,7 +100,7 @@ void _snd_rtr_advs(gnrc_netif_t *netif, const ipv6_addr_t *dst, bool final)
 static gnrc_pktsnip_t *_offl_to_pio(_nib_offl_entry_t *offl,
                                     gnrc_pktsnip_t *ext_opts)
 {
-    uint32_t now = (xtimer_now_usec64() / US_PER_MS) & UINT32_MAX;
+    uint32_t now = evtimer_now_msec();
     gnrc_pktsnip_t *pio;
     uint8_t flags = 0;
     uint32_t valid_ltime = (offl->valid_until == UINT32_MAX) ? UINT32_MAX :
@@ -183,7 +183,7 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
     }
     ltime = (gnrc_netif_is_6lbr(netif)) ?
             (SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT) :
-            (abr->valid_until - _now_min());
+            (abr->valid_until - evtimer_now_min());
     (void)ltime;    /* gnrc_sixlowpan_nd_opt_abr_build might evaluate to NOP */
     abro = gnrc_sixlowpan_nd_opt_abr_build(abr->version, ltime, &abr->addr,
                                            ext_opts);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -41,7 +41,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 #if ENABLE_DEBUG
-#include "xtimer.h"
+#include "evtimer.h"
 #endif
 
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
@@ -327,7 +327,7 @@ void gnrc_ipv6_nib_handle_pkt(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
 void gnrc_ipv6_nib_handle_timer_event(void *ctx, uint16_t type)
 {
     DEBUG("nib: Handle timer event (ctx = %p, type = 0x%04x, now = %ums)\n",
-          ctx, type, (unsigned)xtimer_now_usec() / 1000);
+          ctx, type, (unsigned)evtimer_now_msec());
     _nib_acquire();
     switch (type) {
 #if GNRC_IPV6_NIB_CONF_ARSM
@@ -525,7 +525,7 @@ static void _handle_rtr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                          next_ra_delay);
         }
         else {
-            uint32_t now = (xtimer_now_usec64() / MS_PER_SEC) & UINT32_MAX;
+            uint32_t now = evtimer_now_msec();
 
             /* check for integer overflows and initial value of last_ra */
             if (((netif->ipv6.last_ra > (UINT32_MAX - NDP_MIN_MS_DELAY_BETWEEN_RAS) &&
@@ -1261,7 +1261,7 @@ static void _handle_snd_na(gnrc_pktsnip_t *pkt)
 static void _handle_pfx_timeout(_nib_offl_entry_t *pfx)
 {
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
-    uint32_t now = (xtimer_now_usec64() / US_PER_MS) & UINT32_MAX;
+    uint32_t now = evtimer_now_msec();
 
     gnrc_netif_acquire(netif);
     if (now >= pfx->valid_until) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -100,7 +100,7 @@ void gnrc_ipv6_nib_init(void)
 static void _add_static_lladdr(gnrc_netif_t *netif)
 {
 #ifdef GNRC_IPV6_STATIC_LLADDR
-    /* parse addr from string and explicitely set a link lokal prefix
+    /* parse addr from string and explicitly set a link local prefix
      * if ifnum > 1 each interface will get its own link local address
      * with GNRC_IPV6_STATIC_LLADDR + i
      */

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
@@ -78,7 +78,7 @@ bool gnrc_ipv6_nib_abr_iter(void **state, gnrc_ipv6_nib_abr_t *entry)
 void gnrc_ipv6_nib_abr_print(gnrc_ipv6_nib_abr_t *abr)
 {
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    uint32_t now = _now_min();
+    uint32_t now = evtimer_now_min();
 
     printf("%s v%" PRIu32 " expires %" PRIu32 "min\n",
            ipv6_addr_to_str(addr_str, &abr->addr, sizeof(addr_str)),

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -20,7 +20,7 @@
 #include "net/gnrc/ipv6/nib/pl.h"
 #include "net/gnrc/netif/internal.h"
 #include "timex.h"
-#include "xtimer.h"
+#include "evtimer.h"
 
 #include "_nib-internal.h"
 #include "_nib-router.h"
@@ -142,7 +142,7 @@ void gnrc_ipv6_nib_pl_print(gnrc_ipv6_nib_pl_t *entry)
 {
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
     ipv6_addr_t pfx = IPV6_ADDR_UNSPECIFIED;
-    uint32_t now = ((xtimer_now_usec64() / US_PER_MS)) & UINT32_MAX;
+    uint32_t now = evtimer_now_msec();
 
     ipv6_addr_init_prefix(&pfx, &entry->pfx, entry->pfx_len);
     printf("%s/%u ", ipv6_addr_to_str(addr_str, &pfx, sizeof(addr_str)),


### PR DESCRIPTION
### Contribution description

While working on #13661, I realized that `gnrc_ipv6_nib` implies that evtimer pulls in xtimer. #13661 replaces xtimer with ztimer and, thus, the implication is wrong and `gnrc_ipv6_nib` cannot be built due to the missing xtimer.

This contribution extends evtimer by getters to retrieve the current system time.

### Testing procedure

`tests/gnrc_ipv6_nib` should still pass.

### Issues/PRs references

#13661