### PR TITLE
boards/same54-xpro: configure remaining EXT connectors

### DIFF
--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -30,10 +30,17 @@ extern "C" {
  * @name    AT24MAC402 configuration
  * @{
  */
-#define AT24MAC_PARAM_I2C_DEV   I2C_DEV(0)
+#define AT24MAC_PARAM_I2C_DEV   I2C_DEV(1)
 #define AT24MAC_PARAM_I2C_ADDR  (0x5E)
 #define AT24MAC_PARAM_TYPE      AT24MAC4XX
 #define AT24CXXX_PARAM_ADDR     (0x56)
+/** @} */
+
+/**
+ * @name    ATECC508A configuration
+ * @{
+ */
+#define ATCA_PARAM_I2C           I2C_DEV(1)
 /** @} */
 
 /**

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -87,12 +87,63 @@ static const uart_conf_t uart_config[] = {
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
         .gclk_src = SAM0_GCLK_48MHZ,
+    },
+    {    /* EXT1 */
+        .dev      = &SERCOM0->USART,
+        .rx_pin   = GPIO_PIN(PA, 5),
+        .tx_pin   = GPIO_PIN(PA, 4),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_48MHZ,
+    },
+    {    /* EXT2 */
+        .dev      = &SERCOM5->USART,
+        .rx_pin   = GPIO_PIN(PB, 17),
+        .tx_pin   = GPIO_PIN(PB, 16),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_48MHZ,
+    },
+    {    /* EXT3 */
+        .dev      = &SERCOM1->USART,
+        .rx_pin   = GPIO_PIN(PC, 23),
+        .tx_pin   = GPIO_PIN(PC, 22),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_48MHZ,
     }
 };
 
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom2_2
 #define UART_0_ISR_TX       isr_sercom2_0
+
+#define UART_1_ISR          isr_sercom0_2
+#define UART_1_ISR_TX       isr_sercom0_0
+
+#define UART_2_ISR          isr_sercom5_2
+#define UART_2_ISR_TX       isr_sercom5_0
+
+#define UART_3_ISR          isr_sercom1_2
+#define UART_3_ISR_TX       isr_sercom1_0
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
@@ -102,7 +153,20 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 static const spi_conf_t spi_config[] = {
-    {
+    {    /* EXT1 */
+        .dev      = &(SERCOM4->SPI),
+        .miso_pin = GPIO_PIN(PB, 29),
+        .mosi_pin = GPIO_PIN(PB, 27),
+        .clk_pin  = GPIO_PIN(PB, 26),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_3,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = SAM0_GCLK_48MHZ,
+
+    },
+    {    /* EXT2, EXT3 */
         .dev      = &(SERCOM6->SPI),
         .miso_pin = GPIO_PIN(PC, 7),
         .mosi_pin = GPIO_PIN(PC, 4),
@@ -113,7 +177,6 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
         .gclk_src = SAM0_GCLK_48MHZ,
-
     }
 };
 
@@ -125,7 +188,16 @@ static const spi_conf_t spi_config[] = {
  * @{
  */
 static const i2c_conf_t i2c_config[] = {
-    {
+    {    /* EXT1 */
+        .dev      = &(SERCOM3->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 23),
+        .sda_pin  = GPIO_PIN(PA, 22),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = SAM0_GCLK_48MHZ,
+        .flags    = I2C_FLAG_NONE
+    },
+    {    /* EXT2, EXT3 */
         .dev      = &(SERCOM7->I2CM),
         .speed    = I2C_SPEED_NORMAL,
         .scl_pin  = GPIO_PIN(PD, 9),

--- a/drivers/at86rf215/include/at86rf215_params.h
+++ b/drivers/at86rf215/include/at86rf215_params.h
@@ -28,7 +28,7 @@ extern "C" {
 
 /**
  * @name    Set default configuration parameters for the AT86RF215 driver
- *          Example config for EXT3 on same54-xpro
+ *          Example config for EXT1 on same54-xpro
  * @{
  */
 #ifndef AT86RF215_PARAM_SPI
@@ -38,13 +38,13 @@ extern "C" {
 #define AT86RF215_PARAM_SPI_CLK     (SPI_CLK_5MHZ)
 #endif
 #ifndef AT86RF215_PARAM_CS
-#define AT86RF215_PARAM_CS          (GPIO_PIN(3, 14))
+#define AT86RF215_PARAM_CS          (GPIO_PIN(1, 28))
 #endif
 #ifndef AT86RF215_PARAM_INT
-#define AT86RF215_PARAM_INT         (GPIO_PIN(3, 30))
+#define AT86RF215_PARAM_INT         (GPIO_PIN(1, 7))
 #endif
 #ifndef AT86RF215_PARAM_RESET
-#define AT86RF215_PARAM_RESET       (GPIO_PIN(4, 10))
+#define AT86RF215_PARAM_RESET       (GPIO_PIN(1, 8))
 #endif
 
 #ifndef AT86RF215_PARAMS


### PR DESCRIPTION
### Contribution description

Initially I only configured a few of the SERCOMs connected to the EXT connectors on the `same54-xpro`.

Turns out they are pretty useful to have, so configure them all as described in the board manual.

### Testing procedure

Run tests for SPI, I2C and UART.

<details>
<summary>i2c_scan with REB215-XPRO connected to EXT1</summary>

```
2020-03-24 01:02:02,763 #  i2c_scan 0
2020-03-24 01:02:02,765 # Scanning I2C device 0...
2020-03-24 01:02:02,772 # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2020-03-24 01:02:02,775 #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2020-03-24 01:02:02,779 # 0x00 R R R R R R R R R R R R R R - -
2020-03-24 01:02:02,783 # 0x10 - - - - - - - - - - - - - - - -
2020-03-24 01:02:02,789 # 0x20 - - - - - - - - - - - - - - - -
2020-03-24 01:02:02,794 # 0x30 X - - - - - - - - - - - - - - -
2020-03-24 01:02:02,799 # 0x40 - - - - - - - - - - - - - - - -
2020-03-24 01:02:02,804 # 0x50 X - - - - - - - X - - - - - - -
2020-03-24 01:02:02,809 # 0x60 - - - - - - - - - - - - - - - -
2020-03-24 01:02:02,813 # 0x70 - - - - - - - - R R R R R R R R
2020-03-24 01:02:04,467 #  i2c_scan 1
2020-03-24 01:02:04,469 # Scanning I2C device 1...
2020-03-24 01:02:04,476 # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2020-03-24 01:02:04,479 #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2020-03-24 01:02:04,483 # 0x00 R R R R R R R R R R R R R R - -
2020-03-24 01:02:04,488 # 0x10 - - - - - - - - - - - - - - - -
2020-03-24 01:02:04,493 # 0x20 - - - - - - - - X - - - - - - -
2020-03-24 01:02:04,498 # 0x30 - - - - - - X - - - - - - - - -
2020-03-24 01:02:04,503 # 0x40 - - - - - - - - - - - - - - - -
2020-03-24 01:02:04,508 # 0x50 - - - - - - X - - - - - - - X -
2020-03-24 01:02:04,513 # 0x60 X - - - - - - - - - - - - - - -
2020-03-24 01:02:04,517 # 0x70 - - - - - - - - R R R R R R R R
```
</details>

### Issues/PRs references

obsoletes #13692