### PR TITLE
Makefile.include: guard suit.base.inc.mk inclusion

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -480,8 +480,9 @@ ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
 BINFILE ?= $(ELFFILE:.elf=.bin)
 
-# include basic suit-tool and key handling
-include $(RIOTMAKE)/suit.base.inc.mk
+ifneq (,$(filter suit, $(USEMODULE)))
+  include $(RIOTMAKE)/suit.base.inc.mk
+endif
 
 # include bootloaders support. It should be included early to allow using
 # variables defined in `riotboot.mk` for `FLASHFILE` before it is evaluated.


### PR DESCRIPTION
### Contribution description

`suit.inc.base.mk` should not be included if `suit` is not used, it will force key generation as well as request installed python modules.

### Testing procedure

- Testing procedure in #13680

- `tests/suit_manifest` still works

```
Comparing manifest offset 4096 with other slot offset 8192
Comparing manifest offset 8192 with other slot offset 8192
Comparing manifest offset 4096 with other slot offset 8192
Comparing manifest offset 8192 with other slot offset 8192
riotboot_flashwrite_init_raw() empty mock
Verifying image digest
Verifying image digest
---- res=0 (expected=0)

OK (1 tests)
```

- `examples/suit_update` still works

```
validating class id
Comparing 38204045-80d5-5db8-a8a8-16afa1033217 to 38204045-80d5-5db8-a8a8-16afa1033217 from manifest
validating class id: OK
Comparing manifest offset 4096 with other slot offset 264192
Comparing manifest offset 264192 with other slot offset 264192
Comparing manifest offset 4096 with other slot offset 264192
Comparing manifest offset 264192 with other slot offset 264192
riotboot_flashwrite: initializing update to target slot 1
Fetching firmware |███████████              |  41%
```

### Issues/PRs references

Fixes #13680
