### PR TITLE
cpu/cc2538: clock cleanups

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -30,7 +30,37 @@ extern "C" {
  * @name    Clock system configuration
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* desired core clock frequency, 16MHz */
+/*
+ * 0: use internal 32KHz RCOSC
+ * 1: use external 32KHz XOSC
+ */
+#ifndef SYS_CTRL_OSC32K_USE_XTAL
+#define SYS_CTRL_OSC32K_USE_XTAL        (1)
+#endif
+/*
+ * 0: use internal 16MHz RCOSC
+ * 1: use external 32MHz XOSC, required for RF operation
+ */
+#ifndef SYS_CTRL_OSC_USE_XTAL
+#define SYS_CTRL_OSC_USE_XTAL           (1)
+#endif
+
+#if SYS_CTRL_OSC_USE_XTAL
+#define CLOCK_OSC           (XOSC32M_FREQ)
+#else
+#define CLOCK_OSC           (RCOSC16M_FREQ)
+#endif
+
+#if SYS_CTRL_OSC32K_USE_XTAL
+#define CLOCK_OSC32K        (XOSC32K_FREQ)    /* XCOSC frequency */
+#else
+#define CLOCK_OSC32K        (RCOSC32K_FREQ)    /* XCOSC frequency */
+#endif
+
+/* System clock frequency 32MHz */
+#define CLOCK_CORECLOCK     (CLOCK_OSC)
+/* I/O clock rate setting 16MHz */
+#define CLOCK_IO            (CLOCK_OSC / 2)
 /** @} */
 
 /**

--- a/boards/common/remote/include/cfg_clk_default.h
+++ b/boards/common/remote/include/cfg_clk_default.h
@@ -27,10 +27,40 @@ extern "C" {
 #endif
 
 /**
- * @name Clock system configuration
+ * @name    Clock system configuration
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U) /* 16MHz */
+/*
+ * 0: use internal 32KHz RCOSC
+ * 1: use external 32KHz XOSC
+ */
+#ifndef SYS_CTRL_OSC32K_USE_XTAL
+#define SYS_CTRL_OSC32K_USE_XTAL        (1)
+#endif
+/*
+ * 0: use internal 16MHz RCOSC
+ * 1: use external 32MHz XOSC, required for RF operation
+ */
+#ifndef SYS_CTRL_OSC_USE_XTAL
+#define SYS_CTRL_OSC_USE_XTAL           (1)
+#endif
+
+#if SYS_CTRL_OSC_USE_XTAL
+#define CLOCK_OSC           (XOSC32M_FREQ)
+#else
+#define CLOCK_OSC           (RCOSC16M_FREQ)
+#endif
+
+#if SYS_CTRL_OSC32K_USE_XTAL
+#define CLOCK_OSC32K        (XOSC32K_FREQ)    /* XCOSC frequency */
+#else
+#define CLOCK_OSC32K        (RCOSC32K_FREQ)    /* XCOSC frequency */
+#endif
+
+/* System clock frequency 32MHz */
+#define CLOCK_CORECLOCK     (CLOCK_OSC)
+/* I/O clock rate setting 16MHz */
+#define CLOCK_IO            (CLOCK_OSC / 2)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -33,7 +33,37 @@
  * @name    Clock system configuration
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* desired core clock frequency, 16MHz */
+/*
+ * 0: use internal 32KHz RCOSC
+ * 1: use external 32KHz XOSC
+ */
+#ifndef SYS_CTRL_OSC32K_USE_XTAL
+#define SYS_CTRL_OSC32K_USE_XTAL        (1)
+#endif
+/*
+ * 0: use internal 16MHz RCOSC
+ * 1: use external 32MHz XOSC, required for RF operation
+ */
+#ifndef SYS_CTRL_OSC_USE_XTAL
+#define SYS_CTRL_OSC_USE_XTAL           (1)
+#endif
+
+#if SYS_CTRL_OSC_USE_XTAL
+#define CLOCK_OSC           (XOSC32M_FREQ)
+#else
+#define CLOCK_OSC           (RCOSC16M_FREQ)
+#endif
+
+#if SYS_CTRL_OSC32K_USE_XTAL
+#define CLOCK_OSC32K        (XOSC32K_FREQ)    /* XCOSC frequency */
+#else
+#define CLOCK_OSC32K        (RCOSC32K_FREQ)    /* XCOSC frequency */
+#endif
+
+/* System clock frequency 32MHz */
+#define CLOCK_CORECLOCK     (CLOCK_OSC)
+/* I/O clock rate setting 16MHz */
+#define CLOCK_IO            (CLOCK_OSC / 2)
 /** @} */
 
 /**

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -31,9 +31,38 @@
  * @name    Clock system configuration
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* desired core clock frequency, 16MHz */
-/** @} */
+/*
+ * 0: use internal 32KHz RCOSC
+ * 1: use external 32KHz XOSC
+ */
+#ifndef SYS_CTRL_OSC32K_USE_XTAL
+#define SYS_CTRL_OSC32K_USE_XTAL        (1)
+#endif
+/*
+ * 0: use internal 16MHz RCOSC
+ * 1: use external 32MHz XOSC, required for RF operation
+ */
+#ifndef SYS_CTRL_OSC_USE_XTAL
+#define SYS_CTRL_OSC_USE_XTAL           (1)
+#endif
 
+#if SYS_CTRL_OSC_USE_XTAL
+#define CLOCK_OSC           (XOSC32M_FREQ)
+#else
+#define CLOCK_OSC           (RCOSC16M_FREQ)
+#endif
+
+#if SYS_CTRL_OSC32K_USE_XTAL
+#define CLOCK_OSC32K        (XOSC32K_FREQ)    /* XCOSC frequency */
+#else
+#define CLOCK_OSC32K        (RCOSC32K_FREQ)    /* XCOSC frequency */
+#endif
+
+/* System clock frequency 32MHz */
+#define CLOCK_CORECLOCK     (CLOCK_OSC)
+/* I/O clock rate setting 16MHz */
+#define CLOCK_IO            (CLOCK_OSC / 2)
+/** @} */
 /**
  * @name    Timer configuration
  *

--- a/cpu/cc2538/include/cc2538.h
+++ b/cpu/cc2538/include/cc2538.h
@@ -798,10 +798,14 @@ typedef volatile uint32_t cc2538_reg_t; /**< Least-significant 32 bits of the IE
 #define CCTEST_USBCTRL              ( *(cc2538_reg_t*)0x44010050 ) /**< CCTEST USB PHY stand-by control */
 /** @} */
 
-#define XOSC32M_FREQ                32000000 /**< 32 MHz external oscillator/clock frequency */
-#define RCOSC16M_FREQ               16000000 /**< 16 MHz internal RC oscillator frequency */
+#define XOSC32M_FREQ                32000000U /**< 32 MHz external oscillator/clock frequency */
+#define RCOSC16M_FREQ               16000000U /**< 16 MHz internal RC oscillator frequency */
 
-#define CC2538_VTOR_ALIGN                512 /**< CC2538 Vector Table alignment */
+#define XOSC32K_FREQ                   32768U /**< 32 KHz external oscillator/clock frequency */
+#define RCOSC32K_FREQ                  32753U /**< 32 KHz internal RC oscillator frequency */
+
+
+#define CC2538_VTOR_ALIGN                 512 /**< CC2538 Vector Table alignment */
 
 #ifdef __cplusplus
 }

