### PR TITLE
core/thread_flags: remove #error from header file

### DIFF
--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -54,10 +54,6 @@
 #ifndef THREAD_FLAGS_H
 #define THREAD_FLAGS_H
 
-#ifndef MODULE_CORE_THREAD_FLAGS
-#error Missing USEMODULE += core_thread_flags
-#endif
-
 #include "kernel_types.h"
 #include "sched.h"  /* for thread_t typedef */
 


### PR DESCRIPTION
### Contribution description

This commit removes the #error from the thread_flags header.
This #error makes the usage of
if(IS_USED(MODULE_THAT_DEPENDS_ON_THREAD_FLAGS)) pattern harder,
because the error is triggered each time the header is included.
If a module uses any thread_flags function it will fail in link time
anyway.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try removing the `core_thread_flags` dependency from any component that requires thread flags (e.g `/tests/thread_flags_xtimer`. It should fail.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#13669 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
