### PR TITLE
cpu/esp[32, 8266, _common]: Move dependency resolutions to Makefile.dep

### DIFF
--- a/boards/common/esp32/Makefile.dep
+++ b/boards/common/esp32/Makefile.dep
@@ -1,3 +1,5 @@
+USEMODULE += boards_common_esp32
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/boards/common/esp8266/Makefile.dep
+++ b/boards/common/esp8266/Makefile.dep
@@ -1,3 +1,5 @@
+USEMODULE += boards_common_esp8266
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/boards/esp32-mh-et-live-minikit/Makefile.dep
+++ b/boards/esp32-mh-et-live-minikit/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32
-
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-olimex-evb/Makefile.dep
+++ b/boards/esp32-olimex-evb/Makefile.dep
@@ -1,1 +1,6 @@
 include $(RIOTBOARD)/common/esp32/Makefile.dep
+
+# enables esp_eth as default network device
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += esp_eth
+endif

--- a/boards/esp32-olimex-evb/Makefile.include
+++ b/boards/esp32-olimex-evb/Makefile.include
@@ -1,9 +1,3 @@
 PSEUDOMODULES += olimex_esp32_gateway
 
-# enables esp_eth as default network device
-# cannot be done in Makefile.dep since Makefile.dep is included too late
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
-  USEMODULE += esp_eth
-endif
-
 include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-olimex-evb/Makefile.include
+++ b/boards/esp32-olimex-evb/Makefile.include
@@ -1,7 +1,5 @@
 PSEUDOMODULES += olimex_esp32_gateway
 
-USEMODULE += boards_common_esp32
-
 # enables esp_eth as default network device
 # cannot be done in Makefile.dep since Makefile.dep is included too late
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))