--- a/cpu/cc2538/periph/pm.c
+++ b/cpu/cc2538/periph/pm.c
@@ -58,12 +58,15 @@ void pm_set(unsigned mode)
 
         /* If we used the 32 MHz clock, we have to switch to 16 MHz for deep sleep */
         switch_osc = !SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC;
+        /* set to 0 in order to ensure that the 32 MHz XOSC is started as quick
+           as possible after power mode */
+        SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC_PD = 0;
     }
 
     /* switch to 16 MHz clock */
     if (switch_osc) {
         SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC = 1;
-        while (!SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC) {}
+        while (!SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.OSC) {}
     }
 
     cortexm_sleep(deep);
@@ -71,6 +74,8 @@ void pm_set(unsigned mode)
     /* switch back to 32 MHz clock */
     if (switch_osc) {
         SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC = 0;
-        while (SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC) {}
+        /* Power down the oscillator not selected by OSC bit */
+        SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRLbits.OSC_PD = 1;
+        while (SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.OSC) {}
     }
 }

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -21,7 +21,7 @@ BOARDS_TIMER_32kHz := \
     frdm-k22f \
     #
 
-BOARDS_TIMER_16MHz := \
+BOARDS_TIMER_CLOCK_CORECLOCK := \
   cc2538dk \
   openmote-b \
   openmote-cc2538 \
