### PR TITLE
dist/tools/ethos: fix typo for compiling baud rate 230400

### DIFF
--- a/dist/tools/ethos/ethos.c
+++ b/dist/tools/ethos/ethos.c
@@ -324,7 +324,7 @@ static int _parse_baudrate(const char *arg, unsigned *baudrate)
         *baudrate = B115200;
         break;
     /* the following baudrates might not be available on all platforms */
-    #ifdef B234000
+    #ifdef B230400
         case_baudrate(230400);
     #endif
     #ifdef B460800


### PR DESCRIPTION
### Contribution description
The switch case and the `case_baudrate()` should match.

### Testing procedure

### Issues/PRs references

taken from https://github.com/benemorius/RIOT/tree/openlabs