### PR TITLE
boards: add common cc2538

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -31,3 +31,6 @@ DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 RESET_FLAGS ?= $(BINDIR)
 
 OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
+
+# include common cc2538 includes
+INCLUDES += -I$(RIOTBOARD)/common/cc2538/include

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -22,78 +22,12 @@
 #include "cpu.h"
 #include "periph_cpu.h"
 
+#include "cfg_clk_default.h"
+#include "cfg_timer_default.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock system configuration
- * @{
- */
-/*
- * 0: use internal 32KHz RCOSC
- * 1: use external 32KHz XOSC
- */
-#ifndef SYS_CTRL_OSC32K_USE_XTAL
-#define SYS_CTRL_OSC32K_USE_XTAL        (1)
-#endif
-/*
- * 0: use internal 16MHz RCOSC
- * 1: use external 32MHz XOSC, required for RF operation
- */
-#ifndef SYS_CTRL_OSC_USE_XTAL
-#define SYS_CTRL_OSC_USE_XTAL           (1)
-#endif
-
-#if SYS_CTRL_OSC_USE_XTAL
-#define CLOCK_OSC           (XOSC32M_FREQ)
-#else
-#define CLOCK_OSC           (RCOSC16M_FREQ)
-#endif
-
-#if SYS_CTRL_OSC32K_USE_XTAL
-#define CLOCK_OSC32K        (XOSC32K_FREQ)    /* XCOSC frequency */
-#else
-#define CLOCK_OSC32K        (RCOSC32K_FREQ)    /* XCOSC frequency */
-#endif
-
-/* System clock frequency 32MHz */
-#define CLOCK_CORECLOCK     (CLOCK_OSC)
-/* I/O clock rate setting 16MHz */
-#define CLOCK_IO            (CLOCK_OSC / 2)
-/** @} */
-
-/**
- * @name    Timer configuration
- *
- * General purpose timers (GPT[0-3]) are configured consecutively and in order
- * (without gaps) starting from GPT0, i.e. if multiple timers are enabled.
- *
- * @{
- */
-static const timer_conf_t timer_config[] = {
-    {
-        .chn = 2,
-        .cfg = GPTMCFG_16_BIT_TIMER, /* required for XTIMER */
-    },
-    {
-        .chn = 1,
-        .cfg = GPTMCFG_32_BIT_TIMER,
-    },
-    {
-        .chn = 2,
-        .cfg = GPTMCFG_16_BIT_TIMER,
-    },
-    {
-        .chn = 1,
-        .cfg = GPTMCFG_32_BIT_TIMER,
-    },
-};
-
-#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
-
-#define TIMER_IRQ_PRIO      1
-/** @} */
 
 /**
  * @name    UART configuration

--- a/boards/common/cc2538/doc.txt
+++ b/boards/common/cc2538/doc.txt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_common_cc2538 cc2538 Configuration Snippets
+ * @ingroup     boards_common
+ * @brief       Board configuration snippets for cc2538-based boards
+ *
+ * All boards using a cc2538 share certain parts of their configuration. This
+ * module provides a collection of fine grained configuration snippets that can
+ * be reused for different boards.
+ */

--- a/boards/common/cc2538/include/cfg_clk_default.h
+++ b/boards/common/cc2538/include/cfg_clk_default.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014-2016 Freie Universität Berlin
  *               2015 Zolertia SL
+ *               2020 Inria
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -8,19 +9,25 @@
  */
 
 /**
- * @ingroup     boards_common_remote
+ * @ingroup     boards_common_cc2538
  * @{
  *
  * @file
- * @brief       Common default clock configuration for the RE-Mote board revision A
+ * @brief       Default clock configuration for cc2538 based boards
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Antonio Lignan <alinan@zolertia.com>
  * @author      Sebastian Meiling <s@mlng.net>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
 
 #ifndef CFG_CLK_DEFAULT_H
 #define CFG_CLK_DEFAULT_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +37,7 @@ extern "C" {
  * @name    Clock system configuration
  * @{
  */
+
 /*
  * 0: use internal 32KHz RCOSC
  * 1: use external 32KHz XOSC
@@ -58,13 +66,17 @@ extern "C" {
 #endif
 
 /* System clock frequency 32MHz */
+#ifndef CLOCK_CORECLOCK
 #define CLOCK_CORECLOCK     (CLOCK_OSC)
+#endif
 /* I/O clock rate setting 16MHz */
+#ifndef CLOCK_IO
 #define CLOCK_IO            (CLOCK_OSC / 2)
+#endif
 /** @} */
 
 #ifdef __cplusplus
-} /* end extern "C" */
+}
 #endif
 
 #endif /* CFG_CLK_DEFAULT_H */

