### PR TITLE
boards/nrf51: fix UART hardware flowcontrol configuration

### DIFF
--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -35,7 +35,6 @@ extern "C" {
  */
 #define UART_NUMOF          (1U)
 /* UART pin configuration */
-#define UART_HWFLOWCTRL     0
 #define UART_PIN_RX         25
 #define UART_PIN_TX         24
 /** @} */

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -34,7 +34,6 @@ extern "C" {
  */
 #define UART_NUMOF          (1U)
 /* UART pin configuration */
-#define UART_HWFLOWCTRL     0
 #define UART_PIN_RX         25
 #define UART_PIN_TX         24
 /** @} */

--- a/boards/nrf51dk/Makefile.dep
+++ b/boards/nrf51dk/Makefile.dep
@@ -2,4 +2,6 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+FEATURES_REQUIRED += periph_uart_hw_fc
+
 include $(RIOTBOARD)/common/nrf51/Makefile.dep

--- a/boards/nrf51dk/Makefile.features
+++ b/boards/nrf51dk/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = nrf51x22xxac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart_hw_fc
 
 # include common nrf51 based boards features
 include $(RIOTBOARD)/common/nrf51/Makefile.features

--- a/boards/nrf51dk/include/periph_conf.h
+++ b/boards/nrf51dk/include/periph_conf.h
@@ -34,7 +34,6 @@ extern "C" {
  */
 #define UART_NUMOF          (1U)
 /* UART pin configuration */
-#define UART_HWFLOWCTRL     1
 #define UART_PIN_RX         11
 #define UART_PIN_TX         9
 #define UART_PIN_RTS        8

--- a/boards/nrf51dongle/Makefile.dep
+++ b/boards/nrf51dongle/Makefile.dep
@@ -1,1 +1,3 @@
+FEATURES_REQUIRED += periph_uart_hw_fc
+
 include $(RIOTBOARD)/common/nrf51/Makefile.dep

--- a/boards/nrf51dongle/Makefile.features
+++ b/boards/nrf51dongle/Makefile.features
@@ -2,6 +2,7 @@ CPU_MODEL = nrf51x22xxab
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart_hw_fc
 
 # include common nrf51 based boards features
 include $(RIOTBOARD)/common/nrf51/Makefile.features

--- a/boards/nrf51dongle/include/periph_conf.h
+++ b/boards/nrf51dongle/include/periph_conf.h
@@ -34,7 +34,6 @@ extern "C" {
  */
 #define UART_NUMOF          (1U)
 /* UART pin configuration */
-#define UART_HWFLOWCTRL     1
 #define UART_PIN_RX         11
 #define UART_PIN_TX         9
 #define UART_PIN_RTS        8

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -42,7 +42,6 @@ extern "C" {
 /* UART pin configuration */
 #define UART_PIN_RX       16
 #define UART_PIN_TX       17
-#define UART_HWFLOWCTRL   0
 #define UART_PIN_RTS      19
 #define UART_PIN_CTS      18
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the UART configuration on nrf51dk and nrf51dongle that was broken in #13051.
For other nrf51 based boards, the UART_HWFLOWCTRL define is simply removed since now the feature mechanism is used (see #13051).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test any application with a shell on one of these boards. There are 5 nrf51dk available on iotlab:

<details><summary>master</summary>

```
$ make BOARD=nrf51dk IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "nrf51dk" with MCU "nrf51".

"make" -C /work/riot/RIOT/boards/nrf51dk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf51
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf51/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  16364	    128	   2764	  19256	   4b38	/work/riot/RIOT/examples/saul/bin/nrf51dk/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,nrf51dk,5 --update /work/riot/RIOT/examples/saul/bin/nrf51dk/saul_example.elf | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf51dk-5.saclay.iot-lab.info:20000'
g.���


help





```

</details>

<details><summary>this PR</summary>

```
$ make BOARD=nrf51dk IOTLAB_NODE=auto-ssh -C examples/saul flash term --no-print-directory 
Building application "saul_example" for "nrf51dk" with MCU "nrf51".

"make" -C /work/riot/RIOT/boards/nrf51dk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf51
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf51/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  16440	    128	   2764	  19332	   4b84	/work/riot/RIOT/examples/saul/bin/nrf51dk/saul_example.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,nrf51dk,5 --update /work/riot/RIOT/examples/saul/bin/nrf51dk/saul_example.elf | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf51dk-5.saclay.iot-lab.info:20000'
"*w�����

shell: command not found: �
> 

> help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
ps                   Prints information about running threads.
saul                 interact with sensors and actuators using SAUL
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while testing #13683 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
