### PR TITLE
drivers/at86rf215: fix same54-xpro EXT3 default parameter

### DIFF
--- a/drivers/at86rf215/include/at86rf215_params.h
+++ b/drivers/at86rf215/include/at86rf215_params.h
@@ -38,13 +38,13 @@ extern "C" {
 #define AT86RF215_PARAM_SPI_CLK     (SPI_CLK_5MHZ)
 #endif
 #ifndef AT86RF215_PARAM_CS
-#define AT86RF215_PARAM_CS          (GPIO_PIN(3, 14))
+#define AT86RF215_PARAM_CS          (GPIO_PIN(2, 14))
 #endif
 #ifndef AT86RF215_PARAM_INT
-#define AT86RF215_PARAM_INT         (GPIO_PIN(3, 30))
+#define AT86RF215_PARAM_INT         (GPIO_PIN(2, 30))
 #endif
 #ifndef AT86RF215_PARAM_RESET
-#define AT86RF215_PARAM_RESET       (GPIO_PIN(4, 10))
+#define AT86RF215_PARAM_RESET       (GPIO_PIN(3, 10))
 #endif
 
 #ifndef AT86RF215_PARAMS


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The default config of the `at86rf215` driver is for the REB215-XPRO module connected to EXT3 on `same54-xpro`.

When changing the port names (PC, PD) to generic numbers (2, 3) I made an off-by one error.

Fix this to restore my personal convenience when working with that module.


### Testing procedure

Connect REB215-XPRO to the EXT3 pin header on `same54-xpro`.
Compile any networking example with `USEMODULE += at86rf215`.
The driver should work out of the box.

This does not affect any other boards, as boards that come with this chip already have their own config.

### Issues/PRs references