--- a/boards/esp32-ttgo-t-beam/Makefile.dep
+++ b/boards/esp32-ttgo-t-beam/Makefile.dep
@@ -2,6 +2,4 @@ ifneq (,$(filter esp32_ttgo_t_beam_v1_0,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
-USEMODULE += boards_common_esp32
-
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.dep
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.dep
@@ -1,4 +1,3 @@
-USEMODULE += boards_common_esp32
 USEMODULE += esp_spi_ram
 
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-wroom-32/Makefile.dep
+++ b/boards/esp32-wroom-32/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32
-
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-wrover-kit/Makefile.dep
+++ b/boards/esp32-wrover-kit/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32
-
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp8266-esp-12x/Makefile.dep
+++ b/boards/esp8266-esp-12x/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp8266
-
 include $(RIOTBOARD)/common/esp8266/Makefile.dep

--- a/boards/esp8266-olimex-mod/Makefile.dep
+++ b/boards/esp8266-olimex-mod/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp8266
-
 include $(RIOTBOARD)/common/esp8266/Makefile.dep

--- a/boards/esp8266-sparkfun-thing/Makefile.dep
+++ b/boards/esp8266-sparkfun-thing/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp8266
-
 include $(RIOTBOARD)/common/esp8266/Makefile.dep

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -2,6 +2,11 @@
 
 include $(RIOTCPU)/esp_common/Makefile.dep
 
+USEMODULE += esp_idf_driver
+USEMODULE += esp_idf_esp32
+USEMODULE += esp_idf_soc
+USEMODULE += pm_layered
+
 ifneq (,$(filter cpp,$(FEATURES_USED)))
   USEMODULE += pthread
   BASELIBS += -lstdc++

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -9,7 +9,6 @@ USEMODULE += pm_layered
 
 ifneq (,$(filter cpp,$(FEATURES_USED)))
   USEMODULE += pthread
-  BASELIBS += -lstdc++
   USEMODULE += esp_cxx
 endif
 

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -53,6 +53,10 @@ ifneq (,$(filter esp_rtc_timer_32k,$(USEMODULE)))
     USEMODULE += esp_rtc_timer
 endif
 
+ifneq (,$(filter periph_adc periph_dac,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_adc_ctrl
+endif
+
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
   ifneq (,$(filter esp_i2c_hw,$(USEMODULE)))
     USEMODULE += core_thread_flags

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -5,6 +5,7 @@ include $(RIOTCPU)/esp_common/Makefile.dep
 ifneq (,$(filter cpp,$(FEATURES_USED)))
   USEMODULE += pthread
   BASELIBS += -lstdc++
+  USEMODULE += esp_cxx
 endif
 
 ifneq (,$(filter esp_eth,$(USEMODULE)))

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -4,4 +4,5 @@ include $(RIOTCPU)/esp_common/Makefile.features
 
 FEATURES_PROVIDED += arch_esp32
 FEATURES_PROVIDED += esp_wifi_enterprise
+FEATURES_PROVIDED += periph_adc_ctrl
 FEATURES_PROVIDED += periph_rtc

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -18,14 +18,6 @@ FLASH_FREQ  = 40m   # DO NOT CHANGE
 FLASH_SIZE ?= 4
 BOOTLOADER_POS = 0x1000
 
-# SPECIAL module dependencies
-# cannot be done in Makefile.dep since Makefile.dep is included too late
-
-ifneq (,$(filter esp_now esp_wifi esp_spi_ram,$(USEMODULE)))
-  # the ESP-IDF heap has to be used if any WiFi interface or SPI RAM is used
-  USEMODULE += esp_idf_heap
-endif
-
 include $(RIOTCPU)/esp_common/Makefile.include
 
 # regular Makefile

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -21,10 +21,6 @@ BOOTLOADER_POS = 0x1000
 # SPECIAL module dependencies
 # cannot be done in Makefile.dep since Makefile.dep is included too late
 
-ifneq (,$(filter cpp,$(FEATURES_USED)))
-  USEMODULE += esp_cxx
-endif
-
 ifneq (,$(filter esp_now esp_wifi esp_spi_ram,$(USEMODULE)))
   # the ESP-IDF heap has to be used if any WiFi interface or SPI RAM is used
   USEMODULE += esp_idf_heap
@@ -86,7 +82,8 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections
 
-ifneq (,$(filter esp_cxx,$(USEMODULE)))
+
+ifneq (,$(filter cpp,$(FEATURES_USED)))
   UNDEF += $(BINDIR)/esp_cxx/cxa_guard.o
 endif
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -34,11 +34,6 @@ PSEUDOMODULES += esp_rtc_timer_32k
 PSEUDOMODULES += esp_spi_ram
 PSEUDOMODULES += esp_wifi_enterprise
 
-USEMODULE += esp_idf_driver
-USEMODULE += esp_idf_esp32
-USEMODULE += esp_idf_soc
-USEMODULE += pm_layered
-
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/esp32

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -68,10 +68,9 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections
 
-
-ifneq (,$(filter cpp,$(FEATURES_USED)))
-  UNDEF += $(BINDIR)/esp_cxx/cxa_guard.o
-endif
+# NOTE: This check can be turned into a normal conditional after #9913 is fixed
+UNDEF += $(if $(filter cpp,$(FEATURES_USED)),$(BINDIR)/esp_cxx/cxa_guard.o)
+BASELIBS += $(if $(filter cpp,$(FEATURES_USED)),-lstdc++)
 
 # additional flasher configuration for ESP32 QEMU
 ifneq (,$(filter esp_qemu,$(USEMODULE)))

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -37,7 +37,6 @@ PSEUDOMODULES += esp_wifi_enterprise
 USEMODULE += esp_idf_driver
 USEMODULE += esp_idf_esp32
 USEMODULE += esp_idf_soc
-USEMODULE += periph_adc_ctrl
 USEMODULE += pm_layered
 
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -51,15 +51,6 @@ INCLUDES += -I$(RIOTCPU)/$(CPU)
 CFLAGS += -DSDK_NOT_USED -DCONFIG_FREERTOS_UNICORE=1 -DESP_PLATFORM
 CFLAGS += -DLOG_TAG_IN_BRACKETS
 
-ifneq (,$(filter esp_now esp_wifi,$(USEMODULE)))
-  BASELIBS += -lcore -lrtc -lnet80211 -lpp -lcoexist
-  BASELIBS += -lwps -lwpa -lwpa2 -lphy -lstdc++
-endif
-
-ifneq (,$(filter esp_now,$(USEMODULE)))
-  BASELIBS += -lespnow -lmesh
-endif
-
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ld/
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.common.ld
@@ -68,7 +59,17 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections
 
-# NOTE: This check can be turned into a normal conditional after #9913 is fixed
+# Baselibs needed when using esp_wifi_any pseudomodule
+_ESP_WIFI_ANY_BASELIBS = -lcore -lrtc -lnet80211 -lpp -lcoexist -lwps -lwpa -lwpa2
+_ESP_WIFI_ANY_BASELIBS += -lphy -lstdc++
+
+# Baselibs needed when using esp_now module
+_ESP_NOW_BASELIBS = -lespnow -lmesh
+
+# NOTE: These checks can be turned into a normal conditional when #9913 is fixed
+BASELIBS += $(if $(filter esp_wifi_any,$(USEMODULE)),$(_ESP_WIFI_ANY_BASELIBS))
+BASELIBS += $(if $(filter esp_now,$(USEMODULE)),$(_ESP_NOW_BASELIBS))
+
 UNDEF += $(if $(filter cpp,$(FEATURES_USED)),$(BINDIR)/esp_cxx/cxa_guard.o)
 BASELIBS += $(if $(filter cpp,$(FEATURES_USED)),-lstdc++)
 

--- a/cpu/esp8266/Makefile.dep
+++ b/cpu/esp8266/Makefile.dep
@@ -2,6 +2,17 @@
 
 include $(RIOTCPU)/esp_common/Makefile.dep
 
+USEMODULE += esp_idf_esp8266
+USEMODULE += esp_idf_nvs_flash
+USEMODULE += esp_idf_spi_flash
+USEMODULE += esp_idf_util
+USEMODULE += esp_idf_wpa_supplicant_crypto
+USEMODULE += esp_sdk
+USEMODULE += mtd
+USEMODULE += newlib
+USEMODULE += periph_common
+USEMODULE += ps
+
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
   USEMODULE += esp_i2c_sw
   USEMODULE += periph_i2c_sw

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -28,17 +28,6 @@ TARGET_ARCH ?= xtensa-esp8266-elf
 
 PSEUDOMODULES += esp_sw_timer
 
-USEMODULE += esp_idf_esp8266
-USEMODULE += esp_idf_nvs_flash
-USEMODULE += esp_idf_spi_flash
-USEMODULE += esp_idf_util
-USEMODULE += esp_idf_wpa_supplicant_crypto
-USEMODULE += esp_sdk
-USEMODULE += mtd
-USEMODULE += newlib
-USEMODULE += periph_common
-USEMODULE += ps
-
 INCLUDES += -I$(RIOTCPU)/$(CPU)
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -59,17 +59,13 @@ INCLUDES += -I$(ESP8266_RTOS_SDK_DIR)/components/spi_flash/include
 
 CFLAGS += -D__ESP_FILE__=__FILE__
 
-ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
-  GDBSTUB_DIR ?= $(RIOTCPU)/$(CPU)/vendor/esp-gdbstub
-  CFLAGS      += -DGDBSTUB_BREAK_ON_INIT=1
-  INCLUDES    += -I$(GDBSTUB_DIR)
-endif
+# NOTE: These can be turned into normal conditionals after #9913 is fixed
+GDBSTUB_DIR ?= $(if $(filter esp_gdbstub,$(USEMODULE)),$(RIOTCPU)/$(CPU)/vendor/esp-gdbstub)
+CFLAGS     += $(if $(filter esp_gdbstub,$(USEMODULE)),-DGDBSTUB_BREAK_ON_INIT=1)
+INCLUDES   += $(if $(filter esp_gdbstub,$(USEMODULE)),-I$(GDBSTUB_DIR))
+BASELIBS   += $(if $(filter esp_now, $(USEMODULE)), -lespnow)
 
 BASELIBS += -lgcc -lwpa -lcore -lnet80211 -lphy -lpp -lstdc++
-
-ifneq (, $(filter esp_now, $(USEMODULE)))
-  BASELIBS += -lespnow
-endif
 
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp8266.rom.ld
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp8266.riot-os.ld

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -16,6 +16,25 @@ USEMODULE += random
 USEMODULE += stdio_uart
 USEMODULE += xtensa
 
+ifneq (,$(filter esp_wifi_enterprise,$(USEMODULE)))
+  FEATURES_REQUIRED += esp_wifi_enterprise
+  USEMODULE += esp_wifi
+endif
+
+ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+  ifneq (,$(filter lwip,$(USEMODULE)))
+    # for lwip, use esp_wifi as default netdev if no other netdev is enabled
+    ifeq (,$(filter esp_eth,$(USEMODULE)))
+      USEMODULE += esp_wifi
+    endif
+  else
+    # otherwise use esp_now as default netdev if no other netdev is enabled
+    ifeq (,$(filter esp_wifi esp_eth,$(USEMODULE)))
+      USEMODULE += esp_now
+    endif
+  endif
+endif
+
 # each device has SPI flash memory, but it has to be enabled explicitly
 ifneq (,$(filter esp_spiffs,$(USEMODULE)))
   USEMODULE += spiffs

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -1,5 +1,21 @@
 # additional modules dependencies
 
+# Modules used by ESP*
+
+USEMODULE += esp_common
+USEMODULE += esp_common_periph
+USEMODULE += esp_freertos
+USEMODULE += esp_idf
+USEMODULE += log
+USEMODULE += newlib
+USEMODULE += periph
+USEMODULE += periph_hwrng
+USEMODULE += periph_flash
+USEMODULE += periph_uart
+USEMODULE += random
+USEMODULE += stdio_uart
+USEMODULE += xtensa
+
 # each device has SPI flash memory, but it has to be enabled explicitly
 ifneq (,$(filter esp_spiffs,$(USEMODULE)))
   USEMODULE += spiffs

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -39,6 +39,10 @@ ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
   USEMODULE += esp_gdb
 endif
 
+ifneq (,$(filter log_color,$(USEMODULE)))
+  USEMODULE += esp_log_colored
+endif
+
 # each device has SPI flash memory, but it has to be enabled explicitly
 ifneq (,$(filter esp_spiffs,$(USEMODULE)))
   USEMODULE += spiffs

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -35,6 +35,10 @@ ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
+  USEMODULE += esp_gdb
+endif
+
 # each device has SPI flash memory, but it has to be enabled explicitly
 ifneq (,$(filter esp_spiffs,$(USEMODULE)))
   USEMODULE += spiffs

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -43,6 +43,10 @@ ifneq (,$(filter log_color,$(USEMODULE)))
   USEMODULE += esp_log_colored
 endif
 
+ifneq (,$(filter 4 5,$(LOG_LEVEL)))
+  USEMODULE += esp_log_startup
+endif
+
 # each device has SPI flash memory, but it has to be enabled explicitly
 ifneq (,$(filter esp_spiffs,$(USEMODULE)))
   USEMODULE += spiffs

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -88,14 +88,9 @@ ifneq (,$(filter esp_qemu,$(USEMODULE)))
   CFLAGS += -DQEMU
 endif
 
+# NOTE: These checks can be turned into normal conditionals when #9913 is fixed
 # use 32 priority levels if any WiFi interface or the ETH interface is used
-ifneq (,$(filter esp_wifi esp_now esp_eth,$(USEMODULE)))
-  CFLAGS += -DSCHED_PRIO_LEVELS=32
-endif
-
-ifneq (,$(filter esp_wifi esp_now esp_eth,$(USEMODULE)))
-  INCLUDES += -I$(RIOTCPU)/esp_common/esp-wifi
-endif
+CFLAGS += $(if $(filter esp_wifi_any esp_eth,$(USEMODULE)),-DSCHED_PRIO_LEVELS=32)
 
 # The threads for handling the ESP hardware have the priorities from 2 to 4.
 # The priority of lwIP TCPIP thread should be lower than these priorities.

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -132,11 +132,7 @@ else
   FFLAGS += 0x10000 $(FLASHFILE).bin
 endif
 
+# NOTE: These checks can be turned into normal conditionals when #9913 is fixed
 # increase the test timeout for file system tests that use the SPI flash drive
-ifneq (,$(filter spiffs,$(USEMODULE)))
-  export RIOT_TEST_TIMEOUT = 120
-endif
-
-ifneq (,$(filter littlefs,$(USEMODULE)))
-  export RIOT_TEST_TIMEOUT = 120
-endif
+RIOT_TEST_TIMEOUT = $(if $(filter spiffs littlefs,$(USEMODULE)),120)
+$(call target-export-variables,test,RIOT_TEST_TIMEOUT)

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -62,23 +62,15 @@ ifneq (,$(filter lwip,$(USEMODULE)))
 endif
 
 # if SPI RAM is enabled, the qout flash mode has to be used
-ifneq (,$(filter esp_spi_ram,$(USEMODULE)))
-  FLASH_MODE = qout
-  CFLAGS += -DFLASH_MODE_QOUT=1
-else
-  ifeq ($(FLASH_MODE), qio)
-    CFLAGS += -DFLASH_MODE_QIO=1
-  endif
-  ifeq ($(FLASH_MODE), qout)
-    CFLAGS += -DFLASH_MODE_QOUT=1
-  endif
-  ifeq ($(FLASH_MODE), dio)
-    CFLAGS += -DFLASH_MODE_DIO=1
-  endif
-  ifeq ($(FLASH_MODE), dout)
-    CFLAGS += -DFLASH_MODE_DOUT=1
-  endif
-endif
+# NOTE: These checks can be turned into normal conditionals when #9913 is fixed
+_FLASH_MODE_PREV := $(FLASH_MODE)
+FLASH_MODE = $(if $(filter esp_spi_ram,$(USEMODULE)),qout,$(_FLASH_MODE_PREV))
+
+# set CFLAG for the correspondant FLASH_MODE
+CFLAGS += $(if $(findstring qout,$(FLASH_MODE)),-DFLASH_MODE_QOUT=1)
+CFLAGS += $(if $(findstring qio,$(FLASH_MODE)),-DFLASH_MODE_QIO=1)
+CFLAGS += $(if $(findstring dio,$(FLASH_MODE)),-DFLASH_MODE_DIO=1)
+CFLAGS += $(if $(findstring dout,$(FLASH_MODE)),-DFLASH_MODE_DOUT=1)
 
 BASELIBS += -lhal -lg -lc
 

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -4,13 +4,6 @@
 # use flash mode dout by default to keep GPIO9 and GPIO10 free for use
 FLASH_MODE ?= dout
 
-# SPECIAL module dependencies
-# cannot be done in Makefile.dep since Makefile.dep is included too late
-
-ifneq (,$(filter 4 5,$(LOG_LEVEL)))
-  USEMODULE += esp_log_startup
-endif
-
 # ESP* pseudomodules
 
 PSEUDOMODULES += esp_gdb
@@ -97,11 +90,9 @@ LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 # LINKFLAGS += -Wl,--verbose
 # LINKFLAGS += -Wl,--print-gc-sections
 
+# NOTE: These checks can be turned into normal conditionals when #9913 is fixed
 BOOTLOADER_COLOR = $(if $(filter esp_log_colored,$(USEMODULE)),_colors)
-
-ifneq (,$(filter esp_log_startup,$(USEMODULE)))
-  BOOTLOADER_INFO = _info
-endif
+BOOTLOADER_INFO = $(if $(filter esp_log_startup,$(USEMODULE)),_info)
 
 BOOTLOADER_BIN = bootloader$(BOOTLOADER_COLOR)$(BOOTLOADER_INFO).bin
 

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -7,10 +7,6 @@ FLASH_MODE ?= dout
 # SPECIAL module dependencies
 # cannot be done in Makefile.dep since Makefile.dep is included too late
 
-ifneq (,$(filter log_color,$(USEMODULE)))
-  USEMODULE += esp_log_colored
-endif
-
 ifneq (,$(filter 4 5,$(LOG_LEVEL)))
   USEMODULE += esp_log_startup
 endif
@@ -101,9 +97,7 @@ LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 # LINKFLAGS += -Wl,--verbose
 # LINKFLAGS += -Wl,--print-gc-sections
 
-ifneq (,$(filter esp_log_colored,$(USEMODULE)))
-  BOOTLOADER_COLOR = _colors
-endif
+BOOTLOADER_COLOR = $(if $(filter esp_log_colored,$(USEMODULE)),_colors)
 
 ifneq (,$(filter esp_log_startup,$(USEMODULE)))
   BOOTLOADER_INFO = _info

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -133,25 +133,10 @@ else
 endif
 
 # increase the test timeout for file system tests that use the SPI flash drive
-
 ifneq (,$(filter spiffs,$(USEMODULE)))
   export RIOT_TEST_TIMEOUT = 120
 endif
 
 ifneq (,$(filter littlefs,$(USEMODULE)))
   export RIOT_TEST_TIMEOUT = 120
-endif
-
-# increase the number of netif for each enabled network interface
-
-ifneq (,$(filter esp_wifi,$(USEMODULE)))
-  $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
-endif
-
-ifneq (,$(filter esp_now,$(USEMODULE)))
-  $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
-endif
-
-ifneq (,$(filter esp_eth,$(USEMODULE)))
-  $(eval GNRC_NETIF_NUMOF=$(shell echo $$(($(GNRC_NETIF_NUMOF)+1))))
 endif

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -49,22 +49,6 @@ PSEUDOMODULES += esp_qemu
 PSEUDOMODULES += esp_spiffs
 PSEUDOMODULES += esp_wifi_any
 
-# Modules used by ESP*
-
-USEMODULE += esp_common
-USEMODULE += esp_common_periph
-USEMODULE += esp_freertos
-USEMODULE += esp_idf
-USEMODULE += log
-USEMODULE += newlib
-USEMODULE += periph
-USEMODULE += periph_hwrng
-USEMODULE += periph_flash
-USEMODULE += periph_uart
-USEMODULE += random
-USEMODULE += stdio_uart
-USEMODULE += xtensa
-
 # Common includes
 
 INCLUDES += -I$(RIOTBOARD)/common/$(CPU)/include

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -7,25 +7,6 @@ FLASH_MODE ?= dout
 # SPECIAL module dependencies
 # cannot be done in Makefile.dep since Makefile.dep is included too late
 
-ifneq (,$(filter esp_wifi_enterprise,$(USEMODULE)))
-  FEATURES_REQUIRED += esp_wifi_enterprise
-  USEMODULE += esp_wifi
-endif
-
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
-  ifneq (,$(filter lwip,$(USEMODULE)))
-    # for lwip, use esp_wifi as default netdev if no other netdev is enabled
-    ifeq (,$(filter esp_eth,$(USEMODULE)))
-      USEMODULE += esp_wifi
-    endif
-  else
-    # otherwise use esp_now as default netdev if no other netdev is enabled
-    ifeq (,$(filter esp_wifi esp_eth,$(USEMODULE)))
-      USEMODULE += esp_now
-    endif
-  endif
-endif
-
 ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
   USEMODULE += esp_gdb
 endif

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -7,10 +7,6 @@ FLASH_MODE ?= dout
 # SPECIAL module dependencies
 # cannot be done in Makefile.dep since Makefile.dep is included too late
 
-ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
-  USEMODULE += esp_gdb
-endif
-
 ifneq (,$(filter log_color,$(USEMODULE)))
   USEMODULE += esp_log_colored
 endif
@@ -55,12 +51,9 @@ ASFLAGS += --longcalls --text-section-literals
 ARFLAGS = rcs
 
 CFLAGS_DBG ?= -ggdb -g3
-CFLAGS_OPT ?= -Os
 
 # override default CFLAGS_OPT in case module esp_gdb is enabled
-ifneq (,$(filter esp_gdb,$(USEMODULE)))
-  CFLAGS_OPT = -Og
-endif
+CFLAGS_OPT ?= $(if $(filter esp_gdb,$(USEMODULE)),-Og,-Os)
 
 CFLAGS += $(CFLAGS_OPT) $(CFLAGS_DBG)
 


### PR DESCRIPTION
### Contribution description
This PR is an attempt to cleanup the dependency resolution for ESP CPUs. The main idea is to make use of [GNU Make conditional expansion](https://www.gnu.org/software/make/manual/html_node/Conditional-Functions.html) to check for `USEMODULE` variable in Makefile.include files, so the expansion is delayed until after the dependency resolution occurs.

Currently this depends on #12994, so we do not have to deal with `GNRC_NETIF_NUMOF` in Makefiles. I suggest reviewing this commit per commit.


### Testing procedure
- Using the debug-dependency targets make sure that included modules and features do not change.
- Inspect the CFLAGS to make sure they are correctly added.

### Issues/PRs references
Part of #9913
~~Depends on #12994~~