### PR TITLE
tests: fixes for evtimer_msg and bench_runtime_coreapis

### DIFF
--- a/tests/bench_runtime_coreapis/tests/01-run.py
+++ b/tests/bench_runtime_coreapis/tests/01-run.py
@@ -21,10 +21,11 @@ def testfunc(child):
     child.expect(BENCHMARK_REGEXP.format(func=r"mutex_init\(\)"))
     child.expect(BENCHMARK_REGEXP.format(func="mutex lock/unlock"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"thread_flags_set\(\)"))
+    child.expect(BENCHMARK_REGEXP.format(func=r"thread_flags_clear\(\)"))
     child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait any"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait all"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait one"), timeout=TIMEOUT)
-    child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"))
+    child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
     child.expect_exact('[SUCCESS]')
 

--- a/tests/evtimer_msg/tests/01-run.py
+++ b/tests/evtimer_msg/tests/01-run.py
@@ -23,7 +23,7 @@ def testfunc(child):
         # check if output is correct
         expected = int(child.match.group(2))
         actual = int(child.match.group(1))
-        assert(actual in range(expected - ACCEPTED_ERROR, expected + ACCEPTED_ERROR))
+        assert(actual in range(expected - ACCEPTED_ERROR, expected + ACCEPTED_ERROR + 1))
         print(".", end="", flush=True)
     print("")
     print("All tests successful")


### PR DESCRIPTION
### Contribution description

While testing #12457 I found that two test scripts have some issues, this PR fixes them:

- `tests/evtimer_msg`: the range goes from `[expected - 2, expected -1]` instead of `[expected - 2, expected -2]`
- `tests/bench_runtime_coreapis`: no expect on `thread_flags_clear` so function can TIMEOUT early, no timeout on `msg_try_receive`, it sometimes timeouts on `z1` if it didn't timeout earlier.

### Testing procedure

- this PR

<details><summary>BOARD=z1 make -C tests/bench_runtime_coreapis/ flash test <b>passes</b></summary>

```
2020-03-24 14:14:56,843 # READY
s
2020-03-24 14:14:56,913 # START
2020-03-24 14:14:56,915 # main(): This is RIOT! (Version: 2020.04-devel-1418-g5ef0c-HEAD)
2020-03-24 14:14:56,917 # Runtime of Selected Core API functions
2020-03-24 14:14:56,917 # 
2020-03-24 14:14:57,650 #                  nop loop:     29129us  ---   0.029us per call  ---   34330049 calls per sec
2020-03-24 14:14:57,651 # 
2020-03-24 14:14:57,660 #              mutex_init():        18us  ---   0.000us per call  ---  4015948003 calls per sec
2020-03-24 14:15:11,849 #         mutex lock/unlock:     10496us  ---   0.010us per call  ---   95274390 calls per sec
2020-03-24 14:15:11,849 # 
2020-03-24 14:15:20,463 #        thread_flags_set():     27665us  ---   0.027us per call  ---   36146755 calls per sec
2020-03-24 14:15:28,229 #      thread_flags_clear():      4633us  ---   0.004us per call  ---  215842866 calls per sec
2020-03-24 14:15:51,020 # thread flags set/wait any:     38137us  ---   0.038us per call  ---   26221254 calls per sec
2020-03-24 14:16:11,752 # thread flags set/wait all:     10289us  ---   0.010us per call  ---   97191175 calls per sec
2020-03-24 14:16:34,907 # thread flags set/wait one:     19921us  ---   0.019us per call  ---   50198283 calls per sec
2020-03-24 14:16:34,907 # 
2020-03-24 14:16:45,218 #         msg_try_receive():      8193us  ---   0.008us per call  ---  122055413 calls per sec
2020-03-24 14:16:47,894 #               msg_avail():     63049us  ---   0.063us per call  ---   15860679 calls per sec
2020-03-24 14:16:47,895 # 
2020-03-24 14:16:47,895 # [SUCCESS]
```
</details>

<details><summary>BOARD=z1 make -C tests/evtimer_msg/ flash test <b>passes</b></summary>