@@ -33,8 +33,8 @@ ifneq (,$(filter $(BOARDS_TIMER_25kHz),$(BOARD)))
   TIMER_SPEED ?= 250000
 else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
   TIMER_SPEED ?= 32768
-else ifneq (,$(filter $(BOARDS_TIMER_16MHz),$(BOARD)))
-  TIMER_SPEED ?= 16000000
+else ifneq (,$(filter $(BOARDS_TIMER_CLOCK_CORECLOCK),$(BOARD)))
+  TIMER_SPEED ?= CLOCK_CORECLOCK
 endif
 
 TIMER_SPEED ?= 1000000


### PR DESCRIPTION
### Contribution description

This PR cleanups clock initialization code for `cc2538`. It also documents the configuration in `cc2538` based boards `periph_conf`. Those boards share the same configuartion, I didn't merge it since one could use different configurations depending on the `BOARD`.

I also set `OSC_PD` before entering sleep modes if running from 32Mhz for faster wakeups.

These boards now run at `32Mhz` and use the external 32Khz oscilator.

`tests/periph_timer` is fixed to use `CLOCK_CORECLOCK` for these boards, which now accurately represents those boards clock configuration. 

### Testing procedure

**run `tests/periph_timer`:**

- master

<details><summary>BOARD=openmote-b make -C tests/periph_timer flash -j3</summary>

```
2020-03-20 16:00:09,907 # main(): This is RIOT! (Version: 2020.04-devel-1390-g7d0c4-HEAD)
2020-03-20 16:00:09,907 # 
2020-03-20 16:00:09,907 # Test for peripheral TIMERs
2020-03-20 16:00:09,910 # 
2020-03-20 16:00:09,910 # Available timers: 4
2020-03-20 16:00:09,910 # 
2020-03-20 16:00:09,911 # Testing TIMER_0:
2020-03-20 16:00:09,911 # TIMER_0: initialization successful
2020-03-20 16:00:09,913 # TIMER_0: stopped
2020-03-20 16:00:09,924 # TIMER_0: set channel 0 to 5000
2020-03-20 16:00:09,925 # TIMER_0: set channel 1 to 10000
2020-03-20 16:00:09,926 # TIMER_0: starting
2020-03-20 16:00:09,928 # TIMER_0: channel 0 fired at SW count      333 - init:      333
2020-03-20 16:00:09,939 # TIMER_0: channel 1 fired at SW count      662 - diff:      329
2020-03-20 16:00:09,939 # 
2020-03-20 16:00:09,940 # Testing TIMER_1:
2020-03-20 16:00:09,942 # TIMER_1: initialization successful
2020-03-20 16:00:09,944 # TIMER_1: stopped
2020-03-20 16:00:09,947 # TIMER_1: set channel 0 to 5000
2020-03-20 16:00:09,950 # TIMER_1: starting
2020-03-20 16:00:09,954 # TIMER_1: channel 0 fired at SW count      334 - init:      334
2020-03-20 16:00:09,954 # 
2020-03-20 16:00:09,955 # Testing TIMER_2:
2020-03-20 16:00:09,955 # TIMER_2: initialization successful
2020-03-20 16:00:09,959 # TIMER_2: stopped
2020-03-20 16:00:09,965 # TIMER_2: set channel 0 to 5000
2020-03-20 16:00:09,966 # TIMER_2: set channel 1 to 10000
2020-03-20 16:00:09,966 # TIMER_2: starting
2020-03-20 16:00:09,975 # TIMER_2: channel 0 fired at SW count      333 - init:      333
2020-03-20 16:00:09,977 # TIMER_2: channel 1 fired at SW count      662 - diff:      329
2020-03-20 16:00:09,978 # 
2020-03-20 16:00:09,986 # Testing TIMER_3:
2020-03-20 16:00:09,988 # TIMER_3: initialization successful
2020-03-20 16:00:09,991 # TIMER_3: stopped
2020-03-20 16:00:09,992 # TIMER_3: set channel 0 to 5000
2020-03-20 16:00:09,993 # TIMER_3: starting
2020-03-20 16:00:09,995 # TIMER_3: channel 0 fired at SW count      334 - init:      334
2020-03-20 16:00:10,002 # 
2020-03-20 16:00:10,002 # TEST SUCCEEDED
```
</details>

