### PR TITLE
pkg/libcose: Remove monocypher crypto mode

### DIFF
--- a/pkg/libcose/Makefile.dep
+++ b/pkg/libcose/Makefile.dep
@@ -7,9 +7,6 @@ USEMODULE += random
 ifneq (,$(filter libcose_crypt_hacl,$(USEMODULE)))
   USEPKG += hacl
 endif
-ifneq (,$(filter libcose_crypt_monocypher,$(USEMODULE)))
-  USEPKG += monocypher
-endif
 ifneq (,$(filter libcose_crypt_c25519,$(USEMODULE)))
   USEPKG += c25519
 endif

--- a/pkg/libcose/Makefile.include
+++ b/pkg/libcose/Makefile.include
@@ -4,9 +4,6 @@ CFLAGS += -DUSE_CBOR_CONTEXT
 ifneq (,$(filter libcose_crypt_hacl,$(USEMODULE)))
   CFLAGS += -DCRYPTO_HACL
 endif
-ifneq (,$(filter libcose_crypt_monocypher,$(USEMODULE)))
-  CFLAGS += -DCRYPTO_MONOCYPHER
-endif
 ifneq (,$(filter libcose_crypt_c25519,$(USEMODULE)))
   CFLAGS += -DCRYPTO_C25519
 endif

--- a/tests/pkg_libcose/Makefile
+++ b/tests/pkg_libcose/Makefile
@@ -7,7 +7,6 @@ USEPKG += libcose
 # crypto backend.
 USEMODULE += libcose_crypt_hacl
 # USEMODULE += libcose_crypt_c25519
-# USEMODULE += libcose_crypt_monocypher
 USEMODULE += memarray
 USEMODULE += embunit
 


### PR DESCRIPTION
### Contribution description

With #13351 the Monocypher version included with RIOT is no longer compatible with Libcose. This PR removes the monocypher crypto mode with Libcose. It can be restore when Libcose is updated to restore compatibility.

### Testing procedure

Test that libcose on master (or on #13351) is indeed broken when `libcose_crypto_monocypher` is used for crypto.

### Issues/PRs references

Caused by #13351 