### PR TITLE
dist/testbed-support: use BINFILE for flashing on iotlab

### DIFF
--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -94,6 +94,14 @@ else
   _NODES_DEPLOYED = $(shell iotlab-experiment --jmespath='"0"' --format='" ".join' get $(_IOTLAB_EXP_ID) --deployment)
   _NODES_LIST_OPTION = --nodes
   _NODES_FLASH_OPTION = --flash
+  ifneq (,$(filter-out wsn430-% firefly,$(BOARD)))
+    # All boards in IoT-LAB except firefly and WSN430 can be flashed using $(BINFILE).
+    # On IoT-LAB, firefly only accepts $(ELFFILE) and WSN320 boards on accept $(HEXFILE).
+    # Using $(BINFILE) speeds up the firmware upload since the file is much
+    # smaller than an elffile.
+    # This feature is only available in cli-tools version >= 3.
+    FLASHFILE = $(BINFILE)
+  endif
 endif
 
 # Try detecting the node automatically


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR changes the default firmware format used to flash on iotlab from elffile to binfile. This is only enabled when using IOTLAB_NODE (e.g. when flashing a single board), when using cli-tools v3 and for the supported boards, e.g. all boards except wsn430 (hexfile) and firefly (elffile).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This feature is only available in iotlabcli v3. If you already installed this version, you should the results below: flashed files use the suffix .bin. With iotlabcli version 2, the flashed files have suffix .elf.

- Start experiments on iot-lab with several boards:
```
$ iotlab-experiment submit -d 120 -l saclay,m3,1 -l saclay,nrf51dk,5 -l saclay,st-lrwan1,1 -l saclay,st-iotnode,1 -l saclay,samr21,1 -l saclay,samr30,1
$ iotlab-experiment wait
```
- Verify that the different boards are now flashed with the bin file: the upload must be must faster The upload speed depends on the connection bandwidth but when working from home, at least for me, this is quite noticeable ;)
```
$ make BOARD=<board> IOTLAB_NODE=auto-ssh -C examples/default flash
```

<details><summary>iotlab-m3</summary>

```
$ make BOARD=iotlab-m3 IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "iotlab-m3" with MCU "stm32f1".

"make" -C /work/riot/RIOT/boards/iotlab-m3
"make" -C /work/riot/RIOT/boards/common/iotlab
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32f1
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32f1/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/isl29020
"make" -C /work/riot/RIOT/drivers/l3g4200d
"make" -C /work/riot/RIOT/drivers/lpsxxx
"make" -C /work/riot/RIOT/drivers/lsm303dlhc
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  21036	    132	   2852	  24020	   5dd4	/work/riot/RIOT/examples/saul/bin/iotlab-m3/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,m3,1 --flash /work/riot/RIOT/examples/saul/bin/iotlab-m3/saul_example.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:m3-1.saclay.iot-lab.info:20000'
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
ps                   Prints information about running threads.
saul                 interact with sensors and actuators using SAUL
> 
```

</details>

<details><summary>nrf51dk</summary>

```
make BOARD=nrf51dk IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "nrf51dk" with MCU "nrf51".

"make" -C /work/riot/RIOT/boards/nrf51dk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf51
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf51/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  16412	    128	   2764	  19304	   4b68	/work/riot/RIOT/examples/saul/bin/nrf51dk/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,nrf51dk,5 --flash /work/riot/RIOT/examples/saul/bin/nrf51dk/saul_example.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf51dk-5.saclay.iot-lab.info:20000'
b�k�




```

The UART is broken on this board in master. See #13684 for details

</details>

<details><summary>b-l072z-lrwan1</summary>

```
$ make BOARD=b-l072z-lrwan1 IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "b-l072z-lrwan1" with MCU "stm32l0".

"make" -C /work/riot/RIOT/boards/b-l072z-lrwan1
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32l0
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32l0/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  16648	    132	   2700	  19480	   4c18	/work/riot/RIOT/examples/saul/bin/b-l072z-lrwan1/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,st-lrwan1,1 --flash /work/riot/RIOT/examples/saul/bin/b-l072z-lrwan1/saul_example.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:st-lrwan1-1.saclay.iot-lab.info:20000'
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
ps                   Prints information about running threads.
saul                 interact with sensors and actuators using SAUL
```

</details>

<details><summary>b-l475e-iot01a</summary>