--- a/boards/common/cc2538/include/cfg_timer_default.h
+++ b/boards/common/cc2538/include/cfg_timer_default.h
@@ -8,11 +8,11 @@
  */
 
 /**
- * @ingroup     boards_common_remote
+ * @ingroup     boards_common_cc2538
  * @{
  *
  * @file
- * @brief       Common default timer configuration for the RE-Mote board revision A
+ * @brief       Common default timer configuration for cc2538 boards
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Antonio Lignan <alinan@zolertia.com>

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -27,5 +27,8 @@ FLASHFILE ?= $(BINFILE)
 DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 
+# include common cc2538 includes
+INCLUDES += -I$(RIOTBOARD)/common/cc2538/include
+
 # include common remote includes
 INCLUDES += -I$(RIOTBOARD)/common/remote/include

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -29,3 +29,6 @@ else ifeq ($(PROGRAMMER),jlink)
 endif
 
 OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
+
+# include common cc2538 includes
+INCLUDES += -I$(RIOTBOARD)/common/cc2538/include

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -25,77 +25,12 @@
 #include "cc2538_gpio.h"
 #include "periph_cpu.h"
 
+#include "cfg_clk_default.h"
+#include "cfg_timer_default.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-/**
- * @name    Clock system configuration
- * @{
- */
-/*
- * 0: use internal 32KHz RCOSC
- * 1: use external 32KHz XOSC
- */
-#ifndef SYS_CTRL_OSC32K_USE_XTAL
-#define SYS_CTRL_OSC32K_USE_XTAL        (1)
-#endif
-/*
- * 0: use internal 16MHz RCOSC
- * 1: use external 32MHz XOSC, required for RF operation
- */
-#ifndef SYS_CTRL_OSC_USE_XTAL
-#define SYS_CTRL_OSC_USE_XTAL           (1)
-#endif
-
-#if SYS_CTRL_OSC_USE_XTAL
-#define CLOCK_OSC           (XOSC32M_FREQ)
-#else
-#define CLOCK_OSC           (RCOSC16M_FREQ)
-#endif
-
-#if SYS_CTRL_OSC32K_USE_XTAL
-#define CLOCK_OSC32K        (XOSC32K_FREQ)    /* XCOSC frequency */
-#else
-#define CLOCK_OSC32K        (RCOSC32K_FREQ)    /* XCOSC frequency */
-#endif
-
-/* System clock frequency 32MHz */
-#define CLOCK_CORECLOCK     (CLOCK_OSC)
-/* I/O clock rate setting 16MHz */
-#define CLOCK_IO            (CLOCK_OSC / 2)
-/** @} */
-
-/**
- * @name    Timer configuration
- *
- * General purpose timers (GPT[0-3]) are configured consecutively and
- * in order (without gaps) starting from GPT0, i.e. if multiple timers are enabled.
- *
- * @{
- */
-static const timer_conf_t timer_config[] = {
-    {
-        .chn = 2,
-        .cfg = GPTMCFG_16_BIT_TIMER, /* required for XTIMER */
-    },
-    {
-        .chn = 1,
-        .cfg = GPTMCFG_32_BIT_TIMER,
-    },
-    {
-        .chn = 2,
-        .cfg = GPTMCFG_16_BIT_TIMER,
-    },
-    {
-        .chn = 1,
-        .cfg = GPTMCFG_32_BIT_TIMER,
-    },
-};
-
-#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
-#define TIMER_IRQ_PRIO      1
-/** @} */
 
 /**
  * @name ADC configuration

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -18,3 +18,6 @@ else ifeq ($(PROGRAMMER),cc2538-bsl)
   PROG_BAUD ?= 460800
   include $(RIOTMAKE)/tools/cc2538-bsl.inc.mk
 endif
+
+# include common cc2538 includes
+INCLUDES += -I$(RIOTBOARD)/common/cc2538/include

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -23,76 +23,12 @@
 #include "cc2538_gpio.h"
 #include "periph_cpu.h"
 
+#include "cfg_clk_default.h"
+#include "cfg_timer_default.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-/**
- * @name    Clock system configuration
- * @{
- */
-/*
- * 0: use internal 32KHz RCOSC
- * 1: use external 32KHz XOSC
- */
-#ifndef SYS_CTRL_OSC32K_USE_XTAL
-#define SYS_CTRL_OSC32K_USE_XTAL        (1)
-#endif
-/*
- * 0: use internal 16MHz RCOSC
- * 1: use external 32MHz XOSC, required for RF operation
- */
-#ifndef SYS_CTRL_OSC_USE_XTAL
-#define SYS_CTRL_OSC_USE_XTAL           (1)
-#endif
-
-#if SYS_CTRL_OSC_USE_XTAL
-#define CLOCK_OSC           (XOSC32M_FREQ)
-#else
-#define CLOCK_OSC           (RCOSC16M_FREQ)
-#endif
-
-#if SYS_CTRL_OSC32K_USE_XTAL
-#define CLOCK_OSC32K        (XOSC32K_FREQ)    /* XCOSC frequency */
-#else
-#define CLOCK_OSC32K        (RCOSC32K_FREQ)    /* XCOSC frequency */
-#endif
-
-/* System clock frequency 32MHz */
-#define CLOCK_CORECLOCK     (CLOCK_OSC)
-/* I/O clock rate setting 16MHz */
-#define CLOCK_IO            (CLOCK_OSC / 2)
-/** @} */
-/**
- * @name    Timer configuration
- *
- * General purpose timers (GPT[0-3]) are configured consecutively and in order
- * (without gaps) starting from GPT0, i.e. if multiple timers are enabled.
- *
- * @{
- */
-static const timer_conf_t timer_config[] = {
-    {
-        .chn = 2,
-        .cfg = GPTMCFG_16_BIT_TIMER, /* required for XTIMER */
-    },
-    {
-        .chn = 1,
-        .cfg = GPTMCFG_32_BIT_TIMER,
-    },
-    {
-        .chn = 2,
-        .cfg = GPTMCFG_16_BIT_TIMER,
-    },
-    {
-        .chn = 1,
-        .cfg = GPTMCFG_32_BIT_TIMER,
-    },
-};
-
-#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
-#define TIMER_IRQ_PRIO      1
-/** @} */
 
 /**
  * @name ADC configuration

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -343,13 +343,7 @@ typedef gpio_t adc_conf_t;
 #define RTT_IRQ_PRIO        1
 #define RTT_ISR             isr_sleepmode
 #define RTT_MAX_VALUE       (0xffffffff)
-#if SYS_CTRL_OSC32K_USE_XTAL
-/* Frequency of XOSC off by default */
-#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#else
-/* Frequency of RCOSC on by default */
-#define RTT_FREQUENCY       (32753U)    /* in Hz. For changes see `rtt.c` */
-#endif
+#define RTT_FREQUENCY       (CLOCK_OSC32K)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

