### PR TITLE
riotboot: disable stdio_cdc_acm

### DIFF
--- a/bootloaders/riotboot/Makefile
+++ b/bootloaders/riotboot/Makefile
@@ -16,6 +16,7 @@ CFLAGS += -DRIOTBOOT
 CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 DISABLE_MODULE += core_init core_msg core_panic
 DISABLE_MODULE += auto_init
+DISABLE_MODULE += stdio_cdc_acm
 
 # Include riotboot flash partition functionality
 USEMODULE += riotboot_slot


### PR DESCRIPTION
### Contribution description
`riotboot` disables `auto_init`, so `stdio_cdc_acm` will not work.
But in fact we don't want to pull the whole USB stack in just for debug output of the bootloader, so just disable `stdio_cdc_acm` for `riotboot`.

### Testing procedure

No change expected since `riotboot` did not work with `stdio_cdc_acm` to begin with.

### Issues/PRs references

should fix CI build of #13649