```
$ make BOARD=b-l475e-iot01a IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "b-l475e-iot01a" with MCU "stm32l4".

"make" -C /work/riot/RIOT/boards/b-l475e-iot01a
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32l4
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32l4/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/hts221
"make" -C /work/riot/RIOT/drivers/lis3mdl
"make" -C /work/riot/RIOT/drivers/lpsxxx
"make" -C /work/riot/RIOT/drivers/lsm6dsl
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  22912	    132	   2892	  25936	   6550	/work/riot/RIOT/examples/saul/bin/b-l475e-iot01a/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,st-iotnode,1 --flash /work/riot/RIOT/examples/saul/bin/b-l475e-iot01a/saul_example.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:st-iotnode-1.saclay.iot-lab.info:20000'
��main(): This is RIOT! (Version: 2020.04-devel-1415-g2f99-pr/tools/iotlab_flash_bin)
Welcome to RIOT!

Type `help` for help, type `saul` to see all SAUL devices

> help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
ps                   Prints information about running threads.
saul                 interact with sensors and actuators using SAUL
```

</details>

<details><summary>samr21-xpro</summary>

```
$ make BOARD=samr21-xpro IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  16812	    132	   2660	  19604	   4c94	/work/riot/RIOT/examples/saul/bin/samr21-xpro/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,samr21,1 --flash /work/riot/RIOT/examples/saul/bin/samr21-xpro/saul_example.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:samr21-1.saclay.iot-lab.info:20000'
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
ps                   Prints information about running threads.
saul                 interact with sensors and actuators using SAUL
```

</details>

<details><summary>samr30-xpro</summary>

```
$ make BOARD=samr30-xpro IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "samr30-xpro" with MCU "saml21".

"make" -C /work/riot/RIOT/boards/samr30-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/saml21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/saml21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  16680	    136	   2668	  19484	   4c1c	/work/riot/RIOT/examples/saul/bin/samr30-xpro/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,samr30,1 --flash /work/riot/RIOT/examples/saul/bin/samr30-xpro/saul_example.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:samr30-1.saclay.iot-lab.info:20000'
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
ps                   Prints information about running threads.
saul                 interact with sensors and actuators using SAUL
```

</details>

- Verify the firefly is not affected (#13682 is required here): the elf file is still flashed
```
$ iotlab-experiment submit -d 120 -l lille,firefly,1
$ iotlab-experiment wait
```

<details>

```
$ make BOARD=firefly IOTLAB_NODE=auto-ssh -C examples/default flash term --no-print-directory 
Building application "default" for "firefly" with MCU "cc2538".

"make" -C /work/riot/RIOT/boards/firefly
"make" -C /work/riot/RIOT/boards/common/remote
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/cc2538
"make" -C /work/riot/RIOT/cpu/cc2538/periph
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  17240	    132	   2752	  20124	   4e9c	/work/riot/RIOT/examples/default/bin/firefly/default.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list lille,firefly,1 --flash /work/riot/RIOT/examples/default/bin/firefly/default.elf | grep 0
0
ssh -t abadie@lille.iot-lab.info 'socat - tcp:firefly-1.lille.iot-lab.info:20000'
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
ps                   Prints information about running threads.
saul                 interact with sensors and actuators using SAUL
```

</details>

I'm just giving an example when using this PR with iotlabcli v2.6 on one of the Saclay boards:

<details><summary>iotlab-m3 with iotlabcli==2.6.0</summary>

```
$ iotlab-experiment --version
2.6.0
$ make BOARD=iotlab-m3 IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "iotlab-m3" with MCU "stm32f1".

"make" -C /work/riot/RIOT/boards/iotlab-m3
"make" -C /work/riot/RIOT/boards/common/iotlab
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32f1
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32f1/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/isl29020
"make" -C /work/riot/RIOT/drivers/l3g4200d
"make" -C /work/riot/RIOT/drivers/lpsxxx
"make" -C /work/riot/RIOT/drivers/lsm303dlhc
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  21036	    132	   2852	  24020	   5dd4	/work/riot/RIOT/examples/saul/bin/iotlab-m3/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,m3,1 --update /work/riot/RIOT/examples/saul/bin/iotlab-m3/saul_example.elf | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:m3-1.saclay.iot-lab.info:20000'
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
ps                   Prints information about running threads.
saul                 interact with sensors and actuators using SAUL
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