- pr

<details><summary>BOARD=openmote-b make -C tests/periph_timer flash -j3</summary>

```
2020-03-20 17:53:27,956 # Test for peripheral TIMERs
2020-03-20 17:53:27,956 # 
2020-03-20 17:53:27,956 # Available timers: 4
2020-03-20 17:53:27,956 # 
2020-03-20 17:53:27,956 # Testing TIMER_0:
2020-03-20 17:53:27,956 # TIMER_0: initialization successful
2020-03-20 17:53:27,957 # TIMER_0: stopped
2020-03-20 17:53:27,957 # TIMER_0: set channel 0 to 5000
2020-03-20 17:53:27,972 # TIMER_0: set channel 1 to 10000
2020-03-20 17:53:27,973 # TIMER_0: starting
2020-03-20 17:53:27,980 # TIMER_0: channel 0 fired at SW count      312 - init:      312
2020-03-20 17:53:27,981 # TIMER_0: channel 1 fired at SW count      620 - diff:      308
2020-03-20 17:53:27,981 # 
2020-03-20 17:53:27,982 # Testing TIMER_1:
2020-03-20 17:53:27,988 # TIMER_1: initialization successful
2020-03-20 17:53:27,988 # TIMER_1: stopped
2020-03-20 17:53:27,989 # TIMER_1: set channel 0 to 5000
2020-03-20 17:53:27,990 # TIMER_1: starting
2020-03-20 17:53:27,991 # TIMER_1: channel 0 fired at SW count      313 - init:      313
2020-03-20 17:53:27,992 # 
2020-03-20 17:53:27,992 # Testing TIMER_2:
2020-03-20 17:53:28,007 # TIMER_2: initialization successful
2020-03-20 17:53:28,010 # TIMER_2: stopped
2020-03-20 17:53:28,012 # TIMER_2: set channel 0 to 5000
2020-03-20 17:53:28,013 # TIMER_2: set channel 1 to 10000
2020-03-20 17:53:28,014 # TIMER_2: starting
2020-03-20 17:53:28,019 # TIMER_2: channel 0 fired at SW count      312 - init:      312
2020-03-20 17:53:28,021 # TIMER_2: channel 1 fired at SW count      620 - diff:      308
2020-03-20 17:53:28,021 # 
2020-03-20 17:53:28,023 # Testing TIMER_3:
2020-03-20 17:53:28,024 # TIMER_3: initialization successful
2020-03-20 17:53:28,025 # TIMER_3: stopped
2020-03-20 17:53:28,027 # TIMER_3: set channel 0 to 5000
2020-03-20 17:53:28,036 # TIMER_3: starting
2020-03-20 17:53:28,038 # TIMER_3: channel 0 fired at SW count      313 - init:      313
2020-03-20 17:53:28,038 # 
2020-03-20 17:53:28,039 # TEST SUCCEEDED
```
</details>


**run `tests/xtimer_usleep`**

- master

<details><summary>BOARD=openmote-b make -C tests/xtimer_usleep flash -j3<b> offset: 93us</b></summary>

