### PR TITLE
examples/gnrc_border_router: remove never defined USE_SLIP variable

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -123,7 +123,7 @@ uhcpd-daemon: host-tools
 endif
 endif
 
-ifeq (1,$(USE_SLIP))
+ifeq (slip,$(UPLINK))
 sliptty:
 	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/sliptty
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
PR #13545 removed the definition of the variable USE_SLIP completely but it is still needed currently. If UPLINK=slip is set 'make term' throws 

> make: *** No rule to make target 'sliptty', needed by 'term'.  Stop.

This pull request just removes the ifeq(1, $(USE_SLIP)) and changes it to UPLINK comparison.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Go on upstream and try: make -C examples/gnrc_border_router term UPLINK=slip
The above mentioned error should occur.
Try it again with this PR - now it should work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
