### PR TITLE
sys/shell: add pm command for power management

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -71,6 +71,7 @@ PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano
 PSEUDOMODULES += openthread
 PSEUDOMODULES += pktqueue
+PSEUDOMODULES += pm_cmd
 PSEUDOMODULES += posix_headers
 PSEUDOMODULES += printf_float
 PSEUDOMODULES += prng

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -32,4 +32,9 @@ ifneq (,$(filter rtt_cmd,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtt
 endif
 
+ifneq (,$(filter pm_cmd,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_pm
+  FEATURES_OPTIONAL += periph_rtc
+endif
+
 include $(RIOTBASE)/sys/test_utils/Makefile.dep

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -104,4 +104,8 @@ ifneq (,$(filter suit_coap,$(USEMODULE)))
   SRC += sc_suit.c
 endif
 
+ifneq (,$(filter pm_cmd,$(USEMODULE)))
+  SRC += sc_pm.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/sc_pm.c
+++ b/sys/shell/commands/sc_pm.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell command implementation for power management
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "periph/pm.h"
+
+#ifdef MODULE_PM_LAYERED
+#ifdef MODULE_PERIPH_RTC
+#include "periph/rtc.h"
+#endif /* MODULE_PERIPH_RTC */
+#include "pm_layered.h"
+#endif /* MODULE_PM_LAYERED */
+
+#ifdef MODULE_PM_LAYERED
+static int _pm_cmd_check_mode(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <power mode>\n", argv[0]);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int _pm_cmd_parse_mode(char *argv)
+{
+    uint8_t mode = atoi(argv);
+
+    if (mode >= PM_NUM_MODES) {
+        printf("Error: power mode not in range 0 - %d.\n", PM_NUM_MODES - 1);
+        return -1;
+    }
+
+    return mode;
+}
+
+#ifdef MODULE_PERIPH_RTC
+static int _pm_cmd_check_mode_duration(int argc, char **argv)
+{
+    if (argc != 3) {
+        printf("Usage: %s <power mode> <duration (s)>\n", argv[0]);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int _pm_cmd_parse_duration(char *argv)
+{
+    int duration = atoi(argv);
+
+    if (duration < 0) {
+        puts("Error: duration must be a positive number.");
+        return -1;
+    }
+
+    return duration;
+}
+
+static void _pm_cmd_cb_rtc(void *arg)
+{
+    int level = (int)arg;
+
+    pm_block(level);
+}
+#endif /* MODULE_PERIPH_RTC */
+#endif /* MODULE_PM_LAYERED */
+
+#ifdef MODULE_PM_LAYERED
+static int _pm_cmd_block(int argc, char **argv)
+{
+    if (_pm_cmd_check_mode(argc, argv) != 0) {
+        return 1;
+    }
+
+    int mode = _pm_cmd_parse_mode(argv[1]);
+
+    if (mode < 0) {
+        return 1;
+    }
+
+    printf("Blocking power mode %d.\n", mode);
+    fflush(stdout);
+
+    pm_block(mode);
+
+    return 0;
+}
+
+static int _pm_cmd_set(int argc, char **argv)
+{
+    if (_pm_cmd_check_mode(argc, argv) != 0) {
+        return 1;
+    }
+
+    int mode = _pm_cmd_parse_mode(argv[1]);
+
+    if (mode < 0) {
+        return 1;
+    }
+
+    printf("CPU will enter power mode %d.\n", mode);
+    fflush(stdout);
+
+    pm_set(mode);
+
+    return 0;
+}
+
+static int _pm_cmd_unblock(int argc, char **argv)
+{
+    if (_pm_cmd_check_mode(argc, argv) != 0) {
+        return 1;
+    }
+
+    int mode = _pm_cmd_parse_mode(argv[1]);
+
+    if (mode < 0) {
+        return 1;
+    }
+
+    printf("Unblocking power mode %d.\n", mode);
+    fflush(stdout);
+
+    pm_unblock(mode);
+
+    return 0;
+}
+
+#ifdef MODULE_PERIPH_RTC
+static int _pm_cmd_unblock_rtc(int argc, char **argv)
+{
+    if (_pm_cmd_check_mode_duration(argc, argv) != 0) {
+        return 1;
+    }
+
+    int mode = _pm_cmd_parse_mode(argv[1]);
+    int duration = _pm_cmd_parse_duration(argv[2]);
+
+    if (mode < 0 || duration < 0) {
+        return 1;
+    }
+
+    printf("Unblocking power mode %d for %d seconds.\n", mode, duration);
+    fflush(stdout);
+
+    struct tm time;
+
+    rtc_get_time(&time);
+    time.tm_sec += duration;
+    mktime(&time);
+    rtc_set_alarm(&time, _pm_cmd_cb_rtc, (void *)mode);
+
+    pm_unblock(mode);
+
+    return 0;
+}
+#endif /* MODULE_PERIPH_RTC */
+#endif /* MODULE_PM_LAYERED */
+
+static int _pm_cmd_usage(void)
+{
+    puts("off\t\tturn off");
+    puts("reboot\t\treboot");
+#ifdef MODULE_PM_LAYERED
+    puts("set\t\tset power mode");
+    puts("block\t\tblock power mode");
+    puts("unblock\t\tunblock power mode");
+#ifdef MODULE_PERIPH_RTC
+    puts("unblock_rtc\ttemporary unblock power mode");
+#endif /* MODULE_PERIPH_RTC */
+#endif /* MODULE_PM_LAYERED */
+    return 0;
+}
+
+int _pm_cmd_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        _pm_cmd_usage();
+        return 1;
+    }
+    else if (strncmp(argv[1], "off", 3) == 0) {
+        pm_off();
+    }
+    else if (strncmp(argv[1], "reboot", 6) == 0) {
+        pm_reboot();
+    }
+#ifdef MODULE_PM_LAYERED
+    else if ((strncmp(argv[1], "set", 3) == 0) && (argc == 3)) {
+        return _pm_cmd_set(argc - 1, argv + 1);
+    }
+    else if ((strncmp(argv[1], "block", 5) == 0) && (argc == 3)) {
+        return _pm_cmd_block(argc - 1, argv + 1);
+    }
+#ifdef MODULE_PERIPH_RTC
+    else if ((strncmp(argv[1], "unblock_rtc", 11) == 0) && (argc == 4)) {
+        return _pm_cmd_unblock_rtc(argc - 1, argv + 1);
+    }
+#endif /* MODULE_PERIPH_RTC */
+    else if ((strncmp(argv[1], "unblock", 7) == 0) && (argc == 3)) {
+        return _pm_cmd_unblock(argc - 1, argv +1);
+    }
+#endif /* MODULE_PM_LAYERED */
+    else {
+        printf("unknown command or missing parameters: %s\n\n", argv[1]);
+        _pm_cmd_usage();
+        return 1;
+    }
+    return 0;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -167,6 +167,10 @@ extern int _nimble_netif_handler(int argc, char **argv);
 extern int _suit_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_PM_CMD
+extern int _pm_cmd_handler(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
     {"version", "Prints current RIOT_VERSION", _version_handler},
@@ -279,6 +283,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_SUIT_COAP
     { "suit", "Trigger a SUIT firmware update", _suit_handler },
+#endif
+#ifdef MODULE_PM_CMD
+    {"pm", "Power management commands",  _pm_cmd_handler},
 #endif
     {NULL, NULL, NULL}
 };

--- a/tests/periph_pm/Makefile
+++ b/tests/periph_pm/Makefile
@@ -4,9 +4,10 @@ include ../Makefile.tests_common
 # method `fflush()` is not defined for MSP-430 (#6445 will fix this)
 BOARD_BLACKLIST := chronos msb-430h msb-430 telosb wsn430-v1_3b wsn430-v1_4 z1
 
-FEATURES_OPTIONAL += periph_rtc
 FEATURES_OPTIONAL += periph_gpio_irq
 
 USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += pm_cmd
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -39,179 +39,6 @@
 #define BTN0_INT_FLANK  GPIO_RISING
 #endif
 
-#ifdef MODULE_PM_LAYERED
-static int check_mode(int argc, char **argv)
-{
-    if (argc < 2) {
-        printf("Usage: %s <power mode>\n", argv[0]);
-        return -1;
-    }
-
-    return 0;
-}
-
-static int parse_mode(char *argv)
-{
-    uint8_t mode = atoi(argv);
-
-    if (mode >= PM_NUM_MODES) {
-        printf("Error: power mode not in range 0 - %d.\n", PM_NUM_MODES - 1);
-        return -1;
-    }
-
-    return mode;
-}
-
-#ifdef MODULE_PERIPH_RTC
-static int check_mode_duration(int argc, char **argv)
-{
-    if (argc != 3) {
-        printf("Usage: %s <power mode> <duration (s)>\n", argv[0]);
-        return -1;
-    }
-
-    return 0;
-}
-
-static int parse_duration(char *argv)
-{
-    int duration = atoi(argv);
-
-    if (duration < 0) {
-        puts("Error: duration must be a positive number.");
-        return -1;
-    }
-
-    return duration;
-}
-
-static void cb_rtc(void *arg)
-{
-    int level = (int)arg;
-
-    pm_block(level);
-}
-#endif /* MODULE_PERIPH_RTC */
-#endif /* MODULE_PM_LAYERED */
-
-static int cmd_off(int argc, char **argv)
-{
-    (void) argc;
-    (void) argv;
-
-    puts("CPU will turn off.");
-    fflush(stdout);
-
-    pm_off();
-
-    return 0;
-}
-
-static int cmd_reboot(int argc, char **argv)
-{
-    (void) argc;
-    (void) argv;
-
-    puts("CPU will reboot.");
-    fflush(stdout);
-
-    pm_reboot();
-
-    return 0;
-}
-
-#ifdef MODULE_PM_LAYERED
-static int cmd_block(int argc, char **argv)
-{
-    if (check_mode(argc, argv) != 0) {
-        return 1;
-    }
-
-    int mode = parse_mode(argv[1]);
-
-    if (mode < 0) {
-        return 1;
-    }
-
-    printf("Blocking power mode %d.\n", mode);
-    fflush(stdout);
-
-    pm_block(mode);
-
-    return 0;
-}
-
-static int cmd_set(int argc, char **argv)
-{
-    if (check_mode(argc, argv) != 0) {
-        return 1;
-    }
-
-    int mode = parse_mode(argv[1]);
-
-    if (mode < 0) {
-        return 1;
-    }
-
-    printf("CPU will enter power mode %d.\n", mode);
-    fflush(stdout);
-
-    pm_set(mode);
-
-    return 0;
-}
-
-static int cmd_unblock(int argc, char **argv)
-{
-    if (check_mode(argc, argv) != 0) {
-        return 1;
-    }
-
-    int mode = parse_mode(argv[1]);
-
-    if (mode < 0) {
-        return 1;
-    }
-
-    printf("Unblocking power mode %d.\n", mode);
-    fflush(stdout);
-
-    pm_unblock(mode);
-
-    return 0;
-}
-
-#ifdef MODULE_PERIPH_RTC
-static int cmd_unblock_rtc(int argc, char **argv)
-{
-    if (check_mode_duration(argc, argv) != 0) {
-        return 1;
-    }
-
-    int mode = parse_mode(argv[1]);
-    int duration = parse_duration(argv[2]);
-
-    if (mode < 0 || duration < 0) {
-        return 1;
-    }
-
-    printf("Unblocking power mode %d for %d seconds.\n", mode, duration);
-    fflush(stdout);
-
-    struct tm time;
-
-    rtc_get_time(&time);
-    time.tm_sec += duration;
-    mktime(&time);
-    rtc_set_alarm(&time, cb_rtc, (void *)mode);
-
-    pm_unblock(mode);
-
-    return 0;
-}
-#endif /* MODULE_PERIPH_RTC */
-#endif /* MODULE_PM_LAYERED */
-
 #if defined(MODULE_PERIPH_GPIO_IRQ) && defined(BTN0_PIN)
 static void btn_cb(void *ctx)
 {
@@ -219,23 +46,6 @@ static void btn_cb(void *ctx)
     puts("BTN0 pressed.");
 }
 #endif /* MODULE_PERIPH_GPIO_IRQ */
-
-/**
- * @brief   List of shell commands for this example.
- */
-static const shell_command_t shell_commands[] = {
-    { "off", "turn off", cmd_off },
-    { "reboot", "reboot", cmd_reboot },
-#ifdef MODULE_PM_LAYERED
-    { "block", "block power mode", cmd_block },
-    { "set", "set power mode", cmd_set },
-    { "unblock", "unblock power mode", cmd_unblock },
-#ifdef MODULE_PERIPH_RTC
-    { "unblock_rtc", "temporary unblock power mode", cmd_unblock_rtc },
-#endif
-#endif
-    { NULL, NULL, NULL }
-};
 
 /**
  * @brief   Application entry point.
@@ -263,7 +73,7 @@ int main(void)
 #endif
 
     /* run the shell and wait for the user to enter a mode */
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }


### PR DESCRIPTION
### Contribution description

This PR moves the `pm` commands from `tests/periph_pm`' to a shell command module `pm_cmd` to make them available for embedding in other applications, e.g. for debugging by using
```
USEMODULE=pm_cmd BOARD=... make -C tests/shell
```
The test application `tests/periph_pm` now uses the shell command module instead of defining the `pm` commands by itself.

Dependent on module `pm_layered` and feature `periph_rtc` the following commands are available:
```
off		turn off
reboot		reboot
set		set power mode
block		block power mode
unblock		unblock power mode
unblock_rtc	temporary unblock power mode
```
The `set`, `block`, `unblock` commands are available if the platform supports `pm_layerd`. The `unblock_rtc` is only available if the platform support `pm_layered` and feature `periph_rtc`.

### Testing procedure

Compile and flash `tests/periph` for a board with `periph_rtc` feature, for example
```
make BOARD=nucleo-f411re -C tests/periph_pm flash term
```
and excute the following tests:

- [ ] Set mode 1
   ```
   > rtc gettime
   2020-03-22 16:30:18
   > rtc setalarm 2020-03-22 16:30:40
   > pm set 1
   CPU will enter power mode 1.
   ...
   > 
   ```
- [ ] Set mode 1
   ```
   rtc setalarm 2020-03-22 16:31:50
   > 
   > pm set 0
   CPU will enter power mode 0.
   .main(): This is RIOT! (Version: 2020.04-devel-1400-g5aff3-sys/shell/pm_cmd)
   test_shell.
   >
   ```
- [ ] Unblock mode 1 for 5 seconds
   ```
   > pm unblock 1 5
   ```
- [ ] Reboot with `pm` command
   ```
   > pm reboot
   ```
- [ ] Power off `pm` command
   ```
   > pm off
   ```

### Issues/PRs references