```
2020-03-20 15:58:50,983 # main(): This is RIOT! (Version: 2020.04-devel-1390-g7d0c4-HEAD)
2020-03-20 15:58:50,999 # Running test 5 times with 7 distinct sleep times
2020-03-20 15:58:51,002 # Slept for 10093 us (expected: 10000 us) Offset: 93 us
2020-03-20 15:58:51,064 # Slept for 50093 us (expected: 50000 us) Offset: 93 us
2020-03-20 15:58:51,079 # Slept for 10327 us (expected: 10234 us) Offset: 93 us
2020-03-20 15:58:51,127 # Slept for 56873 us (expected: 56780 us) Offset: 93 us
2020-03-20 15:58:51,143 # Slept for 12215 us (expected: 12122 us) Offset: 93 us
2020-03-20 15:58:51,256 # Slept for 98858 us (expected: 98765 us) Offset: 93 us
2020-03-20 15:58:51,334 # Slept for 75093 us (expected: 75000 us) Offset: 93 us
2020-03-20 15:58:51,350 # Slept for 10093 us (expected: 10000 us) Offset: 93 us
2020-03-20 15:58:51,399 # Slept for 50093 us (expected: 50000 us) Offset: 93 us
2020-03-20 15:58:51,415 # Slept for 10327 us (expected: 10234 us) Offset: 93 us
2020-03-20 15:58:51,478 # Slept for 56873 us (expected: 56780 us) Offset: 93 us
2020-03-20 15:58:51,494 # Slept for 12215 us (expected: 12122 us) Offset: 93 us
2020-03-20 15:58:51,590 # Slept for 98858 us (expected: 98765 us) Offset: 93 us
2020-03-20 15:58:51,671 # Slept for 75093 us (expected: 75000 us) Offset: 93 us
2020-03-20 15:58:51,686 # Slept for 10093 us (expected: 10000 us) Offset: 93 us
2020-03-20 15:58:51,734 # Slept for 50093 us (expected: 50000 us) Offset: 93 us
2020-03-20 15:58:51,751 # Slept for 10327 us (expected: 10234 us) Offset: 93 us
2020-03-20 15:58:51,814 # Slept for 56873 us (expected: 56780 us) Offset: 93 us
2020-03-20 15:58:51,831 # Slept for 12215 us (expected: 12122 us) Offset: 93 us
2020-03-20 15:58:51,926 # Slept for 98858 us (expected: 98765 us) Offset: 93 us
2020-03-20 15:58:52,007 # Slept for 75093 us (expected: 75000 us) Offset: 93 us
2020-03-20 15:58:52,023 # Slept for 10093 us (expected: 10000 us) Offset: 93 us
2020-03-20 15:58:52,071 # Slept for 50093 us (expected: 50000 us) Offset: 93 us
2020-03-20 15:58:52,088 # Slept for 10327 us (expected: 10234 us) Offset: 93 us
2020-03-20 15:58:52,151 # Slept for 56873 us (expected: 56780 us) Offset: 93 us
2020-03-20 15:58:52,167 # Slept for 12215 us (expected: 12122 us) Offset: 93 us
2020-03-20 15:58:52,263 # Slept for 98858 us (expected: 98765 us) Offset: 93 us
2020-03-20 15:58:52,342 # Slept for 75093 us (expected: 75000 us) Offset: 93 us
2020-03-20 15:58:52,358 # Slept for 10093 us (expected: 10000 us) Offset: 93 us
2020-03-20 15:58:52,407 # Slept for 50093 us (expected: 50000 us) Offset: 93 us
2020-03-20 15:58:52,423 # Slept for 10327 us (expected: 10234 us) Offset: 93 us
2020-03-20 15:58:52,487 # Slept for 56873 us (expected: 56780 us) Offset: 93 us
2020-03-20 15:58:52,505 # Slept for 12215 us (expected: 12122 us) Offset: 93 us
2020-03-20 15:58:52,599 # Slept for 98858 us (expected: 98765 us) Offset: 93 us
2020-03-20 15:58:52,680 # Slept for 75093 us (expected: 75000 us) Offset: 93 us
2020-03-20 15:58:52,681 # Test ran for 1692743 us
```
</details>


- pr

<details><summary>BOARD=openmote-b make -C tests/xtimer_usleep flash -j3<b> offset: 57us</b></summary>