This PR adds common board configuration files for `cc2538` based boards for `timer`, `rtt` and `clk`.

`rtt` is moved from `periph_cpu` so that after the refactor in #13673 `RTT_FREQUENCY` is correctly set based on the value of `SYS_CTRL_OSC32K_USE_XTAL` in `cfg_clk_default`.

### Testing procedure

- green murdock

- `SYS_CTRL_OSC32K_USE_XTAL` value applies to `RTT_FREQUENCY`

<details><summary>SYS_CTRL_OSC32K_USE_XTAL = 1 in `cfg_clk_default.h` </summary>

```
2020-03-24 09:38:59,499 # main(): This is RIOT! (Version: 2020.04-devel-1421-g5c84e-pr_boards_common_cc2538)
2020-03-24 09:38:59,499 # 
2020-03-24 09:38:59,500 # RIOT RTT low-level driver test
2020-03-24 09:38:59,502 # This test will display 'Hello' every 5 seconds
2020-03-24 09:38:59,502 # 
2020-03-24 09:38:59,503 # Initializing the RTT driver
2020-03-24 09:38:59,504 # RTT now: 139025
2020-03-24 09:38:59,506 # Setting initial alarm to now + 5 s (302865)
2020-03-24 09:38:59,507 # Done setting up the RTT, wait for many Hellos
2020-03-24 09:39:04,489 # Hello
2020-03-24 09:39:09,489 # Hello
2020-03-24 09:39:14,489 # Hello
```
</details>

<details><summary>SYS_CTRL_OSC32K_USE_XTAL = 0 in `cfg_clk_default.h`  </summary>

```
2020-03-24 09:40:33,139 # main(): This is RIOT! (Version: 2020.04-devel-1421-g5c84e-pr_boards_common_cc2538)
2020-03-24 09:40:33,139 # 
2020-03-24 09:40:33,140 # RIOT RTT low-level driver test
2020-03-24 09:40:33,142 # This test will display 'Hello' every 5 seconds
2020-03-24 09:40:33,142 # 
2020-03-24 09:40:33,144 # Initializing the RTT driver
2020-03-24 09:40:33,145 # RTT now: 1155763
2020-03-24 09:40:33,146 # Setting initial alarm to now + 5 s (1319528)
2020-03-24 09:40:33,147 # Done setting up the RTT, wait for many Hellos
2020-03-24 09:40:38,134 # Hello
2020-03-24 09:40:43,139 # Hello
2020-03-24 09:40:48,146 # Hello
```
</details>

### Issues/PRs references

 #13673 
