### PR TITLE
tests: remove uneeded blacklist

### DIFF
--- a/tests/bench_msg_pingpong/Makefile.ci
+++ b/tests/bench_msg_pingpong/Makefile.ci
@@ -1,8 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_mutex_pingpong/Makefile.ci
+++ b/tests/bench_mutex_pingpong/Makefile.ci
@@ -1,8 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_thread_flags_pingpong/Makefile.ci
+++ b/tests/bench_thread_flags_pingpong/Makefile.ci
@@ -1,8 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_thread_yield_pingpong/Makefile.ci
+++ b/tests/bench_thread_yield_pingpong/Makefile.ci
@@ -1,8 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/driver_ds1307/Makefile.ci
+++ b/tests/driver_ds1307/Makefile.ci
@@ -1,6 +1,0 @@
-BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
-    #

--- a/tests/driver_pca9685/Makefile.ci
+++ b/tests/driver_pca9685/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \

--- a/tests/msg_try_receive/Makefile.ci
+++ b/tests/msg_try_receive/Makefile.ci
@@ -1,8 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/periph_wdt/Makefile.ci
+++ b/tests/periph_wdt/Makefile.ci
@@ -1,8 +1,0 @@
-# workaround to make this test compilable on CI with `shell_commands` in.
-# Remove when https://github.com/RIOT-OS/RIOT/pull/13613 is merged.
-BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
-    #

--- a/tests/thread_msg_block_w_queue/Makefile.ci
+++ b/tests/thread_msg_block_w_queue/Makefile.ci
@@ -1,8 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/thread_msg_block_wo_queue/Makefile.ci
+++ b/tests/thread_msg_block_wo_queue/Makefile.ci
@@ -1,8 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #


### PR DESCRIPTION
### Contribution description

With #12941 and #13613 some of the blacklisting introduced in #12461
are no longer needed, since `test_interactive_test_util` is lighter
or adds no extra code.

### Testing procedure

- green murdock

