### PR TITLE
suit/transport/coap: Make use of exposed tree handler function

### DIFF
--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -79,8 +79,8 @@ void suit_coap_run(void);
  *
  * @returns     ssize_t     Size of the reply
  */
-ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
-                             void *context);
+ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf,
+                             size_t len, void *context);
 
 /**
  * @brief   Type for CoAP resource subtrees

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -101,35 +101,9 @@ static kernel_pid_t _suit_coap_pid;
 ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
                              void *context)
 {
-    uint8_t uri[NANOCOAP_URI_MAX];
-
-    unsigned method_flag = coap_method2flag(coap_get_code_detail(pkt));
-
-    if (coap_get_uri_path(pkt, uri) > 0) {
-        coap_resource_subtree_t *subtree = context;
-
-        for (unsigned i = 0; i < subtree->resources_numof; i++) {
-            const coap_resource_t *resource = &subtree->resources[i];
-
-            if (!(resource->methods & method_flag)) {
-                continue;
-            }
-
-            int res = coap_match_path(resource, uri);
-            if (res > 0) {
-                continue;
-            }
-            else if (res < 0) {
-                break;
-            }
-            else {
-                return resource->handler(pkt, buf, len, resource->context);
-            }
-        }
-    }
-
-    return coap_reply_simple(pkt, COAP_CODE_INTERNAL_SERVER_ERROR, buf,
-                             len, COAP_FORMAT_TEXT, NULL, 0);
+    coap_resource_subtree_t *subtree = context;
+    return coap_tree_handler(pkt, buf, len, subtree->resources,
+                             subtree->resources_numof);
 }
 
 static inline uint32_t _now(void)


### PR DESCRIPTION
### Contribution description

Follow up to #13687. This cleans up the suit coap code to make use of the newly exposed function.

### Testing procedure

Test if the coap endpoints in `examples/suit-update` still work.

### Issues/PRs references

depends on #13687 