```
2020-03-24 14:20:43,486 # READY
s
2020-03-24 14:20:43,556 # START
2020-03-24 14:20:43,558 # main(): This is RIOT! (Version: 2020.04-devel-1420-g62ff1-pr_tests_fixes)
2020-03-24 14:20:43,559 # Testing generic evtimer
2020-03-24 14:20:43,569 # This should list 2 items
2020-03-24 14:20:43,570 # ev #1 offset=997
2020-03-24 14:20:43,570 # ev #2 offset=501
2020-03-24 14:20:43,588 # This should list 4 items
2020-03-24 14:20:43,589 # ev #1 offset=658
2020-03-24 14:20:43,589 # ev #2 offset=339
2020-03-24 14:20:43,589 # ev #3 offset=501
2020-03-24 14:20:43,590 # ev #4 offset=2456
2020-03-24 14:20:43,591 # Are the reception times of all 4 msgs close to the supposed values?
2020-03-24 14:20:44,218 # At   7661 ms received msg 0: "#2 supposed to be 7659"
.2020-03-24 14:20:44,546 # At   8000 ms received msg 1: "#0 supposed to be 7998"
2020-03-24 14:20:45,032 # At   8501 ms received msg 2: "#1 supposed to be 8499"
..2020-03-24 14:20:47,413 # At  10957 ms received msg 3: "#3 supposed to be 10956"
.
All tests successful
```
</details>

- master

<details><summary>BOARD=z1 make -C tests/bench_runtime_coreapis/ flash test <b>fails</b></summary>

```
2020-03-24 14:23:57,572 # READY
s
2020-03-24 14:23:57,642 # START
2020-03-24 14:23:57,644 # main(): This is RIOT! (Version: 2020.04-devel-1418-g5ef0c-HEAD)
2020-03-24 14:23:57,646 # Runtime of Selected Core API functions
2020-03-24 14:23:57,646 # 
2020-03-24 14:23:58,380 #                  nop loop:     29128us  ---   0.029us per call  ---   34331227 calls per sec
2020-03-24 14:23:58,380 # 
2020-03-24 14:23:58,389 #              mutex_init():        19us  ---   0.000us per call  ---  1091971395 calls per sec
2020-03-24 14:24:12,578 #         mutex lock/unlock:     10497us  ---   0.010us per call  ---   95265313 calls per sec
2020-03-24 14:24:12,579 # 
2020-03-24 14:24:21,192 #        thread_flags_set():     27665us  ---   0.027us per call  ---   36146755 calls per sec
2020-03-24 14:24:28,958 #      thread_flags_clear():      4632us  ---   0.004us per call  ---  215889464 calls per sec
Timeout in expect script at "child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait any"), timeout=TIMEOUT)" (tests/bench_runtime_coreapis/tests/01-run.py:24)
```
</details>

<details><summary>BOARD=z1 make -C tests/evtimer_msg/ flash test <b>fails</b></summary>

```
2020-03-24 14:22:29,366 # READY
s
2020-03-24 14:22:29,436 # START
2020-03-24 14:22:29,439 # main(): This is RIOT! (Version: 2020.04-devel-1418-g5ef0c-HEAD)
2020-03-24 14:22:29,440 # Testing generic evtimer
2020-03-24 14:22:29,449 # This should list 2 items
2020-03-24 14:22:29,450 # ev #1 offset=997
2020-03-24 14:22:29,451 # ev #2 offset=501
2020-03-24 14:22:29,468 # This should list 4 items
2020-03-24 14:22:29,469 # ev #1 offset=658
2020-03-24 14:22:29,470 # ev #2 offset=339
2020-03-24 14:22:29,471 # ev #3 offset=501
2020-03-24 14:22:29,472 # ev #4 offset=2456
2020-03-24 14:22:29,474 # Are the reception times of all 4 msgs close to the supposed values?
2020-03-24 14:22:30,098 # At   7236 ms received msg 0: "#2 supposed to be 7234"

Traceback (most recent call last):
  File "/home/francisco/workspace/RIOT2/tests/evtimer_msg/tests/01-run.py", line 33, in <module>
    sys.exit(run(testfunc))
  File "/home/francisco/workspace/RIOT2/dist/pythonlibs/testrunner/__init__.py", line 30, in run
    testfunc(child)
  File "/home/francisco/workspace/RIOT2/tests/evtimer_msg/tests/01-run.py", line 26, in testfunc
    assert(actual in range(expected - ACCEPTED_ERROR, expected + ACCEPTED_ERROR))
AssertionError
```
</details>


### Issues/PRs references

Found while testing #12457