### PR TITLE
tools/radvd: Add script to run radvd on a tun interface

### DIFF
--- a/dist/tools/radvd/radvd.conf
+++ b/dist/tools/radvd/radvd.conf
@@ -1,0 +1,9 @@
+interface ${TAP}
+{
+    AdvSendAdvert on;
+    prefix ${PREFIX}
+    {
+        AdvOnLink on;
+        AdvAutonomous on;
+    };
+};

--- a/dist/tools/radvd/radvd.sh
+++ b/dist/tools/radvd/radvd.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+
+CURRENT_DIR="$(dirname $(readlink -f $0))"
+PIDFILE="/tmp/radvd-${SUDO_USER}.pid"
+
+stop_radvd() {
+    if [ -f "${PIDFILE}" ]; then
+        PID=$(cat ${PIDFILE})
+    fi
+    if [ -n "${PID}" ]; then
+        kill ${PID}
+        rm ${PIDFILE}
+        echo "radvd stopped"
+    fi
+}
+
+start_radvd() {
+    export TAP
+    export PREFIX
+    cat ${CURRENT_DIR}/radvd.conf | envsubst | radvd -C /dev/stdin -u ${SUDO_USER} -p ${PIDFILE}
+
+    if [ $? -ne 0 ]; then
+        echo "radvd failed to start on ${TAP} with prefix ${PREFIX}"
+        exit 1
+    else
+        echo "radvd running on ${TAP}"
+    fi
+}
+
+usage() {
+    echo "usage: $0 [options]" >&2
+    echo "Options:" >&2
+    echo "   -c <tap-device> <prefix>: Start radvd on <tap-device>, advertising <prefix>" >&2
+    echo "   -d, --delete:             Stop radvd" >&2
+}
+
+if ! command -v radvd > /dev/null; then
+    echo "Router Advertisement Daemon 'radvd' not found." >&2
+    echo "Please install 'radvd' on your operating system." >&2
+    exit 1
+fi
+
+while true ; do
+    case "$1" in
+        -c|--create)
+            if [ -n "${COMMAND}" ]; then
+                usage
+                exit 2
+            fi
+            COMMAND="create"
+            shift
+            case "$1" in
+                "")
+                    usage
+                    exit 2 ;;
+                *)
+                    TAP="$1"
+                    shift 1 ;;
+            esac
+            case "$1" in
+                "")
+                    usage
+                    exit 2 ;;
+                *)
+                    PREFIX="$1"
+                    shift 1 ;;
+            esac ;;
+        -d|--delete)
+            if [ -n "${COMMAND}" ]; then
+                usage
+                exit 2
+            fi
+            COMMAND="delete"
+            shift ;;
+        -h|--help)
+            usage
+            exit ;;
+        "")
+            break ;;
+        *)  usage
+            exit 2 ;;
+    esac
+done
+
+if [ -z "${SUDO_USER}" ]; then
+    echo 'Environment variable $SUDO_USER required; Please run with `sudo`'
+    exit 1
+fi
+
+if [ -z "${COMMAND}" ]; then
+    COMMAND="create"
+fi
+
+if [ "${COMMAND}" = 'create' ]; then
+    [ -z "${TAP}" -o -z "${PREFIX}" ] && {
+        usage
+        exit 1
+    }
+    stop_radvd
+    start_radvd || exit 1
+elif [ "${COMMAND}" = 'delete' ]; then
+    stop_radvd || exit 1
+else
+    echo 'unknown command'
+    exit 1
+fi


### PR DESCRIPTION
### Contribution description

This adds a small wrapper script to configure and start radvd on a
tun interface.
This allows the use of router advertisements and global adresses with
the `native` target.

### Testing procedure

 - first create the tap interface as usual
   ```
    sudo dist/tools/tapsetup/tapsetup
   ```
 - now run radvd on the new tapbr0 interface
   ```
    sudo dist/tools/radvd/radvd.sh -c tapbr0 2001:db8::/64
   ```
 - Now run the `gnrc_networking` example on native:
   ```
    make -C examples/gnrc_networking all term
   ```
You should now see that the `native` node has received a global address
in `ifconfig`.
You should be able to reach this address from your host computer.

It may take very long for the native node to obtain the address.
If you are observing this, try turning off router advertisements of the
native node on the upstream interface by running

    ifconfig 6 -rtr_adv

Alternatively change `USEMODULE += gnrc_ipv6_router_default` to
`USEMODULE += gnrc_ipv6_default` in the project's `Makefile`.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->




<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