```
2020-03-20 15:56:19,840 # Running test 5 times with 7 distinct sleep times
2020-03-20 15:56:19,856 # Slept for 10057 us (expected: 10000 us) Offset: 57 us
2020-03-20 15:56:19,905 # Slept for 50057 us (expected: 50000 us) Offset: 57 us
2020-03-20 15:56:19,922 # Slept for 10291 us (expected: 10234 us) Offset: 57 us
2020-03-20 15:56:19,983 # Slept for 56836 us (expected: 56780 us) Offset: 56 us
2020-03-20 15:56:20,000 # Slept for 12178 us (expected: 12122 us) Offset: 56 us
2020-03-20 15:56:20,096 # Slept for 98822 us (expected: 98765 us) Offset: 57 us
2020-03-20 15:56:20,175 # Slept for 75057 us (expected: 75000 us) Offset: 57 us
2020-03-20 15:56:20,191 # Slept for 10057 us (expected: 10000 us) Offset: 57 us
2020-03-20 15:56:20,240 # Slept for 50056 us (expected: 50000 us) Offset: 56 us
2020-03-20 15:56:20,256 # Slept for 10290 us (expected: 10234 us) Offset: 56 us
2020-03-20 15:56:20,320 # Slept for 56837 us (expected: 56780 us) Offset: 57 us
2020-03-20 15:56:20,336 # Slept for 12178 us (expected: 12122 us) Offset: 56 us
2020-03-20 15:56:20,432 # Slept for 98822 us (expected: 98765 us) Offset: 57 us
2020-03-20 15:56:20,512 # Slept for 75057 us (expected: 75000 us) Offset: 57 us
2020-03-20 15:56:20,528 # Slept for 10057 us (expected: 10000 us) Offset: 57 us
2020-03-20 15:56:20,576 # Slept for 50057 us (expected: 50000 us) Offset: 57 us
2020-03-20 15:56:20,593 # Slept for 10291 us (expected: 10234 us) Offset: 57 us
2020-03-20 15:56:20,656 # Slept for 56836 us (expected: 56780 us) Offset: 56 us
2020-03-20 15:56:20,674 # Slept for 12178 us (expected: 12122 us) Offset: 56 us
2020-03-20 15:56:20,768 # Slept for 98822 us (expected: 98765 us) Offset: 57 us
2020-03-20 15:56:20,848 # Slept for 75057 us (expected: 75000 us) Offset: 57 us
2020-03-20 15:56:20,864 # Slept for 10057 us (expected: 10000 us) Offset: 57 us
2020-03-20 15:56:20,911 # Slept for 50056 us (expected: 50000 us) Offset: 56 us
2020-03-20 15:56:20,927 # Slept for 10290 us (expected: 10234 us) Offset: 56 us
2020-03-20 15:56:20,991 # Slept for 56837 us (expected: 56780 us) Offset: 57 us
2020-03-20 15:56:21,008 # Slept for 12178 us (expected: 12122 us) Offset: 56 us
2020-03-20 15:56:21,103 # Slept for 98822 us (expected: 98765 us) Offset: 57 us
2020-03-20 15:56:21,183 # Slept for 75057 us (expected: 75000 us) Offset: 57 us
2020-03-20 15:56:21,200 # Slept for 10057 us (expected: 10000 us) Offset: 57 us
2020-03-20 15:56:21,247 # Slept for 50057 us (expected: 50000 us) Offset: 57 us
2020-03-20 15:56:21,264 # Slept for 10291 us (expected: 10234 us) Offset: 57 us
2020-03-20 15:56:21,327 # Slept for 56836 us (expected: 56780 us) Offset: 56 us
2020-03-20 15:56:21,343 # Slept for 12178 us (expected: 12122 us) Offset: 56 us
2020-03-20 15:56:21,439 # Slept for 98822 us (expected: 98765 us) Offset: 57 us
2020-03-20 15:56:21,519 # Slept for 75057 us (expected: 75000 us) Offset: 57 us
2020-03-20 15:56:21,520 # Test ran for 1686186 us
```
</details>

**networking still works** (rebased on #13653)


<details><summary>BOARD=openmote-b make -C examples/xtimer_usleep</summary>

```
2020-03-20 16:03:00,506 # main(): This is RIOT! (Version: 2020.04-devel-1397-g045dc-pr_cc2538_cleanups)
2020-03-20 16:03:00,507 # RIOT network stack example application
2020-03-20 16:03:00,508 # All up, running the shell now
> ping6 fe80::3c8b:2187:3d8b:2186 -c 1000
2020-03-20 16:03:03,370 #  ping6 fe80::3c8b:2187:3d8b:2186 -c 1000
2020-03-20 16:03:03,386 # 12 bytes from fe80::3c8b:2187:3d8b:2186: icmp_seq=0 ttl=64 rssi=-41 dBm time=9.754 ms
2020-03-20 16:03:04,378 # 12 bytes from fe80::3c8b:2187:3d8b:2186: icmp_seq=1 ttl=64 rssi=-41 dBm time=9.112 ms
2020-03-20 16:03:05,386 # 12 bytes from fe80::3c8b:2187:3d8b:2186: icmp_seq=2 ttl=64 rssi=-41 dBm time=9.434 ms
```
</details>
